### PR TITLE
A row folds its reasons past the third, and says how many

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8093,6 +8093,8 @@ export const de = {
   "worklist.because.pinned": "Von dir angeheftet",
   "worklist.because.buyer_wrote_last": "Sie haben zuletzt geschrieben",
   "worklist.because.waiting_days": "wartet",
+  "worklist.because.more_one": "+{count} weiterer Grund",
+  "worklist.because.more_other": "+{count} weitere Gründe",
   "worklist.because.waiting_days.value_one": "wartet seit {value} Tag",
   "worklist.because.waiting_days.value_other": "wartet seit {value} Tagen",
   "worklist.because.overdue": "überfällig",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8183,6 +8183,8 @@ export const en = {
   "worklist.because.pinned": "You pinned this",
   "worklist.because.buyer_wrote_last": "They wrote last",
   "worklist.because.waiting_days": "waiting",
+  "worklist.because.more_one": "+{count} more reason",
+  "worklist.because.more_other": "+{count} more reasons",
   "worklist.because.waiting_days.value_one": "waiting {value} day",
   "worklist.because.waiting_days.value_other": "waiting {value} days",
   "worklist.because.overdue": "overdue",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8007,6 +8007,8 @@ export const vi = {
   "worklist.because.pinned": "Bạn đã ghim mục này",
   "worklist.because.buyer_wrote_last": "Họ viết sau cùng",
   "worklist.because.waiting_days": "đang chờ",
+  "worklist.because.more_one": "+{count} lý do khác",
+  "worklist.because.more_other": "+{count} lý do khác",
   "worklist.because.waiting_days.value_one": "đã chờ {value} ngày",
   "worklist.because.waiting_days.value_other": "đã chờ {value} ngày",
   "worklist.because.overdue": "quá hạn",

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -139,6 +139,46 @@
   margin: 0;
 }
 
+/* The reasons past the first few, a tap away rather than gone.
+
+   A native <details>, so the toggle is the summary itself and keyboard and
+   screen-reader behaviour come for free. It carries no chevron and no box: a
+   row is not a section, and furniture around one caption line would cost more
+   height than the fold saves.
+
+   The marker is removed on both spellings — ::marker is the standard one and
+   ::-webkit-details-marker is what Safari still uses — because the "+N more"
+   text IS the affordance, and a triangle beside it says the same thing twice.
+   `display: inline` on the summary is what makes the reasons and the "+N more"
+   read as one sentence rather than a line with a control under it. */
+.worklist-row-because-fold > summary {
+  cursor: pointer;
+  display: inline;
+  list-style: none;
+}
+
+.worklist-row-because-fold > summary::marker,
+.worklist-row-because-fold > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* The count reads as the control, so it takes the accent the rest of the line
+   does not. Underlined on hover rather than always: a caption line that is
+   permanently underlined mid-sentence reads as a broken link. */
+.worklist-row-because-more {
+  color: var(--accentText);
+}
+
+.worklist-row-because-fold > summary:hover .worklist-row-because-more {
+  text-decoration: underline;
+}
+
+/* The opened remainder sits under the line it belongs to, not indented: it is
+   more of the same sentence rather than a nested thing. */
+.worklist-row-because-fold[open] > .worklist-row-because {
+  margin-block-start: var(--space-1);
+}
+
 /* The queue is an ordered list for assistive technology and a plain stack on
    screen: the rank number is already drawn in the row. */
 .worklist-list {

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -13,7 +13,7 @@ import { PanelRow } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { translatePlural, useLocale, useT } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
 import { tomorrowMorning } from "./briefqueue";
 import { problemMessageOf } from "./common";
@@ -114,10 +114,9 @@ export function WorklistRow({
       : item.detail;
   // The badged reasons are drawn as badges above and left out here, so one
   // meeting does not report the same finding twice in two registers.
-  const because = phrasedReasons(item)
+  const reasons = phrasedReasons(item)
     .map((reason) => reasonText(reason, t, locale, zone))
-    .filter((phrase): phrase is string => phrase !== null)
-    .join(" · ");
+    .filter((phrase): phrase is string => phrase !== null);
   const above = comparisonText(item.above_next, t, locale, zone);
   const consequence = consequenceText(item, t);
   const emailRow = item.email_summary != null;
@@ -185,7 +184,7 @@ export function WorklistRow({
         <RowCaptions
           when={when}
           facts={facts}
-          because={because}
+          reasons={reasons}
           consequence={consequence}
           above={above}
         />
@@ -324,6 +323,66 @@ function NudgeDismiss({ personId }: Readonly<{ personId: string }>) {
 }
 
 /**
+ * How many reasons a row says before the rest go behind a tap.
+ *
+ * A COUNT, because the ceiling has to survive the vocabulary growing. Saying
+ * only what a row contains today puts it back over the limit the next time
+ * somebody adds a reason, and that person has no way to know they did.
+ *
+ * Three because three still fit on ONE line at 390px. Measured 2026-09-05:
+ * two reasons and three are both 19px; the fourth wraps to 37px and the sixth
+ * to 56px. So the fold costs a reader nothing until the line would have taken
+ * a second line anyway.
+ */
+const REASONS_BEFORE_THE_FOLD = 3;
+
+/**
+ * Why this row is here — the first few said outright, the rest a tap away.
+ *
+ * NOTHING IS DISCARDED, which is the whole shape of this. A cap that dropped
+ * the overflow was tried and abandoned (it dropped the wrong ones: `pinned`,
+ * `expected_revenue` and an absorbed deal's grounds are all appended LAST
+ * because they are applied late, so a head-of-list cut takes exactly the facts
+ * that decided where the row sits). The reasons arrive "in the order they were
+ * weighed", so the first ones are the strongest and the fold falls in the
+ * right place by construction — but the rest stay reachable rather than being
+ * silenced.
+ *
+ * The same shape the deal status card uses: first line out, remainder behind a
+ * disclosure. One answer to "too many reasons", not a second one written here.
+ *
+ * The summary NAMES THE COUNT rather than saying "more". A reader deciding
+ * whether to spend a tap wants to know if it is one more fact or four.
+ */
+function RowReasons({ reasons }: Readonly<{ reasons: readonly string[] }>) {
+  const { locale } = useLocale();
+  if (reasons.length === 0) {
+    return null;
+  }
+  const said = reasons.slice(0, REASONS_BEFORE_THE_FOLD);
+  const folded = reasons.slice(REASONS_BEFORE_THE_FOLD);
+  if (folded.length === 0) {
+    return <p className="t-caption worklist-row-because">{said.join(" · ")}</p>;
+  }
+  return (
+    <details className="worklist-row-because-fold">
+      <summary className="t-caption worklist-row-because">
+        {said.join(" · ")}{" "}
+        <span className="worklist-row-because-more">
+          {translatePlural(locale, "worklist.because.more", folded.length, {
+            // The reader's own notation, not String(): a count drawn for a
+            // person goes through the formatter like every other magnitude,
+            // and jsx-magnitude.test.ts holds that for the whole tree.
+            count: formatNumber(folded.length, locale),
+          })}
+        </span>
+      </summary>
+      <p className="t-caption worklist-row-because">{folded.join(" · ")}</p>
+    </details>
+  );
+}
+
+/**
  * Everything the row says about itself under the title, in the order a reader
  * needs it.
  *
@@ -339,13 +398,13 @@ function NudgeDismiss({ personId }: Readonly<{ personId: string }>) {
 function RowCaptions({
   when,
   facts,
-  because,
+  reasons,
   consequence,
   above,
 }: Readonly<{
   when: string | null;
   facts: string | null;
-  because: string;
+  reasons: readonly string[];
   consequence: string | null;
   above: string | null;
 }>) {
@@ -356,7 +415,7 @@ function RowCaptions({
           this says what time. */}
       {when && <p className="t-caption worklist-row-when">{when}</p>}
       {facts && <p className="t-caption worklist-row-facts">{facts}</p>}
-      {because && <p className="t-caption worklist-row-because">{because}</p>}
+      <RowReasons reasons={reasons} />
       {/* What it costs to do nothing. The question a queue exists to answer,
           and the one the lane feed had no field for. */}
       {consequence && (

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -402,6 +402,89 @@ describe("what the ranked queue tells a reader", () => {
     expect(container.textContent).not.toContain("worklist.because");
   });
 
+  // The reasons past the third go behind a tap — NOT away.
+  //
+  // A cap that dropped them was tried and abandoned: the reasons that matter
+  // most are appended LAST, because they are applied late. `pinned` drives the
+  // row to the top and is appended by applyPins after everything else;
+  // `expected_revenue` is absorbed onto a waiting row last and is a ranking
+  // comparator. A head-of-list cut takes exactly the facts that decided where
+  // the row sits.
+  it("folds the reasons past the third rather than dropping them", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            title: "A buyer is waiting on a funded deal",
+            source: "customer_waiting",
+            because: [
+              { kind: "buyer_wrote_last" },
+              { kind: "stale" },
+              { kind: "no_reply_history" },
+              { kind: "asks_nothing" },
+              // Absorbed from the deal this wait suppressed, appended last.
+              { kind: "expected_revenue" },
+            ],
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText("A buyer is waiting on a funded deal");
+    // The first three are said outright.
+    for (const kind of [
+      "buyer_wrote_last",
+      "stale",
+      "no_reply_history",
+    ] as const) {
+      expect(container.textContent).toContain(en[`worklist.because.${kind}`]);
+    }
+    // The rest are PRESENT — folded, never discarded. The one that decided the
+    // rank is in here, which is the whole reason a cap was wrong.
+    expect(container.textContent).toContain(
+      en["worklist.because.expected_revenue"],
+    );
+    expect(container.textContent).toContain(
+      en["worklist.because.asks_nothing"],
+    );
+    // And the fold names HOW MANY, so a reader can decide whether to spend the
+    // tap. "+2 more reasons", not "more".
+    expect(container.textContent).toContain("2");
+    expect(
+      container.querySelector("details.worklist-row-because-fold"),
+    ).not.toBeNull();
+  });
+
+  // Three reasons still fit on one line at 390px, so folding them would cost a
+  // tap and save nothing. Measured 2026-09-05: two and three are both 19px; the
+  // fourth wraps to 37px.
+  it("draws no fold when every reason fits", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            title: "A task",
+            because: [
+              { kind: "overdue" },
+              { kind: "due_today" },
+              { kind: "unassigned" },
+            ],
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText("A task");
+    expect(container.textContent).toContain(en["worklist.because.unassigned"]);
+    expect(
+      container.querySelector("details.worklist-row-because-fold"),
+    ).toBeNull();
+  });
+
   it("offers a verb that goes somewhere, and none that does not", async () => {
     stub(
       day({


### PR DESCRIPTION
## Why

The `because` line — "why this row is here" — had no bound. Every reason the server sent was drawn, so the line grew by a line each time the reason vocabulary did. The vocabulary is still growing, and the person adding a reason had no way to know they had made every row carrying it taller.

## Fold, don't cap

**Nothing is discarded.** A cap that dropped the overflow was tried and abandoned in #4243, because it dropped the *wrong* ones. `pinned`, `expected_revenue` and an absorbed at-risk deal's grounds are all appended **last**, since they are applied late — so a head-of-list cut takes exactly the facts that decided where the row sits. A row lifted to the top by a pin, or above its neighbours by money, would stop saying why.

So the rest go behind a tap. Same shape the deal status card already uses (`dealstatus.tsx:227`): first out, remainder reachable.

**The fold names its count** — "+2 more reasons", not "more". A reader deciding whether to spend a tap wants to know if it is one more fact or four. This is also the durable half: a ceiling that says only what a row contains *today* breaks again the next time someone adds a reason. A count does not.

**Three before the fold**, because three still fit on one line at 390px:

| reasons | height |
|---|---|
| 2 | 19px |
| 3 | 19px |
| 4 | 37px |
| 6 | 56px |

So the fold costs a reader nothing until the line would have wrapped anyway, and a row that fits is drawn as a plain caption with no disclosure at all.

## What this does not do

**It does not make `AC-WORKLIST-SDR-07` pass**, and I measured afterwards to be sure. The seeded task row carries two reasons, so it never folds and is still 284px against a 176px ceiling. Its remaining spend is 24px padding + three 12px gaps + rank 19 + text 117 + dispositions 44 + verbs 44 — and the two verb groups on separate lines are **100px of it for four small buttons**.

This change stops the ceiling being missed again. It does not recover the overflow already there. Both geometry criteria stay `test.fixme`.

## Evidence

| Obligation | Evidence |
|---|---|
| Nothing is dropped | `folds the reasons past the third rather than dropping them` — asserts the late-appended `expected_revenue` is still present |
| No fold when it fits | `draws no fold when every reason fits` — three reasons, no `<details>` |
| Mutation strength | Two clauses reverted one at a time, each failing its own test: not rendering the folded remainder, and folding unconditionally |
| Accessibility | Native `<details>`/`<summary>`, so keyboard and screen-reader behaviour is the platform's; the marker is hidden on both spellings because the "+N more" text is the affordance |
| Locale | Count goes through `formatNumber` and the label through `translatePlural` (`_one`/`_other`), so German gets "weiterer Grund" vs "weitere Gründe". All three catalogues updated |
| Full lane | `make check-fe` exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the worklist row's `because` line after the third reason. Previously every reason was drawn, so the line grew without bound; now the overflow is one tap away and nothing is discarded.

**Behavior**
- Rows with three or fewer reasons draw as a plain caption with no disclosure.
- The disclosure is a native `<details>`/`<summary>` and names the count as localized `+N more reasons`.
- `de`, `en`, and `vi` catalogs were updated for singular/plural.

**Notes**
- Late-appended reasons like `pinned` and `expected_revenue` stay reachable behind the disclosure; a cap that dropped the overflow would remove the facts that decided the row's rank.
- This does not make `AC-WORKLIST-SDR-07` pass: the seeded row has two reasons, so it never folds and still exceeds its height ceiling.

<sup>Written for commit cb9819e5707afb7ceb8afb5d61a729cec0657c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist rows now display the first three reasons directly, with additional reasons available through a “+N more reasons” expandable control.
  * All reasons remain accessible, including those used for ranking.
  * Added localized labels for the expandable reason count in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->