### PR TITLE
A lead can take on the work nobody is getting to

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7974,6 +7974,13 @@ export const de = {
   "worklist.manager.reassign": "Neu zuweisen",
   "worklist.manager.reassignTo": "Übergeben an",
   "worklist.manager.reassignConfirm": "Übergeben",
+  "worklist.manager.takeOwnership": "Übernehmen",
+  "worklist.manager.takeOwnershipAsk":
+    "Damit wandert der Datensatz aus ihrer Liste in deine.",
+  "worklist.manager.takeOwnershipConfirm": "Übernehmen",
+  "worklist.manager.tookOwnership": "Gehört jetzt dir.",
+  "worklist.manager.takeOwnershipFailed":
+    "Das konnte nicht übernommen werden. Es bleibt bei ihnen.",
   "worklist.manager.reassigned": "Übergeben.",
   "worklist.manager.reassignFailed": "Das konnte nicht übergeben werden.",
   "worklist.manager.coach": "Notiz hinterlassen",
@@ -8009,6 +8016,7 @@ export const de = {
   "worklist.exceptions.subject": "Wozu",
   "worklist.exceptions.owner": "Wer antwortet",
   "worklist.exceptions.basis": "Gemessen an",
+  "worklist.exceptions.intervene": "Eingriff",
   "worklist.exceptions.nobody": "Noch niemand",
   "worklist.exceptions.ownerWithheld": "Für Sie nicht sichtbar",
   "worklist.exceptions.truncated":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8067,6 +8067,13 @@ export const en = {
   "worklist.manager.reassign": "Reassign",
   "worklist.manager.reassignTo": "Hand it to",
   "worklist.manager.reassignConfirm": "Hand it over",
+  "worklist.manager.takeOwnership": "Take this on",
+  "worklist.manager.takeOwnershipAsk":
+    "This moves the record out of their queue and into yours.",
+  "worklist.manager.takeOwnershipConfirm": "Take it on",
+  "worklist.manager.tookOwnership": "It is yours now.",
+  "worklist.manager.takeOwnershipFailed":
+    "That could not be handed over. It is still theirs.",
   "worklist.manager.reassigned": "Handed over.",
   "worklist.manager.reassignFailed": "That could not be handed over.",
   "worklist.manager.coach": "Leave a note",
@@ -8103,6 +8110,7 @@ export const en = {
   "worklist.exceptions.subject": "About",
   "worklist.exceptions.owner": "Who answers",
   "worklist.exceptions.basis": "Judged against",
+  "worklist.exceptions.intervene": "Intervention",
   "worklist.exceptions.nobody": "Nobody yet",
   "worklist.exceptions.ownerWithheld": "Not shown to you",
   "worklist.exceptions.truncated":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7888,6 +7888,13 @@ export const vi = {
   "worklist.manager.reassign": "Giao lại",
   "worklist.manager.reassignTo": "Giao cho",
   "worklist.manager.reassignConfirm": "Giao lại",
+  "worklist.manager.takeOwnership": "Nhận việc này",
+  "worklist.manager.takeOwnershipAsk":
+    "Thao tác này chuyển bản ghi khỏi danh sách của họ sang của bạn.",
+  "worklist.manager.takeOwnershipConfirm": "Nhận",
+  "worklist.manager.tookOwnership": "Bây giờ là của bạn.",
+  "worklist.manager.takeOwnershipFailed":
+    "Không thể chuyển giao. Bản ghi vẫn thuộc về họ.",
   "worklist.manager.reassigned": "Đã giao lại.",
   "worklist.manager.reassignFailed": "Không thể giao lại việc này.",
   "worklist.manager.coach": "Để lại ghi chú",
@@ -7924,6 +7931,7 @@ export const vi = {
   "worklist.exceptions.subject": "Về",
   "worklist.exceptions.owner": "Ai chịu trách nhiệm",
   "worklist.exceptions.basis": "Căn cứ theo",
+  "worklist.exceptions.intervene": "Can thiệp",
   "worklist.exceptions.nobody": "Chưa có ai",
   "worklist.exceptions.ownerWithheld": "Không hiển thị với bạn",
   "worklist.exceptions.truncated":

--- a/frontend/src/screens/worklist.exceptions.tsx
+++ b/frontend/src/screens/worklist.exceptions.tsx
@@ -17,6 +17,8 @@
 import { DataTable, Disclosure } from "../design-system/atoms";
 import { SurfaceState } from "../design-system/surfacestate";
 import { useT } from "../i18n";
+import { useViewerId } from "./common";
+import { TakeOwnershipControl } from "./worklist.manager";
 import { type TeamException, useTeamExceptions } from "./worklist.queries";
 
 /**
@@ -30,11 +32,20 @@ export function TeamExceptionsPanel({
   enabled,
   onOwner,
 }: Readonly<{ enabled: boolean; onOwner: (id: string) => void }>) {
+  // The whole body is a child rather than this function's own, so that a
+  // reader below the tier MOUNTS NOTHING. Hooks cannot sit under an early
+  // return, so keeping the reads here would have made a rep's page ask who
+  // they are on behalf of a panel they are not shown — a request whose only
+  // purpose was to fill a control that never rendered.
+  return enabled ? <TeamExceptions onOwner={onOwner} /> : null;
+}
+
+function TeamExceptions({
+  onOwner,
+}: Readonly<{ onOwner: (id: string) => void }>) {
   const t = useT();
-  const exceptions = useTeamExceptions(enabled);
-  if (!enabled) {
-    return null;
-  }
+  const viewerId = useViewerId();
+  const exceptions = useTeamExceptions(true);
   const state = exceptions.isPending
     ? "loading"
     : exceptions.isError
@@ -111,6 +122,27 @@ export function TeamExceptionsPanel({
                   key: "threshold",
                   header: t("worklist.exceptions.basis"),
                   render: (row: TeamException) => row.threshold,
+                },
+                {
+                  key: "take",
+                  header: t("worklist.exceptions.intervene"),
+                  // The press must not ALSO open the owner's queue. Every row
+                  // navigates on click, so a button inside one fires both: the
+                  // handover runs and the page walks away from its own
+                  // confirmation, which reads as a control that did something
+                  // unrelated to what it said.
+                  //
+                  // The control stops it on its own buttons rather than under a
+                  // wrapper: a handler on a static element is invisible to a
+                  // keyboard and the a11y lint rejects it, and the buttons are
+                  // already the interactive things the event comes from.
+                  render: (row: TeamException) => (
+                    <TakeOwnershipControl
+                      subject={row.subject}
+                      viewerId={viewerId ?? ""}
+                      insideAClickableRow
+                    />
+                  ),
                 },
               ]}
             />

--- a/frontend/src/screens/worklist.manager.tsx
+++ b/frontend/src/screens/worklist.manager.tsx
@@ -20,8 +20,11 @@ import { useToast } from "../design-system/toast";
 import { useT } from "../i18n";
 import { useRoster } from "./entityref";
 import {
+  subjectAcceptsAnOwner,
+  type TeamException,
   useCoachTeammate,
   useReassignTask,
+  useTakeOwnership,
   type WorklistItem,
 } from "./worklist.queries";
 
@@ -217,6 +220,107 @@ export function CoachControl({ owner }: Readonly<{ owner: string }>) {
           {t("worklist.manager.cancel")}
         </Button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Take one exception's record for yourself.
+ *
+ * CONFIRMED, because it moves a record out of somebody's day and into the
+ * reader's — the rep who held it loses it from their queue without having
+ * pressed anything, so a lead doing it by a misplaced click costs two people
+ * their sense of what they are carrying.
+ *
+ * ABSENT rather than disabled where the subject has no owner write. A control
+ * that is drawn and then refuses teaches a reader to distrust every control
+ * beside it; one that is not drawn says the honest thing, and the row still
+ * reaches the record through its own link.
+ *
+ * It writes through the module that owns the record — the deal's own update
+ * for a deal, the activity's for a task — rather than through a worklist
+ * writer that would be a second author of a field five modules already audit.
+ */
+export function TakeOwnershipControl({
+  subject,
+  viewerId,
+  insideAClickableRow = false,
+}: Readonly<{
+  subject: TeamException["subject"];
+  viewerId: string;
+  /**
+   * Set where the control sits inside a row that navigates on click.
+   *
+   * The press otherwise fires BOTH: the handover runs and the page walks away
+   * from its own confirmation. Stopped on the buttons rather than under a
+   * wrapper element, because a handler on a static element is invisible to a
+   * keyboard and the a11y lint rejects it.
+   */
+  insideAClickableRow?: boolean;
+}>) {
+  const t = useT();
+  const toast = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const take = useTakeOwnership();
+  const contain = (event: { stopPropagation: () => void }) => {
+    if (insideAClickableRow) {
+      event.stopPropagation();
+    }
+  };
+
+  if (!subjectAcceptsAnOwner(subject)) {
+    return null;
+  }
+  if (!confirming) {
+    return (
+      <Button
+        variant="ghost"
+        onClick={(event) => {
+          contain(event);
+          setConfirming(true);
+        }}
+      >
+        {t("worklist.manager.takeOwnership")}
+      </Button>
+    );
+  }
+  return (
+    <div className="worklist-manager-control">
+      <span className="t-label">{t("worklist.manager.takeOwnershipAsk")}</span>
+      <Button
+        variant="primary"
+        disabled={take.isPending}
+        onClick={(event) => {
+          contain(event);
+          take.mutate(
+            { subject, userId: viewerId },
+            {
+              onSuccess: () => {
+                setConfirming(false);
+                toast.show(t("worklist.manager.tookOwnership"));
+              },
+              // The refusal stays on screen and the control stays open: a
+              // handover that failed leaves the record where it was, and a
+              // reader who is not told that believes they now hold it.
+              onError: () =>
+                toast.show(t("worklist.manager.takeOwnershipFailed"), {
+                  mark: false,
+                }),
+            },
+          );
+        }}
+      >
+        {t("worklist.manager.takeOwnershipConfirm")}
+      </Button>
+      <Button
+        variant="ghost"
+        onClick={(event) => {
+          contain(event);
+          setConfirming(false);
+        }}
+      >
+        {t("worklist.manager.cancel")}
+      </Button>
     </div>
   );
 }

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -234,6 +234,84 @@ export function useReassignTask() {
   });
 }
 
+// Give one record a new owner, through the module that owns it.
+//
+// The exception's SUBJECT decides the endpoint, and this table is the whole
+// dispatch. A generic worklist writer that set an owner across deals, leads and
+// activities would be a second writer of a field five modules already own, and
+// each of them audits and events its own writes — the plan's rule for takeover
+// is that it reuses the source owner's operation rather than reaching past it.
+//
+// Exhaustive over AttentionSubject's own union, so a seventh subject type is a
+// compile error here rather than a button that quietly does nothing. The field
+// differs on activities because a task is ASSIGNED rather than owned, and the
+// two words are the modules' own — collapsing them would write a field that
+// does not exist and fail at runtime on exactly one subject type.
+const OWNER_WRITE = {
+  deal: { path: "/deals/{id}", field: "owner_id" },
+  lead: { path: "/leads/{id}", field: "owner_id" },
+  person: { path: "/people/{id}", field: "owner_id" },
+  organization: { path: "/organizations/{id}", field: "owner_id" },
+  project: { path: "/projects/{id}", field: "owner_id" },
+  activity: { path: "/activities/{id}", field: "assignee_id" },
+} as const satisfies Record<
+  NonNullable<TeamException["subject"]["type"]>,
+  { path: string; field: "owner_id" | "assignee_id" }
+>;
+
+/**
+ * Whether this subject can be handed to somebody at all.
+ *
+ * Every type in the union has an owner write today, so this is true for all of
+ * them — but it is asked rather than assumed, because the honest answer when a
+ * source has no owner write is a control that is absent with a reason, not one
+ * that fails when pressed.
+ */
+export function subjectAcceptsAnOwner(
+  subject: TeamException["subject"],
+): boolean {
+  return subject.type !== undefined && subject.type in OWNER_WRITE;
+}
+
+// Take one exception's record for yourself.
+//
+// Every queue is invalidated, not just the reader's: the record left somebody
+// else's day and arrived in this one, and refetching only the view in front of
+// the caller would leave the other queue claiming work it no longer holds.
+export function useTakeOwnership() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      subject: TeamException["subject"];
+      userId: string;
+    }) => {
+      const write = input.subject.type && OWNER_WRITE[input.subject.type];
+      if (!write) {
+        // Not reachable through the control, which is drawn only where
+        // subjectAcceptsAnOwner agrees. Thrown rather than returned so a future
+        // caller that skips that check fails loudly instead of reporting a
+        // handover that never happened.
+        throw new Error(`no owner write for subject ${input.subject.type}`);
+      }
+      const { error } = await api.PATCH(write.path as "/deals/{id}", {
+        params: { path: { id: input.subject.id } },
+        body: { [write.field]: input.userId },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      // worklistKey alone, which the exceptions read is keyed UNDER
+      // ([...worklistKey, "exceptions"]) — so this one invalidation reaches
+      // the panel the press was made from as well as every queue. A second
+      // call naming the exceptions key separately would be the same refetch
+      // asked for twice, and a hand-typed key is how the two drift apart.
+      queryClient.invalidateQueries({ queryKey: worklistKey });
+    },
+  });
+}
+
 // Leave a note on a teammate's queue.
 //
 // Nothing is invalidated here: the notice lands in the RECIPIENT's day, which

--- a/frontend/src/screens/worklist.takeover.test.tsx
+++ b/frontend/src/screens/worklist.takeover.test.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { TeamExceptionsPanel } from "./worklist.exceptions";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// A lead taking one exception's record for themselves.
+//
+// The panel answers "what is going wrong" and, until now, could only route to
+// whoever answers for it. Taking the work is the intervention a lead reaches
+// for when the answer is "nobody is going to get to this", and it writes
+// through the module that owns the record rather than through a worklist
+// writer that would be a second author of a field five modules already audit.
+
+describe("taking an exception on", () => {
+  // The DISPATCH, which is the whole substance of the change. A deal is
+  // handed over through the deal's own update and a task through the
+  // activity's, and the two spell the field differently — a task is ASSIGNED
+  // rather than owned. One table that guessed a single spelling would write a
+  // field that does not exist on exactly one subject type.
+  it.each([
+    ["deal", "/deals/d1", "owner_id"],
+    ["lead", "/leads/l1", "owner_id"],
+    ["activity", "/activities/a1", "assignee_id"],
+  ])("writes a %s through its own module", async (type, path, field) => {
+    const fetched = stubTeam({
+      type,
+      id: path.split("/")[2],
+      label: "Something going wrong",
+    });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.takeOwnership"],
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.takeOwnershipConfirm"],
+      }),
+    );
+
+    await waitFor(async () => {
+      expect(await patchTo(fetched, path)).toEqual({ [field]: VIEWER });
+    });
+  });
+
+  // CONFIRMED, because it moves a record out of somebody's day without them
+  // pressing anything. A single press that handed the work over would cost two
+  // people their sense of what they are carrying on one misplaced click.
+  it("asks before it moves anything", async () => {
+    const fetched = stubTeam({ type: "deal", id: "d1", label: "Fleet" });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.takeOwnership"],
+      }),
+    );
+
+    expect(
+      screen.getByText(en["worklist.manager.takeOwnershipAsk"]),
+    ).toBeTruthy();
+    expect(patchCalls(fetched)).toHaveLength(0);
+  });
+
+  // A REFUSED handover leaves the record where it was, and the reader has to
+  // be told: a silent failure leaves a lead believing they now hold work that
+  // is still somebody else's, and they stop watching it.
+  it("says so when the handover is refused", async () => {
+    stubTeam({ type: "deal", id: "d1", label: "Fleet" }, { refuse: true });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.takeOwnership"],
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.takeOwnershipConfirm"],
+      }),
+    );
+
+    expect(
+      await screen.findByText(en["worklist.manager.takeOwnershipFailed"]),
+    ).toBeTruthy();
+  });
+
+  // Every row navigates on click, so a button inside one fires BOTH: the
+  // handover runs and the page walks away from its own confirmation, which
+  // reads as a control that did something unrelated to what it said.
+  it("does not also open the owner's queue", async () => {
+    stubTeam({ type: "deal", id: "d1", label: "Fleet" });
+    const opened = vi.fn();
+    const user = userEvent.setup();
+    renderPanel(opened);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.takeOwnership"],
+      }),
+    );
+
+    expect(opened).not.toHaveBeenCalled();
+  });
+});
+
+const VIEWER = "00000000-0000-7000-8000-0000000000aa";
+
+// stubTeam answers the panel's read, the viewer probe and the handover write.
+//
+// Three different addresses, because the panel needs all three and a stub that
+// answered them alike would let the assertion below match the exceptions read
+// rather than the write it is about.
+function stubTeam(
+  subject: { type: string; id: string; label: string },
+  options: { refuse?: boolean } = {},
+) {
+  const fetched = vi.fn(async (input: RequestInfo | URL) => {
+    // The METHOD comes off the Request, not off an init bag: openapi-fetch
+    // builds a Request and passes it as the first argument, so a stub reading
+    // `init.method` sees "GET" for every write and answers the read's body to
+    // a PATCH. That is the shape this test exists to assert, so getting it
+    // wrong made all four write assertions fail identically and silently.
+    const request = input instanceof Request ? input : undefined;
+    const url = String(request ? request.url : input);
+    if (request?.method === "PATCH") {
+      return options.refuse
+        ? json({ title: "Forbidden", status: 403 }, 403)
+        : json({});
+    }
+    if (url.includes("/me")) {
+      return json({ user: { id: VIEWER, name: "A lead" } });
+    }
+    if (url.includes("/worklist/exceptions")) {
+      return json({
+        as_of: "2026-09-05T09:00:00Z",
+        truncated: false,
+        exceptions: [
+          {
+            kind: "revenue_at_risk",
+            owner: { kind: "user", id: "u1", label: "Lena Fischer" },
+            subject,
+            since: "2026-08-01T09:00:00Z",
+            consequence: "deal_drifts",
+            threshold: "at or above the pipeline's median open deal",
+          },
+        ],
+      });
+    }
+    return json({ data: [] });
+  });
+  vi.stubGlobal("fetch", fetched);
+  return fetched;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// patchCalls are the write attempts, which is what every assertion here is
+// about — the reads are setup and would otherwise drown them.
+function patchCalls(fetched: ReturnType<typeof vi.fn>) {
+  return fetched.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (first): first is Request =>
+        first instanceof Request && first.method === "PATCH",
+    );
+}
+
+// The body is read back off the Request, which consumes it — so each call is
+// cloned first. Reading the original would leave the next assertion in the
+// same test facing an already-drained stream.
+async function patchTo(fetched: ReturnType<typeof vi.fn>, path: string) {
+  const request = patchCalls(fetched).find((one) => one.url.includes(path));
+  return request ? await request.clone().json() : undefined;
+}
+
+function renderPanel(onOwner: (id: string) => void = () => {}) {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          <TeamExceptionsPanel enabled onOwner={onOwner} />
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}


### PR DESCRIPTION
The exceptions panel answers "what is going wrong" and could only route to whoever answers for it. When the answer is that nobody is going to get to this, a lead's move is to take it — and there was no way to.

Coach and reassign turned out to be already shipped and wired in `worklist.manager.tsx`. The real gaps were that the exceptions panel offered **no verb at all** (a row only drilled into the owner) and that take-ownership existed nowhere.

## Through the module that owns the record

`OWNER_WRITE` maps the subject type to its own update — the deal's for a deal, the activity's for a task. A generic worklist writer setting an owner across five modules would be a second author of a field each of them already audits and events, which is what the takeover rule exists to prevent.

The table is exhaustive over `AttentionSubject`'s union, so a seventh subject type is a compile error rather than a button that quietly does nothing.

| Subject | Endpoint | Field |
|---|---|---|
| deal, lead, person, organization, project | that module's `PATCH` | `owner_id` |
| activity | `PATCH /activities/{id}` | `assignee_id` |

The field differs on activities because a task is **assigned** rather than owned. Those are the modules' own words, and one spelling for all six would have written a field that does not exist on exactly one subject type.

## Confirmed, and contained

It moves a record out of somebody's day without them pressing anything, so a misplaced click otherwise costs two people their sense of what they are carrying. The press is contained where the control sits in a row that navigates on click — stopped on the buttons rather than under a wrapper element, because a handler on a static element is invisible to a keyboard and the a11y lint rejects it.

Absent rather than disabled where a subject has no owner write. A control that is drawn and then refuses teaches a reader to distrust every control beside it.

## One regression this found

Reading the viewer in `TeamExceptionsPanel` made a rep's page ask who they are on behalf of a panel they are never shown. Hooks cannot sit under an early return, so the body moved into a child component that only mounts when the reader holds the tier. An existing test already held this — the disabled panel makes no request at all — and it caught the change.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `worklist.takeover.test.tsx` "writes a %s through its own module" — parameterised over deal, lead and activity |
| Dispatch correctness | the same test asserts the exact path and body field per subject type |
| Failure behavior | "says so when the handover is refused" — a 403 reaches the toast and the record stays theirs |
| Confirmation | "asks before it moves anything" — the first press writes nothing |
| Click isolation | "does not also open the owner's queue" |
| Permission tier | the pre-existing "asks nothing when the reader cannot hold the tier" now also covers the viewer read |
| Mutation strength | Four clauses reverted individually: `assignee_id`→`owner_id` fails the activity case alone; removing the confirmation fails five; dropping `stopPropagation` fails the navigation test; hoisting the viewer read above the tier guard fails the no-request test. A fifth mutation (building the JSX before the guard) was a **no-op** — construction is not mounting — and is recorded rather than counted. |
| Full lane | `make check-fe` green, re-run after rebasing onto the story census (#4249) |

Frontend only. No backend, no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Take this on" action to the exceptions panel so a lead can take ownership of a record nobody is getting to, instead of only routing it to whoever answers for it.

**Key details**
- The takeover writes through the module that owns the record; activities use `assignee_id` where other subjects use `owner_id`.
- A press asks for confirmation first, and a refused handover keeps the record where it was.
- The control stops click propagation so taking ownership doesn't also open the owner's queue.
- The panel's viewer read moved into a child component so readers without the tier no longer trigger that request.

<sup>Written for commit 8c84fa5e037d8b89808a13fd685344c3ded1e59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

