### PR TITLE
Two more passes collapse: finance_sync and embed_drift

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -246,14 +246,12 @@ kinds:
       rest due for tomorrow.
 
   finance_sync_sweep:
-    role: dispatcher
+    role: worker
     go_type: FinanceSyncSweepArgs
     queue: default
-    timeout: 2m
+    timeout: 5m
     opts_owner: caller
     cadence: 6h
-    fans_out_to: finance_sync
-    fan_out_unit: workspace
     reason: >-
       Four times a day, and at boot like every pass here. An accounting source
       is not a stream: invoices are issued and settled on a human timetable, so
@@ -262,22 +260,15 @@ kinds:
       staleness threshold is set against — a mirror that has missed four passes
       is what it calls stale.
 
-  finance_sync:
-    role: worker
-    go_type: FinanceSyncArgs
-    queue: default
-    timeout: 5m
-    max_attempts: 3
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
-      One workspace's mirror pass: read the source's customers and the ledger of
-      each linked one, and write only what changed. The hash covers the source's
-      own values, so a pass over an unchanged ledger writes nothing and the
-      retries below are free. Five minutes bounds a first backfill of eighteen
-      months across every linked customer; a pass that runs out simply resumes
-      on the next sweep.
+      ONE declaration (ADR-0103). It walks the live workspaces itself where it
+      used to enqueue a finance_sync child per workspace, and the five minutes
+      is that child's deadline: it bounds a first backfill of eighteen months
+      across every linked customer, where the dispatcher's two only ever
+      bounded an enumeration and an insert.
+
+      Each workspace's pass reads the source's customers and the ledger of each
+      linked one, and writes only what changed. The hash covers the source's own
+      values, so a pass over an unchanged ledger writes nothing.
 
   capture_backfill:
     role: worker
@@ -762,15 +753,22 @@ kinds:
       rep cannot see.
 
   embed_drift_sweep:
-    role: dispatcher
+    role: worker
     go_type: EmbedDriftSweepArgs
     queue: default
-    timeout: 2m
+    timeout:
+      none: true
+      reason: >-
+        The pass is bounded by the pending backlog, not a wall clock, and each
+        embed is bounded by the model lane's per-call timeout. It was the
+        CHILD's posture and it survives the collapse (ADR-0103): the dispatcher
+        carried a real two-minute deadline because it only enumerated and
+        enqueued, and a deadline on the walk itself would put the corpus pass
+        back inside River's rescuer — which is the one thing this declaration
+        exists to keep it out of.
     opts_owner: caller
     cadence: 15m
     registration: {when: [Embedder], absent: registers_nothing}
-    fans_out_to: embed_drift_workspace
-    fan_out_unit: workspace
     reason: >-
       An empty pass is six indexed NOT-EXISTS probes per workspace, so a short
       cadence is cheap; fifteen minutes is how long a lost embed event may keep
@@ -780,28 +778,11 @@ kinds:
       runtime method rather than a JobRunnerConfig field and so cannot be
       declared here. A configured-but-unbound lane — what --ai-fake leaves —
       seeds no binding marker for the sweep to compare a row against, and
-      registers neither embed_drift kind.
+      registers this kind not at all.
 
-  embed_drift_workspace:
-    role: worker
-    go_type: EmbedDriftWorkspaceArgs
-    queue: default
-    timeout:
-      none: true
-      reason: >-
-        The pass is bounded by the pending backlog, not a wall clock, and each
-        embed is bounded by the model lane's per-call timeout.
-    max_attempts: 3
-    opts_owner: fan_out
-    registration: {when: [Embedder], absent: registers_nothing}
-    args:
-      Workspace: id
-    reason: >-
-      Registered by addEmbedDriftSweepJob beside its dispatcher, under the same
-      second condition the when: above cannot express: the embed lane must also
-      be BOUND (a non-empty EmbedIdentity, a runtime method rather than a
-      JobRunnerConfig field), because an unbound lane seeds no binding marker
-      and there is nothing to heal a row against.
+      ONE declaration (ADR-0103). It walks the live workspaces itself where it
+      used to enqueue an embed_drift_workspace child per workspace, and takes
+      that child's unbounded deadline with it — see timeout above.
 
   knowledge_ingest:
     role: worker

--- a/backend/internal/compose/embeddriftsweep.go
+++ b/backend/internal/compose/embeddriftsweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // The embed drift sweep (ADR-0069 §3a, SEARCH-AC-13): the at-least-once
@@ -38,30 +39,12 @@ func (EmbedDriftSweepArgs) Kind() string { return "embed_drift_sweep" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (EmbedDriftSweepArgs) FleetWide() {}
 
-// embedDriftSweepWorker is the dispatcher: it enumerates the fleet and
-// enqueues one sweep per workspace, and heals nothing itself.
+// embedDriftSweepWorker heals every live workspace's drift.
+//
+// One worker where there were two (ADR-0103): the dispatcher that enqueued an
+// embed_drift_workspace child per workspace is gone, and this walks them.
 type embedDriftSweepWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *embedDriftSweepWorker) Work(ctx context.Context, _ *river.Job[EmbedDriftSweepArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(EmbedDriftWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return EmbedDriftWorkspaceArgs{Workspace: ws} }))
-}
-
-// EmbedDriftWorkspaceArgs is one workspace's drift sweep.
-type EmbedDriftWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (EmbedDriftWorkspaceArgs) Kind() string { return "embed_drift_workspace" }
-
-// WorkspaceID binds this sweep to its tenant (jobs.WorkspaceScoped).
-func (a EmbedDriftWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-type embedDriftWorkspaceWorker struct {
+	pool  *pgxpool.Pool
 	store *search.Store
 	// corpora is the knowledge module's half of the same question. It rides
 	// this sweep rather than a job of its own: the sweep already answers "has
@@ -72,12 +55,16 @@ type embedDriftWorkspaceWorker struct {
 	log      *slog.Logger
 }
 
-func (w *embedDriftWorkspaceWorker) Work(ctx context.Context, job *river.Job[EmbedDriftWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	healed, err := w.store.SweepWorkspaceEmbeddingDrift(wsCtx, ids.From[ids.WorkspaceKind](job.Args.Workspace), w.embedder)
+func (w *embedDriftSweepWorker) Work(ctx context.Context, _ *river.Job[EmbedDriftSweepArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.sweepWorkspace))
+}
+
+// sweepWorkspace heals ONE workspace. It was the child job's Work, and binds
+// the workspace itself: the pass walks tenants, so the binding belongs to the
+// tenant's turn rather than to the row.
+func (w *embedDriftSweepWorker) sweepWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
+	healed, err := w.store.SweepWorkspaceEmbeddingDrift(wsCtx, ids.From[ids.WorkspaceKind](workspace), w.embedder)
 	if healed > 0 {
 		w.log.InfoContext(wsCtx, "embed drift sweep healed entities", "healed", healed)
 	}
@@ -133,8 +120,8 @@ func addEmbedDriftSweepJob(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerCo
 	if identity, _ := embedder.EmbedIdentity(); identity == "" {
 		return nil
 	}
-	addDeclaredWorker[EmbedDriftSweepArgs](reg, &embedDriftSweepWorker{pool: pool})
-	addDeclaredWorker[EmbedDriftWorkspaceArgs](reg, &embedDriftWorkspaceWorker{
+	addDeclaredWorker[EmbedDriftSweepArgs](reg, &embedDriftSweepWorker{
+		pool:  pool,
 		store: search.NewStore(InstallationDB(pool)),
 		// WithBlobstore, or the abandoned-ingest sweep marks a document failed
 		// and leaves its stored file behind: FailIngest deletes the bytes

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "5f5c8efdb21834e2f48eb64b52d037dd8bad08e94f6733999b2669d44a0e9c84"
+const jobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -60,9 +60,7 @@ type declaredJobArgs interface {
 		SendEmailArgs |
 		DocumentExtractArgs |
 		EmbedDriftSweepArgs |
-		EmbedDriftWorkspaceArgs |
 		EmbedReindexArgs |
-		FinanceSyncArgs |
 		FinanceSyncSweepArgs |
 		FollowUpReconcileArgs |
 		FollowUpWorkspaceArgs |
@@ -159,8 +157,6 @@ var (
 	_ jobs.FleetWide = CaptureEnrichArgs{}
 	_ jobs.FleetWide = CaptureTraceSweepArgs{}
 	_ jobs.FleetWide = CloseDateSweepArgs{}
-	_ jobs.FleetWide = EmbedDriftSweepArgs{}
-	_ jobs.FleetWide = FinanceSyncSweepArgs{}
 	_ jobs.FleetWide = FollowUpReconcileArgs{}
 	_ jobs.FleetWide = ForecastSnapshotSweepArgs{}
 	_ jobs.FleetWide = GmailSyncArgs{}
@@ -202,8 +198,6 @@ var (
 	_ jobs.WorkspaceScoped = ScheduledSendArgs{}
 	_ jobs.WorkspaceScoped = SendEmailArgs{}
 	_ jobs.WorkspaceScoped = DocumentExtractArgs{}
-	_ jobs.WorkspaceScoped = EmbedDriftWorkspaceArgs{}
-	_ jobs.WorkspaceScoped = FinanceSyncArgs{}
 	_ jobs.WorkspaceScoped = FollowUpWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ForecastSnapshotWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = FxRateRefreshArgs{}

--- a/backend/internal/compose/jobregistry_test.go
+++ b/backend/internal/compose/jobregistry_test.go
@@ -31,21 +31,18 @@ func declaredTimeout(t *testing.T, kind string, supplied time.Duration) time.Dur
 // tree and re-arm the rescuer behind them, and neither change would be visible
 // anywhere else.
 //
-// The unbounded half is whatever actually WALKS a corpus: embed_drift_workspace
-// still does so per tenant, and embed_reindex now does so directly, having
-// absorbed the child it used to fan out to (the corpus stopped being divided
-// when ADR-0091 §8 phase D removed the tenant column). A kind that only
-// enumerates and enqueues carries a real deadline, and embed_drift_sweep is
-// asserted bounded in the same breath to keep the two apart.
+// The unbounded half is whatever actually WALKS a corpus. Both do now:
+// embed_reindex absorbed the child it used to fan out to when ADR-0091 §8 phase
+// D removed the tenant column, and embed_drift_sweep absorbed its own under
+// ADR-0103 — so the kind that was asserted BOUNDED here, on the ground that a
+// dispatcher only enumerates and enqueues, is the same kind that now does the
+// walk. It changed sides rather than leaving, which is the whole content of the
+// collapse: there is no longer a row whose deadline can be short because it
+// does nothing.
 func TestTheTwoPassesDeclaredWithNoWallClockStillResolveToNegativeOne(t *testing.T) {
-	for _, kind := range []string{"embed_reindex", "embed_drift_workspace"} {
+	for _, kind := range []string{"embed_reindex", "embed_drift_sweep"} {
 		if got := declaredTimeout(t, kind, 0); got != -1 {
 			t.Errorf("%s resolves to %v, want -1 — the pass is bounded by its backlog, and the row must stay outside River's rescuer", kind, got)
-		}
-	}
-	for _, kind := range []string{"embed_drift_sweep"} {
-		if got := declaredTimeout(t, kind, 0); got <= 0 {
-			t.Errorf("%s resolves to %v, want a positive bound — a dispatcher only enumerates and enqueues", kind, got)
 		}
 	}
 }

--- a/backend/internal/compose/jobs_finance.go
+++ b/backend/internal/compose/jobs_finance.go
@@ -43,32 +43,17 @@ func (FinanceSyncSweepArgs) Kind() string { return "finance_sync_sweep" }
 // tenant work of its own (jobs.FleetWide).
 func (FinanceSyncSweepArgs) FleetWide() {}
 
-// FinanceSyncArgs is one workspace's mirror pass.
-type FinanceSyncArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (FinanceSyncArgs) Kind() string { return "finance_sync" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a FinanceSyncArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// financeSyncSweepWorker is the dispatcher.
+// financeSyncSweepWorker mirrors every live workspace's accounting source.
+//
+// One worker where there were two (ADR-0103): the dispatcher that enqueued a
+// finance_sync child per workspace is gone, and this walks them itself.
 type financeSyncSweepWorker struct {
 	pool *pgxpool.Pool
+	log  *slog.Logger
 }
 
 func (w *financeSyncSweepWorker) Work(ctx context.Context, _ *river.Job[FinanceSyncSweepArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(FinanceSyncArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return FinanceSyncArgs{Workspace: ws} }))
-}
-
-// financeSyncWorker mirrors one workspace's accounting source.
-type financeSyncWorker struct {
-	pool *pgxpool.Pool
-	log  *slog.Logger
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.syncWorkspace))
 }
 
 // financeSweepPrincipal is who the scheduled mirror pass acts as.
@@ -119,15 +104,15 @@ func financeSweepPrincipal() principal.Principal {
 	}
 }
 
-func (w *financeSyncWorker) Work(ctx context.Context, job *river.Job[FinanceSyncArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+// syncWorkspace mirrors ONE workspace's source. It was the child job's Work,
+// and it still binds the workspace itself — the pass walks tenants, so the
+// binding belongs to the tenant's turn rather than to the row.
+func (w *financeSyncSweepWorker) syncWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
 	wsCtx = principal.WithActor(wsCtx, financeSweepPrincipal())
 	wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
 
-	provider, configured, err := w.providerFor(wsCtx, job.Args.Workspace)
+	provider, configured, err := w.providerFor(wsCtx, workspace)
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
@@ -167,7 +152,7 @@ func (w *financeSyncWorker) Work(ctx context.Context, job *river.Job[FinanceSync
 // would make the choice uninteresting and the second provider a rewrite.
 //
 //nolint:ireturn // the seam IS an interface: this resolves WHICH reader a
-func (w *financeSyncWorker) providerFor(
+func (w *financeSyncSweepWorker) providerFor(
 	ctx context.Context, workspace ids.UUID,
 ) (finance.Provider, bool, error) {
 	var (
@@ -237,7 +222,6 @@ func linkedCustomers(ctx context.Context, tx pgx.Tx) ([]finance.SourceCustomer, 
 func addFinanceJobs(
 	reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger,
 ) []*river.PeriodicJob {
-	addDeclaredWorker[FinanceSyncSweepArgs](reg, &financeSyncSweepWorker{pool: pool})
-	addDeclaredWorker[FinanceSyncArgs](reg, &financeSyncWorker{pool: pool, log: log})
+	addDeclaredWorker[FinanceSyncSweepArgs](reg, &financeSyncSweepWorker{pool: pool, log: log})
 	return periodicFor(cfg, FinanceSyncSweepArgs{})
 }

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -162,9 +162,6 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		IdempotencyRetentionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&idempotencyRetentionWorkspaceWorker{}).Work(ctx, &river.Job[IdempotencyRetentionWorkspaceArgs]{})
 		},
-		EmbedDriftWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&embedDriftWorkspaceWorker{}).Work(ctx, &river.Job[EmbedDriftWorkspaceArgs]{})
-		},
 		GraphEdgeWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&graphEdgeWorkspaceWorker{}).Work(ctx, &river.Job[GraphEdgeWorkspaceArgs]{})
 		},
@@ -272,9 +269,6 @@ func idBearingRefusalDrivers() map[string]func(context.Context) error {
 		},
 		SignalScanWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&signalScanWorkspaceWorker{}).Work(ctx, &river.Job[SignalScanWorkspaceArgs]{})
-		},
-		FinanceSyncArgs{}.Kind(): func(ctx context.Context) error {
-			return (&financeSyncWorker{}).Work(ctx, &river.Job[FinanceSyncArgs]{})
 		},
 		ProviderRunPollArgs{}.Kind(): func(ctx context.Context) error {
 			return (&providerRunPollWorker{}).Work(ctx, &river.Job[ProviderRunPollArgs]{})

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "5f5c8efdb21834e2f48eb64b52d037dd8bad08e94f6733999b2669d44a0e9c84"
+const JobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -378,25 +378,12 @@ var specs = map[string]Spec{
 	"embed_drift_sweep": {
 		Kind:         "embed_drift_sweep",
 		GoType:       "EmbedDriftSweepArgs",
-		Role:         Dispatcher,
-		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "embed_drift_workspace",
-		OptsOwner:    OptsCaller,
-		Cadence:      Cadence{Fixed: 15 * time.Minute},
-		Registration: Registration{When: []string{"Embedder"}},
-	},
-	"embed_drift_workspace": {
-		Kind:         "embed_drift_workspace",
-		GoType:       "EmbedDriftWorkspaceArgs",
 		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{None: true},
-		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
+		OptsOwner:    OptsCaller,
+		Cadence:      Cadence{Fixed: 15 * time.Minute},
 		Registration: Registration{When: []string{"Embedder"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 	"embed_reindex": {
 		Kind:         "embed_reindex",
@@ -409,26 +396,14 @@ var specs = map[string]Spec{
 		Registration: Registration{When: []string{"Embedder"}, AbsentRegistersAnyway: true},
 		Args:         []ArgField{{Name: "Identity", Scalar: true, Reason: "the embed binding in force when the confirm claimed the run -- model, dimension and revision folded into one string. Carried so a mid-flight configuration change is detectable as drift (search.ErrIdentityDrift) instead of the fleet silently re- embedding under whatever it now reports; that comparison is against the value AT CLAIM TIME, which no row still holds by the time the job runs."}, {Name: "Run"}},
 	},
-	"finance_sync": {
-		Kind:        "finance_sync",
-		GoType:      "FinanceSyncArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
-		MaxAttempts: 3,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
-	},
 	"finance_sync_sweep": {
-		Kind:       "finance_sync_sweep",
-		GoType:     "FinanceSyncSweepArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "finance_sync",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{Fixed: 6 * time.Hour},
+		Kind:      "finance_sync_sweep",
+		GoType:    "FinanceSyncSweepArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 5 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{Fixed: 6 * time.Hour},
 	},
 	"follow_up_reconcile": {
 		Kind:       "follow_up_reconcile",

--- a/backend/migrations/core/1788550824_two_more_collapsed_passes_leave_no_orphans.down.sql
+++ b/backend/migrations/core/1788550824_two_more_collapsed_passes_leave_no_orphans.down.sql
@@ -1,0 +1,8 @@
+-- Nothing to restore, for the reason its predecessor gives.
+--
+-- The up migration deleted queue rows for work that had not run. A rollback
+-- re-registers those workers and the passes re-enqueue on their next tick, so
+-- the work returns on its own schedule rather than from a row this file could
+-- forge — one that would carry a new id, a fresh attempt count and this
+-- migration's timestamp, and so would not be the row that was deleted.
+SELECT 1;

--- a/backend/migrations/core/1788550824_two_more_collapsed_passes_leave_no_orphans.up.sql
+++ b/backend/migrations/core/1788550824_two_more_collapsed_passes_leave_no_orphans.up.sql
@@ -1,0 +1,24 @@
+-- Drain the queued children of two more passes that no longer fan out.
+--
+-- Its own migration rather than an edit to the one that drained the first
+-- collapsed pass, and that distinction is the whole reason this file exists: a
+-- migration that has already run does not run again. Adding these kinds to the
+-- earlier file would have drained them only on installations that had not yet
+-- applied it — which is to say, on none of the ones that had already deployed
+-- the first batch.
+--
+-- The reasoning is the earlier file's, unchanged: River does not forget a row
+-- because the code stopped declaring its kind, so a child enqueued by the last
+-- tick before this deploy retries its way to `discarded` against a client that
+-- has no worker for it. NON-TERMINAL states only — a completed row records that
+-- the work ran — and guarded on the table existing, because River owns its own
+-- schema and applies it on first run.
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    DELETE FROM river_job
+     WHERE kind IN ('finance_sync', 'embed_drift_workspace')
+       AND state NOT IN ('completed', 'discarded', 'cancelled');
+  END IF;
+END
+$$;


### PR DESCRIPTION
Batch two of #1857, stacked on #4192 (base is that branch, not main).

Both follow the shape the first PR established: the child kind goes, the dispatcher absorbs the work through `runPerWorkspace`, and the child's queued rows join the drain migration.

**`finance_sync` folds the child's worker into the sweep's** rather than keeping two types. The child carried the pool, the logger, the sync principal and `providerFor`; the dispatcher carried only a pool. Keeping both would have left a type whose whole purpose was to be constructed once and called once.

## The deadline is not always the child's five minutes

This is what the second conversion taught, and it is worth flagging for the remaining 23.

`embed_drift_workspace` declared `timeout: {none: true}` deliberately: a negative River timeout keeps a row outside `job_rescuer`, and the pass walks a corpus bounded by its backlog rather than a wall clock. Giving the collapsed kind the five minutes the first two pairs used would have **re-armed the rescuer behind the longest pass in the tree**, and nothing about the diff would have looked wrong.

`TestTheTwoPassesDeclaredWithNoWallClockStillResolveToNegativeOne` caught it:

```
embed_drift_workspace is not declared in api/jobs.yaml
```

and then had to change. It asserted `embed_drift_sweep` **bounded**, on the ground that a dispatcher only enumerates and enqueues, and asserted the child unbounded. Those are now one kind, so it changed sides rather than leaving — which is the whole content of the collapse: there is no longer a row whose deadline can be short because it does nothing.

## Verification

`make check-backend` exit 0; `internal/compose` and `integration/capture` integration suites green. Kind count 91 → 89.

Remaining after this: 23 workspace pairs.