### PR TITLE
A meeting story shows the brief, or its absence

### DIFF
--- a/frontend/src/screens/worklist.meetingbriefstory.test.tsx
+++ b/frontend/src/screens/worklist.meetingbriefstory.test.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+import { composeStories } from "@storybook/react-vite";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import * as stories from "./worklist.row.stories";
+
+afterEach(cleanup);
+
+const { AMeetingWithItsStartTime, AMeetingWithNobodyToBriefAgainst } =
+  composeStories(stories);
+
+// The two meeting stories must render DIFFERENTLY, and this is what says so.
+//
+// They are one absent field apart: `with_person` decides whether the row can
+// address the brief at all. A pair of stories that looked alike would let a
+// wrong destination ship looking exactly like a right one — which is the whole
+// reason the negative story exists, and it is not a claim a story can make
+// about itself.
+it("draws the brief only for the meeting that names somebody", async () => {
+  render(<AMeetingWithItsStartTime />);
+  const withSomebody = screen
+    .getAllByRole("link")
+    .map((el) => el.getAttribute("href"));
+  cleanup();
+
+  render(<AMeetingWithNobodyToBriefAgainst />);
+  const withNobody = screen
+    .queryAllByRole("link")
+    .map((el) => el.getAttribute("href"));
+
+  // The address is the assertion, not merely the presence of a link: the row
+  // carries other links, and "some link exists" would pass on a row whose
+  // brief never rendered.
+  expect(withSomebody.some((href) => href?.includes("prep="))).toBe(true);
+  expect(withNobody.some((href) => href?.includes("prep="))).toBe(false);
+});

--- a/frontend/src/screens/worklist.row.stories.tsx
+++ b/frontend/src/screens/worklist.row.stories.tsx
@@ -119,6 +119,57 @@ export const AMeetingWithItsStartTime: Story = {
       due_at: "2026-09-02T13:00:00Z",
       because: [{ kind: "meeting_soon" }, { kind: "meeting_unprepared" }],
       actions: [],
+      // The way into the brief, in the shape the server actually sends it.
+      //
+      // The subject stays the ACTIVITY — the row is about the appointment —
+      // and the person rides separately, because the brief is not a page of
+      // its own: it opens as `?prep=<activity>` on somebody's record. Writing
+      // this fixture with a person SUBJECT instead would draw no control at
+      // all, since moveHref reads `with_person` and returns nothing without
+      // it, and the story would look identical to its sibling below while
+      // claiming to show the opposite.
+      subject: { type: "activity", id: "m1" },
+      with_person: "0199f5c0-0000-7000-8000-0000000009a1",
+      move: {
+        action: "open_meeting_brief",
+        activity_id: "m1",
+        arguments: { person_id: "0199f5c0-0000-7000-8000-0000000009a1" },
+      },
+    },
+  },
+  render: (args) => {
+    stubRow(false);
+    return <WorklistRow {...args} />;
+  },
+};
+
+// The same meeting with nobody recorded on it — a calendar event with only
+// colleagues, or one whose attendee links this reader may not see.
+//
+// It sits beside its sibling because the two must LOOK different. The brief
+// opens on a person's page, so a meeting naming none has nowhere to send the
+// reader, and the honest row is the clock with no control under it. A story
+// that showed only the happy row would let a wrong destination ship looking
+// exactly like a right one — and the two states are one absent field apart.
+//
+// The lane cannot tell an internal meeting from one whose attendees are all
+// withheld, and deliberately does not try: both mean there is no page to read
+// this brief on, so both arrive here as the same absence.
+export const AMeetingWithNobodyToBriefAgainst: Story = {
+  args: {
+    ...baseArgs,
+    item: {
+      id: "m2",
+      source: "meeting",
+      category: "meetings",
+      level: 1,
+      consequence: "meeting_unprepared",
+      title: "Team stand-up",
+      kind: "unprepared",
+      due_at: "2026-09-02T13:00:00Z",
+      because: [{ kind: "meeting_soon" }],
+      actions: [],
+      subject: { type: "activity", id: "m2" },
     },
   },
   render: (args) => {


### PR DESCRIPTION
#4255 shipped the way into a meeting's brief and no story drew it. `worklist.row.stories.tsx` held one meeting story and **zero** occurrences of `open_meeting_brief`, so the control went out with no visual coverage.

Found by a parallel session comparing an abandoned worktree against main — the backend half there was redundant, the stories were not.

## Two stories, because one proves nothing

The states are a single absent field apart: `with_person` decides whether the row can address the brief. A happy row alone would let a wrong destination ship looking exactly like a right one.

The sibling is `AMeetingWithNobodyToBriefAgainst` — a calendar event with only colleagues, or one whose attendee links this reader may not see. The lane cannot tell those apart and deliberately does not try: both mean there is no page to read the brief on.

## The fixture carries the shape the server sends

The subject stays the **activity** (the row is about the appointment) and the person rides separately in `with_person`, because the brief is not a page of its own.

Written instead with a person subject — which is how the abandoned draft had it — the row draws **no control at all**: `moveHref` reads `with_person` and returns `undefined` without it. That story would have rendered identically to its negative sibling while claiming the opposite. That is the failure the pair exists to catch, not a detail of fixture spelling.

## A story cannot assert it differs from another story

So `worklist.meetingbriefstory.test.tsx` does, via `composeStories`. It reads the **address**, not the presence of a link: the row carries other links, and "some link exists" passes on a row whose brief never rendered.

## Evidence

| Obligation | Evidence |
|---|---|
| The gap was real | `open_meeting_brief` appears 0 times in the stories file on main; one meeting story existed |
| The pair differs | `draws the brief only for the meeting that names somebody` — asserts `prep=` present, then absent |
| Mutation strength | Two clauses reverted individually. Writing the happy story with a person subject (the abandoned draft's shape) **fails** — confirming that was a defect, not a style difference. Giving the negative story a person and a move **fails** — the pair collapses and the test catches it. |
| Full lane | `make check-fe` green |

Stories and one test. No production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the story and test coverage missing for the meeting-brief control shipped in #4255, which went out with no visual coverage: the worklist row stories held one meeting and zero `open_meeting_brief` occurrences.

- Adds `AMeetingWithNobodyToBriefAgainst`, a sibling story for the same meeting with nobody recorded, so the row renders with no brief control.
- Keeps the fixture in the shape the server sends — subject stays the activity, `with_person` rides separately — since writing the person as the subject renders no control at all.
- The test composes both stories and asserts the `prep=` address appears only in the happy path; checking for any link would pass on a row whose brief never rendered.

<sup>Written for commit 4bf18f1c243f222e1be61e0e9a31123bbdecad45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

