### PR TITLE
A drifting deal says when nobody inside is carrying it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38835,6 +38835,14 @@ components:
         amount_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
         owner_id: { type: [string, 'null'], format: uuid }
+        no_champion:
+          type: [boolean, 'null']
+          description: |
+            `true` when the account has a buying committee and nobody engaged on it holds
+            the champion seat. Null is not `false`: it is sent only when the answer is both
+            known and negative, and stays absent for a committee the caller may not read in
+            full, for a deal carrying no seats at all, and for a server that does not assess
+            coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
 
     AttentionRelationshipFacts:
       type: object
@@ -40096,6 +40104,19 @@ components:
         expected_minor_base: { type: [integer, 'null'], format: int64, description: 'The deal amount converted to the base currency, NOT weighted by win_probability. Null when the amount or the conversion rate is unknown.' }
         expected_close_date: { type: [string, 'null'], format: date }
         quiet_days: { type: [integer, 'null'], minimum: 0 }
+        no_champion:
+          type: [boolean, 'null']
+          description: |
+            `true` when the account has a buying committee and nobody engaged on it holds
+            the champion seat — a deal drifting because nobody INSIDE is arguing for it,
+            which needs a different move from the rep than a deal nobody outside has touched.
+
+            Null is not `false`. It is sent only when the answer is both known and negative,
+            and stays absent in the three cases that would otherwise be rounded down to a
+            finding: a committee the caller may not read in full (a champion they cannot see
+            is still a champion), a deal carrying no seats at all (no committee, so no gap),
+            and a server that does not assess coverage. A client MUST NOT render an absent
+            value as "nobody is carrying this".
 
     WorklistSourceUnavailable:
       type: object

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -48,6 +48,14 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 	} else if known {
 		row.Because = append(row.Because, reason("below_material", money.value(expected, item.Deal)))
 	}
+	// Nobody inside the account is carrying it, which is a different problem
+	// from silence and needs a different move: a quiet deal wants a touch, an
+	// unchampioned one wants somebody found. Stated whenever the lane knew the
+	// answer, at any level — a small deal nobody is arguing for is still a deal
+	// nobody is arguing for, and the reason is what the rep acts on.
+	if item.Deal != nil && item.Deal.NoChampion != nil && *item.Deal.NoChampion {
+		row.Because = append(row.Because, reason("no_champion", nil))
+	}
 	quiet := quietDaysOf(item)
 	if quiet > 0 {
 		row.Because = append(row.Because, reason("quiet_days", daysValue(quiet)))

--- a/backend/internal/compose/attention/lanessilence.go
+++ b/backend/internal/compose/attention/lanessilence.go
@@ -70,6 +70,18 @@ type RiskyDeal struct {
 	// CloseOverdue is set when the expected close date has already passed.
 	CloseOverdue      bool
 	ExpectedCloseDate *time.Time
+	// NoChampion says the account has a committee and nobody engaged on it
+	// holds the champion seat — a deal drifting because nobody inside is
+	// arguing for it, which is a different problem from one nobody outside has
+	// touched and needs a different move from the rep.
+	//
+	// Nil rather than false when the reader could not see every seat, or when
+	// the deal has no committee at all. Both would render as "nobody is
+	// carrying this", and neither is that: a champion the reader may not read
+	// is still a champion, and a deal with no seats has no coverage gap to
+	// report. A tri-state here is what keeps the lane from turning a boundary
+	// into a finding.
+	NoChampion *bool
 }
 
 // Decay is the reader's own relationships that have gone silent.

--- a/backend/internal/compose/attention/nochampion_test.go
+++ b/backend/internal/compose/attention/nochampion_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// A drifting deal nobody inside the account is arguing for.
+//
+// The three cases here are the three the lane must tell apart: a committee
+// with no engaged champion is a finding, a committee the reader could not read
+// in full is NOT, and a deal with no committee at all is not either. Only the
+// first is a sentence a rep should act on, and the other two render identically
+// to it the moment the fact is carried as a plain boolean rather than a
+// tri-state.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// reasonNoChampion is the verdict under test.
+const reasonNoChampion = crmcontracts.WorklistReasonKind("no_champion")
+
+func TestADealNobodyIsCarryingSaysSo(t *testing.T) {
+	uncovered := true
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Fleet retrofit",
+		QuietDays: 19, NoChampion: &uncovered,
+	}))
+	if !hasReason(row, reasonNoChampion) {
+		t.Errorf("the row states %v, want a no_champion reason", kindsOf(row))
+	}
+}
+
+// The BOUNDARY case, and the one direction this claim must never fail in.
+//
+// A champion the reader may not read is still a champion: the seat is absent
+// from every row-scoped read, so a lane treating "I saw no champion" as "there
+// is no champion" tells a rep nobody is arguing for their deal while somebody
+// is. The rep then recruits a second champion into a committee that has one.
+func TestAWithheldCommitteeMakesNoClaimAboutItsChampion(t *testing.T) {
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Fleet retrofit",
+		QuietDays: 19, NoChampion: nil,
+	}))
+	if hasReason(row, reasonNoChampion) {
+		t.Error("the row claims nobody is carrying a deal whose committee it could not read")
+	}
+}
+
+// A deal carrying no seats has no coverage gap — it has no committee.
+//
+// Absent for the same reason as the withheld case, and tested separately
+// because the two arrive by different routes through ChampionCoverFor: one is
+// a row the reader could not see, the other a row that does not exist. A fix
+// repairing one could leave the other reporting.
+func TestADealWithNoCommitteeIsNotCalledUnchampioned(t *testing.T) {
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Nobody has been near it", QuietDays: 40,
+	}))
+	if hasReason(row, reasonNoChampion) {
+		t.Error("the row claims nobody is carrying a deal that has no committee at all")
+	}
+}
+
+// oneRiskRow runs one deal through the whole endpoint and returns its row.
+//
+// Through Worklist rather than the classifier directly, because the fact
+// crosses two shapes on the way — the lane's RiskyDeal, then the item's deal
+// facts — and a test calling classifyRisk with a hand-built item would prove
+// the reason fires while the wiring that carries the fact to it stayed broken.
+func oneRiskRow(t *testing.T, deal RiskyDeal) crmcontracts.WorklistItem {
+	t.Helper()
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{}, nil, stubAtRisk{rows: []RiskyDeal{deal}}, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+	out, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+	if len(out.Queue) != 1 {
+		t.Fatalf("the queue carries %d rows, wanted the one deal", len(out.Queue))
+	}
+	return out.Queue[0]
+}
+
+// withDealFacts gives the deal an amount, so the row carries deal facts at all.
+//
+// Without it the two absent-champion cases passed for the wrong reason: the
+// renderer sends no deal facts for a deal with no stage, owner, amount,
+// currency or champion answer, so `item.Deal` was nil and the clause under
+// test was never reached. Reverting the nil check to treat an unknown answer
+// as a finding left both tests green — a mutation the fixture, not the code,
+// was surviving.
+func withDealFacts(deal RiskyDeal) RiskyDeal {
+	minor, currency := int64(4_000_000), "EUR"
+	deal.AmountMinor, deal.Currency = &minor, &currency
+	return deal
+}

--- a/backend/internal/compose/attention/rendersilence.go
+++ b/backend/internal/compose/attention/rendersilence.go
@@ -151,12 +151,18 @@ func relationshipBand(bucket string) *crmcontracts.AttentionRelationshipFactsStr
 // dealFacts carries the at-risk deal's card facts onto the wire, or nothing:
 // a facts object with every field empty says less than its absence.
 func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
-	if deal.StageID == nil && deal.OwnerID == nil && deal.AmountMinor == nil && deal.Currency == nil {
+	if deal.StageID == nil && deal.OwnerID == nil && deal.AmountMinor == nil &&
+		deal.Currency == nil && deal.NoChampion == nil {
 		return nil
 	}
 	facts := &crmcontracts.AttentionDealFacts{
 		AmountMinor: deal.AmountMinor,
 		Currency:    deal.Currency,
+		// Carried through, not re-decided. The seam that read the committee
+		// already resolved the tri-state — a withheld or seatless read arrives
+		// absent — and a renderer that reapplied the rule would be a second
+		// judgement over a fact it cannot see the evidence for.
+		NoChampion: deal.NoChampion,
 	}
 	if deal.StageID != nil {
 		stage := openapi_types.UUID(*deal.StageID)

--- a/backend/internal/compose/attentionchampioncover.go
+++ b/backend/internal/compose/attentionchampioncover.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Asking whether anybody INSIDE each account is carrying the deal, for the
+// deals that reached the morning queue.
+//
+// Its own file because this lane fact costs a second database read after the
+// candidate sweep, and because the judgement in noChampionOf is a privacy rule
+// rather than a rendering detail: three inputs arrive and only one of them may
+// become a sentence a rep acts on.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// championCover asks the deals module whether anybody inside each account is
+// carrying the deal.
+//
+// Over the SURVIVORS, in one batch, after the candidate sweep has filtered.
+// The queue weighs up to fifty drifting deals and the per-deal coverage read
+// is two statements each, so asking it row by row would put a hundred round
+// trips on the morning assembly for one boolean per row.
+//
+// A nil pool means this seam was built without one, which is how the lane's
+// own tests bind it: the champion question goes unanswered and every row says
+// nothing, rather than the lane failing whole.
+func (a attentionAtRisk) championCover(
+	ctx context.Context, candidates []agents.SlippingDeal, now time.Time,
+) (map[ids.UUID]deals.ChampionCover, error) {
+	if a.pool == nil || len(candidates) == 0 {
+		return map[ids.UUID]deals.ChampionCover{}, nil
+	}
+	dealIDs := make([]ids.UUID, 0, len(candidates))
+	for _, deal := range candidates {
+		dealIDs = append(dealIDs, deal.DealID)
+	}
+	var cover map[ids.UUID]deals.ChampionCover
+	err := database.WithWorkspaceTx(ctx, a.pool, func(tx pgx.Tx) error {
+		var readErr error
+		cover, readErr = deals.ChampionCoverFor(ctx, tx, dealIDs, now)
+		return readErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cover, nil
+}
+
+// noChampionOf turns the module's two flags into the lane's one nullable fact.
+//
+// Absent unless the answer is BOTH known and negative. A withheld committee is
+// absent because a champion the reader may not read is still a champion, and a
+// deal with no seats at all is absent because it has no coverage gap — it has
+// no committee. Reporting either as "nobody is carrying this" would put a
+// finding on a deal that does not have it, which is the one direction this
+// claim must never fail in: a rep told nobody is arguing for their deal goes
+// and finds somebody to argue for it.
+func noChampionOf(cover map[ids.UUID]deals.ChampionCover, deal ids.UUID) *bool {
+	// ABSENT from the map, not its zero value: a deal with no live seats never
+	// appears in the answer, and its zero value reads Covered=false —
+	// indistinguishable from a committee that genuinely has no champion. Asked
+	// the wrong way this claimed nobody was carrying every untouched deal in
+	// the pipeline, which is a warning that is always on.
+	found, ok := cover[deal]
+	if !ok || found.Withheld || found.Covered {
+		return nil
+	}
+	uncovered := true
+	return &uncovered
+}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -87,6 +87,7 @@ func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int
 // rows it returns.
 type attentionAtRisk struct {
 	lister func(context.Context) ([]agents.SlippingDeal, bool, error)
+	pool   *pgxpool.Pool
 }
 
 func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, bool, error) {
@@ -95,6 +96,10 @@ func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, bool
 		return nil, false, err
 	}
 	now := clockNow()
+	cover, err := a.championCover(ctx, candidates, now)
+	if err != nil {
+		return nil, false, err
+	}
 	risky := make([]attention.RiskyDeal, 0, len(candidates))
 	for _, deal := range candidates {
 		risky = append(risky, attention.RiskyDeal{
@@ -107,6 +112,7 @@ func (a attentionAtRisk) Quiet(ctx context.Context) ([]attention.RiskyDeal, bool
 			QuietDays:         idleDaysOf(deal, now),
 			CloseOverdue:      deal.CloseOverdue,
 			ExpectedCloseDate: deal.ExpectedCloseDate,
+			NoChampion:        noChampionOf(cover, deal.DealID),
 		})
 	}
 	return risky, cut, nil

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -276,7 +276,7 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// a reader accepts from a meeting. A promise a rep made is then real
 		// data the queue was still refusing to show.
 		attentionCommitments{store: people.NewStore(db)},
-		attentionAtRisk{lister: quietDealScan(pool, deals.QuietThresholdDays)},
+		attentionAtRisk{lister: quietDealScan(pool, deals.QuietThresholdDays), pool: pool},
 		attentionDecay{pool: pool, store: people.NewStore(db), now: now},
 		attentionMeetings{store: activities.NewStore(db)},
 		attentionFailedEffects{svc: svc},

--- a/backend/internal/compose/championcoverseam_test.go
+++ b/backend/internal/compose/championcoverseam_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Turning the deals module's two coverage flags into the lane's one nullable
+// fact.
+//
+// Three inputs reach this and only ONE of them may become a claim. The other
+// two — a committee the reader could not read in full, and a deal with no
+// committee at all — are absences that render identically to the finding the
+// moment they are rounded down to it, and the rounding is silent: the row
+// simply says nobody is carrying a deal somebody is carrying, and the rep acts
+// on it.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestOnlyAKnownUncoveredCommitteeBecomesAClaim(t *testing.T) {
+	uncovered, covered, withheld := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	absent := ids.NewV7()
+	cover := map[ids.UUID]deals.ChampionCover{
+		uncovered: {},
+		covered:   {Covered: true},
+		// Covered stays false beside Withheld deliberately: a withheld read
+		// answers "no champion seen", which is exactly the pair that must not
+		// become a finding. A fixture setting both would let a check reading
+		// only Covered pass for the wrong reason.
+		withheld: {Withheld: true},
+	}
+	for _, tc := range []struct {
+		name  string
+		deal  ids.UUID
+		claim bool
+	}{
+		{"a committee with no engaged champion", uncovered, true},
+		{"a committee whose champion is engaged", covered, false},
+		{"a committee the reader could not read in full", withheld, false},
+		{"a deal carrying no seats at all", absent, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := noChampionOf(cover, tc.deal)
+			if tc.claim {
+				if got == nil || !*got {
+					t.Errorf("states %v, want a no-champion claim", derefOrNil(got))
+				}
+				return
+			}
+			if got != nil {
+				t.Errorf("states %v, want no claim at all", *got)
+			}
+		})
+	}
+}
+
+// derefOrNil renders the tri-state for a failure message without panicking on
+// the absent case the assertion is complaining about.
+func derefOrNil(v *bool) any {
+	if v == nil {
+		return "nothing"
+	}
+	return *v
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17498,9 +17498,16 @@ type AttentionCounts struct {
 // client already holds the pipelines vocabulary and writes the label in the
 // reader's own language; a label composed server-side would not be.
 type AttentionDealFacts struct {
-	AmountMinor *int64              `json:"amount_minor,omitempty"`
-	Currency    *string             `json:"currency,omitempty"`
-	OwnerId     *openapi_types.UUID `json:"owner_id,omitempty"`
+	AmountMinor *int64  `json:"amount_minor,omitempty"`
+	Currency    *string `json:"currency,omitempty"`
+
+	// NoChampion `true` when the account has a buying committee and nobody engaged on it holds
+	// the champion seat. Null is not `false`: it is sent only when the answer is both
+	// known and negative, and stays absent for a committee the caller may not read in
+	// full, for a deal carrying no seats at all, and for a server that does not assess
+	// coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
+	NoChampion *bool               `json:"no_champion,omitempty"`
+	OwnerId    *openapi_types.UUID `json:"owner_id,omitempty"`
 
 	// StageId The deal's current stage; null for an overlay-mirror deal, whose stage lives with the incumbent.
 	StageId *openapi_types.UUID `json:"stage_id,omitempty"`
@@ -33496,11 +33503,23 @@ type WorklistDealFacts struct {
 	ExpectedCloseDate *openapi_types.Date `json:"expected_close_date,omitempty"`
 
 	// ExpectedMinorBase The deal amount converted to the base currency, NOT weighted by win_probability. Null when the amount or the conversion rate is unknown.
-	ExpectedMinorBase *int64              `json:"expected_minor_base,omitempty"`
-	OwnerId           *openapi_types.UUID `json:"owner_id,omitempty"`
-	QuietDays         *int                `json:"quiet_days,omitempty"`
-	StageId           *openapi_types.UUID `json:"stage_id,omitempty"`
-	WinProbability    *int                `json:"win_probability,omitempty"`
+	ExpectedMinorBase *int64 `json:"expected_minor_base,omitempty"`
+
+	// NoChampion `true` when the account has a buying committee and nobody engaged on it holds
+	// the champion seat — a deal drifting because nobody INSIDE is arguing for it,
+	// which needs a different move from the rep than a deal nobody outside has touched.
+	//
+	// Null is not `false`. It is sent only when the answer is both known and negative,
+	// and stays absent in the three cases that would otherwise be rounded down to a
+	// finding: a committee the caller may not read in full (a champion they cannot see
+	// is still a champion), a deal carrying no seats at all (no committee, so no gap),
+	// and a server that does not assess coverage. A client MUST NOT render an absent
+	// value as "nobody is carrying this".
+	NoChampion     *bool               `json:"no_champion,omitempty"`
+	OwnerId        *openapi_types.UUID `json:"owner_id,omitempty"`
+	QuietDays      *int                `json:"quiet_days,omitempty"`
+	StageId        *openapi_types.UUID `json:"stage_id,omitempty"`
+	WinProbability *int                `json:"win_probability,omitempty"`
 }
 
 // WorklistItem One thing to do, with the reason it sits where it sits.

--- a/backend/internal/modules/deals/championcover.go
+++ b/backend/internal/modules/deals/championcover.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// "Is anybody inside the account carrying this deal?", asked of MANY deals at
+// once.
+//
+// The per-deal answer already exists: Stakeholders lists every seat with its
+// role and engagement, and the coverage rules fold it. That shape is right for
+// one deal on a page and wrong for a queue, which weighs up to fifty drifting
+// deals in a morning assembly — two statements each is a hundred round trips
+// on the hot path for one boolean per row.
+//
+// So this asks the narrow question over the whole set in two statements,
+// through the SAME engagement definition EngagedStakeholders spells. It is not
+// a second coverage rule: it answers strictly less, and ChampionCover.Covered
+// is the one fact it reports.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/dealrole"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ChampionCover is what one deal's committee says about its champion seat.
+//
+// TWO fields rather than one boolean, because "no engaged champion" and "we
+// could not see the whole committee" are different sentences to a rep and the
+// second must never be told as the first. A champion the reader may not read
+// is still a champion: the seat is absent from every row-scoped read, so a
+// bare Covered=false over a partial committee is a claim the data does not
+// support — the deal HAS somebody arguing for it and the queue would say
+// nobody does.
+type ChampionCover struct {
+	// Covered is true when a seat with the champion role is engaged.
+	Covered bool
+	// Withheld is true when this reader could not read every live seat, which
+	// makes Covered unsafe to report as a finding. Callers state the gap or
+	// say nothing; they never round it down to "no champion".
+	Withheld bool
+}
+
+// ChampionCoverFor answers the champion question for each of the given deals.
+//
+// Deals absent from the result are deals with no live seats at all, which is a
+// different fact again — an untouched deal nobody has put a committee on has
+// no coverage gap to report, it has no committee. The caller decides what that
+// means; folding it in here would make an empty deal indistinguishable from an
+// uncovered one.
+//
+// Every read carries the edge admission AND the person row scope, the same
+// pair Stakeholders takes and for the same reason: reading a deal does not
+// license learning who sits on it. A caller refused edges outright gets
+// Withheld on every deal rather than an error, because a queue that failed
+// whole because one lane is gated is worse than a queue that says less.
+func ChampionCoverFor(
+	ctx context.Context, tx pgx.Tx, dealIDs []ids.UUID, now time.Time,
+) (map[ids.UUID]ChampionCover, error) {
+	out := make(map[ids.UUID]ChampionCover, len(dealIDs))
+	if len(dealIDs) == 0 {
+		return out, nil
+	}
+	seats, withheld, err := championSeats(ctx, tx, dealIDs)
+	if err != nil {
+		return nil, err
+	}
+	for deal, isWithheld := range withheld {
+		out[deal] = ChampionCover{Withheld: isWithheld}
+	}
+	if len(seats) == 0 {
+		return out, nil
+	}
+	engaged, err := engagedAmong(ctx, tx, dealIDs, now)
+	if err != nil {
+		return nil, err
+	}
+	for deal, people := range seats {
+		cover := out[deal]
+		for _, person := range people {
+			if engaged[dealPerson{deal: deal, person: person}] {
+				cover.Covered = true
+				break
+			}
+		}
+		out[deal] = cover
+	}
+	return out, nil
+}
+
+// dealPerson keys one seat: engagement is a fact about a person ON a deal, and
+// a person can sit on two of them with a different answer on each.
+type dealPerson struct {
+	deal, person ids.UUID
+}
+
+// championSeats reads the champion-role seats on each deal, and reports which
+// deals had a seat the reader could not see.
+//
+// The withheld count comes from the SAME statement rather than a second one
+// over an unscoped view: a count read outside the row scope would itself
+// disclose how many people sit on a deal the caller may not read. `visible` is
+// the person scope, so `count(*) FILTER (WHERE NOT visible)` counts rows the
+// join already admitted through the edge grant and the person scope refused —
+// which is the boundary being reported, and no wider.
+func championSeats(
+	ctx context.Context, tx pgx.Tx, dealIDs []ids.UUID,
+) (map[ids.UUID][]ids.UUID, map[ids.UUID]bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	dealsPos := arg(dealIDs)
+	rolePos := arg(dealrole.Champion)
+	bound, err := edgeBound(ctx, "r", arg)
+	if err != nil {
+		return nil, nil, err
+	}
+	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	if err != nil {
+		return nil, nil, err
+	}
+	visible := predicateAlways
+	if scope != "" {
+		visible = scope
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT r.deal_id,
+		       array_remove(array_agg(r.person_id) FILTER (WHERE %[3]s AND r.role = $%[2]d), NULL),
+		       count(*) FILTER (WHERE NOT (%[3]s)) > 0
+		  FROM relationship r
+		  JOIN person p ON p.id = r.person_id AND p.archived_at IS NULL
+		 WHERE r.kind = 'deal_stakeholder' AND r.deal_id = ANY($%[1]d) AND r.archived_at IS NULL
+		   AND (%[4]s)
+		 GROUP BY r.deal_id`, dealsPos, rolePos, visible, bound), args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("deals: reading the champion seats on a set of deals: %w", err)
+	}
+	defer rows.Close()
+	seats := make(map[ids.UUID][]ids.UUID, len(dealIDs))
+	withheld := make(map[ids.UUID]bool, len(dealIDs))
+	for rows.Next() {
+		var deal ids.UUID
+		var people []ids.UUID
+		var anyWithheld bool
+		if err := rows.Scan(&deal, &people, &anyWithheld); err != nil {
+			return nil, nil, fmt.Errorf("deals: reading a deal's champion seats: %w", err)
+		}
+		seats[deal] = people
+		withheld[deal] = anyWithheld
+	}
+	return seats, withheld, rows.Err()
+}
+
+// engagedAmong answers which (deal, person) pairs had a two-way exchange in
+// the window.
+//
+// The engagement test is EngagedStakeholders' — both directions required
+// inside the same window, over the same qualifying kinds — asked of a set
+// rather than one deal. Two spellings of "engaged" is how one screen calls a
+// deal single-threaded while another calls it covered, which is the
+// disagreement the single-definition rule in this package's header exists to
+// stop; the shared pieces are healthEngagementWindowDays and
+// healthActivityKinds, so a change to either moves both readers at once.
+func engagedAmong(
+	ctx context.Context, tx pgx.Tx, dealIDs []ids.UUID, now time.Time,
+) (map[dealPerson]bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	dealsPos := arg(dealIDs)
+	windowPos := arg(now.AddDate(0, 0, -healthEngagementWindowDays))
+	bound, err := edgeBound(ctx, "r", arg)
+	if err != nil {
+		return nil, err
+	}
+	// The kind list is an ARGUMENT to Sprintf rather than concatenated into
+	// its format string, for the reason EngagedStakeholders gives: a `%` in a
+	// kind would be read as a verb and corrupt the statement at runtime.
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT DISTINCT r.deal_id, r.person_id FROM relationship r
+		WHERE r.kind = 'deal_stakeholder' AND r.deal_id = ANY($%[1]d) AND r.archived_at IS NULL
+		  AND (%[3]s)
+		  AND EXISTS (
+			SELECT 1 FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			  AND a.occurred_at >= $%[2]d AND a.direction = 'inbound')
+		  AND EXISTS (
+			SELECT 1 FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			  AND a.occurred_at >= $%[2]d AND a.direction = 'outbound')`,
+		dealsPos, windowPos, bound, healthActivityKinds), args...)
+	if err != nil {
+		return nil, fmt.Errorf("deals: reading engagement across a set of deals: %w", err)
+	}
+	defer rows.Close()
+	engaged := make(map[dealPerson]bool)
+	for rows.Next() {
+		var pair dealPerson
+		if err := rows.Scan(&pair.deal, &pair.person); err != nil {
+			return nil, fmt.Errorf("deals: reading one deal's engaged seat: %w", err)
+		}
+		engaged[pair] = true
+	}
+	return engaged, rows.Err()
+}

--- a/backend/internal/modules/deals/edgegrant_test.go
+++ b/backend/internal/modules/deals/edgegrant_test.go
@@ -78,3 +78,37 @@ func TestTheHealthEvidenceReadRefusesRatherThanScoringWithoutTheEdge(t *testing.
 			in.engagedStakeholderIDs)
 	}
 }
+
+// The batch champion read carries the same gate as the per-deal one.
+//
+// It exists so a queue weighing fifty drifting deals asks the champion
+// question once rather than fifty times, and a faster read that had quietly
+// dropped the edge grant would answer where Stakeholders refuses — the
+// optimisation would have widened what a caller can learn about who sits on a
+// deal. The nil transaction is the assertion: only a refusal resolved before
+// the statement can return an error rather than panicking.
+func TestTheBatchChampionReadRefusesBeforeItReachesAStatement(t *testing.T) {
+	_, err := ChampionCoverFor(dealReaderWithoutTheEdgeGrant(), nil,
+		[]ids.UUID{ids.NewV7()}, time.Now().UTC())
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("ChampionCoverFor(no edge grant) = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// An EMPTY set asks nothing, and must not be the way past the gate.
+//
+// The early return for no deals sits above the read, so a caller handing an
+// empty slice gets an empty answer rather than a refusal. That is right — there
+// is nothing to disclose — but it is worth holding: moving the gate below the
+// length check would be invisible here, and moving the length check below the
+// gate would make an ordinary empty queue fail for a caller who is merely
+// unlucky in their grants.
+func TestTheBatchChampionReadAnswersNothingForNoDeals(t *testing.T) {
+	cover, err := ChampionCoverFor(dealReaderWithoutTheEdgeGrant(), nil, nil, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ChampionCoverFor(no deals) = %v, want no error", err)
+	}
+	if len(cover) != 0 {
+		t.Errorf("ChampionCoverFor(no deals) answered %v, want nothing", cover)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29163,6 +29163,14 @@ export interface components {
             currency?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /**
+             * @description `true` when the account has a buying committee and nobody engaged on it holds
+             *     the champion seat. Null is not `false`: it is sent only when the answer is both
+             *     known and negative, and stays absent for a committee the caller may not read in
+             *     full, for a deal carrying no seats at all, and for a server that does not assess
+             *     coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
+             */
+            no_champion?: boolean | null;
         };
         /**
          * @description What the lapsed relationship behind a `relationship_decay` item was WORTH before
@@ -30370,6 +30378,19 @@ export interface components {
             /** Format: date */
             expected_close_date?: string | null;
             quiet_days?: number | null;
+            /**
+             * @description `true` when the account has a buying committee and nobody engaged on it holds
+             *     the champion seat — a deal drifting because nobody INSIDE is arguing for it,
+             *     which needs a different move from the rep than a deal nobody outside has touched.
+             *
+             *     Null is not `false`. It is sent only when the answer is both known and negative,
+             *     and stays absent in the three cases that would otherwise be rounded down to a
+             *     finding: a committee the caller may not read in full (a champion they cannot see
+             *     is still a champion), a deal carrying no seats at all (no committee, so no gap),
+             *     and a server that does not assess coverage. A client MUST NOT render an absent
+             *     value as "nobody is carrying this".
+             */
+            no_champion?: boolean | null;
         };
         /**
          * @description A source that did not contribute, and why. `withheld` means the caller may not


### PR DESCRIPTION
A deal going quiet and a deal nobody is arguing for are different problems needing different moves: one wants a touch, the other wants somebody found. The queue could only say the first.

The coverage rules already answer the second — `network/risk.go` computes a coverage gap as "seats but no engaged champion" — and `no_champion` has sat in the worklist's reason vocabulary since the queue shipped with nothing emitting it. This wires the fact to the reason.

## Not through `CoverageFor`

`CoverageFor` reads a whole coverage payload per deal, and the queue weighs up to fifty drifting deals in a morning assembly — asking it row by row would put a hundred round trips on the hot path to learn one boolean each.

`deals.ChampionCoverFor` asks the narrow question over the whole set in two statements, through the same engagement definition `EngagedStakeholders` spells. The shared pieces are `healthEngagementWindowDays` and `healthActivityKinds`, so a change to either moves both readers rather than letting them drift.

## A tri-state, not a boolean

This is the whole care in the change. Three inputs reach the lane and only one may become a sentence a rep acts on:

| Input | Claim? | Why |
|---|---|---|
| A committee with no engaged champion | **yes** | the finding |
| A committee the reader could not read in full | no | a champion they may not read is still a champion — the seat is absent from every row-scoped read, and rounding that down tells a rep nobody is arguing for their deal while somebody is |
| A deal carrying no seats at all | no | it has no coverage gap; it has no committee |

The last case arrives as **absence from the map**, not a zero value. `ChampionCover{}` reads `Covered=false`, indistinguishable from a genuine gap — asked the wrong way this claimed nobody was carrying every untouched deal in the pipeline, a warning that is always on.

The batch read carries the edge grant and the person row scope, the same pair `Stakeholders` takes: knowing a deal does not license learning who sits on it, and a faster read that dropped the gate would have widened what a caller can learn.

## Scope note

The plan's 5B also lists stall evidence. It is **not** in this PR and is filed rather than built: a parallel measurement of AC-WORKLIST-SDR-07 found an ordinary task row at 284px against a 176px phone ceiling, with 57px of that being the `when`/`because`/`consequence` block. Adding reasons blind makes a measured overflow worse. `no_champion` lands because it adds at most one line and only to `deal_at_risk`, which is not the failing row.

`win_probability` needs nothing: it is already a field on `AttentionDealFacts`, so a client draws it from the facts it receives. It should not be converted into a reason — as a field it costs the `because` block nothing.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestADealNobodyIsCarryingSaysSo` — a deal with an uncovered committee states `no_champion` |
| Permission / row scope | `TestTheBatchChampionReadRefusesBeforeItReachesAStatement` — nil transaction, so only a refusal resolved *before* the statement returns an error rather than panicking |
| Boundary not rounded to a finding | `TestAWithheldCommitteeMakesNoClaimAboutItsChampion`, `TestADealWithNoCommitteeIsNotCalledUnchampioned` |
| Tri-state decision | `TestOnlyAKnownUncoveredCommitteeBecomesAClaim` — four subtests, one per input |
| Empty input | `TestTheBatchChampionReadAnswersNothingForNoDeals` — an empty set asks nothing and is not the way past the gate |
| Contract | `make gen` + `pnpm gen:api`; drift and breaking-change checks green |
| Mutation strength | Six clauses reverted individually. Removing the reason arm fails `SaysSo`; treating nil as a finding fails both boundary tests; each of the three `noChampionOf` clauses fails its own subtest; dropping the edge gate panics on the nil transaction. Two fixtures were corrected when mutation showed them surviving — the absent-champion rows carried no deal facts at all, so `item.Deal` was nil and the clause under test was never reached. |
| Full lane | `make check-backend` green; `make check-fe` green (only `schema.d.ts` changed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `no_champion` reason to the at-risk worklist lane so a deal nobody inside the account is arguing for shows a different reason from a deal nobody outside has touched. The queue previously only reported silence; it now also reports an uncovered buying committee.

**Notes**

- New `deals.ChampionCoverFor` answers the champion question for all drifting deals in one batch read (two statements) instead of one per deal, sharing the engagement definition with `EngagedStakeholders`.
- The fact is a tri-state: `true` only when the committee is fully readable and no seat is an engaged champion. A committee the caller cannot read in full, and a deal with no seats at all, both arrive as absent — never as "no champion".
- The batch read carries the same edge grant and person row scope as the per-deal stakeholder read.
- `no_champion` is added to the deal facts payloads, generated API types, and frontend schema.

<sup>Written for commit c7161a22e7bde22bfcca0c7c97c4d006f8f86a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added champion coverage details to CRM deal and relationship data.
  * Deals with a committee but no engaged champion are now identified with a `no_champion` reason.
  * Coverage remains unspecified when visibility is incomplete or no committee exists.
* **Bug Fixes**
  * Improved handling of champion coverage across worklist and attention-risk results.
* **Tests**
  * Added coverage for identified, unknown, and absent champion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->