### PR TITLE
A reason a row gives is one the contract declares

### DIFF
--- a/backend/gates/worklistreasonkinds_test.go
+++ b/backend/gates/worklistreasonkinds_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every reason a row gives is one the contract declares and a client can render.
+//
+// A `because` entry is a typed pair — the server names the FACT and the client
+// writes the phrase, because the product ships three languages and a sentence
+// composed on the server would reach a German reader in English. That split has
+// a cost: the kind is the whole of the agreement, and nothing enforces it.
+//
+// `WorklistReasonKind` is a string alias, so `reason("stale_deal", …)` compiles
+// exactly as `reason("stale", …)` does. The wrong one is not a crash and not a
+// validation error. The row renders, its rank is unchanged, and the one symptom
+// is a line of evidence missing from the queue — the reader is simply not told
+// why the row is there, on the surface whose entire job is to say why.
+//
+// So: every kind a producer emits must be declared, and every kind the contract
+// declares must be renderable. The second direction is held on the frontend
+// (`KNOWN_REASONS` in worklist.copy.ts); this gate holds the first.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// whereReasonsAreMinted is the package whose producers this gate reads.
+//
+// Named as a directory rather than as a list of files: a lane added tomorrow
+// gets a new file, and a gate naming today's files would not read it — which is
+// the shape of under-recognition this check must not have, since a smaller
+// corpus reports PASS with nothing to notice.
+const whereReasonsAreMinted = "internal/compose/attention"
+
+func TestEveryReasonKindAProducerEmitsIsDeclared(t *testing.T) {
+	t.Parallel()
+	declared := crmYAMLEnum(t, "WorklistReason", "kind")
+	if len(declared) == 0 {
+		t.Fatal("read no reason kinds from crm.yaml: a census over an empty vocabulary passes without looking at anything")
+	}
+	emitted := reasonKindsEmitted(t)
+	// The corpus must not be able to come back empty. A walk that matched
+	// nothing — a renamed constructor, a moved package — would leave this gate
+	// green over a tree it never read.
+	if len(emitted) == 0 {
+		t.Fatalf("found no reason(...) calls under %s: the walk reads nothing, so this gate "+
+			"would pass whatever the producers emit", whereReasonsAreMinted)
+	}
+	for _, kind := range emitted {
+		if !slices.Contains(declared, kind) {
+			t.Errorf("a producer emits the reason kind %q, which crm.yaml does not declare: "+
+				"the row would reach a reader with an evidence line no client can write. "+
+				"Add it to WorklistReason.kind, or use one of %v", kind, declared)
+		}
+	}
+}
+
+// reasonKindsEmitted is every literal kind handed to `reason(...)` in the
+// package that mints them.
+//
+// Held by: TestEveryReasonKindAProducerEmitsIsDeclared
+// (backend/gates/worklistreasonkinds_test.go), whose own corpus check fails
+// when this walk comes back empty — a renamed constructor or a moved package
+// would otherwise leave it reading nothing and reporting PASS.
+//
+// Read as SYNTAX rather than as text. A grep for `reason("` matches the word in
+// a comment and misses a call split across lines by the formatter; the AST
+// matches the call itself, which is the thing this gate is about.
+//
+// Only literal arguments are collected, and that is honest rather than
+// complete: a kind computed at runtime cannot be checked here, and the two that
+// exist — the batch summariser's "routine" and "repeated_failure" — are
+// returned from a helper rather than passed to `reason` directly. Those are
+// covered by the frontend's own vocabulary check, and a comment claiming this
+// gate saw them would be false.
+func reasonKindsEmitted(t *testing.T) []string {
+	t.Helper()
+	found := map[string]bool{}
+	root := whereReasonsAreMinted
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Tests are excluded deliberately: a fixture may mint a deliberately
+		// wrong kind to prove a refusal, and failing on one would make this
+		// gate argue with the tests that hold the behaviour.
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, src, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			name, ok := call.Fun.(*ast.Ident)
+			if !ok || name.Name != "reason" {
+				return true
+			}
+			if kind, literal := kindLiteral(call.Args[0]); literal {
+				found[kind] = true
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading the reason producers under %s: %v", whereReasonsAreMinted, err)
+	}
+	kinds := make([]string, 0, len(found))
+	for kind := range found {
+		kinds = append(kinds, kind)
+	}
+	slices.Sort(kinds)
+	return kinds
+}
+
+// kindLiteral reads the kind out of one argument, through the named conversion
+// the call site may wrap it in.
+//
+// The reading itself is gatekit.StringExpr under FoldStrict — "is this
+// definitely this string" — so this census never judges text it half-invented,
+// and it resolves a constant handed to `reason` rather than seeing only literals.
+//
+// What this adds is the unwrapping of `crmcontracts.WorklistReasonKind("…")`.
+// StringExpr follows the BUILTIN `string(…)` conversion and deliberately not a
+// package-qualified one, since in general that names a function it would have
+// to run. Here the outer name is the kind's own type, whose conversion is the
+// identity on a string constant — so unwrapping exactly one such call and
+// handing the inside back to StringExpr is sound.
+//
+// Held by mutation: writing a wrapped, undeclared literal into a producer fails
+// TestEveryReasonKindAProducerEmitsIsDeclared.
+func kindLiteral(arg ast.Expr) (string, bool) {
+	if call, ok := arg.(*ast.CallExpr); ok && len(call.Args) == 1 {
+		if _, qualified := call.Fun.(*ast.SelectorExpr); qualified {
+			arg = call.Args[0]
+		}
+	}
+	return gatekit.StringExpr(arg, nil, gatekit.FoldStrict)
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (102)
+## Census (103)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -203,6 +203,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `validatedreplypath_test.go` | H2 | A model reply this tree can REFUSE must be asked for through the validated lane, so the refusal reaches the model that can act on it. |
 | `vaultwriters_test.go` | H2 | Every writer of the installation's ciphertext store records its act somewhere. |
 | `worklistdestination_test.go` | H2 | Every source the worklist can emit has one screen it belongs on. |
+| `worklistreasonkinds_test.go` | H2 | Every reason a row gives is one the contract declares and a client can render. |
 
 ## Reachability (16)
 


### PR DESCRIPTION
`WorklistReasonKind` is a string alias, so `reason("stale_deal", …)` compiles exactly as `reason("stale", …)` does. Nothing failed on the difference.

## Why it matters

The server names the **fact** and the client writes the **phrase** — the product ships three languages, so a sentence composed on the server would reach a German reader in English. That split makes the kind the whole of the agreement between the two halves.

Get it wrong and there is no crash and no validation error. The row renders, its rank is unchanged, and the only symptom is a missing line of evidence: the reader is not told why the row is there, on the surface whose entire job is to say why.

**Proven first**, before writing the gate: `reason(crmcontracts.WorklistReasonKind("definitely_not_a_kind"), nil)` compiles clean against the tree today.

## What the gate does

Reads the producers as **syntax**, not text — a grep matches the word in a comment and misses a call the formatter split across lines.

Both halves are derived, so neither is a list that can go stale: the vocabulary from `crm.yaml`, the emitted set from the package that mints them.

**Two ways it could fail short are closed**, because under-recognition is the one failure a census must not have — it reads a smaller tree, reports PASS, and leaves no assertion to notice. An empty vocabulary and an empty producer walk both fail loudly; a renamed constructor is the case that motivated the second.

Reading one argument delegates to `gatekit.StringExpr` under `FoldStrict` rather than being a third hand-rolled answer to "what string does this expression hold" — the tree's own gate caught me writing one. What this adds is unwrapping the named conversion `crmcontracts.WorklistReasonKind("…")`, which `StringExpr` deliberately does not follow in general; here the outer name is the kind's own type and its conversion is the identity on a string constant.

## On `no_champion`

It is declared, rendered by the client, and emitted by nobody. That is a **deliberate silence** with a test of its own (`TestAStrongLapsedRelationshipNeverClaimsTheAccountHasNoChampion`): the word means an account with nobody carrying it, which reads backwards for a champion who *was* carrying it and went quiet. This gate holds the other direction and does not disturb it.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | A producer emitting an undeclared kind now fails `TestEveryReasonKindAProducerEmitsIsDeclared` |
| Mutation strength | `quiet_days` → `quiet_dayz` fails; wrapped `WorklistReasonKind("wrapped_typo")` fails; a non-existent walk directory fails; a renamed constructor fails with "the walk reads nothing" |
| Census cannot fail short | Empty vocabulary and empty producer corpus both `t.Fatal` rather than pass |
| Corpus verified | Probe confirmed the walk reads 22 real kinds, matching a manual census |
| Reuse | Delegates to `gatekit.StringExpr`; the tree's own gate rejected a hand-rolled reader |
| Full lane | `make check-backend` green, re-run after rebase |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a census gate that fails when a producer emits a worklist reason kind the contract doesn't declare, so a typo like `stale_deal` no longer ships as a missing evidence line on the worklist. Previously the wrong kind compiled and rendered cleanly — `WorklistReasonKind` is a string alias — leaving only the absent reason's line as the symptom.

**Why it holds**

- Reads producers as syntax, not text, so a call split across lines is still caught and comments aren't.
- Both vocabulary and emitted set are derived from `crm.yaml` and the minting package, so neither list can go stale; an empty corpus or empty vocabulary fails loudly.
- Delegates string reading to `gatekit.StringExpr` and unwraps the `WorklistReasonKind("…")` named conversion.
- `no_champion` is declared but deliberately unemitted; the gate holds only the producer→contract direction and doesn't disturb it.

<sup>Written for commit 58a37cb0bfbdc4cdb4eda9b8a1c5191c4c548eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

