### PR TITLE
An evidence row is not rewritable by the application

### DIFF
--- a/backend/migrations/core/1788529047_an_evidence_row_is_not_rewritable.down.sql
+++ b/backend/migrations/core/1788529047_an_evidence_row_is_not_rewritable.down.sql
@@ -1,0 +1,7 @@
+REVOKE UPDATE (recipient_address, subject_id, subject_kind)
+    ON TABLE communication_decision FROM margince_app;
+REVOKE UPDATE (person_id, lead_id)
+    ON TABLE consent_event FROM margince_app;
+
+GRANT UPDATE, DELETE ON TABLE communication_decision TO margince_app;
+GRANT UPDATE, DELETE ON TABLE consent_event TO margince_app;

--- a/backend/migrations/core/1788529047_an_evidence_row_is_not_rewritable.up.sql
+++ b/backend/migrations/core/1788529047_an_evidence_row_is_not_rewritable.up.sql
@@ -1,0 +1,40 @@
+-- communication_decision and consent_event are evidence, and the runtime role
+-- could rewrite both.
+--
+-- A consent_event says what a person was shown and what they answered. A
+-- communication_decision says why a message was allowed to go out. Both are
+-- served to a data subject as proof and to a regulator as the controller's
+-- Art. 5(2) accountability record. A proof row the application can silently
+-- edit is not a proof: any defect, any injection, any mistaken repair script
+-- rewrites the history that was supposed to settle the question.
+--
+-- Neither table has ever needed a general UPDATE. Nothing in this tree DELETEs
+-- from either one at all.
+--
+-- COLUMN-SCOPED rather than a blanket REVOKE, because three legitimate writers
+-- do exist and every one of them touches only the columns that IDENTIFY the
+-- subject, never the finding:
+--
+--   privacy/erasure_consent.go, erasure_leadtwins.go and retentionactions.go
+--   tombstone recipient_address and null subject_id/subject_kind. Art. 17 has
+--   to reach the address a message went to; the verdict, category, reason and
+--   ruleset survive as an unattributed statistic about a send that happened.
+--
+--   people/consentcarry.go re-points consent_event onto the surviving record
+--   when a lead is promoted or two records merge. It moves the proof, and
+--   changes nothing the proof says.
+--
+-- So the identity columns stay writable and the evidence columns stop being
+-- writable, which is the invariant stated as a permission rather than as a
+-- comment somebody has to keep obeying. A SECURITY DEFINER function would have
+-- been the alternative and is not needed: no legitimate writer touches a
+-- finding column, so there is nothing to define around.
+
+REVOKE UPDATE, DELETE ON TABLE communication_decision FROM margince_app;
+REVOKE UPDATE, DELETE ON TABLE consent_event FROM margince_app;
+
+-- Exactly what erasure and the lead carry need, and nothing else.
+GRANT UPDATE (recipient_address, subject_id, subject_kind)
+    ON TABLE communication_decision TO margince_app;
+GRANT UPDATE (person_id, lead_id)
+    ON TABLE consent_event TO margince_app;

--- a/backend/migrations/evidencenotrewritable_integration_test.go
+++ b/backend/migrations/evidencenotrewritable_integration_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// A proof row the application can edit is not a proof.
+//
+// consent_event says what a person was shown and what they answered.
+// communication_decision says why a message was allowed to go out. Both are
+// served to a data subject as evidence, so the runtime role holding a general
+// UPDATE on them was a standing invitation for any defect or repair script to
+// rewrite the history that settles the question.
+//
+// Two halves, and BOTH are needed. Proving the rewrite is refused says nothing
+// about whether Art. 17 still reaches the address a message went to — and a
+// permission change that quietly broke erasure would be a worse defect than the
+// one it fixed.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// evidenceRow seeds one decision and one consent event through the owner, and
+// answers the ids the app role then tries to change.
+type evidenceRow struct {
+	person   string
+	decision string
+	event    string
+}
+
+func seedEvidence(t *testing.T, owner *pgx.Conn) evidenceRow {
+	t.Helper()
+	ctx := context.Background()
+	var e evidenceRow
+	if err := owner.QueryRow(ctx,
+		`INSERT INTO person (full_name, source, captured_by)
+		 VALUES ('Evidence Subject', 'manual', 'human:seed') RETURNING id`).Scan(&e.person); err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	var purpose string
+	if err := owner.QueryRow(ctx,
+		`INSERT INTO consent_purpose (key, label, class, requires_double_opt_in)
+		 VALUES ('evidence_news', 'Newsletter', 'marketing', false) RETURNING id`).Scan(&purpose); err != nil {
+		t.Fatalf("seeding the purpose: %v", err)
+	}
+	if err := owner.QueryRow(ctx, `
+		INSERT INTO consent_event
+		    (person_id, purpose_id, new_state, source, captured_by, captured_at, policy_text, policy_version)
+		VALUES ($1, $2, 'granted', 'preference_center', 'human:subject', now(),
+		        'You agreed to receive our newsletter.', 'v1')
+		RETURNING id`, e.person, purpose).Scan(&e.event); err != nil {
+		t.Fatalf("seeding the consent proof: %v", err)
+	}
+
+	var user, activity, delivery string
+	if err := owner.QueryRow(ctx,
+		`INSERT INTO app_user (email, display_name) VALUES ('rep@evidence.test', 'Rep') RETURNING id`).
+		Scan(&user); err != nil {
+		t.Fatalf("seeding the sender: %v", err)
+	}
+	if err := owner.QueryRow(ctx,
+		`INSERT INTO activity (kind, direction, subject, occurred_at, source, captured_by)
+		 VALUES ('email', 'outbound', 'Hello', now(), 'manual', 'human:seed') RETURNING id`).
+		Scan(&activity); err != nil {
+		t.Fatalf("seeding the activity: %v", err)
+	}
+	if err := owner.QueryRow(ctx, `
+		INSERT INTO comms_outbound
+		    (id, activity_id, user_id, provider, message_id,
+		     recipients, cc, references_chain, subject, body, consent_purpose)
+		VALUES (gen_random_uuid(), $1, $2, 'gmail', 'mid-evidence',
+		        '["subject@evidence.test"]'::jsonb, '[]'::jsonb, '[]'::jsonb,
+		        'Hello', 'body', 'evidence_news')
+		RETURNING id`, activity, user).Scan(&delivery); err != nil {
+		t.Fatalf("seeding the delivery: %v", err)
+	}
+	if err := owner.QueryRow(ctx, `
+		INSERT INTO communication_decision
+		    (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
+		     phase, resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, 0, gen_random_uuid(), 'subject@evidence.test', 'person', $2,
+		        'staging', 'marketing', 'allow', 'allowed', 'enforce', 'human:seed')
+		RETURNING id`, delivery, e.person).Scan(&e.decision); err != nil {
+		t.Fatalf("seeding the decision: %v", err)
+	}
+	return e
+}
+
+// TestTheRuntimeRoleCannotRewriteAFinding is the invariant this migration turns
+// from a comment into a permission.
+//
+// Every column below is a FINDING — what the engine concluded, and what the
+// person was told. None of them has a legitimate writer in this tree.
+//
+// Mutation: drop either REVOKE from the up migration and the matching case
+// stops being refused.
+func TestTheRuntimeRoleCannotRewriteAFinding(t *testing.T) {
+	ownerDSN, appDSN := dsns(t)
+	owner := connect(t, ownerDSN)
+	headSchema(t, owner)
+	e := seedEvidence(t, owner)
+	app := connect(t, appDSN)
+	ctx := context.Background()
+
+	for _, c := range []struct {
+		what string
+		sql  string
+	}{
+		{"the verdict on a send", `UPDATE communication_decision SET verdict = 'deny' WHERE id = $1`},
+		{"the reason a send was allowed", `UPDATE communication_decision SET reason_code = 'invented' WHERE id = $1`},
+		{"the category a message was resolved as", `UPDATE communication_decision SET resolved_category = 'marketing' WHERE id = $1`},
+		{"a decision row outright", `DELETE FROM communication_decision WHERE id = $1`},
+	} {
+		if _, err := app.Exec(ctx, c.sql, e.decision); !permissionDenied(err) {
+			t.Errorf("the runtime role could change %s: %v — an evidence row it can edit is not evidence", c.what, err)
+		}
+	}
+
+	for _, c := range []struct {
+		what string
+		sql  string
+	}{
+		{"what a person answered", `UPDATE consent_event SET new_state = 'withdrawn' WHERE id = $1`},
+		{"the wording a person was shown", `UPDATE consent_event SET policy_text = 'something else' WHERE id = $1`},
+		{"who recorded a consent", `UPDATE consent_event SET captured_by = 'human:someone-else' WHERE id = $1`},
+		{"a proof row outright", `DELETE FROM consent_event WHERE id = $1`},
+	} {
+		if _, err := app.Exec(ctx, c.sql, e.event); !permissionDenied(err) {
+			t.Errorf("the runtime role could change %s: %v", c.what, err)
+		}
+	}
+}
+
+// TestErasureAndTheLeadCarryStillReachTheirColumns is the other half, and the
+// reason the REVOKE is column-scoped rather than blanket.
+//
+// Three writers touch communication_decision and one touches consent_event, and
+// every one of them changes only which subject a row points at:
+// privacy/erasure_consent.go, erasure_leadtwins.go and retentionactions.go
+// tombstone the address and null the subject link; people/consentcarry.go
+// re-points a proof onto the surviving record when a lead is promoted.
+//
+// A blanket REVOKE would have passed the test above and broken Art. 17, which
+// is the worse defect.
+//
+// Mutation: drop either GRANT from the up migration and the matching statement
+// starts being refused.
+func TestErasureAndTheLeadCarryStillReachTheirColumns(t *testing.T) {
+	ownerDSN, appDSN := dsns(t)
+	owner := connect(t, ownerDSN)
+	headSchema(t, owner)
+	e := seedEvidence(t, owner)
+	app := connect(t, appDSN)
+	ctx := context.Background()
+
+	// Erasure's own statement, as privacy/erasure_consent.go writes it.
+	if _, err := app.Exec(ctx, `
+		UPDATE communication_decision
+		   SET recipient_address = 'erased+' || id || '@example.invalid',
+		       subject_id = NULL, subject_kind = NULL
+		 WHERE subject_id = $1`, e.person); err != nil {
+		t.Errorf("erasure can no longer retire a subject's decisions: %v — Art. 17 has to reach the address a message went to", err)
+	}
+
+	// The lead carry's own statement, as people/consentcarry.go writes it.
+	if _, err := app.Exec(ctx,
+		`UPDATE consent_event SET person_id = $2 WHERE person_id = $1`, e.person, e.person); err != nil {
+		t.Errorf("the lead-promotion carry can no longer re-point a proof row: %v", err)
+	}
+}
+
+// permissionDenied reads the SQLSTATE rather than the message, so a Postgres
+// upgrade that rewords the error does not turn this test green.
+func permissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "42501") ||
+		strings.Contains(strings.ToLower(err.Error()), "permission denied")
+}

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1459,7 +1459,7 @@ public.communication_basis.valid_until timestamp with time zone gen=- def=-
 public.communication_basis_live_lead CREATE INDEX communication_basis_live_lead ON public.communication_basis USING btree (lead_id, kind) WHERE ((lead_id IS NOT NULL) AND (revoked_at IS NULL))
 public.communication_basis_live_person CREATE INDEX communication_basis_live_person ON public.communication_basis USING btree (person_id, kind) WHERE ((person_id IS NOT NULL) AND (revoked_at IS NULL))
 public.communication_basis_pkey CREATE UNIQUE INDEX communication_basis_pkey ON public.communication_basis USING btree (id)
-public.communication_decision acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.communication_decision acl=margince_owner=arwdDxt/margince_owner,margince_app=ar/margince_owner rls=false force=false
 public.communication_decision.actor text NOT NULL gen=- def=-
 public.communication_decision.attempt integer NOT NULL gen=- def=0
 public.communication_decision.basis text gen=- def=-
@@ -1546,7 +1546,7 @@ public.consent_doi_token.purpose_id uuid NOT NULL gen=- def=-
 public.consent_doi_token.token_hash text NOT NULL gen=- def=-
 public.consent_doi_token_hash_unique CREATE UNIQUE INDEX consent_doi_token_hash_unique ON public.consent_doi_token USING btree (token_hash)
 public.consent_doi_token_pkey CREATE UNIQUE INDEX consent_doi_token_pkey ON public.consent_doi_token USING btree (id)
-public.consent_event acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.consent_event acl=margince_owner=arwdDxt/margince_owner,margince_app=ar/margince_owner rls=false force=false
 public.consent_event.captured_at timestamp with time zone NOT NULL gen=- def=-
 public.consent_event.captured_by text NOT NULL gen=- def=-
 public.consent_event.confirm_ip text gen=- def=-


### PR DESCRIPTION
`consent_event` says what a person was shown and what they answered. `communication_decision` says why a message was allowed to go out. Both are served to a data subject as proof and stand as the controller's Art. 5(2) record — and the runtime role held a general `UPDATE` and `DELETE` on both.

So any defect, any injection, any mistaken repair script could rewrite the history that was supposed to settle the question. Nothing in this tree `DELETE`s from either table at all.

## Why column-scoped and not a blanket REVOKE

Three legitimate writers exist, and every one of them touches only the columns that **identify the subject**, never the finding:

- `privacy/erasure_consent.go`, `erasure_leadtwins.go` and `retentionactions.go` tombstone `recipient_address` and null `subject_id`/`subject_kind`. Art. 17 has to reach the address a message went to; the verdict, category, reason and ruleset survive as an unattributed statistic about a send that happened.
- `people/consentcarry.go` re-points a `consent_event` onto the surviving record when a lead is promoted or two records merge. It moves the proof and changes nothing the proof says.

A blanket REVOKE **passes the refusal test and breaks erasure**, which is the worse defect. Both directions are held, and the mutation on the GRANT is what proves it.

A `SECURITY DEFINER` function was the alternative the plan named. It is not needed: no legitimate writer touches a finding column, so there is nothing to define around.

## One thing the catalog does not record

The head catalog records **table** ACLs and not **column** ACLs. Its diff is two lines — `margince_app` going from `arwd` to `ar` on both tables — which reads like a plain revocation and is not one. `TestErasureAndTheLeadCarryStillReachTheirColumns` is the only thing holding the column grants, which is why that test exists rather than being folded into the first.

## Verified on a real database, not only in the lane

Applied to the dev database as `margince_owner`, then probed as `margince_app`:

```
UPDATE communication_decision SET verdict='deny'     ERROR: permission denied
DELETE FROM consent_event                            ERROR: permission denied
UPDATE ... SET recipient_address=..., subject_id=NULL   succeeds
```

The down migration restores the grants, verified the same way.

## Mutations, one clause at a time

| Mutation | Test that failed | Correctly kept passing |
|---|---|---|
| drop the `communication_decision` REVOKE | `TestTheRuntimeRoleCannotRewriteAFinding` (all four cases) | `TestErasureAndTheLeadCarry…` |
| drop the erasure GRANT | `TestErasureAndTheLeadCarry…` — permission denied, Art. 17 broken | `TestTheRuntimeRoleCannotRewriteAFinding` |
| drop the `consent_event` REVOKE | `TestTheRuntimeRoleCannotRewriteAFinding` (proof cases) | — |

The middle row is the pair that matters: it is exactly the shape a blanket REVOKE would have shipped.

## Gates

`make check-backend` green. `backend/migrations`, `privacy` and `people` lanes green — the last two are where the legitimate writers live. Head catalog regenerated and committed with the migration. `craft static --strict`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the runtime role from rewriting evidence rows: `consent_event` and `communication_decision` previously allowed general `UPDATE` and `DELETE` to `margince_app`, so any defect or repair script could alter the proof history. The role now keeps `UPDATE` only on the identity columns that erasure and the lead carry need, with `DELETE` revoked entirely.

- Nothing in the tree deletes from either table, so the `DELETE` revocation breaks no legitimate writer.
- A blanket `REVOKE` would have broken Art. 17 erasure, so the grants are column-scoped rather than relying on a `SECURITY DEFINER` function.
- The head catalog records only table ACLs, so its diff reads as a plain revocation; the integration test is what holds the column grants.
- The down migration restores the original grants, and both erasure and lead-carry statements are covered by integration tests.

<sup>Written for commit f331cc568ced8bbfdfe4becc25d5967e776574a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Data Integrity**
  * Evidence records are now protected from unauthorized changes or deletion after creation.
  * Evidence content remains immutable while privacy and data-management workflows can still anonymize recipients or update associated subject references.
  * Added validation to ensure application-level permissions enforce these protections consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->