### PR TITLE
The refused-controls lists wait for every control

### DIFF
--- a/frontend/src/screens/companyheader.test.tsx
+++ b/frontend/src/screens/companyheader.test.tsx
@@ -426,11 +426,14 @@ describe("an archived account's verbs", () => {
     await user.click(
       await screen.findByRole("button", { name: "More actions" }),
     );
+    // Each WAITED for. Only the first was, so the three below were read in
+    // the tick it arrived in — and a menu whose items mount a beat apart threw
+    // here, which is the shape that fails under a loaded run and never alone.
     const refused = [
       await screen.findByTestId("edit-record"),
-      screen.getByTestId("merge-record"),
-      screen.getByTestId("archive-record"),
-      screen.getByTestId("share-record"),
+      await screen.findByTestId("merge-record"),
+      await screen.findByTestId("archive-record"),
+      await screen.findByTestId("share-record"),
     ];
     for (const control of refused) {
       expect(control.hasAttribute("disabled")).toBe(true);

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -2122,11 +2122,14 @@ describe("DealScreen — an archived deal keeps its verbs, refused", () => {
     render(<DealScreen id="x" />);
 
     await openHeaderMenu();
+    // Each WAITED for — see the note on the same list in
+    // organizations.header.test.tsx: only the first was, and the rest were
+    // read in the tick it arrived in.
     const refused = [
       await screen.findByTestId("edit-record"),
-      screen.getByTestId("archive-record"),
-      screen.getByTestId("share-record"),
-      screen.getByTestId("reopen-open"),
+      await screen.findByTestId("archive-record"),
+      await screen.findByTestId("share-record"),
+      await screen.findByTestId("reopen-open"),
     ];
     for (const control of refused) {
       expect(control.hasAttribute("disabled")).toBe(true);

--- a/frontend/src/screens/organizations.header.test.tsx
+++ b/frontend/src/screens/organizations.header.test.tsx
@@ -76,10 +76,15 @@ describe("CompanyScreen — a live record that is not the viewer's to change", (
     });
     render(<CompanyScreen id="o-1" />);
 
+    // Each control WAITED for, not read in the tick the first one arrived in.
+    // openRecordMenu waits for `edit-record`; the two below were then fetched
+    // with a non-retrying getByTestId in the same breath, so a menu whose
+    // items mount a beat apart threw here — the failure this file sees under a
+    // loaded full run and never in isolation.
     const refused = [
       await openRecordMenu(user, "edit-record"),
-      screen.getByTestId("archive-record"),
-      screen.getByTestId("share-record"),
+      await screen.findByTestId("archive-record"),
+      await screen.findByTestId("share-record"),
     ];
     for (const control of refused) {
       expect(control.hasAttribute("disabled")).toBe(true);


### PR DESCRIPTION
Refs #3776. **Not a proven cause** — read the last section before merging on the assumption it closes the ticket.

## What the test does

The assertion the ticket names reads three controls out of a menu it has just opened, and waits for **one** of them:

```ts
const refused = [
  await openRecordMenu(user, "edit-record"),  // waits
  screen.getByTestId("archive-record"),       // does not
  screen.getByTestId("share-record"),         // does not
];
```

`openRecordMenu` waits for `edit-record`; the other two are then fetched with a non-retrying `getByTestId` in the tick it arrived in. A menu whose items mount a beat apart throws there.

That is the shape that fails under a loaded full run and passes in isolation, which is exactly what the ticket reports — and it is the same defect class as the `queryByRole` read in #4000: a non-retrying query for something that appears asynchronously.

The same list appears **three times** — the company header, the account header and the deal — each a copy of the same test for a different record type, and each waiting for the first control only. All three now wait for each.

## What I could not do

Reproduce it. Including under the runner that reproduces the hover-intent flake reliably:

```
pnpm exec vitest run --maxWorkers=24 --sequence.shuffle
```

Four consecutive runs, all green. That tool found #4000's instance in two runs, so its silence here is worth something — but it is not proof of absence, and this file's failure has been seen once by somebody.

`frontend/AGENTS.md` is explicit that the failing run's output is what separates the two flake families here, and this ticket does not have it. So I have fixed the one non-retrying read in the named test rather than claiming the cause.

## What that means for the ticket

If the header flake returns, this PR did not fix it, and the next report should capture the assertion text and the rendered DOM — that is the missing evidence, and it is what would tell a slow render from a refusal.

If it does not return, that is consistent with this being it and does not prove it either.

I would merge this as a correctness fix to three tests regardless of which — a list that waits for one of four controls is wrong on its own terms — and leave the ticket open until the flake has been absent long enough to mean something. Marked `Refs`, not `Closes`, for that reason.

`make check-fe` green.
