### PR TITLE
main is red: the largest avatar renders as a squircle

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -201,6 +201,7 @@
    is square already, so the rule that has to be stated is the round one. */
 .avatar-xl:not(.avatar-org) {
   border-radius: var(--r-full);
+  corner-shape: round;
 }
 
 /* An avatar beside its label on one line — a list cell, a search hit, a node


### PR DESCRIPTION
`corners.test.ts` fails on `main`, so every frontend lane is red.

#4126 gave `.avatar-xl:not(.avatar-org)` a full radius and no `corner-shape`. `tokens.css` sets `corner-shape: squircle` on `:where(*)`, so the rule inherits it and the one avatar drawn at portrait size renders as a **squircle tile** — which is precisely the shape the rungs below it square on purpose for organizations. The mark that is meant to say *this is a person* comes out looking like the one that says *this is a company*.

One line, and it is the gate's own instruction:

> `:where(*)` carries no specificity, so that one line always wins.

## Coordination

Not my ticket's work — I hit it running `make check-fe` for #4086. I checked open PRs for a corners or red-main fix before starting and found none in flight, so I am fixing it here and saying so.

`make check-fe` green: 6353 passing, including the 22 corner cases.