### PR TITLE
Three down migrations describe a DELETE that never ran

### DIFF
--- a/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.down.sql
+++ b/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.down.sql
@@ -1,11 +1,38 @@
--- Narrowing the CHECK back would fail on any audit row already written under a
--- Deal Room lifecycle verb, so the rows go first. Deleting audit history is not
--- something a migration should do quietly, and this one does not: it removes
--- ONLY rows carrying the four verbs this migration added, which by construction
--- exist only because the up half ran.
-SET LOCAL lock_timeout = '3s';
+-- Narrowing the CHECK back cannot succeed while any row carries the four Deal Room lifecycle verbs this migration added,
+-- and this migration REFUSES rather than trying to make room.
+--
+-- It used to open with `DELETE FROM audit_log WHERE action ...`, under a comment
+-- saying the rows "go first". They do not and never did: audit_log carries
+-- trg_audit_no_mutate, a BEFORE DELETE OR UPDATE trigger that raises
+-- `audit_log is append-only` on the first matching row. So the statement was
+-- either a no-op (no row carries the verb) or an abort — it never once removed
+-- an audit row, and three migrations described it as if it had.
+-- margince/margince#496.
+--
+-- Refusing says the same thing the trigger would, earlier and in the operator's
+-- terms: the ledger is append-only, so a vocabulary that has been WRITTEN cannot
+-- be narrowed, and the way back is to leave the verb in the CHECK. A trigger
+-- error names a row id; this names the decision.
+--
+-- No row_security change and no workspace bind, because audit_log carries
+-- neither: the committed schema records it `rls=false force=false` and no
+-- migration enables it. An earlier reading of this gap assumed FORCE RLS made
+-- the probe blind; it does not exist to be blind.
 
-DELETE FROM audit_log WHERE action IN ('publish', 'pause', 'resume', 'close');
+DO $$
+DECLARE
+    written bigint;
+BEGIN
+    SELECT count(*) INTO written FROM audit_log WHERE action IN ('publish', 'pause', 'resume', 'close');
+    IF written > 0 THEN
+        RAISE EXCEPTION
+            'audit_log holds % row(s) written under a verb this migration would remove from audit_log_action_check, and audit_log is append-only', written
+            USING ERRCODE = 'check_violation',
+                  HINT = 'The rows cannot be deleted and the narrowed CHECK cannot validate around them. Leave the verb in the vocabulary, or reverse to a point before it was ever written.';
+    END IF;
+END;
+$$;
+SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v1
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',

--- a/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.down.sql
+++ b/backend/migrations/core/1787357528_audit_admits_deal_room_lifecycle_verbs.down.sql
@@ -19,10 +19,23 @@
 -- migration enables it. An earlier reading of this gap assumed FORCE RLS made
 -- the probe blind; it does not exist to be blind.
 
+-- The timeout FIRST, because everything below can block: this is a down
+-- migration on a live table, and a lock that waits forever is how a rollback
+-- becomes an outage.
+SET LOCAL lock_timeout = '3s';
+
 DO $$
 DECLARE
     written bigint;
 BEGIN
+    -- Locked BEFORE the count, and held for the rest of the transaction.
+    -- The count decides whether this migration refuses, and the constraint it
+    -- guards is validated later in the same transaction — so a row written
+    -- under the verb in between would make the refusal miss and the VALIDATE
+    -- fail instead, with the generic constraint error this exists to replace.
+    -- SHARE ROW EXCLUSIVE stops writers and admits readers, which is the
+    -- narrowest mode that closes the window.
+    LOCK TABLE audit_log IN SHARE ROW EXCLUSIVE MODE;
     SELECT count(*) INTO written FROM audit_log WHERE action IN ('publish', 'pause', 'resume', 'close');
     IF written > 0 THEN
         RAISE EXCEPTION
@@ -32,7 +45,6 @@ BEGIN
     END IF;
 END;
 $$;
-SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v1
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',

--- a/backend/migrations/core/1787364347_audit_admits_deal_room_access_verbs.down.sql
+++ b/backend/migrations/core/1787364347_audit_admits_deal_room_access_verbs.down.sql
@@ -19,10 +19,23 @@
 -- migration enables it. An earlier reading of this gap assumed FORCE RLS made
 -- the probe blind; it does not exist to be blind.
 
+-- The timeout FIRST, because everything below can block: this is a down
+-- migration on a live table, and a lock that waits forever is how a rollback
+-- becomes an outage.
+SET LOCAL lock_timeout = '3s';
+
 DO $$
 DECLARE
     written bigint;
 BEGIN
+    -- Locked BEFORE the count, and held for the rest of the transaction.
+    -- The count decides whether this migration refuses, and the constraint it
+    -- guards is validated later in the same transaction — so a row written
+    -- under the verb in between would make the refusal miss and the VALIDATE
+    -- fail instead, with the generic constraint error this exists to replace.
+    -- SHARE ROW EXCLUSIVE stops writers and admits readers, which is the
+    -- narrowest mode that closes the window.
+    LOCK TABLE audit_log IN SHARE ROW EXCLUSIVE MODE;
     SELECT count(*) INTO written FROM audit_log WHERE action IN ('invite', 'revoke');
     IF written > 0 THEN
         RAISE EXCEPTION
@@ -32,7 +45,6 @@ BEGIN
     END IF;
 END;
 $$;
-SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v2
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',

--- a/backend/migrations/core/1787364347_audit_admits_deal_room_access_verbs.down.sql
+++ b/backend/migrations/core/1787364347_audit_admits_deal_room_access_verbs.down.sql
@@ -1,10 +1,38 @@
--- Narrowing the CHECK back would fail on any row already carrying one of the
--- two verbs this migration added, so those rows go first. The DELETE is scoped
--- to exactly those verbs, which by construction exist only because the up half
--- ran -- no audit history predating this migration is touched.
-SET LOCAL lock_timeout = '3s';
+-- Narrowing the CHECK back cannot succeed while any row carries the two Deal Room access verbs this migration added,
+-- and this migration REFUSES rather than trying to make room.
+--
+-- It used to open with `DELETE FROM audit_log WHERE action ...`, under a comment
+-- saying the rows "go first". They do not and never did: audit_log carries
+-- trg_audit_no_mutate, a BEFORE DELETE OR UPDATE trigger that raises
+-- `audit_log is append-only` on the first matching row. So the statement was
+-- either a no-op (no row carries the verb) or an abort — it never once removed
+-- an audit row, and three migrations described it as if it had.
+-- margince/margince#496.
+--
+-- Refusing says the same thing the trigger would, earlier and in the operator's
+-- terms: the ledger is append-only, so a vocabulary that has been WRITTEN cannot
+-- be narrowed, and the way back is to leave the verb in the CHECK. A trigger
+-- error names a row id; this names the decision.
+--
+-- No row_security change and no workspace bind, because audit_log carries
+-- neither: the committed schema records it `rls=false force=false` and no
+-- migration enables it. An earlier reading of this gap assumed FORCE RLS made
+-- the probe blind; it does not exist to be blind.
 
-DELETE FROM audit_log WHERE action IN ('invite', 'revoke');
+DO $$
+DECLARE
+    written bigint;
+BEGIN
+    SELECT count(*) INTO written FROM audit_log WHERE action IN ('invite', 'revoke');
+    IF written > 0 THEN
+        RAISE EXCEPTION
+            'audit_log holds % row(s) written under a verb this migration would remove from audit_log_action_check, and audit_log is append-only', written
+            USING ERRCODE = 'check_violation',
+                  HINT = 'The rows cannot be deleted and the narrowed CHECK cannot validate around them. Leave the verb in the vocabulary, or reverse to a point before it was ever written.';
+    END IF;
+END;
+$$;
+SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v2
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',

--- a/backend/migrations/core/1787818336_audit_admits_a_hard_delete.down.sql
+++ b/backend/migrations/core/1787818336_audit_admits_a_hard_delete.down.sql
@@ -19,10 +19,23 @@
 -- migration enables it. An earlier reading of this gap assumed FORCE RLS made
 -- the probe blind; it does not exist to be blind.
 
+-- The timeout FIRST, because everything below can block: this is a down
+-- migration on a live table, and a lock that waits forever is how a rollback
+-- becomes an outage.
+SET LOCAL lock_timeout = '3s';
+
 DO $$
 DECLARE
     written bigint;
 BEGIN
+    -- Locked BEFORE the count, and held for the rest of the transaction.
+    -- The count decides whether this migration refuses, and the constraint it
+    -- guards is validated later in the same transaction — so a row written
+    -- under the verb in between would make the refusal miss and the VALIDATE
+    -- fail instead, with the generic constraint error this exists to replace.
+    -- SHARE ROW EXCLUSIVE stops writers and admits readers, which is the
+    -- narrowest mode that closes the window.
+    LOCK TABLE audit_log IN SHARE ROW EXCLUSIVE MODE;
     SELECT count(*) INTO written FROM audit_log WHERE action IN ('delete');
     IF written > 0 THEN
         RAISE EXCEPTION
@@ -32,7 +45,6 @@ BEGIN
     END IF;
 END;
 $$;
-SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v3
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',

--- a/backend/migrations/core/1787818336_audit_admits_a_hard_delete.down.sql
+++ b/backend/migrations/core/1787818336_audit_admits_a_hard_delete.down.sql
@@ -1,10 +1,38 @@
--- Narrowing the CHECK back would fail on any row already carrying the verb this
--- migration added, so those rows go first. The DELETE is scoped to exactly that
--- verb, which by construction exists only because the up half ran -- no audit
--- history predating this migration is touched.
-SET LOCAL lock_timeout = '3s';
+-- Narrowing the CHECK back cannot succeed while any row carries the hard-delete verb this migration added,
+-- and this migration REFUSES rather than trying to make room.
+--
+-- It used to open with `DELETE FROM audit_log WHERE action ...`, under a comment
+-- saying the rows "go first". They do not and never did: audit_log carries
+-- trg_audit_no_mutate, a BEFORE DELETE OR UPDATE trigger that raises
+-- `audit_log is append-only` on the first matching row. So the statement was
+-- either a no-op (no row carries the verb) or an abort — it never once removed
+-- an audit row, and three migrations described it as if it had.
+-- margince/margince#496.
+--
+-- Refusing says the same thing the trigger would, earlier and in the operator's
+-- terms: the ledger is append-only, so a vocabulary that has been WRITTEN cannot
+-- be narrowed, and the way back is to leave the verb in the CHECK. A trigger
+-- error names a row id; this names the decision.
+--
+-- No row_security change and no workspace bind, because audit_log carries
+-- neither: the committed schema records it `rls=false force=false` and no
+-- migration enables it. An earlier reading of this gap assumed FORCE RLS made
+-- the probe blind; it does not exist to be blind.
 
-DELETE FROM audit_log WHERE action = 'delete';
+DO $$
+DECLARE
+    written bigint;
+BEGIN
+    SELECT count(*) INTO written FROM audit_log WHERE action IN ('delete');
+    IF written > 0 THEN
+        RAISE EXCEPTION
+            'audit_log holds % row(s) written under a verb this migration would remove from audit_log_action_check, and audit_log is append-only', written
+            USING ERRCODE = 'check_violation',
+                  HINT = 'The rows cannot be deleted and the narrowed CHECK cannot validate around them. Leave the verb in the vocabulary, or reverse to a point before it was ever written.';
+    END IF;
+END;
+$$;
+SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v3
     CHECK (action IN ('create', 'update', 'archive', 'merge', 'promote', 'restore',


### PR DESCRIPTION
Closes #496 — though **not the defect it describes**. See the correction at the bottom; it is the reason this looks nothing like the suggested fix.

## What is actually wrong

Three down migrations open with `DELETE FROM audit_log WHERE action ...`, under comments saying the rows *"go first"* and that the delete is *"scoped to exactly that verb"*.

They do not go first and never did. `audit_log` carries `trg_audit_no_mutate` — a `BEFORE DELETE OR UPDATE` trigger raising `audit_log is append-only` on the first matching row. So the statement is either a **no-op** (no row carries the verb) or an **abort**. It has never once removed an audit row, and three migrations describe it as though it had.

**Verified rather than reasoned about** — one row inserted under the verb, then the exact statement:

```
ERROR:  audit_log is append-only (attempted DELETE on row 01a06000-…-0000000000aa)
CONTEXT:  PL/pgSQL function audit_log_immutable() line 3 at RAISE
```

## What they do now

Refuse, saying what the trigger would say but **earlier and in the operator's terms**: how many rows carry the verb, that the ledger is append-only, and that the way back is to leave the verb in the vocabulary.

```
ERROR:  audit_log holds 1 row(s) written under a verb this migration would remove
        from audit_log_action_check, and audit_log is append-only
HINT:   The rows cannot be deleted and the narrowed CHECK cannot validate around them.
        Leave the verb in the vocabulary, or reverse to a point before it was ever written.
```

A trigger error names a row id; this names the decision. Fixed as the **pattern** across all three, which is what the ticket asks for — they carried the same statement under the same false sentence.

## The correction

#496's premise is that `audit_log` carries FORCE RLS, so the probe sees zero rows and skips its own exception — and it suggests `SET LOCAL row_security = off`.

**That does not hold.** The committed catalog records `public.audit_log … rls=false force=false`, and no migration enables it:

```
$ grep -riE "ENABLE ROW LEVEL|FORCE ROW LEVEL" migrations/core/*.sql | grep audit_log
(nothing)
```

There is no blindness to work around — the probe sees every row. Adding a `row_security` change would be ceremony against a posture the table does not have.

The ticket was right that something here is broken and right about the class (a guard that does not guard). It was wrong about the mechanism, which changed both the diagnosis and the fix.

`make check-backend` exit 0; `migrations` suite green — the up/down replay and the head-catalog comparison both still pass, so the schema these build is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rollback operations now preserve audit records for Deal Room lifecycle, access, and deletion actions.
  - Instead of removing matching audit entries, the system stops with a clear validation error when those records are present.
  - Rollbacks continue normally when no affected records exist, helping maintain the integrity of the append-only audit history.
  - Validation now reliably accounts for audit records created concurrently during rollback processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->