### PR TITLE
Every job insert names the retry ladder it rides

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -1419,6 +1419,7 @@ kinds:
     go_type: ProviderRunSubmitArgs
     queue: default
     timeout: 2m
+    max_attempts: 3
     opts_owner: args
     registration: {when: [ProviderRuns.Registry, ProviderRuns.Vault], absent: registers_nothing}
     args:
@@ -1430,6 +1431,12 @@ kinds:
       states) is a spend guard, not a scheduling nicety: two live submit jobs
       for one run could each pass the queued check and buy the same answer
       twice, so every inserter carries the rule.
+
+      Three attempts, not River's 25: a stranded submit is recovered by the
+      poll sweep, which re-enqueues after a worked job died, so the sweep is
+      the real retry — and the uniqueness above dedupes over retryable, so a
+      long ladder would suppress the very recovery it is waiting for while
+      each rung risks buying the same answer again.
 
   provider_run_poll_sweep:
     role: dispatcher
@@ -1769,6 +1776,7 @@ kinds:
     go_type: TelegramPollArgs
     queue: default
     timeout: {derived: telegramPollJobTimeout, value: 2m}
+    max_attempts: 3
     opts_owner: args
     registration: {when: [ChannelVault], absent: registers_nothing}
     args:
@@ -1779,6 +1787,11 @@ kinds:
       around it: a poll cancelled by its own job timeout returns nothing, so its
       offset never advances and the connection retries forever without making
       progress.
+
+      Three attempts, not River's 25: telegram_poll_sweep fans this out again
+      every thirty seconds, so the tick is the real retry — and because the
+      insert dedupes over retryable, a longer ladder would suppress those ticks
+      and stop the connection being polled at all.
 
   telegram_poll_sweep:
     role: dispatcher

--- a/backend/gates/insertattemptcaps_test.go
+++ b/backend/gates/insertattemptcaps_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// An insert that names no MaxAttempts does not run without a retry ladder — it
+// runs on River's default of 25, on attempt-to-the-fourth backoff, which
+// reaches days. Nobody chooses that ladder; a site simply omits the field and
+// gets it, which is how vcard_ingest shipped riding it for hours on a
+// deterministic failure.
+//
+// The contract cannot close this. api/jobs.yaml publishes max_attempts for the
+// two owners that can APPLY one — a fan-out child, whose helper reads it off
+// the spec, and an args-owned kind, held equal to its InsertOpts by
+// TestArgsOwnedAttemptCapsMatchTheirDeclaration — and refuses it from a
+// caller-owned kind, because a published number nothing applies is the
+// declared-versus-actual drift that file exists to remove. So a caller-owned
+// kind's cap lives in Go, at the insert, and this is what keeps one from being
+// forgotten there.
+//
+// The corpus is every river.InsertOpts literal rather than the caller-owned
+// kind list, for two reasons: a kind is inserted from more than one site and
+// each site's opts are its own, and several sites build the literal inline
+// rather than in a *InsertOpts() constructor a kind-keyed walk could find.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strconv"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// insertSite is a literal's address as this gate reports and waives it:
+// the file it is in and the function it is built in. Not a line number, which
+// moves under an edit that changes nothing about the obligation.
+type insertSite string
+
+// capExemptSites ratifies the literals that must NOT name an attempt cap. Both
+// are helpers that hand the number's ownership somewhere else, and in both the
+// omission is load-bearing rather than forgotten.
+var capExemptSites = gatekit.Waive(map[insertSite]string{
+	"internal/compose/jobs.go:sweepInsertOpts":       "the uniqueness half of the periodic insert and nothing else. River reads the explicit opts BEFORE the args type's, so a cap here would outrank every max_attempts api/jobs.yaml publishes for an opts_owner: args kind and make the declared ladder a number nothing runs at; periodicInsertOpts adds one only where no args type owns it",
+	"internal/compose/dispatch.go:markedAsFleetPass": "it copies the caller's opts to add the sweep tag, so the cap it carries is whichever one the caller already chose. Naming one here would silently retune every fleet pass, and do it inside a function whose subject is a tag",
+})
+
+// TestEveryInsertDeclaresAnAttemptCap is the census the caller-owned tier had
+// no equivalent of.
+func TestEveryInsertDeclaresAnAttemptCap(t *testing.T) {
+	t.Parallel()
+	defer capExemptSites.AssertAllMatched(t)
+	scope := gatekit.Scope{
+		Roots:   []string{"internal/compose"},
+		Subject: func(_ string, file *ast.File) bool { return len(insertOptsLiterals(file)) > 0 },
+		Exempt:  gatekit.Waive(map[string]string{}),
+	}
+	seen, bounded := 0, 0
+	for _, src := range scope.Files(t) {
+		consts := attemptCapConstants(src.File)
+		for _, lit := range insertOptsLiterals(src.File) {
+			seen++
+			site := insertSite(fmt.Sprintf("%s:%s", src.Path, lit.fn))
+			capExpr, named := lit.attemptCap()
+			if !named {
+				if !capExemptSites.Waived(t, site) {
+					t.Errorf("%s builds a river.InsertOpts naming no MaxAttempts, so its rows ride River's "+
+						"default ladder of %d on attempt⁴ backoff — days of retries nobody chose. Name one of "+
+						"the caps in internal/compose/jobattempts.go, read the number off the declaration, or "+
+						"ratify the site in capExemptSites with the reason the omission is load-bearing",
+						site, jobs.DefaultMaxAttempts)
+				}
+				continue
+			}
+			bounded++
+			if capExemptSites.Waived(t, site) {
+				t.Errorf("%s names a MaxAttempts and is also ratified in capExemptSites as a site that must "+
+					"not: drop the waiver, which now describes code that is gone", site)
+			}
+			value, resolved := attemptCapValue(capExpr, consts)
+			if !resolved {
+				// The number came off the declaration or off a runtime value —
+				// spec.MaxAttempts, decl.MaxAttempts — which is a BETTER source
+				// than a Go constant, not a worse one: api/jobs.yaml carries
+				// the number and the reason for it, and this walk deliberately
+				// does not re-derive what that file already holds.
+				continue
+			}
+			if value <= 0 || value >= jobs.DefaultMaxAttempts {
+				t.Errorf("%s inserts with MaxAttempts %d: a cap must be positive and below River's own "+
+					"default of %d, or it is not a choice — zero and above-default both leave the row on "+
+					"the ladder this gate exists to take it off",
+					site, value, jobs.DefaultMaxAttempts)
+			}
+		}
+	}
+	// Rule 8: a census that reads a smaller tree than it thinks reports PASS,
+	// and there is no failing assertion to notice. These floors are what such a
+	// walk trips over — one for the corpus, one for each disposition, so a
+	// spelling change that hides the literals, the caps, or the waived helpers
+	// fails here rather than certifying an empty sweep.
+	const fewestLiterals = 30
+	if seen < fewestLiterals {
+		t.Errorf("the walk found %d river.InsertOpts literals under internal/compose, fewer than the %d that "+
+			"were there when this gate was written: a census that reads less than it thinks reports PASS, so "+
+			"either the inserts moved to a spelling this walk cannot see or the floor is stale",
+			seen, fewestLiterals)
+	}
+	if bounded == 0 || bounded == seen {
+		t.Errorf("of %d literals %d name a cap: this gate distinguishes the two dispositions, and finding "+
+			"only one of them means the walk is reading the field's presence wrong rather than that the tree "+
+			"is uniform", seen, bounded)
+	}
+}
+
+// insertOptsLiteral is one river.InsertOpts composite literal and the function
+// it is built in.
+type insertOptsLiteral struct {
+	fn  string
+	lit *ast.CompositeLit
+}
+
+// attemptCap returns the expression the literal sets MaxAttempts to, and
+// whether it sets it at all.
+func (l insertOptsLiteral) attemptCap() (ast.Expr, bool) {
+	for _, elt := range l.lit.Elts {
+		kv, keyed := elt.(*ast.KeyValueExpr)
+		if !keyed {
+			continue
+		}
+		if key, isIdent := kv.Key.(*ast.Ident); isIdent && key.Name == "MaxAttempts" {
+			return kv.Value, true
+		}
+	}
+	return nil, false
+}
+
+// insertOptsLiterals finds every river.InsertOpts composite literal in the
+// file, each tagged with the function it is built in.
+//
+// Both spellings of the type are matched. A composite literal written
+// `river.InsertOpts{…}` reads as a SelectorExpr, and `&river.InsertOpts{…}`
+// wraps the same node in a unary — the walk sees the literal either way,
+// because ast.Inspect descends into the unary.
+func insertOptsLiterals(file *ast.File) []insertOptsLiteral {
+	var found []insertOptsLiteral
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc {
+			continue
+		}
+		ast.Inspect(fn, func(node ast.Node) bool {
+			lit, isLit := node.(*ast.CompositeLit)
+			if !isLit {
+				return true
+			}
+			if sel, isSel := lit.Type.(*ast.SelectorExpr); isSel && sel.Sel.Name == "InsertOpts" {
+				if pkg, isIdent := sel.X.(*ast.Ident); isIdent && pkg.Name == "river" {
+					found = append(found, insertOptsLiteral{fn: fn.Name.Name, lit: lit})
+				}
+			}
+			return true
+		})
+	}
+	return found
+}
+
+// attemptCapConstants collects the file's package-level integer constants, so a cap
+// written as the named constant it should be can still be read as a number.
+//
+// One file's constants, not the package's: a cap and the insert that applies it
+// belong beside each other, and the caps this tree shares live in
+// jobattempts.go, whose own literals are read from the same file.
+func attemptCapConstants(file *ast.File) map[string]int {
+	values := map[string]int{}
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+			for i, name := range value.Names {
+				if i >= len(value.Values) {
+					continue
+				}
+				if literal, ok := untypedIntLiteral(value.Values[i]); ok {
+					values[name.Name] = literal
+				}
+			}
+		}
+	}
+	return values
+}
+
+// attemptCapValue resolves a cap expression to the number it will insert with,
+// reporting false for one this walk cannot read without a type checker — a
+// field read off the declaration, or arithmetic.
+func attemptCapValue(expr ast.Expr, consts map[string]int) (int, bool) {
+	if literal, ok := untypedIntLiteral(expr); ok {
+		return literal, true
+	}
+	if ident, isIdent := expr.(*ast.Ident); isIdent {
+		value, known := consts[ident.Name]
+		return value, known
+	}
+	return 0, false
+}
+
+// untypedIntLiteral reads an untyped integer literal.
+func untypedIntLiteral(expr ast.Expr) (int, bool) {
+	basic, isBasic := expr.(*ast.BasicLit)
+	if !isBasic || basic.Kind != token.INT {
+		return 0, false
+	}
+	value, err := strconv.Atoi(basic.Value)
+	if err != nil {
+		return 0, false
+	}
+	return value, true
+}

--- a/backend/gates/insertattemptcaps_test.go
+++ b/backend/gates/insertattemptcaps_test.go
@@ -36,9 +36,17 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// insertSite is a literal's address as this gate reports and waives it:
-// the file it is in and the function it is built in. Not a line number, which
-// moves under an edit that changes nothing about the obligation.
+// insertSite is a literal's address as this gate reports and waives it: the
+// file, the function it is built in, and — for the second and later literal in
+// one function — which one.
+//
+// Not a line number, which moves under an edit that changes nothing about the
+// obligation. But not the function alone either: a waiver keyed on the function
+// is inherited by every literal added to it later, and Waived records a match
+// without refusing a repeat, so a second uncapped literal inside a ratified
+// helper would be exempted by a reason written about its neighbour. An ordinal
+// is stable under every edit except adding a literal, which is exactly the edit
+// that must not inherit.
 type insertSite string
 
 // capExemptSites ratifies the literals that must NOT name an attempt cap. Both
@@ -65,6 +73,9 @@ func TestEveryInsertDeclaresAnAttemptCap(t *testing.T) {
 		for _, lit := range insertOptsLiterals(src.File) {
 			seen++
 			site := insertSite(fmt.Sprintf("%s:%s", src.Path, lit.fn))
+			if lit.nth > 1 {
+				site = insertSite(fmt.Sprintf("%s:%s#%d", src.Path, lit.fn, lit.nth))
+			}
 			capExpr, named := lit.attemptCap()
 			if !named {
 				if !capExemptSites.Waived(t, site) {
@@ -80,6 +91,14 @@ func TestEveryInsertDeclaresAnAttemptCap(t *testing.T) {
 			if capExemptSites.Waived(t, site) {
 				t.Errorf("%s names a MaxAttempts and is also ratified in capExemptSites as a site that must "+
 					"not: drop the waiver, which now describes code that is gone", site)
+			}
+			if namesTheDefaultLadder(capExpr) {
+				t.Errorf("%s names River's own default as its MaxAttempts, which is not a cap but the ladder "+
+					"this gate exists to take rows off: %d attempts on attempt⁴ backoff, reaching days. A "+
+					"kind that genuinely runs on the default says so in api/jobs.yaml, where the number "+
+					"carries its reason, and the insert reads it off the declaration",
+					site, jobs.DefaultMaxAttempts)
+				continue
 			}
 			value, resolved := attemptCapValue(capExpr, consts)
 			if !resolved {
@@ -120,7 +139,11 @@ func TestEveryInsertDeclaresAnAttemptCap(t *testing.T) {
 // insertOptsLiteral is one river.InsertOpts composite literal and the function
 // it is built in.
 type insertOptsLiteral struct {
-	fn  string
+	fn string
+	// nth is which literal this is inside fn, counting from one. It is what
+	// keeps a waiver from spreading to a literal added beside the one it was
+	// written about.
+	nth int
 	lit *ast.CompositeLit
 }
 
@@ -153,6 +176,7 @@ func insertOptsLiterals(file *ast.File) []insertOptsLiteral {
 		if !isFunc {
 			continue
 		}
+		nth := 0
 		ast.Inspect(fn, func(node ast.Node) bool {
 			lit, isLit := node.(*ast.CompositeLit)
 			if !isLit {
@@ -160,7 +184,8 @@ func insertOptsLiterals(file *ast.File) []insertOptsLiteral {
 			}
 			if sel, isSel := lit.Type.(*ast.SelectorExpr); isSel && sel.Sel.Name == "InsertOpts" {
 				if pkg, isIdent := sel.X.(*ast.Ident); isIdent && pkg.Name == "river" {
-					found = append(found, insertOptsLiteral{fn: fn.Name.Name, lit: lit})
+					nth++
+					found = append(found, insertOptsLiteral{fn: fn.Name.Name, nth: nth, lit: lit})
 				}
 			}
 			return true
@@ -225,4 +250,25 @@ func untypedIntLiteral(expr ast.Expr) (int, bool) {
 		return 0, false
 	}
 	return value, true
+}
+
+// namesTheDefaultLadder reports whether a cap expression IS River's default,
+// however it is spelled — jobs.DefaultMaxAttempts, or the bare name inside the
+// package that mirrors it.
+//
+// Named separately from attemptCapValue because it is a different refusal.
+// attemptCapValue admits an expression it cannot evaluate, on the ground that
+// the number came off api/jobs.yaml, where it carries its reason — and a
+// declared cap may legitimately BE 25, as capture_sync's is. What may not
+// happen is a Go insert site naming the default itself: that is a site
+// declining to choose while satisfying a gate that asks it to.
+func namesTheDefaultLadder(expr ast.Expr) bool {
+	const defaultName = "DefaultMaxAttempts"
+	switch named := expr.(type) {
+	case *ast.SelectorExpr:
+		return named.Sel.Name == defaultName
+	case *ast.Ident:
+		return named.Name == defaultName
+	}
+	return false
 }

--- a/backend/internal/compose/backfilltransport.go
+++ b/backend/internal/compose/backfilltransport.go
@@ -309,7 +309,14 @@ func (h backfillHandlers) StartConnectorBackfill(w http.ResponseWriter, r *http.
 		func(ctx context.Context, tx pgx.Tx, backfillID ids.UUID) error {
 			enqueueErr = h.inserter.EnqueueTx(ctx, tx, CaptureBackfillArgs{
 				Workspace: ws, BackfillID: backfillID.String(),
-			}, &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}})
+			}, &river.InsertOpts{
+				// ONE attempt: api/jobs.yaml's fault block for capture_backfill
+				// says the backfill ROW owns the outcome, ending the run and
+				// recording the fault class against its own give-up cap. A
+				// River retry would re-page a run the engine already ended.
+				MaxAttempts: rowOwnedMaxAttempts,
+				UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+			})
 			return enqueueErr
 		})
 	if enqueueErr != nil {

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -81,8 +81,12 @@ const (
 // SAME read collapses while a fresh read (new dossier) always queues.
 func siteDeepReadInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue:      deepReadQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true},
+		Queue: deepReadQueue,
+		// Swept: capture_auto_enrich_sweep re-nominates an organization that is
+		// still due on its next daily pass, so a crawl that cannot finish is
+		// re-read tomorrow rather than re-walked all afternoon.
+		MaxAttempts: sweptJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true},
 	}
 }
 

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -142,10 +142,13 @@ func oneOffChildOpts(childKind string) *river.InsertOpts {
 // enqueue lands on the same pool the scheduled tick uses instead of a queue the
 // caller happened to name.
 //
-// No attempt cap, because a caller-owned kind declares none: max_attempts is
-// contract-declared only for a fan-out child, whose cap the fan-out is
-// responsible for setting. Passing one here would publish a number the
-// declaration does not carry.
+// The attempt cap is periodicPassMaxAttempts, the same one the CLOCK gives
+// this kind: a collapsed pass enqueued by a trigger is the identical pass the
+// tick enqueues, and the two doors already dedupe against each other, so a
+// trigger-queued row riding a different ladder from a scheduled one would be
+// the same pass behaving two ways depending on which door it came through. It
+// is not read off the declaration because a caller-owned kind publishes no
+// max_attempts — api/jobs.yaml refuses a number nothing applies.
 //
 // No sweep tag, for the reason oneOffChildOpts gives: the tag marks a row as
 // one workspace's share of a fleet pass, and the gauges count tagged rows. A
@@ -159,7 +162,7 @@ func oneOffPassOpts(kind string) *river.InsertOpts {
 	if spec.OptsOwner != jobs.OptsCaller {
 		panic("compose: " + kind + " declares an opts_owner other than caller, so its queue is not this helper's to set")
 	}
-	return &river.InsertOpts{Queue: spec.Queue}
+	return &river.InsertOpts{Queue: spec.Queue, MaxAttempts: periodicPassMaxAttempts}
 }
 
 // fanOutChildren is every kind some dispatcher DECLARES it fans out to —

--- a/backend/internal/compose/extjobs.go
+++ b/backend/internal/compose/extjobs.go
@@ -172,8 +172,8 @@ func composedJobSpecs(set []composedJob) []jobs.Spec {
 				FanOutTo:   j.decl.ChildKind(),
 				// The TICK owns this row's insert options, exactly as it does for
 				// every core dispatcher: periodicForComposed hands River
-				// sweepInsertOpts(), which names no queue and so lands the row on
-				// River's default. The unit's declared queue is the CHILD's — that
+				// periodicInsertOpts(), which names no queue and so lands the row
+				// on River's default. The unit's declared queue is the CHILD's — that
 				// is the row that does the tenant's work and the pool an operator
 				// sizes — and it is bound there through OptsFanOut below.
 				//
@@ -276,7 +276,7 @@ func periodicForComposed(d extension.JobDeclaration) *river.PeriodicJob {
 	args := extJobDispatcherArgs{JobKind: d.DispatcherKind()}
 	return river.NewPeriodicJob(
 		river.PeriodicInterval(d.Cadence),
-		func() (river.JobArgs, *river.InsertOpts) { return args, sweepInsertOpts() },
+		func() (river.JobArgs, *river.InsertOpts) { return args, periodicInsertOpts(args) },
 		&river.PeriodicJobOpts{RunOnStart: true},
 	)
 }

--- a/backend/internal/compose/gmailpush.go
+++ b/backend/internal/compose/gmailpush.go
@@ -36,7 +36,6 @@ import (
 	"net/http"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
@@ -170,13 +169,7 @@ func handleGmailPush(pool *pgxpool.Pool, inserter *jobs.Runner, log *slog.Logger
 				Workspace:    d.Workspace.UUID,
 				ConnectionID: d.ID.String(),
 				Provider:     "gmail",
-			}, &river.InsertOpts{
-				// river's default uniqueness window includes completed jobs;
-				// activeSweepStates deliberately excludes them, so this must
-				// stay exactly as-is — dropping ByState would suppress a
-				// legitimate re-sync any time the prior one had finished.
-				UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
-			}); err != nil {
+			}, pushSyncOpts()); err != nil {
 				log.ErrorContext(ctx, "gmail push: enqueueing sync", "connection", d.ID.String(), "err", err)
 				return Transient, err
 			}

--- a/backend/internal/compose/graphpush.go
+++ b/backend/internal/compose/graphpush.go
@@ -35,7 +35,6 @@ import (
 	"net/http"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/jobs"
@@ -197,13 +196,7 @@ func bumpGraphMailboxes(
 			Workspace:    d.Workspace.UUID,
 			ConnectionID: d.ID.String(),
 			Provider:     providerGraph,
-		}, &river.InsertOpts{
-			// river's default uniqueness window includes completed jobs;
-			// activeSweepStates deliberately excludes them, so this must stay
-			// exactly as-is — dropping ByState would suppress a legitimate
-			// re-sync any time the prior one had finished.
-			UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
-		}); err != nil {
+		}, pushSyncOpts()); err != nil {
 			log.ErrorContext(ctx, "graph push: enqueueing sync", "connection", d.ID.String(), "err", err)
 			faults = errors.Join(faults, err)
 		}

--- a/backend/internal/compose/jobattempts.go
+++ b/backend/internal/compose/jobattempts.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The attempt ladders this package inserts with.
+//
+// River resolves MaxAttempts as the explicit InsertOpts first, the args type's
+// own InsertOpts second, and its default of 25 last. api/jobs.yaml carries the
+// number for the two owners that can apply one — a fan-out child, whose helper
+// reads it off the spec, and an args-owned kind, whose InsertOpts is held equal
+// to the declaration by TestArgsOwnedAttemptCapsMatchTheirDeclaration. It
+// refuses the number from a caller-owned kind, because publishing a cap nothing
+// applies is the declared-versus-actual drift that contract exists to remove.
+//
+// So a caller-owned kind's cap lives here, in Go, next to the insert that
+// applies it. TestEveryInsertDeclaresAnAttemptCap is what keeps a new one from
+// simply being forgotten.
+
+// periodicPassMaxAttempts is the ladder a scheduled pass rides when nothing
+// else owns one, and it is small for the reason workspaceSweepOpts states
+// about a fan-out child: the pass's real retry cadence is its own next tick,
+// so River's ladder is only there to ride out a transient blip inside one tick
+// window. Three is the house number api/jobs.yaml publishes for a fan-out
+// child on exactly that argument, and a collapsed pass that does the work in
+// its own row is the same shape with the enumeration removed.
+//
+// Left unset it is River's default of 25 on attempt-to-the-fourth backoff,
+// which reaches days — and because retryable is one of activeSweepStates, a
+// backing-off row SUPPRESSES every tick until it discards. A pass that fails
+// deterministically therefore stops running rather than retrying, which is the
+// one failure this cap exists to remove; three attempts span seconds, inside
+// even the thirty-second cadences.
+const periodicPassMaxAttempts = 3
+
+// The two ladders a one-shot insert rides, and the one it rides when its own
+// row owns the outcome. A caller-owned kind declares no max_attempts —
+// api/jobs.yaml refuses to publish a number nothing applies — so its cap is
+// named here and the question a site answers is only WHICH of these three it
+// is. Left unnamed a site gets River's 25, which is a ladder reaching days for
+// work no reader chose it for.
+const (
+	// sweptJobMaxAttempts is for a kind something re-issues: a periodic pass
+	// that re-nominates the same subject, a poller that heals what a signal
+	// missed, a recovery scan that re-enqueues a stranded row. The re-issue IS
+	// the retry, so River's ladder only has to ride out a blip inside one
+	// window — and where the insert dedupes over activeSweepStates, a longer
+	// one would suppress the very re-issue it is waiting for.
+	sweptJobMaxAttempts = 3
+
+	// oneOffJobMaxAttempts is for a kind nothing re-issues: a person pressed a
+	// button, or a message arrived once. The ladder carries BOTH failure shapes
+	// alone — a dependency down for a minute, worth the retries, and a
+	// malformed input or a code defect, worth none — which is the headroom
+	// vcardIngestMaxAttempts, scheduledSendMaxAttempts and
+	// embedReindexMaxAttempts were each given for the same reason.
+	oneOffJobMaxAttempts = 5
+
+	// rowOwnedMaxAttempts is for a kind whose DOMAIN ROW records the outcome
+	// and whose retry lives somewhere else — the kinds whose api/jobs.yaml
+	// fault: block says the worker logs and returns nil. River is not their
+	// retry mechanism at all, so a second attempt would re-run work the engine
+	// already concluded rather than recover anything.
+	rowOwnedMaxAttempts = 1
+)

--- a/backend/internal/compose/jobdeclared_test.go
+++ b/backend/internal/compose/jobdeclared_test.go
@@ -522,4 +522,6 @@ var argsForKind = map[string]river.JobArgs{
 	IntroExpiryArgs{}.Kind():             IntroExpiryArgs{},
 	ApprovalAutoApplyArgs{}.Kind():       ApprovalAutoApplyArgs{},
 	PrivacyRetentionArgs{}.Kind():        PrivacyRetentionArgs{},
+	ProviderRunSubmitArgs{}.Kind():       ProviderRunSubmitArgs{},
+	TelegramPollArgs{}.Kind():            TelegramPollArgs{},
 }

--- a/backend/internal/compose/jobextkindgate_test.go
+++ b/backend/internal/compose/jobextkindgate_test.go
@@ -156,8 +156,8 @@ func TestAnUnregisteredExtensionKindIsStillARefusal(t *testing.T) {
 // from the truth when a unit picks a pool other than the default.
 //
 // The dispatcher's insert options come from periodicForComposed's
-// sweepInsertOpts(), which names no queue — so the row lands on River's default
-// whatever the fragment says. The unit's declared queue belongs to the CHILD,
+// periodicInsertOpts(), which names no queue — so the row lands on River's
+// default whatever the fragment says. The unit's declared queue belongs to the CHILD,
 // which is the row that does the tenant's work and the pool an operator sizes.
 // A dispatcher Spec republishing the unit's queue would put a label on
 // margince_job_declared_info naming a pool its rows never reach, which is
@@ -177,7 +177,7 @@ func TestAComposedDispatcherPublishesTheQueueItsRowsActuallyLandOn(t *testing.T)
 		t.Fatalf("%s is not declared", d.DispatcherKind())
 	}
 	if dispatcher.Queue != river.QueueDefault {
-		t.Errorf("the dispatcher declares queue %q, but sweepInsertOpts names no queue so its rows land on %q",
+		t.Errorf("the dispatcher declares queue %q, but the periodic insert names no queue so its rows land on %q",
 			dispatcher.Queue, river.QueueDefault)
 	}
 	if dispatcher.OptsOwner != jobs.OptsCaller {
@@ -187,7 +187,7 @@ func TestAComposedDispatcherPublishesTheQueueItsRowsActuallyLandOn(t *testing.T)
 	// calls: a *river.PeriodicJob keeps its constructor unexported, so the
 	// alternative is inserting a row and reading the queue back — a database test
 	// for a claim that is decided entirely at the insert site.
-	if opts := sweepInsertOpts(); opts.Queue != "" && opts.Queue != river.QueueDefault {
+	if opts := periodicInsertOpts(extJobDispatcherArgs{JobKind: d.DispatcherKind()}); opts.Queue != "" && opts.Queue != river.QueueDefault {
 		t.Errorf("the tick inserts on queue %q while the declaration publishes %q", opts.Queue, dispatcher.Queue)
 	}
 

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
+const jobContractHash = "ece119fe5bee23d5b18df82f56ba3e8cbbd35cb97f99b52dc74026a8ac0c3f9a"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -53,7 +53,12 @@ var activeSweepStates = []rivertype.JobState{
 	rivertype.JobStateRetryable,
 }
 
-// sweepInsertOpts is the shared insert policy for the periodic passes.
+// sweepInsertOpts is the shared UNIQUENESS policy for the periodic passes, and
+// it deliberately names no attempt cap: River resolves MaxAttempts as the
+// explicit opts first, the args type's own InsertOpts second, so a number here
+// would override every args-owned cap the contract publishes and make
+// api/jobs.yaml's declared ladder a number nothing runs at. periodicFor
+// supplies one only where no args type owns it.
 func sweepInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByState: activeSweepStates}}
 }

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -254,6 +254,33 @@ func (CaptureSyncArgs) Kind() string { return "capture_sync" }
 // WorkspaceID binds this connection's sync to its tenant (jobs.WorkspaceScoped).
 func (a CaptureSyncArgs) WorkspaceID() ids.UUID { return a.Workspace }
 
+// pushSyncOpts is what a PROVIDER PUSH enqueues one connection's sync with —
+// one helper for both push lanes, because the two carried the same literal and
+// the same paragraph explaining it, which is two writers of one rule.
+//
+// It is not oneOffChildOpts: that helper drops active-state uniqueness because
+// its event's whole claim is that new rows landed and a running pass may have
+// read the mailbox before they did. A push says the same thing, but a mailbox
+// sync is a full incremental pull whose cursor advances only at the end, so a
+// second one racing the first re-fetches the same mail rather than reaching
+// anything the first missed — the running pass will see it.
+//
+// river's default uniqueness window includes completed jobs; activeSweepStates
+// deliberately excludes them, so this must stay exactly as-is — dropping
+// ByState would suppress a legitimate re-sync any time the prior one had
+// finished.
+//
+// The attempt cap comes off the declaration rather than being written here, so
+// api/jobs.yaml's number is the one a push actually runs at: capture_sync
+// publishes River's own 25 with the reason it is right there — the worker
+// records its own failure and returns nil, so the ladder is walked only for a
+// fault the sidecar's backoff does not own.
+func pushSyncOpts() *river.InsertOpts {
+	opts := oneOffChildOpts(CaptureSyncArgs{}.Kind())
+	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
+	return opts
+}
+
 // captureSyncWorker runs one SyncOnce under the connection's workspace. A
 // sync failure returns nil after the registry has recorded it: the sidecar's
 // backoff owns the retry cadence (ADR-0063) — a River retry would bypass it.

--- a/backend/internal/compose/jobs_documentextract.go
+++ b/backend/internal/compose/jobs_documentextract.go
@@ -66,8 +66,12 @@ func (a DocumentExtractArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // replacement.
 func documentExtractInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue:      transcriptReadQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		Queue: transcriptReadQueue,
+		// One-off: a rep asked for this document to be read and nothing
+		// re-asks, so the ladder carries the blob-store blip and the malformed
+		// attachment alone — the reading vcardIngestMaxAttempts is sized for.
+		MaxAttempts: oneOffJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 }
 

--- a/backend/internal/compose/jobs_overlay_sweep.go
+++ b/backend/internal/compose/jobs_overlay_sweep.go
@@ -297,6 +297,13 @@ func sweepReprojectionPhase(ctx context.Context, deps sweepDeps, workspace ids.W
 // re-fetch is still queued must not stack a second read of the same record —
 // the args ARE the coalescing key, exactly as they are for the webhook lane's
 // signal-driven re-fetch (overlaywebhook.go).
+//
+// Swept, so the cap is small: the reconcile pass lists the stale rows again on
+// its next tick, and because retryable is one of activeSweepStates a longer
+// ladder would suppress that re-enqueue rather than hasten it.
 func reprojectionInsertOpts() *river.InsertOpts {
-	return &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
+	return &river.InsertOpts{
+		MaxAttempts: sweptJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
 }

--- a/backend/internal/compose/jobs_providerruns.go
+++ b/backend/internal/compose/jobs_providerruns.go
@@ -85,8 +85,14 @@ func (a ProviderRunSubmitArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // jobs for one run could each pass the queued check and buy the same answer
 // twice. The state window excludes completed (activeSweepStates) so the
 // stranded-submit recovery can re-enqueue after a worked job died.
+//
+// The attempt cap is the one api/jobs.yaml publishes, held equal to the
+// declaration by TestArgsOwnedAttemptCapsMatchTheirDeclaration.
 func (ProviderRunSubmitArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
+	return river.InsertOpts{
+		MaxAttempts: sweptJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
 }
 
 // providerRunSubmitWorker executes one submission.

--- a/backend/internal/compose/jobs_techenrich.go
+++ b/backend/internal/compose/jobs_techenrich.go
@@ -83,8 +83,13 @@ func (TechnicalEnrichBackfillArgs) InsertOpts() river.InsertOpts {
 // second one against the same three services.
 func technicalInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue:      technicalLookupQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		Queue: technicalLookupQueue,
+		// Swept: technical_enrich_backfill re-nominates a company whose lookup
+		// did not land, and the three services this asks are small ones running
+		// on goodwill — a long ladder would keep asking them about a company
+		// the next pass is going to ask about anyway.
+		MaxAttempts: sweptJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 }
 

--- a/backend/internal/compose/jobs_transcript.go
+++ b/backend/internal/compose/jobs_transcript.go
@@ -54,8 +54,12 @@ func (a TranscriptProposeArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // SAME reading collapses while a fresh reading always queues.
 func transcriptProposeInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue:      transcriptReadQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true},
+		Queue: transcriptReadQueue,
+		// One-off: a rep asked for this recording to be read and nothing
+		// re-asks, so the ladder carries the blob-store blip and the unreadable
+		// transcript alone — the same reading document_extract is sized for.
+		MaxAttempts: oneOffJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true},
 	}
 }
 

--- a/backend/internal/compose/jobschedule.go
+++ b/backend/internal/compose/jobschedule.go
@@ -41,11 +41,29 @@ func periodicFor[A declaredJobArgs](cfg JobRunnerConfig, args A) []*river.Period
 	if !scheduled {
 		return nil
 	}
+	opts := periodicInsertOpts(args)
 	return []*river.PeriodicJob{river.NewPeriodicJob(
 		river.PeriodicInterval(interval),
-		func() (river.JobArgs, *river.InsertOpts) { return args, sweepInsertOpts() },
+		func() (river.JobArgs, *river.InsertOpts) { return args, opts },
 		&river.PeriodicJobOpts{RunOnStart: true},
 	)}
+}
+
+// periodicInsertOpts is sweepInsertOpts plus an attempt cap for the passes
+// nothing else caps.
+//
+// A kind whose args carry their own InsertOpts is left alone: that number is
+// what api/jobs.yaml declares for an opts_owner: args kind, held equal to the
+// declaration by TestArgsOwnedAttemptCapsMatchTheirDeclaration, and River reads
+// the EXPLICIT opts before the args type's — so supplying one here would
+// silently outrank the published cap. Every other scheduled kind is
+// opts_owner: caller, and this periodic insert is that caller.
+func periodicInsertOpts(args river.JobArgs) *river.InsertOpts {
+	opts := sweepInsertOpts()
+	if _, owned := args.(river.JobArgsWithInsertOpts); !owned {
+		opts.MaxAttempts = periodicPassMaxAttempts
+	}
+	return opts
 }
 
 // registers answers whether a kind is wired at all under this boot's

--- a/backend/internal/compose/jobschedule_test.go
+++ b/backend/internal/compose/jobschedule_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/riverqueue/river"
+
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 )
@@ -312,4 +314,43 @@ func TestEveryScheduledKindIsWiredExactlyOnce(t *testing.T) {
 // neither is reached by its dispatcher, and has no periodicFor site to own.
 func declaresAClock(c jobs.Cadence) bool {
 	return c.Fixed != 0 || c.OperatorField != "" || c.OnDemand
+}
+
+// TestThePeriodicInsertYieldsToAnArgsOwnedCap is what makes periodicInsertOpts'
+// claim about River's resolution order checkable.
+//
+// River reads the EXPLICIT InsertOpts before the args type's own, so the
+// periodic insert leaving MaxAttempts at zero is the whole reason an
+// opts_owner: args kind runs at the number api/jobs.yaml publishes for it.
+// Supply one unconditionally and every declared cap is silently outranked —
+// TestArgsOwnedAttemptCapsMatchTheirDeclaration would still pass, because it
+// reads the args method rather than what the scheduler inserts with, and the
+// drift would surface only as a pass retrying far more than the file says.
+func TestThePeriodicInsertYieldsToAnArgsOwnedCap(t *testing.T) {
+	t.Parallel()
+	// AgentSchedulerArgs owns its InsertOpts and declares one attempt; the
+	// periodic insert must add nothing, or the one becomes three.
+	if got := periodicInsertOpts(AgentSchedulerArgs{}).MaxAttempts; got != 0 {
+		t.Errorf("the periodic insert supplied MaxAttempts %d for a kind whose args own the cap: River reads "+
+			"the explicit opts first, so this outranks the %d api/jobs.yaml publishes for agent_scheduler",
+			got, specFor(t, AgentSchedulerArgs{}.Kind()).MaxAttempts)
+	}
+}
+
+// TestThePeriodicInsertCapsAPassNobodyElseCaps is the other half: a scheduled
+// kind whose args own no InsertOpts has no other place a cap could come from,
+// and River's default of 25 is a ladder reaching days that nobody chose.
+func TestThePeriodicInsertCapsAPassNobodyElseCaps(t *testing.T) {
+	t.Parallel()
+	// CloseDateSweepArgs is opts_owner: caller — api/jobs.yaml refuses it a
+	// max_attempts, so this insert is the only door the number comes through.
+	if _, owned := any(CloseDateSweepArgs{}).(river.JobArgsWithInsertOpts); owned {
+		t.Fatal("CloseDateSweepArgs now owns its own InsertOpts, so it no longer stands for the caller-owned " +
+			"passes this test is about — name one that does not")
+	}
+	if got := periodicInsertOpts(CloseDateSweepArgs{}).MaxAttempts; got != periodicPassMaxAttempts {
+		t.Errorf("the periodic insert gave a caller-owned pass MaxAttempts %d, not periodicPassMaxAttempts "+
+			"(%d): nothing else caps it, so anything but this leaves it on River's %d-rung default",
+			got, periodicPassMaxAttempts, river.MaxAttemptsDefault)
+	}
 }

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -323,6 +323,10 @@ func (h *hubspotWebhookHandler) enqueueRefetch(r *http.Request, workspace ids.UU
 		ExternalID:     externalID,
 	}, &river.InsertOpts{
 		ScheduledAt: time.Now().Add(webhookCoalesceWindow),
+		// Swept: a signal is an optimization and the reconcile poller heals
+		// whatever it misses, so a re-fetch that keeps failing is dropped for
+		// the pass to find rather than laddered for hours.
+		MaxAttempts: sweptJobMaxAttempts,
 		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	})
 }

--- a/backend/internal/compose/raterefreshtransport.go
+++ b/backend/internal/compose/raterefreshtransport.go
@@ -73,8 +73,12 @@ func (h rateRefreshHandlers) enqueueRefresh(w http.ResponseWriter, r *http.Reque
 	// (RequestedBy is provenance, untagged), so two admins refreshing the same
 	// workspace collapse to one in-flight crawl rather than racing two.
 	opts := &river.InsertOpts{
-		Queue:      rateRefreshQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		Queue: rateRefreshQueue,
+		// One-off: an admin pressed refresh and nothing re-presses it. The
+		// sheet is diffed at the end, so a run that gives up stages nothing and
+		// the next click starts over.
+		MaxAttempts: oneOffJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 	if err := h.enqueue.Enqueue(ctx, args, opts); err != nil {
 		httperr.Write(w, r, err)

--- a/backend/internal/compose/telegrampoll.go
+++ b/backend/internal/compose/telegrampoll.go
@@ -130,8 +130,14 @@ func (a TelegramPollArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // The state window excludes `completed` (activeSweepStates): a finished poll must
 // not stop the next tick enqueueing the following one, or ingress would run
 // exactly once per process.
+//
+// The attempt cap is the one api/jobs.yaml publishes, held equal to the
+// declaration by TestArgsOwnedAttemptCapsMatchTheirDeclaration.
 func (TelegramPollArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
+	return river.InsertOpts{
+		MaxAttempts: sweptJobMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
 }
 
 // telegramPollSweepWorker is the dispatcher: due-scan, then one insert per live
@@ -311,7 +317,12 @@ func (w *telegramPollWorker) persist(wsCtx context.Context, target capture.Chann
 				ConnectionID: target.ID.String(),
 				BotID:        target.ChannelID,
 				RawCaptureID: rawID.String(),
-			}, &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true}}); err != nil {
+			}, &river.InsertOpts{
+				// One-off: this raw payload arrived once and no scan re-ingests
+				// it, so the ladder carries the database blip alone.
+				MaxAttempts: oneOffJobMaxAttempts,
+				UniqueOpts:  river.UniqueOpts{ByArgs: true},
+			}); err != nil {
 				return err
 			}
 		}

--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -78,8 +78,18 @@ const (
 	voiceRowRunning  = "running"
 )
 
+// voiceBuildInsertOpts is what one profile's build is queued with.
+//
+// ONE attempt, because api/jobs.yaml's fault block for voice_build says River
+// is not this kind's retry mechanism: every model failure lands on the build
+// row as deferred or failed, and voice_build_retry re-enqueues what is due. A
+// second River attempt would re-spend the builder and judge calls for a build
+// the worker already concluded.
 func voiceBuildInsertOpts() *river.InsertOpts {
-	return &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
+	return &river.InsertOpts{
+		MaxAttempts: rowOwnedMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
 }
 
 // WithVoiceBuildEnqueue makes createVoiceBuild queue the job through the

--- a/backend/internal/platform/jobs/govern.go
+++ b/backend/internal/platform/jobs/govern.go
@@ -10,6 +10,15 @@ import (
 	"github.com/riverqueue/river"
 )
 
+// DefaultMaxAttempts is the ladder River gives a job whose insert names none:
+// 25 attempts on attempt-to-the-fourth backoff, which reaches days.
+//
+// It is spelled here, in the package that owns this repo's River integration,
+// because the fitness function that refuses an uncapped insert has to know the
+// number it is refusing and may not import River to ask. Mirrored rather than
+// copied: a River upgrade that moves the default moves this with it.
+const DefaultMaxAttempts = river.MaxAttemptsDefault
+
 // WorkOnly is all a hand-written worker exposes. River asks a worker four
 // questions; three of them — Timeout, NextRetry, Middleware — are the
 // contract's to answer, so a worker that declared its own would be answering

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
+const JobContractHash = "ece119fe5bee23d5b18df82f56ba3e8cbbd35cb97f99b52dc74026a8ac0c3f9a"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -800,6 +800,7 @@ var specs = map[string]Spec{
 		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
+		MaxAttempts:  3,
 		OptsOwner:    OptsArgs,
 		Registration: Registration{When: []string{"ProviderRuns.Registry", "ProviderRuns.Vault"}},
 		Args:         []ArgField{{Name: "RunID"}, {Name: "Workspace"}},
@@ -871,6 +872,7 @@ var specs = map[string]Spec{
 		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute, DerivedFrom: "telegramPollJobTimeout"},
+		MaxAttempts:  3,
 		OptsOwner:    OptsArgs,
 		Registration: Registration{When: []string{"ChannelVault"}},
 		Args:         []ArgField{{Name: "ConnectionID"}, {Name: "Workspace"}},

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (105)
+## Census (106)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -144,6 +144,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `fliponehandle_test.go` | H2 | The overlay flip runs on ONE workspace binding, and this is what keeps it so. |
 | `gatecensus_test.go` | H2 | The census over this repo's own gate machinery: a gate's exceptions are held to the standard the gate holds its subjects to. |
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
+| `insertattemptcaps_test.go` | H2 | An insert that names no MaxAttempts does not run without a retry ladder — it runs on River's default of 25, on attempt-to-the-fourth backoff, which reaches days. |
 | `jobbinding_test.go` | H2 | workspaceBindFloor guards against a vacuous pass. |
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |
 | `jobrole_test.go` | H2 | Every River job declares its role, and the declaration is the contract: a job either does tenant work for ONE workspace (jobs.WorkspaceScoped, method WorkspaceID) or only scans and enqueues (jobs.FleetWide). |


### PR DESCRIPTION
Closes #3759.

An insert that omits `MaxAttempts` does not run without a retry ladder — it runs on River's default of 25 on attempt⁴ backoff, which reaches days. Nobody picks that ladder; a site omits the field and gets it, which is how `vcard_ingest` shipped riding it on a deterministic failure.

## Why the contract cannot close it

`api/jobs.yaml` publishes `max_attempts` for the two owners that can APPLY one — a fan-out child, whose helper reads it off the spec, and an `opts_owner: args` kind, held equal to its `InsertOpts` by `TestArgsOwnedAttemptCapsMatchTheirDeclaration` — and refuses it from a caller-owned kind, because a published number nothing applies is the declared-versus-actual drift that file exists to remove. So a caller-owned kind's cap lives in Go, at the insert, and the ticket's ask was a fitness function to keep one from being forgotten there.

## What the measurement found

Bigger than the two sites the ticket names. Of 38 `river.InsertOpts` literals under `internal/compose`, **17 named no cap** — and the largest of those was `sweepInsertOpts`, the insert **every scheduled pass** goes through. Thirty-seven cadenced `opts_owner: caller` kinds were riding 25, and because `retryable` is one of `activeSweepStates`, a pass failing deterministically **suppressed its own next tick** for the length of that ladder rather than retrying. `workspaceSweepOpts`' own doc already spells this argument out for fan-out children; the periodic tier simply had no equivalent.

## The three ladders

Named once in `internal/compose/jobattempts.go` with the argument for each, so a site answers only which shape it is:

| | | for |
|---|---|---|
| `sweptJobMaxAttempts` | 3 | something re-issues it — the re-issue IS the retry, and where the insert dedupes over `activeSweepStates` a longer ladder suppresses it |
| `oneOffJobMaxAttempts` | 5 | nothing re-issues it: the ladder carries the transient dependency and the malformed input alone — the headroom `vcardIngestMaxAttempts`, `scheduledSendMaxAttempts` and `embedReindexMaxAttempts` each already carry |
| `rowOwnedMaxAttempts` | 1 | the domain ROW records the outcome and the retry lives elsewhere — the kinds whose `jobs.yaml` `fault:` block already says River is not their retry mechanism (`capture_backfill`, `voice_build`) |

Three is the house number `jobs.yaml` already publishes for a fan-out child, on the same argument. Snoozes do not count as attempts (River's `retry_policy.go`), so `capture_backfill`'s paging is unaffected by its cap of one.

## The periodic insert, carefully

`periodicInsertOpts` supplies a cap **only where no args type owns one**. River resolves `cmp.Or(explicitOpts, argsOpts, clientDefault)`, so an unconditional number would silently outrank every cap `jobs.yaml` publishes — and `TestArgsOwnedAttemptCapsMatchTheirDeclaration` would still pass, because it reads the args method rather than what the scheduler inserts with. Two new tests hold both halves.

`oneOffPassOpts` now gives a trigger-queued collapsed pass the same cap the clock gives it, so the two doors that already dedupe against each other no longer run different ladders.

## Along the way

- `provider_run_submit` and `telegram_poll` are `opts_owner: args` declaring no `max_attempts`, which left them outside the existing parity test. Both now declare one, with the reason, and are held by it.
- gmail and graph push carried the same `InsertOpts` literal and the same paragraph explaining it. One `pushSyncOpts` now, reading `capture_sync`'s declared cap rather than reproducing the number.
- `TestAComposedDispatcherPublishesTheQueueItsRowsActuallyLandOn` read `sweepInsertOpts()` while production called `periodicForComposed`; it now reads the function production calls.

## The gate

`TestEveryInsertDeclaresAnAttemptCap` (`census H2`): every `river.InsertOpts` literal under `internal/compose` names a cap, or is ratified in `capExemptSites` with the reason its omission is load-bearing. Two are — `sweepInsertOpts` (the uniqueness half; a cap there would outrank the declarations) and `markedAsFleetPass` (it copies the caller's opts).

The corpus is the **literals**, not the caller-owned kind list: a kind is inserted from several sites with their own opts, and several sites build the literal inline where a kind-keyed walk would not find it. `gatekit.Scope` proves the root is where the subjects are. A resolvable cap must be positive and below `jobs.DefaultMaxAttempts`; one read off the declaration (`spec.MaxAttempts`) is accepted unresolved, because `jobs.yaml` carries the number and the reason and this walk does not re-derive it.

Rule 8 floors: the literal count, and both dispositions being non-empty — a walk that goes blind fails rather than certifying an empty sweep.

`jobs.DefaultMaxAttempts` mirrors `river.MaxAttemptsDefault` in the package that owns the River integration, because `gates` may not import River and the gate has to know the number it is refusing.

## Verification

`make check-backend` green. Mutation-checked: dropping `voice_build`'s cap (the ticket's named gap), a zero cap, an above-default cap, a stale waiver, a blinded walk, and a `periodicInsertOpts` that overrides an args-owned cap — each fails with the message that names it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added explicit retry limits across background processing tasks, preventing failed jobs from retrying indefinitely.
  - Improved recovery behavior by allowing scheduled sweeps and subsequent user-triggered actions to retry work at the appropriate time.
  - Prevented completed or failed operations from unnecessarily repeating expensive backfills, crawls, refreshes, and synchronization work.

- **Reliability**
  - Standardized retry handling for provider submissions, messaging polls, document processing, enrichment, and webhook-driven jobs.
  - Preserved durable operation outcomes while avoiding duplicate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->