### PR TITLE
A route is not a rendering

### DIFF
--- a/backend/gates/emailpresentation_test.go
+++ b/backend/gates/emailpresentation_test.go
@@ -111,6 +111,7 @@ var emailPassthroughs = gatekit.Waive(map[string]string{
 	"screens/recordchronology.tsx":       "wires onOpenEmail onto the entries it hands to the timeline; the rendering is composed.tsx's",
 	"screens/worklist.row.tsx":           "same branch as the focus card, for the list row",
 	"screens/emailaccesseditor.tsx":      "draws the ACCESS block and no part of the message: who may read it, the named members, and the control to change that. No subject, no body, no party, no attachment. It takes the whole presentation because the audience write needs the id and version off it",
+	"app/searchkinds.ts":                 "answers WHERE a search hit goes. It reads email_summary for one thing — an activity carrying one is a message, and a message has a destination — and returns a Route. No markup at all: the file is .ts and holds no component",
 })
 
 // entrySchemas reads the schemas the contract marks as an email.


### PR DESCRIPTION
**main is red.** `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on a pristine `origin/main` checkout, so every open PR's CI fails with it. Verified by checking out `origin/main` into a detached worktree and running the gate there with no local changes.

## What the gate saw

`app/searchkinds.ts` reads `email_summary` for exactly one thing — an activity carrying one is a message, and a message has a destination, so the hit gets a `Route`:

```ts
if (hit.email_summary) {
  return searchEmailRoute(query, hit.email_summary.activity_id);
}
return searchHitRoute(hit.type, hit.id);
```

It draws no markup. The file is `.ts` and holds no component, which is precisely what the gate asks of a reader of that type.

`rendersCanonically` could not see that: it asks whether every function reading the field hands it to `EmailEntry` or `EmailReference`, and a file that renders nothing at all answers **no** rather than **not applicable**.

## Waived rather than widened

Teaching `describesRatherThanRenders` to pass every `.ts` file would cover this one and also excuse a file that builds markup as a string — the defect the gate exists to catch. The waiver names what the file does instead, which is the form every other entry in `emailPassthroughs` already takes.

## Evidence

| Obligation | Evidence |
|---|---|
| The failure is not mine | gate fails on a detached `origin/main` worktree with no local changes |
| The waiver is true | `searchkinds.ts` contains no component and no JSX; the read feeds `searchEmailRoute` and returns a `Route` |
| The gate still works | `emailPassthroughs.AssertAllMatched` fails if the path stops matching, so a waiver for a file that changes shape does not go stale silently |
| Full lane | `make check-backend` green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red `emailpresentation_test.go` gate on `main` by waiving `app/searchkinds.ts` from the email rendering check.

- The file reads `email_summary` only to return a `Route`; it renders no markup.
- The waiver names the file's actual purpose instead of widening the gate to pass all `.ts` files, which would also excuse files that build markup as strings.
- `AssertAllMatched` fails if the path stops matching, so the waiver can't go stale silently.

<sup>Written for commit 2fb8428a74f3e2f29134e294d88a73b4ce3708f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

