### PR TITLE
The engine decides, and the old purpose gate stops answering first

### DIFF
--- a/backend/gates/decisioncoverage_test.go
+++ b/backend/gates/decisioncoverage_test.go
@@ -19,8 +19,9 @@ package gates
 //
 //   - it stages a row (comms.Store.Stage*Tx);
 //   - it authorizes (AuthorizeStagingTx) on the SAME transaction;
-//   - it refuses an absolute denial (refuseAbsoluteDenial) — the four refusals
-//     no rollout mode may soften;
+//   - it refuses what will not change before dispatch (refuseAtStaging) — an
+//     absolute denial, and any refusal under a category this installation
+//     enforces;
 //   - it fails closed when no authority is wired, rather than staging anyway.
 //
 // The last one is why this gate is not satisfied by a bare call. A census sees
@@ -48,7 +49,7 @@ import (
 // found the same way and a method matching none of them is not a subject.
 const (
 	callAuthorize = "AuthorizeStagingTx"
-	callRefuse    = "refuseAbsoluteDenial"
+	callRefuse    = "refuseAtStaging"
 	callEnqueue   = "EnqueueTx"
 )
 

--- a/backend/internal/compose/commsstager.go
+++ b/backend/internal/compose/commsstager.go
@@ -118,7 +118,7 @@ func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.Deliv
 	if err != nil {
 		return err
 	}
-	if err := refuseAbsoluteDenial(set); err != nil {
+	if err := refuseAtStaging(set); err != nil {
 		return err
 	}
 	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
@@ -159,7 +159,7 @@ func (s commsStager) StageChannelTx(ctx context.Context, tx pgx.Tx, in activitie
 	if err != nil {
 		return err
 	}
-	if err := refuseAbsoluteDenial(set); err != nil {
+	if err := refuseAtStaging(set); err != nil {
 		return err
 	}
 	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
@@ -167,25 +167,46 @@ func (s commsStager) StageChannelTx(ctx context.Context, tx pgx.Tx, in activitie
 	}, sendInsertOpts())
 }
 
-// refuseAbsoluteDenial stops a send at STAGING for the four refusals no
-// rollout mode may soften: an Art. 21 objection, a processing restriction, a
-// hard bounce, and marketing consent whose round trip never completed.
+// refuseAtStaging stops a send while the rep is still at the keyboard, for the
+// two refusals that will not change between now and dispatch.
 //
-// Observe mode is why every other disagreement is recorded and let through: the
-// engine is being measured against the old gate, and blocking on a difference
-// nobody has reviewed would refuse legitimate mail. An absolute denial is not a
-// difference of opinion — the transmit phase already refuses it, so letting it
-// stage buys nothing and costs two things. The rep learns minutes or days
-// later, from a parked row in an operator lane rather than at the moment they
-// pressed send. And the activity commits first, carrying the outbound
-// attestation that makes an address correspondence-positive — so a message to
-// somebody who objected would mint evidence of correspondence with them that
-// never happened.
-func refuseAbsoluteDenial(set commsauthz.DecisionSet) error {
-	if !set.HasAbsoluteDenial() {
+// The FIRST is an absolute denial — an Art. 21 objection, a processing
+// restriction, a hard bounce, marketing whose round trip never completed — which
+// no rollout mode may soften.
+//
+// The SECOND is a refusal under a category this installation ENFORCES. That arm
+// exists because the engine now decides those: the transmit phase would refuse
+// the same send anyway, so letting it stage buys nothing and costs two things.
+// The rep learns minutes or days later, from a parked row in an operator lane
+// rather than at the moment they pressed send. And the activity commits first,
+// carrying the outbound attestation that makes an address
+// correspondence-positive — so a message to somebody who may not receive it
+// would mint evidence of correspondence that never happened.
+//
+// A category still OBSERVING is let through, and that is not an oversight: the
+// engine's answer carries no authority there, the old gate decides, and blocking
+// on a difference nobody has reviewed would refuse legitimate mail. The mode
+// travels on each decision, so this asks the row rather than re-reading the
+// setting the engine has already applied.
+func refuseAtStaging(set commsauthz.DecisionSet) error {
+	denied := set.Denied()
+	if len(denied) == 0 {
 		return nil
 	}
-	denied := set.Denied()
+	if !set.HasAbsoluteDenial() && !anyEnforcedDenial(denied) {
+		return nil
+	}
 	return fmt.Errorf("consent: %d of %d recipients may not be written to (%s): %w",
 		len(denied), len(set.Decisions), denied[0].ReasonCode, apperrors.ErrConsentNotGranted)
+}
+
+// anyEnforcedDenial reports whether a refusal was taken under a category this
+// installation enforces, which is the one the engine's answer binds.
+func anyEnforcedDenial(denied []commsauthz.Decision) bool {
+	for _, d := range denied {
+		if d.Mode == commsauthz.ModeEnforce {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/compose/commsstager_test.go
+++ b/backend/internal/compose/commsstager_test.go
@@ -35,7 +35,7 @@ func TestStagingRefusesTheDenialsNoModeMaySoften(t *testing.T) {
 		set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
 			{Verdict: commsauthz.VerdictDeny, ReasonCode: reason},
 		}}
-		err := refuseAbsoluteDenial(set)
+		err := refuseAtStaging(set)
 		if !errors.Is(err, apperrors.ErrConsentNotGranted) {
 			t.Errorf("%s staged anyway: err = %v", reason, err)
 		}
@@ -43,14 +43,61 @@ func TestStagingRefusesTheDenialsNoModeMaySoften(t *testing.T) {
 }
 
 // And the converse, or the test above would pass with every send refused: an
-// ordinary disagreement is recorded and let through, which is what observe mode
-// is for.
+// ordinary disagreement under a category still being OBSERVED is recorded and
+// let through. The engine's answer carries no authority there, the old gate
+// decides, and blocking on a difference nobody has reviewed would refuse
+// legitimate mail.
 func TestStagingLetsAnObservedDisagreementThrough(t *testing.T) {
 	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
-		{Verdict: commsauthz.VerdictReview, ReasonCode: commsauthz.ReasonNoEvidence},
+		{
+			Verdict: commsauthz.VerdictReview, ReasonCode: commsauthz.ReasonNoEvidence,
+			Mode: commsauthz.ModeObserve,
+		},
 	}}
-	if err := refuseAbsoluteDenial(set); err != nil {
-		t.Errorf("refuseAbsoluteDenial = %v, want nil while the engine is only being observed", err)
+	if err := refuseAtStaging(set); err != nil {
+		t.Errorf("refuseAtStaging = %v, want nil for a category still being observed", err)
+	}
+}
+
+// AN ORDINARY REFUSAL UNDER AN ENFORCED CATEGORY IS REFUSED AT STAGING, and
+// that is the arm the flip added. The transmit phase would refuse the same send
+// anyway, so staging it buys nothing: the rep learns hours later from a parked
+// row, and the activity commits first, minting outbound correspondence evidence
+// for a message that never went.
+//
+// Mutation: drop the enforced arm from refuseAtStaging and this fails.
+func TestStagingRefusesAnOrdinaryDenialUnderEnforce(t *testing.T) {
+	for _, verdict := range []commsauthz.Verdict{commsauthz.VerdictDeny, commsauthz.VerdictReview} {
+		set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+			{Verdict: verdict, ReasonCode: commsauthz.ReasonNoEvidence, Mode: commsauthz.ModeEnforce},
+		}}
+		if err := refuseAtStaging(set); !errors.Is(err, apperrors.ErrConsentNotGranted) {
+			t.Errorf("an enforced %s staged anyway: err = %v", verdict, err)
+		}
+	}
+}
+
+// ONE ENFORCED REFUSAL REFUSES THE MESSAGE, even beside a recipient whose own
+// category is still observed. Whole-message refusal is the shape both
+// authorities already had, and a per-recipient split here would send a message
+// to some of the people it names and quietly drop the rest.
+func TestOneEnforcedRefusalRefusesTheWholeMessage(t *testing.T) {
+	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+		{
+			Verdict: commsauthz.VerdictAllow, ReasonCode: commsauthz.ReasonAllowed,
+			Mode: commsauthz.ModeEnforce,
+		},
+		{
+			Verdict: commsauthz.VerdictReview, ReasonCode: commsauthz.ReasonNoEvidence,
+			Mode: commsauthz.ModeObserve,
+		},
+		{
+			Verdict: commsauthz.VerdictDeny, ReasonCode: commsauthz.ReasonNoEvidence,
+			Mode: commsauthz.ModeEnforce,
+		},
+	}}
+	if err := refuseAtStaging(set); !errors.Is(err, apperrors.ErrConsentNotGranted) {
+		t.Errorf("a message with one enforced refusal staged anyway: err = %v", err)
 	}
 }
 
@@ -59,8 +106,8 @@ func TestStagingAllowsAnOrdinarySend(t *testing.T) {
 	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
 		{Verdict: commsauthz.VerdictAllow, ReasonCode: commsauthz.ReasonAllowed},
 	}}
-	if err := refuseAbsoluteDenial(set); err != nil {
-		t.Errorf("refuseAbsoluteDenial = %v, want nil for an allowed send", err)
+	if err := refuseAtStaging(set); err != nil {
+		t.Errorf("refuseAtStaging = %v, want nil for an allowed send", err)
 	}
 }
 
@@ -75,7 +122,7 @@ func TestTheStagingRefusalNamesNobody(t *testing.T) {
 			Recipient:  connector.Recipient{Email: "objector@example.test"},
 		},
 	}}
-	err := refuseAbsoluteDenial(set)
+	err := refuseAtStaging(set)
 	if err == nil {
 		t.Fatal("want a refusal")
 	}

--- a/backend/internal/modules/activities/channelsend.go
+++ b/backend/internal/modules/activities/channelsend.go
@@ -267,11 +267,6 @@ func (s *Store) SendMessage(ctx context.Context, anchorID ids.ActivityID, in Sen
 	if err != nil {
 		return crmcontracts.Activity{}, err
 	}
-	if err := gate.RequireGrantedForRecipients(ctx,
-		[]connector.Recipient{{Channel: &conversation.recipient}}, in.ConsentPurpose); err != nil {
-		return crmcontracts.Activity{}, err
-	}
-
 	// The files, resolved to snapshots while the sender's own read gate still
 	// applies and BEFORE the transaction — mail's ordering, for mail's reason:
 	// the transaction holds writes only, and the whole send is refused when one

--- a/backend/internal/modules/activities/channelsend_integration_test.go
+++ b/backend/internal/modules/activities/channelsend_integration_test.go
@@ -244,10 +244,17 @@ func TestSendMessageRefusesWhenTheConversationReachesNobody(t *testing.T) {
 	}
 }
 
-// The consent gate must be asked about the RESOLVED account, not about an empty
-// list: a default-deny gate asked about nobody refuses nobody, which is how
-// suppression silently stops applying to a whole channel.
-func TestSendMessageAsksTheConsentGateAboutTheResolvedRecipient(t *testing.T) {
+// THE DELIVERY MUST CARRY THE RESOLVED ACCOUNT, because that account is what
+// the engine authorizes at staging.
+//
+// The invariant is unchanged and the authority moved. This used to assert that
+// the OLD purpose gate was asked about the resolved recipient here, at request
+// time; the engine now decides at staging, inside the transaction that writes
+// the delivery, so what has to be true is that the delivery names the account
+// the conversation resolved to. A delivery staged against a different account
+// would be authorized for somebody else — which is how suppression silently
+// stops applying to a whole channel.
+func TestSendMessageStagesAgainstTheResolvedRecipient(t *testing.T) {
 	e := setupSend(t)
 	anchor := e.seedChannelAnchor(t)
 	person := e.linkPerson(t, anchor, "Telegram Buyer")
@@ -260,20 +267,31 @@ func TestSendMessageAsksTheConsentGateAboutTheResolvedRecipient(t *testing.T) {
 		t.Fatalf("SendMessage: %v", err)
 	}
 
-	if len(gate.recipients) != 1 || gate.recipients[0].Channel == nil {
-		t.Fatalf("the gate was asked about %+v, want exactly one channel recipient", gate.recipients)
+	if len(stager.staged) != 1 {
+		t.Fatalf("staged %+v, want exactly one delivery", stager.staged)
 	}
-	if got := gate.recipients[0].Channel.ChannelUserID; got != testChannelAccount {
-		t.Fatalf("the gate was asked about account %q, want the conversation's %q", got, testChannelAccount)
+	if got := stager.staged[0].Recipient.ChannelUserID; got != testChannelAccount {
+		t.Fatalf("staged against account %q, want the conversation's %q", got, testChannelAccount)
 	}
-	if gate.recipients[0].Email != "" {
-		t.Fatal("the gate was handed a channel recipient carrying a mail address; Recipient names exactly one subject")
+	// The authorization request the staging seam carries names the same one
+	// subject, and carries no mail address beside it: Recipient names exactly
+	// one subject, and a channel send that also named an email would put two
+	// people in one decision.
+	authorized := stager.staged[0].Authorization.Recipients
+	if len(authorized) != 1 || authorized[0].Channel == nil {
+		t.Fatalf("the engine is asked about %+v, want exactly one channel recipient", authorized)
 	}
-	// What the gate answered about is what the delivery carries — a message
-	// staged against a different account would have been consented for somebody
-	// else.
-	if len(stager.staged) != 1 || stager.staged[0].Recipient.ChannelUserID != testChannelAccount {
-		t.Fatalf("staged %+v, want one delivery to the account the gate cleared", stager.staged)
+	if got := authorized[0].Channel.ChannelUserID; got != testChannelAccount {
+		t.Fatalf("the engine is asked about account %q, want the conversation's %q", got, testChannelAccount)
+	}
+	if authorized[0].Email != "" {
+		t.Fatal("the engine was handed a channel recipient carrying a mail address")
+	}
+	// The old purpose gate is no longer asked at request time: the engine
+	// decides at staging, where it can read the anchor this function never
+	// hands over.
+	if len(gate.recipients) != 0 {
+		t.Errorf("the request-time purpose gate was asked about %+v, want nothing", gate.recipients)
 	}
 	if got := e.storedThreadKey(t, ids.UUID(sent.Id)); got != testChannelThreadKey {
 		t.Fatalf("outbound activity thread_key = %q, want the conversation's %q", got, testChannelThreadKey)

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -237,9 +237,17 @@ func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate Co
 	if err != nil {
 		return "", err
 	}
-	if err := gate.RequireGrantedForEmails(ctx, in.Recipients, in.ConsentPurpose); err != nil {
-		return "", err
-	}
+	// NO CONSENT CHECK HERE. It was the old purpose gate, asked before the
+	// engine existed and kept while the engine only observed. The engine now
+	// decides, and it decides at STAGING — inside the transaction that writes
+	// the delivery, where it can read the anchor, the links and the evidence
+	// this function has never been handed. Asking a weaker authority first
+	// meant a reply the engine authorizes on the subject's own thread was
+	// refused here for want of a consent row nobody had reason to record.
+	//
+	// The refusal still reaches the rep at the keyboard: compose's
+	// refuseAtStaging returns it from the same request, before the activity
+	// commits.
 	return provider, nil
 }
 

--- a/backend/internal/modules/activities/scheduledsendfire.go
+++ b/backend/internal/modules/activities/scheduledsendfire.go
@@ -63,6 +63,10 @@ func (s *Store) FireScheduledSend(ctx context.Context, id ids.UUID, grace time.D
 	// what the caller needs afterwards to hold this row without holding a newer
 	// one. It survives the rollback because it never entered it.
 	var observed int64
+	// deferred names a refusal discovered after the transaction had already
+	// written, so the hold cannot ride inside it. Set only by the branch that
+	// rolls back; empty means nothing was deferred.
+	var deferred string
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		claimed, found, err := s.claimForFire(ctx, tx, id)
 		if err != nil {
@@ -103,6 +107,16 @@ func (s *Store) FireScheduledSend(ctx context.Context, id ids.UUID, grace time.D
 		}
 		sent, err := s.SendPreparedTx(ctx, tx, origin, prepared, stager)
 		if err != nil {
+			// The engine decides at STAGING, which happens after the activity
+			// row is written — so this refusal cannot be held under the same
+			// transaction the way PrepareSend's is. Rolling back is what makes
+			// the hold honest: holding here would commit a logged "sent"
+			// activity for a message nobody sent. The reason rides out on
+			// `deferred` and the hold runs in its own transaction below,
+			// bound to the version this attempt claimed under.
+			if reason, ok := holdReasonFor(err); ok {
+				deferred = reason
+			}
 			return err
 		}
 		if err := s.releaseInTx(ctx, tx, id, ids.UUID(sent.Id)); err != nil {
@@ -112,6 +126,17 @@ func (s *Store) FireScheduledSend(ctx context.Context, id ids.UUID, grace time.D
 		return nil
 	})
 	if err != nil {
+		if deferred != "" {
+			// The send was refused about the world, and the rollback undid the
+			// activity it had already written. Hold now, in a fresh
+			// transaction, under the version this attempt claimed: a rep who
+			// rescheduled since has made a newer decision and HoldScheduledSend
+			// declines on their behalf.
+			if holdErr := s.HoldScheduledSend(ctx, id, deferred, observed); holdErr != nil {
+				return FireOutcome{Observed: observed}, errors.Join(err, holdErr)
+			}
+			return FireOutcome{Held: deferred, Observed: observed}, nil
+		}
 		// The observation rides out with the error: it is the only thing the
 		// caller can bind a follow-up hold to.
 		return FireOutcome{Observed: observed}, err

--- a/backend/internal/modules/consent/authorizationdefault_test.go
+++ b/backend/internal/modules/consent/authorizationdefault_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The posture an installation ships with.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// EVERY CATEGORY ENFORCES, and the default is derived from the vocabulary
+// rather than typed out.
+//
+// A hand-written map is a second list. A category added to commsauthz and
+// forgotten here would ship observing — recorded, not binding — which is the
+// state this default exists to leave behind, and nothing would say so.
+//
+// Mutation: return a partial map from enforceEveryCategory and this fails,
+// naming the category left behind.
+func TestTheShippedPostureEnforcesEveryCategory(t *testing.T) {
+	t.Parallel()
+
+	modes := enforceEveryCategory()
+	for _, c := range commsauthz.Categories() {
+		if got := ModeFor(modes, c); got != commsauthz.ModeEnforce {
+			t.Errorf("%s ships in %s, want enforce: it would be recorded and not binding, "+
+				"and nothing would report that", c, got)
+		}
+	}
+	if len(modes) != len(commsauthz.Categories()) {
+		t.Errorf("the shipped posture names %d categories and the vocabulary holds %d",
+			len(modes), len(commsauthz.Categories()))
+	}
+}
+
+// THE DEFAULT IS STILL A VALID SETTING. It goes through the same validator an
+// operator's map does, so a vocabulary drift that made the shipped posture
+// unstorable would fail here rather than at an installation's first write.
+func TestTheShippedPostureValidates(t *testing.T) {
+	t.Parallel()
+
+	if err := validateAuthorizationModes(enforceEveryCategory()); err != nil {
+		t.Fatalf("the shipped posture is not a storable setting: %v", err)
+	}
+}

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -123,6 +123,13 @@ func legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey strin
 	}
 	switch verdict.State {
 	case VerdictAllowed:
+		// A basis this call DERIVED is written down before the send relies on
+		// it (Art. 5(2)). The engine is the only authority now, so it is the
+		// only thing left that can make that record: grantedForRecipient used
+		// to stamp here, and nothing calls it on the send path any more.
+		if err := stampDerivedBasis(ctx, tx, personID, verdict); err != nil {
+			return commsauthz.Decision{}, err
+		}
 		d.Verdict = commsauthz.VerdictAllow
 		d.ReasonCode = commsauthz.ReasonAllowed
 		d.Basis = basisForClass(purpose.Class)

--- a/backend/internal/modules/consent/settingsentry.go
+++ b/backend/internal/modules/consent/settingsentry.go
@@ -40,24 +40,44 @@ const authorizationModesObject = "installation_settings"
 // AuthorizationModes maps a communication category to the authority the
 // engine's answer carries for it.
 //
-// A category absent from the map is `observe`, so the default below can name
-// nothing and still be complete — and so a category added to the vocabulary
-// tomorrow arrives in the safest position rather than in whatever the map
-// happened to say.
+// A category absent from the map is `observe`, so a category added to the
+// vocabulary tomorrow arrives in the position where it is recorded and not yet
+// binding, whatever the stored map says. That default is what makes the map a
+// set of EXCEPTIONS rather than a table that must be complete to be correct.
+//
+// The shipped default names every category that exists today, at `enforce`.
+// Observe was the rollout, not the destination: it ran so the disagreement
+// between the engine and the old purpose gate could be read before it bound
+// anything, and the reading came back empty — where the engine has no evidence
+// of its own it adopts the old gate's answer rather than refusing, so enforcing
+// stops nothing that was being sent. What it ENDS is the old gate overruling
+// the engine on a message the engine can evidence and it cannot.
 var AuthorizationModes = settings.Define[map[string]string](
 	"consent.authorization_modes",
 	authorizationModesObject,
 	"update",
-	// Every category observes. The engine records what it would have done and
-	// the old gate decides, which is what makes the disagreement measurable
-	// before it is binding.
-	map[string]string{},
+	enforceEveryCategory(),
 	validateAuthorizationModes,
 	// MachineryApplied: the transmit gate reads this inside the transaction
 	// that binds its own decision, and the posture must apply whoever the
 	// acting principal is — a worker dispatching a delivery holds the system
 	// principal and has no settings read gate to pass.
 ).MachineryApplied()
+
+// enforceEveryCategory is the shipped posture: every category the vocabulary
+// holds, at enforce.
+//
+// DERIVED from the vocabulary rather than typed out, because a hand-written map
+// is a second list that drifts. A category added to commsauthz and forgotten
+// here would silently ship observing — recorded, not binding — which is exactly
+// the state this default exists to leave behind, and nothing would say so.
+func enforceEveryCategory() map[string]string {
+	out := make(map[string]string, len(commsauthz.Categories()))
+	for _, c := range commsauthz.Categories() {
+		out[string(c)] = string(commsauthz.ModeEnforce)
+	}
+	return out
+}
 
 // validateAuthorizationModes refuses a map that names something that is not a
 // category, or a mode that is not a mode.

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -117,13 +117,33 @@ func (s DecisionSet) Effective(modeFor func(Category) Mode, legacyAllowed bool) 
 		// recipient is not a message that may go out.
 		return false
 	}
+	enforced := false
 	for _, d := range s.Decisions {
 		if modeFor(d.Resolved) != ModeEnforce {
 			continue
 		}
+		enforced = true
 		if d.Verdict != VerdictAllow {
 			return false
 		}
+	}
+	// THE ENGINE ALONE DECIDES A RECIPIENT IT ENFORCES.
+	//
+	// While every category observed, this returned legacyAllowed and the old
+	// purpose gate ruled. Under enforce that conjunction is not caution, it is
+	// the old gate's defects kept alive: it answers on a caller-supplied
+	// purpose key, and its business-correspondence arm reads qualifying events
+	// only — so an ordinary reply to a thread the subject started is refused
+	// for want of a consent row nobody ever had reason to record. The engine
+	// resolves that reply from the thread itself, which is the strongest ground
+	// a message can have, and being overruled by a weaker authority is the
+	// regression this rollout exists to end.
+	//
+	// A set with NO enforced recipient still defers. That is not a fallback: it
+	// is a category still being observed, and the old gate is what decides
+	// there until it is not.
+	if enforced {
+		return true
 	}
 	return legacyAllowed
 }

--- a/backend/internal/shared/ports/commsauthz/commsauthz_test.go
+++ b/backend/internal/shared/ports/commsauthz/commsauthz_test.go
@@ -64,12 +64,42 @@ func TestAnOrdinaryDenialDefersToTheModeWhileObserving(t *testing.T) {
 	}
 }
 
-// Enforce narrows, never widens: an engine allow cannot rescue a send the old
-// gate refused while both still run.
-func TestEnforceNeverOutranksTheOldGate(t *testing.T) {
+// UNDER ENFORCE THE ENGINE ALONE DECIDES, and this is the case that says so:
+// an engine allow sends a message the old purpose gate refused.
+//
+// That is the point of enforcing rather than an accident of it. The old gate
+// answers on a caller-supplied purpose key and its business-correspondence arm
+// reads qualifying events only, so an ordinary reply to a thread the subject
+// started is refused for want of a consent row nobody had reason to record.
+// The engine resolves that reply from the thread itself. Keeping the
+// conjunction would leave the weaker authority able to overrule the stronger
+// one, which is the regression this rollout exists to end.
+//
+// The test previously asserted the opposite — correctly, while every category
+// still observed and both authorities ran together.
+func TestUnderEnforceTheEngineAloneDecides(t *testing.T) {
 	set := DecisionSet{Decisions: []Decision{{Verdict: VerdictAllow, ReasonCode: ReasonAllowed}}}
-	if set.Effective(everywhere(ModeEnforce), false) {
-		t.Error("an engine allow must not send what the legacy gate refused")
+	if !set.Effective(everywhere(ModeEnforce), false) {
+		t.Error("an engine allow was overruled by the old gate under enforce")
+	}
+	// And an engine denial still refuses, or the line above would be a bypass
+	// rather than an authority.
+	denied := DecisionSet{Decisions: []Decision{{Verdict: VerdictDeny, ReasonCode: ReasonNoEvidence}}}
+	if denied.Effective(everywhere(ModeEnforce), true) {
+		t.Error("an engine denial was overruled by the old gate under enforce")
+	}
+}
+
+// A CATEGORY STILL OBSERVING DEFERS, which is what keeps enforce a per-category
+// rollout rather than a switch. A set with no enforced recipient takes the old
+// gate's answer in both directions.
+func TestAnObservedCategoryStillDefersToTheOldGate(t *testing.T) {
+	set := DecisionSet{Decisions: []Decision{{Verdict: VerdictAllow, ReasonCode: ReasonAllowed}}}
+	if set.Effective(everywhere(ModeObserve), false) {
+		t.Error("an observed category sent what the old gate refused")
+	}
+	if !set.Effective(everywhere(ModeObserve), true) {
+		t.Error("an observed category refused what the old gate allowed")
 	}
 }
 


### PR DESCRIPTION
`Allowed = engine` for every enforced category. This is the flip the consent plan called PR 8's core, taken on Lars's decision after a measurement rather than an argument.

## Why it is safe to do now

A simulation on a dev stack produced 106 real decisions across 24 deliveries and **zero disagreements** between the engine and the old gate. Where the engine has no evidence it calls `legacyVerdictFor`, which adopts the old gate's answer — so the two could not disagree, and the flip changes no verdict that ships today.

That also corrects something I had said earlier and got wrong: enforcing does **not** stop legacy transactional mail. It stops nothing that was being sent.

## What changed

**`commsauthz/absolute.go`** — `Effective()` no longer ends in `return legacyAllowed` for a recipient under an enforced category. A decision set with no enforced recipient still defers, so observe remains a real rollout position.

**`consent/settingsentry.go`** — the shipped default is `enforceEveryCategory()`, derived from `commsauthz.Categories()` rather than typed out. An **absent** category still observes, so a category added tomorrow arrives non-binding rather than silently enforcing.

**`activities/email.go` and `channelsend.go`** — the request-time `RequireGrantedFor*` calls are removed. That was the old purpose gate asked before the engine existed and kept while the engine only observed. It refused a reply the engine authorizes on the subject's own thread, for want of a consent row nobody had reason to record. The refusal still reaches the rep in the same request, from `refuseAtStaging`.

**`compose/commsstager.go`** — `refuseAbsoluteDenial` is now `refuseAtStaging`, which also refuses an ordinary denial whose decision carries `Mode=enforce`. The mode travels on each `Decision`, so it asks the row rather than re-reading the setting.

## Two things that had to move with the gate

**The derived-basis stamp.** `grantedForRecipient` wrote the Art. 5(2) record of what authorized a send, and nothing calls it on the send path any more. `TestASendOnADerivedBasisRecordsWhatAuthorizedIt` caught this — the send was allowed on a basis that was never recorded. The engine is the only authority left, so it makes the record, from the same `stampDerivedBasis` helper.

**The scheduled-send hold.** The engine decides at staging, which is *after* `logActivityInTx` has written the activity row. So the refusal can no longer be held inside the fire transaction the way `PrepareSend`'s is — holding there would commit a logged "sent" activity for a message nobody sent. The refusal now rolls the transaction back and holds in its own, bound to the row version the attempt claimed under, so a rep who rescheduled in between is not held under a decision about their older intention.

Four compose integration tests found this, and the hold is the correct product behaviour: a scheduled message whose consent was withdrawn between scheduling and firing goes to a human, not to a retry loop.

## Verification

- `make check-backend` green, before and after the rebase onto `origin/main`.
- `make test-it DIR=backend/internal/compose/integration` green, before and after the rebase (#4115 touches recipient filing, so it was re-run rather than assumed).
- consent and activities integration lanes green.
- `craft static --strict` over the 12 changed files: 0 findings.
- On a dev stack: reply 202, operational 202, marketing-without-consent 409, decision rows stamped `mode=enforce`.

## Mutations, one clause at a time

| Mutation | Test that failed |
|---|---|
| restore `return legacyAllowed` | `TestUnderEnforceTheEngineAloneDecides` |
| enforce stops refusing at staging | `TestStagingRefusesAnOrdinaryDenialUnderEnforce` |
| partial default mode map | `TestTheShippedPostureEnforcesEveryCategory` |
| drop the enforced arm from staging | `TestOneEnforcedRefusalRefusesTheWholeMessage` |
| drop the `deferred` assignment | `TestConsentWithdrawnBeforeFiringHoldsTheMessage` |
| drop the hold-after-rollback | `TestConsentWithdrawnBeforeFiringHoldsTheMessage`, `TestARepCanRetryAHeldMessageFromTheirInbox` |
| drop the derived-basis stamp | `TestASendOnADerivedBasisRecordsWhatAuthorizedIt` |

## What this unblocks

Archiving the `transactional` and `business_correspondence` purposes was blocked on this: both authorities read `archived_at IS NULL` and treat an archived purpose as undefined, which is a default-deny. Proven on a running stack — archiving them turned an operational send and a reply on the customer's own thread from 202 to 409. With the engine no longer falling back to the legacy purpose row, that archive becomes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the consent engine the sole authority for every enforced communication category, replacing the old purpose gate's request-time veto. The shipped default now enforces every category instead of observing, and staging refuses denied sends before the activity commits.

**Behavior changes**
- `Effective()` returns the engine's verdict for any enforced recipient instead of falling back to `legacyAllowed`; sets with no enforced recipient still defer to the old gate.
- `refuseAtStaging` also refuses ordinary denials carrying enforce mode, not just absolute denials.
- The request-time `RequireGrantedFor*` checks are gone from email and channel sends; the refusal still reaches the rep from staging in the same request.
- Categories absent from the shipped map still observe, so a category added tomorrow arrives non-binding rather than silently enforcing.

**What moved with the gate**
- The engine now records the derived basis itself, since nothing calls `grantedForRecipient` on the send path anymore.
- Scheduled-send refusals roll back the fire transaction and hold in their own transaction, so a refused message isn't logged as sent and a rep who rescheduled isn't held under an older decision.

<sup>Written for commit 15c01cb4516e328ccf2eb4f08a3c981140c59c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consent enforcement now evaluates all communication categories, including enforced ordinary denials and reviews.
  * Message staging consistently applies consent decisions across email and channel deliveries.
  * Scheduled sends defer eligible refusals safely and preserve the associated hold.
* **Bug Fixes**
  * Enforced authorization decisions now determine delivery outcomes without being overridden by legacy checks.
  * Observing-mode decisions continue to follow existing behavior.
  * Authorization records now retain the derived decision basis for allowed legacy outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->