### PR TITLE
The tri-state renders itself rather than handing back an any

### DIFF
--- a/backend/internal/compose/championcoverseam_test.go
+++ b/backend/internal/compose/championcoverseam_test.go
@@ -14,6 +14,7 @@ package compose
 // on it.
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/deals"
@@ -59,9 +60,13 @@ func TestOnlyAKnownUncoveredCommitteeBecomesAClaim(t *testing.T) {
 
 // derefOrNil renders the tri-state for a failure message without panicking on
 // the absent case the assertion is complaining about.
-func derefOrNil(v *bool) any {
+//
+// A string rather than an any: the value only ever reaches a %v in a failure
+// message, so rendering it here says what the caller does with it and keeps a
+// bare any out of a signature.
+func derefOrNil(v *bool) string {
 	if v == nil {
 		return "nothing"
 	}
-	return *v
+	return strconv.FormatBool(*v)
 }


### PR DESCRIPTION
**main is red on the craftsmanship lane.** `make craft-static` runs whole-tree and refuses a bare `any` in a signature; `internal/compose/championcoverseam_test.go`'s `derefOrNil` has one, landed with #4242. Every open pull request is failing on a file it never touched.

```
../../backend/internal/compose/championcoverseam_test.go
  62: [MAJOR] naked-any — bare any/interface{} in a signature
BLOCK — 0 blocker, 1 major, 0 minor
```

The value only ever reaches a `%v` in a failure message, so it renders itself — `strconv.FormatBool` for the present case, `"nothing"` for the absent one — and the signature says what the caller does with it. Waiving would have been the other option; it is not a false positive, so it is fixed rather than ratified.

`make craft-static` is back to PASS on all four roots, and the test it belongs to still passes.

No open PR was fixing this, so per AGENTS.md's rule about a red main I fixed it here rather than waiting.