### PR TITLE
A meeting is dealing with somebody, so the ladder counts it

### DIFF
--- a/backend/gates/meetinghorizonparity_test.go
+++ b/backend/gates/meetinghorizonparity_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// How far into the diary a meeting still says a relationship is live, spelled
+// twice in two modules that may not import each other, and held equal here.
+//
+// The two answer the same question about the same rows and are read one after
+// the other in the life of one partner: capture's copy decides whether the
+// guest on a meeting BECOMES a contact, and consent's decides whether writing
+// to that contact is lawful. Drift is silent and lands in the worst possible
+// shape — widen capture's alone and the product creates a record it will then
+// refuse to mail, widen consent's alone and the lawful window covers people no
+// record exists for. Neither fails anything.
+//
+// Two writers of one invariant either share a helper or say why they do not
+// (AGENTS.md). They cannot share one: a module never imports a sibling, and the
+// value is a Postgres interval literal interpolated into each module's own SQL,
+// so a shared constant would have to live in a lower tier that neither owns.
+// This gate is the "say why" — and it fails from either side.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+// The two copies, by the file that holds each — module-relative, because
+// TestMain chdirs to the backend root. Both declare the same constant name,
+// which is deliberate: a reader who greps the name finds both.
+const (
+	meetingHorizonCaptureFile = "internal/modules/capture/sinkmailgates.go"
+	meetingHorizonConsentFile = "internal/modules/consent/qualifyingground.go"
+	meetingHorizonConstName   = "meetingHorizonInterval"
+)
+
+func TestOneSpellingOfTheMeetingHorizon(t *testing.T) {
+	t.Parallel()
+
+	capture := meetingHorizonIn(t, meetingHorizonCaptureFile)
+	consent := meetingHorizonIn(t, meetingHorizonConsentFile)
+
+	if capture != consent {
+		t.Fatalf("the meeting horizon is %q in capture and %q in consent — one decides whether a "+
+			"meeting's guest becomes a contact and the other whether writing to them is lawful, so "+
+			"a difference either creates records the product then refuses to mail, or opens a "+
+			"lawful window over people no record exists for",
+			capture, consent)
+	}
+	// A horizon nobody can read is not a horizon. Postgres would reject an
+	// unparseable interval at query time, on a path that runs inside the capture
+	// transaction, so an empty or renamed constant must fail here instead.
+	if capture == "" {
+		t.Fatalf("neither copy declares %s — the gate is comparing nothing, which is how a "+
+			"census fails short and reports PASS", meetingHorizonConstName)
+	}
+}
+
+// meetingHorizonIn reads the constant's value out of one file, or "" when the
+// file declares no such constant.
+//
+// Parsed rather than grepped: a comment or a test fixture mentioning the name
+// would satisfy a text search, and a gate that can be satisfied by prose is a
+// gate that stops applying the moment somebody writes about it.
+func meetingHorizonIn(t *testing.T, path string) string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	var found string
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for i, name := range spec.Names {
+			if name.Name != meetingHorizonConstName || i >= len(spec.Values) {
+				continue
+			}
+			lit, ok := spec.Values[i].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				t.Fatalf("%s in %s is not a string literal — this gate compares the interval "+
+					"Postgres is handed, and it can only read one that is written out",
+					meetingHorizonConstName, path)
+			}
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatalf("unquoting %s in %s: %v", meetingHorizonConstName, path, err)
+			}
+			found = value
+		}
+		return true
+	})
+	return found
+}

--- a/backend/internal/compose/integration/capture/capture_meetingladder_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_meetingladder_integration_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// Whether a meeting counts as having dealt with somebody.
+//
+// The counterparty ladder asked two questions about an address — did they write
+// back, and did we write to them on two separate threads — and both are about
+// MAIL. A meeting satisfied neither, and worse, it never reached the tiers at
+// all: a meeting names no counterparty, because attendance is a LIST and the
+// mapper leaves the field unset, so the ladder answered "named nobody" and
+// stopped. A partner the workspace was meeting could not become a contact,
+// while the invitation MAIL beside the meeting was read as machine-generated
+// and judged that same partner noise.
+//
+// These run through compose.NewCaptureRegistry — the production wiring — for
+// the reason this file's first draft got wrong: a bare sink has no ensurer, so
+// every creation assertion against one passes or fails for a reason that has
+// nothing to do with the ladder.
+//
+// The bounds carry most of the weight. A meeting is caller-supplied data unless
+// something says otherwise: POST /activities takes the kind, the date and the
+// people from a request body, so an unbounded arm would let any seat mint a
+// contact by logging a "meeting".
+
+import (
+	"testing"
+)
+
+// meetingGuest is the external party on the meetings below.
+const meetingGuest = "guest@partner.example"
+
+// syncMeeting lands one record as a MEETING through the production registry,
+// with the guest as its external party.
+//
+// syncAsKind rather than a calendar connector: what is under test is the ladder,
+// which reads the activity kind and the addresses the record names, and driving
+// it through the mail lane keeps the fixture to the one fact each test varies.
+func syncMeeting(t *testing.T, env captureEnv, msgID string) {
+	t.Helper()
+	env.syncAsKind(t, map[string]string{msgID: "meeting"},
+		email(meetingGuest, "Guest Partner", captureOwner, msgID, ""))
+}
+
+// The guest on a captured meeting becomes a contact.
+//
+// Mutation: drop the meetingKind arm from ladderSubjectTx and this fails with
+// nobody created — which is the state that refused a partner the workspace was
+// meeting.
+func TestTheGuestOnACapturedMeetingBecomesAContact(t *testing.T) {
+	env := newCaptureEnv(t)
+	e := env.e
+
+	syncMeeting(t, env, "meet1@partner.example")
+
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = 'guest@partner.example' AND p.archived_at IS NULL`); n != 1 {
+		t.Fatalf("%d contacts for somebody the workspace is meeting, want 1 — mail is evidence "+
+			"about intent, and a meeting is evidence about time: both sides put an hour in a "+
+			"calendar, which nobody does by accident", n)
+	}
+}
+
+// An ordinary message from the same address still does NOT create on its own.
+//
+// The admit case for the whole tier: one send is intent, and intent is often
+// unreturned. Without this the test above is satisfied by a ladder that creates
+// for everybody, which is what the exchange requirement exists to prevent.
+func TestOneOrdinaryMessageStillCreatesNobody(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	sync(t, email(meetingGuest, "Guest Partner", captureOwner, "mail1@partner.example", ""))
+
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = 'guest@partner.example' AND p.archived_at IS NULL`); n != 0 {
+		t.Fatalf("%d contacts from a single ordinary message, want 0 — one send is intent, "+
+			"and a meeting is what this change admits, not any message at all", n)
+	}
+}

--- a/backend/internal/modules/capture/sinkdealtwith.go
+++ b/backend/internal/modules/capture/sinkdealtwith.go
@@ -52,11 +52,17 @@ func (s *Sink) dealtWithEnoughToRecord(
 	if out.exchanged, out.replied, err = s.exchangedHow(ctx, tx, cp.Email); err != nil {
 		return dealtWith{}, err
 	}
-	met, err := metInPersonTx(ctx, tx, cp.Email)
-	if err != nil {
-		return dealtWith{}, err
+	// The meeting read is LAST and conditional, because it is the only one of
+	// the three that runs per captured message without an index it can fully
+	// use. Mail that already satisfies both clauses cannot be changed by it —
+	// the answer is already yes — so the ordinary case pays nothing, and the
+	// query runs only for the addresses the mail evidence left short.
+	if !out.corresponded || !out.exchanged {
+		if out.met, err = metInPersonTx(ctx, tx, cp.Email); err != nil {
+			return dealtWith{}, err
+		}
 	}
-	out.create = (out.corresponded || met) && (out.exchanged || met) && s.recordWorthy(cp)
+	out.create = (out.corresponded || out.met) && (out.exchanged || out.met) && s.recordWorthy(cp)
 	return out, nil
 }
 
@@ -66,6 +72,8 @@ func (s *Sink) dealtWithEnoughToRecord(
 type dealtWith struct {
 	// create: the tier's answer — a record here is honest.
 	create bool
+	// met: a captured meeting connects the workspace to this address.
+	met bool
 
 	// corresponded: the workspace has provably written to this address.
 	corresponded bool
@@ -76,3 +84,14 @@ type dealtWith struct {
 	// worth a record and is not somebody writing to us first.
 	replied bool
 }
+
+// positive reports T1 in the sense the tiers BELOW it read: this workspace has
+// dealt with the address, so a stale judgement about it no longer governs.
+//
+// The distinction matters and cost a bug. `corresponded` alone is what T2 and
+// the settled-disposition arm used to consult, and it reads attested outbound
+// MAIL — so a partner known only from a meeting was still suppressed by the ESP
+// registry, and a prior `noise` verdict still stopped them, while the comments
+// beside both said T1 outranks them. Meeting somebody is the same claim those
+// arms defer to, so it belongs in the same answer.
+func (d dealtWith) positive() bool { return d.corresponded || d.met }

--- a/backend/internal/modules/capture/sinkdealtwith.go
+++ b/backend/internal/modules/capture/sinkdealtwith.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// T1: whether this workspace has dealt with an address enough for a record to
+// be honest. Its own file because it is the tier's whole question, and the
+// ladder that consults it (sinkensure.go) has four more.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// dealtWithEnoughToRecord answers T1: has this workspace dealt with the address
+// enough that a record is honest.
+//
+// Three questions, and T1 used to ask only the first. Whether the workspace
+// wrote here (corresponded); whether that amounts to an exchange rather than
+// unreturned intent (exchanged); and whether a person is reachable at the
+// address at all (recordWorthy) — a mailbox owner books flights and answers
+// their own robots, so writing somewhere is not evidence a human is behind it.
+// A single send is deferred rather than refused, so a real prospect written to
+// once still becomes a contact, for a reason.
+//
+// A MEETING is the fourth, and the strongest. Mail is evidence about intent —
+// a founder mails forty people and hears from six — while a meeting is evidence
+// about time, which nobody spends by accident. Before this, a partner the
+// workspace was meeting next week satisfied nothing here, and the invitation
+// made it worse: it reaches the mailbox as machine-generated mail, so the
+// classifier read it as transactional and judged that same partner noise.
+//
+// The meeting satisfies BOTH mail clauses, and it has to or it carries nothing:
+// `corresponded` reads attested outbound mail, `exchanged` reads a reply or a
+// second thread, and a guest who only ever appears on a calendar has neither.
+// One answer feeding both is what says the meeting IS the evidence, rather than
+// a third clause somebody must remember to combine.
+//
+// recordWorthy still binds. A meeting names people, and `noreply@` on the
+// invitation is not one of them.
+func (s *Sink) dealtWithEnoughToRecord(
+	ctx context.Context, tx pgx.Tx, cp connector.Counterparty,
+) (dealtWith, error) {
+	var out dealtWith
+	var err error
+	if out.corresponded, err = correspondencePositiveTx(ctx, tx, cp.Email); err != nil {
+		return dealtWith{}, err
+	}
+	if out.exchanged, out.replied, err = s.exchangedHow(ctx, tx, cp.Email); err != nil {
+		return dealtWith{}, err
+	}
+	met, err := metInPersonTx(ctx, tx, cp.Email)
+	if err != nil {
+		return dealtWith{}, err
+	}
+	out.create = (out.corresponded || met) && (out.exchanged || met) && s.recordWorthy(cp)
+	return out, nil
+}
+
+// dealtWith is everything T1 concluded about one address, carried as one value
+// because the fields are all bools answering different questions and a caller
+// that swapped two of them would still compile.
+type dealtWith struct {
+	// create: the tier's answer — a record here is honest.
+	create bool
+
+	// corresponded: the workspace has provably written to this address.
+	corresponded bool
+	// exchanged: that amounts to an exchange rather than unreturned intent.
+	exchanged bool
+	// replied: they wrote to US, the only one that says the person initiated
+	// contact. A meeting deliberately does not set it — sitting in a meeting is
+	// worth a record and is not somebody writing to us first.
+	replied bool
+}

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -231,7 +231,7 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 	if err != nil {
 		return counterpartyDecision{}, err
 	}
-	corresponded := dealt.corresponded
+	corresponded := dealt.positive()
 	decision.create, decision.replied = dealt.create, dealt.replied
 	roleMailbox := refusesToNameAPerson(cp.Email, dealt.exchanged)
 	if roleMailbox {

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -227,24 +227,13 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 	// address. Asked of EVERY sender, not only those a suppression rule matched,
 	// since T4 defers the ambiguous class and this answer decides
 	// create-versus-defer for ordinary senders too.
-	corresponded, err := correspondencePositiveTx(ctx, tx, cp.Email)
+	dealt, err := s.dealtWithEnoughToRecord(ctx, tx, cp)
 	if err != nil {
 		return counterpartyDecision{}, err
 	}
-	exchanged, replied, err := s.exchangedHow(ctx, tx, cp.Email)
-	if err != nil {
-		return counterpartyDecision{}, err
-	}
-	// Three questions, and T1 used to ask only the first. Whether the workspace
-	// wrote here (corresponded); whether that amounts to an exchange rather than
-	// unreturned intent (exchangedWith); and whether a person is reachable at
-	// the address at all (recordWorthy) — a mailbox owner books flights and
-	// answers their own robots, so writing somewhere is not evidence a human is
-	// behind it. A single send is deferred rather than refused, so a real
-	// prospect written to once still becomes a contact, for a reason.
-	decision.create = corresponded && exchanged && s.recordWorthy(cp)
-	decision.replied = replied
-	roleMailbox := refusesToNameAPerson(cp.Email, exchanged)
+	corresponded := dealt.corresponded
+	decision.create, decision.replied = dealt.create, dealt.replied
+	roleMailbox := refusesToNameAPerson(cp.Email, dealt.exchanged)
 	if roleMailbox {
 		decision.create = false
 	}

--- a/backend/internal/modules/capture/sinkmailgates.go
+++ b/backend/internal/modules/capture/sinkmailgates.go
@@ -407,3 +407,67 @@ func wroteOnTwoThreadsTx(ctx context.Context, tx pgx.Tx, email string) (bool, er
 	}
 	return threads >= 2, nil
 }
+
+// metInPersonTx reports whether this workspace and that address share a meeting
+// a connector captured.
+//
+// It is the third shape of "we have actually dealt with this person", beside a
+// reply and two outbound threads, and it is the strongest of them. Mail is
+// evidence about intent — a founder mails forty people and hears from six — and
+// a meeting is evidence about time: both sides put an hour in a calendar, which
+// nobody does by accident.
+//
+// The ladder could not see one, and the shape of the miss was worse than a gap.
+// A calendar invitation reaches the mailbox as machine-generated mail, so the
+// classifier read it as `transactional` and judged the INVITED PARTNER noise on
+// it — the record was created owner-scoped and invisible, on the strength of the
+// message that proves the relationship.
+//
+// The address is matched against the participant rows rather than
+// counterparty_email, because a meeting carries no counterparty: attendance is a
+// LIST and the calendar mapper leaves the field unset. Either the participant
+// row resolved to a person holding this address, or it is the bare address the
+// invitation named — a person the workspace does not have yet is exactly the
+// case this decides.
+//
+// THREE BOUNDS, the same three the consent arm applies (consent's
+// meetingQualifyingEvent), because they answer the same question about the same
+// row and two readings of one fact drift:
+//
+//   - a CONNECTOR captured it, so a hand-logged "meeting" cannot mint a contact;
+//   - it was not declined or abandoned (no_show, canceled);
+//   - it is not dated past the horizon, so a far-future date cannot stand in for
+//     a relationship.
+func metInPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
+	normalized := normalizeEmail(email)
+	if normalized == "" {
+		return false, nil
+	}
+	var met bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1
+		    FROM activity a
+		    JOIN activity_participant p ON p.activity_id = a.id
+		   WHERE a.kind = 'meeting'
+		     AND a.captured_by LIKE 'connector:%'
+		     AND (a.meeting_status IS NULL OR a.meeting_status NOT IN ('no_show', 'canceled'))
+		     AND a.occurred_at <= now() + $2::interval
+		     AND (lower(p.address) = $1
+		          OR EXISTS (
+		            SELECT 1 FROM person_email pe
+		             WHERE pe.person_id = p.person_id
+		               AND lower(pe.email) = $1
+		               AND pe.archived_at IS NULL))
+		     AND `+auth.ActivityAvailableClause("a")+`)`,
+		normalized, meetingHorizonInterval).Scan(&met); err != nil {
+		return false, fmt.Errorf("capture: reading whether this workspace is meeting the sender: %w", err)
+	}
+	return met, nil
+}
+
+// meetingHorizonInterval bounds how far into the diary a meeting still says a
+// relationship is live. Spelled again here rather than imported because a module
+// never imports a sibling; what must not drift is the WINDOW, and the consent
+// arm holds the same one against the same rows.
+const meetingHorizonInterval = "90 days"

--- a/backend/internal/modules/capture/sinkmailgates.go
+++ b/backend/internal/modules/capture/sinkmailgates.go
@@ -438,6 +438,11 @@ func wroteOnTwoThreadsTx(ctx context.Context, tx pgx.Tx, email string) (bool, er
 //   - it was not declined or abandoned (no_show, canceled);
 //   - it is not dated past the horizon, so a far-future date cannot stand in for
 //     a relationship.
+//
+// An ARCHIVED meeting is excluded too, which is not one of the three: a meeting
+// somebody removed is not evidence of anything, and the activity kind index is
+// partial on archived_at IS NULL, so naming it here is also what lets this
+// query use one — it runs per captured address.
 func metInPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
 	normalized := normalizeEmail(email)
 	if normalized == "" {
@@ -450,6 +455,7 @@ func metInPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
 		    FROM activity a
 		    JOIN activity_participant p ON p.activity_id = a.id
 		   WHERE a.kind = 'meeting'
+		     AND a.archived_at IS NULL
 		     AND a.captured_by LIKE 'connector:%'
 		     AND (a.meeting_status IS NULL OR a.meeting_status NOT IN ('no_show', 'canceled'))
 		     AND a.occurred_at <= now() + $2::interval

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (74)
+## Parity (75)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -70,6 +70,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |
+| `meetinghorizonparity_test.go` | H2 | How far into the diary a meeting still says a relationship is live, spelled twice in two modules that may not import each other, and held equal here. |
 | `mergedecidableauthority_test.go` | H2 | Who may settle a duplicate pair has ONE answer, and the card must ask the same thing the write asks. |
 | `minorunitscale_test.go` | H3 | A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one fact, and the table that holds it lives in shared/kernel/values. |
 | `modulecatalogtables_test.go` | H2 | The module catalog's Owns-tables column is the ownership map. |


### PR DESCRIPTION
## What was wrong

The counterparty ladder asked two questions about an address, and both are about **mail**: did they write back, and did we write to them on two separate threads.

A partner the workspace was meeting next week satisfied neither, so no record was created. The invitation made it **worse** rather than better: it reaches the mailbox as machine-generated mail, so the classifier read it as `transactional` and judged that same partner noise — on the strength of the one message that proves the relationship.

## The fix

A meeting is now the third shape of *"we have dealt with this person"*, and the strongest. Mail is evidence about intent — a founder mails forty people and hears from six — while a meeting is evidence about time, which nobody spends by accident.

It satisfies **both** mail clauses, and it has to or it carries nothing: `corresponded` reads attested outbound mail, `exchanged` reads a reply or a second thread, and a guest who only ever appears on a calendar has neither. One answer feeding both says the meeting *is* the evidence rather than a third clause somebody must remember to combine.

`replied` stays untouched — sitting in a meeting is worth a record and is not the person writing to us first.

## Bounds

The same three the consent arm applies (#4155) to the same rows, because two readings of one fact drift:

- **A connector must have captured it.** `POST /activities` takes the kind, the date and the links from a request body, and the log path stamps a participant row for every linked person — so without this any seat that can see a contact could log a "meeting" naming them and mint them a record.
- **Not `no_show` or `canceled`.** An invitation somebody declined is the opposite of evidence.
- **Not past the 90-day horizon**, so a date somebody typed cannot stand in for a relationship.

`recordWorthy` still binds, so `noreply@` on an invitation is not a person.

## Tests

- `TestTheGuestOnACapturedMeetingBecomesAContact` — mutation-checked: revert the `met` clause and it fails with nobody created, which is the state that refused a partner the workspace was meeting.
- `TestOneOrdinaryMessageStillCreatesNobody` — the admit case, so a ladder that created for everybody could not pass.
- `TestCaptureTierGateMintsNoContactForACalendarInvite` (pre-existing) still passes: an invitation **email** mints nobody, unchanged.

T1 moves to its own file as one answer rather than three bools assembled at the call site, which is what kept `decideCounterparty` inside its ceiling.

Full `make check-backend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Qualifying connector-captured meetings now count as evidence that the workspace dealt with a person, so the counterparty ladder can create a contact without a qualifying email exchange. Meetings still do not count as the person replying.

**Bug Fixes**

- Match meeting participants by their address or an existing person email.
- Exclude manually logged, canceled, no-show, archived, and meetings more than 90 days ahead.
- Preserve existing `recordWorthy` filtering for non-person addresses.
- T1's positive answer now includes meetings, so a meeting-known partner is no longer suppressed by a stale noise verdict or the ESP registry.
- Add integration coverage for meeting admission and single-message rejection.

A recycled address can still inherit the former holder's meeting through the bare participant-address arm; that needs a separate decision (#4167).

<sup>Written for commit 38f887285d16ee7d4ce6ca270378a81113b51ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Contacts can now be created for guests who attended captured, recent in-person meetings.
  - Meeting attendance is recognized when participants match an existing contact email.

- **Bug Fixes**
  - Ordinary messages alone no longer create contacts for correspondents.
  - Canceled or missed meetings are excluded from contact creation decisions.
  - Contact creation decisions now consistently account for replies, exchanges, and meeting attendance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->