### PR TITLE
The approver learns a draft cannot be sent before their decision commits

### DIFF
--- a/backend/internal/compose/comms_integration_test.go
+++ b/backend/internal/compose/comms_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -73,13 +74,50 @@ func assertStaged(t *testing.T, stager *recordingStager, want int, when string) 
 	}
 }
 
+// assertDelivered is assertStaged for a suite running the REAL delivery
+// machinery, counting the rows it wrote rather than a double's slice.
+//
+// Two spellings of one count, and the difference is which of them can prove a
+// refusal. A suite asserting that an unconsented send is REFUSED cannot use a
+// double: the engine decides at staging, inside commsStager, so a stand-in for
+// commsStager is a stand-in for the thing that refuses. That is how three
+// suites here went green watching unconsented sends succeed when the engine
+// took over the send decision.
+//
+// A suite that only asks what reaches the wire keeps the double, which is
+// cheaper and needs no job runner.
+func assertDelivered(t *testing.T, e *integration.Env, want int, when string) {
+	t.Helper()
+	if n := e.WsCount(t, `SELECT count(*) FROM comms_outbound`); n != want {
+		t.Fatalf("%s left %d deliveries, want %d", when, n, want)
+	}
+}
+
+// realDeliveryStager builds the delivery machinery production wires, for the
+// suites that assert a refusal.
+//
+// It needs the river schema and a job inserter because staging enqueues the
+// dispatch in the same transaction — one commit, one fact. That cost is the
+// reason the double still exists for everything else.
+func realDeliveryStager(t *testing.T, e *integration.Env) DeliveryMachinery {
+	t.Helper()
+	integration.ApplyRiverSchema(t)
+	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	return NewDeliveryStager(e.Pool, inserter)
+}
+
 func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	e := integration.Setup(t)
-	stager := &recordingStager{}
+	// The REAL delivery machinery, because this suite asserts that an
+	// unconsented send is refused and the engine refuses at staging — inside
+	// commsStager, which a double replaces.
 	adapter := commsAdapter{
 		store:  activities.NewStore(e.DB()),
 		gate:   consent.NewGate(consent.NewStore(InstallationDB(e.Pool))),
-		stager: stager,
+		stager: realDeliveryStager(t, e),
 	}
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms)
 
@@ -118,7 +156,7 @@ func TestCommsAdapterSharesTheGovernedPaths(t *testing.T) {
 	if !errors.Is(err, apperrors.ErrConsentNotGranted) {
 		t.Fatalf("unconsented MCP send → %v, want ErrConsentNotGranted", err)
 	}
-	assertStaged(t, stager, 0, "the suppressed MCP send")
+	assertDelivered(t, e, 0, "the suppressed MCP send")
 
 	from := time.Date(2026, 7, 7, 8, 0, 0, 0, time.UTC)
 	avail, err := adapter.Availability(ctx, nil, from, from.Add(10*time.Hour), 60)

--- a/backend/internal/compose/heldrelease.go
+++ b/backend/internal/compose/heldrelease.go
@@ -31,6 +31,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -178,7 +179,7 @@ func releaseHeldDraft(
 // snapshots, and writes nothing.
 func heldDraftPrecheck(
 	store *activities.Store,
-	gate activities.ConsentGate,
+	gate *consent.Gate,
 	stager activities.DeliveryStager,
 ) approvals.ReleasePrecheck {
 	return func(ctx context.Context, staged, edited json.RawMessage) error {
@@ -197,8 +198,27 @@ func heldDraftPrecheck(
 			proposal = corrected
 		}
 		origin, in := sendFromHeldDraft(proposal)
-		_, err = store.PrepareSend(ctx, origin, in, gate, stager)
-		return err
+		prepared, err := store.PrepareSend(ctx, origin, in, gate, stager)
+		if err != nil {
+			return err
+		}
+		// AND THE ENGINE, which PrepareSend no longer asks.
+		//
+		// The consent answer moved into staging when the engine took over the
+		// send decision, and staging is inside the release's transaction — so
+		// without this the preparation succeeds, the approval commits, and the
+		// refusal arrives from a release that can no longer be taken back. The
+		// message becomes unreleasable and the approver has nothing to act on,
+		// which is the exact failure this precheck exists to prevent.
+		//
+		// Preview and the staging decision run the same decideOne over the same
+		// request, so an approver who is told this will send is not told
+		// something the release will contradict about an unchanged record.
+		set, err := gate.Preview(ctx, prepared.Authorization())
+		if err != nil {
+			return err
+		}
+		return refuseAtStaging(set)
 	}
 }
 

--- a/backend/internal/compose/heldrelease_integration_test.go
+++ b/backend/internal/compose/heldrelease_integration_test.go
@@ -30,10 +30,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/margince/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -422,5 +425,60 @@ func TestAnEditedHeldDraftCannotBeReAimedAtAnotherRecipient(t *testing.T) {
 	if n := e.WsCount(t, `SELECT count(*) FROM approval
 		WHERE id = $1 AND status = 'pending'`, f.approval); n != 1 {
 		t.Error("the retargeting attempt decided the approval — a refused edit must leave the honest draft releasable")
+	}
+}
+
+// TestThePreflightRecordsNothing is Preview's whole contract, checked rather
+// than promised.
+//
+// A precheck runs on every approval decision, including the ones a human then
+// rejects. If it recorded a decision row or stamped a derived basis, an inbox
+// full of drafts nobody released would leave a trail of authorizations for
+// messages that were never sent — and the subject-access export would show a
+// basis this installation relied on to send nothing.
+//
+// decideOne reaches stampDerivedBasis on an allow, which WRITES. So this is not
+// a theoretical guarantee: Preview rolls its transaction back, and this test is
+// what makes that true of the code rather than of the comment above it.
+//
+// Mutation: return nil instead of errPreviewComplete from Preview's
+// transaction, so it commits, and the qualifying-event count goes up.
+func TestThePreflightRecordsNothing(t *testing.T) {
+	e := integration.Setup(t)
+	svc := releaseService(t, e)
+	f := seedHeldDraft(t, e, svc)
+
+	var staged json.RawMessage
+	if err := database.WithWorkspaceTx(decider(e), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(decider(e),
+			`SELECT proposed_change FROM approval WHERE id = $1`, f.approval).Scan(&staged)
+	}); err != nil {
+		t.Fatalf("reading the staged draft: %v", err)
+	}
+
+	before := e.WsCount(t, `SELECT count(*) FROM communication_decision`)
+	beforeBasis := e.WsCount(t, `SELECT count(*) FROM consent_qualifying_event`)
+
+	// The precheck ALONE, with no decision behind it — the shape of an approval
+	// a human opens and does not act on.
+	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	send := SendPath{
+		Delivery:      NewDeliveryStager(e.Pool, inserter),
+		PublicBaseURL: "https://crm.example.test",
+	}
+	precheck := heldDraftPrecheck(sendStore(e.Pool, send), consentGateFor(e.Pool), send.Delivery)
+	if err := precheck(decider(e), staged, nil); err != nil {
+		t.Fatalf("precheck on a releasable draft → %v, want no refusal", err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM communication_decision`); n != before {
+		t.Errorf("the preflight wrote %d decision rows, want 0 — a preview authorizes nothing", n-before)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM consent_qualifying_event`); n != beforeBasis {
+		t.Errorf("the preflight stamped %d qualifying events, want 0 — a basis is the ground a SEND relies on, and nothing has been sent",
+			n-beforeBasis)
 	}
 }

--- a/backend/internal/compose/preference_agent_integration_test.go
+++ b/backend/internal/compose/preference_agent_integration_test.go
@@ -31,15 +31,18 @@ import (
 func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	e := integration.Setup(t)
 	consentStore := consent.NewStore(InstallationDB(e.Pool))
-	stager := &recordingStager{}
 	// Built through the composition root, not by hand: a marketing send is
 	// exactly the case whose derivation depends on the unsubscribe linker and
 	// the public base URL that only newCommsAdapter wires. Assembled field by
 	// field the send would take a path no deployment has, and the opt-out this
 	// suite is about would be proven against the wrong one.
+	//
+	// The REAL delivery machinery for the same reason, one layer down: this
+	// suite's whole claim is that an opt-out REFUSES the next send, and the
+	// engine refuses at staging — inside commsStager, which a double replaces.
 	adapter := newCommsAdapter(e.Pool, nil, SendPath{
 		PublicBaseURL: "https://crm.margince.test",
-		Delivery:      stager,
+		Delivery:      realDeliveryStager(t, e),
 	})
 
 	admin := e.Admin()
@@ -62,10 +65,16 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 
 	// An agent principal with the send-adjacent grants; the gate does not
 	// consult it, which is the point — suppression is principal-independent.
+	//
+	// It carries a UserID because an agent sends on behalf of a SEAT and the
+	// delivery is staged as that human (comms.stagingUser: a principal with no
+	// app_user identity cannot stage at all, because sending is a human act).
+	// A seatless agent could never have staged in production; it only reached
+	// delivery here while a double stood in for the machinery that asks.
 	agentCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 	agentCtx = principal.WithCorrelationID(agentCtx, ids.NewV7())
 	agentCtx = principal.WithActor(agentCtx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:optout-probe",
+		Type: principal.PrincipalAgent, ID: "agent:optout-probe", UserID: e.Rep1,
 		Permissions: principal.Permissions{
 			Objects: map[string]principal.ObjectGrant{
 				"activity": {Create: true, Read: true},
@@ -86,7 +95,7 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	if err := send(); err != nil {
 		t.Fatalf("granted agent send → %v, want success", err)
 	}
-	assertStaged(t, stager, 1, "the granted agent send")
+	assertDelivered(t, e, 1, "the granted agent send")
 
 	// The buyer one-click unsubscribes through the PUBLIC preference surface,
 	// exactly as the anonymous middleware binds it (system principal).
@@ -104,7 +113,7 @@ func TestPreferenceCenterOptOutBlocksAgentSend(t *testing.T) {
 	if err := send(); !errors.Is(err, apperrors.ErrConsentNotGranted) {
 		t.Fatalf("agent send after opt-out → %v, want ErrConsentNotGranted", err)
 	}
-	assertStaged(t, stager, 1, "the send after opt-out (still only the pre-opt-out one)")
+	assertDelivered(t, e, 1, "the send after opt-out (still only the pre-opt-out one)")
 }
 
 // seedReplyAnchor writes the mail activity the send threads onto.

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -194,8 +194,12 @@ func consentGateFor(pool *pgxpool.Pool) *consent.Gate {
 // be released — and a kind that registered the executor without the preflight
 // would answer it only where the answer is too late to act on.
 type lateApprovalEffect struct {
-	effect   func(*approvals.Service, *activities.Store, activities.ConsentGate, activities.DeliveryStager) approvals.ApprovedEffect
-	precheck func(*activities.Store, activities.ConsentGate, activities.DeliveryStager) approvals.ReleasePrecheck
+	effect func(*approvals.Service, *activities.Store, activities.ConsentGate, activities.DeliveryStager) approvals.ApprovedEffect
+	// The CONCRETE gate, not the activities.ConsentGate seam the effect takes.
+	// A precheck has to ask the engine what it would decide, and Preview is not
+	// on that seam — the seam is the send path's default-deny door and this is
+	// the question behind it.
+	precheck func(*activities.Store, *consent.Gate, activities.DeliveryStager) approvals.ReleasePrecheck
 }
 
 // lateApprovalEffects are the approve-side pairs that cannot be registered with

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -18,6 +18,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // SendEmail runs the governed send: origin resolution → the guard sequence
@@ -69,6 +70,21 @@ type PreparedSend struct {
 	in        SendEmailInput
 	message   outboundMessage
 	messageID string
+	// origin is kept so a caller can ask what this send would be authorized as
+	// WITHOUT staging it. The whole request the engine judges is derivable from
+	// the prepared message plus the origin, and rebuilding it anywhere else
+	// would be a second reading of one message.
+	origin SendOrigin
+}
+
+// Authorization is the question the engine will be asked about this send.
+//
+// Exposed so a pre-flight can ask it early — a held draft waits in an approval
+// inbox, and a refusal only helps while the approver can still act on it. It is
+// the SAME value the delivery carries at staging, from the same builder, so an
+// early answer and the real one cannot be about different messages.
+func (p PreparedSend) Authorization() commsauthz.Request {
+	return p.message.authorization(p.origin)
 }
 
 // PrepareSend runs everything an outbound send needs BEFORE it writes: origin
@@ -153,6 +169,7 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 	return PreparedSend{
 		in:        in,
 		messageID: messageID,
+		origin:    origin,
 		message: outboundMessage{
 			in:              in,
 			messageID:       messageID,

--- a/backend/internal/modules/consent/authorizepreview.go
+++ b/backend/internal/modules/consent/authorizepreview.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Asking the engine what it would decide, without deciding.
+//
+// The question exists because a refusal is only useful while somebody can act
+// on it. A held draft waits in an approval inbox for days, and the answer that
+// matters — is this still sendable — has to reach the approver BEFORE their
+// decision commits, not from the release that follows it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/settings"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// Preview answers what the engine would decide for this message, and records
+// nothing.
+//
+// It runs the SAME per-recipient decision AuthorizeStagingTx runs, from the
+// same decideOne, so a preview and the staging decision that follows cannot
+// answer differently about an unchanged record. What it does not do is write:
+// no decision rows, and no basis — the basis is the ground a send RELIES on,
+// and a message nobody has sent has relied on nothing. That is also why
+// commsauthz has no PhasePreview: a preview authorizes nothing, so there is no
+// row for a phase to appear on.
+//
+// It opens its own transaction and rolls it back. Rolling back rather than
+// promising read-only is what makes "records nothing" true of code rather than
+// of intentions: decideOne reaches stampDerivedBasis on an allow, which writes,
+// and a future arm that writes something else would be undone by the same
+// rollback rather than discovered by a reader.
+func (g *Gate) Preview(ctx context.Context, req commsauthz.Request) (commsauthz.DecisionSet, error) {
+	for _, r := range req.Recipients {
+		if err := r.Validate(); err != nil {
+			return commsauthz.DecisionSet{}, fmt.Errorf(
+				"consent: this recipient cannot be put to the engine: %w", err)
+		}
+	}
+	if len(req.Recipients) == 0 {
+		return commsauthz.DecisionSet{}, fmt.Errorf(
+			"consent: a preview needs at least one recipient: %w", apperrors.ErrInvalidArgument)
+	}
+
+	var set commsauthz.DecisionSet
+	err := g.store.db.Tx(ctx, func(tx pgx.Tx) error {
+		modes, err := settings.ApplyTx(ctx, tx, AuthorizationModes)
+		if err != nil {
+			return err
+		}
+		for _, r := range req.Recipients {
+			d, err := g.decideOne(ctx, tx, r, req, commsauthz.PhaseStaging)
+			if err != nil {
+				return err
+			}
+			// PhaseStaging is passed to decideOne and then cleared, and the two
+			// are not in tension. The phase steers what the DECISION does —
+			// staging is the phase that records a basis — so asking as staging
+			// is what makes the preview answer the same question the staging
+			// decision will. Leaving it on the returned decision would be the
+			// lie: nothing here is a staging decision, because nothing here is
+			// recorded.
+			d.Phase = ""
+			d.Mode = ModeFor(modes, d.Resolved)
+			d.Requested = req.Context
+			set.Decisions = append(set.Decisions, d)
+		}
+		// The rollback IS the contract. Returning an error is how pgx.Tx is
+		// told to roll back, and errPreviewComplete is not a failure — the
+		// caller never sees it.
+		return errPreviewComplete
+	})
+	if err != nil && !errors.Is(err, errPreviewComplete) {
+		return commsauthz.DecisionSet{}, err
+	}
+	return set, nil
+}
+
+// errPreviewComplete unwinds Preview's transaction once it has its answer.
+//
+// Sentinel rather than a bare errors.New at the call site so nothing can
+// mistake it for a fault: it never leaves this file's function, and a reader
+// who greps it finds exactly one producer and one consumer.
+var errPreviewComplete = errors.New("consent: preview complete")


### PR DESCRIPTION
Fixes #4144. Three tests in `internal/compose` were red on `main`. They pass at `56921dcf6` and fail from #4125 onward, so the flip to `Allowed = engine` caused them — and I missed them by running `compose/integration` and not `compose`.

Two problems, not one.

## The real defect

`heldDraftPrecheck` ran `PrepareSend` and threw the result away, which was a complete pre-flight while `PrepareSend` held the consent gate. The engine decides at **staging** now, which is inside the release's transaction.

So the preparation succeeded, the approval committed, and the refusal arrived from a release that could no longer be taken back. The message became unreleasable and the approver had nothing to act on — the exact failure this precheck exists to prevent.

Same root cause as the scheduled-send hold fixed in #4125, in a different caller: a refusal that used to reach a human while they could act on it now arrived after a commit.

### `consent.Gate.Preview`

New, and the plan specified it for exactly this. It runs the same `decideOne` that `AuthorizeStagingTx` runs, over the same request, so an early answer and the real one cannot disagree about an unchanged record.

`PreparedSend.Authorization()` exposes that request rather than rebuilding it — two readings of one message drift.

**Preview records nothing, and rolls its transaction back rather than promising to be read-only.** `decideOne` reaches `stampDerivedBasis` on an allow, which writes. `TestThePreflightRecordsNothing` holds that, and its mutation is not theoretical: committing the transaction stamps a qualifying event for a message nobody sent. A precheck runs on every approval decision including the ones a human rejects, so without the rollback an inbox of unreleased drafts would leave a trail of authorizations — and the subject-access export would show a basis relied on to send nothing.

`commsauthz` still has no `PhasePreview`, per its own comment: a preview authorizes nothing, so there is no row for a phase to appear on. Preview asks `decideOne` **as** staging (that is what makes it the same question) and then clears the phase off the returned decision.

## Two suites asserted a refusal against a double that stopped refusing

`recordingStager` stands in for the delivery machinery, and the engine refuses inside `commsStager.refuseAtStaging` — so the double had quietly become the only thing in the path with no opinion. `TestCommsAdapterSharesTheGovernedPaths` watched an unconsented `marketing_email` send succeed and reported it as governed.

**Production was never affected**: `newCommsAdapter` (`compose/sendpath.go`) wires the real stager.

Both suites now use `NewDeliveryStager` and count `comms_outbound` rows through a new `assertDelivered` instead of a slice. `assertStaged` stays for the suites that only ask what reaches the wire — those need no job runner, and the difference between the two is now written down beside them.

The preference suite's agent principal gains a `UserID`. An agent sends on behalf of a **seat**, and `comms.stagingUser` refuses a principal with no app_user identity because sending is a human act — so a seatless agent could never have staged in production either. It only reached delivery while the double stood in.

## Mutations, one clause at a time

| Mutation | Test that failed |
|---|---|
| precheck skips `Preview` | `TestAPreflightRefusalLeavesTheDraftPending` |
| `Preview` commits instead of rolling back | `TestThePreflightRecordsNothing` — stamped 1 qualifying event, want 0 |
| MCP suite back to `recordingStager` | `TestCommsAdapterSharesTheGovernedPaths` — reproduces the original bug exactly |
| preference suite back to `recordingStager` | `TestPreferenceCenterOptOutBlocksAgentSend` |

## Gates

`make check-backend` green before and after the rebase. `internal/compose` **and** `compose/integration` both green — the first is the lane that was red on main and the one I should have run the first time. `consent` and `activities` lanes green. `craft static --strict`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the held-draft approval precheck so the approver learns a draft cannot be sent before their decision commits. Previously the precheck ran a pre-flight that no longer consulted the consent engine, so refusals arrived after the approval committed and left the message unreleasable.

**Bug Fixes**
- `heldDraftPrecheck` now asks the consent engine through new `consent.Gate.Preview` before the approval commits.
- `Preview` runs the same per-recipient decision as staging but records nothing; it rolls its transaction back so no decision rows or qualifying events are written.
- `PreparedSend.Authorization()` exposes the exact request the engine will judge, so the preview and the staging decision cannot disagree about an unchanged record.
- Two test suites asserted refusals against `recordingStager`, which stopped refusing once the engine decided inside the real stager; they now use the real delivery machinery and count `comms_outbound` rows.
- The preference suite's agent principal now carries a `UserID`, required because staging refuses principals without an app_user identity.

<sup>Written for commit dee55dd236d16f166e50687d0ae686b1264acc5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

