### PR TITLE
main is red: the flush search input names a size off the ramp

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -1280,7 +1280,7 @@
   border-radius: 0;
   height: auto;
   padding: 0 0 0 24px;
-  font-size: 14px;
+  font-size: var(--fs-body);
 }
 .input-icon-flush .input:focus,
 .input-icon-flush .input:focus-visible {


### PR DESCRIPTION
`type.test.ts` fails on `main`, so every frontend lane is red.

#4026 gave `.input-icon-flush .input` a literal `font-size: 14px`. The ramp's neighbouring rungs are `--fs-sm: 13px` and `--fs-body: 13.5px`, and the gate's own words are the reason it fails: *"12.5px beside 13px is not a decision a reader can see"*.

`--fs-body` is what `.input` itself uses, so the flush variant now agrees with the control it modifies instead of disagreeing with it by half a pixel — which is also why this needed no judgement call about which rung to pick.

## Coordination

Not my ticket's work — I hit it running `make check-fe` for #4152. I checked open PRs touching `atoms.css` and `type.test.ts` before starting and found none, so I am fixing it here and saying so.

`make check-fe` green.