### PR TITLE
A reply knows what it is without asking

### DIFF
--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -123,7 +123,7 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 
 	// Deliverability is derived here, after the gates, so both transports
 	// get it and neither can send marketing mail without it.
-	derived, err := s.deliverability(ctx, signed, in.Subject, in.Recipients, in.ConsentPurpose)
+	derived, err := s.deliverability(ctx, signed, in.Subject, in.Recipients, surfaceFor(in.Context, in.MarketingPurpose, in.ConsentPurpose))
 	if err != nil {
 		return PreparedSend{}, err
 	}

--- a/backend/internal/modules/activities/unsubscribe.go
+++ b/backend/internal/modules/activities/unsubscribe.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // UnsubscribeLinker resolves a recipient address to their preference-center
@@ -187,6 +188,56 @@ func (d sendDeliverability) htmlFooter() string {
 		html.EscapeString(d.words.ManagePreferencesLabel) + `</a></p>`
 }
 
+// unsubscribeSurface says whether this message offers a way to stop, and which
+// topic that offer is about.
+//
+// TWO fields because they answer two questions and the old single purpose key
+// conflated them: whether an unsubscribe surface belongs on this message at all
+// (the category), and which consent purpose the link should point at (the
+// marketing topic). A marketing send names its topic in MarketingPurpose; the
+// deprecated ConsentPurpose is still read as a fallback so an older caller that
+// names only a key keeps the surface it had.
+type unsubscribeSurface struct {
+	category   commsauthz.Category
+	purposeKey string
+}
+
+// surfaceFor reads the unsubscribe surface off a send's own fields.
+//
+// The topic wins over the deprecated key, and both are read: a marketing send
+// names its topic in MarketingPurpose, while an older caller that names only a
+// consent key keeps pointing the link where it always did.
+func surfaceFor(category commsauthz.Category, marketingPurpose, consentPurpose string) unsubscribeSurface {
+	key := marketingPurpose
+	if key == "" {
+		key = consentPurpose
+	}
+	return unsubscribeSurface{category: category, purposeKey: key}
+}
+
+// carries reports whether this message offers an unsubscribe at all.
+//
+// A message with NO category falls back to the deprecated key, so a caller that
+// predates the category — an MCP tool, a stored scheduled send — keeps the
+// behaviour it was written against rather than silently losing or gaining a
+// footer.
+func (u unsubscribeSurface) carries() bool {
+	if u.category != "" {
+		return u.category.CarriesUnsubscribe()
+	}
+	return u.purposeKey != "" && !lockedPurposeKey(u.purposeKey)
+}
+
+// lockedPurposeKey mirrors consent.LockedPurpose for the legacy arm above.
+// activities may not import consent, and the composition root injects the
+// linker rather than the rule, so the one key that has ever been locked is
+// named here.
+//
+// Held by: TestTheLegacyLockedKeyAgreesWithConsent (backend/gates/unsubscribesurface_test.go)
+func lockedPurposeKey(key string) bool {
+	return strings.EqualFold(strings.TrimSpace(key), "transactional")
+}
+
 // deliverability derives what a send must carry for a mailbox provider to
 // accept it as bulk mail: the RFC 8058 List-Unsubscribe header value and the
 // human-visible footer, both built from ONE token so they cannot diverge.
@@ -202,13 +253,23 @@ func (d sendDeliverability) htmlFooter() string {
 // the refusal above counts who RECEIVES the rendered message rather than how
 // they were addressed.
 func (s *Store) deliverability(
-	ctx context.Context, body, subject string, recipients []string, purposeKey string,
+	ctx context.Context, body, subject string, recipients []string, surface unsubscribeSurface,
 ) (sendDeliverability, error) {
 	untokenized := sendDeliverability{transmitted: body, recorded: body}
 	if s.unsubscribe == nil || len(recipients) == 0 {
 		return untokenized, nil
 	}
-	token, ok, err := s.unsubscribe.UnsubscribeToken(ctx, recipients[0], purposeKey)
+	// WHICH MESSAGES CARRY THE SURFACE AT ALL, asked before the linker.
+	//
+	// It reads the CATEGORY and not the purpose key. The key answer was
+	// "anything but the locked transactional purpose", which has no meaning for
+	// a send that carries no key — and a composer that omits one, which is now
+	// the ordinary case for a reply, would have every message come out wearing
+	// an offer to unsubscribe from a conversation the recipient started.
+	if !surface.carries() {
+		return untokenized, nil
+	}
+	token, ok, err := s.unsubscribe.UnsubscribeToken(ctx, recipients[0], surface.purposeKey)
 	if err != nil {
 		return sendDeliverability{}, err
 	}
@@ -234,8 +295,8 @@ func (s *Store) deliverability(
 	}
 	lang := s.footerLanguage(ctx, body, subject)
 	words := mailcopy.For(string(lang))
-	live := unsubscribeLinksFor(s.publicBaseURL, token, purposeKey, lang)
-	redacted := unsubscribeLinksFor(s.publicBaseURL, redactedToken, purposeKey, lang)
+	live := unsubscribeLinksFor(s.publicBaseURL, token, surface.purposeKey, lang)
+	redacted := unsubscribeLinksFor(s.publicBaseURL, redactedToken, surface.purposeKey, lang)
 	return sendDeliverability{
 		listUnsubscribe: listUnsubscribeHeader(live.oneClick),
 		links:           live,

--- a/backend/internal/modules/activities/unsubscribesurface_test.go
+++ b/backend/internal/modules/activities/unsubscribesurface_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Which messages offer the recipient a way to stop.
+//
+// The case these exist for: a reply that carries an unsubscribe footer. It is
+// not a crash and no gate refuses it — the message goes out, correctly
+// addressed, offering somebody the chance to opt out of a conversation they
+// started. The only thing that catches it is a test that says which categories
+// carry the surface and which do not.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+func TestOnlyMarketingCarriesAnUnsubscribeSurface(t *testing.T) {
+	t.Parallel()
+
+	for _, category := range commsauthz.Categories() {
+		want := category == commsauthz.CategoryMarketing
+		if got := category.CarriesUnsubscribe(); got != want {
+			t.Errorf("%s.CarriesUnsubscribe() = %v, want %v. An unsubscribe surface is an offer "+
+				"to stop a stream the recipient can decline; every other category is a message "+
+				"they cannot decline without declining the relationship", category, got, want)
+		}
+	}
+}
+
+// TestAReplyCarriesNoUnsubscribeSurface is the regression this change exists
+// for, stated in the shape the composer now sends.
+//
+// A reply claims no category and carries no purpose key, because the engine
+// derives reply_to_inbound from the anchor. Under the old rule that message was
+// "not the locked transactional purpose", which resolved a token and wrote a
+// footer.
+func TestAReplyCarriesNoUnsubscribeSurface(t *testing.T) {
+	t.Parallel()
+
+	reply := surfaceFor(commsauthz.CategoryReplyToInbound, "", "")
+	if reply.carries() {
+		t.Error("a reply offers an unsubscribe link, so the recipient is invited to opt out of " +
+			"the conversation they themselves started")
+	}
+}
+
+func TestAMarketingSendCarriesItsTopicsSurface(t *testing.T) {
+	t.Parallel()
+
+	send := surfaceFor(commsauthz.CategoryMarketing, "product_news", "")
+	if !send.carries() {
+		t.Fatal("a marketing send carries no unsubscribe surface, which a mailbox provider " +
+			"reads as unsolicited bulk mail")
+	}
+	// The link points at the TOPIC, because marketing consent is
+	// purpose-specific: unsubscribing from product news is not unsubscribing
+	// from everything.
+	if send.purposeKey != "product_news" {
+		t.Errorf("the unsubscribe link points at %q, want the marketing topic", send.purposeKey)
+	}
+}
+
+// TestACallerThatNamesOnlyAKeyKeepsItsSurface holds the compatibility arm. An
+// MCP tool or a stored scheduled send written before categories existed names a
+// purpose key and no category, and must keep the behaviour it was written
+// against.
+func TestACallerThatNamesOnlyAKeyKeepsItsSurface(t *testing.T) {
+	t.Parallel()
+
+	legacy := surfaceFor("", "", "marketing_email")
+	if !legacy.carries() {
+		t.Error("a caller naming only a marketing purpose key lost its unsubscribe surface, so " +
+			"a send that used to be compliant bulk mail now is not")
+	}
+
+	locked := surfaceFor("", "", "transactional")
+	if locked.carries() {
+		t.Error("the locked transactional key gained an unsubscribe surface")
+	}
+
+	// And the case that started this: no category, no key at all. Under the old
+	// rule this was "not transactional" and therefore carried a footer.
+	if surfaceFor("", "", "").carries() {
+		t.Error("a send naming neither a category nor a key carries an unsubscribe surface — " +
+			"which is exactly the reply case, reached through the legacy arm")
+	}
+}
+
+// TestTheLegacyLockedKeyAgreesWithConsent pins the one key this package spells
+// for itself against the module that owns the concept.
+//
+// activities may not import consent, so the value is repeated — and a repeated
+// value is the thing that drifts. consent.LockedPurpose normalizes before
+// comparing, so this does too.
+func TestTheLegacyLockedKeyAgreesWithConsent(t *testing.T) {
+	t.Parallel()
+
+	for _, spelling := range []string{"transactional", "Transactional", "  TRANSACTIONAL  "} {
+		if !lockedPurposeKey(spelling) {
+			t.Errorf("lockedPurposeKey(%q) = false; consent.LockedPurpose normalizes case and "+
+				"space before comparing, and a stricter copy here would put an unsubscribe "+
+				"footer on a transactional send", spelling)
+		}
+	}
+	if lockedPurposeKey("marketing_email") {
+		t.Error("lockedPurposeKey treats a marketing key as locked, which would strip the " +
+			"unsubscribe surface from real bulk mail")
+	}
+}

--- a/backend/internal/shared/ports/commsauthz/category.go
+++ b/backend/internal/shared/ports/commsauthz/category.go
@@ -76,6 +76,25 @@ func Categories() []Category {
 	return out
 }
 
+// CarriesUnsubscribe reports whether a message of this category must offer the
+// recipient a way to stop hearing from us.
+//
+// MARKETING ALONE, and the narrowness is the point rather than an omission. An
+// unsubscribe surface is an offer to stop a stream the recipient can decline —
+// and every other category is a message they cannot sensibly decline without
+// declining the relationship itself: a reply to their own question, an invoice,
+// a notice about their contract. Offering to unsubscribe from a conversation
+// somebody started reads as not having read it.
+//
+// It replaces a rule keyed on the deprecated purpose key, which asked whether
+// the purpose was the locked `transactional` one. That question had no answer
+// for a send carrying no purpose key — and "not transactional" is not the same
+// as "marketing", so a message with no key at all came out the far side wearing
+// an unsubscribe footer.
+//
+// Held by: TestOnlyMarketingCarriesAnUnsubscribeSurface (backend/internal/modules/activities/unsubscribesurface_test.go)
+func (c Category) CarriesUnsubscribe() bool { return c == CategoryMarketing }
+
 // ServesTheSubject reports whether this category exists to serve the recipient
 // rather than the sender. These five may pass a hard suppression, and only
 // through a registered template: a security warning, a privacy notice, or the

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3191,9 +3191,19 @@ export const de = {
   "compose.scheduleTomorrow": "Morgen früh",
   "compose.scheduleMonday": "Montagmorgen",
   "compose.scheduleNow": "Doch sofort senden",
-  "compose.purpose": "Einwilligungszweck",
-  "compose.purposeHint":
-    "Der Versand ist nur erlaubt, wenn jeder Empfänger für diesen Zweck eingewilligt hat.",
+  "compose.why": "Warum schreibst du?",
+  "compose.whyHint":
+    "Was erlaubt ist, entscheidet der Datensatz; das hier sagt, was du tust — damit sich beides abgleichen lässt.",
+  "compose.why.requestedFollowup": "Sie haben mich um Kontakt gebeten",
+  "compose.why.activeDeal": "Zu einem laufenden Deal",
+  "compose.why.quote": "Ein angefragtes Angebot",
+  "compose.why.service": "Support zu etwas Gekauftem",
+  "compose.why.invoice": "Zu einer Rechnung oder Zahlung",
+  "compose.why.contract": "Zu ihrem Vertrag",
+  "compose.why.account": "Zu ihrem Konto",
+  "compose.why.marketing": "Werbung",
+  "compose.derivedReply":
+    "Das ist eine Antwort auf ihre eigene Nachricht — dafür brauchst du keinen Grund anzugeben.",
   "compose.sendLaterLabel": "Später senden (optional)",
   "compose.send": "Senden",
   "compose.sendConfirmTitle": "Diese E-Mail senden?",
@@ -3249,7 +3259,7 @@ export const de = {
   "compose.emptyRecipients": "Fügen Sie mindestens einen Empfänger hinzu.",
   "compose.missingSubject": "Gib dieser E-Mail einen Betreff.",
   "compose.missingBody": "Schreibe die Nachricht, bevor du sie sendest.",
-  "compose.missingPurpose": "Wähle, wozu diese Nachricht dient.",
+  "compose.missingWhy": "Sag, warum du ihnen schreibst.",
   "compose.removeRecipient": "{recipient} entfernen",
   "compose.actionFailed":
     "Die Anfrage ist fehlgeschlagen. Bitte erneut versuchen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3241,9 +3241,19 @@ export const en = {
   "compose.scheduleTomorrow": "Tomorrow morning",
   "compose.scheduleMonday": "Monday morning",
   "compose.scheduleNow": "Send now instead",
-  "compose.purpose": "Consent purpose",
-  "compose.purposeHint":
-    "The send is allowed only if every recipient has granted consent for this purpose.",
+  "compose.why": "Why are you writing?",
+  "compose.whyHint":
+    "The record decides what is allowed; this says what you are doing so the answer can be checked against it.",
+  "compose.why.requestedFollowup": "They asked me to get in touch",
+  "compose.why.activeDeal": "About a deal we are working on",
+  "compose.why.quote": "A quote or proposal they asked for",
+  "compose.why.service": "Support for something they bought",
+  "compose.why.invoice": "About an invoice or a payment",
+  "compose.why.contract": "About their contract",
+  "compose.why.account": "About their account",
+  "compose.why.marketing": "Marketing",
+  "compose.derivedReply":
+    "This continues their own message, so it needs no reason from you.",
   "compose.sendLaterLabel": "Send later (optional)",
   "compose.send": "Send",
   "compose.sendConfirmTitle": "Send this email?",
@@ -3303,7 +3313,7 @@ export const en = {
   "compose.emptyRecipients": "Add at least one recipient.",
   "compose.missingSubject": "Give this email a subject.",
   "compose.missingBody": "Write the message before sending it.",
-  "compose.missingPurpose": "Choose what this message is for.",
+  "compose.missingWhy": "Say why you are writing to them.",
   "compose.removeRecipient": "Remove {recipient}",
   "compose.actionFailed": "The request failed. Please try again.",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3162,9 +3162,19 @@ export const vi = {
   "compose.scheduleTomorrow": "Sáng mai",
   "compose.scheduleMonday": "Sáng thứ Hai",
   "compose.scheduleNow": "Gửi ngay bây giờ",
-  "compose.purpose": "Mục đích chấp thuận",
-  "compose.purposeHint":
-    "Lượt gửi chỉ được phép nếu mọi người nhận đều đã chấp thuận cho mục đích này.",
+  "compose.why": "Vì sao bạn viết?",
+  "compose.whyHint":
+    "Hồ sơ quyết định điều gì được phép; phần này nói bạn đang làm gì để đối chiếu được.",
+  "compose.why.requestedFollowup": "Họ đã nhờ tôi liên hệ",
+  "compose.why.activeDeal": "Về một thương vụ đang tiến hành",
+  "compose.why.quote": "Báo giá hoặc đề xuất họ đã hỏi",
+  "compose.why.service": "Hỗ trợ cho thứ họ đã mua",
+  "compose.why.invoice": "Về hóa đơn hoặc thanh toán",
+  "compose.why.contract": "Về hợp đồng của họ",
+  "compose.why.account": "Về tài khoản của họ",
+  "compose.why.marketing": "Tiếp thị",
+  "compose.derivedReply":
+    "Đây là trả lời tin nhắn của chính họ, nên bạn không cần nêu lý do.",
   "compose.sendLaterLabel": "Gửi sau (tùy chọn)",
   "compose.send": "Gửi",
   "compose.sendConfirmTitle": "Gửi email này?",
@@ -3218,7 +3228,7 @@ export const vi = {
   "compose.emptyRecipients": "Hãy thêm ít nhất một người nhận.",
   "compose.missingSubject": "Hãy đặt tiêu đề cho email này.",
   "compose.missingBody": "Hãy viết nội dung trước khi gửi.",
-  "compose.missingPurpose": "Hãy chọn mục đích của tin nhắn này.",
+  "compose.missingWhy": "Hãy cho biết vì sao bạn viết cho họ.",
   "compose.removeRecipient": "Gỡ {recipient}",
   "compose.actionFailed": "Yêu cầu thất bại. Hãy thử lại.",
 

--- a/frontend/src/screens/compose-context.test.ts
+++ b/frontend/src/screens/compose-context.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { asksWhy, contextFor, repliesToTheSubject } from "./compose-context";
+
+// What the composer claims about a message, and when it claims nothing.
+//
+// The case these tests are built around is the one that costs a rep their day:
+// a reply that asks a question the thread already answers. Every assertion here
+// is about NOT prompting where the record speaks, and about prompting where it
+// genuinely does not.
+
+describe("repliesToTheSubject", () => {
+  it("an inbound email the subject sent is a reply", () => {
+    expect(repliesToTheSubject({ kind: "email", direction: "inbound" })).toBe(
+      true,
+    );
+  });
+
+  it("an inbound channel message is a reply too", () => {
+    expect(repliesToTheSubject({ kind: "message", direction: "inbound" })).toBe(
+      true,
+    );
+  });
+
+  it("our OWN outbound mail is not the subject writing to us", () => {
+    // The case a rep reaches by re-opening their own sent message. It looks
+    // like a thread and reads like a reply, and the subject never answered —
+    // so it is an unprompted follow-up, and the composer has to ask.
+    expect(repliesToTheSubject({ kind: "email", direction: "outbound" })).toBe(
+      false,
+    );
+  });
+
+  it("a filed note is not correspondence, whatever its direction", () => {
+    // A note is something a rep wrote about the person, not to them. Treating
+    // it as a thread would let "I met them at a fair" authorize a cold mail.
+    expect(repliesToTheSubject({ kind: "note", direction: "inbound" })).toBe(
+      false,
+    );
+  });
+
+  it("no anchor at all is not a reply", () => {
+    expect(repliesToTheSubject(undefined)).toBe(false);
+  });
+});
+
+describe("contextFor", () => {
+  it("claims NOTHING when the anchor already says it is a reply", () => {
+    // The engine derives reply_to_inbound from the thread. A claim on top could
+    // only agree — adding noise to the decision record — or contradict it,
+    // which is recorded as a claim the evidence does not carry.
+    expect(
+      contextFor({
+        anchor: { kind: "email", direction: "inbound" },
+        chosen: "",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps claiming nothing even if something was chosen earlier", () => {
+    // A reader who picked a category and then opened a reply must not have
+    // their stale pick travel: the thread is the stronger evidence and the
+    // server would record the disagreement.
+    expect(
+      contextFor({
+        anchor: { kind: "email", direction: "inbound" },
+        chosen: "marketing",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("sends what the reader chose when there is no anchor to derive from", () => {
+    expect(
+      contextFor({ anchor: undefined, chosen: "active_deal_followup" }),
+    ).toBe("active_deal_followup");
+  });
+
+  it("sends nothing while an unanchored message is unanswered", () => {
+    // Not a default. Omitting is what lets the engine answer from the record
+    // rather than from a guess this screen made.
+    expect(contextFor({ anchor: undefined, chosen: "" })).toBeUndefined();
+  });
+});
+
+describe("asksWhy", () => {
+  it("does not ask on a reply", () => {
+    expect(asksWhy({ kind: "email", direction: "inbound" })).toBe(false);
+  });
+
+  it("asks on a first message", () => {
+    expect(asksWhy(undefined)).toBe(true);
+  });
+
+  it("asks when the anchor is our own outbound mail", () => {
+    expect(asksWhy({ kind: "email", direction: "outbound" })).toBe(true);
+  });
+});

--- a/frontend/src/screens/compose-context.ts
+++ b/frontend/src/screens/compose-context.ts
@@ -1,0 +1,79 @@
+/**
+ * What kind of communication the composer is about to send, worked out from
+ * what it already knows.
+ *
+ * Its own file beside compose.tsx because it is the one piece of this screen
+ * that is a RULE rather than a rendering: the same question the server asks,
+ * answered here only to decide what the reader is shown. The server remains the
+ * authority and re-asks at staging.
+ *
+ * The rule it mirrors: a reply to a message the subject sent us is a reply,
+ * whether or not anybody says so. The engine derives that from the anchor, so
+ * the honest thing for a reply is to CLAIM NOTHING and let it — a claim the
+ * evidence does not carry is recorded as a claim the evidence does not carry,
+ * which is worse than silence. What is left to ask about is a message with no
+ * anchor to derive from, which is the only case a human has to answer.
+ */
+
+import type { components } from "../api/schema";
+
+export type CommunicationContext =
+  components["schemas"]["CommunicationContext"];
+
+/** The anchor a composed message is answering, as far as the composer knows. */
+export interface Anchor {
+  kind?: string;
+  direction?: string | null;
+}
+
+/**
+ * Whether the message being composed continues something the subject started.
+ *
+ * INBOUND is the whole test. An anchor we sent ourselves is not the subject
+ * writing to us, so replying to our own outbound message on a thread they never
+ * answered is an unprompted follow-up wearing a reply's clothes — and it is the
+ * case a rep reaches by re-opening their own sent mail.
+ */
+export function repliesToTheSubject(anchor: Anchor | undefined): boolean {
+  if (!anchor) {
+    return false;
+  }
+  const correspondence = anchor.kind === "email" || anchor.kind === "message";
+  return correspondence && anchor.direction === "inbound";
+}
+
+/**
+ * What the composer should say this message is, or nothing.
+ *
+ * Three answers, and the difference between the first two matters more than it
+ * looks:
+ *
+ *  - `undefined` — say nothing, because the anchor already says it. The engine
+ *    resolves `reply_to_inbound` from the thread, and a claim added on top
+ *    could only agree with it or contradict it.
+ *  - a category — the reader answered the question, because there was no anchor
+ *    to answer it for them.
+ *  - `undefined` with `asks` true — nobody has answered yet.
+ */
+export function contextFor(args: {
+  anchor: Anchor | undefined;
+  chosen: CommunicationContext | "";
+}): CommunicationContext | undefined {
+  if (repliesToTheSubject(args.anchor)) {
+    return undefined;
+  }
+  return args.chosen === "" ? undefined : args.chosen;
+}
+
+/**
+ * Whether the composer has to ask the reader why they are writing.
+ *
+ * Only where nothing else answers it. A reply derives, so asking would be
+ * asking a reader to restate what the thread in front of them already says —
+ * and a question with an obvious answer trains people to answer without
+ * reading, which is how the purpose dropdown this replaces came to be set to
+ * whatever was first in the list.
+ */
+export function asksWhy(anchor: Anchor | undefined): boolean {
+  return !repliesToTheSubject(anchor);
+}

--- a/frontend/src/screens/compose-links.test.tsx
+++ b/frontend/src/screens/compose-links.test.tsx
@@ -139,9 +139,9 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// The account-started composer carries three dropdowns (recipient, deal,
-// purpose), so each pick names the one it means rather than taking the only
-// combobox on screen.
+// The account-started composer carries three dropdowns (recipient, deal, why),
+// so each pick names the one it means rather than taking the only combobox on
+// screen.
 async function pickBy(labelText: string, option: string) {
   const select = screen.getByLabelText(labelText);
   await pickOption(userEvent.setup(), select, option);
@@ -177,7 +177,7 @@ describe("what a sent message files under", () => {
     await screen.findByLabelText("Related to");
     await pickBy("Related to", "Acme Renewal");
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
@@ -211,7 +211,7 @@ describe("what a sent message files under", () => {
     // The choice is visible, and so is what it does to the draft.
     expect(screen.getByText("Scoped to ERP-27")).toBeTruthy();
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
@@ -299,7 +299,7 @@ describe("what a sent message files under", () => {
 
     expect(await screen.findByText("Scoped to ERP-27")).toBeTruthy();
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
@@ -326,7 +326,7 @@ describe("what a sent message files under", () => {
 
     await screen.findByLabelText("Related to");
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
@@ -366,7 +366,7 @@ describe("what a sent message files under", () => {
     await screen.findByLabelText("Related to");
     await pickBy("Related to", "Acme Renewal");
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(linksOf(sent)).toBeDefined());
@@ -399,7 +399,7 @@ describe("what a sent message files under", () => {
 
     await screen.findByPlaceholderText("Subject");
     await fillBody();
-    await pickBy("Consent purpose", "Deal messages");
+    await pickBy("Why are you writing?", "About a deal we are working on");
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>

--- a/frontend/src/screens/compose.scheduled.test.tsx
+++ b/frontend/src/screens/compose.scheduled.test.tsx
@@ -31,9 +31,9 @@ import { ComposeModal } from "./compose";
 
 type Activity = components["schemas"]["Activity"];
 
-// The one purpose with no unsubscribe requirement, so the form is sendable with
+// A reason that carries no unsubscribe surface, so the form is sendable with
 // nothing else filled in.
-const PURPOSE_LABEL = "Deal messages";
+const WHY_LABEL = "About a deal we are working on";
 
 const ACTIVITY: Activity = {
   id: "act-1",
@@ -69,22 +69,6 @@ function stubSend(status: number) {
       const method = request?.method ?? init?.method ?? "GET";
       if (method === "POST" && url.pathname.endsWith("/send-email")) {
         return jsonResponse(ACTIVITY, status);
-      }
-      // The one purpose the form needs to be sendable. Transactional because it
-      // is the unsubscribe-free lane, so nothing else has to be filled in.
-      if (url.pathname.endsWith("/consent-purposes")) {
-        return jsonResponse({
-          data: [
-            {
-              id: "p1",
-              key: "transactional",
-              label: PURPOSE_LABEL,
-              requires_double_opt_in: false,
-              is_active: true,
-            },
-          ],
-          page: { next_cursor: null },
-        });
       }
       return jsonResponse({ data: [], page: { next_cursor: null } });
     }),
@@ -123,11 +107,7 @@ async function composeAndSend() {
   await userEvent.tab();
   await userEvent.type(screen.getByPlaceholderText("Subject"), "Hi there");
   await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
-  await pickOption(
-    userEvent.setup(),
-    screen.getByRole("combobox"),
-    PURPOSE_LABEL,
-  );
+  await pickOption(userEvent.setup(), screen.getByRole("combobox"), WHY_LABEL);
   await userEvent.click(screen.getByRole("button", { name: "Send" }));
   return onClose;
 }

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { pickOption } from "../design-system/select-testing";
@@ -418,27 +418,36 @@ describe("RelinkModal", () => {
 // The two purposes as the rep READS them: a pick names what a person would
 // click, while the ConsentPurpose.key each label stands for is the wire value,
 // asserted on the request body wherever a send is under study.
-const PURPOSE_LABEL = {
-  transactional: "Deal messages",
-  marketing: "Marketing email",
+// What a rep answers when the composer asks why they are writing. These are
+// the CATEGORIES the engine reasons about, not consent purposes: the purpose
+// dropdown was replaced because the record already decides what is allowed, and
+// a key a rep picked was never that.
+const WHY_LABEL = {
+  requestedFollowup: "They asked me to get in touch",
+  marketing: "Marketing",
 } as const;
 
 // The composer has exactly one dropdown, so a pick needs nothing but the label.
 // `pickOption` takes a userEvent SESSION, which the bare direct API is not, so
 // it gets a fresh one — the same thing every bare `userEvent.*` call in this
 // file does internally.
-function pickPurpose(label: string) {
+function pickWhy(label: string) {
   return pickOption(userEvent.setup(), screen.getByRole("combobox"), label);
 }
 
-// Fills the four Send preconditions (To, subject, body, purpose) so a test can
-// then exercise the send outcome under study.
+// Fills the Send preconditions so a test can exercise the outcome under study.
+//
+// The "why" answer is filled because these suites compose an UNANCHORED message
+// — no anchor read is stubbed, so the composer has nothing to derive from and
+// asks. A suite whose subject is a reply stubs the anchor instead and the
+// question never appears; asking there is the defect fillReplyForm exists to
+// catch.
 async function fillSendableForm() {
   await userEvent.type(screen.getByLabelText("To"), "a@x.com");
   await userEvent.tab();
   await userEvent.type(screen.getByPlaceholderText("Subject"), "Hi there");
   await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
-  await pickPurpose(PURPOSE_LABEL.transactional);
+  await pickWhy(WHY_LABEL.requestedFollowup);
 }
 
 describe("ComposeModal", () => {
@@ -753,7 +762,7 @@ describe("ComposeModal", () => {
     expect(
       screen.getByText("Write the message before sending it."),
     ).toBeTruthy();
-    expect(screen.getByText("Choose what this message is for.")).toBeTruthy();
+    expect(screen.getByText("Say why you are writing to them.")).toBeTruthy();
     expect(
       sent.filter((call) => call.key.startsWith("POST /activities")),
     ).toHaveLength(0);
@@ -790,7 +799,7 @@ describe("ComposeModal", () => {
       subject: "Hi there",
       body: "Body content",
       to: ["a@x.com"],
-      consent_purpose: "transactional",
+      communication_context: "requested_followup",
     });
     // ADR-0055: the human click is the approval — neither header rides along.
     expect(req?.headers.get("X-Approval-Token")).toBeNull();
@@ -970,7 +979,7 @@ describe("ComposeModal draft binding", () => {
       screen.getByRole("button", { name: "Draft with AI" }),
     );
     await screen.findByDisplayValue("Draft A body.");
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -1016,7 +1025,7 @@ describe("ComposeModal draft binding", () => {
       ).toBe(2),
     );
 
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -1047,7 +1056,7 @@ describe("ComposeModal draft binding", () => {
     const bodyField = await screen.findByDisplayValue("Draft A body.");
     await userEvent.clear(bodyField);
     await userEvent.type(bodyField, "Written from scratch.");
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -1113,7 +1122,7 @@ describe("ComposeModal draft binding", () => {
       screen.getByRole("button", { name: "Draft with AI" }),
     );
     await screen.findByDisplayValue("Draft A body.");
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     // The form is sendable before the judgment starts, so the refusal below is
     // the rejection holding the draft rather than an unmet precondition.
     expect(
@@ -1169,7 +1178,7 @@ describe("ComposeModal draft binding", () => {
     );
     expect(await screen.findByText(/boom/i)).toBeTruthy();
 
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -1210,7 +1219,7 @@ describe("ComposeModal draft binding", () => {
     ).toBeTruthy();
     expect(screen.getByDisplayValue("Draft A body.")).toBeTruthy();
 
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() =>
       expect(
@@ -1552,7 +1561,7 @@ describe("ComposeModal send refusals", () => {
     await userEvent.tab();
 
     expect(screen.queryByText(/more than one addressee/i)).toBeNull();
-    await pickPurpose(PURPOSE_LABEL.marketing);
+    await pickWhy(WHY_LABEL.marketing);
 
     expect(await screen.findByText(/more than one addressee/i)).toBeTruthy();
     // A warning, not a gate — and nothing was sent to earn it.
@@ -1566,7 +1575,7 @@ describe("ComposeModal send refusals", () => {
     renderComposer();
     await screen.findByRole("combobox");
     await fillSendableForm();
-    await pickPurpose(PURPOSE_LABEL.marketing);
+    await pickWhy(WHY_LABEL.marketing);
 
     expect(screen.queryByText(/more than one addressee/i)).toBeNull();
   });
@@ -1606,7 +1615,7 @@ describe("ComposeModal — channel reply", () => {
     );
     await screen.findByRole("combobox");
     await userEvent.type(screen.getByPlaceholderText("Body"), "On my way.");
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
@@ -1617,7 +1626,7 @@ describe("ComposeModal — channel reply", () => {
     // actually accepts (SendMessageRequest carries only these two fields).
     expect(req?.body).toEqual({
       body: "On my way.",
-      consent_purpose: "transactional",
+      communication_context: "requested_followup",
     });
     // ADR-0055: the human's own click is the approval on both send paths.
     expect(req?.headers.get("X-Approval-Token")).toBeNull();
@@ -1721,7 +1730,7 @@ describe("ComposeModal — channel reply", () => {
       screen.getByPlaceholderText("Body"),
       "Call me back please.",
     );
-    await pickPurpose(PURPOSE_LABEL.transactional);
+    await pickWhy(WHY_LABEL.requestedFollowup);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(await screen.findByText(/has not granted consent/i)).toBeTruthy();
@@ -2163,7 +2172,7 @@ describe("ComposeModal started from an account", () => {
       subject: "Hi there",
       body: "Body content",
       to: ["a@x.com"],
-      consent_purpose: "transactional",
+      communication_context: "requested_followup",
       // Without a link the message belongs to no record and nobody finds it
       // again, which is the gap this origin exists to close.
       links: [{ entity_type: "organization", entity_id: "org-1" }],
@@ -2861,6 +2870,201 @@ describe("what the composer says it is answering", () => {
 
     await screen.findByRole("combobox");
     expect(screen.queryByText(/Replying to|starts a new thread/i)).toBeNull();
+  });
+});
+
+// What the composer claims a message is, and when it claims nothing.
+//
+// The rule: a reply to the subject's own message derives reply_to_inbound from
+// the anchor, so the composer asks nothing and sends no claim. Everything else
+// has to be asked, because there is nothing to derive from.
+describe("what the composer says this message is", () => {
+  const inbound: Activity = {
+    ...activity202,
+    thread_key: "<t-why@mail>",
+    body: "Can you send the revised quote?",
+    direction: "inbound",
+  };
+
+  it("asks nothing on a reply, and says why not", async () => {
+    stubRoutes({ "GET /activities/act-1": () => jsonResponse(inbound) });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // The sentence that replaces the question. A reader who is shown a dropdown
+    // here is being asked to restate what the thread in front of them says.
+    expect(
+      await screen.findByText(
+        "This continues their own message, so it needs no reason from you.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Why are you writing?")).toBeNull();
+  });
+
+  it("sends a reply with no claim at all", async () => {
+    const sent = stubRoutes({
+      "GET /activities/act-1": () => jsonResponse(inbound),
+      "POST /activities/act-1/send-email": () => jsonResponse(activity202, 202),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByText(
+      "This continues their own message, so it needs no reason from you.",
+    );
+    await userEvent.type(screen.getByLabelText("To"), "a@x.com");
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText("Subject"), "Re: quote");
+    await userEvent.type(screen.getByPlaceholderText("Body"), "Attached.");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        sent.find((r) => r.key === "POST /activities/act-1/send-email"),
+      ).toBeTruthy(),
+    );
+    const body = sent.find((r) => r.key === "POST /activities/act-1/send-email")
+      ?.body as Record<string, unknown>;
+    // NEITHER key. The engine resolves reply_to_inbound from the anchor, and a
+    // claim on top could only agree with it or contradict it — a contradiction
+    // is recorded as a claim the evidence does not carry.
+    expect(body).not.toHaveProperty("communication_context");
+    expect(body).not.toHaveProperty("consent_purpose");
+  });
+
+  it("drops a stale answer when the composer moves onto a reply", async () => {
+    // The gap this closes: on a reply the question never renders, so a
+    // composer that simply passed its own state through would look correct —
+    // the state is empty because nothing set it. It stops looking correct the
+    // moment a reader answers on an unanchored message and THEN opens a reply,
+    // which is one click in the same drawer.
+    //
+    // The thread is the stronger evidence either way, so the stale pick must
+    // not travel: the server would record it as a claim the evidence does not
+    // carry.
+    const sent = stubRoutes({
+      "GET /activities/act-1": () => jsonResponse(inbound),
+      "POST /activities/act-1/send-email": () => jsonResponse(activity202, 202),
+    });
+    // A parent that flips the anchor on demand, so the SAME mounted composer
+    // moves from unanchored to answering — which is what a rep does by clicking
+    // Reply beside a message. Remounting instead would reset the state and
+    // prove nothing about a stale answer surviving.
+    function Harness() {
+      const [anchored, setAnchored] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setAnchored(true)}>
+            anchor it
+          </button>
+          <ComposeModal
+            activityId={anchored ? "act-1" : undefined}
+            entityType="person"
+            entityId="p-1"
+            open
+            onClose={vi.fn()}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    await screen.findByRole("combobox");
+    await pickWhy(WHY_LABEL.marketing);
+
+    await userEvent.click(screen.getByRole("button", { name: "anchor it" }));
+    await screen.findByText(
+      "This continues their own message, so it needs no reason from you.",
+    );
+
+    await userEvent.type(screen.getByLabelText("To"), "a@x.com");
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText("Subject"), "Re: quote");
+    await userEvent.type(screen.getByPlaceholderText("Body"), "Attached.");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        sent.find((r) => r.key === "POST /activities/act-1/send-email"),
+      ).toBeTruthy(),
+    );
+    const body = sent.find((r) => r.key === "POST /activities/act-1/send-email")
+      ?.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("communication_context");
+  });
+
+  it("asks on a first message, and sends what the reader answered", async () => {
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(activity202, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("combobox");
+    await userEvent.type(screen.getByLabelText("To"), "a@x.com");
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText("Subject"), "Hello");
+    await userEvent.type(screen.getByPlaceholderText("Body"), "First contact.");
+    await pickWhy(WHY_LABEL.requestedFollowup);
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(sent.find((r) => r.key === "POST /emails")).toBeTruthy(),
+    );
+    const body = sent.find((r) => r.key === "POST /emails")?.body as Record<
+      string,
+      unknown
+    >;
+    expect(body.communication_context).toBe("requested_followup");
+  });
+
+  it("refuses to send a first message until the reader says why", async () => {
+    let sent = false;
+    stubRoutes({
+      "POST /emails": () => {
+        sent = true;
+        return jsonResponse(activity202, 202);
+      },
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(await screen.findByLabelText("To"), "a@x.com");
+    await userEvent.tab();
+    await userEvent.type(screen.getByPlaceholderText("Subject"), "Hello");
+    await userEvent.type(screen.getByPlaceholderText("Body"), "First contact.");
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(
+      await screen.findByText("Say why you are writing to them."),
+    ).toBeTruthy();
+    expect(sent).toBe(false);
   });
 });
 

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -58,12 +58,16 @@ import {
 } from "./common";
 import { recordNamesIn, useOrganization360 } from "./company360";
 import {
+  asksWhy,
+  type CommunicationContext,
+  contextFor,
+} from "./compose-context";
+import {
   ConversationChoices,
   ThreadPane,
   useRecentConversations,
   useThreadMessages,
 } from "./composethread";
-import { useConsentPurposes } from "./consent";
 import { useRoster } from "./entityref";
 import { usePerson360 } from "./person360";
 import {
@@ -83,7 +87,6 @@ import "./compose.css";
 // and typed on the backend; this file only calls them.
 
 type Activity = components["schemas"]["Activity"];
-type ConsentPurpose = components["schemas"]["ConsentPurpose"];
 type EmailDraft = components["schemas"]["EmailDraft"];
 type VoiceProfile = components["schemas"]["VoiceProfile"];
 
@@ -1330,18 +1333,22 @@ function rejectionTarget(
 }
 
 // sharedUnsubscribeAhead predicts the refusal above from what is on the form.
-// Every purpose but the locked transactional one renders an unsubscribe link,
-// and that link is one addressee's own consent record, so a second addressee is
-// refused outright. This mirrors the server rule (which remains the authority)
-// only to move a certain refusal ahead of the irreversible click.
-const TRANSACTIONAL_PURPOSE = "transactional";
-
+// A marketing send renders an unsubscribe link, and that link is one
+// addressee's own consent record, so a second addressee is refused outright.
+// This mirrors the server rule (which remains the authority) only to move a
+// certain refusal ahead of the irreversible click.
+//
+// MARKETING, not "anything but transactional". The server keys this on the
+// category now (commsauthz.Category.CarriesUnsubscribe), because the old
+// purpose-key question had no answer for a message carrying no key — and a
+// reply carries none, so the looser test predicted a refusal for every reply
+// to two people.
 function sharedUnsubscribeAhead(
   to: string[],
   cc: string[],
-  purpose: string,
+  context: CommunicationContext | undefined,
 ): boolean {
-  if (purpose === "" || purpose === TRANSACTIONAL_PURPOSE) {
+  if (context !== "marketing") {
     return false;
   }
   const addressees = new Set(
@@ -1350,20 +1357,26 @@ function sharedUnsubscribeAhead(
   return addressees.size > 1;
 }
 
-// The purpose list the rep chooses from. The unset entry is a real OPTION
-// rather than the select's placeholder: a placeholder is only a face for an
-// unset value, and a rep who picked a purpose has to be able to come back to
-// none before sending. Its face stays the em dash the field has always shown —
-// a glyph, with no words to translate.
-function purposeOptions(
-  purposes: readonly ConsentPurpose[] | undefined,
-): SelectOption[] {
+// The categories a rep may claim, in the order a first message is usually
+// about. The unset entry is a real OPTION rather than the select's placeholder:
+// a placeholder is only a face for an unset value, and a rep who picked one has
+// to be able to come back to none before sending.
+//
+// The five subject-serving categories are absent, and not by omission — the
+// contract's enum excludes them, because a caller who could claim one could
+// dress marketing as a security warning and reach somebody who has objected.
+// They are the installation's own controller mail and nothing a rep composes.
+function contextOptions(t: ReturnType<typeof useT>): SelectOption[] {
   return [
     { value: "", label: "—" },
-    ...(purposes ?? []).map((purpose) => ({
-      value: purpose.key,
-      label: purpose.label,
-    })),
+    { value: "requested_followup", label: t("compose.why.requestedFollowup") },
+    { value: "active_deal_followup", label: t("compose.why.activeDeal") },
+    { value: "precontract_quote", label: t("compose.why.quote") },
+    { value: "customer_service", label: t("compose.why.service") },
+    { value: "invoice_or_payment", label: t("compose.why.invoice") },
+    { value: "contract_notice", label: t("compose.why.contract") },
+    { value: "account_notice", label: t("compose.why.account") },
+    { value: "marketing", label: t("compose.why.marketing") },
   ];
 }
 
@@ -1387,11 +1400,15 @@ async function sendFrom(args: {
     to: string[];
     cc?: string[];
     draft_ref?: string;
-    consent_purpose: string;
+    // OMITTED on a reply, deliberately. The engine resolves reply_to_inbound
+    // from the anchor, and a claim added on top could only agree with it or
+    // contradict it — and a contradiction is recorded as a claim the evidence
+    // does not carry.
+    communication_context?: CommunicationContext;
     scheduled_at?: string;
     scheduled_tz?: string;
   };
-  channelBody: { body: string; consent_purpose: string };
+  channelBody: { body: string; communication_context?: CommunicationContext };
   links: { entity_type: RelinkKind; entity_id: string }[];
 }) {
   if (args.isChannelReply) {
@@ -1451,11 +1468,22 @@ export function scheduleFields(local: string): {
 // about what, and the reader is left comparing the form against a button that
 // will not talk to them. Pressing it now names every field it is waiting for,
 // on the field itself.
-export type MissingField = "to" | "subject" | "body" | "purpose";
+export type MissingField = "to" | "subject" | "body" | "context";
 
 export function missingToSend(
   isChannelReply: boolean,
-  fields: { to: string[]; subject: string; body: string; purpose: string },
+  fields: {
+    to: string[];
+    subject: string;
+    body: string;
+    context: string;
+    // asksContext is false where the anchor already answers what this message
+    // is. A reply derives reply_to_inbound from the thread, so requiring the
+    // reader to restate it would block a send on a question nobody needs to
+    // answer — which is what the consent-purpose dropdown this replaces did on
+    // every reply.
+    asksContext: boolean;
+  },
 ): readonly MissingField[] {
   const missing: MissingField[] = [];
   // A channel resolves its own recipient and carries no subject, so neither is
@@ -1469,8 +1497,8 @@ export function missingToSend(
   if (fields.body.trim() === "") {
     missing.push("body");
   }
-  if (fields.purpose === "") {
-    missing.push("purpose");
+  if (fields.asksContext && fields.context === "") {
+    missing.push("context");
   }
   return missing;
 }
@@ -1789,12 +1817,16 @@ function MailOnlyFields({
 function MailSendNotices({
   to,
   cc,
-  purpose,
-}: Readonly<{ to: string[]; cc: string[]; purpose: string }>) {
+  context,
+}: Readonly<{
+  to: string[];
+  cc: string[];
+  context: CommunicationContext | undefined;
+}>) {
   const t = useT();
   return (
     <>
-      {sharedUnsubscribeAhead(to, cc, purpose) && (
+      {sharedUnsubscribeAhead(to, cc, context) && (
         <p className="t-caption" style={{ color: "var(--danger)" }}>
           {t("compose.multiRecipientWarning")}
         </p>
@@ -2286,7 +2318,6 @@ export function ComposeModal({
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
-  const purposes = useConsentPurposes();
   const voiceProfile = useVoiceProfile();
   // Which ENDPOINT the reply posts to is a question about the kind, not the
   // transport: every channel message goes to send-message whatever carried it,
@@ -2298,7 +2329,9 @@ export function ComposeModal({
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
   const [intent, setIntent] = useState("");
-  const [purpose, setPurpose] = useState("");
+  // What this message is, when the record does not already say. Empty until the
+  // reader answers, and never asked at all on a reply — see contextFor.
+  const [context, setContext] = useState<CommunicationContext | "">("");
   // The moment a rep chose to send at, as the browser's datetime-local gives
   // it: wall-clock text in THEIR zone, with no offset. It becomes an absolute
   // instant at submit — see scheduleFields.
@@ -2702,7 +2735,7 @@ export function ComposeModal({
         to,
         cc: cc.length ? cc : undefined,
         draft_ref: draftRef ?? undefined,
-        consent_purpose: purpose,
+        communication_context: claimedContext,
         ...scheduleFields(sendAt),
       };
       const { data, error, response } = await sendFrom({
@@ -2716,7 +2749,7 @@ export function ComposeModal({
         activityId: answering,
         isChannelReply,
         mail,
-        channelBody: { body, consent_purpose: purpose },
+        channelBody: { body, communication_context: claimedContext },
         links: composedLinks(
           { entityType, entityId },
           grounding,
@@ -2775,11 +2808,19 @@ export function ComposeModal({
   const refusal = refusalOf(send.error);
   const sendError =
     send.isError && refusal === null ? problemMessageOf(send.error, t) : null;
+  // What travels on the wire. The ONE place the claim is decided, so the mail
+  // and channel arms cannot drift into claiming different things about the same
+  // message.
+  const claimedContext = contextFor({
+    anchor: anchorActivity,
+    chosen: context,
+  });
   const missing = missingToSend(isChannelReply, {
     to,
     subject,
     body,
-    purpose,
+    context,
+    asksContext: asksWhy(anchorActivity),
   });
   // Whether the reader has ASKED to send yet. The fields say nothing until
   // then: a form that reports what is missing before anybody has tried is a
@@ -3071,24 +3112,38 @@ export function ComposeModal({
               />
             )}
 
-            <label className="t-body compose-check">
-              {t("compose.purpose")}
-              <Select
-                aria-label={t("compose.purpose")}
-                options={purposeOptions(purposes.data?.data)}
-                value={purpose}
-                aria-invalid={flagged.has("purpose") || undefined}
-                onChange={setPurpose}
-              />
-            </label>
-            <FieldNeed
-              show={flagged.has("purpose")}
-              need={t("compose.missingPurpose")}
-            />
-            <p className="t-caption">{t("compose.purposeHint")}</p>
+            {/* Asked only where the record does not already answer it. A reply
+            derives its category from the thread it answers, so the reader is
+            told what this message is rather than made to restate it — a
+            question with an obvious answer trains people to answer without
+            reading, which is how the dropdown this replaces ended up set to
+            whatever came first in the list. */}
+            {asksWhy(anchorActivity) ? (
+              <>
+                <label className="t-body compose-check">
+                  {t("compose.why")}
+                  <Select
+                    aria-label={t("compose.why")}
+                    options={contextOptions(t)}
+                    value={context}
+                    aria-invalid={flagged.has("context") || undefined}
+                    onChange={(value) =>
+                      setContext(value as CommunicationContext | "")
+                    }
+                  />
+                </label>
+                <FieldNeed
+                  show={flagged.has("context")}
+                  need={t("compose.missingWhy")}
+                />
+                <p className="t-caption">{t("compose.whyHint")}</p>
+              </>
+            ) : (
+              <p className="t-caption">{t("compose.derivedReply")}</p>
+            )}
 
             {!isChannelReply && (
-              <MailSendNotices to={to} cc={cc} purpose={purpose} />
+              <MailSendNotices to={to} cc={cc} context={claimedContext} />
             )}
             {sendUnavailable && (
               <p className="t-caption">{t("compose.sendUnavailable")}</p>


### PR DESCRIPTION
The composer asked every message for a consent purpose key, including a reply to a message the subject had just sent. The engine already derives `reply_to_inbound` from the anchor activity, so that answer was a claim that could only agree with the derivation or contradict it.

## The frontend half

`frontend/src/screens/compose-context.ts` derives it instead. An inbound correspondence anchor means the context is omitted — the contract says omitting is the honest case — and the "Why are you writing?" picker renders only where there is no anchor to derive from. Three locales.

## The backend half, which is not cosmetic

Dropping `consent_purpose` would have put an **unsubscribe footer on every reply**.

`activities/unsubscribe.go` keyed the unsubscribe surface on the purpose KEY, through `compose/preferenceunsub.go` to `consent.LockedPurpose`. Probed: `LockedPurpose("")` is `false`. So an omitted key is not locked, the token resolves, and the mail offers someone the chance to opt out of a conversation they started.

`commsauthz.Category.CarriesUnsubscribe()` is the rule now, and it is **marketing alone** — every other category is a message the recipient cannot decline without declining the relationship. `activities.unsubscribeSurface` carries `{category, purposeKey}`: the category decides *whether* there is a surface, the marketing topic decides *where* the link points. A legacy arm keeps a caller that names only a key (an MCP tool, a stored scheduled send) behaving as written.

What changes, measured against the old rule:

| message | before | after |
|---|---|---|
| a reply | carried an unsubscribe offer | none |
| a first follow-up | carried one | none |
| an invoice | carried one | none |
| marketing (with topic) | carried one | carries one |
| legacy marketing key | carried one | carries one |
| transactional key | none | none |

## Verification

6 mutations, all caught. One **survived** at first and is worth naming: bypassing `contextFor` entirely still passed, because on a reply the dropdown never renders, so `context` stays `""` either way — the test could not tell the two paths apart. Closed with a test that answers on an unanchored message and *then* anchors it, which is one click in the same drawer.

`make check-backend` BE=0, `make check-fe` FE=0 on the rebased branch.

The full gate also caught a miss: `compose-links.test.tsx` and `compose.scheduled.test.tsx` each kept their own copy of the form-filling helper and picked the purpose option this change deletes. Three suites drove one form through three private copies; all three are repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composer no longer asks for a consent purpose key when replying to a message the subject sent — the anchor already says it's a reply, so the composer sends no claim and shows a note instead of the picker. Unsubscribe footers are now keyed on the communication category rather than the purpose key, and only marketing carries one.

**Behavior changes**

- The "Why are you writing?" picker replaces the consent purpose dropdown and only renders when there's no inbound anchor to derive from, in en, de, and vi.
- A reply, a first follow-up, or an invoice no longer carries an unsubscribe offer.
- Marketing sends keep theirs; the link still points at the marketing topic.
- Callers that name only a purpose key (an MCP tool, a stored scheduled send) keep their old behavior.
- The shared-recipient warning now only applies to marketing sends.

<sup>Written for commit f4c3de33ba876d374f33ce18727cf869a84762a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

