### PR TITLE
A verdict pass cannot ask twice about every sender

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -387,6 +387,16 @@ kinds:
       judging stage leases and commits in claims of eight, so a cut-off pass
       keeps every verdict it paid for.
 
+      One call each is what these twenty minutes are sized against, and the
+      asymmetric confidence floor made a SECOND call ordinary: a creating
+      answer between the two floors is re-asked, which is the common case on a
+      mailbox of first-time senders. reAskBudget bounds those at
+      verdictCatchUpCap / verdictReAskShare, so the worst case is cap + budget
+      calls rather than twice the cap — the arithmetic above holds by
+      construction, at any model speed and whatever fraction of answers land in
+      the band. Lowering the cap or raising this wall would both need a
+      measured pass on real hardware; the bound does not.
+
   capture_confidentiality_verdict:
     role: dispatcher
     go_type: ConfidentialityVerdictArgs

--- a/backend/internal/compose/captureverdict.go
+++ b/backend/internal/compose/captureverdict.go
@@ -147,6 +147,7 @@ func (e *CounterpartyVerdictEngine) RunWorkspace(ctx context.Context, maxVerdict
 	if maxVerdicts <= 0 {
 		maxVerdicts = verdictCatchUpCap
 	}
+	budget := reAskBudgetFor(maxVerdicts)
 	return e.inWorkspace(ctx, func(wsCtx context.Context, _ ids.UUID) error {
 		resolved := 0
 		for resolved < maxVerdicts {
@@ -157,7 +158,7 @@ func (e *CounterpartyVerdictEngine) RunWorkspace(ctx context.Context, maxVerdict
 			if len(batch) == 0 {
 				return nil
 			}
-			n, err := e.judgeClaimed(wsCtx, batch)
+			n, err := e.judgeClaimed(wsCtx, batch, budget)
 			resolved += n
 			if errors.Is(err, ai.ErrBudgetDeferred) {
 				// Every row this pass never reached is refunded: no model saw
@@ -189,10 +190,12 @@ func (e *CounterpartyVerdictEngine) RunWorkspace(ctx context.Context, maxVerdict
 // when the victim's id was legitimately in the request. The extra calls land on
 // the cheapest rung of a background task, which is the right price for a
 // decision that creates or destroys records.
-func (e *CounterpartyVerdictEngine) judgeClaimed(ctx context.Context, claimed []capture.PendingCounterparty) (int, error) {
+func (e *CounterpartyVerdictEngine) judgeClaimed(
+	ctx context.Context, claimed []capture.PendingCounterparty, budget *reAskBudget,
+) (int, error) {
 	applied := 0
 	for _, row := range claimed {
-		n, err := e.judgeOne(ctx, row)
+		n, err := e.judgeOne(ctx, row, budget)
 		if err != nil {
 			// WHY it failed decides whether the row pays for it, and the cause
 			// has to be read BEFORE the deferral — a Defer clears claimed_by, so
@@ -225,7 +228,9 @@ func (e *CounterpartyVerdictEngine) judgeClaimed(ctx context.Context, claimed []
 // judgeOne asks about ONE sender and applies what comes back, if it clears the
 // floor. An answer still below the floor retires the row to `unsure` for a human
 // rather than spending another attempt on a question this model cannot answer.
-func (e *CounterpartyVerdictEngine) judgeOne(ctx context.Context, row capture.PendingCounterparty) (int, error) {
+func (e *CounterpartyVerdictEngine) judgeOne(
+	ctx context.Context, row capture.PendingCounterparty, budget *reAskBudget,
+) (int, error) {
 	// The OWNER's own decision first, and no model call at all when there is
 	// one. A person who told this product what a sender is has answered the
 	// question; asking anyway would spend a call to be told something we then
@@ -259,6 +264,21 @@ func (e *CounterpartyVerdictEngine) judgeOne(ctx context.Context, row capture.Pe
 	// a hope that the same question answers differently: an unbound structured
 	// call escalates the routing ladder, so the second attempt is a stronger
 	// model looking at the same message.
+	//
+	// A pass whose re-ask budget is spent takes the answer the floor already
+	// gives it: terminally unsure, a human decides. Not deferred — the row has
+	// been judged, and a deferral would spend one of PendingMaxAttempts on a
+	// pass that never asked its second question. Not accepted either: the whole
+	// point of the floor is that an answer this unconfident does not act.
+	if !budget.spend() {
+		// The same helper, asked with no retry answer to prefer: a human is
+		// owed what the model DID say, which here is the one answer it gave.
+		if err := e.pending.Retire(ctx, row, "below the confidence floor, and this pass had no re-ask left",
+			lastMeasurement(nil, "", answers, servedModel)); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
 	retry, retryModel, err := e.ask(ctx, row)
 	if err != nil {
 		return 0, err

--- a/backend/internal/compose/captureverdictbudget.go
+++ b/backend/internal/compose/captureverdictbudget.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// One pass's allowance of second opinions.
+//
+// capture_counterparty_verdict's twenty-minute wall was sized when a pass cost
+// one model call per sender: verdictCatchUpCap senders, verdictCatchUpCap
+// calls, plus the occasional re-ask of an answer below verdictConfidenceFloor,
+// which was the exception.
+//
+// The asymmetric floor made the re-ask ordinary. A creating answer now needs
+// verdictCreateFloor, so a `person` or `advisor` between the two floors is
+// re-asked — and borderline creating answers are the common case on a mailbox
+// full of first-time senders. A pass sized for 200 calls could make 400, run
+// past its wall, and be retried whole by River, with review staging and the
+// noise sweeps waiting behind it. Nothing is lost; the backlog simply drains
+// slower than the numbers say, and nothing says so.
+//
+// The bound here is the remedy that needs no measurement. Lowering the cap or
+// raising the wall are both numbers — by how much, to what — and neither has an
+// answer without measuring a live pass on real hardware. Bounding the re-asks
+// makes the cost bounded BY CONSTRUCTION: at most cap + budget calls, whatever
+// fraction of answers land between the floors and however fast the model is. So
+// the twenty minutes is exactly as valid as it was before the floor landed.
+
+// verdictReAskShare is how much of a pass's sender budget may be spent a second
+// time: one call in ten, so a re-ask stays the exception it was when the wall
+// was sized rather than becoming a second pass hidden inside the first.
+//
+// A share rather than a count, so lowering verdictCatchUpCap lowers this with
+// it — a cap and a budget that drifted apart would be a wall sized against
+// neither.
+const verdictReAskShare = 10
+
+// reAskBudget is what one pass has left to spend on second opinions.
+//
+// Per pass and not per workspace-run, for verdictCatchUpCap's own reason: a
+// shared counter would let one large backlog spend the allowance and leave
+// every workspace after it unable to ask twice about anything.
+type reAskBudget struct{ left int }
+
+// reAskBudgetFor sizes the allowance against the senders this pass may drain.
+//
+// At least one however small the cap: a pass allowed five senders that could
+// not ask twice about any of them would answer a different question from the
+// same pass allowed five hundred, and the floor's re-ask is not a luxury of
+// large passes.
+func reAskBudgetFor(maxVerdicts int) *reAskBudget {
+	return &reAskBudget{left: max(1, maxVerdicts/verdictReAskShare)}
+}
+
+// spend takes one second opinion, reporting false when the pass has none left.
+func (b *reAskBudget) spend() bool {
+	if b.left <= 0 {
+		return false
+	}
+	b.left--
+	return true
+}

--- a/backend/internal/compose/captureverdictbudget_integration_test.go
+++ b/backend/internal/compose/captureverdictbudget_integration_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The re-ask budget, over a real backlog.
+//
+// capture_counterparty_verdict's wall was sized for one model call per sender.
+// The asymmetric floor made the second call ordinary rather than exceptional —
+// a creating answer between verdictConfidenceFloor and verdictCreateFloor is
+// re-asked, and that is the common case on a mailbox of first-time senders — so
+// a pass sized for one call each could make two.
+//
+// What this proves is the property the wall rests on: a pass whose answers are
+// ALL borderline still makes at most cap + budget calls.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// borderlineBacklog seeds senders whose answers all land between the two
+// floors: confident enough to mean something, not confident enough to create.
+// Every one of them asks for a second opinion, which is the worst case the
+// budget exists to bound.
+func borderlineBacklog(t *testing.T, e *integration.Env, senders int) *scriptedVerdictBrain {
+	t.Helper()
+	brain := &scriptedVerdictBrain{
+		verdicts:   map[string]string{},
+		confidence: map[string]float64{},
+	}
+	for range senders {
+		address := "borderline-" + ids.NewV7().String() + "@ambiguous.example"
+		activityID := seedCapturedMail(t, e, address, "hello")
+		dispositionID := seedPendingDisposition(t, e, address, "ambiguous.example", activityID)
+		// A CREATING answer under verdictCreateFloor and over
+		// verdictConfidenceFloor: the band the asymmetric floor re-asks, and
+		// the reason a pass's cost could double.
+		brain.verdicts[dispositionID.String()] = capture.KindPerson
+		brain.confidence[dispositionID.String()] = 0.8
+	}
+	if got := len(brain.verdicts); got != senders {
+		t.Fatalf("seeded %d senders, want %d — two ids collided and the backlog is smaller than the test thinks", got, senders)
+	}
+	return brain
+}
+
+// The whole ruling in one assertion: however borderline the backlog, one pass
+// costs at most one call per sender plus its re-ask budget. Unbounded, this
+// backlog would cost two calls each and run the pass past a wall sized for one.
+func TestAnEntirelyBorderlinePassStaysInsideItsCallBudget(t *testing.T) {
+	e := integration.Setup(t)
+	const senders = 12
+	brain := borderlineBacklog(t, e, senders)
+
+	engine := NewCounterpartyVerdictEngine(e.Pool, brain, slog.Default())
+	if err := engine.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), senders); err != nil {
+		t.Fatalf("verdict pass: %v", err)
+	}
+
+	budget := reAskBudgetFor(senders)
+	ceiling := senders + budget.left
+	if brain.calls > ceiling {
+		t.Errorf("%d model calls for %d senders, want at most %d (one each plus %d re-asks): the wall was "+
+			"sized for one call per sender, and a pass that can ask twice about every one of them is a "+
+			"second pass hidden inside the first",
+			brain.calls, senders, ceiling, budget.left)
+	}
+	// And the budget was actually SPENT — otherwise a pass that stopped
+	// re-asking altogether would pass the ceiling assertion above while having
+	// quietly dropped the floor's second opinion.
+	if brain.calls != ceiling {
+		t.Errorf("%d model calls, want exactly %d: every sender is borderline, so the pass should spend its "+
+			"whole re-ask budget and no more", brain.calls, ceiling)
+	}
+}
+
+// A sender the budget could not pay for takes the answer the floor already
+// gives: terminally unsure, for a human. Not deferred — the row WAS judged, and
+// a deferral would spend one of PendingMaxAttempts on a question this pass
+// never asked twice. Not accepted either: an answer this unconfident is exactly
+// what the floor exists to refuse.
+func TestASenderTheBudgetCouldNotPayForIsLeftForAHuman(t *testing.T) {
+	e := integration.Setup(t)
+	const senders = 12
+	brain := borderlineBacklog(t, e, senders)
+
+	engine := NewCounterpartyVerdictEngine(e.Pool, brain, slog.Default())
+	if err := engine.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS), senders); err != nil {
+		t.Fatalf("verdict pass: %v", err)
+	}
+
+	// Every one of them is unsure: the ones that got their re-ask were still
+	// borderline on it, and the ones that did not took the same answer.
+	if n := countIn(t, e, `SELECT count(*) FROM capture_pending_counterparty WHERE status = $1`,
+		capture.PendingStatusUnsure); n != senders {
+		t.Errorf("%d of %d senders are unsure: a sender the budget could not re-ask must take the floor's "+
+			"own answer rather than being dropped or accepted", n, senders)
+	}
+	// None created, which is what "not accepted" means for a creating answer.
+	if n := countIn(t, e, `SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		 WHERE pe.email LIKE 'borderline-%@ambiguous.example'`); n != 0 {
+		t.Errorf("%d people created from answers below the creating floor", n)
+	}
+	// And none left pending, which is what "not dropped" means: a row still
+	// claimable would be re-judged next pass at the cost of another attempt.
+	if n := countIn(t, e, `SELECT count(*) FROM capture_pending_counterparty WHERE status = 'pending'`); n != 0 {
+		t.Errorf("%d senders were left claimable rather than answered", n)
+	}
+}

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
+const jobContractHash = "4115942d6410ef80926392c452e32e3cc5b45277cbfc249d6331962acf1d18a5"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "07684b458ea1541bd4f2d3978402a90cb8a73009c324b509e5c7da24c17ce654"
+const JobContractHash = "4115942d6410ef80926392c452e32e3cc5b45277cbfc249d6331962acf1d18a5"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it


### PR DESCRIPTION
Closes #3754, to the ruling recorded on it: bound the re-ask, so a pass cannot double its own cost.

## The arithmetic

`capture_counterparty_verdict_workspace`'s twenty-minute wall was sized for **one model call per sender** — `verdictCatchUpCap` senders, that many calls, plus the occasional re-ask of an answer below `verdictConfidenceFloor`, which was the exception.

The asymmetric floor (#3751) made the second call ordinary: a creating answer now needs `verdictCreateFloor`, so a `person` or `advisor` **between** the two floors is re-asked — and that is the common case on a mailbox of first-time senders. A pass sized for 200 calls could make 400.

## Why this remedy and not the other two

The ticket lists three — lower the cap, raise the wall, bound the re-ask — and says to pick *"whichever the measurement says"*. **Only one of the three does not need the measurement.** Lowering the cap and raising the wall are both numbers: by how much, to what. Neither has an answer without a live pass over a real backlog on real hardware, which nobody can do from the tree.

Bounding the re-asks makes the cost bounded **by construction** — at most `cap + budget` calls, at any model speed, whatever fraction of answers land in the band. So the twenty minutes is exactly as valid as it was before the floor landed. This is not a holding measure ahead of the real fix; it restores the property the wall was sized against. Measure later to tune the number.

Halving the cap was the other measurement-free option and it is worse: it halves throughput for **every** installation to protect against a worst case that may be uncommon. The budget costs throughput only in the case that actually causes the overrun.

## What happens when the budget is spent

The decision the bound forces, made explicitly rather than left as a fallthrough. A sender that would have been re-asked and cannot be **takes the answer the floor already gives it**: terminally unsure, for a human.

- **Not deferred.** The row *was* judged, and a deferral would spend one of `PendingMaxAttempts` on a question this pass never asked twice.
- **Not accepted.** An answer this unconfident is exactly what the floor exists to refuse — and for a creating answer, accepting it would create the record the higher floor was raised to protect.

The human still gets the evidence: the retirement carries the one answer the model did give.

## The floor is not reconsidered

*"A record in a shared CRM should need more evidence than a refusal."* #3751 stands. This is the operational budget that was tuned around the old call count.

## The share, not a count

`verdictReAskShare = 10` — one call in ten, so a re-ask stays the exception it was when the wall was sized. A **share** rather than a fixed number so lowering `verdictCatchUpCap` lowers this with it; a cap and a budget that drifted apart would be a wall sized against neither. Floored at one, because a pass allowed five senders that could not ask twice about any of them would answer a different question from the same pass allowed five hundred.

## The contract said something that had stopped being true

`api/jobs.yaml`'s reason for the kind read *"Up to verdictCatchUpCap (200) senders judged one model call each"* — false since the floor landed. It now states the arithmetic the wall actually rests on.

## Verification

`make check-backend` green; the whole `internal/compose` integration package green. The ruling's own assertion is `TestAnEntirelyBorderlinePassStaysInsideItsCallBudget`: a backlog where **every** answer is borderline still costs `senders + budget` calls — asserted as an equality, so a pass that stopped re-asking altogether fails it too rather than passing a ceiling by doing less.

Mutation-checked: an unconsulted budget (unbounded re-asks), a budget that never pays (no re-ask at all — which also breaks the existing below-floor test), and an exhausted budget that defers rather than retires. Each fails with the test that names the property.