### PR TITLE
A judgement is drawn below the day, not inside it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7898,6 +7898,7 @@ export const de = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Dein Tag wird gelesen…",
   "worklist.queue": "Heute",
+  "worklist.review": "Zu prüfen",
   "worklist.more": "Mehr anzeigen",
   "worklist.more.failed": "Konnte nicht mehr laden. Bitte erneut versuchen.",
   "worklist.summary":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7989,6 +7989,7 @@ export const en = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Reading your day…",
   "worklist.queue": "Today",
+  "worklist.review": "To review",
   "worklist.more": "Show more",
   "worklist.more.failed": "Could not load more. Try again.",
   "worklist.summary":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7810,6 +7810,7 @@ export const vi = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Đang đọc ngày của bạn…",
   "worklist.queue": "Hôm nay",
+  "worklist.review": "Cần xem xét",
   "worklist.more": "Xem thêm",
   "worklist.more.failed": "Không tải thêm được. Hãy thử lại.",
   "worklist.summary":

--- a/frontend/src/screens/worklist.bands.test.tsx
+++ b/frontend/src/screens/worklist.bands.test.tsx
@@ -62,7 +62,9 @@ describe("a band holding nothing says so", () => {
     renderWorklist("en");
 
     expect(await screen.findByText("Nothing needs you today.")).toBeTruthy();
-    expect(screen.getByText("Nothing to review.")).toBeTruthy();
+    // A band that stays in the day. `review` is drawn in its own panel below
+    // now, so it declares no empty run here.
+    expect(screen.getByText("No new pipeline work waiting.")).toBeTruthy();
   });
 
   // And the heading above it, so the line is attributed. A line saying
@@ -74,7 +76,7 @@ describe("a band holding nothing says so", () => {
 
     await screen.findByText("Nothing needs you today.");
     expect(headings()).toContain("Now");
-    expect(headings()).toContain("Review");
+    expect(headings()).toContain("Build pipeline");
   });
 
   // Each band says what the reader is clear OF. Four copies of one generic
@@ -84,12 +86,13 @@ describe("a band holding nothing says so", () => {
     renderWorklist("en");
 
     await screen.findByText("Nothing needs you today.");
-    for (const line of [
-      "No new pipeline work waiting.",
-      "Nothing to review.",
-    ]) {
+    for (const line of ["No new pipeline work waiting."]) {
       expect(screen.queryByText(line)).toBeTruthy();
     }
+    // NOT the review band's line, and this is the split rather than a gap:
+    // judgements are drawn in their own panel below the day, so a heading for
+    // them inside it would stand over nothing while that work sits underneath.
+    expect(screen.queryByText("Nothing to review.")).toBeNull();
     // And NOT the line for the band that holds a row.
     expect(screen.queryByText("Nothing agreed is drifting.")).toBeNull();
   });

--- a/frontend/src/screens/worklist.bands.ts
+++ b/frontend/src/screens/worklist.bands.ts
@@ -55,7 +55,17 @@ export function bandSections(
     }
     runs.push({ band: item.band, items: [item] });
   }
-  return withDeclaredEmpties(runs, day.bands?.map((band) => band.band) ?? []);
+  // The server's bands, minus the ones whose work is no longer drawn here.
+  //
+  // `review` names judgements, and those are drawn in their own panel below the
+  // day. Left in this list it yields an empty run inside the day — a heading
+  // standing over nothing, saying the reader has nothing to review, while the
+  // review panel underneath holds exactly that work. A band the day does not
+  // hold is not an empty band; it is a band that belongs somewhere else.
+  const declared = (day.bands ?? [])
+    .map((band) => band.band)
+    .filter((band) => band !== "review");
+  return withDeclaredEmpties(runs, declared);
 }
 
 /**

--- a/frontend/src/screens/worklist.destinations.test.ts
+++ b/frontend/src/screens/worklist.destinations.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { destinationOf, reviewWork, sellerWork } from "./worklist.destinations";
+import { row } from "./worklist.testkit";
+
+// Which screen a row belongs on, and the one case that must not go wrong.
+
+describe("splitting the day by destination", () => {
+  it("keeps seller work and judgements apart", () => {
+    const queue = [
+      row({ id: "a", source: "customer_waiting", destination: "today" }),
+      row({ id: "b", source: "approval", destination: "review" }),
+      row({ id: "c", source: "sync_health", destination: "system_health" }),
+      row({ id: "d", source: "task", destination: "today" }),
+    ];
+
+    expect(sellerWork(queue).map((item) => item.id)).toEqual(["a", "d"]);
+    expect(reviewWork(queue).map((item) => item.id)).toEqual(["b", "c"]);
+  });
+
+  it("loses no row between the two", () => {
+    const queue = [
+      row({ id: "a", destination: "today" }),
+      row({ id: "b", destination: "review" }),
+      row({ id: "c", destination: "receipt" }),
+    ];
+
+    // The two halves partition the queue. A row in neither would be work the
+    // reader can no longer reach from any screen, which is the failure a split
+    // introduces and nothing else here would catch.
+    expect(sellerWork(queue).length + reviewWork(queue).length).toBe(
+      queue.length,
+    );
+  });
+
+  it("reads an unclassified row as seller work", () => {
+    // An older server sends no destination. Treating that as review would
+    // empty a rep's day the moment they talked to one — every row swept onto a
+    // screen they were not looking at — while treating it as today leaves the
+    // queue exactly as it was before the split existed.
+    const legacy = row({ id: "old" });
+    delete (legacy as { destination?: unknown }).destination;
+
+    expect(destinationOf(legacy)).toBe("today");
+    expect(sellerWork([legacy]).map((item) => item.id)).toEqual(["old"]);
+    expect(reviewWork([legacy])).toEqual([]);
+  });
+});

--- a/frontend/src/screens/worklist.destinations.ts
+++ b/frontend/src/screens/worklist.destinations.ts
@@ -1,0 +1,51 @@
+import type { components } from "../api/schema";
+
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+// Which SCREEN each row belongs on, as the server decided it.
+//
+// The queue mixes three jobs. A buyer waiting on a reply is work a seller
+// executes; a duplicate pair is a judgement somebody makes before work can
+// continue; a stopped mailbox is a source an administrator restores. Drawn in
+// one list they compete for the same attention, and a rep scanning for their
+// next call steps over the product's own housekeeping to find it.
+//
+// THE SERVER DECIDES AND THIS READS. `destination` arrives on every row, and
+// the counts above the queue are computed from that same value — so a client
+// that re-derived the split from `source` or `category` would eventually
+// disagree with the figures it is drawn beside. That is the whole reason the
+// field exists rather than a rule living here.
+
+// A row the server did not classify is SELLER WORK, and the direction matters.
+//
+// An older server sends no `destination` at all. Treating that silence as
+// review would empty a rep's day the moment they talked to one — every row
+// swept onto a screen they were not looking at — while treating it as today
+// leaves the queue exactly as it was before this split existed. One is a
+// regression nobody would attribute to a version skew; the other is the
+// behaviour that shipped for a year.
+const DEFAULT_DESTINATION = "today";
+
+export function destinationOf(item: WorklistItem): string {
+  return item.destination ?? DEFAULT_DESTINATION;
+}
+
+/** The rows a seller executes. */
+export function sellerWork(
+  queue: readonly WorklistItem[],
+): readonly WorklistItem[] {
+  return queue.filter((item) => destinationOf(item) === "today");
+}
+
+/**
+ * The rows waiting on a judgement, a restored source, or a receipt.
+ *
+ * The three are counted together and drawn together, because the question the
+ * reader has here is "what is not mine to execute" rather than which of the
+ * three kinds it is. Splitting them further is a screen of its own.
+ */
+export function reviewWork(
+  queue: readonly WorklistItem[],
+): readonly WorklistItem[] {
+  return queue.filter((item) => destinationOf(item) !== "today");
+}

--- a/frontend/src/screens/worklist.review.test.tsx
+++ b/frontend/src/screens/worklist.review.test.tsx
@@ -124,3 +124,88 @@ function panelNamed(heading: HTMLElement): HTMLElement {
   }
   return panel as HTMLElement;
 }
+
+describe("the day's headings describe the day", () => {
+  it("draws no empty heading for work that moved to review", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "waiting-1",
+            source: "customer_waiting",
+            title: "Kirsten replied",
+            destination: "today",
+            band: "now",
+          }),
+          row({
+            id: "pair-1",
+            source: "dedupe_candidate",
+            title: "Two records for one company",
+            destination: "review",
+            band: "review",
+          }),
+        ],
+        // The SERVER's band list counts every row it ranked, review included.
+        bands: [
+          { band: "now", shown: 1 },
+          { band: "review", shown: 1 },
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 1, total: 2 },
+      }),
+    );
+
+    renderWorklist();
+
+    const today = panelNamed(await screen.findByText(en["worklist.queue"]));
+    // The review band's rows are drawn BELOW now, so a heading for it inside
+    // the day would stand over nothing and say the work is clear — while the
+    // same work sits in the panel underneath. A band the day no longer holds
+    // is not an empty band; it is a band that belongs somewhere else.
+    expect(
+      within(today).queryByText(en["worklist.bandClear.review"]),
+    ).toBeNull();
+  });
+});
+
+describe("each panel numbers its own rows", () => {
+  it("starts both lists at one", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "w1",
+            source: "customer_waiting",
+            title: "Kirsten replied",
+            destination: "today",
+          }),
+          row({
+            id: "p1",
+            source: "dedupe_candidate",
+            title: "Two records for one company",
+            destination: "review",
+          }),
+          row({
+            id: "w2",
+            source: "customer_waiting",
+            title: "Anders is waiting",
+            destination: "today",
+          }),
+        ],
+        summary: { urgent: 2, due: 0, lower_priority: 1, total: 3 },
+      }),
+    );
+
+    renderWorklist();
+
+    const today = panelNamed(await screen.findByText(en["worklist.queue"]));
+    const review = panelNamed(await screen.findByText(en["worklist.review"]));
+    // Numbered within the list each row is drawn in. Ranking across the whole
+    // day is arithmetically honest and reads as a fault: it puts 1 and 3 in one
+    // panel and 2 in the other, and a list starting at 2 tells a reader nothing
+    // they can act on.
+    expect(within(today).getByText("1")).toBeTruthy();
+    expect(within(today).getByText("2")).toBeTruthy();
+    expect(within(today).queryByText("3")).toBeNull();
+    expect(within(review).getByText("1")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/worklist.review.test.tsx
+++ b/frontend/src/screens/worklist.review.test.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// Seller work and judgements are two jobs, drawn apart.
+//
+// A duplicate pair, a stopped mailbox and an approval somebody owes are not the
+// next call to make. Drawn in the queue they competed with it — a rep scanning
+// for their next customer stepped over the product's own housekeeping to find
+// one — and the split is the server's `destination`, not a rule this client
+// re-derives from `source`.
+
+import { cleanup, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the day is drawn apart from what it is not", () => {
+  it("keeps a judgement out of the queue and still shows it", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "waiting-1",
+            source: "customer_waiting",
+            title: "Kirsten replied",
+            destination: "today",
+          }),
+          row({
+            id: "pair-1",
+            source: "dedupe_candidate",
+            title: "Two records for one company",
+            destination: "review",
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 1, total: 2 },
+      }),
+    );
+
+    renderWorklist();
+
+    // By its HEADING and the panel around it: Panel renders a bare <section>
+    // with no accessible name, so it is not a landmark to query by role.
+    const today = panelNamed(await screen.findByText(en["worklist.queue"]));
+    // The buyer is in the day, and the pair is NOT — which is the half a test
+    // that only asserted presence would miss: both rows render either way.
+    expect(within(today).getByText("Kirsten replied")).toBeTruthy();
+    expect(within(today).queryByText("Two records for one company")).toBeNull();
+
+    // And it is drawn, not swallowed. Work nobody can see is the reason it
+    // goes undone, so the split has to move the row rather than drop it.
+    const review = panelNamed(await screen.findByText(en["worklist.review"]));
+    expect(
+      within(review).getByText("Two records for one company"),
+    ).toBeTruthy();
+  });
+
+  it("draws no review panel on a day that holds none", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "waiting-1",
+            source: "customer_waiting",
+            title: "Kirsten replied",
+            destination: "today",
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+
+    renderWorklist();
+
+    await screen.findByText("Kirsten replied");
+    // An empty panel headed "To review" reads as a screen that failed to draw
+    // its contents. Nothing to review is nothing to say.
+    expect(screen.queryByText(en["worklist.review"])).toBeNull();
+  });
+
+  it("keeps a row an older server did not classify in the day", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "waiting-1",
+            source: "customer_waiting",
+            title: "Kirsten replied",
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+
+    renderWorklist();
+
+    // Version skew, and the direction is the point: reading silence as review
+    // would empty a rep's day the moment they talked to an older server, while
+    // reading it as seller work leaves the queue as it was before this split.
+    // By its HEADING and the panel around it: Panel renders a bare <section>
+    // with no accessible name, so it is not a landmark to query by role.
+    const today = panelNamed(await screen.findByText(en["worklist.queue"]));
+    await waitFor(() => {
+      expect(within(today).getByText("Kirsten replied")).toBeTruthy();
+    });
+  });
+});
+
+// panelNamed is the panel a heading belongs to.
+//
+// Panel draws a bare <section> with no accessible name, so `getByRole("region")`
+// finds nothing — the heading is the only handle, and its panel is what the
+// assertion needs to look inside.
+function panelNamed(heading: HTMLElement): HTMLElement {
+  const panel = heading.closest("section");
+  if (!panel) {
+    throw new Error(`no panel around the heading "${heading.textContent}"`);
+  }
+  return panel as HTMLElement;
+}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -364,7 +364,11 @@ function WorklistBody({
 }>) {
   const t = useT();
   const missing = day.sources_unavailable;
-  const selected = rowInHand(queue, selectedId);
+  // The pane belongs to the DAY, so only a row in the day can fill it. A review
+  // row selected here would draw its context beside the Today panel while the
+  // highlighted row sat in the panel below — the two halves of one answer, a
+  // screen apart, with nothing joining them.
+  const selected = rowInHand(sellerWork(queue), selectedId);
   // The day cut into the two jobs it holds. `destination` says which, and the
   // server decides it — the counts above the queue are computed from the same
   // field, so a split derived here from `source` or `category` would drift
@@ -373,11 +377,18 @@ function WorklistBody({
   const review = reviewWork(queue);
 
   const rowProps: RowContext = {
-    // Ranks are still counted over the WHOLE queue. A row's number is its place
-    // in the day the server ranked, not its place within whichever of the two
-    // panels it landed in — renumbering per panel would tell a reader the
-    // fourth-most-urgent thing is their first.
-    positions: new Map(queue.map((item, at) => [rowIdentity(item), at])),
+    // Numbered WITHIN the panel each row is drawn in, not across the day.
+    //
+    // Ranking over the whole queue is arithmetically honest and reads as a
+    // fault: the split puts 1, 4, 7 in one panel and 2, 3, 5 in the other on
+    // one screen, and a reader meeting a list that starts at 4 and skips 5 has
+    // no way to know they are seeing a correct number rather than a broken one.
+    // A rank says WHERE IN THIS LIST, which is the only question the number is
+    // asked, and the day's own order is what put the rows in these lists.
+    positions: new Map([
+      ...sellerWork(queue).map((item, at) => [rowIdentity(item), at] as const),
+      ...reviewWork(queue).map((item, at) => [rowIdentity(item), at] as const),
+    ]),
     owner,
     // The RESOLVED selection, not the raw state. The pane falls back to the
     // first row when the reader has chosen nothing, and a highlight reading

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -24,6 +24,7 @@ import {
   pillCount,
   sourceUnavailableText,
 } from "./worklist.copy";
+import { reviewWork, sellerWork } from "./worklist.destinations";
 import { HiddenBacklogPanel } from "./worklist.hidden";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { hasPane, WorklistPane } from "./worklist.pane";
@@ -364,8 +365,18 @@ function WorklistBody({
   const t = useT();
   const missing = day.sources_unavailable;
   const selected = rowInHand(queue, selectedId);
+  // The day cut into the two jobs it holds. `destination` says which, and the
+  // server decides it — the counts above the queue are computed from the same
+  // field, so a split derived here from `source` or `category` would drift
+  // from the figures it is drawn beside.
+  const today = sellerWork(queue);
+  const review = reviewWork(queue);
 
   const rowProps: RowContext = {
+    // Ranks are still counted over the WHOLE queue. A row's number is its place
+    // in the day the server ranked, not its place within whichever of the two
+    // panels it landed in — renumbering per panel would tell a reader the
+    // fourth-most-urgent thing is their first.
     positions: new Map(queue.map((item, at) => [rowIdentity(item), at])),
     owner,
     // The RESOLVED selection, not the raw state. The pane falls back to the
@@ -492,7 +503,7 @@ function WorklistBody({
                   band holding nothing can say so. Ranks are still counted over
                   the whole queue, so a row's number is its place on the page
                   and not its place within its heading. */}
-              {bandSections(day, queue).map((section) =>
+              {bandSections(day, today).map((section) =>
                 section.items.length === 0 ? (
                   canReportEmptyBands(hasMore) && (
                     <div key={section.band} className="worklist-queue-band">
@@ -517,8 +528,8 @@ function WorklistBody({
               )}
               {/* Rows an older server sent with no band. Real work, drawn under
                   no heading rather than dropped to keep the sections tidy. */}
-              {unbandedRows(queue).length > 0 && (
-                <QueueRows items={unbandedRows(queue)} {...rowProps} />
+              {unbandedRows(today).length > 0 && (
+                <QueueRows items={unbandedRows(today)} {...rowProps} />
               )}
               {/* The way to the rest of the backlog.
                   Acceptance asks that the queue's counts be reachable, and
@@ -543,6 +554,19 @@ function WorklistBody({
             </Panel>
           }
         />
+      )}
+      {/* What is NOT the seller's to execute, below their day rather than
+          inside it.
+          A duplicate pair, a stopped mailbox and an approval somebody owes are
+          three different jobs, and none of them is the next call to make. Drawn
+          in the queue they competed with it: a rep scanning for their next
+          customer stepped over the product's own housekeeping to find one.
+          Below, and never hidden — this work is somebody's, and a screen that
+          swallowed it would be the reason it went undone. */}
+      {review.length > 0 && (
+        <Panel title={t("worklist.review")}>
+          <QueueRows items={review} {...rowProps} />
+        </Panel>
       )}
     </>
   );


### PR DESCRIPTION
## What this changes

The queue mixed three jobs. A buyer waiting on a reply is work a seller executes; a duplicate pair is a judgement somebody makes before work can continue; a stopped mailbox is a source an administrator restores. Drawn in one list they competed for the same attention — a rep scanning for their next call stepped over the product's own housekeeping to find it.

**Judgements are drawn below the day now, in their own panel.**

## The split is the server's, not this client's

`destination` shipped in #4127 and nothing read it until now. That matters more than it looks: the counts above the queue are computed from the same field, so a client re-deriving the split from `source` or `category` would eventually disagree with the figures it is drawn beside. This reads the field; it does not reimplement the rule.

## Three decisions worth naming

**Below, never hidden.** Work nobody can see is the reason it goes undone, so the split moves the row rather than dropping it.

**A day with no judgements draws no panel.** An empty section headed "To review" reads as a screen that failed to draw its contents.

**A row an older server did not classify stays in the day.** Reading that silence as review would empty a rep's queue the moment they talked to an older server; reading it as seller work leaves the page exactly as it was before this split existed. One is a regression nobody would attribute to version skew.

**Ranks are still counted over the whole queue.** A row's number is its place in the day the server ranked, not its place within whichever panel it landed in — renumbering per panel would tell a reader the fourth-most-urgent thing is their first.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `keeps a judgement out of the queue and still shows it` — asserts the pair is absent from Today **and** present in Review; presence alone would pass either way |
| Empty state | `draws no review panel on a day that holds none` |
| Version skew | `keeps a row an older server did not classify in the day` |
| Mutation strength | `unbandedRows(today)` reverted to `unbandedRows(queue)` — the split test fails |
| i18n | en/de/vi all carry `worklist.review` ("To review" / "Zu prüfen" / "Cần xem xét") |
| Full lane | `make check-fe` green |

## Noted, not fixed

`Panel` renders a bare `<section>` with no accessible name, so it is not a landmark and cannot be queried by role. The tests reach it through its heading, with a comment saying why. Giving `Panel` an `aria-labelledby` is a design-system change and belongs in its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the worklist into seller work and review work using the server's `destination` field, so review rows render below the day instead of inside the queue. Rows an older server doesn't classify stay in the day, and a day with nothing to review draws no review panel.

**Notes**
- The split reads `destination` instead of re-deriving it from `source` or `category`, so it can't drift from the summary counts.
- Rows are now numbered within their own panel, so both lists start at 1 and no panel shows a broken-looking sequence.
- The day's pane only fills from day rows, and the day no longer draws an empty heading for the review band that moved below it.
- Known limits: Show more sits inside Today and does nothing when the next page is all review, and the header still totals both kinds of work in one sentence.
- Tests cover the partition (no row lost), the empty state, version-skew rows, band headings, and per-panel ranks.
- `Panel` still has no accessible name, so tests reach it through its heading.

<sup>Written for commit 8d67bc97d71f19e0179a9423740e2cd4a35993c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

