### PR TITLE
An inbound message opens a window, not a standing permission

### DIFF
--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -132,7 +132,13 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 			WithSubjectAccessAssembler(newSubjectAccessAssembler(InstallationDB(pool))).
 			WithInstallationName(consent.InstallationNameFunc(func(ctx context.Context) (string, error) {
 				return identity.InstallationNameForPublicPage(ctx, pool)
-			})),
+			})).
+			// The guard endpoint previews the same verdict the send path
+			// takes, so it resolves the same jurisdiction windows. Without
+			// this it would answer on the core defaults while a pack shortened
+			// the real ones, and tell a rep a send is allowed that the engine
+			// then refuses.
+			WithInstallationCountry(consent.InstallationCountryFunc(identity.CountryOf)),
 		collectionsHandlers: newCollectionsHandlers(pool),
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by people; injected through the adapter below so

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -65,7 +65,7 @@ func newPeopleHandlers(pool *pgxpool.Pool) peopleHandlers {
 // modules its inbound and outbound edges need.
 func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
 	return activities.NewHandlers(InstallationDB(pool)).
-		WithConsent(consent.NewGate(consent.NewStore(InstallationDB(pool)))).
+		WithConsent(consentGateFor(pool)).
 		// The public booking capture seams (feedback/14): people is the
 		// idempotent-on-email person path, consent records the
 		// passthrough — both injected here, never sibling imports.

--- a/backend/internal/modules/consent/authorizecap.go
+++ b/backend/internal/modules/consent/authorizecap.go
@@ -53,7 +53,7 @@ const capLockNamespace = int64(0x636d7361) << 32 // "cmsa"
 // held, sorted, before the first count, and a per-recipient lock taken inside
 // the decide loop would order them by the caller's To list.
 func (g *Gate) lockCapAddresses(ctx context.Context, tx pgx.Tx, recipients []connector.Recipient) error {
-	rules, applicable, err := g.applicableRules(ctx, tx)
+	rules, applicable, err := g.store.applicableRules(ctx, tx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.De
 		// rule — stated here because silence would read as an oversight.
 		return d, nil
 	}
-	rules, applicable, err := g.applicableRules(ctx, tx)
+	rules, applicable, err := g.store.applicableRules(ctx, tx)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
@@ -246,8 +246,8 @@ func advertisingMessagesReceived(ctx context.Context, tx pgx.Tx, address string,
 // a jurisdiction's own number and there is no universal one to fall back to.
 // The consent requirement that DOES bind everywhere is enforced by the marketing
 // verdict itself, which runs before this and does not depend on a pack.
-func (g *Gate) applicableRules(ctx context.Context, tx pgx.Tx) (messagingrules.Rules, bool, error) {
-	code, err := g.installationCountry(ctx, tx)
+func (s *Store) applicableRules(ctx context.Context, tx pgx.Tx) (messagingrules.Rules, bool, error) {
+	code, err := s.installationCountry(ctx, tx)
 	if err != nil {
 		return messagingrules.Rules{}, false, err
 	}

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -13,6 +13,7 @@ package consent
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -45,7 +46,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 		// separation staging established. Transmit still re-checks the
 		// evidence; what it does not do is write a second, weaker record of it.
 		if phase == commsauthz.PhaseStaging {
-			w, err := g.windowsFor(ctx, tx)
+			w, err := g.store.windowsFor(ctx, tx)
 			if err != nil {
 				return commsauthz.Decision{}, err
 			}
@@ -86,7 +87,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 	// TestAnUnsupportedClaimIsRecordedButNeverResolvedTo, which is what that
 	// test's own comment records.
 	d.Requested = res.Category
-	return legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, res, d)
+	return g.legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, res, d)
 }
 
 // legacyVerdictFor answers on the old purpose model when the record supports no
@@ -97,7 +98,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 // answering with one body of code about one person. A second implementation
 // here would be a second answer, and the one that stopped matching would look
 // exactly like the one that still did.
-func legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey string, res resolution, d commsauthz.Decision) (commsauthz.Decision, error) {
+func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey string, res resolution, d commsauthz.Decision) (commsauthz.Decision, error) {
 	purpose, defined, err := purposeRowFor(ctx, tx, purposeKey)
 	if err != nil {
 		return commsauthz.Decision{}, err
@@ -117,7 +118,11 @@ func legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey strin
 	// (the supported arm) is covered only by the first.
 	d.Resolved = resolutionForClass(purpose.Class).Category
 
-	verdict, err := VerdictForPerson(ctx, tx, personID, purpose)
+	w, err := g.store.windowsFor(ctx, tx)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, time.Now().Add(-w.reply))
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}

--- a/backend/internal/modules/consent/authorizeresolve.go
+++ b/backend/internal/modules/consent/authorizeresolve.go
@@ -123,7 +123,7 @@ func (g *Gate) resolveFromClaimAndPurpose(ctx context.Context, tx pgx.Tx, req co
 				Reason:    commsauthz.ReasonUnknownPurpose,
 			}, nil
 		}
-		w, err := g.windowsFor(ctx, tx)
+		w, err := g.store.windowsFor(ctx, tx)
 		if err != nil {
 			return resolution{}, err
 		}

--- a/backend/internal/modules/consent/authorizewindows.go
+++ b/backend/internal/modules/consent/authorizewindows.go
@@ -54,9 +54,9 @@ type windows struct {
 // country stated should behave exactly as it did before jurisdiction packs
 // existed, rather than losing the ability to follow up because nobody has
 // filled in a setting.
-func (g *Gate) windowsFor(ctx context.Context, tx pgx.Tx) (windows, error) {
+func (s *Store) windowsFor(ctx context.Context, tx pgx.Tx) (windows, error) {
 	out := windows{reply: defaultReplyWindow, dealFollow: defaultDealFollowUpWindow}
-	rules, applicable, err := g.applicableRules(ctx, tx)
+	rules, applicable, err := s.applicableRules(ctx, tx)
 	if err != nil {
 		return windows{}, err
 	}

--- a/backend/internal/modules/consent/correspondenceconsent_integration_test.go
+++ b/backend/internal/modules/consent/correspondenceconsent_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -126,5 +127,139 @@ func TestTheTimelineStillAnswersForSomebodyWhoNeverSaid(t *testing.T) {
 	}
 	if after.Qualifying == nil || after.Qualifying.Kind != "in_person" {
 		t.Errorf("the verdict cites %+v, want the in-person exchange", after.Qualifying)
+	}
+}
+
+// TestAnInboundStopsAuthorizingWhenItLapses is the rule Lars chose: an inbound
+// message opens broader contact for a bounded window, then it lapses back to
+// needing its own reason.
+//
+// It used to open everything, permanently. A person who asked one question in
+// 2024 authorized unrelated outreach in 2026, because the arm read "is there
+// any inbound from them" with no bound at all — which is not what the
+// relationship they started actually says.
+//
+// What this does NOT touch is a reply. resolveCategory answers
+// CategoryReplyToInbound from the anchor thread before the legacy verdict is
+// consulted, so a rep answering a two-year-old thread is unaffected.
+//
+// Mutation: drop `occurred_at >= $2` from inboundQualifyingEvent and the
+// lapsed case allows, failing the second assertion.
+func TestAnInboundStopsAuthorizingWhenItLapses(t *testing.T) {
+	e := setupQualifying(t)
+
+	fresh := time.Now().Add(-30 * 24 * time.Hour)
+	e.inbound(t, fresh)
+
+	within := e.verdictSince(t, time.Now().Add(-defaultReplyWindow))
+	if within.State != VerdictAllowed {
+		t.Fatalf("a month-old inbound = %q (%s), want allowed — the window is twelve months",
+			within.State, within.Reason)
+	}
+
+	// The SAME row, judged from a window that has moved past it. Nothing about
+	// the record changed; only how far back the rule is willing to look.
+	lapsed := e.verdictSince(t, fresh.Add(24*time.Hour))
+	if lapsed.State != VerdictUnknown {
+		t.Fatalf("an inbound older than the window = %q (%s), want unknown — a lapsed contact is not standing permission",
+			lapsed.State, lapsed.Reason)
+	}
+}
+
+// TestARecordedExchangeLapsesToo holds the other source to the same rule.
+//
+// The typed row and the derived inbound are two spellings of "something on
+// file says we may write to them", and a window that bound only one of them
+// would leave a two-year-old trade-fair note authorizing today's cold mail
+// while a two-year-old email did not.
+//
+// Mutation: drop `occurred_at >= $2` from recordedQualifyingEvent and this
+// fails while TestAnInboundStopsAuthorizingWhenItLapses still passes, which is
+// what makes it a separate test rather than a second assertion.
+func TestARecordedExchangeLapsesToo(t *testing.T) {
+	e := setupQualifying(t)
+
+	met := time.Now().Add(-60 * 24 * time.Hour).Truncate(time.Second)
+	if _, err := e.store.RecordQualifyingEvent(e.ctx, e.person, RecordQualifyingEventInput{
+		Kind:       "in_person",
+		Note:       "Met at the Frankfurt trade fair, stand B12.",
+		OccurredAt: met,
+	}); err != nil {
+		t.Fatalf("recording the exchange: %v", err)
+	}
+
+	if within := e.verdictSince(t, time.Now().Add(-defaultReplyWindow)); within.State != VerdictAllowed {
+		t.Fatalf("a two-month-old exchange = %q, want allowed", within.State)
+	}
+	if lapsed := e.verdictSince(t, met.Add(24*time.Hour)); lapsed.State != VerdictUnknown {
+		t.Fatalf("an exchange older than the window = %q (%s), want unknown",
+			lapsed.State, lapsed.Reason)
+	}
+}
+
+// TestAnExplicitYesOutlivesTheWindow is the direction the window must not
+// break. A recorded grant is the subject's own answer about being written to,
+// and it does not expire because they have not been in touch lately — reading
+// it before the timeline is what #4045 fixed, and a window applied to it would
+// undo that fix from the other side.
+//
+// Mutation: move the recordedState branch below latestQualifyingEvent in
+// correspondenceVerdict and this fails.
+func TestAnExplicitYesOutlivesTheWindow(t *testing.T) {
+	e := setupQualifying(t)
+
+	e.grant(t, "granted")
+
+	// A window that closed years ago. The grant is not evidence read off the
+	// timeline, so nothing here should consult it at all.
+	after := e.verdictSince(t, time.Now())
+	if after.State != VerdictAllowed {
+		t.Fatalf("an explicit yes under a closed window = %q (%s), want allowed",
+			after.State, after.Reason)
+	}
+}
+
+// TestTheGuardAnswersOnTheSameWindowAsTheSend is why the window is resolved by
+// the store rather than by each caller.
+//
+// The guard endpoint is the preview a composer shows before a rep writes
+// anything. If it read a different span than the send path binds a decision
+// to, it would tell them a message is allowed and the engine would then refuse
+// it — a preview that is wrong in the permissive direction is worse than none,
+// because the rep only finds out after writing the mail.
+//
+// The pin is that the guard reports the SAME verdict as VerdictForPerson for
+// the same person under the same window, across the lapse boundary. Mutation:
+// replace the guard's `since` with a zero time and the lapsed case reports
+// allowed while the send path says unknown, failing the second assertion.
+func TestTheGuardAnswersOnTheSameWindowAsTheSend(t *testing.T) {
+	e := setupQualifying(t)
+
+	// Old enough that the default twelve-month window has closed on it.
+	e.inbound(t, time.Now().Add(-400*24*time.Hour))
+
+	guard, err := e.store.PersonConsentGuard(e.ctx, e.person)
+	if err != nil {
+		t.Fatalf("reading the guard: %v", err)
+	}
+	var entry *crmcontracts.PersonConsentGuardEntry
+	for i := range guard.Entries {
+		if guard.Entries[i].PurposeKey == "business_correspondence" {
+			entry = &guard.Entries[i]
+		}
+	}
+	if entry == nil {
+		t.Fatal("the guard has no business_correspondence entry — the fixture's purpose is not reaching it")
+	}
+	if entry.Verdict != crmcontracts.PersonConsentGuardEntryVerdictUnknown {
+		t.Errorf("the guard reports %q for a 400-day-old inbound, want unknown; the send path refuses it, so the preview would promise a send that is then refused",
+			entry.Verdict)
+	}
+
+	// And the send path, asked directly, agrees. Both assertions together are
+	// the point: either alone would pass against a build where BOTH had lost
+	// the window.
+	if v := e.verdict(t); v.State != VerdictUnknown {
+		t.Errorf("the send path verdict on the same lapsed inbound = %q, want unknown", v.State)
 	}
 }

--- a/backend/internal/modules/consent/gate.go
+++ b/backend/internal/modules/consent/gate.go
@@ -6,6 +6,7 @@ package consent
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -20,10 +21,6 @@ import (
 // different purpose authorizes nothing.
 type Gate struct {
 	store *Store
-	// country selects which jurisdiction's messaging rules a decision is taken
-	// under. Injected by compose because the setting lives in identity
-	// (installationcountry.go).
-	country InstallationCountryReader
 }
 
 func NewGate(store *Store) *Gate {
@@ -73,8 +70,16 @@ func (g *Gate) RequireGrantedForRecipients(ctx context.Context, recipients []con
 			// Unknown purpose ⇒ nothing can be granted under it.
 			return fmt.Errorf("consent: purpose %q is not defined: %w", purposeKey, apperrors.ErrConsentNotGranted)
 		}
+		// The window a qualifying event still supports an unprompted message
+		// within, resolved once for the whole set so two recipients of one
+		// message cannot be judged against different spans.
+		w, err := g.store.windowsFor(ctx, tx)
+		if err != nil {
+			return err
+		}
+		since := time.Now().Add(-w.reply)
 		for _, r := range recipients {
-			granted, err := grantedForRecipient(ctx, tx, r, purpose)
+			granted, err := grantedForRecipient(ctx, tx, r, purpose, since)
 			if err != nil {
 				return err
 			}
@@ -106,7 +111,7 @@ func (g *Gate) RequireGrantedForRecipients(ctx context.Context, recipients []con
 // grant predicate below. A lead carries no qualifying events and no §7(3) flag
 // — those hang off a person — so for a lead the class model has nothing extra
 // to say and the recorded grant IS the whole answer.
-func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, purpose PurposeRow) (bool, error) {
+func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, purpose PurposeRow, since time.Time) (bool, error) {
 	personID, found, err := resolvePerson(ctx, tx, r)
 	if err != nil {
 		return false, err
@@ -114,7 +119,7 @@ func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 	if !found {
 		return grantedForLead(ctx, tx, r, purpose.ID, purpose.RequiresDOI)
 	}
-	verdict, err := VerdictForPerson(ctx, tx, personID, purpose)
+	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, since)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/modules/consent/guard.go
+++ b/backend/internal/modules/consent/guard.go
@@ -67,8 +67,16 @@ func (s *Store) PersonConsentGuard(ctx context.Context, personID ids.PersonID) (
 		if err != nil {
 			return err
 		}
+		// The SAME window the send path binds a decision to. A preview that
+		// answered on a different span would tell a rep a send is allowed that
+		// the engine then refuses, which is worse than no preview at all.
+		w, err := s.windowsFor(ctx, tx)
+		if err != nil {
+			return err
+		}
+		since := s.now().Add(-w.reply)
 		for _, purpose := range purposes {
-			verdict, err := VerdictForPerson(ctx, tx, personID.String(), purpose)
+			verdict, err := VerdictForPerson(ctx, tx, personID.String(), purpose, since)
 			if err != nil {
 				return err
 			}

--- a/backend/internal/modules/consent/installationcountry.go
+++ b/backend/internal/modules/consent/installationcountry.go
@@ -39,9 +39,31 @@ func (f InstallationCountryFunc) InstallationCountryTx(ctx context.Context, tx p
 }
 
 // WithInstallationCountry injects the reader behind jurisdiction resolution.
+//
+// It lands on the STORE rather than the gate because two callers need the
+// jurisdiction's windows and only one of them is a gate: the send path asks
+// through the engine, and GET /people/{id}/consent/guard asks through the
+// store. A preview that answered on a different window than the send would be
+// the second answer to one question, which is the failure this repository
+// spends most of its gates preventing.
 func (g *Gate) WithInstallationCountry(r InstallationCountryReader) *Gate {
-	g.country = r
+	g.store.country = r
 	return g
+}
+
+// WithInstallationCountry is the store-side spelling, for the surfaces that
+// hold a store and no gate.
+func (s *Store) WithInstallationCountry(r InstallationCountryReader) *Store {
+	s.country = r
+	return s
+}
+
+// WithInstallationCountry is the handlers-side spelling. The consent guard
+// endpoint reads the same windows the send path binds a decision to, so it
+// needs the same jurisdiction.
+func (h Handlers) WithInstallationCountry(r InstallationCountryReader) Handlers {
+	h.store = h.store.WithInstallationCountry(r)
+	return h
 }
 
 // installationCountry resolves the code, or empty when nothing is wired or
@@ -54,9 +76,9 @@ func (g *Gate) WithInstallationCountry(r InstallationCountryReader) *Gate {
 // is consulted — doing exactly what it did before. A reader added later that
 // RELAXES a rule on the strength of a country must not use this, because it
 // would then relax on an unstated one.
-func (g *Gate) installationCountry(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
-	if g.country == nil {
+func (s *Store) installationCountry(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
+	if s.country == nil {
 		return "", nil
 	}
-	return g.country.InstallationCountryTx(ctx, tx)
+	return s.country.InstallationCountryTx(ctx, tx)
 }

--- a/backend/internal/modules/consent/qualifyingevent_integration_test.go
+++ b/backend/internal/modules/consent/qualifyingevent_integration_test.go
@@ -29,7 +29,12 @@ import (
 )
 
 type qualifyingEnv struct {
-	store          *Store
+	store *Store
+	// owner seeds timeline rows the consent store does not own. Activities
+	// belong to another module, so there is no production writer this package
+	// can reach — the shape is copied from what capture writes, and the
+	// authorship test the derivation applies is what makes the copy honest.
+	owner          *pgx.Conn
 	ctx            context.Context
 	ws, user       ids.UUID
 	person         ids.PersonID
@@ -60,7 +65,7 @@ func setupQualifying(t *testing.T) *qualifyingEnv {
 		t.Fatal(err)
 	}
 
-	e := &qualifyingEnv{ws: ids.NewV7(), user: ids.NewV7(), person: ids.New[ids.PersonKind]()}
+	e := &qualifyingEnv{owner: owner, ws: ids.NewV7(), user: ids.NewV7(), person: ids.New[ids.PersonKind]()}
 	purposeID := ids.New[ids.PurposeKind]()
 	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, e.ws); err != nil {
 		t.Fatal(err)
@@ -111,15 +116,51 @@ func setupQualifying(t *testing.T) *qualifyingEnv {
 // verdict reads what business correspondence to this person would answer now.
 func (e *qualifyingEnv) verdict(t *testing.T) Verdict {
 	t.Helper()
+	return e.verdictSince(t, time.Now().Add(-defaultReplyWindow))
+}
+
+// verdictSince reads the verdict against an explicit window start, which is
+// what lets a test move the window rather than the clock. The row keeps its
+// real timestamp and only the rule's reach changes, so a failure is about the
+// bound under test and not about a fixture that time-travelled.
+func (e *qualifyingEnv) verdictSince(t *testing.T, since time.Time) Verdict {
+	t.Helper()
 	var out Verdict
 	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = VerdictForPerson(e.ctx, tx, e.person.String(), e.correspondence)
+		out, err = VerdictForPerson(e.ctx, tx, e.person.String(), e.correspondence, since)
 		return err
 	}); err != nil {
 		t.Fatalf("reading the verdict: %v", err)
 	}
 	return out
+}
+
+// inbound files a message the PERSON wrote, the way capture files one: an
+// activity, a link putting it on their record, and a participant row naming
+// them as the author. All three, because the derivation requires all three —
+// seeding only the link would test a shape the product never produces and pass
+// against a reader that had stopped checking authorship.
+func (e *qualifyingEnv) inbound(t *testing.T, at time.Time) {
+	t.Helper()
+	activityID := ids.NewV7()
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO activity (id, kind, direction, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'inbound', 'A question about your pricing', $2, 'capture', 'human:x')`,
+		activityID, at); err != nil {
+		t.Fatalf("seeding the inbound activity: %v", err)
+	}
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`,
+		activityID, e.person); err != nil {
+		t.Fatalf("filing the inbound activity: %v", err)
+	}
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO activity_participant (activity_id, role, person_id, address)
+		VALUES ($1, 'from', $2, 'dana@metatrade.test')`,
+		activityID, e.person); err != nil {
+		t.Fatalf("naming the author of the inbound activity: %v", err)
+	}
 }
 
 func TestAnInPersonExchangeMakesCorrespondenceLawful(t *testing.T) {

--- a/backend/internal/modules/consent/qualifyingground.go
+++ b/backend/internal/modules/consent/qualifyingground.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -35,15 +36,26 @@ import (
 // evidence, and a model that only recognised events recorded after this build
 // shipped would tell a rep they may not answer somebody who wrote to them last
 // week.
-func latestQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, eventSource, error) {
-	event, found, err := recordedQualifyingEvent(ctx, tx, personID)
+//
+// SINCE BOUNDS BOTH SOURCES, and it is the reply window
+// (authorizewindows.go). An event older than it stops supporting an unprompted
+// message: somebody who asked a question two years ago and never came back has
+// not agreed to an ongoing relationship, and treating one inbound as permanent
+// authority is what let unrelated cold outreach ride on a single old message.
+//
+// What this does NOT bound is a same-thread reply. That path never reaches
+// here — resolveCategory answers CategoryReplyToInbound from the anchor before
+// the legacy verdict is consulted — so a rep answering a months-old thread is
+// unaffected. The window governs contact the subject did not prompt.
+func latestQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string, since time.Time) (QualifyingEvent, eventSource, error) {
+	event, found, err := recordedQualifyingEvent(ctx, tx, personID, since)
 	if err != nil {
 		return QualifyingEvent{}, sourceNone, err
 	}
 	if found {
 		return event, sourceRecorded, nil
 	}
-	event, found, err = inboundQualifyingEvent(ctx, tx, personID)
+	event, found, err = inboundQualifyingEvent(ctx, tx, personID, since)
 	if err != nil {
 		return QualifyingEvent{}, sourceNone, err
 	}
@@ -111,15 +123,15 @@ func RecordDerivedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID strin
 }
 
 // recordedQualifyingEvent reads a row a human or an integration wrote.
-func recordedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
+func recordedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string, since time.Time) (QualifyingEvent, bool, error) {
 	var event QualifyingEvent
 	var sourceType, sourceID, note *string
 	err := tx.QueryRow(ctx, `
 		SELECT kind, occurred_at, source_entity_type, source_entity_id, note
 		FROM consent_qualifying_event
-		WHERE person_id = $1
+		WHERE person_id = $1 AND occurred_at >= $2
 		ORDER BY occurred_at DESC
-		LIMIT 1`, personID).Scan(&event.Kind, &event.OccurredAt, &sourceType, &sourceID, &note)
+		LIMIT 1`, personID, since).Scan(&event.Kind, &event.OccurredAt, &sourceType, &sourceID, &note)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return QualifyingEvent{}, false, nil
 	}
@@ -156,7 +168,7 @@ func recordedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (Q
 // merely received. Capture files a message under every participant it resolves
 // (capture/sinkmaillinks.go), so the link alone stopped meaning authorship the
 // moment a cc'd contact could be filed under.
-func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
+func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string, since time.Time) (QualifyingEvent, bool, error) {
 	var event QualifyingEvent
 	var activityID string
 	err := tx.QueryRow(ctx, `
@@ -166,8 +178,9 @@ func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (Qu
 		JOIN activity_participant p ON p.activity_id = a.id
 		     AND p.role = 'from' AND p.person_id = $1::uuid
 		WHERE a.direction = 'inbound' AND a.archived_at IS NULL
+		  AND a.occurred_at >= $2
 		ORDER BY a.occurred_at DESC
-		LIMIT 1`, personID).Scan(&activityID, &event.OccurredAt)
+		LIMIT 1`, personID, since).Scan(&activityID, &event.OccurredAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return QualifyingEvent{}, false, nil
 	}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -32,6 +32,10 @@ type Store struct {
 	// module never imports a sibling; nil on any installation that has not
 	// wired it, which the page renders as an omission rather than a blank.
 	installationName InstallationNameReader
+	// country selects which jurisdiction's messaging rules a decision is taken
+	// under. Injected by compose because the setting lives in identity
+	// (installationcountry.go).
+	country InstallationCountryReader
 }
 
 // NewStore binds the store to the pool every read and write runs through.

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -117,7 +117,15 @@ type PurposeRow struct {
 // direct marketing Art 21(2)–(3) is absolute — there is no balancing and no
 // override toggle, so there is no branch here that can reach past a
 // suppression.
-func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow) (Verdict, error) {
+//
+// `since` is how far back a qualifying event still supports an UNPROMPTED
+// message — the reply window, resolved by Store.windowsFor so the send path and
+// the guard endpoint answer on the same span. It is passed rather than computed
+// here because computing it needs the installation's country, and this function
+// is deliberately free of settings reads: a rep holds no settings-read grant
+// and a gated read inside the verdict would fail a send with a 500 rather than
+// an answer about consent.
+func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow, since time.Time) (Verdict, error) {
 	suppressed, at, err := objectionStands(ctx, tx, personID, purpose.ID)
 	if err != nil {
 		return Verdict{}, err
@@ -132,7 +140,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{State: VerdictAllowed, Reason: "account and contract notices need no consent"}, nil
 
 	case ClassBusinessCorrespondence:
-		return correspondenceVerdict(ctx, tx, personID, purpose)
+		return correspondenceVerdict(ctx, tx, personID, purpose, since)
 
 	case ClassPhoneOutreach:
 		// Dormant by decision: the purpose exists so the model is complete. A
@@ -161,7 +169,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 // The implied arm below is unchanged and stays second: it is the Art 6(1)(f)
 // reading of a relationship the subject started, and it is what answers for the
 // overwhelming majority of people, who never record an answer either way.
-func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow) (Verdict, error) {
+func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow, since time.Time) (Verdict, error) {
 	// requiresDOI is passed as the purpose declares it rather than as a
 	// constant false. Correspondence does not demand the round trip today, and
 	// hard-coding that here would silently ignore an installation that turned
@@ -183,7 +191,7 @@ func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purp
 			Code:   BlockUnconfirmedDOI,
 		}, nil
 	}
-	event, source, err := latestQualifyingEvent(ctx, tx, personID)
+	event, source, err := latestQualifyingEvent(ctx, tx, personID, since)
 	if err != nil {
 		return Verdict{}, err
 	}
@@ -192,7 +200,13 @@ func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purp
 		// exchange. There is nothing here to balance, so this is not the easy
 		// Art 6(1)(f) case and the honest answer is that nobody has decided.
 		return Verdict{
-			State:  VerdictUnknown,
+			State: VerdictUnknown,
+			// The reason does not distinguish "never" from "not lately", and
+			// deliberately: both mean the same thing to the rep reading it —
+			// nothing on file supports writing to this person out of the blue
+			// right now — and a message that said "their last contact has
+			// lapsed" would invite hunting for an expiry to override rather
+			// than recording why this send is lawful.
 			Reason: "they have never written to you and no deal or inquiry connects you",
 		}, nil
 	}


### PR DESCRIPTION
One email from a person used to authorize unrelated outreach to them **forever**. Somebody who asked a price in 2024 was open to a cold pitch in 2026, because the correspondence arm asked "is there any inbound from them" with no bound at all.

This is the middle of the three options put to Lars — not "leave it open", not "an inbound only justifies replying on that thread", but **an inbound justifies broader contact for a bounded window, then it lapses back to needing its own reason**.

## The rule

Both qualifying-event readers now take a window: the derived inbound (`inboundQualifyingEvent`) and the typed row a rep recorded (`recordedQualifyingEvent`).

Twelve months — `defaultReplyWindow`, which already governed unprompted follow-up in the engine's own validators (`validateRequestedFollowup`). This closes a gap rather than inventing a number: the engine bounded its own evidence path and the legacy path it falls back to did not, so the bound was reachable only where the engine had independent evidence. A jurisdiction pack may shorten it and never lengthen it (`windowsFor` takes the smaller).

## Three things this deliberately does not bound

**A same-thread reply.** `resolveCategory` answers `CategoryReplyToInbound` from the anchor before the legacy verdict is consulted, so a rep answering a two-year-old thread is unaffected. The window governs contact the subject did not prompt. Proven on a dev stack below.

**A recorded grant.** Somebody who said in as many words that we may write to them has not withdrawn that by going quiet. `correspondenceVerdict` still reads their answer before the timeline — which is what #4045 fixed, and a window applied to it would undo that fix from the other side.

**Marketing.** It needs consent either way and never reached this arm.

## One window, two readers

`WithInstallationCountry` moved from the `Gate` to the `Store`, and `windowsFor` with it. The gate delegates.

The reason is `GET /people/{id}/consent/guard` — the preview a composer shows before a rep writes anything. It is served by the store and has no gate. If it read a different span than the send path binds a decision to, it would tell a rep a message is allowed and the engine would then refuse it. A preview that is wrong in the permissive direction is worse than no preview, because the rep only finds out after writing the mail.

`serverassembly.go` also built a second consent gate with no country reader at all; it now goes through `consentGateFor`, the one construction that wires it.

## Verified on a running stack

Same person, same request, only the inbound's date moved:

| Probe | Result |
|---|---|
| Guard, fresh person, nothing on file | `unknown` — "they have never written to you…" |
| Guard, inbound at **400 days** | `unknown` — lapsed |
| Guard, same row moved to **30 days** | `allowed` — "they wrote to you on 5 Aug" |
| **Reply** on the 400-day-old thread | **202** — the anchor resolves before the window |
| Cold send, no anchor, inbound at 400 days | **409** `no_compatible_evidence` |
| Same cold send, inbound moved to 30 days | **202** |

The last two are the pair that matters: identical body, identical recipient, identical purpose key — only the age of one row differs.

## Mutations, one clause at a time

| Mutation | Test that failed | Test that correctly kept passing |
|---|---|---|
| drop `occurred_at >= $2` from `inboundQualifyingEvent` | `TestAnInboundStopsAuthorizingWhenItLapses` | `TestARecordedExchangeLapsesToo` |
| drop `occurred_at >= $2` from `recordedQualifyingEvent` | `TestARecordedExchangeLapsesToo` | the other two |
| drop the recorded-grant branch | `TestAnExplicitYesOutlivesTheWindow`, `TestAnExplicitYesAuthorizesCorrespondence` | — |
| guard reads a zero window instead of `windowsFor` | `TestTheGuardAnswersOnTheSameWindowAsTheSend` | — |

The first two isolating cleanly is why they are two tests and not two assertions.

`TestTheGuardAnswersOnTheSameWindowAsTheSend` asserts both sides — the guard *and* `VerdictForPerson` — because either alone would pass against a build where both had lost the window.

## Gates

`make check-backend` green before and after the rebase. Consent, activities and compose integration lanes green, before and after. `craft static --strict` over 14 changed files: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
One inbound email used to authorize unrelated outreach forever. Both qualifying-event readers — the derived inbound and the recorded typed row — now support contact only for a bounded window (`defaultReplyWindow`, 12 months), then lapse back to needing their own reason.

**What this does not bound**
- A same-thread reply resolves from the anchor before the window is consulted, so a rep answering an old thread is unaffected.
- An explicit recorded grant is still read before the timeline and outlives the window.
- Marketing never reached this arm; it needs consent either way.

**The guard preview answers on the same window as the send path**
- `WithInstallationCountry` moved from the Gate to the Store so `GET /people/{id}/consent/guard` resolves the same jurisdiction windows a send is bound to; compose now wires it into the store.
- The activities handler's second consent gate construction now goes through the shared `consentGateFor`.

<sup>Written for commit 7030b8a88732d2851cf6cb0947f23e70ee54af5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Consent and Messaging**
  - Consent decisions now use the installation’s country to apply the appropriate jurisdiction rules.
  - Reply windows are applied consistently across consent checks, previews, and message sending.
  - Inbound contacts and recorded exchanges no longer authorize correspondence after the configured window expires.
  - Explicit consent remains valid after the reply window ends.
- **Bug Fixes**
  - Consent guards and send-time decisions now return matching results for expired contact authorization.
  - Explanations for unsupported consent decisions now consistently indicate that current authorization is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->