### PR TITLE
A PENDING WRITER claim fails when the writer lands

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 36
+	wantFixtureAnnotations = 37
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/pendingwriter_test.go
+++ b/backend/gates/pendingwriter_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A "no writer yet" classification stops being true the moment a writer lands.
+//
+// backend/migrations/schema_fitness_integration_test.go classifies every FK
+// column into a row-scoped table, and some entries say PENDING WRITER: nobody
+// creates a row here, so there is no gate to name, and the entry carries the
+// obligation on whoever writes the first one instead.
+//
+// Nothing failed when that writer arrived. The entry simply became false, and
+// the next reader greps, finds a confident sentence about how the column is
+// gated, and stops looking — the failure AGENTS.md's one-source-of-truth page
+// and rule 8 both name. It is not hypothetical: five of the seven entries this
+// gate was filed over have since gained writers, and each was corrected by
+// hand, whenever somebody happened to notice.
+//
+// So the claim holds itself. A table named here that gains an INSERT fails,
+// and the entry has to be replaced with the gate that now covers it.
+//
+// ## The column, not the table
+//
+// A table gaining a row creator is not the same event. conversation_claim is
+// INSERTed into today and names nine columns, none of them task_activity_id —
+// so that claim is still true, and a table-level trigger would have reported it
+// false on the day this gate was written. The column list is what the claim is
+// about, so the column list is what is read.
+//
+// ## Why the set is declared here
+//
+// The classification lives in an integration-tagged file under
+// backend/migrations, which this lane cannot import. Rather than reach across,
+// each lane holds what it can actually see: the entries there cite this gate,
+// and this names the tables. TestEveryPendingWriterTableIsStillClassified is
+// what keeps the two from drifting apart — it fails if a table here has no
+// PENDING WRITER entry left over there.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// pendingWriterTables are the tables whose FK classification says no writer
+// exists yet. One entry per table, with the column that carries the claim.
+// gatekit:fixture the column each table's PENDING WRITER claim is about — a
+// subject and its column, not a subject and the cost of exempting it
+var pendingWriterTables = map[string]string{
+	// conversation_claim IS inserted into — nine columns, none of them this
+	// one. The claim is about the column, which is why a table-level trigger
+	// would have reported it false on the day this gate was written.
+	"conversation_claim": "task_activity_id",
+}
+
+func TestNoPendingWriterHasAWriter(t *testing.T) {
+	t.Parallel()
+	writes := collectTableWrites(t)
+
+	var landed []string
+	inserts, withColumns := 0, 0
+	for owner, ws := range writes {
+		for _, w := range ws {
+			if w.verb != "insert" {
+				continue
+			}
+			inserts++
+			if len(w.cols) > 0 {
+				withColumns++
+			}
+			column, pending := pendingWriterTables[w.table]
+			if !pending {
+				continue
+			}
+			// An INSERT whose column list this reader could not extract is
+			// UNKNOWN, not empty — reported, because the alternative is a
+			// claim quietly surviving a statement nobody could read.
+			if len(w.cols) == 0 {
+				landed = append(landed, w.table+"."+column+
+					" — an INSERT whose columns could not be read, "+owner+" at "+w.pos)
+				continue
+			}
+			for _, col := range w.cols {
+				if col == column {
+					landed = append(landed, w.table+"."+column+" — "+owner+" at "+w.pos)
+					break
+				}
+			}
+		}
+	}
+
+	// Under-recognition is the one way this must not break, and it has two
+	// shapes here: a walk that reads no INSERTs at all, and one that reads
+	// them but extracts no column lists. Either reports every claim intact.
+	if inserts < 100 {
+		t.Fatalf("the walk found %d INSERT statements, want at least 100 — "+
+			"it is reading less than it thinks, and a census that can fail "+
+			"short has already failed", inserts)
+	}
+	if withColumns*2 < inserts {
+		t.Fatalf("only %d of %d INSERTs yielded a column list — the extraction "+
+			"is reading less than it thinks, and every claim below rests on it",
+			withColumns, inserts)
+	}
+
+	for _, finding := range landed {
+		t.Errorf("%s is classified PENDING WRITER and now has one.\n"+
+			"\tThe entry in backend/migrations/schema_fitness_integration_test.go "+
+			"states an obligation on whoever writes the first row. Somebody has. "+
+			"Replace it with the gate that covers the write, and drop the table "+
+			"from pendingWriterTables here.", finding)
+	}
+}
+
+// The two lanes hold two halves of one claim, so each has to be able to fail
+// when the other moves. This is the half that catches an entry retired over
+// there while the table stays listed here — which would leave this gate
+// guarding a claim nobody makes any more.
+func TestEveryPendingWriterTableIsStillClassified(t *testing.T) {
+	t.Parallel()
+	const classification = "migrations/schema_fitness_integration_test.go"
+	source, err := os.ReadFile(classification)
+	if err != nil {
+		t.Fatalf("reading %s: %v", classification, err)
+	}
+	text := string(source)
+	if !strings.Contains(text, "PENDING WRITER") {
+		t.Fatalf("%s names no PENDING WRITER at all — either every entry was "+
+			"retired, in which case pendingWriterTables should be empty, or "+
+			"this gate is reading the wrong file", classification)
+	}
+	for table, column := range pendingWriterTables {
+		entry := `"` + table + "." + column + `":`
+		if !strings.Contains(text, entry) {
+			t.Errorf("%s.%s is listed here but %s carries no entry for it",
+				table, column, classification)
+			continue
+		}
+		// The entry exists; it has to still be the PENDING WRITER one. A
+		// classification rewritten to name a real gate is the good outcome,
+		// and it is the moment this table stops belonging here.
+		rest := text[strings.Index(text, entry)+len(entry):]
+		line := rest
+		if end := strings.Index(rest, "\n"); end >= 0 {
+			line = rest[:end]
+		}
+		if !strings.Contains(line, "PENDING WRITER") {
+			t.Errorf("%s.%s is no longer classified PENDING WRITER — drop it "+
+				"from pendingWriterTables, which exists to hold that claim",
+				table, column)
+		}
+	}
+}

--- a/backend/gates/sqlwrites_test.go
+++ b/backend/gates/sqlwrites_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gates
+
+// Reading a SQL literal for what it WRITES.
+//
+// Its own file because it is not one gate's helper: table ownership, the PII
+// censuses, the satellite lifecycle, the person scrub and the pending-writer
+// claim all ask it, and the last time two of them read statements separately
+// the two answers drifted.
+//
+// Everything here is a FLOOR and never a ceiling. A statement assembled at
+// runtime, an INSERT … SELECT with no column list, a fragment naming no table
+// — each contributes nothing, so a caller must read an empty answer as
+// "unknown" and never as "writes nothing". Every gate over this corpus carries
+// its own floor assertion for that reason.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// sqlWriteTargets extracts write-statement table names from one SQL (or
+// SQL-carrying format) string. UPDATE requires a SET clause so prose and
+// `DO UPDATE SET`/`FOR UPDATE` never match; INSERT/DELETE are unambiguous.
+var (
+	insertRe = regexp.MustCompile(`(?is)\binsert\s+into\s+([a-z_][a-z0-9_]*)`)
+	deleteRe = regexp.MustCompile(`(?is)\bdelete\s+from\s+([a-z_][a-z0-9_]*)`)
+	updateRe = regexp.MustCompile(`(?is)\b(do\s+|for\s+)?update\s+([a-z_][a-z0-9_]*)\s+(?:[a-z_][a-z0-9_]*\s+)?set\b`)
+)
+
+var (
+	insertColsRe = regexp.MustCompile(`(?is)\binsert\s+into\s+[a-z_][a-z0-9_]*\s*\(([^)]*)\)`)
+	setColRe     = regexp.MustCompile(`(?is)([a-z_][a-z0-9_]*)\s*=`)
+)
+
+// insertColumns reads the column list of the FIRST insert in a literal. One
+// statement per literal is this tree's style; a literal carrying two inserts
+// gets the first one's list, which is why cols is a floor.
+func insertColumns(literal string) []string {
+	m := insertColsRe.FindStringSubmatch(literal)
+	if m == nil {
+		return nil
+	}
+	var cols []string
+	for _, raw := range strings.Split(m[1], ",") {
+		name := strings.ToLower(strings.Trim(strings.TrimSpace(raw), `"`))
+		if name != "" {
+			cols = append(cols, name)
+		}
+	}
+	return cols
+}
+
+// setColumns reads the assignment targets of an UPDATE's SET clause, stopping
+// at WHERE so a predicate's comparisons are not read as writes.
+func setColumns(literal string) []string {
+	lower := strings.ToLower(literal)
+	at := strings.Index(lower, " set ")
+	if at < 0 {
+		return nil
+	}
+	clause := literal[at+len(" set "):]
+	if end := strings.Index(strings.ToLower(clause), " where "); end >= 0 {
+		clause = clause[:end]
+	}
+	var cols []string
+	for _, m := range setColRe.FindAllStringSubmatch(clause, -1) {
+		cols = append(cols, strings.ToLower(m[1]))
+	}
+	return cols
+}
+
+// sqlWriteTargets is sqlWrites projected to the table names, which is all most
+// callers ask. One scan underneath, so a statement shape learned by one view
+// is learned by both.
+func sqlWriteTargets(literal string) []string {
+	writes := sqlWrites(literal)
+	tables := make([]string, 0, len(writes))
+	for _, w := range writes {
+		tables = append(tables, w.table)
+	}
+	return tables
+}
+
+func sqlWrites(literal string) []sqlTarget {
+	var tables []sqlTarget
+	for _, m := range insertRe.FindAllStringSubmatch(literal, -1) {
+		tables = append(tables, sqlTarget{strings.ToLower(m[1]), "insert", insertColumns(literal)})
+	}
+	for _, m := range deleteRe.FindAllStringSubmatch(literal, -1) {
+		tables = append(tables, sqlTarget{strings.ToLower(m[1]), "delete", nil})
+	}
+	for _, m := range updateRe.FindAllStringSubmatch(literal, -1) {
+		if m[1] != "" { // ON CONFLICT … DO UPDATE / SELECT … FOR UPDATE — not a new target
+			continue
+		}
+		tables = append(tables, sqlTarget{strings.ToLower(m[2]), "update", setColumns(literal)})
+	}
+	return tables
+}

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -38,7 +38,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -481,30 +480,17 @@ var tableOwners = map[string]string{
 	"system_log":       storekitOwned,
 }
 
-// sqlWriteTargets extracts write-statement table names from one SQL (or
-// SQL-carrying format) string. UPDATE requires a SET clause so prose and
-// `DO UPDATE SET`/`FOR UPDATE` never match; INSERT/DELETE are unambiguous.
-var (
-	insertRe = regexp.MustCompile(`(?is)\binsert\s+into\s+([a-z_][a-z0-9_]*)`)
-	deleteRe = regexp.MustCompile(`(?is)\bdelete\s+from\s+([a-z_][a-z0-9_]*)`)
-	updateRe = regexp.MustCompile(`(?is)\b(do\s+|for\s+)?update\s+([a-z_][a-z0-9_]*)\s+(?:[a-z_][a-z0-9_]*\s+)?set\b`)
-)
-
-func sqlWriteTargets(literal string) []string {
-	var tables []string
-	for _, m := range insertRe.FindAllStringSubmatch(literal, -1) {
-		tables = append(tables, strings.ToLower(m[1]))
-	}
-	for _, m := range deleteRe.FindAllStringSubmatch(literal, -1) {
-		tables = append(tables, strings.ToLower(m[1]))
-	}
-	for _, m := range updateRe.FindAllStringSubmatch(literal, -1) {
-		if m[1] != "" { // ON CONFLICT … DO UPDATE / SELECT … FOR UPDATE — not a new target
-			continue
-		}
-		tables = append(tables, strings.ToLower(m[2]))
-	}
-	return tables
+// sqlTarget is one write a literal performs: which table, by which verb, and
+// which columns it names.
+//
+// cols is best-effort and only ever a FLOOR: an INSERT's parenthesised column
+// list and an UPDATE's SET targets are read, and anything else — a fragment
+// assembled at runtime, an INSERT … SELECT with no list — contributes none.
+// Every reader of it has to treat an empty list as "unknown", never as "writes
+// nothing".
+type sqlTarget struct {
+	table, verb string
+	cols        []string
 }
 
 // owningDir normalizes a package dir to its ownership unit: the module root
@@ -618,6 +604,18 @@ func stringConstsByPackage(t *testing.T, fset *token.FileSet, roots []string) ma
 type tableWrite struct {
 	pos   string // file:line for the finding
 	table string
+	// verb is which write this is — "insert", "delete" or "update".
+	//
+	// cols carries the columns the statement names, where they can be read.
+	//
+	// Ownership does not care: writing a table you do not own is the same
+	// finding whichever verb does it. It is recorded because a SECOND gate
+	// asks a question ownership cannot — whether a column classified as
+	// having no writer yet has gained one — and "a row was created here" is
+	// not the same claim as "privacy deletes from this table", which it
+	// already does for both communication tables.
+	verb string
+	cols []string
 	// site is the write's INSTANCE — "path/to/file.go:enclosingFunc" — and it
 	// is what a waiver ratifies. The enclosing FUNCTION rather than the line:
 	// a line moves whenever anything above it does, so a line-keyed waiver
@@ -685,11 +683,13 @@ func collectTableWrites(t *testing.T) map[string][]tableWrite {
 			// walk: ast.Inspect is flat, and a stack maintained by hand here
 			// would be a second traversal to keep correct.
 			enclosing := unnamedDeclSite
-			record := func(pos token.Pos, tables []string) {
-				for _, table := range tables {
+			record := func(pos token.Pos, tables []sqlTarget) {
+				for _, target := range tables {
 					writes[owner] = append(writes[owner], tableWrite{
 						pos:   fset.Position(pos).String(),
-						table: table,
+						table: target.table,
+						verb:  target.verb,
+						cols:  target.cols,
 						// Relative to the owner, which the key already names:
 						// the absolute path would repeat that prefix in every
 						// entry and push the part a reader is actually
@@ -708,7 +708,7 @@ func collectTableWrites(t *testing.T) map[string][]tableWrite {
 					if err != nil {
 						return
 					}
-					record(node.Pos(), sqlWriteTargets(text))
+					record(node.Pos(), sqlWrites(text))
 				case *ast.CallExpr:
 					sel, ok := node.Fun.(*ast.SelectorExpr)
 					if !ok || !storekitTableArg[sel.Sel.Name] || len(node.Args) < 4 {
@@ -729,7 +729,12 @@ func collectTableWrites(t *testing.T) map[string][]tableWrite {
 							fset.Position(node.Pos()), exprText(fset, sel.X), sel.Sel.Name)
 						return
 					}
-					record(node.Pos(), []string{strings.ToLower(table)})
+					// Not "insert", and that is checkable rather than assumed:
+					// storekitTableArg holds Apply* and Lock* only, and none
+					// of them creates a row. TestNoPendingWriterHasAWriter
+					// leans on that — an INSERT cannot arrive through this arm
+					// and be read as an update.
+					record(node.Pos(), []sqlTarget{{table: strings.ToLower(table), verb: "storekit"}})
 					storekitWrites++
 				}
 			}

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -156,7 +156,11 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// a promise: nothing writes task_activity_id.
 	"conversation_claim.person_id":          "gated: RecordConversationClaim opens with auth.RequireHuman + auth.Require(person, update), then auth.EnsureWritableLive on the person inside the write's own transaction — a claim may only be recorded against a person the caller could already change",
 	"conversation_claim.source_activity_id": "gated: the same writer takes auth.EnsureActivityContentVisibleLive on the cited activity in that transaction, so a claim can never quote a message the caller may not open — and LIVE rather than merely visible, because a claim must not outlive its evidence",
-	"conversation_claim.task_activity_id":   "PENDING WRITER: the column has no writer. The task an extracted commitment creates is written through the tasks substrate's own gated path, and this entry is replaced with that gate when the routing edge lands",
+	// Held by backend/gates/pendingwriter_test.go, which fails when a column
+	// classified PENDING WRITER gains one — the entry becoming false is
+	// otherwise silent, and five of the seven this file once carried went
+	// stale exactly that way.
+	"conversation_claim.task_activity_id": "PENDING WRITER: the column has no writer. The task an extracted commitment creates is written through the tasks substrate's own gated path, and this entry is replaced with that gate when the routing edge lands",
 	// Owned child rows: the row is an attribute of its visible parent,
 	// written only through the parent's own gated paths.
 	"organization_geocode_state.organization_id": "child row: the sidecar for an organization's own coordinate lookup, and no caller ever names the organization it keys on. " +
@@ -240,7 +244,7 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// subject a writer may name is the run's own, which QueueRun gated before
 	// the run existed, and a writer that named a person of its own instead
 	// would need its own gate and its own entry.
-	"provider_applied_field.person_id": "PENDING WRITER: the obligation on whoever writes it — the subject must be the run's own, which QueueRun already gated, as its sibling person_provider_claim.person_id is",
+	"provider_applied_field.person_id": "child row: written by ApplyProviderClaims (people/providerclaimapply.go) from the run's own subject, which QueueRun already gated; the writer re-takes the check itself — auth.HoldWritableLive on the person, inside the hand-off transaction — so every fill that puts provider PII on a shareable record is gated where it is written rather than two packages back",
 	// telegram-oa design §6.4: the channel-aware ensure contract creates the
 	// Person (owner_id NULL) and this identity satellite in the same
 	// transaction, from the inbound message's own channel principal —

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (102)
+## Census (103)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -171,6 +171,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `parallelgates_test.go` | H3 | Every gate here runs in parallel with the others, and this is what keeps that true as gates are added. |
 | `passportlessagents_test.go` | H1 | An agent principal carrying no passport is a principal nobody can revoke. |
 | `passportmint_test.go` | H1 | A passport is minted for the session user, and for nobody else. |
+| `pendingwriter_test.go` | H2 | A "no writer yet" classification stops being true the moment a writer lands. |
 | `personattachlock_test.go` | H2 | A relationship carrying a person is written under that person's row lock. |
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicolumncoverage_test.go` | H2 | The Art. 17 redaction, judged by COLUMN rather than by table. |


### PR DESCRIPTION
Closes #3831.

## The gate found a stale claim on its first run

The ticket says seven entries were classified `PENDING WRITER`. By the time I looked, five had already gained writers and been corrected **by hand** — which is the defect, not evidence against it: the entries went false silently and were fixed whenever somebody happened to notice.

Running the new census for the first time found a sixth. `provider_applied_field.person_id` is written by `ApplyProviderClaims`, and has been for a while:

```sql
INSERT INTO provider_applied_field
       (person_id, run_id, provider, …)
```

Its entry still said *"the obligation on whoever writes it"*. It now names the gate that actually covers the write — `auth.HoldWritableLive` on the person, taken by the writer itself inside the hand-off transaction.

## The column, not the table

The ticket's sketch fires when a pending column's **table** gains an INSERT. That would have been wrong on day one: `conversation_claim` is INSERTed into today and names nine columns, **none of them `task_activity_id`**. The claim is still true, and a table-level trigger would have reported it false immediately.

So `sqlWrites` reads the INSERT's column list and the UPDATE's SET targets, and the census asks about the column the claim is about.

## The two pieces the ticket named

- **The verb.** `tableWrite` recorded the table but not the verb, so "has an INSERT" could not be told from "has the DELETE privacy already performs". It carries both now. The storekit arm records `storekit` rather than guessing — `storekitTableArg` holds `Apply*` and `Lock*` only, none of which creates a row, so an INSERT cannot arrive through it and be misread.
- **The map's home.** The classification lives in an integration-tagged file under `backend/migrations`, which the gates lane cannot import. Each lane holds what it can actually see: this gate names the tables, the entries there cite this gate, and `TestEveryPendingWriterTableIsStillClassified` fails when the two drift — which it did, on the first run, when the entry above was retired.

`sqlWriteTargets` and its siblings move into `sqlwrites_test.go`. Five gates read statements through it and it is not one gate's helper; `tableownership_test.go` also crossed the 1000-line test cap.

## Two floors, because this census has two ways to fail short

Rule 8 in both directions:

- fewer than 100 INSERTs found → the walk is reading less than it thinks;
- fewer than half of those yielding a column list → the extraction is, and every claim rests on it.

The second one earned its place immediately: it caught a real bug of mine — a `\b` that became a literal backspace byte in the regex — that would otherwise have shipped a census reading 0 of 308 column lists and reporting every claim intact.

An INSERT into a listed table whose columns *cannot* be read is reported rather than skipped, for the same reason.

## Testing

Mutation-checked both directions: adding `task_activity_id` to `conversation_claim`'s INSERT fails the census by name, and neutering `insertColumns` trips the extraction floor rather than passing quietly.

`make check-backend` green; `craft static --strict` clean on the diff. Two other gates asked for things on the way and both are in the diff: the map is declared `gatekit:fixture` (its values are column names, not costs) and the fixture pin moved with it.
