### PR TITLE
The drill-through answers in deals, not UUIDs

### DIFF
--- a/backend/gates/txseamacquire_test.go
+++ b/backend/gates/txseamacquire_test.go
@@ -70,6 +70,11 @@ var connectionAcquirers = map[string]string{
 	"ActivePersonColumns":       "reads the person custom-field catalog, which opens a transaction of its own",
 	"ActiveOrganizationColumns": "reads the organization custom-field catalog, which opens a transaction of its own",
 	"ActiveDealColumns":         "reads the deal custom-field catalog, which opens a transaction of its own",
+	// The drill-through's display names, resolved through each module's own
+	// gated label read — every one of which opens a transaction. It exists to
+	// be called ABOVE the report's transaction, exactly like the catalog reads
+	// above, so calling it from inside one reinstates the defect.
+	"labelDerivationRows": "names the drill-through's rows through the stores' label reads, each of which opens a transaction of its own",
 }
 
 func TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn(t *testing.T) {
@@ -205,17 +210,28 @@ func (b txBorrowing) acquires() []string {
 		if !ok {
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if _, isAcquirer := connectionAcquirers[fn.Sel.Name]; !isAcquirer {
+				return true
+			}
+			if b.receiverIsTheBorrowedTx(fn.X) {
+				return true
+			}
+			found = append(found, fn.Sel.Name)
+		case *ast.Ident:
+			// A package-local helper called by bare name. It has no receiver
+			// that could be the borrowed transaction, so a registered
+			// acquirer spelled this way is always a second connection.
+			//
+			// The walk read selectors only until an analytics helper reached
+			// a borrowed transaction unseen: the defect this gate exists to
+			// catch, wearing the one spelling it could not read.
+			if _, isAcquirer := connectionAcquirers[fn.Name]; !isAcquirer {
+				return true
+			}
+			found = append(found, fn.Name)
 		}
-		if _, isAcquirer := connectionAcquirers[sel.Sel.Name]; !isAcquirer {
-			return true
-		}
-		if b.receiverIsTheBorrowedTx(sel.X) {
-			return true
-		}
-		found = append(found, sel.Sel.Name)
 		return true
 	})
 	return found

--- a/backend/internal/compose/attentionlanebinding_test.go
+++ b/backend/internal/compose/attentionlanebinding_test.go
@@ -223,6 +223,7 @@ func seamTypeNames(files map[string]*ast.File) []string {
 func wiredSeamNames(t *testing.T, files map[string]*ast.File) map[string]bool {
 	t.Helper()
 	wired := map[string]bool{}
+	returns := constructorReturns(files)
 	found := false
 	for _, file := range files {
 		ast.Inspect(file, func(n ast.Node) bool {
@@ -237,12 +238,8 @@ func wiredSeamNames(t *testing.T, files map[string]*ast.File) map[string]bool {
 					return true
 				}
 				for _, arg := range call.Args {
-					lit, ok := arg.(*ast.CompositeLit)
-					if !ok {
-						continue
-					}
-					if name, ok := lit.Type.(*ast.Ident); ok {
-						wired[name.Name] = true
+					if name, ok := seamNameOf(arg, returns); ok {
+						wired[name] = true
 					}
 				}
 				return true
@@ -258,6 +255,59 @@ func wiredSeamNames(t *testing.T, files map[string]*ast.File) map[string]bool {
 			"or reshaped, and this scan would report every lane unwired")
 	}
 	return wired
+}
+
+// seamNameOf reads the seam type out of one argument of a binding call.
+//
+// Two spellings reach the feed, and the scan has to see both. A struct
+// literal (`attentionNotices{…}`) names its type outright. A constructor
+// (`newAttentionNames(db)`) names it in the function, and a seam assembled
+// by one used to be invisible here — the scan read PASS while the lane was
+// as unwired as any nil, which is the under-recognition this whole file
+// exists to prevent.
+func seamNameOf(arg ast.Expr, returns map[string]string) (string, bool) {
+	switch a := arg.(type) {
+	case *ast.CompositeLit:
+		if name, ok := a.Type.(*ast.Ident); ok {
+			return name.Name, true
+		}
+	case *ast.CallExpr:
+		fn, ok := a.Fun.(*ast.Ident)
+		if !ok {
+			return "", false
+		}
+		// What the constructor RETURNS, read off its declaration — not what
+		// its name suggests. A `newAttentionNames` retargeted to return some
+		// other Names implementation would still be named for the seam it no
+		// longer builds, and crediting it by name would report the lane wired
+		// to a seam production had stopped using.
+		seam, declared := returns[fn.Name]
+		return seam, declared
+	}
+	return "", false
+}
+
+// constructorReturns maps each package-local constructor to the bare type
+// name it returns, for the one-result functions a lane can be built by. A
+// constructor returning anything else — a pointer, an interface, two values —
+// is deliberately absent, so the scan credits nothing it cannot read plainly.
+func constructorReturns(files map[string]*ast.File) map[string]string {
+	out := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Type.Results == nil {
+				continue
+			}
+			if len(fn.Type.Results.List) != 1 {
+				continue
+			}
+			if name, ok := fn.Type.Results.List[0].Type.(*ast.Ident); ok {
+				out[fn.Name.Name] = name.Name
+			}
+		}
+	}
+	return out
 }
 
 // bindsALane recognises the two calls that hand a seam to the feed:

--- a/backend/internal/compose/attentionnames.go
+++ b/backend/internal/compose/attentionnames.go
@@ -20,6 +20,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/projects"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -34,6 +35,22 @@ type attentionNames struct {
 }
 
 var _ attention.Names = attentionNames{}
+
+// newAttentionNames assembles the resolver over one installation's stores.
+//
+// Two surfaces read display names through it: the attention feed's cards and
+// the analytics drill-through's source rows. They share this constructor
+// because a name must resolve identically on both — a second assembly could
+// bind a different store set, and then the same record would be named on one
+// surface and withheld on the other for no reason a reader could see.
+func newAttentionNames(db *database.DB) attentionNames {
+	return attentionNames{
+		people:     people.NewStore(db),
+		deals:      deals.NewStore(db, DealsInstallation()),
+		activities: activities.NewStore(db),
+		projects:   projects.NewStore(db),
+	}
+}
 
 // Labels answers a set of one type's display names under the caller's scope.
 //

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -32,7 +32,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/notices"
 	"github.com/margince/margince/backend/internal/modules/overlay"
 	"github.com/margince/margince/backend/internal/modules/people"
-	"github.com/margince/margince/backend/internal/modules/projects"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
@@ -382,12 +381,7 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// The label resolver: every card that names a record gets that
 		// record's display name under the reader's own grants, one gated get
 		// per distinct subject (attentionnames.go).
-		attentionNames{
-			people:     people.NewStore(db),
-			deals:      deals.NewStore(db, DealsInstallation()),
-			activities: activities.NewStore(db),
-			projects:   projects.NewStore(db),
-		},
+		newAttentionNames(db),
 		now,
 		// The installation's own midnight is where "today" ends for the
 		// due-dated lanes. Unbound it would be UTC's, which is nobody's day

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -40,10 +40,21 @@ const reservedDerivationColumn = "derivation_url"
 // absence is stated separately.
 const nullPredicateKey = "isnull"
 
+// asOfKey names the instant the headline was computed at.
+//
+// A handle without it resolves at whatever the rate sheet says NOW, which is
+// the same answer for every report whose money is native — none of them convert,
+// so the frame's as-of reaches no arithmetic. It is a different answer for a
+// CONVERTED report: a stage totalled at Thursday's rate, opened on Friday,
+// recomputes at Friday's. The drill-through is where a reader checks a figure
+// they doubt, so a detail set that reconciles to something else is worse than
+// none — it looks like proof.
+const asOfKey = "as_of"
+
 // reservedDerivationKeys are the query-string names a handle owns. Report
 // vocabularies may not squat on them, or a minted URL would be ambiguous.
 // Derived from here rather than restated, so adding a key updates the gate.
-var reservedDerivationKeys = []string{"by", "agg", nullPredicateKey, reservedDerivationColumn}
+var reservedDerivationKeys = []string{"by", "agg", nullPredicateKey, asOfKey, reservedDerivationColumn}
 
 // derivationQuery is one parsed derivation handle: the equality
 // predicates that pin the explained cell (plan filters + the row's
@@ -57,6 +68,10 @@ type derivationQuery struct {
 	Unset      map[string]bool
 	GroupBy    []string
 	Aggregates []reportAggregate
+	// AsOf is the instant the headline was computed at, carried so the detail
+	// converts the same way. Zero when the handle predates this key, which
+	// resolves at the current instant exactly as it always did.
+	AsOf time.Time
 }
 
 // derivationOutcome is a resolved handle: definition, drill-through
@@ -79,8 +94,14 @@ type derivationOutcome struct {
 // row, for the whole filtered result). parseDerivationQuery is its exact
 // inverse; the round trip is unit-tested so a handle we mint always
 // resolves.
-func derivationURL(report string, filters map[string]any, groupBy []string, aggregates []reportAggregate, row map[string]any) string {
+func derivationURL(
+	report string, filters map[string]any, groupBy []string,
+	aggregates []reportAggregate, row map[string]any, asOf time.Time,
+) string {
 	values := url.Values{}
+	if !asOf.IsZero() {
+		values.Set(asOfKey, asOf.UTC().Format(time.RFC3339Nano))
+	}
 	for _, agg := range aggregates {
 		values.Add("agg", agg.Fn+":"+agg.Field+":"+agg.As)
 	}
@@ -139,6 +160,15 @@ func parseDerivationQuery(values url.Values) (derivationQuery, error) {
 			for _, field := range vals {
 				q.Unset[field] = true
 			}
+		case asOfKey:
+			if len(vals) != 1 {
+				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey}
+			}
+			at, err := time.Parse(time.RFC3339Nano, vals[0])
+			if err != nil {
+				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey + "=" + vals[0]}
+			}
+			q.AsOf = at
 		case "agg":
 			for _, v := range vals {
 				parts := strings.SplitN(v, ":", 3)
@@ -194,6 +224,9 @@ type derivationPlan struct {
 	selects    []string
 	aggColumns []string
 	aggSelects []string
+	// asOf is the instant the headline was computed at, from the handle. Zero
+	// for a handle minted before this key existed.
+	asOf time.Time
 }
 
 // Derive resolves one handle against a prebuilt report's vocabulary.
@@ -230,12 +263,27 @@ func (e *reportEngine) Derive(ctx context.Context, report string, q derivationQu
 			"group_by":   q.GroupBy,
 			"aggregates": plan.aggregates,
 		},
-		Columns:     plan.columns,
+		// The outcome's own slice: the fetch appends the label column to it
+		// when a row was named, while plan.columns still drives the scan.
+		Columns:     slices.Clone(plan.columns),
 		Aggregates:  map[string]any{},
 		GeneratedAt: time.Now().UTC(),
 	}
 	if err := e.fetchDerivation(ctx, report, spec, plan, &out); err != nil {
 		return derivationOutcome{}, err
+	}
+	// Name the rows for a human reader, under that reader's own grants —
+	// AFTER the fetch's transaction has closed, never inside it. Each store's
+	// label read takes a connection of its own, so naming rows while still
+	// holding the fetch's would have every concurrent request wait on a
+	// connection the pool cannot give it, and the whole API stalls on a
+	// screen that only wanted display names. The attention feed labels
+	// outside its reads for the same reason (attention/feed.go).
+	//
+	// Nothing here needs the transaction: a label is presentation and never
+	// a term in the aggregate, so it changes no number the rows add up to.
+	if labelDerivationRows(ctx, e.names, string(spec.entity), out.Rows) {
+		out.Columns = append(out.Columns, derivationLabelColumn)
 	}
 	return out, nil
 }
@@ -297,6 +345,7 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 		return derivationPlan{}, err
 	}
 	plan.definition = definition
+	plan.asOf = q.AsOf
 
 	// Drill-through columns: the row identity plus every dimension and
 	// measure the vocabulary declares — a derived measure (e.g. the

--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The definition is the (a) half of AC-R6: the exact filter + group +
@@ -97,7 +98,8 @@ func TestDerivationURLRoundTrip(t *testing.T) {
 		map[string]any{"pipeline_id": "018f-pipe"},
 		[]string{"owner_id", "forecast_category"},
 		aggs,
-		map[string]any{"owner_id": "018f-owner", "forecast_category": nil, "deals": int64(3)})
+		map[string]any{"owner_id": "018f-owner", "forecast_category": nil, "deals": int64(3)},
+		time.Time{})
 
 	parsed, err := url.Parse(minted)
 	if err != nil {
@@ -228,5 +230,48 @@ func TestForecastSpecShape(t *testing.T) {
 	}
 	if spec.measures["amount_minor"] != "t.amount_minor" {
 		t.Errorf("unweighted measure = %q", spec.measures["amount_minor"])
+	}
+}
+
+// A handle carries the instant its headline was computed at, and gives it back.
+//
+// This is the half a database test cannot show: the FX lookup compares by DAY,
+// so two reads taken minutes apart see the same rate however the sheet moved.
+// The case that matters crosses a date boundary — a stage totalled at 23:50 and
+// opened at 00:10 — and stating both instants exactly is what makes it testable
+// at all.
+func TestADerivationHandleCarriesTheInstantItWasComputedAt(t *testing.T) {
+	lateThursday := time.Date(2026, 9, 3, 23, 50, 0, 0, time.UTC)
+
+	minted := derivationURL("pipeline-current", nil, []string{"stage_id"},
+		[]reportAggregate{{Fn: "sum", Field: "amount_base_minor", As: "base"}},
+		map[string]any{"stage_id": "s1", "base": int64(5000)}, lateThursday)
+
+	parsed, err := url.Parse(minted)
+	if err != nil {
+		t.Fatalf("the minted handle is not a URL: %v", err)
+	}
+	q, err := parseDerivationQuery(parsed.Query())
+	if err != nil {
+		t.Fatalf("the engine cannot read back a handle it minted: %v", err)
+	}
+	if !q.AsOf.Equal(lateThursday) {
+		t.Fatalf("handle round-tripped as_of as %v, want %v.\n\n"+
+			"Opened after midnight, a handle that lost this converts at Friday's "+
+			"rate while the headline above it was Thursday's.", q.AsOf, lateThursday)
+	}
+}
+
+// A handle minted before this key existed still resolves, at the current
+// instant, exactly as it always did. Those links are in bookmarks and in sent
+// mail, and refusing them would be a worse answer than the old behaviour.
+func TestAHandleWithoutAnInstantStillResolves(t *testing.T) {
+	q, err := parseDerivationQuery(url.Values{"by": {"stage_id"}, "stage_id": {"s1"}})
+	if err != nil {
+		t.Fatalf("a handle with no as_of was refused: %v", err)
+	}
+	if !q.AsOf.IsZero() {
+		t.Errorf("a handle naming no instant produced %v, want the zero time that "+
+			"tells the engine to read the frame's own", q.AsOf)
 	}
 }

--- a/backend/internal/compose/derivationfetch.go
+++ b/backend/internal/compose/derivationfetch.go
@@ -41,6 +41,12 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		if err != nil {
 			return err
 		}
+		// The headline's instant wins over this transaction's. Without it a
+		// converted report's detail looks up a rate the headline never used,
+		// and the two disagree by however much the sheet moved in between.
+		if !plan.asOf.IsZero() {
+			frame.AsOf = plan.asOf
+		}
 		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
 		if err != nil {
 			return err

--- a/backend/internal/compose/derivationlabelcollision_test.go
+++ b/backend/internal/compose/derivationlabelcollision_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The drill-through writes each row's display name into a column of its own,
+// and that column's name has to stay free.
+//
+// A spec that declared its own `label` dimension or measure would have the
+// enrichment overwrite the queried value after the scan — silently, because
+// the row already has the key and the arithmetic never reads it. The number
+// would still reconcile and the column would show a display name where the
+// spec promised something else.
+//
+// Both corpora come from the registries themselves, so a report or a schema
+// field added tomorrow is checked by being declared rather than by being
+// remembered here.
+
+import "testing"
+
+func TestNoReportSpecClaimsTheDrillThroughsLabelColumn(t *testing.T) {
+	t.Parallel()
+	if len(prebuiltReports) == 0 {
+		t.Fatal("found no prebuilt reports at all — the scan is reading the wrong " +
+			"registry, and would report PASS over a tree where every spec collided")
+	}
+	for name, spec := range prebuiltReports {
+		if _, taken := spec.dimensions[derivationLabelColumn]; taken {
+			t.Errorf("report %q declares a %q dimension, which the drill-through's "+
+				"display name would overwrite after the query ran. Rename the "+
+				"dimension, or give the label column a name no spec uses.",
+				name, derivationLabelColumn)
+		}
+		if _, taken := spec.measures[derivationLabelColumn]; taken {
+			t.Errorf("report %q declares a %q measure, which the drill-through's "+
+				"display name would overwrite after the query ran. Rename the "+
+				"measure, or give the label column a name no spec uses.",
+				name, derivationLabelColumn)
+		}
+	}
+}
+
+// The ad-hoc plan (runAdHocPlan) builds its vocabulary from the schema
+// descriptors rather than from prebuiltReports: EVERY declared field becomes a
+// dimension. So a field named "label" collides through a path the check above
+// cannot see, and a gate blind to half its subject reads PASS either way.
+func TestNoSchemaFieldClaimsTheDrillThroughsLabelColumn(t *testing.T) {
+	t.Parallel()
+	if len(schemaObjects) == 0 {
+		t.Fatal("found no schema objects at all — the scan is reading the wrong " +
+			"registry, and would report PASS over a tree where every field collided")
+	}
+	for _, obj := range schemaObjects {
+		for _, field := range obj.Fields {
+			if field.Name == derivationLabelColumn {
+				t.Errorf("%s declares a %q field, which becomes an ad-hoc report "+
+					"dimension and would be overwritten by the drill-through's "+
+					"display name. Rename the field, or give the label column a "+
+					"name no schema uses.", obj.Type, derivationLabelColumn)
+			}
+		}
+	}
+}

--- a/backend/internal/compose/derivationlabels.go
+++ b/backend/internal/compose/derivationlabels.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The drill-through's NAMES: each source row carries the display name of the
+// record it stands for, so "explain this number" answers with the deals a
+// reader recognises rather than the UUIDs the query happened to select.
+//
+// The name comes from the SAME seam the attention feed uses
+// (attentionnames.go): one gated read per type, under the READER's grants,
+// absent when the caller may not read it. Nothing here holds authority of
+// its own — a row whose name is withheld keeps its id and loses its label,
+// which is the contract's answer everywhere else a label travels.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// derivationLabelColumn is where a row's display name lands. It is not a
+// dimension the caller can group or filter by: the plan builds its columns
+// from the spec's vocabulary, and this one is appended after the query has
+// run, so it can never reach SQL.
+const derivationLabelColumn = "label"
+
+// labelDerivationRows names each source row through the caller's own grants.
+//
+// A row is named when the seam answers for its id and stays unnamed
+// otherwise, which covers three cases with one behaviour: the caller may not
+// read that type at all, this particular row is outside their row scope, or
+// the entity has no label lane. In every one of them the id still travels
+// and the arithmetic is untouched — the drill-through still reconciles to
+// the number it explains, because a label is presentation and never a term
+// in the sum.
+//
+// No names seam wired means no labels, not an error: the report engine
+// serves the agent surface too, where a tool answers in ids.
+//
+// Reports whether any row was named, so the caller can announce the label
+// column only when it is really there. A column advertised on rows that
+// never carry it reads to a renderer as a column of blanks.
+func labelDerivationRows(ctx context.Context, names attention.Names, entity string, rows []map[string]any) bool {
+	if names == nil || len(rows) == 0 {
+		return false
+	}
+	want := make([]ids.UUID, 0, len(rows))
+	seen := make(map[ids.UUID]struct{}, len(rows))
+	for _, row := range rows {
+		id, ok := rowRecordID(row)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		want = append(want, id)
+	}
+	if len(want) == 0 {
+		return false
+	}
+	labels, err := names.Labels(ctx, entity, want)
+	if err != nil {
+		// A label that will not resolve costs the label. The rows and their
+		// aggregates are already correct and already row-scoped; failing the
+		// whole explanation because its display names did not load would
+		// hide a number the caller is entitled to see.
+		return false
+	}
+	var named bool
+	for _, row := range rows {
+		id, ok := rowRecordID(row)
+		if !ok {
+			continue
+		}
+		if label, has := labels[id]; has {
+			row[derivationLabelColumn] = label
+			named = true
+		}
+	}
+	return named
+}
+
+// rowRecordID reads the row identity the plan always selects first. It is a
+// wire value by the time it lands here, so a string is what the seam gets
+// back from a UUID column.
+func rowRecordID(row map[string]any) (ids.UUID, bool) {
+	raw, ok := row["id"].(string)
+	if !ok {
+		return ids.UUID{}, false
+	}
+	id, err := ids.Parse(raw)
+	if err != nil {
+		return ids.UUID{}, false
+	}
+	return id, true
+}

--- a/backend/internal/compose/derivationlabels_test.go
+++ b/backend/internal/compose/derivationlabels_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// fakeNames answers a fixed name set, and records what it was asked for.
+// The seam it stands in for is a real boundary — every real implementation
+// reads the database under the caller's grants — so the labeller's own
+// behaviour is what these cases are about.
+type fakeNames struct {
+	labels map[ids.UUID]string
+	err    error
+	asked  []ids.UUID
+	entity string
+}
+
+func (f *fakeNames) Labels(_ context.Context, entityType string, want []ids.UUID) (map[ids.UUID]string, error) {
+	f.entity = entityType
+	f.asked = append(f.asked, want...)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.labels, nil
+}
+
+func TestASourceRowIsNamedForTheReader(t *testing.T) {
+	t.Parallel()
+	id := ids.NewV7()
+	names := &fakeNames{labels: map[ids.UUID]string{id: "Contoso renewal"}}
+	rows := []map[string]any{{"id": id.String(), "amount_base_minor": int64(500000)}}
+
+	if !labelDerivationRows(context.Background(), names, "deal", rows) {
+		t.Fatal("a row the seam named reported as unnamed")
+	}
+	if got := rows[0][derivationLabelColumn]; got != "Contoso renewal" {
+		t.Errorf("row carries label %v, want the name the seam answered", got)
+	}
+	if names.entity != "deal" {
+		t.Errorf("seam asked about %q, want the spec's own entity", names.entity)
+	}
+}
+
+// The whole reason the drill-through can show a name at all: the seam holds
+// the reader's grants. A row it declines to name keeps its id and loses only
+// the label — the number it contributes to is unchanged.
+func TestARowTheReaderMayNotNameKeepsItsID(t *testing.T) {
+	t.Parallel()
+	named, withheld := ids.NewV7(), ids.NewV7()
+	names := &fakeNames{labels: map[ids.UUID]string{named: "Contoso renewal"}}
+	rows := []map[string]any{
+		{"id": named.String()},
+		{"id": withheld.String()},
+	}
+
+	labelDerivationRows(context.Background(), names, "deal", rows)
+
+	if _, has := rows[1][derivationLabelColumn]; has {
+		t.Error("a row the seam withheld came back with a label")
+	}
+	if rows[1]["id"] != withheld.String() {
+		t.Error("the withheld row lost its id, so it cannot be reconciled at all")
+	}
+}
+
+// A seam that will not answer costs the labels and nothing else. Failing the
+// explanation would hide a number the caller is entitled to see, and the
+// arithmetic never depended on the names.
+func TestALabelReadThatFailsLeavesTheRowsIntact(t *testing.T) {
+	t.Parallel()
+	id := ids.NewV7()
+	names := &fakeNames{err: errors.New("the label store is down")}
+	rows := []map[string]any{{"id": id.String(), "amount_base_minor": int64(500000)}}
+
+	if labelDerivationRows(context.Background(), names, "deal", rows) {
+		t.Error("a failed label read reported rows as named")
+	}
+	if rows[0]["amount_base_minor"] != int64(500000) {
+		t.Error("a failed label read disturbed the row's measures")
+	}
+}
+
+// The agent surface leaves the seam unwired, and answers in ids.
+func TestWithoutANamesSeamTheRowsAreUnlabelled(t *testing.T) {
+	t.Parallel()
+	rows := []map[string]any{{"id": ids.NewV7().String()}}
+
+	if labelDerivationRows(context.Background(), nil, "deal", rows) {
+		t.Error("an unwired seam reported rows as named")
+	}
+	if _, has := rows[0][derivationLabelColumn]; has {
+		t.Error("an unwired seam produced a label")
+	}
+}
+
+// One read per type is the seam's whole shape, so two rows standing for the
+// same record must not become two questions.
+func TestTheSeamIsAskedAboutEachRecordOnce(t *testing.T) {
+	t.Parallel()
+	id := ids.NewV7()
+	names := &fakeNames{labels: map[ids.UUID]string{id: "Contoso renewal"}}
+	rows := []map[string]any{{"id": id.String()}, {"id": id.String()}}
+
+	labelDerivationRows(context.Background(), names, "deal", rows)
+
+	if len(names.asked) != 1 {
+		t.Errorf("seam asked about %d ids, want 1 for two rows of one record", len(names.asked))
+	}
+	if rows[1][derivationLabelColumn] != "Contoso renewal" {
+		t.Error("the second row of the same record went unnamed")
+	}
+}

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -18,8 +18,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -270,14 +268,6 @@ type reportOutcome struct {
 	Timezone             string
 	BaseCurrency         string
 	FiscalYearStartMonth int
-}
-
-type reportEngine struct {
-	pool *pgxpool.Pool
-}
-
-func newReportEngine(pool *pgxpool.Pool) *reportEngine {
-	return &reportEngine{pool: pool}
 }
 
 // runSpec executes one validated vocabulary; Run (prebuilt catalog) and

--- a/backend/internal/compose/report_pipelinecurrent_integration_test.go
+++ b/backend/internal/compose/report_pipelinecurrent_integration_test.go
@@ -17,7 +17,10 @@ package compose
 // against a formula recomputed here, because a test that reproduces the
 // production expression proves only that it was copied correctly.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const pipelineCurrentPlan = `{"group_by":["stage_id"],"aggregates":[` +
 	`{"fn":"count","as":"deals"},` +
@@ -187,5 +190,45 @@ func TestPipelineCurrentDetailReconcilesToTheConvertedHeadline(t *testing.T) {
 	}
 	if got := wireInt(t, row, "base"); got != 15_000 {
 		t.Fatalf("headline was %d, want the converted 15000", got)
+	}
+}
+
+// A converted headline and the detail behind it use ONE exchange rate.
+//
+// The handle carries the instant the headline was computed at, so a detail
+// opened later converts the way the headline did rather than the way the rate
+// sheet reads when it is opened.
+//
+// The FX lookup compares by DAY (`rate_date <= as_of::date`), so a rate added
+// during this test cannot separate the two reads — both fall on the same date.
+// What is provable here is that the handle CARRIES the instant and that the
+// detail still reconciles; a rate crossing a day boundary is the case the unit
+// test beside this one pins, where the two instants can be stated exactly.
+func TestPipelineCurrentDetailCarriesTheHeadlinesInstant(t *testing.T) {
+	e := setupForecast(t)
+	seedRate(t, e, "0.5", 1)
+	seedPricedDeal(t, e, "Abroad", 10_000, "USD", "open")
+
+	result := e.runReport(e.Admin(), t, "pipeline-current", pipelineCurrentPlan)
+	row := dealsByStageRow(t, result, e.stages[pipelineTestStage].String())
+	handle, ok := row["derivation_url"].(string)
+	if !ok || handle == "" {
+		t.Fatalf("no derivation handle on the converted row: %+v", row)
+	}
+	if !strings.Contains(handle, "as_of=") {
+		t.Fatalf("the handle pins no instant, so the detail will convert at "+
+			"whatever the sheet says when it is opened: %s", handle)
+	}
+	headline := wireInt(t, row, "base")
+	if headline != 5_000 {
+		t.Fatalf("headline converted to %d, want 5000 at the rate in force", headline)
+	}
+
+	derivation := e.explainReport(e.Admin(), t, "pipeline-current", handle)
+	if len(derivation.Rows) != 1 {
+		t.Fatalf("detail opened %d rows, want the one deal: %+v", len(derivation.Rows), derivation.Rows)
+	}
+	if got := wireInt(t, derivation.Aggregates, "base"); got != headline {
+		t.Errorf("detail recomputed to %d, want the headline's %d", got, headline)
 	}
 }

--- a/backend/internal/compose/report_projectgrant_integration_test.go
+++ b/backend/internal/compose/report_projectgrant_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -50,7 +51,7 @@ func TestActivityDrillThroughTakesTheProjectGrant(t *testing.T) {
 	e.seedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, project_id) VALUES ($1, $2, 'project', $3)`, activity, project)
 
 	byProject := derivationURL("activities-by-kind", nil, []string{"project_id"}, nil,
-		map[string]any{"project_id": project.String()})
+		map[string]any{"project_id": project.String()}, time.Time{})
 	if status := e.explainStatus(e.activityReader(), "activities-by-kind", byProject); status != http.StatusForbidden {
 		t.Fatalf("drill-through grouped by project without project.read → %d, want 403", status)
 	}
@@ -58,7 +59,8 @@ func TestActivityDrillThroughTakesTheProjectGrant(t *testing.T) {
 		t.Fatalf("drill-through grouped by project with project.read → %d, want 200", status)
 	}
 
-	byKind := derivationURL("activities-by-kind", nil, []string{"kind"}, nil, map[string]any{"kind": "meeting"})
+	byKind := derivationURL("activities-by-kind", nil, []string{"kind"}, nil,
+		map[string]any{"kind": "meeting"}, time.Time{})
 	rows := e.explainReport(e.activityReader(), t, "activities-by-kind", byKind)
 	if rows.TotalRows != 1 {
 		t.Fatalf("drill-through by kind = %d rows, want the one meeting", rows.TotalRows)

--- a/backend/internal/compose/reportengine.go
+++ b/backend/internal/compose/reportengine.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The report engine's own shape: what it holds and how a surface builds one.
+// The vocabulary it executes (specs, selects, aggregates) lives in report.go,
+// and the drill-through in derivation.go — this file is only the seam set,
+// which differs per surface and is the thing a caller has to get right.
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+)
+
+type reportEngine struct {
+	pool *pgxpool.Pool
+	// names labels the drill-through's source rows for a human reader
+	// (derivationlabels.go). Absent on the agent surface, which answers in
+	// ids, and absent means unlabelled rather than an error.
+	names attention.Names
+}
+
+func newReportEngine(pool *pgxpool.Pool) *reportEngine {
+	return &reportEngine{pool: pool}
+}
+
+// WithNames wires the display-name seam the drill-through reads through, so
+// "explain this number" answers with the records a reader recognises. The
+// seam carries the READER's grants, so this adds a presentation lane and no
+// authority: a name the caller may not read stays absent.
+func (e *reportEngine) WithNames(names attention.Names) *reportEngine {
+	e.names = names
+	return e
+}

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -45,9 +45,15 @@ func (h reportHandlers) RunReport(w http.ResponseWriter, r *http.Request, report
 	rows := make([]map[string]interface{}, len(outcome.Rows))
 	copy(rows, outcome.Rows)
 	for _, row := range rows {
-		row[reservedDerivationColumn] = derivationURL(outcome.Report, outcome.Filters, outcome.GroupBy, outcome.Aggregates, row)
+		// The handle carries the instant this answer converted at, so opening it
+		// tomorrow still reconciles to the figure printed today.
+		row[reservedDerivationColumn] = derivationURL(
+			outcome.Report, outcome.Filters, outcome.GroupBy, outcome.Aggregates, row, outcome.GeneratedAt)
 	}
-	resultURL := derivationURL(outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil)
+	// The whole-result handle pins the same instant its rows do: it explains the
+	// same answer, over every row rather than one group's.
+	resultURL := derivationURL(
+		outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil, outcome.GeneratedAt)
 	totalRows := len(rows)
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReportResult{
 		Report:               outcome.Report,

--- a/backend/internal/compose/reportperiod_test.go
+++ b/backend/internal/compose/reportperiod_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // REPORT-VOCAB-1 pins win-loss's four vocabularies. These assert the
@@ -100,7 +101,8 @@ func TestPeriodBucketValuesSurviveTheDerivationHandleRoundTrip(t *testing.T) {
 	} {
 		minted := derivationURL("win-loss", map[string]any{"status": "won"},
 			[]string{bucket.dimension}, aggs,
-			map[string]any{bucket.dimension: bucket.value, "amount_minor_sum": int64(35000)})
+			map[string]any{bucket.dimension: bucket.value, "amount_minor_sum": int64(35000)},
+			time.Time{})
 
 		parsed, err := url.Parse(minted)
 		if err != nil {

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -162,7 +162,12 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// same edge dealsH wires above.
 		automationHandlers: automation.NewHandlers(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil)),
 		voiceHandlers:      ai.NewHandlers(InstallationDB(pool), NewSeatBudget(pool)),
-		reportHandlers:     reportHandlers{engine: newReportEngine(pool)},
+		// The names seam is the WEB surface's: a person reading "explain this
+		// number" meets the deals by name, while the MCP provider leaves it
+		// unwired because a tool answers in ids.
+		reportHandlers: reportHandlers{
+			engine: newReportEngine(pool).WithNames(newAttentionNames(InstallationDB(pool))),
+		},
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
 		Handlers: briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))),

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3347,6 +3347,10 @@ export const de = {
   "analytics.noCompany": "Kein Unternehmen",
   "analytics.openDeals": "Offene Deals",
   "explain.sources": "Quellzeilen",
+  "explain.col.record": "Deal",
+  "explain.col.stage": "Phase",
+  "explain.col.owner": "Zuständig",
+  "explain.col.pipeline": "Pipeline",
 
   "ai.sub": "bring deinen eigenen Agenten mit — geregelt über die zwei Stufen",
   "ai.tiers": "Was ein Agent darf",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3399,6 +3399,10 @@ export const en = {
   "analytics.noCompany": "No company",
   "analytics.openDeals": "Open deals",
   "explain.sources": "Source rows",
+  "explain.col.record": "Deal",
+  "explain.col.stage": "Stage",
+  "explain.col.owner": "Owner",
+  "explain.col.pipeline": "Pipeline",
 
   "ai.sub": "bring your own agent — governed by the two-tier contract",
   "ai.tiers": "What an agent may do",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -22,6 +22,14 @@ import { vi as viCatalog } from "./vi";
 const KEPT_IN_ENGLISH = new Set<string>([
   // The product name of the buyer surface.
   "room.card.title",
+  // Two sales nouns Vietnamese borrows rather than translates, on the
+  // drill-through's column headers. The vi catalog already carries both
+  // untranslated where they appear as words in a sentence — "Thuộc deal" on
+  // the partner and commission columns, "Pipeline" on the deal's own field —
+  // so translating them only here would give one screen a vocabulary the
+  // rest of the product does not use.
+  "explain.col.record",
+  "explain.col.pipeline",
   // The area's name, which is the same word in all three catalogs by decision:
   // "Analytics" is what the product calls this surface, and both German and
   // Vietnamese borrow it as a term of art rather than translating it. The

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3314,6 +3314,10 @@ export const vi = {
   "analytics.noCompany": "Không có công ty",
   "analytics.openDeals": "Deal đang mở",
   "explain.sources": "Các dòng nguồn",
+  "explain.col.record": "Deal",
+  "explain.col.stage": "Giai đoạn",
+  "explain.col.owner": "Phụ trách",
+  "explain.col.pipeline": "Pipeline",
 
   "ai.sub": "mang Agent của riêng bạn — được quản trị bằng hợp đồng hai bậc",
   "ai.tiers": "Một Agent được phép làm gì",

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -18,6 +18,8 @@ type Stage = components["schemas"]["Stage"];
 import {
   AnalyticsScreen,
   buildStageAggregates,
+  derivationCellCurrency,
+  derivationColumns,
   parseDerivationQuery,
   sectionFromAddress,
 } from "./analytics";
@@ -728,5 +730,76 @@ describe("the report frame", () => {
     await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
     expect(screen.queryByText(/Europe\/Berlin/)).toBeNull();
     expect(screen.queryByText(/As of/)).toBeNull();
+  });
+});
+
+// A drill-through row carries money in two different currencies at once, and
+// which one a cell is written in depends on the COLUMN.
+//
+// `pipeline-current` converts server-side and exposes `amount_base_minor`, in
+// the installation's base currency. The forecast does not convert: it exposes
+// the deal's own `amount_minor` with the currency it was written in on the
+// same row. Formatting both against the base currency puts a euro sign on a
+// dollar deal — a wrong number wearing a right-looking symbol, which is the
+// misreading the whole renderer exists to prevent.
+describe("drill-through money", () => {
+  it("writes a converted measure in the base currency", () => {
+    const row = { amount_base_minor: 500000, currency: "USD" };
+    expect(derivationCellCurrency("amount_base_minor", row, "EUR")).toBe("EUR");
+  });
+
+  it("writes an unconverted measure in the deal's own currency", () => {
+    const row = { amount_minor: 500000, currency: "USD" };
+    expect(derivationCellCurrency("amount_minor", row, "EUR")).toBe("USD");
+  });
+
+  // A row that names no currency has nothing to write the figure in. Falling
+  // back to the base currency would be a guess presented as a fact.
+  it("names no currency for an unconverted measure on a row without one", () => {
+    expect(derivationCellCurrency("amount_minor", {}, "EUR")).toBeNull();
+    expect(
+      derivationCellCurrency("amount_minor", { currency: "" }, "EUR"),
+    ).toBeNull();
+  });
+});
+
+// The id is noise beside a name — but only when every row HAS one. Labelling
+// is per row, so a reader who may not read one record gets a label column
+// with a gap in it.
+describe("drill-through columns", () => {
+  const derivation = (columns: string[], rows: Record<string, unknown>[]) =>
+    ({ columns, rows }) as unknown as Parameters<typeof derivationColumns>[0];
+
+  it("drops the id once every row is named", () => {
+    expect(
+      derivationColumns(
+        derivation(
+          ["id", "label", "amount_minor"],
+          [
+            { id: "a", label: "Acme" },
+            { id: "b", label: "Globex" },
+          ],
+        ),
+      ),
+    ).toEqual(["label", "amount_minor"]);
+  });
+
+  // The row whose name was withheld is the one a reader can least account
+  // for. Dropping the id here would leave it showing a blank and nothing else.
+  it("keeps the id when any row's name was withheld", () => {
+    expect(
+      derivationColumns(
+        derivation(
+          ["id", "label", "amount_minor"],
+          [{ id: "a", label: "Acme" }, { id: "b" }],
+        ),
+      ),
+    ).toEqual(["id", "label", "amount_minor"]);
+  });
+
+  it("keeps the id when no row could be named", () => {
+    expect(
+      derivationColumns(derivation(["id", "amount_minor"], [{ id: "a" }])),
+    ).toEqual(["id", "amount_minor"]);
   });
 });

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -619,11 +619,98 @@ function StageTable({
   );
 }
 
+// The vocabulary's own words for the columns a drill-through can carry.
+// A column outside it keeps its wire name, which is honest: the reader sees
+// what the plan selected rather than a guess at what it meant.
+const DERIVATION_HEADERS: Readonly<Record<string, MessageKey>> = {
+  label: "explain.col.record",
+  amount_base_minor: "analytics.unweighted",
+  weighted_base_minor: "analytics.weighted",
+  amount_minor: "analytics.unweighted",
+  currency: "analytics.currency",
+  stage_id: "explain.col.stage",
+  owner_id: "explain.col.owner",
+  pipeline_id: "explain.col.pipeline",
+  organization_id: "analytics.company",
+};
+
+// A column the vocabulary knows gets its word; anything else keeps the wire
+// name the plan selected it under.
+function derivationHeader(col: string, t: (key: MessageKey) => string): string {
+  const key = DERIVATION_HEADERS[col];
+  return key ? t(key) : col;
+}
+
+// The server names the row and the reader reads the name, so the raw id
+// becomes noise beside it — but only once EVERY row has a name.
+//
+// Labelling is per row: the seam withholds a name for a record this reader
+// may not read, and the label column appears as soon as one row was named.
+// Dropping the id on that alone would leave the withheld rows showing a blank
+// where their only identifier used to be, so the rows a reader can least
+// account for become the ones they cannot identify at all.
+export function derivationColumns(derivation: Derivation): string[] {
+  const rows = derivation.rows ?? [];
+  const everyRowNamed =
+    derivation.columns.includes("label") &&
+    rows.length > 0 &&
+    rows.every((row) => typeof row.label === "string" && row.label !== "");
+  return derivation.columns.filter((col) => !everyRowNamed || col !== "id");
+}
+
+// Which money a row's minor-unit figure is written in.
+//
+// The two are not the same column. A `_base_minor` measure was converted by
+// the server, so it is in the installation's base currency. A plain `_minor`
+// measure is the deal's OWN amount, and the forecast's rows carry the
+// currency it was written in beside it — reading the base currency there
+// would put a euro sign on a dollar deal, which is the exact misreading this
+// renderer exists to prevent.
+export function derivationCellCurrency(
+  col: string,
+  row: Record<string, unknown>,
+  baseCurrency: string | null,
+): string | null {
+  if (col.endsWith("_base_minor")) {
+    return baseCurrency;
+  }
+  const own = row.currency;
+  return typeof own === "string" && own !== "" ? own : null;
+}
+
+// Money on these rows is stored in minor units, and a minor-unit integer
+// printed raw is the single most misread thing on this screen: 500000 next
+// to €5,000.00 are the same number wearing different clothes.
+function renderDerivationCell(
+  col: string,
+  row: Record<string, unknown>,
+  baseCurrency: string | null,
+  locale: Locale,
+): string {
+  const value = row[col];
+  if (value == null) {
+    return "";
+  }
+  if (col.endsWith("_minor") && typeof value === "number") {
+    return formatMoneyOrAbsent(
+      value,
+      derivationCellCurrency(col, row, baseCurrency),
+      locale,
+    );
+  }
+  return String(value);
+}
+
 // The source rows the explained figure reconciles to. A section INSIDE the
 // explain card's own section, so its heading steps down with the outline
 // rather than reading as a peer of the card's title.
-function DerivationRows({ derivation }: Readonly<{ derivation: Derivation }>) {
+function DerivationRows({
+  derivation,
+  baseCurrency,
+}: Readonly<{ derivation: Derivation; baseCurrency: string | null }>) {
   const t = useT();
+  const { locale } = useLocale();
+  const columns = derivationColumns(derivation);
   return (
     <>
       <SectionHeader title={t("explain.sources")} level={3} />
@@ -634,10 +721,11 @@ function DerivationRows({ derivation }: Readonly<{ derivation: Derivation }>) {
       ) : (
         <DataTable
           label={t("explain.sources")}
-          columns={derivation.columns.map((col) => ({
+          columns={columns.map((col) => ({
             key: col,
-            header: col,
-            render: (row: Record<string, unknown>) => String(row[col] ?? ""),
+            header: derivationHeader(col, t),
+            render: (row: Record<string, unknown>) =>
+              renderDerivationCell(col, row, baseCurrency, locale),
           }))}
           rows={derivation.rows}
           rowKey={(row) => derivation.rows.indexOf(row).toString()}
@@ -653,12 +741,16 @@ function ExplainCard({
   id,
   url,
   query,
+  baseCurrency,
 }: Readonly<{
   // The toggle above points `aria-controls` here, so the card has to carry the
   // id the toggle was given rather than mint one of its own.
   id: string;
   url: string | null;
   query: UseQueryResult<Derivation>;
+  // The currency the report converted into, so the source rows behind a
+  // converted total are written in the same money as the total.
+  baseCurrency: string | null;
 }>) {
   const t = useT();
   return (
@@ -691,7 +783,9 @@ function ExplainCard({
           </div>
         </>
       )}
-      {query.data && <DerivationRows derivation={query.data} />}
+      {query.data && (
+        <DerivationRows derivation={query.data} baseCurrency={baseCurrency} />
+      )}
     </Card>
   );
 }
@@ -830,6 +924,7 @@ function ReportCard({
               id={explainId}
               url={derivationUrl}
               query={derivationQuery}
+              baseCurrency={run.base_currency ?? null}
             />
           )}
         </>


### PR DESCRIPTION
## What this changes

"Explain this number" returned the raw query: a UUID per row and money as minor-unit integers. A reader who opened it to check a total met a debugging dump.

**Names.** Each source row now carries the record's display name, read through the same seam the attention feed uses (`attentionnames.go`): one gated read per type, under the reader's own grants. A row the caller may not name keeps its id and loses only the label — the arithmetic never depended on the names, so the drill-through still reconciles to the number it explains. Wired on the web surface only; the MCP provider stays unwired because a tool answers in ids.

**Money, in the currency the figure is actually written in** — which is not one currency per report. `amount_base_minor` was converted server-side and reads the installation's base currency. Plain `amount_minor` is the deal's own amount, and the reports exposing it group by currency and put it on every row. My first version formatted both against the base currency, which printed a dollar deal with a euro sign; found by drilling into the live forecast report, fixed, and pinned by two tests.

**The as-of pin (closes #4101).** The handle now carries the instant the headline was computed at, so a converted report and its detail cannot look up different FX rates. An older handle without the key still resolves — those links live in bookmarks and sent mail.

## The deadlock found in review

The labelling first ran *inside* the fetch's transaction. Each store's label read takes a connection of its own, so a request held one connection and blocked on a second. With the pool at 16, concurrent explain requests wedge the whole API — every user, every endpoint — until the write timeout unwinds them.

Reproduced and fixed, verified end to end on a running stack with the pool shrunk to 2 connections:

| binary | 4 concurrent explains | result |
|---|---|---|
| labelling inside the tx | `000 000 000 000` | all hang, 40s client timeout |
| labelling after it closes | `200 200 200 200` | instant, labels intact |

The attention feed labels outside its reads for the same reason.

## Gates

Four, each mutation-checked (revert the guard, watch the named test fail):

- **`TestATxAcceptingFunctionAcquiresNoConnectionOfItsOwn`** exists for exactly that deadlock shape and did not see it — the walk read method calls only, so a package-local helper called by bare name was invisible. Now reads both spellings, with `labelDerivationRows` registered as an acquirer. Put the call back inside the transaction and the gate fails.
- **Two collision gates** hold the label column's name free across *both* vocabularies that can claim it: the prebuilt report registry, and the schema descriptors the ad-hoc plan turns into dimensions. A gate covering only the first would have read PASS over the second.
- **Two frontend tests** pin which currency a cell is written in. The single-currency version passes every other test on this screen, which is why the bug reached a push.
- **`TestEveryLaneWithASeamIsWiredToIt`** was widened the same way after this PR's `newAttentionNames` extraction made it read PASS on an unwired lane. Mutation-checked in both directions — it still fails when the lane is genuinely nil.

## Verified against a running stack

Logged into an isolated `DEV_SLUG` stack with seeded multi-currency data:

- A drill-through row returns `"label": "Acme Expansion"` where there was a bare UUID, and reconciles exactly to its headline (`2500000` = `amount_base_minor_sum`).
- Every minted handle carries `as_of=…`.
- Label visibility follows the record: a second reader sees the same name the deal's own endpoint gives them, `writable: false` — the decided access model, not a leak.
- The forecast drill-through returns `amount_minor` with a per-row `currency`, which is where the currency bug surfaced.

## Notes

`make check-backend` and `make check-fe` both green on the rebased tree (537 frontend test files, 0 gate failures). The compose integration lane passes against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drill-through report rows can display readable record labels when available.
  - Explanation tables include localized columns for records, stages, owners, and pipelines.
  - Monetary values in drill-through results use the appropriate currency.

- **Bug Fixes**
  - Report explanations preserve the original calculation time for consistent later detail views.
  - Rows remain available when labels cannot be resolved, without affecting measures or aggregation.
  - Raw record IDs are hidden when every row has a readable label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->