### PR TITLE
worklistFrom hands its two side sources their own ranking

### DIFF
--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -18,6 +18,7 @@ package attention
 import (
 	"context"
 	"sort"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -198,56 +199,8 @@ func (s *Service) worklistFrom(
 		limit = worklistMaxPage
 	}
 	rows := classifyDay(day, day.AsOf, s.money)
-	// Longest wait first, so the few that LEAD are the ones most likely to have
-	// been forgotten rather than whichever the database returned first.
-	waits := make([]ranked, 0, len(waiting.rows))
-	for _, customer := range waiting.rows {
-		waits = append(waits, classifyWaiting(customer, day.AsOf))
-	}
-	sort.SliceStable(waits, func(i, j int) bool {
-		return waits[i].occurredAt.Before(waits[j].occurredAt)
-	})
-	// Narrowed BEFORE the crowding mark, through the same filters every other
-	// source is narrowed by. Crowding is a fact about position — the ninth wait
-	// on THIS page — so marking it over rows the scope then removes would demote
-	// a reader's second waiting customer for standing behind seven of a
-	// colleague's.
-	//
-	// One spelling for one rule. This loop used to judge ownership itself, in
-	// terms of the WaitingCustomer rather than the ranked row, which is how the
-	// two ended up disagreeing: a named owner's queue dropped every wait because
-	// the filter below could not see an owner this loop could.
-	waits = s.narrowToScope(ctx, waits, scope, s.taskOwner)
-	for i, row := range waits {
-		// Past the lead, a wait sorts BELOW the other kinds without ceasing to
-		// be one: its level still says a customer is waiting, because that is
-		// what it is and the summary counts on it. What changes is only where
-		// it sits, through the ordering's own last tiebreak.
-		//
-		// Rewriting the level instead would have told the reader the ninth
-		// waiting customer was agreed work, while the row went on saying a
-		// buyer wrote last — the page contradicting itself.
-		if i >= waitingLead {
-			row.crowded = true
-		}
-		rows = append(rows, row)
-	}
-	// The leads still owed a first reply, ranked among everything else rather
-	// than in a queue of their own. Longest overdue first, so the few that LEAD
-	// are the ones most likely to have been forgotten.
-	sort.SliceStable(leads.rows, func(i, j int) bool {
-		return leads.rows[i].DeadlineAt.Before(leads.rows[j].DeadlineAt)
-	})
-	for i, lead := range leads.rows {
-		row := classifyLead(lead, day.AsOf)
-		// Past the lead, an overdue lead sorts BELOW the other kinds without
-		// ceasing to be one — the same treatment a ninth waiting customer gets,
-		// and for the same reason: its level still states the fact.
-		if i >= leadLead {
-			row.crowded = true
-		}
-		rows = append(rows, row)
-	}
+	rows = append(rows, s.rankedWaits(ctx, waiting, day.AsOf, scope)...)
+	rows = append(rows, rankedLeads(leads, day.AsOf)...)
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
@@ -422,6 +375,68 @@ func (s *Service) worklistFrom(
 	// would be a claim about a walk that does not exist.
 	if state := walk.state(); state != nil {
 		out.Walk = state
+	}
+	return out
+}
+
+// rankedWaits ranks the customers waiting on us, newest wait last.
+//
+// Longest wait first, so the few that LEAD are the ones most likely to have
+// been forgotten rather than whichever the database returned first.
+//
+// NARROWED BEFORE THE CROWDING MARK, through the same filters every other
+// source is narrowed by. Crowding is a fact about position — the ninth wait on
+// THIS page — so marking it over rows the scope then removes would demote a
+// reader's second waiting customer for standing behind seven of a colleague's.
+//
+// One spelling for one rule. This used to judge ownership itself, in terms of
+// the WaitingCustomer rather than the ranked row, which is how the two ended up
+// disagreeing: a named owner's queue dropped every wait because the caller's
+// filter could not see an owner this loop could.
+func (s *Service) rankedWaits(
+	ctx context.Context, waiting waitingRead, asOf time.Time, scope string,
+) []ranked {
+	waits := make([]ranked, 0, len(waiting.rows))
+	for _, customer := range waiting.rows {
+		waits = append(waits, classifyWaiting(customer, asOf))
+	}
+	sort.SliceStable(waits, func(i, j int) bool {
+		return waits[i].occurredAt.Before(waits[j].occurredAt)
+	})
+	waits = s.narrowToScope(ctx, waits, scope, s.taskOwner)
+	for i := range waits {
+		// Past the lead, a wait sorts BELOW the other kinds without ceasing to
+		// be one: its level still says a customer is waiting, because that is
+		// what it is and the summary counts on it. What changes is only where
+		// it sits, through the ordering's own last tiebreak.
+		//
+		// Rewriting the level instead would have told the reader the ninth
+		// waiting customer was agreed work, while the row went on saying a
+		// buyer wrote last — the page contradicting itself.
+		if i >= waitingLead {
+			waits[i].crowded = true
+		}
+	}
+	return waits
+}
+
+// rankedLeads ranks the leads still owed a first reply, among everything else
+// rather than in a queue of their own. Longest overdue first, so the few that
+// LEAD are the ones most likely to have been forgotten.
+func rankedLeads(leads leadRead, asOf time.Time) []ranked {
+	sort.SliceStable(leads.rows, func(i, j int) bool {
+		return leads.rows[i].DeadlineAt.Before(leads.rows[j].DeadlineAt)
+	})
+	out := make([]ranked, 0, len(leads.rows))
+	for i, lead := range leads.rows {
+		row := classifyLead(lead, asOf)
+		// Past the lead, an overdue lead sorts BELOW the other kinds without
+		// ceasing to be one — the same treatment a ninth waiting customer gets,
+		// and for the same reason: its level still states the fact.
+		if i >= leadLead {
+			row.crowded = true
+		}
+		out = append(out, row)
 	}
 	return out
 }


### PR DESCRIPTION
Main is red on `craftsmanship`:

```
../../backend/internal/compose/attention/worklist.go
  185: [MAJOR] long-func — worklistFrom is 85 code lines (> 80) — extract helpers
BLOCK — 0 blocker, 1 major, 0 minor
```

Reproduced on plain `main` (1efecf16d); #4161 grew the function past the cap.

The two blocks extracted are the ones that were already separable — the waiting customers and the overdue leads. Each collects rows from a source read *beside* the assembled day, sorts them oldest-first, and marks the ones past the lead as crowded; neither touches the day's own rows, and between them they were a third of the function.

Behaviour is unchanged, and one detail had to be preserved rather than tidied: `rankedWaits` narrows to scope **before** marking crowding, because crowding is a fact about position on the page — marking it over rows the scope then removes demotes a reader's second waiting customer for standing behind seven of a colleague's. The comment saying so travels with the code that depends on it.

`rankedWaits` assigns through the slice index rather than the loop's copy, which the original achieved by appending; `rankedLeads` returns its own slice for the same reason.

`make check-backend` exit 0, `make craft-static` PASS, and the attention unit + integration suites green.