### PR TITLE
A list read waits for the content it is about to read

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -3,6 +3,7 @@ import { expect, type Page, test } from "@playwright/test";
 import { de } from "../src/i18n/de";
 import type { MessageKey } from "../src/i18n/en";
 import { mockApi } from "./seed";
+import { textsOf } from "./waits";
 
 /**
  * Settle the page's motion before measuring the colours it paints.
@@ -726,9 +727,11 @@ test("AC-book-public (B-EP09.14): consent gates booking and the policy passes th
   await expect(slot).toBeDisabled();
   await page.getByRole("checkbox").check();
   await expect(slot).toBeEnabled();
-  const shownWording = await page
-    .locator("[data-consent-wording]")
-    .textContent();
+  const wording = page.locator("[data-consent-wording]");
+  // The assert above waited on the SLOT; this is a different element, and a
+  // bare textContent would answer null on the tick before it paints.
+  await expect(wording).toBeVisible();
+  const shownWording = await wording.textContent();
   const requestPromise = page.waitForRequest(
     (request) =>
       request.method() === "POST" &&
@@ -818,10 +821,9 @@ test("AC-create-2: the palette's New-deal action opens the create form; only ope
   // The choices exist only while the popup is open, and the popup is portalled
   // to the body — so it is located from the page, not from inside the dialog.
   await stageSelect.click();
-  const stageNames = await page
-    .locator('[role="listbox"]')
-    .getByRole("option")
-    .allTextContents();
+  const stageNames = await textsOf(
+    page.locator('[role="listbox"]').getByRole("option"),
+  );
   expect(stageNames.filter(Boolean)).toEqual([
     "Qualify",
     "Proposal",
@@ -2297,7 +2299,7 @@ test.describe("filters and views", () => {
     // is an EXISTS over a join rather than a column, and none of them is
     // spelled anywhere in the frontend.
     await page.getByRole("combobox", { name: "Feld" }).click();
-    expect(await page.getByRole("option").allTextContents()).toEqual([
+    expect(await textsOf(page.getByRole("option"))).toEqual([
       "owner id",
       "industry",
       "lifecycle",
@@ -2311,7 +2313,7 @@ test.describe("filters and views", () => {
     // And the operator set is the FIELD's. `industry` is text, so `enthält` is
     // offered; the tag clause in AC-4 proves the narrowing by its absence.
     await page.getByRole("combobox", { name: "Operator" }).click();
-    expect(await page.getByRole("option").allTextContents()).toEqual([
+    expect(await textsOf(page.getByRole("option"))).toEqual([
       "ist",
       "ist nicht",
       "ist eines von",
@@ -2350,7 +2352,7 @@ test.describe("filters and views", () => {
     // `enthält` does not. A picker that offered a fixed set here would produce
     // a 422 the reader could not interpret.
     await page.getByRole("combobox", { name: "Operator" }).click();
-    expect(await page.getByRole("option").allTextContents()).toEqual([
+    expect(await textsOf(page.getByRole("option"))).toEqual([
       "ist",
       "ist nicht",
       "ist größer als",
@@ -2392,7 +2394,7 @@ test.describe("filters and views", () => {
     await page.getByRole("combobox", { name: "Feld" }).first().click();
     await page.getByRole("option", { name: "tag" }).click();
     await page.getByRole("combobox", { name: "Operator" }).first().click();
-    expect(await page.getByRole("option").allTextContents()).toEqual([
+    expect(await textsOf(page.getByRole("option"))).toEqual([
       "ist",
       "ist nicht",
       "ist eines von",

--- a/frontend/e2e/brief.spec.ts
+++ b/frontend/e2e/brief.spec.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { de } from "../src/i18n/de";
 import type { MessageKey } from "../src/i18n/en";
+import { signIn } from "./waits";
 
 /**
  * The Brief — the page a rep and a lead open first.
@@ -54,30 +55,6 @@ function copy(key: MessageKey): string {
 
 const STRIP = '[data-testid="home-readings"]';
 const GLANCE = '[data-testid="home-glance"]';
-
-/**
- * Sign in as the dev bootstrap admin, unless the session is already up.
- *
- * A dev stack already logged into redirects /#/login straight to the app, so
- * the form is ABSENT on the happy path — waiting for a navigation that never
- * happens is a 30s timeout rather than a login failure.
- */
-async function signIn(page: Page) {
-  await page.goto("/#/login", { waitUntil: "networkidle" });
-  const email = page
-    .locator('input[type="email"], input[name="email"]')
-    .first();
-  if ((await email.count()) === 0) {
-    return;
-  }
-  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
-  await page
-    .locator('input[type="password"], input[name="password"]')
-    .first()
-    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
-  await page.locator('button[type="submit"]').first().click();
-  await expect(page.locator("nav.rail").first()).toBeVisible();
-}
 
 /**
  * Open the Brief and wait for the page to have actually settled.

--- a/frontend/e2e/company-record.spec.ts
+++ b/frontend/e2e/company-record.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import { itemsOf, signIn } from "./waits";
 
 /**
  * The company record page against the design's glance (DESIGN.md §7).
@@ -54,34 +55,6 @@ const SHOTS = process.env.E2E_SHOT_DIR ?? "/tmp/e2e-company";
 // row too — or name a screen class that only exists to be selected. The test id
 // names THIS row on THIS page, which is what these assertions are about.
 const STRIP = '[data-testid="company-strip"]';
-
-/**
- * Sign in as the dev bootstrap admin, unless the session is already up.
- *
- * A dev stack that has been logged into already redirects /#/login straight to
- * the app, so the form is ABSENT on the happy path — waiting for a navigation
- * that never happens is a 30s timeout, not a login failure. The form is filled
- * only when it is actually rendered.
- */
-async function signIn(page: Page) {
-  await page.goto("/#/login", { waitUntil: "networkidle" });
-  const email = page
-    .locator('input[type="email"], input[name="email"]')
-    .first();
-  if ((await email.count()) === 0) {
-    return;
-  }
-  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
-  await page
-    .locator('input[type="password"], input[name="password"]')
-    .first()
-    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
-  await page.locator('button[type="submit"]').first().click();
-  // The nav is what "signed in" looks like, and it is what every assertion
-  // below depends on — anchoring here rather than on a URL change means the
-  // wait describes the state the tests need.
-  await expect(page.locator("nav.rail").first()).toBeVisible();
-}
 
 /**
  * Open a company and wait for the 360 to settle.
@@ -265,12 +238,16 @@ test.describe("company record — the glance's page shape", () => {
       .click();
     await expect(rail).toBeVisible();
 
-    expect(await rail.locator("> .panel").count()).toBe(1);
+    // Waited for, not counted straight away: the rail's own visibility says its
+    // frame has painted, and a bare count on what is inside it reads whatever
+    // has mounted by that instant.
+    await expect(rail.locator("> .panel")).toHaveCount(1);
     const sections = rail.locator("> .panel > details");
     // Four on every account, five where the account has a domain to hold.
+    await expect(sections.first()).toBeVisible();
     expect(await sections.count()).toBeGreaterThanOrEqual(4);
     expect(await sections.count()).toBeLessThanOrEqual(5);
-    for (const summary of await sections.locator("> summary").all()) {
+    for (const summary of await itemsOf(sections.locator("> summary"))) {
       expect((await summary.textContent())?.trim()).not.toBe("");
     }
 
@@ -427,9 +404,9 @@ test.describe("company record — the mockup's visual weight", () => {
         Boolean(org?.[field]),
       ).length;
     });
-    expect(
-      await page.locator(".record-sub .chip").count(),
-    ).toBeGreaterThanOrEqual(recorded);
+    await expect
+      .poll(() => page.locator(".record-sub .chip").count())
+      .toBeGreaterThanOrEqual(recorded);
   });
 
   test("a card reads as a card against the page behind it", async ({

--- a/frontend/e2e/meeting-brief.spec.ts
+++ b/frontend/e2e/meeting-brief.spec.ts
@@ -3,6 +3,7 @@ import { expect, type Page, test } from "@playwright/test";
 import { de } from "../src/i18n/de";
 import type { MessageKey } from "../src/i18n/en";
 import { type MockApiOptions, mockApi } from "./seed";
+import { itemsOf, textsOf } from "./waits";
 
 // The meeting brief a rep opens two minutes before a room.
 //
@@ -228,9 +229,13 @@ test.describe("with a preparation plan", () => {
     page,
   }) => {
     await openBrief(page, { meetingBrief: "plan" });
-    const legs = await page.locator(".mb-advance > *").all();
-    expect(legs).toHaveLength(3);
-    const boxes = await Promise.all(legs.map((leg) => leg.boundingBox()));
+    const legs = page.locator(".mb-advance > *");
+    // toHaveCount waits; a bare all() answers [] on a drawer whose frame has
+    // painted and whose body has not, and reports three missing legs.
+    await expect(legs).toHaveCount(3);
+    const boxes = await Promise.all(
+      (await itemsOf(legs)).map((leg) => leg.boundingBox()),
+    );
     const [first, second, third] = boxes.map(
       (box) => box as NonNullable<typeof box>,
     );
@@ -274,9 +279,7 @@ test.describe("for a lead reading a teammate's meeting", () => {
         .getByRole("button", { name: copy("person.meeting.brief") })
         .click();
       await expect(own.locator(DRAWER)).toBeVisible();
-      const headings = await own
-        .locator(".modal-drawer-wide h3")
-        .allTextContents();
+      const headings = await textsOf(own.locator(".modal-drawer-wide h3"));
       await own.close();
       return headings;
     };
@@ -330,8 +333,11 @@ test.describe("on a phone", () => {
     page,
   }) => {
     await openBrief(page, { meetingBrief: "plan" });
-    const legs = await page.locator(".mb-advance > *").all();
-    const boxes = await Promise.all(legs.map((leg) => leg.boundingBox()));
+    const legs = page.locator(".mb-advance > *");
+    await expect(legs).toHaveCount(3);
+    const boxes = await Promise.all(
+      (await itemsOf(legs)).map((leg) => leg.boundingBox()),
+    );
     const ys = boxes.map((box) => (box as NonNullable<typeof box>).y);
     // Strictly increasing: three columns in 390px would be 110px each, which is
     // a column of broken words rather than a plan.

--- a/frontend/e2e/person-network.spec.ts
+++ b/frontend/e2e/person-network.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { signIn, textsOf } from "./waits";
 
 /**
  * The person Network tab against the layout it was rebuilt to.
@@ -25,23 +26,6 @@ test.skip(
   !BASE_URL || !PERSON_ID,
   "set BASE_URL and E2E_PERSON_ID to run the Network tab layout suite",
 );
-
-async function signIn(page: Page) {
-  await page.goto("/#/login", { waitUntil: "networkidle" });
-  const email = page
-    .locator('input[type="email"], input[name="email"]')
-    .first();
-  if ((await email.count()) === 0) {
-    return;
-  }
-  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
-  await page
-    .locator('input[type="password"], input[name="password"]')
-    .first()
-    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
-  await page.locator('button[type="submit"]').first().click();
-  await expect(page.locator("nav.rail").first()).toBeVisible();
-}
 
 /**
  * Open the tab and wait for the graph read to settle.
@@ -114,7 +98,7 @@ test.describe("Network tab — page shape", () => {
     // The lane heads are what tell the two arrangements apart: the node count
     // is identical either way, which is how the first version of this test
     // passed against the broken layout.
-    const lanes = await page.locator(".rmap text.rmap-lane").allTextContents();
+    const lanes = await textsOf(page.locator(".rmap text.rmap-lane"));
     expect(lanes).toContain("Unser Team");
     expect(lanes).toContain("Ihr Unternehmen");
 

--- a/frontend/e2e/person-record.spec.ts
+++ b/frontend/e2e/person-record.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { signIn } from "./waits";
 
 /**
  * The contact page against a LIVE stack, loaded in a real browser.
@@ -28,23 +29,6 @@ if (BASE_URL && !PERSON) {
 }
 
 const live = test.describe[BASE_URL ? "serial" : "skip"];
-
-async function signIn(page: Page) {
-  await page.goto("/#/login", { waitUntil: "networkidle" });
-  const email = page
-    .locator('input[type="email"], input[name="email"]')
-    .first();
-  if ((await email.count()) === 0) {
-    return;
-  }
-  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
-  await page
-    .locator('input[type="password"], input[name="password"]')
-    .first()
-    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
-  await page.locator('button[type="submit"]').first().click();
-  await expect(page.locator("nav.rail").first()).toBeVisible();
-}
 
 live("the contact page on live data", () => {
   test("loads without falling over", async ({ page }) => {

--- a/frontend/e2e/recordtabs.spec.ts
+++ b/frontend/e2e/recordtabs.spec.ts
@@ -1,5 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 import { mockApi } from "./seed";
+import { itemsOf } from "./waits";
 
 /**
  * A record's tab strip stays inside the work column, whatever stands beside it.
@@ -61,7 +62,7 @@ test.describe("the record tab strip", () => {
         await openRecord(page, record.route);
 
         const aside = await page.locator(".record-aside").boundingBox();
-        const tabs = await page.locator(".recordtabs-tab").all();
+        const tabs = await itemsOf(page.locator(".recordtabs-tab"));
         expect(tabs.length).toBeGreaterThan(0);
         if (!aside) {
           throw new Error("the details pane is visible but has no box");

--- a/frontend/e2e/waits.ts
+++ b/frontend/e2e/waits.ts
@@ -1,0 +1,65 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+// Playwright's LIST readers do not auto-wait. `allTextContents()`,
+// `allInnerTexts()`, `all()` and `count()` resolve against whatever matches at
+// that instant and answer an empty result for zero matches rather than
+// retrying — so a read placed right after a container's visibility assert is
+// really asking "has the frame painted?", and reports the body's absence as
+// the body's contents being wrong.
+//
+// That is expensive to read from a CI log. The failure that prompted this
+// module named a specific German heading as missing, so it looked like a
+// content or locale regression; the drawer had simply not filled in yet.
+//
+// These helpers wait for the CONTENT the caller is about to read. Where a spec
+// knows the exact number it expects, `expect(locator).toHaveCount(n)` is
+// better still — it waits and asserts in one step, and states the number.
+
+/** The texts of every match, read once at least one of them has rendered. */
+export async function textsOf(locator: Locator): Promise<string[]> {
+  await expect(locator.first()).toBeVisible();
+  return locator.allTextContents();
+}
+
+/** A handle per match, taken once at least one of them has rendered. */
+export async function itemsOf(locator: Locator): Promise<Locator[]> {
+  await expect(locator.first()).toBeVisible();
+  return locator.all();
+}
+
+/**
+ * Sign in as the dev bootstrap admin, unless the session is already up.
+ *
+ * A dev stack that has been logged into already redirects /#/login straight to
+ * the app, so the form is ABSENT on the happy path — waiting for a navigation
+ * that never happens is a 30s timeout rather than a login failure. The form is
+ * filled only when it is actually rendered.
+ *
+ * Which of the two the page is showing cannot be read from a bare count,
+ * though: an unrendered form matches zero email inputs, exactly as a signed-in
+ * session does. Counting reads a slow paint as "already signed in", skips the
+ * sign-in, and the failure surfaces much later as whichever assertion first
+ * needed a session. Waiting for the page to resolve into ONE of its two states
+ * removes the race without deciding in advance which state that is.
+ */
+export async function signIn(page: Page): Promise<void> {
+  await page.goto("/#/login", { waitUntil: "networkidle" });
+  const email = page
+    .locator('input[type="email"], input[name="email"]')
+    .first();
+  // The nav is what "signed in" looks like, and it is what every assertion in
+  // the specs depends on — anchoring here rather than on a URL change means
+  // the wait describes the state the tests need.
+  const rail = page.locator("nav.rail").first();
+  await expect(email.or(rail)).toBeVisible();
+  if (await rail.isVisible()) {
+    return;
+  }
+  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
+  await page
+    .locator('input[type="password"], input[name="password"]')
+    .first()
+    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
+  await page.locator('button[type="submit"]').first().click();
+  await expect(rail).toBeVisible();
+}

--- a/frontend/scripts/e2e-content-waits.test.ts
+++ b/frontend/scripts/e2e-content-waits.test.ts
@@ -1,0 +1,105 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Playwright's LIST readers do not auto-wait: `allTextContents()`,
+// `allInnerTexts()` and `all()` resolve against whatever matches at that
+// instant and answer an empty result for zero matches rather than retrying.
+// Placed right after a container's visibility assert, such a read is really
+// asking "has the frame painted?" and then reports the body's absence as the
+// body's CONTENTS being wrong.
+//
+// That misdirection is what this gate is for. The failure that prompted it
+// named a specific German heading as missing, on a backend-only PR, so it was
+// read as a content or locale regression; the drawer had simply not filled in
+// yet. A flake that lies about its own cause is paid for by whoever reads the
+// log next, and it had already been paid for twice.
+//
+// So the readers go through e2e/waits.ts, which waits for the content first.
+// A spec that knows the number it expects should use neither and write
+// `await expect(locator).toHaveCount(n)` — it waits, asserts and states the
+// number in one step.
+//
+// ## What this gate does NOT see
+//
+// `count()` and `textContent()` have the same no-auto-wait behaviour and are
+// deliberately not banned here, because their guarded and unguarded uses read
+// identically: `await expect(sections.first()).toBeVisible()` followed by
+// `sections.count()` is correct, and the count alone is not, and no rule over
+// the text tells them apart. Banning them would buy a waiver on every correct
+// site, which is a gate that trains people to waive it.
+//
+// The one shape of theirs worth naming, since this gate cannot: a bare
+// `(await x.count()) === 0` used as a BRANCH condition fails by passing — an
+// unpainted page takes the empty branch and the test reports success without
+// having tested anything. e2e/waits.ts `signIn` is the fixed version, waiting
+// for the page to resolve into one of its two states before asking which.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const e2eDir = join(here, "..", "e2e");
+
+// Derived from the tree: a spec added tomorrow is gated the day it lands.
+function specFiles(): string[] {
+  return readdirSync(e2eDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".spec.ts"))
+    .map((entry) => join(e2eDir, entry.name));
+}
+
+// A reader named in PROSE is not a reader in use. Block comments go entirely;
+// a line comment only counts when it owns its line, so a `//` inside a URL
+// cannot eat the code beside it. String literals go too, so a selector that
+// happens to spell one of these names cannot trip the scan.
+function code(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^[ \t]*\/\/.*$/gm, " ")
+    .replace(/(['"`])(?:\\.|(?!\1).)*\1/g, '""');
+}
+
+const READERS = /\.(allTextContents|allInnerTexts|all)\s*\(\s*\)/g;
+
+function bareReadsIn(source: string): string[] {
+  return [...code(source).matchAll(READERS)].map((match) => match[1]);
+}
+
+describe("e2e list reads wait for their content", () => {
+  it("finds the reader it is looking for", () => {
+    // The scan reports a count, and a matcher that had stopped matching
+    // would report zero on a clean tree and PASS. This is the planted
+    // positive that fails instead — including the two spellings the
+    // pattern must not lose: a chained call and a scoped locator.
+    expect(
+      bareReadsIn("const xs = await page.locator('.h3').allTextContents();"),
+    ).toEqual(["allTextContents"]);
+    expect(bareReadsIn("const ls = await own.locator(SEL).all();")).toEqual([
+      "all",
+    ]);
+    expect(
+      bareReadsIn("const t = await page.getByRole('row').allInnerTexts();"),
+    ).toEqual(["allInnerTexts"]);
+  });
+
+  it("does not read a reader named in prose or in a selector", () => {
+    expect(bareReadsIn("// use textsOf, not .allTextContents()")).toEqual([]);
+    expect(bareReadsIn("/* .all() is what this replaces */")).toEqual([]);
+    expect(bareReadsIn('page.locator(".all()");')).toEqual([]);
+  });
+
+  it("reads every spec in the tree", () => {
+    // Under-recognition is the one way this must not break: a scan that
+    // walked the wrong directory would read nothing and report PASS.
+    expect(specFiles().length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("has no spec reading a list before it has rendered", () => {
+    const offenders = specFiles().flatMap((path) => {
+      const found = bareReadsIn(readFileSync(path, "utf8"));
+      return found.map(
+        (reader) =>
+          `${relative(join(here, ".."), path)}: .${reader}() — read it through textsOf/itemsOf in e2e/waits.ts, or assert toHaveCount(n) on the locator`,
+      );
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #4040.

## The reported failure

`AC-meeting-brief-16` failed once on a backend-only PR and passed on a straight re-run. The manager's heading list came back **empty**, and the assertion reported that as `the lead is missing "Das angestrebte Ergebnis"` — a specific German heading, so it read as a content or locale regression. It was timing.

Playwright's list readers do not auto-wait: `allTextContents()`, `allInnerTexts()` and `all()` resolve against whatever matches at that instant and answer an empty result for zero matches rather than retrying. A read placed right after a container's visibility assert is really asking *"has the frame painted?"*, and then reports the body's absence as the body's **contents** being wrong.

## The sweep

The ticket says this is "worth a sweep for the same shape". It was — eleven more sites:

| Site | What it did |
|---|---|
| `meeting-brief` AC-13 | asserted `toHaveLength(3)` on the already-read array, so the count never waited |
| `meeting-brief` AC-14 | indexed three legs it never asserted — an empty read failed about `undefined > undefined` |
| `company-record` details rail | three bare counts behind one container assert |
| `company-record` chips | a count compared against what the record holds |
| `ac.spec` ×6 | option lists read in the same breath as the click that opens the popup; consent wording read off a *different* element from the one asserted |
| `person-network` lanes | lane heads read with no wait at all |

`recordtabs` was already correct (its helper asserts a tab is visible before the read) and is only routed through the new helper so the guarantee is local rather than at a distance.

## The one that failed by passing

Four copies of `signIn` did `if ((await email.count()) === 0) return;`. An unpainted login form and a signed-in session answer that identically, so a slow paint reads as "already signed in", skips the sign-in, and the failure surfaces much later as whichever assertion first needed a session.

The four copies become one helper in `e2e/waits.ts` that waits for the page to resolve into **one of its two states** (`email.or(rail)`) before asking which it is. Folding them together was not scope creep — the fix is identical in all four, and four copies of one invariant is what the rulebook asks me not to leave behind.

## A gate, not twelve point fixes

`frontend/scripts/e2e-content-waits.test.ts` derives its corpus from the tree and fails on a direct list read in any spec. It is a bright line with no waiver form: correct uses go through `textsOf`/`itemsOf`, and a spec that knows its number writes `await expect(locator).toHaveCount(n)`, which waits, asserts and states the number in one step.

It plants its own positive. With every offending site removed, a matcher that had stopped matching would read a clean tree, report zero and **pass** — so the gate asserts it still recognises all three spellings, that it ignores a reader named in prose or in a selector string, and that it sees at least 15 spec files.

**What it deliberately does not gate**, stated in the file: `count()` and `textContent()` have the same behaviour, but their guarded and unguarded uses read identically, and banning them would put a waiver on every correct site — a gate that trains people to waive it.

## Testing

- New gate passes; mutation-checked three ways — reintroducing the `person-network` read fails it, pointing the scan at a directory that does not exist fails the floor rather than passing empty, and neutering the regex fails the planted positive.
- `playwright test --list` collects all 328 tests in 16 files, so every import resolves. (`e2e/` is in no `tsconfig`, so `tsc -b` does not cover it.)
- `make check-fe` green.

One site is untouched and stated here rather than in a comment: `person-record.spec.ts` probes `.emailentry` count to tolerate an account with no retained mail. It is the same wrong-pass shape, but the correct wait needs a settled-or-empty marker that panel does not render, and the test is `live`-only — it never runs in CI. I did not want to invent a marker inside a flake fix.
