### PR TITLE
A meeting reaches the brief that prepares it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38705,6 +38705,23 @@ components:
             sentence, and every one of those uses would go quietly wrong together.
         relationship:
           $ref: '#/components/schemas/AttentionRelationshipFacts'
+        with_person:
+          type: string
+          format: uuid
+          description: |
+            Whose record a `meeting` row's brief is read on. Sent only for
+            `source: meeting`, and only where the meeting names a person this caller may
+            see.
+
+            It is not the row's SUBJECT, which is the meeting itself — the row is about
+            the appointment, and the brief happens to be reached through somebody's page:
+            it opens as `?prep=<activity>` on a person's record rather than as a page of
+            its own. Both ids are needed to name it, and the row already carried only one.
+
+            ABSENT rather than empty for an internal meeting, and for one whose only
+            attendees are people the caller may not read — the two are indistinguishable
+            here on purpose, since both mean the same thing to a client: there is no page
+            to read this brief on, so offer no way in rather than one that opens nothing.
         cause_ref:
           type: string
           description: |
@@ -39845,6 +39862,22 @@ components:
             no merge. A row that named neither record could only ask a reader to go and
             look, which is the hand-off this queue exists to remove.
         move: { $ref: '#/components/schemas/WorklistMove' }
+        with_person:
+          type: string
+          format: uuid
+          description: |
+            Whose record a `meeting` row's brief is read on, carried out from
+            `AttentionItem.with_person`.
+
+            Sent only for `source: meeting`, and only where the meeting names a person
+            this caller may see. It is not the row's SUBJECT — the row is about the
+            appointment — and it exists because the brief is not a page of its own: it
+            opens as `?prep=<activity>` on a person's record, so the address needs both
+            ids and the subject carries only one.
+
+            A client MUST NOT draw a way into the brief without it. Absent means there is
+            no page to read this brief on, which an internal meeting and a meeting whose
+            attendees are all withheld both produce, and both mean the same thing here.
         due_at: { type: string, format: date-time, description: 'When this is due, or when the meeting starts.' }
         overdue: { type: boolean, description: 'Past due at the read instant, resolved server-side so every surface agrees.' }
         occurred_at: { type: string, format: date-time, description: 'When the thing being reported happened.' }

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -128,6 +128,10 @@ func base(
 		CauseLabel: item.CauseLabel,
 		Subject:    item.Subject,
 		Deal:       dealFactsOf(item),
+		// Whose page a meeting's brief opens on. Forwarded rather than derived
+		// here: the lane already decided whether the reader may see anybody on
+		// the meeting, and an absent value is that decision rather than a gap.
+		WithPerson: item.WithPerson,
 		// Forwarded, never re-derived here. The lane already applied the
 		// both-sides-visible rule and set `merge` only where it held, so
 		// carrying the payload keeps the verb and the records it acts on

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -350,6 +350,20 @@ type Meeting struct {
 	Subject  string
 	StartsAt time.Time
 
+	// PersonID is whose page the brief is read on, and it is zero whenever the
+	// meeting names nobody this reader may see.
+	//
+	// The brief is not a page of its own: it opens as `?prep=<activity>` on a
+	// PERSON's record, so the activity id the row already carries names the
+	// meeting and says nothing about where to read it. Without this the lane
+	// could describe a meeting and offer no way to prepare for it, which is
+	// the one thing a rep opens the row to do.
+	//
+	// An internal meeting legitimately has none, and so does one whose only
+	// attendees are people the reader cannot read. Both stay zero and the row
+	// offers no verb rather than a link to somebody's page picked at random.
+	PersonID ids.UUID
+
 	// NeedsPrep is true when nothing has been written down for a meeting that
 	// is about to happen: no agenda or notes body, and nobody outside this
 	// organization recorded on it.

--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -11,6 +11,8 @@ package attention
 import (
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
@@ -22,13 +24,21 @@ import (
 // meeting that has not started cannot be late, and the lane only carries the
 // ones still ahead.
 //
-// It offers NO verb. The pre-meeting brief is its own surface with its own eight
-// cited sections, and a queue that tried to summarise it here would be a second
-// answer to "prepare me for this". `open` is withheld for a narrower reason than
-// it once was: this card's subject is the ACTIVITY, which is a timeline entry
-// rather than a record with a page of its own, so the verb would advertise a
-// destination that does not exist. The two cards whose subject IS a record —
-// the quiet deal and the promise — now send it.
+// It offers no `open`, and for a reason that still holds: this card's subject is
+// the ACTIVITY, which is a timeline entry rather than a record with a page of
+// its own, so the verb would advertise a destination that does not exist. The
+// two cards whose subject IS a record — the quiet deal and the promise — send it.
+//
+// It DOES offer the brief, where the meeting names somebody. The brief is not a
+// page either, which is why this read as unreachable for so long: it opens as
+// `?prep=<activity>` on a PERSON's record, so the move needs both ids and the
+// row already carried only one. The person rides in the move's arguments rather
+// than as the row's subject, because the subject names what the row is ABOUT
+// and this row is about the meeting.
+//
+// The brief itself is still its own surface with its own cited sections. This
+// names the way in; a queue that tried to summarise it here would be a second
+// answer to "prepare me for this".
 func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 	subject := meeting.Subject
 	starts := meeting.StartsAt
@@ -39,6 +49,13 @@ func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 		Subject: subjectOf("activity", meeting.ID),
 		DueAt:   &starts,
 		Actions: []crmcontracts.AttentionItemActions{},
+	}
+	// Only where a person is named. A meeting with no attendee this reader may
+	// see has no page to read the brief on, so the field stays absent and the
+	// classifier below offers no way in — rather than one that opens nothing.
+	if !meeting.PersonID.IsZero() {
+		with := openapi_types.UUID(meeting.PersonID)
+		item.WithPerson = &with
 	}
 	// `kind` is the producer's own sub-type, for the icon and the label and
 	// never for authority — which is exactly what "nobody has written anything
@@ -82,6 +99,20 @@ func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		reasons = append(reasons, reason("meeting_unprepared", nil))
 	}
 	row := base(item, level, "meetings", "meeting_unprepared")
+	// The way into the brief, where the row named a person to read it on. Both
+	// ids travel because neither names it alone: the activity says WHICH
+	// meeting, the person says WHOSE page it opens on.
+	// The meeting id comes off the SUBJECT rather than being parsed back out of
+	// item.Id: the subject already holds it as a uuid, and re-parsing the
+	// string form would introduce a failure case where there is none.
+	if item.WithPerson != nil && item.Subject != nil {
+		meetingID := item.Subject.Id
+		row.Move = &crmcontracts.WorklistMove{
+			Action:     crmcontracts.WorklistMoveActionOpenMeetingBrief,
+			ActivityId: &meetingID,
+			Arguments:  &map[string]any{"person_id": item.WithPerson.String()},
+		}
+	}
 	// A meeting's start time IS a deadline the reader is racing, so it counts
 	// as work due — unlike a proposal's expiry, which merely lapses.
 	stampDeadline(&row, item.DueAt, asOf)

--- a/backend/internal/compose/attention/meetingbrief_test.go
+++ b/backend/internal/compose/attention/meetingbrief_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The way into a meeting's brief.
+//
+// The row could describe a meeting and offer no way to prepare for it, which is
+// the one thing a rep opens that row to do. The brief is not a page of its own —
+// it opens as `?prep=<activity>` on a PERSON's record — so naming it needs two
+// ids and the row carried only one.
+//
+// Both halves are tested here because a move that names one id is not half a
+// control, it is a control that opens nothing.
+
+import (
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAMeetingWithSomebodyOnItReachesTheBrief(t *testing.T) {
+	person := ids.NewV7()
+	meeting := ids.NewV7()
+	row := classifyMeeting(meetingItem(Meeting{
+		ID: meeting, Subject: "Fleet retrofit review",
+		StartsAt: fixedClock().Add(2 * time.Hour), PersonID: person,
+	}), fixedClock())
+
+	if row.item.Move == nil {
+		t.Fatal("the row offers no move, so a rep reading it cannot prepare")
+	}
+	if row.item.Move.Action != crmcontracts.WorklistMoveActionOpenMeetingBrief {
+		t.Errorf("the move is %q, want open_meeting_brief", row.item.Move.Action)
+	}
+	// WHICH meeting. Without it the brief has nothing to prepare.
+	if row.item.Move.ActivityId == nil || ids.UUID(*row.item.Move.ActivityId) != meeting {
+		t.Errorf("the move names meeting %v, want %v", row.item.Move.ActivityId, meeting)
+	}
+	// WHOSE page. Without it the address has no record to open on, and the
+	// client draws nothing — which is the failure this whole change is about.
+	if row.item.WithPerson == nil || ids.UUID(*row.item.WithPerson) != person {
+		t.Errorf("the row names person %v, want %v", row.item.WithPerson, person)
+	}
+}
+
+// A meeting naming nobody this reader may see offers NO way in.
+//
+// An internal meeting has no attendee, and so does one whose only attendees are
+// people the caller cannot read — the lane cannot tell those apart and does not
+// need to, because both mean the same thing: there is no page to read this
+// brief on. A move sent anyway would be a control that opens nothing, which is
+// worse than a row that admits it has no step.
+func TestAMeetingNamingNobodyOffersNoBrief(t *testing.T) {
+	row := classifyMeeting(meetingItem(Meeting{
+		ID: ids.NewV7(), Subject: "Internal planning",
+		StartsAt: fixedClock().Add(2 * time.Hour),
+	}), fixedClock())
+
+	if row.item.Move != nil {
+		t.Errorf("the row offers %q into a brief it has no page for", row.item.Move.Action)
+	}
+	if row.item.WithPerson != nil {
+		t.Errorf("the row names person %v on a meeting that named nobody", row.item.WithPerson)
+	}
+}

--- a/backend/internal/compose/attentionmeetingseam.go
+++ b/backend/internal/compose/attentionmeetingseam.go
@@ -52,7 +52,7 @@ func (m attentionMeetings) Today(
 		needsPrep, known := meetingPrep(row)
 		ahead = append(ahead, attention.Meeting{
 			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
-			NeedsPrep: needsPrep, PrepKnown: known,
+			NeedsPrep: needsPrep, PrepKnown: known, PersonID: personOnMeeting(row),
 		})
 	}
 	// Soonest first: the lane is a countdown, and the store returns activities
@@ -110,4 +110,28 @@ func subjectOfMeeting(row crmcontracts.Activity) string {
 		return *row.Subject
 	}
 	return ""
+}
+
+// personOnMeeting is whose page this meeting's brief is read on.
+//
+// The FIRST person link in the row's own order, which is the store's, so two
+// reads of an unchanged meeting choose the same page. A meeting with several
+// attendees has several honest answers and the row shows one link; picking by
+// anything cleverer here would be a ranking this lane has no basis for, and
+// picking a different one each read would move a control under the reader.
+//
+// Zero where the meeting links no person at all — an internal meeting, or one
+// whose attendees this reader may not see, since the links come back already
+// scoped. The row then offers no brief rather than a link to somebody's page
+// chosen at random.
+func personOnMeeting(row crmcontracts.Activity) ids.UUID {
+	if row.Links == nil {
+		return ids.UUID{}
+	}
+	for _, link := range *row.Links {
+		if link.EntityType == crmcontracts.ActivityLinkEntityTypePerson {
+			return ids.UUID(link.EntityId)
+		}
+	}
+	return ids.UUID{}
 }

--- a/backend/internal/compose/meetingattendee_test.go
+++ b/backend/internal/compose/meetingattendee_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Whose page a meeting's brief is read on.
+//
+// The links come back already scoped, so this reads what the caller may see and
+// nothing else. Its whole job is to pick ONE of them deterministically, because
+// the row draws one link and a choice that moved between reads would move a
+// control under the reader.
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheBriefOpensOnAPersonTheMeetingNames(t *testing.T) {
+	person := ids.NewV7()
+	got := personOnMeeting(withLinks(
+		link("organization", ids.NewV7()),
+		link("person", person),
+	))
+	if got != person {
+		t.Errorf("personOnMeeting = %v, want the person link %v", got, person)
+	}
+}
+
+// The FIRST person link, in the row's own order.
+//
+// A meeting with several attendees has several honest answers and the row draws
+// one. Taking the store's order makes two reads of an unchanged meeting choose
+// the same page; anything cleverer would be a ranking this lane has no basis
+// for, and anything unstable moves a control under the reader between reads.
+func TestSeveralAttendeesResolveToTheSamePageEveryRead(t *testing.T) {
+	first, second := ids.NewV7(), ids.NewV7()
+	row := withLinks(link("person", first), link("person", second))
+	for range 3 {
+		if got := personOnMeeting(row); got != first {
+			t.Fatalf("personOnMeeting = %v, want the first person link %v", got, first)
+		}
+	}
+}
+
+// A meeting naming no person at all yields nothing, and the row then offers no
+// brief. An internal meeting is the honest common case; a meeting whose
+// attendees the caller may not read arrives the same way, because the links are
+// already scoped. Both mean there is no page to read the brief on.
+func TestAMeetingLinkingNoPersonNamesNobody(t *testing.T) {
+	if got := personOnMeeting(withLinks(link("deal", ids.NewV7()))); !got.IsZero() {
+		t.Errorf("personOnMeeting = %v, want nobody", got)
+	}
+	if got := personOnMeeting(crmcontracts.Activity{}); !got.IsZero() {
+		t.Errorf("personOnMeeting(no links at all) = %v, want nobody", got)
+	}
+}
+
+func withLinks(links ...crmcontracts.ActivityLink) crmcontracts.Activity {
+	return crmcontracts.Activity{Links: &links}
+}
+
+func link(kind string, id ids.UUID) crmcontracts.ActivityLink {
+	return crmcontracts.ActivityLink{
+		EntityType: crmcontracts.ActivityLinkEntityType(kind),
+		EntityId:   openapi_types.UUID(id),
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17674,6 +17674,21 @@ type AttentionItem struct {
 	// three languages, so a duplicate pair sends its `kind` and `confidence`
 	// and the client writes the line in the reader's own.
 	Title *string `json:"title,omitempty"`
+
+	// WithPerson Whose record a `meeting` row's brief is read on. Sent only for
+	// `source: meeting`, and only where the meeting names a person this caller may
+	// see.
+	//
+	// It is not the row's SUBJECT, which is the meeting itself — the row is about
+	// the appointment, and the brief happens to be reached through somebody's page:
+	// it opens as `?prep=<activity>` on a person's record rather than as a page of
+	// its own. Both ids are needed to name it, and the row already carried only one.
+	//
+	// ABSENT rather than empty for an internal meeting, and for one whose only
+	// attendees are people the caller may not read — the two are indistinguishable
+	// here on purpose, since both mean the same thing to a client: there is no page
+	// to read this brief on, so offer no way in rather than one that opens nothing.
+	WithPerson *openapi_types.UUID `json:"with_person,omitempty"`
 }
 
 // AttentionItemActions defines model for AttentionItem.Actions.
@@ -33734,6 +33749,20 @@ type WorklistItem struct {
 
 	// Title The server's own sentence for this item, where it has one.
 	Title *string `json:"title,omitempty"`
+
+	// WithPerson Whose record a `meeting` row's brief is read on, carried out from
+	// `AttentionItem.with_person`.
+	//
+	// Sent only for `source: meeting`, and only where the meeting names a person
+	// this caller may see. It is not the row's SUBJECT — the row is about the
+	// appointment — and it exists because the brief is not a page of its own: it
+	// opens as `?prep=<activity>` on a person's record, so the address needs both
+	// ids and the subject carries only one.
+	//
+	// A client MUST NOT draw a way into the brief without it. Absent means there is
+	// no page to read this brief on, which an internal meeting and a meeting whose
+	// attendees are all withheld both produce, and both mean the same thing here.
+	WithPerson *openapi_types.UUID `json:"with_person,omitempty"`
 }
 
 // WorklistItemActions defines model for WorklistItem.Actions.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29031,6 +29031,23 @@ export interface components {
             quiet_days?: number | null;
             relationship?: components["schemas"]["AttentionRelationshipFacts"];
             /**
+             * Format: uuid
+             * @description Whose record a `meeting` row's brief is read on. Sent only for
+             *     `source: meeting`, and only where the meeting names a person this caller may
+             *     see.
+             *
+             *     It is not the row's SUBJECT, which is the meeting itself — the row is about
+             *     the appointment, and the brief happens to be reached through somebody's page:
+             *     it opens as `?prep=<activity>` on a person's record rather than as a page of
+             *     its own. Both ids are needed to name it, and the row already carried only one.
+             *
+             *     ABSENT rather than empty for an internal meeting, and for one whose only
+             *     attendees are people the caller may not read — the two are indistinguishable
+             *     here on purpose, since both mean the same thing to a client: there is no page
+             *     to read this brief on, so offer no way in rather than one that opens nothing.
+             */
+            with_person?: string;
+            /**
              * @description Which underlying CONDITION this row reports, for a surface that groups repeated
              *     failures of one thing into one row. Two failures of one broken automation carry
              *     the same value; a failure of a different rule carries a different one.
@@ -30120,6 +30137,22 @@ export interface components {
              */
             pair?: components["schemas"]["AttentionPair"];
             move?: components["schemas"]["WorklistMove"];
+            /**
+             * Format: uuid
+             * @description Whose record a `meeting` row's brief is read on, carried out from
+             *     `AttentionItem.with_person`.
+             *
+             *     Sent only for `source: meeting`, and only where the meeting names a person
+             *     this caller may see. It is not the row's SUBJECT — the row is about the
+             *     appointment — and it exists because the brief is not a page of its own: it
+             *     opens as `?prep=<activity>` on a person's record, so the address needs both
+             *     ids and the subject carries only one.
+             *
+             *     A client MUST NOT draw a way into the brief without it. Absent means there is
+             *     no page to read this brief on, which an internal meeting and a meeting whose
+             *     attendees are all withheld both produce, and both mean the same thing here.
+             */
+            with_person?: string;
             /**
              * Format: date-time
              * @description When this is due, or when the meeting starts.

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -189,17 +189,17 @@ describe("the verbs the row can and cannot take a reader to", () => {
     expect(moveLabel(onADeal, t)).toBe("Open to write");
   });
 
-  // These are PERFORMED, not navigated: one posts a task body, one opens a
-  // drawer, and one leaves for a provider's consent screen. A link drawn for
-  // any of them would be pressable with nothing behind it — the exact defect
-  // the move slot's own comment warned about.
+  // These are PERFORMED, not navigated: one posts a task body, one leaves for a
+  // provider's consent screen, and one names no step at all. A link drawn for
+  // any of them would be pressable with nothing behind it.
+  //
+  // `open_meeting_brief` was on this list and no longer is. It reads as a
+  // drawer, so it looked unaddressable — but the way IN is an address: the
+  // brief opens as `?prep=<activity>` on a person's record. It is covered by
+  // its own describe block below, including the case where the row names
+  // nobody and correctly draws nothing.
   it("draws no link for a verb no address can perform", () => {
-    for (const action of [
-      "create_task",
-      "open_meeting_brief",
-      "reconnect",
-      "none",
-    ]) {
+    for (const action of ["create_task", "reconnect", "none"]) {
       const item = movingRow(action);
       expect(moveHref(item)).toBeUndefined();
       expect(moveOpensComposer(item)).toBe(false);
@@ -408,3 +408,44 @@ describe("an unavailable source", () => {
     }
   });
 });
+
+// The brief is not a page of its own: it opens as `?prep=<activity>` on a
+// PERSON's record, so the address needs both ids and the row's subject — the
+// meeting — carries only one.
+describe("moveHref — the open_meeting_brief move", () => {
+  it("opens the brief on the person the meeting names", () => {
+    const href = moveHref(briefRow("p-9"));
+    expect(href).toContain("#/contacts/p-9");
+    expect(href).toContain("prep=a-7");
+  });
+
+  // A meeting naming nobody has no page to read the brief on. An internal
+  // meeting and one whose attendees are all withheld arrive identically, and
+  // both must draw NO way in rather than one that opens nothing.
+  it("offers nothing where the meeting names nobody", () => {
+    expect(moveHref(briefRow(undefined))).toBeUndefined();
+  });
+
+  // It is not the composer, and must not be described as one: the label reads
+  // off the same predicate, so a brief announced as a draft would be a button
+  // whose words and destination disagree.
+  it("is not a draft", () => {
+    expect(moveOpensComposer(briefRow("p-9"))).toBe(false);
+  });
+});
+
+function briefRow(withPerson: string | undefined) {
+  return {
+    id: "m1",
+    source: "meeting",
+    category: "meetings",
+    title: "Fleet retrofit review",
+    because: [],
+    actions: [],
+    dispositions: [],
+    overdue: false,
+    subject: { type: "activity", id: "a-7" },
+    with_person: withPerson,
+    move: { action: "open_meeting_brief", activity_id: "a-7" },
+  } as unknown as WorklistItem;
+}

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -10,7 +10,7 @@ import {
 } from "../format/format";
 import type { Locale, useT } from "../i18n";
 import { translatePlural } from "../i18n";
-import { COMPOSE_PARAM } from "./personpage.address";
+import { BRIEF_PARAM, COMPOSE_PARAM } from "./personpage.address";
 import { settingsAddress } from "./settings";
 import type {
   Worklist,
@@ -480,13 +480,26 @@ function sameDayInZone(utcIso: string, now: Date, zone: string): boolean {
 // but not to the address, because the composer picks its own transport and
 // threading from the person.
 //
-// The other verbs are absent, each for its own reason. `create_task` and
-// `open_meeting_brief` are PERFORMED rather than navigated: one posts a task
-// body, the other opens a drawer, and neither is a thing a link can do. `none`
-// names no step. `reconnect` leaves for a provider's consent screen, which is a
-// handoff rather than a destination. A row keeps its own verbs in every case,
-// so none of these leaves the reader with nothing.
-const NAVIGABLE_MOVES = new Set(["draft_reply", "draft_email"]);
+// `open_meeting_brief` is the third, and it lands somewhere else entirely: the
+// brief is read as `?prep=<activity>` on the PERSON's record, so the address
+// needs an id the subject does not carry. The server sends it as `with_person`,
+// and only where the meeting names somebody this reader may see.
+//
+// It used to be described here as PERFORMED rather than navigated — "opens a
+// drawer, and neither is a thing a link can do" — which was true of the drawer
+// and false of the way in. The row could describe a meeting and offer no way to
+// prepare for it, which is the one thing a rep opens that row to do.
+//
+// The remaining verbs are absent, each for its own reason. `create_task` posts
+// a task body, which is a write rather than a destination. `none` names no
+// step. `reconnect` leaves for a provider's consent screen, which is a handoff.
+// A row keeps its own verbs in every case, so none of these leaves the reader
+// with nothing.
+const NAVIGABLE_MOVES = new Set([
+  "draft_reply",
+  "draft_email",
+  "open_meeting_brief",
+]);
 
 /**
  * Whether a move has what its own verb needs.
@@ -503,10 +516,30 @@ function moveIsComplete(move: NonNullable<WorklistItem["move"]>): boolean {
   return move.action !== "draft_reply" || move.activity_id !== undefined;
 }
 
+/**
+ * The brief's address: which meeting, on whose page.
+ *
+ * BOTH ids, because neither names it. The activity says which meeting to brief
+ * and the person says whose record it opens on — the brief is not a page of its
+ * own. A row missing either names nothing openable and draws no control, which
+ * is the same promise every other verb here makes about its own operand.
+ */
+function briefHref(item: WorklistItem): string | undefined {
+  const meeting = item.move?.activity_id;
+  if (!meeting || !item.with_person) {
+    return undefined;
+  }
+  const person = routeHash(ENTITY.person.route(item.with_person));
+  return `${person}?${BRIEF_PARAM}=${meeting}`;
+}
+
 export function moveHref(item: WorklistItem): string | undefined {
   const move = item.move;
   if (!move || !NAVIGABLE_MOVES.has(move.action) || !moveIsComplete(move)) {
     return undefined;
+  }
+  if (move.action === "open_meeting_brief") {
+    return briefHref(item);
   }
   const record = subjectHref(item);
   if (!record || item.subject?.type !== "person") {


### PR DESCRIPTION
The meeting row could describe an appointment and offer no way to prepare for it — the one thing a rep opens that row to do.

## Why it read as unreachable

The brief is not a page. It opens as `?prep=<activity>` on a **person's** record, so naming it takes two ids, and the row carried only one: its subject is the meeting, which is a timeline entry with no page of its own.

That much was already understood, and it correctly stopped `open` from being offered — the comment in `meeting.go` says so. What nobody had noticed is that the **way in** is an ordinary address. The missing half was whose page it opens on.

## The change

`Meeting` carries a `PersonID`, filled in the seam from the activity's own person link. **No new query** — the links already travel on the row, and they come back already scoped, so this reads what the caller may see and nothing else.

The row sends `with_person` on the wire and its move becomes `open_meeting_brief`, carrying `activity_id` (which meeting) and `arguments.person_id` (whose page). `moveHref` routes it to `#/contacts/<person>?prep=<activity>`.

**The first person link, in the store's order.** A meeting with several attendees has several honest answers and the row draws one link. Anything cleverer would be a ranking this lane has no basis for; anything unstable would move a control under the reader between two reads of an unchanged meeting.

**Absent where the meeting names nobody.** An internal meeting and one whose only attendees are withheld arrive identically, and both mean the same thing — there is no page to read this brief on — so the row offers no way in rather than one that opens nothing.

## One existing test narrowed

`worklist.copy.test.ts` asserted that `open_meeting_brief` draws no link, alongside three verbs for which that is still true. Its premise was that the brief opens a drawer and a drawer is not something a link can do: true of the drawer, false of the door. The verb came out of that loop; `create_task`, `reconnect` and `none` stayed, and the test says why.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestAMeetingWithSomebodyOnItReachesTheBrief` — the move names both ids |
| The honest absence | `TestAMeetingNamingNobodyOffersNoBrief`, `TestAMeetingLinkingNoPersonNamesNobody` |
| Deterministic choice | `TestSeveralAttendeesResolveToTheSamePageEveryRead` — three reads, same page |
| Client route | `worklist.copy.test.ts` "opens the brief on the person the meeting names", "offers nothing where the meeting names nobody", "is not a draft" |
| Row scope | the links arrive already scoped by the activities store; a withheld attendee is absent, and absent yields no control |
| Contract | `make gen` + `pnpm gen:api`; drift and breaking-change checks green |
| Mutation strength | Five clauses reverted individually: sending `with_person` unconditionally, sending the move without a person, taking the first link of any type, drawing the brief without a person, and letting the brief fall through to the subject route. Each fails its own test and no other. |
| Full lane | `make check-backend` and `make check-fe` both green |

Note: CI will be red until #4254 lands — `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` currently fails on `origin/main` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the worklist meeting row open its meeting brief, which it previously could not. The brief opens as `?prep=<activity>` on a person's record, so the row now carries the person id alongside the meeting id.

**New Features**
- The row sends `with_person` and a new `open_meeting_brief` move; the client routes to `#/contacts/<person>?prep=<activity>`.
- The person id is the first person link in the activity's own order, so repeated reads of an unchanged meeting pick the same page; no new query.
- When the meeting names nobody the caller may see, the field is absent and no way in is drawn — internal meetings and meetings with only withheld attendees both behave this way.
- An existing test that asserted `open_meeting_brief` draws no link was narrowed; `create_task`, `reconnect`, and `none` keep that assertion.
- CI is red until #4254 lands; `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on `origin/main` itself.

<sup>Written for commit 0c7854cb4c24a5d87b7e154655b76e94d9a0e7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

