### PR TITLE
Two main repairs: the forged meeting kind, and worklistFrom's length

### DIFF
--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -18,6 +18,7 @@ package attention
 import (
 	"context"
 	"sort"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -198,56 +199,8 @@ func (s *Service) worklistFrom(
 		limit = worklistMaxPage
 	}
 	rows := classifyDay(day, day.AsOf, s.money)
-	// Longest wait first, so the few that LEAD are the ones most likely to have
-	// been forgotten rather than whichever the database returned first.
-	waits := make([]ranked, 0, len(waiting.rows))
-	for _, customer := range waiting.rows {
-		waits = append(waits, classifyWaiting(customer, day.AsOf))
-	}
-	sort.SliceStable(waits, func(i, j int) bool {
-		return waits[i].occurredAt.Before(waits[j].occurredAt)
-	})
-	// Narrowed BEFORE the crowding mark, through the same filters every other
-	// source is narrowed by. Crowding is a fact about position — the ninth wait
-	// on THIS page — so marking it over rows the scope then removes would demote
-	// a reader's second waiting customer for standing behind seven of a
-	// colleague's.
-	//
-	// One spelling for one rule. This loop used to judge ownership itself, in
-	// terms of the WaitingCustomer rather than the ranked row, which is how the
-	// two ended up disagreeing: a named owner's queue dropped every wait because
-	// the filter below could not see an owner this loop could.
-	waits = s.narrowToScope(ctx, waits, scope, s.taskOwner)
-	for i, row := range waits {
-		// Past the lead, a wait sorts BELOW the other kinds without ceasing to
-		// be one: its level still says a customer is waiting, because that is
-		// what it is and the summary counts on it. What changes is only where
-		// it sits, through the ordering's own last tiebreak.
-		//
-		// Rewriting the level instead would have told the reader the ninth
-		// waiting customer was agreed work, while the row went on saying a
-		// buyer wrote last — the page contradicting itself.
-		if i >= waitingLead {
-			row.crowded = true
-		}
-		rows = append(rows, row)
-	}
-	// The leads still owed a first reply, ranked among everything else rather
-	// than in a queue of their own. Longest overdue first, so the few that LEAD
-	// are the ones most likely to have been forgotten.
-	sort.SliceStable(leads.rows, func(i, j int) bool {
-		return leads.rows[i].DeadlineAt.Before(leads.rows[j].DeadlineAt)
-	})
-	for i, lead := range leads.rows {
-		row := classifyLead(lead, day.AsOf)
-		// Past the lead, an overdue lead sorts BELOW the other kinds without
-		// ceasing to be one — the same treatment a ninth waiting customer gets,
-		// and for the same reason: its level still states the fact.
-		if i >= leadLead {
-			row.crowded = true
-		}
-		rows = append(rows, row)
-	}
+	rows = append(rows, s.rankedWaits(ctx, waiting, day.AsOf, scope)...)
+	rows = append(rows, rankedLeads(leads, day.AsOf)...)
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
@@ -422,6 +375,68 @@ func (s *Service) worklistFrom(
 	// would be a claim about a walk that does not exist.
 	if state := walk.state(); state != nil {
 		out.Walk = state
+	}
+	return out
+}
+
+// rankedWaits ranks the customers waiting on us, newest wait last.
+//
+// Longest wait first, so the few that LEAD are the ones most likely to have
+// been forgotten rather than whichever the database returned first.
+//
+// NARROWED BEFORE THE CROWDING MARK, through the same filters every other
+// source is narrowed by. Crowding is a fact about position — the ninth wait on
+// THIS page — so marking it over rows the scope then removes would demote a
+// reader's second waiting customer for standing behind seven of a colleague's.
+//
+// One spelling for one rule. This used to judge ownership itself, in terms of
+// the WaitingCustomer rather than the ranked row, which is how the two ended up
+// disagreeing: a named owner's queue dropped every wait because the caller's
+// filter could not see an owner this loop could.
+func (s *Service) rankedWaits(
+	ctx context.Context, waiting waitingRead, asOf time.Time, scope string,
+) []ranked {
+	waits := make([]ranked, 0, len(waiting.rows))
+	for _, customer := range waiting.rows {
+		waits = append(waits, classifyWaiting(customer, asOf))
+	}
+	sort.SliceStable(waits, func(i, j int) bool {
+		return waits[i].occurredAt.Before(waits[j].occurredAt)
+	})
+	waits = s.narrowToScope(ctx, waits, scope, s.taskOwner)
+	for i := range waits {
+		// Past the lead, a wait sorts BELOW the other kinds without ceasing to
+		// be one: its level still says a customer is waiting, because that is
+		// what it is and the summary counts on it. What changes is only where
+		// it sits, through the ordering's own last tiebreak.
+		//
+		// Rewriting the level instead would have told the reader the ninth
+		// waiting customer was agreed work, while the row went on saying a
+		// buyer wrote last — the page contradicting itself.
+		if i >= waitingLead {
+			waits[i].crowded = true
+		}
+	}
+	return waits
+}
+
+// rankedLeads ranks the leads still owed a first reply, among everything else
+// rather than in a queue of their own. Longest overdue first, so the few that
+// LEAD are the ones most likely to have been forgotten.
+func rankedLeads(leads leadRead, asOf time.Time) []ranked {
+	sort.SliceStable(leads.rows, func(i, j int) bool {
+		return leads.rows[i].DeadlineAt.Before(leads.rows[j].DeadlineAt)
+	})
+	out := make([]ranked, 0, len(leads.rows))
+	for i, lead := range leads.rows {
+		row := classifyLead(lead, asOf)
+		// Past the lead, an overdue lead sorts BELOW the other kinds without
+		// ceasing to be one — the same treatment a ninth waiting customer gets,
+		// and for the same reason: its level still states the fact.
+		if i >= leadLead {
+			row.crowded = true
+		}
+		out = append(out, row)
 	}
 	return out
 }

--- a/backend/internal/modules/capture/sinkdealtwith.go
+++ b/backend/internal/modules/capture/sinkdealtwith.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -42,7 +43,7 @@ import (
 // recordWorthy still binds. A meeting names people, and `noreply@` on the
 // invitation is not one of them.
 func (s *Sink) dealtWithEnoughToRecord(
-	ctx context.Context, tx pgx.Tx, cp connector.Counterparty,
+	ctx context.Context, tx pgx.Tx, cp connector.Counterparty, capturing ids.UUID,
 ) (dealtWith, error) {
 	var out dealtWith
 	var err error
@@ -58,7 +59,7 @@ func (s *Sink) dealtWithEnoughToRecord(
 	// the answer is already yes — so the ordinary case pays nothing, and the
 	// query runs only for the addresses the mail evidence left short.
 	if !out.corresponded || !out.exchanged {
-		if out.met, err = metInPersonTx(ctx, tx, cp.Email); err != nil {
+		if out.met, out.metElsewhere, err = metInPersonTx(ctx, tx, cp.Email, capturing); err != nil {
 			return dealtWith{}, err
 		}
 	}
@@ -72,8 +73,13 @@ func (s *Sink) dealtWithEnoughToRecord(
 type dealtWith struct {
 	// create: the tier's answer — a record here is honest.
 	create bool
-	// met: a captured meeting connects the workspace to this address.
+	// met: a captured meeting connects the workspace to this address. The row
+	// being captured counts, which is how a calendar record's guest becomes a
+	// contact.
 	met bool
+	// metElsewhere: the same, minus the row being decided about. It is what may
+	// outrank a settled judgement — see positive() and metInPersonTx.
+	metElsewhere bool
 
 	// corresponded: the workspace has provably written to this address.
 	corresponded bool
@@ -94,4 +100,11 @@ type dealtWith struct {
 // registry, and a prior `noise` verdict still stopped them, while the comments
 // beside both said T1 outranks them. Meeting somebody is the same claim those
 // arms defer to, so it belongs in the same answer.
-func (d dealtWith) positive() bool { return d.corresponded || d.met }
+//
+// It reads metElsewhere and NOT met, and the difference is the whole guard.
+// `kind` is caller-supplied, so a message that calls itself a meeting would
+// otherwise be its own authority to lift the suppression standing against its
+// own sender — one word in a request body, and a judged sender's mail is
+// published to the workspace. A meeting captured on some OTHER row is evidence;
+// the row under judgement is not evidence about itself.
+func (d dealtWith) positive() bool { return d.corresponded || d.metElsewhere }

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -227,7 +227,7 @@ func (s *Sink) decideCounterparty(ctx context.Context, tx pgx.Tx, rec connector.
 	// address. Asked of EVERY sender, not only those a suppression rule matched,
 	// since T4 defers the ambiguous class and this answer decides
 	// create-versus-defer for ordinary senders too.
-	dealt, err := s.dealtWithEnoughToRecord(ctx, tx, cp)
+	dealt, err := s.dealtWithEnoughToRecord(ctx, tx, cp, activityID)
 	if err != nil {
 		return counterpartyDecision{}, err
 	}

--- a/backend/internal/modules/capture/sinkmailgates.go
+++ b/backend/internal/modules/capture/sinkmailgates.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
@@ -443,15 +444,30 @@ func wroteOnTwoThreadsTx(ctx context.Context, tx pgx.Tx, email string) (bool, er
 // somebody removed is not evidence of anything, and the activity kind index is
 // partial on archived_at IS NULL, so naming it here is also what lets this
 // query use one — it runs per captured address.
-func metInPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
+// TWO ANSWERS, because the meeting has to carry different weight depending on
+// what is being asked, and one bool cannot say both.
+//
+// `met` counts every qualifying meeting, the row being captured included. That
+// is what creates the contact: a calendar record names a guest, and the guest
+// is the point of it.
+//
+// `elsewhere` counts only meetings OTHER than the row being decided about, and
+// it is what may outrank a settled judgement about the sender. `kind` is a word
+// the CALLER supplies — a connector reports it beside the raw bytes, the
+// extension ingress copies Activity.Kind off a third-party record with no
+// vocabulary check, and the column carries no CHECK constraint. A message that
+// calls itself a meeting must not therefore be the evidence that lifts the
+// suppression standing against its own sender: that is a caller writing one
+// word to publish judged mail to the whole workspace.
+func metInPersonTx(
+	ctx context.Context, tx pgx.Tx, email string, capturing ids.UUID,
+) (met, elsewhere bool, err error) {
 	normalized := normalizeEmail(email)
 	if normalized == "" {
-		return false, nil
+		return false, false, nil
 	}
-	var met bool
 	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (
-		  SELECT 1
+		SELECT count(*) > 0, count(*) FILTER (WHERE a.id <> $3) > 0
 		    FROM activity a
 		    JOIN activity_participant p ON p.activity_id = a.id
 		   WHERE a.kind = 'meeting'
@@ -465,11 +481,11 @@ func metInPersonTx(ctx context.Context, tx pgx.Tx, email string) (bool, error) {
 		             WHERE pe.person_id = p.person_id
 		               AND lower(pe.email) = $1
 		               AND pe.archived_at IS NULL))
-		     AND `+auth.ActivityAvailableClause("a")+`)`,
-		normalized, meetingHorizonInterval).Scan(&met); err != nil {
-		return false, fmt.Errorf("capture: reading whether this workspace is meeting the sender: %w", err)
+		     AND `+auth.ActivityAvailableClause("a"),
+		normalized, meetingHorizonInterval, capturing).Scan(&met, &elsewhere); err != nil {
+		return false, false, fmt.Errorf("capture: reading whether this workspace is meeting the sender: %w", err)
 	}
-	return met, nil
+	return met, elsewhere, nil
 }
 
 // meetingHorizonInterval bounds how far into the diary a meeting still says a


### PR DESCRIPTION
Main is red on `integration shard (4/6)`. `TestTheLimiterStillHoldsAMeetingThatNamesAJudgedSender` fails from #4164 — reproduced on plain `main`, passing at `1efecf16d` and failing at `438c95405` — and it is failing about something worth keeping.

```
a meeting-kind record naming a judged sender was born audience="workspace" reason="",
want participants/no_record — the kind is a word the caller chose, and the ladder
judged the person who sent it
```

## Why the two are in tension

#4164 made a meeting the fourth and strongest sense of *"we have dealt with this person"*, which is right — a founder mails forty people and hears from six, while nobody spends an hour by accident. It also let that meeting **outrank a settled judgement** about the sender, so a partner known only from a calendar stops being suppressed by the ESP registry.

The trouble is where `kind` comes from. A connector reports it beside the raw bytes, the extension ingress copies `Activity.Kind` straight off a third-party record with no vocabulary check, and the column carries no `CHECK` constraint. **"meeting" is a word a caller writes.** With the override in place, a suppressed sender could land one message that calls itself a meeting and have that same message be the evidence lifting the suppression standing against it — published to the whole workspace on the strength of its own label.

## The fix

The read answers two questions instead of one, in the same query:

| | counts | used for |
|---|---|---|
| `met` | every qualifying meeting, **including the row being captured** | creating the contact — a calendar record names a guest, and the guest is the point of it |
| `metElsewhere` | only meetings **other than the row being decided about** | outranking a settled judgement |

A meeting on some other row is evidence; the row under judgement is not evidence about itself. #4164's headline case — `TestTheGuestOnACapturedMeetingBecomesAContact` — is untouched.

## What I did not do

Reverting `positive()` to `corresponded` alone also makes both tests pass, and throws away the thing #4164 set out to fix. No test covered that arm — it was asserted in prose — which is exactly why the blunter fix looks equally good from the outside. Worth knowing when reviewing this.

## Verification

`make check-backend` exit 0; `internal/modules/capture` and `integration/capture` suites green.

Mutation: read `met` where `positive()` reads `metElsewhere` →

```
--- PASS: TestTheGuestOnACapturedMeetingBecomesAContact
--- FAIL: TestTheLimiterStillHoldsAMeetingThatNamesAJudgedSender
```

That pair is what shows the distinction is the load-bearing thing, rather than the meeting read as a whole.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved meeting-based contact evaluation by distinguishing the current captured activity from other qualifying meetings.
  - A meeting record can no longer independently serve as evidence to lift a communication suppression; separate meeting activity is required.
  - Updated activity processing to apply this evidence consistently when deciding whether a counterparty can be recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->