### PR TITLE
The purpose key is deprecated in the contract, not merely ignored in the code

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29940,7 +29940,7 @@ components:
           description: A recorded communication basis this send relies on.
     SendEmailRequest:
       type: object
-      required: [subject, body, to, consent_purpose]
+      required: [subject, body, to]
       properties:
         subject: { type: string }
         body: { type: string, description: The (possibly edited) final body that is sent. }
@@ -30038,9 +30038,14 @@ components:
         consent_purpose:
           type: string
           description: |
-            The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
-            The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
-            `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
+            DEPRECATED, and no longer required. The engine resolves what a message is from
+            the record — the thread it answers, the deal or invoice it names, the evidence
+            supplied in `evidence` — and a purpose key is not that. Send
+            `communication_context` instead.
+
+            A key that is still supplied is recorded as the caller's claim and is consulted
+            only where the record supports no category on its own. An unknown or archived
+            key authorizes nothing.
         scheduled_at:
           type: [string, 'null']
           format: date-time
@@ -30166,7 +30171,7 @@ components:
 
     SendAccountEmailRequest:
       type: object
-      required: [subject, body, to, consent_purpose, links]
+      required: [subject, body, to, links]
       description: |
         One account-started send. It is SendEmailRequest plus the `links` an anchor would
         otherwise have supplied — the records this new conversation belongs to.
@@ -30270,9 +30275,14 @@ components:
         consent_purpose:
           type: string
           description: |
-            The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
-            suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
-            `person_consent` for THIS purpose.
+            DEPRECATED, and no longer required. The engine resolves what a message is from
+            the record — the thread it answers, the deal or invoice it names, the evidence
+            supplied in `evidence` — and a purpose key is not that. Send
+            `communication_context` instead.
+
+            A key that is still supplied is recorded as the caller's claim and is consulted
+            only where the record supports no category on its own. An unknown or archived
+            key authorizes nothing.
         scheduled_at:
           type: [string, 'null']
           format: date-time
@@ -30313,7 +30323,7 @@ components:
 
     SendMessageRequest:
       type: object
-      required: [body, consent_purpose]
+      required: [body]
       description: |
         One channel reply. It carries no subject and no addressee list, and that absence is the
         shape of the transport rather than an omission: a messaging channel has no subject line
@@ -30370,9 +30380,14 @@ components:
         consent_purpose:
           type: string
           description: |
-            The consent purpose this send falls under (e.g. `transactional`). The send is
-            suppressed (409 `consent_not_granted`) unless the recipient has an active `granted`
-            `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
+            DEPRECATED, and no longer required. The engine resolves what a message is from
+            the record — the thread it answers, the deal or invoice it names, the evidence
+            supplied in `evidence` — and a purpose key is not that. Send
+            `communication_context` instead.
+
+            A key that is still supplied is recorded as the caller's claim and is consulted
+            only where the record supports no category on its own. An unknown or archived
+            key authorizes nothing.
         attachment_ids:
           type: array
           maxItems: 10

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -473,3 +473,74 @@ func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 		t.Fatalf("audit/event counts = %d/%d, want 1/1", audits, events)
 	}
 }
+
+// TestASendWithNoPurposeKeyReachesTheEngine is what makes the legacy purposes
+// retireable.
+//
+// consent_purpose was a required field for as long as it was the authority.
+// The engine decides now, from the record — so a caller that omits the key is
+// not withholding an answer, it is declining to make a claim the engine was
+// going to check against the tables anyway.
+//
+// The assertion is that the request is JUDGED rather than rejected as
+// malformed: a 409 naming a consent code is the engine answering, and it is a
+// different outcome from the 422 the contract used to produce before consent
+// was asked at all. The person here has nothing on file, so the answer is a
+// refusal — which is the correct one, and the point is who gave it.
+//
+// This is the case that has to work before `transactional` and
+// `business_correspondence` are archived. While the key was required,
+// archiving them left every caller with nothing valid to name.
+//
+// Mutation: put consent_purpose back on the schema's `required` list and this
+// fails with 422 validation_error.
+func TestASendWithNoPurposeKeyReachesTheEngine(t *testing.T) {
+	c := setupConsent(t)
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to": []string{"subject@consent.test"},
+	}, nil, &problem)
+	if status == http.StatusUnprocessableEntity {
+		t.Fatalf("a send with no consent_purpose → 422 %q; the contract still demands a key the engine no longer needs",
+			problem.Code)
+	}
+	if status != http.StatusConflict || problem.Code != "consent_not_granted" {
+		t.Fatalf("a send with no consent_purpose → %d %q, want 409 consent_not_granted — the engine judged it on the record",
+			status, problem.Code)
+	}
+}
+
+// TestOmittingThePurposeKeyIsNotAWayPastTheGate holds the direction the
+// relaxation must not break.
+//
+// Making the key optional must not turn omitting it into an allow. A message
+// with no thread, no deal and no evidence has nothing supporting it, and
+// dropping the claim does not supply one.
+//
+// It differs from the test above in the recipient: that one asks whether the
+// engine ANSWERED, this one asks whether a stranger is still refused. Both
+// currently refuse, and they would diverge the moment an empty claim started
+// resolving to something supported — which is the regression this pins.
+//
+// Mutation: make resolveFromClaimAndPurpose treat an empty key as supported
+// and this fails with a 202.
+func TestOmittingThePurposeKeyIsNotAWayPastTheGate(t *testing.T) {
+	c := setupConsent(t)
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := c.Call(t, "POST", "/v1/emails", AnyMap{
+		"subject": "Something unrelated", "body": "out of the blue",
+		"to":    []string{"subject@consent.test"},
+		"links": []AnyMap{{"entity_type": "person", "entity_id": c.personID}},
+	}, nil, &problem)
+	if status != http.StatusConflict {
+		t.Fatalf("an unevidenced account send with no consent_purpose → %d %q, want 409 — omitting the claim is not evidence",
+			status, problem.Code)
+	}
+}

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -234,7 +234,7 @@ func TestBothSendTransportsCarryTheDraftOutcomeRecorder(t *testing.T) {
 
 		body, err := json.Marshal(crmcontracts.SendEmailRequest{
 			To: []openapi_types.Email{openapi_types.Email(e.recipient)}, Subject: "Pricing",
-			Body: voiceDraftBody, ConsentPurpose: "transactional", DraftRef: &draft.ref,
+			Body: voiceDraftBody, ConsentPurpose: ptrTo("transactional"), DraftRef: &draft.ref,
 		})
 		if err != nil {
 			t.Fatalf("marshaling the send request: %v", err)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30072,10 +30072,15 @@ type SendAccountEmailRequest struct {
 	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendAccountEmailRequestCommunicationContext `json:"communication_context,omitempty"`
 
-	// ConsentPurpose The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
-	// suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
-	// `person_consent` for THIS purpose.
-	ConsentPurpose string `json:"consent_purpose"`
+	// ConsentPurpose DEPRECATED, and no longer required. The engine resolves what a message is from
+	// the record — the thread it answers, the deal or invoice it names, the evidence
+	// supplied in `evidence` — and a purpose key is not that. Send
+	// `communication_context` instead.
+	//
+	// A key that is still supplied is recorded as the caller's claim and is consulted
+	// only where the record supports no category on its own. An unknown or archived
+	// key authorizes nothing.
+	ConsentPurpose *string `json:"consent_purpose,omitempty"`
 
 	// DraftRef Opaque reference returned by the drafting operation, exactly as on `send_email`.
 	// Omit for independently composed mail.
@@ -30237,10 +30242,15 @@ type SendEmailRequest struct {
 	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendEmailRequestCommunicationContext `json:"communication_context,omitempty"`
 
-	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
-	// The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
-	// `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
-	ConsentPurpose string `json:"consent_purpose"`
+	// ConsentPurpose DEPRECATED, and no longer required. The engine resolves what a message is from
+	// the record — the thread it answers, the deal or invoice it names, the evidence
+	// supplied in `evidence` — and a purpose key is not that. Send
+	// `communication_context` instead.
+	//
+	// A key that is still supplied is recorded as the caller's claim and is consulted
+	// only where the record supports no category on its own. An unknown or archived
+	// key authorizes nothing.
+	ConsentPurpose *string `json:"consent_purpose,omitempty"`
 
 	// DraftRef Opaque reference returned by the drafting operation. After a successful send, the
 	// server compares this protected original with the final body and records accepted or
@@ -30363,10 +30373,15 @@ type SendMessageRequest struct {
 	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendMessageRequestCommunicationContext `json:"communication_context,omitempty"`
 
-	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`). The send is
-	// suppressed (409 `consent_not_granted`) unless the recipient has an active `granted`
-	// `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
-	ConsentPurpose string `json:"consent_purpose"`
+	// ConsentPurpose DEPRECATED, and no longer required. The engine resolves what a message is from
+	// the record — the thread it answers, the deal or invoice it names, the evidence
+	// supplied in `evidence` — and a purpose key is not that. Send
+	// `communication_context` instead.
+	//
+	// A key that is still supplied is recorded as the caller's claim and is consulted
+	// only where the record supports no category on its own. An unknown or archived
+	// key authorizes nothing.
+	ConsentPurpose *string `json:"consent_purpose,omitempty"`
 
 	// Evidence Records the caller names in support of this send. Checked, never trusted.
 	Evidence *CommunicationEvidence `json:"evidence,omitempty"`

--- a/backend/internal/modules/activities/handlers_channelsend.go
+++ b/backend/internal/modules/activities/handlers_channelsend.go
@@ -50,7 +50,7 @@ func (h Handlers) SendMessage(w http.ResponseWriter, r *http.Request, id crmcont
 	sent, err := h.store.SendMessage(r.Context(), pathID[ids.ActivityKind](id), SendMessageInput{
 		Body:             req.Body,
 		AttachmentIDs:    attachmentIDsFrom(req.AttachmentIds),
-		ConsentPurpose:   req.ConsentPurpose,
+		ConsentPurpose:   legacyPurposeOf(req.ConsentPurpose),
 		Context:          claimed.category,
 		MarketingPurpose: claimed.marketing,
 		OperatorReason:   claimed.reason,

--- a/backend/internal/modules/activities/sendcontext.go
+++ b/backend/internal/modules/activities/sendcontext.go
@@ -156,7 +156,7 @@ func replySendInput(req crmcontracts.SendEmailRequest) (SendEmailInput, error) {
 	}
 	return claimed.applyTo(sendInputFrom(
 		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
-		req.ConsentPurpose, req.DraftRef,
+		legacyPurposeOf(req.ConsentPurpose), req.DraftRef,
 	)), nil
 }
 
@@ -171,7 +171,7 @@ func accountSendInput(req crmcontracts.SendAccountEmailRequest) (SendEmailInput,
 	}
 	return claimed.applyTo(sendInputFrom(
 		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
-		req.ConsentPurpose, req.DraftRef,
+		legacyPurposeOf(req.ConsentPurpose), req.DraftRef,
 	)), nil
 }
 
@@ -231,4 +231,18 @@ func decodeSendContext(claim SendContextInput) (sendContext, error) {
 	// each named record and asks whether it supports the category.
 	decoded.evidence = claim.Evidence
 	return decoded, nil
+}
+
+// legacyPurposeOf reads the deprecated purpose key a caller may still send.
+//
+// Omitted becomes the empty key, which claims nothing: the engine resolves the
+// category from the record, and consults a purpose row only where the record
+// supports no category on its own. An empty key reaching that fallback resolves
+// no row and authorizes nothing, which is the same default-deny an unknown key
+// has always produced. Omitting the claim is not a way past the gate.
+func legacyPurposeOf(key *string) string {
+	if key == nil {
+		return ""
+	}
+	return *key
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21640,11 +21640,16 @@ export interface components {
             /** @description Records the caller names in support of this send. Checked, never trusted. */
             evidence?: components["schemas"]["CommunicationEvidence"];
             /**
-             * @description The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
-             *     The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
-             *     `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
+             * @description DEPRECATED, and no longer required. The engine resolves what a message is from
+             *     the record — the thread it answers, the deal or invoice it names, the evidence
+             *     supplied in `evidence` — and a purpose key is not that. Send
+             *     `communication_context` instead.
+             *
+             *     A key that is still supplied is recorded as the caller's claim and is consulted
+             *     only where the record supports no category on its own. An unknown or archived
+             *     key authorizes nothing.
              */
-            consent_purpose: string;
+            consent_purpose?: string;
             /**
              * Format: date-time
              * @description Send this message at this instant instead of now (ADR-0104/A155). Absolute
@@ -21862,11 +21867,16 @@ export interface components {
             /** @description Records the caller names in support of this send. Checked, never trusted. */
             evidence?: components["schemas"]["CommunicationEvidence"];
             /**
-             * @description The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
-             *     suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
-             *     `person_consent` for THIS purpose.
+             * @description DEPRECATED, and no longer required. The engine resolves what a message is from
+             *     the record — the thread it answers, the deal or invoice it names, the evidence
+             *     supplied in `evidence` — and a purpose key is not that. Send
+             *     `communication_context` instead.
+             *
+             *     A key that is still supplied is recorded as the caller's claim and is consulted
+             *     only where the record supports no category on its own. An unknown or archived
+             *     key authorizes nothing.
              */
-            consent_purpose: string;
+            consent_purpose?: string;
             /**
              * Format: date-time
              * @description Send this message at this instant instead of now (ADR-0104/A155). Absolute
@@ -21952,11 +21962,16 @@ export interface components {
             /** @description Records the caller names in support of this send. Checked, never trusted. */
             evidence?: components["schemas"]["CommunicationEvidence"];
             /**
-             * @description The consent purpose this send falls under (e.g. `transactional`). The send is
-             *     suppressed (409 `consent_not_granted`) unless the recipient has an active `granted`
-             *     `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
+             * @description DEPRECATED, and no longer required. The engine resolves what a message is from
+             *     the record — the thread it answers, the deal or invoice it names, the evidence
+             *     supplied in `evidence` — and a purpose key is not that. Send
+             *     `communication_context` instead.
+             *
+             *     A key that is still supplied is recorded as the caller's claim and is consulted
+             *     only where the record supports no category on its own. An unknown or archived
+             *     key authorizes nothing.
              */
-            consent_purpose: string;
+            consent_purpose?: string;
             /**
              * @description Files already in the record library to send with this message, named by id
              *     — never uploaded here. Each is snapshotted at staging (ADR-0086/A131 §4) so


### PR DESCRIPTION
`consent_purpose` was marked `required` on all three send requests while nothing enforced it.

**Measured, not inferred.** On the unchanged build, an account send that omits the key returns **409 `consent_not_granted`**, never 422. oapi-codegen renders a required body string as a non-pointer, `encoding/json` leaves an absent key at `""` with no error, and only `httperr.RequireBodyID` makes "required" true — for ids alone.

So the contract was describing an authority the engine took over in #4125. It now says what is true: the key is optional and deprecated, the engine resolves the category from the record, and a key still supplied is the caller's claim rather than the authority.

Relaxing `required` **widens** what is accepted, so `check-contract-breaking.sh` reports no breaking change and no allowlist entry is needed.

## Tests

Two directions, deliberately paired:

`TestASendWithNoPurposeKeyReachesTheEngine` — a send with no key is **judged** rather than rejected. This is what has to be true before the seeded purposes can be archived.

`TestOmittingThePurposeKeyIsNotAWayPastTheGate` — an unevidenced send is still refused. Dropping a claim does not supply evidence.

## What this does NOT do

**It does not archive `transactional` and `business_correspondence`.** I went looking for that and found the real blocker, which is not the one the plan named.

Proven on a running stack with both purposes archived:

| Probe | Result |
|---|---|
| Reply on a thread the subject started | **202** — the engine resolves it from the anchor |
| Operational send, no invoice | 409 `unknown_purpose` |
| Explicit `communication_context`, live purpose | 409 `no_compatible_evidence` — the engine judging on its own terms |

The first row matters: #4125 **did** remove the engine's dependency on the legacy purpose row, which the ledger had recorded as the blocker. That finding is now stale.

The live blocker is different. `compose/followupdraft.go:49` and `automation/handlers_event.go:314` both name `business_correspondence` on drafts an approver later releases, and `automation.draftEmailArgs` carries no `communication_context` to replace it with. Giving it one changes the persisted args, the held-draft proposal, the release path and the retarget pin — the plan's PR 5 automation work, a larger change than the archive it would enable.

## One test file adapted

`sendvoiceoutcome_integration_test.go` assigned the field directly; it now takes `ptrTo("transactional")`. The generator makes a required body string a non-pointer and an optional one a pointer, so every direct assignment is a compile error rather than a silent behaviour change — the type system caught this one, which is why it is the only such change in the diff.

## Gates

`make check-backend` green before and after the rebase onto `origin/main`. `make check-fe` green. `activities` and `compose/integration` lanes green. `craft static --strict`: 0 findings.

**Not clean, and not caused by this branch:** `TestCommsAdapterSharesTheGovernedPaths`, `TestPreferenceCenterOptOutBlocksAgentSend` and `TestAPreflightRefusalLeavesTheDraftPending` fail in `internal/compose` on clean `origin/main`. I verified they pass at `56921dcf6` (before #4125) and fail after, so the flip introduced them and I missed them by running `compose/integration` and not `compose`. They are described in #4144 rather than fixed here, because two are test doubles that need rewriting against `comms_outbound` rows and the third is a real defect in the held-draft preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `consent_purpose` optional and deprecated on all three send request types, matching what the engine already does — the contract claimed it was required, but nothing enforced it.

- The engine resolves message category from the record; a supplied key is recorded as the caller's claim.
- Omitting the key is not a way past the gate: unevidenced sends are still refused with 409.
- The legacy purposes (`transactional`, `business_correspondence`) are not archived; that remains blocked by automation work in `compose/followupdraft.go` and `automation/handlers_event.go`.
- Callers should use `communication_context` instead.

<sup>Written for commit 3e90ea1a14f35920fdafe920156cc2c2933f7df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Updates**
  - The `consent_purpose` field is now optional when sending emails or messages.
  - The field is deprecated; consent categories are determined from available records and communication context.
  - Provided purpose keys are treated as claims, and unknown or archived keys grant no authorization.

- **Consent Validation**
  - Requests without a purpose key are still evaluated by consent checks and remain blocked when supporting evidence is absent.
  - Updated handling maintains compatibility with callers that still provide the field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->