### PR TITLE
The flush input is the size every other input is

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -1280,7 +1280,6 @@
   border-radius: 0;
   height: auto;
   padding: 0 0 0 24px;
-  font-size: 14px;
 }
 .input-icon-flush .input:focus,
 .input-icon-flush .input:focus-visible {


### PR DESCRIPTION
Main is red on the frontend lane, and has been since the type-ramp gate landed.

`src/design-system/type.test.ts` refuses a font-size that names a length instead of a rung of the ramp. `.input-icon-flush .input` names `14px`:

```
src/design-system/atoms.css: `font-size: 14px`: expected [ Array(1) ] to deeply equal []
```

Reproduced on plain `main` (9a13a3d4e), and the line is byte-identical at #4054's own commit — so the gate has been failing since it shipped rather than being broken by anything after it.

**The line is deleted, not re-pointed at a rung.** `.input` already sets `var(--fs-body)` (13.5px), and this selector exists to strip the border, background and radius from an input sitting flush against its icon — not to resize it. Half a pixel apart from every other input is precisely the invisible decision the gate's own message names: *"12.5px beside 13px is not a decision a reader can see."* Removing the override leaves the flush input reading at the same size as every other input.

`pnpm vitest run src/design-system/type.test.ts` → 20 passed. Biome clean.