### PR TITLE
The review panel says how much of the day it is showing

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7915,6 +7915,8 @@ export const de = {
   "worklist.summary.noMiddle":
     "{urgent} dringend · {due} fällig · {lower} nachrangig — {total} insgesamt",
   "worklist.completeness": "{shown} von {considered} angezeigt",
+  "worklist.review.partial":
+    "{loaded} von {total} angezeigt — blättern Sie den Tag weiter, um den Rest zu erreichen",
   "worklist.completeness.bounded":
     "{shown} angezeigt · {sources} Quellen haben mehr",
   "worklist.clear": "Nichts wartet auf dich.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8006,6 +8006,8 @@ export const en = {
   "worklist.summary.noMiddle":
     "{urgent} urgent · {due} due · {lower} routine — {total} in all",
   "worklist.completeness": "{shown} of {considered} shown",
+  "worklist.review.partial":
+    "{loaded} of {total} shown — page the day to reach the rest",
   "worklist.completeness.bounded":
     "{shown} shown · {sources} sources have more",
   "worklist.clear": "Nothing is waiting on you.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7827,6 +7827,8 @@ export const vi = {
   "worklist.summary.noMiddle":
     "{urgent} khẩn · {due} đến hạn · {lower} thường lệ — tổng {total}",
   "worklist.completeness": "Hiển thị {shown} trong {considered}",
+  "worklist.review.partial":
+    "Hiển thị {loaded} trong {total} — xem tiếp trong ngày để thấy phần còn lại",
   "worklist.completeness.bounded": "Hiển thị {shown} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",
   "worklist.clearOfWhatWasRead":

--- a/frontend/src/screens/worklist.destinations.test.ts
+++ b/frontend/src/screens/worklist.destinations.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { destinationOf, reviewWork, sellerWork } from "./worklist.destinations";
+import {
+  destinationOf,
+  reviewShortfall,
+  reviewWork,
+  sellerWork,
+} from "./worklist.destinations";
 import { row } from "./worklist.testkit";
 
 // Which screen a row belongs on, and the one case that must not go wrong.
@@ -43,5 +48,32 @@ describe("splitting the day by destination", () => {
     expect(destinationOf(legacy)).toBe("today");
     expect(sellerWork([legacy]).map((item) => item.id)).toEqual(["old"]);
     expect(reviewWork([legacy])).toEqual([]);
+  });
+});
+
+// What the Review panel is allowed to say about its own completeness.
+
+describe("saying how much review work is not on screen", () => {
+  it("reports the shortfall when the day holds more than the panel", () => {
+    expect(reviewShortfall(2, 7)).toEqual({ loaded: 2, total: 7 });
+  });
+
+  it("says nothing once the panel holds the whole day", () => {
+    // "3 of 3" is noise on a complete list, and the completeness line above
+    // the queue falls silent on the same condition.
+    expect(reviewShortfall(3, 3)).toBeNull();
+  });
+
+  it("says nothing when the walk outran the day's own count", () => {
+    // The two are counted over different populations — the day's candidates
+    // against the rows this walk has served — so a loaded count above the
+    // total is not a shortfall. Drawing "5 of 3" reads as a broken product.
+    expect(reviewShortfall(5, 3)).toBeNull();
+  });
+
+  it("says nothing when the server sends no partition", () => {
+    // An older server has no buckets. A figure invented here would be a claim
+    // about a day this client cannot count.
+    expect(reviewShortfall(2, undefined)).toBeNull();
   });
 });

--- a/frontend/src/screens/worklist.destinations.ts
+++ b/frontend/src/screens/worklist.destinations.ts
@@ -49,3 +49,40 @@ export function reviewWork(
 ): readonly WorklistItem[] {
   return queue.filter((item) => destinationOf(item) !== "today");
 }
+
+/**
+ * What the Review panel can honestly say about how much it is showing.
+ *
+ * The panel draws the review rows LOADED SO FAR, and it has no cursor of its
+ * own: review rows arrive as a side effect of paging the day. So a reader with
+ * an approval past the page cut sees a panel that looks complete, and nothing
+ * on the screen says otherwise — which is the whole reason this figure exists.
+ *
+ * `buckets.review` is the day's own total, counted over every candidate the
+ * read weighed rather than over the page. Drawn bare beside the panel it would
+ * CLAIM ROWS THE PANEL DOES NOT HOLD, so it is only ever shown as the
+ * denominator of what is loaded.
+ *
+ * Null once the two agree: a panel holding everything the day has needs no
+ * fraction, and "3 of 3" is noise on a complete list. This mirrors the
+ * completeness line above the queue, deliberately — one page should not have
+ * two different ways of admitting it is showing part of something.
+ */
+export function reviewShortfall(
+  loaded: number,
+  total: number | undefined,
+): { loaded: number; total: number } | null {
+  // An older server sends no partition. Saying nothing is right: a figure
+  // invented here would be a claim about a day this client cannot count.
+  if (total === undefined) {
+    return null;
+  }
+  // A total BELOW what is loaded is not a shortfall to report. The two are
+  // counted over different populations — the day's candidates against the rows
+  // this walk has served — and a walk that outran its own total would draw
+  // "5 of 3", which reads as a bug in the product rather than in the number.
+  if (loaded >= total) {
+    return null;
+  }
+  return { loaded, total };
+}

--- a/frontend/src/screens/worklist.review.test.tsx
+++ b/frontend/src/screens/worklist.review.test.tsx
@@ -209,3 +209,79 @@ describe("each panel numbers its own rows", () => {
     expect(within(review).getByText("1")).toBeTruthy();
   });
 });
+
+// What the panel says about the work it is NOT holding.
+//
+// The panel has no cursor of its own: review rows arrive as a side effect of
+// paging the day. Before this, an approval past the page cut simply did not
+// render and nothing on the screen said it existed — a rep saw a clean panel
+// and had no way to learn otherwise.
+describe("the review panel admits what it is not showing", () => {
+  it("says how many the day holds when the panel has fewer", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "t1",
+            source: "task",
+            destination: "today",
+            title: "A task",
+          }),
+          row({
+            id: "a1",
+            source: "dedupe_candidate",
+            destination: "review",
+            title: "Two records for one company",
+          }),
+        ],
+        summary: {
+          urgent: 0,
+          due: 0,
+          lower_priority: 2,
+          total: 2,
+          buckets: { urgent: 0, due_today: 0, planned: 1, review: 4 },
+        },
+      }),
+    );
+
+    renderWorklist();
+    await screen.findByText("Two records for one company");
+
+    expect(
+      screen.getByText(
+        en["worklist.review.partial"]
+          .replace("{loaded}", "1")
+          .replace("{total}", "4"),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("says nothing when the panel holds the day's whole review", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "a1",
+            source: "dedupe_candidate",
+            destination: "review",
+            title: "Two records for one company",
+          }),
+        ],
+        summary: {
+          urgent: 0,
+          due: 0,
+          lower_priority: 1,
+          total: 1,
+          buckets: { urgent: 0, due_today: 0, planned: 0, review: 1 },
+        },
+      }),
+    );
+
+    renderWorklist();
+    await screen.findByText("Two records for one company");
+
+    // "1 of 1" is noise on a complete list, and the completeness line above
+    // the queue falls silent on the same condition.
+    expect(screen.queryByText(/of 1/)).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -24,7 +24,11 @@ import {
   pillCount,
   sourceUnavailableText,
 } from "./worklist.copy";
-import { reviewWork, sellerWork } from "./worklist.destinations";
+import {
+  reviewShortfall,
+  reviewWork,
+  sellerWork,
+} from "./worklist.destinations";
 import { HiddenBacklogPanel } from "./worklist.hidden";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { hasPane, WorklistPane } from "./worklist.pane";
@@ -375,6 +379,11 @@ function WorklistBody({
   // from the figures it is drawn beside.
   const today = sellerWork(queue);
   const review = reviewWork(queue);
+  // How much review work the day holds that this panel has not loaded.
+  const reviewMissing = reviewShortfall(
+    review.length,
+    day.summary.buckets?.review,
+  );
 
   const rowProps: RowContext = {
     // Numbered WITHIN the panel each row is drawn in, not across the day.
@@ -574,12 +583,48 @@ function WorklistBody({
           customer stepped over the product's own housekeeping to find one.
           Below, and never hidden — this work is somebody's, and a screen that
           swallowed it would be the reason it went undone. */}
-      {review.length > 0 && (
-        <Panel title={t("worklist.review")}>
-          <QueueRows items={review} {...rowProps} />
-        </Panel>
-      )}
+      <ReviewPanel items={review} shortfall={reviewMissing} rows={rowProps} />
     </>
+  );
+}
+
+// The work that is not the day's, drawn below it and never hidden.
+//
+// Its own component because WorklistBody had grown past what one function
+// should hold: the split, the bands, the pane and the paging all read there,
+// and a panel that also decides what to admit about itself is a sixth job.
+function ReviewPanel({
+  items,
+  shortfall,
+  rows,
+}: Readonly<{
+  items: readonly WorklistItem[];
+  shortfall: { loaded: number; total: number } | null;
+  rows: RowContext;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <Panel title={t("worklist.review")}>
+      <QueueRows items={items} {...rows} />
+      {/* What this panel is NOT showing. It has no cursor of its own — review
+          rows arrive as a side effect of paging the day — so a reader with an
+          approval past the page cut sees a panel that looks complete and
+          nothing that says otherwise. The day's own total is the denominator,
+          never drawn bare: it counts every candidate the read weighed, so
+          alone it would claim rows this panel does not hold. */}
+      {shortfall && (
+        <p className="t-caption worklist-completeness">
+          {t("worklist.review.partial", {
+            loaded: formatNumber(shortfall.loaded, locale),
+            total: formatNumber(shortfall.total, locale),
+          })}
+        </p>
+      )}
+    </Panel>
   );
 }
 


### PR DESCRIPTION
The panel draws the review rows **loaded so far**, and it has no cursor of its own — review rows arrive as a side effect of paging the day. So a reader with an approval past the page cut saw a panel that looked complete, with nothing on screen to say otherwise. That is the same lie the queue's completeness line exists to prevent, one panel down.

`summary.buckets.review` is the day's own count, over every candidate the read weighed rather than over the page. Drawn bare it would claim rows the panel does not hold, so it appears only as the denominator of what is loaded.

## Three silences, all deliberate

- **A panel holding the whole day says nothing.** "3 of 3" is noise on a complete list.
- **A walk that outran its own total says nothing.** The two figures are counted over different populations, and "5 of 3" reads as a bug in the product rather than in the number.
- **An older server sending no partition says nothing** — a figure invented here would be a claim about a day this client cannot count.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `says how many the day holds when the panel has fewer` — drives the rendered panel, not just the helper |
| The three silences | one test each in `worklist.destinations.test.ts` |
| Mutation strength | `return { loaded, total }` → `null`: two tests fail. The `loaded >= total` guard removed: three fail. Both directions held. |
| i18n | en/de/vi |
| Full lane | `make check-fe` green |

This is the honest half of #4185. The header still totals both panels in one sentence; that is a copy decision and stays filed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The review panel now says how much of the day it is showing, so a reader with approvals past the page cut no longer sees a clean panel with nothing to say otherwise.

- Shows "{loaded} of {total} shown" only when the panel holds fewer rows than the day's review total; the total comes from `summary.buckets.review` and is never drawn alone.
- Stays silent when the panel holds the whole day, when loaded exceeds the total, or when the server sends no bucket total.
- Extracts the review panel into its own component.

<sup>Written for commit 89acbca580b6cefd800ae614dacab8905fd64796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review lists now show how many items are currently displayed when additional items remain for the day.
  * Added localized completeness messaging in English, German, and Vietnamese.

* **Bug Fixes**
  * Completeness messaging is hidden when all review items are loaded or when total counts are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->