### PR TITLE
Every source the queue draws has a story that draws it

### DIFF
--- a/frontend/src/screens/worklist.row.stories.tsx
+++ b/frontend/src/screens/worklist.row.stories.tsx
@@ -175,3 +175,194 @@ export const ATaskOnAPhone: Story = {
   globals: { viewport: { value: "phone" } },
   play: undefined,
 };
+
+// The five sources the row could draw and no story showed.
+//
+// Each is drawn from the shape its own producer emits, so the story is a
+// picture of what a reader actually meets rather than of a fixture invented
+// here. Held by TestEverySourceHasARowStory in worklist.storycensus.test.ts,
+// which fails when a source the queue can draw has no story naming it.
+
+// A brief item: the overnight ranking's pick, with the three verbs it carries.
+// The row drew a Pin button and nothing else until #4230, which is the defect
+// this story would have made visible.
+export const ABriefItemToAdvance: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "bi1",
+      source: "brief_item",
+      category: "deals_at_risk",
+      level: 3,
+      consequence: "deal_slips_past_close",
+      title: "Advance the Northstar renewal",
+      because: [],
+      actions: ["act", "set_aside", "dismiss"],
+      subject: {
+        type: "deal",
+        id: "01a05500-0000-7000-8000-0000000000bb",
+        label: "Northstar",
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// A promise the rep made, with the words they wrote under it. The quote is the
+// whole point: a commitment card has to show both when it is due and where it
+// was promised.
+export const APromiseWithItsEvidence: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "cc1",
+      source: "conversation_claim",
+      category: "tasks",
+      level: 2,
+      consequence: "promise_breaks",
+      title: "Send the retrofit quote",
+      detail: "“I’ll get the quote over to you by Thursday.”",
+      because: [],
+      actions: ["open"],
+      subject: {
+        type: "person",
+        id: "01a05500-0000-7000-8000-0000000000aa",
+        label: "Kirsten Vogel",
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// A contact who has gone quiet, and the verb that sets them aside for a month.
+export const AQuietContactToSetAside: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "01a05500-0000-7000-8000-0000000000aa",
+      source: "relationship_decay",
+      category: "customer_waiting",
+      level: 5,
+      consequence: "deal_drifts",
+      title: "Kirsten Vogel has gone quiet",
+      because: [],
+      actions: ["open", "dismiss"],
+      subject: {
+        type: "person",
+        id: "01a05500-0000-7000-8000-0000000000aa",
+        label: "Kirsten Vogel",
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// Work a person approved that then did not run. It names what was released
+// rather than what was decided: the decision stands, the effect did not.
+export const AnApprovedThingThatDidNotRun: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "fa1",
+      source: "failed_approval",
+      category: "system",
+      level: 3,
+      consequence: "customer_never_received",
+      title: "This was approved, but the send did not run",
+      because: [],
+      actions: ["open"],
+      subject: {
+        type: "person",
+        id: "01a05500-0000-7000-8000-0000000000aa",
+        label: "Kirsten Vogel",
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// A source that stopped answering. No verb: restoring a mailbox is an
+// administrator's job on another screen, and a button here would promise a
+// repair this queue cannot make.
+export const AMailboxThatStopped: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "sh1",
+      source: "sync_health",
+      category: "system",
+      level: 6,
+      consequence: "data_drifts",
+      title: "A mailbox stopped syncing",
+      because: [],
+      actions: [],
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// A new lead waiting on a first reply, with the clock the SLA policy is
+// counting. `response_overdue` is the reason the row gives; the phrase is the
+// client's to write.
+export const ALeadWaitingOnAFirstReply: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "lr1",
+      source: "lead_response",
+      category: "leads",
+      level: 2,
+      consequence: "buyer_waits",
+      title: "Kirsten at LOXXESS asked about pricing",
+      because: [{ kind: "response_overdue" }],
+      actions: ["open"],
+      subject: {
+        type: "lead",
+        id: "01a05500-0000-7000-8000-0000000000dd",
+        label: "Kirsten at LOXXESS",
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// A privacy request, which is on this page only so a rep is not the last to
+// know it exists. It is answered in the privacy queue, and the row says so by
+// carrying a destination and no verb of its own.
+export const APrivacyRequestOnItsClock: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "dsr1",
+      source: "dsr",
+      category: "system",
+      level: 1,
+      consequence: "legal_deadline_missed",
+      title: "A subject access request is due",
+      because: [{ kind: "legal_deadline" }],
+      actions: [],
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};

--- a/frontend/src/screens/worklist.storycensus.test.ts
+++ b/frontend/src/screens/worklist.storycensus.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { KNOWN_SOURCES } from "./worklist.copy";
+
+// Every source the queue can draw has a story that draws it.
+//
+// A story is where a person LOOKS at a row. The row for a source nobody has a
+// story for is one nobody has seen outside the running product — and this tree
+// has shipped two rows that were wrong in ways a glance would have caught: a
+// brief item offering three verbs the client drew none of, and a failed
+// automation with no address at all.
+//
+// Neither was a logic error a unit test would find. Both were "the row is
+// there and it is useless", which is exactly what a story shows and an
+// assertion does not.
+//
+// THE CORPUS IS DERIVED, from KNOWN_SOURCES rather than a list here. A second
+// copy of the vocabulary is the thing that goes stale, and a census reading a
+// shorter world reports PASS with nothing to notice.
+
+const storiesDir = join(__dirname);
+
+// `batch` names no single record — it stands for a pile of other rows, and its
+// screen and verbs are its members'. There is nothing source-shaped to draw.
+const standsForOtherRows = "batch";
+
+function everySourceDrawnInAStory(): Set<string> {
+  const drawn = new Set<string>();
+  // The WORKLIST's own stories, not every story in the directory. `source` is
+  // an ordinary field name — an AI call's story names a `source: "heuristic"`,
+  // a verdict's a `source: "human"` — and a sweep over all of them reads two
+  // dozen words from vocabularies this census knows nothing about.
+  for (const file of readdirSync(storiesDir)) {
+    if (!file.startsWith("worklist.") || !file.endsWith(".stories.tsx")) {
+      continue;
+    }
+    const text = readFileSync(join(storiesDir, file), "utf8");
+    for (const match of text.matchAll(/source: "([a-z_]+)"/g)) {
+      drawn.add(match[1]);
+    }
+  }
+  return drawn;
+}
+
+describe("every source the queue draws has a story", () => {
+  const sources = Object.keys(KNOWN_SOURCES).filter(
+    (source) => source !== standsForOtherRows,
+  );
+
+  // The corpus must not be able to come back empty or short. A glob that
+  // matched no files, or a KNOWN_SOURCES that stopped being read, would leave
+  // every assertion below vacuously true.
+  it("reads a real vocabulary and a real set of stories", () => {
+    expect(sources.length).toBeGreaterThan(15);
+    expect(everySourceDrawnInAStory().size).toBeGreaterThan(15);
+  });
+
+  it.each(sources)("draws %s", (source) => {
+    expect(everySourceDrawnInAStory()).toContain(source);
+  });
+
+  // And nothing storied that the queue can no longer draw, which reads to the
+  // next author as though that source still existed.
+  it("draws nothing the queue no longer knows", () => {
+    const known = new Set(Object.keys(KNOWN_SOURCES));
+    const stale = [...everySourceDrawnInAStory()].filter(
+      (source) => !known.has(source),
+    );
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Seven of twenty sources had no story: `brief_item`, `conversation_claim`, `failed_approval`, `relationship_decay`, `sync_health`, `lead_response`, `dsr`.

## Why a story and not another assertion

A story is where a person **looks** at a row. This tree has shipped two rows that were wrong in ways a glance would have caught:

- A **brief item** offered three verbs the client drew none of, so a rep met their most important next move with a `Pin` button (#4230).
- A **failed automation** carried no address at all (#4239).

Neither was a logic error a unit test would find. Both were *"the row is there and it is useless"* — exactly what a story shows and an assertion does not. Both sources were among the seven with nothing to look at.

## The corpus is derived

From `KNOWN_SOURCES`, not listed in the test. A second copy of the vocabulary is the thing that goes stale, and a census reading a shorter world reports PASS with nothing to notice.

## The sweep needed narrowing, and that found more

My first version swept every `*.stories.tsx` in the directory. `source` is an ordinary field name — an AI call's story names a `heuristic`, a verdict's names a `human` — so it read two dozen words from vocabularies this census knows nothing about.

Scoping it to worklist stories also showed that `lead_response` and `dsr` were only ever "covered" by stories belonging to **other screens**. They now have their own.

`batch` is excluded with its reason stated: it stands for a pile of other rows, so its screen and verbs are its members' and there is nothing source-shaped to draw.

## Evidence

| Obligation | Evidence |
|---|---|
| Coverage | 20 of 20 sources drawn; `it.each` names each one, so a gap fails by name |
| Mutation strength | Changing the `brief_item` story's source fails `draws brief_item`; widening the sweep back to every stories file fails the reverse check |
| Census cannot fail short | A file filter matching nothing fails `reads a real vocabulary and a real set of stories` — 21 of 22 tests go red |
| Both directions | A storied source the queue no longer knows fails too |
| Fixtures are real | The composed typecheck rejected five invented `category`/`consequence` values I had guessed; all now use the generated vocabulary |
| Full lane | `make check-fe` green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Storybook stories for the seven worklist sources that had none, plus a census test that fails when a source has no story. Two of those sources previously shipped broken rows that a glance at a story would have caught — a brief item offering verbs the client didn't draw, and a failed automation with no address.

- The test derives its source list from `KNOWN_SOURCES` instead of a hardcoded copy, so it can't pass against a stale vocabulary.
- The scan only reads worklist stories, since `source` is a common field name in other story files.
- `lead_response` and `dsr` previously appeared only in other screens' stories and now have their own.
- `batch` is excluded with a stated reason: it stands for a pile of rows with nothing source-shaped to draw.
- The test also fails when a story names a source the queue no longer knows, and guards against an empty or short corpus.

<sup>Written for commit 9fbdbd22242b5bacfc65f9e1da81f08674e6de77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

