### PR TITLE
A folded group takes its screen from its members

### DIFF
--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -298,11 +298,17 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		},
 		Actions: []crmcontracts.WorklistItemActions{},
 		// The members' own screen, carried onto the row that stands for them.
-		// The fold has already refused to group rows that disagree, so the first
-		// member answers for all of them — and deriving it from the word `batch`
-		// instead would put a pile of approvals wherever `batch` was mapped
-		// rather than where its members belong.
-		Destination: destinationPtr(destinationOf(members[0])),
+		// Deriving it from the word `batch` instead would put a pile of
+		// approvals wherever `batch` was mapped rather than where its members
+		// belong.
+		//
+		// Read the same way the OWNER below is read — from the members, and only
+		// where they agree. The fold refuses to group rows bound for different
+		// screens, so today this can only be the one they share; asking the
+		// members rather than trusting that keeps the two answers from drifting
+		// apart if a second caller ever reaches this function without the
+		// guard in front of it.
+		Destination: destinationPtr(destinationOfGroup(members)),
 	}
 	if cause != "" {
 		row.Batch.Cause = &cause

--- a/backend/internal/compose/attention/destination.go
+++ b/backend/internal/compose/attention/destination.go
@@ -179,3 +179,23 @@ func sameDestination(members []ranked) bool {
 	}
 	return true
 }
+
+// destinationOfGroup is the screen a folded row belongs on, asked of its
+// members.
+//
+// The fold refuses to group rows that disagree, so members already sharing one
+// screen is the only shape that reaches here — and this asks anyway. The guard
+// is eight lines away in another function, which is exactly the distance over
+// which a claim stops being true without anybody noticing: a second caller
+// reaching batchRow without it would silently file a group wherever its first
+// member happened to sit.
+//
+// Disagreement answers `review` for the reason the unmapped case does: an
+// unexpected group on the review screen is one row somebody looks at, while the
+// same group in Today claims to be executable seller work.
+func destinationOfGroup(members []ranked) crmcontracts.WorklistItemDestination {
+	if len(members) == 0 || !sameDestination(members) {
+		return destinationReview
+	}
+	return destinationOf(members[0])
+}

--- a/backend/internal/compose/attention/worklistincidents_test.go
+++ b/backend/internal/compose/attention/worklistincidents_test.go
@@ -304,3 +304,48 @@ func systemRowWithCause(source crmcontracts.AttentionItemSource, id string) rank
 	at.CauseRef = &cause
 	return classifySystem(at, rankInstant)
 }
+
+// A folded group's screen comes from its MEMBERS, not from the guard that
+// happens to run before it.
+//
+// foldRoutineDecisions refuses to group rows bound for different screens, so in
+// production batchRow only ever sees members that agree. That makes the claim
+// true and unheld at the same time: the guard is in another function, and a
+// second caller reaching batchRow without it would file a group wherever its
+// first member happened to sit. This calls batchRow directly, which is the
+// shape that guard cannot protect.
+func TestAGroupTakesItsScreenFromItsMembers(t *testing.T) {
+	members := []ranked{
+		systemRowWithCause("capture_health", "one"),
+		systemRowWithCause("capture_health", "two"),
+		systemRowWithCause("capture_health", "three"),
+	}
+	if at := destinationOf(members[0]); at != destinationSystemHealth {
+		t.Fatalf("the fixture's members belong to %q, so this test cannot show a group "+
+			"taking system_health from them", at)
+	}
+
+	group := batchRow(keySystemIncident, "sync_failing", members, false)
+
+	if group.item.Destination == nil {
+		t.Fatal("a folded group says nothing about which screen it belongs on")
+	}
+	if *group.item.Destination != destinationSystemHealth {
+		t.Errorf("a group of broken mailboxes belongs to %q, want %q — its members' screen",
+			*group.item.Destination, destinationSystemHealth)
+	}
+	// And members that disagree are filed for review rather than taking the
+	// first one's answer. Driven through batchRow, not through the helper it
+	// calls: the helper on its own proves nothing about what the group row
+	// actually carries, and a batchRow that went back to reading members[0]
+	// passed a version of this test that asked destinationOfGroup directly.
+	mixed := append([]ranked{systemRowWithCause("notice", "four")}, members...)
+	disagreeing := batchRow(keySystemIncident, "sync_failing", mixed, false)
+	if disagreeing.item.Destination == nil {
+		t.Fatal("a group of disagreeing members says nothing about its screen")
+	}
+	if *disagreeing.item.Destination != destinationReview {
+		t.Errorf("a group whose members disagree answered %q, want %q rather than the "+
+			"first member's screen", *disagreeing.item.Destination, destinationReview)
+	}
+}


### PR DESCRIPTION
A background security review flagged a gate/action mismatch in `batches.go`, and it was right.

`batchRow` read `members[0]` for the group's destination, and its comment justified that by pointing at the fold's `sameDestination` guard. The guard is real and runs first, so the claim was **true and unheld at the same time** — it lives in another function, and a second caller reaching `batchRow` without it would silently file a pile of approvals wherever its first member happened to sit.

The group asks its members now, the same way the owner beside it already does, and answers `review` where they disagree. An unexpected group on the review screen is one row somebody looks at; the same group in Today claims to be executable seller work nobody wrote a verb for.

**The first version of the test passed for the wrong reason.** It called `destinationOfGroup` directly, so reverting `batchRow` to `members[0]` changed nothing it observed — it proved the helper and nothing about the row. It drives `batchRow` now, and fails on that mutation.

`make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `batchRow` so a folded group takes its screen from its members, not from `members[0]`, and answers `review` when they disagree.

The previous code relied on a `sameDestination` guard living in another function; now the group asks its members directly.

- Disagreeing members route the group to `review` instead of the first member's screen.
- The test drives `batchRow` directly, so reverting to `members[0]` would fail it.

<sup>Written for commit 722ce924b35817cd1c702b8eb9be46f0685af9f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grouped work items now use the shared destination of their members instead of relying on the first member.
  * Groups containing members with different destinations are now routed to review for safer handling.
  * Empty groups also fall back to review rather than being assigned an incorrect destination.

* **Tests**
  * Added coverage to verify destination assignment for groups with matching and conflicting member destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->