### PR TITLE
Six kinds of work are ordered against each other, not five

### DIFF
--- a/backend/internal/compose/attention/crosssourcerank_test.go
+++ b/backend/internal/compose/attention/crosssourcerank_test.go
@@ -82,8 +82,19 @@ func TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem(t *testing.T) {
 			AsOf:        rankInstant,
 			Commitments: lane(item("promise", "conversation_claim", withDue(soon))),
 			Meetings:    lane(item("meeting", "meeting", withDue(soon))),
-			AtRisk:      lane(item("risk", "deal_at_risk", withDeal(900_000_00))),
-			Notices:     lane(item("notice", "notice")),
+			// TWO deals, and the second is what makes the first material. The
+			// bar is the pipeline's own median and the test is `expected >
+			// bar`, so a lane holding one deal has that deal AS the median and
+			// it never clears itself — the row lands at the agreed level and
+			// this fixture would order five kinds of work while claiming six.
+			// The small one also proves the bar CUTS: it is a deal at risk that
+			// does not interrupt the day, drawn below the material one and above
+			// the hygiene.
+			AtRisk: lane(
+				item("risk", "deal_at_risk", withDeal(900_000_00)),
+				item("small-risk", "deal_at_risk", withDeal(1_000_00)),
+			),
+			Notices: lane(item("notice", "notice")),
 		},
 	)
 
@@ -91,7 +102,8 @@ func TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem(t *testing.T) {
 		"meeting",             // somebody else's clock, at a stated minute
 		waitActivity.String(), // somebody else's clock, all day
 		"promise",             // a promise the rep made
-		"risk",                // revenue at risk
+		"risk",                // revenue at risk, past the pipeline's median
+		"small-risk",          // a deal below that bar: agreed work, not urgent
 		"notice",              // hygiene
 	)
 }
@@ -226,7 +238,15 @@ func TestSixKindsOfWorkAreOrderedAgainstEachOther(t *testing.T) {
 			AsOf:        rankInstant,
 			Commitments: lane(item("promise", "conversation_claim", withDue(soon))),
 			Meetings:    lane(item("meeting", "meeting", withDue(soon))),
-			AtRisk:      lane(item("risk", "deal_at_risk", withDeal(900_000_00))),
+			// TWO deals, and the second is what makes the first material. The bar
+			// is the pipeline's own median and the test is `expected > bar`, so a
+			// lane holding ONE deal has that deal as the median and it never clears
+			// itself — the row lands at the agreed level, and this fixture would
+			// order five kinds of work while its name claims six.
+			AtRisk: lane(
+				item("risk", "deal_at_risk", withDeal(900_000_00)),
+				item("small-risk", "deal_at_risk", withDeal(1_000_00)),
+			),
 			NeedsYou: []crmcontracts.AttentionItem{
 				item("pair", "dedupe_candidate"),
 			},
@@ -244,7 +264,8 @@ func TestSixKindsOfWorkAreOrderedAgainstEachOther(t *testing.T) {
 		"meeting",             // a clock at a stated minute, still to come
 		waitActivity.String(), // a customer waiting, with no stated minute
 		"promise",             // a promise the rep made
-		"risk",                // revenue at risk
+		"risk",                // revenue at risk, past the pipeline's median
+		"small-risk",          // a deal below that bar: agreed work, not urgent
 		"pair",                // a judgement that blocks nobody
 	)
 }

--- a/backend/internal/compose/attention/crosssourcerank_test.go
+++ b/backend/internal/compose/attention/crosssourcerank_test.go
@@ -29,9 +29,23 @@ import (
 // feed through classifyDay, the waiting seam through classifyWaiting — and
 // ranks the union.
 func aWholeDay(waits []WaitingCustomer, day crmcontracts.Attention) []crmcontracts.WorklistItem {
+	return aWholeDayWithLeads(waits, nil, day)
+}
+
+// aWholeDayWithLeads is the same day plus the owed-leads lane.
+//
+// Leads are read BESIDE the assembled day, the way waits are — the lane takes
+// the scope as a query argument — so classifyDay never produces one and a
+// fixture built from it alone cannot order a lead against anything.
+func aWholeDayWithLeads(
+	waits []WaitingCustomer, leads []OwedLead, day crmcontracts.Attention,
+) []crmcontracts.WorklistItem {
 	rows := classifyDay(day, rankInstant, dayMoney{})
 	for _, wait := range waits {
 		rows = append(rows, classifyWaiting(wait, rankInstant))
+	}
+	for _, lead := range leads {
+		rows = append(rows, classifyLead(lead, rankInstant))
 	}
 	return rankAll(stampAsOf(rows, rankInstant))
 }
@@ -172,4 +186,65 @@ func TestAStaleWaitWithAnOpenDealKeepsItsPlace(t *testing.T) {
 var (
 	waitActivity = ids.MustParse("00000000-0000-7000-8000-00000000a001")
 	waitPerson   = ids.MustParse("00000000-0000-7000-8000-00000000b001")
+	leadOwed     = ids.MustParse("00000000-0000-7000-8000-00000000c001")
 )
+
+// The whole fixture the campaign's plan names: six kinds at once.
+//
+// The test above orders five, and two of the six it does not reach are the two
+// a rep would most likely dispute. A LEAD whose first-reply target has already
+// been missed sits at the waiting level beside a customer, and is read from a
+// lane BESIDE the assembled day — so a fixture built from classifyDay alone
+// could not have ordered one at all. A routine DECISION is the hygiene the
+// queue exists to keep out of the way, and `notice` stood in for it: system
+// news rather than a judgement somebody owes.
+//
+// What it holds to: every one of the four seller obligations leads the two
+// housekeeping rows, and the two clocks that have already run out lead the
+// promise that has not.
+func TestSixKindsOfWorkAreOrderedAgainstEachOther(t *testing.T) {
+	t.Parallel()
+
+	soon := rankInstant.Add(90 * time.Minute)
+	got := aWholeDayWithLeads(
+		[]WaitingCustomer{{
+			ActivityID: waitActivity,
+			Subject:    "Can you confirm the retrofit price?",
+			Since:      rankInstant.Add(-72 * time.Hour),
+			PersonID:   waitPerson,
+			Engaged:    true,
+		}},
+		[]OwedLead{{
+			ID:   leadOwed,
+			Name: "Kirsten at LOXXESS",
+			// Already missed, which is why it ranks with the customer rather
+			// than with the promise: the clock did not merely start, it ran out.
+			DeadlineAt: rankInstant.Add(-2 * time.Hour),
+			State:      "breached",
+		}},
+		crmcontracts.Attention{
+			AsOf:        rankInstant,
+			Commitments: lane(item("promise", "conversation_claim", withDue(soon))),
+			Meetings:    lane(item("meeting", "meeting", withDue(soon))),
+			AtRisk:      lane(item("risk", "deal_at_risk", withDeal(900_000_00))),
+			NeedsYou: []crmcontracts.AttentionItem{
+				item("pair", "dedupe_candidate"),
+			},
+		},
+	)
+
+	// The lead LEADS, and that surprised this test before it taught it. The
+	// lead, the meeting and the wait all sit at the waiting level, so the
+	// deadline step decides between them — and the lead's target ran out two
+	// hours ago while the meeting's is ninety minutes off. An overdue clock
+	// precedes a running one, which is the same rule that puts the meeting
+	// above the wait that carries no deadline at all.
+	assertOrder(t, got,
+		leadOwed.String(),     // a first reply already late
+		"meeting",             // a clock at a stated minute, still to come
+		waitActivity.String(), // a customer waiting, with no stated minute
+		"promise",             // a promise the rep made
+		"risk",                // revenue at risk
+		"pair",                // a judgement that blocks nobody
+	)
+}


### PR DESCRIPTION
Nothing compared the sources. Each lane had tests for its own rows, and the claim the whole ranked queue rests on — a customer waiting outranks a pile of hygiene, whatever the pile — was asserted nowhere across them.

One fixture now holds a breached lead, a meeting inside the horizon, a waiting customer, a promise, revenue at risk and a judgement, and states the order a rep would call right.

## The material bar was not reachable

The first version of this test could not see its own subject. The bar is the pipeline's **own median** and the check is `expected > bar`, so a lane holding one deal has that deal as the median and it never clears itself. The row landed at `levelAgreed`, and a fixture claiming to order *revenue at risk* was ordering agreed work under that name.

Proof: promoting `levelMaterialRisk` to the waiting level changed nothing and no test failed.

A second, smaller deal fixes it and earns its place twice — it makes the first deal material, **and** it proves the bar cuts: a deal at risk that does not interrupt the day, drawn below the material one and above the hygiene.

## What the test taught its author

The lead leads. The lead, the meeting and the wait all sit at the waiting level, so the deadline step decides between them — and the lead's target ran out two hours ago while the meeting's is ninety minutes off. An overdue clock precedes a running one. That surprised the fixture, and the comment records the rule rather than the surprise.

## Evidence

| Obligation | Evidence |
|---|---|
| Cross-source order | `TestSixKindsOfWorkAreOrderedAgainstEachOther` — six sources, one asserted sequence |
| The bar cuts | `small-risk` drawn below the material deal and above the hygiene, in both fixtures |
| Mutation strength | Deadline step neutered → fails. `levelMaterialRisk` promoted to `levelWaiting` → **now** fails; before the second deal it did not. |
| Full lane | `make check-backend` green |

Test-only; no production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for ordering work across multiple sources and work types.
  - Added validation for owed leads, meetings, waiting customers, promises, material risks, sub-bar risks, and deduplication decisions.
  - Added scenarios with multiple at-risk deals to verify consistent prioritization across the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The cross-source ranking test now orders all six kinds of work against each other, not five, and fixes a material-bar bug that made the old test pass while claiming something it did not verify.

The bar is the pipeline's own median and the check is `expected > bar`, so a lane holding one deal has that deal as the median and it never clears itself. The old fixture's "revenue at risk" row was actually landing at the agreed level. A second, smaller deal makes the first one material and proves the bar cuts.

The new fixture also adds a breached lead, which ranks above the meeting because both sit at the waiting level and the deadline step decides between them — an overdue clock precedes a running one. A dedupe decision stands in as the hygiene row.

**Bug Fixes**
- Material-risk rows now actually test the material level instead of silently falling back to agreed work.

<sup>Written for commit 5241725819feb4044c9a9a3c189027e27af1bdd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

