### PR TITLE
Two skipped criteria say why they are skipped, measured

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1221,17 +1221,21 @@ test.describe("§3.8: 390px mobile", () => {
   // page is not scrolled first: this asserts the arriving screen.
   // FAILS TODAY, and is left failing on purpose.
   //
-  // The queue's first seeded row is an approval that draws its whole decision
-  // inline — evidence, draft and three answers — so its primary verb ends at
-  // 864px on an 844px screen. Nothing above the queue is the cause any more:
-  // the readings moved below it and the header is down to 174px. The remaining
-  // 20px is the row's own height.
+  // MEASURED 2026-09-05, after the Review split (#4182) moved `approval` to
+  // destinationReview: "Übernehmen" ends at 921px on an 844px screen. The
+  // first seeded row is still an approval drawing its whole decision inline —
+  // evidence, draft and three answers — at 657px against its own 208px
+  // ceiling. Moving the SOURCE to another destination did not move the seeded
+  // row off this queue, so the drawer this note has always pointed at is still
+  // the fix and is still unbuilt.
   //
-  // The fix is to take long decisions out of the row and into the shared
-  // drawer, which is the Review work rather than this screen's. Marked `fixme`
-  // rather than relaxed to 900px: a ceiling tuned to today's failure is a test
-  // that agrees with the defect, and this one has to go GREEN when the drawer
-  // lands rather than have to be tightened by somebody who remembers to.
+  // An earlier version of this comment said 864px and blamed the last 20px on
+  // the row alone. Both numbers were stale; the row is the whole of it.
+  //
+  // Marked `fixme` rather than relaxed to 950px: a ceiling tuned to today's
+  // failure is a test that agrees with the defect, and this one has to go
+  // GREEN when the drawer lands rather than be tightened by somebody who
+  // remembers to.
   test.fixme("AC-WORKLIST-SDR-01: the first primary action is above the fold at 390x844", async ({
     page,
   }) => {
@@ -1302,8 +1306,23 @@ test.describe("§3.8: 390px mobile", () => {
   //
   // 208px for a row carrying an inline decision, 176px for one that does not:
   // the two ceilings the product's own row anatomy sets.
-  // FAILS TODAY for the same one cause, and left failing for the same reason.
-  // An approval row draws 601px against a 208px ceiling.
+  //
+  // FAILS TODAY on TWO rows, and they have different causes — which is why
+  // this note no longer says "the same one cause" as it once did.
+  //
+  // The approval draws 657px against 208px, and the drawer AC-01 waits for
+  // fixes that one.
+  //
+  // The second is an ORDINARY TASK at 284px against 176px, and no drawer
+  // touches it. Measured 2026-09-05, its parts are: rank 19, title 49 (it
+  // wraps to two lines at 390px), when/because/consequence 57, dispositions
+  // 44, verbs 44, and ~71 of gap and padding. Every one of those was added
+  // deliberately and the 44px floor is the touch target the row owes a thumb,
+  // so there is no slack to reclaim by tightening. A 176px row cannot hold
+  // this anatomy on a phone: something has to be dropped or folded, and which
+  // is a product decision rather than a fix. Left failing rather than
+  // relaxed, so the decision is made by someone rather than by a number
+  // quietly rising.
   test.fixme("AC-WORKLIST-SDR-07: no row outgrows its ceiling at 390x844", async ({
     page,
   }) => {


### PR DESCRIPTION
## Why

`AC-WORKLIST-SDR-01` and `AC-WORKLIST-SDR-07` have been `test.fixme` in the required `frontend-e2e` lane since #4173. That lane has been reporting green over two acceptance criteria nobody has run since.

Both notes said they would go green "when 4A moves decisions into the shared drawer". 4A merged as #4182, so I ran them. Both still fail, and both notes were wrong — about the numbers and, for one of them, about the cause.

## What the measurement says

**AC-01 measures 921px, not the 864px recorded.** The Review split moved the `approval` *source* to `destinationReview`, which is why I expected the tall inline card to be gone from Today. The seeded row is still on this queue, drawing its whole decision inline at 657px against its own 208px ceiling. The drawer is still the fix and is still unbuilt.

**AC-07 fails on two rows with different causes**, where the note claimed one. The approval is the first. The second is an **ordinary task at 284px against a 176px ceiling**, and no drawer touches it:

| Part | Height |
|---|---|
| rank | 19 |
| title (wraps to two lines at 390px) | 49 |
| when · because · consequence | 57 |
| dispositions | 44 |
| verbs (Pin) | 44 |
| gaps + padding | ~71 |
| **total** | **284** vs **176** |

Every one of those was added deliberately, and the 44px floor is the touch target the row owes a thumb — `worklist.css` says so and gives the reason. There is no slack to reclaim by tightening CSS. A 176px row cannot hold this anatomy on a phone.

## What this changes

Comments only. Both tests stay `fixme`, and no ceiling is relaxed.

Which part of a row to drop or fold on a phone is a product decision, not a fix, and a ceiling tuned to today's failure is a test that agrees with the defect. What the notes now carry is the measurement, so whoever makes that decision starts from numbers rather than from a stale explanation.

## Evidence

| Obligation | Evidence |
|---|---|
| The claim is measured, not reasoned | Ran both tests un-fixme'd at 390×844 against the built app with the seed fixture mocked at the network edge; restored the `fixme` afterwards. Numbers above are from that run. |
| The row breakdown is real | A throwaway spec measured each child of `.worklist-row-text` and each verb group in the live DOM; it was deleted, not committed. |
| Tests still parse and stay skipped | `playwright test --grep "AC-WORKLIST-SDR-0[17]" --list` lists both; `grep -c 'test.fixme("AC-WORKLIST-SDR-0'` returns 2. |
| No behaviour changed | The diff touches one file and only comment lines. |
| Full lane | `make check-fe` exits 0. |

## What is still open

The drawer that AC-01 waits for, and a decision on the phone row anatomy that AC-07 needs. Neither is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the comments on two skipped worklist acceptance criteria tests with fresh measurements after the approval source moved to `destinationReview`. Both tests still fail, and the old notes recorded stale numbers and, for one, an incomplete cause.

- AC-01's primary verb ends at 921px, not the 864px the note recorded; the seeded approval row still draws its whole decision inline at 657px against a 208px ceiling.
- AC-07 fails on two rows with different causes: the approval at 657px, and an ordinary task at 284px against a 176px ceiling that no drawer touches.
- Both tests stay `fixme` and no ceiling is relaxed; which row part to drop or fold on a phone is a product decision, not a fix.

<sup>Written for commit a611c9cdaca9c3c5968bd14bbc888d86cd1aa8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal test notes with current measurements and failure details for two worklist layout checks.
  * Clarified the distinct layout constraints affecting approval and ordinary task rows.
* **Tests**
  * No test behavior changed; both worklist checks remain marked for future fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->