### PR TITLE
WIP: A row says at most three reasons

### DIFF
--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -114,9 +114,15 @@ export function WorklistRow({
       : item.detail;
   // The badged reasons are drawn as badges above and left out here, so one
   // meeting does not report the same finding twice in two registers.
+  //
+  // CAPPED, and capped AFTER the unspeakable ones are dropped. Capping the
+  // reasons before `reasonText` runs would let a row carrying three reasons
+  // this build has no sentence for show nothing at all, while the two it could
+  // have said sat just past the cut.
   const because = phrasedReasons(item)
     .map((reason) => reasonText(reason, t, locale, zone))
     .filter((phrase): phrase is string => phrase !== null)
+    .slice(0, MOST_REASONS_SHOWN)
     .join(" · ");
   const above = comparisonText(item.above_next, t, locale, zone);
   const consequence = consequenceText(item, t);
@@ -322,6 +328,33 @@ function NudgeDismiss({ personId }: Readonly<{ personId: string }>) {
     </div>
   );
 }
+
+/**
+ * How many reasons a row may say before it stops explaining and starts
+ * listing.
+ *
+ * THE COUNT IS A CEILING THE ROW OWES ITS HEIGHT, not a judgement about which
+ * reasons matter — the server already ranked them. `because` arrives "in the
+ * order they were weighed" (the contract says so outright), so the first three
+ * are the three that put the row where it is, and taking a prefix keeps that
+ * ranking rather than inventing a second one here.
+ *
+ * WHY A CAP EXISTS AT ALL. This block is not a fixed cost: it grows by one
+ * line every time the reason vocabulary does, and the vocabulary is still
+ * growing. Measured at 390px on 2026-09-05, an ordinary task row is 284px
+ * against the 176px ceiling AC-WORKLIST-SDR-07 asserts, and 57px of that is
+ * this block with only two reasons in it. Without a bound, every reason added
+ * anywhere makes every row that carries it taller, and the next person to add
+ * one has no way to know they did.
+ *
+ * Three rather than two: a task that is due today AND unassigned AND overdue
+ * is saying three true things a rep acts on differently, and cutting to two
+ * would drop one of them on a row that fits today. This does not by itself
+ * make AC-07 pass — that row carries two reasons — and it is not meant to.
+ * What it does is stop the ceiling being missed again by a change nobody
+ * connected to it.
+ */
+const MOST_REASONS_SHOWN = 3;
 
 /**
  * Everything the row says about itself under the title, in the order a reader

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -402,6 +402,69 @@ describe("what the ranked queue tells a reader", () => {
     expect(container.textContent).not.toContain("worklist.because");
   });
 
+  // The `because` line is not a fixed cost: it grows by a line every time the
+  // reason vocabulary does, and an ordinary task row is already 108px over the
+  // ceiling AC-WORKLIST-SDR-07 asserts. Without a bound, a reason added
+  // anywhere makes every row carrying it taller and nobody connects the two.
+  it("says at most three reasons, keeping the ones the server weighed first", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            title: "A crowded task",
+            because: [
+              { kind: "overdue" },
+              { kind: "due_today" },
+              { kind: "unassigned" },
+              { kind: "routine" },
+            ],
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText("A crowded task");
+    // The first three are said. They arrive "in the order they were weighed",
+    // so a prefix keeps the server's ranking rather than inventing one here.
+    for (const kind of ["overdue", "due_today", "unassigned"] as const) {
+      expect(container.textContent).toContain(en[`worklist.because.${kind}`]);
+    }
+    // The fourth is not, and it is a phrase this build KNOWS — which is what
+    // tells a cap apart from the unknown-reason drop above.
+    expect(container.textContent).not.toContain(en["worklist.because.routine"]);
+  });
+
+  // The cap runs AFTER the unspeakable reasons are dropped. Capping the raw
+  // list first would let a row carrying three reasons this build has no
+  // sentence for say nothing at all, while the two it could have said sat
+  // just past the cut.
+  it("still says the reasons it knows when unknown ones come first", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            title: "A task from a newer server",
+            because: [
+              { kind: "customer_escalated" as never },
+              { kind: "contract_expiring" as never },
+              { kind: "renewal_slipping" as never },
+              { kind: "overdue" },
+              { kind: "unassigned" },
+            ],
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText("A task from a newer server");
+    expect(container.textContent).toContain(en["worklist.because.overdue"]);
+    expect(container.textContent).toContain(en["worklist.because.unassigned"]);
+  });
+
   it("offers a verb that goes somewhere, and none that does not", async () => {
     stub(
       day({


### PR DESCRIPTION
## Why

The `because` line had no bound. Every reason the server sent was drawn, and the line wrapped freely — so the block is not a fixed cost. It grows by a line every time the reason vocabulary does, and the vocabulary is still growing.

That matters because the row is already too tall. Measured at 390×844 while investigating the skipped criteria in #4238, an **ordinary task row is 284px against the 176px ceiling** `AC-WORKLIST-SDR-07` asserts:

| Part | Height |
|---|---|
| rank | 19 |
| title (wraps to two lines at 390px) | 49 |
| when · **because** · consequence | **57** |
| dispositions | 44 |
| verbs (Pin) | 44 |
| gaps + padding | ~71 |

57px of that is this block carrying **only two reasons**. Without a bound, a reason added anywhere makes every row that carries it taller, and the person adding it has no way to know they did.

## The decisions

**The cap is a ceiling the row owes its height, not a judgement about which reasons matter.** The server already ranked them — `crm.yaml` says `because` arrives *"in the order they were weighed"* — so the first three are the three that put the row where it is. Taking a prefix keeps the server's ranking rather than inventing a second one in the client.

**Three rather than two**: a task that is due today *and* unassigned *and* overdue is saying three true things a rep acts on differently, and two would drop one of them on a row that fits today.

**Applied after the unspeakable reasons are dropped.** Capping the raw list first would let a row carrying three reasons this build has no sentence for say nothing at all, while the two it could have said sat just past the cut. That ordering has its own test.

## What this does not do

**It does not make AC-07 pass, and is not meant to.** The row measured there carries two reasons, so a cap of three changes nothing about it. Both geometry criteria stay `fixme`.

What it does is stop the ceiling being missed again by a change nobody connected to it. The decision about what a 176px row actually holds is still open, and still a product call.

## Evidence

| Obligation | Evidence |
|---|---|
| The cap holds | `says at most three reasons, keeping the ones the server weighed first` — asserts the first three appear and the fourth, a phrase this build **knows**, does not |
| Ordering is right | `still says the reasons it knows when unknown ones come first` — three unknown reasons ahead of two known ones; both known ones still appear |
| Mutation strength | Two clauses reverted one at a time, each observed failing its own test: removing `.slice(0, MOST_REASONS_SHOWN)`, and moving it before the `.filter` instead of after |
| Fixture is not vacuous | The four copy keys are distinct strings (`overdue`, `due today`, `nobody owns it`, `routine tidying`), so the absence assertion cannot pass by accidental substring match |
| Full lane | `make check-fe` exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the worklist row's `because` line to at most three reasons so the row stops growing taller every time the reason vocabulary expands.

- Takes the first three reasons in the server's weighted order, preserving the ranking instead of re-sorting in the client.
- Capping runs after unknown phrases are dropped, so a row with three unspeakable reasons still shows the two known ones past the cut.
- Does not make `AC-WORKLIST-SDR-07` pass: that row carries two reasons, so the cap changes nothing there.

<sup>Written for commit 98bb593ff63d7b762610383d571b1be2d1ebba9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

