### PR TITLE
Two uat assertions catch up with the copy they test

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -745,7 +745,7 @@ test("AC-book-public (B-EP09.14): consent gates booking and the policy passes th
   expect(body.consent.purpose_id).toBeTruthy();
   expect(body.consent.policy_version).toBeTruthy();
   await expect(
-    page.getByText("Gebucht. Die Einladung ist unterwegs."),
+    page.getByText("Gebucht."),
   ).toBeVisible();
 });
 
@@ -766,7 +766,7 @@ test("AC-book-public-409: a taken slot degrades honestly — no fabricated confi
   ).toBeVisible();
   await expect(page.getByText("slot no longer available")).toBeVisible();
   await expect(
-    page.getByText("Gebucht. Die Einladung ist unterwegs."),
+    page.getByText("Gebucht."),
   ).toHaveCount(0);
 });
 
@@ -2455,17 +2455,18 @@ test.describe("filters and views", () => {
       objects.getByRole("button", { name: "Geschäfte", pressed: true }),
     ).toBeVisible();
 
-    // "Kontakte", not "Personen": these tabs read `filters.tab.contacts`,
-    // which is a different key from the nav's and is not one the People ruling
-    // moved. Noted on the ticket as a surface its inventory did not reach.
-    await objects.getByRole("button", { name: "Kontakte" }).click();
+    // "Personen": `filters.tab.contacts` is a different KEY from the nav's,
+    // which is why it was read as out of the People ruling's reach — but the
+    // key is not the word, and the catalog moved this one too. The tab says
+    // what every other surface says.
+    await objects.getByRole("button", { name: "Personen" }).click();
     await expect(page).toHaveURL(/#\/filters\/contacts$/);
 
     // Reloaded, not just navigated: the tab is where you ARE, so a shared link
     // and a refresh have to land on the same object.
     await page.reload();
     await expect(
-      objects.getByRole("button", { name: "Kontakte", pressed: true }),
+      objects.getByRole("button", { name: "Personen", pressed: true }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
**Fixing main.** No open PR touches `frontend/e2e/ac.spec.ts`, so nobody else has this in flight.

main is red on the `uat` lane, in two places. Neither is a bug in the product: both are assertions that went stale when two changes that were green *separately* landed past each other.

## 1. AC-book-public

Waited for `"Gebucht. Die Einladung ist unterwegs."`

The invite half of that sentence is gone. This build sends no invite — there is no outbound calendar or mail transport behind the booking at all — and #4091 removed the claim rather than leaving the product asserting something it cannot do. `book.confirmed` is now `"Gebucht."`, with `book.tellThemYourself` beside it on the authenticated path where an attendee was named.

That was my change, and I did not update this spec with it. It is the same defect the change was about, one level up: the e2e said the invite was on its way after the screen stopped saying so.

## 2. AC-filters-and-views-1

Waited for a filter tab named `"Kontakte"`, with a comment reasoning that `filters.tab.contacts` is a different **key** from the nav's and therefore outside the People ruling's reach.

The key is not the word. `frontend/src/i18n/de.ts` now reads `"filters.tab.contacts": "Personen"` — the catalog moved this one too, so the tab says what every other surface says and the comment stated something false. Rewritten rather than deleted, because the key/word distinction is exactly what misled the last reader.

## Testing

- `pnpm exec playwright test ac.spec.ts -g "AC-book-public|AC-filters-and-views-1"` — **2 failed, 1 passed** before; **3 passed** after. Verified in that order on this branch.
- `make check-fe` green.

## One thing I noticed and did not change

The **public** booking page (`book.tsx`, the second confirmation card) renders `book.confirmed` alone — no `book.tellThemYourself`. That is not a false claim, so it is not the defect #4091 was about, and a public booker is the attendee rather than a third party who must be told. But they still receive no calendar invite from a page that just said "Gebucht.", which may be worth a sentence of its own. Left for the ticket rather than decided inside a main repair.
