### PR TITLE
The walk's change count answers over the walk, and can fall

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38689,9 +38689,20 @@ components:
             deleted, or no longer visible to this reader.
 
             Counted so the reader is told WHY the total fell rather than watching it move.
-            It is cumulative over the walk, not per page: the question a reader has is how
-            much of their morning has already been dealt with, not how much went between
-            two clicks.
+            It answers over the WHOLE walk rather than over the last page: the question a
+            reader has is how much of their morning is already dealt with, not how much
+            went between two clicks.
+
+            It is not monotonic, and the exception is real rather than theoretical. Each
+            page asks the question afresh against the walk's frozen list, so a row that
+            comes BACK — a task reopened, a record whose visibility is restored — stops
+            counting as gone and this figure falls. That is the honest answer: the row is
+            on the reader's queue again, and reporting it as dealt with because it once
+            was would be the number lying in the harder direction.
+
+            A row missing because its own SOURCE could not be read is never counted here.
+            The queue has no news about it, which is not the same as it being handled, and
+            `sources_unavailable` is where that is said.
         new_available:
           type: integer
           minimum: 0

--- a/backend/internal/compose/attention/walk_test.go
+++ b/backend/internal/compose/attention/walk_test.go
@@ -460,3 +460,66 @@ func aDayOfAlikeDecisions(n int) crmcontracts.Attention {
 	}
 	return crmcontracts.Attention{AsOf: rankInstant, NeedsYou: pairs}
 }
+
+// TestARowThatComesBackStopsCountingAsGone.
+//
+// `changed_since_snapshot` answers over the whole walk, and it is deliberately
+// NOT monotonic. A task reopened between pages, or a record whose visibility is
+// restored, is on the reader's queue again — and reporting it as dealt with
+// because it once was would be the number lying in the harder direction.
+//
+// Held here because the contract now says so out loud, and a claim about a
+// figure moving is worth exactly as much as the test under it.
+func TestARowThatComesBackStopsCountingAsGone(t *testing.T) {
+	t.Parallel()
+	walks := &walkStore{}
+	svc := (&Service{now: func() time.Time { return rankInstant }}).WithWalks(walks)
+
+	first := walkFrom(t, svc, aDayOfTasks(6), 2, worklistCursor{})
+	if first.NextCursor == nil {
+		t.Fatal("the first page minted no cursor")
+	}
+
+	// Two are dealt with, and the walk says so. Removed BY ID: aDayOfTasks
+	// re-mints its rows, so slicing drops whichever ids sit at the end rather
+	// than the ones this test means.
+	thinner := aDayOfTasksWithout(6, "task-0", "task-1")
+	gone := walkFrom(t, svc, thinner, 10, decodedCursor(t, *first.NextCursor))
+	if gone.Walk == nil || gone.Walk.ChangedSinceSnapshot != 2 {
+		t.Fatalf("the walk reports %v gone, want the two that were dealt with", gone.Walk)
+	}
+
+	// One is reopened. It is back on the queue, so it is no longer gone.
+	restored := aDayOfTasksWithout(6, "task-0")
+	back := walkFrom(t, svc, restored, 10, decodedCursor(t, *first.NextCursor))
+
+	if back.Walk == nil {
+		t.Fatal("the resumed page carried no walk")
+	}
+	if back.Walk.ChangedSinceSnapshot != 1 {
+		t.Errorf("after one row came back the walk reports %d gone, want 1 — a row on the "+
+			"reader's queue again is not work they have dealt with",
+			back.Walk.ChangedSinceSnapshot)
+	}
+}
+
+// aDayOfTasksWithout is the same day with named rows dealt with.
+//
+// By ID rather than by slicing, because the fixture re-mints its rows on every
+// call: a slice drops whichever ids happen to sit at the end, which is not the
+// row a test about a SPECIFIC departure means.
+func aDayOfTasksWithout(n int, dealtWith ...string) crmcontracts.Attention {
+	skip := make(map[string]bool, len(dealtWith))
+	for _, id := range dealtWith {
+		skip[id] = true
+	}
+	whole := aDayOfTasks(n)
+	out := crmcontracts.Attention{AsOf: whole.AsOf}
+	for _, at := range whole.Planned {
+		if skip[at.Id] {
+			continue
+		}
+		out.Planned = append(out.Planned, at)
+	}
+	return out
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -33558,9 +33558,20 @@ type WorklistWalk struct {
 	// deleted, or no longer visible to this reader.
 	//
 	// Counted so the reader is told WHY the total fell rather than watching it move.
-	// It is cumulative over the walk, not per page: the question a reader has is how
-	// much of their morning has already been dealt with, not how much went between
-	// two clicks.
+	// It answers over the WHOLE walk rather than over the last page: the question a
+	// reader has is how much of their morning is already dealt with, not how much
+	// went between two clicks.
+	//
+	// It is not monotonic, and the exception is real rather than theoretical. Each
+	// page asks the question afresh against the walk's frozen list, so a row that
+	// comes BACK — a task reopened, a record whose visibility is restored — stops
+	// counting as gone and this figure falls. That is the honest answer: the row is
+	// on the reader's queue again, and reporting it as dealt with because it once
+	// was would be the number lying in the harder direction.
+	//
+	// A row missing because its own SOURCE could not be read is never counted here.
+	// The queue has no news about it, which is not the same as it being handled, and
+	// `sources_unavailable` is where that is said.
 	ChangedSinceSnapshot int `json:"changed_since_snapshot"`
 
 	// NewAvailable How much work has arrived since this walk started, and is deliberately not in

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29118,9 +29118,20 @@ export interface components {
              *     deleted, or no longer visible to this reader.
              *
              *     Counted so the reader is told WHY the total fell rather than watching it move.
-             *     It is cumulative over the walk, not per page: the question a reader has is how
-             *     much of their morning has already been dealt with, not how much went between
-             *     two clicks.
+             *     It answers over the WHOLE walk rather than over the last page: the question a
+             *     reader has is how much of their morning is already dealt with, not how much
+             *     went between two clicks.
+             *
+             *     It is not monotonic, and the exception is real rather than theoretical. Each
+             *     page asks the question afresh against the walk's frozen list, so a row that
+             *     comes BACK — a task reopened, a record whose visibility is restored — stops
+             *     counting as gone and this figure falls. That is the honest answer: the row is
+             *     on the reader's queue again, and reporting it as dealt with because it once
+             *     was would be the number lying in the harder direction.
+             *
+             *     A row missing because its own SOURCE could not be read is never counted here.
+             *     The queue has no news about it, which is not the same as it being handled, and
+             *     `sources_unavailable` is where that is said.
              */
             changed_since_snapshot: number;
             /**


### PR DESCRIPTION
A follow-up to #4160, correcting one claim its contract made.

`changed_since_snapshot` was documented as cumulative over the walk. It is **not monotonic**, and the exception is real rather than theoretical: each page asks the question afresh against the frozen list, so a row that comes back — a task reopened, a record whose visibility is restored — stops counting as gone and the figure falls.

That is the honest answer. The row is on the reader's queue again, and reporting it as dealt with because it once left would be a claim the queue itself contradicts on the same screen.

Prose and regenerated clients only; no behaviour change. `make check-backend` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `changed_since_snapshot` contract, which wrongly claimed the count is cumulative and monotonic over the walk. It actually answers over the whole walk and can fall when a row comes back; no runtime behavior changes.

- Adds a regression test for the reopened-row case.
- Regenerates the Go and TypeScript clients from the updated OpenAPI spec.

<sup>Written for commit 0f90c580b44de63d4b7c7e8f0f57244bd6f0df3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that walk and queue figures are cumulative across the full walk, not limited to individual pages.
  - Documented that figures may decrease when previously missing rows return, while source-read failures are reported separately.

- **Tests**
  - Added coverage confirming that restored rows no longer count as missing and that only currently absent rows are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->