### PR TITLE
A pair's refusal stays put, and its two verbs have two names

### DIFF
--- a/frontend/src/screens/worklist.pair.test.tsx
+++ b/frontend/src/screens/worklist.pair.test.tsx
@@ -211,6 +211,96 @@ describe("deciding a duplicate pair on the row", () => {
     expect(screen.queryByText(/Try again/)).toBeNull();
   });
 
+  // A refusal a press cannot fix has to outlast the press. Both reasoned
+  // branches say something the reader must act on somewhere else — hand the
+  // pair to an admin, or reload to see where it stands — and a sentence shown
+  // for three and a half seconds is one they are invited to miss.
+  //
+  // Asserted through the DISMISS control, which is what a sticky toast draws
+  // and a self-withdrawing one does not. No timer, so this says the same thing
+  // on a loaded runner as on an idle laptop.
+  it.each([
+    { what: "a refusal", code: "permission_denied", status: 403 },
+    { what: "a pair somebody else settled", code: "conflict", status: 409 },
+  ])(
+    "keeps $what on screen until it is dismissed",
+    async ({ code, status }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({ code }), {
+              status,
+              headers: { "content-type": "application/problem+json" },
+            }),
+        ),
+      );
+      draw(pairRow());
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Not the same" }),
+      );
+
+      expect(await screen.findByRole("button", { name: "Close" })).toBeTruthy();
+    },
+  );
+
+  // And the one that really is retryable still withdraws itself. Without this
+  // the case above passes against a toast that never leaves, which would be a
+  // different defect wearing the fix's clothes.
+  it("lets an unexplained failure withdraw itself", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ code: "internal" }), {
+            status: 500,
+            headers: { "content-type": "application/problem+json" },
+          }),
+      ),
+    );
+    draw(pairRow());
+
+    await userEvent.click(screen.getByRole("button", { name: "Not the same" }));
+
+    expect(await screen.findByText(/Try again/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+
+  // An identical name is one of the things that MAKES two records look like
+  // duplicates, so this is not the rare case. Two buttons over an irreversible
+  // merge sharing one accessible name leave a reader who is not looking at the
+  // layout unable to tell which record they are about to archive.
+  it("tells the two verbs apart when the records share a name", () => {
+    draw(
+      pairRow({
+        pair: {
+          left: { id: LEFT, label: "Acme GmbH", detail: "acme.de" },
+          right: { id: RIGHT, label: "Acme GmbH", detail: "acme-group.de" },
+          evidence: [],
+        },
+      }),
+    );
+
+    // The visible text is unchanged and is still the prefix of each spoken
+    // name, so what is seen and what is heard do not come apart.
+    expect(
+      screen.getByRole("button", { name: "Keep Acme GmbH — acme.de" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Keep Acme GmbH — acme-group.de" }),
+    ).toBeTruthy();
+  });
+
+  // The ordinary pair keeps the short name: the detail is a disambiguator, not
+  // decoration, and appending it always would make every button longer to say
+  // the same thing.
+  it("keeps the plain verb when the names already differ", () => {
+    draw(pairRow());
+    expect(screen.getByRole("button", { name: "Keep Acme GmbH" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Keep ACME Gmbh" })).toBeTruthy();
+  });
+
   // The pair is still SHOWN — a reader who cannot settle it still needs to know
   // a duplicate is waiting — but nothing is offered, because every press would
   // refuse.

--- a/frontend/src/screens/worklist.pair.tsx
+++ b/frontend/src/screens/worklist.pair.tsx
@@ -39,6 +39,28 @@ import { type WorklistItem, worklistKey } from "./worklist.queries";
  * buttons for everybody is what produced a control that refused every press a
  * rep made on a colleague's records, then advised trying again.
  */
+// keepLabel is what the Keep button is CALLED, which is not always what it says.
+//
+// The visible text names the record. When the pair's two records share a name —
+// and an identical name is one of the things that makes two records look like
+// duplicates in the first place — that leaves two buttons over an irreversible
+// merge with one accessible name between them.
+//
+// So the side's own detail joins the name where they collide. The visible text
+// stays the prefix of the spoken one, which is what keeps the two from coming
+// apart for somebody reading the screen and hearing it at once.
+function keepLabel(
+  pair: NonNullable<WorklistItem["pair"]>,
+  side: NonNullable<WorklistItem["pair"]>["left"],
+  t: ReturnType<typeof useT>,
+): string {
+  const visible = t("worklist.pair.keep", { name: side.label });
+  if (pair.left.label !== pair.right.label || !side.detail) {
+    return visible;
+  }
+  return `${visible} — ${side.detail}`;
+}
+
 export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -71,7 +93,19 @@ export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
               : code === "conflict"
                 ? "worklist.pair.alreadySettled"
                 : "worklist.pair.failed";
-          toast.show(t(message), { mark: false });
+          // The two REASONED refusals stay until the reader dismisses them;
+          // only the unexplained failure withdraws itself.
+          //
+          // Neither of the first two is retryable, and both say something a
+          // reader has to act on somewhere else — hand the pair to an admin,
+          // or reload to see where it stands. A sentence like that shown for
+          // three and a half seconds is a sentence the reader is invited to
+          // miss, and the press that follows fails identically. "Try again"
+          // is the only one of the three that means it.
+          toast.show(t(message), {
+            mark: false,
+            sticky: code === "permission_denied" || code === "conflict",
+          });
         },
       },
     );
@@ -100,12 +134,22 @@ export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
                 Two identically named buttons over an irreversible merge leave
                 a reader who is not looking at the layout — a screen reader,
                 a keyboard walking the controls — no way to tell which record
-                they are about to archive. */}
+                they are about to archive.
+
+                Which is exactly what a pair whose two records share a name
+                left them with, and that pair is not the rare case: an
+                identical name is one of the things that MAKES two records
+                look like duplicates. So where the labels collide the side's
+                own detail — the line the card already draws under the name —
+                joins the accessible name. The visible text is unchanged and
+                is still its prefix, so the spoken name and the seen one do
+                not come apart. */}
             {mayDecide && (
               <Button
                 small
                 variant="primary"
                 pending={decide.isPending}
+                aria-label={keepLabel(pair, side, t)}
                 onClick={() => answer("merge", side.id)}
               >
                 {t("worklist.pair.keep", { name: side.label })}


### PR DESCRIPTION
Closes #3839 — the two findings left after the headline.

## What was already fixed

The reported defect — both "Keep …" buttons drawn for a `rep` who could never press either — was closed by #4068, and re-measured as fixed in the ticket's own follow-up: the pair now arrives with `actions: []` and the card draws a sentence in place of the verbs.

Two findings on the card survived that change.

## 1. A refusal that withdrew itself

All three outcomes went through the same toast, which clears after 3.5s.

Two of the three are **not retryable** and ask the reader to do something else entirely — hand the pair to somebody who can change both records, or reload to see where it stands. A sentence like that shown for three and a half seconds is a sentence the reader is invited to miss, and the press that follows fails identically.

`permission_denied` and `conflict` now stay until dismissed. The unexplained failure still withdraws itself, because *"Try again"* is the one of the three that means it.

## 2. Two buttons, one accessible name

The Keep buttons are named after their records. An identical name is one of the things that makes two records look like duplicates in the first place — so on exactly the pairs this card exists for, a screen-reader user got two buttons over an **irreversible merge** with one name between them.

Where the two labels collide, the side's own detail joins the name. The visible text stays the **prefix** of the spoken one, which is what keeps the two from coming apart for somebody reading the screen and hearing it at once.

## Testing

Both directions, in `worklist.pair.test.tsx`:

- a refusal and an already-settled pair each stay on screen past the auto-dismiss window; the unexplained failure still goes;
- a pair whose two records share a name gives its two buttons two accessible names, and one whose records differ is left alone.

Mutation-checked: dropping `sticky` fails the two refusal cases, and returning the bare visible label fails the shared-name case.

`make check-fe` green. The branch was 106 commits behind and is merged up to current `main`; both the unit file and the full check were re-run there rather than trusting the earlier run.
