### PR TITLE
A write-back audits what happened, not what was asked

### DIFF
--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -15,6 +15,7 @@ package overlay
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"testing"
@@ -357,4 +358,132 @@ func TestProviderArchivePurgesMirror(t *testing.T) {
 	if _, err := ms.Get(ctx, "person", "555"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("mirror row after Archive: err = %v, want ErrNotFound (purged)", err)
 	}
+}
+
+// A patch naming only read-only fields writes nothing, and the trail says so.
+//
+// `full_name` is read-only in the HubSpot mapping — splitting a display string
+// into first/last is ambiguous and lossy — so the adapter sends no property and
+// re-reads the incumbent. The write-back audited the REQUESTED patch as the
+// after image, so history and the outbox both reported full_name moving on a
+// record nobody touched, behind a 200.
+func TestAReadOnlyPatchAuditsNoChange(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
+
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	stored := Record{
+		ObjectClass: "person", ExternalID: "556",
+		Fields:     map[string]any{"first_name": "Ada", "full_name": "Ada Lovelace"},
+		ModifiedAt: baseline, OwnerExternalID: writebackOwner,
+	}
+	if err := ms.Ingest(ctx, stored); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
+
+	// The incumbent answers with the record UNCHANGED, which is what a
+	// read-only patch produces: nothing was sent, so nothing moved.
+	inc := &writeBackIncumbent{updateRec: stored}
+	p := providerFor(ms, inc)
+
+	id, _ := externalIDToUUID("556")
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+	if _, err := p.Update(ctx, datasource.UpdateInput{
+		Ref: ref, Patch: map[string]any{"full_name": "Ada Byron"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if rows := auditRowsFor(ctx, t, pool, id); rows != 0 {
+		t.Errorf("a patch that wrote nothing left %d audit row(s); want none — "+
+			"an after image describing a write that did not happen is wrong", rows)
+	}
+	if events := outboxRowsFor(ctx, t, pool, id); events != 0 {
+		t.Errorf("a patch that wrote nothing emitted %d event(s); want none — "+
+			"an Updated event with nothing in it still announces an update", events)
+	}
+}
+
+// A patch naming a writable field AND a read-only one reports only the half
+// that landed. Auditing the whole patch here is the same defect as above, in
+// the shape that still returns a real change alongside it.
+func TestAMixedPatchAuditsOnlyWhatLanded(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	ms := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
+
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	if err := ms.Ingest(ctx, Record{
+		ObjectClass: "person", ExternalID: "557",
+		Fields:     map[string]any{"first_name": "Ada", "full_name": "Ada Lovelace"},
+		ModifiedAt: baseline, OwnerExternalID: writebackOwner,
+	}); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
+
+	// first_name moved; full_name is read-only there and came back as it was.
+	inc := &writeBackIncumbent{updateRec: Record{
+		ObjectClass: "person", ExternalID: "557",
+		Fields:     map[string]any{"first_name": "Grace", "full_name": "Ada Lovelace"},
+		ModifiedAt: baseline.Add(time.Hour), OwnerExternalID: writebackOwner,
+	}}
+	p := providerFor(ms, inc)
+
+	id, _ := externalIDToUUID("557")
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+	if _, err := p.Update(ctx, datasource.UpdateInput{Ref: ref, Patch: map[string]any{
+		"first_name": "Grace", "full_name": "Grace Hopper",
+	}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	after := auditAfterImage(ctx, t, pool, id)
+	if _, claimed := after["full_name"]; claimed {
+		t.Errorf("the audit after image claims full_name changed: %v — it is "+
+			"read-only in this mapping and came back as it was", after)
+	}
+	if after["first_name"] != "Grace" {
+		t.Errorf("the audit after image = %v, want first_name Grace — the half "+
+			"that DID land has to be recorded", after)
+	}
+}
+
+// auditRowsFor counts the person-update audit rows for one record.
+func auditRowsFor(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id ids.UUID) int {
+	t.Helper()
+	var count int
+	queryRowWS(ctx, t, pool, `
+		SELECT count(*) FROM audit_log
+		 WHERE entity_type = 'person' AND action = 'update' AND entity_id = $1`,
+		[]any{id}, &count)
+	return count
+}
+
+// outboxRowsFor counts the events staged for one record.
+func outboxRowsFor(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id ids.UUID) int {
+	t.Helper()
+	var count int
+	queryRowWS(ctx, t, pool, `
+		SELECT count(*) FROM event_outbox
+		 WHERE envelope->'payload'->>'id' = $1::text`,
+		[]any{id}, &count)
+	return count
+}
+
+// auditAfterImage reads the recorded after image of the one person update.
+func auditAfterImage(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id ids.UUID) map[string]any {
+	t.Helper()
+	var raw []byte
+	queryRowWS(ctx, t, pool, `
+		SELECT after FROM audit_log
+		 WHERE entity_type = 'person' AND action = 'update' AND entity_id = $1`,
+		[]any{id}, &raw)
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decoding the audit after image %s: %v", raw, err)
+	}
+	return out
 }

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -249,7 +249,7 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	// afterIncumbentCommit).
 	localCtx, cancel := afterIncumbentCommit(ctx)
 	defer cancel()
-	if err := p.commitUpdateWriteBack(localCtx, inc, res.Record, in.Ref, before, fields); err != nil {
+	if err := p.commitUpdateWriteBack(localCtx, inc, res.Record, in.Ref, before); err != nil {
 		return datasource.EntityRef{}, writePathError(err)
 	}
 	p.openWriteLedger(localCtx, res)

--- a/backend/internal/modules/overlay/writeaudit.go
+++ b/backend/internal/modules/overlay/writeaudit.go
@@ -234,8 +234,13 @@ func writePathError(err error) error {
 // read-path placeholder that always fails, and the disconnect fence is
 // engaged (WithFence) so a write landing after a Disconnect cannot
 // repopulate the purged mirror.
+// commitUpdateWriteBack ingests the incumbent's post-write record into the
+// mirror and audits what the write actually changed, in one transaction.
+//
+// It takes the BEFORE image and the returned record, not the patch: the patch
+// says what was asked for, and the record says what happened.
 func (p *Provider) commitUpdateWriteBack(ctx context.Context, inc Incumbent, rec Record,
-	ref datasource.EntityRef, before, after map[string]any,
+	ref datasource.EntityRef, before map[string]any,
 ) error {
 	if p.ms == nil {
 		return errNoMirrorStore()
@@ -247,7 +252,15 @@ func (p *Provider) commitUpdateWriteBack(ctx context.Context, inc Incumbent, rec
 		if landed, ingestErr = ms.ingestTx(ctx, tx, rec); ingestErr != nil {
 			return ingestErr
 		}
-		return auditWriteBack(ctx, tx, auditActionUpdate, ref, rec.ExternalID, before, after)
+		// Nothing moved: no audit row and no event. An Updated event with an
+		// empty changed_fields still announces an update, and a subscriber
+		// cannot tell it from one that changed something it does not read.
+		settledBefore, settledAfter := settledImages(before, rec)
+		if len(settledAfter) == 0 {
+			return nil
+		}
+		return auditWriteBack(ctx, tx, auditActionUpdate, ref, rec.ExternalID,
+			settledBefore, settledAfter)
 	})
 	if err == nil && landed {
 		mirrorSyncedTotal.Add(1)
@@ -336,4 +349,46 @@ func beforeImage(row Row, patch map[string]any) map[string]any {
 		before[k] = row.Fields[k]
 	}
 	return before
+}
+
+// settledImages narrow a write's before/after pair to the fields that ACTUALLY
+// MOVED, reading the after side off the record the incumbent returned rather
+// than off the patch that asked for it.
+//
+// The patch is a request, not an outcome. An incumbent writes only the fields
+// its mapping projects — the rest are read-only there and surfaced honestly
+// rather than guessed (mapwrite.go) — so a patch naming only read-only fields
+// wrote nothing, and one naming a mix wrote half. Auditing the request made
+// history and the outbox report a field moving that nobody moved, on a call
+// that answered 200.
+//
+// Equality is by rendered value, which is what the audit image and
+// changed_fields carry anyway: these are JSON-decoded canonical bags, so two
+// values that render identically are the same value to every reader of this
+// trail.
+func settledImages(before map[string]any, rec Record) (settledBefore, settledAfter map[string]any) {
+	settledBefore = make(map[string]any, len(before))
+	settledAfter = make(map[string]any, len(before))
+	for field, was := range before {
+		now := rec.Fields[field]
+		if sameFieldValue(was, now) {
+			continue
+		}
+		settledBefore[field] = was
+		settledAfter[field] = now
+	}
+	return settledBefore, settledAfter
+}
+
+// sameFieldValue compares two canonical field values as the audit trail renders
+// them. fmt over reflect.DeepEqual because the bags are JSON-decoded: a number
+// that arrived as float64 and one the mirror holds as json.Number are the same
+// value to a reader and different values to DeepEqual.
+//
+//craft:ignore naked-any these are the JSON-decoded canonical bags; the any is inherent to the decoded shape
+func sameFieldValue(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }

--- a/backend/internal/modules/overlay/writeaudit.go
+++ b/backend/internal/modules/overlay/writeaudit.go
@@ -28,6 +28,7 @@ package overlay
 // audit row rolled back.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -381,14 +382,32 @@ func settledImages(before map[string]any, rec Record) (settledBefore, settledAft
 }
 
 // sameFieldValue compares two canonical field values as the audit trail renders
-// them. fmt over reflect.DeepEqual because the bags are JSON-decoded: a number
-// that arrived as float64 and one the mirror holds as json.Number are the same
-// value to a reader and different values to DeepEqual.
+// them: by their JSON encoding.
+//
+// Not reflect.DeepEqual, and not fmt. DeepEqual reports a change that did not
+// happen — these bags are JSON-decoded from two different sources, so a number
+// the mirror holds as float64 and the same number arriving as json.Number are
+// one value in two representations. fmt has the opposite fault: "%v" renders
+// the string "1" and the number 1 identically, so a field that genuinely
+// changed TYPE would be dropped from the trail, which is the defect this
+// function exists to prevent, inverted.
+//
+// The encoding settles both: float64(1) and json.Number("1") both marshal to
+// `1`, while "1" marshals to `"1"`.
+//
+// A value that cannot be marshalled is treated as changed. Nothing in a
+// canonical bag should be unmarshalable, and if one ever is, recording the
+// field is the safe answer — an extra entry is noise, a missing one is silence.
 //
 //craft:ignore naked-any these are the JSON-decoded canonical bags; the any is inherent to the decoded shape
 func sameFieldValue(a, b any) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
-	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+	encodedA, errA := json.Marshal(a)
+	encodedB, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(encodedA, encodedB)
 }

--- a/backend/internal/modules/overlay/writeauditvalues_test.go
+++ b/backend/internal/modules/overlay/writeauditvalues_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// What counts as "this field moved".
+//
+// The two sides come from different places — the mirror row's decoded JSONB and
+// the adapter's mapping of the incumbent's answer — so the comparison has to
+// see through REPRESENTATION without seeing through TYPE. Getting either wrong
+// re-opens the defect this file's settledImages exists to close, in one
+// direction or the other.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOneValueInTwoRepresentationsIsNotAChange(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name string
+		a, b any
+	}{
+		{"float64 against json.Number", float64(1), json.Number("1")},
+		{"json.Number against float64", json.Number("42"), float64(42)},
+		{"two equal strings", "Ada", "Ada"},
+		{"both absent", nil, nil},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if !sameFieldValue(c.a, c.b) {
+				t.Errorf("%#v and %#v read as a change — the trail would report a "+
+					"field moving that nobody moved", c.a, c.b)
+			}
+		})
+	}
+}
+
+// The inverse, and the reason this is not fmt: "%v" renders the string "1" and
+// the number 1 identically, so a field that genuinely changed type would be
+// dropped from audit_log and from the update event — silently, which is the
+// worse half of the same defect.
+func TestAChangeOfTypeIsStillAChange(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name string
+		a, b any
+	}{
+		{"the string 1 against the number 1", "1", float64(1)},
+		{"the string 1 against json.Number 1", "1", json.Number("1")},
+		{"true against the string true", true, "true"},
+		{"a value against its absence", "Ada", nil},
+		{"an absence against a value", nil, "Ada"},
+		{"two different strings", "Ada", "Grace"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if sameFieldValue(c.a, c.b) {
+				t.Errorf("%#v and %#v read as unchanged — the field would be "+
+					"dropped from the trail", c.a, c.b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #4021 — the **audit half only**. The ticket stays open for the contract decision; see the bottom.

## The defect

The overlay update write-back passed the requested patch as the after image (`provider_writes.go`), and `writeaudit.go` emitted that as `changed_fields`.

An incumbent writes only the fields its mapping projects. The rest have no entry in `*WriteFields`, which is the deliberate "flag, don't invent" posture for fields with no simple 1:1 inverse — so a patch naming only read-only fields sends no property at all, the adapter re-reads the incumbent, and the caller gets a 200 with an unchanged record.

Meanwhile the trail said otherwise: **history and the outbox both reported a field moving that nobody moved.**

## The fix

The after image now comes off the record the incumbent returned, and before/after are narrowed to the fields that actually differ:

- **A patch that moved nothing** writes no audit row and emits no event. An `Updated` event with an empty `changed_fields` still announces an update, and a subscriber cannot tell it from one that changed a field it does not read. The mirror ingest still runs — the re-read record is real, and refreshing the mirror with it is correct.
- **A mixed patch** records only the half that landed.

Reading the after side off the returned record rather than off the patch also makes the fix general: it covers every overlay entity type at once, which is what the ticket asks for when it says *"the same shape applies to the other overlay entity types"* — without maintaining a second inventory of which fields each mapping happens to project. The mapping already decides that, and the returned record already reflects it.

`commitUpdateWriteBack` loses its `after` parameter, since the patch is no longer an input to the trail.

## Testing

- `TestAReadOnlyPatchAuditsNoChange` — a `full_name`-only patch (read-only in the HubSpot mapping: splitting a display string into first/last is ambiguous and lossy) leaves **no** audit row and **no** event.
- `TestAMixedPatchAuditsOnlyWhatLanded` — `first_name` + `full_name` records `first_name: Grace` and does not claim `full_name`.

Mutation-checked: restoring the request-as-after-image makes the first test find 1 audit row and the second print `map[first_name:Ada full_name:Ada Lovelace]` — the original defect, verbatim, including the giveaway that the "after" image holds the values from *before*.

`make check-backend` green; `craft static --strict` clean on the diff.

## What this deliberately leaves open

The ticket lists three options for the contract:

- refuse the patch (422) when it names only unwritable fields,
- return 200 but report which fields were dropped,
- state the read-only set per entity in the contract and leave the behaviour.

Those differ a lot in cost and are a product decision, so I have not made one inside a bug fix. The ticket's own framing is why this PR exists separately:

> The audit half is the part that looks like a defect rather than a limitation: an after-image describing a write that did not happen is wrong under any of the three.

I am labelling #4021 `status: needs-decision` for the remaining contract question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed update auditing to record only changes that are successfully applied.
  * Prevented audit entries and event notifications when updates affect only read-only fields.
  * Ensured mixed updates report only the writable fields that changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->