### PR TITLE
A drafted reply says what it is, not only what it is licensed under

### DIFF
--- a/backend/gates/sendcontext_test.go
+++ b/backend/gates/sendcontext_test.go
@@ -68,15 +68,12 @@ var claimedByTheirCallers = map[string]bool{"sendInputFrom": true}
 
 // contextlessSends ratifies each construction that states no claim, with what
 // the omission costs.
-var contextlessSends = gatekit.Waive(map[string]string{
-	"internal/compose/heldrelease.go": "KNOWN GAP, not a settled exemption. An automation-drafted " +
-		"message released by an approver reaches the engine with no claimed category, no evidence " +
-		"and no operator reason, because automation.HeldDraftProposal carries none to pass — the " +
-		"consent plan's PR 5 was to add them and never landed. The send is still authorized: the " +
-		"engine resolves from the anchor thread, which is the strongest ground a reply can have, " +
-		"so this is a missing STATEMENT rather than a missing check. Waived because adding the " +
-		"fields reaches the approval payload and the edit-scope pin, which is its own change",
-})
+//
+// It is EMPTY, and that is the finished state rather than an oversight. Its one
+// entry was the automation-drafted message released by an approver, which
+// reached the engine claiming nothing because HeldDraftProposal carried nothing
+// to pass. It carries a context now, so every send door states what it is.
+var contextlessSends = gatekit.Waive(map[string]string{})
 
 func TestEverySendStatesWhyItIsBeingSent(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/compose/followupdraft.go
+++ b/backend/internal/compose/followupdraft.go
@@ -38,9 +38,11 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
-// followUpDraftPurpose is the lawful basis a drafted reply is sent under.
+// followUpDraftPurpose is the lawful basis a drafted reply is sent under when
+// the engine cannot bear the reply out on the thread's own evidence.
 //
 // Answering somebody who wrote to us individually rests on contract or
 // legitimate interest, not on consent — the consent purpose whose German
@@ -124,6 +126,9 @@ func draftFollowUpReply(
 		Subject:          subject,
 		Body:             body,
 		ConsentPurpose:   followUpDraftPurpose,
+		// The nightly pass only ever drafts INTO an existing thread, which is
+		// the reply the engine can bear out on the anchor's own evidence.
+		CommunicationContext: commsauthz.CategoryReplyToInbound,
 		// Intent is the rep-facing note on the card, never body text.
 		Intent: "no next step was planned after this message",
 	}, true, nil

--- a/backend/internal/compose/heldrelease.go
+++ b/backend/internal/compose/heldrelease.go
@@ -127,6 +127,7 @@ func sendFromHeldDraft(p automation.HeldDraftProposal) (activities.SendOrigin, a
 		Subject:        p.Subject,
 		Body:           p.Body,
 		ConsentPurpose: p.ConsentPurpose,
+		Context:        p.CommunicationContext,
 	}
 }
 
@@ -241,6 +242,10 @@ func heldDraftPrecheck(
 // The PURPOSE. It is the lawful basis the send is made under, chosen by the
 // operator when the automation was configured. Editing it at release would let
 // somebody re-license a message at the moment of sending it.
+//
+// The CONTEXT, which the engine actually decides on. Same violation, quieter
+// shape: a purpose reads as a permission and a context reads as a description,
+// so an edit to it looks like a correction to the words.
 // The refusal is approvals' OWN RetargetedEditError, not a new error beside it.
 // This is the same violation the edit scope refuses for entity references, in a
 // field whose shape that check cannot see — so it should read identically to the
@@ -252,6 +257,13 @@ func refuseRetargetedDraft(staged, edited automation.HeldDraftProposal) error {
 	}
 	if edited.ConsentPurpose != staged.ConsentPurpose {
 		moved = append(moved, "consent_purpose")
+	}
+	// The CONTEXT, for the purpose's own reason. It is what the engine decides
+	// on, so editing it at release re-licenses the message just as surely as
+	// editing the purpose does — and more quietly, because a context reads as a
+	// description rather than as a permission.
+	if edited.CommunicationContext != staged.CommunicationContext {
+		moved = append(moved, "communication_context")
 	}
 	if len(moved) == 0 {
 		return nil

--- a/backend/internal/compose/heldretarget_test.go
+++ b/backend/internal/compose/heldretarget_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a human may correct on a staged draft, and what they may not.
+//
+// ADR-0036 §4 lets an approver release a corrected version of a staged action,
+// and the correction is CONTENT. The approvals edit scope enforces that by
+// pinning anything shaped like a uuid — which leaves the fields that decide
+// WHO the message reaches and WHAT IT IS unprotected, because both are prose.
+//
+// A unit test rather than an integration one: refuseRetargetedDraft is a pure
+// comparison, and a database would only slow down the case it cannot make
+// clearer.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// stagedDraft is the proposal an approver read, against which every edit below
+// is judged.
+func stagedDraft() automation.HeldDraftProposal {
+	return automation.HeldDraftProposal{
+		AnchorActivityID:     ids.NewV7(),
+		To:                   "customer@example.test",
+		Subject:              "Recap: kickoff",
+		Body:                 "here is what we agreed",
+		ConsentPurpose:       "business_correspondence",
+		CommunicationContext: commsauthz.CategoryReplyToInbound,
+	}
+}
+
+// retargetedPaths reads the paths a refusal names, failing the test when the
+// edit was allowed through.
+func retargetedPaths(t *testing.T, edited automation.HeldDraftProposal) []string {
+	t.Helper()
+	err := refuseRetargetedDraft(stagedDraft(), edited)
+	if err == nil {
+		t.Fatal("the edit was allowed through; want a RetargetedEditError")
+	}
+	var retargeted *approvals.RetargetedEditError
+	if !errors.As(err, &retargeted) {
+		t.Fatalf("refusal is %T (%v), want *approvals.RetargetedEditError", err, err)
+	}
+	return retargeted.Paths
+}
+
+// TestCorrectingTheWordsIsAllowed holds the other half of the rule. A guard
+// that refused everything would pass every test below and break the feature
+// ADR-0036 §4 exists for, so the permitted edit is asserted first.
+func TestCorrectingTheWordsIsAllowed(t *testing.T) {
+	edited := stagedDraft()
+	edited.Subject = "Recap: our kickoff call"
+	edited.Body = "here is what we agreed, with the dates filled in"
+
+	if err := refuseRetargetedDraft(stagedDraft(), edited); err != nil {
+		t.Fatalf("editing subject and body was refused: %v", err)
+	}
+}
+
+// TestReaimingTheDraftIsRefused is the addressee half, already true before the
+// context joined it. It is asserted here so a change to the refusal cannot
+// quietly trade one pinned field for another.
+func TestReaimingTheDraftIsRefused(t *testing.T) {
+	edited := stagedDraft()
+	edited.To = "someone.else@example.test"
+
+	if got := retargetedPaths(t, edited); len(got) != 1 || got[0] != "to" {
+		t.Errorf("refusal names %v, want exactly [to]", got)
+	}
+}
+
+// TestRelicensingTheDraftAtReleaseIsRefused is why this file exists.
+//
+// The context is what the engine decides on. An approver who could edit it
+// would re-license the message at the moment of sending it: a marketing send
+// re-labelled as a reply reaches a lane that asks for no consent at all. It is
+// the same violation the purpose has always been refused for, in a field that
+// reads as a description rather than as a permission — which is exactly why
+// nothing else would have caught it.
+func TestRelicensingTheDraftAtReleaseIsRefused(t *testing.T) {
+	edited := stagedDraft()
+	edited.CommunicationContext = commsauthz.CategoryMarketing
+
+	got := retargetedPaths(t, edited)
+	if len(got) != 1 || got[0] != "communication_context" {
+		t.Errorf("refusal names %v, want exactly [communication_context]", got)
+	}
+}
+
+// TestEveryMovedFieldIsNamed proves the refusal reports the whole edit rather
+// than stopping at the first thing it found. An approver told only that the
+// addressee moved would fix that and hit the same 422 again on the context.
+func TestEveryMovedFieldIsNamed(t *testing.T) {
+	edited := stagedDraft()
+	edited.To = "someone.else@example.test"
+	edited.ConsentPurpose = "marketing_email"
+	edited.CommunicationContext = commsauthz.CategoryMarketing
+
+	got := retargetedPaths(t, edited)
+	want := map[string]bool{"to": true, "consent_purpose": true, "communication_context": true}
+	if len(got) != len(want) {
+		t.Fatalf("refusal names %v, want all three of to, consent_purpose, communication_context", got)
+	}
+	for _, path := range got {
+		if !want[path] {
+			t.Errorf("refusal names unexpected path %q", path)
+		}
+	}
+}
+
+// TestTheReleasedSendCarriesWhatTheDraftClaimed is the reason the context is
+// threaded at all.
+//
+// The engine decides on SendEmailInput.Context. A release that built the send
+// without it would compile, pass every refusal test above, and reach the engine
+// claiming nothing — falling through to the legacy purpose model, which is the
+// model this change exists to stop depending on. Nothing else fails when that
+// one assignment goes, so this asserts it directly.
+func TestTheReleasedSendCarriesWhatTheDraftClaimed(t *testing.T) {
+	staged := stagedDraft()
+
+	_, in := sendFromHeldDraft(staged)
+
+	if in.Context != commsauthz.CategoryReplyToInbound {
+		t.Errorf("released send Context = %q, want %q — the engine decides on this field",
+			in.Context, commsauthz.CategoryReplyToInbound)
+	}
+	// The purpose still travels too: a draft whose anchor no longer bears the
+	// reply out reaches the legacy fallback, which reads this and nothing else.
+	if in.ConsentPurpose != staged.ConsentPurpose {
+		t.Errorf("released send ConsentPurpose = %q, want %q",
+			in.ConsentPurpose, staged.ConsentPurpose)
+	}
+	if len(in.Recipients) != 1 || in.Recipients[0] != staged.To {
+		t.Errorf("released send Recipients = %v, want exactly [%s]", in.Recipients, staged.To)
+	}
+}
+
+// fixedDrafter is the drafting seam with the model taken out: it answers the
+// same reply for any anchor, so a test about WHAT THE DRAFT CLAIMS is not also
+// a test about what a model wrote.
+type fixedDrafter struct {
+	to string
+}
+
+func (f fixedDrafter) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
+	return "Re: your question", "answering the point you raised", nil
+}
+
+func (f fixedDrafter) ReplyAddress(context.Context, ids.UUID) (string, error) {
+	return f.to, nil
+}
+
+// TestTheNightlyFollowUpClaimsTheReplyItIs holds the nightly pass to the same
+// bar as the recap starter.
+//
+// The pass only ever drafts INTO an existing thread, which is the one case the
+// engine can bear out on the anchor's own evidence. Claiming nothing would send
+// it to the legacy purpose model instead — the model this change stops
+// depending on — and nothing about the draft would look wrong until the day
+// that purpose is archived and every follow-up starts being refused.
+func TestTheNightlyFollowUpClaimsTheReplyItIs(t *testing.T) {
+	proposal := deals.FollowUpProposal{
+		DealID:             ids.New[ids.DealKind](),
+		EvidenceActivityID: ids.New[ids.ActivityKind](),
+		EvidenceDirection:  "inbound",
+	}
+
+	draft, ok, err := draftFollowUpReply(
+		context.Background(), fixedDrafter{to: "customer@example.test"}, proposal)
+	if err != nil {
+		t.Fatalf("drafting the follow-up: %v", err)
+	}
+	if !ok {
+		t.Fatal("the thread produced no draft; want one it can answer")
+	}
+	if draft.CommunicationContext != commsauthz.CategoryReplyToInbound {
+		t.Errorf("follow-up draft context = %q, want %q",
+			draft.CommunicationContext, commsauthz.CategoryReplyToInbound)
+	}
+	if draft.ConsentPurpose != followUpDraftPurpose {
+		t.Errorf("follow-up draft purpose = %q, want %q",
+			draft.ConsentPurpose, followUpDraftPurpose)
+	}
+}

--- a/backend/internal/modules/automation/handlers_actions.go
+++ b/backend/internal/modules/automation/handlers_actions.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
@@ -80,6 +81,17 @@ type draftEmailArgs struct {
 	// one refuses at compose time, where the operator can see and fix it,
 	// rather than staging a draft that can never be released.
 	ConsentPurpose string `json:"consent_purpose"`
+	// CommunicationContext is what the message IS — a reply into a thread the
+	// subject started, a follow-up they asked for — rather than a lawful basis
+	// chosen on the operator's behalf.
+	//
+	// The distinction is why this one MAY be defaulted where ConsentPurpose may
+	// not. A purpose names the ground a send is licensed on, so picking one in
+	// code decides the licence. A context names the message, and the engine
+	// still judges it against the record's own evidence: a claimed
+	// reply_to_inbound with no inbound anchor is recorded as claimed and
+	// resolves to nothing, so a wrong context cannot authorize a send.
+	CommunicationContext commsauthz.Category `json:"communication_context,omitempty"`
 }
 
 // MissingConsentPurposeError refuses to compose a draft for an automation that
@@ -157,6 +169,10 @@ type HeldDraftProposal struct {
 	Subject          string   `json:"subject"`
 	Body             string   `json:"body"`
 	ConsentPurpose   string   `json:"consent_purpose"`
+	// CommunicationContext travels with the draft so the release sends the
+	// message the approver read. Staging resolved it; carrying it means the
+	// engine is asked the same question at release that it answered at compose.
+	CommunicationContext commsauthz.Category `json:"communication_context,omitempty"`
 	// Intent is the automation's own instruction, carried so the approver can
 	// see what the draft was ASKED to do and judge whether it did it.
 	Intent string `json:"intent,omitempty"`
@@ -224,12 +240,13 @@ func applyDraftEmail(ctx context.Context, comms Comms, action workflow.Action) (
 	}
 	action.Args = recorded
 	return action, HeldDraftProposal{
-		AnchorActivityID: action.Target.ID,
-		To:               to,
-		Subject:          subject,
-		Body:             body,
-		ConsentPurpose:   in.ConsentPurpose,
-		Intent:           in.Intent,
+		AnchorActivityID:     action.Target.ID,
+		To:                   to,
+		Subject:              subject,
+		Body:                 body,
+		ConsentPurpose:       in.ConsentPurpose,
+		CommunicationContext: in.CommunicationContext,
+		Intent:               in.Intent,
 	}, nil
 }
 

--- a/backend/internal/modules/automation/handlers_event.go
+++ b/backend/internal/modules/automation/handlers_event.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
@@ -311,6 +312,13 @@ const postMeetingRecapName = "post_meeting_recap"
 // Art 6(1)(b)/(f), and consent with its German evidence standard belongs to
 // marketing. Spelled once here so a starter and its tests cannot disagree
 // about which purpose a recap is sent under.
+//
+// It rides ALONGSIDE the context rather than being replaced by it. The context
+// is what the engine decides on; the purpose is what the legacy fallback reads
+// when a record supports no category on its own evidence. A recap into a thread
+// with a real inbound anchor never reaches that fallback, but one whose anchor
+// has since been archived does, and dropping the key would turn that into a
+// denial rather than the answer the old model gave.
 const purposeBusinessCorrespondence = "business_correspondence"
 
 func (postMeetingRecap) Spec() workflow.Spec {
@@ -348,8 +356,9 @@ func (postMeetingRecap) Plan(_ context.Context, ev workflow.Event) (workflow.Eff
 	// starter whose recipient and register are both fixed by the template, so
 	// its purpose is fixed with them.
 	args, err := json.Marshal(draftEmailArgs{
-		Intent:         recapIntent,
-		ConsentPurpose: purposeBusinessCorrespondence,
+		Intent:               recapIntent,
+		ConsentPurpose:       purposeBusinessCorrespondence,
+		CommunicationContext: commsauthz.CategoryReplyToInbound,
 	})
 	if err != nil {
 		return workflow.Effect{}, fmt.Errorf("automation: encoding the draft_email action: %w", err)

--- a/backend/internal/modules/automation/handlers_event_test.go
+++ b/backend/internal/modules/automation/handlers_event_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
@@ -333,6 +334,21 @@ func TestPostMeetingRecapPlanEmitsOneDraftEmailWithTheRecapIntent(t *testing.T) 
 	}
 	if args.Intent != recapIntent {
 		t.Errorf("draft_email intent = %q, want %q", args.Intent, recapIntent)
+	}
+	// The recap says WHAT IT IS, not only which purpose it is licensed under.
+	// Without this the send reaches the engine claiming nothing, falls through
+	// to the legacy purpose model, and is answered by a row this product is
+	// archiving — so a recap would start denying the day that row goes.
+	if args.CommunicationContext != commsauthz.CategoryReplyToInbound {
+		t.Errorf("draft_email context = %q, want %q",
+			args.CommunicationContext, commsauthz.CategoryReplyToInbound)
+	}
+	// The purpose rides ALONGSIDE it. A recap whose anchor has since been
+	// archived bears no evidence, reaches the legacy fallback, and needs the
+	// key to get the answer the old model gave.
+	if args.ConsentPurpose != purposeBusinessCorrespondence {
+		t.Errorf("draft_email purpose = %q, want %q",
+			args.ConsentPurpose, purposeBusinessCorrespondence)
 	}
 }
 


### PR DESCRIPTION
An automation-drafted message released by an approver reached the engine **claiming nothing**. It was still authorized — the engine resolves a reply from the anchor thread, which is the strongest ground a reply can have — but the claim arm found nothing to check and the decision row recorded a sender who stated no intent.

`gates/sendcontext_test.go` had already named this work in its own waiver, including the scope:

> the consent plan's PR 5 was to add them and never landed … Waived because adding the fields reaches the approval payload and the edit-scope pin, which is its own change

Both are here. **The waiver is deleted and `contextlessSends` is now empty** — every send door states what it is.

## The change

`draftEmailArgs` and `HeldDraftProposal` carry a `CommunicationContext` beside the `ConsentPurpose`, and both starters set `reply_to_inbound`: the post-meeting recap answers the person you just met, and the nightly follow-up pass only ever drafts into an existing thread.

The purpose **rides alongside** rather than being replaced. A draft whose anchor has since been archived bears no evidence, falls through to the legacy purpose model, and needs the key to get the answer the old model gave.

### Why a context may be defaulted where a purpose may not

This is the crux, and it is a deliberate departure from `draftEmailArgs.ConsentPurpose`'s doc comment, which refuses a default because code must not choose a lawful basis for the operator.

A purpose names the *ground a send is licensed on*, so picking one in code decides the licence. A context names *what the message is*, and the engine still judges it against the record's own evidence — a claimed `reply_to_inbound` with no inbound anchor is recorded as claimed and resolves to nothing. **A wrong context cannot authorize a send.**

`refuseRetargetedDraft` pins the context beside the addressee and the purpose. Editing it at release would re-license the message, and more quietly than the purpose does: a context reads as a description rather than as a permission.

## What is NOT here, and why

The ledger item was "archive the legacy purposes". That half is **filed, not built**, for a reason only visible in the code:

`transactional` is a **security boundary**, not just a seeded row. `compose/bookingconsent.go:35` scopes the anonymous public booking form to that one purpose, so a stranger who knows only a victim's email cannot plant a grant under an operator's marketing purpose. `consent/preference.go:38` also makes it the one locked purpose in the preference centre. Archiving it means redesigning both — a product decision about the public form's lawful lane, not a mechanical archive.

`business_correspondence` is closer but not free: both starters now deliberately carry the key as the legacy fallback, and archiving the row turns that path into a denial.

This PR closes the gap that made the archive impossible in the first place.

## Verification

`make check-backend` BE=0 post-rebase. Both integration lanes green: `internal/compose` and `internal/compose/integration`. `craft static --strict` clean.

**7 mutations, all caught**, including the emptied waiver map re-checked so it is not vacuous.

**One gap found and closed.** Dropping `Context: p.CommunicationContext` from `sendFromHeldDraft` compiled and passed every refusal test above — nothing asserted that the send *carries* what the draft claimed, which is the entire point. `TestTheReleasedSendCarriesWhatTheDraftClaimed` closes it and fails without that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automation-drafted replies now state what they are, not just what they're licensed under. Both the post-meeting recap and the nightly follow-up set `reply_to_inbound` as a communication context carried through `draftEmailArgs` and `HeldDraftProposal`, so a released send reaches the engine claiming what it is instead of claiming nothing.

**Why the purpose still rides alongside**
- A purpose names the lawful basis a send is licensed on; a context names what the message is, so a purpose may not be defaulted but a context may.
- The engine still judges a claimed context against the record's own evidence, so a wrong context cannot authorize a send.
- Drafts whose anchor has been archived bear no evidence and fall through to the legacy purpose model, which is why the purpose still travels with the draft.

**Also in this PR**
- `refuseRetargetedDraft` now pins the context beside the addressee and purpose, so an approver cannot re-license a message by editing it at release.
- The `contextlessSends` waiver in `sendcontext_test.go` is deleted; every send door now states what it is.
- A new test asserts the released send carries the context the draft claimed — a line whose absence compiled and passed every other test.

<sup>Written for commit f247770c7853567333de9fc9bb6fe290294270fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

