### PR TITLE
A self-only proposal is matched as one member's, not the workspace's

### DIFF
--- a/backend/internal/modules/approvals/selfonlysubject_integration_test.go
+++ b/backend/internal/modules/approvals/selfonlysubject_integration_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// A self-only kind's identity-keyed paths, over a real Postgres.
+//
+// decidable says a self-only proposal belongs to ONE member: only they may read
+// it and only they may decide it. The staging engine's matching statements did
+// not know that. They matched on kind, target and either the logical identity
+// or the diff hash — so two members proposing the same thing landed on ONE row,
+// expired each other's pending proposals, and inherited each other's declines.
+//
+// These are Postgres tests because the boundary IS the predicate: the clause
+// lives in SQL, and a Go double would be asserting against its own idea of what
+// the statement matches.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// forMember is the connector principal that stages a card ON BEHALF OF one
+// member — the shape every self-only kind is staged in. A human staging
+// directly carries no OnBehalfOf, and a self-only row without one is decidable
+// by nobody (decidable fails closed), so it is not the shape under test.
+func (e *stagingEnv) forMember(member ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalConnector, ID: "connector:vcard",
+		UserID: member, OnBehalfOf: member,
+		Permissions: principal.Permissions{RoleKeys: []string{"admin"}},
+	})
+}
+
+// secondMember seeds another seat in the same workspace.
+func (e *stagingEnv) secondMember(t *testing.T) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Second')`,
+		id, "second-"+id.String()+"@st.test"); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// nameOnlyCard is the card the ticket's reachable case is about: two members
+// upload a card for two DIFFERENT people who happen to share a name, so the
+// logical identity collides while the subjects do not.
+func nameOnlyCard() StageInput {
+	const sharedName = "Jan Mueller"
+	return StageInput{
+		Kind:           "vcard_create",
+		ProposedChange: []byte(`{"full_name":"` + sharedName + `"}`),
+		DiffHash:       "hash-of-" + sharedName,
+		Identity:       []byte(`{"full_name":"` + sharedName + `"}`),
+		Summary:        "Add " + sharedName + "?",
+		JoinPending:    true,
+	}
+}
+
+// subjectOf reads the member a proposal was staged for, and nil for one staged
+// on nobody's behalf — the nullable case the scope's IS NOT DISTINCT FROM
+// exists for, which a non-pointer scan could not even report.
+func (e *stagingEnv) subjectOf(t *testing.T, id ids.ApprovalID) *ids.UUID {
+	t.Helper()
+	var subject *ids.UUID
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT on_behalf_of FROM approval WHERE id = $1`, id).Scan(&subject); err != nil {
+		t.Fatalf("reading the proposal's subject: %v", err)
+	}
+	return subject
+}
+
+// Two members, one identity, two proposals. Joining them would hand the second
+// member a row the first owns — invisible to them under decidable's own gate,
+// and undecidable by them, with nothing saying why their card never appeared.
+func TestTwoMembersStagingOneIdentityKeepTheirOwnProposal(t *testing.T) {
+	e := setupStaging(t)
+	other := e.secondMember(t)
+	card := nameOnlyCard()
+
+	first, staged, err := e.svc.StageUnlessDeclined(e.forMember(e.rep), card)
+	if err != nil || !staged {
+		t.Fatalf("staging the first member's card: staged=%v err=%v", staged, err)
+	}
+	second, staged, err := e.svc.StageUnlessDeclined(e.forMember(other), card)
+	if err != nil || !staged {
+		t.Fatalf("staging the second member's card: staged=%v err=%v", staged, err)
+	}
+
+	if first == second {
+		t.Fatal("both members' cards landed on ONE proposal: the second member cannot read or decide a " +
+			"row staged for the first, so their card is in the queue for nobody")
+	}
+	if got := e.subjectOf(t, first); got == nil || *got != e.rep {
+		t.Errorf("the first proposal is staged for %v, not the member who uploaded it", got)
+	}
+	if got := e.subjectOf(t, second); got == nil || *got != other {
+		t.Errorf("the second proposal is staged for %v, not the member who uploaded it", got)
+	}
+}
+
+// Supersession expires the proposals a new one replaces. Under one identity and
+// two members it must expire only the proposer's own: a colleague's pending
+// card is not a stale version of this one.
+func TestSupersessionUnderOneIdentityLeavesTheOtherMembersProposalPending(t *testing.T) {
+	e := setupStaging(t)
+	other := e.secondMember(t)
+
+	theirs, _, err := e.svc.StageUnlessDeclined(e.forMember(other), nameOnlyCard())
+	if err != nil {
+		t.Fatalf("staging the other member's card: %v", err)
+	}
+	// Same identity, different payload, so this is a NEW proposal that
+	// supersedes rather than a join.
+	restaged := nameOnlyCard()
+	restaged.ProposedChange = []byte(`{"full_name":"Jan Mueller","title":"Buyer"}`)
+	restaged.DiffHash = "hash-of-jan-with-title"
+	mine, _, err := e.svc.StageUnlessDeclined(e.forMember(e.rep), restaged)
+	if err != nil {
+		t.Fatalf("staging this member's card: %v", err)
+	}
+
+	if got := e.statusOf(t, theirs); got != "pending" {
+		t.Errorf("the other member's card is %q: one member's re-proposal expired a colleague's card, "+
+			"and the sweep will not even record it as unactioned", got)
+	}
+	if got := e.statusOf(t, mine); got != "pending" {
+		t.Errorf("this member's own card is %q rather than pending", got)
+	}
+}
+
+// The declined memory is one member's refusal. Applied across members it
+// refuses a colleague's proposal, and the colleague sees no offer and no reason
+// for its absence.
+func TestOneMembersDeclineDoesNotRefuseAnotherMembersProposal(t *testing.T) {
+	e := setupStaging(t)
+	other := e.secondMember(t)
+	card := nameOnlyCard()
+
+	theirs, _, err := e.svc.StageUnlessDeclined(e.forMember(other), card)
+	if err != nil {
+		t.Fatalf("staging the other member's card: %v", err)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE approval SET status = 'rejected', decided_at = now(), decided_by = $2 WHERE id = $1`,
+		theirs, other); err != nil {
+		t.Fatalf("recording the other member's refusal: %v", err)
+	}
+
+	mine, staged, err := e.svc.StageUnlessDeclined(e.forMember(e.rep), card)
+	if err != nil {
+		t.Fatalf("staging this member's card: %v", err)
+	}
+	if !staged {
+		t.Fatal("this member's card was refused by a colleague's decline: the two are different cards for " +
+			"different people who share a name, and this member is never told why theirs never arrived")
+	}
+	if got := e.subjectOf(t, mine); got == nil || *got != e.rep {
+		t.Errorf("the staged proposal belongs to %v rather than the member who uploaded it", got)
+	}
+}
+
+// The narrowing must not over-reach. A SHARED kind is the inbox working as
+// designed — a manager triages what a rep staged — so two members proposing the
+// same change still land on one row and still inherit each other's decisions.
+// Without this assertion the fix above could be "scope everything" and nothing
+// would say the inbox had stopped being shared.
+func TestASharedKindStillMatchesAcrossMembers(t *testing.T) {
+	e := setupStaging(t)
+	other := e.secondMember(t)
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Gitex', 'gmail:seed', 'connector:gmail')`, target); err != nil {
+		t.Fatal(err)
+	}
+	rename := StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: []byte(`{"proposed_name":"Gitex Global"}`),
+		DiffHash:       "one-shared-proposal",
+		TargetType:     "organization",
+		TargetID:       target,
+		Summary:        "Rename Gitex to Gitex Global?",
+		JoinPending:    true,
+	}
+
+	first, _, err := e.svc.StageUnlessDeclined(e.forMember(e.rep), rename)
+	if err != nil {
+		t.Fatalf("staging the first proposal: %v", err)
+	}
+	second, _, err := e.svc.StageUnlessDeclined(e.forMember(other), rename)
+	if err != nil {
+		t.Fatalf("staging the second proposal: %v", err)
+	}
+
+	if first != second {
+		t.Error("two members proposing one rename produced two inbox rows: a shared kind matches across " +
+			"members by design, and the subject narrowing has reached a kind it is not for")
+	}
+}
+
+// on_behalf_of is nullable, and `=` against NULL is NULL rather than true. A
+// scope written with `=` would therefore match NOTHING for a proposal staged on
+// nobody's behalf — the join never joins, the supersede never supersedes and
+// the decline is never remembered, each failing silently as a control that
+// quietly does nothing.
+//
+// The decline is the one with teeth: forgotten, the next pass re-offers exactly
+// what a human refused.
+func TestASubjectlessProposalStillRemembersItsOwnDecline(t *testing.T) {
+	e := setupStaging(t)
+	card := nameOnlyCard()
+	// A HUMAN principal carries no OnBehalfOf, so the row it stages holds NULL —
+	// the case `=` cannot see.
+	refused, _, err := e.svc.StageUnlessDeclined(e.as(), card)
+	if err != nil {
+		t.Fatalf("staging the first card: %v", err)
+	}
+	if got := e.subjectOf(t, refused); got != nil {
+		t.Fatalf("this proposal was staged for %s, so it is not the subjectless case under test", *got)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE approval SET status = 'rejected', decided_at = now(), decided_by = $2 WHERE id = $1`,
+		refused, e.rep); err != nil {
+		t.Fatalf("recording the refusal: %v", err)
+	}
+
+	if _, staged, err := e.svc.StageUnlessDeclined(e.as(), card); err != nil || staged {
+		t.Errorf("the refused card was staged again (staged=%v err=%v): a scope comparing a NULL subject "+
+			"with `=` matches nothing, so the memory forgets a refusal instead of holding it", staged, err)
+	}
+}

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -149,6 +149,10 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 	if !ok {
 		return ids.ApprovalID{}, errors.New("crmapprovals: no workspace bound to context")
 	}
+	stager, ok := principal.Actor(ctx)
+	if !ok {
+		return ids.ApprovalID{}, errors.New("crmapprovals: no actor bound to context")
+	}
 	if err := lockProposalIdentity(ctx, tx, wsID, in); err != nil {
 		return ids.ApprovalID{}, err
 	}
@@ -165,10 +169,18 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 	// history into the fresh act's bundle. Under the lock the predicate is
 	// re-evaluated, so a settled row is simply not found and the re-proposal
 	// creates the live member it meant to.
+	//
+	// Scoped to the staging member for a shape whose proposal is one member's
+	// (stagingsubject.go): without it two colleagues staging a byte-identical
+	// payload produce ONE row, owned by whoever staged first — so the second
+	// member's proposal is invisible to them and undecidable by them, for a
+	// kind whose own gate says a row belongs to one person.
+	joinArgs := []any{in.Kind, nullUUID(in.TargetID), in.DiffHash}
 	err := tx.QueryRow(ctx, `SELECT id FROM approval
 			WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2 AND diff_hash = $3
-			  AND status = 'pending' AND expires_at > now()
-			ORDER BY created_at DESC LIMIT 1 FOR UPDATE`, in.Kind, nullUUID(in.TargetID), in.DiffHash).Scan(&id)
+			  AND status = 'pending' AND expires_at > now()`+
+		subjectScope(in, stager, &joinArgs)+`
+			ORDER BY created_at DESC LIMIT 1 FOR UPDATE`, joinArgs...).Scan(&id)
 	switch {
 	case err == nil:
 		if err := s.rebundleJoinedInTx(ctx, tx, in, id); err != nil {
@@ -259,7 +271,7 @@ func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, in StageI
 	// which is nobody's order in particular — and a bundle decision walking the
 	// same rows in (created_at, id) is precisely the transaction on the other
 	// side of that. See lockOrder.
-	superseded, err := lockPendingUnderIdentity(ctx, tx, in, survivor)
+	superseded, err := lockPendingUnderIdentity(ctx, tx, in, p, survivor)
 	if err != nil {
 		return err
 	}
@@ -295,14 +307,21 @@ func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, in StageI
 // Split from the write because the order is the point: the predicate is the
 // one that used to sit on the UPDATE itself, and reading it under lockOrder
 // first is what stops this transaction taking those locks in scan order.
-func lockPendingUnderIdentity(ctx context.Context, tx pgx.Tx, in StageInput, survivor ids.ApprovalID) ([]ids.UUID, error) {
+func lockPendingUnderIdentity(
+	ctx context.Context, tx pgx.Tx, in StageInput, p principal.Principal, survivor ids.ApprovalID,
+) ([]ids.UUID, error) {
+	// Scoped to the staging member for a shape whose proposal is one member's
+	// (stagingsubject.go): the identity is a logical key the CALLER built, and
+	// two members' identities colliding would expire a colleague's pending row.
+	args := []any{in.Kind, nullUUID(in.TargetID), survivor, in.Identity}
 	rows, err := tx.Query(ctx, `
 		SELECT id FROM approval
 		 WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2
 		   AND status = 'pending' AND expires_at > now()
-		   AND id <> $3 AND proposed_change @> $4
+		   AND id <> $3 AND proposed_change @> $4`+
+		subjectScope(in, p, &args)+`
 		 `+lockOrder+`
-		 FOR UPDATE`, in.Kind, nullUUID(in.TargetID), survivor, in.Identity)
+		 FOR UPDATE`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("lock the proposals this one supersedes: %w", err)
 	}

--- a/backend/internal/modules/approvals/stagingidentity.go
+++ b/backend/internal/modules/approvals/stagingidentity.go
@@ -223,10 +223,15 @@ func (s *Service) WithdrawInTx(ctx context.Context, tx pgx.Tx, id ids.ApprovalID
 // refusal keyed on it is forgotten the moment any of that moves, and the next
 // pass re-offers the rename a human just refused. Containment matches the
 // decision the human actually made: this record, this proposed value.
-func declinedProbeSQL(byIdentity bool) string {
+// Both discriminators are scoped by subjectScope for a shape whose proposal is
+// one member's (stagingsubject.go). Unscoped, the memory is the WORKSPACE's: one
+// member's refusal would refuse a colleague's proposal, for exactly the kinds
+// whose own gate says a row is one person's business — and the colleague would
+// see no offer and no reason for its absence.
+func declinedProbeSQL(byIdentity bool, subject string) string {
 	const prefix = `SELECT status FROM approval
 		 WHERE kind = $1 AND target_entity_id IS NOT DISTINCT FROM $2 AND `
-	const suffix = `
+	suffix := subject + `
 		 ` + lockOrder + `
 		 FOR UPDATE`
 	if byIdentity {
@@ -359,7 +364,12 @@ func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.A
 		if byIdentity {
 			discriminator = in.Identity
 		}
-		rows, err := tx.Query(ctx, declinedProbeSQL(byIdentity), in.Kind, nullUUID(in.TargetID), discriminator)
+		stager, ok := principal.Actor(ctx)
+		if !ok {
+			return errors.New("crmapprovals: no actor bound to context")
+		}
+		args := []any{in.Kind, nullUUID(in.TargetID), discriminator}
+		rows, err := tx.Query(ctx, declinedProbeSQL(byIdentity, subjectScope(in, stager, &args)), args...)
 		if err != nil {
 			return fmt.Errorf("lock the prior offers for this proposal: %w", err)
 		}

--- a/backend/internal/modules/approvals/stagingsubject.go
+++ b/backend/internal/modules/approvals/stagingsubject.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// Whose proposal a staged row is, for the statements that match "the same
+// proposal" as one another.
+//
+// decidable states the boundary for READING and DECIDING: two shapes belong to
+// one member rather than to the shared inbox — a self-only kind, and a staged
+// create against a table whose rows belong to one human each. The staging
+// engine's own matching statements did not know it. They matched on kind,
+// target and either the logical identity or the diff hash, so one member's
+// pending row could be joined as another's, expired as superseded by another's,
+// and one member's decline could refuse another member's proposal — for exactly
+// the kinds whose own gate says a row is one person's business.
+//
+// The engine's answer to this used to be that a caller builds a
+// collision-proof identity. No caller states that property and none tests it,
+// and #3410 shows how subtle it is: a bare full name is not a card's own
+// addressing, it is every card sharing that name. An unstated, untested
+// property held by every future caller is a hope rather than a boundary.
+
+// subjectScopedShape reports whether a staging of this shape belongs to ONE
+// member, and is the same question decidable asks of a stored row.
+//
+// Asked of the SHAPE rather than of a kind list at each statement, so a kind
+// added to selfOnlyKinds, or a table enrolled in probeOwnerOnly, inherits the
+// narrowing instead of quietly staying shared.
+func subjectScopedShape(in StageInput) bool {
+	if selfOnlyKinds[in.Kind] {
+		return true
+	}
+	var targetType *string
+	if in.TargetType != "" {
+		targetType = &in.TargetType
+	}
+	return stagedForStagerOnly(targetType, in.TargetID != ids.Nil)
+}
+
+// subjectScope is the clause narrowing a same-proposal match to the member this
+// staging is for, and the empty string for a shared shape — where matching
+// across members is the point, and narrowing would split one team's proposal
+// into one row per person.
+//
+// It APPENDS the subject to args and derives the placeholder from the position
+// it landed in, because a hand-typed $N is a number nothing checks: the column
+// list, the placeholders and the arguments have to agree and only counting them
+// says so.
+//
+// IS NOT DISTINCT FROM, never `=`. on_behalf_of is nullable — a system pass
+// proposes on nobody's behalf — and `=` against NULL is NULL, so an `=` here
+// would match nothing at all for those rows: the join never joins, the
+// supersede never supersedes and the decline is never remembered, each failing
+// silently as a control that quietly does nothing.
+func subjectScope(in StageInput, p principal.Principal, args *[]any) string {
+	if !subjectScopedShape(in) {
+		return ""
+	}
+	*args = append(*args, nullUUID(p.OnBehalfOf))
+	return fmt.Sprintf(" AND on_behalf_of IS NOT DISTINCT FROM $%d", len(*args))
+}


### PR DESCRIPTION
Closes #3758, to the ruling recorded on it.

## The gap

`decidable` says a self-only proposal belongs to ONE member: only they may read it and only they may decide it. The shared staging engine's matching statements did not know that — they matched on kind, target and either the logical identity or the diff hash.

So for exactly the kinds whose own gate says a row is one person's business, two members proposing the same thing:

- **joined** onto one row (`stageOrJoinPendingInTx`'s diff-hash step — the sibling [tinnhlt-gra found](https://github.com/margince/margince/issues/3758#issuecomment-5544117127), same root cause),
- **expired** each other's pending proposals (`lockPendingUnderIdentity`),
- **inherited** each other's declines (`declinedProbeSQL`, both discriminators).

Each is silent from the member's side: their card never appears in their queue and nothing says why.

## Why not leave it to the callers

The engine trusts each caller to build a collision-proof identity. **No caller states that property and none tests it**, and #3410 shows how subtle it is — a bare full name *"is not this card's own addressing, it is every card sharing that name"*, which took a review to notice. An unstated, untested property held by every future caller is a hope rather than a boundary.

## The shape

One predicate, `subjectScopedShape`, asked of the staging: it is the same question `decidable` asks of a stored row — a self-only **kind**, or a staged create against a table whose rows belong to one human each. **Derived, not listed at each statement**, so a kind added to `selfOnlyKinds` or a table enrolled in `probeOwnerOnly` inherits the narrowing rather than quietly staying shared.

`subjectScope` appends the subject to the argument slice and derives `$N` from where it landed, per the rulebook — a hand-typed placeholder is a number nothing checks.

**`IS NOT DISTINCT FROM`, never `=`.** `on_behalf_of` is nullable, and `=` against NULL is NULL — so an `=` here would match nothing at all for those rows and the memory would forget a refusal rather than hold it. `TestASubjectlessProposalStillRemembersItsOwnDecline` is what holds that, and it is the mutation `=` fails.

## The narrowing stops there

`TestASharedKindStillMatchesAcrossMembers` is the assertion protecting this from over-reaching: a shared kind still matches across members, which is the inbox working as designed — a manager triages what a rep staged. Without it the fix could have been "scope everything" with nothing to say the inbox had stopped being shared.

## Verification

`make check-backend` green; `make test-it DIR=backend/internal/modules/approvals RUN=…` green on the five new tests. Mutation-checked: the scope never applying, the scope applying to every kind, `selfOnlyKinds` no longer consulted, and `=` for `IS NOT DISTINCT FROM` — each fails with the test that names it, and the shared-kind assertion fails in the opposite direction.

## Two things about main, not about this change

1. **`make craft-static` is red on main** (`championcoverseam_test.go`'s naked `any`, from #4242) — every open PR fails the craftsmanship lane on a file it never touched. Fixed separately in #4269.
2. **`TestAnApprovalTheAgentNeverRedeemedIsMarkedRatherThanLeftSilent` fails when the approvals integration package is run whole, and passes when run alone** — reproduced on a pristine `origin/main` checkout with no local changes, so it is not this change. `MarkLapsedRedemptions` counts 2 where the test expects 1, which reads as cross-test interference in the sweep's own scope. Filed rather than fixed here: it is a different subject and would double this diff.