### PR TITLE
The team's Monday has an agenda, in the week's own order

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37900,7 +37900,7 @@ components:
       type: object
       additionalProperties: false
       description: One team's week, as it was measured when the week closed.
-      required: [id, team_id, team_name, local_week_start, generated_at, as_of, counts, reps]
+      required: [id, team_id, team_name, local_week_start, generated_at, as_of, counts, reps, agenda]
       properties:
         id: { type: string, format: uuid }
         team_id: { type: string, format: uuid }
@@ -37930,7 +37930,26 @@ components:
           items: { $ref: '#/components/schemas/TeamWeeklyRep' }
           description: |
             Who was on the team that week — the frozen membership, which a join against the
-            live team could never answer.
+            live team could never answer. Ordered by name, because that is what a membership
+            list is read as; the order a MEETING takes them in is `agenda`.
+        agenda:
+          type: array
+          items: { type: string, format: uuid }
+          description: |
+            The Monday agenda: every id in `reps`, permuted into the order a lead should raise
+            them. Derived on read from the same focus ranking that picked each rep's
+            `focus_kind` — a rep who ASKED for help first, a quiet week last — so the meeting
+            takes the week in the order the review already decided, rather than alphabetically.
+
+            An ORDER over `reps` rather than a second list of them. The items are the reps'
+            own focuses and are already on the wire; publishing them again would be one agenda
+            spelled twice, and the two would eventually disagree. A client renders `reps` in
+            this order and has the whole agenda.
+
+            As many items as there are members, never a fixed count: a week with two things
+            worth discussing is a two-item meeting, and padding it to a layout's number would
+            be inventing an item. Empty exactly when `reps` is — a team whose week could not be
+            read has no agenda, which a client says rather than drawing an empty list.
     TeamWeeklyCounts:
       type: object
       additionalProperties: false

--- a/backend/internal/compose/weekly/teamagenda.go
+++ b/backend/internal/compose/weekly/teamagenda.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+import (
+	"slices"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The Monday agenda: the team's own week, in the order a lead should take it.
+//
+// Not a fixed number of items and no minute budgets. A week with two things
+// worth discussing is a two-item meeting, and a budget printed beside an item
+// would read as guidance somebody derived from something — while nothing in the
+// product knows a team's size or how long it meets.
+
+// focusPriority is the order a lead raises the focuses in, which is the order
+// focusFor tries its rules in and the order the constants are declared in.
+//
+// Stated as a list because an ORDER is what the agenda needs and a switch
+// cannot be asked for one. TestTheAgendaOrderIsTheOrderTheRulesAreTried holds
+// the two together in both directions: every declared focus is ranked here, and
+// the rules fire in this sequence.
+var focusPriority = []string{
+	FocusHelpRequested,
+	FocusLeadsBreached,
+	FocusCommitmentsMissed,
+	FocusMeetingsWithoutNextStep,
+	FocusStrongWeek,
+	FocusQuietWeek,
+}
+
+// agendaOrder is the reps' ids in agenda order: the thing to raise first, the
+// quiet week last.
+//
+// An ORDER over the reps rather than a second list of them. The items are the
+// reps' own focuses, already assembled and already on the wire; composing a
+// parallel list of the same labels would be one agenda spelled twice.
+//
+// Ties break on the rep order the caller hands in, which is by name, so two
+// reps carrying the same focus appear in an order a reader can predict and a
+// second read of one snapshot cannot shuffle.
+func agendaOrder(reps []TeamRep) []ids.UUID {
+	ordered := make([]int, len(reps))
+	for i := range ordered {
+		ordered[i] = i
+	}
+	slices.SortStableFunc(ordered, func(a, b int) int {
+		return agendaRank(reps[a].FocusKind) - agendaRank(reps[b].FocusKind)
+	})
+	agenda := make([]ids.UUID, 0, len(reps))
+	for _, i := range ordered {
+		agenda = append(agenda, reps[i].UserID)
+	}
+	return agenda
+}
+
+// agendaRank is where a focus sits in the meeting.
+//
+// A kind nobody ranked sorts LAST rather than first: an unranked focus is one
+// this file has not been told about, and opening the meeting with it would put
+// the least understood item where the most urgent one belongs. The census that
+// makes the case unreachable is in the test beside this.
+func agendaRank(kind string) int {
+	if rank := slices.Index(focusPriority, kind); rank >= 0 {
+		return rank
+	}
+	return len(focusPriority)
+}

--- a/backend/internal/compose/weekly/teamagenda_test.go
+++ b/backend/internal/compose/weekly/teamagenda_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestTheAgendaOrderIsTheOrderTheRulesAreTried is what stops the agenda's
+// ranking becoming a second, quietly different copy of focusFor's rule order.
+//
+// The two are written apart because a switch cannot be asked for an order and a
+// list cannot pick a focus, so the only thing holding them together is this: it
+// drives focusFor through focusRules — one case per rule, in the order the
+// switch tries them — and asks whether what came back IS focusPriority. A rule
+// that moved, or a rank that did, fails here rather than re-ordering a meeting.
+func TestTheAgendaOrderIsTheOrderTheRulesAreTried(t *testing.T) {
+	t.Parallel()
+	fired := make([]string, 0, len(focusRules))
+	for _, rule := range focusRules {
+		kind, _ := focusFor(rule.counts, rule.help)
+		fired = append(fired, kind)
+	}
+	if !slices.Equal(fired, focusPriority) {
+		t.Errorf("focusFor fires %v and the agenda ranks %v: one of the two moved, and the meeting would "+
+			"then take the week in an order the review did not decide", fired, focusPriority)
+	}
+}
+
+// TestEveryDeclaredFocusIsRanked is the census half: a focus kind added to the
+// switch without a rank sorts LAST by agendaRank's fallback, which is a real
+// order and therefore a silent one — the new rule would be raised after the
+// quiet weeks with nothing failing.
+func TestEveryDeclaredFocusIsRanked(t *testing.T) {
+	t.Parallel()
+	declared := []string{
+		FocusHelpRequested, FocusLeadsBreached, FocusCommitmentsMissed,
+		FocusMeetingsWithoutNextStep, FocusStrongWeek, FocusQuietWeek,
+	}
+	for _, kind := range declared {
+		if slices.Index(focusPriority, kind) < 0 {
+			t.Errorf("%s is a declared focus with no rank: it would be raised last, after the quiet weeks, "+
+				"and nothing else would say so", kind)
+		}
+	}
+	if len(focusPriority) != len(declared) {
+		t.Errorf("focusPriority ranks %d kinds and %d are declared: a rank for a focus nobody produces is "+
+			"an order over nothing", len(focusPriority), len(declared))
+	}
+}
+
+// TestTheAgendaIsThePermutationTheContractPromises holds the claim the schema
+// makes to every client: the agenda names every rep exactly once, so a client
+// rendering `reps` in this order draws the whole team and nobody twice.
+func TestTheAgendaIsThePermutationTheContractPromises(t *testing.T) {
+	t.Parallel()
+	reps := []TeamRep{
+		{UserID: ids.NewV7(), DisplayName: "Ada", FocusKind: FocusQuietWeek},
+		{UserID: ids.NewV7(), DisplayName: "Bo", FocusKind: FocusHelpRequested},
+		{UserID: ids.NewV7(), DisplayName: "Cy", FocusKind: FocusStrongWeek},
+		{UserID: ids.NewV7(), DisplayName: "Di", FocusKind: FocusLeadsBreached},
+	}
+	agenda := agendaOrder(reps)
+	if len(agenda) != len(reps) {
+		t.Fatalf("the agenda holds %d of %d reps: the contract says every id in reps appears",
+			len(agenda), len(reps))
+	}
+	for _, rep := range reps {
+		if slices.Index(agenda, rep.UserID) < 0 {
+			t.Errorf("%s is on the team and not on the agenda", rep.DisplayName)
+		}
+	}
+	// Bo asked for help, Di let a lead breach, Cy had a strong week, Ada's was
+	// quiet — which is the order, and it is not the order they were handed in.
+	want := []ids.UUID{reps[1].UserID, reps[3].UserID, reps[2].UserID, reps[0].UserID}
+	if !slices.Equal(agenda, want) {
+		t.Errorf("the agenda took the team in the order it was given rather than the order the review ranks")
+	}
+}
+
+// TestTiesTakeTheNameOrderTheyCameIn keeps a second read of one frozen snapshot
+// from shuffling the meeting: the store reads reps by name, and a sort that was
+// not stable would order two quiet weeks differently on each open.
+func TestTiesTakeTheNameOrderTheyCameIn(t *testing.T) {
+	t.Parallel()
+	reps := []TeamRep{
+		{UserID: ids.NewV7(), DisplayName: "Ada", FocusKind: FocusQuietWeek},
+		{UserID: ids.NewV7(), DisplayName: "Bo", FocusKind: FocusQuietWeek},
+		{UserID: ids.NewV7(), DisplayName: "Cy", FocusKind: FocusQuietWeek},
+	}
+	want := []ids.UUID{reps[0].UserID, reps[1].UserID, reps[2].UserID}
+	if got := agendaOrder(reps); !slices.Equal(got, want) {
+		t.Error("three reps sharing one focus came back in an order other than the one they arrived in, " +
+			"so one snapshot draws two different agendas")
+	}
+}
+
+// TestATeamNobodyCouldBeReadForHasNoAgenda is the empty week the schema
+// promises: empty exactly when reps is, so a client says the week could not be
+// read rather than drawing an empty meeting.
+func TestATeamNobodyCouldBeReadForHasNoAgenda(t *testing.T) {
+	t.Parallel()
+	if agenda := agendaOrder(nil); len(agenda) != 0 {
+		t.Errorf("a team with no reps produced a %d-item agenda", len(agenda))
+	}
+}

--- a/backend/internal/compose/weekly/teamreview_test.go
+++ b/backend/internal/compose/weekly/teamreview_test.go
@@ -32,25 +32,33 @@ func TestARepWhoAskedForHelpIsRaisedFirst(t *testing.T) {
 
 // Every rep gets a focus, including the one whose week went well. Without this
 // a page promising one row per rep quietly shortens to the troubled ones.
-func TestEveryWeekProducesAFocus(t *testing.T) {
-	cases := map[string]struct {
-		counts Counts
-		help   int
-		want   string
-	}{
-		"asked for help":     {Counts{}, 2, FocusHelpRequested},
-		"a lead went past":   {Counts{LeadsRouted: 3, LeadsBreached: 1}, 0, FocusLeadsBreached},
-		"missed commitments": {Counts{CommitmentsDue: 3, CommitmentsKept: 1}, 0, FocusCommitmentsMissed},
-		"meetings with no next step": {
-			Counts{MeetingsHeld: 2, MeetingsWithNextStep: 1}, 0, FocusMeetingsWithoutNextStep,
-		},
-		"won something":         {Counts{DealsWon: 2}, 0, FocusStrongWeek},
-		"kept every commitment": {Counts{CommitmentsDue: 3, CommitmentsKept: 3}, 0, FocusStrongWeek},
-		"nothing happened":      {Counts{}, 0, FocusQuietWeek},
-	}
+// focusRules is one case per rule focusFor can fire, IN THE ORDER the switch
+// tries them. Ordered and one-per-kind on purpose: the agenda's ranking is read
+// off this sequence by TestTheAgendaOrderIsTheOrderTheRulesAreTried, so a case
+// added out of order, or a second case for a kind, would quietly re-rank the
+// Monday meeting.
+//
+// Each case supplies only what its own rule needs. One that supplies more would
+// still reach its rule and still pass, while proving nothing about the rules
+// above it.
+var focusRules = []struct {
+	name   string
+	counts Counts
+	help   int
+	want   string
+}{
+	{"asked for help", Counts{}, 2, FocusHelpRequested},
+	{"a lead went past", Counts{LeadsRouted: 3, LeadsBreached: 1}, 0, FocusLeadsBreached},
+	{"missed commitments", Counts{CommitmentsDue: 3, CommitmentsKept: 1}, 0, FocusCommitmentsMissed},
+	{"meetings with no next step",
+		Counts{MeetingsHeld: 2, MeetingsWithNextStep: 1}, 0, FocusMeetingsWithoutNextStep},
+	{"won something", Counts{DealsWon: 2}, 0, FocusStrongWeek},
+	{"nothing happened", Counts{}, 0, FocusQuietWeek},
+}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+func TestEveryWeekProducesAFocus(t *testing.T) {
+	for _, tc := range focusRules {
+		t.Run(tc.name, func(t *testing.T) {
 			kind, label := focusFor(tc.counts, tc.help)
 			if kind != tc.want {
 				t.Errorf("focus = %q, want %q", kind, tc.want)
@@ -59,6 +67,19 @@ func TestEveryWeekProducesAFocus(t *testing.T) {
 				t.Error("the focus carries no words — a row a lead cannot read is not a focus")
 			}
 		})
+	}
+}
+
+// A week with nothing won is still a strong week when every commitment was
+// kept. It is the second route to strong_week and so cannot sit in focusRules,
+// which carries one case per kind because the agenda's order is read off it.
+func TestKeepingEveryCommitmentIsAStrongWeek(t *testing.T) {
+	kind, label := focusFor(Counts{CommitmentsDue: 3, CommitmentsKept: 3}, 0)
+	if kind != FocusStrongWeek {
+		t.Errorf("focus = %q, want %q — a rep who kept all three has something to copy", kind, FocusStrongWeek)
+	}
+	if label == "" {
+		t.Error("the focus carries no words — a row a lead cannot read is not a focus")
 	}
 }
 

--- a/backend/internal/compose/weekly/teamreviewhandlers.go
+++ b/backend/internal/compose/weekly/teamreviewhandlers.go
@@ -71,5 +71,18 @@ func teamReviewToWire(review TeamReview) crmcontracts.TeamWeeklyReview {
 		},
 		Pipeline: pipelineToWire(review.Money),
 		Reps:     reps,
+		// Derived here rather than stored: it is an order over the reps this
+		// same call assembled, so it cannot go stale, and a snapshot written
+		// before the agenda existed answers one anyway.
+		Agenda: agendaToWire(agendaOrder(review.Reps)),
 	}
+}
+
+// agendaToWire renders the agenda's order in the contract's uuid type.
+func agendaToWire(order []ids.UUID) []openapi_types.UUID {
+	agenda := make([]openapi_types.UUID, 0, len(order))
+	for _, id := range order {
+		agenda = append(agenda, openapi_types.UUID(id))
+	}
+	return agenda
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31715,11 +31715,26 @@ type TeamWeeklyRepFocusKind string
 
 // TeamWeeklyReview One team's week, as it was measured when the week closed.
 type TeamWeeklyReview struct {
-	AsOf           time.Time          `json:"as_of"`
-	Counts         TeamWeeklyCounts   `json:"counts"`
-	GeneratedAt    time.Time          `json:"generated_at"`
-	Id             openapi_types.UUID `json:"id"`
-	LocalWeekStart openapi_types.Date `json:"local_week_start"`
+	// Agenda The Monday agenda: every id in `reps`, permuted into the order a lead should raise
+	// them. Derived on read from the same focus ranking that picked each rep's
+	// `focus_kind` — a rep who ASKED for help first, a quiet week last — so the meeting
+	// takes the week in the order the review already decided, rather than alphabetically.
+	//
+	// An ORDER over `reps` rather than a second list of them. The items are the reps'
+	// own focuses and are already on the wire; publishing them again would be one agenda
+	// spelled twice, and the two would eventually disagree. A client renders `reps` in
+	// this order and has the whole agenda.
+	//
+	// As many items as there are members, never a fixed count: a week with two things
+	// worth discussing is a two-item meeting, and padding it to a layout's number would
+	// be inventing an item. Empty exactly when `reps` is — a team whose week could not be
+	// read has no agenda, which a client says rather than drawing an empty list.
+	Agenda         []openapi_types.UUID `json:"agenda"`
+	AsOf           time.Time            `json:"as_of"`
+	Counts         TeamWeeklyCounts     `json:"counts"`
+	GeneratedAt    time.Time            `json:"generated_at"`
+	Id             openapi_types.UUID   `json:"id"`
+	LocalWeekStart openapi_types.Date   `json:"local_week_start"`
 
 	// Pipeline What the team's week did to the pipeline. ABSENT when any member's week could not
 	// be converted — summing only the ones that did would be a confident number quietly
@@ -31727,7 +31742,8 @@ type TeamWeeklyReview struct {
 	Pipeline *WeeklyReviewPipeline `json:"pipeline,omitempty"`
 
 	// Reps Who was on the team that week — the frozen membership, which a join against the
-	// live team could never answer.
+	// live team could never answer. Ordered by name, because that is what a membership
+	// list is read as; the order a MEETING takes them in is `agenda`.
 	Reps []TeamWeeklyRep `json:"reps"`
 
 	// RepsUnread Members whose week could not be read at all. Zero is the claim that every member's

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28362,9 +28362,27 @@ export interface components {
             reps_unread?: number;
             /**
              * @description Who was on the team that week — the frozen membership, which a join against the
-             *     live team could never answer.
+             *     live team could never answer. Ordered by name, because that is what a membership
+             *     list is read as; the order a MEETING takes them in is `agenda`.
              */
             reps: components["schemas"]["TeamWeeklyRep"][];
+            /**
+             * @description The Monday agenda: every id in `reps`, permuted into the order a lead should raise
+             *     them. Derived on read from the same focus ranking that picked each rep's
+             *     `focus_kind` — a rep who ASKED for help first, a quiet week last — so the meeting
+             *     takes the week in the order the review already decided, rather than alphabetically.
+             *
+             *     An ORDER over `reps` rather than a second list of them. The items are the reps'
+             *     own focuses and are already on the wire; publishing them again would be one agenda
+             *     spelled twice, and the two would eventually disagree. A client renders `reps` in
+             *     this order and has the whole agenda.
+             *
+             *     As many items as there are members, never a fixed count: a week with two things
+             *     worth discussing is a two-item meeting, and padding it to a layout's number would
+             *     be inventing an item. Empty exactly when `reps` is — a team whose week could not be
+             *     read has no agenda, which a client says rather than drawing an empty list.
+             */
+            agenda: string[];
         };
         TeamWeeklyCounts: {
             /** @description Members whose week was read and totalled. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2568,10 +2568,17 @@ export const de = {
   "teamweekly.movement.moved": "Vorangebracht",
   "teamweekly.movement.meetings": "Gehaltene Termine",
   "teamweekly.movement.leads": "Zugewiesene Leads",
-  "teamweekly.coach.title": "Diese Woche begleiten",
-  "teamweekly.coach.sub":
-    "Ein Schwerpunkt pro Mitglied — auch für das Mitglied, dessen Woche gut lief.",
-  "teamweekly.coach.empty": "In dieser Woche war niemand in diesem Team.",
+  "teamweekly.agenda.title": "Agenda für Montag",
+  "teamweekly.agenda.sub":
+    "Die Themen dieser Woche, das Wichtigste zuerst. Eines pro Mitglied — auch für das Mitglied, dessen Woche gut lief.",
+  "teamweekly.agenda.empty":
+    "Für dieses Team ließ sich niemandes Woche lesen, also gibt es nichts für das Meeting.",
+  "teamweekly.agenda.summary":
+    "{count} Themen für Montag, beginnend mit {first}.",
+  "teamweekly.agenda.copy": "Agenda kopieren",
+  "teamweekly.agenda.copied": "Kopiert",
+  "teamweekly.agenda.copyFailed":
+    "Dieser Browser gibt die Zwischenablage nicht frei. Markier die Liste und kopier sie.",
   "teamweekly.focus.help_requested": "Hat um Hilfe gebeten",
   "teamweekly.focus.leads_breached": "Leads blieben unbeantwortet",
   "teamweekly.focus.commitments_missed": "Planzusagen verpasst",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2620,10 +2620,17 @@ export const en = {
   "teamweekly.movement.moved": "Advanced",
   "teamweekly.movement.meetings": "Meetings held",
   "teamweekly.movement.leads": "Leads routed",
-  "teamweekly.coach.title": "Coach this week",
-  "teamweekly.coach.sub":
-    "One focus per member, including the member whose week went well.",
-  "teamweekly.coach.empty": "Nobody was on this team that week.",
+  "teamweekly.agenda.title": "Monday agenda",
+  "teamweekly.agenda.sub":
+    "The week's own items, first to raise at the top. One per member, including the member whose week went well.",
+  "teamweekly.agenda.empty":
+    "Nobody's week could be read for this team, so there is nothing to take to the meeting.",
+  "teamweekly.agenda.summary":
+    "{count} to take to Monday, starting with {first}.",
+  "teamweekly.agenda.copy": "Copy agenda",
+  "teamweekly.agenda.copied": "Copied",
+  "teamweekly.agenda.copyFailed":
+    "This browser would not hand over the clipboard. Select the list and copy it.",
   "teamweekly.focus.help_requested": "Asked for help",
   "teamweekly.focus.leads_breached": "Leads went unanswered",
   "teamweekly.focus.commitments_missed": "Plan commitments missed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2545,10 +2545,16 @@ export const vi = {
   "teamweekly.movement.moved": "Đã tiến triển",
   "teamweekly.movement.meetings": "Cuộc họp đã diễn ra",
   "teamweekly.movement.leads": "Lead được phân",
-  "teamweekly.coach.title": "Đồng hành tuần này",
-  "teamweekly.coach.sub":
-    "Một trọng tâm cho mỗi thành viên, kể cả người có tuần tốt.",
-  "teamweekly.coach.empty": "Tuần đó không có ai trong nhóm này.",
+  "teamweekly.agenda.title": "Chương trình họp thứ Hai",
+  "teamweekly.agenda.sub":
+    "Các mục của chính tuần này, việc cần nêu trước nằm trên cùng. Mỗi thành viên một mục, kể cả người có tuần tốt.",
+  "teamweekly.agenda.empty":
+    "Không đọc được tuần của bất kỳ ai trong nhóm này, nên không có gì để mang tới buổi họp.",
+  "teamweekly.agenda.summary": "{count} mục cho thứ Hai, bắt đầu với {first}.",
+  "teamweekly.agenda.copy": "Sao chép chương trình",
+  "teamweekly.agenda.copied": "Đã sao chép",
+  "teamweekly.agenda.copyFailed":
+    "Trình duyệt này không cho phép truy cập bộ nhớ tạm. Hãy chọn danh sách và tự sao chép.",
   "teamweekly.focus.help_requested": "Đã nhờ giúp đỡ",
   "teamweekly.focus.leads_breached": "Lead không được trả lời",
   "teamweekly.focus.commitments_missed": "Cam kết kế hoạch bị bỏ lỡ",

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -38,7 +38,7 @@ function review(
   counts: Partial<TeamWeeklyReview["counts"]> = {},
   over: Partial<TeamWeeklyReview> = {},
 ): TeamWeeklyReview {
-  return {
+  const base = {
     id: "r1",
     team_id: "t1",
     team_name: "Nord",
@@ -62,6 +62,14 @@ function review(
     },
     reps: [rep()],
     ...over,
+  };
+  // Every response carries an agenda — an ORDER over the reps — so a fixture
+  // without one would be testing a shape the server never sends. It defaults to
+  // the reps' own order and sits BEFORE the spread, so a test about the order
+  // supplies its own and this does not overwrite it.
+  return {
+    agenda: base.reps.map((r) => r.user_id),
+    ...base,
   } as TeamWeeklyReview;
 }
 
@@ -308,7 +316,9 @@ describe("the team's frozen week", () => {
     const { container } = render(<TeamWeeklySection teamId="t1" />);
 
     await screen.findByText("Three leads went unanswered");
-    expect(container.querySelectorAll(".teamweekly-rep")).toHaveLength(2);
+    expect(container.querySelectorAll(".teamweekly-agenda-item")).toHaveLength(
+      2,
+    );
     // The good week is marked as something to copy, not as a problem.
     expect(screen.getByText(en["teamweekly.focus.strong_week"])).toBeTruthy();
     expect(screen.getByText("Fastest first response on the team")).toBeTruthy();

--- a/frontend/src/screens/brief.teamweekly.tsx
+++ b/frontend/src/screens/brief.teamweekly.tsx
@@ -4,7 +4,7 @@
 import { useState } from "react";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, StatCard } from "../design-system/atoms";
-import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { Panel, PanelBody } from "../design-system/panel";
 import { Meter } from "../design-system/readings";
 import { Select } from "../design-system/select";
 import { StatStrip } from "../design-system/statstrip";
@@ -12,9 +12,8 @@ import { SurfaceState } from "../design-system/surfacestate";
 import { formatDate, formatMoney, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { EntityRef } from "./entityref";
+import { AgendaPanel, AgendaSummary } from "./brief.teamweeklyagenda";
 import {
-  type TeamWeeklyFocusKind,
   type TeamWeeklyReview,
   useTeams,
   useTeamWeeklyReview,
@@ -37,21 +36,6 @@ import "./brief.teamweekly.css";
  */
 const HEALTHY_RATE = 0.9;
 const WEAK_RATE = 0.7;
-
-/** Which focus rules are a coaching prompt and which are something to copy. */
-const CELEBRATED: ReadonlySet<TeamWeeklyFocusKind> = new Set([
-  "strong_week",
-  "quiet_week",
-]);
-
-const FOCUS_LABEL: Readonly<Record<TeamWeeklyFocusKind, MessageKey>> = {
-  help_requested: "teamweekly.focus.help_requested",
-  leads_breached: "teamweekly.focus.leads_breached",
-  commitments_missed: "teamweekly.focus.commitments_missed",
-  meetings_without_next_step: "teamweekly.focus.meetings_without_next_step",
-  strong_week: "teamweekly.focus.strong_week",
-  quiet_week: "teamweekly.focus.quiet_week",
-};
 
 /** A rate, or null when nothing was due — zero of zero is not zero per cent. */
 function rate(part: number, whole: number): number | null {
@@ -179,6 +163,7 @@ export function TeamWeeklySection({
             <>
               <PanelBody>
                 <Headline review={review} />
+                <AgendaSummary review={review} />
                 <Coverage review={review} />
               </PanelBody>
               <Scorecard review={review} />
@@ -187,7 +172,7 @@ export function TeamWeeklySection({
           )}
         </SurfaceState>
       </Panel>
-      {review && <CoachPanel review={review} />}
+      {review && <AgendaPanel review={review} />}
     </section>
   );
 }
@@ -369,47 +354,6 @@ function Movement({ review }: Readonly<{ review: TeamWeeklyReview }>) {
         />
       ))}
     </PanelBody>
-  );
-}
-
-/**
- * One row per rep, including the rep whose week went well.
- *
- * A page promising one focus per rep and delivering rows only for the troubled
- * ones reads as a team where only those people exist — which is why the server
- * has positive focus kinds at all.
- */
-function CoachPanel({ review }: Readonly<{ review: TeamWeeklyReview }>) {
-  const t = useT();
-  return (
-    <Panel title={t("teamweekly.coach.title")} sub={t("teamweekly.coach.sub")}>
-      {review.reps.length === 0 && (
-        <PanelBody>
-          <p>{t("teamweekly.coach.empty")}</p>
-        </PanelBody>
-      )}
-      {review.reps.map((rep) => (
-        <PanelRow key={rep.user_id}>
-          <div className="teamweekly-rep">
-            <span className="teamweekly-rep-name">
-              <EntityRef kind="user" id={rep.user_id} name={rep.display_name} />
-            </span>
-            <span className="teamweekly-rep-focus">
-              <Badge
-                quiet
-                tone={CELEBRATED.has(rep.focus_kind) ? "success" : "warn"}
-              >
-                {t(FOCUS_LABEL[rep.focus_kind])}
-              </Badge>
-              {/* Composed by the server from the stored figures, never
-                  model-written, so it cannot say what the snapshot does not
-                  hold. */}
-              <span>{rep.focus_label}</span>
-            </span>
-          </div>
-        </PanelRow>
-      ))}
-    </Panel>
   );
 }
 

--- a/frontend/src/screens/brief.teamweeklyagenda.css
+++ b/frontend/src/screens/brief.teamweeklyagenda.css
@@ -1,0 +1,33 @@
+/* The Monday agenda: a numbered list of the week's own items, in the order the
+   review ranks them. The ordinal is decoration — the list order carries the
+   meaning and a screen reader hears the rows in it — so it is aria-hidden. */
+.teamweekly-agenda-summary {
+  margin: 0;
+  color: var(--textMeta);
+}
+
+.teamweekly-agenda-item {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.teamweekly-agenda-ordinal {
+  color: var(--textMeta);
+  font-variant-numeric: tabular-nums;
+}
+
+.teamweekly-agenda-name {
+  font-weight: 500;
+  color: var(--textContent);
+}
+
+.teamweekly-agenda-focus {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/brief.teamweeklyagenda.test.tsx
+++ b/frontend/src/screens/brief.teamweeklyagenda.test.tsx
@@ -1,0 +1,193 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { TeamWeeklySection } from "./brief.teamweekly";
+import { agendaRows, agendaText } from "./brief.teamweeklyagenda";
+import { jsonResponse, render, stubApi } from "./home.testkit";
+import type { TeamWeeklyRep, TeamWeeklyReview } from "./teamweekly.queries";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function rep(over: Partial<TeamWeeklyRep> = {}): TeamWeeklyRep {
+  return {
+    user_id: "u1",
+    display_name: "Lena Fischer",
+    deals_won: 0,
+    leads_breached: 0,
+    meetings_held: 0,
+    commitments_due: 0,
+    commitments_kept: 0,
+    help_requested: 0,
+    focus_kind: "quiet_week",
+    focus_label: "A quiet week",
+    ...over,
+  } as TeamWeeklyRep;
+}
+
+const lena = rep();
+const noah = rep({
+  user_id: "u2",
+  display_name: "Noah Berger",
+  focus_kind: "help_requested",
+  focus_label: "Asked for help on 2 commitments",
+});
+
+/**
+ * A snapshot whose agenda DISAGREES with the order its reps arrived in.
+ *
+ * That disagreement is the whole point: the server sends reps by name and the
+ * agenda by rank, so a fixture where the two agree would pass against a screen
+ * that ignored the agenda entirely.
+ */
+function review(over: Partial<TeamWeeklyReview> = {}): TeamWeeklyReview {
+  return {
+    id: "r1",
+    team_id: "t1",
+    team_name: "Nord",
+    local_week_start: "2026-06-01",
+    generated_at: "2026-06-08T06:00:00Z",
+    as_of: "2026-06-08T06:00:00Z",
+    reps_unread: 0,
+    counts: {
+      reps_counted: 2,
+      deals_won: 0,
+      deals_lost: 0,
+      deals_moved: 0,
+      leads_routed: 0,
+      leads_answered_in_target: 0,
+      leads_breached: 0,
+      meetings_held: 0,
+      meetings_with_next_step: 0,
+      commitments_due: 0,
+      commitments_kept: 0,
+    },
+    reps: [lena, noah],
+    agenda: ["u2", "u1"],
+    ...over,
+  } as TeamWeeklyReview;
+}
+
+describe("the agenda is the server's order, not the page's", () => {
+  it("takes the reps in agenda order rather than the order they arrived", () => {
+    const names = agendaRows(review()).map((r) => r.display_name);
+
+    expect(names).toEqual(["Noah Berger", "Lena Fischer"]);
+  });
+
+  // The contract says the agenda names every rep exactly once and the server
+  // holds it. A client that trusted it anyway would draw a nameless row against
+  // an older server, and an anonymous item is worse than a missing one.
+  it("drops an id the snapshot carries no rep for", () => {
+    const rows = agendaRows(review({ agenda: ["u2", "ghost", "u1"] }));
+
+    expect(rows.map((r) => r.display_name)).toEqual([
+      "Noah Berger",
+      "Lena Fischer",
+    ]);
+  });
+
+  it("has no items for a team whose week nobody could read", () => {
+    expect(agendaRows(review({ reps: [], agenda: [] }))).toHaveLength(0);
+  });
+});
+
+describe("what Copy puts on the clipboard", () => {
+  // The point of the action in a Monday meeting is that what was copied is what
+  // was read, so the text is composed from the rows on screen.
+  it("numbers the items in agenda order, with the server's own labels", () => {
+    const text = agendaText(agendaRows(review()), "Monday agenda");
+
+    expect(text).toBe(
+      [
+        "Monday agenda",
+        "1. Noah Berger — Asked for help on 2 commitments",
+        "2. Lena Fischer — A quiet week",
+      ].join("\n"),
+    );
+  });
+
+  it("is the heading alone when there is nothing to raise", () => {
+    expect(agendaText([], "Monday agenda")).toBe("Monday agenda");
+  });
+});
+
+describe("the agenda on the screen", () => {
+  it("draws the items in order and says what opens the meeting", async () => {
+    stubApi({ "GET /weekly-reviews/team": () => jsonResponse(review()) });
+    const { container } = render(<TeamWeeklySection teamId="t1" />);
+
+    await screen.findByText("Asked for help on 2 commitments");
+    const names = [
+      ...container.querySelectorAll(".teamweekly-agenda-name"),
+    ].map((node) => node.textContent);
+    expect(names).toEqual(["Noah Berger", "Lena Fischer"]);
+    // The header summary and the list are one derivation, so the summary names
+    // the rep the first row does.
+    const summary = container.querySelector(
+      '[data-testid="teamweekly-agenda-summary"]',
+    );
+    expect(summary?.textContent).toContain("Noah Berger");
+    expect(summary?.textContent).toContain("2");
+  });
+
+  it("says the week could not be read rather than drawing an empty meeting", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(review({ reps: [], agenda: [] })),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(await screen.findByText(en["teamweekly.agenda.empty"])).toBeTruthy();
+    // No copy control over an agenda with nothing on it.
+    expect(screen.queryByText(en["teamweekly.agenda.copy"])).toBeNull();
+  });
+
+  it("copies exactly what is on screen", async () => {
+    const written: string[] = [];
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: (text: string) => {
+          written.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+    stubApi({ "GET /weekly-reviews/team": () => jsonResponse(review()) });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    const copy = await screen.findByText(en["teamweekly.agenda.copy"]);
+    copy.click();
+
+    await waitFor(() =>
+      expect(written).toEqual([
+        [
+          en["teamweekly.agenda.title"],
+          "1. Noah Berger — Asked for help on 2 commitments",
+          "2. Lena Fischer — A quiet week",
+        ].join("\n"),
+      ]),
+    );
+    await screen.findByText(en["teamweekly.agenda.copied"]);
+  });
+
+  // navigator.clipboard is UNDEFINED outside a secure context, so this is a
+  // missing capability rather than a rejected promise — and a lead who pressed
+  // Copy and got nothing has no way to know the agenda is still on screen to
+  // select by hand.
+  it("says so when the browser will not hand over a clipboard", async () => {
+    vi.stubGlobal("navigator", {});
+    stubApi({ "GET /weekly-reviews/team": () => jsonResponse(review()) });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    const copy = await screen.findByText(en["teamweekly.agenda.copy"]);
+    copy.click();
+
+    expect(
+      await screen.findByText(en["teamweekly.agenda.copyFailed"]),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/brief.teamweeklyagenda.tsx
+++ b/frontend/src/screens/brief.teamweeklyagenda.tsx
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useState } from "react";
+import { Badge, Button } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { EntityRef } from "./entityref";
+import type {
+  TeamWeeklyFocusKind,
+  TeamWeeklyRep,
+  TeamWeeklyReview,
+} from "./teamweekly.queries";
+
+import "./brief.teamweeklyagenda.css";
+
+// The Monday agenda: the team's own week, in the order the review already
+// ranks it.
+//
+// As many items as there are members, never a fixed number, and no minute
+// budgets: a week with two things worth discussing is a two-item meeting, and a
+// budget beside an item would read as guidance derived from a team size and a
+// meeting length the product does not know.
+
+/** Which focus rules are a coaching prompt and which are something to copy. */
+const CELEBRATED: ReadonlySet<TeamWeeklyFocusKind> = new Set([
+  "strong_week",
+  "quiet_week",
+]);
+
+const FOCUS_LABEL: Readonly<Record<TeamWeeklyFocusKind, MessageKey>> = {
+  help_requested: "teamweekly.focus.help_requested",
+  leads_breached: "teamweekly.focus.leads_breached",
+  commitments_missed: "teamweekly.focus.commitments_missed",
+  meetings_without_next_step: "teamweekly.focus.meetings_without_next_step",
+  strong_week: "teamweekly.focus.strong_week",
+  quiet_week: "teamweekly.focus.quiet_week",
+};
+
+/**
+ * The agenda, as rows to draw.
+ *
+ * `agenda` is an ORDER — the server sends the rep ids permuted into the order a
+ * lead should raise them, and the rows themselves are the reps already on the
+ * snapshot. Reading it this way is what keeps the ranking in one place: the
+ * priority that decided the order is the same rule that picked each focus, and
+ * it is spelled in Go and nowhere else.
+ *
+ * An id the reps do not carry is dropped rather than drawn as a blank row. The
+ * contract says the agenda is a permutation of `reps` and the server holds it,
+ * so this cannot happen against a current server — but a client that trusted it
+ * would draw a nameless row against an older one, and a meeting agenda with an
+ * anonymous item on it is worse than one item short.
+ */
+export function agendaRows(review: TeamWeeklyReview): readonly TeamWeeklyRep[] {
+  const byId = new Map(review.reps.map((rep) => [rep.user_id, rep]));
+  return review.agenda
+    .map((id) => byId.get(id))
+    .filter((rep): rep is TeamWeeklyRep => rep !== undefined);
+}
+
+/**
+ * The agenda as text, which is what Copy puts on the clipboard.
+ *
+ * Composed from the rows on screen rather than from the review again, so what
+ * is copied is what was read — the point of the action in an actual Monday
+ * meeting is that the two agree.
+ */
+export function agendaText(
+  rows: readonly TeamWeeklyRep[],
+  heading: string,
+): string {
+  const items = rows.map(
+    (rep, index) => `${index + 1}. ${rep.display_name} — ${rep.focus_label}`,
+  );
+  return [heading, ...items].join("\n");
+}
+
+/**
+ * The one-line reading of the agenda for the header band.
+ *
+ * It says how long the meeting is and what opens it, which are the two facts
+ * somebody scanning the header wants; the items themselves are in the panel.
+ * Both are drawn from agendaRows, so the summary cannot promise an item the
+ * list below does not have.
+ */
+export function AgendaSummary({
+  review,
+}: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const rows = agendaRows(review);
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <p
+      className="teamweekly-agenda-summary"
+      data-testid="teamweekly-agenda-summary"
+    >
+      {t("teamweekly.agenda.summary", {
+        count: formatNumber(rows.length, locale),
+        first: rows[0].display_name,
+      })}
+    </p>
+  );
+}
+
+/** Copy agenda, and what to say when the browser will not hand over a clipboard. */
+function CopyAgenda({ rows }: Readonly<{ rows: readonly TeamWeeklyRep[] }>) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function copy() {
+    // navigator.clipboard is UNDEFINED outside a secure context, so this is a
+    // missing capability rather than a rejected promise, and asking for
+    // writeText on it would throw before any catch could say why.
+    const writer = navigator.clipboard;
+    if (!writer) {
+      setFailed(true);
+      return;
+    }
+    try {
+      await writer.writeText(agendaText(rows, t("teamweekly.agenda.title")));
+      setCopied(true);
+      setFailed(false);
+    } catch {
+      setCopied(false);
+      setFailed(true);
+    }
+  }
+
+  return (
+    <>
+      <Button small onClick={() => void copy()}>
+        {copied ? t("teamweekly.agenda.copied") : t("teamweekly.agenda.copy")}
+      </Button>
+      {failed && (
+        <Callout tone="danger" live="alert">
+          {t("teamweekly.agenda.copyFailed")}
+        </Callout>
+      )}
+    </>
+  );
+}
+
+/**
+ * The agenda itself: one numbered item per member, the thing to raise first at
+ * the top and the quiet week last.
+ *
+ * Every member gets an item, including the one whose week went well — a meeting
+ * that lists only the troubled people reads as a team where only those people
+ * exist, which is both untrue and demoralising to be named in.
+ */
+export function AgendaPanel({
+  review,
+}: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const rows = agendaRows(review);
+  return (
+    <Panel
+      title={t("teamweekly.agenda.title")}
+      sub={t("teamweekly.agenda.sub")}
+      titleAction={rows.length > 0 ? <CopyAgenda rows={rows} /> : undefined}
+    >
+      {rows.length === 0 && (
+        <PanelBody>
+          <p>{t("teamweekly.agenda.empty")}</p>
+        </PanelBody>
+      )}
+      {rows.map((rep, index) => (
+        <PanelRow key={rep.user_id}>
+          <div className="teamweekly-agenda-item">
+            <span className="teamweekly-agenda-ordinal" aria-hidden="true">
+              {formatNumber(index + 1, locale)}
+            </span>
+            <span className="teamweekly-agenda-name">
+              <EntityRef kind="user" id={rep.user_id} name={rep.display_name} />
+            </span>
+            <span className="teamweekly-agenda-focus">
+              <Badge
+                quiet
+                tone={CELEBRATED.has(rep.focus_kind) ? "success" : "warn"}
+              >
+                {t(FOCUS_LABEL[rep.focus_kind])}
+              </Badge>
+              {/* Composed by the server from the stored figures, never
+                  model-written, so it cannot say what the snapshot does not
+                  hold. */}
+              <span>{rep.focus_label}</span>
+            </span>
+          </div>
+        </PanelRow>
+      ))}
+    </Panel>
+  );
+}


### PR DESCRIPTION
Closes #3766, to the ruling recorded on it: the agenda is the week's own items in the review's own order — no fixed four, no minute budgets.

## What was already there, and what was thrown away

The ticket says the contract carries no `team_weekly_review` for an agenda to be computed from. That has since changed — #3765 landed it, and `TeamWeeklyRep` already carries `focus_kind` and `focus_label`: **one thing to raise per member**, picked by a rule set whose own doc says it is *"ordered by what a lead should raise FIRST"*.

So the agenda was already computed. What was missing was the order: the panel drew the reps by **name**, which is the order a membership list is read in and not the order a meeting takes.

## The shape

`TeamWeeklyReview.agenda` — the rep ids permuted into the order a lead should raise them.

**An order over `reps`, not a second list of them.** The items are the reps' own focuses and are already on the wire; publishing them again would be one agenda spelled twice, and the two would eventually disagree. A client renders `reps` in this order and has the whole agenda.

**No fixed four, no minute budgets.** A week with two things worth discussing is a two-item meeting; padding it to a layout's number invents an item. A budget beside an item would read as guidance derived from a team size and a meeting length nothing in the product knows. Empty exactly when `reps` is, and a team whose week could not be read is told that rather than shown an empty meeting.

## Where the ranking lives

In Go, once. `focusPriority` is the sequence `focusFor` tries its rules in, and the two are written apart because a switch cannot be asked for an order. `TestTheAgendaOrderIsTheOrderTheRulesAreTried` drives `focusFor` through one ordered table — one case per rule, in switch order — and asks whether what came back **is** `focusPriority`. That table is the one `TestEveryWeekProducesAFocus` already used, now ordered and one-per-kind rather than a map, so the two tests share it instead of keeping two copies of the same cases.

Also held: every declared focus is ranked (an unranked one sorts last, which is a real order and therefore a silent one), the agenda is the permutation the schema promises, ties keep the arrival order so one snapshot cannot draw two different agendas, and a team with no reps has no agenda.

## On screen

`CoachPanel` becomes `AgendaPanel` — same rows, numbered, in agenda order, with `Copy agenda`. The header band gains a one-line summary.

The summary and the panel are **one derivation**: both read `agendaRows`, so the summary cannot promise an item the list does not have. `Copy agenda` composes its text from the rows on screen rather than from the review again — the point of the action in an actual Monday meeting is that the two agree.

An agenda id no rep matches is dropped rather than drawn. The contract says that cannot happen and the server holds it, but against an older server a trusting client would draw a nameless row, and an anonymous item on a meeting agenda is worse than one item short.

`teamweekly.coach.*` is replaced by `teamweekly.agenda.*` in en/de/vi.

## Verification

`make check-backend` and `make check-fe` both green. Mutation-checked on both sides: swapping two ranks, dropping a rank, an unstable sort, an agenda short one rep, a screen that ignores the order, a blank row kept, copy text taken from somewhere other than the rows, and a swallowed missing clipboard — each fails with the message that names it.

## Found along the way, not fixed here

`navigator.clipboard` is hand-rolled at **seven** call sites (`webhooks`, `dealroomaccess`, `aiexport`, `analytics.share`, `oauth-app`, `users-password-link`, `companypeople/introrequest`), each with its own slightly different handling of the undefined-outside-a-secure-context case. This is an eighth. Converting all of them is a change about clipboards rather than about a Monday meeting, so it is filed rather than folded in.
