### PR TITLE
An owner the reader cannot name is not nobody

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8010,6 +8010,7 @@ export const de = {
   "worklist.exceptions.owner": "Wer antwortet",
   "worklist.exceptions.basis": "Gemessen an",
   "worklist.exceptions.nobody": "Noch niemand",
+  "worklist.exceptions.ownerWithheld": "Für Sie nicht sichtbar",
   "worklist.exceptions.truncated":
     "Mehr als das. Die Liste endet bei dem, was eine Sitzung fasst.",
   "worklist.exceptions.kind.response_breached":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8104,6 +8104,7 @@ export const en = {
   "worklist.exceptions.owner": "Who answers",
   "worklist.exceptions.basis": "Judged against",
   "worklist.exceptions.nobody": "Nobody yet",
+  "worklist.exceptions.ownerWithheld": "Not shown to you",
   "worklist.exceptions.truncated":
     "More than this. The list stops at what one sitting can hold.",
   "worklist.exceptions.kind.response_breached": "A first reply is late",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7925,6 +7925,7 @@ export const vi = {
   "worklist.exceptions.owner": "Ai chịu trách nhiệm",
   "worklist.exceptions.basis": "Căn cứ theo",
   "worklist.exceptions.nobody": "Chưa có ai",
+  "worklist.exceptions.ownerWithheld": "Không hiển thị với bạn",
   "worklist.exceptions.truncated":
     "Còn nhiều hơn thế. Danh sách dừng ở mức một lần xem có thể chứa.",
   "worklist.exceptions.kind.response_breached": "Phản hồi đầu tiên đã trễ",

--- a/frontend/src/screens/worklist.exceptions.test.tsx
+++ b/frontend/src/screens/worklist.exceptions.test.tsx
@@ -129,7 +129,7 @@ function stubExceptions(body: unknown) {
   return fetched;
 }
 
-function renderPanel() {
+function renderPanel(onOwner: (id: string) => void = () => {}) {
   return render(
     <QueryClientProvider
       client={
@@ -137,7 +137,7 @@ function renderPanel() {
       }
     >
       <LocaleProvider initial="en">
-        <TeamExceptionsPanel enabled onOwner={() => {}} />
+        <TeamExceptionsPanel enabled onOwner={onOwner} />
       </LocaleProvider>
     </QueryClientProvider>,
   );
@@ -219,3 +219,109 @@ function jsonOf(body: unknown) {
     headers: { "content-type": "application/json" },
   });
 }
+
+// Who answers for a row, when the reader cannot be told who.
+//
+// `WorklistOwner` carries a KIND — `user` or `unassigned` — and separately a
+// label the caller may not be able to resolve. Those are two different facts
+// and the panel was reading only one: any row without a label rendered as
+// "Nobody yet".
+//
+// So an exception a teammate is already carrying was reported to their lead as
+// unassigned work. That is not a display nicety. A lead reads "nobody" as "this
+// is going nowhere" and takes it on, when somebody is already on it — and the
+// row's click sent them to the unassigned scope, which is the one queue the
+// work is definitely not in.
+describe("an owner the reader cannot name is not nobody", () => {
+  const heldByAStranger = {
+    as_of: "2026-09-05T09:00:00Z",
+    truncated: false,
+    exceptions: [
+      {
+        kind: "response_breached",
+        // A real person holds it. The caller may not resolve their name.
+        owner: { kind: "user", id: "01a05500-0000-7000-8000-0000000000aa" },
+        subject: { type: "lead", id: "l1", label: "Kirsten at LOXXESS" },
+        since: "2026-09-01T09:00:00Z",
+        consequence: "customer_waits",
+        threshold: "first reply past target",
+      },
+    ],
+  };
+
+  it("says the owner is withheld rather than absent", async () => {
+    stubExceptions(heldByAStranger);
+    renderPanel();
+
+    await screen.findByText(/Kirsten at LOXXESS/);
+    expect(
+      screen.getByText(en["worklist.exceptions.ownerWithheld"]),
+    ).toBeTruthy();
+    expect(screen.queryByText(en["worklist.exceptions.nobody"])).toBeNull();
+  });
+
+  // The routing reads the KIND, and the case that tells the two readings apart
+  // is an `unassigned` owner that still carries an id.
+  //
+  // Reading `owner.id ?? ""` gets the withheld-name row right by accident — the
+  // id is there, so it routes correctly — and gets THIS one wrong: it would
+  // send a lead to a person's queue for work the wire says nobody holds. Only a
+  // fixture carrying both an `unassigned` kind and an id can fail one reading
+  // and pass the other.
+  it("opens the unassigned scope for work nobody holds, whatever id rides along", async () => {
+    stubExceptions({
+      as_of: "2026-09-05T09:00:00Z",
+      truncated: false,
+      exceptions: [
+        {
+          kind: "unassigned",
+          owner: {
+            kind: "unassigned",
+            id: "01a05500-0000-7000-8000-0000000000cc",
+          },
+          subject: { type: "lead", id: "l3", label: "A lead nobody took" },
+          since: "2026-09-01T09:00:00Z",
+          consequence: "customer_waits",
+          threshold: "nobody has taken it",
+        },
+      ],
+    });
+    const opened: string[] = [];
+    renderPanel((id) => opened.push(id));
+
+    (await screen.findByText(/A lead nobody took/)).click();
+
+    expect(opened).toEqual([""]);
+  });
+
+  it("opens that owner's queue when a person holds it", async () => {
+    stubExceptions(heldByAStranger);
+    const opened: string[] = [];
+    renderPanel((id) => opened.push(id));
+
+    (await screen.findByText(/Kirsten at LOXXESS/)).click();
+
+    expect(opened).toEqual(["01a05500-0000-7000-8000-0000000000aa"]);
+  });
+
+  it("still says nobody when the wire says nobody", async () => {
+    stubExceptions({
+      as_of: "2026-09-05T09:00:00Z",
+      truncated: false,
+      exceptions: [
+        {
+          kind: "unassigned",
+          owner: { kind: "unassigned" },
+          subject: { type: "lead", id: "l2", label: "An untaken lead" },
+          since: "2026-09-01T09:00:00Z",
+          consequence: "customer_waits",
+          threshold: "nobody has taken it",
+        },
+      ],
+    });
+    renderPanel();
+
+    await screen.findByText(/An untaken lead/);
+    expect(screen.getByText(en["worklist.exceptions.nobody"])).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/worklist.exceptions.tsx
+++ b/frontend/src/screens/worklist.exceptions.tsx
@@ -62,7 +62,16 @@ export function TeamExceptionsPanel({
               // the intervention this page routes to. A row nobody holds opens
               // the unassigned scope instead: the work is real and somebody has
               // to take it.
-              onRowClick={(row) => onOwner(row.owner.id ?? "")}
+              //
+              // Read off the OWNER'S KIND, not off the id. A `user` row whose
+              // id this caller may not resolve still has somebody carrying it,
+              // and sending the manager to the unassigned scope for it would
+              // route them to a queue the work is not in.
+              onRowClick={(row) =>
+                row.owner.kind === "user" && row.owner.id
+                  ? onOwner(row.owner.id)
+                  : onOwner("")
+              }
               columns={[
                 {
                   key: "kind",
@@ -79,11 +88,24 @@ export function TeamExceptionsPanel({
                 {
                   key: "owner",
                   header: t("worklist.exceptions.owner"),
-                  // The name where the caller may resolve it, and the honest
-                  // absence otherwise. Never the raw id: a uuid in front of a
-                  // lead is the defect the label exists to prevent.
+                  // Three answers, because there are three facts and the wire
+                  // tells them apart: a name, somebody this caller may not
+                  // name, and nobody at all.
+                  //
+                  // Falling back to "Nobody yet" on a missing LABEL conflated
+                  // the last two. An exception owned by a real person whose
+                  // name the reader cannot resolve was reported as unassigned
+                  // work — which is not a display nicety: a lead reads that as
+                  // "this is going nowhere" and takes it, when a teammate is
+                  // already carrying it.
+                  //
+                  // Never the raw id either: a uuid in front of a lead is the
+                  // defect the label exists to prevent.
                   render: (row: TeamException) =>
-                    row.owner.label ?? t("worklist.exceptions.nobody"),
+                    row.owner.kind === "unassigned"
+                      ? t("worklist.exceptions.nobody")
+                      : (row.owner.label ??
+                        t("worklist.exceptions.ownerWithheld")),
                 },
                 {
                   key: "threshold",


### PR DESCRIPTION
An exception a teammate was **already carrying** was reported to their lead as unassigned work.

## The defect

`WorklistOwner` carries a **kind** — `user` or `unassigned` — and separately a **label** the caller may not be able to resolve. Those are two different facts, and the panel read only one: any row without a label rendered as "Nobody yet".

Verified before touching anything, with a `kind: "user"` row carrying an id and no label: the panel drew **"Nobody yet"**.

This is not a display nicety. A lead reads "nobody" as *this is going nowhere* and takes the work on, when a teammate is already on it. The row's click made the same mistake from the other side — sending them to the unassigned scope, which is the one queue the work is definitely not in.

## The fix

Both the label and the routing now read the **kind**. Three answers where the wire has three facts: a name, somebody this caller may not name, and nobody at all.

## The fixture that was too weak

My first routing test passed **without the fix**, and that is worth stating plainly. Reading `owner.id ?? ""` gets a withheld-*name* row right by accident — the id is there, so it routes correctly. Only a fixture carrying an `unassigned` kind **and** an id can fail one reading and pass the other. That is the fixture now.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `says the owner is withheld rather than absent` — asserts the withheld string is shown and "Nobody yet" is not |
| Honest absence preserved | `still says nobody when the wire says nobody` |
| Routing, owned | `opens that owner's queue when a person holds it` |
| Routing, unowned | `opens the unassigned scope for work nobody holds, whatever id rides along` |
| Mutation strength | Reverting the label fallback fails; reverting the routing to `id ?? ""` fails **only** against the strengthened fixture, which is why it was strengthened |
| Locale coverage | New key added to all three catalogs |
| Full lane | `make check-fe` green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the exceptions worklist mislabeling rows whose owner is a real person the caller can't resolve as "Nobody yet" and routing them to the unassigned scope.

- The panel now reads the owner's `kind`: a `user`-kind owner with no label shows a new "Not shown to you" string, and only `unassigned`-kind rows show "Nobody yet" and route to the unassigned queue.
- Adds the new string to all three locale catalogs and strengthens the routing test with a fixture that only passes when reading the kind.

<sup>Written for commit 9a989d9473782abb518dddf0bfcd158946e675bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

