### PR TITLE
A seat reaches the settings its grants already open

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6498,6 +6498,8 @@ export const de = {
   "aicalls.title": "KI-Aufrufprotokoll",
   "aicalls.withheld":
     "Nur ein Betreiber liest die Aufrufspur. Sie verzeichnet jeden Modellaufruf dieser Installation und wird deshalb nicht breiter gezeigt.",
+  "aiHealth.withheld":
+    "Nur ein Betreiber sieht, ob die Modellstufen antworten. Das ist die Verkabelung der Installation, keine Aussage über Ihre Arbeit.",
   "aicalls.sub":
     "Jeder Modellaufruf — Routing, Tokens, Wiederholungen und erfasste Nutzdaten.",
   "aicalls.col.detail": "Detail",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6564,6 +6564,8 @@ export const en = {
   "aicalls.title": "AI call trace",
   "aicalls.withheld":
     "Only an operator can read the per-call trace. It records every model call the installation made, so it is not shown more widely.",
+  "aiHealth.withheld":
+    "Only an operator can read whether the model lanes are answering. It is the installation's own wiring, not a fact about your work.",
   "aicalls.sub":
     "Every model call — routing identity, tokens, retries, captured payload.",
   "aicalls.col.detail": "Detail",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6432,6 +6432,8 @@ export const vi = {
   "aicalls.title": "Dấu vết lượt gọi AI",
   "aicalls.withheld":
     "Chỉ người vận hành mới đọc được dấu vết từng lượt gọi. Nó ghi lại mọi lượt gọi mô hình của bản cài đặt, nên không hiển thị rộng hơn.",
+  "aiHealth.withheld":
+    "Chỉ người vận hành mới xem được các tầng mô hình có đang trả lời hay không. Đó là hệ thống của bản cài đặt, không phải điều gì về công việc của bạn.",
   "aicalls.sub":
     "Mọi lượt gọi mô hình — danh tính định tuyến, token, số lần thử lại, nội dung đã ghi.",
   "aicalls.col.detail": "Chi tiết",

--- a/frontend/src/screens/ai-health.test.tsx
+++ b/frontend/src/screens/ai-health.test.tsx
@@ -9,7 +9,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
-import { meFixture } from "../app/mefixture";
+import { type GrantSpec, meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
 import { AiHealthCard } from "./ai-health";
 
@@ -38,7 +38,16 @@ const DEAD: RungHealth = {
   last_call_at: "2026-09-01T09:10:00Z",
 };
 
-function renderCard(rungs: RungHealth[], windowHours = 1) {
+// The grant `GET /ai/health` is gated on server-side. Named rather than
+// implied: a fixture that grants nothing renders the withheld state, and every
+// claim below about what the table says would then pass against an empty panel.
+const OPERATOR: GrantSpec = { automation: ["read", "update"] };
+
+function renderCard(
+  rungs: RungHealth[],
+  windowHours = 1,
+  allow: GrantSpec = OPERATOR,
+) {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -51,7 +60,7 @@ function renderCard(rungs: RungHealth[], windowHours = 1) {
       const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
       const body =
         key === "GET /me"
-          ? meFixture({})
+          ? meFixture({ allow })
           : { window_hours: windowHours, rungs };
       return new Response(JSON.stringify(body), {
         status: 200,
@@ -103,5 +112,35 @@ describe("model lane health", () => {
     expect(
       await screen.findByText(/no model was called in the last 1 hour/i),
     ).toBeInTheDocument();
+  });
+
+  it("withholds the lanes from a reader whose role cannot read them", async () => {
+    // The AI page opens on `automation:read`, which every seeded role holds,
+    // while this card's endpoint demands `automation:update`, which manager,
+    // rep and read_only do not. Without the card's own gate the refusal
+    // arrives as a red failure telling that reader the installation is
+    // broken, and the poll re-issues the doomed call every minute.
+    renderCard([ANSWERING], 1, { automation: ["read"] });
+    expect(
+      await screen.findByText(/only an operator can read whether/i),
+    ).toBeInTheDocument();
+    // The lane that WOULD have rendered is absent, so this is the withheld
+    // state and not merely a card that failed to draw its table.
+    expect(screen.queryByText("local_small")).not.toBeInTheDocument();
+  });
+
+  it("asks the server for nothing it may not read", async () => {
+    // The half a rendered EmptyState cannot show: `enabled` is what keeps a
+    // withheld reader from a 403 they cannot act on, and a refetchInterval
+    // left standing would resume the call the moment a grant changed.
+    renderCard([ANSWERING], 1, { automation: ["read"] });
+    await screen.findByText(/only an operator can read whether/i);
+    const calls = (
+      globalThis.fetch as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls;
+    const asked = calls.map((call) =>
+      String(call[0] instanceof Request ? call[0].url : call[0]),
+    );
+    expect(asked.some((url) => url.includes("/ai/health"))).toBe(false);
   });
 });

--- a/frontend/src/screens/ai-health.tsx
+++ b/frontend/src/screens/ai-health.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCan } from "../app/capability";
 import { Badge, DataTable, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
-import { QueryGate, throwProblem } from "./common";
+import { QueryGate, throwProblem, useMe } from "./common";
 
 // Whether the model lanes are answering.
 //
@@ -22,8 +23,19 @@ type RungHealth = components["schemas"]["AiRungHealth"];
 export function AiHealthCard() {
   const t = useT();
   const { locale } = useLocale();
+  // `GET /ai/health` is gated on `automation:update` server-side, which the
+  // seeded manager, rep and read_only roles do not hold — and this page opens
+  // on `automation:read`, which they do. Asking here is what keeps a reader who
+  // may not have this from being told their installation is broken when their
+  // ROLE is what stopped them: without it the refusal arrives as a red failure
+  // with a Retry that cannot succeed, and `refetchInterval` re-issues the
+  // doomed call every minute for as long as the tab is open. The keys and calls
+  // cards beside it answer the same question the same way.
+  const canSee = useCan("automation", "update");
+  const me = useMe();
   const query = useQuery({
     queryKey: ["ai-health"],
+    enabled: canSee,
     queryFn: async () => {
       const { data, error } = await api.GET("/ai/health");
       if (error) throwProblem(error);
@@ -33,8 +45,30 @@ export function AiHealthCard() {
     // page open watches it rather than reading a snapshot from when they
     // arrived. One minute against a one-hour window: often enough to notice a
     // lane die, rare enough to cost nothing.
-    refetchInterval: 60_000,
+    //
+    // Off with the grant, not merely disabled with it: `enabled` stops the poll
+    // today, and an interval left standing is what would resume it the moment
+    // the flag flipped mid-session.
+    refetchInterval: canSee ? 60_000 : false,
   });
+
+  if (!canSee) {
+    // Withheld rather than absent, and the card keeps its place: a missing
+    // health panel on a page that opens for a reader would read as "the lanes
+    // are fine", which is a different claim from "this is not yours to read".
+    // Behind the /me probe, because every grant reads false while it is in
+    // flight and an admin must not see this line flash on every load.
+    return (
+      <Panel title={t("aiHealth.title")}>
+        <PanelBody>
+          <p className="settings-panel-sub">{t("aiHealth.sub")}</p>
+          <QueryGate query={me} pendingLabel={t("aiHealth.title")}>
+            {() => <EmptyState>{t("aiHealth.withheld")}</EmptyState>}
+          </QueryGate>
+        </PanelBody>
+      </Panel>
+    );
+  }
 
   return (
     <Panel title={t("aiHealth.title")}>

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -407,28 +407,21 @@ describe("SettingsScreen Admin settings group", () => {
     await waitFor(() => expect(navTabs()).toEqual(OPERATOR_TABS));
   });
 
-  // The seat, on its own, from the other side. This principal holds every read
-  // the admin group's entries ask for — the ops matrix entire — and reaches NONE
-  // of them, because the group is not theirs to open. The heading is what makes
-  // it a claim about the group rather than about nine predicates: an empty
-  // "Admin settings" panel would say the installation has settings this reader
-  // may not touch, where the truth is that configuring it is not their job.
+  // The grant, not the role name. This principal holds every read the admin
+  // group's entries ask for and is neither admin nor ops — and it reaches every
+  // entry those reads open, because what the server answers 200 is what the
+  // product offers. The seat check that used to stand here returned false for
+  // the whole group whatever these predicates decided, so a manager holding the
+  // ops matrix was shown an empty rail while the API served them.
   it.each(["manager", "rep"] as const)(
-    "offers a seeded %s no admin group at all, holding every read it asks for",
+    "offers a seeded %s every entry the reads it holds open",
     async (role) => {
       vi.stubGlobal(
         "fetch",
         adminNavBackend({ roles: [role], allow: SEEDED_OPS_READS }),
       );
-      const { client } = renderNav();
-      // The ANSWER has to be in the cache before an absence claim means
-      // anything. Every other case here waits on an entry appearing, which is
-      // its own proof that /me settled; this one expects no entry to appear, and
-      // a nav read taken mid-flight looks exactly like the result it wants.
-      await waitFor(() =>
-        expect(client.getQueryState(["me"])?.status).toBe("success"),
-      );
-      expect(navTabs()).toEqual(PERSONAL_TABS);
+      renderNav();
+      await waitFor(() => expect(navTabs()).toEqual(OPERATOR_TABS));
       const nav = screen.getByRole("navigation", {
         name: /primary navigation/i,
       });
@@ -436,9 +429,24 @@ describe("SettingsScreen Admin settings group", () => {
         within(nav)
           .getAllByRole("heading", { level: 3 })
           .map((heading) => heading.textContent),
-      ).toEqual(["You"]);
+      ).toEqual(["You", "Admin settings"]);
     },
   );
+
+  // The floor, and the reason removing the seat gate is not "everyone gets
+  // everything". A principal holding NO admin-group grant reaches exactly the
+  // one entry that asks for none: the member roster, which `GET /users` serves
+  // to anyone signed in and which the same handler narrows by role — a rep's
+  // page carries no role keys and no inactive members. Every other entry is
+  // absent because its predicate says so, which is the same sentence for this
+  // seat as for an admin.
+  it("offers a principal holding no admin grant only the entry that asks for none", async () => {
+    vi.stubGlobal("fetch", adminNavBackend({ roles: ["rep"], allow: {} }));
+    renderNav();
+    await waitFor(() =>
+      expect(navTabs()).toEqual([...PERSONAL_TABS, "Users & teams"]),
+    );
+  });
 
   // A write is still not what opens a page, inside the group as it was outside
   // it: this operator may AUTHOR custom fields and holds no read anywhere, and

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -35,12 +35,7 @@ import {
 import { api, FIRST_PAGE } from "../api/client";
 import type { components, operations } from "../api/schema";
 import { dotTier } from "../app/autonomy";
-import {
-  useCan,
-  useCanWrite,
-  useHoldsAdminRole,
-  useHoldsOperatorSeat,
-} from "../app/capability";
+import { useCan, useCanWrite, useHoldsAdminRole } from "../app/capability";
 import { isEntityKind } from "../app/entity";
 import { unitsForSecretScope } from "../app/extensions";
 import type { NavLevelEntry, NavLevelGroup, NavSection } from "../app/nav";
@@ -187,24 +182,23 @@ import "./settings.css";
 // fourteen — a number in prose beside a list is a second source of truth that
 // nothing updates and no test can check. The list below is the count.
 //
-// Two groups: "you" (per-user, every member) and "admin" (installation posture,
-// operator seats only — `useHoldsOperatorSeat`, which is admin or ops). The
-// whole admin group is ABSENT for a rep or a manager: it is the only place the
-// product offers installation configuration, so a seat that configures none of
-// it is offered none of it rather than a page of withheld cards.
+// Two groups: "you" (per-user, every member) and "admin" (installation
+// posture). The group NAMES the subject, not an audience — every entry in it
+// carries its own predicate, which is the grant the cards on it actually ask
+// for, and the heading renders when at least one member survives.
 //
-// Every admin entry ALSO carries its own predicate — the grant the cards on it
-// actually ask for — and the group heading renders when at least one member
-// survives. The two gates answer different questions and both are needed: the
-// seat says whether this reader administers the installation at all, the grant
-// says whether this particular page has anything in it for them. An ops
-// principal whose role was edited to drop `license:read` loses that row and
-// keeps the rest, which no role check alone could express.
-// One predicate for the whole group could only ever be a guess about a
+// There is no second gate above those predicates. One used to sit here — a
+// seat check for admin-or-ops — and it answered false for the whole group
+// whatever the entry underneath had decided. That is a guess about a
 // heterogeneous set: it spans surfaces with clean object grants (data model,
-// organization) and surfaces with no RBAC object at all (users, privacy),
-// which the server gates on the role itself. The server stays the RBAC
-// authority on every card within.
+// organization, knowledge) and surfaces the server gates on the role itself
+// (users, extensions). Every seeded role holds `pipeline`, `custom_field`,
+// `knowledge_corpus`, `automation`, `product`, `offer_template` and `tag`
+// reads, so the server answered those seats 200 while the product showed them
+// nothing — and showed it by ABSENCE, so nobody could see the disagreement.
+// A role edited to drop `license:read` loses that row and keeps the rest,
+// which is the same rule applied to everyone rather than to two role names.
+// The server stays the RBAC authority on every card within.
 //
 // The personal group is where a credential or a connection the PERSON holds
 // lives: `agents` carries the caller's own passports, so gating it would regress
@@ -611,21 +605,22 @@ export function useSettingsEntryVisibility(
   // consent/store.go's ListPurposes calls auth.Require(ctx, "person", read).
   const person = useCan("person", "read");
   const overlay = useCan("overlay_connection", "read");
-  // Whether this reader administers the installation at all. It gates the WHOLE
-  // group below rather than any one entry: every predicate in the returned map
-  // is ANDed with it, so a rep holding `automation:read` — which every seeded
-  // role holds — does not reach the AI page through a grant the section is not
-  // theirs to open. Read unconditionally, like every hook here.
-  const operator = useHoldsOperatorSeat();
   // The one predicate below that is a ROLE rather than a grant. `GET /admin/reset-data`
   // and the job-health read are gated on the literal admin role server-side and no
   // RBAC object describes them — a `role` object would encode a constant, and an
   // admin who revoked their own grant on it could never restore it (capability.ts).
   // Everything else above is a `read`, because opening a page is reading it.
   const isAdmin = useHoldsAdminRole();
-  // Each entry's own read predicate, before the seat gate. Kept as its own
-  // object so the two gates stay legible as two rules: what this page asks for,
-  // and then whether this reader is in the half of settings that holds it.
+  // Each entry's own read predicate, and the whole answer. There is no second
+  // gate above these: a reader reaches an entry when they hold what it asks
+  // for, which is the same question the SERVER answers on every route behind
+  // it. The seat check that used to sit here returned false for every one of
+  // these entries unless the reader held `admin` or `ops`, so a seat holding
+  // `pipeline:read` — which every seeded role holds — was shown nothing while
+  // the API answered it 200. That is the client disagreeing with the authority,
+  // and the disagreement was invisible: the page was absent rather than
+  // refused. What an entry offers once opened is still each card's own
+  // question, and the cards ask their own writes.
   const granted = {
     // The organization, its profile and its currency table are one entry now, so
     // the predicate is the union of what they each asked for. Each is gated on
@@ -643,30 +638,24 @@ export function useSettingsEntryVisibility(
       installation ||
       (organization && (capabilities.data?.read_enabled ?? false)) ||
       fxRate,
-    // The member roster, the roles on it, and what a role may reach. This is the
-    // one entry with no grant to ask for: no RBAC object describes identity
-    // administration and none can — a `role` object would encode a constant, and
-    // an admin who revoked their own grant on it could never restore it
-    // (capability.ts) — so the server gates it on the role directly.
+    // The member roster, the roles on it, and what a role may reach. No RBAC
+    // object describes identity administration and none can — a `role` object
+    // would encode a constant, and an admin who revoked their own grant on it
+    // could never restore it (capability.ts) — so the server gates the VERBS on
+    // the role directly and serves the roster itself to anyone signed in.
     //
-    // `true` here means "this page asks for no grant of its own" and nothing
-    // more: the seat gate above it is what decides who reaches it, and under
-    // that gate the reader is an operator by the time this is read.
+    // `true` matches that: `GET /users` answers 200 to any authenticated
+    // principal, and "who is on my team" is not an admin's private question.
+    // The same handler decides what the answer CONTAINS — role keys and the
+    // inactive view are an admin's, everyone else gets the active roster the
+    // share and assignee pickers already show them (handlers_roster.go).
     //
-    // The roster used to be open to every member, because the server is: `GET
-    // /users` answers 200 to any authenticated principal, and "who is on my team
-    // and what may they do" is not an admin's private question. That read is
-    // what this change costs a rep — a deliberate cost, not an oversight. The
-    // server still serves them; nothing in the product offers it any more. If
-    // the team directory turns out to be a read a rep needs, it belongs on a
-    // directory screen of its own rather than back inside admin configuration.
-    //
-    // The invite form and every role control below still withhold themselves on
-    // their own authority, so an operator who is not an admin sees the roster
-    // and none of the controls.
+    // The invite form and every role control below withhold themselves on their
+    // own authority, so a reader without them sees the roster and none of the
+    // controls.
     users: true,
     // `GET /extensions` is admin-only server-side, so the entry follows the
-    // role rather than a grant: an operator who is not an admin would open a
+    // role rather than a grant: any reader who is not an admin would open a
     // page whose only read answers 403.
     extensions: isAdmin,
     capture: captureSettings,
@@ -735,33 +724,6 @@ export function useSettingsEntryVisibility(
     license: licenseRead,
     maintenance: isAdmin || embeddingReindex,
   } satisfies Readonly<Record<AdminTabId, boolean>>;
-  // The seat, applied to the whole group at once. It gates the SECTION rather
-  // than any one entry, so the honest shape is one answer for all of them: a
-  // reader who does not administer the installation is offered none of it,
-  // whatever their grants say.
-  //
-  // Written out rather than mapped over the object, because `Object.entries`
-  // widens the keys to `string` and coming back to `AdminTabId` from there takes
-  // an assertion — and an assertion is exactly what must not stand between a
-  // permission map and the nav that reads it. The return type demands all nine
-  // keys, so an entry added above and forgotten here fails to compile rather
-  // than shipping ungated. Every hook above has already run, so returning here
-  // costs no hook: the count is fixed before the seat is consulted.
-  if (!operator) {
-    return {
-      general: false,
-      users: false,
-      extensions: false,
-      capture: false,
-      integrations: false,
-      "data-model": false,
-      ai: false,
-      privacy: false,
-      knowledge: false,
-      license: false,
-      maintenance: false,
-    };
-  }
   return granted;
 }
 


### PR DESCRIPTION
## What was wrong

`useSettingsEntryVisibility` computed a correct per-entry answer from live grants, then threw it away: every predicate was ANDed with an admin-or-ops seat check, so the whole Admin settings group returned false for anybody else whatever their grants said.

The server disagrees with that. Every seeded role — manager, rep, read_only and management — holds read on `pipeline`, `custom_field`, `knowledge_corpus`, `automation`, `product`, `offer_template`, `tag` and `installation_settings`. The API answers those reads 200. The product showed those seats nothing.

It showed it by **absence**, which is why nobody caught it: there was no refusal to notice and no page to report it. The client was disagreeing with the authority, silently, in the direction of showing less than the person is allowed to see.

## What changed

The override is gone. Each entry stays gated on the grant its cards actually ask for, which is the rule the group was already written to follow — the comments above it argued for exactly this and then the code did the opposite.

Nothing widens that a card does not already withhold on its own authority:

- **Extensions** still asks for the admin role, because `GET /extensions` is admin-only server-side.
- **Members** still asks for nothing, because `GET /users` serves any authenticated principal and the same handler narrows what it *returns* by role — a rep's page carries no role keys and no inactive members (`handlers_roster.go`).
- Every **write** inside every page is unchanged and still asks for its own grant.

## Visible effect

A rep, Team Lead, Management or Read-only seat now sees the settings pages their grants already allow: Data model, Knowledge, AI, Capture, Integrations, Users & teams and the rest, according to what each holds. This is a deliberate, user-visible change on merge.

## Tests

The nav suite stated the old behaviour plainly — a manager holding the entire ops read matrix reached none of it — so it now states the new one. Added the floor case: a principal holding no grant on the group reaches only the entry that asks for none, so this is not "everyone gets everything".

`make check-fe` green. `make craft-static` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the blanket admin/ops check that hid the whole Admin settings group from non-admin seats, so each settings entry is now shown according to the grants its page actually requires, and gates the AI lane health card on the grant its endpoint demands.

- A manager, rep, read-only, or management seat holding the required reads now sees those settings entries instead of an empty settings rail.
- `Users & teams` is now offered to any signed-in seat because `GET /users` serves any authenticated principal and narrows the returned roster by role.
- `Extensions` still requires the admin role because `GET /extensions` is admin-only server-side.
- The AI health card now asks for `automation:update`; without it, it renders a withheld state and does not call or poll `/ai/health`.
- Adds nav tests for a seat with no admin grants and tests that the AI card withholds without the grant.
- No endpoint permissions change; this only makes the frontend stop hiding pages the server already allows.

<sup>Written for commit a726975b04d4d0f860241f33e8df00eb5540e969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI health information is now restricted to users with operator-level access. Other users see a clear explanation instead of health details.
  * Settings navigation now displays available sections based on each user’s permissions, allowing eligible representatives and managers to access relevant administrative settings.
  * Authenticated users can access the Users section.
  * Added German, English, and Vietnamese translations for the restricted AI health message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->