### PR TITLE
A held draft's preflight asks the engine that now decides

### DIFF
--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -73,13 +74,41 @@ func assertStaged(t *testing.T, stager *recordingStager, want int, when string) 
 	}
 }
 
+// governedDelivery is the REAL delivery machinery, for the suites whose claim is
+// that a send is refused.
+//
+// A double cannot stand in for it in those suites any more, and that is not a
+// preference. The consent decision moved INTO this seam: the stager is what asks
+// the engine and what refuses. A recordingStager put in its place removes the
+// authority and then reports that nothing was refused — a suite named for the
+// governed path, passing because it no longer contains one.
+func governedDelivery(t *testing.T, e *integration.Env) DeliveryMachinery {
+	t.Helper()
+	integration.ApplyRiverSchema(t)
+	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	return NewDeliveryStager(e.Pool, inserter)
+}
+
+// assertDelivered counts the delivery rows the real machinery wrote, which is
+// what assertStaged counts for a double: what actually reached transmission.
+func assertDelivered(t *testing.T, e *integration.Env, want int, when string) {
+	t.Helper()
+	if n := e.WsCount(t, `SELECT count(*) FROM comms_outbound`); n != want {
+		t.Fatalf("%s staged %d deliveries, want %d", when, n, want)
+	}
+}
+
 func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	e := integration.Setup(t)
-	stager := &recordingStager{}
+	// The real machinery: this suite's claim is that an unconsented send is
+	// REFUSED, and the refusal now lives in the stager.
 	adapter := commsAdapter{
 		store:  activities.NewStore(e.DB()),
 		gate:   consent.NewGate(consent.NewStore(InstallationDB(e.Pool))),
-		stager: stager,
+		stager: governedDelivery(t, e),
 	}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
@@ -118,7 +147,7 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	if !errors.Is(err, apperrors.ErrConsentNotGranted) {
 		t.Fatalf("unconsented MCP send → %v, want ErrConsentNotGranted", err)
 	}
-	assertStaged(t, stager, 0, "the suppressed MCP send")
+	assertDelivered(t, e, 0, "the suppressed MCP send")
 
 	from := time.Date(2026, 7, 7, 8, 0, 0, 0, time.UTC)
 	avail, err := adapter.Availability(ctx, nil, from, from.Add(10*time.Hour), 60)

--- a/backend/internal/compose/heldrelease.go
+++ b/backend/internal/compose/heldrelease.go
@@ -178,7 +178,7 @@ func releaseHeldDraft(
 // snapshots, and writes nothing.
 func heldDraftPrecheck(
 	store *activities.Store,
-	gate activities.ConsentGate,
+	gate releaseAuthority,
 	stager activities.DeliveryStager,
 ) approvals.ReleasePrecheck {
 	return func(ctx context.Context, staged, edited json.RawMessage) error {
@@ -197,8 +197,28 @@ func heldDraftPrecheck(
 			proposal = corrected
 		}
 		origin, in := sendFromHeldDraft(proposal)
-		_, err = store.PrepareSend(ctx, origin, in, gate, stager)
-		return err
+		prepared, err := store.PrepareSend(ctx, origin, in, gate, stager)
+		if err != nil {
+			return err
+		}
+		// And then the ENGINE, which is the authority that actually decides a
+		// send. Preparation stopped answering that question when the request-time
+		// purpose gate was removed from it: the decision moved to staging, and
+		// staging happens inside the transaction that has already decided the
+		// approval. A precheck that stopped at PrepareSend would report "this
+		// draft can be sent" about every message the engine refuses.
+		//
+		// The SAME request staging will decide on, carried from preparation
+		// rather than rebuilt, so this cannot answer about a different message
+		// than the one that would go out.
+		set, err := gate.PreviewStaging(ctx, prepared.Authorization())
+		if err != nil {
+			return err
+		}
+		// The same reading of the same decision set the stager applies. A
+		// second spelling of "which refusals stop a send" would be the half
+		// that falls behind.
+		return refuseAtStaging(set)
 	}
 }
 

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -31,7 +31,6 @@ import (
 func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	e := integration.Setup(t)
 	consentStore := consent.NewStore(InstallationDB(e.Pool))
-	stager := &recordingStager{}
 	// Built through the composition root, not by hand: a marketing send is
 	// exactly the case whose derivation depends on the unsubscribe linker and
 	// the public base URL that only newCommsAdapter wires. Assembled field by
@@ -39,7 +38,10 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	// suite is about would be proven against the wrong one.
 	adapter := newCommsAdapter(e.Pool, nil, SendPath{
 		PublicBaseURL: "https://crm.margince.test",
-		Delivery:      stager,
+		// The real machinery. The suppression this suite is about is applied
+		// by the stager, so a double here would remove the very gate the
+		// opt-out is supposed to close.
+		Delivery: governedDelivery(t, e),
 	})
 
 	admin := e.Admin()
@@ -66,6 +68,13 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	agentCtx = principal.WithCorrelationID(agentCtx, ids.NewV7())
 	agentCtx = principal.WithActor(agentCtx, principal.Principal{
 		Type: principal.PrincipalAgent, ID: "agent:optout-probe",
+		// The seat the agent acts for. An agent reaches a send through a
+		// passport issued against a human's seat, and staging refuses a
+		// principal carrying no app_user identity at all — sending is a human
+		// act. Naming it here is what makes this an agent send rather than an
+		// unauthenticated one, and it does not soften the suppression: the gate
+		// never consults the principal, which is this suite's whole point.
+		UserID: e.Rep1, OnBehalfOf: e.Rep1,
 		Permissions: principal.Permissions{
 			Objects: map[string]principal.ObjectGrant{
 				"activity": {Create: true, Read: true},
@@ -86,7 +95,7 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	if err := send(); err != nil {
 		t.Fatalf("granted agent send → %v, want success", err)
 	}
-	assertStaged(t, stager, 1, "the granted agent send")
+	assertDelivered(t, e, 1, "the granted agent send")
 
 	// The buyer one-click unsubscribes through the PUBLIC preference surface,
 	// exactly as the anonymous middleware binds it (system principal).
@@ -104,7 +113,7 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	if err := send(); !errors.Is(err, apperrors.ErrConsentNotGranted) {
 		t.Fatalf("agent send after opt-out → %v, want ErrConsentNotGranted", err)
 	}
-	assertStaged(t, stager, 1, "the send after opt-out (still only the pre-opt-out one)")
+	assertDelivered(t, e, 1, "the send after opt-out (still only the pre-opt-out one)")
 }
 
 // seedReplyAnchor writes the mail activity the send threads onto.

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -36,6 +36,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 )
 
@@ -193,9 +194,23 @@ func consentGateFor(pool *pgxpool.Pool) *consent.Gate {
 // They travel together because they are two readings of ONE question — can this
 // be released — and a kind that registered the executor without the preflight
 // would answer it only where the answer is too late to act on.
+// releaseAuthority is everything a late-registered release has to ask about a
+// message before it decides the approval that releases it.
+//
+// TWO questions, because there are two authorities and only one of them the
+// store takes: activities.ConsentGate is the old purpose gate the send path
+// still carries, and PreviewStaging is the engine, which is what actually
+// decides a send now. A precheck holding only the first would pass a message
+// the engine then refuses — and it would refuse it after the approval had
+// already committed.
+type releaseAuthority interface {
+	activities.ConsentGate
+	PreviewStaging(ctx context.Context, req commsauthz.Request) (commsauthz.DecisionSet, error)
+}
+
 type lateApprovalEffect struct {
 	effect   func(*approvals.Service, *activities.Store, activities.ConsentGate, activities.DeliveryStager) approvals.ApprovedEffect
-	precheck func(*activities.Store, activities.ConsentGate, activities.DeliveryStager) approvals.ReleasePrecheck
+	precheck func(*activities.Store, releaseAuthority, activities.DeliveryStager) approvals.ReleasePrecheck
 }
 
 // lateApprovalEffects are the approve-side pairs that cannot be registered with

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // stubUnsubscribeLinker stands in for the consent module's preference-token
@@ -265,7 +266,7 @@ func TestASendGoesOutThroughTheMailboxItResolved(t *testing.T) {
 			// transmits, and the activity's source_system is the natural key the
 			// provider's own echo carries. Two answers here would file a
 			// duplicate timeline row for every message anybody sends.
-			if got := m.delivery(ids.NewV7(), threading{}, SendOrigin{}).Provider; got != provider {
+			if got := m.delivery(ids.NewV7(), threading{}, commsauthz.Request{}).Provider; got != provider {
 				t.Errorf("delivery provider = %q, want %q — handed to a connector this sender has no grant on", got, provider)
 			}
 			act := m.activity(threading{})

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -99,7 +99,7 @@ func (m outboundMessage) activity(chain threading) LogActivityInput {
 }
 
 // delivery is the same message as the delivery machinery receives it.
-func (m outboundMessage) delivery(activityID ids.UUID, chain threading, origin SendOrigin) DeliveryRequest {
+func (m outboundMessage) delivery(activityID ids.UUID, chain threading, authorization commsauthz.Request) DeliveryRequest {
 	return DeliveryRequest{
 		ActivityID:      ids.From[ids.ActivityKind](activityID),
 		Provider:        m.provider,
@@ -113,7 +113,7 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading, origin S
 		FromName:        m.fromName,
 		Attachments:     m.files,
 		ConsentPurpose:  m.in.ConsentPurpose,
-		Authorization:   m.authorization(origin),
+		Authorization:   authorization,
 		InReplyTo:       chain.inReplyTo,
 		References:      chain.references,
 		ThreadKey:       chain.threadKey,

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -13,6 +13,7 @@ package activities
 
 import (
 	"context"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 
@@ -87,7 +88,17 @@ type PreparedSend struct {
 // approval first, and a refusal discovered after that leaves an approved row
 // nothing can decide again. It is a getter and not a field so a caller outside
 // this package can read the request and cannot forge one.
-func (p PreparedSend) Authorization() commsauthz.Request { return p.authorization }
+func (p PreparedSend) Authorization() commsauthz.Request {
+	req := p.authorization
+	// The slices are CLONED, and that is the same guarantee the unexported
+	// fields give: a caller may carry this request and may not forge one.
+	// Handing back the backing arrays would be a forge by another name —
+	// staging decides on p.authorization, so rewriting a recipient through the
+	// returned request would send to somebody the preview never asked about.
+	req.Recipients = slices.Clone(p.authorization.Recipients)
+	req.Links = slices.Clone(p.authorization.Links)
+	return req
+}
 
 // PrepareSend runs everything an outbound send needs BEFORE it writes: origin
 // resolution, the guard sequence, the sign-off, deliverability, attachment

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -18,6 +18,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // SendEmail runs the governed send: origin resolution → the guard sequence
@@ -69,7 +70,24 @@ type PreparedSend struct {
 	in        SendEmailInput
 	message   outboundMessage
 	messageID string
+	// authorization is the question the engine will be asked about this
+	// message, built HERE and carried rather than rebuilt at staging. One
+	// construction is the point: a caller that must know the answer before it
+	// commits something else (the held-draft release) previews it, and staging
+	// then decides on the identical request. Two constructions would be two
+	// readings of one message, and the preview that stopped matching would
+	// promise a send the engine refuses.
+	authorization commsauthz.Request
 }
+
+// Authorization is the question the engine will be asked about this message.
+//
+// Exported for callers that have to know the answer before they commit
+// something the answer would invalidate: releasing a held draft decides an
+// approval first, and a refusal discovered after that leaves an approved row
+// nothing can decide again. It is a getter and not a field so a caller outside
+// this package can read the request and cannot forge one.
+func (p PreparedSend) Authorization() commsauthz.Request { return p.authorization }
 
 // PrepareSend runs everything an outbound send needs BEFORE it writes: origin
 // resolution, the guard sequence, the sign-off, deliverability, attachment
@@ -150,22 +168,24 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 		return PreparedSend{}, err
 	}
 
+	message := outboundMessage{
+		in:              in,
+		messageID:       messageID,
+		fromName:        fromName,
+		body:            derived.transmitted,
+		recordedBody:    derived.recorded,
+		htmlBody:        htmlBody,
+		files:           files,
+		listUnsubscribe: derived.listUnsubscribe,
+		to:              toRecipients(in.Recipients, in.Cc, in.Bcc),
+		links:           links,
+		provider:        provider,
+	}
 	return PreparedSend{
-		in:        in,
-		messageID: messageID,
-		message: outboundMessage{
-			in:              in,
-			messageID:       messageID,
-			fromName:        fromName,
-			body:            derived.transmitted,
-			recordedBody:    derived.recorded,
-			htmlBody:        htmlBody,
-			files:           files,
-			listUnsubscribe: derived.listUnsubscribe,
-			to:              toRecipients(in.Recipients, in.Cc, in.Bcc),
-			links:           links,
-			provider:        provider,
-		},
+		in:            in,
+		messageID:     messageID,
+		message:       message,
+		authorization: message.authorization(origin),
 	}, nil
 }
 
@@ -204,7 +224,7 @@ func (s *Store) SendPreparedTx(ctx context.Context, tx pgx.Tx, origin SendOrigin
 	if err != nil {
 		return crmcontracts.Activity{}, err
 	}
-	if err := stager.StageTx(ctx, tx, p.message.delivery(ids.UUID(sent.Id), chain, origin)); err != nil {
+	if err := stager.StageTx(ctx, tx, p.message.delivery(ids.UUID(sent.Id), chain, p.authorization)); err != nil {
 		return crmcontracts.Activity{}, err
 	}
 	// in.Body, not message.body: the judgment is about the text the HUMAN

--- a/backend/internal/modules/activities/sendcoreauthorization_test.go
+++ b/backend/internal/modules/activities/sendcoreauthorization_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What a caller may do with the authorization request it is handed.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// The request a caller reads cannot be used to rewrite the one that gets staged.
+//
+// PreparedSend keeps its fields unexported so a caller outside this package may
+// carry a prepared send and may not forge one. A getter handing back the
+// backing arrays would defeat that without touching a field: staging decides on
+// the carried request, so a caller that rewrote a recipient through the value it
+// previewed would send to somebody the engine was never asked about — the
+// preview and the send disagreeing, which is the one thing this seam exists to
+// prevent.
+func TestTheAuthorizationHandedOutCannotRewriteTheOneThatStages(t *testing.T) {
+	link := ids.NewV7()
+	p := PreparedSend{
+		authorization: commsauthz.Request{
+			Recipients: connector.EmailRecipients([]string{"buyer@acme.test"}),
+			Links:      []ids.UUID{link},
+		},
+	}
+
+	got := p.Authorization()
+	got.Recipients[0] = connector.EmailRecipients([]string{"stranger@elsewhere.test"})[0]
+	got.Links[0] = ids.NewV7()
+
+	if addr := p.authorization.Recipients[0].Email; addr != "buyer@acme.test" {
+		t.Errorf("the staged recipient is now %q — a caller rewrote the send through the request it previewed", addr)
+	}
+	if p.authorization.Links[0] != link {
+		t.Error("the staged links were rewritten through the previewed request")
+	}
+}

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -39,6 +39,58 @@ import (
 // describes. That also means it must not acquire a connection of its own, which
 // is why every read below runs on the passed tx.
 func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID, req commsauthz.Request) (commsauthz.DecisionSet, error) {
+	set, err := g.stagingDecisions(ctx, tx, req)
+	if err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
+	if err := g.recordStagingDecisions(ctx, tx, deliveryID, ids.NewV7(), req, set); err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
+	return set, nil
+}
+
+// PreviewStagingTx answers the staging question WITHOUT writing the record.
+//
+// It exists for the callers that must know whether a message could be staged
+// before they commit something else that depends on the answer — the held-draft
+// release is the one that needs it: its approval decision commits first, and a
+// refusal discovered after that leaves an approved row nothing can decide again
+// and a message a human said yes to that will never exist.
+//
+// It shares stagingDecisions with AuthorizeStagingTx rather than asking the
+// same question a second way. A preview that answered on its own code would be
+// a second authority, and the one that stopped matching would look exactly like
+// the one that still did — the failure this module is built to prevent.
+//
+// It records NOTHING on purpose. An Art. 5(2) record describes a message that
+// was staged; writing one for a message nobody sent would put a decision in the
+// register for a send that never happened.
+func (g *Gate) PreviewStagingTx(ctx context.Context, tx pgx.Tx, req commsauthz.Request) (commsauthz.DecisionSet, error) {
+	return g.stagingDecisions(ctx, tx, req)
+}
+
+// PreviewStaging is the pool-side spelling for a caller holding no transaction.
+//
+// It opens a read transaction of its own because the callers that need a
+// preview are outside one by construction: they are deciding whether to START
+// the work that would open it.
+func (g *Gate) PreviewStaging(ctx context.Context, req commsauthz.Request) (commsauthz.DecisionSet, error) {
+	var set commsauthz.DecisionSet
+	err := g.store.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		set, err = g.stagingDecisions(ctx, tx, req)
+		return err
+	})
+	if err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
+	return set, nil
+}
+
+// stagingDecisions is the decision itself: validation, the live posture, and one
+// decision per recipient. The single body both the recorded and the previewed
+// answer come from.
+func (g *Gate) stagingDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.Request) (commsauthz.DecisionSet, error) {
 	for _, r := range req.Recipients {
 		if err := r.Validate(); err != nil {
 			return commsauthz.DecisionSet{}, fmt.Errorf(
@@ -58,7 +110,6 @@ func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids
 		return commsauthz.DecisionSet{}, err
 	}
 
-	setID := ids.NewV7()
 	set := commsauthz.DecisionSet{}
 	for _, r := range req.Recipients {
 		d, err := g.decideOne(ctx, tx, r, req, commsauthz.PhaseStaging)
@@ -71,9 +122,6 @@ func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids
 		d.Mode = ModeFor(modes, d.Resolved)
 		d.Requested = req.Context
 		set.Decisions = append(set.Decisions, d)
-	}
-	if err := g.recordStagingDecisions(ctx, tx, deliveryID, setID, req, set); err != nil {
-		return commsauthz.DecisionSet{}, err
 	}
 	return set, nil
 }


### PR DESCRIPTION
Main has been red since #4125 on three suites, and one of them was reporting a real defect rather than drift.

## The regression

#4125 moved the send decision out of request-time preparation and into staging: `refuseUnsendable` stopped asking the purpose gate, and the engine now answers inside the transaction that writes the delivery. The held-draft release did not move with it.

Its preflight runs `PrepareSend` and throws the result away — that used to be how a human learned **now** that consent was withdrawn, while the approval was still pending and they could fix the cause and approve the same row again. After #4125 that preparation answers nothing about consent, so the refusal arrived from staging instead: *after* the approval had committed. An approved row nothing can decide again, a parked run, and a message a human said yes to that will never exist.

`TestAPreflightRefusalLeavesTheDraftPending` says exactly that in its failure text, and it has been saying it since #4125:

```
the approval was decided by a release that refused — the preflight is not
running before the decision, so this message is now unreleasable
```

## The fix

The preflight asks the engine. `PreviewStagingTx` answers the staging question without writing the Art. 5(2) record — a record describes a message that was staged, and this one may never be. It shares `stagingDecisions` with `AuthorizeStagingTx` rather than asking the same question a second way: a preview with its own code would be a second authority, and the one that stopped matching would look exactly like the one that still did.

It previews the **same request** staging will decide on. `PrepareSend` builds the authorization once and carries it, and `delivery()` takes it instead of rebuilding it from the origin, so a preview cannot answer about a different message than the one that would go out.

## The other two suites

Drift, of a kind worth naming. Both replace the delivery machinery with a recording double — and the authority #4125 moved lives **in** that seam. The double removed the gate and then reported that nothing was refused: a suite named for the governed path, passing because it no longer contained one. Both now stage through the real machinery and count the delivery rows it wrote.

The opt-out suite's agent principal gained the seat it acts for. Staging refuses a principal with no `app_user` identity — sending is a human act — and an agent reaches a send through a passport issued against a human's seat. It does not soften the suppression: the gate never consults the principal, which is that suite's whole point.

## Verification

`make check-backend` exit 0, plus the compose, consent, activities and comms integration suites.

Each fix mutation-checked:

| mutation | result |
|---|---|
| drop the preview from the preflight | reproduces the decided-approval failure verbatim |
| disable `refuseAtStaging` | all three suites fail |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pre-send authorization preview to ensure messages are evaluated against delivery rules before staging.
  - Delivery requests now carry their authorization details consistently through the send process.
- **Bug Fixes**
  - Improved enforcement of consent and suppression rules across message delivery paths, including MCP and agent-initiated sends.
  - Prevented unauthorized or opted-out messages from being delivered while preserving approved sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->