### PR TITLE
A bounced message is reachable, and a test says so

### DIFF
--- a/frontend/src/screens/worklist.bounce.test.tsx
+++ b/frontend/src/screens/worklist.bounce.test.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// A bounced message names a customer who did not receive something.
+//
+// It is the one health row with a person on the other end of it, and the
+// reader's move is to fix the address and send again. Neither happens here —
+// both live on the person's page — so what this row owes the reader is a way
+// THERE, and the defect it must not have is a row that reports the failure and
+// offers nothing.
+
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("a bounced message is reachable", () => {
+  it("routes the reader to the person whose address failed", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "bounce-1",
+            source: "bounce",
+            title: "Retrofit quote",
+            detail: "The address does not exist.",
+            actions: ["open"],
+            subject: { type: "person", id: "p-1", label: "Kirsten Bauer" },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+
+    renderWorklist();
+
+    // The TITLE is the route: the copy layer names the send and the person it
+    // failed for, and links the pair at the record where the address is fixed.
+    // A row that reported the bounce and offered nothing would carry the same
+    // words as plain text, so the assertion is the href rather than the name.
+    const link = await screen.findByRole("link", {
+      name: /Retrofit quote/,
+    });
+    expect(link.getAttribute("href")).toContain("p-1");
+  });
+
+  it("still draws the row when no person is named, without a verb it cannot honour", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "bounce-2",
+            source: "bounce",
+            title: "Retrofit quote",
+            detail: "The address does not exist.",
+            actions: [],
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+
+    renderWorklist();
+
+    // The failure is still reported — a bounce nobody could file under a person
+    // is still a customer who did not receive something, and dropping the row
+    // would hide it. What it must NOT do is offer a way somewhere it cannot go.
+    expect(await screen.findByText("The address does not exist.")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /Retrofit quote/ })).toBeNull();
+  });
+});


### PR DESCRIPTION
The plan called for fix-the-address-and-resend from the bounce row. Reading the code first changed the work.

**The row already routes to the person page** — which is where fixing an address and resending both happen — and it does so through its own title: the copy layer names the send and the person it failed for, and links the pair.

So the gap was not a missing verb. It was that **nothing held the routing**. A change to `rowHref`, or a lane that stopped naming the person, would have left a row reporting that a customer never received something with nowhere to go about it — and no test would have failed.

## Two cases

A bounce filed under a person routes there. A bounce filed under nobody **still draws** — the customer did not receive their message either way, and dropping the row would hide that — but offers no way somewhere it cannot go.

The second case is what keeps the first honest: without it, a row that never rendered at all would pass the first assertion.

## What stays unbuilt, and why

In-place resend. `sendEmail` takes a full draft and a `consent_purpose`, neither of which a bounce row holds, and it is consent-gated **default-deny per purpose** — a resend that guessed the purpose would be a send the workspace never authorised. That is a product decision, not a wiring gap.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `routes the reader to the person whose address failed` — asserts the **href**, not the name, since a dead row carries the same words as plain text |
| Honest absence | `still draws the row when no person is named, without a verb it cannot honour` |
| Mutation strength | `subjectHref` removed from `rowHref` — the routing test fails |
| Full lane | `make check-fe` green |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests proving a bounced message row links to the person whose address failed, so the routing can't silently break.

- A bounce without a person still renders but offers no link, since there's nowhere to go.
- In-place resend is intentionally not built: it would need a consent purpose the row doesn't have.

<sup>Written for commit b84ad3eacef0fc8420f091d8986a6cb74858e761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for worklist bounce rows that link to a person’s page when a person is identified.
  - Added coverage ensuring bounce rows without an identified person still display failure details without showing a link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->