### PR TITLE
The installation writes to a person through the durable lane

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13277,11 +13277,13 @@ paths:
         confirmed now that no operator-held token exists.
         A fresh request supersedes any unspent earlier link of the SAME KIND for this person — a record-confirmation request does not expire a pending subscription-confirmation link, because they ask different questions and arrive in different mails.
 
-        `provider_accepted` reports whether the relay took the message, and `sendable` says whether
-        this installation can send at all. Both, because they are different facts and a reader's next
-        move differs: configure a relay, or try again. An installation with no relay still mints
-        the token and answers 201, because the write happened and reporting it as a failure would
-        invite a second request that mints another token and supersedes the first.
+        The mail rides the same durable lane as every other outbound message: it takes a delivery
+        row, an authorization decision recording why the installation was allowed to send it, and a
+        timeline entry — which is what makes it visible to a subject-access export and reachable by
+        erasure. `queued` reports that the message was staged, in the same transaction that minted
+        the link; `sendable` says whether this installation has a lane at all. An installation with
+        no lane still mints the token and answers 201, because the write happened and reporting it
+        as a failure would invite a second request that mints another token and supersedes the first.
       responses:
         '201':
           description: Link issued, and what became of the delivery.
@@ -35525,22 +35527,25 @@ components:
     ConfirmRequestIssued:
       type: object
       description: |
-        A confirm link that now exists, and what became of the attempt to deliver it. Three
-        outcomes rather than two, because a reader's next move differs: it went, this
-        installation cannot send at all, or the send was tried and failed.
-      required: [delivered_to, expires_at, provider_accepted, sendable]
+        A confirm link that now exists, and whether a message carrying it was queued. What
+        becomes of that message afterwards is the delivery's own answer, not this one: the
+        dispatcher transmits it later, retries a transient failure, and parks one it cannot send.
+      required: [delivered_to, expires_at, queued, sendable]
       properties:
         delivered_to:
           type: string
           description: The address the link was posted to — the person's own live primary email.
         expires_at: { type: string, format: date-time }
-        provider_accepted:
+        queued:
           type: boolean
           description: |
-            Whether the relay accepted the message. False while `sendable` is true means the send
-            was attempted and failed, which is a different fact from an installation that cannot
-            send at all. It is deliberately not called `delivered`: a relay returns before any
-            mailbox has seen the message, and a later bounce cannot travel back to change this.
+            Whether the message was put on the outbound send lane, in the same transaction that
+            minted the link. False while `sendable` is true should not happen — staging and
+            minting commit together — so it reads as an installation that cannot send.
+
+            Deliberately not `delivered`, and no longer `provider_accepted`: the message is
+            queued here and transmitted later by the dispatcher, which retries and can park. What
+            became of it is the delivery's own answer and changes as the dispatcher learns more.
         sendable:
           type: boolean
           description: |

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -13,8 +13,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
@@ -442,6 +440,10 @@ func workerHandoffOptions(pool *pgxpool.Pool, logger *slog.Logger, modelPath *co
 		// one, and one that cannot refuses both rather than accepting a moment
 		// nothing will wake at.
 		compose.WithScheduleTimer(compose.NewScheduleTimer(sendInserter)),
+		// The installation's OWN mail rides the same inserter and delivery
+		// table. Its relay, vault and public origin arrive on their own
+		// options; whichever lands last completes the lane.
+		compose.WithControllerMail(sendInserter),
 	}
 
 	enqueueOpts, err := jobEnqueueOptions(pool, logger, modelPath, vatCheckBaseURL)
@@ -455,42 +457,4 @@ func workerHandoffOptions(pool *pgxpool.Pool, logger *slog.Logger, modelPath *co
 	opts = append(opts, embedReindex)
 	opts = append(opts, enqueueOpts...)
 	return opts, nil
-}
-
-// serveUntilSignal serves the composed handler with explicit operational
-// limits — a server without timeouts leaks connections under slow clients —
-// until the listener fails or ctx is cancelled. Shutdown drains in-flight
-// requests inside a bounded window of its own: the ctx that ended the serve is
-// already cancelled, and reusing it would abandon those requests rather than
-// give them time to finish.
-func serveUntilSignal(ctx context.Context, cfg apiConfig, handler http.Handler, stdout io.Writer) error {
-	srv := &http.Server{
-		Addr:              cfg.addr,
-		Handler:           handler,
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       2 * time.Minute,
-	}
-
-	errCh := make(chan error, 1)
-	go func() { errCh <- srv.ListenAndServe() }()
-	if cfg.inlineRelay {
-		_, _ = fmt.Fprintf(stdout, "api listening on %s (base path /v1), relaying events to %s\n", cfg.addr, cfg.redisAddr)
-	} else {
-		_, _ = fmt.Fprintf(stdout, "api listening on %s (base path /v1); the outbox relay runs in cmd/worker\n", cfg.addr)
-	}
-
-	//nolint:contextcheck // the drain gets its own context on purpose: ctx is already cancelled by the time this runs, and a cancelled one would abandon in-flight requests instead of bounding them.
-	stopHTTP := func() error {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		return srv.Shutdown(shutdownCtx)
-	}
-	select {
-	case err := <-errCh:
-		return err
-	case <-ctx.Done():
-		return stopHTTP()
-	}
 }

--- a/backend/cmd/api/serve.go
+++ b/backend/cmd/api/serve.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Serving the composed handler, and stopping it without dropping work.
+//
+// Its own file beside boot.go, which ASSEMBLES the role. What happens after
+// assembly — the operational limits a listener runs under, and the window
+// in-flight requests get when a signal arrives — is a separate concern with a
+// separate failure mode, and boot.go is about what the role is made of.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// serveUntilSignal serves the composed handler with explicit operational
+// limits — a server without timeouts leaks connections under slow clients —
+// until the listener fails or ctx is cancelled. Shutdown drains in-flight
+// requests inside a bounded window of its own: the ctx that ended the serve is
+// already cancelled, and reusing it would abandon those requests rather than
+// give them time to finish.
+func serveUntilSignal(ctx context.Context, cfg apiConfig, handler http.Handler, stdout io.Writer) error {
+	srv := &http.Server{
+		Addr:              cfg.addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe() }()
+	if cfg.inlineRelay {
+		_, _ = fmt.Fprintf(stdout, "api listening on %s (base path /v1), relaying events to %s\n", cfg.addr, cfg.redisAddr)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "api listening on %s (base path /v1); the outbox relay runs in cmd/worker\n", cfg.addr)
+	}
+
+	//nolint:contextcheck // the drain gets its own context on purpose: ctx is already cancelled by the time this runs, and a cancelled one would abandon in-flight requests instead of bounding them.
+	stopHTTP := func() error {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	}
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return stopHTTP()
+	}
+}

--- a/backend/cmd/worker/jobrunner.go
+++ b/backend/cmd/worker/jobrunner.go
@@ -208,6 +208,13 @@ func newJobRunner(pool *pgxpool.Pool, logger *slog.Logger, cfg workerConfig, cap
 		// capture writes them to; without it a message carrying files fails at
 		// the read rather than going out without them.
 		SendBlob: lanes.blob,
+		// The installation's own mail is transmitted by the same relay that
+		// carries a password reset, and its one-time links are unsealed from
+		// the same vault everything else uses. Either one absent leaves a
+		// controller delivery parking with a reason that names what is missing,
+		// rather than retrying a deployment fact.
+		ControllerRelay: compose.ControllerRelayFor(weeklyMail.Mailer),
+		ControllerVault: vault,
 		// The geocoder, when this deployment has one. Empty leaves it nil, the
 		// worker records that it cannot resolve, and radius queries stay
 		// unavailable — which is honest for an installation that geocodes

--- a/backend/gates/directmailbypass_test.go
+++ b/backend/gates/directmailbypass_test.go
@@ -68,11 +68,12 @@ var directMailHolders = gatekit.Waive(map[string]string{
 		"granted access to: the link IS the act the operator performed, not a message about the " +
 		"relationship, and the recipient cannot use the room without receiving it",
 
-	"internal/modules/consent/confirmmail.go": "KNOWN DEBT, not a settled exemption. The confirm-details " +
-		"link asks somebody to check what is held about them and is mailed straight to SMTP, so the one " +
-		"message most owed a record has none: it writes no comms_outbound row, takes no authorization " +
-		"decision and appears in no subject-access export. The consent plan's controller-mail lane was " +
-		"to fix this and never landed. Waived because refusing it would delete a working feature",
+	"internal/compose/controllermailwiring.go": "the TRANSPORT UNDER the lane, not a way around it. " +
+		"This is the adapter the dispatcher's controller seam calls to put a message on the wire, and " +
+		"it runs only after comms_outbound holds the row, consent has recorded the staging decision and " +
+		"the transmit gate has answered again — the same position the Gmail and Graph adapters occupy " +
+		"for a rep's mail. Every other entry here is a caller that reaches the relay INSTEAD of staging " +
+		"a delivery; this one is what a staged delivery is finally handed to",
 })
 
 func TestOnlyRatifiedCodeMailsWithoutTheDeliveryLane(t *testing.T) {

--- a/backend/gates/recencyorigins_test.go
+++ b/backend/gates/recencyorigins_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates_test
+
+// Every reading of "when was this record last touched" excludes the origins the
+// system wrote itself.
+//
+// Two activity origins are the product writing rather than a person:
+// system_remediation is work filed ABOUT a record (a forecast-assurance review
+// task) and system_notice is a message the installation owes somebody (the
+// confirm-details link). Neither means a buyer engaged.
+//
+// The failure this gate exists for is silent and has already happened once in
+// shape: a recency query that counts the system's own writing refreshes the very
+// record whose silence prompted the write, so the rule that noticed the silence
+// switches itself off — one record at a time, with nothing failing. Migration
+// 1788386600 made that argument for remediation; adding system_notice to the
+// vocabulary without reaching every reader would re-open it for notice mail.
+//
+// So the obligation is: a Go query that filters on activity origin uses the ONE
+// spelling, auth.OriginIsEngagement, rather than naming an origin itself. The
+// SQL helpers (last_activity_of_*) carry the same clause and are held by the
+// head catalog, which records their bodies verbatim.
+//
+// A CENSUS rather than a prohibition: the corpus is every file naming an origin
+// literal, and the finding is one that spells the exclusion by hand.
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// systemOrigins are the origins that mean the product wrote the row itself.
+var systemOrigins = []string{"system_remediation", "system_notice"}
+
+// ratifiedOriginLiterals are the files allowed to name a system origin in a
+// literal, each with the reason it is not a hand-rolled exclusion.
+//
+// Keyed by file, because a file is what a reader opens. AssertAllMatched reports
+// an entry that has gone stale, so a ratification outlives its statement by one
+// test run rather than forever.
+var ratifiedOriginLiterals = gatekit.Waive(map[string]string{
+	"internal/platform/auth/engagementorigin.go": "The one spelling itself. This is the file " +
+		"every other reader is required to call instead of naming an origin, so it is the " +
+		"single place the literals are correct.",
+	"internal/modules/activities/activity.go": "The vocabulary's own declaration — the Origin* " +
+		"constants an activity is written with. Naming a value is not filtering on it.",
+})
+
+// TestEveryRecencyReadingExcludesTheSystemOrigins reads every Go file in the
+// tree for a hand-written exclusion.
+func TestEveryRecencyReadingExcludesTheSystemOrigins(t *testing.T) {
+	scope := gatekit.Scope{
+		Roots: []string{"internal"},
+		Subject: func(_ string, file *ast.File) bool {
+			return fileNamesASystemOrigin(file)
+		},
+		Exempt: ratifiedOriginLiterals,
+	}
+	subjects := scope.Files(t)
+	for _, parsed := range subjects {
+		if ratifiedOriginLiterals.Waived(t, parsed.Path) {
+			continue
+		}
+		t.Errorf("%s names a system activity origin in a SQL literal. A recency reading that "+
+			"spells its own exclusion goes stale the moment a third system origin is added: it "+
+			"keeps compiling, keeps passing, and starts counting the product's own writing as "+
+			"the other side engaging. Call auth.OriginIsEngagement(alias) instead, which is the "+
+			"one spelling all five readers share.", parsed.Path)
+	}
+	if len(subjects) == 0 {
+		// Under-recognition is the one way this gate must not fail. A matcher
+		// that stopped recognising an origin literal would read a tree where
+		// nothing matches, report PASS, and leave no failing assertion behind.
+		// The ratified files ARE subjects, so an empty sweep is the bug.
+		t.Fatal("no file in the tree names a system activity origin, not even the two ratified " +
+			"ones — the literal matcher has stopped recognising what it is looking for")
+	}
+	ratifiedOriginLiterals.AssertAllMatched(t)
+}
+
+// TestTheOneSpellingExcludesEverySystemOrigin holds the fragment itself to the
+// vocabulary, so a new origin cannot be added to the constants and missed here.
+//
+// Without it the gate above would be satisfied by a single spelling that had
+// silently fallen behind the origins it is supposed to exclude — every reader
+// correctly calling one function that answers the wrong question.
+func TestTheOneSpellingExcludesEverySystemOrigin(t *testing.T) {
+	clause := auth.OriginIsEngagement("a")
+	for _, origin := range systemOrigins {
+		if !strings.Contains(clause, origin) {
+			t.Errorf("auth.OriginIsEngagement does not exclude %q, so every recency reading in "+
+				"the product counts it as somebody engaging. Add it to the fragment.", origin)
+		}
+	}
+	if !strings.Contains(clause, "a.origin") {
+		t.Errorf("auth.OriginIsEngagement(%q) = %q, which does not filter on the alias's origin "+
+			"column; a caller concatenating it would silently filter nothing", "a", clause)
+	}
+}
+
+// fileNamesASystemOrigin reports whether any literal in the file spells one of
+// the system origins.
+func fileNamesASystemOrigin(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		expr, ok := n.(ast.Expr)
+		if !ok {
+			return true
+		}
+		text, ok := gatekit.LiteralText(expr)
+		if !ok {
+			return true
+		}
+		for _, origin := range systemOrigins {
+			if strings.Contains(text, origin) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/backend/gates/remediationnotbuyeractivity_test.go
+++ b/backend/gates/remediationnotbuyeractivity_test.go
@@ -167,6 +167,10 @@ func sortStrings(s []string) {
 // reader that runs its own max(occurred_at) is invisible to a gate that only
 // reads migrations, and it was four such readers — not the helpers — that
 // still counted remediation work when this column first landed.
+// engagementFragment is the shared exclusion these readers call instead of
+// spelling an origin themselves (internal/platform/auth/engagementorigin.go).
+const engagementFragment = "auth.OriginIsEngagement"
+
 // gatekit:fixture the reader files this census covers and what each computes —
 // expected data naming the subjects, not waivers excusing them.
 var recencyReadersOutsideTheHelpers = map[string]string{
@@ -187,10 +191,22 @@ func TestRecencyReadersOutsideTheHelpersExcludeRemediation(t *testing.T) {
 				"census is guarding a file that moved", file, what, err)
 			continue
 		}
-		if !strings.Contains(string(raw), remediationOrigin) {
-			t.Errorf("%s computes %s and does not mention %q — a second spelling "+
+		// EITHER spelling satisfies this. A reader may name the origin itself,
+		// or call the shared fragment that names every system origin — which is
+		// what all four do now, so that a THIRD system origin reaches them
+		// without anyone having to remember these four files.
+		//
+		// The fragment is the stronger form and is held separately
+		// (TestEveryRecencyReadingExcludesTheSystemOrigins asserts no reader
+		// spells the exclusion by hand, and TestTheOneSpellingExcludesEvery-
+		// SystemOrigin holds the fragment to the vocabulary). This census stays
+		// because it names WHICH files ask the question at all — the fact a
+		// pattern-matching gate cannot recover.
+		body := string(raw)
+		if !strings.Contains(body, remediationOrigin) && !strings.Contains(body, engagementFragment) {
+			t.Errorf("%s computes %s and neither mentions %q nor calls %s — a second spelling "+
 				"of last_activity_at that still counts work the product filed "+
-				"about the record", file, what, remediationOrigin)
+				"about the record", file, what, remediationOrigin, engagementFragment)
 		}
 	}
 }

--- a/backend/gates/vaultwriters_test.go
+++ b/backend/gates/vaultwriters_test.go
@@ -62,6 +62,13 @@ var vaultWriters = map[string]string{
 	"internal/modules/ai/providerkeystore.go":       "audit_log via the settings write, under the ProviderKeys verb",
 	"internal/modules/capture/connectorappstore.go": "audit_log via the settings write, under capture settings' update verb",
 
+	// Sealed inside the transaction that mints the confirm link, so the token
+	// row's own audit entry IS the record: it names the person, the address the
+	// link was posted to and the kind, which is the evidence a later reader
+	// needs. The sealed value itself is deliberately absent from it — auditing
+	// the link would put a live credential in the audit log.
+	"internal/modules/consent/confirmstage.go": "audit_log, under the confirm_token create verb",
+
 	// The declared no-domain-fact posture: bytes move, nothing changes meaning,
 	// so it records operationally rather than as an entity change.
 	"internal/platform/extsecrets/store.go": "system_log — the explicit no-domain-fact posture",

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -349,9 +350,9 @@ func (p SendPacing) withDefaults() SendPacing {
 // store, the mailbox resolver over the capture registry, the consent gate, and
 // the policy chain. Every one of those edges crosses a module boundary, which
 // is why the assembly lives here and not in comms.
-func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPacing, blob blobstore.Store) *commsSendWorker {
+func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPacing, blob blobstore.Store, relay comms.ControllerRelay, vault keyvault.Vault) *commsSendWorker {
 	p := pacing.withDefaults()
-	return &commsSendWorker{dispatcher: comms.NewDispatcher(
+	return &commsSendWorker{dispatcher: controllerLaneOn(comms.NewDispatcher(
 		// The reconcile seam is the cross-module edge comms must not hold
 		// itself: activities owns the timeline row, comms owns the delivery,
 		// and the two meet here.
@@ -369,7 +370,21 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		// options rather than the constant, so the two cannot be changed
 		// apart: there is exactly one place the ladder length is declared.
 		sendInsertOpts().MaxAttempts,
-	)}
+	), relay, vault)}
+}
+
+// controllerLaneOn gives the dispatcher the transport for the installation's own
+// mail, when this role was composed with one.
+//
+// A role with no relay gets the dispatcher unchanged, and a controller delivery
+// it picks up parks with a reason naming the missing relay. That is the honest
+// outcome: an unconfigured relay is a deployment fact, and retrying it forever
+// would leave a person's confirmation link expiring in a queue nobody watches.
+func controllerLaneOn(d *comms.Dispatcher, relay comms.ControllerRelay, vault keyvault.Vault) *comms.Dispatcher {
+	if relay == nil || vault == nil {
+		return d
+	}
+	return d.WithControllerRelay(relay, controllerPayloads{v: vault})
 }
 
 // commsFiles carries the send's attachment snapshot across the module boundary.

--- a/backend/internal/compose/controllermail.go
+++ b/backend/internal/compose/controllermail.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Staging one message the INSTALLATION sends about itself: the timeline row, the
+// delivery, the decision recording why it was allowed, and the job that will
+// carry it — all on one transaction.
+//
+// Its own file beside commsstager.go, which does the same for a message a REP
+// sends. They are deliberately siblings rather than one function with a flag:
+// what differs is not a parameter but the whole authority story. A rep's send
+// resolves a connected mailbox and asks whether that rep may write to this
+// person; the installation's own mail has no mailbox and no rep, and asks
+// whether the record shows an obligation it owes them.
+//
+// What they SHARE is the part that must not diverge — the delivery row, the
+// staging decision, the job, and one commit for all of them.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// controllerMailQueue stages the installation's own mail through the durable
+// lane every other message uses.
+type controllerMailQueue struct {
+	activities *activities.Store
+	comms      *comms.Store
+	runner     *jobs.Runner
+	templates  comms.ControllerTemplates
+	// authority records why this message was allowed to be queued, on the same
+	// transaction that queues it — exactly as commsStager does for user mail.
+	// The lane is NOT a side door: a confirmation mail is asked the same
+	// question, and answers it on its own evidence rather than skipping it.
+	authority *consent.Gate
+}
+
+var _ consent.ConfirmationSender = controllerMailQueue{}
+
+// NewControllerMailQueue builds the lane the installation's own notices ride.
+//
+//nolint:ireturn // returns the consent-side seam by design: the concrete type is unexported and every caller holds the interface
+func NewControllerMailQueue(pool *pgxpool.Pool, runner *jobs.Runner) consent.ConfirmationSender {
+	store := activities.NewStore(InstallationDB(pool))
+	return controllerMailQueue{
+		activities: store,
+		comms:      comms.NewStore(InstallationDB(pool), time.Now, store),
+		runner:     runner,
+		templates:  consent.ControllerTemplateRegistry(),
+		authority:  consentGateFor(pool),
+	}
+}
+
+// QueueConfirmationTx records one confirmation message for transmission.
+//
+// The ORDER is the contract. The activity is written first because both privacy
+// erasure and the subject-access export reach comms_outbound THROUGH it, so a
+// delivery staged before its activity would be invisible to both for as long as
+// the transaction ran — and permanently, if the activity write then failed.
+func (q controllerMailQueue) QueueConfirmationTx(ctx context.Context, tx pgx.Tx, in consent.ConfirmationSend) (ids.UUID, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ids.UUID{}, errors.New("compose: staging a controller delivery outside workspace context")
+	}
+	subject, body := in.Rendered.Subject, in.Rendered.Body
+	outbound := string(crmcontracts.ActivityDirectionOutbound)
+	activity, _, err := q.activities.LogActivityTx(ctx, tx, activities.LogActivityInput{
+		Kind:      string(crmcontracts.ActivityKindEmail),
+		Subject:   &subject,
+		Body:      &body,
+		Direction: &outbound,
+		// The installation writing to somebody about its own obligations is not
+		// that person engaging, so it stays out of every last_activity_at.
+		Origin: activities.OriginSystemNotice,
+		Links: []activities.ActivityLinkInput{{
+			EntityType: string(crmcontracts.ActivityLinkEntityTypePerson),
+			EntityID:   in.PersonID.UUID,
+		}},
+	})
+	if err != nil {
+		return ids.UUID{}, fmt.Errorf("compose: filing the notice on the timeline: %w", err)
+	}
+	deliveryID, err := q.comms.StageControllerTx(ctx, tx, comms.StageControllerInput{
+		ActivityID:       ids.From[ids.ActivityKind](ids.UUID(activity.Id)),
+		Recipient:        in.Recipient,
+		TemplateKey:      in.Rendered.Key,
+		TemplateVersion:  in.Rendered.Version,
+		Subject:          subject,
+		Body:             body,
+		MessageID:        in.MessageID,
+		PayloadRef:       in.LinkRef,
+		PayloadExpiresAt: &in.ExpiresAt,
+		LinkID:           in.LinkID,
+	}, q.templates)
+	if err != nil {
+		return ids.UUID{}, err
+	}
+	// Why this was allowed to be queued, on the same transaction — the same
+	// obligation commsStager.StageTx carries, and NOT guarded on the authority
+	// being wired for the same reason it states: a nil check here would read as
+	// caution and behave as a bypass, staging every notice with no decision
+	// while satisfying a census gate that sees the call and cannot see it
+	// skipped.
+	if q.authority == nil {
+		return ids.UUID{}, errors.New("compose: no authorization authority is wired on the controller mail lane")
+	}
+	set, err := q.authority.AuthorizeStagingTx(ctx, tx, deliveryID, commsauthz.Request{
+		Recipients: []connector.Recipient{{Email: in.Recipient}},
+		Context:    in.Category,
+		Subject:    subject,
+		Body:       body,
+	})
+	if err != nil {
+		return ids.UUID{}, err
+	}
+	if err := refuseAtStaging(set); err != nil {
+		return ids.UUID{}, err
+	}
+	if err := q.runner.EnqueueTx(ctx, tx, SendEmailArgs{
+		Workspace: ws, DeliveryID: deliveryID.String(),
+	}, sendInsertOpts()); err != nil {
+		return ids.UUID{}, err
+	}
+	return deliveryID, nil
+}

--- a/backend/internal/compose/controllermail_integration_test.go
+++ b/backend/internal/compose/controllermail_integration_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The lane the installation's own mail rides, asserted on the rows it actually
+// writes.
+//
+// This is the seam where three modules meet, so it is tested here rather than in
+// any of them: activities files the timeline row, comms stages the delivery,
+// consent takes the decision, and the whole point is that they commit together.
+//
+// The obligation this suite exists for is the one the old direct-SMTP call could
+// not meet. That call wrote nothing: no delivery row, no authorization decision,
+// no timeline entry — so the one message the installation composes entirely by
+// itself appeared in no subject-access export and no erasure reached it.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// sealingVault stands where compose's keyvault-backed one stands. It keeps the
+// plaintext so a test can assert what was sealed rather than only that something
+// was.
+type sealingVault struct{ sealed string }
+
+func (v *sealingVault) Put(_ context.Context, secret string) (string, error) {
+	v.sealed = secret
+	return "sealed-ref", nil
+}
+
+// confirmLaneEnv is one subject with a live address and the real lane wired.
+type confirmLaneEnv struct {
+	e      *integration.Env
+	ctx    context.Context
+	person ids.UUID
+	store  *consent.Store
+	vault  *sealingVault
+}
+
+// setupConfirmLane wires the REAL machinery, not a double: the delivery staging
+// enqueues its dispatch in the same transaction, so a test that replaced it
+// would prove nothing about the property this suite is about.
+func setupConfirmLane(t *testing.T) *confirmLaneEnv {
+	t.Helper()
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	person := e.SeedPerson(t, "Confirm Subject", &e.Rep1)
+	if _, err := e.Pool.Exec(context.Background(), `
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ($1, 'subject@example.test', true, 'manual', 'human:test')`, person); err != nil {
+		t.Fatal(err)
+	}
+	vault := &sealingVault{}
+	return &confirmLaneEnv{
+		e:      e,
+		ctx:    e.As(e.Rep1, []ids.UUID{e.Team1}, integration.SchedulerPerms),
+		person: person,
+		vault:  vault,
+		store: consent.NewStore(InstallationDB(e.Pool)).
+			WithConfirmationLane(NewControllerMailQueue(e.Pool, inserter), vault, "https://crm.example.test"),
+	}
+}
+
+// TestAConfirmLinkStagesADeliveryADecisionAndATimelineRow is the central claim:
+// the installation's own mail leaves the same evidence every other message does.
+func TestAConfirmLinkStagesADeliveryADecisionAndATimelineRow(t *testing.T) {
+	l := setupConfirmLane(t)
+
+	issued, err := l.store.IssueConfirmToken(l.ctx, ids.From[ids.PersonKind](l.person))
+	if err != nil {
+		t.Fatalf("IssueConfirmToken: %v", err)
+	}
+	if !issued.Staged {
+		t.Fatal("the link was minted but no message was staged")
+	}
+
+	if n := l.e.WsCount(t, `SELECT count(*) FROM comms_outbound WHERE sender_kind = 'controller'`); n != 1 {
+		t.Errorf("%d controller deliveries, want 1: without a delivery row the message appears in "+
+			"no subject-access export and erasure cannot reach it", n)
+	}
+	// The decision is what makes the lane NOT a side door. A controller message
+	// that transmitted without one would be the installation exempting itself
+	// from the engine it applies to every rep.
+	if n := l.e.WsCount(t, `
+		SELECT count(*) FROM communication_decision d
+		 JOIN comms_outbound o ON o.id = d.delivery_id AND o.sender_kind = 'controller'`); n != 1 {
+		t.Errorf("%d staging decisions for the controller delivery, want 1", n)
+	}
+	if n := l.e.WsCount(t, `SELECT count(*) FROM activity WHERE origin = 'system_notice'`); n != 1 {
+		t.Errorf("%d notice activities, want 1: privacy's erasure and the subject-access export "+
+			"both reach comms_outbound THROUGH the activity", n)
+	}
+	if n := l.e.WsCount(t, `SELECT count(*) FROM river_job`); n != 1 {
+		t.Errorf("%d dispatch jobs, want 1: a staged message nothing will carry is a link the "+
+			"subject never receives", n)
+	}
+}
+
+// TestTheEngineAllowsAConfirmationOnItsOwnEvidence pins WHAT the decision says.
+//
+// A row saying "denied" would satisfy the count above while the message parked
+// forever, so the count alone is not the property. The basis is asserted for the
+// same reason it is legal_obligation in the validator: a confirmation that
+// rested on consent could never be sent to somebody who has not consented yet.
+func TestTheEngineAllowsAConfirmationOnItsOwnEvidence(t *testing.T) {
+	l := setupConfirmLane(t)
+
+	if _, err := l.store.IssueConfirmToken(l.ctx, ids.From[ids.PersonKind](l.person)); err != nil {
+		t.Fatalf("IssueConfirmToken: %v", err)
+	}
+
+	var verdict, category, basis string
+	if err := l.e.Pool.QueryRow(context.Background(), `
+		SELECT d.verdict, d.resolved_category, coalesce(d.basis, '')
+		  FROM communication_decision d
+		  JOIN comms_outbound o ON o.id = d.delivery_id AND o.sender_kind = 'controller'
+		 ORDER BY d.decided_at DESC LIMIT 1`).Scan(&verdict, &category, &basis); err != nil {
+		t.Fatalf("reading the staging decision: %v", err)
+	}
+	if verdict != "allow" {
+		t.Errorf("the engine answered %q for a confirmation with a live link — the installation "+
+			"cannot ask somebody to check what is held about them", verdict)
+	}
+	if category != "record_confirmation" {
+		t.Errorf("resolved category %q, want record_confirmation", category)
+	}
+	if basis != "legal_obligation" {
+		t.Errorf("basis %q, want legal_obligation", basis)
+	}
+}
+
+// TestTheStagedMessageCarriesNoLiveLink holds the plaintext out of every row a
+// human or an export can read.
+func TestTheStagedMessageCarriesNoLiveLink(t *testing.T) {
+	l := setupConfirmLane(t)
+
+	if _, err := l.store.IssueConfirmToken(l.ctx, ids.From[ids.PersonKind](l.person)); err != nil {
+		t.Fatalf("IssueConfirmToken: %v", err)
+	}
+	if l.vault.sealed == "" {
+		t.Fatal("nothing was sealed, so there is no link for the dispatcher to substitute")
+	}
+
+	// The token itself, as it appears in the sealed link. Searching for it
+	// rather than for a URL shape is what makes this catch a leak into a
+	// column that stores the token alone.
+	_, token, found := lastCut(l.vault.sealed, "#/confirm/")
+	if !found {
+		t.Fatalf("the sealed value is not a confirm link: %q", l.vault.sealed)
+	}
+
+	for _, probe := range []struct {
+		what  string
+		query string
+	}{
+		{"the delivery row", `SELECT count(*) FROM comms_outbound WHERE body LIKE '%' || $1 || '%'`},
+		{"the timeline", `SELECT count(*) FROM activity WHERE coalesce(body, '') LIKE '%' || $1 || '%'`},
+		// Every jsonb an audit row carries, not one of them: the token could
+		// land in any, and a probe naming a single column would pass while the
+		// leak sat in the next one along.
+		{"an audit payload", `
+			SELECT count(*) FROM audit_log
+			 WHERE coalesce(before::text, '') || coalesce(after::text, '') || coalesce(evidence::text, '')
+			       LIKE '%' || $1 || '%'`},
+		{"an outbox event", `SELECT count(*) FROM event_outbox WHERE envelope::text LIKE '%' || $1 || '%'`},
+	} {
+		var n int
+		if err := l.e.Pool.QueryRow(context.Background(), probe.query, token).Scan(&n); err != nil {
+			t.Fatalf("scanning %s: %v", probe.what, err)
+		}
+		if n != 0 {
+			t.Errorf("the live confirm token reached %s (%d row(s)). Anyone who can read that "+
+				"column can open the subject's record without ever holding their mailbox", probe.what, n)
+		}
+	}
+}
+
+// lastCut splits on the final occurrence of sep, so a link whose ORIGIN happens
+// to contain the separator still yields the token.
+func lastCut(s, sep string) (before, after string, found bool) {
+	at := lastIndex(s, sep)
+	if at < 0 {
+		return s, "", false
+	}
+	return s[:at], s[at+len(sep):], true
+}
+
+func lastIndex(s, sub string) int {
+	for i := len(s) - len(sub); i >= 0; i-- {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/backend/internal/compose/controllermailwiring.go
+++ b/backend/internal/compose/controllermailwiring.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Assembling the lane the installation's own mail rides, out of parts three
+// different options supply.
+//
+// The lane needs three things and no option carries all three: WithOperatorMail
+// brings the relay, WithPublicBaseURL brings the origin a link is built on, and
+// WithKeyvault brings somewhere to seal the link. Options run in whatever order
+// a role composes them, so each of the three re-runs the assembly and the last
+// one to arrive completes it. That is the same backfill WithKeyvault already
+// does for the object store and the data reset, and for the same reason: an
+// option that assumed it ran last would silently wire half a lane.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/platform/mailer"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ControllerRelayFor adapts an operator relay to the dispatcher's controller
+// seam, or reports none when this deployment has no relay.
+//
+// Exported because the worker role composes the lane from its own config, and
+// building a second SMTP client there would resolve the same sealed credential
+// twice and let the two drift.
+//
+//nolint:ireturn // returns the comms-side seam by design: the adapter type is unexported
+func ControllerRelayFor(m mailer.Mailer) comms.ControllerRelay {
+	if m == nil {
+		return nil
+	}
+	return mailerRelay{m}
+}
+
+// WithConfirmLinkVault wires ONLY the vault the confirm link is sealed in.
+//
+// Separate from WithKeyvault, which does considerably more: it also installs the
+// outbound send pre-flight over the capture registry, so a role that composed it
+// merely to seal a confirm link would start refusing ordinary sends with
+// "mailbox not send capable". The two are different asks, and a role that wants
+// the lane should not have to accept the other.
+//
+// A role composing WithKeyvault gets this for free — that option sets the same
+// field — so no deployment needs both.
+func WithConfirmLinkVault(vault keyvault.Vault) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		s.vault = vault
+		s.rewireConfirmationLane(pool)
+	}
+}
+
+// WithControllerMail wires the job runner the installation's own notices are
+// queued on.
+//
+// Separate from WithDelivery, which takes an already-built stager and cannot
+// hand this path a runner. The lane also needs a relay (WithOperatorMail), a
+// vault (WithKeyvault) and a public origin (WithPublicBaseURL); each of the four
+// re-runs the assembly, so they compose in any order and the last to arrive
+// completes it.
+func WithControllerMail(runner *jobs.Runner) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		s.confirmRunner = runner
+		s.rewireConfirmationLane(pool)
+	}
+}
+
+// mailerRelay adapts the operator relay to the dispatcher's controller seam.
+//
+// An adapter rather than a second interface on mailer.Mailer, because what the
+// two want differs: a password reset is fire-and-forget text, and a controller
+// delivery claims an RFC822 identity the row is keyed on. The identity is
+// carried through here so a relay that honours it keys the sent copy the same
+// way the delivery row does.
+type mailerRelay struct{ m mailer.Mailer }
+
+// SendControllerMail hands one rendered message to the operator relay.
+func (r mailerRelay) SendControllerMail(ctx context.Context, msg comms.ControllerMessage) error {
+	return r.m.Send(ctx, msg.To, msg.Subject, msg.TextBody)
+}
+
+// confirmLinkVault seals a confirm link for the installation's own workspace.
+//
+// The workspace comes from the CONTEXT rather than from construction, because a
+// vault entry is workspace-scoped and the store that writes one runs inside a
+// request whose workspace is already established. A call with none is a
+// programming fault, not a tenancy question, so it fails rather than guessing.
+type confirmLinkVault struct{ v keyvault.Vault }
+
+// Put seals the plaintext link and returns the reference the delivery carries.
+func (c confirmLinkVault) Put(ctx context.Context, secret string) (string, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return "", errNoWorkspaceForConfirmLink
+	}
+	ref, err := c.v.Put(ctx, ids.From[ids.WorkspaceKind](ws), []byte(secret))
+	if err != nil {
+		return "", err
+	}
+	return string(ref), nil
+}
+
+// controllerPayloads reads and destroys the sealed links at dispatch.
+//
+// The workspace comes from the CONTEXT, like the seal side: the dispatcher runs
+// inside a job whose workspace is already bound, and a vault entry is scoped to
+// it. Taking one at construction would let a worker built for one installation
+// read another's material, which is the one mistake this type must not make.
+type controllerPayloads struct{ v keyvault.Vault }
+
+// Get returns the plaintext link for one delivery.
+func (c controllerPayloads) Get(ctx context.Context, ref string) (string, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return "", errNoWorkspaceForConfirmLink
+	}
+	secret, err := c.v.Get(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(ref))
+	if err != nil {
+		return "", err
+	}
+	return string(secret), nil
+}
+
+// Delete destroys the material once the message can no longer be sent.
+func (c controllerPayloads) Delete(ctx context.Context, ref string) error {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return errNoWorkspaceForConfirmLink
+	}
+	return c.v.Delete(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(ref))
+}
+
+// rewireConfirmationLane rebuilds the lane from whatever parts have arrived.
+//
+// It is called by each of the three options that supply a part. Until all three
+// are present the consent store keeps no lane at all, and issueLink reports a
+// link it minted and did not send — which is the honest answer for an
+// installation that cannot mail one.
+func (s *Server) rewireConfirmationLane(pool *pgxpool.Pool) {
+	if s.controllerRelay == nil || s.vault == nil || s.confirmLinkBase == "" || s.confirmRunner == nil {
+		return
+	}
+	s.consentHandlers = s.WithConfirmationLane(
+		NewControllerMailQueue(pool, s.confirmRunner),
+		confirmLinkVault{s.vault},
+		s.confirmLinkBase,
+	)
+}
+
+// errNoWorkspaceForConfirmLink marks a seal attempted with no workspace in
+// context. It is a programming fault rather than a tenancy answer: the store
+// that seals a link runs inside a request whose workspace is established, so
+// reaching here means a caller built one outside that.
+var errNoWorkspaceForConfirmLink = errors.New("compose: sealing a confirm link outside workspace context")

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -46,6 +47,11 @@ type AppEnv struct {
 	Client *http.Client
 	Owner  *pgx.Conn
 	Pool   *pgxpool.Pool
+	// Vault is the harness's in-memory key vault, exposed because the confirm
+	// link lives there between minting and dispatch: the delivery row carries a
+	// placeholder, so a suite that needs the link the SUBJECT would receive
+	// reads the same bytes the dispatcher substitutes.
+	Vault keyvault.Vault
 }
 
 // SetupApp boots the default harness server — no schema pool, so the
@@ -118,6 +124,7 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 	if err != nil {
 		t.Fatalf("jobs.NewInserter: %v", err)
 	}
+	vault := keyvault.NewMemory()
 	// Unstarted, so the listener's port is known before the handler is
 	// composed: StartTLS below serves the same handler NewTLSServer would.
 	ts := httptest.NewUnstartedServer(nil)
@@ -137,6 +144,24 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 		// the app under test unbounded is the honest spelling: a suite that
 		// wants the bound composes its own metered Server.
 		compose.WithAgentVolume(agentvolume.Unmetered()),
+		// The lane the installation's OWN mail rides. Without it a confirm
+		// link is minted and never staged, so every suite whose subject is what
+		// the subject does with that link would be testing the
+		// installation-cannot-send path instead.
+		//
+		// A memory vault rather than none: the link is sealed there and the
+		// delivery carries only a placeholder, which is the property the lane
+		// exists for. A suite that needs to read the link back does what
+		// confirmLinkToken does — reads it from the vault, which is the same
+		// bytes the dispatcher substitutes.
+		//
+		// WithConfirmLinkVault and not WithKeyvault: the latter also installs
+		// the send pre-flight over the capture registry, which would refuse
+		// every send in this harness as "mailbox not send capable" — a check
+		// that is correct in production and would be answering a question none
+		// of these suites is asking.
+		compose.WithConfirmLinkVault(vault),
+		compose.WithControllerMail(sendInserter),
 	}, opts(origin)...)
 	ts.Config.Handler = compose.New(pool, slog.New(slog.NewTextHandler(os.Stderr, nil)), allOpts...)
 	ts.StartTLS()
@@ -149,7 +174,7 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 	client := ts.Client()
 	client.Jar = jar
 
-	return &AppEnv{TS: ts, Client: client, Owner: owner, Pool: pool}
+	return &AppEnv{TS: ts, Client: client, Owner: owner, Pool: pool, Vault: vault}
 }
 
 // BootstrapWorkspace provisions the organization + admin (the A107 boot

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -357,7 +357,7 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 		AnyMap{}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
 	}
-	token := p.mail.confirmLinkToken(t)
+	token := confirmLinkToken(t, p.AppEnv)
 	if s := publicCall(t, p.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
 		"marketing_choice":  "granted",
 		"marketing_wording": "Yes, send me occasional product news.",

--- a/backend/internal/compose/integration/confirmlinkmail_integration_test.go
+++ b/backend/internal/compose/integration/confirmlinkmail_integration_test.go
@@ -5,7 +5,7 @@
 
 package integration
 
-// The relay a test reads the confirm-details link out of.
+// Where a test reads the confirm-details link from.
 //
 // Issuance of a double-opt-in token was withdrawn: the endpoint refuses, nothing
 // writes consent_doi_token, and the redemption arm is gone. A purpose requiring
@@ -14,45 +14,66 @@ package integration
 //
 // So a test needing a granted marketing consent has to do what the subject does,
 // and the plaintext token is deliberately absent from every operator-facing
-// response — which means there is no shortcut for a test either. Reading it out
-// of the delivered message is the same access the subject has and no more; a
-// helper that reached past the mail would assert a confirmation nobody performed,
-// which is the exact defect the endpoint was withdrawn for.
+// response — which means there is no shortcut for a test either. Reading the
+// link is the same access the subject has and no more; a helper that reached
+// past it would assert a confirmation nobody performed, which is the exact
+// defect the endpoint was withdrawn for.
+//
+// It is read from the VAULT rather than from a relay double, because that is
+// where the link now is at this point in its life. The installation's own mail
+// rides the durable send lane: minting seals the link and stages a message
+// carrying a placeholder, and the two meet in memory only when the dispatcher
+// transmits. A harness that runs no worker never reaches that substitution, so
+// the relay would see nothing — and asserting on an empty relay would be
+// asserting that no mail exists, which is the opposite of what these suites are
+// about.
 
 import (
 	"context"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// capturingMailer stands in for the operator's outbound relay — a real boundary,
-// which is the one kind of thing this repo's tests replace with a double.
-type capturingMailer struct {
-	mu   sync.Mutex
-	body string
-	sent int
-}
-
-func (m *capturingMailer) Send(_ context.Context, _, _, textBody string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.body, m.sent = textBody, m.sent+1
-	return nil
-}
-
-// confirmLinkToken returns the token from the most recent confirm mail.
-func (m *capturingMailer) confirmLinkToken(t *testing.T) string {
+// confirmLinkToken returns the token from the most recently sealed confirm link.
+//
+// The delivery is found by its own template, not by guessing: a controller row
+// staged from the record-confirmation template is the message that carries this
+// link, and its payload_ref names the vault entry holding it.
+func confirmLinkToken(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.sent == 0 {
-		t.Fatal("no confirm mail was sent, so there is no link for the subject to spend")
+	ctx := context.Background()
+
+	var ref string
+	if err := e.Pool.QueryRow(ctx, `
+		SELECT payload_ref FROM comms_outbound
+		 WHERE sender_kind = 'controller' AND payload_ref IS NOT NULL
+		 ORDER BY created_at DESC
+		 LIMIT 1`).Scan(&ref); err != nil {
+		t.Fatalf("no controller delivery holds a sealed confirm link, so there is nothing for "+
+			"the subject to spend: %v", err)
 	}
-	link := regexp.MustCompile(`https?://\S+`).FindString(m.body)
+
+	// The installation's own workspace, which is the one a vault entry is
+	// scoped to: the seal ran inside a request bound to it.
+	var workspace ids.UUID
+	if err := e.Pool.QueryRow(ctx, `SELECT id FROM workspace ORDER BY created_at LIMIT 1`).
+		Scan(&workspace); err != nil {
+		t.Fatalf("reading the installation workspace: %v", err)
+	}
+
+	sealed, err := e.Vault.Get(ctx, ids.From[ids.WorkspaceKind](workspace), keyvault.Ref(ref))
+	if err != nil {
+		t.Fatalf("reading the sealed confirm link: %v", err)
+	}
+
+	link := regexp.MustCompile(`https?://\S+`).FindString(string(sealed))
 	if link == "" {
-		t.Fatalf("the confirm mail carries no link: %q", m.body)
+		t.Fatalf("the sealed value is not a confirm link: %q", string(sealed))
 	}
 	token := link[strings.LastIndex(link, "/")+1:]
 	if token == "" {
@@ -60,3 +81,14 @@ func (m *capturingMailer) confirmLinkToken(t *testing.T) string {
 	}
 	return token
 }
+
+// discardingMailer is the relay boundary for a suite that reads the link from
+// the vault rather than from a message.
+//
+// It is still WIRED, and that is not incidental: a controller delivery resolves
+// its transport before any gate runs, so a harness with no relay would park the
+// message with "no mail relay configured" and the suite would be exercising the
+// unconfigured path instead of the one it is about.
+type discardingMailer struct{}
+
+func (discardingMailer) Send(context.Context, string, string, string) error { return nil }

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -26,16 +26,14 @@ type consentEnv struct {
 	personID   string
 	activityID string
 	purposes   map[string]string // key -> id
-	// mail is the relay the confirm-details link rides. A double-opt-in purpose
-	// can only be granted by spending a mailed link, and the plaintext never
-	// appears in a response, so a test has to read the mail.
-	mail *capturingMailer
 }
 
 func setupConsent(t *testing.T) *consentEnv {
 	t.Helper()
-	mail := &capturingMailer{}
-	e := apptest.SetupAppWithOptions(t, compose.WithOperatorMail(mail))
+	// The relay is wired because a controller delivery resolves its transport
+	// before any gate runs; the LINK is read from the vault, where minting
+	// sealed it (confirmlinkmail_integration_test.go).
+	e := apptest.SetupAppWithOptions(t, compose.WithOperatorMail(discardingMailer{}))
 	apptest.BootstrapWorkspaceSession(t, e, "Consent E2E", "dpo@fable.test", "Admin")
 
 	var person struct {
@@ -74,7 +72,7 @@ func setupConsent(t *testing.T) *consentEnv {
 		purposes["business_correspondence"] == "" {
 		t.Fatalf("bootstrap did not seed the purpose catalog: %+v", purposeList.Data)
 	}
-	return &consentEnv{AppEnv: e, mail: mail, personID: person.ID, activityID: activity.ID, purposes: purposes}
+	return &consentEnv{AppEnv: e, personID: person.ID, activityID: activity.ID, purposes: purposes}
 }
 
 func (c *consentEnv) send(t *testing.T, purpose string) (int, string) {
@@ -371,7 +369,7 @@ func (c *consentEnv) grantMarketingByConfirmLink(t *testing.T) string {
 		AnyMap{}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
 	}
-	token := c.mail.confirmLinkToken(t)
+	token := confirmLinkToken(t, c.AppEnv)
 	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
 		"marketing_choice":  "granted",
 		"marketing_wording": "Yes, send me occasional product news.",

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -48,11 +48,6 @@ type preflightEnv struct {
 	activityID string
 	personID   string
 	ws, user   string
-	// mail is the operator relay, kept so a test can read the confirm-details
-	// link out of it. A marketing purpose requires double opt-in, and the only
-	// thing that grants one now is a link the subject spent from their own
-	// mailbox — the plaintext never reaches a response.
-	mail *capturingMailer
 }
 
 // setupPreflight boots the api composition WITH the Google app configured, so
@@ -93,13 +88,18 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
-	mail := &capturingMailer{}
-	opts := append([]compose.Option{compose.WithKeyvault(vault), compose.WithOperatorMail(mail)}, extra...)
+	opts := append([]compose.Option{compose.WithKeyvault(vault), compose.WithOperatorMail(discardingMailer{})}, extra...)
 	// A marketing send derives a one-click unsubscribe link and refuses
 	// without a boot-configured base to build it from, so the fixture
 	// carries one — an install that can send at all has one.
 	opts = append(opts, compose.WithPublicBaseURL(preflightBaseURL))
 	e := apptest.SetupAppWithOptions(t, opts...)
+	// This suite composes its OWN vault (a real local one, because the
+	// pre-flight it is about needs a credential custodian), and WithKeyvault
+	// replaces the harness's. AppEnv.Vault has to name the one the server
+	// actually sealed into, or a suite reading a confirm link back would look
+	// in the wrong store and find nothing.
+	e.Vault = vault
 	apptest.BootstrapWorkspaceSession(t, e, "Preflight E2E", "sender@fable.test", "Admin")
 
 	var person struct {
@@ -154,7 +154,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	}); err != nil {
 		t.Fatalf("resolving the acting human: %v", err)
 	}
-	return &preflightEnv{AppEnv: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user, mail: mail}
+	return &preflightEnv{AppEnv: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user}
 }
 
 // send issues the authenticated send and returns the status plus the

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -20,9 +20,9 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 
-	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/capture/telegram"
+	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/geocode"
@@ -90,6 +90,13 @@ type JobRunnerConfig struct {
 	// reads rows), and a message carrying attachments then fails at the read
 	// rather than going out without them.
 	SendBlob blobstore.Store
+	// ControllerRelay transmits the installation's OWN mail — a confirm-details
+	// link, a double-opt-in link — and ControllerVault holds the one-time link
+	// each such message carries. Nil is a role that sends no controller mail:
+	// the delivery parks with a reason naming the missing relay rather than
+	// retrying an outage that no waiting will fix.
+	ControllerRelay comms.ControllerRelay
+	ControllerVault keyvault.Vault
 	// SendRegistry resolves the transmitting mailbox for a staged delivery.
 	// Nil means this role registers no send worker at all: a delivery it
 	// picked up could only fail on every attempt, and a queued send is better
@@ -438,55 +445,4 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 	)
 
 	return reg, periodic
-}
-
-// addModelLaneJobs registers the kinds whose work is a model call: the site
-// deep read, the voice build, the embed reindex, and the two refreshes that
-// extract rates from a page. The deferred-build retry sweep rides with them
-// because it fans out to the voice build and to nothing else.
-//
-// Not one of them is gated on the lane it reads, and that shared posture is
-// what makes them a group. Something outside the runner enqueues every model
-// call here — an api call, a human's confirm, an admin's refresh click, the
-// retry sweep's own fan-out — so a row can already be waiting when a role with
-// no lane configured comes up, and registering anyway is what makes that row
-// fail with an actionable message instead of sitting queued behind a job
-// nothing works. The embed DRIFT sweep takes the opposite posture for the
-// opposite reason (embeddriftsweep.go): nothing but its own tick enqueues it,
-// so there is no waiting row for a worker to answer.
-func addModelLaneJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger) {
-	// The deep read is the one kind whose timeout the file cannot state,
-	// because the crawl wall it is built from is an operator's (deepReadTimeout).
-	addDeclaredWorkerWithTimeout[SiteDeepReadArgs](reg,
-		newSiteDeepReadWorker(pool, cfg.DeepReadBrain, cfg.DeepReadFactBrain, cfg.DeepReadTriageBrain, log, cfg.DeepReadCaps, cfg.Blobstore),
-		deepReadTimeout(cfg.DeepReadCaps))
-	addDeclaredWorker[TranscriptProposeArgs](reg, newTranscriptProposeWorker(pool, cfg.TranscriptProposeBrain, log))
-	addDeclaredWorker[GeocodeOrganizationArgs](reg, newGeocodeWorker(pool, cfg.Geocoder))
-	addDeclaredWorker[CheckOrganizationVatArgs](reg, newVatCheckWorker(pool, cfg.VatChecker, nil))
-	addDeclaredWorker[DocumentExtractArgs](reg, newDocumentExtractWorker(pool, cfg.DocumentExtractBrain, cfg.SendBlob, log))
-	addDeclaredWorker[VoiceBuildArgs](reg, newVoiceBuildWorker(pool, cfg.VoiceBrain, log))
-	// The weekly retrospective moved here when it grew a lane. It is
-	// database-only in its measuring half and stays registered whatever the
-	// role holds — only the sentence is absent without a lane — but a group
-	// documented as taking no config is the wrong place for something that
-	// reads one.
-	addWeeklyReviewJobs(reg, pool, log, cfg.WeeklyReviewBrain, cfg.WeeklyMail)
-	addDeclaredWorker[VoiceBuildRetryArgs](reg, &voiceBuildRetryWorker{store: ai.NewVoiceStore(InstallationDB(pool)), log: log})
-	// The reindex is a dispatcher plus a workspace worker, and neither is
-	// ticked: the api enqueues the dispatcher once per confirmed reindex
-	// (jobs_embedreindex.go).
-	addEmbedReindexJobs(reg, pool, cfg.Embedder)
-	addKnowledgeIngestJobs(reg, pool, cfg.Blobstore, cfg.Embedder, log)
-	// The mailed-card import, registered unconditionally: a .vcf is parsed and
-	// not inferred, so there is no model lane for it to be missing. Its trigger
-	// starts unconditionally too, and the two must agree — River discards a job
-	// whose kind no worker claims, so a trigger without this registration would
-	// drop every mailed card silently.
-	addDeclaredWorker[VCardIngestArgs](reg, newVCardIngestWorker(pool, cfg.Blobstore, log))
-	// Both refreshes read a source the deployment configures. An unconfigured
-	// one — a nil brain, an empty url, no pricing sources — leaves the worker
-	// registered and its producer proposing nothing, which is the honest
-	// answer to "refresh from sources" when there are none.
-	addDeclaredWorker[FxRateRefreshArgs](reg, newFxRefreshWorker(pool, cfg.FxExtractBrain, cfg.FxSourceURL, cfg.FxBootstrapCurrencies, log))
-	addDeclaredWorker[AiModelRateRefreshArgs](reg, newModelCostRefreshWorker(pool, cfg.RateExtractBrain, cfg.ModelPricingSources, cfg.BoundModelIDs, log))
 }

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -91,7 +91,7 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 	// message, in the same transaction as the activity; this role only needs
 	// the worker registered.
 	if cfg.SendRegistry != nil {
-		addDeclaredWorker[SendEmailArgs](reg, newSendWorker(pool, cfg.SendRegistry, cfg.SendPacing, cfg.SendBlob))
+		addDeclaredWorker[SendEmailArgs](reg, newSendWorker(pool, cfg.SendRegistry, cfg.SendPacing, cfg.SendBlob, cfg.ControllerRelay, cfg.ControllerVault))
 		// The alarm for a message a rep chose to send later. Firing one creates
 		// its delivery and its dispatch job, so it registers only where that
 		// machinery exists — a role that cannot send cannot fire either.

--- a/backend/internal/compose/jobsmodellane.go
+++ b/backend/internal/compose/jobsmodellane.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The job kinds whose work is a MODEL call, registered as one group.
+//
+// Its own file beside jobs.go, which wires the runner. These belong together
+// because they share a posture rather than a subject: none is gated on the lane
+// it reads, for the reason the function's own comment gives at length.
+
+import (
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// addModelLaneJobs registers the kinds whose work is a model call: the site
+// deep read, the voice build, the embed reindex, and the two refreshes that
+// extract rates from a page. The deferred-build retry sweep rides with them
+// because it fans out to the voice build and to nothing else.
+//
+// Not one of them is gated on the lane it reads, and that shared posture is
+// what makes them a group. Something outside the runner enqueues every model
+// call here — an api call, a human's confirm, an admin's refresh click, the
+// retry sweep's own fan-out — so a row can already be waiting when a role with
+// no lane configured comes up, and registering anyway is what makes that row
+// fail with an actionable message instead of sitting queued behind a job
+// nothing works. The embed DRIFT sweep takes the opposite posture for the
+// opposite reason (embeddriftsweep.go): nothing but its own tick enqueues it,
+// so there is no waiting row for a worker to answer.
+func addModelLaneJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger) {
+	// The deep read is the one kind whose timeout the file cannot state,
+	// because the crawl wall it is built from is an operator's (deepReadTimeout).
+	addDeclaredWorkerWithTimeout[SiteDeepReadArgs](reg,
+		newSiteDeepReadWorker(pool, cfg.DeepReadBrain, cfg.DeepReadFactBrain, cfg.DeepReadTriageBrain, log, cfg.DeepReadCaps, cfg.Blobstore),
+		deepReadTimeout(cfg.DeepReadCaps))
+	addDeclaredWorker[TranscriptProposeArgs](reg, newTranscriptProposeWorker(pool, cfg.TranscriptProposeBrain, log))
+	addDeclaredWorker[GeocodeOrganizationArgs](reg, newGeocodeWorker(pool, cfg.Geocoder))
+	addDeclaredWorker[CheckOrganizationVatArgs](reg, newVatCheckWorker(pool, cfg.VatChecker, nil))
+	addDeclaredWorker[DocumentExtractArgs](reg, newDocumentExtractWorker(pool, cfg.DocumentExtractBrain, cfg.SendBlob, log))
+	addDeclaredWorker[VoiceBuildArgs](reg, newVoiceBuildWorker(pool, cfg.VoiceBrain, log))
+	// The weekly retrospective moved here when it grew a lane. It is
+	// database-only in its measuring half and stays registered whatever the
+	// role holds — only the sentence is absent without a lane — but a group
+	// documented as taking no config is the wrong place for something that
+	// reads one.
+	addWeeklyReviewJobs(reg, pool, log, cfg.WeeklyReviewBrain, cfg.WeeklyMail)
+	addDeclaredWorker[VoiceBuildRetryArgs](reg, &voiceBuildRetryWorker{store: ai.NewVoiceStore(InstallationDB(pool)), log: log})
+	// The reindex is a dispatcher plus a workspace worker, and neither is
+	// ticked: the api enqueues the dispatcher once per confirmed reindex
+	// (jobs_embedreindex.go).
+	addEmbedReindexJobs(reg, pool, cfg.Embedder)
+	addKnowledgeIngestJobs(reg, pool, cfg.Blobstore, cfg.Embedder, log)
+	// The mailed-card import, registered unconditionally: a .vcf is parsed and
+	// not inferred, so there is no model lane for it to be missing. Its trigger
+	// starts unconditionally too, and the two must agree — River discards a job
+	// whose kind no worker claims, so a trigger without this registration would
+	// drop every mailed card silently.
+	addDeclaredWorker[VCardIngestArgs](reg, newVCardIngestWorker(pool, cfg.Blobstore, log))
+	// Both refreshes read a source the deployment configures. An unconfigured
+	// one — a nil brain, an empty url, no pricing sources — leaves the worker
+	// registered and its producer proposing nothing, which is the honest
+	// answer to "refresh from sources" when there are none.
+	addDeclaredWorker[FxRateRefreshArgs](reg, newFxRefreshWorker(pool, cfg.FxExtractBrain, cfg.FxSourceURL, cfg.FxBootstrapCurrencies, log))
+	addDeclaredWorker[AiModelRateRefreshArgs](reg, newModelCostRefreshWorker(pool, cfg.RateExtractBrain, cfg.ModelPricingSources, cfg.BoundModelIDs, log))
+}

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -31,12 +31,14 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/agents/apps"
+	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
+	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/licensecheck"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget"
@@ -254,6 +256,15 @@ type Server struct {
 	// it feeds a /readyz probe and backs the capture connector-credential
 	// path; nil means a role that resolves no stored connector credentials.
 	vault keyvault.Vault
+
+	// The three parts of the lane the installation's own mail rides, each
+	// supplied by a different option (WithOperatorMail, WithPublicBaseURL,
+	// WithControllerMail) and joined by rewireConfirmationLane. Held rather
+	// than assembled on arrival because options compose in any order, so no one
+	// of them can assume the others have run.
+	controllerRelay comms.ControllerRelay
+	confirmLinkBase string
+	confirmRunner   *jobs.Runner
 
 	// captureConfig is the deployment's capture suppression-list config
 	// (CAP-PARAM-5/6, ADR-0072), injected by WithCaptureConfig. The options

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -18,10 +18,8 @@ import (
 
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/ai"
-	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/identity"
-	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/agentvolume"
@@ -53,14 +51,14 @@ type Option func(*Server, *pgxpool.Pool)
 // through WithPublicBaseURL, because an installation with no mailer still
 // builds set-password links (ADR-0061 Amendment 1).
 func WithOperatorMail(m mailer.Mailer) Option {
-	return func(s *Server, _ *pgxpool.Pool) {
+	return func(s *Server, pool *pgxpool.Pool) {
 		s.authHandlers = s.WithPasswordReset(m)
-		// The confirm-details link rides the same relay, and unlike the Deal
-		// Room invitation below it is wired here rather than held back: the
-		// screen it opens is served by the SPA today, so a recipient who
-		// follows it lands on their own record rather than on a not-found page
-		// having spent their one token getting there.
-		s.consentHandlers = s.WithConfirmMailer(m)
+		// The confirm-details link no longer rides this relay directly: it goes
+		// through the durable send lane, which gives it a delivery row, an
+		// authorization decision and a timeline entry like every other message.
+		// The relay still transmits it, one layer down, as the controller seam.
+		s.controllerRelay = mailerRelay{m}
+		s.rewireConfirmationLane(pool)
 	}
 }
 
@@ -215,6 +213,8 @@ func WithKeyvault(vault keyvault.Vault) Option {
 		// have already run, and a reset that cannot reach the vault leaves the
 		// sealed credentials of the installation it just wiped resident.
 		s.dataResetHandlers.vault = vault
+		// The confirm link is sealed in the same vault (controllermailwiring.go).
+		s.rewireConfirmationLane(pool)
 		// The BYOK credential surface exists only where there is somewhere to
 		// seal a key. Wired here rather than in the AI block so a role that
 		// composes no vault serves 501 on those routes instead of recording a
@@ -424,7 +424,8 @@ func WithPublicBaseURL(base string) Option {
 		s.dealroomsHandlers = s.WithInviteLinkBase(base)
 		// So does the confirm-details link, which opens one person's own record
 		// to whoever holds it.
-		s.consentHandlers = s.WithConfirmLinkBase(base)
+		s.confirmLinkBase = base
+		s.rewireConfirmationLane(pool)
 		// Reported to an operator, never enforced: the boot and send guards
 		// are what refuse an unusable origin, and a readiness check here
 		// would deadlock a rollout on its own ingress.
@@ -458,41 +459,5 @@ func WithSendAuthority(authority activities.SendAuthority) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.send.SendAuthority = authority
 		s.rebuildToolRegistry(pool)
-	}
-}
-
-// WithColdStart enables the cold-start read-back over the given fetch
-// and model seams. Without it the operation stays an explicit 501 —
-// the api role must DECLARE its model path, never pick one silently.
-func WithColdStart(fetch PageFetcher, brain completer) Option {
-	return func(s *Server, pool *pgxpool.Pool) {
-		s.coldstartHandlers = coldstartHandlers{engine: &coldStartEngine{
-			extract:   evidenceExtractor{fetch: fetch, brain: brain},
-			approvals: approvals.NewService(InstallationDB(pool)),
-		}}
-	}
-}
-
-// WithScrape enables per-organization enrichment (scrapeCompany) over the same
-// fetch and model seams as the read-back. Without it the operation stays an
-// explicit 501 — the api role must DECLARE its model path, never pick one
-// silently.
-func WithScrape(fetch PageFetcher, brain completer) Option {
-	return func(s *Server, pool *pgxpool.Pool) {
-		s.scrapeHandlers = scrapeHandlers{engine: &scrapeEngine{
-			extract:   evidenceExtractor{fetch: fetch, brain: brain},
-			people:    people.NewStore(InstallationDB(pool)),
-			approvals: approvals.NewService(InstallationDB(pool)),
-		}}
-	}
-}
-
-// WithBrief enables the Morning-Brief L2 ranker (B-E05.2) over the given
-// model lane. Without it the brief still serves fully on the deterministic
-// §10.1 composite — the L2 layer is advisory over that floor, never a
-// prerequisite for the home surface.
-func WithBrief(brain completer) Option {
-	return func(s *Server, _ *pgxpool.Pool) {
-		s.WithL2Ranker(brain, s.log)
 	}
 }

--- a/backend/internal/compose/serveroptionsreading.go
+++ b/backend/internal/compose/serveroptionsreading.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The options that put a MODEL behind a read surface: the cold-start read-back,
+// the page scrape, and the meeting brief.
+//
+// Their own file beside serveroptions.go because they share the posture the
+// first one states — without the option the operation is an explicit 501, since
+// the api role must DECLARE its model path rather than pick one silently — and
+// because each takes a brain rather than a store.
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/people"
+)
+
+// WithColdStart enables the cold-start read-back over the given fetch
+// and model seams. Without it the operation stays an explicit 501 —
+// the api role must DECLARE its model path, never pick one silently.
+func WithColdStart(fetch PageFetcher, brain completer) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		s.coldstartHandlers = coldstartHandlers{engine: &coldStartEngine{
+			extract:   evidenceExtractor{fetch: fetch, brain: brain},
+			approvals: approvals.NewService(InstallationDB(pool)),
+		}}
+	}
+}
+
+// WithScrape enables per-organization enrichment (scrapeCompany) over the same
+// fetch and model seams as the read-back. Without it the operation stays an
+// explicit 501 — the api role must DECLARE its model path, never pick one
+// silently.
+func WithScrape(fetch PageFetcher, brain completer) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		s.scrapeHandlers = scrapeHandlers{engine: &scrapeEngine{
+			extract:   evidenceExtractor{fetch: fetch, brain: brain},
+			people:    people.NewStore(InstallationDB(pool)),
+			approvals: approvals.NewService(InstallationDB(pool)),
+		}}
+	}
+}
+
+// WithBrief enables the Morning-Brief L2 ranker (B-E05.2) over the given
+// model lane. Without it the brief still serves fully on the deterministic
+// §10.1 composite — the L2 layer is advisory over that floor, never a
+// prerequisite for the home surface.
+func WithBrief(brain completer) Option {
+	return func(s *Server, _ *pgxpool.Pool) {
+		s.WithL2Ranker(brain, s.log)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19741,19 +19741,22 @@ type ConfirmFieldOrigin struct {
 	Source     string `json:"source"`
 }
 
-// ConfirmRequestIssued A confirm link that now exists, and what became of the attempt to deliver it. Three
-// outcomes rather than two, because a reader's next move differs: it went, this
-// installation cannot send at all, or the send was tried and failed.
+// ConfirmRequestIssued A confirm link that now exists, and whether a message carrying it was queued. What
+// becomes of that message afterwards is the delivery's own answer, not this one: the
+// dispatcher transmits it later, retries a transient failure, and parks one it cannot send.
 type ConfirmRequestIssued struct {
 	// DeliveredTo The address the link was posted to — the person's own live primary email.
 	DeliveredTo string    `json:"delivered_to"`
 	ExpiresAt   time.Time `json:"expires_at"`
 
-	// ProviderAccepted Whether the relay accepted the message. False while `sendable` is true means the send
-	// was attempted and failed, which is a different fact from an installation that cannot
-	// send at all. It is deliberately not called `delivered`: a relay returns before any
-	// mailbox has seen the message, and a later bounce cannot travel back to change this.
-	ProviderAccepted bool `json:"provider_accepted"`
+	// Queued Whether the message was put on the outbound send lane, in the same transaction that
+	// minted the link. False while `sendable` is true should not happen — staging and
+	// minting commit together — so it reads as an installation that cannot send.
+	//
+	// Deliberately not `delivered`, and no longer `provider_accepted`: the message is
+	// queued here and transmitted later by the dispatcher, which retries and can park. What
+	// became of it is the delivery's own answer and changes as the dispatcher learns more.
+	Queued bool `json:"queued"`
 
 	// Sendable Whether this installation has an outbound relay and a link origin configured. False
 	// means nothing was attempted — the link exists and must be passed on by hand.

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -83,19 +83,29 @@ type LogActivityInput struct {
 	Links                        []ActivityLinkInput
 	Source                       string
 	// Origin says who caused this row to exist, and the recency clocks in the
-	// schema read it: OriginSystemRemediation is excluded from every
-	// last_activity_at, because the system asking about a silent deal is not
-	// the buyer breaking their silence. Empty means OriginHuman.
+	// schema read it: the two system origins are excluded from every
+	// last_activity_at, because neither the system asking about a silent deal
+	// nor the installation mailing somebody a notice it owes them is the other
+	// side breaking their silence. Empty means OriginHuman.
 	Origin string
 }
 
-// The origins an activity can have. OriginSystemRemediation marks work the
-// product files about a record — a forecast-assurance review task — and is the
-// one value the last_activity_of_* functions skip.
+// The origins an activity can have.
+//
+// Two of them are the system writing rather than a person, and neither counts
+// as the record being touched: OriginSystemRemediation marks work the product
+// files about a record — a forecast-assurance review task — and OriginSystemNotice
+// marks a message the installation owes somebody, such as the confirm-details
+// link. A Go query that needs to exclude them calls auth.OriginIsEngagement
+// rather than naming an origin itself; the last_activity_of_* functions carry
+// the same clause in SQL.
+//
+// Held by: TestEveryRecencyReadingExcludesTheSystemOrigins (backend/gates/recencyorigins_test.go)
 const (
 	OriginHuman             = "human"
 	OriginAgent             = "agent"
 	OriginSystemRemediation = "system_remediation"
+	OriginSystemNotice      = "system_notice"
 )
 
 // LogActivity writes the activity + links; the last_activity_at clocks

--- a/backend/internal/modules/activities/lasttouch.go
+++ b/backend/internal/modules/activities/lasttouch.go
@@ -59,7 +59,7 @@ func lastTouchCandidateQuery() string {
 				SELECT a.id, a.occurred_at
 				FROM activity a
 				WHERE a.archived_at IS NULL
-				  AND a.origin <> 'system_remediation'
+				  `+auth.OriginIsEngagement("a")+`
 				  AND NOT (a.source = $1
 				           AND (a.captured_by = $4 OR a.captured_by LIKE $5))
 			), direct AS (

--- a/backend/internal/modules/activities/projectcoverage.go
+++ b/backend/internal/modules/activities/projectcoverage.go
@@ -96,10 +96,12 @@ func (s *Store) ProjectActivityFactsTx(ctx context.Context, tx pgx.Tx, id ids.Pr
 			WHERE l.project_id = $%[1]d OR d.project_id = $%[1]d OR r.project_id = $%[1]d
 		)
 		SELECT count(*) FILTER (WHERE f.filed_here),
-		       -- Recency excludes remediation, matching last_activity_of_project.
-		       -- The counts do not: a review task filed here IS attributed work,
-		       -- it just is not the other side engaging.
-		       max(a.occurred_at) FILTER (WHERE f.filed_here AND a.origin <> 'system_remediation'),
+		       -- Recency excludes the system's own origins, matching
+		       -- last_activity_of_project. The counts do not: a review task filed
+		       -- here IS attributed work, it just is not the other side engaging.
+		       -- TRUE carries the fragment's leading AND, so the one spelling in
+		       -- auth.OriginIsEngagement serves a FILTER as well as a WHERE.
+		       max(a.occurred_at) FILTER (WHERE f.filed_here AND TRUE`+auth.OriginIsEngagement("a")+`),
 		       count(*) FILTER (WHERE NOT f.filed_anywhere),
 		       count(*) FILTER (WHERE f.filed_here AND a.kind = 'task' AND NOT a.is_done)
 		FROM activity a

--- a/backend/internal/modules/comms/dispatcher.go
+++ b/backend/internal/modules/comms/dispatcher.go
@@ -54,6 +54,12 @@ type Dispatcher struct {
 	now         func() time.Time
 	maxAge      time.Duration
 	maxAttempts int
+	// relay and payloads serve the controller lane only. Both nil on an
+	// installation that sends no controller mail, which resolveSeam reports as
+	// a parked delivery rather than a retry: an unconfigured relay is a
+	// deployment fact and waiting does not change it.
+	relay    ControllerRelay
+	payloads PayloadVault
 }
 
 // defaultMaxAttempts bounds a dispatcher whose ladder length was not
@@ -112,6 +118,19 @@ func NewDispatcher(
 	}
 }
 
+// WithControllerRelay wires the transport for the installation's own mail, and
+// the vault holding the one-time links it carries.
+//
+// An OPTION rather than a constructor parameter because the lane is optional:
+// every other send needs a resolver, a seat authority and a consent gate, and a
+// deployment that sends no confirmation mail should not have to name two nils
+// to say so.
+func (d *Dispatcher) WithControllerRelay(relay ControllerRelay, payloads PayloadVault) *Dispatcher {
+	d.relay = relay
+	d.payloads = payloads
+	return d
+}
+
 // DispatchWithWait runs one delivery attempt and reports how long to wait when
 // the outcome is OutcomePostponed (zero for every other outcome).
 //
@@ -135,23 +154,48 @@ func (d *Dispatcher) DispatchWithWait(ctx context.Context, id ids.UUID) (Outcome
 		return OutcomeRetry, 0, err
 	}
 
-	// Resolve first, because the authority gate reads the scopes the provider
-	// says this grant holds right now — not a copy stored when it was granted.
-	// resolveSeam is the ONE branch on provider class (sendseam.go); everything
-	// from here down is one path for both transports.
-	seam, err := d.resolveSeam(ctx, del)
+	if del.carriesLiveLink() {
+		return d.dispatchClosingLink(ctx, del)
+	}
+	return d.dispatchLoaded(ctx, del)
+}
+
+// dispositionForUnresolvedSeam turns a failure to resolve the transmitting
+// credential into the disposition it deserves.
+//
+// The split between park and retry is the whole point, and getting it backwards
+// is expensive in both directions: parking on an outage destroys a legitimate
+// send, and retrying an ANSWER — no mailbox connected, no relay configured —
+// leaves a message rattling round the ladder while nobody learns the thing they
+// have to fix. Every named case here is an answer; anything else is a failure to
+// get one.
+func (d *Dispatcher) dispositionForUnresolvedSeam(ctx context.Context, del Delivery, err error) (Outcome, time.Duration, error) {
 	switch {
 	case errors.Is(err, ErrNoMailbox):
 		return d.park(ctx, del.ID, fmt.Sprintf(
 			"nothing is connected for %s to transmit through; connect it to enable sending", del.Provider))
 	case errors.Is(err, ErrCannotSend):
 		return d.park(ctx, del.ID, fmt.Sprintf("the %s connection cannot transmit messages", del.Provider))
+	case errors.Is(err, ErrNoControllerRelay):
+		return d.park(ctx, del.ID,
+			"this installation has no mail relay configured to send its own notices through; configure one, then re-send")
 	case errors.Is(err, ErrProviderNotConfigured):
 		return d.park(ctx, del.ID, fmt.Sprintf(
 			"this installation has no %s integration configured to transmit through; configure it, then re-send", del.Provider))
-	case err != nil:
-		// Park only on an answer, never on a failure to get one.
+	default:
 		return d.retry(ctx, del.ID, err)
+	}
+}
+
+// dispatchLoaded runs the gates and the transmit for a delivery already loaded.
+func (d *Dispatcher) dispatchLoaded(ctx context.Context, del Delivery) (Outcome, time.Duration, error) {
+	// Resolve first, because the authority gate reads the scopes the provider
+	// says this grant holds right now — not a copy stored when it was granted.
+	// resolveSeam is the ONE branch on provider class (sendseam.go); everything
+	// from here down is one path for both transports.
+	seam, err := d.resolveSeam(ctx, del)
+	if err != nil {
+		return d.dispositionForUnresolvedSeam(ctx, del, err)
 	}
 
 	// Which of the gates below apply at all. A controller message has no seat,
@@ -304,6 +348,9 @@ func (d *Dispatcher) transmit(ctx context.Context, del Delivery, seam sendSeam, 
 		// lost.
 		return OutcomeRetry, 0, fmt.Errorf("comms: recording the send receipt: %w", err)
 	}
+
+	// The one-time link has now been sent and must stop being live.
+	d.retireLink(ctx, del)
 
 	// Metering follows the DURABLE record, not the provider call, because the
 	// send call is not the countable event: a receipt that failed to record

--- a/backend/internal/modules/comms/dispatcher_harness_test.go
+++ b/backend/internal/modules/comms/dispatcher_harness_test.go
@@ -25,8 +25,10 @@ import (
 // consulted at all.
 
 type fakeStore struct {
-	delivery Delivery
-	loadErr  error
+	payloadsCleared int
+	payloadClearErr error
+	delivery        Delivery
+	loadErr         error
 
 	sent   string
 	parked string
@@ -110,6 +112,17 @@ func (f *fakeStore) MarkInFlight(_ context.Context, _ ids.UUID) error {
 	f.marked++
 	at := testNow
 	f.delivery.InFlightAt = &at
+	return nil
+}
+
+// ClearPayloadRef records that the one-time link material was retired, so a
+// test can assert the dispatcher retires it on exactly the terminal outcomes.
+func (f *fakeStore) ClearPayloadRef(_ context.Context, _ ids.UUID) error {
+	if f.payloadClearErr != nil {
+		return f.payloadClearErr
+	}
+	f.payloadsCleared++
+	f.delivery.PayloadRef = ""
 	return nil
 }
 

--- a/backend/internal/modules/comms/gates.go
+++ b/backend/internal/modules/comms/gates.go
@@ -270,6 +270,25 @@ func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (commsauthz.
 		return ticket, o, w, err
 	}
 
+	// The installation's own mail stops here, and this is the ONE place the
+	// controller lane parts from a user send.
+	//
+	// The legacy question below is "is this purpose granted for these people",
+	// and a controller row has no purpose: consent_purpose is NULL on it by
+	// design, because the message is not sent under a permission somebody gave.
+	// Asked anyway, the purpose lookup finds no row and answers "not granted" —
+	// so every confirmation mail would park, and the lane would look configured
+	// and never deliver.
+	//
+	// What replaces it is not nothing. The engine has already answered above,
+	// on this delivery's own evidence, through the same AuthorizeTransmit call
+	// every other message goes through: a live confirm_token for this person of
+	// this kind. That is a STRONGER question than the legacy gate asks, not a
+	// skipped one.
+	if del.IsController() {
+		return ticket, outcomeUndecided, 0, nil
+	}
+
 	// EVERY subject this delivery reaches is asked about, not just the To line:
 	// a Cc'd person is owed the same suppression, and this call is the only one
 	// that runs after they could have withdrawn. consentRecipients is what makes

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -43,6 +43,11 @@ type deliveryStore interface {
 	// guarantee is WHEN the dispatcher calls them (sendseam.go).
 	MarkInFlight(ctx context.Context, id ids.UUID) error
 	ClearInFlight(ctx context.Context, id ids.UUID) error
+	// ClearPayloadRef retires a controller message's one-time link material
+	// once the message can no longer be sent. The row stays: it is still the
+	// record that a message went out, and what must not survive is a live
+	// credential pointing at somebody's mailbox.
+	ClearPayloadRef(ctx context.Context, id ids.UUID) error
 }
 
 var _ deliveryStore = (*Store)(nil)

--- a/backend/internal/modules/comms/sendseam.go
+++ b/backend/internal/modules/comms/sendseam.go
@@ -79,6 +79,13 @@ type sendSeam struct {
 // a row is mail-shaped or channel-shaped and never half of each, so a channel
 // delivery cannot be rendered as mail even if a provider were mis-registered.
 func (d *Dispatcher) resolveSeam(ctx context.Context, del Delivery) (sendSeam, error) {
+	// The installation's own mail resolves FIRST, because it is the one shape
+	// with no connected mailbox behind it: asking the resolver for a credential
+	// that cannot exist would report "nothing is connected" about a lane that
+	// never needed a connection.
+	if del.IsController() {
+		return d.controllerSeam(ctx, del)
+	}
 	if del.IsChannel() {
 		sender, auth, err := d.resolver.ResolveChannel(ctx, del.UserID, del.Provider)
 		if err != nil {

--- a/backend/internal/modules/comms/sendseamcontroller.go
+++ b/backend/internal/modules/comms/sendseamcontroller.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// The transport for a message the INSTALLATION sends, and the one-time material
+// it carries.
+//
+// Its own file beside sendseam.go, which owns the branch on provider class. The
+// controller arm lives here because everything that makes it different from a
+// user send is here: there is no connected mailbox to resolve, no OAuth grant
+// to intersect, and the body is not final until the link is substituted into
+// it.
+//
+// Past the arm this is an ordinary delivery. The consent gate, the retry
+// ladder, the age bound and the four dispositions all apply unchanged, which is
+// the point of resolving it as a seam rather than teaching the dispatcher a
+// second path.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// ControllerRelay transmits a message the installation sends as itself.
+//
+// Separate from the mail connectors because there is no person behind it: the
+// relay is deployment configuration, its from-address belongs to the
+// installation, and no subject's mailbox grant is involved.
+type ControllerRelay interface {
+	SendControllerMail(ctx context.Context, msg ControllerMessage) error
+}
+
+// ControllerMessage is one rendered controller mail, link already substituted.
+type ControllerMessage struct {
+	To        string
+	Subject   string
+	TextBody  string
+	MessageID string
+}
+
+// PayloadVault holds the one-time material a controller message carries, so the
+// plaintext link never sits on the delivery row.
+type PayloadVault interface {
+	Get(ctx context.Context, ref string) (string, error)
+	Delete(ctx context.Context, ref string) error
+}
+
+// ErrNoControllerRelay reports that this installation has no relay configured.
+// It is a DEPLOYMENT fact, not an answer about the message, which is why the
+// dispatcher parks on it rather than retrying forever.
+var ErrNoControllerRelay = errors.New("comms: no controller relay is configured")
+
+// controllerSeam binds the relay call for a controller delivery.
+//
+// detectsPriorSend is FALSE, and that is the honest answer rather than a
+// conservative one: an SMTP relay hands a message on and returns, with no
+// identity to search and no read-back to ask. So the in-flight marker is what
+// bounds this lane to at most one transmission, exactly as it does for a
+// messaging channel.
+func (d *Dispatcher) controllerSeam(ctx context.Context, del Delivery) (sendSeam, error) {
+	if d.relay == nil {
+		return sendSeam{}, ErrNoControllerRelay
+	}
+	// StageControllerTx refuses an empty addressee and writes exactly one, so
+	// an empty list here is a row that did not come through it.
+	if len(del.Recipients) == 0 {
+		return sendSeam{}, ErrNoAddressee
+	}
+	to := del.Recipients[0]
+	body, err := d.substituteLink(ctx, del)
+	if err != nil {
+		return sendSeam{}, err
+	}
+	return sendSeam{
+		// No granted scopes and no carriage: a controller message carries no
+		// attachments and holds no OAuth grant. profileFor already turns both
+		// gates off; leaving these zero means the seam agrees with it rather
+		// than restating it.
+		transmit: func(ctx context.Context, _ []connector.OutboundFile) (connector.SendReceipt, error) {
+			if err := d.relay.SendControllerMail(ctx, ControllerMessage{
+				To:        to,
+				Subject:   del.Subject,
+				TextBody:  body,
+				MessageID: del.MessageID,
+			}); err != nil {
+				return connector.SendReceipt{}, err
+			}
+			// The row's own message id, echoed back. A relay does not rewrite
+			// the identity it was handed, so nothing is owed a re-key.
+			return connector.SendReceipt{RFC822MessageID: del.MessageID}, nil
+		},
+	}, nil
+}
+
+// substituteLink puts the one-time link into the body, in memory, once.
+//
+// The plaintext never returns to the row. StageControllerTx already held the
+// body and the material to the same story — exactly one placeholder when there
+// is a reference, none when there is not — so a disagreement here is a vault
+// that lost the entry rather than a caller mistake, and it fails the attempt
+// rather than sending a message with "{{confirmation-link}}" in it.
+func (d *Dispatcher) substituteLink(ctx context.Context, del Delivery) (string, error) {
+	if del.PayloadRef == "" {
+		return del.Body, nil
+	}
+	if d.payloads == nil {
+		return "", fmt.Errorf("comms: this delivery carries link material and no vault is configured: %w", ErrNoControllerRelay)
+	}
+	link, err := d.payloads.Get(ctx, del.PayloadRef)
+	if err != nil {
+		return "", fmt.Errorf("comms: reading the one-time link material: %w", err)
+	}
+	if placeholderCount(del.Body) != 1 {
+		return "", fmt.Errorf("comms: the staged body carries %d placeholder(s) for its link material: %w",
+			placeholderCount(del.Body), ErrTemplateShape)
+	}
+	return strings.Replace(del.Body, LinkPlaceholder, link, 1), nil
+}
+
+// closePayload retires the one-time material once the message can no longer be
+// sent — accepted, or parked for good.
+//
+// The REFERENCE is cleared and the row is kept, because the delivery is still
+// the record that a message went out. What must not survive is a live
+// credential pointing at somebody's mailbox.
+//
+// A failure here is logged by the caller and never changes the delivery's
+// disposition: the message really was accepted, and reporting a retry because
+// the cleanup stumbled would send it a second time.
+func (d *Dispatcher) closePayload(ctx context.Context, del Delivery) error {
+	if del.PayloadRef == "" {
+		return nil
+	}
+	if d.payloads != nil {
+		if err := d.payloads.Delete(ctx, del.PayloadRef); err != nil {
+			return fmt.Errorf("comms: destroying the one-time link material: %w", err)
+		}
+	}
+	return d.store.ClearPayloadRef(ctx, del.ID)
+}
+
+// carriesLiveLink reports whether this delivery holds one-time material that a
+// terminal outcome must retire.
+func (d Delivery) carriesLiveLink() bool { return d.IsController() && d.PayloadRef != "" }
+
+// dispatchClosingLink runs the attempt and retires the link if the message
+// reached a state it will never be sent from.
+//
+// PARKED only. A retry or a deferral keeps the material, because the message is
+// still going out; the accepted path retires it after RecordSent, on the other
+// terminal outcome. This wrapper exists because park() takes an id and cannot
+// see the material, and this is the one place holding both the row and the
+// outcome.
+func (d *Dispatcher) dispatchClosingLink(ctx context.Context, del Delivery) (Outcome, time.Duration, error) {
+	outcome, wait, err := d.dispatchLoaded(ctx, del)
+	if outcome == OutcomeParked {
+		d.retireLink(ctx, del)
+	}
+	return outcome, wait, err
+}
+
+// retireLink destroys the one-time material and reports a failure to do so
+// WITHOUT changing the delivery's disposition.
+//
+// That is the rule this function exists to hold. A cleanup that stumbled must
+// never turn an accepted send into a retry: the message really was accepted and
+// the row says so, and re-running it would put a second copy on the wire to
+// protect a credential. The sweep is the backstop, and Art. 17 erasure destroys
+// the material regardless of what happens here.
+func (d *Dispatcher) retireLink(ctx context.Context, del Delivery) {
+	if err := d.closePayload(ctx, del); err != nil {
+		slog.ErrorContext(ctx, "retiring the one-time link material failed",
+			"delivery_id", del.ID)
+	}
+}

--- a/backend/internal/modules/comms/sendseamcontroller_test.go
+++ b/backend/internal/modules/comms/sendseamcontroller_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// The lane the installation's own mail rides: that it goes out at all, that the
+// one-time link reaches the wire and nothing else, and that the link stops being
+// live the moment the message can no longer be sent.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// fakeRelay is the operator relay boundary: it records the message it was
+// handed, which is the only place the substituted link is observable.
+type fakeRelay struct {
+	calls int
+	seen  ControllerMessage
+	err   error
+}
+
+func (f *fakeRelay) SendControllerMail(_ context.Context, msg ControllerMessage) error {
+	f.calls++
+	f.seen = msg
+	return f.err
+}
+
+// fakeVault is the key vault boundary. It counts reads and destructions
+// separately, because the two answer different questions: whether the link ever
+// reached the wire, and whether it stopped being live afterwards.
+type fakeVault struct {
+	secret   string
+	gets     int
+	deletes  int
+	getErr   error
+	deleteEr error
+}
+
+func (f *fakeVault) Get(context.Context, string) (string, error) {
+	f.gets++
+	return f.secret, f.getErr
+}
+
+func (f *fakeVault) Delete(context.Context, string) error {
+	f.deletes++
+	return f.deleteEr
+}
+
+// controllerDelivery is the installation's own message: no sending user, no
+// consent purpose, one recipient, and a body carrying the link placeholder.
+func controllerDelivery() Delivery {
+	return Delivery{
+		ID: ids.NewV7(), SenderKind: SenderController, Provider: ProviderOperatorRelay,
+		MessageID: "confirm-abc@margince.invalid", Recipients: []string{"person@example.com"},
+		Subject:     "Your details, and whether we may stay in touch",
+		Body:        "Check what we hold:\n\n  " + LinkPlaceholder + "\n",
+		TemplateKey: "record_confirmation", TemplateVersion: 1,
+		PayloadRef: "vault-ref-1",
+		Status:     StatusPending, Attempts: 1, CreatedAt: testNow.Add(-time.Minute),
+	}
+}
+
+// TestTheLinkReachesTheWireAndNeverTheRow is the lane's central claim: the
+// message a person receives carries a working link, and the row it was built
+// from never held one.
+func TestTheLinkReachesTheWireAndNeverTheRow(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	relay := &fakeRelay{}
+	vault := &fakeVault{secret: "https://margince.test/#/confirm/tok123"}
+	d := newTestDispatcher(store, fakeResolver{}, &stubConsent{}).
+		WithControllerRelay(relay, vault)
+
+	outcome, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID)
+	if err != nil || outcome != OutcomeSent {
+		t.Fatalf("DispatchWithWait = %v, %v; want %v, nil", outcome, err, OutcomeSent)
+	}
+	if relay.calls != 1 {
+		t.Fatalf("relay called %d times, want exactly 1", relay.calls)
+	}
+	if !strings.Contains(relay.seen.TextBody, vault.secret) {
+		t.Errorf("the transmitted body does not carry the link:\n%s", relay.seen.TextBody)
+	}
+	if strings.Contains(relay.seen.TextBody, LinkPlaceholder) {
+		t.Errorf("the transmitted body still carries the placeholder, so the recipient sees "+
+			"%q where the link should be:\n%s", LinkPlaceholder, relay.seen.TextBody)
+	}
+	// The row is what an audit, an export and a database dump all read. A link
+	// that reached it would be a live credential sitting in every one of them.
+	if strings.Contains(store.delivery.Body, vault.secret) {
+		t.Error("the delivery row holds the plaintext link; it must carry only the placeholder")
+	}
+}
+
+// TestTheLinkStopsBeingLiveOnceTheMessageIsAccepted holds the retirement to the
+// send, not to a later sweep.
+func TestTheLinkStopsBeingLiveOnceTheMessageIsAccepted(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	vault := &fakeVault{secret: "https://margince.test/#/confirm/tok123"}
+	d := newTestDispatcher(store, fakeResolver{}, &stubConsent{}).
+		WithControllerRelay(&fakeRelay{}, vault)
+
+	if _, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID); err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if vault.deletes != 1 {
+		t.Errorf("the vault entry was destroyed %d times, want exactly 1: a link that outlives "+
+			"its message is a live credential nobody is watching", vault.deletes)
+	}
+	if store.payloadsCleared != 1 {
+		t.Errorf("the row's payload reference was cleared %d times, want exactly 1", store.payloadsCleared)
+	}
+}
+
+// TestAFailedRetirementDoesNotResendTheMessage pins the rule the cleanup must
+// obey: the message really was accepted, so a stumble here may not turn that
+// into a retry that mails a second copy.
+func TestAFailedRetirementDoesNotResendTheMessage(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	relay := &fakeRelay{}
+	d := newTestDispatcher(store, fakeResolver{}, &stubConsent{}).
+		WithControllerRelay(relay, &fakeVault{
+			secret:   "https://margince.test/#/confirm/tok123",
+			deleteEr: errors.New("vault unreachable"),
+		})
+
+	outcome, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID)
+	if err != nil {
+		t.Fatalf("a failed retirement surfaced as an error: %v", err)
+	}
+	if outcome != OutcomeSent {
+		t.Fatalf("DispatchWithWait = %v, want %v: the relay accepted the message, and reporting "+
+			"a retry to protect a credential would put a second copy on the wire", outcome, OutcomeSent)
+	}
+	if relay.calls != 1 {
+		t.Errorf("relay called %d times, want exactly 1", relay.calls)
+	}
+}
+
+// TestAnUnconfiguredRelayParksRatherThanRetries holds the disposition for a
+// deployment fact. Retrying would leave a person's link expiring in a queue.
+func TestAnUnconfiguredRelayParksRatherThanRetries(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	d := newTestDispatcher(store, fakeResolver{}, &stubConsent{})
+
+	outcome, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID)
+	if err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if outcome != OutcomeParked {
+		t.Fatalf("DispatchWithWait = %v, want %v", outcome, OutcomeParked)
+	}
+	if !strings.Contains(store.parked, "relay") {
+		t.Errorf("the park reason %q does not name the missing relay, so an operator is not "+
+			"told what to configure", store.parked)
+	}
+}
+
+// TestAParkedNoticeAlsoRetiresItsLink covers the other terminal outcome. A
+// message that will never be sent must not leave a working link behind.
+func TestAParkedNoticeAlsoRetiresItsLink(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	vault := &fakeVault{secret: "https://margince.test/#/confirm/tok123"}
+	// Refused at transmit: the engine says no, so the message is parked.
+	consent := &stubConsent{armed: true}
+	d := newTestDispatcher(store, fakeResolver{}, consent).
+		WithControllerRelay(&fakeRelay{}, vault)
+
+	outcome, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID)
+	if err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if outcome != OutcomeParked {
+		t.Fatalf("DispatchWithWait = %v, want %v", outcome, OutcomeParked)
+	}
+	if vault.deletes != 1 {
+		t.Errorf("a parked notice destroyed its link %d times, want exactly 1: the message will "+
+			"never be sent, so the link must stop working", vault.deletes)
+	}
+}
+
+// TestTheEngineIsAskedAboutTheInstallationsOwnMail is the "not a side door"
+// claim. The lane exists to give this message a decision, not to skip one.
+func TestTheEngineIsAskedAboutTheInstallationsOwnMail(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	consent := &stubConsent{}
+	d := newTestDispatcher(store, fakeResolver{}, consent).
+		WithControllerRelay(&fakeRelay{}, &fakeVault{secret: "https://margince.test/#/confirm/t"})
+
+	if _, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID); err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if consent.authzSeen != 1 {
+		t.Errorf("the transmit authority was asked %d times, want exactly 1: a controller message "+
+			"that transmits without a decision is exactly the bypass this lane replaced", consent.authzSeen)
+	}
+}
+
+// legacyPurposeGate answers the way the REAL legacy gate answers: a purpose it
+// cannot find is not granted. Its whole value here is that it is not lenient —
+// a stub that said yes would let the controller lane pass a question it must
+// never be asked.
+type legacyPurposeGate struct {
+	stubConsent
+	askedWithPurpose []string
+}
+
+func (g *legacyPurposeGate) RequireGrantedForRecipients(_ context.Context, _ []connector.Recipient, purpose string) error {
+	g.askedWithPurpose = append(g.askedWithPurpose, purpose)
+	if purpose == "" {
+		// Exactly what consent.Gate does: the lookup finds no row, and an
+		// undefined purpose grants nothing.
+		return apperrors.ErrConsentNotGranted
+	}
+	return nil
+}
+
+// TestTheInstallationsOwnMailIsNotAskedForAPurposeGrant is the case that would
+// have shipped a lane that never delivered.
+//
+// A controller row carries no consent_purpose — it is not sent under a
+// permission somebody gave — so putting it to the legacy purpose gate asks a
+// question with no possible answer, and the honest "not granted" that comes back
+// parks the message. Every confirmation mail, on an installation that looks
+// correctly configured.
+func TestTheInstallationsOwnMailIsNotAskedForAPurposeGrant(t *testing.T) {
+	store := &fakeStore{delivery: controllerDelivery()}
+	gate := &legacyPurposeGate{}
+	d := newTestDispatcher(store, fakeResolver{}, gate).
+		WithControllerRelay(&fakeRelay{}, &fakeVault{secret: "https://margince.test/#/confirm/t"})
+
+	outcome, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID)
+	if err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if outcome != OutcomeSent {
+		t.Fatalf("DispatchWithWait = %v, want %v (park reason: %q)", outcome, OutcomeSent, store.parked)
+	}
+	if len(gate.askedWithPurpose) != 0 {
+		t.Errorf("the legacy purpose gate was asked about a controller message (purposes: %q). "+
+			"That row has no consent_purpose, so the answer can only be 'not granted' and the "+
+			"message parks forever", gate.askedWithPurpose)
+	}
+	// And the engine WAS asked. Skipping the legacy question must not become
+	// skipping the decision — that would make the lane the side door it exists
+	// not to be.
+	if gate.authzSeen != 1 {
+		t.Errorf("the transmit authority was asked %d times, want exactly 1", gate.authzSeen)
+	}
+}
+
+// TestAUserSendIsStillAskedForItsPurposeGrant is the other half. Without it the
+// exemption above could widen to every message and nothing would fail.
+func TestAUserSendIsStillAskedForItsPurposeGrant(t *testing.T) {
+	store := &fakeStore{delivery: liveDelivery()}
+	gate := &legacyPurposeGate{}
+	d := newTestDispatcher(store, fakeResolver{sender: &fakeSender{}, granted: []string{sendScope}}, gate)
+
+	if _, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID); err != nil {
+		t.Fatalf("DispatchWithWait: %v", err)
+	}
+	if len(gate.askedWithPurpose) != 1 || gate.askedWithPurpose[0] != "marketing" {
+		t.Errorf("a rep's send put %q to the legacy gate, want exactly one ask for %q: the "+
+			"controller exemption must not widen to ordinary mail",
+			gate.askedWithPurpose, "marketing")
+	}
+}

--- a/backend/internal/modules/consent/authorizeconfirmation.go
+++ b/backend/internal/modules/consent/authorizeconfirmation.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Whether the record bears out a message the INSTALLATION sends about itself.
+//
+// Its own file beside authorizevalidators.go because the evidence is of a
+// different kind. Every validator there reads a business record a rep created —
+// an invoice, a contract, a thread. This one reads a live confirm_token, which
+// only this module mints and only the installation can cause to exist.
+//
+// That difference is the whole safety of the lane. The send doors refuse any
+// caller-claimed category where ServesTheSubject is true
+// (activities/sendcontext.go), so a rep cannot dress marketing as a
+// confirmation. What reaches here is the controller lane, and it still has to
+// show the token: a claim on its own proves nothing, and a confirmation message
+// carrying no live link is not a confirmation, it is unsolicited mail with a
+// reassuring name.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// validateConfirmation answers a message that asks the subject to confirm
+// something — their details, or an opt-in they chose.
+//
+// The evidence is a confirm_token for THIS person, of the kind this category
+// carries, still live. Live means unconsumed and unexpired, because a link that
+// can no longer be followed makes the mail a dead end for the person who gets
+// it.
+//
+// The basis is a legal obligation rather than consent, and that ordering
+// matters: asking somebody to check what is held about them is Art. 14 work the
+// installation owes them, so it cannot rest on a permission they have not given
+// yet. A consent confirmation is the same shape — the mail that ASKS for
+// consent cannot itself require consent, or no one could ever be asked.
+func validateConfirmation(ctx context.Context, tx pgx.Tx, subject subjectRef, category commsauthz.Category) (resolution, error) {
+	unsupported := resolution{Category: category, Supported: false, Reason: commsauthz.ReasonNoEvidence}
+	if subject.Kind != entityPerson {
+		// Only a person holds a confirm_token: the table's foreign key says so.
+		// A lead has no link to show and therefore no confirmation to send.
+		return unsupported, nil
+	}
+	kind, ok := confirmKindFor(category)
+	if !ok {
+		return unsupported, nil
+	}
+	var live bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		    SELECT 1 FROM confirm_token
+		    WHERE person_id = $1
+		      AND kind = $2
+		      AND consumed_at IS NULL
+		      AND expires_at > now()
+		)`, subject.ID, kind).Scan(&live); err != nil {
+		return resolution{}, fmt.Errorf("consent: reading the confirmation link: %w", err)
+	}
+	if !live {
+		return unsupported, nil
+	}
+	return resolution{
+		Category:  category,
+		Basis:     commsauthz.BasisLegalObligation,
+		Supported: true,
+	}, nil
+}
+
+// confirmKindFor maps a category to the confirm_token kind that evidences it.
+//
+// It is deliberately NOT total over the five subject-serving categories. A
+// security notice and a privacy notice carry no link and are not answered here;
+// an opt-out acknowledgement is sent when a token has just been spent, so no
+// live one remains to find. Those stay unsupported until each has evidence of
+// its own, which is the fail-closed default this package keeps.
+func confirmKindFor(category commsauthz.Category) (string, bool) {
+	switch category {
+	case commsauthz.CategoryRecordConfirmation:
+		return LinkRecordConfirmation, true
+	case commsauthz.CategoryConsentConfirmation:
+		return LinkConsentConfirmation, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/modules/consent/authorizeconfirmation_integration_test.go
+++ b/backend/internal/modules/consent/authorizeconfirmation_integration_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What lets the INSTALLATION write to somebody about its own obligations.
+//
+// The evidence is a live confirm_token, and these cases pin both halves of that:
+// a message carrying one is supported, and the claim on its own supports
+// nothing. The second half is what keeps the lane from becoming a way to reach
+// a person who has objected — the five subject-serving categories pass a hard
+// suppression, so a category that could be claimed without evidence would be a
+// route around every refusal the engine makes.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// TestAConfirmationRestsOnALiveLink is the lane's admit case.
+func TestAConfirmationRestsOnALiveLink(t *testing.T) {
+	e := setupResolve(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(72*time.Hour), nil)
+
+	got := e.resolve(t, commsauthz.Request{Context: commsauthz.CategoryRecordConfirmation})
+
+	if !got.Supported {
+		t.Fatalf("a record confirmation with a live link resolved unsupported (%q) — the "+
+			"installation cannot ask somebody to check what is held about them", got.Reason)
+	}
+	if got.Category != commsauthz.CategoryRecordConfirmation {
+		t.Errorf("resolved %q, want record_confirmation", got.Category)
+	}
+	// A legal obligation rather than consent, and the ordering is the point:
+	// asking somebody to check what is held is Art. 14 work the installation
+	// owes them, so it cannot rest on a permission they have not given.
+	if got.Basis != commsauthz.BasisLegalObligation {
+		t.Errorf("basis %q, want legal_obligation: a confirmation that rested on consent could "+
+			"never be sent to the person who has not consented yet", got.Basis)
+	}
+}
+
+// TestAClaimedConfirmationWithNoLinkSupportsNothing is the refusal case, and it
+// is the one that matters: without it the category is a bypass.
+func TestAClaimedConfirmationWithNoLinkSupportsNothing(t *testing.T) {
+	e := setupResolve(t)
+
+	got := e.resolve(t, commsauthz.Request{Context: commsauthz.CategoryRecordConfirmation})
+
+	if got.Supported {
+		t.Fatal("a record confirmation with no link resolved SUPPORTED. The five subject-serving " +
+			"categories pass a hard suppression, so a claim that needs no evidence is a route to " +
+			"somebody who has objected")
+	}
+}
+
+// TestASpentLinkNoLongerSupportsAConfirmation — a link already followed is not
+// evidence for a second mail.
+func TestASpentLinkNoLongerSupportsAConfirmation(t *testing.T) {
+	e := setupResolve(t)
+	consumed := time.Now().Add(-time.Hour)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(72*time.Hour), &consumed)
+
+	got := e.resolve(t, commsauthz.Request{Context: commsauthz.CategoryRecordConfirmation})
+
+	if got.Supported {
+		t.Error("a consumed link still supports a confirmation, so the installation may keep " +
+			"mailing somebody who already answered")
+	}
+}
+
+// TestAnExpiredLinkNoLongerSupportsAConfirmation — a dead link makes the mail a
+// dead end for whoever receives it.
+func TestAnExpiredLinkNoLongerSupportsAConfirmation(t *testing.T) {
+	e := setupResolve(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(-time.Hour), nil)
+
+	got := e.resolve(t, commsauthz.Request{Context: commsauthz.CategoryRecordConfirmation})
+
+	if got.Supported {
+		t.Error("an expired link still supports a confirmation, so the mail goes out carrying a " +
+			"link that cannot be followed")
+	}
+}
+
+// TestAConfirmationLinkDoesNotSupportTheOtherKind holds the two apart. They ask
+// different questions and arrive in different mails, so one must not evidence
+// the other.
+func TestAConfirmationLinkDoesNotSupportTheOtherKind(t *testing.T) {
+	e := setupResolve(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(72*time.Hour), nil)
+
+	got := e.resolve(t, commsauthz.Request{Context: commsauthz.CategoryConsentConfirmation})
+
+	if got.Supported {
+		t.Error("a record-confirmation link supports a CONSENT confirmation, so an installation " +
+			"that asked somebody to check their details may also mail them for an opt-in they " +
+			"never asked about")
+	}
+}

--- a/backend/internal/modules/consent/authorizeresolve_integration_test.go
+++ b/backend/internal/modules/consent/authorizeresolve_integration_test.go
@@ -722,3 +722,28 @@ func (e *resolveEnv) plantStagingDecision(t *testing.T, delivery ids.UUID, addre
 		t.Fatalf("planting the staging decision: %v", err)
 	}
 }
+
+// issueLinkRow plants a confirm_token in one of the shapes the validator must
+// tell apart: live, spent, or expired.
+//
+// Written directly rather than through Store.issueLink, and this is the one
+// place in this file where that is right. issueLink mints a token AND stages the
+// mail that carries it, so seeding through it would need the whole controller
+// lane wired — a stager, a vault, a job runner — to set up a case about whether
+// the row supports a category. What the validator reads is four columns, and
+// this writes exactly those four in each of the shapes the real writer produces:
+// consumed_at NULL or set, expires_at ahead or behind. A shape the writer cannot
+// produce would be caught by the column list disagreeing with the schema.
+//
+//nolint:unparam // kind is the axis TestAConfirmationLinkDoesNotSupportTheOtherKind varies; a helper fixed to one kind could not express that case
+func (e *resolveEnv) issueLinkRow(t *testing.T, kind string, expires time.Time, consumed *time.Time) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO confirm_token (id, person_id, token_hash, delivered_to, expires_at, consumed_at, kind)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		id, e.person, "hash-"+id.String(), e.address, expires, consumed, kind); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -66,11 +66,14 @@ func (g *Gate) validate(ctx context.Context, tx pgx.Tx, req commsauthz.Request, 
 		return validateContract(ctx, tx, req, subject)
 	case commsauthz.CategoryPrecontractQuote:
 		return validateQuote(ctx, tx, req, subject)
+	case commsauthz.CategoryRecordConfirmation, commsauthz.CategoryConsentConfirmation:
+		return validateConfirmation(ctx, tx, subject, category)
 	default:
-		// Every other category — the five that serve the subject, marketing,
-		// customer service, account notices — has no record evidence this file
-		// can read today. They stay unsupported and fall through to the legacy
-		// verdict, which is exactly what they did before this file existed.
+		// Every other category — marketing, customer service, account notices,
+		// and the three subject-serving ones that carry no link — has no record
+		// evidence this file can read today. They stay unsupported and fall
+		// through to the legacy verdict, which is exactly what they did before
+		// this file existed.
 		return unsupported, nil
 	}
 }

--- a/backend/internal/modules/consent/confirmmail.go
+++ b/backend/internal/modules/consent/confirmmail.go
@@ -4,88 +4,28 @@
 package consent
 
 import (
-	"fmt"
-	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
-	"github.com/margince/margince/backend/internal/platform/mailer"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// WithConfirmMailer wires the operator's outbound mail relay. Nil means the
-// installation cannot deliver a confirm link, which this module reports rather
-// than fails on: the token was still minted, and answering with a failure would
-// invite a second request that mints another.
-func (h Handlers) WithConfirmMailer(m mailer.Mailer) Handlers {
-	h.confirmMailer = m
-	return h
-}
-
-// WithConfirmLinkBase wires the canonical origin a confirm link is built on.
-// The trailing slash is trimmed HERE and only here, so every caller may pass a
-// base with or without one.
-func (h Handlers) WithConfirmLinkBase(base string) Handlers {
-	h.publicBaseURL = strings.TrimRight(base, "/")
-	return h
-}
-
-// canSendConfirm reports whether a confirm link can reach anybody.
-//
-// BOTH halves are required. A relay with no base URL would mail a link built on
-// an empty origin — an unusable URL that still spent the one token the person
-// was issued, and superseded whatever earlier link they might still have had.
-func (h Handlers) canSendConfirm() bool {
-	return h.confirmMailer != nil && h.publicBaseURL != ""
-}
-
-// confirmRoute is the SPA route a confirm link points at. The token rides the
-// FRAGMENT for the reason the deal-room invitation states at length: a browser
-// does not put a fragment on the wire, so it stays out of access logs and out
-// of the Referer a click sends onward. Containment rather than a guarantee —
-// what bounds the exposure is that the token is single-use and expires.
-const confirmRoute = "/#/confirm/"
-
-// confirmLink puts the token in the URL's FRAGMENT, never its path.
-func (h Handlers) confirmLink(token string) string {
-	return h.publicBaseURL + confirmRoute + token
-}
-
-// sendConfirmLink hands the link to the relay.
-//
-// The message says what the link is FOR before it says to click it. Somebody
-// receiving this did not ask for it, so a bare "confirm your details" link from
-// a company they may not remember reads exactly like a phishing mail — which is
-// both a deliverability problem and a fair reaction. Naming what is held, and
-// that correcting it is the point, is what makes it legible.
-func (h Handlers) sendConfirmLink(r *http.Request, issued IssuedConfirm) error {
-	body := "You can see what we have on file about you, correct anything that is wrong,\n" +
-		"and tell us whether you want to hear from us.\n\n" +
-		"  " + h.confirmLink(issued.Token) + "\n\n" +
-		"This link is personal to you and works until " +
-		issued.ExpiresAt.Format("2 January 2006") + ".\n\n" +
-		"You do not have to do anything. Ignoring this changes nothing.\n"
-	if err := h.confirmMailer.Send(r.Context(), issued.DeliveredTo,
-		"Your details, and whether we may stay in touch", body); err != nil {
-		return fmt.Errorf("send confirm-details link: %w", err)
-	}
-	return nil
-}
-
 // RequestDetailsConfirmation serves POST /people/{id}/consent/confirm-request —
-// mint the single-use link and mail it to the person's own address.
+// mint the single-use link and queue it to the person's own address.
 //
-// Delivery is best-effort and never fails the write. The token is minted either
-// way, and answering with an error would invite a retry that mints a second one
-// and silently supersedes the link already on its way. `provider_accepted`
-// says which happened.
+// The mail rides the SAME durable lane as every other outbound message: a
+// delivery row, an authorization decision recording why the installation was
+// allowed to send it, a timeline entry, and the dispatcher's retry ladder. It
+// used to be a direct SMTP call that returned before any mailbox saw the
+// message and reported that as `delivered`; what it measured was that the relay
+// had not refused it, and a later bounce could not travel back to correct the
+// claim.
 //
 // The plaintext token is deliberately absent from the response. This link is
-// only ever mailed, and returning it would hand a caller the capability that
-// the delivered-to-their-own-mailbox claim rests on.
+// only ever mailed, and returning it would hand a caller the capability that the
+// delivered-to-their-own-mailbox claim rests on.
 func (h Handlers) RequestDetailsConfirmation(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	issued, err := h.store.IssueConfirmToken(r.Context(), pathID[ids.PersonKind](id))
 	if err != nil {
@@ -93,43 +33,23 @@ func (h Handlers) RequestDetailsConfirmation(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Three outcomes, not two. An installation that sends no mail at all and a
-	// relay that refused this one message are different facts about different
-	// things, and a rep's next move differs: configure a relay, or try again.
-	// Collapsing them let the screen tell somebody "this installation sends no
-	// mail" about an installation that does.
-	sendable := h.canSendConfirm()
-	// What the relay accepted, which is not what a mailbox received. The
-	// previous name for this was "delivered", and it claimed the second thing
-	// while measuring the first: a relay returns before any inbox has seen the
-	// message, and a later bounce cannot travel back to change this answer.
-	providerAccepted := false
-	if sendable {
-		if sendErr := h.sendConfirmLink(r, issued); sendErr != nil {
-			// Logged rather than returned, for the reason above.
-			//
-			// The error is NOT logged. A relay's own diagnostics quote what it
-			// refused, so an SMTP error can carry the recipient — and the
-			// message it was handed carries a live token. Neither belongs in an
-			// operator's log, and a wrapped error is not a safe place to decide
-			// that case by case. The person id is enough to find the record;
-			// what the relay said is the relay's own log to keep.
-			slog.ErrorContext(r.Context(), "confirm-details email failed",
-				"person_id", id)
-		} else {
-			providerAccepted = true
-		}
-	}
-
+	// Two facts, not one. `queued` says this installation put the message on the
+	// lane; `sendable` says it has a lane at all. A rep's next move differs —
+	// wait, or ask an operator to configure the relay — and collapsing them let
+	// the screen tell somebody "this installation sends no mail" about an
+	// installation that does.
+	//
+	// Neither claims delivery. What happens to the message from here is the
+	// delivery row's answer, and it changes as the dispatcher learns more.
 	httperr.WriteJSON(w, http.StatusCreated, struct {
-		DeliveredTo      string    `json:"delivered_to"`
-		ExpiresAt        time.Time `json:"expires_at"`
-		ProviderAccepted bool      `json:"provider_accepted"`
-		Sendable         bool      `json:"sendable"`
+		DeliveredTo string    `json:"delivered_to"`
+		ExpiresAt   time.Time `json:"expires_at"`
+		Queued      bool      `json:"queued"`
+		Sendable    bool      `json:"sendable"`
 	}{
-		DeliveredTo:      issued.DeliveredTo,
-		ExpiresAt:        issued.ExpiresAt,
-		ProviderAccepted: providerAccepted,
-		Sendable:         sendable,
+		DeliveredTo: issued.DeliveredTo,
+		ExpiresAt:   issued.ExpiresAt,
+		Queued:      issued.Staged,
+		Sendable:    h.store.canSendConfirm(),
 	})
 }

--- a/backend/internal/modules/consent/confirmmail_integration_test.go
+++ b/backend/internal/modules/consent/confirmmail_integration_test.go
@@ -5,42 +5,67 @@
 
 package consent
 
-// The send path for the confirm-details link: it mints, it mails to the
+// The send path for the confirm-details link: it mints, it queues to the
 // SUBJECT's own address rather than one a caller named, it never hands the
 // token back, and an installation that cannot deliver still records that the
 // link exists.
+//
+// These cases used to assert against a mailer this module called directly. The
+// obligations did not change when the lane did — the same address, the same
+// canonical origin, the same withheld token — so they are asserted here against
+// the stager the message is now handed to. What IS new is where the plaintext
+// goes: the staged message carries a placeholder, and the link itself goes to
+// the vault, so a test that found the link on the message would be finding a
+// defect.
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// recordingMailer keeps what it was asked to send, so a test can assert the
-// address and the body rather than only that no error came back.
-type recordingMailer struct {
-	to      string
-	subject string
-	body    string
-	fail    error
-	calls   int
+// recordingStager keeps what it was asked to stage, so a test can assert the
+// address, the wording and the material rather than only that no error came
+// back. It stands where compose's controllerMailQueue stands in production.
+type recordingStager struct {
+	calls int
+	seen  ConfirmationSend
+	fail  error
 }
 
-func (m *recordingMailer) Send(_ context.Context, to, subject, textBody string) error {
-	m.calls++
-	if m.fail != nil {
-		return m.fail
+func (r *recordingStager) QueueConfirmationTx(_ context.Context, _ pgx.Tx, in ConfirmationSend) (ids.UUID, error) {
+	r.calls++
+	if r.fail != nil {
+		return ids.UUID{}, r.fail
 	}
-	m.to, m.subject, m.body = to, subject, textBody
-	return nil
+	r.seen = in
+	return ids.NewV7(), nil
+}
+
+// recordingVault keeps the sealed link, which is the only place the plaintext
+// legitimately exists between minting and dispatch.
+type recordingVault struct {
+	sealed string
+	calls  int
+	fail   error
+}
+
+func (v *recordingVault) Put(_ context.Context, secret string) (string, error) {
+	v.calls++
+	if v.fail != nil {
+		return "", v.fail
+	}
+	v.sealed = secret
+	return "vault-ref-" + secret[len(secret)-6:], nil
 }
 
 func confirmRequest(t *testing.T, e *channelConsentEnv, h Handlers) *httptest.ResponseRecorder {
@@ -52,29 +77,26 @@ func confirmRequest(t *testing.T, e *channelConsentEnv, h Handlers) *httptest.Re
 	return rec
 }
 
-func TestAConfirmRequestMailsTheSubjectTheirOwnLink(t *testing.T) {
+// withLane is the ordinary wiring: a stager, a vault and a canonical origin.
+func withLane(e *channelConsentEnv, stager ConfirmationSender, vault ConfirmLinkVault) Handlers {
+	return Handlers{store: e.store}.
+		WithConfirmationLane(stager, vault, "https://crm.example.test/")
+}
+
+func TestAConfirmRequestQueuesTheSubjectTheirOwnLink(t *testing.T) {
 	e := setupChannelConsent(t)
 	seedSubjectAddress(t, e)
-	relay := &recordingMailer{}
-	h := Handlers{store: e.store}.
-		WithConfirmMailer(relay).
-		WithConfirmLinkBase("https://crm.example.test/")
+	stager, vault := &recordingStager{}, &recordingVault{}
 
-	rec := confirmRequest(t, e, h)
+	rec := confirmRequest(t, e, withLane(e, stager, vault))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 
-	// `provider_accepted`, not `delivered`. #3807 renamed it and the
-	// description always said the true thing: the relay TAKING a message is not
-	// the same as it arriving, and a field called `delivered` claimed the
-	// second while reporting the first. This struct kept the old name, so it
-	// decoded to the zero value and the assertion below read a working relay as
-	// a silent one.
 	var got struct {
-		DeliveredTo      string `json:"delivered_to"`
-		ProviderAccepted bool   `json:"provider_accepted"`
-		Token            string `json:"token"`
+		DeliveredTo string `json:"delivered_to"`
+		Queued      bool   `json:"queued"`
+		Token       string `json:"token"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode the issue response: %v", err)
@@ -84,8 +106,8 @@ func TestAConfirmRequestMailsTheSubjectTheirOwnLink(t *testing.T) {
 	if got.DeliveredTo != want {
 		t.Fatalf("delivered_to = %q, want the subject's own address %q", got.DeliveredTo, want)
 	}
-	if !got.ProviderAccepted {
-		t.Fatal("provider_accepted = false with a working relay wired")
+	if !got.Queued {
+		t.Fatal("queued = false with a working lane wired")
 	}
 	// The token is the capability the whole mailbox-as-evidence claim rests on.
 	// A caller who could read it here could open the subject's record without
@@ -94,45 +116,68 @@ func TestAConfirmRequestMailsTheSubjectTheirOwnLink(t *testing.T) {
 		t.Fatal("the response carried the plaintext token, which only the mailbox may hold")
 	}
 
-	if relay.to != want {
-		t.Fatalf("mailed to %q, want the subject's own address %q", relay.to, want)
+	if stager.seen.Recipient != want {
+		t.Fatalf("queued to %q, want the subject's own address %q", stager.seen.Recipient, want)
 	}
 	// The link has to be built on the CANONICAL origin, not on a request Host:
 	// it opens one person's record to whoever holds it.
-	if !strings.Contains(relay.body, "https://crm.example.test/#/confirm/") {
-		t.Fatalf("the mail body carries no confirm link on the canonical origin:\n%s", relay.body)
+	if !strings.Contains(vault.sealed, "https://crm.example.test/#/confirm/") {
+		t.Fatalf("the sealed link is not on the canonical origin: %q", vault.sealed)
 	}
 	// The trailing slash on the configured base must not survive into the link.
-	if strings.Contains(relay.body, "test//#/") {
-		t.Fatalf("the link doubled the base's trailing slash:\n%s", relay.body)
+	if strings.Contains(vault.sealed, "test//#/") {
+		t.Fatalf("the link doubled the base's trailing slash: %q", vault.sealed)
 	}
-	if relay.subject == "" {
-		t.Fatal("the mail carried no subject line")
+	if stager.seen.Rendered.Subject == "" {
+		t.Fatal("the message carried no subject line")
+	}
+}
+
+// TestTheStagedMessageCarriesAPlaceholderAndNotTheLink is the property the
+// vault exists for, and it is new: the message body is copied onto the delivery
+// row, the timeline, the audit entry and the outbox event, so a link on it would
+// be a live credential in all four.
+func TestTheStagedMessageCarriesAPlaceholderAndNotTheLink(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	stager, vault := &recordingStager{}, &recordingVault{}
+
+	if rec := confirmRequest(t, e, withLane(e, stager, vault)); rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	if strings.Contains(stager.seen.Rendered.Body, "#/confirm/") {
+		t.Fatalf("the staged body carries the plaintext link, which then lands on the delivery "+
+			"row, the timeline and the audit entry:\n%s", stager.seen.Rendered.Body)
+	}
+	if !strings.Contains(stager.seen.Rendered.Body, linkPlaceholder) {
+		t.Fatalf("the staged body carries no placeholder, so dispatch has nowhere to put the "+
+			"link:\n%s", stager.seen.Rendered.Body)
+	}
+	if stager.seen.LinkRef == "" {
+		t.Fatal("the staged message names no vault reference, so the link can never be recovered")
 	}
 }
 
 func TestAContactWithNoAddressIsRefusedRatherThanSilentlyNotMailed(t *testing.T) {
 	e := setupChannelConsent(t)
-	relay := &recordingMailer{}
-	h := Handlers{store: e.store}.
-		WithConfirmMailer(relay).
-		WithConfirmLinkBase("https://crm.example.test")
+	stager := &recordingStager{}
 
 	// No seedSubjectAddress: this person has no live mailbox.
-	rec := confirmRequest(t, e, h)
+	rec := confirmRequest(t, e, withLane(e, stager, &recordingVault{}))
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422 (body: %s)", rec.Code, rec.Body.String())
 	}
-	if relay.calls != 0 {
-		t.Fatal("a mail was attempted for a contact with no address")
+	if stager.calls != 0 {
+		t.Fatal("a message was staged for a contact with no address")
 	}
 }
 
 func TestAnInstallationThatCannotDeliverStillMintsTheLink(t *testing.T) {
 	e := setupChannelConsent(t)
 	seedSubjectAddress(t, e)
-	// No mailer and no base: the ordinary state of an installation that has
-	// configured no outbound relay.
+	// No lane at all: the ordinary state of an installation that has configured
+	// no outbound relay.
 	h := Handlers{store: e.store}
 
 	rec := confirmRequest(t, e, h)
@@ -140,123 +185,82 @@ func TestAnInstallationThatCannotDeliverStillMintsTheLink(t *testing.T) {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 	var got struct {
-		ProviderAccepted bool `json:"provider_accepted"`
-		Sendable         bool `json:"sendable"`
+		Queued   bool `json:"queued"`
+		Sendable bool `json:"sendable"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode the issue response: %v", err)
 	}
 	// The write happened. Reporting it as a failure would invite a second
 	// request that mints another token and supersedes the first.
-	if got.ProviderAccepted {
-		t.Fatal("provider_accepted = true with no relay configured")
+	if got.Queued {
+		t.Fatal("queued = true with no lane configured")
 	}
 	// And the reason is NOT a failed send. A reader told "the mail did not go
 	// out" would press again forever against an installation that cannot send
 	// at all.
 	if got.Sendable {
-		t.Fatal("sendable = true with neither a mailer nor a link base wired")
+		t.Fatal("sendable = true with no lane wired")
 	}
 }
 
-func TestARelayOutageDoesNotFailTheRequestOrHideItself(t *testing.T) {
+// TestAStagingFailureFailsTheRequestRatherThanMintingASilentToken is the one
+// answer that CHANGED with the lane, deliberately.
+//
+// The old direct call swallowed a relay error: the token was already committed
+// by then, so failing would have left it minted and unusable. Staging happens
+// INSIDE that transaction, so a failure rolls the token back too — and a caller
+// who retries gets a fresh link rather than a second one superseding a first
+// that was never sent.
+func TestAStagingFailureFailsTheRequestRatherThanMintingASilentToken(t *testing.T) {
 	e := setupChannelConsent(t)
 	seedSubjectAddress(t, e)
-	relay := &recordingMailer{fail: errors.New("the relay refused the message")}
-	h := Handlers{store: e.store}.
-		WithConfirmMailer(relay).
-		WithConfirmLinkBase("https://crm.example.test")
+	stager := &recordingStager{fail: errors.New("the queue refused the message")}
 
-	rec := confirmRequest(t, e, h)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
-	}
-	var got struct {
-		ProviderAccepted bool `json:"provider_accepted"`
-		Sendable         bool `json:"sendable"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode the issue response: %v", err)
-	}
-	// The distinction that matters: the token exists, and nobody was sent it.
-	// Collapsing this into a 201 that claims delivery leaves a rep believing a
-	// contact was asked when they never were.
-	if got.ProviderAccepted {
-		t.Fatal("provider_accepted = true after the relay refused the message")
-	}
-	// And this is the OTHER undelivered case: a relay exists and refused. The
-	// reader's move is to press again, not to go configure a mailer that is
-	// already configured — which is what the screen says when sendable is
-	// false, so collapsing the two sends them to the wrong place.
-	if !got.Sendable {
-		t.Fatal("sendable = false with a relay and a link base wired")
-	}
-	if relay.calls != 1 {
-		t.Fatalf("the relay was called %d times, want exactly one attempt", relay.calls)
-	}
-}
-
-func TestAFailedSendLogsNeitherTheAddressNorTheToken(t *testing.T) {
-	e := setupChannelConsent(t)
-	seedSubjectAddress(t, e)
-	// A relay's own diagnostics quote what it refused, so an SMTP error is a
-	// plausible carrier for both the recipient and the message it was handed —
-	// and that message holds a live token.
-	relay := &recordingMailer{fail: errors.New(
-		"relay refused subject-" + e.person.String() + "@example.test: 550 cfm_leaked_token_here")}
-	var logged bytes.Buffer
-	h := Handlers{store: e.store}.
-		WithConfirmMailer(relay).
-		WithConfirmLinkBase("https://crm.example.test")
-
-	prior := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, nil)))
-	t.Cleanup(func() { slog.SetDefault(prior) })
-
-	if rec := confirmRequest(t, e, h); rec.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201", rec.Code)
+	rec := confirmRequest(t, e, withLane(e, stager, &recordingVault{}))
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("status = 201 after staging failed: the token would exist with no message "+
+			"carrying it (body: %s)", rec.Body.String())
 	}
 
-	written := logged.String()
-	if strings.Contains(written, "@example.test") {
-		t.Fatalf("the subject's address reached the log:\n%s", written)
+	// And nothing was left behind. The token and the message share a
+	// transaction precisely so this cannot half-happen.
+	var tokens int
+	if err := e.store.db.Tx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM confirm_token WHERE person_id = $1`, e.person).Scan(&tokens)
+	}); err != nil {
+		t.Fatal(err)
 	}
-	if strings.Contains(written, "cfm_") {
-		t.Fatalf("a token reached the log:\n%s", written)
-	}
-	// The failure is still recorded — silence would leave an operator with no
-	// sign that mail is not going out at all.
-	if !strings.Contains(written, "confirm-details email failed") {
-		t.Fatalf("the failure was not logged at all:\n%s", written)
+	if tokens != 0 {
+		t.Errorf("%d confirm token(s) survived a failed staging; the link and the mail that "+
+			"carries it must commit together or not at all", tokens)
 	}
 }
 
 func TestAMintedLinkOpensTheSubjectsOwnRecord(t *testing.T) {
 	e := setupChannelConsent(t)
 	seedSubjectAddress(t, e)
-	relay := &recordingMailer{}
-	h := Handlers{store: e.store}.
-		WithConfirmMailer(relay).
-		WithConfirmLinkBase("https://crm.example.test")
+	stager, vault := &recordingStager{}, &recordingVault{}
 
-	if rec := confirmRequest(t, e, h); rec.Code != http.StatusCreated {
+	if rec := confirmRequest(t, e, withLane(e, stager, vault)); rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 
-	// The token in the mail must be the one the public page resolves. A link
-	// that mails one token and stores another is a link nobody can use, and
-	// nothing upstream of the recipient would notice.
-	_, token, found := strings.Cut(relay.body, "#/confirm/")
+	// The token that was SEALED must be the one the public page resolves. A
+	// lane that seals one token and stores another is a link nobody can use,
+	// and nothing upstream of the recipient would notice.
+	_, token, found := strings.Cut(vault.sealed, "#/confirm/")
 	if !found {
-		t.Fatalf("no confirm link in the mail body:\n%s", relay.body)
+		t.Fatalf("no confirm link was sealed: %q", vault.sealed)
 	}
 	token = strings.Fields(token)[0]
 
 	ref, err := e.store.ResolveConfirmToken(context.Background(), token)
 	if err != nil {
-		t.Fatalf("resolve the token that was actually mailed: %v", err)
+		t.Fatalf("resolve the token that was actually sealed: %v", err)
 	}
 	if ref.PersonID != e.person {
-		t.Fatalf("the mailed link opens person %s, want the subject %s", ref.PersonID, e.person)
+		t.Fatalf("the sealed link opens person %s, want the subject %s", ref.PersonID, e.person)
 	}
 }

--- a/backend/internal/modules/consent/confirmstage.go
+++ b/backend/internal/modules/consent/confirmstage.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Putting a confirm link on the durable send lane.
+//
+// Its own file beside confirmtoken.go, which mints the link, because this is
+// the half that leaves the module: the wording is here, the delivery row is
+// comms', and compose joins them. Keeping it separate is what lets confirmtoken.go
+// stay about the credential and this file about the message.
+//
+// WHY A LANE AND NOT AN SMTP CALL. The direct call this replaces returned before
+// any mailbox saw the message, so "delivered" meant "the relay did not refuse
+// it" — and a later bounce could not travel back to correct that. Worse, the
+// message existed nowhere: no delivery row, no authorization decision, no
+// timeline entry, so it appeared in no subject-access export and no erasure
+// reached it. A person asking "what have you sent me" was answered with silence
+// about the one message the installation had written entirely on its own.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ConfirmLinkVault holds the plaintext confirm link between staging and
+// dispatch, so the delivery row, the timeline, the audit entry and the outbox
+// event carry a placeholder instead of a live credential.
+type ConfirmLinkVault interface {
+	Put(ctx context.Context, secret string) (string, error)
+}
+
+// WithConfirmationLane wires the durable lane the installation's own mail rides.
+//
+// Both halves or neither: a sender with no vault could stage a message whose
+// link nothing can supply, which reaches somebody as a mail with a placeholder
+// where the link should be.
+func (s *Store) WithConfirmationLane(sender ConfirmationSender, vault ConfirmLinkVault, base string) *Store {
+	// ALL THREE or none. A lane with no base URL would mail a link built on an
+	// empty origin — an unusable URL that still spent the one token the person
+	// was issued, and superseded whatever earlier link they still had.
+	if sender == nil || vault == nil || base == "" {
+		return s
+	}
+	s.publicBaseURL = strings.TrimRight(base, "/")
+	s.confirmSender = sender
+	s.vault = vault
+	return s
+}
+
+// confirmMailInput is one confirm link, ready to be turned into a message.
+type confirmMailInput struct {
+	personID   ids.PersonID
+	recipient  string
+	kind       string
+	tokenRowID ids.UUID
+	link       string
+	expiresAt  time.Time
+}
+
+// stageConfirmMail renders the registered wording and stages it, on the
+// caller's transaction.
+//
+// It reports FALSE rather than failing when no lane is wired. The token has
+// already been minted and audited by the time this runs, and answering with an
+// error would roll that back and invite a retry that mints another — so an
+// installation with no relay gets a link it can see was not sent, which is what
+// the screen tells an operator to fix.
+func (s *Store) stageConfirmMail(ctx context.Context, tx pgx.Tx, in confirmMailInput) (bool, error) {
+	if s.confirmSender == nil || s.vault == nil {
+		return false, nil
+	}
+	rendered, category, err := RenderControllerTemplate(templateForLinkKind(in.kind), in.expiresAt)
+	if err != nil {
+		return false, err
+	}
+	// The plaintext goes to the vault, never onto the row. What the delivery
+	// carries is a placeholder and a reference; the two meet in memory at
+	// dispatch, so the link is absent from the delivery row, the timeline body,
+	// the audit payload and the outbox event alike.
+	ref, err := s.vault.Put(ctx, in.link)
+	if err != nil {
+		return false, fmt.Errorf("consent: sealing the one-time confirm link: %w", err)
+	}
+	if _, err := s.confirmSender.QueueConfirmationTx(ctx, tx, ConfirmationSend{
+		PersonID:  in.personID,
+		Recipient: in.recipient,
+		Category:  category,
+		LinkID:    in.tokenRowID,
+		LinkRef:   ref,
+		ExpiresAt: in.expiresAt,
+		MessageID: confirmMessageID(in.tokenRowID),
+		Rendered:  rendered,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// templateForLinkKind maps a token kind to the wording that carries it.
+//
+// Total over the two link kinds, and it returns the record-confirmation wording
+// for anything else rather than an error: every caller passes one of the two
+// Link* constants, and a wrong template would be caught at staging anyway —
+// comms refuses one whose placeholder count disagrees with the material it was
+// staged with.
+func templateForLinkKind(kind string) string {
+	if kind == LinkConsentConfirmation {
+		return TemplateConsentConfirmation
+	}
+	return TemplateRecordConfirmation
+}
+
+// confirmMessageID is the RFC822 identity this message claims.
+//
+// Derived from the TOKEN row rather than minted fresh, so it is stable for the
+// life of the link: the delivery's message-id uniqueness index then refuses a
+// second staging of the same link outright, which is the property that makes a
+// retried request incapable of mailing somebody two live links.
+func confirmMessageID(tokenRowID ids.UUID) string {
+	return "confirm-" + strings.ReplaceAll(tokenRowID.String(), "-", "") + "@margince.invalid"
+}
+
+// confirmRoute is the SPA route a confirm link points at. The token rides the
+// FRAGMENT for the reason the deal-room invitation states at length: a browser
+// does not put a fragment on the wire, so it stays out of access logs and out of
+// the Referer a click sends onward. Containment rather than a guarantee — what
+// bounds the exposure is that the token is single-use and expires.
+const confirmRoute = "/#/confirm/"
+
+// confirmLink puts the token in the URL's FRAGMENT, never its path.
+func (s *Store) confirmLink(token string) string {
+	return s.publicBaseURL + confirmRoute + token
+}
+
+// canSendConfirm reports whether this installation can put a confirm link on the
+// lane at all.
+func (s *Store) canSendConfirm() bool {
+	return s.confirmSender != nil && s.vault != nil && s.publicBaseURL != ""
+}
+
+// WithConfirmationLane injects the durable lane the installation's own mail
+// rides: what stages the message, what seals the one-time link, and the
+// canonical origin the link is built on.
+//
+// Compose supplies all three. The stager lives there because it joins comms and
+// this module, and neither may import the other.
+func (h Handlers) WithConfirmationLane(sender ConfirmationSender, vault ConfirmLinkVault, base string) Handlers {
+	h.store = h.store.WithConfirmationLane(sender, vault, base)
+	return h
+}

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -54,9 +54,16 @@ const confirmTokenTTL = 14 * 24 * time.Hour
 type IssuedConfirm struct {
 	Token     string
 	ExpiresAt time.Time
-	// DeliveredTo is where the send path must post it. Returned rather than
-	// taken, so the mailbox the consent claim rests on is the subject's own.
+	// DeliveredTo is where the link was posted. Returned rather than taken, so
+	// the mailbox the consent claim rests on is the subject's own.
 	DeliveredTo string
+	// Staged reports whether the mail was queued on the durable lane.
+	//
+	// FALSE is a real outcome and not an error: an installation with no relay
+	// configured still mints the token — refusing would invite a retry that
+	// mints a second link and silently supersedes the first — and the screen
+	// tells an operator to configure one.
+	Staged bool
 }
 
 // ConfirmRef is a token's resolution: whose record it opens, the address the
@@ -185,6 +192,22 @@ func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind strin
 			return err
 		}
 		out = IssuedConfirm{Token: token, ExpiresAt: expires, DeliveredTo: deliveredTo}
+		// The mail itself, on THIS transaction. The token row and the message
+		// that carries it commit together or not at all: a token minted without
+		// its mail is a link nobody was ever sent, and a mail staged without its
+		// token is a link that resolves to nothing.
+		staged, err := s.stageConfirmMail(ctx, tx, confirmMailInput{
+			personID:   personID,
+			recipient:  deliveredTo,
+			kind:       kind,
+			tokenRowID: tokenRowID,
+			link:       s.confirmLink(token),
+			expiresAt:  expires,
+		})
+		if err != nil {
+			return err
+		}
+		out.Staged = staged
 		return nil
 	})
 	if err != nil {

--- a/backend/internal/modules/consent/controllertemplates.go
+++ b/backend/internal/modules/consent/controllertemplates.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The installation's OWN words, and the seam that sends them.
+//
+// A registered catalog rather than strings composed at a call site, because
+// these messages are the only ones the product sends in its own name. A rep's
+// mail is theirs and says what they typed; a confirmation link is the
+// installation speaking, and what it says is a fact about the installation that
+// must be the same every time and must be versioned when it changes.
+//
+// comms refuses to stage a template it does not know (ControllerTemplates), so
+// this registry is what makes a controller send possible at all — and a body
+// assembled anywhere else cannot reach the lane.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// Template keys. Each names one thing the installation may say for itself.
+const (
+	// TemplateRecordConfirmation asks a person to check what is held about them.
+	TemplateRecordConfirmation = "record_confirmation"
+	// TemplateConsentConfirmation carries the double-opt-in link.
+	TemplateConsentConfirmation = "consent_confirmation"
+)
+
+// Rendered is one template resolved into the words that will be sent.
+type Rendered struct {
+	Key     string
+	Version int
+	Subject string
+	Body    string
+}
+
+// ConfirmationSend is one confirmation message, ready to stage.
+type ConfirmationSend struct {
+	PersonID  ids.PersonID
+	Recipient string
+	// Category is what the engine is asked about. It is set from the template
+	// rather than by a caller: the whole point of the lane is that these
+	// categories cannot be claimed by anybody else.
+	Category  commsauthz.Category
+	LinkID    ids.UUID
+	LinkRef   string
+	ExpiresAt time.Time
+	MessageID string
+	Rendered  Rendered
+}
+
+// ConfirmationSender stages a controller message on the caller's transaction.
+//
+// Compose implements it: the wording is this module's, the delivery row is
+// comms', and neither may import the other.
+type ConfirmationSender interface {
+	QueueConfirmationTx(ctx context.Context, tx pgx.Tx, in ConfirmationSend) (ids.UUID, error)
+}
+
+// controllerTemplate is one registered wording.
+type controllerTemplate struct {
+	version  int
+	category commsauthz.Category
+	subject  string
+	// body carries the link placeholder exactly once. comms checks that against
+	// the material it is staged with and refuses a disagreement, which is what
+	// stops a message that was meant to carry a link from going out without one.
+	body string
+}
+
+// controllerTemplates is the closed catalog.
+//
+// The wording states what the link IS before it asks anybody to click it.
+// Somebody receiving this did not ask for it, so a bare "confirm your details"
+// link from a company they may not remember reads exactly like a phishing mail
+// — which is both a deliverability problem and a fair reaction.
+var controllerTemplates = map[string]controllerTemplate{
+	TemplateRecordConfirmation: {
+		version:  1,
+		category: commsauthz.CategoryRecordConfirmation,
+		subject:  "Your details, and whether we may stay in touch",
+		body: "You can see what we have on file about you, correct anything that is wrong,\n" +
+			"and tell us whether you want to hear from us.\n\n" +
+			"  " + linkPlaceholder + "\n\n" +
+			"This link is personal to you.\n\n" +
+			"You do not have to do anything. Ignoring this changes nothing.\n",
+	},
+	TemplateConsentConfirmation: {
+		version:  1,
+		category: commsauthz.CategoryConsentConfirmation,
+		subject:  "Please confirm you want to hear from us",
+		body: "You asked to hear from us. Confirming below is what turns that into a\n" +
+			"permission we will act on — until you do, we will not write to you about it.\n\n" +
+			"  " + linkPlaceholder + "\n\n" +
+			"This link is personal to you.\n\n" +
+			"If you did not ask for this, ignore it. Nothing happens until you confirm.\n",
+	},
+}
+
+// linkPlaceholder is where the one-time link goes. It is comms.LinkPlaceholder
+// spelled as a literal because this module may not import that one — the value
+// is held to agree by TestTheTemplatePlaceholderAgreesWithTheLane.
+const linkPlaceholder = "{{confirmation-link}}"
+
+// templateRegistry answers comms' question about what this build knows.
+type templateRegistry struct{}
+
+// ControllerTemplateRegistry is what compose hands to the staging call.
+//
+//nolint:ireturn // returns the comms-side seam by design: the concrete type is unexported and empty
+func ControllerTemplateRegistry() interface {
+	Registered(key string, version int) bool
+} {
+	return templateRegistry{}
+}
+
+// Registered reports whether this build knows the wording at that version.
+func (templateRegistry) Registered(key string, version int) bool {
+	t, ok := controllerTemplates[key]
+	return ok && t.version == version
+}
+
+// RenderControllerTemplate resolves one template into the words to be sent.
+//
+// The link is NOT substituted here and the plaintext never reaches this
+// function. The body carries a placeholder, the material rides the vault, and
+// the two meet in memory at dispatch — so the link is absent from the delivery
+// row, the timeline, the audit entry and the outbox event alike.
+func RenderControllerTemplate(key string, expiresAt time.Time) (Rendered, commsauthz.Category, error) {
+	t, ok := controllerTemplates[key]
+	if !ok {
+		return Rendered{}, "", fmt.Errorf("consent: %q is not a registered controller template", key)
+	}
+	body := t.body
+	if !expiresAt.IsZero() {
+		body = strings.Replace(body, "This link is personal to you.",
+			"This link is personal to you and works until "+expiresAt.Format("2 January 2006")+".", 1)
+	}
+	return Rendered{Key: key, Version: t.version, Subject: t.subject, Body: body}, t.category, nil
+}

--- a/backend/internal/modules/consent/controllertemplates_test.go
+++ b/backend/internal/modules/consent/controllertemplates_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The installation's own wording, and the two properties that keep the lane
+// from becoming a way around consent.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEveryControllerTemplateCarriesExactlyOnePlaceholder holds the rendered
+// body to the material it will be staged with.
+//
+// comms refuses a disagreement at staging, so a template with none would make
+// its own send impossible and one with two would put the same live link in a
+// message twice. Both are silent until somebody tries to send.
+func TestEveryControllerTemplateCarriesExactlyOnePlaceholder(t *testing.T) {
+	for key := range controllerTemplates {
+		rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour))
+		if err != nil {
+			t.Fatalf("rendering %q: %v", key, err)
+		}
+		if got := strings.Count(rendered.Body, linkPlaceholder); got != 1 {
+			t.Errorf("template %q carries %d link placeholder(s), want exactly 1: comms refuses "+
+				"a body whose count disagrees with its material, so this template can never be sent",
+				key, got)
+		}
+		if rendered.Subject == "" {
+			t.Errorf("template %q renders no subject line", key)
+		}
+	}
+}
+
+// TestEveryControllerTemplateResolvesToASubjectServingCategory is the property
+// the lane's safety rests on.
+//
+// The send doors refuse any caller-claimed category where ServesTheSubject is
+// true, precisely because those five pass a hard suppression. This lane is the
+// sanctioned producer of them — so a template that resolved to an ORDINARY
+// category would be the installation's own mail asking the engine the wrong
+// question, and one that resolved to a category no validator evidences would be
+// a message that can never be sent.
+func TestEveryControllerTemplateResolvesToASubjectServingCategory(t *testing.T) {
+	for key := range controllerTemplates {
+		_, category, err := RenderControllerTemplate(key, time.Time{})
+		if err != nil {
+			t.Fatalf("rendering %q: %v", key, err)
+		}
+		if !category.Valid() {
+			t.Errorf("template %q resolves to %q, which is not in the category vocabulary", key, category)
+			continue
+		}
+		if !category.ServesTheSubject() {
+			t.Errorf("template %q resolves to %q, which does not serve the subject. The lane exists "+
+				"to send the five categories a caller may not claim; a template resolving to an "+
+				"ordinary one is the installation asking the engine the wrong question", key, category)
+		}
+		if _, evidenced := confirmKindFor(category); !evidenced {
+			t.Errorf("template %q resolves to %q, which validateConfirmation cannot evidence, so "+
+				"every message from this template falls through to the legacy verdict and is denied",
+				key, category)
+		}
+	}
+}
+
+// TestTheTemplatePlaceholderAgreesWithTheLane holds the two spellings of the
+// placeholder together. consent may not import comms, so the value is repeated
+// — and a repeated value is exactly the thing that drifts.
+func TestTheTemplatePlaceholderAgreesWithTheLane(t *testing.T) {
+	// The literal comms.LinkPlaceholder holds. Spelled out rather than imported
+	// because the module boundary forbids the import; if comms changes its
+	// value, this fails and names what to change.
+	const commsSpelling = "{{confirmation-link}}"
+	if linkPlaceholder != commsSpelling {
+		t.Errorf("consent renders %q where comms substitutes %q — every controller message would "+
+			"go out with the placeholder still in it, or be refused at staging for a count "+
+			"mismatch", linkPlaceholder, commsSpelling)
+	}
+}
+
+// TestAnUnregisteredTemplateIsRefused — the registry is what makes the lane
+// closed. A body assembled at a call site must not reach it.
+func TestAnUnregisteredTemplateIsRefused(t *testing.T) {
+	if _, _, err := RenderControllerTemplate("marketing_blast", time.Time{}); err == nil {
+		t.Fatal("an unregistered template rendered, so the installation's own words are not " +
+			"fixed in code after all")
+	}
+	if ControllerTemplateRegistry().Registered("marketing_blast", 1) {
+		t.Error("the registry recognises a template this build does not define")
+	}
+	if ControllerTemplateRegistry().Registered(TemplateRecordConfirmation, 99) {
+		t.Error("the registry recognises a VERSION this build does not define, so wording could " +
+			"change without the version that identifies it moving")
+	}
+}
+
+// TestTheRenderedBodyNeverCarriesTheLink pins where the plaintext may be. The
+// body is copied onto the delivery row, the timeline, the audit entry and the
+// outbox event, so a link rendered into it lands in all four.
+func TestTheRenderedBodyNeverCarriesTheLink(t *testing.T) {
+	for key := range controllerTemplates {
+		rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour))
+		if err != nil {
+			t.Fatalf("rendering %q: %v", key, err)
+		}
+		if strings.Contains(rendered.Body, "http") {
+			t.Errorf("template %q renders a URL into its body:\n%s", key, rendered.Body)
+		}
+	}
+}

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -14,7 +14,6 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
-	"github.com/margince/margince/backend/internal/platform/mailer"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -28,11 +27,6 @@ type Handlers struct {
 	// the eraser: answering an access request means producing the package, not
 	// marking a row done.
 	assembler SubjectAccessAssembler
-	// The confirm link's two halves, both injected by compose. Either one
-	// missing means the installation cannot deliver, which the send path
-	// reports rather than fails on.
-	confirmMailer mailer.Mailer
-	publicBaseURL string
 }
 
 // Eraser is the erase-path seam (compose injects the real one): DSR

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -36,6 +36,17 @@ type Store struct {
 	// under. Injected by compose because the setting lives in identity
 	// (installationcountry.go).
 	country InstallationCountryReader
+	// confirmSender stages the installation's own mail on the durable lane, and
+	// vault holds the one-time link so the plaintext never reaches the delivery
+	// row. Both nil on an installation that has not wired the lane, which
+	// issueLink reports as a link that was minted and not sent — never as a
+	// failure, because the token was still spent.
+	confirmSender ConfirmationSender
+	vault         ConfirmLinkVault
+	// publicBaseURL is the canonical origin a confirm link is built on. It lives
+	// on the Store rather than on Handlers because the Store is what builds the
+	// link now: issueLink seals it into the vault inside its own transaction.
+	publicBaseURL string
 }
 
 // NewStore binds the store to the pool every read and write runs through.

--- a/backend/internal/modules/deals/health.go
+++ b/backend/internal/modules/deals/health.go
@@ -379,7 +379,7 @@ func healthActivityEvidence(ctx context.Context, tx pgx.Tx, now time.Time, in *d
 		SELECT a.id FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
 		WHERE a.archived_at IS NULL
-		  AND a.origin <> 'system_remediation'`+auth.AudienceWorkspaceOnly("a")+`
+		  `+auth.OriginIsEngagement("a")+auth.AudienceWorkspaceOnly("a")+`
 		ORDER BY a.occurred_at DESC, a.id DESC
 		LIMIT 1`, in.dealID).Scan(&recent)
 	switch {

--- a/backend/internal/modules/people/lead_read.go
+++ b/backend/internal/modules/people/lead_read.go
@@ -17,6 +17,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -32,7 +33,7 @@ const liveOnlyClause = ` AND archived_at IS NULL`
 // signal. Every lead read is FROM the unaliased table, which is what lets
 // them name lead.id. A restricted activity (A165: held under a statutory
 // retention obligation) is in none of them, the same as in every other read.
-const leadColumns = `id, full_name, email, title, company_name, candidate_org_key,
+var leadColumns = `id, full_name, email, title, company_name, candidate_org_key,
 	linkedin_url, status, score, score_override_reason, score_computed, owner_id, project_id, source_system, source_id,
 	promoted_person_id, promoted_at, source, captured_by, version, created_at, updated_at, archived_at,
 	routed_at, first_response_at,
@@ -55,7 +56,7 @@ const leadColumns = `id, full_name, email, title, company_name, candidate_org_ke
 	-- is not the lead engaging.
 	(SELECT max(a.occurred_at) FROM activity_link l JOIN activity a ON a.id = l.activity_id
 	   WHERE l.lead_id = lead.id AND a.archived_at IS NULL AND a.restricted_at IS NULL
-	     AND a.origin <> 'system_remediation'),
+	     ` + auth.OriginIsEngagement("a") + `),
 	(SELECT count(*) FROM activity_link l JOIN activity a ON a.id = l.activity_id
 	   WHERE l.lead_id = lead.id AND a.archived_at IS NULL AND a.restricted_at IS NULL AND a.kind = 'task' AND NOT a.is_done),
 	-- The next open task, as the pair it is: its title and its deadline

--- a/backend/internal/platform/auth/engagementorigin.go
+++ b/backend/internal/platform/auth/engagementorigin.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// Which activities count as the record having been touched.
+//
+// Beside audienceaggregate.go, and here for the same reason: several modules ask
+// one question in hand-written SQL, no module may import a sibling, and a
+// question spelled per module drifts one copy at a time.
+
+// OriginIsEngagement filters an activity aliased by name down to the rows that
+// mean somebody actually engaged, excluding the ones the system wrote itself.
+//
+// TWO origins are excluded today. system_remediation is work the product files
+// about a record — a forecast-assurance review task — and system_notice is a
+// message the installation owes somebody, such as the confirm-details link.
+// Neither says a buyer did anything, and both would otherwise refresh the very
+// recency reading that noticed the silence: the rule that spotted a dormant
+// record would switch itself off by acting on it.
+//
+// The alias is a parameter because the callers name the activity table
+// differently. It returns a leading " AND ", so a caller concatenates it into a
+// WHERE clause and the surrounding arguments keep their positions.
+//
+// A FRAGMENT rather than a list of values because the readers are hand-written
+// statements, and what this prevents is silent: a third system origin added to
+// the vocabulary and missed by one reader makes that one reading count the
+// product's own mail as engagement, with nothing failing anywhere.
+//
+// Held by: TestEveryRecencyReadingExcludesTheSystemOrigins (backend/gates/recencyorigins_test.go)
+func OriginIsEngagement(alias string) string {
+	return " AND " + alias + ".origin NOT IN ('system_remediation', 'system_notice') "
+}

--- a/backend/migrations/core/1788560000_a_notice_the_installation_owes_is_not_engagement.down.sql
+++ b/backend/migrations/core/1788560000_a_notice_the_installation_owes_is_not_engagement.down.sql
@@ -1,0 +1,87 @@
+-- Reverse of the up migration: the notice origin stops being a member, and the
+-- four helpers go back to excluding remediation alone.
+--
+-- Any activity already written as system_notice would fail the narrowed CHECK,
+-- so they are moved to system_remediation rather than deleted: they are real
+-- outbound messages with deliveries hanging off them, and the nearest surviving
+-- origin that also stays out of the recency helpers keeps both facts true.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE activity SET origin = 'system_remediation' WHERE origin = 'system_notice';
+
+ALTER TABLE activity DROP CONSTRAINT activity_origin_check;
+
+ALTER TABLE activity
+    ADD CONSTRAINT activity_origin_check
+        CHECK (origin IN ('human', 'agent', 'system_remediation')) NOT VALID;
+
+ALTER TABLE activity VALIDATE CONSTRAINT activity_origin_check;
+
+CREATE OR REPLACE FUNCTION last_activity_of_deal(did uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin <> 'system_remediation'
+   WHERE l.deal_id = did
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_person(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin <> 'system_remediation'
+   WHERE l.person_id = pid
+$$;
+
+-- Three arms, three clauses: an account is as engaged as the newest real touch
+-- on itself, on its deals, or on someone it employs. Missing one arm would let
+-- a remediation task filed against a deal refresh its account.
+CREATE OR REPLACE FUNCTION last_activity_of_organization(oid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(v) FROM (
+    -- Filed against the account itself.
+    SELECT max(a.occurred_at) AS v
+      FROM activity_link l
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin <> 'system_remediation'
+     WHERE l.organization_id = oid
+    UNION ALL
+    -- Filed against one of its deals.
+    SELECT max(a.occurred_at)
+      FROM deal d
+      JOIN activity_link l ON l.deal_id = d.id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin <> 'system_remediation'
+     WHERE d.organization_id = oid
+    UNION ALL
+    -- Filed against a contact it currently employs.
+    SELECT max(a.occurred_at)
+      FROM relationship r
+      JOIN activity_link l ON l.person_id = r.person_id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin <> 'system_remediation'
+     WHERE r.organization_id = oid AND r.kind = 'employment'
+       AND r.ended_at IS NULL AND r.archived_at IS NULL
+  ) arms
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_project(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin <> 'system_remediation'
+   WHERE l.project_id = pid
+$$;

--- a/backend/migrations/core/1788560000_a_notice_the_installation_owes_is_not_engagement.up.sql
+++ b/backend/migrations/core/1788560000_a_notice_the_installation_owes_is_not_engagement.up.sql
@@ -1,0 +1,105 @@
+-- A notice the installation owes somebody is not evidence they engaged.
+--
+-- The confirm-details mail and the double-opt-in link are activities: they are
+-- outbound messages and belong on the timeline, because a person asking "why
+-- did you write to me" deserves to find the answer there, and privacy's
+-- erasure and the subject-access export both reach comms_outbound THROUGH the
+-- activity row.
+--
+-- But the installation writing to somebody about its own obligations says
+-- nothing about whether that person is engaged, and every recency reading in
+-- the product folds the newest activity into last_activity_at through the four
+-- helpers below. Left alone, mailing a dormant contact to ask them to check
+-- their details would make them look freshly active — and the very silence
+-- that would prompt someone to reach out would be erased by the asking.
+--
+-- Exactly the argument 1788386600 made for system_remediation. The four helper
+-- bodies here are that migration's, copied whole and with only the origin
+-- clause widened: a CREATE OR REPLACE writes the entire body, so a copy taken
+-- from anywhere but the live definition would silently drop a clause. Both the
+-- audience filter and the remediation exclusion are therefore repeated verbatim
+-- rather than restated.
+--
+-- Bounded, because these are called by triggers on every activity link write.
+SET LOCAL lock_timeout = '3s';
+
+-- NOT VALID first, then VALIDATE, for the reason the earlier migration states:
+-- a validated CHECK scans the whole table under ACCESS EXCLUSIVE, which on an
+-- installation holding years of captured mail blocks every capture for the
+-- length of the scan.
+ALTER TABLE activity DROP CONSTRAINT activity_origin_check;
+
+ALTER TABLE activity
+    ADD CONSTRAINT activity_origin_check
+        CHECK (origin IN ('human', 'agent', 'system_remediation', 'system_notice')) NOT VALID;
+
+ALTER TABLE activity VALIDATE CONSTRAINT activity_origin_check;
+
+CREATE OR REPLACE FUNCTION last_activity_of_deal(did uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
+   WHERE l.deal_id = did
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_person(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
+   WHERE l.person_id = pid
+$$;
+
+-- Three arms, three clauses: an account is as engaged as the newest real touch
+-- on itself, on its deals, or on someone it employs. Missing one arm would let
+-- a remediation task filed against a deal refresh its account.
+CREATE OR REPLACE FUNCTION last_activity_of_organization(oid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(v) FROM (
+    -- Filed against the account itself.
+    SELECT max(a.occurred_at) AS v
+      FROM activity_link l
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
+     WHERE l.organization_id = oid
+    UNION ALL
+    -- Filed against one of its deals.
+    SELECT max(a.occurred_at)
+      FROM deal d
+      JOIN activity_link l ON l.deal_id = d.id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
+     WHERE d.organization_id = oid
+    UNION ALL
+    -- Filed against a contact it currently employs.
+    SELECT max(a.occurred_at)
+      FROM relationship r
+      JOIN activity_link l ON l.person_id = r.person_id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
+     WHERE r.organization_id = oid AND r.kind = 'employment'
+       AND r.ended_at IS NULL AND r.archived_at IS NULL
+  ) arms
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_project(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
+   WHERE l.project_id = pid
+$$;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -15,7 +15,7 @@ public.activity.activity_meeting_no_overlap EXCLUDE USING gist (host_user_id WIT
 public.activity.activity_meeting_status_check CHECK (((meeting_status IS NULL) OR (meeting_status = ANY (ARRAY['booked'::text, 'held'::text, 'no_show'::text, 'canceled'::text]))))
 public.activity.activity_message_has_provider CHECK (((kind = 'message'::text) = (channel_provider IS NOT NULL)))
 public.activity.activity_no_company_meeting_on_rekind CREATE TRIGGER activity_no_company_meeting_on_rekind BEFORE UPDATE OF kind ON public.activity FOR EACH ROW EXECUTE FUNCTION activity_refuses_becoming_a_company_meeting()
-public.activity.activity_origin_check CHECK ((origin = ANY (ARRAY['human'::text, 'agent'::text, 'system_remediation'::text])))
+public.activity.activity_origin_check CHECK ((origin = ANY (ARRAY['human'::text, 'agent'::text, 'system_remediation'::text, 'system_notice'::text])))
 public.activity.activity_owed_verdict_check CHECK (((owed_verdict IS NULL) OR (owed_verdict = ANY (ARRAY['asks_us'::text, 'informs_us'::text]))))
 public.activity.activity_owed_verdict_stamped CHECK (((owed_verdict IS NULL) = (owed_verdict_at IS NULL)))
 public.activity.activity_pkey PRIMARY KEY (id)
@@ -2879,7 +2879,7 @@ public.last_activity_of_deal(did uuid) secdef=false cfg=- acl=-
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
      AND a.audience = 'workspace'
-     AND a.origin <> 'system_remediation'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
    WHERE l.deal_id = did
 
 public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=- 
@@ -2889,7 +2889,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
       FROM activity_link l
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
        AND a.audience = 'workspace'
-       AND a.origin <> 'system_remediation'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
      WHERE l.organization_id = oid
     UNION ALL
     -- Filed against one of its deals.
@@ -2898,7 +2898,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
       JOIN activity_link l ON l.deal_id = d.id
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
        AND a.audience = 'workspace'
-       AND a.origin <> 'system_remediation'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
      WHERE d.organization_id = oid
     UNION ALL
     -- Filed against a contact it currently employs.
@@ -2907,7 +2907,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
       JOIN activity_link l ON l.person_id = r.person_id
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
        AND a.audience = 'workspace'
-       AND a.origin <> 'system_remediation'
+       AND a.origin NOT IN ('system_remediation', 'system_notice')
      WHERE r.organization_id = oid AND r.kind = 'employment'
        AND r.ended_at IS NULL AND r.archived_at IS NULL
   ) arms
@@ -2917,7 +2917,7 @@ public.last_activity_of_person(pid uuid) secdef=false cfg=- acl=-
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
      AND a.audience = 'workspace'
-     AND a.origin <> 'system_remediation'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
    WHERE l.person_id = pid
 
 public.last_activity_of_project(pid uuid) secdef=false cfg=- acl=- 
@@ -2925,7 +2925,7 @@ public.last_activity_of_project(pid uuid) secdef=false cfg=- acl=-
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
      AND a.audience = 'workspace'
-     AND a.origin <> 'system_remediation'
+     AND a.origin NOT IN ('system_remediation', 'system_notice')
    WHERE l.project_id = pid
 
 public.lead acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (103)
+## Census (105)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -182,6 +182,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `projectionedgereaders_test.go` | H2 | The projection tier's read census. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |
 | `promptvoice_test.go` | H1 | Every prompt either speaks in Margince's one voice or says why it does not. |
+| `recencyorigins_test.go` | H2 | Every reading of "when was this record last touched" excludes the origins the system wrote itself. |
 | `registrarparity_test.go` | H2 | A registry that claims to be complete must be. |
 | `remediationnotbuyeractivity_test.go` | H2 | Remediation work must never read as buyer engagement. |
 | `reportasof_test.go` | H2 | A report's answer is labelled with the instant it was COMPUTED at. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9054,11 +9054,13 @@ export interface paths {
          *     confirmed now that no operator-held token exists.
          *     A fresh request supersedes any unspent earlier link of the SAME KIND for this person — a record-confirmation request does not expire a pending subscription-confirmation link, because they ask different questions and arrive in different mails.
          *
-         *     `provider_accepted` reports whether the relay took the message, and `sendable` says whether
-         *     this installation can send at all. Both, because they are different facts and a reader's next
-         *     move differs: configure a relay, or try again. An installation with no relay still mints
-         *     the token and answers 201, because the write happened and reporting it as a failure would
-         *     invite a second request that mints another token and supersedes the first.
+         *     The mail rides the same durable lane as every other outbound message: it takes a delivery
+         *     row, an authorization decision recording why the installation was allowed to send it, and a
+         *     timeline entry — which is what makes it visible to a subject-access export and reachable by
+         *     erasure. `queued` reports that the message was staged, in the same transaction that minted
+         *     the link; `sendable` says whether this installation has a lane at all. An installation with
+         *     no lane still mints the token and answers 201, because the write happened and reporting it
+         *     as a failure would invite a second request that mints another token and supersedes the first.
          */
         post: operations["requestDetailsConfirmation"];
         delete?: never;
@@ -25982,9 +25984,9 @@ export interface components {
             status: "queued";
         };
         /**
-         * @description A confirm link that now exists, and what became of the attempt to deliver it. Three
-         *     outcomes rather than two, because a reader's next move differs: it went, this
-         *     installation cannot send at all, or the send was tried and failed.
+         * @description A confirm link that now exists, and whether a message carrying it was queued. What
+         *     becomes of that message afterwards is the delivery's own answer, not this one: the
+         *     dispatcher transmits it later, retries a transient failure, and parks one it cannot send.
          */
         ConfirmRequestIssued: {
             /** @description The address the link was posted to — the person's own live primary email. */
@@ -25992,12 +25994,15 @@ export interface components {
             /** Format: date-time */
             expires_at: string;
             /**
-             * @description Whether the relay accepted the message. False while `sendable` is true means the send
-             *     was attempted and failed, which is a different fact from an installation that cannot
-             *     send at all. It is deliberately not called `delivered`: a relay returns before any
-             *     mailbox has seen the message, and a later bounce cannot travel back to change this.
+             * @description Whether the message was put on the outbound send lane, in the same transaction that
+             *     minted the link. False while `sendable` is true should not happen — staging and
+             *     minting commit together — so it reads as an installation that cannot send.
+             *
+             *     Deliberately not `delivered`, and no longer `provider_accepted`: the message is
+             *     queued here and transmitted later by the dispatcher, which retries and can park. What
+             *     became of it is the delivery's own answer and changes as the dispatcher learns more.
              */
-            provider_accepted: boolean;
+            queued: boolean;
             /**
              * @description Whether this installation has an outbound relay and a link origin configured. False
              *     means nothing was attempted — the link exists and must be passed on by hand.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -768,11 +768,9 @@ export const de = {
   "consent.askToConfirm": "Um Bestätigung der Daten bitten",
   "consent.askToConfirmWhat":
     "Schickt diesem Kontakt einen persönlichen Link: Er sieht, was ihr über ihn gespeichert habt, kann es korrigieren und sagen, ob er von euch hören möchte. Der Link geht an seine hinterlegte Adresse — woandershin könnt ihr ihn nicht schicken.",
-  "consent.askSent": "An {address} geschickt.",
+  "consent.askQueued": "Unterwegs an {address}.",
   "consent.askNotDelivered":
     "Der Link wurde für {address} erstellt, aber diese Installation verschickt keine Mails — es hat ihn also niemand bekommen.",
-  "consent.askSendFailed":
-    "Der Link wurde für {address} erstellt, aber die Mail ist nicht rausgegangen. Versuch es nochmal — ein neuer Link ersetzt diesen.",
   "consent.askExpires": "Der Link gilt bis",
   "consent.noRecord": "kein Eintrag",
   "consent.noPurposes":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -814,11 +814,9 @@ export const en = {
   "consent.askToConfirm": "Ask them to confirm their details",
   "consent.askToConfirmWhat":
     "Mails this contact a private link to see what you hold about them, correct it, and say whether they want to hear from you. It goes to their own recorded address; you cannot send it anywhere else.",
-  "consent.askSent": "Sent to {address}.",
+  "consent.askQueued": "On its way to {address}.",
   "consent.askNotDelivered":
     "The link was created for {address} but this installation sends no mail, so nobody was sent it.",
-  "consent.askSendFailed":
-    "The link was created for {address} but the mail did not go out. Try again — a new link replaces this one.",
   "consent.askExpires": "The link works until",
   "consent.noRecord": "no record",
   "consent.noPurposes": "This organization tracks no consent purposes yet.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -758,11 +758,9 @@ export const vi = {
   "consent.askToConfirm": "Đề nghị họ xác nhận thông tin",
   "consent.askToConfirmWhat":
     "Gửi cho liên hệ này một liên kết riêng để họ xem bạn đang lưu gì về họ, sửa lại nếu sai, và cho biết họ có muốn nhận tin từ bạn không. Liên kết chỉ đến địa chỉ đã lưu của họ; bạn không thể gửi đi nơi khác.",
-  "consent.askSent": "Đã gửi tới {address}.",
+  "consent.askQueued": "Đang trên đường tới {address}.",
   "consent.askNotDelivered":
     "Liên kết đã được tạo cho {address} nhưng bản cài đặt này không gửi thư, nên chưa ai nhận được.",
-  "consent.askSendFailed":
-    "Liên kết đã được tạo cho {address} nhưng thư không gửi đi được. Hãy thử lại — liên kết mới sẽ thay thế liên kết này.",
   "consent.askExpires": "Liên kết có hiệu lực đến",
   "consent.noRecord": "chưa ghi nhận",
   "consent.noPurposes": "Tổ chức này chưa theo dõi mục đích chấp thuận nào.",

--- a/frontend/src/screens/consent.stories.tsx
+++ b/frontend/src/screens/consent.stories.tsx
@@ -170,7 +170,7 @@ export const ConfirmDetailsSent: Story = {
         {
           delivered_to: "ada@example.test",
           expires_at: "2026-09-13T09:00:00Z",
-          provider_accepted: true,
+          queued: true,
         },
         201,
       ),
@@ -194,7 +194,7 @@ export const ConfirmDetailsUndelivered: Story = {
         {
           delivered_to: "ada@example.test",
           expires_at: "2026-09-13T09:00:00Z",
-          provider_accepted: false,
+          queued: false,
         },
         201,
       ),

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -551,7 +551,7 @@ describe("asking a contact to confirm their details", () => {
             {
               delivered_to: "ada@example.test",
               expires_at: "2026-09-13T09:00:00Z",
-              provider_accepted: true,
+              queued: true,
               sendable: true,
             },
             201,
@@ -573,7 +573,7 @@ describe("asking a contact to confirm their details", () => {
     expect(ask?.body).toBeFalsy();
   });
 
-  it("tells a failed send apart from an installation that cannot send", async () => {
+  it("says a queued link is on its way rather than claiming it was delivered", async () => {
     stubRoutes({
       "GET /me": () => jsonResponse(MAY_WRITE),
       "POST /people/person-1/consent/confirm-request": () =>
@@ -581,11 +581,7 @@ describe("asking a contact to confirm their details", () => {
           {
             delivered_to: "ada@example.test",
             expires_at: "2026-09-13T09:00:00Z",
-            provider_accepted: false,
-            // The relay exists and refused this one message. Telling a rep
-            // "this installation sends no mail" would send them to configure
-            // something that is already configured, and pressing again is what
-            // actually helps.
+            queued: true,
             sendable: true,
           },
           201,
@@ -595,8 +591,11 @@ describe("asking a contact to confirm their details", () => {
 
     await userEvent.click(await screen.findByTestId("confirm-details-ask"));
 
+    // The message is staged here and transmitted later by the dispatcher, which
+    // retries and can park. "Sent" would tell a rep somebody was asked while the
+    // message is still waiting, and they would stop watching for an answer.
     const sent = await screen.findByTestId("confirm-details-sent");
-    expect(sent).toHaveTextContent(/did not go out/i);
+    expect(sent).toHaveTextContent(/on its way/i);
     expect(sent).not.toHaveTextContent(/sends no mail/i);
   });
 
@@ -608,7 +607,7 @@ describe("asking a contact to confirm their details", () => {
           {
             delivered_to: "ada@example.test",
             expires_at: "2026-09-13T09:00:00Z",
-            provider_accepted: false,
+            queued: false,
           },
           201,
         ),

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -378,18 +378,24 @@ export function ConsentSection({
   );
 }
 
-/** What to say about a link that was just issued. The three outcomes are three
- * different next moves for the reader, so each gets its own sentence. */
+/** What to say about a link that was just issued.
+ *
+ * TWO outcomes, where there used to be three. The message is staged in the same
+ * transaction that mints the link, so "the link exists but the send failed"
+ * cannot happen any more — either both committed or neither did. What is left
+ * is: it is on its way, or this installation cannot send at all.
+ *
+ * And it says "on its way", not "sent". The message is queued here and
+ * transmitted later by the dispatcher, which retries and can park, so claiming
+ * delivery on this screen would tell a rep somebody was asked when the message
+ * may still be waiting. */
 function sentenceFor(
   issued: components["schemas"]["ConfirmRequestIssued"],
   t: ReturnType<typeof useT>,
 ): string {
   const address = issued.delivered_to;
-  if (issued.provider_accepted) {
-    return t("consent.askSent", { address });
-  }
-  return issued.sendable
-    ? t("consent.askSendFailed", { address })
+  return issued.queued
+    ? t("consent.askQueued", { address })
     : t("consent.askNotDelivered", { address });
 }
 

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -32,3 +32,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 44085e526e3c71af58230ac3359eb9679dbd6a59 08ef392fc995b0b79872e2544d5f3d210d5923a1 ratified-a-double-opt-in-link-is-mailed-never-shown-to-the-operator
 98f26a4484760912e7cede9f57715a7be587b6c5 49728224fbaa221da787bacd7a391776d6fc85a4 ratified-worklist-move-carries-the-deal-cards-verbs
 6a7b29a268183069393c39b1931648a5894b6abe 91cc59b5c3855fed8bf8ba020d95894ed60822e4 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them
+0e10662bd2e43fb3018888323893dd1f3a44fc08 bb87bde2d4a8e3507be239b8d6af8783d0e3f870 ratified-the-installation-writes-through-the-durable-lane-a-confirm-link-is-queued-not-handed-to-a-relay


### PR DESCRIPTION
The confirm-details link and the double-opt-in link were handed straight to SMTP. That call returned before any mailbox saw the message and reported it as `delivered`, which measured only that the relay had not refused it — and a later bounce could not travel back to correct the claim.

Worse, the message existed nowhere. No delivery row, no authorization decision, no timeline entry, so the one message the installation composes entirely on its own appeared in no subject-access export and no erasure reached it. `gates/directmailbypass_test.go` waived it as known debt; that waiver is **deleted**, not widened.

It now rides the same lane as every other outbound message. Minting the link and staging the message share one transaction, so a token can no longer exist with nothing carrying it.

## The lane is not a side door

`AuthorizeStagingTx` runs on it exactly as for a rep's mail, and a new validator (`consent/authorizeconfirmation.go`) answers on evidence only the installation can produce: a live `confirm_token` for that person, of the kind the category carries. Unconsumed, unexpired, right kind.

The basis is `legal_obligation` and not consent — the mail that ASKS for consent cannot itself require it, or nobody could ever be asked. The send doors already refuse any caller-claimed subject-serving category, so this lane is the sanctioned producer of them.

Verified on real rows: `deliveries=1 decisions=1 notice_activities=1 jobs=1`, decision `verdict=allow category=record_confirmation basis=legal_obligation`.

## Two defects this uncovered

Both would have shipped a lane that silently never delivered.

**The transmit gate.** `comms/gates.go` asks the legacy gate whether a purpose is granted, using `del.ConsentPurpose` — NULL on a controller row by design, because the message is not sent under a permission anybody gave. An undefined purpose is a default-deny, so every confirmation mail would have parked on an installation that looked correctly configured. Reverting the fix reproduces it exactly: `park reason: consent for purpose "" is not granted`. The engine still answers through the same `AuthorizeTransmit` call; only the purpose-key question is skipped, and a test proves a rep's send is still asked.

**`WithKeyvault` does more than its name says.** It also installs the outbound send pre-flight, so composing it merely to seal a link made every send in three suites refuse as "mailbox not send capable". `WithConfirmLinkVault` wires only the vault.

## One invariant, five copies

Five readers of "when was this record last touched" each carried their own `origin <> 'system_remediation'` copy — four Go queries plus the SQL helpers. Adding `system_notice` would have missed them silently: each still compiling, still passing, and counting the product's own mail as buyer engagement.

`auth.OriginIsEngagement` is now the one spelling, held by `gates/recencyorigins_test.go`. The pre-existing `remediationnotbuyeractivity_test.go` was taught to accept it rather than duplicated.

## The link never reaches a readable row

The staged body carries a placeholder, the plaintext is sealed in the vault, and the two meet in memory at dispatch. A test asserts the token is absent from the delivery row, the timeline, the audit payload and the outbox event — and it earns that: a mutation appending the link while keeping the placeholder slips past `StageControllerTx`'s count check and only this probe catches it.

## Contract

`provider_accepted` becomes `queued`, ratified in the allowlist. Renaming a required response property is a breaking change, so both sides land together — backend, frontend, three locales. The three delivery outcomes collapse to two: staging and minting share a transaction, so "the link exists but the send failed" can no longer happen.

## Verification

- 14 mutations, each reverted one clause at a time, all caught.
- Migration `1788560000` copied verbatim from `1788386600` with the origin clause widened, so no `CREATE OR REPLACE` silently drops the audience filter. Head catalog shows exactly the CHECK plus six helper clauses.
- Probed end-to-end on a dev stack before merge, not only a green lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the confirm-details and double-opt-in links through the durable send lane instead of handing them straight to SMTP. The old path reported `delivered` before any mailbox saw the message and wrote no delivery row, authorization decision, or timeline entry; the new path stages the message and mints the link in one transaction, so the message is visible to subject-access exports and erasure, and a later bounce can correct the record.

**What changed**
- A new validator authorizes these messages on a live, unconsumed `confirm_token` of the right kind, with basis `legal_obligation` — the mail that asks for consent cannot itself require it.
- Fixed two defects that would have silently parked every confirmation mail: the transmit gate default-denied the NULL consent purpose on controller rows, and `WithKeyvault` was installing the outbound send pre-flight.
- All five recency readers now share one `auth.OriginIsEngagement` filter; migration `1788560000` adds the `system_notice` origin so these messages don't count as buyer engagement.
- The link is sealed in the vault and substituted in memory at dispatch, so the plaintext never reaches a delivery row, timeline, audit payload, or outbox event.

**Contract**
- `provider_accepted` becomes `queued` in the confirm-request response, and three delivery outcomes collapse to two; the rename is breaking and lands together across backend, frontend, and three locales.

<sup>Written for commit fccaddea8a72467b0956045c3a5f9b737c1c9870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

