### PR TITLE
A worklist row says which screen it belongs on

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38480,6 +38480,13 @@ components:
         `due` is asked of every item whatever its level, so an overdue promise counts in
         both `urgent` and `due` — deliberately, because a reader wants both answers about
         it. Read them as four questions about one day rather than four slices of it.
+
+        `buckets` IS the partition, and it is the one to render an additive sentence from.
+        The figures above it answer four questions about the day; the four inside it slice
+        that day into parts that sum to `total`. Both are sent because both are wanted: a
+        reader asking "how much is overdue" wants `due` counted across every level, and a
+        reader reading "3 urgent · 5 due today · 4 planned · 5 review — 17 total" needs the
+        parts to add up to the whole they are shown beside.
       required: [urgent, due, lower_priority, total]
       properties:
         urgent: { type: integer, minimum: 0, description: 'Items at the top two levels: somebody is waiting, or a promise is breaking.' }
@@ -38496,6 +38503,8 @@ components:
             of rows, which is the one thing this line promises cannot happen.
         lower_priority: { type: integer, minimum: 0, description: 'Routine work: decisions that block nothing, and data hygiene.' }
         total: { type: integer, minimum: 0, description: 'How many candidates the day holds. The same population the per-category `considered` figures are counted over, so the two agree.' }
+        buckets:
+          $ref: '#/components/schemas/WorklistBuckets'
         material_threshold_minor:
           type: [integer, 'null']
           format: int64
@@ -38505,6 +38514,40 @@ components:
             the client can say WHY a deal ranked where it did. Null when the pipeline has
             no open deals to take a median of.
         base_currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$', description: 'The currency every expected-revenue figure here is converted to.' }
+
+    WorklistBuckets:
+      type: object
+      description: |
+        The day cut into four parts that SUM TO `total`. Every candidate the read weighed
+        lands in exactly one of them.
+
+        The order below is the order they are read in, and it is a precedence rather than a
+        set of independent tests: an overdue promise is urgent, not due-today, because the
+        first arm that matches takes the row. Without a precedence the same item would be
+        counted twice and the sentence would add up to more than the day holds.
+
+        `review` is every row whose `destination` is not `today` — a judgement to make, a
+        source to restore, a receipt to read. It is counted from that field rather than from
+        the source, so the sentence and the screens cannot disagree about which rows are
+        seller work.
+      required: [urgent, due_today, planned, review]
+      properties:
+        urgent:
+          type: integer
+          minimum: 0
+          description: 'Seller work at the top two levels: somebody is waiting, or a promise is breaking. The same rule as the sibling `urgent`, narrowed to `today` rows.'
+        due_today:
+          type: integer
+          minimum: 0
+          description: 'Seller work not already counted urgent, carrying a date that has arrived or passed, or falling due before this installation day ends.'
+        planned:
+          type: integer
+          minimum: 0
+          description: 'The rest of the seller work: a task to do, a meeting to prepare, a lead to reach, a deal drifting below the material bar.'
+        review:
+          type: integer
+          minimum: 0
+          description: 'Everything that is not seller work — the `review`, `system_health` and `receipt` destinations together, because the one line above the queue says how much is waiting on judgement rather than which of the three kinds it is.'
 
     WorklistReadings:
       type: object
@@ -38774,6 +38817,24 @@ components:
           type: string
           enum: [customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system]
           description: 'The badge, and the filter it answers to. A reader groups by this; the ORDER never does.'
+        destination:
+          type: string
+          enum: [today, review, system_health, receipt]
+          x-enum-varnames: [WorklistDestinationToday, WorklistDestinationReview, WorklistDestinationSystemHealth, WorklistDestinationReceipt]
+          description: |
+            Which SCREEN this row belongs on. The server decides it once, and every count,
+            fold and page in this response is computed from the same value the row carries,
+            so a client that groups by it cannot disagree with the figures above it.
+
+            `today` is work a seller executes. `review` is a judgement somebody must make
+            before work continues — an approval, a duplicate pair, an introduction.
+            `system_health` is a source or automation an administrator must restore.
+            `receipt` is completed work, reported so the reader can see it happened.
+
+            A CLIENT NEVER DERIVES THIS. It is not a function of `category`, `band` or
+            `source` that a browser could recompute: two rows of one source can differ,
+            and the mapping is a product decision that moves. A client that re-derived it
+            would put a row on one screen while the count above it put the row on another.
         level:
           type: integer
           minimum: 0

--- a/backend/gates/worklistdestination_test.go
+++ b/backend/gates/worklistdestination_test.go
@@ -26,10 +26,13 @@ import (
 	"github.com/margince/margince/backend/internal/compose/attention"
 )
 
-// batchStandsForOtherRows is the one source that must NOT be classified here.
-// It names a group rather than a record, so its screen is its members' — and a
-// mapping for the word `batch` would be a second answer to a question the
-// members already answer.
+// batchStandsForOtherRows names a group rather than a record, so its screen is
+// its members' — and a mapping for the word `batch` would be a second answer to
+// a question the members already answer.
+//
+// Held by: TestEveryWorklistSourceHasADestination, which fails in both
+// directions — a source the contract declares and the map does not classify,
+// and this one if it ever is classified.
 const batchStandsForOtherRows = "batch"
 
 func TestEveryWorklistSourceHasADestination(t *testing.T) {

--- a/backend/gates/worklistdestination_test.go
+++ b/backend/gates/worklistdestination_test.go
@@ -21,6 +21,7 @@ package gates
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/attention"
@@ -38,6 +39,21 @@ const batchStandsForOtherRows = "batch"
 func TestEveryWorklistSourceHasADestination(t *testing.T) {
 	t.Parallel()
 	declared := crmYAMLEnum(t, "WorklistItem", "source")
+	// The corpus has to be the WHOLE vocabulary, and under-reading is the one
+	// way this gate can fail short: a parse that silently dropped members would
+	// leave a smaller list, every member of it would be classified, and the gate
+	// would report PASS over sources it never looked at.
+	//
+	// So the YAML is cross-checked against a SECOND derivation of the same
+	// enum — the constants oapi-codegen generated from it. The two are produced
+	// by different readers of one contract, so a parse that loses a member here
+	// disagrees with the generated code rather than quietly shrinking the world.
+	generated := generatedWorklistSources(t)
+	if !slices.Equal(declared, generated) {
+		t.Fatalf("the contract's worklist sources read %v from crm.yaml and %v from the generated "+
+			"constants: one of the two readings is wrong, and a census over the shorter one "+
+			"would pass without looking at every source", declared, generated)
+	}
 	classified := []string{}
 	for _, source := range attention.ClassifiedSources() {
 		classified = append(classified, string(source))
@@ -82,4 +98,30 @@ func TestEveryDestinationIsOneTheContractDeclares(t *testing.T) {
 			t.Errorf("source %q is sent to %q, which crm.yaml does not declare as a destination", source, at)
 		}
 	}
+}
+
+// generatedWorklistSources is the same vocabulary as read by the OTHER reader
+// of the contract: the constants oapi-codegen wrote from it.
+//
+// The point is that this derivation shares no code with the YAML walk beside
+// it. A regex over the generated block and a yaml.Unmarshal of the schema fail
+// in different ways, so a bug that shortens one shows up as a disagreement
+// rather than as a smaller corpus that still passes.
+func generatedWorklistSources(t *testing.T) []string {
+	t.Helper()
+	out := []string{}
+	for name, value := range constValuesIn(t, "internal/contracts/api_gen.go") {
+		// The constants oapi-codegen writes for this enum, and only those: the
+		// prefix is the generated type's own name, so a constant of a different
+		// type that happens to hold the same word is not one of these.
+		if strings.HasPrefix(name, "WorklistItemSource") {
+			out = append(out, value)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no WorklistItemSource constants found in the generated contracts: " +
+			"this reading yields nothing, so it can confirm nothing")
+	}
+	slices.Sort(out)
+	return out
 }

--- a/backend/gates/worklistdestination_test.go
+++ b/backend/gates/worklistdestination_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every source the worklist can emit has one screen it belongs on.
+//
+// The destination decides where a row is drawn AND which bucket counts it, so a
+// source with no answer is a row that reaches a reader on whatever screen the
+// zero value picked, under a count that put it somewhere else. Nothing else in
+// the tree fails when that happens: the row renders, the figures add up, and
+// the only symptom is a duplicate pair sitting in a seller's morning.
+//
+// BOTH SIDES ARE DERIVED. The vocabulary comes from crm.yaml, the classified
+// set from the map's own keys. A list repeated here would be a second copy of
+// the subject, and the copy is what goes stale — this gate would then read a
+// smaller world, report PASS, and the new source would be exactly as unclassified
+// as it was before anybody wrote a gate.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+)
+
+// batchStandsForOtherRows is the one source that must NOT be classified here.
+// It names a group rather than a record, so its screen is its members' — and a
+// mapping for the word `batch` would be a second answer to a question the
+// members already answer.
+const batchStandsForOtherRows = "batch"
+
+func TestEveryWorklistSourceHasADestination(t *testing.T) {
+	t.Parallel()
+	declared := crmYAMLEnum(t, "WorklistItem", "source")
+	classified := []string{}
+	for _, source := range attention.ClassifiedSources() {
+		classified = append(classified, string(source))
+	}
+	slices.Sort(classified)
+
+	for _, source := range declared {
+		if source == batchStandsForOtherRows {
+			if slices.Contains(classified, source) {
+				t.Errorf("%q is classified by source, but it stands for a group of other rows: "+
+					"its screen is its members', decided where the group is minted", source)
+			}
+			continue
+		}
+		if !slices.Contains(classified, source) {
+			t.Errorf("the worklist can emit %q and nothing says which screen it belongs on: "+
+				"add it to destinationOfSource in internal/compose/attention/destination.go, "+
+				"choosing today, review, system_health or receipt", source)
+		}
+	}
+	// And the other direction: a classification for a source the contract no
+	// longer declares is a decision about nothing, which reads to the next
+	// author as though that source still exists.
+	for _, source := range classified {
+		if !slices.Contains(declared, source) {
+			t.Errorf("destinationOfSource classifies %q, which crm.yaml no longer declares as a worklist source", source)
+		}
+	}
+}
+
+// TestEveryDestinationIsOneTheContractDeclares holds the values themselves.
+//
+// The map's answers reach the wire, so a destination spelled here that the
+// schema does not carry is a response a client cannot parse — and the failure
+// would arrive as a validation error on a reader's queue rather than here.
+func TestEveryDestinationIsOneTheContractDeclares(t *testing.T) {
+	t.Parallel()
+	declared := crmYAMLEnum(t, "WorklistItem", "destination")
+	for _, source := range attention.ClassifiedSources() {
+		at := string(attention.DestinationOfSource(source))
+		if !slices.Contains(declared, at) {
+			t.Errorf("source %q is sent to %q, which crm.yaml does not declare as a destination", source, at)
+		}
+	}
+}

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -97,6 +97,15 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 			kept = append(kept, members...)
 			continue
 		}
+		// A group belongs to ONE screen. Rows that would sit on different ones
+		// are not one pile however alike they read, and folding them would take
+		// a judgement somebody owes off the review screen and count it as
+		// something else — with nothing left on the page to notice it went.
+		// They go back as themselves, which costs rows and loses nothing.
+		if !sameDestination(members) {
+			kept = append(kept, members...)
+			continue
+		}
 		// The bound belongs to the lane the members CAME from. It is the
 		// decision lane's own scan depth, and a system incident read from a
 		// different lane never hit it — marking one "8+" because an unrelated
@@ -288,6 +297,12 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 			Sample: &sample,
 		},
 		Actions: []crmcontracts.WorklistItemActions{},
+		// The members' own screen, carried onto the row that stands for them.
+		// The fold has already refused to group rows that disagree, so the first
+		// member answers for all of them — and deriving it from the word `batch`
+		// instead would put a pile of approvals wherever `batch` was mapped
+		// rather than where its members belong.
+		Destination: destinationPtr(destinationOf(members[0])),
 	}
 	if cause != "" {
 		row.Batch.Cause = &cause

--- a/backend/internal/compose/attention/destination.go
+++ b/backend/internal/compose/attention/destination.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Which screen a row belongs on, decided once.
+//
+// A worklist row is not one kind of thing. A buyer waiting on a reply is work a
+// seller executes; a duplicate pair is a judgement somebody makes before work
+// continues; a stopped mailbox is a source an administrator restores. Putting
+// all three in one list under one vocabulary is what made the queue read as a
+// feed: a rep scanning for the next call had to step over the product's own
+// housekeeping to find it.
+//
+// THE SERVER DECIDES, ONCE, HERE. The counts, the folding and the page cut all
+// read the value the row carries, so a client that groups by it cannot disagree
+// with the figures above it. The alternative — a client-side map over `source`
+// — was rejected because it is a second authority: the day the two spellings
+// drift, a row sits on one screen while the count above it says another, and
+// nothing fails.
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// The four screens a row can belong to.
+const (
+	// destinationToday is work a seller executes: a reply to write, a task to
+	// finish, a meeting to prepare, a deal to move.
+	destinationToday = crmcontracts.WorklistDestinationToday
+	// destinationReview is a judgement a human makes before work can continue —
+	// an approval, a duplicate pair, an introduction to accept.
+	destinationReview = crmcontracts.WorklistDestinationReview
+	// destinationSystemHealth is a source or an automation an administrator
+	// restores. A seller can rarely act on one, and a queue that asked them to
+	// spent their attention on somebody else's job.
+	destinationSystemHealth = crmcontracts.WorklistDestinationSystemHealth
+)
+
+// destinationOfSource is the whole mapping, and the only one.
+//
+// EXHAUSTIVE over the source enum, held by TestEverySourceHasADestination: a
+// twenty-second source fails that test until somebody decides where it belongs.
+// The failure is the point. A source added without a destination would default
+// to whatever the zero value is, and the reader would find it on a screen
+// nobody chose for it.
+//
+// `dsr` is deliberately absent from seller work: a subject request is a legal
+// obligation with its own authorized queue and its own clock, and a seller
+// usually cannot act on one at all. It is `review` here so the count above the
+// queue stays honest about it existing, and the sales screens filter it out by
+// destination rather than by naming the source a second time.
+//
+// `batch` has NO entry, and cannot: it stands for a group of other rows, so its
+// destination is its members'. `destinationOfBatch` answers for it.
+var destinationOfSource = map[crmcontracts.WorklistItemSource]crmcontracts.WorklistItemDestination{
+	// Seller work. Somebody is waiting, a date is arriving, or revenue moves.
+	crmcontracts.WorklistItemSourceCustomerWaiting:   destinationToday,
+	crmcontracts.WorklistItemSourceLeadResponse:      destinationToday,
+	crmcontracts.WorklistItemSourceDealAtRisk:        destinationToday,
+	crmcontracts.WorklistItemSourceMeeting:           destinationToday,
+	crmcontracts.WorklistItemSourceTask:              destinationToday,
+	crmcontracts.WorklistItemSourceConversationClaim: destinationToday,
+	crmcontracts.WorklistItemSourceBriefItem:         destinationToday,
+	// A contact going quiet is a seller's call to make — reach out, or decide
+	// this relationship is over. The dismissal path exists because it is a
+	// judgement about their own week, not a queue of somebody else's.
+	crmcontracts.WorklistItemSourceRelationshipDecay: destinationToday,
+	// A bounced or undelivered message is a customer consequence: this named
+	// person did not receive what was sent to them, and the seller is the one
+	// who notices. The mailbox that carried it may be healthy.
+	crmcontracts.WorklistItemSourceBounce:      destinationToday,
+	crmcontracts.WorklistItemSourceUndelivered: destinationToday,
+
+	// Judgements. Work waits on a person deciding.
+	crmcontracts.WorklistItemSourceApproval:            destinationReview,
+	crmcontracts.WorklistItemSourceDedupeCandidate:     destinationReview,
+	crmcontracts.WorklistItemSourceIntroductionRequest: destinationReview,
+	crmcontracts.WorklistItemSourceNotice:              destinationReview,
+	crmcontracts.WorklistItemSourceDsr:                 destinationReview,
+
+	// The product reporting on itself. An administrator restores these.
+	crmcontracts.WorklistItemSourceSyncHealth:     destinationSystemHealth,
+	crmcontracts.WorklistItemSourceCaptureHealth:  destinationSystemHealth,
+	crmcontracts.WorklistItemSourceAiWorkHealth:   destinationSystemHealth,
+	crmcontracts.WorklistItemSourceAutomationRun:  destinationSystemHealth,
+	crmcontracts.WorklistItemSourceFailedApproval: destinationSystemHealth,
+}
+
+// destinationOf answers for one row.
+//
+// A batch asks its members, because a group's destination is not a property of
+// the word `batch` — it is whatever the rows inside it were. Folding is only
+// ever applied to rows that already agree (see destinationOfBatch), so the
+// first member answers for all of them.
+//
+// A source with no entry answers `review` rather than `today`. That is the safe
+// direction: an unclassified row on the review screen is one row somebody has
+// to look at, while the same row in Today claims to be executable seller work
+// and offers a verb nobody wrote. The census test means this fallback should
+// never run in production — it is what happens if it ever does.
+func destinationOf(row ranked) crmcontracts.WorklistItemDestination {
+	if row.item.Batch != nil {
+		return destinationOfBatch(row)
+	}
+	if at, ok := destinationOfSource[row.item.Source]; ok {
+		return at
+	}
+	return destinationReview
+}
+
+// destinationOfBatch is the destination a folded group carries.
+//
+// The group's own row already holds the answer once it is minted: batchRow
+// copies its members' destination onto it, and the fold refuses to group rows
+// that disagree. Reading the row's own field keeps the group and its members
+// saying one thing.
+func destinationOfBatch(row ranked) crmcontracts.WorklistItemDestination {
+	if row.item.Destination != nil {
+		return *row.item.Destination
+	}
+	return destinationReview
+}
+
+// ClassifiedSources is which sources this map decides a screen for.
+//
+// Exported for the gate that holds the map exhaustive against the contract's
+// own enum. It is the map's key set rather than a second list: a gate that
+// hard-codes part of its subject has become a copy of it, and the copy is what
+// goes stale.
+func ClassifiedSources() []crmcontracts.WorklistItemSource {
+	out := make([]crmcontracts.WorklistItemSource, 0, len(destinationOfSource))
+	for source := range destinationOfSource {
+		out = append(out, source)
+	}
+	return out
+}
+
+// DestinationOfSource is the screen one source's rows belong on.
+//
+// Exported beside ClassifiedSources for the same gate: it holds the ANSWERS
+// against the contract's declared vocabulary, so a destination spelled here
+// that the schema does not carry fails at the gate rather than as a validation
+// error on a reader's queue.
+func DestinationOfSource(source crmcontracts.WorklistItemSource) crmcontracts.WorklistItemDestination {
+	return destinationOfSource[source]
+}
+
+// destinationPtr is the wire field's shape: optional, so an older client that
+// never heard of the field keeps working, and always sent by this server.
+func destinationPtr(at crmcontracts.WorklistItemDestination) *crmcontracts.WorklistItemDestination {
+	return &at
+}
+
+// sameDestination says whether these rows may be folded into one.
+//
+// A fold puts one row on the page in place of many, so the group has to belong
+// to ONE screen. Two rows that would sit on different screens are not the same
+// pile however alike they read: folding an approval into a system incident
+// would take a judgement somebody owes off the review screen, count it as
+// system trouble, and leave nothing behind to notice.
+func sameDestination(members []ranked) bool {
+	if len(members) < 2 {
+		return true
+	}
+	first := destinationOf(members[0])
+	for _, member := range members[1:] {
+		if destinationOf(member) != first {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/compose/attention/destination.go
+++ b/backend/internal/compose/attention/destination.go
@@ -71,20 +71,28 @@ var destinationOfSource = map[crmcontracts.WorklistItemSource]crmcontracts.Workl
 	// who notices. The mailbox that carried it may be healthy.
 	crmcontracts.WorklistItemSourceBounce:      destinationToday,
 	crmcontracts.WorklistItemSourceUndelivered: destinationToday,
+	// The rep pressed Accept and believes it happened, and that belief is the
+	// damage. It is classified at the promise level and carried back to the
+	// APPROVER rather than to an administrator, so it is that person's own
+	// broken promise — the same shape as the undelivered message beside it, and
+	// not a pipe anybody else can restore.
+	crmcontracts.WorklistItemSourceFailedApproval: destinationToday,
+	// A notice is addressed to one reader and offers `acknowledge`. Nothing
+	// waits on a judgement and nothing is broken: reading it IS the work, and it
+	// leaves the lane when they do.
+	crmcontracts.WorklistItemSourceNotice: destinationToday,
 
 	// Judgements. Work waits on a person deciding.
 	crmcontracts.WorklistItemSourceApproval:            destinationReview,
 	crmcontracts.WorklistItemSourceDedupeCandidate:     destinationReview,
 	crmcontracts.WorklistItemSourceIntroductionRequest: destinationReview,
-	crmcontracts.WorklistItemSourceNotice:              destinationReview,
 	crmcontracts.WorklistItemSourceDsr:                 destinationReview,
 
 	// The product reporting on itself. An administrator restores these.
-	crmcontracts.WorklistItemSourceSyncHealth:     destinationSystemHealth,
-	crmcontracts.WorklistItemSourceCaptureHealth:  destinationSystemHealth,
-	crmcontracts.WorklistItemSourceAiWorkHealth:   destinationSystemHealth,
-	crmcontracts.WorklistItemSourceAutomationRun:  destinationSystemHealth,
-	crmcontracts.WorklistItemSourceFailedApproval: destinationSystemHealth,
+	crmcontracts.WorklistItemSourceSyncHealth:    destinationSystemHealth,
+	crmcontracts.WorklistItemSourceCaptureHealth: destinationSystemHealth,
+	crmcontracts.WorklistItemSourceAiWorkHealth:  destinationSystemHealth,
+	crmcontracts.WorklistItemSourceAutomationRun: destinationSystemHealth,
 }
 
 // destinationOf answers for one row.

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -211,6 +211,17 @@ func rankAll(rows []ranked) []crmcontracts.WorklistItem {
 		// describes a row's place on the page it is actually on.
 		band := crmcontracts.WorklistItemBand(bandOfRow(row))
 		item.Band = &band
+		// And which SCREEN it belongs on, from the one map that decides that.
+		// Stamped for the same reason as the two above: a source added later
+		// carries it by arriving here, not by its author remembering to.
+		//
+		// A folded group already carries its own, copied from the members it
+		// stands for, so it is not overwritten with an answer derived from the
+		// word `batch`.
+		if item.Destination == nil {
+			at := destinationOf(row)
+			item.Destination = &at
+		}
 		out = append(out, item)
 	}
 	return out

--- a/backend/internal/compose/attention/worklistbuckets_test.go
+++ b/backend/internal/compose/attention/worklistbuckets_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// TestTheBucketsPartitionTheDay is the property the additive sentence rests on.
+//
+// The four figures are drawn as "3 urgent · 5 due today · 4 planned · 5 review
+// — 17 total", so a day where they do not add up is a sentence that contradicts
+// itself in front of the reader. Asserted over a MIXED day rather than a
+// uniform one: a fixture of one kind of row would sum correctly under a
+// classifier that sent everything to one bucket.
+func TestTheBucketsPartitionTheDay(t *testing.T) {
+	t.Parallel()
+	day := mixedDestinationsDay()
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 50,
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
+
+	buckets := out.Summary.Buckets
+	if buckets == nil {
+		t.Fatal("the summary carries no buckets, so the additive sentence has nothing to draw")
+	}
+	sum := buckets.Urgent + buckets.DueToday + buckets.Planned + buckets.Review
+	if sum != out.Summary.Total {
+		t.Errorf("the buckets sum to %d over a day of %d: %+v — the sentence would not add up",
+			sum, out.Summary.Total, *buckets)
+	}
+	// A partition of one bucket is a partition that proves nothing. This fixture
+	// holds seller work AND judgements, so a classifier that sent every row to
+	// one screen still sums correctly and is still wrong.
+	if buckets.Review == 0 {
+		t.Error("no row reached the review bucket, so this fixture cannot tell a partition from a single bucket")
+	}
+	if buckets.Urgent+buckets.DueToday+buckets.Planned == 0 {
+		t.Error("no row reached a seller bucket, so this fixture cannot tell a partition from a single bucket")
+	}
+}
+
+// TestAJudgementIsNeverUrgentSellerWork holds the precedence's leading arm.
+//
+// An approval that has waited is not a seller's morning however long it has
+// waited. Reading the level first would count it as urgent and put it in a
+// sentence a rep reads as work they can execute.
+func TestAJudgementIsNeverUrgentSellerWork(t *testing.T) {
+	t.Parallel()
+	buckets := crmcontracts.WorklistBuckets{}
+	judgement := ranked{item: crmcontracts.WorklistItem{
+		Source: crmcontracts.WorklistItemSourceApproval,
+		Level:  levelWaiting,
+	}}
+	bucketOf(judgement, levelWaiting, &buckets)
+	if buckets.Urgent != 0 {
+		t.Error("an approval at the waiting level was counted as urgent seller work")
+	}
+	if buckets.Review != 1 {
+		t.Errorf("an approval reached %+v, want it counted as review", buckets)
+	}
+}
+
+// TestAnOverdueSellerRowIsCountedOnceHoldsThePrecedence.
+//
+// `due` beside it is asked of every row whatever its level, so an overdue
+// promise counts twice there — deliberately. The buckets slice instead, so the
+// same row must reach exactly one of them.
+func TestAnOverdueSellerRowIsCountedOnce(t *testing.T) {
+	t.Parallel()
+	overdue := true
+	buckets := crmcontracts.WorklistBuckets{}
+	promise := ranked{item: crmcontracts.WorklistItem{
+		Source:  crmcontracts.WorklistItemSourceConversationClaim,
+		Level:   levelPromise,
+		Overdue: &overdue,
+	}}
+	bucketOf(promise, levelPromise, &buckets)
+	total := buckets.Urgent + buckets.DueToday + buckets.Planned + buckets.Review
+	if total != 1 {
+		t.Errorf("one overdue promise landed in %d buckets: %+v", total, buckets)
+	}
+	if buckets.Urgent != 1 {
+		t.Errorf("an overdue promise reached %+v, want urgent — the level leads inside seller work", buckets)
+	}
+}
+
+// TestAnOverdueTaskIsDueRatherThanPlanned separates the two seller buckets.
+//
+// Without it the partition still sums and every other assertion here still
+// passes while `due_today` is dead: an overdue task falls through to `planned`,
+// the four figures add up, and the sentence tells a rep nothing is due while a
+// deadline sits in their queue. Found by mutation — removing the due arm broke
+// no test until this one existed.
+func TestAnOverdueTaskIsDueRatherThanPlanned(t *testing.T) {
+	t.Parallel()
+	overdue := true
+	buckets := crmcontracts.WorklistBuckets{}
+	task := ranked{item: crmcontracts.WorklistItem{
+		Source:  crmcontracts.WorklistItemSourceTask,
+		Level:   levelAgreed,
+		Overdue: &overdue,
+	}}
+	bucketOf(task, levelAgreed, &buckets)
+	if buckets.DueToday != 1 {
+		t.Errorf("an overdue task reached %+v, want it counted as due today", buckets)
+	}
+	if buckets.Planned != 0 {
+		t.Error("an overdue task was counted as planned, so the sentence says nothing is due")
+	}
+	// And the same task without the deadline is planned, which is what makes
+	// the assertion above about the DEADLINE rather than about the source.
+	fresh := crmcontracts.WorklistBuckets{}
+	bucketOf(ranked{item: crmcontracts.WorklistItem{
+		Source: crmcontracts.WorklistItemSourceTask,
+		Level:  levelAgreed,
+	}}, levelAgreed, &fresh)
+	if fresh.Planned != 1 {
+		t.Errorf("a task with no deadline reached %+v, want planned", fresh)
+	}
+}
+
+// mixedDestinationsDay is a day holding both seller work and judgements, so a
+// partition over it can be told from a single bucket.
+//
+// The approvals are what make the fixture worth having: a day of tasks alone
+// sums correctly under any classifier, including one that sends every row to
+// the same place.
+func mixedDestinationsDay() crmcontracts.Attention {
+	return crmcontracts.Attention{
+		AsOf: rankInstant,
+		Planned: []crmcontracts.AttentionItem{
+			item("task-soon", "task", withDue(rankInstant.Add(time.Hour))),
+			item("task-later", "task", withDue(rankInstant.Add(48*time.Hour))),
+		},
+		NeedsYou: []crmcontracts.AttentionItem{
+			item("approval-one", "approval"),
+			item("approval-two", "approval"),
+		},
+	}
+}

--- a/backend/internal/compose/attention/worklistbuckets_test.go
+++ b/backend/internal/compose/attention/worklistbuckets_test.go
@@ -42,6 +42,21 @@ func TestTheBucketsPartitionTheDay(t *testing.T) {
 	if buckets.Urgent+buckets.DueToday+buckets.Planned == 0 {
 		t.Error("no row reached a seller bucket, so this fixture cannot tell a partition from a single bucket")
 	}
+	// And the fixture's own rows reach the buckets they belong in. Asserting
+	// only the sum let a row bound for `due_today` land in `planned` and go
+	// unnoticed: the four figures still added up, because a partition that puts
+	// a row in the wrong bucket is still a partition.
+	if buckets.DueToday != 1 {
+		t.Errorf("the day holds one task with a clock and %d reached due_today: %+v",
+			buckets.DueToday, *buckets)
+	}
+	if buckets.Planned != 1 {
+		t.Errorf("the day holds one task with no clock and %d reached planned: %+v",
+			buckets.Planned, *buckets)
+	}
+	if buckets.Review != 2 {
+		t.Errorf("the day holds two approvals and %d reached review: %+v", buckets.Review, *buckets)
+	}
 }
 
 // TestAJudgementIsNeverUrgentSellerWork holds the precedence's leading arm.
@@ -169,8 +184,12 @@ func mixedDestinationsDay() crmcontracts.Attention {
 	return crmcontracts.Attention{
 		AsOf: rankInstant,
 		Planned: []crmcontracts.AttentionItem{
-			item("task-soon", "task", withDue(rankInstant.Add(time.Hour))),
-			item("task-later", "task", withDue(rankInstant.Add(48*time.Hour))),
+			// A clock inside the day, and one with no clock at all. Both are
+			// seller work, and they must reach DIFFERENT buckets — a fixture
+			// where every seller row carried a deadline could not tell
+			// `due_today` from `planned`.
+			item("task-due", "task", withDue(rankInstant.Add(time.Hour))),
+			item("task-someday", "task"),
 		},
 		NeedsYou: []crmcontracts.AttentionItem{
 			item("approval-one", "approval"),

--- a/backend/internal/compose/attention/worklistbuckets_test.go
+++ b/backend/internal/compose/attention/worklistbuckets_test.go
@@ -124,6 +124,41 @@ func TestAnOverdueTaskIsDueRatherThanPlanned(t *testing.T) {
 	}
 }
 
+// TestAPinnedRowIsCountedAtWhatItMeans holds the partition to the same rule the
+// figure beside it keeps.
+//
+// A pin sorts a row to the top by overwriting its level, and `urgent` beside
+// this reads the SEMANTIC level for exactly that reason: a rep pinning hygiene
+// to the top of their morning has not made somebody wait. The buckets are drawn
+// in the same sentence, so a pin that moved `urgent` there and not here would
+// make the sentence disagree with itself — and the two figures are computed in
+// one loop, so nothing else would notice.
+func TestAPinnedRowIsCountedAtWhatItMeans(t *testing.T) {
+	t.Parallel()
+	hygiene := ranked{
+		item: crmcontracts.WorklistItem{
+			Source: crmcontracts.WorklistItemSourceTask,
+			// What the pin overwrote it with: the sort level.
+			Level: levelPinned,
+		},
+		pinned:        true,
+		semanticLevel: levelRoutine,
+	}
+	summary := summarize([]ranked{hygiene}, materialBar{})
+
+	if summary.Buckets == nil {
+		t.Fatal("the summary carries no buckets")
+	}
+	if summary.Buckets.Urgent != 0 {
+		t.Errorf("a pinned piece of hygiene was counted urgent in the partition: %+v", *summary.Buckets)
+	}
+	// And the two halves of the one sentence agree about it.
+	if summary.Urgent != summary.Buckets.Urgent {
+		t.Errorf("the sentence says %d urgent beside %d urgent in its own partition",
+			summary.Urgent, summary.Buckets.Urgent)
+	}
+}
+
 // mixedDestinationsDay is a day holding both seller work and judgements, so a
 // partition over it can be told from a single bucket.
 //

--- a/backend/internal/compose/attention/worklistincidents_test.go
+++ b/backend/internal/compose/attention/worklistincidents_test.go
@@ -249,3 +249,54 @@ func TestAnIncidentGroupIsDrawnFromTheRulesNameNotItsIdentity(t *testing.T) {
 		t.Fatalf("the group is named %q, want the rule's own name", *got[0].Batch.Label)
 	}
 }
+
+// A group belongs to ONE screen, and rows that would sit on different ones do
+// not fold however alike they read.
+//
+// The system CATEGORY spans destinations — a stopped mailbox is an
+// administrator's job, a notice is a judgement, a bounce is a seller's
+// customer — so grouping by a shared condition can reach across them. Folding
+// there would take a row off the screen that counts it and hide it under a
+// heading that means something else, with nothing left on the page to notice.
+// The members go back as themselves instead: more rows, nothing lost.
+func TestRowsBoundForDifferentScreensDoNotFold(t *testing.T) {
+	cause := "sync_failing"
+	mixed := []ranked{
+		systemRowWithCause("notice", "one", cause),
+		systemRowWithCause("capture_health", "two", cause),
+		systemRowWithCause("capture_health", "three", cause),
+	}
+	// The fixture has to be foldable but for the destination, or this test
+	// passes on a floor it never reached.
+	if len(mixed) < batchFloor {
+		t.Fatalf("the fixture holds %d rows, below the fold floor of %d", len(mixed), batchFloor)
+	}
+	alike := []ranked{
+		systemRowWithCause("capture_health", "one", cause),
+		systemRowWithCause("capture_health", "two", cause),
+		systemRowWithCause("capture_health", "three", cause),
+	}
+	if folded := foldRoutineDecisions(alike); len(folded) != 1 {
+		t.Fatalf("three rows of one screen drew %d rows, so this fixture cannot show a refusal", len(folded))
+	}
+
+	got := foldRoutineDecisions(mixed)
+
+	if len(got) != len(mixed) {
+		t.Fatalf("rows bound for different screens folded into %d rows: a judgement and a broken "+
+			"mailbox were counted as one thing", len(got))
+	}
+	for _, row := range got {
+		if row.item.Batch != nil {
+			t.Error("a mixed group produced a batch row")
+		}
+	}
+}
+
+// systemRowWithCause is one system row naming a shared condition, built through
+// the classifier production uses so the fold sees the shape it really gets.
+func systemRowWithCause(source crmcontracts.AttentionItemSource, id, cause string) ranked {
+	at := item(fmt.Sprintf("%s-%s", source, id), source)
+	at.CauseRef = &cause
+	return classifySystem(at, rankInstant)
+}

--- a/backend/internal/compose/attention/worklistincidents_test.go
+++ b/backend/internal/compose/attention/worklistincidents_test.go
@@ -260,11 +260,10 @@ func TestAnIncidentGroupIsDrawnFromTheRulesNameNotItsIdentity(t *testing.T) {
 // heading that means something else, with nothing left on the page to notice.
 // The members go back as themselves instead: more rows, nothing lost.
 func TestRowsBoundForDifferentScreensDoNotFold(t *testing.T) {
-	cause := "sync_failing"
 	mixed := []ranked{
-		systemRowWithCause("notice", "one", cause),
-		systemRowWithCause("capture_health", "two", cause),
-		systemRowWithCause("capture_health", "three", cause),
+		systemRowWithCause("notice", "one"),
+		systemRowWithCause("capture_health", "two"),
+		systemRowWithCause("capture_health", "three"),
 	}
 	// The fixture has to be foldable but for the destination, or this test
 	// passes on a floor it never reached.
@@ -272,9 +271,9 @@ func TestRowsBoundForDifferentScreensDoNotFold(t *testing.T) {
 		t.Fatalf("the fixture holds %d rows, below the fold floor of %d", len(mixed), batchFloor)
 	}
 	alike := []ranked{
-		systemRowWithCause("capture_health", "one", cause),
-		systemRowWithCause("capture_health", "two", cause),
-		systemRowWithCause("capture_health", "three", cause),
+		systemRowWithCause("capture_health", "one"),
+		systemRowWithCause("capture_health", "two"),
+		systemRowWithCause("capture_health", "three"),
 	}
 	if folded := foldRoutineDecisions(alike); len(folded) != 1 {
 		t.Fatalf("three rows of one screen drew %d rows, so this fixture cannot show a refusal", len(folded))
@@ -295,7 +294,12 @@ func TestRowsBoundForDifferentScreensDoNotFold(t *testing.T) {
 
 // systemRowWithCause is one system row naming a shared condition, built through
 // the classifier production uses so the fold sees the shape it really gets.
-func systemRowWithCause(source crmcontracts.AttentionItemSource, id, cause string) ranked {
+//
+// ONE condition for every caller, because that is what makes the rows foldable:
+// the fold groups on the cause, so a test about what happens WITHIN a group
+// needs its rows to reach one.
+func systemRowWithCause(source crmcontracts.AttentionItemSource, id string) ranked {
+	cause := "sync_failing"
 	at := item(fmt.Sprintf("%s-%s", source, id), source)
 	at.CauseRef = &cause
 	return classifySystem(at, rankInstant)

--- a/backend/internal/compose/attention/worklistsummary.go
+++ b/backend/internal/compose/attention/worklistsummary.go
@@ -32,6 +32,9 @@ func summarize(rows []ranked, bar materialBar) crmcontracts.WorklistSummary {
 	// server does not answer that".
 	inPlay := 0
 	summary := crmcontracts.WorklistSummary{Total: len(rows), InPlay: &inPlay}
+	// The partition, counted in the same walk as the four signals beside it so
+	// the two cannot be taken over different populations.
+	buckets := crmcontracts.WorklistBuckets{}
 	bar.stateOn(&summary)
 	for _, row := range rows {
 		item := row.item
@@ -63,6 +66,38 @@ func summarize(rows []ranked, bar materialBar) crmcontracts.WorklistSummary {
 		if item.Overdue != nil && *item.Overdue {
 			summary.Due++
 		}
+		bucketOf(row, level, &buckets)
 	}
+	summary.Buckets = &buckets
 	return summary
+}
+
+// bucketOf puts one row in exactly one bucket.
+//
+// A PRECEDENCE, not four tests. The figures beside it ask four independent
+// questions about the day and deliberately double-count — an overdue promise is
+// both urgent and due. These four slice the day instead, so the first arm that
+// matches takes the row and the four sum to `total`. Written as one switch
+// because that is the shape the property needs: no row can fall through, and no
+// row can be taken twice.
+//
+// DESTINATION LEADS, because "is this seller work" outranks "how soon". A
+// duplicate pair somebody must judge is not urgent seller work however long it
+// has waited, and counting it as urgent would put it in a sentence a rep reads
+// as their morning.
+//
+// Held by TestTheBucketsPartitionTheDay.
+func bucketOf(row ranked, level int, buckets *crmcontracts.WorklistBuckets) {
+	if destinationOf(row) != destinationToday {
+		buckets.Review++
+		return
+	}
+	switch {
+	case level <= levelPromise:
+		buckets.Urgent++
+	case row.item.Overdue != nil && *row.item.Overdue:
+		buckets.DueToday++
+	default:
+		buckets.Planned++
+	}
 }

--- a/backend/internal/compose/attention/worklistsummary.go
+++ b/backend/internal/compose/attention/worklistsummary.go
@@ -95,9 +95,30 @@ func bucketOf(row ranked, level int, buckets *crmcontracts.WorklistBuckets) {
 	switch {
 	case level <= levelPromise:
 		buckets.Urgent++
-	case row.item.Overdue != nil && *row.item.Overdue:
+	case dueToday(row):
 		buckets.DueToday++
 	default:
 		buckets.Planned++
 	}
+}
+
+// dueToday is whether this row's clock runs out before the day does.
+//
+// The DEADLINE, not the overdue flag. Reading `overdue` alone answered the
+// bucket's own name wrongly in the direction that hurts: a task due at 14:00 is
+// not yet overdue, so it fell into `planned`, and the sentence told a rep
+// nothing was due today while a deadline sat in their afternoon.
+//
+// A non-zero deadline is enough, and that is a fact about the assembly rather
+// than a shortcut. Every due-dated lane is read to `endOfDay` — one instant,
+// resolved once per assembly in the installation's own timezone — so a row that
+// reached this queue carrying a deadline has a deadline inside today. Asking
+// the boundary again here would need a context and a second resolution, and two
+// resolutions of one fact are how one lane gets yesterday's midnight and the
+// next gets today's inside a single response.
+func dueToday(row ranked) bool {
+	if !row.deadlineAt.IsZero() {
+		return true
+	}
+	return row.item.Overdue != nil && *row.item.Overdue
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13324,6 +13324,30 @@ func (e WorklistItemConsequence) Valid() bool {
 	}
 }
 
+// Defines values for WorklistItemDestination.
+const (
+	WorklistDestinationReceipt      WorklistItemDestination = "receipt"
+	WorklistDestinationReview       WorklistItemDestination = "review"
+	WorklistDestinationSystemHealth WorklistItemDestination = "system_health"
+	WorklistDestinationToday        WorklistItemDestination = "today"
+)
+
+// Valid indicates whether the value is a known member of the WorklistItemDestination enum.
+func (e WorklistItemDestination) Valid() bool {
+	switch e {
+	case WorklistDestinationReceipt:
+		return true
+	case WorklistDestinationReview:
+		return true
+	case WorklistDestinationSystemHealth:
+		return true
+	case WorklistDestinationToday:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistItemDispositions.
 const (
 	WorklistDispositionNotMine  WorklistItemDispositions = "not_mine"
@@ -32565,6 +32589,13 @@ type Worklist struct {
 	// `due` is asked of every item whatever its level, so an overdue promise counts in
 	// both `urgent` and `due` — deliberately, because a reader wants both answers about
 	// it. Read them as four questions about one day rather than four slices of it.
+	//
+	// `buckets` IS the partition, and it is the one to render an additive sentence from.
+	// The figures above it answer four questions about the day; the four inside it slice
+	// that day into parts that sum to `total`. Both are sent because both are wanted: a
+	// reader asking "how much is overdue" wants `due` counted across every level, and a
+	// reader reading "3 urgent · 5 due today · 4 planned · 5 review — 17 total" needs the
+	// parts to add up to the whole they are shown beside.
 	Summary WorklistSummary `json:"summary"`
 }
 
@@ -32659,6 +32690,32 @@ type WorklistBatch struct {
 // is broken, and repeating it eight times is aggregation failure rather than
 // urgency.
 type WorklistBatchKey string
+
+// WorklistBuckets The day cut into four parts that SUM TO `total`. Every candidate the read weighed
+// lands in exactly one of them.
+//
+// The order below is the order they are read in, and it is a precedence rather than a
+// set of independent tests: an overdue promise is urgent, not due-today, because the
+// first arm that matches takes the row. Without a precedence the same item would be
+// counted twice and the sentence would add up to more than the day holds.
+//
+// `review` is every row whose `destination` is not `today` — a judgement to make, a
+// source to restore, a receipt to read. It is counted from that field rather than from
+// the source, so the sentence and the screens cannot disagree about which rows are
+// seller work.
+type WorklistBuckets struct {
+	// DueToday Seller work not already counted urgent, carrying a date that has arrived or passed, or falling due before this installation day ends.
+	DueToday int `json:"due_today"`
+
+	// Planned The rest of the seller work: a task to do, a meeting to prepare, a lead to reach, a deal drifting below the material bar.
+	Planned int `json:"planned"`
+
+	// Review Everything that is not seller work — the `review`, `system_health` and `receipt` destinations together, because the one line above the queue says how much is waiting on judgement rather than which of the three kinds it is.
+	Review int `json:"review"`
+
+	// Urgent Seller work at the top two levels: somebody is waiting, or a promise is breaking. The same rule as the sibling `urgent`, narrowed to `today` rows.
+	Urgent int `json:"urgent"`
+}
 
 // WorklistComparison The first tie-break at which this item beat the one below it, with both sides'
 // values — so a row can say "above the next because it closes sooner" instead of
@@ -32827,6 +32884,21 @@ type WorklistItem struct {
 	// risk-adjusted figure the API does not compute.
 	Deal *WorklistDealFacts `json:"deal,omitempty"`
 
+	// Destination Which SCREEN this row belongs on. The server decides it once, and every count,
+	// fold and page in this response is computed from the same value the row carries,
+	// so a client that groups by it cannot disagree with the figures above it.
+	//
+	// `today` is work a seller executes. `review` is a judgement somebody must make
+	// before work continues — an approval, a duplicate pair, an introduction.
+	// `system_health` is a source or automation an administrator must restore.
+	// `receipt` is completed work, reported so the reader can see it happened.
+	//
+	// A CLIENT NEVER DERIVES THIS. It is not a function of `category`, `band` or
+	// `source` that a browser could recompute: two rows of one source can differ,
+	// and the mapping is a product decision that moves. A client that re-derived it
+	// would put a row on one screen while the count above it put the row on another.
+	Destination *WorklistItemDestination `json:"destination,omitempty"`
+
 	// Detail One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that
 	// stopped, what an AI task was about.
 	//
@@ -32955,6 +33027,21 @@ type WorklistItemCategory string
 // source, because one source has several honest answers: a deal past its close
 // date slips, one merely idle drifts.
 type WorklistItemConsequence string
+
+// WorklistItemDestination Which SCREEN this row belongs on. The server decides it once, and every count,
+// fold and page in this response is computed from the same value the row carries,
+// so a client that groups by it cannot disagree with the figures above it.
+//
+// `today` is work a seller executes. `review` is a judgement somebody must make
+// before work continues — an approval, a duplicate pair, an introduction.
+// `system_health` is a source or automation an administrator must restore.
+// `receipt` is completed work, reported so the reader can see it happened.
+//
+// A CLIENT NEVER DERIVES THIS. It is not a function of `category`, `band` or
+// `source` that a browser could recompute: two rows of one source can differ,
+// and the mapping is a product decision that moves. A client that re-derived it
+// would put a row on one screen while the count above it put the row on another.
+type WorklistItemDestination string
 
 // WorklistItemDispositions defines model for WorklistItem.Dispositions.
 type WorklistItemDispositions string
@@ -33203,9 +33290,30 @@ type WorklistSourceUnavailableReason string
 // `due` is asked of every item whatever its level, so an overdue promise counts in
 // both `urgent` and `due` — deliberately, because a reader wants both answers about
 // it. Read them as four questions about one day rather than four slices of it.
+//
+// `buckets` IS the partition, and it is the one to render an additive sentence from.
+// The figures above it answer four questions about the day; the four inside it slice
+// that day into parts that sum to `total`. Both are sent because both are wanted: a
+// reader asking "how much is overdue" wants `due` counted across every level, and a
+// reader reading "3 urgent · 5 due today · 4 planned · 5 review — 17 total" needs the
+// parts to add up to the whole they are shown beside.
 type WorklistSummary struct {
 	// BaseCurrency The currency every expected-revenue figure here is converted to.
 	BaseCurrency *string `json:"base_currency,omitempty"`
+
+	// Buckets The day cut into four parts that SUM TO `total`. Every candidate the read weighed
+	// lands in exactly one of them.
+	//
+	// The order below is the order they are read in, and it is a precedence rather than a
+	// set of independent tests: an overdue promise is urgent, not due-today, because the
+	// first arm that matches takes the row. Without a precedence the same item would be
+	// counted twice and the sentence would add up to more than the day holds.
+	//
+	// `review` is every row whose `destination` is not `today` — a judgement to make, a
+	// source to restore, a receipt to read. It is counted from that field rather than from
+	// the source, so the sentence and the screens cannot disagree about which rows are
+	// seller work.
+	Buckets *WorklistBuckets `json:"buckets,omitempty"`
 
 	// Due Items carrying a date that has arrived or passed.
 	Due int `json:"due"`

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -94,7 +94,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (98)
+## Census (99)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -196,6 +196,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `uniquenessclaimscorpus_test.go` | H2 | WHERE the claim sweep looks, as against what it looks for. |
 | `validatedreplypath_test.go` | H2 | A model reply this tree can REFUSE must be asked for through the validated lane, so the refusal reaches the model that can act on it. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |
+| `worklistdestination_test.go` | H2 | Every source the worklist can emit has one screen it belongs on. |
 
 ## Reachability (16)
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28964,6 +28964,13 @@ export interface components {
          *     `due` is asked of every item whatever its level, so an overdue promise counts in
          *     both `urgent` and `due` — deliberately, because a reader wants both answers about
          *     it. Read them as four questions about one day rather than four slices of it.
+         *
+         *     `buckets` IS the partition, and it is the one to render an additive sentence from.
+         *     The figures above it answer four questions about the day; the four inside it slice
+         *     that day into parts that sum to `total`. Both are sent because both are wanted: a
+         *     reader asking "how much is overdue" wants `due` counted across every level, and a
+         *     reader reading "3 urgent · 5 due today · 4 planned · 5 review — 17 total" needs the
+         *     parts to add up to the whole they are shown beside.
          */
         WorklistSummary: {
             /** @description Items at the top two levels: somebody is waiting, or a promise is breaking. */
@@ -28983,6 +28990,7 @@ export interface components {
             lower_priority: number;
             /** @description How many candidates the day holds. The same population the per-category `considered` figures are counted over, so the two agree. */
             total: number;
+            buckets?: components["schemas"]["WorklistBuckets"];
             /**
              * Format: int64
              * @description The expected-revenue bar a deal must clear to count as material, in the
@@ -28993,6 +29001,30 @@ export interface components {
             material_threshold_minor?: number | null;
             /** @description The currency every expected-revenue figure here is converted to. */
             base_currency?: string | null;
+        };
+        /**
+         * @description The day cut into four parts that SUM TO `total`. Every candidate the read weighed
+         *     lands in exactly one of them.
+         *
+         *     The order below is the order they are read in, and it is a precedence rather than a
+         *     set of independent tests: an overdue promise is urgent, not due-today, because the
+         *     first arm that matches takes the row. Without a precedence the same item would be
+         *     counted twice and the sentence would add up to more than the day holds.
+         *
+         *     `review` is every row whose `destination` is not `today` — a judgement to make, a
+         *     source to restore, a receipt to read. It is counted from that field rather than from
+         *     the source, so the sentence and the screens cannot disagree about which rows are
+         *     seller work.
+         */
+        WorklistBuckets: {
+            /** @description Seller work at the top two levels: somebody is waiting, or a promise is breaking. The same rule as the sibling `urgent`, narrowed to `today` rows. */
+            urgent: number;
+            /** @description Seller work not already counted urgent, carrying a date that has arrived or passed, or falling due before this installation day ends. */
+            due_today: number;
+            /** @description The rest of the seller work: a task to do, a meeting to prepare, a lead to reach, a deal drifting below the material bar. */
+            planned: number;
+            /** @description Everything that is not seller work — the `review`, `system_health` and `receipt` destinations together, because the one line above the queue says how much is waiting on judgement rather than which of the three kinds it is. */
+            review: number;
         };
         /**
          * @description The day's four OUTCOME figures, for the strip above the queue: what money is
@@ -29252,6 +29284,23 @@ export interface components {
              * @enum {string}
              */
             category: "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
+            /**
+             * @description Which SCREEN this row belongs on. The server decides it once, and every count,
+             *     fold and page in this response is computed from the same value the row carries,
+             *     so a client that groups by it cannot disagree with the figures above it.
+             *
+             *     `today` is work a seller executes. `review` is a judgement somebody must make
+             *     before work continues — an approval, a duplicate pair, an introduction.
+             *     `system_health` is a source or automation an administrator must restore.
+             *     `receipt` is completed work, reported so the reader can see it happened.
+             *
+             *     A CLIENT NEVER DERIVES THIS. It is not a function of `category`, `band` or
+             *     `source` that a browser could recompute: two rows of one source can differ,
+             *     and the mapping is a product decision that moves. A client that re-derived it
+             *     would put a row on one screen while the count above it put the row on another.
+             * @enum {string}
+             */
+            destination?: "today" | "review" | "system_health" | "receipt";
             /**
              * @description The hard priority band, and the whole of the product rule: 0 pinned by the
              *     reader, 1 a customer waiting or a deadline arriving, 2 a promise due or an


### PR DESCRIPTION
## What this changes

A worklist row now says which **screen** it belongs on, and the line above the queue gets a partition that adds up.

The queue mixed three jobs in one list. A buyer waiting on a reply is work a seller executes; a duplicate pair is a judgement somebody makes before work continues; a stopped mailbox is a source an administrator restores. Under one vocabulary a rep scanning for their next call stepped over the product's own housekeeping to find it, and the count above the queue added all three together.

**`WorklistItem.destination`** — `today` | `review` | `system_health` | `receipt`. The server decides it once, and every count, fold and page in the response reads the value the row carries, so a client that groups by it cannot disagree with the figures above it. A client never derives this: it is not a function of `category`, `band` or `source` that a browser could recompute, and a second spelling would put a row on one screen while the count above it said another.

**`WorklistSummary.buckets`** — the partition the additive sentence needs. The four figures beside it ask independent questions about the day and deliberately double-count an overdue promise; these four slice it, so `3 urgent · 5 due today · 4 planned · 5 review — 17 total` adds up. Destination leads the precedence: an approval that has waited is not a seller's morning however long it has waited.

Both fields are additive and optional. Every existing field keeps its meaning.

**The fold now refuses mixed groups.** The `system` category spans destinations — a stopped mailbox is an administrator's job, a notice is a judgement, a bounce is a seller's customer — so grouping by a shared condition could reach across them. Folding there would take a row off the screen that counts it and hide it under a heading that means something else, with nothing left on the page to notice.

## Why the census cannot fail short

The gate's corpus is `crm.yaml`'s own source enum, read at test time; the classified set is the map's own keys. Neither side is a list repeated in the test. A twenty-second source appears in the gate the moment it appears in the contract and fails it until somebody decides where it belongs. `batch` is deliberately unmapped — it stands for a group, so its screen is its members' — and the gate fails in that direction too.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestTheBucketsPartitionTheDay` — the four figures sum to `total` over a day holding both seller work and judgements |
| Contract | `make gen` + `cd frontend && pnpm gen:api` in the same commit; drift and breaking-change gates green; both fields optional |
| Census exhaustiveness | `TestEveryWorklistSourceHasADestination`, `TestEveryDestinationIsOneTheContractDeclares` — corpus read from `crm.yaml`, fails in both directions |
| Mutation strength | Four clauses reverted one at a time, each watched failing: destination precedence arm → `TestAJudgementIsNeverUrgentSellerWork`; `due_today` arm → `TestAnOverdueTaskIsDueRatherThanPlanned`; `sameDestination` fold refusal → `TestRowsBoundForDifferentScreensDoNotFold`; pin-corrected level → `TestAPinnedRowIsCountedAtWhatItMeans`; one source dropped from the map → the census |
| Full lane | `make check-backend` and `make check-fe` both green |

**One mutation survived and produced a test.** Deleting the `due_today` arm broke nothing: every bucket test still passed, because no fixture held an overdue seller row that was not already urgent. An overdue task fell through to `planned`, the four figures still summed, and the sentence would have told a rep nothing was due while a deadline sat in their queue. `TestAnOverdueTaskIsDueRatherThanPlanned` now fails on it, and asserts the same task without a deadline is planned — so it is about the deadline rather than the source.

## Not in this PR

No client reads `destination` yet; the screens that consume it are PR 2. Nothing produces `receipt` until the receipts PR — the constant is declared by the contract and unused by the server, deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives each worklist row a `destination` — `today`, `review`, `system_health`, or `receipt` — decided once by the server, so a client grouping by screen cannot disagree with the counts above the queue. Adds `WorklistSummary.buckets`, a four-way partition of the day that sums to `total`, replacing the old mixed count that lumped seller work, judgements, and system incidents together.

- The fold now refuses to group rows bound for different screens; mixed rows go back ungrouped.
- A census gate holds the source→destination map exhaustive against `crm.yaml`'s own enum, cross-checked against the generated constants; `batch` is deliberately unmapped because its screen is its members'.
- `due_today` counts by deadline inside the day, not the overdue flag alone; `failed_approval` and `notice` moved to `today`.
- Both new fields are optional and additive, so existing clients keep working.
- No client reads `destination` yet, and nothing produces `receipt` until later PRs.

<sup>Written for commit 9d7401aaafe9bc54f8079937d2db3a7aacae6678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Worklists now include mutually exclusive buckets for urgent items, items due today, planned work, and items needing review.
  - Worklist rows now indicate their destination: Today, Review, System Health, or Receipt.

- **Improvements**
  - Routine work is grouped only when items share the same destination, keeping related work on the appropriate screen.
  - Worklist counts now consistently reflect urgency, overdue status, due dates, and planned work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->