### PR TITLE
The record's name and its verbs stand at the scale the head is drawn at

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -182,12 +182,22 @@
   height: 46px;
   font-size: var(--fs-h2);
 }
-/* The mark of a record PAGE, the mock's 56px: the one picture in the head,
-   beside a display-size name. */
+/* The mark of a record PAGE: the one picture in the head, beside a name set
+   at the record rung. Sized to the reference's 72, which reads as the page's
+   own mark rather than as a large list avatar — at 56 beside a 44px name it
+   was the smaller of the two things naming the record. Squared to the pane's
+   radius, because at this size a chip's radius reads as a rounded photo. */
 .avatar-xl {
-  width: 56px;
-  height: 56px;
-  font-size: var(--fs-h2);
+  width: 72px;
+  height: 72px;
+  border-radius: var(--r-lg);
+  font-size: var(--fs-h1);
+}
+/* A round mark keeps its circle at every rung: a person is a portrait, an
+   organization is a tile. `.avatar-org` squares the small rungs and this one
+   is square already, so the rule that has to be stated is the round one. */
+.avatar-xl:not(.avatar-org) {
+  border-radius: var(--r-full);
 }
 
 /* An avatar beside its label on one line — a list cell, a search hit, a node

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -288,7 +288,12 @@
    Set on the ROW's rung variable rather than on each button, because
    `.record-actions` spends that one variable on both shapes it holds: raising
    the labelled buttons alone is exactly how the ellipsis square came to be 32
-   wide beside 40-tall neighbours once already. */
+   wide beside 40-tall neighbours once already.
+
+   A descendant selector reaches every verb a wide head has: `RecordView` draws
+   this header wide only when it was handed `controls` or `actionsInline`, and
+   both of those place the verbs INSIDE it. The row below the header belongs to
+   the narrow head, which keeps the form rung. */
 .record-head-wide .record-actions {
   --control-h: var(--control-h-lg);
 }

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -196,6 +196,10 @@
  * beside the chips rather than beside the name it belongs to. */
 .record-head-wide {
   align-items: flex-start;
+  /* The name's rung answers to THIS row's width rather than the window's, so
+     the row has to be measurable. It is the record page's own width — the
+     details pane sits below it and does not narrow it, the nav rail does. */
+  container-type: inline-size;
 }
 .record-head-wide .record-controls {
   display: flex;
@@ -230,6 +234,13 @@
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+  /* The floor the h1's own ellipsis needs to mean anything. A flex item's
+     minimum is its min-content, and a name set `nowrap` has no break in it —
+     so without this the row's minimum is the whole name, the identity block
+     inherits it, and the verbs beside it are pushed to a row of their own
+     rather than the name being cut. It is the name that gives way: the verbs
+     are the same four whatever the record is called. */
+  min-width: 0;
 }
 /* Small and tinted rather than the button-sized accent badge every other
    inline choice draws elsewhere on the page — beside a 22-34px name it
@@ -264,8 +275,25 @@
    than the list-row avatar it shares a component with. The list keeps its own
    compact sizes — this applies only where the header runs wide. */
 .record-head-wide h1 {
-  font-size: var(--fs-display);
-  line-height: 1.1;
+  font-size: var(--fs-record-fluid);
+  line-height: 1.05;
+  /* Tighter than the display rung's tracking: a name set this large wears the
+     scale's own spacing as gaps between its letters. */
+  letter-spacing: -0.035em;
+}
+/* The record page's verbs are the page's own rather than a toolbar's: one rung
+   taller than a control in a form, beside a name at the record rung. Below
+   that they read as chrome that happens to sit near the name.
+
+   Set on the ROW's rung variable rather than on each button, because
+   `.record-actions` spends that one variable on both shapes it holds: raising
+   the labelled buttons alone is exactly how the ellipsis square came to be 32
+   wide beside 40-tall neighbours once already. */
+.record-head-wide .record-actions {
+  --control-h: var(--control-h-lg);
+}
+.record-head-wide .record-actions > .btn {
+  padding-inline: var(--space-4);
 }
 .record-head .record-sub {
   font-size: 13px;

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -735,7 +735,6 @@ export function RecordView({
   pulse,
   actions,
   controls,
-  wide,
   markShape = "person",
   actionsInline,
   band,
@@ -782,11 +781,6 @@ export function RecordView({
   // like a face or as a rounded square like a logo. Defaults to `person`,
   // which is what every record but an organization is.
   markShape?: "person" | "organization";
-  // Forces the record-head-wide sizing (display-size name, the page's own
-  // mark, wrapping identity block) independent of `controls`. For a record whose standing
-  // lives inside `pulse` itself rather than in a stacked controls column —
-  // the company page's shape — and still wants the same scale.
-  wide?: boolean;
   // Puts `actions` on the SAME row as the identity block, right-aligned,
   // instead of the default full-width row underneath the header (or the
   // stacked column `controls` produces). An explicit opt-in: every other
@@ -851,7 +845,14 @@ export function RecordView({
   // a name over a description, a chip row and a meta line, and centring the
   // mark against a stack that tall floats it to the middle of the chips
   // instead of beside the name it belongs to.
-  const headerWide = Boolean(controls) || Boolean(actionsInline) || wide;
+  //
+  // These are the SAME two slots `actionsPlacement` reads, which is what makes
+  // "a wide head never puts its verbs in the row below it" a fact about the
+  // component rather than a convention its callers keep: a head is wide only
+  // if it was handed `controls` or `actionsInline`, and either of those places
+  // the verbs inside the header. The record-head-wide rules in composed.css
+  // rest on that.
+  const headerWide = Boolean(controls) || Boolean(actionsInline);
   const actionsAt = actionsPlacement(actions, actionsInline, controls);
   return (
     /* The record's own blocks arrive in order — head, then actions, then the

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -283,6 +283,14 @@
      to whatever its padding produced. */
   --control-h: 36px;
   --control-h-sm: 32px;
+  /* One rung ABOVE the form control, for the verbs a page owns rather than the
+     ones inside a card: a record's own actions stand beside a name set at the
+     record rung, and at the form rung they read as chrome that happens to sit
+     near it. Under touch the pointer arm below takes every rung to 44, so this
+     one stops being a step up there — a bigger target is the right answer to a
+     finger, and a verb taller than 44 would be the only oversized thing on the
+     screen. */
+  --control-h-lg: 40px;
 
   /* Vertical-rhythm scale — the 4/8/12/16/24 rungs the screens were already
    * reaching for ad-hoc (inconsistently spelled 10/12/14/16 before this).
@@ -362,11 +370,19 @@
   --fs-h3: 17px; /* card title */
   --fs-h2: 20px; /* section title */
   --fs-h1: 24px; /* the title of a step */
-  --fs-display: 32px; /* a record's name; the title of a full-viewport moment */
-  /* Two fluid rungs, for the two surfaces that own a whole viewport and
-     therefore have room to answer to it: the gate and the handoff scene. */
+  --fs-display: 32px; /* the title of a full-viewport moment */
+  /* Three fluid rungs, for the surfaces that own their width and therefore
+     have room to answer to it: the gate, the handoff scene, and a RECORD's
+     own name. A record's name is the largest thing on its page, so it is the
+     first thing to stop being a name and start being a banner when the header
+     narrows — which happens whenever a reader opens the nav rail.
+     Measured in `cqi` and not `vw` for that reason: the window does not
+     change when the rail does, and the header is what the name has to fit.
+     `.record-head-wide` declares the container; with none in the tree the
+     unit falls back to the viewport, which is the pre-container answer. */
   --fs-display-fluid: clamp(24px, 2.6vw, 32px);
   --fs-hero-fluid: clamp(30px, 6vw, 46px);
+  --fs-record-fluid: clamp(26px, 3.7cqi, 44px);
 
   /* Four weights. Outfit and DM Sans are both variable, so 550/560/580/600/620/
      650 rendered as six genuinely different weights for one "emphasis" role —
@@ -750,5 +766,6 @@
   :root {
     --control-h: 44px;
     --control-h-sm: 36px;
+    --control-h-lg: 44px;
   }
 }


### PR DESCRIPTION
## What

The record head — every record page shares one, so this lands on company,
contact, lead, deal and project together — moves off the list's rungs onto its
own:

- the mark goes 56px → 72px, and an **organization's** is squared to the pane's
  radius while a person's stays a portrait;
- the name takes a new fluid rung, `--fs-record-fluid`, in place of the fixed
  32px display rung;
- the verbs take a rung above the form control, `--control-h-lg` (40px, and 44
  under a coarse pointer where every rung is already 44).

## Why

Beside a name that is the largest thing on the page, verbs at the *form
control's* rung read as chrome that happens to sit near the record rather than
as the record's own actions. Same for the mark: at 56px beside a 44px name it
was the smaller of the two things naming the record.

Two details are the point of the diff rather than the sizes:

- **The name's rung is measured in `cqi`, not `vw`.** The window does not
  narrow when a reader opens the nav rail — the head does, and the head is what
  the name has to fit. A `vw` rung would have been a fluid rung that answers to
  the one thing the reader never changes. `.record-head-wide` declares the
  container; with no container in the tree the unit falls back to the viewport,
  which is the pre-container answer.
- **The verb rung is set on the ROW's variable, not on each button.**
  `.record-actions` already spends one `--control-h` on both shapes it holds —
  the labelled buttons and the icon-only squares — precisely because raising
  one shape alone is how the ellipsis square came to be 32 wide beside 40-tall
  neighbours once already.

`.record-name-row` also gains the `min-width: 0` its h1's ellipsis needs to mean
anything: a flex item's minimum is its min-content, and a name set `nowrap` has
no break in it, so without a shrink floor the row's minimum is the whole name
and the verbs beside it are pushed to a row of their own rather than the name
being cut.

## How verified

- `make check-fe`: `fe-quality` and `fe-lint` clean; vitest 6329 passed. The two
  red files (`aiusage`, `buyerroom`) are red on a clean `origin/main` in this
  sandbox too — a jsdom/blob difference, not this diff.
- Playwright, full suite against the built preview: **264 passed, 54 skipped,
  exit 0**.
- Measured rather than eyeballed: the verbs and the ellipsis square both compute
  to 40px in the built app, and the name to 43.5px at a 1176px head. The first
  attempt at the verb rung silently lost a specificity contest with
  `.record-actions :is(.btn, .overflow-menu > .btn)` and measured 36 — hence the
  variable rather than a competing rule.
- Shot each record head at 1440px: company, contact, deal, project. (A lead has
  no wide head.)

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — CSS only
- [x] `make craft-static` reports no new blockers — no Go in this diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code under Jo's direction, against a visual reference Jo
supplied. Every value here was measured in the running app rather than taken
from the reference on faith.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC


---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales the record head on every record page from list-level rungs to page-level ones, so the mark, name, and actions read as the record's own rather than as chrome sitting next to it.

- The avatar grows from 56px to 72px; people stay round, organizations become square tiles matching the pane's radius.
- The name swaps the fixed 32px display rung for `--fs-record-fluid`, a `cqi` clamp (26–44px) that follows the head's width and falls back to the viewport when no container is declared.
- The action verbs move up to a new `--control-h-lg` token (40px, 44px under coarse pointers), set on the row so the ellipsis square scales with the labelled buttons.
- Adds `min-width: 0` to `.record-name-row` so a long name's ellipsis truncates instead of pushing the actions onto their own line.
- Removes the unused `wide` prop from `RecordView`; a head is now wide only when handed `controls` or `actionsInline`, and both keep the verbs inside the header.
- No data or migration changes.

<sup>Written for commit 6fcb170091b0c31e67f9223a28ad9eac616d2ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enlarged extra-large avatars and refined their typography and shapes, while preserving square styling for organization avatars.
  * Improved wide record headers with responsive title sizing, better handling of long names, and updated action control dimensions.
  * Added responsive design tokens for large controls and fluid record titles, including adjusted sizing for touch-based interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->