### PR TITLE
Every producer says who answers for its rows

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38587,6 +38587,48 @@ components:
             no open deals to take a median of.
         base_currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$', description: 'The currency every expected-revenue figure here is converted to.' }
 
+    WorklistOwner:
+      type: object
+      description: |
+        Who this row answers to.
+
+        RESPONSIBILITY, not visibility. The two are different facts and reading one
+        for the other is how a rep's queue fills with a colleague's work: a notice
+        addressed to somebody else may be unreadable, and a shared deal may be
+        readable by a whole team while exactly one person owes the next move.
+
+        Stated by the PRODUCER that raised the row, never inferred downstream. A
+        reader who can see a row is not thereby its owner; a row surviving a `mine`
+        filter is not evidence either, because several lanes take the scope as a
+        query argument and answer it in SQL. Both of those inferences were available
+        here and both are wrong in the same direction — they would make every row a
+        reader can see look like a row a reader owes.
+
+        `kind: unassigned` is a real answer and the honest one for work nobody has
+        taken. It is what the `unassigned` scope surfaces, and a row that reached a
+        rep's Mine queue while answering `unassigned` is a bug in the lane that
+        produced it rather than a display choice here.
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [user, unassigned]
+          x-enum-varnames: [WorklistOwnerUser, WorklistOwnerUnassigned]
+          description: 'Whether a person answers for this row, or nobody does yet.'
+        id:
+          type: string
+          format: uuid
+          description: 'The owning user. Present when `kind` is `user`.'
+        label:
+          type: string
+          description: |
+            The owner's display name, resolved under the CALLER's own grants.
+
+            Absent where the caller may not resolve it — the same refusal shape the
+            rest of this response uses for a name it cannot read. A client draws the
+            row without a name rather than inventing one, and never treats an absent
+            label as an absent owner: `kind` is what says whether anybody answers.
+
     WorklistBuckets:
       type: object
       description: |
@@ -38889,6 +38931,8 @@ components:
           type: string
           enum: [customer_waiting, leads, deals_at_risk, meetings, tasks, decisions, system]
           description: 'The badge, and the filter it answers to. A reader groups by this; the ORDER never does.'
+        owner:
+          $ref: '#/components/schemas/WorklistOwner'
         destination:
           type: string
           enum: [today, review, system_health, receipt]

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -326,5 +326,39 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 			occurred = member.occurredAt
 		}
 	}
-	return ranked{item: row, foldedFrom: from, occurredAt: occurred}
+	return ranked{
+		item:       row,
+		foldedFrom: from,
+		occurredAt: occurred,
+		// The group's own answer, from the members it stands for. A fold is one
+		// row in place of many, so it can only name an owner where the many
+		// AGREE — a pile of duplicate pairs nobody holds is unassigned, and a
+		// pile whose members answer differently names nobody rather than
+		// picking one member's owner and reporting it as the group's.
+		ownerRef: ownerOfTheGroup(members),
+	}
+}
+
+// ownerOfTheGroup is the one answer a folded row may give.
+//
+// A batch is not a record and has no owner of its own; it stands for members
+// that do. Where they agree the group says what they say. Where they disagree
+// it says nothing — not the first member's answer, which would report one
+// person as holding a pile most of which is somebody else's, and not
+// `unassigned`, which would claim nobody holds work several people do.
+//
+// Silence here is the honest answer AND a visible one: the row reaches the wire
+// with no owner, which the contract already means as "nothing is being said
+// about this", rather than as a claim a reader would act on.
+func ownerOfTheGroup(members []ranked) ownerRef {
+	if len(members) == 0 {
+		return ownerRef{}
+	}
+	first := members[0].ownerRef
+	for _, member := range members[1:] {
+		if member.ownerRef != first {
+			return ownerRef{}
+		}
+	}
+	return first
 }

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -162,6 +162,7 @@ func classifyCommitment(item crmcontracts.AttentionItem, asOf time.Time) ranked 
 		row.Because = append(row.Because, reason("overdue", nil))
 	}
 	return ranked{
+		ownerRef:   ownedByWhoeverIsReading(),
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		overdue:    overdueAt(item.DueAt, asOf),
@@ -175,7 +176,8 @@ func classifyCommitment(item crmcontracts.AttentionItem, asOf time.Time) ranked 
 func classifyFailedApproval(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelPromise, "system", "you_believe_it_happened")
 	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
-	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
+	return ranked{
+		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
 }
 
 // classifyIntroduction: a colleague is waiting on this reader to answer.
@@ -194,6 +196,7 @@ func classifyIntroduction(item crmcontracts.AttentionItem, asOf time.Time) ranke
 	stampDeadline(&row, item.DueAt, asOf)
 	row.Because = []crmcontracts.WorklistReason{reason("blocks_customer_work", nil)}
 	return ranked{
+		ownerRef:   ownedByWhoeverIsReading(),
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		overdue:    overdueAt(item.DueAt, asOf),
@@ -208,6 +211,7 @@ func classifyDSR(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	stampDeadline(&row, item.DueAt, asOf)
 	row.Because = []crmcontracts.WorklistReason{reason("legal_deadline", nil)}
 	return ranked{
+		ownerRef:   ownedByWhoeverIsReading(),
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		overdue:    overdueAt(item.DueAt, asOf),
@@ -348,6 +352,11 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 		// without this it is a row the filters cannot place: a named owner's
 		// queue dropped every one of them.
 		owner: waiting.OwnerID,
+		// The same fact for the CLIENT, which needs the difference between "this
+		// customer is nobody's" and "no lane answered" that the id above cannot
+		// carry. A zero owner here is a real unowned customer, which is what the
+		// unassigned scope surfaces.
+		ownerRef: ownerFrom(waiting.OwnerID),
 		// And WHO it is about, which the subject above may have given to a deal.
 		// The decay suppressor reads this rather than the subject, so a contact
 		// whose wait is filed under a deal is still recognised as answered.
@@ -423,6 +432,12 @@ func classifyTask(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		deadlineAt: deadlineOf(item.DueAt),
 		overdue:    overdueAt(item.DueAt, asOf),
 		occurredAt: occurredOf(item, asOf),
+		// The assignee the lane read, which is the same fact the reason above
+		// states in words. Absent means nobody has taken it — the state the
+		// unassigned scope exists to surface — and the two must agree: a row
+		// saying "unassigned" in its reasons while naming an owner beside them
+		// is a row a reader cannot make sense of.
+		ownerRef: ownerFromAssignee(item.AssigneeId),
 	}
 }
 
@@ -432,7 +447,8 @@ func classifyTask(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 func classifyBounce(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelPromise, "system", "customer_never_received")
 	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
-	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
+	return ranked{
+		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
 }
 
 // classifyUndelivered: a message the rep believes they sent and which never
@@ -446,7 +462,8 @@ func classifyBounce(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelPromise, "system", "you_believe_it_happened")
 	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
-	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
+	return ranked{
+		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
 }
 
 // classifySystem: the pipes. A mailbox that stopped capturing makes every quiet
@@ -461,5 +478,6 @@ func classifySystem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		consequence = valueNone
 	}
 	row := base(item, levelBlocking, "system", consequence)
-	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
+	return ranked{
+		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
 }

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -215,7 +215,11 @@ func classifyDSR(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	stampDeadline(&row, item.DueAt, asOf)
 	row.Because = []crmcontracts.WorklistReason{reason("legal_deadline", nil)}
 	return ranked{
-		ownerRef:   ownedByWhoeverIsReading(),
+		// A compliance queue, not a personal one: the lane reads every open
+		// request due soonest behind the DSR-admin gate, so several admins see
+		// the same case and none of them owns it by having looked. The request
+		// has no assignee column to read.
+		ownerRef:   unassigned(),
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		overdue:    overdueAt(item.DueAt, asOf),

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -360,11 +360,14 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 		// without this it is a row the filters cannot place: a named owner's
 		// queue dropped every one of them.
 		owner: waiting.OwnerID,
-		// The same fact for the CLIENT, which needs the difference between "this
-		// customer is nobody's" and "no lane answered" that the id above cannot
-		// carry. A zero owner here is a real unowned customer, which is what the
-		// unassigned scope surfaces.
-		ownerRef: ownerFrom(waiting.OwnerID),
+		// The same fact for the CLIENT — but NOT through ownerFrom, because a
+		// zero here does not mean what a zero means to the task and lead lanes.
+		// This lane qualifies a row through an ungated lookup and reads its
+		// owner through a gated one, so a customer whose owning record the
+		// reader may not open arrives with no owner id at all. Reporting that
+		// as `unassigned` would turn a withheld fact into a claim that nobody
+		// owes the reply, and the reader has no way to tell the two apart.
+		ownerRef: waitingOwner(waiting.OwnerID),
 		// And WHO it is about, which the subject above may have given to a deal.
 		// The decay suppressor reads this rather than the subject, so a contact
 		// whose wait is filed under a deal is still recognised as answered.
@@ -446,5 +449,11 @@ func classifyTask(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		// saying "unassigned" in its reasons while naming an owner beside them
 		// is a row a reader cannot make sense of.
 		ownerRef: ownerFromAssignee(item.AssigneeId),
+		// And the SAME id where the scope filters read it. Without this a task
+		// answers nobody to answersTo, so keepTeams keeps it as unowned work —
+		// which is the hole its own comment describes for link-less tasks, and
+		// which now also puts an outside-team colleague's user id on the wire
+		// through the owner field. One assignee, read by both.
+		owner: assigneeID(item.AssigneeId),
 	}
 }

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -177,7 +177,11 @@ func classifyFailedApproval(item crmcontracts.AttentionItem, asOf time.Time) ran
 	row := base(item, levelPromise, "system", "you_believe_it_happened")
 	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
 	return ranked{
-		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
+		item:       row,
+		occurredAt: occurredOf(item, asOf),
+		// Carried back to the person who APPROVED it, by a lane bound to them.
+		ownerRef: ownedByWhoeverIsReading(),
+	}
 }
 
 // classifyIntroduction: a colleague is waiting on this reader to answer.
@@ -439,45 +443,4 @@ func classifyTask(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		// is a row a reader cannot make sense of.
 		ownerRef: ownerFromAssignee(item.AssigneeId),
 	}
-}
-
-// classifyBounce: a customer never received something the rep believes they
-// sent. A consequence with a named customer and a verb, so it ranks as its own
-// row rather than disappearing into an aggregate.
-func classifyBounce(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	row := base(item, levelPromise, "system", "customer_never_received")
-	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
-	return ranked{
-		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
-}
-
-// classifyUndelivered: a message the rep believes they sent and which never
-// left. The belief is the damage — they are waiting on a reply to something
-// nobody has — so it sits with the broken promises rather than with the system
-// news, exactly where a bounce sits.
-//
-// It is a separate consequence from the bounce beside it: nobody received this
-// one because nobody was ever sent it, and the reader's move is to send it
-// rather than to fix an address.
-func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	row := base(item, levelPromise, "system", "you_believe_it_happened")
-	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
-	return ranked{
-		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
-}
-
-// classifySystem: the pipes. A mailbox that stopped capturing makes every quiet
-// claim on this page suspect, which is why it is here at all rather than only in
-// an admin screen.
-func classifySystem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	consequence := crmcontracts.WorklistItemConsequence("work_blocked")
-	if item.Source == "capture_health" || item.Source == "sync_health" {
-		consequence = "mailbox_blind"
-	}
-	if item.Source == "notice" {
-		consequence = valueNone
-	}
-	row := base(item, levelBlocking, "system", consequence)
-	return ranked{
-		ownerRef: ownedByWhoeverIsReading(), item: row, occurredAt: occurredOf(item, asOf)}
 }

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -42,7 +42,10 @@ func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time, money da
 	expected, known := expectedRevenue(item, money)
 	priceDealsAtRiskRow(&row, expected, known, money)
 	return ranked{
-		item:             row,
+		item: row,
+		// Deferred to the deal for the reason the at-risk lane defers: the owner
+		// arrives with the facts pass, after this runs.
+		ownerRef:         deferredToTheDeal(),
 		deadlineAt:       deadlineOf(item.DueAt),
 		overdue:          item.Overdue != nil && *item.Overdue,
 		expectedBase:     expected,

--- a/backend/internal/compose/attention/classifydecay.go
+++ b/backend/internal/compose/attention/classifydecay.go
@@ -50,7 +50,11 @@ func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		row.Because = append(row.Because, reason("expected_revenue", nil))
 	}
 	return ranked{
-		item:        row,
+		item: row,
+		// A relationship going quiet, raised for the reader whose contacts they
+		// are. The lane is bound to them, and the dismissal beside it is
+		// per-reader for the same reason.
+		ownerRef:    ownedByWhoeverIsReading(),
 		waitingDays: quiet,
 		waitingRank: orderingAge(quiet),
 		occurredAt:  occurredOf(item, asOf),

--- a/backend/internal/compose/attention/classifydecision.go
+++ b/backend/internal/compose/attention/classifydecision.go
@@ -36,7 +36,10 @@ func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	// would put one decision in two groups across two reads.
 	facts := stagedFactsOf(item)
 	return ranked{
-		item:          row,
+		item: row,
+		// A decision the reader is being asked to make. The lane reads what THIS
+		// person may decide, so the row is theirs by construction of that read.
+		ownerRef:      ownedByWhoeverIsReading(),
 		occurredAt:    occurredOf(item, asOf),
 		machineSender: facts.MachineSender,
 		knownCompany:  facts.KnownCompany,

--- a/backend/internal/compose/attention/classifydecision.go
+++ b/backend/internal/compose/attention/classifydecision.go
@@ -37,9 +37,17 @@ func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	facts := stagedFactsOf(item)
 	return ranked{
 		item: row,
-		// A decision the reader is being asked to make. The lane reads what THIS
-		// person may decide, so the row is theirs by construction of that read.
-		ownerRef:      ownedByWhoeverIsReading(),
+		// NOBODY, until somebody takes it. A duplicate pair and a staged
+		// approval are read under the caller's ROW SCOPE — a team-scoped reader
+		// sees their whole team's — so the read is not bound to one person and
+		// "whoever is reading" would be the very inference this field exists to
+		// refuse: it would name a manager as the owner of every pair on their
+		// team, and each rep as the owner of the same pair when they looked.
+		//
+		// These queues have no owner column. Saying so is the honest answer and
+		// the one the unassigned scope is for; a claim endpoint is what would
+		// change it, and none exists yet.
+		ownerRef:      unassigned(),
 		occurredAt:    occurredOf(item, asOf),
 		machineSender: facts.MachineSender,
 		knownCompany:  facts.KnownCompany,

--- a/backend/internal/compose/attention/classifydelivery.go
+++ b/backend/internal/compose/attention/classifydelivery.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What the product reports about DELIVERY and about itself.
+//
+// Three classifiers with one thing in common: none of them is a record a seller
+// worked on. A bounce and an undelivered message are consequences a customer is
+// on the other end of; the pipes are the product saying its own machinery
+// stopped. They sit together because a reader meeting one of them is being told
+// something did not happen rather than being handed something to do, and the
+// difference decides both the words on the row and the screen it lands on.
+
+import (
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// classifyBounce: a customer never received something the rep believes they
+// sent. A consequence with a named customer and a verb, so it ranks as its own
+// row rather than disappearing into an aggregate.
+func classifyBounce(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	row := base(item, levelPromise, "system", "customer_never_received")
+	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
+	return ranked{
+		item:       row,
+		occurredAt: occurredOf(item, asOf),
+		// The lane is bound to the acting user, so no other person's row could
+		// have come back.
+		ownerRef: ownedByWhoeverIsReading(),
+	}
+}
+
+// classifyUndelivered: a message the rep believes they sent and which never
+// left. The belief is the damage — they are waiting on a reply to something
+// nobody has — so it sits with the broken promises rather than with the system
+// news, exactly where a bounce sits.
+//
+// It is a separate consequence from the bounce beside it: nobody received this
+// one because nobody was ever sent it, and the reader's move is to send it
+// rather than to fix an address.
+func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	row := base(item, levelPromise, "system", "you_believe_it_happened")
+	row.Because = []crmcontracts.WorklistReason{reason("approved_and_failed", nil)}
+	return ranked{
+		item:       row,
+		occurredAt: occurredOf(item, asOf),
+		// The lane is bound to the acting user, so no other person's row could
+		// have come back.
+		ownerRef: ownedByWhoeverIsReading(),
+	}
+}
+
+// classifySystem: the pipes. A mailbox that stopped capturing makes every quiet
+// claim on this page suspect, which is why it is here at all rather than only in
+// an admin screen.
+func classifySystem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	consequence := crmcontracts.WorklistItemConsequence("work_blocked")
+	if item.Source == "capture_health" || item.Source == "sync_health" {
+		consequence = "mailbox_blind"
+	}
+	if item.Source == "notice" {
+		consequence = valueNone
+	}
+	row := base(item, levelBlocking, "system", consequence)
+	return ranked{
+		item:       row,
+		occurredAt: occurredOf(item, asOf),
+		// The lane is bound to the acting user, so no other person's row could
+		// have come back.
+		ownerRef: ownedByWhoeverIsReading(),
+	}
+}

--- a/backend/internal/compose/attention/classifydelivery.go
+++ b/backend/internal/compose/attention/classifydelivery.go
@@ -18,6 +18,15 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
+// The two system sources that are ONE person's: a mailbox belongs to whoever
+// connected it, and a notice is addressed to whoever it names. Spelled as
+// constants because both the consequence switch and the ownership switch read
+// them, and a typo in either would silently move a row to the wrong answer.
+const (
+	sourceCaptureHealth = crmcontracts.AttentionItemSource("capture_health")
+	sourceNotice        = crmcontracts.AttentionItemSource("notice")
+)
+
 // classifyBounce: a customer never received something the rep believes they
 // sent. A consequence with a named customer and a verb, so it ranks as its own
 // row rather than disappearing into an aggregate.
@@ -58,18 +67,39 @@ func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked
 // an admin screen.
 func classifySystem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	consequence := crmcontracts.WorklistItemConsequence("work_blocked")
-	if item.Source == "capture_health" || item.Source == "sync_health" {
+	if item.Source == sourceCaptureHealth || item.Source == "sync_health" {
 		consequence = "mailbox_blind"
 	}
-	if item.Source == "notice" {
+	if item.Source == sourceNotice {
 		consequence = valueNone
 	}
 	row := base(item, levelBlocking, "system", consequence)
 	return ranked{
 		item:       row,
 		occurredAt: occurredOf(item, asOf),
-		// The lane is bound to the acting user, so no other person's row could
-		// have come back.
-		ownerRef: ownedByWhoeverIsReading(),
+		// ONE classifier, two different truths — which is why this branches
+		// rather than stating a single answer for everything it draws.
+		ownerRef: systemRowOwner(item.Source),
+	}
+}
+
+// systemRowOwner separates the personal system rows from the workspace ones.
+//
+// classifySystem draws five sources and they do not agree about ownership. A
+// notice is addressed to one person and a mailbox belongs to one person: both
+// lanes read per-user, so the row is the reader's by construction. A failing
+// sync, a broken AI task and a stopped automation are the WORKSPACE's — those
+// services read no user at all, several admins see the same row, and naming
+// whoever opened the page would make one shared failure look like five people's
+// separate problems.
+//
+// Stated here rather than in the classifier's literal so the difference is
+// visible: a source added to that switch has to answer this question too.
+func systemRowOwner(source crmcontracts.AttentionItemSource) ownerRef {
+	switch source {
+	case sourceNotice, sourceCaptureHealth:
+		return ownedByWhoeverIsReading()
+	default:
+		return unassigned()
 	}
 }

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -59,7 +59,12 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 		row.Because = append(row.Because, reason("closing_soon", nil))
 	}
 	return ranked{
-		item:             row,
+		item: row,
+		// The deal's own owner, and it is not known yet: dealfacts fills OwnerId
+		// onto the wire AFTER this classification runs. So this lane defers, and
+		// the wire step reads the deal the facts pass attached — the same second
+		// carrier answersTo has always consulted for these rows.
+		ownerRef:         deferredToTheDeal(),
 		deadlineAt:       deadlineOf(item.DueAt),
 		overdue:          item.Overdue != nil && *item.Overdue,
 		expectedBase:     expected,

--- a/backend/internal/compose/attention/lead.go
+++ b/backend/internal/compose/attention/lead.go
@@ -113,6 +113,9 @@ func classifyLead(lead OwedLead, asOf time.Time) ranked {
 		// Saying who owns the row is the general answer, and it costs the next
 		// source no case of its own.
 		owner: lead.OwnerID,
+		// And the same answer for the client. A lead nobody has taken is the
+		// state this lane exists to surface, so a zero id here means it.
+		ownerRef: ownerFrom(lead.OwnerID),
 	}
 }
 

--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -86,5 +86,12 @@ func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	// as work due — unlike a proposal's expiry, which merely lapses.
 	stampDeadline(&row, item.DueAt, asOf)
 	row.Because = reasons
-	return ranked{item: row, deadlineAt: deadlineOf(item.DueAt), occurredAt: occurredOf(item, asOf)}
+	return ranked{
+		item:       row,
+		deadlineAt: deadlineOf(item.DueAt),
+		occurredAt: occurredOf(item, asOf),
+		// The reader's own calendar. The lane reads the meetings THIS person is
+		// on, so a colleague's meeting could not have come back.
+		ownerRef: ownedByWhoeverIsReading(),
+	}
 }

--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -90,8 +90,15 @@ func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		occurredAt: occurredOf(item, asOf),
-		// The reader's own calendar. The lane reads the meetings THIS person is
-		// on, so a colleague's meeting could not have come back.
-		ownerRef: ownedByWhoeverIsReading(),
+		// NOT the reader's, and the obvious claim here is false. The lane lists
+		// meeting activities under the caller's ROW SCOPE — no owner or attendee
+		// predicate — so a team-scoped reader receives their team's meetings and
+		// naming the reader would make every one of them look like the reader's
+		// own appointment.
+		//
+		// The activity carries no owner this lane reads, so nobody is named. A
+		// meeting's real owner is its organiser, which arrives with the attendee
+		// read that does not exist yet.
+		ownerRef: unassigned(),
 	}
 }

--- a/backend/internal/compose/attention/owner.go
+++ b/backend/internal/compose/attention/owner.go
@@ -168,8 +168,12 @@ func idPtr(user ids.UUID) *openapi_types.UUID {
 //
 // Tasks, leads and waiting customers all work this way: the query returns the
 // owner it found, and finding none means nobody has taken the row rather than
-// meaning the lane declined to say. Spelled once so the three cannot disagree
-// about what a zero means.
+// meaning the lane declined to say. Spelled once so the three answer a zero
+// alike.
+//
+// Held by: TestEveryProducerStatesAnOwner (owner_test.go), which reads every
+// lane's answer, and TestATasksOwnerAgreesWithItsOwnReason, which holds one of
+// the three to the same fact spelled in its own reasons.
 func ownerFrom(user ids.UUID) ownerRef {
 	if user.IsZero() {
 		return unassigned()

--- a/backend/internal/compose/attention/owner.go
+++ b/backend/internal/compose/attention/owner.go
@@ -19,6 +19,7 @@ package attention
 
 import (
 	"context"
+	"fmt"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -51,6 +52,16 @@ const (
 	// classification. A real answer — the lane knows WHERE the answer comes
 	// from — rather than the silence the census refuses.
 	ownerFromTheDeal
+	// ownerUnreadable: this lane HAS an owner and could not read it.
+	//
+	// A real answer, and a different one from every kind above. The waiting
+	// lane qualifies a row through an ungated lookup and reads its owner
+	// through a visibility-gated one, so a customer whose owning record the
+	// reader may not open arrives here owner-less while somebody plainly owes
+	// the reply. Saying `unassigned` would be a claim the workspace never made;
+	// saying nothing at all would be indistinguishable from a lane that was
+	// never wired, which is exactly what the census exists to catch.
+	ownerUnreadable
 )
 
 // ownerRef is the producer's answer, before the reader is known.
@@ -115,18 +126,32 @@ func ownerOnTheWire(row ranked, reader ids.UUID) *crmcontracts.WorklistOwner {
 		}
 	case ownerNobody:
 		return &crmcontracts.WorklistOwner{Kind: crmcontracts.WorklistOwnerUnassigned}
-	case ownerFromTheDeal:
-		// The facts pass has run by now, so the deal carries its owner. A deal
-		// the caller may not read arrives without figures — the same refusal
-		// shape the rest of the response uses — and a row whose owner could not
-		// be read says nothing rather than claiming nobody owns it.
-		if row.item.Deal != nil && row.item.Deal.OwnerId != nil {
-			return &crmcontracts.WorklistOwner{
-				Kind: crmcontracts.WorklistOwnerUser,
-				Id:   row.item.Deal.OwnerId,
-			}
-		}
+	case ownerUnreadable:
+		// Withheld, and the contract's own answer for a fact this caller may
+		// not resolve: the field is absent. A client draws the row without an
+		// owner rather than being told nobody owes it.
 		return nil
+	case ownerFromTheDeal:
+		// The facts pass has run by now. THREE states, and conflating the last
+		// two is what this spells out: the deal resolved and names an owner;
+		// the deal resolved and names none, which is a real unassigned deal;
+		// and the deal did not resolve at all, because the caller may not read
+		// it — the same refusal shape the rest of the response uses, where the
+		// honest answer is to say nothing rather than to report a withheld
+		// owner as an absent one.
+		//
+		// `Deal` is the discriminator: applyDealFigures attaches it whenever
+		// the figures came back, and leaves it nil when they did not.
+		if row.item.Deal == nil {
+			return nil
+		}
+		if row.item.Deal.OwnerId == nil {
+			return &crmcontracts.WorklistOwner{Kind: crmcontracts.WorklistOwnerUnassigned}
+		}
+		return &crmcontracts.WorklistOwner{
+			Kind: crmcontracts.WorklistOwnerUser,
+			Id:   row.item.Deal.OwnerId,
+		}
 	case ownerTheReader:
 		// No human behind the call is not "unassigned": an agent reading the
 		// queue has no personal lane, and saying nobody owns these rows would
@@ -210,17 +235,21 @@ func ownerFromAssignee(assignee *openapi_types.UUID) ownerRef {
 // common case for this — a caller on no team has no roster — and a row that
 // says "you" by carrying the reader's own id needs no name to be legible.
 //
-// An UNBOUND seam names nobody, and an error is not fatal here: an owner id
-// with no name still tells a client who answers for the row, while failing the
-// whole page over a display name would take the queue away from a reader whose
-// work is on it.
-func (s *Service) nameTheOwners(ctx context.Context, queue []crmcontracts.WorklistItem) {
+// An UNBOUND seam names nobody, which is the same absence.
+//
+// A FAILURE travels. The contract says an absent label means the caller may not
+// resolve that name, so swallowing a database error here would publish a
+// refusal the workspace never made — and a reader comparing two pages would see
+// names appear and disappear with nothing to explain it. The row scope has
+// already decided what this caller may see; a roster that will not answer is a
+// fault, not a policy.
+func (s *Service) nameTheOwners(ctx context.Context, queue []crmcontracts.WorklistItem) error {
 	if s.teammates == nil || !anyOwnerNeedsAName(queue) {
-		return
+		return nil
 	}
 	roster, _, err := s.teammates.LiveTeammatesOfCaller(ctx)
 	if err != nil {
-		return
+		return fmt.Errorf("attention: naming the owners on the queue: %w", err)
 	}
 	names := make(map[ids.UUID]string, len(roster))
 	for _, member := range roster {
@@ -235,6 +264,7 @@ func (s *Service) nameTheOwners(ctx context.Context, queue []crmcontracts.Workli
 			owner.Label = &name
 		}
 	}
+	return nil
 }
 
 // anyOwnerNeedsAName reports whether the roster read is worth making.
@@ -248,4 +278,35 @@ func anyOwnerNeedsAName(queue []crmcontracts.WorklistItem) bool {
 		}
 	}
 	return false
+}
+
+// assigneeID is the assignee as the SCOPE filters read it.
+//
+// The same value ownerFromAssignee turns into the wire's answer, in the shape
+// answersTo wants: a zero id where nobody holds the row. Both readings come off
+// this one field so a task cannot be unowned to the filters and owned to the
+// client — which is how an outside-team assignee reached both the page and the
+// wire while `keepTeams` counted the row as nobody's.
+func assigneeID(assignee *openapi_types.UUID) ids.UUID {
+	if assignee == nil {
+		return ids.UUID{}
+	}
+	return ids.UUID(*assignee)
+}
+
+// waitingOwner is the waiting lane's answer, where a zero id is ambiguous.
+//
+// Every other owner-column lane can read a zero as "nobody has taken it". This
+// one cannot: its eligibility is qualified through an ungated lookup and its
+// owner through a visibility-gated one, so a row whose owning record the reader
+// may not open reaches here indistinguishable from an unowned customer.
+//
+// It says nothing in that case. A withheld owner reported as `unassigned` is a
+// claim the workspace never made — somebody does owe that reply — and the
+// reader has nothing on the row to tell them the difference.
+func waitingOwner(owner ids.UUID) ownerRef {
+	if owner.IsZero() {
+		return ownerRef{kind: ownerUnreadable}
+	}
+	return ownedBy(owner)
 }

--- a/backend/internal/compose/attention/owner.go
+++ b/backend/internal/compose/attention/owner.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Who answers for a row, said by the producer that raised it.
+//
+// RESPONSIBILITY IS NOT VISIBILITY, and the whole of this file is that
+// distinction. A rep can read a colleague's deal and owes nothing on it; a
+// notice addressed to somebody else is unreadable and is still theirs. The two
+// inferences that were available here — the reader can see it, so it is theirs;
+// the row survived a `mine` filter, so it is theirs — are both wrong in the
+// same direction, and both would fill a rep's morning with work they do not
+// owe.
+//
+// So a producer STATES it. Silence is not "unassigned": it is a producer that
+// has not answered, which the census catches, and which would otherwise reach
+// a reader as a confident claim that nobody owns the row.
+
+import (
+	"context"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ownerKind is WHICH WAY a producer knows who owns its rows.
+//
+// Three answers, and the third is the one that makes this a producer statement
+// rather than a downstream guess. A lane that reads a named owner column says
+// so; a lane whose rows nobody has taken says so; a lane whose QUERY is bound
+// to the acting user says that, and means it — the row is theirs because the
+// read could not have returned anybody else's, which is a fact about the lane
+// and not about who happens to be looking.
+type ownerKind int
+
+const (
+	// ownerUnstated is the zero value, and it is not an answer. A row carrying
+	// it reached a page from a lane that never said, which the census fails on.
+	ownerUnstated ownerKind = iota
+	// ownerNamed: this lane resolved a person.
+	ownerNamed
+	// ownerNobody: this lane's rows are genuinely unheld.
+	ownerNobody
+	// ownerTheReader: this lane's read is bound to the acting user.
+	ownerTheReader
+	// ownerFromTheDeal: this row's owner arrives with the deal facts, after
+	// classification. A real answer — the lane knows WHERE the answer comes
+	// from — rather than the silence the census refuses.
+	ownerFromTheDeal
+)
+
+// ownerRef is the producer's answer, before the reader is known.
+//
+// It carries a KIND rather than a resolved id because the classifiers are pure
+// functions of the day — classifyDay takes no principal, deliberately, and
+// threading one through fifteen of them to write the same id fifteen times
+// would put the reader's identity inside a pure ranking. The one place that
+// knows the reader resolves it, once, on the page.
+type ownerRef struct {
+	kind ownerKind
+	// user is who answers, for ownerNamed.
+	user ids.UUID
+}
+
+// ownedBy is a producer naming the person who answers for a row.
+func ownedBy(user ids.UUID) ownerRef { return ownerRef{kind: ownerNamed, user: user} }
+
+// unassigned is a producer saying nobody has taken this yet.
+//
+// A real answer rather than an absence, which is why it is spelled. Work
+// nobody owns is what the unassigned scope is for, and a lane that means it
+// says so here rather than by staying quiet.
+func unassigned() ownerRef { return ownerRef{kind: ownerNobody} }
+
+// ownedByWhoeverIsReading is the answer for the intrinsically per-user sources.
+//
+// A notice is addressed to one person, a mailbox belongs to one person, a
+// promise was made by one person, an approved action failed for the person who
+// approved it. Those reads are bound to the acting user INSIDE the modules that
+// own them — `mineOnly`'s own comment says so — so the row is the reader's by
+// construction of the read.
+//
+// This is NOT "the reader can see it, so it is theirs". That inference is
+// available two lines away and is wrong: a rep can read a colleague's deal and
+// owes nothing on it. What this says is narrower and true — the query that
+// produced this row took the acting user as a parameter, so no other person's
+// row could have come back.
+func ownedByWhoeverIsReading() ownerRef { return ownerRef{kind: ownerTheReader} }
+
+// deferredToTheDeal is a lane whose rows are owned through their deal.
+//
+// The at-risk and brief lanes classify before dealfacts fills OwnerId onto the
+// wire, so they cannot name the person here — but they know exactly where the
+// answer comes from, and saying so is a statement rather than a silence. The
+// wire step reads the deal the facts pass attached.
+func deferredToTheDeal() ownerRef { return ownerRef{kind: ownerFromTheDeal} }
+
+// ownerOnTheWire is the field a client draws, with the label still to resolve.
+//
+// The DEAL's owner is consulted only where the lane itself did not answer, and
+// the order matters for the reason answersTo documents: a waiting row absorbs a
+// drifting deal's facts for display between two passes, so asking the deal
+// first can answer differently on the second pass than on the first, and a
+// customer lands on neither person's queue.
+func ownerOnTheWire(row ranked, reader ids.UUID) *crmcontracts.WorklistOwner {
+	switch row.ownerRef.kind {
+	case ownerNamed:
+		return &crmcontracts.WorklistOwner{
+			Kind: crmcontracts.WorklistOwnerUser,
+			Id:   idPtr(row.ownerRef.user),
+		}
+	case ownerNobody:
+		return &crmcontracts.WorklistOwner{Kind: crmcontracts.WorklistOwnerUnassigned}
+	case ownerFromTheDeal:
+		// The facts pass has run by now, so the deal carries its owner. A deal
+		// the caller may not read arrives without figures — the same refusal
+		// shape the rest of the response uses — and a row whose owner could not
+		// be read says nothing rather than claiming nobody owns it.
+		if row.item.Deal != nil && row.item.Deal.OwnerId != nil {
+			return &crmcontracts.WorklistOwner{
+				Kind: crmcontracts.WorklistOwnerUser,
+				Id:   row.item.Deal.OwnerId,
+			}
+		}
+		return nil
+	case ownerTheReader:
+		// No human behind the call is not "unassigned": an agent reading the
+		// queue has no personal lane, and saying nobody owns these rows would
+		// be a claim about the work rather than about the caller.
+		if reader.IsZero() {
+			return nil
+		}
+		return &crmcontracts.WorklistOwner{
+			Kind: crmcontracts.WorklistOwnerUser,
+			Id:   idPtr(reader),
+		}
+	default:
+		// A producer that never answered. Reported as no owner field at all
+		// rather than as `unassigned`: the census fails on this, and until it
+		// does a reader is better served by a row that says nothing about
+		// ownership than by one that confidently says nobody owns it.
+		return nil
+	}
+}
+
+// readerOf is who is asking, for the lanes whose rows are theirs by
+// construction. Zero where nothing human is behind the call.
+func readerOf(ctx context.Context) ids.UUID {
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return ids.UUID{}
+	}
+	return actor.UserID
+}
+
+// idPtr is the wire's optional-uuid shape.
+func idPtr(user ids.UUID) *openapi_types.UUID {
+	out := openapi_types.UUID(user)
+	return &out
+}
+
+// ownerFrom is a lane that read an owner COLUMN, where the absence of a value
+// is itself the answer.
+//
+// Tasks, leads and waiting customers all work this way: the query returns the
+// owner it found, and finding none means nobody has taken the row rather than
+// meaning the lane declined to say. Spelled once so the three cannot disagree
+// about what a zero means.
+func ownerFrom(user ids.UUID) ownerRef {
+	if user.IsZero() {
+		return unassigned()
+	}
+	return ownedBy(user)
+}
+
+// ownerFromAssignee is a lane that read an assignee COLUMN on the wire item.
+//
+// The task lane states the same fact twice — as a `unassigned` reason a reader
+// sees, and as the owner a client draws — so both read this one function. Two
+// spellings of "nobody has taken it" would eventually disagree, and the row
+// would say one thing in its reasons and another beside them.
+func ownerFromAssignee(assignee *openapi_types.UUID) ownerRef {
+	if assignee == nil {
+		return unassigned()
+	}
+	return ownedBy(ids.UUID(*assignee))
+}
+
+// nameTheOwners fills in the display name beside each owner id.
+//
+// THROUGH THE ROSTER THE TEAM BOARD ALREADY READS, rather than a second reader
+// of app_user. LiveTeammatesOfCaller answers live human seats sharing a live
+// team with the caller — which is exactly the set whose names this caller may
+// see — so the label carries the same visibility rule the board does, and a
+// name the reader could not otherwise reach never arrives through this field.
+// A second query with its own scope clause would be a second answer to "whose
+// name may this person read", and the two would drift.
+//
+// A missing name is left ABSENT rather than filled with the id: the contract
+// says a client draws the row without a name in that case, and an id on screen
+// is the defect the label exists to prevent. The reader's own rows are the
+// common case for this — a caller on no team has no roster — and a row that
+// says "you" by carrying the reader's own id needs no name to be legible.
+//
+// An UNBOUND seam names nobody, and an error is not fatal here: an owner id
+// with no name still tells a client who answers for the row, while failing the
+// whole page over a display name would take the queue away from a reader whose
+// work is on it.
+func (s *Service) nameTheOwners(ctx context.Context, queue []crmcontracts.WorklistItem) {
+	if s.teammates == nil || !anyOwnerNeedsAName(queue) {
+		return
+	}
+	roster, _, err := s.teammates.LiveTeammatesOfCaller(ctx)
+	if err != nil {
+		return
+	}
+	names := make(map[ids.UUID]string, len(roster))
+	for _, member := range roster {
+		names[member.UserID] = member.DisplayName
+	}
+	for i := range queue {
+		owner := queue[i].Owner
+		if owner == nil || owner.Id == nil {
+			continue
+		}
+		if name, known := names[ids.UUID(*owner.Id)]; known && name != "" {
+			owner.Label = &name
+		}
+	}
+}
+
+// anyOwnerNeedsAName reports whether the roster read is worth making.
+//
+// A page of the reader's own work names nobody else, and reading a roster to
+// label nothing is a query per page for no reader's benefit.
+func anyOwnerNeedsAName(queue []crmcontracts.WorklistItem) bool {
+	for _, item := range queue {
+		if item.Owner != nil && item.Owner.Id != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/attention/owner_test.go
+++ b/backend/internal/compose/attention/owner_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestEveryProducerStatesAnOwner is the census, and the reason ownerRef carries
+// a kind rather than a bare id.
+//
+// A lane that never answers reaches a reader as a row with no owner, and the
+// next thing anybody would do about that is default it — to the reader,
+// because the row is on their page, or to `unassigned`, because nothing was
+// found. Both defaults are wrong in the same direction and neither fails: the
+// row renders, the count adds up, and a rep's morning quietly fills with work
+// they do not owe.
+//
+// The corpus is a day carrying EVERY lane, so a producer added to classifyDay
+// without an answer appears here by arriving in the day rather than by somebody
+// adding it to a list.
+func TestEveryProducerStatesAnOwner(t *testing.T) {
+	t.Parallel()
+	rows := classifyDay(dayOfEveryLane(), rankInstant, dayMoney{})
+	// The two lanes read BESIDE the assembled day rather than as part of it —
+	// the who-is-waiting and owed-leads reads take the scope as a query argument
+	// — so classifyDay never produces them and a census over it alone would
+	// leave both unexamined. They are appended through their own classifiers,
+	// which is what the assembler calls.
+	rows = append(rows,
+		classifyWaiting(WaitingCustomer{Since: rankInstant}, rankInstant),
+		classifyLead(OwedLead{}, rankInstant))
+	if len(rows) == 0 {
+		t.Fatal("the fixture produced no rows, so this census would pass over nothing")
+	}
+	seen := map[crmcontracts.WorklistItemSource]bool{}
+	for _, row := range rows {
+		seen[row.item.Source] = true
+		if row.ownerRef.kind == ownerUnstated {
+			t.Errorf("a %q row reached the page and no producer said who answers for it: "+
+				"state one in its classifier — ownedBy, unassigned, ownedByWhoeverIsReading "+
+				"or deferredToTheDeal", row.item.Source)
+		}
+	}
+	// And the fixture really did drive every lane. Without this the census
+	// passes on a day that produced three sources: a producer added later would
+	// be as unexamined as it was before anybody wrote this test.
+	for _, source := range ClassifiedSources() {
+		if !seen[source] {
+			t.Errorf("no %q row reached this census, so nothing here proves that producer "+
+				"states an owner: give dayOfEveryLane a row for it", source)
+		}
+	}
+}
+
+// TestAReaderLaneNamesTheReader holds the one answer that needs somebody to
+// resolve it.
+//
+// The per-user lanes say "whoever is reading" rather than a resolved id,
+// because the classifiers are pure functions of the day. If the wire step
+// dropped the reader the rows would carry no owner at all — which reads to a
+// client exactly like a lane that never answered.
+func TestAReaderLaneNamesTheReader(t *testing.T) {
+	t.Parallel()
+	reader := ids.MustParse("01a05500-0000-7000-8000-00000000feed")
+	row := ranked{
+		item:     crmcontracts.WorklistItem{Source: crmcontracts.WorklistItemSourceNotice},
+		ownerRef: ownedByWhoeverIsReading(),
+	}
+
+	owner := ownerOnTheWire(row, reader)
+
+	if owner == nil {
+		t.Fatal("a personal lane's row carries no owner, which reads as a lane that never answered")
+	}
+	if owner.Kind != crmcontracts.WorklistOwnerUser {
+		t.Errorf("a personal lane's row answers %q, want a named user", owner.Kind)
+	}
+	if owner.Id == nil || ids.UUID(*owner.Id) != reader {
+		t.Errorf("a personal lane's row names %v, want the reader %v", owner.Id, reader)
+	}
+}
+
+// TestAnAgentGetsNoOwnerRatherThanAnUnassignedClaim.
+//
+// A call with nothing human behind it has no personal lane. Answering
+// `unassigned` there would be a claim about the WORK — nobody owns this — made
+// on the basis of a fact about the CALLER, and a manager reading that queue
+// would see a rep's own notices reported as unheld.
+func TestAnAgentGetsNoOwnerRatherThanAnUnassignedClaim(t *testing.T) {
+	t.Parallel()
+	row := ranked{
+		item:     crmcontracts.WorklistItem{Source: crmcontracts.WorklistItemSourceNotice},
+		ownerRef: ownedByWhoeverIsReading(),
+	}
+
+	if owner := ownerOnTheWire(row, ids.UUID{}); owner != nil {
+		t.Errorf("a reader-bound row answered %+v to a caller with no human behind it, "+
+			"want no owner stated", *owner)
+	}
+}
+
+// TestUnassignedIsSaidRatherThanImplied separates the two things a missing
+// owner can mean.
+//
+// A lane that read an owner column and found none is stating a fact the
+// unassigned scope exists to surface. A lane that never answered is silence.
+// They must not reach the wire the same way, or the census above could not tell
+// them apart either.
+func TestUnassignedIsSaidRatherThanImplied(t *testing.T) {
+	t.Parallel()
+	stated := ranked{
+		item:     crmcontracts.WorklistItem{Source: crmcontracts.WorklistItemSourceTask},
+		ownerRef: unassigned(),
+	}
+	silent := ranked{item: crmcontracts.WorklistItem{Source: crmcontracts.WorklistItemSourceTask}}
+
+	said := ownerOnTheWire(stated, ids.UUID{})
+	if said == nil || said.Kind != crmcontracts.WorklistOwnerUnassigned {
+		t.Errorf("a lane that found no owner answered %v, want an explicit unassigned", said)
+	}
+	if quiet := ownerOnTheWire(silent, ids.UUID{}); quiet != nil {
+		t.Errorf("a lane that never answered claimed %+v, which a reader cannot tell from a "+
+			"real unassigned row", *quiet)
+	}
+}
+
+// TestATasksOwnerAgreesWithItsOwnReason holds the two spellings of one fact
+// together.
+//
+// The task lane says "nobody has taken this" twice — as a reason a reader sees
+// and as the owner a client draws. Two spellings that could disagree is how a
+// row ends up naming an owner beside the word `unassigned`.
+func TestATasksOwnerAgreesWithItsOwnReason(t *testing.T) {
+	t.Parallel()
+	for _, probe := range []struct {
+		name       string
+		task       crmcontracts.AttentionItem
+		unassigned bool
+	}{
+		{"nobody has taken it", item("t1", "task"), true},
+		{"assigned", assignedTask("t2"), false},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			row := classifyTask(probe.task, rankInstant)
+			saysUnassigned := false
+			for _, because := range row.item.Because {
+				if because.Kind == "unassigned" {
+					saysUnassigned = true
+				}
+			}
+			owner := ownerOnTheWire(row, ids.UUID{})
+			ownerSaysUnassigned := owner != nil && owner.Kind == crmcontracts.WorklistOwnerUnassigned
+			if saysUnassigned != ownerSaysUnassigned {
+				t.Errorf("the row's reasons say unassigned=%v and its owner says %v: "+
+					"a reader is told two different things about one fact",
+					saysUnassigned, ownerSaysUnassigned)
+			}
+			if saysUnassigned != probe.unassigned {
+				t.Errorf("the row reads unassigned=%v, want %v", saysUnassigned, probe.unassigned)
+			}
+		})
+	}
+}
+
+// assignedTask is a task somebody holds.
+func assignedTask(id string) crmcontracts.AttentionItem {
+	at := item(id, "task")
+	assignee := openapi_types.UUID(ids.MustParse("01a05500-0000-7000-8000-00000000a551"))
+	at.AssigneeId = &assignee
+	return at
+}
+
+// dayOfEveryLane drives every producer classifyDay knows, so the census reads
+// the whole set rather than the lanes somebody remembered.
+func dayOfEveryLane() crmcontracts.Attention {
+	return crmcontracts.Attention{
+		AsOf:              rankInstant,
+		Meetings:          lane(item("meeting", "meeting")),
+		ThisMorning:       []crmcontracts.AttentionItem{item("brief", "brief_item")},
+		Commitments:       lane(item("promise", "conversation_claim")),
+		DidNotRun:         lane(item("failed", "failed_approval")),
+		Dsr:               lane(item("dsr", "dsr")),
+		AtRisk:            lane(item("deal", "deal_at_risk")),
+		Planned:           []crmcontracts.AttentionItem{item("task", "task")},
+		Bounces:           lane(item("bounce", "bounce")),
+		Undelivered:       lane(item("undelivered", "undelivered")),
+		NeedsYou:          []crmcontracts.AttentionItem{item("approval", "approval"), item("pair", "dedupe_candidate")},
+		RelationshipDecay: lane(item("decay", "relationship_decay")),
+		CaptureHealth:     lane(item("capture", "capture_health")),
+		AiWorkHealth:      lane(item("ai", "ai_work_health")),
+		AutomationHealth:  lane(item("automation", "automation_run")),
+		SyncHealth:        lane(item("sync", "sync_health")),
+		Notices:           lane(item("notice", "notice")),
+		Introductions:     lane(item("introduction", "introduction_request")),
+	}
+}

--- a/backend/internal/compose/attention/owner_test.go
+++ b/backend/internal/compose/attention/owner_test.go
@@ -201,3 +201,44 @@ func dayOfEveryLane() crmcontracts.Attention {
 		Introductions:     lane(item("introduction", "introduction_request")),
 	}
 }
+
+// TestOnlyAReaderBoundLaneNamesTheReader is the claim's evidence.
+//
+// `ownedByWhoeverIsReading` asserts something specific about the LANE: its
+// query takes the acting user, so no other person's row could have come back.
+// That is checkable, and four of the lanes that first carried the claim failed
+// it — decisions, meetings, DSR and three of the five system sources are read
+// under the caller's ROW SCOPE instead, which is a different thing. A
+// team-scoped reader receives their team's rows there, and naming the reader
+// would have made a colleague's duplicate pair look like the reader's own work.
+//
+// The table is the audit. A source moving between the columns is somebody
+// changing what a lane reads, and it should cost them this test.
+func TestOnlyAReaderBoundLaneNamesTheReader(t *testing.T) {
+	t.Parallel()
+	readerBound := map[crmcontracts.WorklistItemSource]string{
+		"conversation_claim":   "OpenCommitmentsDue takes the actor's id",
+		"failed_approval":      "ListWire with FailedForDecider carries the decider",
+		"introduction_request": "AwaitingMyAnswer is the reader's own asks",
+		"relationship_decay":   "QuietEdgesForUser binds the edges to the actor",
+		"bounce":               "HardBouncesFor is the comms store's per-user read",
+		"undelivered":          "the same per-user read as the bounce beside it",
+		"notice":               "a notice is addressed to one person",
+		"capture_health":       "a mailbox belongs to one person",
+	}
+	rows := classifyDay(dayOfEveryLane(), rankInstant, dayMoney{})
+	for _, row := range rows {
+		why, claimed := readerBound[row.item.Source]
+		isReaderBound := row.ownerRef.kind == ownerTheReader
+		if claimed && !isReaderBound {
+			t.Errorf("%q no longer names the reader, though %s — if the lane still reads "+
+				"per-user the claim belongs back on it", row.item.Source, why)
+		}
+		if !claimed && isReaderBound {
+			t.Errorf("%q names whoever is reading, and no entry here says its query is bound "+
+				"to them: a row read under the caller's ROW SCOPE reaches a team-scoped "+
+				"reader carrying a colleague's work, and this would call it theirs",
+				row.item.Source)
+		}
+	}
+}

--- a/backend/internal/compose/attention/owner_test.go
+++ b/backend/internal/compose/attention/owner_test.go
@@ -4,6 +4,7 @@
 package attention
 
 import (
+	"fmt"
 	"testing"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -36,6 +37,16 @@ func TestEveryProducerStatesAnOwner(t *testing.T) {
 	rows = append(rows,
 		classifyWaiting(WaitingCustomer{Since: rankInstant}, rankInstant),
 		classifyLead(OwedLead{}, rankInstant))
+	// And the FOLD, which mints rows of its own after everything above has run.
+	// A census that stopped at the classifiers never met the one producer that
+	// synthesises a row rather than classifying one, so a batch reached readers
+	// with nothing said about who owned it and this test reported PASS.
+	folded := foldRoutineDecisions(aPileOfAlikeDecisions())
+	if !holdsABatch(folded) {
+		t.Fatal("the fold fixture produced no batch row, so this census still does not " +
+			"reach the one producer that synthesises rows")
+	}
+	rows = append(rows, folded...)
 	if len(rows) == 0 {
 		t.Fatal("the fixture produced no rows, so this census would pass over nothing")
 	}
@@ -240,5 +251,103 @@ func TestOnlyAReaderBoundLaneNamesTheReader(t *testing.T) {
 				"reader carrying a colleague's work, and this would call it theirs",
 				row.item.Source)
 		}
+	}
+}
+
+// aPileOfAlikeDecisions is enough alike routine decisions to fold, so the
+// census meets a real batch row rather than a hand-built one.
+func aPileOfAlikeDecisions() []ranked {
+	rows := make([]ranked, 0, batchFloor+1)
+	for i := 0; i <= batchFloor; i++ {
+		rows = append(rows, classifyDecision(
+			item(fmt.Sprintf("pair-%d", i), "dedupe_candidate"), rankInstant))
+	}
+	return rows
+}
+
+// holdsABatch reports whether the fold actually folded. Without asking, the
+// census passes over a fixture that produced ordinary rows and never met the
+// producer it was extended to reach.
+func holdsABatch(rows []ranked) bool {
+	for _, row := range rows {
+		if row.item.Batch != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestATeamPageDropsAnOutsideTeamTask closes the hole publishing the owner
+// opened.
+//
+// keepTeams judges a row through answersTo, which reads `ranked.owner`. The
+// task lane never set it, so a task answered nobody and the filter kept it as
+// unowned work — the gap its own comment describes for link-less tasks, which
+// auth.ActivityDiscoverClause makes discoverable installation-wide. Putting the
+// assignee on the wire made that worse: the colleague's user id travelled with
+// the row.
+//
+// The two readings come off one field now, so a task cannot be unowned to the
+// filter and owned to the client.
+func TestATeamPageDropsAnOutsideTeamTask(t *testing.T) {
+	t.Parallel()
+	outsider := ids.MustParse("01a05500-0000-7000-8000-00000000d15e")
+	row := classifyTask(taskAssignedTo(outsider), rankInstant)
+
+	named, ok := answersTo(row)
+
+	if !ok {
+		t.Fatal("a task with an assignee answers to nobody, so keepTeams keeps it as unowned " +
+			"work and publishes an outside-team user id with it")
+	}
+	if named != outsider {
+		t.Errorf("the task answers to %v, want its assignee %v", named, outsider)
+	}
+	// And an unheld task still answers nobody, which is what keeps genuinely
+	// unowned work on a team page rather than hiding it.
+	if _, held := answersTo(classifyTask(item("nobody", "task"), rankInstant)); held {
+		t.Error("a task nobody has taken answers to somebody, so unowned work would " +
+			"disappear from the only wider scope most readers hold")
+	}
+}
+
+// taskAssignedTo is a task one named person holds.
+func taskAssignedTo(assignee ids.UUID) crmcontracts.AttentionItem {
+	at := item("assigned", "task")
+	held := openapi_types.UUID(assignee)
+	at.AssigneeId = &held
+	return at
+}
+
+// TestAWithheldOwnerIsNotAnUnassignedOne holds the three states apart.
+//
+// The waiting lane can produce a row whose owner it could not read: its
+// eligibility is qualified through an ungated lookup while its owner comes off
+// a visibility-gated join, so a customer on a record this reader may not open
+// arrives with no owner id. Reporting that as `unassigned` is a claim the
+// workspace never made — somebody does owe the reply — and the reader has
+// nothing on the row to tell them otherwise.
+//
+// It must also stay distinguishable from a lane that never answered, or the
+// census could not tell the two apart either.
+func TestAWithheldOwnerIsNotAnUnassignedOne(t *testing.T) {
+	t.Parallel()
+	withheld := classifyWaiting(WaitingCustomer{Since: rankInstant}, rankInstant)
+
+	if withheld.ownerRef.kind == ownerUnstated {
+		t.Fatal("a waiting row with no readable owner states nothing, which the census " +
+			"cannot tell from a lane nobody wired")
+	}
+	if owner := ownerOnTheWire(withheld, ids.UUID{}); owner != nil {
+		t.Errorf("a withheld owner reached the wire as %+v, want the field absent — "+
+			"`unassigned` would say nobody owes a reply somebody does owe", *owner)
+	}
+	// And a readable one still names its person, so the case above is about
+	// the reading rather than about the lane.
+	owed := ids.MustParse("01a05500-0000-7000-8000-0000000000ed")
+	named := classifyWaiting(WaitingCustomer{Since: rankInstant, OwnerID: owed}, rankInstant)
+	owner := ownerOnTheWire(named, ids.UUID{})
+	if owner == nil || owner.Id == nil || ids.UUID(*owner.Id) != owed {
+		t.Errorf("a waiting row whose owner was read answered %v, want %v", owner, owed)
 	}
 }

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -137,6 +137,16 @@ type ranked struct {
 	// can judge it. Zero means the row names nobody, which for a wait is an
 	// unowned customer rather than a missing answer.
 	owner ids.UUID
+	// ownerRef is the same question answered for the CLIENT rather than for the
+	// scope filters, and it carries one thing `owner` cannot: whether the
+	// producer answered at all.
+	//
+	// A zero `owner` means two different things — nobody holds this row, and
+	// this lane never said — and the filters can live with that because a row
+	// they cannot judge simply stays. A reader cannot: told `unassigned`, they
+	// would read a confident claim that nobody owes it. So the producers state
+	// this one, and the census fails on a lane that does not.
+	ownerRef ownerRef
 	// person is WHO a waiting row is about, when it names one.
 	//
 	// The subject cannot answer this. A wait carrying both a deal and a person
@@ -184,7 +194,7 @@ func stampAsOf(rows []ranked, asOf time.Time) []ranked {
 // The explanation is produced HERE, during the sort, rather than by re-comparing
 // on the client: the tie-breaks depend on the base-currency conversion and the
 // material threshold, both of which the server holds and the browser does not.
-func rankAll(rows []ranked) []crmcontracts.WorklistItem {
+func rankAllFor(rows []ranked, reader ids.UUID) []crmcontracts.WorklistItem {
 	sort.SliceStable(rows, func(i, j int) bool {
 		return less(rows[i], rows[j])
 	})
@@ -211,6 +221,11 @@ func rankAll(rows []ranked) []crmcontracts.WorklistItem {
 		// describes a row's place on the page it is actually on.
 		band := crmcontracts.WorklistItemBand(bandOfRow(row))
 		item.Band = &band
+		// Who answers for it, as the PRODUCER said. Stamped here beside the
+		// band and the primary action, and for the same reason those are: a
+		// source added later carries it by arriving in this loop rather than by
+		// its author remembering to.
+		item.Owner = ownerOnTheWire(row, reader)
 		// And which SCREEN it belongs on, from the one map that decides that.
 		// Stamped for the same reason as the two above: a source added later
 		// carries it by arriving here, not by its author remembering to.

--- a/backend/internal/compose/attention/ranktesthelp_test.go
+++ b/backend/internal/compose/attention/ranktesthelp_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// rankAll orders a day for a test that is not asking about ownership.
+//
+// The production entry point takes the reader, because the lanes whose rows are
+// theirs by construction can only be resolved against somebody. A test about
+// ORDERING has no such reader and does not need one: the comparator never looks
+// at the owner. The tests that ARE about ownership call rankAllFor with a real
+// id, which is what makes the distinction visible rather than hidden behind a
+// default.
+func rankAll(rows []ranked) []crmcontracts.WorklistItem {
+	return rankAllFor(rows, ids.UUID{})
+}

--- a/backend/internal/compose/attention/waitinglane.go
+++ b/backend/internal/compose/attention/waitinglane.go
@@ -128,8 +128,20 @@ type WaitingCustomer struct {
 	// the queue a second place to spell it.
 	AsksNothing bool
 	// OwnerID is who owes this reply, resolved by the module from the record
-	// the thread is filed under. Zero when nothing on it names an owner, which
-	// is an unowned customer rather than a missing answer.
+	// the thread is filed under.
+	//
+	// ZERO IS AMBIGUOUS HERE, unlike the task and lead lanes beside it, and the
+	// SQL is where the difference lives: eligibility is qualified through an
+	// UNGATED sales-link lookup — deliberately, so the same message is not work
+	// for one colleague and personal mail for another — while the owner is read
+	// through the visibility-gated link join, so an owner off a record this
+	// reader may not open is correctly withheld. A row can therefore qualify
+	// while its owner cannot be read.
+	//
+	// So zero means "this lane cannot say", not "nobody owns it". The scope
+	// filters can live with that: a row they cannot judge simply stays. The
+	// wire cannot, which is why classifyWaiting states nothing rather than
+	// reporting a withheld owner as an unassigned customer.
 	OwnerID ids.UUID
 }
 

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -158,6 +158,10 @@ func (s *Service) Worklist(
 	if err := reader.nameTheStep(ctx, out.Queue); err != nil {
 		return crmcontracts.Worklist{}, err
 	}
+	// And the name beside each owner id, over the same cut page and for the same
+	// reason: a label is drawn and never ranked, so resolving one for a row this
+	// caller will not receive spends a read on nothing.
+	reader.nameTheOwners(ctx, out.Queue)
 	return out, nil
 }
 
@@ -307,7 +311,7 @@ func (s *Service) worklistFrom(
 	// the whole narrowed set — so page two weighs exactly what page one weighed
 	// and continues it rather than re-deciding it.
 	shown, more, reached := pageFrom(rows, limit, cursor)
-	ordered := rankAll(stampAsOf(shown, day.AsOf))
+	ordered := rankAllFor(stampAsOf(shown, day.AsOf), readerOf(ctx))
 	bands := bandsOf(ordered)
 	// What never answered, assembled ONCE and used twice: the page names these
 	// lanes to the reader, and the readings below refuse to state exact figures

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -161,7 +161,9 @@ func (s *Service) Worklist(
 	// And the name beside each owner id, over the same cut page and for the same
 	// reason: a label is drawn and never ranked, so resolving one for a row this
 	// caller will not receive spends a read on nothing.
-	reader.nameTheOwners(ctx, out.Queue)
+	if err := reader.nameTheOwners(ctx, out.Queue); err != nil {
+		return crmcontracts.Worklist{}, err
+	}
 	return out, nil
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13513,6 +13513,24 @@ func (e WorklistMoveAction) Valid() bool {
 	}
 }
 
+// Defines values for WorklistOwnerKind.
+const (
+	WorklistOwnerUnassigned WorklistOwnerKind = "unassigned"
+	WorklistOwnerUser       WorklistOwnerKind = "user"
+)
+
+// Valid indicates whether the value is a known member of the WorklistOwnerKind enum.
+func (e WorklistOwnerKind) Valid() bool {
+	switch e {
+	case WorklistOwnerUnassigned:
+		return true
+	case WorklistOwnerUser:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistReachSource.
 const (
 	WorklistReachSourceAiWorkHealth        WorklistReachSource = "ai_work_health"
@@ -33010,6 +33028,26 @@ type WorklistItem struct {
 	// Overdue Past due at the read instant, resolved server-side so every surface agrees.
 	Overdue *bool `json:"overdue,omitempty"`
 
+	// Owner Who this row answers to.
+	//
+	// RESPONSIBILITY, not visibility. The two are different facts and reading one
+	// for the other is how a rep's queue fills with a colleague's work: a notice
+	// addressed to somebody else may be unreadable, and a shared deal may be
+	// readable by a whole team while exactly one person owes the next move.
+	//
+	// Stated by the PRODUCER that raised the row, never inferred downstream. A
+	// reader who can see a row is not thereby its owner; a row surviving a `mine`
+	// filter is not evidence either, because several lanes take the scope as a
+	// query argument and answer it in SQL. Both of those inferences were available
+	// here and both are wrong in the same direction — they would make every row a
+	// reader can see look like a row a reader owes.
+	//
+	// `kind: unassigned` is a real answer and the honest one for work nobody has
+	// taken. It is what the `unassigned` scope surfaces, and a row that reached a
+	// rep's Mine queue while answering `unassigned` is a bug in the lane that
+	// produced it rather than a display choice here.
+	Owner *WorklistOwner `json:"owner,omitempty"`
+
 	// Pair The two records a `dedupe_candidate` proposes to merge, and the evidence that
 	// raised it — the same payload the lane feed carries, forwarded so the decision
 	// can be MADE where it is shown rather than sent somewhere to be made.
@@ -33177,6 +33215,43 @@ type WorklistMove struct {
 // read the same to a reader, so the producers drop it and send no `move`. A
 // client that meets one anyway draws nothing, which is the same outcome.
 type WorklistMoveAction string
+
+// WorklistOwner Who this row answers to.
+//
+// RESPONSIBILITY, not visibility. The two are different facts and reading one
+// for the other is how a rep's queue fills with a colleague's work: a notice
+// addressed to somebody else may be unreadable, and a shared deal may be
+// readable by a whole team while exactly one person owes the next move.
+//
+// Stated by the PRODUCER that raised the row, never inferred downstream. A
+// reader who can see a row is not thereby its owner; a row surviving a `mine`
+// filter is not evidence either, because several lanes take the scope as a
+// query argument and answer it in SQL. Both of those inferences were available
+// here and both are wrong in the same direction — they would make every row a
+// reader can see look like a row a reader owes.
+//
+// `kind: unassigned` is a real answer and the honest one for work nobody has
+// taken. It is what the `unassigned` scope surfaces, and a row that reached a
+// rep's Mine queue while answering `unassigned` is a bug in the lane that
+// produced it rather than a display choice here.
+type WorklistOwner struct {
+	// Id The owning user. Present when `kind` is `user`.
+	Id *openapi_types.UUID `json:"id,omitempty"`
+
+	// Kind Whether a person answers for this row, or nobody does yet.
+	Kind WorklistOwnerKind `json:"kind"`
+
+	// Label The owner's display name, resolved under the CALLER's own grants.
+	//
+	// Absent where the caller may not resolve it — the same refusal shape the
+	// rest of this response uses for a name it cannot read. A client draws the
+	// row without a name rather than inventing one, and never treats an absent
+	// label as an absent owner: `kind` is what says whether anybody answers.
+	Label *string `json:"label,omitempty"`
+}
+
+// WorklistOwnerKind Whether a person answers for this row, or nobody does yet.
+type WorklistOwnerKind string
 
 // WorklistPinRequest defines model for WorklistPinRequest.
 type WorklistPinRequest struct {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29029,6 +29029,47 @@ export interface components {
             base_currency?: string | null;
         };
         /**
+         * @description Who this row answers to.
+         *
+         *     RESPONSIBILITY, not visibility. The two are different facts and reading one
+         *     for the other is how a rep's queue fills with a colleague's work: a notice
+         *     addressed to somebody else may be unreadable, and a shared deal may be
+         *     readable by a whole team while exactly one person owes the next move.
+         *
+         *     Stated by the PRODUCER that raised the row, never inferred downstream. A
+         *     reader who can see a row is not thereby its owner; a row surviving a `mine`
+         *     filter is not evidence either, because several lanes take the scope as a
+         *     query argument and answer it in SQL. Both of those inferences were available
+         *     here and both are wrong in the same direction — they would make every row a
+         *     reader can see look like a row a reader owes.
+         *
+         *     `kind: unassigned` is a real answer and the honest one for work nobody has
+         *     taken. It is what the `unassigned` scope surfaces, and a row that reached a
+         *     rep's Mine queue while answering `unassigned` is a bug in the lane that
+         *     produced it rather than a display choice here.
+         */
+        WorklistOwner: {
+            /**
+             * @description Whether a person answers for this row, or nobody does yet.
+             * @enum {string}
+             */
+            kind: "user" | "unassigned";
+            /**
+             * Format: uuid
+             * @description The owning user. Present when `kind` is `user`.
+             */
+            id?: string;
+            /**
+             * @description The owner's display name, resolved under the CALLER's own grants.
+             *
+             *     Absent where the caller may not resolve it — the same refusal shape the
+             *     rest of this response uses for a name it cannot read. A client draws the
+             *     row without a name rather than inventing one, and never treats an absent
+             *     label as an absent owner: `kind` is what says whether anybody answers.
+             */
+            label?: string;
+        };
+        /**
          * @description The day cut into four parts that SUM TO `total`. Every candidate the read weighed
          *     lands in exactly one of them.
          *
@@ -29310,6 +29351,7 @@ export interface components {
              * @enum {string}
              */
             category: "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
+            owner?: components["schemas"]["WorklistOwner"];
             /**
              * @description Which SCREEN this row belongs on. The server decides it once, and every count,
              *     fold and page in this response is computed from the same value the row carries,


### PR DESCRIPTION
## What this changes

A worklist row now says **who answers for it**, and the producer that raised the row is what says so.

The owner was already resolved inside the scope filters and thrown away. A manager looking at a team queue read rows with no way to say whose they were, and the `unassigned` scope surfaced work nobody held without any row admitting it.

`WorklistItem.owner` carries a kind, an id and a display name. Additive and optional; every existing field keeps its meaning.

## Why the producer states it

Two inferences were available downstream and **both are wrong in the same direction**: the reader can see the row, so it is theirs; the row survived a `mine` filter, so it is theirs. A rep can read a colleague's deal and owes nothing on it, and several lanes take the scope as a query argument and answer it in SQL. Either default fills a rep's morning with work they do not owe, and neither fails anything.

So `ownerRef` carries a **kind**, and silence is not `unassigned`. Five answers:

- **named** — this lane resolved a person.
- **nobody** — genuinely unheld; what the `unassigned` scope exists to surface.
- **whoever is reading** — the lane's *query* takes the acting user, so no other person's row could have come back.
- **from the deal** — the at-risk and brief lanes classify before the facts pass fills the deal's owner.
- **unreadable** — the lane has an owner and could not read it. Reaches the wire as an absent field.

A lane that says nothing reaches the wire with no owner at all rather than a confident claim, and the census fails on it.

## What review caught

**Five lanes did not own their rows the way they claimed.** `ownedByWhoeverIsReading` asserts something checkable about a lane, and decisions, meetings, DSR, sync health and automation health are read under the caller's **row scope** instead. A team-scoped reader receives their team's rows there, so naming the reader made a colleague's duplicate pair look like the reader's own work — two people opening the same row were told two different owners. `TestOnlyAReaderBoundLaneNamesTheReader` is the audit, and its table names the read that binds each surviving claim.

**A waiting row's zero owner meant two things.** Eligibility is qualified through an ungated lookup while the owner comes off a gated join — the SQL says so in its own comments — so a customer on an unreadable record arrives owner-less while somebody plainly owes the reply. That is `ownerUnreadable` now.

**A task published an outside-team colleague's user id.** `keepTeams` judges through `answersTo`, which reads `ranked.owner`; the task lane only set the new wire field, so the filter counted the row as unowned and kept it. One assignee, read by both.

**A folded batch stated nothing, and the census could not see it** — the fold mints rows after every classifier runs, so the one producer that synthesises rows was the one the census never met.

Plus: a visible ownerless deal said nothing instead of `unassigned`, and the label lookup swallowed its roster error (an absent label means "you may not resolve this name", so a failure published a refusal nobody made).

## Evidence

| Obligation | Evidence |
|---|---|
| Producer census | `TestEveryProducerStatesAnOwner` — every lane in `classifyDay`, the two read beside it, and the fold; asserts the fold fixture actually folded |
| Claim truthfulness | `TestOnlyAReaderBoundLaneNamesTheReader` — a table naming the binding read per source, failing in both directions |
| Row scope | `TestATeamPageDropsAnOutsideTeamTask` — an assigned task answers its assignee; an unheld one still answers nobody |
| Withheld vs absent | `TestAWithheldOwnerIsNotAnUnassignedOne`, `TestUnassignedIsSaidRatherThanImplied` |
| Two spellings of one fact | `TestATasksOwnerAgreesWithItsOwnReason` — reasons and owner cannot disagree |
| Label scope | reuses `Teammates.LiveTeammatesOfCaller`, the team board's own roster — no second answer to "whose name may this person read" |
| Mutation strength | Five clauses reverted one at a time, each watched failing: decay's owner → census; meeting's claim → audit; batch's owner → census; task's scope owner → team test; YAML corpus truncation → the 1A census |
| Contract | `make gen` + `pnpm gen:api` same commit; drift and breaking-change gates green |
| Full lane | `make check-backend` and `make check-fe` green |

## Not in this PR

No client draws the owner yet — that is PR 2. `classify.go` crossed the 500-line cap on the way, so the delivery classifiers (bounce, undelivered, the pipes) moved to their own file: they share a concept, not just a line count.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Worklist rows now carry an `owner` field — kind, id, and display name — stated by the producer that raised each row rather than inferred by the reader, and a lane that stays silent reaches the wire with no owner rather than a confident `unassigned`. Previously the owner was resolved inside the scope filters and thrown away, so a manager reading a team queue couldn't tell whose rows were whose; the field is additive and optional, and no client draws it yet.

**Bug Fixes**
- Decisions, meetings, DSR, sync health, and automation health are read under the caller's row scope, so they answer `unassigned` instead of naming the reader.
- A waiting row whose owner couldn't be read now reaches the wire with the owner absent rather than as `unassigned`.
- Tasks now feed the same assignee to the scope filters and the client, so an outside-team colleague's user id is no longer published with the row.
- Folded batches state their members' owner when the members agree and nothing when they don't.
- An ownerless deal now answers `unassigned` instead of staying silent.
- Roster errors now travel instead of being swallowed into a false label refusal.

**Refactors**
- The delivery classifiers (bounce, undelivered, system pipes) moved to their own file after `classify.go` crossed the 500-line cap.

<sup>Written for commit 13caaf3fab31d2527255b83caf958109ec26190e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist entries now show ownership information, including assigned users and explicitly unassigned items.
  * Ownership is populated consistently across tasks, leads, meetings, messages, deals, and system notifications.
  * Owner names are displayed when available and authorized.
  * Worklist filtering now uses task assignees consistently.
* **Bug Fixes**
  * Improved handling of shared batches and cases where owner information is unavailable or intentionally withheld.
  * System-generated items and staged decisions are no longer incorrectly attributed to the current reader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->