### PR TITLE
The engine inherits the record it was given

### DIFF
--- a/backend/migrations/core/1788527759_the_engine_inherits_the_record_it_was_given.down.sql
+++ b/backend/migrations/core/1788527759_the_engine_inherits_the_record_it_was_given.down.sql
@@ -1,0 +1,5 @@
+-- Only what this migration wrote, identified by the provenance it stamped.
+-- A basis or suppression the running product recorded carries a different note
+-- and source, and survives.
+DELETE FROM communication_suppression WHERE source = 'carried_from_person_consent';
+DELETE FROM communication_basis WHERE note LIKE 'carried from the qualifying event%';

--- a/backend/migrations/core/1788527759_the_engine_inherits_the_record_it_was_given.up.sql
+++ b/backend/migrations/core/1788527759_the_engine_inherits_the_record_it_was_given.up.sql
@@ -1,0 +1,137 @@
+-- The engine's own tables start empty, and the record they describe does not.
+--
+-- communication_basis and communication_suppression were added with the engine
+-- (1788407500) and only ever written going forward. So an installation with
+-- years of consent history handed the engine a blank sheet: every qualifying
+-- event a rep recorded and every unsubscribe a subject clicked lived on in the
+-- OLD tables, which the engine's suppression reader never consults.
+--
+-- This carries that history across. It invents nothing: no consent, no double
+-- opt-in, no wording. Every row below is derived from a row somebody already
+-- wrote, and anything that cannot be derived is left absent rather than guessed.
+
+-- Qualifying events become the scoped basis they always were.
+--
+-- kind is subject_initiated_correspondence for all four source kinds, because
+-- that is what a qualifying event MEANT: the subject did something that makes
+-- answering them lawful. The old vocabulary (inbound_message, inquiry,
+-- active_deal, in_person) described HOW we learned it, which survives in
+-- source_activity_id and note rather than in the basis kind.
+--
+-- valid_until is occurred_at + 365 days, the reply window the engine already
+-- applies to an unprompted follow-up (consent.defaultReplyWindow). A row older
+-- than that is inserted ALREADY EXPIRED and authorizes nothing — which is the
+-- honest carry, because the engine would not honour it if it were read live
+-- either. Inserting it anyway keeps the history readable in a subject-access
+-- export instead of silently dropping what the installation was told.
+--
+-- No thread_key. A qualifying event names an activity, not a conversation, and
+-- a basis that claimed a thread it was not earned on would authorize every
+-- message on that thread. Absent is correct: the reply arm reads the anchor.
+INSERT INTO communication_basis
+    (person_id, kind, source_activity_id, valid_from, valid_until, note, captured_by, captured_at)
+SELECT
+    qe.person_id,
+    'subject_initiated_correspondence',
+    -- Only an activity source survives as a source_activity_id. A 'deal' source
+    -- is a real ground and NOT an activity, so it carries its provenance in the
+    -- note instead of pointing the FK at a deal id that column cannot hold.
+    CASE WHEN qe.source_entity_type = 'activity' THEN qe.source_entity_id END,
+    qe.occurred_at,
+    qe.occurred_at + interval '365 days',
+    -- The provenance a reader needs to tell a carried row from a live one, in
+    -- the column that already exists for prose. Not a ticket reference and not
+    -- build narration: it says what this row was derived from, which is the
+    -- question a data subject asks about it.
+    'carried from the qualifying event recorded as ' || qe.kind
+        || COALESCE(': ' || qe.note, ''),
+    qe.captured_by,
+    qe.created_at
+FROM consent_qualifying_event qe
+JOIN person p ON p.id = qe.person_id
+WHERE
+    -- An event whose source record is gone proves nothing a reader can check.
+    -- The plan's own rule: no source, no basis - it stays unknown_legacy.
+    (qe.source_entity_type IS DISTINCT FROM 'activity'
+     OR EXISTS (SELECT 1 FROM activity a WHERE a.id = qe.source_entity_id))
+    -- Idempotent, and this is the whole of it: re-running finds the row it
+    -- wrote. Matched on the pair that identifies the carry rather than on a
+    -- generated id, so a second run cannot double a person's history.
+    AND NOT EXISTS (
+        SELECT 1 FROM communication_basis cb
+        WHERE cb.person_id = qe.person_id
+          AND cb.kind = 'subject_initiated_correspondence'
+          AND cb.captured_at = qe.created_at
+    );
+
+-- Withdrawals become marketing objections, and ONLY the marketing ones.
+--
+-- This filter is the whole safety of this migration, so it is stated rather
+-- than implied. communication_suppression is NOT purpose-scoped: liveSuppression
+-- reads the strongest live row for a person and applies it to every category,
+-- and marketing_objection is in commsauthz.Absolute — no rollout mode softens
+-- it, no evidence reaches past it.
+--
+-- So carrying every withdrawn person_consent row across would take somebody who
+-- unsubscribed from one newsletter and block their invoices, their contract
+-- notices and their security mail, permanently, with no way to see why. A
+-- development database on this machine already holds a withdrawal against a
+-- non-marketing purpose, so this is not a hypothetical shape.
+--
+-- Art. 21 is an objection to DIRECT MARKETING. The class filter is that rule.
+INSERT INTO communication_suppression
+    (person_id, kind, source, recorded_at, captured_by)
+SELECT
+    pc.person_id,
+    'marketing_objection',
+    'carried_from_person_consent',
+    COALESCE(
+        (SELECT ce.captured_at
+           FROM consent_event ce
+          WHERE ce.person_id = pc.person_id
+            AND ce.purpose_id = pc.purpose_id
+            AND ce.new_state = 'withdrawn'
+          ORDER BY ce.captured_at DESC
+          LIMIT 1),
+        -- person_consent.captured_at is nullable, and a suppression with no
+        -- recorded_at would sort last in liveSuppression's tie-break. now() is
+        -- the honest floor: the objection is live NOW whenever it was made,
+        -- and the proof row above carries the real moment where one exists.
+        pc.captured_at, now()),
+    COALESCE(
+        (SELECT ce.captured_by
+           FROM consent_event ce
+          WHERE ce.person_id = pc.person_id
+            AND ce.purpose_id = pc.purpose_id
+            AND ce.new_state = 'withdrawn'
+          ORDER BY ce.captured_at DESC
+          LIMIT 1),
+        'system:migration')
+FROM person_consent pc
+JOIN consent_purpose cp ON cp.id = pc.purpose_id
+JOIN person p ON p.id = pc.person_id
+WHERE pc.state = 'withdrawn'
+  AND cp.class = 'marketing'
+  -- One row per person, however many marketing purposes they withdrew from.
+  -- The suppression is not purpose-scoped, so a second row would say the same
+  -- thing twice and the reader takes LIMIT 1 anyway.
+  AND NOT EXISTS (
+      SELECT 1 FROM communication_suppression cs
+      WHERE cs.person_id = pc.person_id
+        AND cs.kind = 'marketing_objection'
+  );
+
+DO $$
+DECLARE
+    bases int;
+    suppressions int;
+BEGIN
+    SELECT count(*) INTO bases FROM communication_basis
+     WHERE note LIKE 'carried from the qualifying event%';
+    SELECT count(*) INTO suppressions FROM communication_suppression
+     WHERE source = 'carried_from_person_consent';
+    -- Counts only. Naming a person here would put a consent state into a
+    -- migration log, which is the one place nobody expects to find one.
+    RAISE NOTICE 'the engine inherits % basis row(s) and % marketing objection(s)',
+        bases, suppressions;
+END $$;

--- a/backend/migrations/enginebackfill_integration_test.go
+++ b/backend/migrations/enginebackfill_integration_test.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// Carrying the consent record the engine was never given.
+//
+// The rows under test are the ones the OLD writers produced — a
+// consent_qualifying_event, a withdrawn person_consent — because that is the
+// only shape a deployed database holds. Seeding the NEW tables and checking they
+// are still there would pass against a migration that does nothing.
+//
+// It applies the actual migration file. A test that retyped the SQL would pass
+// for a migration that no longer says it.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const engineBackfillMigration = "core/1788527759_the_engine_inherits_the_record_it_was_given.up.sql"
+
+// backfillFixture is one person and the pre-engine rows recorded about them.
+type backfillFixture struct {
+	person      string
+	marketing   string
+	operational string
+}
+
+// seedPreEngineRecord writes what the product wrote before the engine existed.
+func seedPreEngineRecord(t *testing.T, conn *pgx.Conn) backfillFixture {
+	t.Helper()
+	ctx := context.Background()
+	var f backfillFixture
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO person (full_name, source, captured_by)
+		 VALUES ('Backfill Subject', 'manual', 'human:seed') RETURNING id`).Scan(&f.person); err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO consent_purpose (key, label, class, requires_double_opt_in)
+		 VALUES ('backfill_news', 'Newsletter', 'marketing', false) RETURNING id`).Scan(&f.marketing); err != nil {
+		t.Fatalf("seeding the marketing purpose: %v", err)
+	}
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO consent_purpose (key, label, class, requires_double_opt_in)
+		 VALUES ('backfill_ops', 'Account notices', 'transactional', false) RETURNING id`).Scan(&f.operational); err != nil {
+		t.Fatalf("seeding the operational purpose: %v", err)
+	}
+	return f
+}
+
+// TestTheEngineInheritsAQualifyingEvent is the carry that gives the engine its
+// history: a ground a rep recorded years before communication_basis existed.
+func TestTheEngineInheritsAQualifyingEvent(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+	f := seedPreEngineRecord(t, conn)
+
+	var anchor string
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO activity (kind, direction, subject, occurred_at, source, captured_by)
+		 VALUES ('email', 'inbound', 'A question', now() - interval '30 days', 'capture', 'human:seed')
+		 RETURNING id`).Scan(&anchor); err != nil {
+		t.Fatalf("seeding the source activity: %v", err)
+	}
+	occurred := time.Now().Add(-30 * 24 * time.Hour)
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO consent_qualifying_event
+		   (person_id, kind, source_entity_type, source_entity_id, occurred_at, source, captured_by)
+		 VALUES ($1, 'inbound_message', 'activity', $2, $3, 'derived', 'human:seed')`,
+		f.person, anchor, occurred); err != nil {
+		t.Fatalf("seeding the qualifying event: %v", err)
+	}
+
+	applyMigrationFile(t, conn, engineBackfillMigration)
+
+	var kind, note string
+	var source *string
+	var validUntil time.Time
+	if err := conn.QueryRow(ctx,
+		`SELECT kind, note, source_activity_id::text, valid_until
+		   FROM communication_basis WHERE person_id = $1`, f.person).
+		Scan(&kind, &note, &source, &validUntil); err != nil {
+		t.Fatalf("the engine inherited no basis for a person who has one on file: %v", err)
+	}
+	if kind != "subject_initiated_correspondence" {
+		t.Errorf("carried kind = %q, want subject_initiated_correspondence — a qualifying event IS the subject having started something", kind)
+	}
+	if source == nil || *source != anchor {
+		t.Errorf("carried source_activity_id = %v, want the seeded anchor %s — a basis nobody can trace to a record proves nothing", source, anchor)
+	}
+	// The engine's own reply window, so a carried row and a live one expire on
+	// the same rule rather than the carry outliving what the product would grant.
+	want := occurred.Add(365 * 24 * time.Hour)
+	if validUntil.Sub(want).Abs() > time.Minute {
+		t.Errorf("carried valid_until = %s, want %s (occurred_at + the reply window)", validUntil, want)
+	}
+}
+
+// TestACarriedGroundWithNoRecordBehindItIsNotCarried holds the plan's own rule:
+// nothing is invented. An event whose source activity is gone proves nothing a
+// reader could check, so it stays absent rather than becoming a basis nobody
+// can trace.
+func TestACarriedGroundWithNoRecordBehindItIsNotCarried(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+	f := seedPreEngineRecord(t, conn)
+
+	// An activity id that never existed. The old table's FK-less
+	// source_entity_id is exactly how a deployed database ends up holding one.
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO consent_qualifying_event
+		   (person_id, kind, source_entity_type, source_entity_id, occurred_at, source, captured_by)
+		 VALUES ($1, 'inbound_message', 'activity', gen_random_uuid(), now() - interval '10 days', 'derived', 'human:seed')`,
+		f.person); err != nil {
+		t.Fatalf("seeding the orphaned qualifying event: %v", err)
+	}
+
+	applyMigrationFile(t, conn, engineBackfillMigration)
+
+	var n int
+	if err := conn.QueryRow(ctx,
+		`SELECT count(*) FROM communication_basis WHERE person_id = $1`, f.person).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("carried %d basis rows for an event whose source is gone, want 0 — a ground nobody can check is not a ground", n)
+	}
+}
+
+// TestAMarketingWithdrawalBecomesAnObjection is the suppression half.
+func TestAMarketingWithdrawalBecomesAnObjection(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+	f := seedPreEngineRecord(t, conn)
+
+	withdrawn(t, conn, f.person, f.marketing)
+
+	applyMigrationFile(t, conn, engineBackfillMigration)
+
+	var kind, source string
+	if err := conn.QueryRow(ctx,
+		`SELECT kind, source FROM communication_suppression WHERE person_id = $1`, f.person).
+		Scan(&kind, &source); err != nil {
+		t.Fatalf("a marketing withdrawal carried no objection: %v", err)
+	}
+	if kind != "marketing_objection" {
+		t.Errorf("carried kind = %q, want marketing_objection", kind)
+	}
+	if source != "carried_from_person_consent" {
+		t.Errorf("carried source = %q — the down migration identifies this row by it", source)
+	}
+}
+
+// TestANonMarketingWithdrawalIsNotAnObjection is the assertion this whole
+// migration is shaped around, and the one a careless version fails.
+//
+// communication_suppression is NOT purpose-scoped: liveSuppression takes the
+// strongest live row for a person and applies it to EVERY category, and
+// marketing_objection is in commsauthz.Absolute — no rollout mode softens it.
+// So carrying every withdrawn person_consent row across would take somebody who
+// unsubscribed from one newsletter and block their invoices, their contract
+// notices and their security mail, permanently.
+//
+// This is not hypothetical: a development database on this machine already held
+// a withdrawal against a non-marketing purpose when the migration was written.
+//
+// Mutation: drop `AND cp.class = 'marketing'` from the second INSERT and this
+// fails with a suppression this person should never have carried.
+func TestANonMarketingWithdrawalIsNotAnObjection(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+	f := seedPreEngineRecord(t, conn)
+
+	withdrawn(t, conn, f.person, f.operational)
+
+	applyMigrationFile(t, conn, engineBackfillMigration)
+
+	var n int
+	if err := conn.QueryRow(ctx,
+		`SELECT count(*) FROM communication_suppression WHERE person_id = $1`, f.person).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("carried %d suppression(s) from a NON-marketing withdrawal, want 0 — Art. 21 is an objection to direct marketing, and this row would block their invoices forever", n)
+	}
+}
+
+// TestTheCarryIsIdempotent. A migration runner can re-run a file after a failed
+// deploy, and a second run that doubled somebody's history would be a
+// correctness bug nothing else catches.
+func TestTheCarryIsIdempotent(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+	f := seedPreEngineRecord(t, conn)
+
+	var anchor string
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO activity (kind, direction, subject, occurred_at, source, captured_by)
+		 VALUES ('email', 'inbound', 'A question', now() - interval '5 days', 'capture', 'human:seed')
+		 RETURNING id`).Scan(&anchor); err != nil {
+		t.Fatalf("seeding the source activity: %v", err)
+	}
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO consent_qualifying_event
+		   (person_id, kind, source_entity_type, source_entity_id, occurred_at, source, captured_by)
+		 VALUES ($1, 'inbound_message', 'activity', $2, now() - interval '5 days', 'derived', 'human:seed')`,
+		f.person, anchor); err != nil {
+		t.Fatalf("seeding the qualifying event: %v", err)
+	}
+	withdrawn(t, conn, f.person, f.marketing)
+
+	applyMigrationFile(t, conn, engineBackfillMigration)
+	applyMigrationFile(t, conn, engineBackfillMigration)
+
+	for _, c := range []struct {
+		table string
+		sql   string
+	}{
+		{"communication_basis", `SELECT count(*) FROM communication_basis WHERE person_id = $1`},
+		{"communication_suppression", `SELECT count(*) FROM communication_suppression WHERE person_id = $1`},
+	} {
+		var n int
+		if err := conn.QueryRow(ctx, c.sql, f.person).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Errorf("%s holds %d rows after two runs, want 1", c.table, n)
+		}
+	}
+}
+
+// withdrawn records a withdrawal the way the pre-engine product recorded one:
+// the person_consent state plus the consent_event proof behind it.
+func withdrawn(t *testing.T, conn *pgx.Conn, person, purpose string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO person_consent (person_id, purpose_id, state, source, captured_at)
+		 VALUES ($1, $2, 'withdrawn', 'preference_center', now() - interval '2 days')`, person, purpose); err != nil {
+		t.Fatalf("seeding the withdrawal: %v", err)
+	}
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO consent_event
+		   (person_id, purpose_id, new_state, source, captured_by, captured_at, policy_text, policy_version)
+		 VALUES ($1, $2, 'withdrawn', 'preference_center', 'human:subject',
+		         now() - interval '2 days', 'You asked us to stop emailing you.', 'v1')`,
+		person, purpose); err != nil {
+		t.Fatalf("seeding the withdrawal proof: %v", err)
+	}
+}


### PR DESCRIPTION
`communication_basis` and `communication_suppression` arrived with the engine (migration `1788407500`) and were only ever written going forward. So an installation with years of consent history handed the engine a blank sheet: every qualifying event a rep recorded and every unsubscribe a subject clicked lived on in the **old** tables, which the engine's suppression reader never consults.

This carries that history across. It invents nothing — no consent, no double opt-in, no wording. Every row is derived from a row somebody already wrote, and what cannot be derived stays absent.

## The basis half

Qualifying events become `subject_initiated_correspondence` bases, scoped to the source activity, valid for **365 days from `occurred_at`** — the same reply window the engine already applies to an unprompted follow-up (`consent.defaultReplyWindow`, #4133).

An event older than that is carried **already expired**. That is the honest shape: the engine would not honour it read live either, and dropping it would silently discard what the installation was told rather than keeping it readable in a subject-access export.

An event whose source activity is gone is not carried at all — a ground nobody can check is not a ground. The mutation for that guard is instructive: without it the migration doesn't carry a bad row, it **fails the deploy** on the `source_activity_id` foreign key.

No `thread_key`. A qualifying event names an activity, not a conversation, and a basis claiming a thread it was not earned on would authorize every message on that thread.

## The class filter is the safety of this migration

`communication_suppression` is **not** purpose-scoped. `liveSuppression` takes the strongest live row for a person and applies it to every category, and `marketing_objection` is in `commsauthz.Absolute` — no rollout mode softens it, no evidence reaches past it.

So carrying every withdrawn `person_consent` row across would take somebody who unsubscribed from one newsletter and block their **invoices, contract notices and security mail**, permanently, with no way to see why. Art. 21 is an objection to direct marketing, so only marketing-class withdrawals become objections.

**That is not hypothetical.** I measured before writing: the development database on this machine holds exactly one withdrawal and it is non-marketing. Running this migration against it carries 3 bases and **0** objections — which is the correct answer, and the answer a careless version gets wrong.

## Verified on the real dev database, not only in the lane

```
before      basis: 1   suppressions: 0
after       basis: 4   suppressions: 0    NOTICE: inherits 3 basis row(s) and 0 marketing objection(s)
re-run      INSERT 0 0, INSERT 0 0        basis still 4
down        DELETE 0,  DELETE 3           basis: 1 — the row the running product wrote survives
```

The down migration identifies its own rows by the provenance the up stamped (`note LIKE 'carried from the qualifying event%'`, `source = 'carried_from_person_consent'`), so a basis the product recorded is never touched.

## Mutations, one clause at a time

| Mutation | Test that failed | Correctly kept passing |
|---|---|---|
| drop `AND cp.class = 'marketing'` | `TestANonMarketingWithdrawalIsNotAnObjection` | `TestAMarketingWithdrawalBecomesAnObjection` |
| drop the source-exists guard | `TestACarriedGroundWithNoRecordBehindItIsNotCarried` (FK violation — fails the deploy) | `TestTheEngineInheritsAQualifyingEvent` |
| drop the basis idempotence guard | `TestTheCarryIsIdempotent` — 2 rows after two runs | — |
| drop the suppression idempotence guard | `TestTheCarryIsIdempotent` — 2 rows after two runs | — |

The tests seed through the **old** writers' shapes (`consent_qualifying_event`, a withdrawn `person_consent` with its `consent_event` proof), because that is the only shape a deployed database holds — seeding the new tables and checking they are still there would pass against a migration that does nothing. They apply the actual migration file rather than retyping its SQL.

## Gates

`make check-backend` green before and after the rebase. Full `backend/migrations` lane green, head catalog unchanged (this migration adds no DDL). `craft static --strict`: 0 findings. Migration number re-checked against `origin/main` after the rebase — still the highest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills the engine's consent tables from pre-engine history so existing installs no longer hand the engine a blank sheet. Every carried row is derived from existing data — nothing is invented, and anything that can't be derived stays absent.

**Migration**
- Qualifying events become `subject_initiated_correspondence` bases scoped to their source activity, valid 365 days from `occurred_at`; older events carry already expired.
- Events whose source activity no longer exists are not carried.
- Only marketing-class withdrawals become `marketing_objection` suppressions; non-marketing withdrawals would block invoices and security mail because suppressions aren't purpose-scoped.
- Both halves are idempotent, and the down migration removes only rows it stamped with provenance.
- Integration tests seed pre-engine row shapes and apply the actual migration file.

<sup>Written for commit 77481c77991457c38491e9499f26042ee4b0c9a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

