### PR TITLE
The deal and lead threads open the conversations they name

### DIFF
--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -4260,6 +4260,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                     <TimelineThread
                       thread={threadQuery}
                       commercial={{ next_close_on: deal.expected_close_date }}
+                      onOpenEmail={setOpenEmail}
                     />
                   }
                   coverage={coverageRead}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1012,10 +1012,15 @@ function LeadCall({
   lead,
   thread,
   overlay,
+  onOpenEmail,
 }: Readonly<{
   lead: Lead;
   thread: RecordTimeline;
   overlay: boolean;
+  // The page's one drawer, handed down to the thread. A conversation the
+  // thread names and cannot open is the one place in the product that does
+  // that.
+  onOpenEmail: (activityId: string) => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -1031,7 +1036,11 @@ function LeadCall({
           never runs and its page is empty — which the thread would draw as a
           lead nobody has written to. The call stands; under it the reader is
           told the history lives in the incumbent. */}
-      {overlay ? <OverlayUnavailable /> : <TimelineThread thread={thread} />}
+      {overlay ? (
+        <OverlayUnavailable />
+      ) : (
+        <TimelineThread thread={thread} onOpenEmail={onOpenEmail} />
+      )}
     </CallCard>
   );
 }
@@ -1409,6 +1418,7 @@ function LeadOverviewPane({
   onQualify,
   onDisqualify,
   onTouchLogged,
+  onOpenEmail,
 }: Readonly<{
   lead: Lead;
   id: string;
@@ -1425,6 +1435,8 @@ function LeadOverviewPane({
   // schedules must survive this pane unmounting when the reader flips to
   // History mid-climb.
   onTouchLogged: () => void;
+  // The page's one email drawer, for the thread under the call.
+  onOpenEmail: (activityId: string) => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -1467,7 +1479,12 @@ function LeadOverviewPane({
           under them the two sections a reader consults rather than reads —
           why it scores what it scores, and what the rep knows about it. */}
       <RecordReading>
-        <LeadCall lead={lead} thread={thread} overlay={overlay} />
+        <LeadCall
+          lead={lead}
+          thread={thread}
+          overlay={overlay}
+          onOpenEmail={onOpenEmail}
+        />
         <TodayPanel onOpenTasks={() => navigate({ screen: "worklist" })}>
           {leadTodoRows(lead, t, locale)}
         </TodayPanel>
@@ -1930,6 +1947,7 @@ function LeadRecord({
           overlay={overlay}
           terminalReasonId={terminalReasonId}
           thread={threadQuery}
+          onOpenEmail={setOpenEmail}
           onQualify={() => setDialog("qualify")}
           onDisqualify={() => setDialog("disqualify")}
           onTouchLogged={refreshAfterTouch}

--- a/frontend/src/screens/record360/timelinethread.test.tsx
+++ b/frontend/src/screens/record360/timelinethread.test.tsx
@@ -3,8 +3,8 @@
 
 /** @vitest-environment jsdom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-
 import type { components } from "../../api/schema";
 import type { RecordTimeline } from "../../design-system/recordtimeline";
 import { LocaleProvider } from "../../i18n";
@@ -30,6 +30,21 @@ function row(extra: Partial<Activity>): Activity {
   };
 }
 
+// A complete email summary, so the fixture keeps describing the wire: a cast
+// one can drop a required field and go on compiling after the shape moves.
+function summary(
+  displayStatus: "team" | "withheld",
+): NonNullable<Activity["email_summary"]> {
+  return {
+    activity_id: "a1",
+    occurred_at: "2026-08-01T09:00:00Z",
+    attachment_count: 0,
+    move: "none",
+    version: 1,
+    display_status: displayStatus,
+  };
+}
+
 function thread(overrides: Partial<RecordTimeline> = {}): RecordTimeline {
   return {
     activities: [],
@@ -44,10 +59,13 @@ function thread(overrides: Partial<RecordTimeline> = {}): RecordTimeline {
   };
 }
 
-function draw(source: RecordTimeline) {
+function draw(
+  source: RecordTimeline,
+  onOpenEmail?: (activityId: string) => void,
+) {
   render(
     <LocaleProvider initial="en">
-      <TimelineThread thread={source} />
+      <TimelineThread thread={source} onOpenEmail={onOpenEmail} />
     </LocaleProvider>,
   );
 }
@@ -85,5 +103,52 @@ describe("TimelineThread", () => {
     expect(screen.queryByText(FAILED)).toBeNull();
     expect(screen.getByText("Today")).toBeTruthy();
     expect(screen.getByText("More conversations before this")).toBeTruthy();
+  });
+
+  // The spine names each past conversation by its subject. Naming one without
+  // a way in is the thing #3824 is about — it reads as the analytics being a
+  // different kind of object from the mail they describe — and the deal and
+  // the lead reach the spine through here, so this is where the opener has to
+  // arrive.
+  it("opens a conversation it names, through the page's own drawer", async () => {
+    const opened: string[] = [];
+    draw(
+      thread({
+        activities: [
+          row({
+            id: "a1",
+            subject: "Renewal terms",
+            email_summary: summary("team"),
+          }),
+        ],
+      }),
+      (id) => opened.push(id),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Renewal terms/ }),
+    );
+    expect(opened).toEqual(["a1"]);
+  });
+
+  // A message outside the reader's audience is NAMED and not offered: a
+  // control that draws a placeholder teaches a reader that citations do not
+  // work, which costs more than the press it saves.
+  it("names a withheld conversation without offering to open it", () => {
+    draw(
+      thread({
+        activities: [
+          row({
+            id: "a2",
+            subject: "Renewal terms",
+            email_summary: summary("withheld"),
+          }),
+        ],
+      }),
+      () => undefined,
+    );
+
+    expect(screen.getByText(/Renewal terms/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Renewal terms/ })).toBeNull();
   });
 });

--- a/frontend/src/screens/record360/timelinethread.tsx
+++ b/frontend/src/screens/record360/timelinethread.tsx
@@ -32,9 +32,16 @@ import { timelineSpineSource } from "./timelinespine";
 export function TimelineThread({
   thread,
   commercial,
+  onOpenEmail,
 }: Readonly<{
   thread: RecordTimeline;
   commercial?: SpineCommercial | null;
+  // Opens a cited message, handed straight to the spine. The record page owns
+  // its one drawer, so this asks rather than mounting a second one behind the
+  // first — and without it a conversation this thread NAMES is the one place
+  // in the product a reader cannot open, which reads as the analytics being a
+  // different kind of object from the mail they describe.
+  onOpenEmail?: (activityId: string) => void;
 }>) {
   const t = useT();
   if (thread.isPending) {
@@ -51,6 +58,7 @@ export function TimelineThread({
         thread.hasNextPage,
       )}
       commercial={commercial}
+      onOpenEmail={onOpenEmail}
     />
   );
 }


### PR DESCRIPTION
Closes #3824.

## Most of this was already done

The ticket describes the whole change — carry the newest message's id through `exchanges()` → `Exchange` → `Stop` → the renderer, and draw `EmailReference` rather than `EmailEntry`. All of that is on `main`:

- `Exchange.emailId` exists, with `openableEmailId` deciding it off `email_summary` rather than the kind string;
- `pastStop` draws `EmailReference` and opens through `ctx.onOpenEmail`;
- the person 360 (`persontoday`) and the company 360 (`organizations`) both pass an opener.

What was left is the **deal and the lead**. They reach the spine through `TimelineThread`, which took no opener and passed none — so `RecordSpine`'s `onOpenEmail` arrived `undefined` and `pastStop` fell to the plain-text arm. On those two records the thread still named a conversation with no way in, which is the ticket's complaint exactly.

## The change

`TimelineThread` takes the opener and hands it straight to the spine. Both pages already own a drawer (`useOpenEmail`), so this asks the page rather than mounting a second one behind the first — the `deals` site passes `setOpenEmail` directly, and the `leads` one threads it down through `LeadOverviewPane` → `LeadCall`, which is where its drawer already lives.

No change to the spine's model, the leaf rendering, or the decision about which message a stop opens.

## Testing

In `timelinethread.test.tsx`, because that is the component that was dropping it:

- a conversation the thread names is openable, and hands the page **the newest message's id**;
- a **withheld** message is still named and *not* offered — `openableEmailId` already decided that, and the reason is worth holding: a control that draws a placeholder teaches a reader that citations do not work, which costs more than the press it saves.

Mutation-checked: dropping the prop from the spine call fails the first and leaves the second passing, which is the right pair — the withheld case must not depend on the opener existing.

The fixture builds a **complete** `email_summary` rather than a cast partial, so it keeps describing the wire if that shape moves. `make check-fe` green.
