### PR TITLE
The evidence mark stops racing its own hover timer

### DIFF
--- a/frontend/src/design-system/evidencemark.test.tsx
+++ b/frontend/src/design-system/evidencemark.test.tsx
@@ -108,13 +108,22 @@ describe("evidence mark", () => {
         }}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /1998/ }));
+    const trigger = screen.getByRole("button", { name: /1998/ });
+    await userEvent.click(trigger);
     await userEvent.click(screen.getByText("Full history"));
+    // The pointer leaves, which is what a reader who has navigated away has
+    // done. Without it the hover-intent poll this click armed is still running
+    // on the real clock — a 25ms tick with a 260ms ceiling that settles
+    // whatever the pointer is doing — and it re-opens the panel a moment after
+    // the assertion below, or a moment before it on a loaded machine.
+    await userEvent.unhover(trigger);
 
     expect(opened).toBe(true);
     // The panel closes on the way out, so the reader does not return to a
     // stale popover hanging over the surface they navigated to.
-    expect(screen.queryByRole("region")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByRole("region")).toBeNull();
+    });
   });
 
   it("keeps one panel open at a time, whatever opened it", async () => {

--- a/frontend/src/design-system/hoverintent.ts
+++ b/frontend/src/design-system/hoverintent.ts
@@ -23,6 +23,27 @@ const SETTLE = 0.08;
 
 // A resting hand sends no move events at all, so silence has to BE the answer
 // rather than leaving the last speed standing.
+// ## Testing a component that uses this hook
+//
+// This hook reasons in REAL milliseconds — a 25ms poll, a floor, and a ceiling
+// that settles whatever the pointer is doing. A jsdom pointer reports no
+// movement, which reads as "resting", so a trigger that receives a pointer
+// event opens on its own within the ceiling whether the test asked for it or
+// not.
+//
+// A test that renders one of these and then asserts on what is on screen is
+// therefore racing that timer, and the race is decided by how loaded the
+// machine is: the case passes alone, passes on a quiet gate, and fails on a
+// parallel one — on a different file each run, which is what makes it
+// expensive to read (#4000).
+//
+// Two ways out, and a test needs one of them:
+//
+//   - own the clock, as hoverintent.test.tsx does (fake `performance` too, or
+//     the thresholds are measured against a clock that is still running); or
+//   - leave the trigger before asserting, which stops the poll through
+//     onPointerLeave the way a reader's pointer does.
+
 const STILL_AFTER_MS = 70;
 
 // The smoothing is weighted to history: one stuttered sample from a hand about


### PR DESCRIPTION
Refs #4000. **This does not close the ticket** — it fixes one confirmed instance and identifies the mechanism. See the bottom for what is left.

## The variable is not leaked state

Lars's bisect established that file parallelism is the variable. The hypothesis on the ticket was a module-level singleton captured at import and reused across files.

I checked, and that is not it. `useHoverIntent` does hold module-level state — `openCount`, `activeOwner`, `lastClosedAt`, `speed`, `sampled` — but `watchPointer`'s teardown resets every one of them when the last watcher unmounts (`hoverintent.ts:118-129`), and RTL unmounts between tests. Vitest also isolates modules per file by default, so nothing crosses a file boundary either.

## What it actually is

The hook reasons in **real milliseconds**: a 25ms poll, a 70ms floor, and a 260ms ceiling that calls `settle()` *whatever the pointer is doing*.

A jsdom pointer reports no movement, and `pointerSpeed()` reads silence as "the hand is resting" — which is correct for a real hand and is exactly wrong here. So any trigger that receives a pointer event arms a poll that opens it on its own, within 260ms, whether the test asked for it or not.

A test that then asserts on what is on screen is racing that timer, and which side wins is decided by how loaded the machine is. That is the whole shape the ticket describes: passes alone, passes on a quiet gate, fails on a parallel one, on a different file each run.

It also explains the *file list*. `useHoverIntent` has four callers — `tooltip.tsx`, `popover.tsx`, `evidencemark.tsx` and `navlevel.tsx` — and between tooltips, popovers and the nav, that reaches every file on the ticket: `App.test`, `shell`, `leads`, `project360`, `organizations`, `personreadings`, `company-act`, `onboarding-conversation`, `privacy.assignee`.

## Reproduction

The default gate reproduces roughly once in eight runs, which is why this took a session to see. Oversubscribing the workers makes it reliable enough to work with:

```
pnpm exec vitest run --maxWorkers=24 --sequence.shuffle
```

On an unchanged tree that failed on run 2 of 3, in `evidencemark.test.tsx`:

```
AssertionError: expected <section class="evmark-panel" …> to be null
```

The panel the test had just closed had been **re-opened** by the poll armed two lines earlier.

## The fix here

The pointer leaves before the assertion, which stops the poll through `onPointerLeave` — the same thing a reader's pointer does after clicking through to full history — and the assertion waits rather than reading a single tick.

Six consecutive oversubscribed shuffled runs green afterwards. Given the base rate was about one in eight, that is *consistent with* the instance being fixed rather than proof, and I would not read it as more.

## Two things I tried and backed out

**Requiring pointer evidence before settling.** Guarding the poll on `sampled` would kill the whole class at once — no pointer movement, no auto-open. It broke five tests, and reading them showed why it should: *"A hand that has settled sends no move events at all, so the silence itself is what says the pointer stopped."* Silence-as-signal is the deliberate design, not an oversight, and those tests encode it correctly. Reverted.

**Fake timers in `evidencemark.test.tsx`**, matching `hoverintent.test.tsx` next door. Every case then timed out at 10s: RTL's own `waitFor` does not advance under vitest's partial `toFake` list, and making that work is a bigger change than this fix.

## What is left, and why I am not doing it here

The mechanism is general and this PR fixes one site. Every suite that renders a tooltip, a popover or the nav and asserts across the poll window has the same exposure — that is most screen tests, and I have no way to tell the genuinely racy assertions from the stable ones by reading them.

The two systemic options differ a lot in cost, so they are worth choosing rather than defaulting into:

1. **Make hover-intent inert in jsdom unless a test opts in** — one change, in `vitest.setup.ts`, alongside the `matchMedia` and `ResizeObserver` stubs that already live there for the same reason. It needs a seam the hook does not currently have.
2. **Convert the affected suites to own the clock** — faithful, but it is 10+ files and it hits the RTL/`waitFor` problem above in each one.

I have written the obligation into `hoverintent.ts` beside the thresholds that cause it, so the next author who tests one of these components meets it before they lose an afternoon.

`make check-fe` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for full-history panel behavior by simulating pointer movement and waiting for hover-related state changes before asserting closure.

* **Documentation**
  * Added guidance for testing hover interactions, including timer behavior and strategies for avoiding timing-related test races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->