### PR TITLE
A scheduled pass is one job declaration: the mechanism, and the first

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -223,29 +223,23 @@ kinds:
       provider set rather than a single page.
 
   capture_auto_enrich_sweep:
-    role: dispatcher
+    role: worker
     go_type: CaptureAutoEnrichSweepArgs
     queue: default
-    timeout: 2m
+    timeout: 5m
     opts_owner: caller
     cadence: 24h
-    fans_out_to: capture_auto_enrich_workspace
-    fan_out_unit: workspace
     reason: >-
       Daily, and run at boot like every pass here, so the captured backlog an
       installation already carries is enriched on the first start rather than a
       day into it.
 
-  capture_auto_enrich_workspace:
-    role: worker
-    go_type: CaptureAutoEnrichWorkspaceArgs
-    queue: default
-    timeout: 5m
-    max_attempts: 3
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
+      ONE declaration (ADR-0103). This used to be a dispatcher that enqueued
+      capture_auto_enrich_workspace per workspace; the pass now walks them
+      itself. The five minutes is the CHILD's old deadline, not the
+      dispatcher's two: the deadline has to bound the work, and the two minutes
+      only ever bounded an enumeration and an insert.
+
       Database-only: the pass reserves a budget slot and queues a deep read per
       due org, and never crawls anything itself. autoEnrichDailyCap bounds it at
       500 trigger transactions, and a pass that stops early simply leaves the

--- a/backend/gates/jobfleetwide_test.go
+++ b/backend/gates/jobfleetwide_test.go
@@ -33,16 +33,24 @@ package gates
 //
 // # Which arm carries the weight
 //
-// The FAN-OUT requirement is the load-bearing one. The regression this phase
-// exists to prevent is a worker that loops the fleet and calls a store method
-// per tenant — the pre-conversion shape — and that worker calls none of the
-// spellings above, so it fails here and nowhere else. jobbinding_test.go does
-// not look at writes at all (it catches a Work body binding its own workspace),
-// and the RLS lane catches only UNBOUND writes, while a fleet loop that binds
-// the GUC per workspace and then writes satisfies RLS completely. Nothing
-// downstream covers that shape.
+// The FLEET-WALK requirement is the load-bearing one, and what it prohibits has
+// narrowed once. It used to read "a FleetWide job must fan out", and the
+// regression it prevented was a worker that looped the fleet and called a store
+// method per tenant. ADR-0103 makes that loop the intended shape for a
+// scheduled pass — one job declaration, not a dispatcher and a child — so the
+// loop itself is no longer the finding.
 //
-// # The one kind that owns no tenant and still does the work
+// What is still a finding is reaching the fleet by HAND. runPerWorkspace is now
+// a sanctioned spelling beside the three dispatch helpers: it enumerates the
+// live workspaces, attempts every one, and joins the failures, so a pass that
+// walks the fleet through it cannot silently skip a tenant or swallow a
+// tenant's error. A `for` loop written at the call site gets none of that, and
+// nothing downstream catches it — jobbinding_test.go does not look at writes at
+// all (it catches a Work body binding its own workspace), and the RLS lane
+// catches only UNBOUND writes, while a fleet loop that binds the GUC per
+// workspace and then writes satisfies RLS completely.
+//
+// # Kinds that own no tenant and still do the work
 //
 // A FleetWide declaration says the job owns no tenant. Until ADR-0091 §8 that
 // implied a fan-out, because the work itself always belonged to some workspace.
@@ -86,7 +94,15 @@ const fleetWideDispatcherFloor = 20
 
 // fanOutHelpers are the compose helpers that ARE a fan-out. See the allowlist
 // above for why the set is closed and why a direct River insert is not in it.
-var fanOutHelpers = []string{"dispatchPerWorkspace", "dispatchWith", "dispatchOne"}
+// fanOutHelpers are the sanctioned ways a FleetWide job reaches the fleet.
+//
+// The first three ENQUEUE one child per unit; runPerWorkspace RUNS the pass for
+// each workspace in this process, which is what ADR-0103 collapsed the
+// workspace dispatchers into. All four are listed together because the arm
+// below is about the same thing for all of them: a FleetWide job must reach the
+// fleet through a helper that knows what a unit is, and not through a loop it
+// wrote itself.
+var fanOutHelpers = []string{"dispatchPerWorkspace", "dispatchWith", "dispatchOne", "runPerWorkspace"}
 
 // fleetWideDispatcher is one resolved args→worker→Work association and what
 // the gate found in it.
@@ -367,7 +383,7 @@ func checkFleetWideDispatchers(t *testing.T, dir string) {
 			continue
 		}
 		if !d.fansOut {
-			t.Errorf("%s:%d: %s works FleetWide args %s but never fans out. A dispatcher enqueues one job per unit of its fan-out, through dispatchPerWorkspace, dispatchWith or dispatchOne — those three build the child's insert options, so a direct River insert around them loses the sweep tag and the declared attempt cap. If it does tenant work instead, it is WorkspaceScoped and its args must carry the workspace.",
+			t.Errorf("%s:%d: %s works FleetWide args %s but never reaches the fleet. It must do so through dispatchPerWorkspace, dispatchWith or dispatchOne — which build the child's insert options, so a direct River insert around them loses the sweep tag and the declared attempt cap — or through runPerWorkspace, which walks the live workspaces in this process (ADR-0103). A loop of its own is the shape all four exist to replace.",
 				d.pos.Filename, d.pos.Line, d.worker, d.args)
 		}
 		for _, verb := range d.writes {

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -96,37 +96,16 @@ func newCaptureAutoEnrichSweepWorker(pool *pgxpool.Pool, log *slog.Logger) *capt
 	}
 }
 
-// Work is the DISPATCHER: it enumerates the fleet and enqueues one sweep per
-// workspace, and touches no tenant data itself.
+// Work is the PASS: it walks the live workspaces and enriches each one.
+//
+// It used to be a dispatcher that enqueued one capture_auto_enrich_workspace
+// per workspace (ADR-0103). The child kind is gone; the enumeration is not,
+// because the collapse is about how many job kinds describe one pass and not
+// about assuming a single tenant.
 func (w *captureAutoEnrichSweepWorker) Work(ctx context.Context, _ *river.Job[CaptureAutoEnrichSweepArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(CaptureAutoEnrichWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return CaptureAutoEnrichWorkspaceArgs{Workspace: ws} }))
-}
-
-// CaptureAutoEnrichWorkspaceArgs is one workspace's auto-enrich pass.
-type CaptureAutoEnrichWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (CaptureAutoEnrichWorkspaceArgs) Kind() string { return "capture_auto_enrich_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a CaptureAutoEnrichWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// captureAutoEnrichWorkspaceWorker runs one workspace's pass. It reuses the
-// dispatcher's wiring rather than a second copy: the stores, the daily cap and
-// the actor are the pass's, not the fan-out's.
-type captureAutoEnrichWorkspaceWorker struct {
-	sweeper *captureAutoEnrichSweepWorker
-}
-
-func (w *captureAutoEnrichWorkspaceWorker) Work(ctx context.Context, job *river.Job[CaptureAutoEnrichWorkspaceArgs]) error {
-	if _, err := workspaceJobCtx(ctx, job.Args); err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	return jobs.FaultContext(ctx, w.sweeper.sweepWorkspace(ctx, ids.From[ids.WorkspaceKind](job.Args.Workspace)))
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, func(ctx context.Context, ws ids.UUID) error {
+		return w.sweepWorkspace(ctx, ids.From[ids.WorkspaceKind](ws))
+	}))
 }
 
 // sweepWorkspace enriches the due orgs of one workspace, respecting the flag

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -12,6 +12,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -132,6 +133,35 @@ func oneOffChildOpts(childKind string) *river.InsertOpts {
 	return &river.InsertOpts{Queue: spec.Queue, MaxAttempts: spec.MaxAttempts}
 }
 
+// oneOffPassOpts is oneOffChildOpts for a COLLAPSED pass: a scheduled kind that
+// does the work in its own row rather than fanning out (ADR-0103).
+//
+// Its sibling insists the kind is somebody's fan-out child, which this one
+// cannot be — that is the whole of the collapse. What it keeps is the reason
+// that helper exists: the queue comes from the DECLARATION, so an on-demand
+// enqueue lands on the same pool the scheduled tick uses instead of a queue the
+// caller happened to name.
+//
+// No attempt cap, because a caller-owned kind declares none: max_attempts is
+// contract-declared only for a fan-out child, whose cap the fan-out is
+// responsible for setting. Passing one here would publish a number the
+// declaration does not carry.
+//
+// No sweep tag, for the reason oneOffChildOpts gives: the tag marks a row as
+// one workspace's share of a fleet pass, and the gauges count tagged rows. A
+// one-off wearing it would inflate the coverage reading of a pass that never
+// ran.
+func oneOffPassOpts(kind string) *river.InsertOpts {
+	spec, ok := jobs.SpecFor(kind)
+	if !ok {
+		panic("compose: enqueuing " + kind + ", which api/jobs.yaml does not declare")
+	}
+	if spec.OptsOwner != jobs.OptsCaller {
+		panic("compose: " + kind + " declares an opts_owner other than caller, so its queue is not this helper's to set")
+	}
+	return &river.InsertOpts{Queue: spec.Queue}
+}
+
 // fanOutChildren is every kind some dispatcher DECLARES it fans out to —
 // fans_out_to, read as the registry it is, over BOTH halves of the declaration
 // table (jobs.Declared covers the compiled core kinds and this installation's
@@ -185,6 +215,40 @@ func dispatchPerWorkspace(ctx context.Context, pool *pgxpool.Pool, opts *river.I
 		return err
 	}
 	return dispatchWith(ctx, workspaces, clientInsertMany(ctx), opts, argsFor)
+}
+
+// runPerWorkspace runs a scheduled pass for every live workspace, IN THIS
+// PROCESS, and is what a collapsed pass uses where it used to fan out.
+//
+// ADR-0103: a scheduled pass over the installation is one job declaration, not
+// two. The dispatchers this replaces existed only to enumerate workspaces and
+// enqueue one child each — a second kind, a second row and a second retry
+// ladder for work the pass could simply do.
+//
+// It still ENUMERATES. The collapse is about how many job kinds describe one
+// pass, not about assuming a single tenant: an installation holds one active
+// workspace today (identity.InstallationWorkspace refuses more), and a pass
+// written against that assumption would silently skip the second one the day
+// it stops being true. So the loop stays and only the fan-out goes.
+//
+// EVERY WORKSPACE IS ATTEMPTED. One workspace's failure does not stop the
+// others — the fan-out it replaces gave each child its own row, so a failure in
+// one never touched the rest, and collapsing must not quietly introduce that
+// coupling. The errors are joined, so the pass still FAILS: a tick that
+// swallowed them would be the swallowed-error shape the fan-out's own
+// atomicity argument exists to prevent.
+func runPerWorkspace(ctx context.Context, pool *pgxpool.Pool, run func(context.Context, ids.UUID) error) error {
+	workspaces, err := enumerateWorkspaces(ctx, pool)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, ws := range workspaces {
+		if err := run(ctx, ws); err != nil {
+			failures = append(failures, fmt.Errorf("workspace %s: %w", ws, err))
+		}
+	}
+	return errors.Join(failures...)
 }
 
 // clientInsertMany binds the fan-out to the River client already in context —

--- a/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_auto_enrich_sweep_integration_test.go
@@ -79,9 +79,12 @@ func TestCaptureAutoEnrichSweepTriggersADeepReadForACapturedOrg(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	// The WORKSPACE job, not the dispatcher: a dispatcher completes as soon as
-	// its fan-out is enqueued, so waiting on it would race the work.
-	integration.AwaitKindCompleted(waitCtx, t, sub, compose.CaptureAutoEnrichWorkspaceArgs{}.Kind())
+	// THE PASS ITSELF, which is now the only kind there is (ADR-0103). This
+	// used to wait on the workspace child, because a dispatcher completed as
+	// soon as its fan-out was enqueued and waiting on it raced the work. A
+	// collapsed pass completes when the work is done, so the thing to wait for
+	// and the thing that does the work are the same row.
+	integration.AwaitKindCompleted(waitCtx, t, sub, compose.CaptureAutoEnrichSweepArgs{}.Kind())
 
 	// The sweep created a system-requested dossier for the org...
 	var readCount int

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "7debad373823f8c1db17b96b79ae3d8afc9a146bcd86628dc63ff99a4274a080"
+const jobContractHash = "5f5c8efdb21834e2f48eb64b52d037dd8bad08e94f6733999b2669d44a0e9c84"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -37,7 +37,6 @@ type declaredJobArgs interface {
 		BriefGenerateArgs |
 		BriefGenerateWorkspaceArgs |
 		CaptureAutoEnrichSweepArgs |
-		CaptureAutoEnrichWorkspaceArgs |
 		CaptureBackfillArgs |
 		CaptureClassifyArgs |
 		CaptureClassifyWorkspaceArgs |
@@ -153,7 +152,6 @@ func addDeclaredWorkerWithTimeout[T declaredJobArgs](reg *jobRegistry, w jobs.Wo
 var (
 	_ jobs.FleetWide = AssuranceSweepArgs{}
 	_ jobs.FleetWide = BriefGenerateArgs{}
-	_ jobs.FleetWide = CaptureAutoEnrichSweepArgs{}
 	_ jobs.FleetWide = CaptureClassifyArgs{}
 	_ jobs.FleetWide = ConfidentialityVerdictArgs{}
 	_ jobs.FleetWide = CounterpartyVerdictArgs{}
@@ -191,7 +189,6 @@ var (
 	_ jobs.WorkspaceScoped = AiModelRateRefreshArgs{}
 	_ jobs.WorkspaceScoped = AssuranceWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = BriefGenerateWorkspaceArgs{}
-	_ jobs.WorkspaceScoped = CaptureAutoEnrichWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureBackfillArgs{}
 	_ jobs.WorkspaceScoped = CaptureClassifyWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ConfidentialityVerdictWorkspaceArgs{}

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -87,7 +87,6 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 	// registered, it enqueues system deep reads the site worker applies.
 	autoEnrich := newCaptureAutoEnrichSweepWorker(pool, log)
 	addDeclaredWorker[CaptureAutoEnrichSweepArgs](reg, autoEnrich)
-	addDeclaredWorker[CaptureAutoEnrichWorkspaceArgs](reg, &captureAutoEnrichWorkspaceWorker{sweeper: autoEnrich})
 	// The outbound send is not periodic — the api stages one job per accepted
 	// message, in the same transaction as the activity; this role only needs
 	// the worker registered.

--- a/backend/internal/compose/orgautoenrich.go
+++ b/backend/internal/compose/orgautoenrich.go
@@ -87,11 +87,6 @@ func (g *OrgAutoEnrichTrigger) HandleEvent(ctx context.Context, env events.Envel
 	if time.Since(env.OccurredAt) > orgAutoEnrichFreshWindow {
 		return nil
 	}
-	// The envelope carries no tenant (ADR-0091 §6); the store's handle names it.
-	ws, err := InstallationDB(g.pool).Workspace(ctx)
-	if err != nil {
-		return err
-	}
 	// The uniqueness is the flood bound: any authenticated writer can emit
 	// organization.updated in a loop (the store's emit has no value-changed
 	// guard), and without it every event would land its own row on the
@@ -109,8 +104,15 @@ func (g *OrgAutoEnrichTrigger) HandleEvent(ctx context.Context, env events.Envel
 	// doors dedupe against each other instead of stacking; the sweep-tag
 	// gauges may therefore occasionally count a day's coverage against a
 	// trigger-queued pass that did the identical work untagged.
-	child := CaptureAutoEnrichWorkspaceArgs{Workspace: ws.UUID}
-	opts := oneOffChildOpts(child.Kind())
+	// The PASS, not a per-workspace child: the child kind is gone with the
+	// fan-out (ADR-0103). Its args carried the workspace, so ByArgs deduped one
+	// trigger against another for the SAME workspace; the pass carries none, so
+	// the same dedupe now means one pending sweep at a time — which is what
+	// this trigger wanted in the first place. The pass walks the workspaces
+	// itself, so `ws` is no longer named: a pass over the installation cannot
+	// be aimed at one tenant.
+	child := CaptureAutoEnrichSweepArgs{}
+	opts := oneOffPassOpts(child.Kind())
 	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
 	return g.enqueue.Enqueue(ctx, child, opts)
 }

--- a/backend/internal/compose/orgautoenrich_integration_test.go
+++ b/backend/internal/compose/orgautoenrich_integration_test.go
@@ -30,25 +30,27 @@ func TestAnOrganizationEventQueuesTheEnrichPassNow(t *testing.T) {
 	}
 	trigger := NewOrgAutoEnrichTrigger(e.Pool, inserter, slog.Default())
 	ctx := context.Background()
-	kind := CaptureAutoEnrichWorkspaceArgs{}.Kind()
+	kind := CaptureAutoEnrichSweepArgs{}.Kind()
 
-	// A create queues exactly one pass, addressed to the installation's own
-	// workspace — the envelope carries no tenant, so naming the wrong one
-	// here would run the pass against nobody's data and read as a no-op.
+	// A create queues exactly one pass.
 	if err := trigger.HandleEvent(ctx, envelopeFor(e.WS, "organization.created", "organization", ids.NewV7())); err != nil {
 		t.Fatalf("organization.created: %v", err)
 	}
 	if n := countJobsOfKind(ctx, t, e.Pool, kind); n != 1 {
 		t.Fatalf("organization.created queued %d enrich pass(es), want exactly 1", n)
 	}
+	// It names NO workspace, and that is the collapse (ADR-0103) rather than a
+	// missing field. The trigger used to queue one child per tenant and had to
+	// address it; the pass walks the live workspaces itself, so a tenant in
+	// these args would be a claim this row is about one of them.
 	var workspace string
 	if err := e.Pool.QueryRow(ctx,
 		`SELECT coalesce(args->>'workspace_id', '') FROM river_job WHERE kind = $1`, kind,
 	).Scan(&workspace); err != nil {
 		t.Fatalf("reading the queued pass: %v", err)
 	}
-	if workspace != e.WS.String() {
-		t.Errorf("the queued pass names workspace %q, want the installation's %q", workspace, e.WS)
+	if workspace != "" {
+		t.Errorf("the queued pass names workspace %q; a pass over the installation addresses no tenant", workspace)
 	}
 
 	// A burst dedupes onto the pass already queued: the uniqueness is the

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -162,9 +162,6 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		IdempotencyRetentionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&idempotencyRetentionWorkspaceWorker{}).Work(ctx, &river.Job[IdempotencyRetentionWorkspaceArgs]{})
 		},
-		CaptureAutoEnrichWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&captureAutoEnrichWorkspaceWorker{}).Work(ctx, &river.Job[CaptureAutoEnrichWorkspaceArgs]{})
-		},
 		EmbedDriftWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&embedDriftWorkspaceWorker{}).Work(ctx, &river.Job[EmbedDriftWorkspaceArgs]{})
 		},

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "7debad373823f8c1db17b96b79ae3d8afc9a146bcd86628dc63ff99a4274a080"
+const JobContractHash = "5f5c8efdb21834e2f48eb64b52d037dd8bad08e94f6733999b2669d44a0e9c84"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -131,25 +131,13 @@ var specs = map[string]Spec{
 		Args:        []ArgField{{Name: "Workspace"}},
 	},
 	"capture_auto_enrich_sweep": {
-		Kind:       "capture_auto_enrich_sweep",
-		GoType:     "CaptureAutoEnrichSweepArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "capture_auto_enrich_workspace",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{Fixed: 24 * time.Hour},
-	},
-	"capture_auto_enrich_workspace": {
-		Kind:        "capture_auto_enrich_workspace",
-		GoType:      "CaptureAutoEnrichWorkspaceArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
-		MaxAttempts: 3,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
+		Kind:      "capture_auto_enrich_sweep",
+		GoType:    "CaptureAutoEnrichSweepArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 5 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{Fixed: 24 * time.Hour},
 	},
 	"capture_backfill": {
 		Kind:         "capture_backfill",

--- a/backend/migrations/core/1788542751_a_collapsed_pass_leaves_no_orphan_children.down.sql
+++ b/backend/migrations/core/1788542751_a_collapsed_pass_leaves_no_orphan_children.down.sql
@@ -1,0 +1,12 @@
+-- Nothing to restore, and that is not a gap.
+--
+-- The up migration deleted queue rows for work that had not run: a pending
+-- child of a pass that no longer exists. A rollback re-registers the child's
+-- worker, and the pass it belongs to re-enqueues on its next tick — so the work
+-- returns on its own schedule rather than from a row this file could recreate.
+--
+-- Recreating them would be worse than doing nothing. A row forged here would
+-- carry a new id, a fresh attempt count and this migration's timestamp, so it
+-- would not be the row that was deleted; it would be a new claim that work is
+-- pending, made by a migration rather than by the pass that decides.
+SELECT 1;

--- a/backend/migrations/core/1788542751_a_collapsed_pass_leaves_no_orphan_children.up.sql
+++ b/backend/migrations/core/1788542751_a_collapsed_pass_leaves_no_orphan_children.up.sql
@@ -1,0 +1,38 @@
+-- Drain the queued children of a pass that no longer fans out.
+--
+-- ADR-0103 collapses a scheduled pass over the installation into ONE job
+-- declaration. The child kind the dispatcher used to enqueue per workspace is
+-- gone from the contract and no longer registered on any client.
+--
+-- River does not forget a row because the code stopped declaring its kind. A
+-- child enqueued by the last tick before this deploy is still sitting in
+-- river_job in a runnable state, and the new binary has no worker for it: the
+-- client reports an unknown kind and the row retries its way to `discarded`
+-- rather than draining. That is at most one tick's worth per kind, and it is
+-- permanent debris in the table an operator reads to see whether the queue is
+-- healthy — a handful of rows failing forever, for work that was already done
+-- by the pass that replaced them.
+--
+-- NON-TERMINAL states only. A `completed`, `discarded` or `cancelled` row is
+-- history: it records that the work ran, and deleting it would erase the
+-- evidence of the last passes before the collapse. What is removed is only what
+-- would otherwise be attempted and cannot be.
+--
+-- Losing the queued work is the point rather than a cost. The pass that
+-- replaced these children runs on the same cadence and covers the same
+-- workspaces, so anything a drained child would have done is done by the next
+-- tick — which is also what would have happened had the child simply failed.
+-- GUARDED on the table existing, because river_job is not ours. River owns its
+-- own schema and applies it on the client's first run, so on a fresh
+-- installation the core migrations land before the queue table exists at all.
+-- An unguarded DELETE would fail the whole migration run on exactly the
+-- installations that have no orphan rows to drain.
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    DELETE FROM river_job
+     WHERE kind = 'capture_auto_enrich_workspace'
+       AND state NOT IN ('completed', 'discarded', 'cancelled');
+  END IF;
+END
+$$;


### PR DESCRIPTION
First of a series for #1857. Lands the mechanism, the gate change, the migration pattern and one conversion; the remaining 26 pairs follow the same shape.

**Why not one PR.** 27 pairs in one diff is not reviewable, and each pair carries its own attachments — this one had two that no amount of pattern-matching would have found without opening it.

## The collapse

ADR-0103: a scheduled pass over the installation is one job declaration, not two. 31 kinds are `role: dispatcher`; 27 fan out per **workspace** and are the vestigial ones (`InstallationWorkspace` refuses more than one active workspace, so each enumerates exactly one row and enqueues exactly one child). The other 4 fan out per connection or build and are genuine one-to-many — they stay.

`runPerWorkspace` is the collapsed pass's fleet walk. It **still enumerates**: the collapse is about how many job kinds describe one pass, not about assuming a single tenant — a pass written against that assumption would silently skip the second workspace the day it stops being true. It attempts every workspace and joins the failures, so one tenant's error neither stops the others nor disappears.

The deadline becomes the **child's** five minutes, not the dispatcher's two. A deadline has to bound the work; two minutes only ever bounded an enumeration and an insert.

## The gate narrows, on purpose

`jobfleetwide_test.go` read *"a FleetWide job must fan out"*, and the regression it named was a worker that loops the fleet and calls a store method per tenant. **That loop is now the intended shape.** So the finding is no longer the loop but reaching the fleet by hand: `runPerWorkspace` joins the three dispatch helpers as a sanctioned spelling, and a `for` written at the call site still fails. Nothing downstream catches that — `jobbinding_test.go` does not look at writes, and RLS is satisfied by a loop that binds the GUC per workspace.

The no-tenant-write arm is untouched and still has no live subject.

## Two attachments this pair carried

- The **org-created trigger** enqueued the child directly for one workspace. It now enqueues the pass: its `ByArgs` dedupe used to mean "one trigger per workspace" and now means "one pending sweep", which is what a flood bound wanted in the first place. `oneOffPassOpts` is its insert-options helper — the sibling insists its kind is somebody's fan-out child, which a collapsed pass cannot be.
- The **sweep's integration test** waited on the child, because a dispatcher completed as soon as its fan-out was enqueued. A collapsed pass completes when the work is done, so it waits on the pass — the test got simpler, which is the point.

## The migration

River does not forget a row because the code stopped declaring its kind. A child enqueued by the last tick before this deploy retries its way to `discarded` against a client with no worker for it — permanent debris in the table an operator reads to judge queue health. The migration drains **non-terminal** rows only (a completed row is the record that the work ran) and is guarded on `to_regclass`, because River owns its own schema and applies it on first run, so core migrations can land before the table exists.

## Verification

`make check-backend` exit 0; `internal/compose` and `integration/capture` suites green. Kind count 92 → 91.