### PR TITLE
An approval pins every row its meaning rests on

### DIFF
--- a/backend/gates/piicolumncoverage_test.go
+++ b/backend/gates/piicolumncoverage_test.go
@@ -112,7 +112,12 @@ var erasureColumnBaseline = map[string][]string{
 		"effect_failure",
 		"kind",
 		"proposed_by",
+		// Both are a TABLE NAME — "tag", "deal" — naming which kind of row the
+		// approval pins, never anything a subject wrote or anything written
+		// about them. The ids and versions beside them are not text and are
+		// outside this gate's subject.
 		"target_entity_type",
+		"co_target_entity_type",
 	},
 	"comms_outbound": {
 		// The controller lane's vocabulary: which kind of sender, and which

--- a/backend/internal/compose/approvalsadapter.go
+++ b/backend/internal/compose/approvalsadapter.go
@@ -32,6 +32,8 @@ func (a approvalsAdapter) StageCall(ctx context.Context, in agents.StageRequest)
 		DiffHash:       in.DiffHash,
 		TargetType:     in.TargetType,
 		TargetID:       in.TargetID,
+		CoTargetType:   in.CoTargetType,
+		CoTargetID:     in.CoTargetID,
 		Summary:        in.Summary,
 	})
 }

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -62,7 +62,12 @@ type StageRequest struct {
 	TargetType     string
 	TargetID       ids.UUID
 	TargetVersion  *int64
-	Summary        string
+	// CoTarget* name a SECOND row the staged call's meaning rests on. The
+	// approvals engine pins it the way it pins the primary target, and
+	// redemption refuses if it has moved. Zero for a call that rests on one row.
+	CoTargetType string
+	CoTargetID   ids.UUID
+	Summary      string
 }
 
 // StageInfo is what a 🟡-capable tool contributes to its own staging: the
@@ -80,7 +85,14 @@ type StageInfo struct {
 	TargetType    string
 	TargetID      ids.UUID
 	TargetVersion *int64
-	Summary       string
+	// CoTarget* name the SECOND row this call's meaning rests on, where it has
+	// one. A tag merge is the case: it retires one word into another and the
+	// card names both, so both have to still be what they were when the human
+	// read it. Unlike TargetVersion above, these DO reach the staged row — the
+	// engine resolves the version from them inside the staging transaction.
+	CoTargetType string
+	CoTargetID   ids.UUID
+	Summary      string
 }
 
 // stageableTool is implemented by tools whose refused 🟡 calls should

--- a/backend/internal/modules/agents/commandtagvocab.go
+++ b/backend/internal/modules/agents/commandtagvocab.go
@@ -40,9 +40,15 @@ func NewMergeTagsCall(tags Tags, cmd MergeTagsCommand) GovernedCall {
 
 type mergeTagsResolver struct{ tags Tags }
 
-// Subject names the SOURCE tag, which is the row the merge destroys: the
-// target survives the act unchanged in every column, so an approval bound to
-// it would pin a version nothing is about to move.
+// Subject names the SOURCE tag as the target — the row the merge destroys —
+// and the SURVIVOR as the co-target.
+//
+// Both are pinned, because both are the decision. The survivor comes through
+// the act unchanged in every column, which is why it looked like it needed no
+// pin; the pin is not there to catch what the merge writes, it is there to
+// catch what somebody ELSE writes while the card waits. A survivor renamed
+// between the staging and the release turns "fold A into B" into "fold A into
+// whatever B is called now", and the human approved the first sentence.
 //
 // The summary spells BOTH words, because the two tags are the whole of the
 // decision and the inbox shows nothing else about them. A human releasing
@@ -65,8 +71,10 @@ func (r *mergeTagsResolver) Subject(ctx context.Context, cmd MergeTagsCommand) (
 		return StageInfo{}, err
 	}
 	return StageInfo{
-		TargetType: tagRecordType,
-		TargetID:   cmd.SourceID,
+		TargetType:   tagRecordType,
+		TargetID:     cmd.SourceID,
+		CoTargetType: tagRecordType,
+		CoTargetID:   cmd.TargetID,
 		Summary: fmt.Sprintf("Fold tag %q into %q, releasing the name %q",
 			source.Name, target.Name, source.Name),
 	}, nil

--- a/backend/internal/modules/agents/commandtagvocabsubject_test.go
+++ b/backend/internal/modules/agents/commandtagvocabsubject_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What a merge staging binds itself to.
+//
+// The approvals engine pins whatever a subject declares; this is the half that
+// says merge_tags declares BOTH words. Without it the engine's own cases pass
+// over a stager that names only the retired one — which is the state the defect
+// was in.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAMergeStagingPinsBothWords(t *testing.T) {
+	t.Parallel()
+	source, survivor := ids.NewV7(), ids.NewV7()
+	r := &mergeTagsResolver{tags: stubTags{names: map[ids.UUID]string{
+		source: "SkewSource", survivor: "SkewTarget",
+	}}}
+
+	got, err := r.Subject(context.Background(), MergeTagsCommand{
+		SourceID: source, TargetID: survivor,
+	})
+	if err != nil {
+		t.Fatalf("Subject: %v", err)
+	}
+
+	// The retired word is the target: it is the row the merge destroys.
+	if got.TargetID != source || got.TargetType != tagRecordType {
+		t.Errorf("target = %s/%s, want the retired word", got.TargetType, got.TargetID)
+	}
+	// And the survivor is the co-target, so a rename between the card and the
+	// release is refused rather than silently folded into.
+	if got.CoTargetID != survivor || got.CoTargetType != tagRecordType {
+		t.Errorf("co-target = %s/%s, want the surviving word — the human approved "+
+			"folding into a NAME, and nothing else pins it", got.CoTargetType, got.CoTargetID)
+	}
+}

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -343,6 +343,8 @@ func (r *Registry) stageRefusedCall(ctx context.Context, t mcp.Tool, tool string
 		TargetType:     info.TargetType,
 		TargetID:       info.TargetID,
 		TargetVersion:  info.TargetVersion,
+		CoTargetType:   info.CoTargetType,
+		CoTargetID:     info.CoTargetID,
 		Summary:        info.Summary,
 	})
 	if err != nil {

--- a/backend/internal/modules/approvals/cotargetpin_integration_test.go
+++ b/backend/internal/modules/approvals/cotargetpin_integration_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// The SECOND row an approval's meaning can rest on.
+//
+// A tag merge retires one word into another, and the card a human reads names
+// both. The retired side has been pinned since pins existed; the survivor was
+// pinned by nothing, so it could be renamed while the card was pending and the
+// merge still ran as though it had not been. The human approved folding into
+// one word; it folded into whatever that row was called by then.
+//
+// Both directions run here, and the second is not ceremony: a check that
+// refuses every redemption passes the first half perfectly.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedTag mints one word. The name carries part of the id because uq_tag_name
+// is unique on lower(name) across the whole database, and these cases share
+// one — two of them seeding "SkewSource" collide on the second, which says
+// nothing about pins.
+//
+// The TAIL of the id, not the head: a uuidv7 opens with its timestamp, so two
+// minted in the same millisecond agree on their first eight characters and the
+// suffix distinguishes nothing.
+func (e *stagingEnv) seedTag(t *testing.T, name string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO tag (id, name) VALUES ($1, $2)`,
+		id, name+"-"+id.String()[24:]); err != nil {
+		t.Fatalf("seeding tag %q: %v", name, err)
+	}
+	return id
+}
+
+// mergeCall is the staging merge_tags makes: the retired word is the target,
+// the surviving word is the co-target.
+func (e *stagingEnv) mergeCall(source, survivor ids.UUID) StageInput {
+	return StageInput{
+		Kind:           "merge_tags",
+		ProposedChange: []byte(`{"tag_id":"` + source.String() + `","into_tag_id":"` + survivor.String() + `"}`),
+		DiffHash:       "b91a2f0c4d6e8a13-one-merge",
+		TargetType:     "tag",
+		TargetID:       source,
+		CoTargetType:   "tag",
+		CoTargetID:     survivor,
+		Summary:        `Fold tag "SkewSource" into "SkewTarget", releasing the name "SkewSource"`,
+	}
+}
+
+// The reported reproduction, end to end: rename the SURVIVOR while the card is
+// pending and the redemption must refuse.
+func TestRenamingTheWordAMergeFoldsIntoRefusesTheRedemption(t *testing.T) {
+	e := setupStaging(t)
+	passport := e.seedPassport(t)
+	source := e.seedTag(t, "SkewSource")
+	survivor := e.seedTag(t, "SkewTarget")
+
+	in := e.mergeCall(source, survivor)
+	id, err := e.svc.Stage(e.asPassport(passport), in)
+	if err != nil {
+		t.Fatalf("staging the merge: %v", err)
+	}
+	e.approve(t, id)
+
+	// The human has approved "fold SkewSource into SkewTarget". Somebody now
+	// renames the survivor — HTTP 200, nothing refuses it, and the card still
+	// reads the old sentence.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE tag SET name = 'CompletelyDifferentWord', version = version + 1 WHERE id = $1`,
+		survivor); err != nil {
+		t.Fatalf("renaming the survivor: %v", err)
+	}
+
+	_, _, err = e.svc.Redeem(e.asPassport(passport), id, in.Kind, in.DiffHash)
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("redeeming after the survivor was renamed = %v, want version skew — "+
+			"the human approved folding into one word and this would fold into another", err)
+	}
+}
+
+// The mirror: an untouched survivor redeems. Without this the case above is
+// satisfied by a check that refuses everything.
+func TestAMergeWhoseBothWordsHeldStillRedeems(t *testing.T) {
+	e := setupStaging(t)
+	passport := e.seedPassport(t)
+	source := e.seedTag(t, "SkewSource")
+	survivor := e.seedTag(t, "SkewTarget")
+
+	in := e.mergeCall(source, survivor)
+	id, err := e.svc.Stage(e.asPassport(passport), in)
+	if err != nil {
+		t.Fatalf("staging the merge: %v", err)
+	}
+	e.approve(t, id)
+
+	if _, _, err := e.svc.Redeem(e.asPassport(passport), id, in.Kind, in.DiffHash); err != nil {
+		t.Fatalf("redeeming a merge whose two words both held: %v", err)
+	}
+}
+
+// A co-target of a type that carries no version column cannot be pinned, and
+// minting a pin redemption could never verify is worse than refusing to stage.
+func TestACoTargetThatCannotBePinnedIsRefusedAtStaging(t *testing.T) {
+	e := setupStaging(t)
+	passport := e.seedPassport(t)
+	source := e.seedTag(t, "SkewSource")
+
+	in := e.mergeCall(source, ids.NewV7())
+	in.CoTargetType = "workspace"
+
+	if _, err := e.svc.Stage(e.asPassport(passport), in); !errors.Is(err, apperrors.ErrInvalidArgument) {
+		t.Fatalf("staging a co-target with no version to read = %v, want invalid argument", err)
+	}
+}

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -37,6 +37,11 @@ type row struct {
 	TargetType    *string
 	TargetID      *ids.UUID
 	TargetVersion *int64
+	// CoTarget* is the SECOND row a proposal's meaning can rest on, pinned the
+	// same way. All three are set together or none is; the schema holds it.
+	CoTargetType    *string
+	CoTargetID      *ids.UUID
+	CoTargetVersion *int64
 	// TargetLabel is what the target was CALLED when the proposal was staged.
 	// Nil where the type has no name, or where the row had gone by then — the
 	// card says nothing rather than saying unknown.
@@ -63,14 +68,16 @@ type row struct {
 }
 
 const columns = `id, kind, status, proposed_by, on_behalf_of, passport_id,
-	target_entity_type, target_entity_id, target_version, target_label, summary,
+	target_entity_type, target_entity_id, target_version,
+	co_target_entity_type, co_target_entity_id, co_target_version, target_label, summary,
 	proposed_change, diff_hash, expires_at, decided_by, decided_at, consumed_at, created_at,
 	bundle_id, evidence, effect_failed_at, effect_failure`
 
 func scan(r pgx.Row) (row, error) {
 	var a row
 	err := r.Scan(&a.ID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
-		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.TargetLabel, &a.Summary,
+		&a.TargetType, &a.TargetID, &a.TargetVersion,
+		&a.CoTargetType, &a.CoTargetID, &a.CoTargetVersion, &a.TargetLabel, &a.Summary,
 		&a.ProposedChange, &a.DiffHash, &a.ExpiresAt, &a.DecidedBy, &a.DecidedAt, &a.ConsumedAt, &a.CreatedAt,
 		&a.BundleID, &a.Evidence, &a.EffectFailedAt, &a.EffectFailure)
 	return a, err

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -140,16 +140,33 @@ func validateRedemption(a row, p principal.Principal, tool, diffHash string, now
 }
 
 func validateRedemptionTarget(ctx context.Context, tx pgx.Tx, a row) error {
-	if a.TargetVersion == nil || a.TargetID == nil || a.TargetType == nil {
+	if err := checkPin(ctx, tx, a.TargetType, a.TargetID, a.TargetVersion, "target"); err != nil {
+		return err
+	}
+	// The SECOND row, where the proposal declared one. A tag merge names two
+	// words and the human judged both, so both have to still be what they were
+	// — the retired side has always been checked here, and the survivor being
+	// exempt is what let a rename slip between the card and the merge.
+	return checkPin(ctx, tx, a.CoTargetType, a.CoTargetID, a.CoTargetVersion, "co-target")
+}
+
+// checkPin re-reads one pinned row and refuses if it has moved since the
+// approval was staged. A pin that is not set short-circuits, which is every
+// approval that rests on a single row.
+func checkPin(
+	ctx context.Context, tx pgx.Tx,
+	entityType *string, id *ids.UUID, pinned *int64, which string,
+) error {
+	if pinned == nil || id == nil || entityType == nil {
 		return nil
 	}
-	current, err := targetVersion(ctx, tx, *a.TargetType, *a.TargetID)
+	current, err := targetVersion(ctx, tx, *entityType, *id)
 	if err != nil {
 		return err
 	}
-	if current != *a.TargetVersion {
-		return fmt.Errorf("target changed since approval (v%d → v%d): %w",
-			*a.TargetVersion, current, apperrors.ErrVersionSkew)
+	if current != *pinned {
+		return fmt.Errorf("%s changed since approval (v%d → v%d): %w",
+			which, *pinned, current, apperrors.ErrVersionSkew)
 	}
 	return nil
 }

--- a/backend/internal/modules/approvals/stageagentcall_integration_test.go
+++ b/backend/internal/modules/approvals/stageagentcall_integration_test.go
@@ -91,6 +91,10 @@ func (e *stagingEnv) approve(t *testing.T, id ids.ApprovalID) {
 			Objects: map[string]principal.ObjectGrant{
 				"organization": {Create: true, Read: true, Update: true, Delete: true},
 				"approval":     {Create: true, Read: true, Update: true, Delete: true},
+				// A merge staging targets tags, and a decider who cannot see
+				// the target is answered not-found — existence-hiding working
+				// correctly, and not what any case here is about.
+				"tag": {Create: true, Read: true, Update: true, Delete: true},
 			},
 		},
 	})

--- a/backend/internal/modules/approvals/stageinput.go
+++ b/backend/internal/modules/approvals/stageinput.go
@@ -30,7 +30,20 @@ type StageInput struct {
 	TargetType    string
 	TargetID      ids.UUID
 	TargetVersion *int64
-	Summary       string
+	// CoTargetType + CoTargetID name a SECOND row this proposal's meaning
+	// rests on, pinned the same way the primary target is.
+	//
+	// A tag merge is the case: it retires one word and folds it into another,
+	// and the card a human reads names both. Pinning only the retired side let
+	// the survivor be renamed while the card was pending, so the human
+	// approved folding into one word and the merge folded into another.
+	//
+	// Zero for the ordinary operation, which rests on one row. The version is
+	// resolved server-side at staging, never taken from the caller — a version
+	// the gate never read is a version nothing proved.
+	CoTargetType string
+	CoTargetID   ids.UUID
+	Summary      string
 	// JoinPending collapses an identical live proposal under an atomic
 	// transaction lock. It is for at-least-once worker paths whose retries
 	// must return the existing approval instead of multiplying inbox rows.

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -313,45 +313,6 @@ func lockPendingUnderIdentity(ctx context.Context, tx pgx.Tx, in StageInput, sur
 	return superseded, nil
 }
 
-// resolveTargetVersion reads the staged target's CURRENT version inside the
-// staging transaction, so what a human approves is bound to the row as it
-// stood when they were asked.
-//
-// The pin is taken here, at the ONE place every stager passes through, and
-// never from what the caller supplied. A caller-supplied pin is a pin the
-// caller can decline to supply: on the REST admission path it came from the
-// optional If-Match header, so an agent that simply left the header off
-// staged target_version NULL, and validateRedemptionTarget short-circuits on
-// NULL — the approval then authorized the operation against whatever the row
-// had drifted to inside the TTL, which for a body-less action route (send
-// this offer) is any content state at all. Automation-staged actions carried
-// no pin for the same reason: nothing had computed one.
-//
-// A target type outside versionTables has no version column to read, so it
-// stays unpinned and the diff_hash identical-call binding is what holds. That
-// residue is bounded and declared: TestConfirmFirstTargetsArePinnable holds
-// the confirm-first surface to a ratified list of them.
-// pinned is false for a target with no version column to read, and for a
-// create, which has no prior row to bind to.
-func resolveTargetVersion(ctx context.Context, tx pgx.Tx, in StageInput) (version int64, pinned bool, err error) {
-	if in.TargetID.IsZero() || !TargetVersionCheckable(in.TargetType) {
-		return 0, false, nil
-	}
-	// Two declared waivers, both meaning "this kind stages with no pin", and
-	// each says a different thing about why: the target is context rather than
-	// operand (contextTargetKinds), or it is the operand and the pin still binds
-	// nothing the human judged (unpinnedKinds). Both are read here because this
-	// is the one place a pin is taken.
-	if TargetIsContextOnly(in.Kind) || TargetVersionUnpinned(in.Kind) {
-		return 0, false, nil
-	}
-	current, err := targetVersion(ctx, tx, in.TargetType, in.TargetID)
-	if err != nil {
-		return 0, false, err
-	}
-	return current, true, nil
-}
-
 // StageInTx records a proposal through a caller-owned transaction. Compose
 // uses it when another module's state transition creates the target the
 // proposal refers to, so the target and its separately governed follow-up
@@ -392,6 +353,14 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	if pinned {
 		in.TargetVersion = &current
 	}
+	coVersion, coPinned, err := resolveCoTargetVersion(ctx, tx, in)
+	if err != nil {
+		return ids.ApprovalID{}, err
+	}
+	var coTargetVersion *int64
+	if coPinned {
+		coTargetVersion = &coVersion
+	}
 	id := ids.New[ids.ApprovalKind]()
 	evidence, err := marshalEvidence(in.Evidence)
 	if err != nil {
@@ -412,12 +381,15 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	if err := tx.QueryRow(ctx,
 		`INSERT INTO approval (id, kind, proposed_by, on_behalf_of, passport_id,
 			                       target_entity_type, target_entity_id, target_version,
+			                       co_target_entity_type, co_target_entity_id, co_target_version,
 			                       target_label, summary, proposed_change, diff_hash, expires_at,
 			                       bundle_id, evidence)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, now() + $13::interval, $14, $15)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+			         now() + $16::interval, $17, $18)
 			 RETURNING expires_at`,
 		id, in.Kind, p.ID, nullUUID(p.OnBehalfOf), nullUUID(p.PassportID),
 		nullStr(in.TargetType), nullUUID(in.TargetID), in.TargetVersion,
+		nullStr(in.CoTargetType), nullUUID(in.CoTargetID), coTargetVersion,
 		targetLabel(ctx, tx, in.TargetType, in.TargetID),
 		nullStr(in.Summary), in.ProposedChange, in.DiffHash, ttlFor(in.Kind, in.TTL).String(),
 		nullUUID(in.BundleID), evidence).Scan(&expiresAt); err != nil {

--- a/backend/internal/modules/approvals/stagingpins.go
+++ b/backend/internal/modules/approvals/stagingpins.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// Which rows a staging binds itself to.
+//
+// A pin is what stops a confirmed act running over a record that changed after
+// the human read the card. Taking one is a decision with two halves — WHICH
+// rows the proposal's meaning rests on, and whether each can be re-checked at
+// redemption — and both are answered here so a stager cannot answer either by
+// omission.
+//
+// The re-check that consumes these lives in redeem.go, and the two have to be
+// read together: a pin taken here that redemption cannot verify is a pin in
+// name only.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// resolveTargetVersion reads the staged target's CURRENT version inside the
+// staging transaction, so what a human approves is bound to the row as it
+// stood when they were asked.
+//
+// The pin is taken here, at the ONE place every stager passes through, and
+// never from what the caller supplied. A caller-supplied pin is a pin the
+// caller can decline to supply: on the REST admission path it came from the
+// optional If-Match header, so an agent that simply left the header off
+// staged target_version NULL, and validateRedemptionTarget short-circuits on
+// NULL — the approval then authorized the operation against whatever the row
+// had drifted to inside the TTL, which for a body-less action route (send
+// this offer) is any content state at all. Automation-staged actions carried
+// no pin for the same reason: nothing had computed one.
+//
+// A target type outside versionTables has no version column to read, so it
+// stays unpinned and the diff_hash identical-call binding is what holds. That
+// residue is bounded and declared: TestConfirmFirstTargetsArePinnable holds
+// the confirm-first surface to a ratified list of them.
+// pinned is false for a target with no version column to read, and for a
+// create, which has no prior row to bind to.
+func resolveTargetVersion(ctx context.Context, tx pgx.Tx, in StageInput) (version int64, pinned bool, err error) {
+	if in.TargetID.IsZero() || !TargetVersionCheckable(in.TargetType) {
+		return 0, false, nil
+	}
+	// Two declared waivers, both meaning "this kind stages with no pin", and
+	// each says a different thing about why: the target is context rather than
+	// operand (contextTargetKinds), or it is the operand and the pin still binds
+	// nothing the human judged (unpinnedKinds). Both are read here because this
+	// is the one place a pin is taken.
+	if TargetIsContextOnly(in.Kind) || TargetVersionUnpinned(in.Kind) {
+		return 0, false, nil
+	}
+	current, err := targetVersion(ctx, tx, in.TargetType, in.TargetID)
+	if err != nil {
+		return 0, false, err
+	}
+	return current, true, nil
+}
+
+// resolveCoTargetVersion pins the SECOND row a proposal rests on.
+//
+// Same rule as the primary pin and deliberately not the same waivers: the
+// kind-level exemptions above say something about the row a staging TARGETS —
+// that it is context rather than operand, or that its version binds nothing a
+// human judged. A co-target exists only where a caller declared that this
+// proposal's meaning rests on that row too, so the declaration IS the claim
+// that it should be pinned. What still applies is the table check: a type with
+// no version column to read cannot be pinned by anyone, and minting a pin
+// redemption could never verify is worse than not pinning.
+func resolveCoTargetVersion(ctx context.Context, tx pgx.Tx, in StageInput) (version int64, pinned bool, err error) {
+	if in.CoTargetID.IsZero() || in.CoTargetType == "" {
+		return 0, false, nil
+	}
+	if !TargetVersionCheckable(in.CoTargetType) {
+		return 0, false, fmt.Errorf(
+			"approvals: %q cannot carry a version pin, so it cannot be a co-target: %w",
+			in.CoTargetType, apperrors.ErrInvalidArgument)
+	}
+	current, err := targetVersion(ctx, tx, in.CoTargetType, in.CoTargetID)
+	if err != nil {
+		return 0, false, err
+	}
+	return current, true, nil
+}

--- a/backend/migrations/core/1788553737_an_approval_pins_every_row_its_meaning_rests_on.down.sql
+++ b/backend/migrations/core/1788553737_an_approval_pins_every_row_its_meaning_rests_on.down.sql
@@ -1,0 +1,11 @@
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock on a table every
+-- staged approval is written to: an open transaction holding a conflicting
+-- lock would otherwise stall every write to it for as long as this migration
+-- is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval DROP CONSTRAINT approval_co_target_whole;
+ALTER TABLE approval
+  DROP COLUMN co_target_version,
+  DROP COLUMN co_target_entity_id,
+  DROP COLUMN co_target_entity_type;

--- a/backend/migrations/core/1788553737_an_approval_pins_every_row_its_meaning_rests_on.up.sql
+++ b/backend/migrations/core/1788553737_an_approval_pins_every_row_its_meaning_rests_on.up.sql
@@ -1,0 +1,36 @@
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock on a table every
+-- staged approval is written to: an open transaction holding a conflicting
+-- lock would otherwise stall every write to it for as long as this migration
+-- is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+-- A tag merge is a TWO-row operation with a ONE-row precondition.
+--
+-- approval pins target_entity_*, which for a merge is the word being retired.
+-- The word it folds INTO is named in the card a human reads and pinned by
+-- nothing, so it can be renamed while the card is pending and the merge still
+-- runs as though it had not been. A human approves folding into "SkewTarget";
+-- it folds into whatever that row is called by the time the agent retries.
+--
+-- The retired side has been protected all along, which is what made the
+-- asymmetry easy to miss.
+--
+-- Nullable, and NULL for every approval that pins one row: an operation whose
+-- meaning rests on a single record is the ordinary case and stays exactly as
+-- it was. The re-check at redemption short-circuits on NULL the same way the
+-- primary pin already does.
+ALTER TABLE approval
+  ADD COLUMN co_target_entity_type text,
+  ADD COLUMN co_target_entity_id uuid,
+  ADD COLUMN co_target_version bigint;
+
+-- All three or none. A type and an id with no version is a pin that cannot be
+-- re-checked, and a version with nothing to read it from is worse — the
+-- redemption would either skip the check or look up a row it cannot name, and
+-- both read as "this was verified" to anyone auditing the trail.
+ALTER TABLE approval
+  ADD CONSTRAINT approval_co_target_whole CHECK (
+    (co_target_entity_type IS NULL AND co_target_entity_id IS NULL AND co_target_version IS NULL)
+    OR
+    (co_target_entity_type IS NOT NULL AND co_target_entity_id IS NOT NULL AND co_target_version IS NOT NULL)
+  );

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -665,6 +665,7 @@ public.app_user.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.app_user.weekly_delivery text gen=- def=-
 public.app_user_pkey CREATE UNIQUE INDEX app_user_pkey ON public.app_user USING btree (id)
 public.approval acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.approval.approval_co_target_whole CHECK ((((co_target_entity_type IS NULL) AND (co_target_entity_id IS NULL) AND (co_target_version IS NULL)) OR ((co_target_entity_type IS NOT NULL) AND (co_target_entity_id IS NOT NULL) AND (co_target_version IS NOT NULL))))
 public.approval.approval_decided CHECK ((((status = 'pending'::text) AND (decided_at IS NULL)) OR (status = 'expired'::text) OR ((status = ANY (ARRAY['approved'::text, 'rejected'::text])) AND (decided_at IS NOT NULL))))
 public.approval.approval_decided_by_fkey FOREIGN KEY (decided_by) REFERENCES app_user(id) ON DELETE SET NULL (decided_by)
 public.approval.approval_effect_failure_is_stated CHECK (((effect_failed_at IS NULL) = (effect_failure IS NULL))) NOT VALID
@@ -673,6 +674,9 @@ public.approval.approval_passport_id_fkey FOREIGN KEY (passport_id) REFERENCES p
 public.approval.approval_pkey PRIMARY KEY (id)
 public.approval.approval_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'approved'::text, 'rejected'::text, 'expired'::text])))
 public.approval.bundle_id uuid gen=- def=-
+public.approval.co_target_entity_id uuid gen=- def=-
+public.approval.co_target_entity_type text gen=- def=-
+public.approval.co_target_version bigint gen=- def=-
 public.approval.consumed_at timestamp with time zone gen=- def=-
 public.approval.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.approval.decided_at timestamp with time zone gen=- def=-


### PR DESCRIPTION
Closes #3876 — the agent half. #4047 closed the REST one.

## The defect, as reported

`POST /v1/tags/{id}/merge` is a two-row operation with a one-row precondition. The approval pins `target_entity_*`, which for a merge is the word being **retired**. The word it folds **into** is named in the card a human reads and pinned by nothing.

The reproduction on the ticket runs exactly as written: stage the merge, rename the survivor while the card is pending (HTTP 200, nothing refuses it), approve, retry. The human approved *"Fold SkewSource into SkewTarget"*. It folded into `CompletelyDifferentWord`.

The retired side has been protected all along — which is what made the asymmetry easy to miss.

## Why the survivor looked like it needed no pin

The stager said so, and it was half right:

> the target survives the act unchanged in every column, so an approval bound to it would pin a version nothing is about to move

True, and beside the point. The pin is not there to catch what the merge writes. It is there to catch what **somebody else** writes while the card waits.

## The shape

An approval can now carry a **second** pin — `co_target_entity_type` / `co_target_entity_id` / `co_target_version`:

- resolved **server-side** inside the staging transaction, like the first. A version the gate never read is a version nothing proved, and the file already says so about the primary pin;
- re-checked at redemption by the same code path, so the survivor gets exactly the protection the retired word has had. `validateRedemptionTarget` now calls one `checkPin` per pin rather than carrying two copies of the compare;
- nullable, and NULL for every approval that rests on a single row. A database CHECK holds all-three-or-none: a type and an id with no version is a pin nothing can verify that reads like one in the audit trail.

`merge_tags` declares the survivor as its co-target — its `Subject` already read both tags to spell the card's sentence and threw the second one away.

A co-target whose type carries no version column is **refused at staging**. Minting a pin redemption could never check is worse than not pinning: the same reasoning `versionTables` already applies to the primary target.

## What I deliberately did not do

The two alternatives from my earlier note on the ticket, so they do not get re-proposed:

- **Swap the pin to the survivor** — closes the reported case and opens its mirror. The ticket is right that the source is the correct primary target, being the row destroyed.
- **Re-read the survivor's name at redemption and compare it to the card's text** — parsing a summary sentence to recover a precondition is worse than the gap.

I also did not extend `Redeem`'s return with the co-target version. It is not needed: the redemption-time re-check is what protects the source today, and mirroring it gives the survivor the same guarantee without changing a signature every caller uses.

## Testing

`cotargetpin_integration_test.go` runs the reported reproduction end to end against real Postgres — stage, approve, rename the survivor, redeem → version skew. Plus the mirror (both words untouched still redeems, so a check that refuses everything cannot pass), and the unpinnable-type refusal.

`TestAMergeStagingPinsBothWords` holds the stager to declaring the survivor. That test exists because the first mutation check found the gap: with the engine's own cases passing, removing the co-target from `merge_tags` changed nothing — the mechanism worked and nothing said the merge used it.

Mutation-checked both halves:
- redemption stops checking the co-target → the reproduction test fails, the mirror still passes;
- the stager stops declaring it → the subject test fails naming the zero id.

`make check-backend` green, `make test-it DIR=backend/migrations` green, `craft static --strict` clean on the diff. `head_catalog.txt` regenerated in the same commit.

Two gates caught things worth having and both are in the diff: the lock-timeout gate (the migration takes ACCESS EXCLUSIVE on a table every staging writes to, so it bounds its wait) and the Art. 17 redaction census (`co_target_entity_type` is a table name and is accounted for in the baseline rather than left to look unhandled).
