### PR TITLE
The merge attestation stops passing --slurp with --jq

### DIFF
--- a/.github/workflows/merge-attest.yml
+++ b/.github/workflows/merge-attest.yml
@@ -110,6 +110,13 @@ jobs:
             # as an array and .[].check_runs[] flattens them into the one list
             # the judge expects.
             #
+            # The filter runs in a SEPARATE jq rather than gh's --jq: gh
+            # refuses `--slurp` together with `--jq` ("the --slurp option is
+            # not supported with --jq or --template") and exits 1, which is
+            # what this step had been doing on every merge — writing no
+            # delimiter and taking the judge down with it. Piping keeps the
+            # slurped array and the filter exactly as they were.
+            #
             # A KNOWN CEILING remains and is GitHub's rather than ours: this
             # endpoint stops at the 1000 most recent check SUITES for a ref.
             # Reaching that would need a commit re-run into four figures, and
@@ -117,7 +124,7 @@ jobs:
             # more request budget on every push to cover a case nothing here
             # has approached. Named rather than silently inherited.
             gh api --paginate --slurp "repos/${{ github.repository }}/commits/${{ steps.pulls.outputs.head }}/check-runs?per_page=100&filter=all" \
-              --jq '{check_runs: [.[].check_runs[] | {name, status, conclusion, completed_at}]}'
+              | jq -c '{check_runs: [.[].check_runs[] | {name, status, conclusion, completed_at}]}'
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
       - name: Was there a verdict behind this merge?


### PR DESCRIPTION
**Fixing main.** No open PR touches `.github/workflows/merge-attest.yml`, so nobody else has this in flight. No ticket either — I found it while checking main's health for #3959.

## What is broken

`merge-attest` has failed on **every** merge to main. Recent runs: `d307e44b9`, `05ac8ff3b`, `4f04090b5`, `1c15c273f`, `294d7dfad`, `fac054a08` — all `failure`, `verdict` job.

```
the `--slurp` option is not supported with `--jq` or `--template`
##[error]Process completed with exit code 1.
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found 'EOF'
```

`gh` refuses `--slurp` together with `--jq` and exits 1. Because the call sits inside a `{ … } >>"$GITHUB_OUTPUT"` block that writes its own heredoc delimiter, the failure also took the delimiter with it — hence the second error, which is a consequence and not a separate fault.

## Why it matters more than a red badge

This is the workflow that records whether a merge had a green verdict behind it. Its own comments are explicit about why it exists:

> …have made that rule silently unenforceable.

It has been silently unenforced instead — the `verdict` job dies before it judges anything, and `report` is skipped, so nothing says so anywhere a person looks.

## The fix

The filter moves out of `gh --jq` into a separate `jq -c`. The slurped array and the filter expression are untouched, so the judge receives exactly the shape it received before.

## Testing

Reproduced and verified against the live API on main's tip, both forms:

```
$ gh api --paginate --slurp ".../check-runs?..." --jq '...'
the `--slurp` option is not supported with `--jq` or `--template`

$ gh api --paginate --slurp ".../check-runs?..." | jq -c '{check_runs: [...]}'
{"check_runs":[{"name":"report","status":"completed","conclusion":"skipped",...},
               {"name":"verdict","status":"completed","conclusion":"failure",...}]}
```

`scripts/test-check-merge-verdict.sh` — all cases hold, including "an unset lookup fails the alarm rather than accusing the merge", which is the one that would have caught an empty payload had the step failed *quietly* instead of taking the delimiter with it.

The real proof is this PR's own merge: the workflow runs on `push` to main, so `merge-attest` going green on the commit that lands this is the check that matters.
