### PR TITLE
A failed rule says where to go and look at it

### DIFF
--- a/frontend/src/screens/worklist.automationrow.test.tsx
+++ b/frontend/src/screens/worklist.automationrow.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+// A failed rule says where to go and look at it.
+//
+// The row named a broken automation — "Notify sales on a new lead", failed —
+// and carried no address at all. Not the run, not the rule, not the screen
+// either lives on. A reader was told something was wrong and left to go and
+// find it, which on a queue whose whole promise is "here is your work" is the
+// row doing the opposite of its job.
+//
+// It is a DESTINATION and not a verb. Fixing a rule is the automations page's
+// job; the queue performs nothing. Retry is deliberately not offered: a re-run
+// would have to replay the event that fired the rule, and `workflow_run` keeps
+// only a pointer to a bus event the bus drops after about three days — so the
+// button would silently do nothing on day four, which is worse than no button.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function aFailedRule(over = {}) {
+  return row({
+    id: "01a05500-0000-7000-8000-0000000000a1",
+    source: "automation_run",
+    category: "system",
+    title: "Notify sales on a new lead",
+    band: "keep_momentum",
+    destination: "system_health",
+    actions: [],
+    ...over,
+  });
+}
+
+function linksIn(container: HTMLElement): (string | null)[] {
+  return [...container.querySelectorAll(".worklist-list li a")].map((link) =>
+    link.getAttribute("href"),
+  );
+}
+
+describe("a failed automation reaches the page that owns it", () => {
+  it("links the row to the automations page", async () => {
+    stub(
+      day({
+        queue: [aFailedRule()],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText(/Notify sales on a new lead/);
+    // The ADDRESS, not merely that a link exists: a row pointing at the wrong
+    // screen renders exactly like one pointing at the right screen.
+    expect(linksIn(container)).toContain("#/settings/admin/ai");
+  });
+
+  it("gives the same address to the AI work a rule set off", async () => {
+    stub(
+      day({
+        queue: [
+          aFailedRule({
+            id: "01a05500-0000-7000-8000-0000000000a2",
+            source: "ai_work_health",
+            title: "A drafting run did not finish",
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText(/A drafting run did not finish/);
+    expect(linksIn(container)).toContain("#/settings/admin/ai");
+  });
+
+  // The queue can send a reader somewhere; it cannot fix a rule. A button here
+  // would promise a repair this surface does not perform — and Retry
+  // specifically would promise one the SERVER cannot perform either.
+  it("offers no verb, because the queue performs none", async () => {
+    stub(
+      day({
+        queue: [aFailedRule()],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText(/Notify sales on a new lead/);
+    expect(screen.queryByRole("button", { name: /Retry/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Investigate/i })).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -62,6 +62,28 @@ export function subjectHref(item: WorklistItem): string | undefined {
 // that decision would keep pointing at the old address the day it moves.
 const SOURCE_QUEUE: Partial<Record<WorklistItem["source"], string>> = {
   dsr: routeHash(settingsAddress("privacy")),
+  // A rule that failed, and the page that lists the rules.
+  //
+  // The row named a broken automation and offered no address at all — not the
+  // run, not the rule, not the screen either lives on — so a reader was told
+  // something was wrong and left to go and find it. The queue still performs
+  // nothing here: fixing a rule is the automations page's job, and this is the
+  // difference between saying where a room is and claiming to have opened the
+  // door.
+  //
+  // NOT a retry. A re-run would have to replay the event that fired the rule,
+  // and `workflow_run` does not keep it — the row holds a pointer to a bus
+  // event the bus drops after about three days, so a retry would silently do
+  // nothing on day four. Offering one would be the promise this table exists
+  // to avoid making.
+  //
+  // The `ai` tab is where the automations list lives, and its read is the one
+  // every seeded role holds — so this address answers for a rep as well as for
+  // an operator rather than routing most readers into a refusal.
+  automation_run: routeHash(settingsAddress("ai")),
+  // The same page answers for the AI work that a rule set off, for the same
+  // reason and with the same limit.
+  ai_work_health: routeHash(settingsAddress("ai")),
 };
 
 // The address a row's headline links to: its record where it has one, the


### PR DESCRIPTION
The row named a broken automation — "Notify sales on a new lead", failed — and carried **no address at all**. Not the run, not the rule, not the screen either lives on.

A reader was told something was wrong and left to go and find it, which on a queue whose whole promise is "here is your work" is the row doing the opposite of its job. Verified before touching anything: the row rendered one control, `Pin`, and no link.

## A destination, not a verb

Fixing a rule is the automations page's job; the queue performs nothing. That is the difference between saying where a room is and claiming to have opened the door — the rule `SOURCE_QUEUE` already holds for the privacy queue.

## Why not Retry

A re-run would have to replay the event that fired the rule, and `workflow_run` does not keep it. The row holds a pointer to a bus event the bus drops after about three days, so the button would **silently do nothing on day four**. `claimRun` also makes a failed run terminal for its `(handler, idempotency_key)`, so a naive replay hits `ON CONFLICT DO NOTHING`.

A button that does nothing without saying so is worse than no button. An honest Retry needs the firing persisted on the run row — a schema change to a hot path — plus a rule for clearing the terminal claim. That is a product decision, and this PR does not pretend to have made it.

## The address

Through `settingsAddress` rather than a path spelled here, so the link follows the tab if it moves. The `ai` tab is where the automations list lives and its read is the one **every seeded role holds** — so this answers for a rep as well as an operator rather than routing most readers into a refusal.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `links the row to the automations page` asserts the address `#/settings/admin/ai`, not merely that a link exists |
| Second source covered | `gives the same address to the AI work a rule set off` |
| No false promise | `offers no verb, because the queue performs none` — no Retry, no Investigate button |
| Mutation strength | Removing either route fails its test; routing `automation_run` to `privacy` instead fails — a wrong screen renders identically to a right one |
| Full lane | `make check-fe` green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives failed automation worklist rows a link to the automations page, so a reader isn't told something is wrong and left to find it on their own.

- The row previously rendered only the Pin control — no link at all — for a failed rule.
- `automation_run` and `ai_work_health` rows now link to `#/settings/admin/ai` through `settingsAddress`, so the link follows the tab if it moves.
- Retry is intentionally not offered: the bus drops the firing event after about three days, and `claimRun` makes a failed run terminal, so a retry would silently do nothing.
- Tests assert the exact address rather than just the presence of a link.

<sup>Written for commit fbe5a594d46de5edc82bb0b9198349bb00676187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

