### PR TITLE
A drill-through converts at the instant its headline did

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33562,6 +33562,25 @@ components:
         total_rows: { type: integer, description: Source rows matched (rows is capped at the report row limit). }
         excluded_by_permission: { type: [integer, 'null'], description: 'Visible rows a field mask withheld — the same exclusion the explained report applied, so the drill-through reconciles exactly.' }
         generated_at: { type: string, format: date-time }
+        as_of:
+          type: string
+          format: date-time
+          description: |
+            The instant these figures were computed at — the moment any currency conversion read the
+            rate sheet, not the moment this response was assembled (`generated_at`).
+
+            When the handle pinned an instant this is the one the explained number was computed at, so
+            the detail reconciles to its headline. When it did not, this is a fresh reading and
+            `as_of_pinned` is false.
+        as_of_pinned:
+          type: boolean
+          description: |
+            Whether the handle carried the instant the explained number was computed at.
+
+            False means the link predates that key, so these figures were recomputed at a NEW moment
+            and a rate sheet effective in between will make them disagree with the number they explain.
+            A reader opening a drill-through is checking a figure they already doubt, so a detail set
+            that quietly reconciles to something else is worse than none.
 
     # ---- Search ----
     SearchResult:

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -40,10 +40,21 @@ const reservedDerivationColumn = "derivation_url"
 // absence is stated separately.
 const nullPredicateKey = "isnull"
 
+// asOfKey carries the instant the explained number was computed at.
+//
+// A handle pins WHICH rows the cell covered; without this it did not pin WHEN.
+// That cost nothing while every report summed money in its own currency — the
+// frame's as-of reached no arithmetic — and became a defect the moment a report
+// CONVERTED, because the drill-through sampled a fresh `now()` and could pick a
+// different rate sheet. The headline said EUR 5,000 and the detail behind it
+// said EUR 9,000, and the detail is where a reader goes to check a number they
+// already doubt.
+const asOfKey = "asof"
+
 // reservedDerivationKeys are the query-string names a handle owns. Report
 // vocabularies may not squat on them, or a minted URL would be ambiguous.
 // Derived from here rather than restated, so adding a key updates the gate.
-var reservedDerivationKeys = []string{"by", "agg", nullPredicateKey, reservedDerivationColumn}
+var reservedDerivationKeys = []string{"by", "agg", asOfKey, nullPredicateKey, reservedDerivationColumn}
 
 // derivationQuery is one parsed derivation handle: the equality
 // predicates that pin the explained cell (plan filters + the row's
@@ -57,6 +68,11 @@ type derivationQuery struct {
 	Unset      map[string]bool
 	GroupBy    []string
 	Aggregates []reportAggregate
+	// AsOf is the instant the explained number was computed at, nil when the
+	// handle predates this key. Nil is not an error: links already minted, and
+	// links a reader saved, must keep resolving — but the answer says it was
+	// recomputed at a fresh instant rather than passing it off as the same one.
+	AsOf *time.Time
 }
 
 // derivationOutcome is a resolved handle: definition, drill-through
@@ -73,14 +89,26 @@ type derivationOutcome struct {
 	// nil when no mask applied, exactly like the report envelope it explains.
 	ExcludedByPermission *int
 	GeneratedAt          time.Time
+	// AsOf is the instant this detail was computed at: the headline's, when the
+	// handle pinned one, and a fresh reading when it did not.
+	AsOf time.Time
+	// AsOfPinned says which of those it was. False means the figures below may
+	// have moved since the number they explain, which a reader checking a
+	// total they doubt has to be told rather than left to discover.
+	AsOfPinned bool
 }
 
 // derivationURL mints the handle for one aggregate row (or, with a nil
 // row, for the whole filtered result). parseDerivationQuery is its exact
 // inverse; the round trip is unit-tested so a handle we mint always
 // resolves.
-func derivationURL(report string, filters map[string]any, groupBy []string, aggregates []reportAggregate, row map[string]any) string {
+func derivationURL(report string, filters map[string]any, groupBy []string, aggregates []reportAggregate, row map[string]any, asOf time.Time) string {
 	values := url.Values{}
+	// RFC3339 with nanoseconds, which round-trips a timestamptz exactly: the
+	// instant came from the database and carries microseconds, and a format
+	// that truncated would hand the detail a different moment from the one the
+	// headline converted at — this defect again, one decimal place down.
+	values.Set(asOfKey, asOf.UTC().Format(time.RFC3339Nano))
 	for _, agg := range aggregates {
 		values.Add("agg", agg.Fn+":"+agg.Field+":"+agg.As)
 	}
@@ -139,6 +167,19 @@ func parseDerivationQuery(values url.Values) (derivationQuery, error) {
 			for _, field := range vals {
 				q.Unset[field] = true
 			}
+		case asOfKey:
+			if len(vals) != 1 {
+				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey}
+			}
+			at, err := time.Parse(time.RFC3339Nano, vals[0])
+			if err != nil {
+				// Refused rather than ignored. A handle carrying an unreadable
+				// instant is not an old link — it is a link that MEANT to pin
+				// one, and silently recomputing would answer at a moment
+				// nobody asked for while looking pinned.
+				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey + "=" + vals[0]}
+			}
+			q.AsOf = &at
 		case "agg":
 			for _, v := range vals {
 				parts := strings.SplitN(v, ":", 3)
@@ -194,6 +235,10 @@ type derivationPlan struct {
 	selects    []string
 	aggColumns []string
 	aggSelects []string
+	// asOf is the instant the explained number was computed at, nil when the
+	// handle predates the key. The execution half binds it in place of a fresh
+	// reading, so the detail converts at the moment the headline did.
+	asOf *time.Time
 }
 
 // Derive resolves one handle against a prebuilt report's vocabulary.
@@ -233,6 +278,7 @@ func (e *reportEngine) Derive(ctx context.Context, report string, q derivationQu
 		Columns:     plan.columns,
 		Aggregates:  map[string]any{},
 		GeneratedAt: time.Now().UTC(),
+		AsOfPinned:  q.AsOf != nil,
 	}
 	if err := e.fetchDerivation(ctx, report, spec, plan, &out); err != nil {
 		return derivationOutcome{}, err
@@ -243,7 +289,7 @@ func (e *reportEngine) Derive(ctx context.Context, report string, q derivationQu
 // compileDerivation validates a parsed handle against the report's
 // closed vocabulary and renders every SQL fragment and the definition.
 func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, error) {
-	plan := derivationPlan{aggregates: q.Aggregates, predicates: q.Predicates}
+	plan := derivationPlan{aggregates: q.Aggregates, predicates: q.Predicates, asOf: q.AsOf}
 	if len(plan.aggregates) == 0 {
 		plan.aggregates = spec.defaultAggs
 	}

--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The definition is the (a) half of AC-R6: the exact filter + group +
@@ -93,11 +94,16 @@ func TestDerivationURLRoundTrip(t *testing.T) {
 		{Fn: "count", As: "deals"},
 		{Fn: "sum", Field: "amount_minor", As: "unweighted_minor"},
 	}
+	// A microsecond-precision instant, which is what a timestamptz hands back.
+	// The round trip has to preserve it exactly: a format that truncated would
+	// let the detail read a rate sheet the headline did not.
+	headlineAt := time.Date(2026, 9, 4, 11, 30, 15, 123_456_000, time.UTC)
 	minted := derivationURL("forecast",
 		map[string]any{"pipeline_id": "018f-pipe"},
 		[]string{"owner_id", "forecast_category"},
 		aggs,
-		map[string]any{"owner_id": "018f-owner", "forecast_category": nil, "deals": int64(3)})
+		map[string]any{"owner_id": "018f-owner", "forecast_category": nil, "deals": int64(3)},
+		headlineAt)
 
 	parsed, err := url.Parse(minted)
 	if err != nil {
@@ -128,6 +134,16 @@ func TestDerivationURLRoundTrip(t *testing.T) {
 	if !reflect.DeepEqual(q.Unset, map[string]bool{"forecast_category": true}) {
 		t.Errorf("unset = %v, want forecast_category", q.Unset)
 	}
+	// The instant is part of the round trip, not decoration: it is what makes
+	// the drill-through convert at the moment its headline did.
+	if q.AsOf == nil {
+		t.Fatal("the handle carries no as-of — a converted report's detail would " +
+			"sample a fresh rate sheet and reconcile to a number nobody sees")
+	}
+	if !q.AsOf.Equal(headlineAt) {
+		t.Errorf("as-of round-tripped to %s, want %s",
+			q.AsOf.Format(time.RFC3339Nano), headlineAt.Format(time.RFC3339Nano))
+	}
 }
 
 func TestParseDerivationQueryRejectsMalformedHandles(t *testing.T) {
@@ -135,6 +151,11 @@ func TestParseDerivationQueryRejectsMalformedHandles(t *testing.T) {
 		"agg without triplet": "agg=sum",
 		"agg without fn":      "agg=:amount_minor:x",
 		"repeated predicate":  "owner_id=a&owner_id=b",
+		// A handle MEANT to pin an instant and failed to say which. Recomputing
+		// at a fresh one would answer at a moment nobody asked for while
+		// looking pinned, so it is refused rather than ignored.
+		"unreadable as-of": asOfKey + "=yesterday",
+		"repeated as-of":   asOfKey + "=2026-09-04T11:30:15Z&" + asOfKey + "=2026-09-05T11:30:15Z",
 	} {
 		values, err := url.ParseQuery(raw)
 		if err != nil {

--- a/backend/internal/compose/derivationfetch.go
+++ b/backend/internal/compose/derivationfetch.go
@@ -41,6 +41,15 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		if err != nil {
 			return err
 		}
+		// The instant the headline converted at, when the handle carried one.
+		// Everything below binds the frame — the mask count, the rows, the
+		// aggregate recompute — so overriding it here is what makes the detail
+		// reconcile to the number it explains rather than to a fresh reading of
+		// the rate sheet.
+		if plan.asOf != nil {
+			frame.AsOf = *plan.asOf
+		}
+		out.AsOf = frame.AsOf
 		maskClauses, masked, err := maskExclusionClauses(ctx, spec, arg)
 		if err != nil {
 			return err

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -190,6 +191,8 @@ type derivationWire struct {
 	Aggregates           map[string]any   `json:"aggregates"`
 	TotalRows            int              `json:"total_rows"`
 	ExcludedByPermission *int             `json:"excluded_by_permission"`
+	AsOf                 *time.Time       `json:"as_of"`
+	AsOfPinned           *bool            `json:"as_of_pinned"`
 }
 
 //craft:ignore naked-any decodeWire is the one JSON unmarshal seam; the wire structs above give it shape

--- a/backend/internal/compose/report_pipelinecurrent_integration_test.go
+++ b/backend/internal/compose/report_pipelinecurrent_integration_test.go
@@ -17,7 +17,11 @@ package compose
 // against a formula recomputed here, because a test that reproduces the
 // production expression proves only that it was copied correctly.
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+	"time"
+)
 
 const pipelineCurrentPlan = `{"group_by":["stage_id"],"aggregates":[` +
 	`{"fn":"count","as":"deals"},` +
@@ -188,4 +192,95 @@ func TestPipelineCurrentDetailReconcilesToTheConvertedHeadline(t *testing.T) {
 	if got := wireInt(t, row, "base"); got != 15_000 {
 		t.Fatalf("headline was %d, want the converted 15000", got)
 	}
+}
+
+// The detail behind a converted number reads the rate sheet its headline read.
+//
+// A handle pins WHICH rows a cell covered. Until the report engine converted
+// money, it did not need to pin WHEN: the frame's as-of reached no arithmetic,
+// so a drill-through sampling a fresh `now()` answered the same question. It
+// stopped being harmless the moment a rate sheet could take effect between the
+// two, because the drill-through is where a reader goes to check a figure they
+// already doubt — and a detail set that reconciles to something else does not
+// read as a discrepancy, it reads as proof.
+//
+// Two sheets either side of a day boundary, one deal, three readings.
+func TestADerivationConvertsAtTheInstantItsHeadlineDid(t *testing.T) {
+	e := setupForecast(t)
+	seedRate(t, e, "0.5", 2)
+	seedRate(t, e, "0.9", 0)
+	seedPricedDeal(t, e, "Abroad", 10_000, "USD", "open")
+
+	result := e.runReport(e.Admin(), t, "pipeline-current", pipelineCurrentPlan)
+	row := dealsByStageRow(t, result, e.stages[pipelineTestStage].String())
+	if got := wireInt(t, row, "base"); got != 9_000 {
+		t.Fatalf("the headline converted to %d, want 9000 at today's 0.9 — the rest of "+
+			"this case compares against it, so it has to be the sheet in force now", got)
+	}
+	handle, ok := row["derivation_url"].(string)
+	if !ok || handle == "" {
+		t.Fatalf("the converted stage row minted no derivation handle: %+v", row)
+	}
+
+	// Opened now, pinned to now: the same sheet, the same number.
+	live := e.explainReport(e.Admin(), t, "pipeline-current", handle)
+	if live.AsOfPinned == nil || !*live.AsOfPinned {
+		t.Errorf("a freshly minted handle reports as_of_pinned %v — the mint is what "+
+			"puts the instant in it, so an unpinned one here means it never went in",
+			live.AsOfPinned)
+	}
+	if got := derivationSum(t, live, "base"); got != 9_000 {
+		t.Errorf("the detail behind a 9000 headline recomputed %d", got)
+	}
+
+	// The same handle as it would have been minted the day before yesterday,
+	// when 0.5 was the sheet in force. This is the reported defect: the pin has
+	// to beat `now()`, or the detail prices the deal at today's rate and
+	// silently disagrees with the number it explains.
+	yesterday := e.explainReport(e.Admin(), t, "pipeline-current",
+		rehandle(t, handle, asOfKey, time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339Nano)))
+	if got := derivationSum(t, yesterday, "base"); got != 5_000 {
+		t.Errorf("a handle pinned before today's sheet recomputed %d, want 5000 at 0.5 — "+
+			"the detail re-read the rate sheet instead of the one its headline used", got)
+	}
+
+	// A link minted before this key existed still resolves, and says so. It
+	// recomputes at a fresh instant, which is honest only because the answer
+	// carries as_of_pinned=false rather than passing it off as the headline's.
+	old := e.explainReport(e.Admin(), t, "pipeline-current", rehandle(t, handle, asOfKey, ""))
+	if old.AsOfPinned == nil || *old.AsOfPinned {
+		t.Errorf("an unpinned handle reports as_of_pinned %v, want false — a reader "+
+			"cannot tell the figures may have moved unless the answer says so",
+			old.AsOfPinned)
+	}
+	if got := derivationSum(t, old, "base"); got != 9_000 {
+		t.Errorf("the unpinned handle recomputed %d, want today's 9000", got)
+	}
+}
+
+// rehandle rewrites one query parameter of a minted handle; an empty value
+// removes it, which is what a link minted before that key looks like.
+func rehandle(t *testing.T, handle, key, value string) string {
+	t.Helper()
+	parsed, err := url.Parse(handle)
+	if err != nil {
+		t.Fatalf("parsing the minted handle: %v", err)
+	}
+	q := parsed.Query()
+	if value == "" {
+		q.Del(key)
+	} else {
+		q.Set(key, value)
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// derivationSum reads one recomputed aggregate off a derivation answer.
+func derivationSum(t *testing.T, d derivationWire, key string) int64 {
+	t.Helper()
+	if d.Aggregates == nil {
+		t.Fatalf("the derivation recomputed no aggregates: %+v", d)
+	}
+	return wireInt(t, d.Aggregates, key)
 }

--- a/backend/internal/compose/report_projectgrant_integration_test.go
+++ b/backend/internal/compose/report_projectgrant_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -50,7 +51,7 @@ func TestActivityDrillThroughTakesTheProjectGrant(t *testing.T) {
 	e.seedID(t, `INSERT INTO activity_link (id, activity_id, entity_type, project_id) VALUES ($1, $2, 'project', $3)`, activity, project)
 
 	byProject := derivationURL("activities-by-kind", nil, []string{"project_id"}, nil,
-		map[string]any{"project_id": project.String()})
+		map[string]any{"project_id": project.String()}, time.Now().UTC())
 	if status := e.explainStatus(e.activityReader(), "activities-by-kind", byProject); status != http.StatusForbidden {
 		t.Fatalf("drill-through grouped by project without project.read → %d, want 403", status)
 	}
@@ -58,7 +59,8 @@ func TestActivityDrillThroughTakesTheProjectGrant(t *testing.T) {
 		t.Fatalf("drill-through grouped by project with project.read → %d, want 200", status)
 	}
 
-	byKind := derivationURL("activities-by-kind", nil, []string{"kind"}, nil, map[string]any{"kind": "meeting"})
+	byKind := derivationURL("activities-by-kind", nil, []string{"kind"}, nil,
+		map[string]any{"kind": "meeting"}, time.Now().UTC())
 	rows := e.explainReport(e.activityReader(), t, "activities-by-kind", byKind)
 	if rows.TotalRows != 1 {
 		t.Fatalf("drill-through by kind = %d rows, want the one meeting", rows.TotalRows)

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -45,9 +45,11 @@ func (h reportHandlers) RunReport(w http.ResponseWriter, r *http.Request, report
 	rows := make([]map[string]interface{}, len(outcome.Rows))
 	copy(rows, outcome.Rows)
 	for _, row := range rows {
-		row[reservedDerivationColumn] = derivationURL(outcome.Report, outcome.Filters, outcome.GroupBy, outcome.Aggregates, row)
+		row[reservedDerivationColumn] = derivationURL(
+			outcome.Report, outcome.Filters, outcome.GroupBy, outcome.Aggregates, row, outcome.GeneratedAt)
 	}
-	resultURL := derivationURL(outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil)
+	resultURL := derivationURL(
+		outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil, outcome.GeneratedAt)
 	totalRows := len(rows)
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReportResult{
 		Report:               outcome.Report,
@@ -94,5 +96,7 @@ func (h reportHandlers) ExplainReport(w http.ResponseWriter, r *http.Request, re
 		TotalRows:            &outcome.TotalRows,
 		ExcludedByPermission: outcome.ExcludedByPermission,
 		GeneratedAt:          &outcome.GeneratedAt,
+		AsOf:                 &outcome.AsOf,
+		AsOfPinned:           &outcome.AsOfPinned,
 	})
 }

--- a/backend/internal/compose/reportperiod_test.go
+++ b/backend/internal/compose/reportperiod_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // REPORT-VOCAB-1 pins win-loss's four vocabularies. These assert the
@@ -100,7 +101,8 @@ func TestPeriodBucketValuesSurviveTheDerivationHandleRoundTrip(t *testing.T) {
 	} {
 		minted := derivationURL("win-loss", map[string]any{"status": "won"},
 			[]string{bucket.dimension}, aggs,
-			map[string]any{bucket.dimension: bucket.value, "amount_minor_sum": int64(35000)})
+			map[string]any{bucket.dimension: bucket.value, "amount_minor_sum": int64(35000)},
+			time.Date(2026, 9, 4, 11, 30, 15, 0, time.UTC))
 
 		parsed, err := url.Parse(minted)
 		if err != nil {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29420,7 +29420,23 @@ type ReportCell struct {
 type ReportDerivation struct {
 	// Aggregates The requested aggregates recomputed over exactly these source rows — equals the explained cell.
 	Aggregates *map[string]interface{} `json:"aggregates,omitempty"`
-	Columns    []string                `json:"columns"`
+
+	// AsOf The instant these figures were computed at — the moment any currency conversion read the
+	// rate sheet, not the moment this response was assembled (`generated_at`).
+	//
+	// When the handle pinned an instant this is the one the explained number was computed at, so
+	// the detail reconciles to its headline. When it did not, this is a fresh reading and
+	// `as_of_pinned` is false.
+	AsOf *time.Time `json:"as_of,omitempty"`
+
+	// AsOfPinned Whether the handle carried the instant the explained number was computed at.
+	//
+	// False means the link predates that key, so these figures were recomputed at a NEW moment
+	// and a rate sheet effective in between will make them disagree with the number they explain.
+	// A reader opening a drill-through is checking a figure they already doubt, so a detail set
+	// that quietly reconciles to something else is worse than none.
+	AsOfPinned *bool    `json:"as_of_pinned,omitempty"`
+	Columns    []string `json:"columns"`
 
 	// Definition Plain-language reading of the exact filter + group + aggregate that produced the number.
 	Definition string `json:"definition"`

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24446,6 +24446,25 @@ export interface components {
             excluded_by_permission?: number | null;
             /** Format: date-time */
             generated_at?: string;
+            /**
+             * Format: date-time
+             * @description The instant these figures were computed at — the moment any currency conversion read the
+             *     rate sheet, not the moment this response was assembled (`generated_at`).
+             *
+             *     When the handle pinned an instant this is the one the explained number was computed at, so
+             *     the detail reconciles to its headline. When it did not, this is a fresh reading and
+             *     `as_of_pinned` is false.
+             */
+            as_of?: string;
+            /**
+             * @description Whether the handle carried the instant the explained number was computed at.
+             *
+             *     False means the link predates that key, so these figures were recomputed at a NEW moment
+             *     and a rate sheet effective in between will make them disagree with the number they explain.
+             *     A reader opening a drill-through is checking a figure they already doubt, so a detail set
+             *     that quietly reconciles to something else is worse than none.
+             */
+            as_of_pinned?: boolean;
         };
         SearchResult: {
             /** @enum {string} */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -244,6 +244,8 @@ export const de = {
   "common.close": "Schließen",
 
   "explain.open": "Diese Zahl erklären",
+  "explain.mayHaveMoved":
+    "Dieser Link nennt nicht, wann die Zahl ermittelt wurde — diese Werte wurden gerade neu berechnet. Hat sich zwischenzeitlich ein Wechselkurs geändert, ergeben sie nicht die angeklickte Zahl.",
   "explain.title": "So setzt sich die Zahl zusammen",
   "explain.rate": "Kurs {rate} am {date}",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -264,6 +264,8 @@ export const en = {
   "common.close": "Close",
 
   "explain.open": "Explain this number",
+  "explain.mayHaveMoved":
+    "This link does not say when the number was worked out, so these figures were recalculated just now. If an exchange rate changed in between, they will not add up to the number you clicked.",
   "explain.title": "How this number is built",
   "explain.rate": "rate {rate} on {date}",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -249,6 +249,8 @@ export const vi = {
   "common.close": "Đóng",
 
   "explain.open": "Giải thích con số này",
+  "explain.mayHaveMoved":
+    "Liên kết này không ghi con số được tính vào lúc nào, nên các số dưới đây vừa được tính lại. Nếu tỷ giá đã thay đổi trong khoảng đó, chúng sẽ không khớp với con số bạn đã bấm.",
   "explain.title": "Con số này được dựng thế nào",
   "explain.rate": "tỷ giá {rate} ngày {date}",
 

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -403,6 +403,18 @@ describe("parseDerivationQuery", () => {
     expect(q.agg).toEqual(["sum:amount_minor:raw"]);
     expect(q.stage_id).toBe("s1");
   });
+
+  // The instant rides through as an ordinary extra key, which is what the
+  // caller forwards wholesale. Dropping it here would send the drill-through
+  // unpinned and it would re-read the rate sheet — the defect this key exists
+  // to close, reintroduced one layer up.
+  it("carries the as-of through as a forwarded key", () => {
+    const q = parseDerivationQuery(
+      "/v1/reports/pipeline-current/derivation?by=stage_id&asof=2026-09-04T11%3A30%3A15Z&stage_id=s1",
+    );
+    expect(q.asof).toBe("2026-09-04T11:30:15Z");
+    expect(q.by).toEqual(["stage_id"]);
+  });
 });
 
 // Money never sums across currencies (data-semantics §1 r4, AC-DS-FX1): every

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -691,6 +691,13 @@ function ExplainCard({
           </div>
         </>
       )}
+      {/* A link minted before the handle carried an instant. The figures below
+          were recomputed at a NEW moment, so a rate sheet effective in between
+          makes them disagree with the number they explain — said plainly,
+          because a reader opens this to check a figure they already doubt. */}
+      {query.data?.as_of_pinned === false && (
+        <p className="surfacestate-stale">{t("explain.mayHaveMoved")}</p>
+      )}
       {query.data && <DerivationRows derivation={query.data} />}
     </Card>
   );


### PR DESCRIPTION
Closes #4101.

A derivation handle pinned **which** rows a cell covered and never **when**. `fetchDerivation` called `readReportFrame` itself, sampling a fresh `now()`.

That cost nothing while every report summed money in its own currency — the frame's as-of reached no arithmetic. It became a defect the moment `pipeline-current` **converted**, because `BaseValueSQL` picks the sheet with `fr.rate_date <= as_of::date ORDER BY rate_date DESC LIMIT 1`, so the headline and its own drill-through could read different rate sheets.

## Reproduced first

Against a real database, two sheets either side of a day boundary and one USD 10,000 open deal:

| | rate | base |
|---|---|---|
| headline, today | 0.9 | **9000** |
| the same handle, pinned before today's sheet | 0.5 | **5000** |

The drill-through is where a reader goes to check a figure they already doubt. A detail set that reconciles to something else does not read as a discrepancy — it reads as proof.

## The fix

The handle carries the instant as a reserved key beside `by` and `agg`, and the execution half binds it in place of a fresh reading. **The frame is what the mask count, the rows and the aggregate recompute all read**, so overriding it in one place is the whole fix rather than three.

RFC3339 with nanoseconds: the instant comes from a `timestamptz`, and a format that truncated would hand the detail a different moment — this same defect, one decimal place down. The round-trip test pins a microsecond value for that reason.

## The two cases that are not the happy path

**An old link still resolves.** It recomputes at a new instant, and the answer says so — `as_of_pinned: false`, and the screen states plainly that the figures were recalculated and may not add up to the number that was clicked. Refusing the link would break every saved drill-through; recomputing *silently* is what made this invisible in the first place. English, German and Vietnamese.

**An unreadable as-of is refused, not ignored.** A handle carrying one meant to pin an instant. Recomputing would answer at a moment nobody asked for while looking pinned, which is worse than the bug.

## Checks

- `make check-backend`, `make check-fe` green.
- **Mutation-checked**: with the override disabled, the integration case fails with exactly the reported figures — *"a handle pinned before today's sheet recomputed 9000, want 5000"*.
- The reserved-key gate derives from `reservedDerivationKeys`, so `asof` is now refused as a report vocabulary name without touching the gate.
- `make gen` + `pnpm gen:api` run and the artifacts committed.

## Note for the reviewer

The frontend needed no transport change — `parseDerivationQuery` already forwards every non-`by`/`agg` key wholesale, so the instant rides along. I added a test pinning that, because it is exactly the kind of thing a later tidy-up removes: narrowing that forward to known keys would send the drill-through unpinned and reintroduce this one layer up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Derivation results now preserve and report the timestamp used to calculate figures.
  - Explain views indicate whether results use a fixed timestamp or may reflect newer data.
  - Added a warning when recalculated figures may differ due to exchange-rate changes.
  - Derivation links remain compatible with links that do not include a timestamp.
- **Localization**
  - Added the recalculation warning in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->