### PR TITLE
The reader is told what arrived behind them, and refreshing brings it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7989,6 +7989,12 @@ export const de = {
   "worklist.board.title": "Wie es meinem Team geht",
   "worklist.exceptions.title": "Was mich braucht",
   "worklist.handled.title": "Für Sie erledigt",
+  "worklist.walk.arrived":
+    "{arrived} weitere seit Ihrem Start. Sie warten auf eine Aktualisierung, damit diese Liste ruhig bleibt.",
+  "worklist.walk.gone": "{gone} davon wurden seit Ihrem Start erledigt.",
+  "worklist.walk.both":
+    "{arrived} weitere seit Ihrem Start, und {gone} bereits erledigt.",
+  "worklist.walk.refresh": "Aktualisieren",
   "worklist.handled.empty": "Heute wurde nichts für Sie erledigt.",
   "worklist.handled.loading": "Erledigtes wird gelesen",
   "worklist.handled.what": "Was geschehen ist",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8082,6 +8082,13 @@ export const en = {
   "worklist.board.title": "How my team is doing",
   "worklist.exceptions.title": "What needs me",
   "worklist.handled.title": "Handled for you",
+  "worklist.walk.arrived":
+    "{arrived} more since you started. They wait for a refresh so this list holds still.",
+  "worklist.walk.gone":
+    "{gone} of these have been dealt with since you started.",
+  "worklist.walk.both":
+    "{arrived} more since you started, and {gone} already dealt with.",
+  "worklist.walk.refresh": "Refresh",
   "worklist.handled.empty": "Nothing was done on your behalf today.",
   "worklist.handled.loading": "Reading what was done",
   "worklist.handled.what": "What happened",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7903,6 +7903,13 @@ export const vi = {
   "worklist.board.title": "Nhóm của tôi đang thế nào",
   "worklist.exceptions.title": "Việc cần đến bạn",
   "worklist.handled.title": "Đã xử lý giúp bạn",
+  "worklist.walk.arrived":
+    "Có thêm {arrived} kể từ khi bạn bắt đầu. Chúng chờ làm mới để danh sách này đứng yên.",
+  "worklist.walk.gone":
+    "{gone} trong số này đã được xử lý kể từ khi bạn bắt đầu.",
+  "worklist.walk.both":
+    "Có thêm {arrived} kể từ khi bạn bắt đầu, và {gone} đã được xử lý.",
+  "worklist.walk.refresh": "Làm mới",
   "worklist.handled.empty": "Hôm nay chưa có việc nào được xử lý giúp bạn.",
   "worklist.handled.loading": "Đang đọc những việc đã xử lý",
   "worklist.handled.what": "Điều đã xảy ra",

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -390,3 +390,23 @@ export function usePinRow() {
     },
   });
 }
+
+/**
+ * Start a NEW walk over today's rows.
+ *
+ * `refetch` is not this. An infinite query refetches every page it holds, each
+ * with the cursor it was loaded under — and every page past the first carries
+ * the SNAPSHOT. So a reader who had paged once and then pressed the refresh
+ * this notice offers resumed the very walk they were asking to leave: the work
+ * that arrived behind them stayed absent, and the notice sat there telling them
+ * to do what they had just done.
+ *
+ * Resetting drops the loaded pages, so the next fetch is a first page with no
+ * cursor and the server freezes a fresh snapshot over the day as it stands now.
+ */
+export function useRefreshWalk() {
+  const queryClient = useQueryClient();
+  return () => {
+    void queryClient.resetQueries({ queryKey: worklistKey });
+  };
+}

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -38,6 +38,7 @@ export type WorklistDisposition = NonNullable<
 export type TeamBoard = components["schemas"]["TeamBoard"];
 export type TeamExceptions = components["schemas"]["TeamExceptions"];
 export type HandledForYou = components["schemas"]["HandledForYou"];
+export type WorklistWalk = components["schemas"]["WorklistWalk"];
 export type Receipt = components["schemas"]["Receipt"];
 export type TeamException = components["schemas"]["TeamException"];
 export type TeamBoardMember = components["schemas"]["TeamBoardMember"];

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -37,6 +37,7 @@ import { hasPane, WorklistPane } from "./worklist.pane";
 import {
   loadedQueue,
   UNASSIGNED,
+  useRefreshWalk,
   useWorklist,
   type Worklist,
   type WorklistFilter,
@@ -751,6 +752,7 @@ export function WorklistScreen({
       set(next);
     };
   const day = useWorklist(scope, filter, owner === "" ? undefined : owner);
+  const refreshWalk = useRefreshWalk();
   // A failed SHOW MORE is not a failed page. `isError` covers both, and
   // treating them alike would replace a screen of rows the reader is working
   // through with an error panel because one extra page did not arrive. The
@@ -797,10 +799,10 @@ export function WorklistScreen({
             day={first}
             walk={walk}
             // Refreshing starts a NEW walk, which is what brings in the work
-            // that arrived behind the reader. Refetching the query is exactly
-            // that: the first page is fetched without a cursor, so the server
-            // freezes a fresh snapshot over today's rows.
-            onRefresh={() => void day.refetch()}
+            // that arrived behind the reader — and a refetch is NOT that: it
+            // re-runs every loaded page with its own cursor, so a reader who
+            // had paged once resumed the walk they were asking to leave.
+            onRefresh={refreshWalk}
             queue={queue}
             scope={scope}
             filter={filter}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -42,9 +42,11 @@ import {
   type WorklistFilter,
   type WorklistItem,
   type WorklistScope,
+  type WorklistWalk,
 } from "./worklist.queries";
 import { WorklistReadings } from "./worklist.readings";
 import { WorklistRow } from "./worklist.row";
+import { WalkNotice } from "./worklist.walknotice";
 import "./worklist.css";
 
 // The Worklist: one ranked list, not fourteen lanes.
@@ -336,6 +338,8 @@ function QueueRows({
 // describe a slice as though it were the day.
 function WorklistBody({
   day,
+  walk,
+  onRefresh,
   queue,
   scope,
   filter,
@@ -363,6 +367,11 @@ function WorklistBody({
   onSelect: (next: string) => void;
   // Opens a waiting email into the page's one drawer.
   onOpenEmail: (activityId: string) => void;
+  // What has moved since this walk started, from the LATEST page: the two
+  // figures answer over the whole walk and are recomputed on every page, so
+  // page one's copy is stale the moment a reader pages once.
+  walk: WorklistWalk | undefined;
+  onRefresh: () => void;
   hasMore: boolean;
   loadingMore: boolean;
   moreFailed: boolean;
@@ -484,6 +493,10 @@ function WorklistBody({
       {owner === "" && scope === "mine" && (
         <HiddenBacklogPanel enabled={day.scope_options.includes("team")} />
       )}
+      {/* What has moved since the reader started paging. An offer to refresh
+          rather than a fault: the day on screen is correct, it is simply no
+          longer complete. */}
+      <WalkNotice walk={walk} onRefresh={onRefresh} />
       {/* A day cannot read as clear while something that would have filled it
           was never read. This is the surface speaking about ITSELF, which is
           what Callout is for. */}
@@ -750,6 +763,12 @@ export function WorklistScreen({
   // reader pages, so they are read from page one rather than from the latest
   // page, whose numbers describe only its own slice.
   const first = day.data?.pages[0];
+  // The WALK is the exception to the rule above, and the reason it is spelled
+  // apart from it. `changed_since_snapshot` and `new_available` answer over the
+  // whole walk and are recomputed on every page, so page one's copy is stale
+  // the moment a reader pages once — the opposite of the day figures beside it,
+  // which describe an assembly that does not move.
+  const walk = day.data?.pages.at(-1)?.walk;
   // The rows, which DO grow. Deduped in the query, because a re-rank between
   // reads can serve one row on two pages.
   const queue = day.data ? loadedQueue(day.data.pages) : [];
@@ -776,6 +795,12 @@ export function WorklistScreen({
         {first && (
           <WorklistBody
             day={first}
+            walk={walk}
+            // Refreshing starts a NEW walk, which is what brings in the work
+            // that arrived behind the reader. Refetching the query is exactly
+            // that: the first page is fetched without a cursor, so the server
+            // freezes a fresh snapshot over today's rows.
+            onRefresh={() => void day.refetch()}
             queue={queue}
             scope={scope}
             filter={filter}

--- a/frontend/src/screens/worklist.walknotice.test.tsx
+++ b/frontend/src/screens/worklist.walknotice.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { WalkNotice } from "./worklist.walknotice";
+
+afterEach(cleanup);
+
+// What a reader is told about a walk that has moved under them.
+
+describe("what has moved since the reader started", () => {
+  it("says nothing about a walk that has not moved", () => {
+    render(
+      notice({
+        as_of: "2026-09-05T09:00:00Z",
+        changed_since_snapshot: 0,
+        new_available: 0,
+      }),
+    );
+
+    // A line saying "0 new" would be noise on every page a reader turns.
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(document.body.textContent?.trim()).toBe("");
+  });
+
+  it("offers a refresh for work that arrived behind the reader", async () => {
+    const refreshed = vi.fn();
+    render(
+      notice(
+        {
+          as_of: "2026-09-05T09:00:00Z",
+          changed_since_snapshot: 0,
+          new_available: 3,
+        },
+        refreshed,
+      ),
+    );
+
+    // The remedy is ON the notice. Naming the state and leaving the reader to
+    // find the way to act on it is half an answer.
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: en["worklist.walk.refresh"] }));
+    expect(refreshed).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains a count that fell without offering a refresh", () => {
+    render(
+      notice({
+        as_of: "2026-09-05T09:00:00Z",
+        // Dealt with since the walk started. Refreshing does not bring these
+        // back, so offering it here would point at the wrong remedy.
+        changed_since_snapshot: 2,
+        new_available: 0,
+      }),
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText(/2/)).toBeTruthy();
+  });
+
+  it("reports arrivals and departures separately", () => {
+    render(
+      notice({
+        as_of: "2026-09-05T09:00:00Z",
+        changed_since_snapshot: 2,
+        new_available: 3,
+      }),
+    );
+
+    // NOT netted off. "Three arrived and two left" is two facts a reader acts
+    // on differently; one net figure would hide both behind a number that
+    // means neither.
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("3");
+    expect(text).toContain("2");
+  });
+});
+
+function notice(
+  walk: {
+    as_of: string;
+    changed_since_snapshot: number;
+    new_available?: number;
+  },
+  onRefresh: () => void = () => {},
+) {
+  return (
+    <LocaleProvider initial="en">
+      <WalkNotice walk={walk} onRefresh={onRefresh} />
+    </LocaleProvider>
+  );
+}

--- a/frontend/src/screens/worklist.walknotice.test.tsx
+++ b/frontend/src/screens/worklist.walknotice.test.tsx
@@ -3,11 +3,12 @@
 
 /** @vitest-environment jsdom */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
+import { day, renderWorklist, row } from "./worklist.testkit";
 import { WalkNotice } from "./worklist.walknotice";
 
 afterEach(cleanup);
@@ -97,3 +98,69 @@ function notice(
     </LocaleProvider>
   );
 }
+
+// Refreshing must start a NEW walk, not resume the frozen one.
+//
+// The whole point of the notice is that work arrived which this walk cannot
+// show. A refetch of an infinite query re-runs every loaded page with its own
+// stored cursor, and pages past the first carry the SNAPSHOT — so it would
+// resume the same frozen walk, the newcomers would still be absent, and the
+// notice would sit there after the reader did what it asked.
+describe("refreshing starts a new walk", () => {
+  it("asks for a first page with no cursor", async () => {
+    const asked: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/worklist") && !url.includes("/worklist/")) {
+          asked.push(url);
+          return new Response(
+            JSON.stringify(
+              day({
+                summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+                queue: [
+                  row({ id: "t1", source: "task", title: "Send the quote" }),
+                ],
+                next_cursor: "page-two",
+                walk: {
+                  as_of: "2026-09-05T09:00:00Z",
+                  changed_since_snapshot: 0,
+                  new_available: 3,
+                },
+              }),
+            ),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText("Send the quote");
+    // PAGE FIRST, which is the case the concern is about: with only page one
+    // loaded there is no cursor to resume and any implementation passes.
+    await userEvent.click(
+      await screen.findByRole("button", { name: en["worklist.more"] }),
+    );
+    await waitFor(() => {
+      expect(asked.some((url) => url.includes("cursor="))).toBe(true);
+    });
+    const before = asked.length;
+    await userEvent.click(
+      await screen.findByRole("button", { name: en["worklist.walk.refresh"] }),
+    );
+
+    await waitFor(() => {
+      expect(asked.length).toBeGreaterThan(before);
+    });
+    // The request the refresh made carries NO cursor. One that did would
+    // resume the walk the reader is trying to leave.
+    const refreshed = asked[asked.length - 1];
+    expect(refreshed).not.toContain("cursor=");
+  });
+});

--- a/frontend/src/screens/worklist.walknotice.tsx
+++ b/frontend/src/screens/worklist.walknotice.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// What has happened to this walk since the reader started it.
+//
+// A walk is frozen at its first page so the order and the count hold still
+// while somebody pages — that is what stops the queue moving under them. The
+// two things freezing cannot hide are reported here rather than absorbed:
+// work that ARRIVED behind the reader and waits for a refresh, and work that
+// LEFT because it was dealt with, deleted, or is no longer theirs to see.
+//
+// AN OFFER, NOT AN ERROR. The day on screen is still correct — it is simply no
+// longer complete, and the remedy is to refresh when the reader is ready. A
+// warn tone would tell them something is wrong with a page that is working
+// exactly as designed.
+
+import { Button } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { WorklistWalk } from "./worklist.queries";
+
+/**
+ * The notice, where there is anything to say.
+ *
+ * Null on a walk that has not moved, which is the common case: a reader who
+ * pages a quiet day sees nothing, and a line saying "0 new" would be noise on
+ * every page they turn.
+ */
+export function WalkNotice({
+  walk,
+  onRefresh,
+}: Readonly<{ walk: WorklistWalk | undefined; onRefresh: () => void }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  if (!walk) {
+    return null;
+  }
+  const arrived = walk.new_available ?? 0;
+  const gone = walk.changed_since_snapshot;
+  if (arrived === 0 && gone === 0) {
+    return null;
+  }
+  return (
+    <Callout tone="info">
+      {noticeText(arrived, gone, t, locale)}{" "}
+      {/* The way to act on it. Refreshing starts a new walk, which is what
+          brings the arrived work in — the notice without it would name a
+          problem and leave the reader to find the remedy. */}
+      {arrived > 0 && (
+        <Button small onClick={onRefresh}>
+          {t("worklist.walk.refresh")}
+        </Button>
+      )}
+    </Callout>
+  );
+}
+
+// What the notice says, in the reader's own terms.
+//
+// The two facts are reported SEPARATELY rather than netted off. "Three arrived
+// and two left" is two things a reader can act on differently — one is a reason
+// to refresh, the other explains why a count fell — and a single net figure
+// would hide both behind a number that means neither.
+function noticeText(
+  arrived: number,
+  gone: number,
+  t: ReturnType<typeof useT>,
+  locale: ReturnType<typeof useLocale>["locale"],
+): string {
+  if (arrived > 0 && gone > 0) {
+    return t("worklist.walk.both", {
+      arrived: formatNumber(arrived, locale),
+      gone: formatNumber(gone, locale),
+    });
+  }
+  if (arrived > 0) {
+    return t("worklist.walk.arrived", {
+      arrived: formatNumber(arrived, locale),
+    });
+  }
+  return t("worklist.walk.gone", { gone: formatNumber(gone, locale) });
+}


### PR DESCRIPTION
A walk is frozen at its first page so the order and the count hold still while somebody pages. The two things freezing cannot hide are reported rather than absorbed: work that **arrived** behind the reader and waits, and work that **left** because it was dealt with or is no longer theirs to see.

**An offer, not an error.** The day on screen is still correct — it is simply no longer complete. A warn tone would say something is wrong with a page working exactly as designed. A walk that has not moved says nothing at all, which is most pages.

## Refreshing did not start a new walk

`day.refetch()` re-runs **every page the query holds**, each with the cursor it was loaded under — and every page past the first carries the snapshot. So a reader who had paged once and pressed the refresh this notice offers **resumed the very walk they were asking to leave**: the newcomers stayed absent, and the notice sat there telling them to do what they had just done.

Resetting the query drops the loaded pages, so the next fetch is a first page with no cursor and the server freezes a fresh snapshot over the day as it stands.

**The first version of the test could not see it.** With only page one loaded there is no cursor to resume and any implementation passes. The test pages first now, which is the state the defect lives in.

## Evidence

| Obligation | Evidence |
|---|---|
| Silence when quiet | `says nothing about a walk that has not moved` |
| Arrivals | `offers a refresh for work that arrived behind the reader` |
| Departures | `explains a count that fell without offering a refresh` — refreshing cannot bring back dealt-with work, so it is explained and not offered |
| Both at once | `reports arrivals and departures separately` |
| The refresh works | `asks for a first page with no cursor` — **after paging**, which is the only state that can fail |
| Mutation strength | Reverted to `day.refetch()` → the paged-refresh test fails; the silence guard removed → the quiet test fails |
| i18n | en/de/vi |
| Full lane | `make check-fe` green |

Reads `new_available` and `changed_since_snapshot` from the snapshot walk shipped in #4160.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a notice to the worklist that tells readers when work arrived or left while they were paging, and makes the offered refresh actually start a new walk.

- The notice reads from the latest page and shows arrivals and departures separately; a walk that has not moved stays silent.
- Refresh now resets the worklist query instead of refetching it, so a reader who paged once gets a fresh snapshot rather than resuming the frozen walk where newcomers stayed hidden.

<sup>Written for commit 563a8f1cb3c7f552e9f3832dd1562787aa77c9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added worklist status notifications showing items that arrived or were completed while viewing the list.
  - Added a refresh action to load the latest worklist snapshot when new items are available.
  - Arrival and completion counts are displayed separately for clearer updates.

- **Localization**
  - Added English, German, and Vietnamese translations for worklist notifications and the refresh action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->