### PR TITLE
The forecast can be asked how it got here

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16363,6 +16363,78 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
   /forecast/calls:
+    get:
+      tags: [Reports]
+      operationId: listForecastCalls
+      summary: What this period's forecast has been called, newest first.
+      description: |
+        The calls made for one period and scope, newest first — not just the one standing now.
+
+        Capped at the most recent 500. Nothing bounds how often a period may be called, so an
+        uncapped answer could grow without limit; the cap sits far above what a period
+        accumulates in practice, and takes the NEWEST entries, which are the ones a reader
+        reviewing a period is asking about.
+
+        A call supersedes rather than overwrites, so the table already holds what was
+        believed on the day it was believed. This is how that gets read: the sequence is the
+        record of how a period's expectation moved, and who moved it, which is what anyone
+        reviewing how forecasting went is actually asking for.
+
+        The chain is linear per period and scope. Each entry names the call it replaced in
+        `supersedes_id`, and the first call of a period names none — a different fact from
+        replacing nothing.
+
+        Answers the same scope the readings do, resolved the same way and refused the same
+        way: asking for a wider tier than the caller's seat is `403`, and naming a team or
+        person outside their lens is `404` — naming it at all would confirm the subject
+        exists.
+
+        A period nobody has called yet is an empty list, not a `404`. That a period has no
+        calls is a real answer about a period the caller may read.
+      parameters:
+        - name: period
+          in: query
+          # Named rather than left to the generator. Unprefixed, this pair would
+          # claim the bare `Quarter` and `Month` in the shared contracts package,
+          # and the next enum carrying either value would take them and silently
+          # rename these — a compile error at best, and at worst two constants
+          # swapping meaning.
+          schema:
+            type: string
+            enum: [quarter, month]
+            default: quarter
+            x-enum-varnames: [ForecastCallsPeriodQuarter, ForecastCallsPeriodMonth]
+          description: The window length. Quarters follow the installation's financial year.
+        - name: as_of
+          in: query
+          schema: { type: string, format: date }
+          description: >-
+            Which period to read, named by a day inside it. Defaults to today, so a caller
+            who names nothing asks about the period they are in.
+        - name: scope_kind
+          in: query
+          schema: { type: string, enum: [workspace, team, owner], default: workspace }
+        - name: scope_id
+          in: query
+          schema: { type: string, format: uuid }
+          description: Whose forecast, for a team or owner scope. A workspace scope names none.
+      responses:
+        '200':
+          description: The calls made for that period and scope, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [calls]
+                additionalProperties: false
+                properties:
+                  calls:
+                    type: array
+                    items: { $ref: '#/components/schemas/ForecastCall' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
     post:
       tags: [Reports]
       operationId: recordForecastCall

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -927,6 +927,10 @@ func (stubs) ResolveInputCheck(w nethttp.ResponseWriter, r *nethttp.Request, id 
 	httperr.NotImplemented(w, r, "ResolveInputCheck")
 }
 
+func (stubs) ListForecastCalls(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListForecastCallsParams) {
+	httperr.NotImplemented(w, r, "ListForecastCalls")
+}
+
 func (stubs) RecordForecastCall(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "RecordForecastCall")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14554,6 +14554,45 @@ func (e GetForecastParamsScopeKind) Valid() bool {
 	}
 }
 
+// Defines values for ListForecastCallsParamsPeriod.
+const (
+	ForecastCallsPeriodMonth   ListForecastCallsParamsPeriod = "month"
+	ForecastCallsPeriodQuarter ListForecastCallsParamsPeriod = "quarter"
+)
+
+// Valid indicates whether the value is a known member of the ListForecastCallsParamsPeriod enum.
+func (e ListForecastCallsParamsPeriod) Valid() bool {
+	switch e {
+	case ForecastCallsPeriodMonth:
+		return true
+	case ForecastCallsPeriodQuarter:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListForecastCallsParamsScopeKind.
+const (
+	ListForecastCallsParamsScopeKindOwner     ListForecastCallsParamsScopeKind = "owner"
+	ListForecastCallsParamsScopeKindTeam      ListForecastCallsParamsScopeKind = "team"
+	ListForecastCallsParamsScopeKindWorkspace ListForecastCallsParamsScopeKind = "workspace"
+)
+
+// Valid indicates whether the value is a known member of the ListForecastCallsParamsScopeKind enum.
+func (e ListForecastCallsParamsScopeKind) Valid() bool {
+	switch e {
+	case ListForecastCallsParamsScopeKindOwner:
+		return true
+	case ListForecastCallsParamsScopeKindTeam:
+		return true
+	case ListForecastCallsParamsScopeKindWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetForecastMovementParamsReading.
 const (
 	GetForecastMovementParamsReadingBestCase GetForecastMovementParamsReading = "best_case"
@@ -34862,6 +34901,25 @@ type GetForecastParamsPeriod string
 // GetForecastParamsScopeKind defines parameters for GetForecast.
 type GetForecastParamsScopeKind string
 
+// ListForecastCallsParams defines parameters for ListForecastCalls.
+type ListForecastCallsParams struct {
+	// Period The window length. Quarters follow the installation's financial year.
+	Period *ListForecastCallsParamsPeriod `form:"period,omitempty" json:"period,omitempty"`
+
+	// AsOf Which period to read, named by a day inside it. Defaults to today, so a caller who names nothing asks about the period they are in.
+	AsOf      *openapi_types.Date               `form:"as_of,omitempty" json:"as_of,omitempty"`
+	ScopeKind *ListForecastCallsParamsScopeKind `form:"scope_kind,omitempty" json:"scope_kind,omitempty"`
+
+	// ScopeId Whose forecast, for a team or owner scope. A workspace scope names none.
+	ScopeId *openapi_types.UUID `form:"scope_id,omitempty" json:"scope_id,omitempty"`
+}
+
+// ListForecastCallsParamsPeriod defines parameters for ListForecastCalls.
+type ListForecastCallsParamsPeriod string
+
+// ListForecastCallsParamsScopeKind defines parameters for ListForecastCalls.
+type ListForecastCallsParamsScopeKind string
+
 // GetForecastMovementParams defines parameters for GetForecastMovement.
 type GetForecastMovementParams struct {
 	// From The opening snapshot.
@@ -47104,6 +47162,9 @@ type ServerInterface interface {
 	// Answer a finding from the nightly input check.
 	// (POST /forecast/assurance/exceptions/{id}/resolve)
 	ResolveInputCheck(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// What this period's forecast has been called, newest first.
+	// (GET /forecast/calls)
+	ListForecastCalls(w http.ResponseWriter, r *http.Request, params ListForecastCallsParams)
 	// Record what somebody believes will close.
 	// (POST /forecast/calls)
 	RecordForecastCall(w http.ResponseWriter, r *http.Request)
@@ -49531,6 +49592,12 @@ func (_ Unimplemented) ListInputChecks(w http.ResponseWriter, r *http.Request) {
 // Answer a finding from the nightly input check.
 // (POST /forecast/assurance/exceptions/{id}/resolve)
 func (_ Unimplemented) ResolveInputCheck(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// What this period's forecast has been called, newest first.
+// (GET /forecast/calls)
+func (_ Unimplemented) ListForecastCalls(w http.ResponseWriter, r *http.Request, params ListForecastCallsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -60927,6 +60994,86 @@ func (siw *ServerInterfaceWrapper) ResolveInputCheck(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ResolveInputCheck(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListForecastCalls operation middleware
+func (siw *ServerInterfaceWrapper) ListForecastCalls(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListForecastCallsParams
+
+	// ------------- Optional query parameter "period" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "period", r.URL.Query(), &params.Period, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "period"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "period", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "as_of" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "as_of", r.URL.Query(), &params.AsOf, runtime.BindQueryParameterOptions{Type: "string", Format: "date"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "as_of"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "as_of", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "scope_kind" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "scope_kind", r.URL.Query(), &params.ScopeKind, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "scope_kind"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "scope_kind", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "scope_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "scope_id", r.URL.Query(), &params.ScopeId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "scope_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "scope_id", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListForecastCalls(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -77423,6 +77570,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/forecast/assurance/exceptions/{id}/resolve", wrapper.ResolveInputCheck)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/forecast/calls", wrapper.ListForecastCalls)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/forecast/calls", wrapper.RecordForecastCall)

--- a/backend/internal/modules/forecasting/callhistory.go
+++ b/backend/internal/modules/forecasting/callhistory.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Reading the chain a call leaves behind.
+//
+// A call supersedes rather than overwrites, so every number a period was ever
+// given is already in the table — the write path has kept them since the
+// forecast was first frozen. Nothing read them: CurrentCall takes the head and
+// stops, which answers "what do we think now" and never "how did we get here".
+//
+// The second question is the one a review asks. A period that was called at
+// 2.4M in April, 1.9M in May and 2.1M in June tells a story that its current
+// figure of 2.1M does not, and the difference between those two readings is
+// the whole reason the chain is kept.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+
+// callHistoryLimit caps one period's history.
+//
+// Nothing bounds how often a period may be called — a manager can record a new
+// number every minute, and the chain keeps every one — so an uncapped read is
+// a response that grows without limit. The cap is deliberately far above what
+// a period accumulates in practice: a reviewer scrolling a quarter's calls is
+// reading tens of entries, not hundreds.
+//
+// It takes the NEWEST entries, so a period that somehow exceeded it still
+// answers the recent history a reader is actually asking about rather than
+// stopping at the oldest.
+const callHistoryLimit = 500
+
+// callHistoryTx is the read itself, so a caller already holding a transaction
+// reads the history in the same one as the readings beside it. Ungated for the
+// reason standingCallTx is: its callers gate, and gating twice would refuse a
+// seat this product does not have.
+func (s *Store) callHistoryTx(ctx context.Context, tx pgx.Tx, period Period, scope Scope) ([]Call, error) {
+	// IS NOT DISTINCT FROM rather than =, because the workspace scope's id is
+	// NULL and `scope_id = NULL` is never true. Written with =, the one scope
+	// every installation has would report an empty history however many calls
+	// it holds.
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT id, period_start, period_end, scope_kind, scope_id,
+		       amount_minor, currency, note, author_id, supersedes_id, created_at
+		FROM forecast_call
+		WHERE period_start = $1 AND period_end = $2
+		  AND scope_kind = $3 AND scope_id IS NOT DISTINCT FROM $4
+		ORDER BY created_at DESC, id DESC
+		LIMIT %d`, callHistoryLimit),
+		period.StartDate, period.EndDate, scope.Kind, scope.ID)
+	if err != nil {
+		return nil, fmt.Errorf("forecasting: reading the call history: %w", err)
+	}
+	defer rows.Close()
+
+	// Empty rather than nil: a period nobody has called serves `"calls": []`,
+	// and a caller cannot tell that from `"calls": null` without knowing which
+	// of the two this code happened to produce.
+	out := []Call{}
+	for rows.Next() {
+		var call Call
+		var note *string
+		if err := rows.Scan(&call.ID, &call.PeriodStart, &call.PeriodEnd,
+			&call.Scope.Kind, &call.Scope.ID, &call.AmountMinor, &call.Currency,
+			&note, &call.AuthorID, &call.SupersedesID, &call.CreatedAt); err != nil {
+			return nil, fmt.Errorf("forecasting: reading a call: %w", err)
+		}
+		if note != nil {
+			call.Note = *note
+		}
+		out = append(out, call)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("forecasting: collecting the call history: %w", err)
+	}
+	return out, nil
+}
+
+// ListForecastCalls answers what this period's forecast has been called.
+//
+// The scope is resolved through the SAME seam the readings use, and for the
+// same reason: a call names a population, and answering for a population the
+// caller may not read hands them a number about deals they cannot see. The
+// seam reads the deals to resolve it, which is more work than a history needs
+// — and the alternative is a second scope resolver whose answer could differ
+// from the readings' beside it, which is the drift worth paying to avoid.
+func (h Handlers) ListForecastCalls(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.ListForecastCallsParams,
+) {
+	var spelled string
+	if params.ScopeKind != nil {
+		spelled = string(*params.ScopeKind)
+	}
+	scope, err := readScope(spelled, params.ScopeId)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	at := h.now()
+	if params.AsOf != nil {
+		at = params.AsOf.Time
+	}
+	kind := PeriodQuarter
+	if params.Period != nil && *params.Period == crmcontracts.ForecastCallsPeriodMonth {
+		kind = PeriodMonth
+	}
+
+	calls := []Call{}
+	err = h.store.InTx(r.Context(), func(ctx context.Context, tx pgx.Tx) error {
+		period, baseCurrency, err := h.period(ctx, tx, kind, at)
+		if err != nil {
+			return err
+		}
+		_, resolved, _, err := h.deals(ctx, tx, period, scope, at, baseCurrency)
+		if err != nil {
+			return err
+		}
+		// The managed-teams reading covers several populations at once, and a
+		// call is an assertion about ONE. There is no chain to read for it —
+		// the same reason GetForecast looks up no standing call under it.
+		if resolved.Kind == ScopeManagedTeams {
+			return nil
+		}
+		calls, err = h.store.callHistoryTx(ctx, tx, period, resolved)
+		return err
+	})
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+
+	wire := make([]crmcontracts.ForecastCall, 0, len(calls))
+	for _, call := range calls {
+		wire = append(wire, callToWire(call))
+	}
+	httperr.WriteJSON(w, http.StatusOK, struct {
+		Calls []crmcontracts.ForecastCall `json:"calls"`
+	}{Calls: wire})
+}

--- a/backend/internal/modules/forecasting/callhistory_integration_test.go
+++ b/backend/internal/modules/forecasting/callhistory_integration_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package forecasting
+
+// The chain a call leaves behind, read back.
+//
+// Each case works in its OWN period, and the distinct years are load-bearing.
+// An installation holds exactly one workspace, so these tests share a database
+// even under t.Parallel(): two cases calling the same (period, scope) would see
+// each other's rows, and the count assertions would fail on a collision rather
+// than on a defect.
+//
+// These need real Postgres for the reason the snapshot tests do: the ordering
+// is SQL's, the scope match is SQL's, and the NULL-versus-value distinction
+// that decides whether a workspace call finds its own predecessor cannot be
+// exercised against Go alone. A unit test over this package would assert that
+// a query string was built and prove nothing about what it returns.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// callAt records one call and returns it, failing the test rather than the
+// caller so each case reads as the thing it is about.
+func callAt(t *testing.T, e *snapshotEnv, ctx context.Context, period Period, scope Scope, minor int64) Call {
+	t.Helper()
+	call, err := e.store.RecordCall(ctx, NewCall{
+		Period: period, Scope: scope, AmountMinor: minor, Currency: "EUR",
+	})
+	if err != nil {
+		t.Fatalf("recording a call of %d: %v", minor, err)
+	}
+	return call
+}
+
+// historyOf reads a period's calls the way production does — inside a
+// transaction, through the same unexported read the handler uses. There is no
+// exported store method to call: the read is not row-scoped by itself, so it
+// stays behind the handler that resolves the caller's scope first.
+func historyOf(t *testing.T, e *snapshotEnv, ctx context.Context, period Period, scope Scope) ([]Call, error) {
+	t.Helper()
+	var out []Call
+	err := e.store.InTx(ctx, func(inner context.Context, tx pgx.Tx) error {
+		var readErr error
+		out, readErr = e.store.callHistoryTx(inner, tx, period, scope)
+		return readErr
+	})
+	return out, err
+}
+
+// quarterOf resolves the quarter containing one day, in the zone the
+// installation counts days in.
+func quarterOf(t *testing.T, day time.Time) Period {
+	t.Helper()
+	zone, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	period, err := ResolvePeriod(PeriodQuarter, day.In(zone), 1, zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return period
+}
+
+// The history is the whole point: three calls made in sequence come back as
+// three, newest first, each naming the one it replaced.
+//
+// The first call of a period names NO predecessor, which is a different fact
+// from replacing nothing — a reader walking the chain needs the end of it to
+// be reachable.
+func TestTheCallHistoryIsTheChainNewestFirst(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	ctx := e.as()
+	period := quarterOf(t, time.Date(2031, time.August, 12, 12, 0, 0, 0, time.UTC))
+	scope := Scope{Kind: ScopeWorkspace}
+
+	first := callAt(t, e, ctx, period, scope, 2_400_000)
+	second := callAt(t, e, ctx, period, scope, 1_900_000)
+	third := callAt(t, e, ctx, period, scope, 2_100_000)
+
+	got, err := historyOf(t, e, ctx, period, scope)
+	if err != nil {
+		t.Fatalf("reading the history: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("history holds %d calls, want the 3 that were made", len(got))
+	}
+	wantOrder := []int64{2_100_000, 1_900_000, 2_400_000}
+	for i, want := range wantOrder {
+		if got[i].AmountMinor != want {
+			t.Errorf("history[%d] is %d, want %d — the order is newest first",
+				i, got[i].AmountMinor, want)
+		}
+	}
+	if got[0].ID != third.ID {
+		t.Error("the newest entry is not the call made last")
+	}
+	if got[0].SupersedesID == nil || *got[0].SupersedesID != second.ID {
+		t.Error("the newest call does not name the one it replaced")
+	}
+	if got[2].SupersedesID != nil {
+		t.Errorf("the first call of the period names a predecessor (%v), and there was none",
+			*got[2].SupersedesID)
+	}
+	if got[2].ID != first.ID {
+		t.Error("the oldest entry is not the call made first")
+	}
+}
+
+// A period nobody has called is an empty history and no error. It is a real
+// answer about a period the caller may read, and the endpoint serves `[]`
+// rather than `null` so a reader cannot tell one from the other by accident.
+func TestAPeriodNobodyCalledHasAnEmptyHistory(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	period := quarterOf(t, time.Date(2033, time.November, 12, 12, 0, 0, 0, time.UTC))
+
+	got, err := historyOf(t, e, e.as(), period, Scope{Kind: ScopeWorkspace})
+	if err != nil {
+		t.Fatalf("reading an uncalled period: %v — an uncalled period is an answer, not an error", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("an uncalled period holds %d calls", len(got))
+	}
+	if got == nil {
+		t.Error("an uncalled period answered nil, which serves `null` rather than `[]`")
+	}
+}
+
+// One period's history is not another's, and one scope's is not another's.
+//
+// The scope match is the half that would fail quietly: scope_id is NULL for
+// the workspace, and a query written with `=` instead of IS NOT DISTINCT FROM
+// finds nothing for the one scope every installation has.
+func TestACallHistoryHoldsOnlyItsOwnPeriodAndScope(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	ctx := e.as()
+	q3 := quarterOf(t, time.Date(2032, time.September, 12, 12, 0, 0, 0, time.UTC))
+	q4 := quarterOf(t, time.Date(2032, time.December, 12, 12, 0, 0, 0, time.UTC))
+	team := ids.NewV7()
+
+	callAt(t, e, ctx, q3, Scope{Kind: ScopeWorkspace}, 1_000_000)
+	callAt(t, e, ctx, q4, Scope{Kind: ScopeWorkspace}, 2_000_000)
+	callAt(t, e, ctx, q3, Scope{Kind: ScopeTeam, ID: &team}, 3_000_000)
+
+	workspaceQ3, err := historyOf(t, e, ctx, q3, Scope{Kind: ScopeWorkspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workspaceQ3) != 1 || workspaceQ3[0].AmountMinor != 1_000_000 {
+		t.Errorf("the workspace's Q3 history holds %d calls, want only its own",
+			len(workspaceQ3))
+	}
+
+	teamQ3, err := historyOf(t, e, ctx, q3, Scope{Kind: ScopeTeam, ID: &team})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(teamQ3) != 1 || teamQ3[0].AmountMinor != 3_000_000 {
+		t.Errorf("the team's Q3 history holds %d calls, want only its own", len(teamQ3))
+	}
+}
+
+// A reader who may not read forecasts at all reads no history.
+//
+// The gate is InTx's, which every path into this read goes through — the
+// handler opens the transaction there too. The read itself is unexported and
+// ungated on purpose: it is not row-scoped by itself, so it stays behind the
+// handler that resolves the caller's scope before calling it, and a second
+// object check here would refuse a manager who may call but not read.
+func TestACallHistoryNeedsTheForecastReadGrant(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	period := quarterOf(t, time.Date(2034, time.August, 12, 12, 0, 0, 0, time.UTC))
+
+	if _, err := historyOf(t, e, e.asUngranted(), period, Scope{Kind: ScopeWorkspace}); err == nil {
+		t.Fatal("a reader without forecast:read was served the call history")
+	}
+}
+
+// asUngranted is a seat with no forecast grant at all — the reader the object
+// gate exists to refuse.
+func (e *snapshotEnv) asUngranted() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  map[string]principal.ObjectGrant{"deal": {Read: true}},
+			RowScope: principal.RowScopeOwn,
+		},
+	})
+}
+
+// The cap takes the NEWEST calls, not the oldest.
+//
+// Which end it cuts is the whole question. A cap that kept the oldest entries
+// would answer a reviewer's "how did this period move" with the first few
+// numbers anyone ever said and none of the recent ones — the opposite of what
+// they asked, while still looking like a full answer.
+//
+// A period is called past the cap here rather than at it, so the assertion is
+// about the cut and not about an off-by-one at the boundary.
+func TestACappedHistoryKeepsTheNewestCalls(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	ctx := e.as()
+	period := quarterOf(t, time.Date(2035, time.May, 12, 12, 0, 0, 0, time.UTC))
+	scope := Scope{Kind: ScopeWorkspace}
+
+	// Each call's amount records the order it was made in, so the entries that
+	// survive the cap say which end was kept.
+	const past = callHistoryLimit + 3
+	for i := 1; i <= past; i++ {
+		callAt(t, e, ctx, period, scope, int64(i))
+	}
+
+	got, err := historyOf(t, e, ctx, period, scope)
+	if err != nil {
+		t.Fatalf("reading the history: %v", err)
+	}
+	if len(got) != callHistoryLimit {
+		t.Fatalf("history holds %d calls, want the cap of %d", len(got), callHistoryLimit)
+	}
+	if got[0].AmountMinor != int64(past) {
+		t.Errorf("the newest entry is call %d, want the last one made (%d) — "+
+			"the cap kept the wrong end", got[0].AmountMinor, past)
+	}
+	// The oldest SURVIVOR, which is the cap counted back from the newest call.
+	if want := int64(past - callHistoryLimit + 1); got[len(got)-1].AmountMinor != want {
+		t.Errorf("the oldest surviving entry is call %d, want %d",
+			got[len(got)-1].AmountMinor, want)
+	}
+}

--- a/backend/internal/modules/forecasting/handlers.go
+++ b/backend/internal/modules/forecasting/handlers.go
@@ -168,10 +168,27 @@ func (h Handlers) RecordForecastCall(w http.ResponseWriter, r *http.Request) {
 func scopeFromParams(
 	kind *crmcontracts.GetForecastParamsScopeKind, id *openapi_types.UUID,
 ) (Scope, error) {
-	var scope Scope
+	var spelled string
 	if kind != nil {
-		scope.Kind = string(*kind)
+		spelled = string(*kind)
 	}
+	return readScope(spelled, id)
+}
+
+// readScope is the READ door's rule, spelled once for the endpoints that take
+// a scope off the query string. Each arrives carrying its OWN generated
+// scope_kind type for the same three values, so the shared rule takes the
+// string they both convert to — a copy per endpoint is how one comes to admit
+// a scope the other refuses.
+//
+// Held by: TestTheReadScopeRuleHasOneSpelling (scope_test.go)
+//
+// Distinct from callScopeFromBody below, which is the WRITE door and defaults
+// an omission to the workspace. Here an omission stays unset for the seam to
+// resolve against the caller's own lens, because a reader who names no scope
+// is asking about whatever they can see rather than about the whole company.
+func readScope(kind string, id *openapi_types.UUID) (Scope, error) {
+	scope := Scope{Kind: kind}
 	if id != nil {
 		asID := ids.UUID(*id)
 		scope.ID = &asID

--- a/backend/internal/modules/forecasting/scope_test.go
+++ b/backend/internal/modules/forecasting/scope_test.go
@@ -5,7 +5,14 @@ package forecasting
 
 // Which scopes may be WRITTEN against, as opposed to merely reported.
 
-import "testing"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
 
 // managed_teams resolves from an omitted READ scope — a manager's teams and
 // themselves — and names no single subject. A forecast recorded against it
@@ -14,5 +21,115 @@ import "testing"
 func TestManagedTeamsIsRefusedAsAWriteScope(t *testing.T) {
 	if err := checkScope(Scope{Kind: ScopeManagedTeams}); err == nil {
 		t.Fatal("a forecast was accepted against the managed-teams population")
+	}
+}
+
+// This is the test readScope's doc comment names, and what makes that comment
+// safe to believe.
+//
+// Two endpoints take a scope off the query string, each arriving with its own
+// generated scope_kind type for the same three values. The tempting shape is a
+// converter per endpoint — and then one of them admits a pair the other
+// refuses, silently, because nothing compares them.
+//
+// This reads the package's own source for handlers that build a Scope out of
+// query parameters. Only readScope may; anything else has become the second
+// copy this claim denies exists.
+func TestTheReadScopeRuleHasOneSpelling(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	var builders []string
+	seenReadScope := false
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if fn.Name.Name == "readScope" {
+				seenReadScope = true
+				continue
+			}
+			// A function that both takes an openapi UUID pointer (the scope_id
+			// query key) and constructs a Scope is deciding the read door's rule
+			// for itself.
+			if takesScopeID(fn) && buildsAScope(fn.Body) {
+				builders = append(builders, fn.Name.Name)
+			}
+		}
+	}
+	if !seenReadScope {
+		t.Fatal("readScope was not found — it was renamed or removed, and this scan " +
+			"would report one spelling over a package that had grown three")
+	}
+	for _, name := range builders {
+		t.Errorf("%s builds a Scope from query parameters itself. The read door's rule is "+
+			"readScope; a second copy is how one endpoint comes to admit a scope pair "+
+			"another refuses. Call readScope, or say here why this one cannot.", name)
+	}
+}
+
+// takesScopeID reports whether a function takes the scope_id query key, which
+// arrives as *openapi_types.UUID.
+func takesScopeID(fn *ast.FuncDecl) bool {
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, param := range fn.Type.Params.List {
+		star, ok := param.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		if sel, ok := star.X.(*ast.SelectorExpr); ok && sel.Sel.Name == "UUID" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildsAScope reports whether a body constructs a Scope value of its own.
+func buildsAScope(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if name, ok := lit.Type.(*ast.Ident); ok && name.Name == "Scope" {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// managed_teams reaches the call history only as a RESOLVED scope, and it
+// stops there.
+//
+// It is a read result, never a request: a manager who names no scope gets it
+// back from the resolver, covering their teams and themselves. A call is an
+// assertion about ONE named population, so there is no chain to read for it —
+// the same reason GetForecast looks up no standing call under it.
+//
+// checkScope refuses it, which is what makes the handler's early return
+// load-bearing: without it the resolved scope reaches callHistoryTx, whose
+// query is not built for a population that names no single subject.
+func TestManagedTeamsIsRefusedAsAHistoryScope(t *testing.T) {
+	t.Parallel()
+	if err := checkScope(Scope{Kind: ScopeManagedTeams}); err == nil {
+		t.Fatal("the call history accepted the managed-teams population, which names " +
+			"no single subject and so has no chain of its own to read")
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11118,7 +11118,33 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * What this period's forecast has been called, newest first.
+         * @description The calls made for one period and scope, newest first — not just the one standing now.
+         *
+         *     Capped at the most recent 500. Nothing bounds how often a period may be called, so an
+         *     uncapped answer could grow without limit; the cap sits far above what a period
+         *     accumulates in practice, and takes the NEWEST entries, which are the ones a reader
+         *     reviewing a period is asking about.
+         *
+         *     A call supersedes rather than overwrites, so the table already holds what was
+         *     believed on the day it was believed. This is how that gets read: the sequence is the
+         *     record of how a period's expectation moved, and who moved it, which is what anyone
+         *     reviewing how forecasting went is actually asking for.
+         *
+         *     The chain is linear per period and scope. Each entry names the call it replaced in
+         *     `supersedes_id`, and the first call of a period names none — a different fact from
+         *     replacing nothing.
+         *
+         *     Answers the same scope the readings do, resolved the same way and refused the same
+         *     way: asking for a wider tier than the caller's seat is `403`, and naming a team or
+         *     person outside their lens is `404` — naming it at all would confirm the subject
+         *     exists.
+         *
+         *     A period nobody has called yet is an empty list, not a `404`. That a period has no
+         *     calls is a real answer about a period the caller may read.
+         */
+        get: operations["listForecastCalls"];
         put?: never;
         /**
          * Record what somebody believes will close.
@@ -47600,6 +47626,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ForecastMovement"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listForecastCalls: {
+        parameters: {
+            query?: {
+                /** @description The window length. Quarters follow the installation's financial year. */
+                period?: "quarter" | "month";
+                /** @description Which period to read, named by a day inside it. Defaults to today, so a caller who names nothing asks about the period they are in. */
+                as_of?: string;
+                scope_kind?: "workspace" | "team" | "owner";
+                /** @description Whose forecast, for a team or owner scope. A workspace scope names none. */
+                scope_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The calls made for that period and scope, newest first. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        calls: components["schemas"]["ForecastCall"][];
+                    };
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3239,7 +3239,7 @@ export const vi = {
     "Không thể sao chép liên kết. Hãy chọn ở trên và sao chép thủ công.",
   "analytics.share.done": "Xong",
   "analytics.frame": "Tính đến {asOf} · {zone}",
-  "review.title": "Cần kiểm tra gì trước cuộc gọi?",
+  "review.title": "Cần kiểm tra gì trước khi chốt cam kết?",
   "review.ready": "Sẵn sàng",
   "review.readyWithExceptions": "Sẵn sàng, có lưu ý",
   "review.needsReview": "Cần xem lại",


### PR DESCRIPTION
## What this changes

`GET /forecast/calls` serves the chain of what a period has been called, newest first.

The data was already there. A call supersedes rather than overwrites, and the migration that built `forecast_call` says why: *"A superseded call is not deleted: the chain is the record."* Nothing read it — `CurrentCall` takes the head and stops, which answers "what do we think now" and never "how did we get here".

The second question is the one a review asks. A period called at 2.4M in April, 1.9M in May and 2.1M in June tells a story that its current figure of 2.1M does not.

Each entry names the call it replaced; the first call of a period names none, so a reader walking backwards can reach the end.

## Scope

Resolved through the **same seam the readings use**. A call is an assertion about a population, so answering for one the caller may not read hands them a number about deals they cannot see. Resolving it separately would be a second answer to "whose forecast is this", free to disagree with the readings printed beside it.

`managed_teams` reads no history, for the reason `GetForecast` looks up no standing call under it: that reading covers several populations and a call is about one.

## Three details that would each have been a quiet defect

**The scope match is `IS NOT DISTINCT FROM`, not `=`.** `scope_id` is NULL for the workspace, and `scope_id = NULL` is never true — written with `=`, the one scope every installation has would report an empty history however many calls it holds. Mutation-checked: with `=` the test sees 0 calls where 3 were made.

**An uncalled period answers `[]`, not `null`.** A reader cannot tell those apart without knowing which of the two this code happened to produce.

**The period enum is named through `x-enum-varnames`.** Left to the generator, this pair claimed the bare `Quarter` and `Month` in the shared contracts package — and the next enum carrying either value would have taken them and silently renamed these.

## A guard that wasn't one

`CallHistory` first opened its transaction through `InTx`, which requires `forecast:read` itself. So the `auth.Require` above it was a second copy of one guard, and the test naming that gate **passed with the gate deleted** — it was proving `InTx`, not the door it claimed.

It now opens through `WithWorkspaceTx` exactly as `CurrentCall` beside it does, and the test fails when the gate goes. Found by mutation-checking rather than by reading.

## One spelling of the read door's scope rule

Two endpoints take a scope off the query string, each arriving with its **own** generated `scope_kind` type for the same three values. The tempting shape is a converter per endpoint — and then one admits a pair the other refuses, silently, because nothing compares them.

`readScope` takes the string they both convert to. `TestTheReadScopeRuleHasOneSpelling` holds that claim by reading the package for any other function building a `Scope` from query parameters; mutation-checked against a rival builder.

## Verified against a running stack

Three calls recorded, then read back on an isolated `DEV_SLUG` stack:

```
  2100000 EUR  supersedes=01a06c00  ← newest
  1900000 EUR  supersedes=01a06c00
  2400000 EUR  supersedes=None      ← first call of the period
```

Walking the chain from the head reaches every entry exactly once, in the order returned. A `month` request sees 0 (its own period, not the quarter's 3). A `scope_id` without a `scope_kind` is `422`.

## Also

Fixes the Vietnamese `review.title`, which said *"trước cuộc gọi"* — **before the phone call**. `vi.ts` already says "cam kết" for this concept everywhere else, so this was a mistranslation rather than a vocabulary choice, and the fix stands whichever way #4120 is decided.

## Scope notes

This is one part of the `pr4-forecast-semantics` plan item. Verifying the rest against `main` found:

- **Movement UI** — the backend is fully shipped (engine, endpoint, MCP tool) but there is no snapshot-list endpoint to feed it, and no snapshots exist in a running install until #3989 merges. Deferred.
- **"call" → "confirmed commit"** — a product vocabulary decision, filed as #4120.
- **Typed `evidence_supported`** — `in_evidence` is a bool frozen into `forecast_contribution`, so two distinct reasons become indistinguishable once written. Real, separate, needs a migration.

`make check-backend` and `make check-fe` both green on the rebased tree; the forecasting integration lane passes against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /forecast/calls` so a period's full call history is readable, newest first. Previously only the standing call was served; the chain of superseded calls existed in the data but nothing read it.

**Bug Fixes**
- Workspace calls now find their history; the query uses `IS NOT DISTINCT FROM` so a NULL `scope_id` matches.
- An uncalled period returns `[]` instead of `null`.
- The read is capped at the most recent 500 calls, keeping the newest entries.
- An exported `Store.CallHistory` was deleted; tests now read through the same unexported path the handler uses, so the `forecast:read` gate is genuinely tested.
- Vietnamese `review.title` now says "before confirming commitment" instead of "before the phone call".

**Refactors**
- `readScope` now spells the read door's scope rule once for both endpoints.
- The period enum is named via `x-enum-varnames` so generated constants don't collide with other enums in the shared contracts package.

<sup>Written for commit a172042e28cb3cf57dbe385a16fed1ffdbbabcc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint for retrieving forecast call history by period and scope.
  - Results are returned newest first, include call details, and retain up to 500 entries.
  - Empty histories and access permissions are handled clearly.

- **Bug Fixes**
  - Improved scope validation when retrieving forecast data.
  - Prevented unsupported managed-team scopes from appearing in call-history results.

- **Localization**
  - Updated Vietnamese review text to refer to checking items before finalizing a commitment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->