### PR TITLE
The booking confirmation is asserted exactly, so a longer promise fails it

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -744,9 +744,10 @@ test("AC-book-public (B-EP09.14): consent gates booking and the policy passes th
   expect(body.consent.wording).toBe(shownWording);
   expect(body.consent.purpose_id).toBeTruthy();
   expect(body.consent.policy_version).toBeTruthy();
-  await expect(
-    page.getByText("Gebucht."),
-  ).toBeVisible();
+  // Exact: this build transmits nothing, so the card confirms the slot and
+  // promises nothing beyond it. A substring is satisfied by a longer sentence
+  // that does promise something, which is the claim this copy had removed.
+  await expect(page.getByText("Gebucht.", { exact: true })).toBeVisible();
 });
 
 test("AC-book-public-409: a taken slot degrades honestly — no fabricated confirmation", async ({


### PR DESCRIPTION
## What

One assertion in `AC-book-public` matches the confirmation card exactly rather than by substring. One line, plus the comment saying why.

The rest of what this branch originally carried — the two stale German assertions — landed first in #4194 and is dropped here. This is what remains.

## Why

The confirmation card's whole line is the word, and a substring match also passes against any longer sentence beginning with it. Including the one this product removed: the sentence telling a visitor an invitation was on its way, which nothing sends.

That is precisely the regression this test sits in front of and cannot see. The copy could go back to promising a transmission and the lane would stay green — the same shape of gap as an assertion that can only pass, which this suite has been bitten by already. Exact matching makes the assertion about what the card says rather than what it starts with.

The negative assertion in `AC-book-public-409` deliberately stays a substring: there, anything claiming a booking should fail it, so broad matching is the stricter reading.

## How verified

Held both ways, against a build with the longer sentence restored in `de.ts`:

| | substring (as merged) | `exact: true` |
|---|---|---|
| shipped copy | passes | passes |
| longer sentence restored | **passes — regression invisible** | **fails — caught** |

- [x] Full e2e suite on a fresh `pnpm build` of this branch against shipped copy: **274 passed, 0 failed, 56 skipped**
- [x] `biome check` clean on the changed file
- [x] This change does not touch tenant data, RLS, or the write shape — it edits one assertion in one spec file
- [x] `make craft-static` reports no new blockers (it sweeps the Go trees; this diff is TypeScript)
- [x] No secrets, no customer data, no local machine paths, nothing quoted from or pointing at a private document

## AI involvement

Claude Code found the drift independently while resolving a merge, arrived at the same two fixes #4194 had already merged, and reduced this branch to the one difference between them. The mutation table above is the argument for keeping it; a reviewer who reads the substring as sufficient should say so and close this.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. Commits are signed off (`git commit -s`, DCO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nq3oEHxq6Po8YN7Ph4R8Jk