### PR TITLE
A wait says what it is waiting for

### DIFF
--- a/extensions/openchannel/frontend/screen.tsx
+++ b/extensions/openchannel/frontend/screen.tsx
@@ -118,7 +118,10 @@ export default function OpenchannelScreen() {
           // undefined both while the read is in flight and when it failed, and
           // rendering either as "no endpoint" states something the read did
           // not establish.
-          <QueryStates query={endpoint}>
+          <QueryStates
+            query={endpoint}
+            pendingLabel={t("extOpenchannel.endpoint.title")}
+          >
             <EndpointCard endpoint={endpoint.data?.endpoint} />
           </QueryStates>
         ) : (

--- a/extensions/openchannel/frontend/traffic.tsx
+++ b/extensions/openchannel/frontend/traffic.tsx
@@ -112,7 +112,10 @@ export function InboundList({ canRead }: Readonly<{ canRead: boolean }>) {
         sub={t("extOpenchannel.inbound.sub")}
       />
       {canRead ? (
-        <QueryStates query={inbound}>
+        <QueryStates
+          query={inbound}
+          pendingLabel={t("extOpenchannel.inbound.title")}
+        >
           {inbound.data && inbound.data.length > 0 ? (
             <DataTable<InboundEntry>
               label={t("extOpenchannel.inbound.title")}
@@ -199,7 +202,10 @@ export function OutboundList({ canRead }: Readonly<{ canRead: boolean }>) {
         sub={t("extOpenchannel.outboundList.sub")}
       />
       {canRead ? (
-        <QueryStates query={outbound}>
+        <QueryStates
+          query={outbound}
+          pendingLabel={t("extOpenchannel.outboundList.title")}
+        >
           {outbound.data && outbound.data.length > 0 ? (
             <DataTable<OutboundAttempt>
               label={t("extOpenchannel.outboundList.title")}

--- a/frontend/src/design-system/decisioncard.stories.tsx
+++ b/frontend/src/design-system/decisioncard.stories.tsx
@@ -56,6 +56,7 @@ const LABELS: DecisionCardLabels = {
   showMore: "Show the whole message",
   showLess: "Show less",
   noContent: "This proposal carries nothing to read.",
+  loading: "Reading the proposal",
 };
 
 const BODY = `Hi Marek,

--- a/frontend/src/design-system/decisioncard.test.tsx
+++ b/frontend/src/design-system/decisioncard.test.tsx
@@ -37,6 +37,7 @@ const LABELS: DecisionCardLabels = {
   showMore: "Show the whole message",
   showLess: "Show less",
   noContent: "This proposal carries nothing to read.",
+  loading: "Reading the proposal",
 };
 
 function approval(over: Partial<DecisionApproval> = {}): DecisionApproval {

--- a/frontend/src/design-system/decisioncard.tsx
+++ b/frontend/src/design-system/decisioncard.tsx
@@ -274,6 +274,10 @@ export type DecisionCardLabels = Readonly<{
   showLess?: string;
   /** What there is none OF: a proposal whose payload carries nothing to read. */
   noContent: string;
+  // What the card's body is waiting for, spoken while it waits. Beside
+  // noContent because they answer the same question in the two states a body
+  // can be absent in, and the card knows neither — only the screen does.
+  loading: string;
 }>;
 
 /** The old→new sides of one field the proposal would change. */
@@ -856,6 +860,7 @@ export function DecisionCard({
         <SurfaceState
           state={state ?? (payload.hasContent ? "ready" : "empty")}
           emptyLabel={labels.noContent}
+          loadingLabel={labels.loading}
         >
           <DecisionContent
             draft={payload.draft}

--- a/frontend/src/design-system/decisiondeck.stories.tsx
+++ b/frontend/src/design-system/decisiondeck.stories.tsx
@@ -60,6 +60,7 @@ const CARD_LABELS: DecisionCardLabels = {
   showMore: "Show the whole message",
   showLess: "Show less",
   noContent: "This proposal carries nothing to read.",
+  loading: "Reading the proposal",
 };
 
 const LABELS: DecisionDeckLabels = {
@@ -184,6 +185,7 @@ const CHIPS = (
 
 const BASE = {
   now: NOW,
+  loadingLabel: "Reading the proposals",
   labels: LABELS,
   chips: CHIPS,
   onCommit: () => undefined,

--- a/frontend/src/design-system/decisiondeck.test.tsx
+++ b/frontend/src/design-system/decisiondeck.test.tsx
@@ -33,6 +33,7 @@ const CARD_LABELS: DecisionCardLabels = {
   draftSubject: "Subject",
   draftBody: "Message",
   noContent: "Nothing to read.",
+  loading: "Reading the proposal",
 };
 
 const LABELS: DecisionDeckLabels = {
@@ -85,6 +86,7 @@ function deck(over: Partial<Parameters<typeof DecisionDeck>[0]> = {}) {
     <DecisionDeck
       items={THREE}
       now={NOW}
+      loadingLabel="Reading the proposals"
       labels={LABELS}
       onCommit={() => undefined}
       {...over}

--- a/frontend/src/design-system/decisiondeck.tsx
+++ b/frontend/src/design-system/decisiondeck.tsx
@@ -380,7 +380,10 @@ export type DecisionDeckProps = Readonly<{
    *  above all a retry, without which `failed` is `unavailable` with extra
    *  words. */
   stateDetail?: SectionDetail;
-  loadingLabel?: string;
+  // Required, like the SurfaceState it forwards to: this deck cannot know what
+  // its caller is waiting for, and a generic line is what the required prop
+  // one level down exists to prevent.
+  loadingLabel: string;
   /** Under the tray: what a refused commit said, in the caller's words. */
   notice?: ReactNode;
   chips?: (

--- a/frontend/src/design-system/emaildetail.tsx
+++ b/frontend/src/design-system/emaildetail.tsx
@@ -165,6 +165,7 @@ export function EmailDetail({
         // asked again, and a failure with nothing to press is the same as
         // being told the message is not there.
         <SurfaceState
+          loadingLabel={t("email.detail.loading")}
           state="failed"
           emptyLabel={t("email.detail.none")}
           detail={{ onRetry: () => void read.refetch() }}
@@ -197,6 +198,7 @@ function EmailBody({
     // message is limited describes what it is about.
     return (
       <SurfaceState
+        loadingLabel={t("email.detail.loading")}
         state="withheld"
         emptyLabel={t("email.detail.none")}
         // The generic sentence says "your role cannot read this", and an

--- a/frontend/src/design-system/panel.tsx
+++ b/frontend/src/design-system/panel.tsx
@@ -281,7 +281,15 @@ export function RailPanel({
         children
       ) : (
         <PanelBody>
-          <SurfaceState state={state} emptyLabel={emptyLabel} detail={detail}>
+          {/* The panel's own title is what it is waiting for, so the caller is
+              not asked to say it twice. Every other SurfaceState takes the
+              label from whoever knows; here the wrapper knows. */}
+          <SurfaceState
+            state={state}
+            emptyLabel={emptyLabel}
+            loadingLabel={title}
+            detail={detail}
+          >
             {null}
           </SurfaceState>
         </PanelBody>

--- a/frontend/src/design-system/surfacestate.stories.tsx
+++ b/frontend/src/design-system/surfacestate.stories.tsx
@@ -64,6 +64,7 @@ function AllStates() {
       {ALL.map((state) => (
         <Card key={state} title={state}>
           <SurfaceState
+            loadingLabel="Loading the section"
             state={state}
             emptyLabel="No open deal on this account."
             detail={DETAIL}
@@ -87,6 +88,7 @@ function OrderDemo() {
     <div style={{ display: "grid", gap: "var(--space-4)", maxWidth: 420 }}>
       <Card title="Stale — caveat first">
         <SurfaceState
+          loadingLabel="Loading the section"
           state="stale"
           emptyLabel="No open deal on this account."
           detail={{ staleAsOf: "9:15 this morning" }}
@@ -96,6 +98,7 @@ function OrderDemo() {
       </Card>
       <Card title="Partial — count last">
         <SurfaceState
+          loadingLabel="Loading the section"
           state="partial"
           emptyLabel="No open deal on this account."
           detail={{ remaining: 4 }}
@@ -117,6 +120,7 @@ function RetryDemo() {
     <div style={{ display: "grid", gap: "var(--space-4)", maxWidth: 420 }}>
       <Card title="Failed, retryable">
         <SurfaceState
+          loadingLabel="Loading the section"
           state="failed"
           emptyLabel="Nothing recorded."
           detail={{ onRetry: () => undefined }}
@@ -125,7 +129,11 @@ function RetryDemo() {
         </SurfaceState>
       </Card>
       <Card title="Failed, nothing to retry">
-        <SurfaceState state="failed" emptyLabel="Nothing recorded.">
+        <SurfaceState
+          state="failed"
+          emptyLabel="Nothing recorded."
+          loadingLabel="Loading the section"
+        >
           {ROWS}
         </SurfaceState>
       </Card>
@@ -143,10 +151,20 @@ export const FailedWithAndWithoutRetry: Story = {
 function LabelledDemo() {
   return (
     <Card title="Tags and lists" style={{ maxWidth: 420 }}>
-      <SurfaceState label="Lists" state="ready" emptyLabel="Not on any list.">
+      <SurfaceState
+        label="Lists"
+        state="ready"
+        emptyLabel="Not on any list."
+        loadingLabel="Loading the section"
+      >
         <p className="t-body">Q3 expansion targets</p>
       </SurfaceState>
-      <SurfaceState label="Tags" state="withheld" emptyLabel="No tags.">
+      <SurfaceState
+        label="Tags"
+        state="withheld"
+        emptyLabel="No tags."
+        loadingLabel="Loading the section"
+      >
         <p className="t-body">strategic</p>
       </SurfaceState>
     </Card>
@@ -164,6 +182,7 @@ function NestedDemo() {
     <Card title="Company 360" style={{ maxWidth: 420 }}>
       <Eyebrow as="h3">What is in flight</Eyebrow>
       <SurfaceState
+        loadingLabel="Loading the section"
         label="Deals"
         labelLevel="h4"
         state="ready"
@@ -172,6 +191,7 @@ function NestedDemo() {
         <p className="t-body">Fleet retrofit 2026</p>
       </SurfaceState>
       <SurfaceState
+        loadingLabel="Loading the section"
         label="Projects"
         labelLevel="h4"
         state="withheld"

--- a/frontend/src/design-system/surfacestate.tsx
+++ b/frontend/src/design-system/surfacestate.tsx
@@ -232,7 +232,7 @@ export function SurfaceState({
   // `loadingLabel` is the caller's because only the caller knows: the loading
   // arm used to be a mute bar, and three screens had bolted their own spoken
   // line beside it rather than being able to hand it one.
-  loadingLabel?: string;
+  loadingLabel: string;
   loadingLines?: number;
   // What the four §7 states need in order to be honest. Each is read by
   // exactly one state and ignored by the rest; a state whose detail is absent

--- a/frontend/src/screens/ai-health.tsx
+++ b/frontend/src/screens/ai-health.tsx
@@ -40,7 +40,7 @@ export function AiHealthCard() {
     <Panel title={t("aiHealth.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("aiHealth.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("aiHealth.title")}>
           {(health) =>
             health.rungs.length === 0 ? (
               // No rung called anything in the window. That is not an outage —

--- a/frontend/src/screens/ai-provider-keys.tsx
+++ b/frontend/src/screens/ai-provider-keys.tsx
@@ -132,7 +132,7 @@ export function AiProviderKeysCard() {
   // paste fields to find the one vendor that is not set up.
   return (
     <Panel title={t("aiProviderKeys.title")} sub={t("aiProviderKeys.sub")}>
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("aiProviderKeys.title")}>
         {(list) => (
           <>
             {list.providers.map((p) => (

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -138,7 +138,7 @@ export function AiRoutingCard({
   }
 
   return (
-    <QueryGate query={query}>
+    <QueryGate query={query} pendingLabel={t("aiRouting.title")}>
       {(routing) => (
         <RoutingForm
           routing={routing}

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -46,7 +46,7 @@ export function CallDetailPanel({
     },
   });
   return (
-    <QueryStates query={query}>
+    <QueryStates query={query} pendingLabel={t("aicalls.title")}>
       {query.data && (
         <Card as="div" inset className="aicalls-detail">
           <p>
@@ -224,7 +224,7 @@ export function AiCallsCard() {
       <Panel title={t("aicalls.title")}>
         <PanelBody>
           <p className="settings-panel-sub">{t("aicalls.sub")}</p>
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("aicalls.title")}>
             {() => <EmptyState>{t("aicalls.withheld")}</EmptyState>}
           </QueryGate>
         </PanelBody>
@@ -237,7 +237,7 @@ export function AiCallsCard() {
     <Panel title={t("aicalls.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("aicalls.sub")}</p>
-        <QueryStates query={query}>
+        <QueryStates query={query} pendingLabel={t("aicalls.title")}>
           <SettingList>
             <SettingRow
               label={t("aicalls.col.task")}

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -356,7 +356,7 @@ export function AiUsageCard() {
       <Panel title={t("aiusage.title")}>
         <PanelBody>
           <p className="settings-panel-sub">{t("aiusage.sub")}</p>
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("aiusage.title")}>
             {() => <EmptyState>{t("aiusage.withheld")}</EmptyState>}
           </QueryGate>
         </PanelBody>
@@ -369,7 +369,7 @@ export function AiUsageCard() {
     <Panel title={t("aiusage.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("aiusage.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("aiusage.title")}>
           {(data) => (
             <AiUsageBody data={data} month={month} onMonth={setMonth} />
           )}

--- a/frontend/src/screens/analytics.forecast.review.tsx
+++ b/frontend/src/screens/analytics.forecast.review.tsx
@@ -51,7 +51,7 @@ export function ForecastReview() {
   });
 
   return (
-    <QueryGate query={assurance}>
+    <QueryGate query={assurance} pendingLabel={t("review.title")}>
       {(run) =>
         run === null ? (
           <Panel title={t("review.title")}>
@@ -99,7 +99,7 @@ function ReviewPanel({
             what happened. */}
         <CoverageLine run={run} />
       </PanelBody>
-      <QueryGate query={checks}>
+      <QueryGate query={checks} pendingLabel={title}>
         {(found) =>
           found.length === 0 ? (
             <PanelBody>

--- a/frontend/src/screens/analytics.forecast.tsx
+++ b/frontend/src/screens/analytics.forecast.tsx
@@ -50,7 +50,7 @@ export function ForecastView({
   });
 
   return (
-    <QueryGate query={readings}>
+    <QueryGate query={readings} pendingLabel={t("forecast.updateCall")}>
       {(data) => (
         <>
           <ForecastAnswer readings={data} locale={locale} />

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -731,7 +731,11 @@ function DerivationRows({
     <>
       <SectionHeader title={t("explain.sources")} level={3} />
       {derivation.rows.length === 0 ? (
-        <SurfaceState state="empty" emptyLabel={t("common.empty")}>
+        <SurfaceState
+          state="empty"
+          emptyLabel={t("common.empty")}
+          loadingLabel={t("explain.sources")}
+        >
           {null}
         </SurfaceState>
       ) : (
@@ -876,7 +880,7 @@ function ReportCard({
   });
 
   return (
-    <QueryGate query={reportQuery}>
+    <QueryGate query={reportQuery} pendingLabel={t(REPORT_LABEL_KEY[report])}>
       {(run) => (
         <>
           <Card title={t(REPORT_LABEL_KEY[report])}>

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -127,6 +127,7 @@ function rowLabels(t: Translator): DecisionCardLabels {
     draftSubject: t("decision.draftSubject"),
     draftBody: t("decision.draftBody"),
     noContent: t("common.empty"),
+    loading: t("decision.detailLoading"),
   };
 }
 

--- a/frontend/src/screens/automationdetail.tsx
+++ b/frontend/src/screens/automationdetail.tsx
@@ -256,7 +256,9 @@ export function AutomationRuns({
           );
         })}
       </div>
-      <QueryStates query={query}>{body}</QueryStates>
+      <QueryStates query={query} pendingLabel={t("auto.runs.title")}>
+        {body}
+      </QueryStates>
     </Card>
   );
 }
@@ -343,7 +345,7 @@ export function AutomationPreview({
       {/* Polite live region: announce when the estimate resolves or the window
           result changes, without stealing focus from the control. */}
       <div aria-live="polite">
-        <QueryStates query={query}>
+        <QueryStates query={query} pendingLabel={t("auto.preview.title")}>
           {result && (
             <div
               style={{

--- a/frontend/src/screens/automations.tsx
+++ b/frontend/src/screens/automations.tsx
@@ -921,7 +921,11 @@ function ConfiguredAutomationsRow({
       layout="stack"
       control={
         canViewRuns ? (
-          <QueryGate query={instances} empty={(page) => page.data.length === 0}>
+          <QueryGate
+            query={instances}
+            empty={(page) => page.data.length === 0}
+            pendingLabel={t("auto.instances")}
+          >
             {(page) => (
               <ul className="auto-instances">
                 {page.data.map((automation) => (
@@ -938,7 +942,7 @@ function ConfiguredAutomationsRow({
             )}
           </QueryGate>
         ) : (
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("auto.instances")}>
             {() => <EmptyState>{t("auto.withheld")}</EmptyState>}
           </QueryGate>
         )
@@ -969,7 +973,11 @@ function StarterLibraryRow({
       description={t("auto.catalogSub")}
       layout="stack"
       control={
-        <QueryGate query={catalog} empty={(page) => page.data.length === 0}>
+        <QueryGate
+          query={catalog}
+          empty={(page) => page.data.length === 0}
+          pendingLabel={t("auto.catalog")}
+        >
           {(page) => (
             // A nested SettingList, so the interval between two entries and the
             // hairline that separates them are the row language's own. As a bare

--- a/frontend/src/screens/autonomy-settings.tsx
+++ b/frontend/src/screens/autonomy-settings.tsx
@@ -184,6 +184,7 @@ export function AutonomySettingsCard() {
             is also what keeps noneDecidedYet from having to speak for a set
             that does not exist. */}
         <QueryGate
+          pendingLabel={t("autonomy.title")}
           query={query}
           empty={(settings) => settings.data.length === 0}
         >

--- a/frontend/src/screens/blocked-domains.tsx
+++ b/frontend/src/screens/blocked-domains.tsx
@@ -192,7 +192,10 @@ export function BlockedDomainsCard() {
             label={t("blockedDomains.listTitle")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("blockedDomains.listTitle")}
+              >
                 {(list) =>
                   list.data.length === 0 ? (
                     // `empty`, and only `empty`: no decision has been recorded,

--- a/frontend/src/screens/book.tsx
+++ b/frontend/src/screens/book.tsx
@@ -180,6 +180,7 @@ function SessionBookingScreen() {
         </Card>
       ) : (
         <QueryGate
+          pendingLabel={t("book.title")}
           query={availability}
           empty={(data) => data.slots.length === 0}
         >
@@ -340,6 +341,7 @@ function PublicBookingScreen({ hostSlug }: Readonly<{ hostSlug: string }>) {
         </Card>
       ) : (
         <QueryGate
+          pendingLabel={t("book.title")}
           query={availability}
           empty={(data) => data.slots.length === 0}
         >

--- a/frontend/src/screens/buyerroom.tsx
+++ b/frontend/src/screens/buyerroom.tsx
@@ -374,7 +374,11 @@ function RoomBody({
     onSettled: onSessionLost,
   });
   return (
-    <QueryStates query={room} pendingLines={4}>
+    <QueryStates
+      query={room}
+      pendingLines={4}
+      pendingLabel={t("room.card.title")}
+    >
       {room.data ? (
         <>
           <RoomView
@@ -601,8 +605,16 @@ function BuyerBoard({
     actions: <BuyerDocumentVerbs token={token} doc={doc} />,
   }));
   return (
-    <QueryStates query={docs} pendingLines={3}>
-      <QueryStates query={threads} pendingLines={3}>
+    <QueryStates
+      query={docs}
+      pendingLines={3}
+      pendingLabel={t("buyer.docs.title")}
+    >
+      <QueryStates
+        query={threads}
+        pendingLines={3}
+        pendingLabel={t("buyer.docs.title")}
+      >
         {docs.data && threads.data ? (
           <DocumentBoard
             title={t("buyer.docs.title")}

--- a/frontend/src/screens/capture-activity-drawer.tsx
+++ b/frontend/src/screens/capture-activity-drawer.tsx
@@ -118,6 +118,7 @@ export function CaptureActivityDrawer({
         // this state; it names what there would be none OF, if the state were
         // ever `empty`.
         <SurfaceState
+          loadingLabel={t("pipeline.title")}
           state="unavailable"
           emptyLabel={t("pipeline.unavailable")}
         >

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -226,7 +226,7 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
   });
 
   return (
-    <QueryGate query={query}>
+    <QueryGate query={query} pendingLabel={t("captureActivity.title")}>
       {(loaded) => {
         // The funnel is a property of the WINDOW, not of the loaded pages, so
         // it comes off the first page and does not grow as more are fetched.
@@ -291,6 +291,7 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
                   // on pages nobody has fetched, and saying "no capture
                   // activity" there would contradict the number beside it.
                   <SurfaceState
+                    loadingLabel={t("captureActivity.title")}
                     state="empty"
                     emptyLabel={t(
                       filter

--- a/frontend/src/screens/capture-exclusions.tsx
+++ b/frontend/src/screens/capture-exclusions.tsx
@@ -153,7 +153,10 @@ export function CaptureExclusionsCard() {
             description={t("captureExclusions.notRetroactive")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("captureExclusions.current")}
+              >
                 {(list) => (
                   <ExclusionRows
                     list={list.data}

--- a/frontend/src/screens/capture-owner-identities.tsx
+++ b/frontend/src/screens/capture-owner-identities.tsx
@@ -118,7 +118,10 @@ export function OwnerIdentitiesCard() {
             description={t("ownerIdentities.notRetroactive")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("ownerIdentities.title")}
+              >
                 {(list) => (
                   <IdentityRows
                     list={list.data}

--- a/frontend/src/screens/capture-senders.tsx
+++ b/frontend/src/screens/capture-senders.tsx
@@ -121,7 +121,7 @@ export function CaptureSendersCard() {
     <Panel title={t("senders.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("senders.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("senders.title")}>
           {(list) =>
             list.data.length === 0 ? (
               <EmptyState title={t("senders.emptyTitle")}>

--- a/frontend/src/screens/capture-settings.tsx
+++ b/frontend/src/screens/capture-settings.tsx
@@ -80,7 +80,7 @@ export function CaptureSettingsCard() {
           on the same 16px it does in a plain one. */}
       <PanelBody className="form-stack">
         <p className="settings-panel-sub">{t("captureSettings.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("captureSettings.title")}>
           {(settings) => (
             <SettingList>
               {/* The row draws the naming — what the setting is, and what it

--- a/frontend/src/screens/common.stories.tsx
+++ b/frontend/src/screens/common.stories.tsx
@@ -33,7 +33,11 @@ function Demo({ empty }: Readonly<{ empty?: boolean }>) {
     },
   });
   return (
-    <QueryGate query={query} empty={empty ? () => true : undefined}>
+    <QueryGate
+      query={query}
+      empty={empty ? () => true : undefined}
+      pendingLabel="Loading the section"
+    >
       {(data) => <p>{data?.name}</p>}
     </QueryGate>
   );

--- a/frontend/src/screens/common.test.tsx
+++ b/frontend/src/screens/common.test.tsx
@@ -586,7 +586,10 @@ describe("QueryStates", () => {
 
   it("prints the server's detail for a failed query", () => {
     render(
-      <QueryStates query={failing(new ProblemError({ detail: "no seat" }))}>
+      <QueryStates
+        query={failing(new ProblemError({ detail: "no seat" }))}
+        pendingLabel="Loading the section"
+      >
         {null}
       </QueryStates>,
     );
@@ -595,7 +598,10 @@ describe("QueryStates", () => {
 
   it("prints the shared line, not the message, when the failure is not a problem", () => {
     render(
-      <QueryStates query={failing(new TypeError("Failed to fetch"))}>
+      <QueryStates
+        query={failing(new TypeError("Failed to fetch"))}
+        pendingLabel="Loading the section"
+      >
         {null}
       </QueryStates>,
     );
@@ -608,7 +614,10 @@ describe("QueryStates", () => {
   // most of the product at once.
   it("announces a failed load, headline and cause in one region", () => {
     render(
-      <QueryStates query={failing(new ProblemError({ detail: "no seat" }))}>
+      <QueryStates
+        query={failing(new ProblemError({ detail: "no seat" }))}
+        pendingLabel="Loading the section"
+      >
         {null}
       </QueryStates>,
     );
@@ -629,6 +638,7 @@ describe("QueryStates", () => {
   it("reports a load in progress as busy, since the shimmer bars say nothing", () => {
     render(
       <QueryStates
+        pendingLabel="Loading the section"
         query={{
           isPending: true,
           isError: false,

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -245,7 +245,7 @@ export function QueryStates({
   // the generic answer is honest for them; a screen whose body is a table or a
   // timeline says so, or its content lands in a third of the space the
   // placeholder held and pushes the page down as it arrives.
-  pendingLabel?: string;
+  pendingLabel: string;
   pendingLines?: number;
   children: ReactNode;
 }>) {
@@ -328,7 +328,7 @@ export function QueryGate<Data>({
   empty?: (data: Data) => boolean;
   // Forwarded to QueryStates: the gate adds the empty check, not a second
   // pending state, so there is one place a screen names its wait.
-  pendingLabel?: string;
+  pendingLabel: string;
   pendingLines?: number;
   children: (data: Data) => ReactNode;
 }>) {

--- a/frontend/src/screens/company-context.tsx
+++ b/frontend/src/screens/company-context.tsx
@@ -669,7 +669,10 @@ function CompanyFactsCard({
         {readOnly && (
           <p className="t-caption">{t("settings.companyReadOnly")}</p>
         )}
-        <QueryGate query={company}>
+        <QueryGate
+          query={company}
+          pendingLabel={t("settings.companySourceTitle")}
+        >
           {(profile) =>
             form && (
               <>

--- a/frontend/src/screens/company/glance.tsx
+++ b/frontend/src/screens/company/glance.tsx
@@ -71,6 +71,7 @@ export function ThreadFold({
         ) : (
           <PanelBody>
             <SurfaceState
+              loadingLabel={t("co.recent.title")}
               state={state}
               emptyLabel={t("co.recent.empty")}
               emptyDetail={t("co.recent.emptyDetail")}
@@ -182,6 +183,7 @@ export function MoneyPane({
           <PanelGroupHead title={t("companyProjects.title")} level="h3" />
           <PanelBody>
             <SurfaceState
+              loadingLabel={t("companyProjects.title")}
               state={projectsState}
               emptyLabel={t("projectLinks.emptyTitle")}
             >
@@ -259,7 +261,11 @@ export function PeopleChips({
             )}
           </ul>
         ) : (
-          <SurfaceState state={state} emptyLabel={t("co.rail.people.empty")}>
+          <SurfaceState
+            state={state}
+            emptyLabel={t("co.rail.people.empty")}
+            loadingLabel={t("co.rail.people.title")}
+          >
             {null}
           </SurfaceState>
         )}

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -244,7 +244,11 @@ export function DealsCard({
         </>
       ) : (
         <PanelBody>
-          <SurfaceState state={state} emptyLabel={t("co.deals.empty")}>
+          <SurfaceState
+            state={state}
+            emptyLabel={t("co.deals.empty")}
+            loadingLabel={t("co.deals.title")}
+          >
             {null}
           </SurfaceState>
         </PanelBody>
@@ -386,7 +390,11 @@ export function CommercialPanel({
             read as an empty account. */}
         {state !== "ready" && state !== "empty" && (
           <PanelBody>
-            <SurfaceState state={state} emptyLabel={t("co.deals.empty")}>
+            <SurfaceState
+              state={state}
+              emptyLabel={t("co.deals.empty")}
+              loadingLabel={t("co.deals.title")}
+            >
               {null}
             </SurfaceState>
           </PanelBody>
@@ -457,7 +465,11 @@ export function CommercialPanel({
         </>
       ) : (
         <PanelBody>
-          <SurfaceState state={state} emptyLabel={t("co.deals.empty")}>
+          <SurfaceState
+            state={state}
+            emptyLabel={t("co.deals.empty")}
+            loadingLabel={t("co.deals.title")}
+          >
             {null}
           </SurfaceState>
         </PanelBody>
@@ -579,7 +591,11 @@ export function RecentActivityPanel({
       ))
     ) : (
       <PanelBody>
-        <SurfaceState state={state} emptyLabel={t("co.recent.empty")}>
+        <SurfaceState
+          state={state}
+          emptyLabel={t("co.recent.empty")}
+          loadingLabel={t("co.recent.title")}
+        >
           {null}
         </SurfaceState>
       </PanelBody>

--- a/frontend/src/screens/companycontracts.tsx
+++ b/frontend/src/screens/companycontracts.tsx
@@ -217,7 +217,11 @@ export function CompanyContractsCard({ orgId }: Readonly<{ orgId: string }>) {
           )
         ) : (
           <PanelBody>
-            <SurfaceState state={state} emptyLabel={t("contracts.empty")}>
+            <SurfaceState
+              state={state}
+              emptyLabel={t("contracts.empty")}
+              loadingLabel={t("contracts.title")}
+            >
               {null}
             </SurfaceState>
           </PanelBody>
@@ -444,6 +448,7 @@ function ContractPaper({
           first and the label stops reading as a label for both. */}
       <div className="rec-files-items">
         <SurfaceState
+          loadingLabel={t("contracts.files")}
           state={complete ? "ready" : "partial"}
           emptyLabel=""
           detail={{ remaining: paper.remaining }}

--- a/frontend/src/screens/companydocuments.tsx
+++ b/frontend/src/screens/companydocuments.tsx
@@ -268,6 +268,7 @@ export function CompanyDocumentsCard({ orgId }: Readonly<{ orgId: string }>) {
       ) : (
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("docs.title")}
             state={state}
             emptyLabel={t("docs.empty")}
             detail={

--- a/frontend/src/screens/companyfactspanel.tsx
+++ b/frontend/src/screens/companyfactspanel.tsx
@@ -161,9 +161,13 @@ export function CompanyFactsPanel({
             onDone={() => setAdding(false)}
           />
         )}
-        <QueryStates query={factsQuery}>
+        <QueryStates query={factsQuery} pendingLabel={t("co.facts.title")}>
           {facts.length === 0 ? (
-            <SurfaceState state="empty" emptyLabel={t("co.facts.empty")}>
+            <SurfaceState
+              state="empty"
+              emptyLabel={t("co.facts.empty")}
+              loadingLabel={t("co.facts.title")}
+            >
               {null}
             </SurfaceState>
           ) : (

--- a/frontend/src/screens/companyfinance.tsx
+++ b/frontend/src/screens/companyfinance.tsx
@@ -142,6 +142,7 @@ export function CompanyFinanceCard({
       <Panel title={title}>
         <PanelBody>
           <SurfaceState
+            loadingLabel={title}
             state={withheld ? "withheld" : "failed"}
             emptyLabel={t("finance.none")}
             detail={withheld ? {} : { onRetry: () => void query.refetch() }}
@@ -166,6 +167,7 @@ export function CompanyFinanceCard({
     <Panel title={title} {...chromeOf(summary, present, t)}>
       <PanelBody>
         <SurfaceState
+          loadingLabel={title}
           state={cardState}
           emptyLabel={t(EMPTY_LABEL[summary.state] ?? "finance.none")}
           detail={{

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -267,6 +267,7 @@ function DealsSection({
       ) : (
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("co.rail.deals.title")}
             state={state}
             emptyLabel={
               hasClosedHistory
@@ -463,7 +464,11 @@ function PeopleSection({
         ))
       ) : (
         <PanelBody>
-          <SurfaceState state={state} emptyLabel={t("co.rail.people.empty")}>
+          <SurfaceState
+            state={state}
+            emptyLabel={t("co.rail.people.empty")}
+            loadingLabel={t("co.rail.people.title")}
+          >
             {null}
           </SurfaceState>
           {/* The empty state's one verb; the foot below stands only once
@@ -691,6 +696,7 @@ export function SignalsSection({ orgId }: Readonly<{ orgId: string }>) {
       ) : (
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("co.signals.title")}
             state={state}
             emptyLabel={t("co.signals.empty")}
             emptyDetail={t("co.signals.emptyDetail")}

--- a/frontend/src/screens/companytechnical.tsx
+++ b/frontend/src/screens/companytechnical.tsx
@@ -125,7 +125,11 @@ function TechnicalSections({
   const t = useT();
   if (facts.length === 0) {
     return (
-      <SurfaceState state="empty" emptyLabel={t("co.tech.empty")}>
+      <SurfaceState
+        state="empty"
+        emptyLabel={t("co.tech.empty")}
+        loadingLabel={t("co.tech.title")}
+      >
         {null}
       </SurfaceState>
     );

--- a/frontend/src/screens/companywork.tsx
+++ b/frontend/src/screens/companywork.tsx
@@ -319,7 +319,11 @@ function WorkGroup({
             {emptyDetail}
           </EmptyState>
         ) : (
-          <SurfaceState state={state} emptyLabel={emptyLabel}>
+          <SurfaceState
+            state={state}
+            emptyLabel={emptyLabel}
+            loadingLabel={label}
+          >
             {null}
           </SurfaceState>
         )}

--- a/frontend/src/screens/composethread.tsx
+++ b/frontend/src/screens/composethread.tsx
@@ -178,6 +178,7 @@ export function ThreadPane({
           <PendingBody label={t("compose.threadPending")} lines={3} />
         ) : (
           <SurfaceState
+            loadingLabel={t("compose.threadPending")}
             state={failed ? "failed" : "ready"}
             emptyLabel={t("compose.threadPending")}
             detail={{ onRetry }}
@@ -322,6 +323,7 @@ export function ConversationChoices({
           <PendingBody label={t("compose.threadPending")} lines={3} />
         ) : (
           <SurfaceState
+            loadingLabel={t("compose.threadPending")}
             state={failed ? "failed" : "ready"}
             emptyLabel={t("compose.threadPending")}
             detail={{ onRetry }}

--- a/frontend/src/screens/connected-agents.tsx
+++ b/frontend/src/screens/connected-agents.tsx
@@ -137,7 +137,7 @@ function ConnectGuide() {
     queryFn: fetchConnectorState,
   });
   return (
-    <QueryGate query={state}>
+    <QueryGate query={state} pendingLabel={t("agents.connected")}>
       {(connector) =>
         connector.enabled ? (
           <>
@@ -484,7 +484,7 @@ export function ConnectedAgentsCard() {
             {/* The gate renders straight into the list, so its rows are the
               list's own children and the hairline falls between them. Its
               pending and error surfaces stand in the same place a row would. */}
-            <QueryGate query={list}>
+            <QueryGate query={list} pendingLabel={t("agents.connected")}>
               {() =>
                 connections.length === 0 ? (
                   // Written out here rather than left to QueryGate's generic

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -358,7 +358,9 @@ export function ConsentSection({
       title={t("person.consent")}
       sub={t("consent.defaultDeny")}
     >
-      <QueryStates query={consentQuery}>{body}</QueryStates>
+      <QueryStates query={consentQuery} pendingLabel={t("person.consent")}>
+        {body}
+      </QueryStates>
       {/* Per PERSON rather than per purpose, so it sits under the rows instead
           of inside one: the link opens everything held about them and asks the
           marketing question once, which is not a fact about any single

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -267,7 +267,7 @@ export function ConsumerMailDomainsCard() {
             label={t("consumerMail.addedTitle")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate query={query} pendingLabel={t("consumerMail.title")}>
                 {(entries) =>
                   entries.length === 0 ? (
                     // `empty`, and only `empty`: nothing has been added, so the

--- a/frontend/src/screens/context.tsx
+++ b/frontend/src/screens/context.tsx
@@ -84,7 +84,10 @@ export function RecordContextPanel({
 
   return (
     <Card className="record-context" title={t("context.title")}>
-      <QueryGate query={query as QueryLike<ContextResponse>}>
+      <QueryGate
+        query={query as QueryLike<ContextResponse>}
+        pendingLabel={t("context.title")}
+      >
         {(data) => {
           const sections = neighbourhood(
             data.sections ?? [],

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -481,6 +481,7 @@ export function SignedFileField({
               missing UNDER them, which is where a count about a list belongs. */}
           {state === "empty" ? null : (
             <SurfaceState
+              loadingLabel={t("contracts.form.file")}
               state={state}
               emptyLabel=""
               detail={{

--- a/frontend/src/screens/customfields.tsx
+++ b/frontend/src/screens/customfields.tsx
@@ -486,6 +486,7 @@ export function AuditRail({
 
   return (
     <SurfaceState
+      loadingLabel={t("cf.audit.title")}
       state={state}
       emptyLabel={t("cf.audit.empty")}
       detail={{ onRetry }}
@@ -809,7 +810,10 @@ export function CustomFieldsAdmin() {
             layout="stack"
             control={
               <div className="arrive-stack">
-                <QueryGate query={list}>
+                <QueryGate
+                  query={list}
+                  pendingLabel={t("cf.listLabel", { object: objectName })}
+                >
                   {(page) => (
                     <FieldTable
                       object={object}

--- a/frontend/src/screens/deal360/dealcommittee.tsx
+++ b/frontend/src/screens/deal360/dealcommittee.tsx
@@ -114,6 +114,7 @@ export function DealCommitteeMap({
   return (
     <Card className="dc-card" title={t("deal.committee.title")}>
       <SurfaceState
+        loadingLabel={t("deal.committee.title")}
         state={state}
         emptyLabel={t("deal.committee.empty")}
         detail={

--- a/frontend/src/screens/dealfiles.tsx
+++ b/frontend/src/screens/dealfiles.tsx
@@ -101,6 +101,7 @@ export function DealFiles({ dealId }: Readonly<{ dealId: string }>) {
         onClose={() => setAdding(false)}
       />
       <SurfaceState
+        loadingLabel={t("files.title")}
         state={state}
         emptyLabel={t("files.empty")}
         detail={

--- a/frontend/src/screens/dealroom.tsx
+++ b/frontend/src/screens/dealroom.tsx
@@ -62,10 +62,15 @@ export function DealRoomAside({
   dealId,
   dealName,
 }: Readonly<{ dealId: string; dealName: string }>) {
+  const t = useT();
   const roomQuery = useDealRoom(dealId);
   const room = roomQuery.data?.data?.[0];
   return (
-    <QueryStates query={roomQuery} pendingLines={3}>
+    <QueryStates
+      query={roomQuery}
+      pendingLines={3}
+      pendingLabel={t("room.card.title")}
+    >
       {room ? (
         <RoomCard room={room} />
       ) : roomQuery.isSuccess ? (

--- a/frontend/src/screens/dealroomaccess.tsx
+++ b/frontend/src/screens/dealroomaccess.tsx
@@ -105,10 +105,18 @@ export function DealRoomAccess({
         ) : undefined
       }
     >
-      <QueryStates query={participants} pendingLines={2}>
+      <QueryStates
+        query={participants}
+        pendingLines={2}
+        pendingLabel={t("access.title")}
+      >
         {rows.length === 0 ? (
           <PanelBody>
-            <SurfaceState state="empty" emptyLabel={t("access.empty")}>
+            <SurfaceState
+              state="empty"
+              emptyLabel={t("access.empty")}
+              loadingLabel={t("access.title")}
+            >
               {null}
             </SurfaceState>
           </PanelBody>

--- a/frontend/src/screens/dealroomconversation.tsx
+++ b/frontend/src/screens/dealroomconversation.tsx
@@ -132,8 +132,16 @@ export function DealRoomConversation({
     actions: <RemoveButton room={room} doc={doc} refusal={refusal} />,
   }));
   return (
-    <QueryStates query={docs} pendingLines={3}>
-      <QueryStates query={threads} pendingLines={3}>
+    <QueryStates
+      query={docs}
+      pendingLines={3}
+      pendingLabel={t("room.docs.title")}
+    >
+      <QueryStates
+        query={threads}
+        pendingLines={3}
+        pendingLabel={t("room.docs.title")}
+      >
         {threads.data && docs.data ? (
           <DocumentBoard
             title={t("room.docs.title")}

--- a/frontend/src/screens/dealroompage.tsx
+++ b/frontend/src/screens/dealroompage.tsx
@@ -51,7 +51,11 @@ export function DealRoomPage({ dealId }: Readonly<{ dealId: string }>) {
   // element is on screen for all three.
   return (
     <div className="wrap">
-      <QueryStates query={roomQuery} pendingLines={6}>
+      <QueryStates
+        query={roomQuery}
+        pendingLines={6}
+        pendingLabel={t("roompage.text.title")}
+      >
         {room ? (
           <RoomPage room={room} dealId={dealId} />
         ) : roomQuery.isSuccess ? (

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1858,6 +1858,7 @@ function DealBoardBody({
     typeof PipelineBoard
   >["columnDropHandlers"];
 }>) {
+  const t = useT();
   // Every company the CARDS name. The picker's capped page answers most of them
   // for free; the rest are resolved by id (useOrgMarks), so no card is left
   // standing over a company the board simply failed to look up.
@@ -1868,7 +1869,7 @@ function DealBoardBody({
   const orgMarks = useOrgMarks(loadedDeals, orgs, orgsSettled);
   return (
     <>
-      <QueryGate query={pipelinesQuery}>
+      <QueryGate query={pipelinesQuery} pendingLabel={t("nav.deals")}>
         {() =>
           effectivePipeline ? (
             // Only the INITIAL load goes through the gate. An infinite
@@ -1879,7 +1880,9 @@ function DealBoardBody({
             // retries — exactly what OverlayDealsTable does above, and for
             // the same reason.
             (dealsQuery.data?.pages ?? []).length === 0 ? (
-              <QueryGate query={dealsQuery}>{() => null}</QueryGate>
+              <QueryGate query={dealsQuery} pendingLabel={t("nav.deals")}>
+                {() => null}
+              </QueryGate>
             ) : (
               <>
                 <PipelineBoard
@@ -4119,7 +4122,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
 
   return (
     <div className="wrap">
-      <QueryGate query={dealQuery}>
+      <QueryGate query={dealQuery} pendingLabel={t("nav.deals")}>
         {(deal) => {
           const stages = [...(pipelineQuery.data?.stages ?? [])].sort(
             (a, b) => a.position - b.position,

--- a/frontend/src/screens/dealstatus.tsx
+++ b/frontend/src/screens/dealstatus.tsx
@@ -147,7 +147,11 @@ export function DealStatusCardPanel({
   return (
     <>
       <CallCard name={dealName}>
-        <QueryStates query={status} pendingLines={6}>
+        <QueryStates
+          query={status}
+          pendingLines={6}
+          pendingLabel={t("nav.deals")}
+        >
           {status.isSuccess && !status.data?.story ? (
             // `story` is required on the wire and the server always writes at
             // least one line, so reaching here means a response that is not

--- a/frontend/src/screens/embedreindex.tsx
+++ b/frontend/src/screens/embedreindex.tsx
@@ -310,13 +310,13 @@ export function EmbedReindexCard() {
   let body: ReactNode;
   if (!canRead) {
     body = (
-      <QueryGate query={me}>
+      <QueryGate query={me} pendingLabel={t("embedreindex.title")}>
         {() => <EmptyState>{t("embedreindex.withheld")}</EmptyState>}
       </QueryGate>
     );
   } else {
     body = (
-      <QueryGate query={status}>
+      <QueryGate query={status} pendingLabel={t("embedreindex.title")}>
         {(data) => {
           const isRunning = data.status === "reembedding";
           return (

--- a/frontend/src/screens/extension-access.tsx
+++ b/frontend/src/screens/extension-access.tsx
@@ -286,7 +286,7 @@ export function ExtensionAccessCard() {
           <p className="t-caption ext-lead-sub">{t("extAccess.sub")}</p>
           {/* Gate on the role probe itself so the admin-only notice appears only
               once /me has answered — never as a flash while it loads. */}
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("extAccess.title")}>
             {() =>
               isAdmin ? (
                 <InventoryLead query={query} />
@@ -330,7 +330,7 @@ function InventoryLead({
   const t = useT();
   const units = query.data?.extensions;
   return (
-    <QueryStates query={query}>
+    <QueryStates query={query} pendingLabel={t("extAccess.title")}>
       {units?.length === 0 ? (
         <EmptyState>{t("extAccess.empty")}</EmptyState>
       ) : null}

--- a/frontend/src/screens/filters.tsx
+++ b/frontend/src/screens/filters.tsx
@@ -225,7 +225,9 @@ function PreviewSection({
         <SectionHeader level={2} title={t("filters.resultsTitle")} />
         {/* The house spelling of a failed read: the headline and the server's
             own cause in one live region, with the retry beside it. */}
-        <QueryStates query={preview}>{null}</QueryStates>
+        <QueryStates query={preview} pendingLabel={t("filters.resultsTitle")}>
+          {null}
+        </QueryStates>
       </Card>
     );
   }

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -59,7 +59,7 @@ export function HeldThreadsCard() {
     <Panel title={t("heldThreads.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("heldThreads.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("heldThreads.title")}>
           {(list) =>
             list.data.length === 0 ? (
               // Nothing held is a READING, not an absent list: "my mailbox is

--- a/frontend/src/screens/historyentries.tsx
+++ b/frontend/src/screens/historyentries.tsx
@@ -500,7 +500,9 @@ export function RecordHistory({
 
   return (
     <Card style={{ marginBottom: "var(--space-4)" }}>
-      <QueryStates query={query}>{body}</QueryStates>
+      <QueryStates query={query} pendingLabel={t("tab.timeline")}>
+        {body}
+      </QueryStates>
     </Card>
   );
 }

--- a/frontend/src/screens/historyfields.tsx
+++ b/frontend/src/screens/historyfields.tsx
@@ -309,7 +309,9 @@ export function FieldHistoryTimeline({
           </div>
         )}
       </div>
-      <QueryStates query={query}>{body}</QueryStates>
+      <QueryStates query={query} pendingLabel={t("history.allFields")}>
+        {body}
+      </QueryStates>
     </Card>
   );
 }

--- a/frontend/src/screens/home.decisions.tsx
+++ b/frontend/src/screens/home.decisions.tsx
@@ -103,6 +103,7 @@ function deckLabels(
     showMore: t("home.deck.showMore"),
     showLess: t("home.deck.showLess"),
     noContent: t("common.empty"),
+    loading: t("home.panel.decisions"),
   };
   return {
     card,

--- a/frontend/src/screens/home.rail.test.tsx
+++ b/frontend/src/screens/home.rail.test.tsx
@@ -200,8 +200,10 @@ describe("HomeScreen — the context rail", () => {
     const user = userEvent.setup();
     render(<HomeScreen />);
 
-    await screen.findByText("Overnight");
-    expect(screen.getByText("Emails synced")).toBeTruthy();
+    // Waited on CONTENT, not on the panel's name: the name is also what the
+    // pending state announces now that a wait says what it is waiting for, so
+    // finding it proves the panel exists rather than that the digest arrived.
+    await screen.findByText("Emails synced");
     expect(screen.getByText("People created")).toBeTruthy();
     expect(screen.getByText("Companies created")).toBeTruthy();
     expect(

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -172,7 +172,7 @@ export function OvernightPanel() {
   const recordZone = useRecordZone();
   const digestQuery = useMorningDigest();
   return (
-    <QueryGate query={digestQuery}>
+    <QueryGate query={digestQuery} pendingLabel={t("home.panel.overnight")}>
       {(digest) => {
         if (digest === null) {
           return null;
@@ -396,7 +396,11 @@ export function WatchPanel({
   return (
     <Panel title={t("home.panel.watch")} className="rail-panel">
       <PanelBody className={deals.length > 0 ? "rail-watch-list" : undefined}>
-        <SurfaceState state={resolved} emptyLabel={t("home.watch.clear")}>
+        <SurfaceState
+          state={resolved}
+          emptyLabel={t("home.watch.clear")}
+          loadingLabel={t("home.panel.watch")}
+        >
           {deals.map((deal) => (
             <DealCard
               key={deal.id}

--- a/frontend/src/screens/home.schedule.tsx
+++ b/frontend/src/screens/home.schedule.tsx
@@ -46,6 +46,7 @@ export function SchedulePanel({
             padded twice and read as an indented block against every other
             panel in the rail. `SurfaceState` draws its sentence either way. */}
         <SurfaceState
+          loadingLabel={t("home.panel.schedule")}
           state={state === "ready" && meetings.length === 0 ? "empty" : state}
           emptyLabel={t("home.schedule.clear")}
         >
@@ -86,6 +87,7 @@ export function PromisesPanel({
     <section id="home-promises" aria-label={t("home.panel.promises")}>
       <Panel title={t("home.panel.promises")} className="rail-panel">
         <SurfaceState
+          loadingLabel={t("home.panel.promises")}
           state={state === "ready" && tasks.length === 0 ? "empty" : state}
           emptyLabel={t("home.promises.clear")}
         >

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -318,7 +318,11 @@ function WeeklyBody({
     // hand-rolled here, it was the one line on the card set as a caption while
     // every other absence on the page read as prose.
     return (
-      <SurfaceState state="empty" emptyLabel={t("home.weekly.none")}>
+      <SurfaceState
+        state="empty"
+        emptyLabel={t("home.weekly.none")}
+        loadingLabel={t("home.panel.weekly")}
+      >
         {null}
       </SurfaceState>
     );

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -145,11 +145,12 @@ export function useUpdateInstallationSettings(onSaved: () => void) {
 }
 
 export function InstallationSettingsCard() {
+  const t = useT();
   const canManage = useCanWrite("installation_settings", "update");
   const query = useInstallationSettings();
 
   return (
-    <QueryGate query={query}>
+    <QueryGate query={query} pendingLabel={t("nav.settings")}>
       {(settings) => (
         <InstallationSettingsForm settings={settings} canManage={canManage} />
       )}

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -98,7 +98,7 @@ export function ProviderCard() {
           <p className="settings-panel-sub">{t("provider.readOnly")}</p>
         )}
       </PanelBody>
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("provider.title")}>
         {(result) =>
           // An empty list means the same thing a 501 does: no adapter is
           // compiled in. The server returns a row for every REGISTERED

--- a/frontend/src/screens/jobhealth.tsx
+++ b/frontend/src/screens/jobhealth.tsx
@@ -425,7 +425,7 @@ export function JobHealthCard() {
     // Behind the probe, so the notice states a settled denial rather than the
     // absence of an answer: while /me is in flight nobody holds any role yet.
     body = (
-      <QueryGate query={me}>
+      <QueryGate query={me} pendingLabel={t("settings.jobs")}>
         {() => <EmptyState>{t("jobs.adminOnly")}</EmptyState>}
       </QueryGate>
     );
@@ -433,7 +433,7 @@ export function JobHealthCard() {
     // No `empty` predicate on the gate: its generic copy would understate the
     // one thing this card exists to report, so the body owns that rung.
     body = (
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("settings.jobs")}>
         {(health) => <JobHealthBody health={health} zone={zone} />}
       </QueryGate>
     );

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -184,6 +184,7 @@ async function createLead(
 }
 
 export function LeadsScreen() {
+  const t = useT();
   const me = useMe();
   return (
     // The page's own root, OUTSIDE the gate: inside it, only the loaded screen
@@ -192,7 +193,7 @@ export function LeadsScreen() {
     // `.wrap:has(> .lt)` is what gives a list screen its full height and a div
     // between the two would take that away.
     <div className="wrap lead-surface lead-queue">
-      <QueryGate query={me}>
+      <QueryGate query={me} pendingLabel={t("nav.leads")}>
         {(session) => (
           <LeadsWorkbench
             viewerId={session.user.id}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1512,6 +1512,7 @@ function LeadOverviewPane({
           write. */}
       {!lead.archived_at && overlay && askedToLogCall && (
         <SurfaceState
+          loadingLabel={t("tab.overview")}
           state="unsupported"
           // Never drawn — the state above is fixed — but the primitive asks
           // every caller for the sentence it would say if it were empty.
@@ -1959,6 +1960,7 @@ function LeadRecord({
 }
 
 export function LeadScreen({ id }: Readonly<{ id: string }>) {
+  const t = useT();
   const cf = useObjectCustomFields("lead");
   // The seam serves update for a mirrored lead (write-back projects onto the
   // incumbent, overlay/provider_writes.go), so Edit renders in overlay too.
@@ -1982,7 +1984,7 @@ export function LeadScreen({ id }: Readonly<{ id: string }>) {
 
   return (
     <div className="wrap lead-surface">
-      <QueryGate query={leadQuery}>
+      <QueryGate query={leadQuery} pendingLabel={t("nav.leads")}>
         {(lead) => (
           // Keyed by lead: every piece of page state below — the open dialog,
           // the tab, a half-typed score override — is about THIS lead, and

--- a/frontend/src/screens/leadvocab.tsx
+++ b/frontend/src/screens/leadvocab.tsx
@@ -386,7 +386,10 @@ export function LeadSourcesCard() {
             label={t("leadSources.listLabel")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("leadSources.listLabel")}
+              >
                 {(list) => (
                   <ul
                     className="lead-vocab-list"
@@ -594,7 +597,7 @@ export function LeadDisqualifyReasonsCard() {
             label={t("leadReasons.listLabel")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate query={query} pendingLabel={t("leadReasons.title")}>
                 {(reasons) => (
                   <ul
                     className="lead-vocab-list"
@@ -771,7 +774,7 @@ export function LeadHandlingCard() {
       {/* Plain body, for the reason the sources card carries in full. */}
       <PanelBody>
         <p className="settings-panel-sub">{t("leadHandling.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("leadHandling.title")}>
           {(settings) => {
             const shown =
               draft ?? String(settings.first_response_target_minutes);

--- a/frontend/src/screens/license.tsx
+++ b/frontend/src/screens/license.tsx
@@ -70,9 +70,10 @@ export function useLicenseEntitlement(enabled = true) {
 }
 
 export function LicenseCard() {
+  const t = useT();
   const query = useLicenseEntitlement();
   return (
-    <QueryGate query={query}>
+    <QueryGate query={query} pendingLabel={t("license.seats.title")}>
       {(entitlement) => (
         <>
           {/* Only a verified license has a holder. An unlicensed installation

--- a/frontend/src/screens/mail-sharing.tsx
+++ b/frontend/src/screens/mail-sharing.tsx
@@ -83,7 +83,7 @@ export function MailSharingCard() {
     <Panel title={t("mailSharing.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("mailSharing.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("mailSharing.title")}>
           {(settings) => {
             const shown = pending ?? settings.mail_sharing;
             const dirty = pending !== null && pending !== settings.mail_sharing;

--- a/frontend/src/screens/meetingbrief/sections.tsx
+++ b/frontend/src/screens/meetingbrief/sections.tsx
@@ -176,6 +176,7 @@ export function Background({
         )}
         {omitted.map((omission) => (
           <SurfaceState
+            loadingLabel={t("person.meeting.omittedSource")}
             key={omission.source}
             state="withheld"
             labelLevel="h4"

--- a/frontend/src/screens/oauth-app.tsx
+++ b/frontend/src/screens/oauth-app.tsx
@@ -261,7 +261,7 @@ export function OAuthAppCard({ provider }: Readonly<{ provider: Vendor }>) {
     <Panel title={t(copy.title)}>
       <PanelBody>
         <p className="t-body">{t(copy.sub)}</p>
-        <QueryGate query={app}>
+        <QueryGate query={app} pendingLabel={t(copy.title)}>
           {(status) => (
             <>
               {failure && (

--- a/frontend/src/screens/oauthconsent.tsx
+++ b/frontend/src/screens/oauthconsent.tsx
@@ -296,7 +296,7 @@ export function OAuthConsent() {
 
   return (
     <div className="wrap narrow">
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("consent.title")}>
         {(data) => (
           <ConsentSelector data={data} params={params} consent={consent} />
         )}

--- a/frontend/src/screens/offers.tsx
+++ b/frontend/src/screens/offers.tsx
@@ -1337,7 +1337,7 @@ export function OfferScreen({ id }: Readonly<{ id: string }>) {
 
   return (
     <div className="wrap">
-      <QueryGate query={offerQuery}>
+      <QueryGate query={offerQuery} pendingLabel={t("nav.offers")}>
         {(offer) => (
           <>
             <Card>

--- a/frontend/src/screens/onboarding-conversation/prefs-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/prefs-act.tsx
@@ -158,7 +158,7 @@ export function PrefsAct({ state, dispatch, persist }: PrefsActProps) {
     >
       <div className="ob-scene ob-prefs-scene">
         {canManage && (
-          <QueryGate query={settings}>
+          <QueryGate query={settings} pendingLabel={t("ob.conv.prefs.title")}>
             {(current) => (
               <section className="ob-prefs-section">
                 <h3>{t("ob.conv.prefs.reportingTitle")}</h3>

--- a/frontend/src/screens/onboarding-gate.tsx
+++ b/frontend/src/screens/onboarding-gate.tsx
@@ -155,6 +155,7 @@ export function OnboardingGate({
     return (
       <GateColumn name={named}>
         <SurfaceState
+          loadingLabel={t("ob.gate.sub")}
           state="failed"
           // Read by the `empty` arm alone, which a failed read never reaches:
           // what there is none of is not a question a broken poll has an

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1403,7 +1403,7 @@ export function CompanyScreen({ id }: Readonly<{ id: string }>) {
 
   return (
     <div className="wrap">
-      <QueryGate query={orgQuery}>
+      <QueryGate query={orgQuery} pendingLabel={t("nav.companies")}>
         {(org) => (
           <CompanyRecord org={org} view={view} tab={tab} onTab={setTab} t={t} />
         )}

--- a/frontend/src/screens/overlay-health.tsx
+++ b/frontend/src/screens/overlay-health.tsx
@@ -133,6 +133,7 @@ function SyncStatusPanel({
         </Callout>
       ) : (
         <SurfaceState
+          loadingLabel={t("overlay.title")}
           state={readingState(query.isPending, objects.length)}
           emptyLabel={t("overlay.syncEmpty")}
         >
@@ -288,6 +289,7 @@ function BudgetPanel({
         </Callout>
       ) : (
         <SurfaceState
+          loadingLabel={t("overlay.title")}
           state={readingState(query.isPending, query.data ? 1 : 0)}
           emptyLabel={t("overlay.budgetEmpty")}
         >

--- a/frontend/src/screens/overnight-grant.tsx
+++ b/frontend/src/screens/overnight-grant.tsx
@@ -212,7 +212,7 @@ export function OvernightGrantCard() {
     <Panel title={t("overnightGrant.title")}>
       <PanelBody>
         <p className="settings-panel-sub">{t("overnightGrant.sub")}</p>
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("overnightGrant.title")}>
           {(grants) => {
             const grant = morningBriefGrant(grants);
             const granted = grant?.state === "granted";

--- a/frontend/src/screens/own-domains.tsx
+++ b/frontend/src/screens/own-domains.tsx
@@ -174,7 +174,10 @@ export function OwnDomainsCard() {
             description={t("ownDomains.irreversible")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("ownDomains.curatedTitle")}
+              >
                 {(list) => (
                   <CuratedDomains
                     list={list.data}

--- a/frontend/src/screens/partnercommissions.tsx
+++ b/frontend/src/screens/partnercommissions.tsx
@@ -120,7 +120,7 @@ export function PartnerCommissions({
 
   return (
     <Panel title={t("commission.panelTitle")} sub={t("commission.panelSub")}>
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("commission.panelTitle")}>
         {(entries) =>
           entries.length === 0 ? (
             <PanelBody>

--- a/frontend/src/screens/partnerdeals.tsx
+++ b/frontend/src/screens/partnerdeals.tsx
@@ -66,7 +66,7 @@ export function PartnerDeals({
       title={t("partnerDeals.panelTitle")}
       sub={t("partnerDeals.panelSub")}
     >
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t("partnerDeals.panelTitle")}>
         {(deals) => (
           <PanelBody>
             {deals.length === 0 ? (

--- a/frontend/src/screens/partners.tsx
+++ b/frontend/src/screens/partners.tsx
@@ -483,7 +483,7 @@ export function PartnerTab({
   }
 
   return (
-    <QueryGate query={query}>
+    <QueryGate query={query} pendingLabel={t("nav.partners")}>
       {(partner) =>
         partner ? (
           <>

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -801,7 +801,7 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
 
   return (
     <div className="wrap">
-      <QueryGate query={personQuery}>
+      <QueryGate query={personQuery} pendingLabel={t("nav.contacts")}>
         {(person) => (
           <RecordView
             name={person.full_name}

--- a/frontend/src/screens/persondealrooms.tsx
+++ b/frontend/src/screens/persondealrooms.tsx
@@ -78,7 +78,11 @@ export function PersonDealRooms({
   }
   return (
     <Panel title={t("persondealrooms.title")} sub={t("persondealrooms.sub")}>
-      <QueryStates query={rooms} pendingLines={2}>
+      <QueryStates
+        query={rooms}
+        pendingLines={2}
+        pendingLabel={t("persondealrooms.title")}
+      >
         {seats.map(({ room, email }) => (
           <RoomRow key={room.id} room={room} email={email} emails={emails} />
         ))}

--- a/frontend/src/screens/personfiles.tsx
+++ b/frontend/src/screens/personfiles.tsx
@@ -125,6 +125,7 @@ export function PersonFilesTab({ personId }: Readonly<{ personId: string }>) {
         onClose={() => setAdding(false)}
       />
       <SurfaceState
+        loadingLabel={t("tab.documents")}
         state={state}
         emptyLabel={t("person.documents.empty")}
         detail={

--- a/frontend/src/screens/personnetwork/index.tsx
+++ b/frontend/src/screens/personnetwork/index.tsx
@@ -152,6 +152,7 @@ export function PersonNetworkTab({
               reader who scrolled past this. */}
           {read.withheld ? (
             <SurfaceState
+              loadingLabel={t("tab.network")}
               state="withheld"
               emptyLabel={t("person.graph.noDirect")}
             >

--- a/frontend/src/screens/personnetwork/moments.tsx
+++ b/frontend/src/screens/personnetwork/moments.tsx
@@ -70,7 +70,11 @@ export function MomentsCard({ view }: Readonly<{ view: RelationshipMoments }>) {
       title={t("person.network.momentsTitle")}
       sub={t("person.network.momentsSub")}
     >
-      <SurfaceState state={state} emptyLabel={t("person.network.noMoments")}>
+      <SurfaceState
+        state={state}
+        emptyLabel={t("person.network.noMoments")}
+        loadingLabel={t("person.network.title")}
+      >
         <ul className="pn-moments">
           {changes.map((change) => (
             <li key={`${change.kind}-${change.at}`} className="pn-moment">

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -713,6 +713,7 @@ function Employers({ view }: Readonly<{ view: Person360 }>) {
     >
       <PanelBody>
         <SurfaceState
+          loadingLabel={t("person.rail.employmentTitle")}
           state={bodyState(
             withheldSections(view).employments,
             employments.length,
@@ -1193,6 +1194,7 @@ function WhoKnows({
     <Panel title={t("person.rail.whoKnows", { name: firstName })}>
       <PanelBody>
         <SurfaceState
+          loadingLabel={t("person.rail.whoKnows", { name: firstName })}
           state={bodyState(withheldSections(view).network, colleagues.length)}
           emptyLabel={t("person.rail.nobodyYet")}
         >
@@ -1236,6 +1238,7 @@ function SignalsAndRisks({ view }: Readonly<{ view: Person360 }>) {
     <Panel title={t("person.rail.signals")}>
       <PanelBody>
         <SurfaceState
+          loadingLabel={t("person.rail.signals")}
           state={signalsState(signals.length, skipped)}
           emptyLabel={t("person.rail.noSignals")}
         >
@@ -1468,6 +1471,7 @@ function RecentActivity({
     >
       <PanelBody>
         <SurfaceState
+          loadingLabel={t("person.rail.recentActivity")}
           state={bodyState(withheld, rows.length)}
           emptyLabel={t("person.rail.nothingCaptured")}
         >

--- a/frontend/src/screens/personresearch.tsx
+++ b/frontend/src/screens/personresearch.tsx
@@ -51,7 +51,11 @@ export function PersonResearchTab({
     return (
       <Panel title={t("tab.research")}>
         <PanelBody>
-          <SurfaceState state="empty" emptyLabel={t("person.research.empty")}>
+          <SurfaceState
+            state="empty"
+            emptyLabel={t("person.research.empty")}
+            loadingLabel={t("tab.research")}
+          >
             {null}
           </SurfaceState>
         </PanelBody>
@@ -66,6 +70,7 @@ export function PersonResearchTab({
           <Panel title={t("provider.profile.title")}>
             <PanelBody>
               <SurfaceState
+                loadingLabel={t("provider.profile.title")}
                 state="withheld"
                 emptyLabel={t("person.research.empty")}
               >
@@ -82,6 +87,7 @@ export function PersonResearchTab({
       <Panel title={t("person.research.fields")}>
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("person.research.fields")}
             state={fieldsState}
             emptyLabel={t("person.research.fieldsEmpty")}
           >

--- a/frontend/src/screens/persontabs.tsx
+++ b/frontend/src/screens/persontabs.tsx
@@ -156,6 +156,7 @@ export function PersonTimelineTab({
           />
         ) : (
           <SurfaceState
+            loadingLabel={t("tab.timeline")}
             state={timelineState(
               view,
               filter,
@@ -291,7 +292,11 @@ export function PersonDealsTab({
   return (
     <div className="record-stack">
       <Panel title={t("tab.deals")}>
-        <SurfaceState state={state} emptyLabel={t("person.deals.empty")}>
+        <SurfaceState
+          state={state}
+          emptyLabel={t("person.deals.empty")}
+          loadingLabel={t("tab.deals")}
+        >
           {roles.map((role) => (
             <PanelRow className="pe-row" key={role.relationship_id}>
               {/* The seat first, in the row grid's own label column: which
@@ -403,6 +408,7 @@ export function PersonMeetingsTab({
       <Panel title={t("person.meetings.next")}>
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("person.meetings.next")}
             state={sectionState(
               view,
               "next_meeting",
@@ -456,6 +462,7 @@ export function PersonMeetingsTab({
       <Panel title={t("person.meetings.past")}>
         <PanelBody>
           <SurfaceState
+            loadingLabel={t("person.meetings.past")}
             state={past === "ready" && hasMore ? "partial" : past}
             emptyLabel={t("person.meetings.noneLogged")}
           >

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -265,7 +265,11 @@ export function ConsentPurposesCard() {
             }
             layout="stack"
             control={
-              <QueryGate query={query} empty={(page) => page.data.length === 0}>
+              <QueryGate
+                query={query}
+                empty={(page) => page.data.length === 0}
+                pendingLabel={t("privacy.purposesRegistry")}
+              >
                 {(page) => (
                   <div className="purpose-badges">
                     {page.data.map((purpose) => (
@@ -1066,7 +1070,7 @@ export function PrivacyInboxCard() {
     // Behind the probe, so this states a settled denial and not the absence of
     // an answer — while /me is in flight nobody holds any role yet.
     body = (
-      <QueryGate query={me}>
+      <QueryGate query={me} pendingLabel={t("privacy.inboxAdminOnly")}>
         {() => <EmptyState>{t("privacy.inboxAdminOnly")}</EmptyState>}
       </QueryGate>
     );
@@ -1077,7 +1081,7 @@ export function PrivacyInboxCard() {
     // beside the retry. The hand-rolled pair said neither out loud, and it
     // measured its own gaps in inline style objects.
     body = (
-      <QueryStates query={query}>
+      <QueryStates query={query} pendingLabel={t("privacy.facetAll")}>
         {rows.length === 0 ? (
           <EmptyState>{t("common.empty")}</EmptyState>
         ) : (

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -88,10 +88,11 @@ export function useProject360(id: string) {
 }
 
 export function ProjectScreen({ id }: Readonly<{ id: string }>) {
+  const t = useT();
   const view = useProject360(id);
   return (
     <div className="wrap">
-      <QueryGate query={view}>
+      <QueryGate query={view} pendingLabel={t("nav.projects")}>
         {(data) => <ProjectPage view={data} />}
       </QueryGate>
     </div>
@@ -467,7 +468,11 @@ function useProjectChronology(
       timeline: [],
       timelineHeader: <ChronologyFilter filter={filter} onFilter={setFilter} />,
       timelineNotice: (
-        <SurfaceState state="withheld" emptyLabel="">
+        <SurfaceState
+          state="withheld"
+          emptyLabel=""
+          loadingLabel={t("nav.projects")}
+        >
           {null}
         </SurfaceState>
       ),

--- a/frontend/src/screens/projectreadings.tsx
+++ b/frontend/src/screens/projectreadings.tsx
@@ -50,7 +50,11 @@ export function RollupsStrip({ view }: Readonly<{ view: Project360 }>) {
   const state = stateOf(view, "rollups", Boolean(rollups), rollups ? 1 : 0);
   if (state !== "ready" || !rollups) {
     return (
-      <SurfaceState state={state} emptyLabel={t("project.rollups.empty")}>
+      <SurfaceState
+        state={state}
+        emptyLabel={t("project.rollups.empty")}
+        loadingLabel={t("project.rollups.openValue")}
+      >
         {null}
       </SurfaceState>
     );

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -76,7 +76,11 @@ function SectionPanel({
         children
       ) : (
         <PanelBody>
-          <SurfaceState state={state} emptyLabel={emptyLabel}>
+          <SurfaceState
+            state={state}
+            emptyLabel={emptyLabel}
+            loadingLabel={title}
+          >
             {null}
           </SurfaceState>
         </PanelBody>

--- a/frontend/src/screens/rates.tsx
+++ b/frontend/src/screens/rates.tsx
@@ -60,7 +60,7 @@ function WithheldRateCard({
   return (
     <Panel title={title}>
       <PanelBody>
-        <QueryGate query={me}>
+        <QueryGate query={me} pendingLabel={title}>
           {() => <EmptyState>{reason}</EmptyState>}
         </QueryGate>
       </PanelBody>
@@ -165,7 +165,10 @@ export function FxRatesCard() {
             label={t("settings.rates.fxTableLabel")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("settings.rates.fxTableLabel")}
+              >
                 {(rows) =>
                   rows.length === 0 ? (
                     <EmptyState>
@@ -393,7 +396,10 @@ export function ModelCostsCard() {
             label={t("settings.rates.modelTableLabel")}
             layout="stack"
             control={
-              <QueryGate query={query}>
+              <QueryGate
+                query={query}
+                pendingLabel={t("settings.rates.modelTableLabel")}
+              >
                 {(rows) =>
                   rows.length === 0 ? (
                     <EmptyState>

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -651,7 +651,7 @@ export function RelationshipsTab({
       title={t(copy.title)}
       actions={<AddRelationshipAction scope={scope} />}
     >
-      <QueryGate query={query}>
+      <QueryGate query={query} pendingLabel={t(copy.title)}>
         {(rows) =>
           rows.length === 0 ? (
             <EmptyState>{t(copy.empty)}</EmptyState>

--- a/frontend/src/screens/restrictedrecords.tsx
+++ b/frontend/src/screens/restrictedrecords.tsx
@@ -198,7 +198,7 @@ export function RestrictedRecordsCard() {
       <Panel title={t("restricted.title")}>
         <PanelBody>
           <p className="settings-panel-sub">{t("restricted.sub")}</p>
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("restricted.title")}>
             {() => <EmptyState>{t("restricted.withheld")}</EmptyState>}
           </QueryGate>
         </PanelBody>
@@ -306,7 +306,10 @@ export function RestrictedRecordsCard() {
               label={t("restricted.heldLabel")}
               layout="stack"
               control={
-                <QueryStates query={records}>
+                <QueryStates
+                  query={records}
+                  pendingLabel={t("restricted.title")}
+                >
                   {records.data &&
                     (records.data.data.length === 0 ? (
                       <EmptyState>{t("restricted.empty")}</EmptyState>

--- a/frontend/src/screens/retention.tsx
+++ b/frontend/src/screens/retention.tsx
@@ -482,7 +482,7 @@ export function RetentionCard() {
       <Panel title={t("retention.title")}>
         <PanelBody>
           <p className="settings-panel-sub">{t("retention.sub")}</p>
-          <QueryGate query={me}>
+          <QueryGate query={me} pendingLabel={t("retention.title")}>
             {() => <EmptyState>{t("retention.withheld")}</EmptyState>}
           </QueryGate>
         </PanelBody>
@@ -632,5 +632,9 @@ function PolicyList({
   // hand-rolled copy: the skeleton announces itself as busy, and the failure is
   // an assertive live region carrying the server's own explanation beside the
   // retry. The hand-rolled version said neither out loud.
-  return <QueryStates query={query}>{body}</QueryStates>;
+  return (
+    <QueryStates query={query} pendingLabel={t("retention.title")}>
+      {body}
+    </QueryStates>
+  );
 }

--- a/frontend/src/screens/savedviews.tsx
+++ b/frontend/src/screens/savedviews.tsx
@@ -335,6 +335,7 @@ export function SaveViewAction({
     <>
       {railDrawn && views.isError && (
         <SurfaceState
+          loadingLabel={t("views.rail")}
           state="failed"
           label={t("views.rail")}
           // Read by the `empty` arm alone, which this call never reaches: what

--- a/frontend/src/screens/scheduledsends.tsx
+++ b/frontend/src/screens/scheduledsends.tsx
@@ -446,12 +446,16 @@ export function ScheduledSendsScreen() {
         </Callout>
       )}
       {writeError && <Callout tone="danger">{writeError}</Callout>}
-      <QueryStates query={query}>
+      <QueryStates query={query} pendingLabel={t("nav.scheduled")}>
         {query.data && query.data.length === 0 ? (
           // One sentence for the whole page, not one per group: a rep who has
           // never scheduled anything is not reading three findings, and three
           // empty blocks make a page that is simply clear look broken.
-          <SurfaceState state="empty" emptyLabel={t("sched.empty")}>
+          <SurfaceState
+            state="empty"
+            emptyLabel={t("sched.empty")}
+            loadingLabel={t("nav.scheduled")}
+          >
             {null}
           </SurfaceState>
         ) : (
@@ -466,6 +470,7 @@ export function ScheduledSendsScreen() {
                   <section key={group} aria-label={title}>
                     <SectionHeader title={title} />
                     <SurfaceState
+                      loadingLabel={title}
                       label={title}
                       state={rows.length === 0 ? "empty" : "ready"}
                       emptyLabel={t(GROUP_EMPTY[group])}

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1007,7 +1007,7 @@ function AccountCard() {
       }
     >
       <PanelBody className="form-stack">
-        <QueryGate query={query}>
+        <QueryGate query={query} pendingLabel={t("settings.accountCard")}>
           {(me) => (
             <div className="settings-identity">
               {/* Both halves are required on the wire, so the `?? ""` is not a
@@ -1466,6 +1466,7 @@ function PassportCard() {
               rather than wrapped in a list of their own: the hairline between
               two credentials belongs to the card that holds both. */}
           <QueryGate
+            pendingLabel={t("settings.passports")}
             query={list}
             empty={(page) =>
               page.data.every((passport) => passport.connection != null)
@@ -1833,7 +1834,11 @@ function AgentToolsCard() {
               One row per governed tool, handed to the list inside as its own
               children so the hairline between two tools comes from the list
               that holds both. */}
-          <QueryGate query={tools} empty={(data) => data.data.length === 0}>
+          <QueryGate
+            query={tools}
+            empty={(data) => data.data.length === 0}
+            pendingLabel={t("tools.title")}
+          >
             {(data) => (
               <Disclosure
                 summary={t("tools.inventory", {
@@ -2534,6 +2539,7 @@ export function PipelinesCard() {
         )}
         <SettingList>
           <QueryGate
+            pendingLabel={t("settings.pipelines")}
             query={query}
             empty={(pipelines) => pipelines.length === 0}
           >

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -843,7 +843,11 @@ function ShareScreenBody({
       </Card>
 
       <Card as="div" title={t("share.whoHasAccess")}>
-        <QueryGate query={grantsQuery} empty={(rows) => rows.length === 0}>
+        <QueryGate
+          query={grantsQuery}
+          empty={(rows) => rows.length === 0}
+          pendingLabel={t("share.whoHasAccess")}
+        >
           {(rows) => (
             <ul className="share-acl-list" data-testid="share-acl-list">
               {rows.map((g) => (

--- a/frontend/src/screens/sign-in-methods.tsx
+++ b/frontend/src/screens/sign-in-methods.tsx
@@ -63,7 +63,7 @@ export function SignInMethodsCard() {
     <Panel title={t("signInMethods.title")}>
       <PanelBody>
         <p className="t-body">{t("signInMethods.sub")}</p>
-        <QueryGate query={settings}>
+        <QueryGate query={settings} pendingLabel={t("signInMethods.title")}>
           {(current) => {
             // Defaulted, not asserted. The field is contract-required, but a
             // body that lost one hands over `undefined` anyway, and this card

--- a/frontend/src/screens/tagadmin.tsx
+++ b/frontend/src/screens/tagadmin.tsx
@@ -83,7 +83,7 @@ export function TagVocabularyCard() {
               label={t("tagAdmin.listLabel")}
               layout="stack"
               control={
-                <QueryGate query={catalog}>
+                <QueryGate query={catalog} pendingLabel={t("tagAdmin.title")}>
                   {(answer) => {
                     const words = answer.data ?? [];
                     if (words.length === 0) {

--- a/frontend/src/screens/users-access.tsx
+++ b/frontend/src/screens/users-access.tsx
@@ -67,7 +67,7 @@ export function AccessPreviewPanel({
   return (
     <div className="users-access-preview" aria-live="polite">
       <p className="t-caption">{t("users.access.title")}</p>
-      <QueryGate query={preview}>
+      <QueryGate query={preview} pendingLabel={t("users.access.title")}>
         {(access) => <AccessSummary access={access} />}
       </QueryGate>
     </div>
@@ -232,7 +232,7 @@ export function TeamsCard() {
             {problemMessageOf(archive.error, t)}
           </Callout>
         )}
-        <QueryGate query={teams}>
+        <QueryGate query={teams} pendingLabel={t("users.teamsTitle")}>
           {(list) => {
             // The roster hook serves users and teams alike, so narrow to the
             // entries that actually carry a team's name rather than asserting
@@ -391,7 +391,7 @@ function TeamMembers({
   }
 
   return (
-    <QueryGate query={users}>
+    <QueryGate query={users} pendingLabel={t("users.teamMembersLabel")}>
       {(list) => {
         // The roster serves users and teams alike, so narrow to the entries
         // that carry an address rather than asserting the shape — and then to

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -134,7 +134,7 @@ function MembersCard({
           {t("users.membersSub")}
           {probeSettled && !canAdminister && ` ${t("users.adminOnly")}`}
         </p>
-        <QueryGate query={members}>
+        <QueryGate query={members} pendingLabel={t("users.membersTitle")}>
           {(list) =>
             list.length === 0 ? (
               <EmptyState>{t("users.empty")}</EmptyState>

--- a/frontend/src/screens/voice-dna.tsx
+++ b/frontend/src/screens/voice-dna.tsx
@@ -100,7 +100,7 @@ export function VoiceDnaCard() {
   const qc = useQueryClient();
   const profile = useVoiceProfile();
   return (
-    <QueryGate query={profile}>
+    <QueryGate query={profile} pendingLabel={t("settings.voice.title")}>
       {(data) =>
         data ? (
           <VoiceDnaBody profile={data} />
@@ -451,7 +451,7 @@ function CorpusManifest({
 
   return (
     <div className="vdna-manifest settingrow-measure">
-      <QueryGate query={sources}>
+      <QueryGate query={sources} pendingLabel={t("settings.voice.title")}>
         {(manifest) => (
           <div>
             <p className="t-small">

--- a/frontend/src/screens/voice-versions.tsx
+++ b/frontend/src/screens/voice-versions.tsx
@@ -53,9 +53,10 @@ export function ActiveVoiceInsights({
   canEdit: boolean;
   onChanged: () => void;
 }>) {
+  const t = useT();
   const versions = useVoiceVersions(profileId);
   return (
-    <QueryGate query={versions}>
+    <QueryGate query={versions} pendingLabel={t("settings.voice.title")}>
       {(list) => {
         const active = list.find((version) => version.status === "active");
         const candidate = list.find(
@@ -285,10 +286,14 @@ export function VoiceHistory({
     // `settingrow-measure` is the row primitive's hook for a control that takes
     // a stacked row's full width, which is the only place this list is drawn.
     <div className="settingrow-measure">
-      <QueryGate query={versions}>
+      <QueryGate query={versions} pendingLabel={t("voice.history.label")}>
         {(page) =>
           allVersions.length === 0 ? (
-            <SurfaceState state="empty" emptyLabel={t("voice.history.empty")}>
+            <SurfaceState
+              state="empty"
+              emptyLabel={t("voice.history.empty")}
+              loadingLabel={t("voice.history.label")}
+            >
               {null}
             </SurfaceState>
           ) : (
@@ -318,7 +323,7 @@ export function VoiceHistory({
           )
         }
       </QueryGate>
-      <QueryGate query={learning}>
+      <QueryGate query={learning} pendingLabel={t("voice.history.label")}>
         {(summary) => (
           <p className="t-small vdna-learning">
             {t("voice.history.learning", {
@@ -362,7 +367,7 @@ export function VoiceChangeLog({ profileId }: Readonly<{ profileId: string }>) {
     },
   });
   return (
-    <QueryGate query={deltas}>
+    <QueryGate query={deltas} pendingLabel={t("voice.history.label")}>
       {(page) =>
         allDeltas.length === 0 ? (
           <p className="t-small">{t("voice.history.deltasEmpty")}</p>

--- a/frontend/src/screens/webhooks.tsx
+++ b/frontend/src/screens/webhooks.tsx
@@ -652,7 +652,7 @@ function DeliveriesPanel({
 
   return (
     <div className="webhook-deliveries-panel" id={id}>
-      <QueryStates query={query}>
+      <QueryStates query={query} pendingLabel={t("webhooks.deliveries.title")}>
         <DeliveriesBody
           response={query.data}
           subscriptionId={subscription.id}
@@ -966,6 +966,7 @@ export function WebhooksCard() {
             `SettingList` — which is the whole reason the rows no longer space
             themselves. */}
         <QueryGate
+          pendingLabel={t("webhooks.title")}
           query={query}
           empty={(result) => result.deliveryEnabled && result.data.length === 0}
         >


### PR DESCRIPTION
Closes #3863, on the ruling recorded there: required on both wrappers, tree cleared in one pass.

## Before and after

```
                            before        after
PendingBody.label           required  ->  unchanged
QueryGate.pendingLabel      3 of 120  ->  required
SurfaceState.loadingLabel  14 of  78  ->  required
                          ─────────────────────────
wait sites naming their wait   17     ->  197 of 197
```

183 of 198 waits used to announce a generic "Loading…". None does now.

## Most of these labels were not written — they were already on the screen

That is the part worth reviewing, because it is what kept the diff honest. The obligation was pushed to whoever already knew the answer, in this order:

1. **A titled `Panel`/`RailPanel` hands its own title down.** Its callers say nothing, because the wrapper knows. (45 sites)
2. **A section with its own `label` reuses it** — it has already named itself on screen. (5)
3. **An `emptyLabel` of `x.empty` takes its sibling `x.title`** where the catalog has one. (22)
4. **A nearby `title={t(…)}` or heading.** (13)
5. The rest — where the screen genuinely had to say it — were chosen per screen from the key that names that section. Only where nothing existed did I reach for the screen's nav word.

No new i18n keys were minted. Every label is a key the catalog already carries, so there is no new copy to translate and nothing for the locale census to catch.

## Two components pass the obligation up instead of inventing an answer

- `DecisionDeck` takes a required `loadingLabel`.
- `DecisionCard`'s `labels` gain `loading`, beside `noContent` — they answer the same question in the two states a body can be absent in, and the card knows neither. Two production callers fill it in.

## One test was resting on an ambiguous signal

`home.rail.test` did `await screen.findByText("Overnight")` and then read the counts synchronously. "Overnight" is the panel's name — and now also what its pending state announces, so the wait resolved while the digest was still in flight and every count was still a skeleton.

The signal was ambiguous before this change and happened to work; it now waits on content. Worth flagging because it is the one behavioural consequence of announcing a section's name while it loads, and it is the announcement working rather than a regression.

## Testing

`make check-fe` green — biome, the unit suite, the composed typecheck and the build. The three `extensions/openchannel/frontend` sites are in the composed lane and are labelled too.

The compiler is the completeness proof here: with both props required, a site that says nothing does not build. I re-measured after the fact rather than trusting that — 197 of 197.

## Reviewing this

120 files, and the diff is mechanical by construction. The parts that carry judgement and are worth a real read are `design-system/panel.tsx`, `design-system/surfacestate.tsx`, `design-system/decisioncard.tsx`, `design-system/decisiondeck.tsx` and `screens/common.tsx` — the signature changes and the two wrappers that supply a label rather than demand one. Everything else is one prop taking a name that was already in scope.
