### PR TITLE
Authoring the tag vocabulary needs an unbounded seat

### DIFF
--- a/backend/internal/compose/integration/tagvocabscope_integration_test.go
+++ b/backend/internal/compose/integration/tagvocabscope_integration_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Who may author the tag VOCABULARY.
+//
+// Renaming, retiring, restoring or folding a word changes what every record
+// carrying it is filed under — including records the caller cannot see or
+// write through any other route. So `tag.update` alone was never the whole
+// question, and a caller bounded to their own or their team's rows holding it
+// could rewrite the workspace's vocabulary.
+//
+// Not reachable through the seed: every role holding the grant today is
+// row_scope=all. It becomes reachable the moment an admin grants `tag` to a
+// bounded role, which the contract documents as intentional.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/collections"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// boundedTagAuthor holds the vocabulary grants in FULL and sees only its own
+// rows — the caller an admin creates by granting `tag` to a team-scoped role,
+// and the one this gate exists for. A refusal can only come from the scope.
+func boundedTagAuthor() principal.Permissions {
+	return principal.Permissions{
+		Objects: map[string]principal.ObjectGrant{
+			"tag":          {Create: true, Read: true, Update: true, Delete: true},
+			"person":       {Create: true, Read: true, Update: true, Delete: true},
+			"organization": {Create: true, Read: true, Update: true, Delete: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	}
+}
+
+func TestABoundedSeatCannotAuthorTheVocabulary(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	word, err := store.CreateTag(e.Admin(), "BoundedScopeWord", nil, nil)
+	if err != nil {
+		t.Fatalf("coining the word: %v", err)
+	}
+	bounded := e.As(e.AdminUser, nil, boundedTagAuthor())
+	other, err := store.CreateTag(e.Admin(), "BoundedScopeOther", nil, nil)
+	if err != nil {
+		t.Fatalf("coining the second word: %v", err)
+	}
+
+	name := "Renamed"
+	for _, c := range []struct {
+		verb string
+		run  func() error
+	}{
+		{"rename", func() error {
+			_, err := store.UpdateTag(bounded, word.ID, collections.TagUpdate{Name: &name}, 0)
+			return err
+		}},
+		{"retire", func() error { _, err := store.ArchiveTag(bounded, word.ID); return err }},
+		{"restore", func() error { _, err := store.RestoreTag(bounded, word.ID); return err }},
+		{"fold", func() error {
+			_, err := store.MergeTags(bounded, other.ID, word.ID, 0)
+			return err
+		}},
+	} {
+		t.Run(c.verb, func(t *testing.T) {
+			if err := c.run(); !errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("a bounded seat holding tag.update could %s a word → %v, "+
+					"want permission denied — a vocabulary write reaches every "+
+					"record carrying the word, including ones this seat cannot see",
+					c.verb, err)
+			}
+		})
+	}
+}
+
+// The grant half of the same gate. It predates this change and nothing held
+// it: every case above and below holds the SCOPE, so a gate that dropped the
+// object check would have passed all of them.
+func TestASeatWithoutTheGrantCannotAuthorTheVocabulary(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	word, err := store.CreateTag(e.Admin(), "NoGrantWord", nil, nil)
+	if err != nil {
+		t.Fatalf("coining the word: %v", err)
+	}
+	// Unbounded, and holding tag READ only — so a refusal can only come from
+	// the grant, which is the mirror of the cases above.
+	reader := e.As(e.AdminUser, nil, principal.Permissions{
+		Objects:  map[string]principal.ObjectGrant{"tag": {Read: true}},
+		RowScope: principal.RowScopeAll,
+	})
+
+	name := "NoGrantRenamed"
+	if _, err := store.UpdateTag(reader, word.ID,
+		collections.TagUpdate{Name: &name}, 0); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a seat holding only tag.read renamed a word → %v, want permission denied", err)
+	}
+	if _, err := store.ArchiveTag(reader, word.ID); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a seat holding only tag.read retired a word → %v, want permission denied", err)
+	}
+}
+
+// The other half: the gate refuses a SCOPE, not the grant. An unbounded seat
+// holding it authors as it always did — without this, a check that refused
+// everybody would pass the case above perfectly.
+func TestAnUnboundedSeatStillAuthorsTheVocabulary(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	word, err := store.CreateTag(e.Admin(), "UnboundedScopeWord", nil, nil)
+	if err != nil {
+		t.Fatalf("coining the word: %v", err)
+	}
+	name := "UnboundedScopeRenamed"
+	if _, err := store.UpdateTag(e.Admin(), word.ID,
+		collections.TagUpdate{Name: &name}, 0); err != nil {
+		t.Fatalf("an unbounded seat renaming a word: %v", err)
+	}
+	if _, err := store.ArchiveTag(e.Admin(), word.ID); err != nil {
+		t.Fatalf("an unbounded seat retiring a word: %v", err)
+	}
+}
+
+// And the narrowing stops at the vocabulary. Tagging a RECORD is a different
+// question with its own answer — write authority over the record being tagged
+// (#3755) — and a bounded seat's own records are within their honest reach.
+func TestABoundedSeatStillTagsItsOwnRecords(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	word, err := store.CreateTag(e.Admin(), "BoundedScopeApplies", nil, nil)
+	if err != nil {
+		t.Fatalf("coining the word: %v", err)
+	}
+	bounded := e.As(e.AdminUser, nil, boundedTagAuthor())
+	// Created BY the bounded seat, so the row is theirs by construction rather
+	// than by a seeded owner column somebody has to keep in step.
+	mine, err := e.People.CreatePerson(bounded, people.CreatePersonInput{
+		FullName: "Own Record", Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("the bounded seat creating its own record: %v", err)
+	}
+
+	if _, err := store.ApplyTag(bounded, word.ID, "person",
+		ids.UUID(mine.Id)); err != nil {
+		t.Fatalf("a bounded seat tagging its OWN record: %v — the vocabulary "+
+			"gate must not reach a per-record write", err)
+	}
+}

--- a/backend/internal/modules/collections/tagmerge.go
+++ b/backend/internal/modules/collections/tagmerge.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -57,7 +56,7 @@ type MergeResult struct {
 // still set (identity.Service.SetRoleObjectGrant), which this gate does not
 // itself refuse.
 func (s *Store) MergeTags(ctx context.Context, source, target ids.TagID, expectedTargetVersion int64) (MergeResult, error) {
-	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
+	if err := requireVocabularyAuthority(ctx, principal.ActionUpdate); err != nil {
 		return MergeResult{}, err
 	}
 	// An absent into_tag_id decodes to the zero UUID with no error, so without

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -111,7 +111,7 @@ func (s *Store) CreateTag(ctx context.Context, name string, color, description *
 }
 
 func (s *Store) ArchiveTag(ctx context.Context, id ids.TagID) (tagRow, error) {
-	if err := auth.Require(ctx, "tag", principal.ActionDelete); err != nil {
+	if err := requireVocabularyAuthority(ctx, principal.ActionDelete); err != nil {
 		return tagRow{}, err
 	}
 	var out tagRow

--- a/backend/internal/modules/collections/tagvocab.go
+++ b/backend/internal/modules/collections/tagvocab.go
@@ -252,7 +252,7 @@ type TagUpdate struct {
 // admits. A mismatch is version skew, not a missing row — the difference
 // matters to a client deciding whether to re-read or give up.
 func (s *Store) UpdateTag(ctx context.Context, id ids.TagID, in TagUpdate, expectedVersion int64) (tagRow, error) {
-	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
+	if err := requireVocabularyAuthority(ctx, principal.ActionUpdate); err != nil {
 		return tagRow{}, err
 	}
 	var name *string
@@ -325,7 +325,7 @@ func derefOrNil(v **string) *string {
 // "conflict" alone does not tell them they have to rename one of two words
 // they can both see.
 func (s *Store) RestoreTag(ctx context.Context, id ids.TagID) (tagRow, error) {
-	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
+	if err := requireVocabularyAuthority(ctx, principal.ActionUpdate); err != nil {
 		return tagRow{}, err
 	}
 	var out tagRow

--- a/backend/internal/modules/collections/tagvocabgate.go
+++ b/backend/internal/modules/collections/tagvocabgate.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+// The gate every write to the tag VOCABULARY passes.
+//
+// A vocabulary write is workspace-wide by construction: renaming, retiring,
+// restoring or folding a word changes what every record carrying it is filed
+// under, including records the caller cannot see or write through any other
+// route. So the object grant is not the whole question — the caller also has
+// to be unbounded.
+//
+// It is not reachable through the seed: every role holding `tag.update` today
+// (admin, ops) is row_scope=all. But object grants are editable per role, and
+// the contract documents that as intentional — so an admin granting
+// `tag: {update: true}` to a team-scoped role would mint exactly the caller
+// this refuses. The cheap moment to make an invariant true is before somebody
+// relies on it being false.
+//
+// ONE gate rather than a check at each of the four writes: four call sites is
+// how the fifth vocabulary write ships without it. Per-RECORD tag writes are a
+// different question and keep their own answer — ApplyTag and RemoveTag gate
+// on write authority over the record being tagged (#3755), which is a bounded
+// caller's honest reach and is deliberately not narrowed here.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func requireVocabularyAuthority(ctx context.Context, action principal.Action) error {
+	if err := auth.Require(ctx, "tag", action); err != nil {
+		return err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return apperrors.ErrPermissionDenied
+	}
+	if !auth.Unbounded(actor) {
+		return apperrors.ErrPermissionDenied
+	}
+	return nil
+}

--- a/backend/internal/modules/identity/grantreachability_test.go
+++ b/backend/internal/modules/identity/grantreachability_test.go
@@ -85,7 +85,15 @@ const dynamicObjectCeiling = 106
 // warns about. A new dynamic-action call site adds no resolved pair, so no pair
 // assertion fires; it removes none either, so `requireSitesFloor` does not
 // fall. The blind spot grew and everything reported PASS.
-const dynamicActionCeiling = 6
+//
+// 7 since the tag vocabulary gained one gate for its four authoring writes.
+// requireVocabularyAuthority takes the verb as a parameter because rename,
+// retire, restore and fold pass through it — one gate rather than four checks
+// is what stops the fifth vocabulary write shipping without one, and it costs
+// this scan the verb. The four verbs are pinned instead by
+// compose/integration/tagvocabscope_integration_test.go, which drives each of
+// the four writes through the gate.
+const dynamicActionCeiling = 7
 
 // requireSitesFloor is the fail-short guard. The scan walking a smaller tree
 // than it thinks — a moved directory, a parser error swallowed — would report


### PR DESCRIPTION
Closes #3772, on the 2026-09-03 ruling: **an unbounded-only check at the shared vocabulary-authoring gate.**

## The gap

`tag.update` was the whole gate on `MergeTags`, `ArchiveTag`, `UpdateTag` and `RestoreTag`. A vocabulary write is workspace-wide by construction — renaming, retiring, restoring or folding a word changes what **every** record carrying it is filed under, including records the caller cannot see or write through any other route.

So a caller bounded to their own or their team's rows, holding `tag.update`, could rewrite the workspace's vocabulary. #3755 established "a caller may only write a record within their scope" for per-record tag writes; the four authoring writes did not hold it, and nothing said so.

Not reachable through the seed — every role holding the grant today is `row_scope=all` — and reachable the moment an admin grants `tag` to a bounded role, which the contract documents as intentional.

## One gate, not four checks

`requireVocabularyAuthority` is the single door all four now pass through, which is what the ruling asked for and why:

> **not four times.** Four call sites is how the fifth vocabulary write ships without it.

The reason lives beside it in `tagvocabgate.go`, including what it deliberately does **not** reach: per-record tag writes keep their own answer — write authority over the record being tagged — because a bounded seat's own records are its honest reach.

## Testing

The three cases the ruling named, plus one the mutation check demanded:

- a bounded seat holding the grant in full is refused **each** of rename, retire, restore and fold;
- an unbounded seat still authors — without this, a gate that refused everybody would pass the first case perfectly;
- that same bounded seat still tags **its own** record, which is what proves the narrowing stopped at the vocabulary;
- a seat holding only `tag.read` is refused. That half predates this change and **nothing held it**: every other case here holds the scope, so a gate that dropped the object check would have passed all of them. Found by mutation-checking my own gate.

Mutation-checked both halves: neutering the scope check fails all four verbs of the first case, and neutering the grant check fails the fourth.

`make check-backend` green; `craft static --strict` clean.

The grant-reachability scan asked for something on the way, and it is in the diff: a shared gate takes its verb as a parameter, so the scan cannot resolve it. The action ceiling moves by one **with the reason**, and the four verbs are pinned instead by the integration test above, which drives every one of them through the gate.

## The fourth item on the ruling, not done here

> Worth checking in the same pass whether any **other** object grant confers a workspace-wide authoring write with no scope check beside it.

I have not done that sweep. It is a real question and a different one — a survey of every object grant rather than a fix to this one — and folding it in would have made one change out of two. Worth its own issue if somebody wants it before the next finding of this shape.
