### PR TITLE
A role states where it departs, not all forty-four columns

### DIFF
--- a/backend/internal/modules/identity/internal/policy/defaults.go
+++ b/backend/internal/modules/identity/internal/policy/defaults.go
@@ -32,6 +32,12 @@ var (
 	// product does not offer reads as an oversight the next author has to
 	// research.
 	createRead = grant{Create: true, Read: true}
+	// none is the zero grant, named so a role's override map says WHY a line is
+	// there. Inside a `map[string]grant` the literal simplifies to a bare `{}`,
+	// which reads as an oversight rather than as "this role holds nothing on
+	// this object" — and holding nothing is a decision every bit as deliberate
+	// as holding crud.
+	none = grant{}
 )
 
 // defaults are the seeded system-role policies (they encode
@@ -81,13 +87,229 @@ var (
 // overlay→native flip executes through it), and unlike custom_field or
 // overlay_connection there is no per-rep read surface — the mode-flip
 // and migrate-in screens are admin surfaces.
+// grid builds one role's document: every core object at `base`, then the
+// objects that differ. It replaces a 44-argument positional zip in which the
+// object a grant belonged to was decided by COUNTING — a transposed pair
+// typechecked, read identically in review, and would have been caught only by
+// the replay fixture. Here each grant is written beside the object it governs,
+// and a role states only where it departs from its own baseline, which is the
+// sentence the reader actually wants: not "what does rep hold on all 44" but
+// "where is rep NOT the record posture".
+//
+// An override naming an object outside coreObjects panics at package init: a
+// typo has to be a build failure rather than a grant that silently governs
+// nothing, which is the rule `Parse` already applies to a stored document.
+func grid(base grant, overrides map[string]grant) map[string]grant {
+	out := make(map[string]grant, len(coreObjects))
+	for _, object := range coreObjects {
+		out[object] = base
+	}
+	for object, g := range overrides {
+		if _, ok := out[object]; !ok {
+			//craft:ignore panic-in-domain runs only during package initialization (the `defaults` var) — a role naming an object the vocabulary does not have is a typo in this file, and booting with it would seed that role a grant short forever
+			panic(fmt.Sprintf("policy: a default grant names %q, which is not a core object", object))
+		}
+		out[object] = g
+	}
+	return out
+}
+
+// The object names a role's overrides repeat. Constants rather than repeated
+// literals so a typo is a compile error here too, not only inside `grid` at
+// init: these fourteen appear in three or more role documents, and a misspelt
+// one in a single map would otherwise take that role's grant with it.
+const (
+	// The rate sheets. Append-forward on every role that holds them —
+	// create, read, same-day-correct, never delete — because a past-dated row
+	// prices a historical rollup and must not disappear. No delete surface
+	// exists at all, so no role holds one.
+	objAiModelRate = "ai_model_rate"
+	// Which vendor this installation's text is sent to (ai-operational-spec
+	// §1.4). Deliberately NOT folded into installation_settings: whoever may
+	// rename the organization has no business re-pointing where its people's
+	// correspondence is processed, and those become one grant the moment the
+	// two share an object.
+	//
+	// Narrow on BOTH verbs, unlike most read-broad objects here. Nobody needs
+	// this grant to see which models are bound — the AI profile surface answers
+	// that from the running config, not from a settings read — so a read grant
+	// would buy a rep nothing and widen the reach of the object governing egress.
+	objAiRouting = "ai_routing"
+	// Everyone reads (a rep sees whether auto-enrich is on); only admin/ops
+	// toggle it or carve a domain back out of the consumer-mail baseline.
+	// `create` is the one write a rep holds: contributing a consumer domain the
+	// shipped baseline missed (CAP-PARAM-5) is everyday judgment about the mail
+	// they read, not workspace config.
+	objCaptureSettings = "capture_settings"
+	// The workspace's SHARED-CHANNEL capture trace (a bot binding's inbound
+	// traffic). Read-only for everyone who holds it, because nothing writes it
+	// but the pipeline and nothing deletes it but its 24h sweep — there is no
+	// create/update/delete anyone could hold.
+	//
+	// It reaches ONLY rows with no member behind them. A member's own capture
+	// traffic is personal data and no grant widens it, which is why rep and
+	// read_only hold nothing here rather than holding read: there is no
+	// shared-channel debugging in their job, and a grant that looked harmless
+	// would be the one somebody later widened.
+	objCaptureTrace = "capture_trace"
+	// Read-only for every role, admin/ops included — RD-AC-7: no runtime
+	// formula-authoring surface exists, so there is no write to grant.
+	objComputedField = "computed_field"
+	// Nothing, below admin/ops. Source health is connector freshness,
+	// permission-limited checks and import backlog: an OPERATOR's view. A rep
+	// shown their installation's connector health has been handed somebody
+	// else's job, and the screen that would tell them is one they cannot act on.
+	objDataCoverage = "data_coverage"
+	// No create/delete surface at all — it is a single deployment-level
+	// trigger, not a record kind — so only read and update are ever granted,
+	// and both are admin/ops-only. Admin/ops may update (trigger a reindex; the
+	// confirm route carries x-agent-access: human-only in the contract, so the
+	// grant only ever fires from a human session, never an agent), and admin/ops
+	// alone may read it: the banner that consumes the read is itself ops-gated,
+	// so manager/rep/read_only have no legitimate consumer and get nothing —
+	// unlike the custom_field catalog or overlay_connection's status, which
+	// every role legitimately reads.
+	objEmbeddingReindex = "embedding_reindex"
+	// createRead everywhere it is held: a reading is derived, and a current
+	// call SUPERSEDES rather than being rewritten, so neither update nor delete
+	// has a surface to gate. A grant for a verb the product does not offer
+	// reads as an oversight the next author has to research.
+	objForecast = "forecast"
+	// Append-forward like ai_model_rate, and for the same reason: a past-dated
+	// row prices a historical rollup.
+	objFxRate = "fx_rate"
+	// Admin/ops-only on EVERY verb, read included: a migration run is a
+	// workspace-wide bulk mutation of the estate (the overlay→native flip
+	// executes through it), and unlike custom_field or overlay_connection there
+	// is no per-rep read surface — the mode-flip and migrate-in screens are
+	// admin surfaces.
+	objImportRun = "import_run"
+	// The organization's own identity and reporting calendar (ADR-0090/A135).
+	// Read is broad — the base currency and the business timezone shape what
+	// every seat sees — and only admin/ops change it.
+	objInstallationSettings = "installation_settings"
+	// Asking a colleague to open a door, and answering an ask made of you, are
+	// both the job, so every seat holds it. WHICH of the two parties a caller is
+	// on a given row is the row's own check, and no grant stands in for it.
+	//
+	// No delete on ANY role, admin included: an ask that was made is a thing
+	// that happened, so it is withdrawn rather than erased. That is a property
+	// of the object rather than a posture per role, which is why the backfill
+	// migration grants the same — a database that upgraded into this object and
+	// one created after it answer alike.
+	objIntroduction = "introduction"
+	// READ IS THE ONLY VERB, for admin as much as anyone: the token is resolved
+	// from the deployment file at boot, so there is no write path for a grant to
+	// govern. Admin/ops-only — a rep reads their own seat elsewhere; the
+	// workspace's entitlement is not theirs to see (UC-ADMIN-03 F1).
+	objLicense = "license"
+	// Admin/ops-only, read included (UC-GDPR-09, GCS-WIRE-1..5). The retain-only
+	// posture setting is gated by this same object, so whoever may author a
+	// policy may also suspend every destructive one.
+	objRetentionPolicy = "retention_policy"
+	// The rep's own per-user view state, owner-scoped in the store, so full
+	// self-service is correct for every seat — read_only included.
+	objSavedView = "saved_view"
+)
+
+// The objects whose posture is not visible from any one role's overrides,
+// because every role treats them the same way or because the reason lives in a
+// relationship no grant expresses.
+//
+// finance — the ingested accounting mirror (ADR-0083/A128). READ is broad:
+// every role that opens a company page sees whether the customer pays on time.
+// Connecting or disconnecting the source is destructive workspace-wide config,
+// so create/update/delete are admin/ops-only, exactly like overlay_connection.
+// No role holds a write on a finance RECORD, because there is no such action:
+// the mirror's read-only posture is the ABSENCE of the grant (FIN-DDL-N-1),
+// not a runtime refusal.
+//
+// contract (ADR-0109/A160) and commission carry no owner column of their own —
+// visibility is inherited from the deal they hang off, so the row scope that
+// reaches them is the DEAL's. A rep records and maintains the agreements they
+// close and sees what their partner-sourced deal earned; approving and paying
+// are the business's decisions, and an entry is written by the won-deal accrual
+// rather than by hand.
+//
+// integrations (ADR-0101/A152) — a rep reads whether a provider is connected,
+// so a dated value on a person record has an explanation; connecting one spends
+// money and is admin/ops.
+//
+// offer_template follows product and offer rather than the pipeline-config
+// posture: it is the offer's own branding input, not a locked-down schema
+// surface, so reps create and work templates like any other offer-adjacent
+// record. Delete stays manager/admin/ops — archiveOfferTemplate carries no
+// x-agent-access gate, so any role holding delete may call it directly.
+//
+// overlay_connection, channel_connection and webhook_subscription share one
+// posture: each binds the whole workspace to something outside it — an
+// incumbent CRM, a chat bot carrying every seat's inbound traffic, an outbound
+// egress of governed events — so create/update/delete are admin/ops-only while
+// every role reads the binding's status. A rep needs to know whether overlay
+// mode is live, or whether the channel is up, before expecting a reply to
+// arrive there. (UC-E10-04 narrates a Rep registering a subscription; that
+// posture question is tracked upstream, not settled here.)
+//
+// weekly_plan — a rep plans their own week and settles it. Their own only: the
+// store resolves the plan from the caller and takes no owner argument, so the
+// grant admits them to their week and to nobody else's. A lead's read of a
+// rep's plan is a separate path gated on the shared-team question, not on a
+// wider grant here. No delete, for the reason introduction carries: a week that
+// was planned is a thing that happened, and a commitment is dropped rather than
+// erased.
+
 // managerObjects is the grid a team lead (`manager`) and the whole-organization
 // `management` seat share; only their row scope differs.
-var managerObjects = objects(crud, crud, crud, crud, crud, readOnly, crud, readOnly, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, crud, grant{}, crud, crud, readOnly, readOnly, writeNoDelete, crud, createRead, grant{})
+var managerObjects = grid(crud, map[string]grant{
+	objAiModelRate:          none,
+	objAiRouting:            none,
+	"automation":            readOnly,
+	objCaptureSettings:      createRead,
+	objCaptureTrace:         readOnly,
+	"channel_connection":    readOnly,
+	objComputedField:        readOnly,
+	"custom_field":          readOnly,
+	objDataCoverage:         none,
+	objEmbeddingReindex:     none,
+	"finance":               readOnly,
+	objForecast:             createRead,
+	objFxRate:               none,
+	objImportRun:            none,
+	objInstallationSettings: readOnly,
+	"integrations":          readOnly,
+	objIntroduction:         writeNoDelete,
+	"knowledge_corpus":      readOnly,
+	"knowledge_document":    readOnly,
+	objLicense:              none,
+	"overlay_connection":    readOnly,
+	"pipeline":              readOnly,
+	objRetentionPolicy:      none,
+	"tag":                   readOnly,
+	"webhook_subscription":  readOnly,
+})
 
 var defaults = map[string]Document{
+	// The installation's administrator: every object, every verb, except where
+	// the PRODUCT offers no such verb. computed_field has no authoring surface
+	// (RD-AC-7); license is issued rather than edited; capture_trace is written
+	// by the pipeline and swept by its own job; the rate sheets and
+	// capture_settings are append-forward because a past-dated row prices a
+	// historical rollup; forecast supersedes rather than being rewritten.
 	"admin": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead, readOnly),
+		Objects: grid(crud, map[string]grant{
+			objAiModelRate:          writeNoDelete,
+			objAiRouting:            readUpdate,
+			objCaptureSettings:      writeNoDelete,
+			objCaptureTrace:         readOnly,
+			objComputedField:        readOnly,
+			objDataCoverage:         readOnly,
+			objEmbeddingReindex:     readUpdate,
+			objForecast:             createRead,
+			objFxRate:               writeNoDelete,
+			objInstallationSettings: readUpdate,
+			objIntroduction:         writeNoDelete,
+			objLicense:              readOnly,
+		}),
 		RowScope: principal.RowScopeAll,
 	},
 	// management is the sales leader's seat (ADR-0110): the manager grid over
@@ -114,281 +336,110 @@ var defaults = map[string]Document{
 		// ACROSS teams, and for every seat that is not this one.
 		RowScope: principal.RowScopeTeam,
 	},
+	// The rep's baseline is READ. Sixteen objects take it and sixteen take
+	// writeNoDelete, so the tie is broken deliberately rather than by the
+	// count: a base is what an object added later inherits before anybody
+	// revisits this file, and inheriting "may read" is a smaller mistake than
+	// inheriting "may create and edit". The overrides below are the records
+	// they actually work. Those take writeNoDelete — create, read, same-day-correct, never
+	// delete — because archiving a commercial record is a manager's call.
+	//
+	// The three departures from that rule each have a reason. `lead` is crud
+	// because disqualifying IS the delete and is routine rep work.
+	// `saved_view` is crud because it is the rep's own per-user view state
+	// (owner-scoped in the store), so full self-service is correct.
+	//
+	// Nine objects take the zero grant, and not all for one reason. Most are
+	// surfaces with no rep consumer: the workspace's entitlement (UC-ADMIN-03
+	// F1), the retention ladder, the two rate sheets, the reindex trigger, the
+	// import run, source coverage, and which vendor receives the installation's
+	// text. The shared-channel capture trace is a different and stronger claim
+	// — a member's own capture traffic is personal data that no grant widens —
+	// and its reason is written beside its constant rather than folded in here.
+	//
+	// A custom field is read-only even for the rep who fills it in: the field
+	// itself is admin/ops-set config, and only the VALUE on a record is theirs.
+	// knowledge_corpus and knowledge_document are reads because the ask itself
+	// is that read — an answer whose source is unreadable is not a citation —
+	// while uploading the prose every seat then asks stays with admin/ops.
+	// `introduction` and `weekly_plan` carry no delete for a shared reason: an
+	// ask that was made and a week that was planned are things that happened,
+	// so they are withdrawn rather than erased, and EVERY seat carries that
+	// property, admin included.
 	"rep": {
-		// Reps create and work records but never delete them — except
-		// leads, where disqualify IS the delete and is routine rep work.
-		// Lists and tags are everyday organizational surfaces: reps
-		// create and use them; archiving stays manager/admin. A voice
-		// profile is the rep's own working material: create/maintain
-		// yes, delete stays manager/admin. Rate-card products, offers and
-		// warm-room signals follow the record posture: reps create and
-		// work them, delete stays manager/admin. An offer template
-		// follows the same posture (see the comment above defaults). A
-		// saved view is the rep's own per-user view state (owner-scoped
-		// in the store) — full self-service, including deleting one's own
-		// view. A custom field is read-only even for the rep who fills it
-		// in: the field itself is admin/ops-set config, not the rep's
-		// working material — only the VALUE on a record is theirs.
-		Objects: objects(
-			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
-			crud,
-			grant{Create: true, Read: true, Update: true},
-			readOnly,
-			grant{Create: true, Read: true, Update: true},
-			readOnly,
-			grant{Create: true, Read: true, Update: true},
-			readOnly,
-			readOnly,
-			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
-			crud,
-			readOnly,
-			readOnly,
-			grant{Create: true, Read: true, Update: true},
-			readOnly,
-			grant{},
-			readOnly,
-			grant{}, // fx_rate — admin/ops-only
-			grant{}, // ai_model_rate — admin/ops-only
-			// capture_settings — everyone reads (a rep sees whether
-			// auto-enrich is on), only admin/ops toggle it or carve a
-			// domain back out of the consumer-mail baseline. `create` is
-			// the one write a rep holds: contributing a consumer domain
-			// the shipped baseline missed (CAP-PARAM-5) is everyday
-			// judgment about the mail they read, not workspace config.
-			grant{Create: true, Read: true},
-			// project — the record posture: reps create and work a body
-			// of work, archiving stays manager/admin/ops.
-			grant{Create: true, Read: true, Update: true},
-			// channel_connection — everyone reads (a rep needs to know
-			// whether the channel is live), only admin/ops bind one.
-			readOnly,
-			grant{},  // import_run — admin/ops-only
-			readOnly, // installation_settings — the base currency and zone
-			readOnly, // finance — a rep reads whether the customer pays on time
-			// integrations — a rep reads whether a provider is connected, so
-			// a dated value on a person record has an explanation; connecting
-			// one spends money and is admin/ops.
-			readOnly,
-			// retention_policy — admin/ops-only, read included (see objects()).
-			grant{},
-			// capture_trace — a rep debugs no shared bot binding, and their own
-			// capture activity needs no grant.
-			grant{},
-			// license — admin/ops-only. A rep reads their own seat elsewhere;
-			// the workspace's entitlement is not theirs to see (UC-ADMIN-03 F1).
-			grant{},
-			// A rep records and maintains the agreements they close; archiving
-			// one stays with manager/admin, like every other commercial record.
-			grant{Create: true, Read: true, Update: true},
-			// ai_routing — re-pointing which vendor receives the installation's text
-			// is not a rep's decision, and reading the binding is not part of the job.
-			grant{},
-			// commission — a rep sees what their partner-sourced deal earned, and
-			// nothing more: approving and paying are the business's decisions, and
-			// an entry is written by the won-deal accrual rather than by hand.
-			readOnly,
-			// deal_room — a rep opens and runs the room on their own deal:
-			// create, publish, invite, revoke. Deleting one stays manager/admin,
-			// the same posture every other record the rep works carries.
-			grant{Create: true, Read: true, Update: true},
-			// knowledge_corpus — the ask itself is this read, so a rep holds it
-			// or the help bot is an admin tool. The floor that decides what the
-			// product refuses to answer is not theirs to move.
-			readOnly,
-			// knowledge_document — a rep who receives a cited answer can open
-			// what it cited; an answer whose source is unreadable is not a
-			// citation. Uploading third-party prose every seat then asks, and
-			// deleting it for good, stay with admin/ops.
-			readOnly,
-			// introduction — asking a colleague to open a door, and answering
-			// an ask made of you, are both the job. The grant admits a rep to
-			// the surface; WHICH of the two parties they are on a given row is
-			// the row's own check, and no grant stands in for it. No delete: an
-			// ask that was made is a thing that happened, so it is withdrawn
-			// rather than erased — a property of the object, so EVERY seat
-			// carries it, admin and ops included. The backfill migration grants
-			// the same, so a database that upgraded into this object and one
-			// created after it answer alike.
-			writeNoDelete,
-			// weekly_plan — a rep plans their own week and settles it. Their
-			// own only: the store resolves the plan from the caller and takes
-			// no owner argument, so this grant admits them to their week and to
-			// nobody else's. The lead's read of a rep's plan is a separate path
-			// gated on the shared-team question, not on a wider grant here.
-			// No delete: a week that was planned is a thing that happened, and
-			// a commitment is dropped rather than erased — the same ruling
-			// introduction carries directly above.
-			writeNoDelete,
-			// forecast — a rep reads the forecast their own pipeline is in.
-			// No create: a current CALL is a manager's assertion about a team's
-			// number, and a rep asserting one would be calling a figure they
-			// are not accountable for. The reading itself is derived, so there
-			// is no update or delete surface for any seat to hold.
-			readOnly,
-			// data_coverage — nothing. Source health is connector freshness,
-			// permission-limited checks and import backlog: an OPERATOR's
-			// view. A rep shown their installation's connector health has been
-			// handed somebody else's job, and the screen that would tell them
-			// is one they cannot act on.
-			grant{}),
-		// Own scope, not team: membership of a team is not by itself permission
-		// to rewrite a teammate's records. Writing somebody else's customer
-		// record takes an explicit share — a record_grant naming the user or
-		// one of their teams — or an unbounded seat.
-		//
-		// The team ARM survives in the write predicate and is not dead: a
-		// record_grant may name a team, and an operator may still author a
-		// custom role at team scope. What changed is only what the seeded
-		// roles claim by default.
+		Objects: grid(readOnly, map[string]grant{
+			"activity":          writeNoDelete,
+			objAiModelRate:      none,
+			objAiRouting:        none,
+			objCaptureSettings:  createRead,
+			objCaptureTrace:     none,
+			"contract":          writeNoDelete,
+			objDataCoverage:     none,
+			"deal":              writeNoDelete,
+			"deal_room":         writeNoDelete,
+			objEmbeddingReindex: none,
+			objFxRate:           none,
+			objImportRun:        none,
+			objIntroduction:     writeNoDelete,
+			"lead":              crud,
+			objLicense:          none,
+			"list":              writeNoDelete,
+			"offer":             writeNoDelete,
+			"offer_template":    writeNoDelete,
+			"organization":      writeNoDelete,
+			"person":            writeNoDelete,
+			"product":           writeNoDelete,
+			"project":           writeNoDelete,
+			"relationship":      writeNoDelete,
+			objRetentionPolicy:  none,
+			objSavedView:        crud,
+			"signal":            writeNoDelete,
+			"voice_profile":     writeNoDelete,
+			"weekly_plan":       writeNoDelete,
+		}),
 		RowScope: principal.RowScopeOwn,
 	},
 	"read_only": {
 		// A read-only role still owns its personal view state: saved views
 		// are P1-exempt per-user prefs (runtime-config-surface.md §3), not
-		// shared records, so full self-service is correct even here.
-		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, grant{}, grant{}, readOnly, grant{}, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, grant{}),
+		// shared records, so full self-service is correct even here. The zero
+		// grants are the same set the rep holds nothing on, for the same
+		// reasons.
+		Objects: grid(readOnly, map[string]grant{
+			objAiModelRate:      none,
+			objAiRouting:        none,
+			objCaptureTrace:     none,
+			objDataCoverage:     none,
+			objEmbeddingReindex: none,
+			objFxRate:           none,
+			objImportRun:        none,
+			objLicense:          none,
+			objRetentionPolicy:  none,
+			objSavedView:        crud,
+		}),
 		RowScope: principal.RowScopeAll,
 	},
+	// ops administers the installation's wiring on the admin grid, and differs
+	// from admin in row scope alone at this layer: what actually separates them
+	// is the literal-admin gate on identity and governance routes, which no
+	// grant here expresses.
 	"ops": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead, readOnly),
+		Objects: grid(crud, map[string]grant{
+			objAiModelRate:          writeNoDelete,
+			objAiRouting:            readUpdate,
+			objCaptureSettings:      writeNoDelete,
+			objCaptureTrace:         readOnly,
+			objComputedField:        readOnly,
+			objDataCoverage:         readOnly,
+			objEmbeddingReindex:     readUpdate,
+			objForecast:             createRead,
+			objFxRate:               writeNoDelete,
+			objInstallationSettings: readUpdate,
+			objIntroduction:         writeNoDelete,
+			objLicense:              readOnly,
+		}),
 		RowScope: principal.RowScopeAll,
 	},
-}
-
-// objects zips grants onto coreObjects in declaration order — one line
-// per role instead of twelve repeated map literals.
-//
-// The parameter list IS the mechanism, which is why it is this long: each role
-// states its grants once, positionally, against the object order declared above,
-// and rbacfixture_test.go holds the result to the matrix the server seeds. Five
-// map literals of every key is what this replaced. Shortening it is a refactor of
-// the seed rather than of this call.
-func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField, offerTemplate, overlayConnection, embeddingReindex, webhookSubscription, fxRate, aiModelRate, captureSettings, project, channelConnection, importRun, installationSettings, finance, integrations, retentionPolicy, captureTrace, license, contract, aiRouting, commission, dealRoom, knowledgeCorpus, knowledgeDocument, introduction, weeklyPlan, forecast, dataCoverage grant) map[string]grant { // NOSONAR(go:S107) -- the parameter list is the mechanism; see above
-	return map[string]grant{
-		"person": person, "organization": organization, "deal": deal,
-		"lead": lead, "activity": activity, "pipeline": pipeline,
-		"list": list, "tag": tag, "relationship": relationship, "partner": partner,
-		"automation": automation, "voice_profile": voiceProfile,
-		"product": product, "offer": offer, "signal": signal,
-		"saved_view": savedView, "custom_field": customField,
-		"computed_field": computedField,
-		"offer_template": offerTemplate, "overlay_connection": overlayConnection,
-		"embedding_reindex":    embeddingReindex,
-		"webhook_subscription": webhookSubscription,
-		"fx_rate":              fxRate,
-		"ai_model_rate":        aiModelRate,
-		"capture_settings":     captureSettings,
-		"project":              project,
-		"channel_connection":   channelConnection,
-		"import_run":           importRun,
-		// The workspace's SHARED-CHANNEL capture trace (a bot binding's inbound
-		// traffic). Read-only for everyone who holds it, because nothing writes
-		// it but the pipeline and nothing deletes it but its 24h sweep -- there
-		// is no create/update/delete anyone could hold.
-		//
-		// It reaches ONLY rows with no member behind them. A member's own capture
-		// traffic is personal data and no grant widens it, which is why rep and
-		// read_only hold nothing here rather than holding read: there is no
-		// shared-channel debugging in their job, and a grant that looked
-		// harmless would be the one somebody later widened.
-		"capture_trace": captureTrace,
-		// The agreements an account has signed (ADR-0109/A160). Read is broad
-		// because a contract is what makes an account's commercial state legible
-		// and every role that opens a company page needs it; writing one stays
-		// with the roles that own commercial records, and read_only holds read
-		// alone. A contract carries no owner column — visibility is inherited
-		// from its deal, falling back to its organization — so the row scope
-		// that reaches it is the deal's, not one of its own.
-		"contract": contract,
-		// What a partner earned on a won deal. Read is broad because a rep
-		// working a partner-sourced deal needs to see what it earned; approving
-		// and paying stay with the roles that own commercial records, and a rep
-		// holds read alone. A commission entry carries no owner column —
-		// visibility is inherited from its deal — so the row scope that reaches
-		// it is the deal's, not one of its own.
-		"commission": commission,
-		"deal_room":  dealRoom,
-		// Which vendor this installation's text is sent to (ai-operational-spec
-		// §1.4). Deliberately NOT folded into installation_settings: whoever may
-		// rename the organization has no business re-pointing where its people's
-		// correspondence is processed, and those become one grant the moment the
-		// two share an object.
-		//
-		// Narrow on BOTH verbs, unlike most read-broad objects here. Nobody needs
-		// this grant to see which models are bound — the AI profile surface answers
-		// that from the running config, not from a settings read — so a read grant
-		// would buy a rep nothing and widen the reach of the object governing egress.
-		"ai_routing": aiRouting,
-		// The installation's own identity and reporting basis (ADR-0090/A135).
-		// Read is broad on purpose — a rep reading amounts benefits from knowing
-		// which currency they are in — and only admin/ops change it.
-		"installation_settings": installationSettings,
-		// The ingested finance mirror (ADR-0083/A128). READ is broad — every
-		// role that opens a company page sees whether the customer pays on
-		// time — and connecting or disconnecting the accounting source is
-		// destructive workspace-wide config, so create/update/delete are
-		// admin/ops only, exactly like overlay_connection.
-		//
-		// No role holds a write on a finance RECORD, because there is no such
-		// action: the mirror's read-only posture is the absence of the grant
-		// (FIN-DDL-N-1), not a runtime refusal.
-		"finance": finance,
-		// The licensed data-provider connections (ADR-0101/A152). READ is
-		// broad for the same reason finance's is: a rep looking at a person
-		// record needs to know whether a provider is connected and why a
-		// value is dated, and every state the card renders is a fact about
-		// the installation rather than about a customer. Connecting one
-		// spends the customer's money and sends their contacts' identifiers
-		// to a third party, so the writes are admin/ops only.
-		"integrations": integrations,
-		// The installation's entitlement: what the license grants, and how much of
-		// it is used. Admin/ops-only on read — import_run's and retention_policy's
-		// posture rather than custom_field's, because a seat meter is commercial standing
-		// and UC-ADMIN-03 F1 gives a rep their own seat and not the workspace's
-		// entitlement.
-		//
-		// READ IS THE ONLY VERB, for admin as much as anyone: the token is resolved
-		// from the deployment file at boot, so there is no write path for a grant to
-		// govern. Any other verb here would describe an action this product has not
-		// got.
-		"license": license,
-		// The storage-limitation ladder (UC-GDPR-09, GCS-WIRE-1..5). Admin/ops-only
-		// on EVERY verb, READ INCLUDED — the import_run precedent, not custom_field's. A
-		// retention policy decides what the installation destroys and when, and the
-		// screen showing it is an admin surface: unlike the custom_field catalog or an
-		// overlay connection's status, no rep has a legitimate consumer for the read.
-		// The retain-only posture setting is gated by this same object, so whoever may
-		// author a policy may also suspend every destructive one.
-		"retention_policy": retentionPolicy,
-		// A named body of uploaded documents a person asks free-text questions
-		// of. READ IS THE ASK: the ask returns corpus content, and anything that
-		// returns a record is a read — so every role that reads records holds it,
-		// or the help bot is an admin tool. Defining a corpus, editing its words
-		// and moving its grounding floor are workspace config in the
-		// installation_settings sense: the floor decides what the product will
-		// refuse to answer for everyone, so it is admin/ops.
-		"knowledge_corpus": knowledgeCorpus,
-		// The uploaded files themselves. Read is broad for the same reason the
-		// corpus read is — a person who gets a cited answer must be able to open
-		// what it cited, and an answer whose source is unreadable is not a
-		// citation. Uploading and deleting are admin/ops: an upload puts third-
-		// party prose into the corpus every seat then asks, and the delete is a
-		// hard one that takes the chunks, the vectors and the stored file.
-		"knowledge_document": knowledgeDocument,
-		// One rep asking a colleague to open a door to a contact. Create and
-		// update are a rep's: asking is the job, and answering an ask made OF
-		// you is answering for yourself — the row's own party check decides
-		// which of the two you are, and a grant cannot substitute for it.
-		"introduction":  introduction,
-		"weekly_plan":   weeklyPlan,
-		"forecast":      forecast,
-		"data_coverage": dataCoverage,
-	}
 }
 
 // MustDefaultJSON returns the seeded policy document for a system role key,

--- a/backend/internal/modules/identity/internal/policy/policy_test.go
+++ b/backend/internal/modules/identity/internal/policy/policy_test.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -256,6 +258,68 @@ func TestZeroRolesDenyEverything(t *testing.T) {
 		for _, a := range []principal.Action{principal.ActionCreate, principal.ActionRead, principal.ActionUpdate, principal.ActionDelete} {
 			if merged.Allows(object, a) {
 				t.Errorf("a user with no roles was granted %s.%s", object, a)
+			}
+		}
+	}
+}
+
+// The builder's own guard. `grid` is what replaced a 44-argument positional
+// zip, and the one failure the positional form made impossible is the one this
+// form could introduce: a key that names nothing. Silently ignoring it would
+// seed a role missing an object it was written to hold, which reads as a
+// permission bug in the product rather than a typo in this file — and
+// `TestEverySystemRoleHasAValidDefaultDocument` above would not catch it,
+// because the base still covers every object.
+func TestGridRefusesAnOverrideNamingNoCoreObject(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("grid accepted an override naming a non-object; a typo must fail the build, not seed a role that silently governs nothing")
+		}
+	}()
+	grid(readOnly, map[string]grant{"persson": crud})
+}
+
+// The admit case beside it: a real object name is applied, and every other
+// object keeps the base. Without this the test above would pass against a
+// `grid` that panicked on everything.
+func TestGridAppliesAnOverrideAndLeavesTheRestAtBase(t *testing.T) {
+	got := grid(readOnly, map[string]grant{"deal": crud})
+	if got["deal"] != crud {
+		t.Errorf("the overridden object holds %+v, want crud", got["deal"])
+	}
+	if got["person"] != readOnly {
+		t.Errorf("an object with no override holds %+v, want the base readOnly", got["person"])
+	}
+	if len(got) != len(coreObjects) {
+		t.Errorf("the grid covers %d objects, want all %d", len(got), len(coreObjects))
+	}
+}
+
+// A role's override map may not restate its own base. Such a line says nothing
+// — `grid` already gave the object that grant — but it reads as a decision, so
+// the next author weighs it and the one after that preserves it.
+//
+// Read from SOURCE, because the defect is invisible in the result: an override
+// that restates the base produces exactly the map a missing override produces,
+// so no amount of inspecting `defaults` can find it. The parser walks each
+// `grid(base, map[string]grant{...})` call and compares each value expression
+// against that call's base expression, which is the same comparison a reader
+// makes and the only one that can fail.
+func TestNoOverrideRestatesItsOwnBase(t *testing.T) {
+	source, err := os.ReadFile("defaults.go")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	calls := regexp.MustCompile(`grid\((\w+), map\[string\]grant\{([^}]*)\}`).FindAllStringSubmatch(string(source), -1)
+	if len(calls) == 0 {
+		t.Fatal("no grid(base, overrides) call found — this test is reading the wrong shape")
+	}
+	for _, call := range calls {
+		base := call[1]
+		for _, line := range regexp.MustCompile(`(\w+):\s*(\w+),`).FindAllStringSubmatch(call[2], -1) {
+			if line[2] == base {
+				t.Errorf("an override sets %s to %s, which is already the base of that grid — "+
+					"the line changes nothing and reads as a decision", line[1], base)
 			}
 		}
 	}

--- a/backend/internal/modules/search/queryjoins_test.go
+++ b/backend/internal/modules/search/queryjoins_test.go
@@ -689,21 +689,34 @@ func TestEveryJoinTableThatIsAnRBACObjectDeclaresIt(t *testing.T) {
 		t.Fatalf("%q is not in identity's object list, so this gate is reading the wrong thing",
 			objectRelationship)
 	}
-	// The list is cross-checked against a SECOND derivation from the same file:
-	// policy's `objects(...)` takes one parameter per object. A literal read
-	// alone would go on passing if a later object were appended somewhere other
-	// than the literal — an init, a helper, a second slice — and this module
-	// would then leave a governed join table ungated while the gate reported
-	// green. Two readings that must agree is what makes the omission loud.
-	signature := regexp.MustCompile(`func objects\(([^)]*)\) map\[string\]grant`).FindSubmatch(body)
-	if signature == nil {
-		t.Fatal("identity no longer declares objects() in the shape this gate cross-checks")
-	}
-	params := strings.Split(strings.ReplaceAll(string(signature[1]), " grant", ""), ",")
-	if len(params) != len(objects) {
-		t.Errorf("identity's object literal names %d objects and its objects() takes %d parameters — "+
-			"the two disagree, so the literal is no longer the whole list and a join table could be "+
-			"governed by an object this gate cannot see", len(objects), len(params))
+	// The literal is cross-checked against a SECOND reading of the same source,
+	// because one reading cannot tell a shrinking list from a correct one.
+	//
+	// That second reading used to be `objects(...)`'s parameter count, one per
+	// object. The seed now builds each role with `grid(base, overrides)`, which
+	// RANGES over coreObjects rather than restating it, so there is no
+	// parameter list left to count.
+	//
+	// What this reading proves, exactly: the seed still DERIVES from the
+	// literal. An edit that went back to spelling a role's grants out object by
+	// object would let the two disagree again, and would do it silently — the
+	// join tables below would go on being checked against a list the seed no
+	// longer honours. Scoped to `grid`'s own body rather than to a bare loop
+	// header, so an unrelated future range over coreObjects elsewhere in the
+	// package cannot stand in for the seeder and keep this green.
+	//
+	// What it does NOT prove, and never did in either form: that nothing
+	// appends to coreObjects after package init. A `func init()` doing so
+	// passes this gate and passed the parameter count before it. The literal is
+	// the whole list by convention, not by proof.
+	// Bounded to `grid`'s own body: `[^}]*?` cannot cross the first closing
+	// brace, so a range in a LATER function cannot stand in for the seeder and
+	// keep this green. An earlier spelling used `(?s).*?`, which matched nine
+	// kilobytes into an unrelated helper and reported a gutted `grid` as fine.
+	seeder := regexp.MustCompile(`func grid\(base grant[^}]*?for _, object := range coreObjects`)
+	if !seeder.Match(body) {
+		t.Error("identity's `grid` no longer seeds from coreObjects — a role's grants and the object " +
+			"list can now disagree, and a join table could be governed by an object this gate cannot see")
 	}
 	for _, join := range joinTables {
 		switch {

--- a/docs/how-to/add-an-rbac-object.md
+++ b/docs/how-to/add-an-rbac-object.md
@@ -19,18 +19,30 @@ In `backend/internal/modules/identity/internal/policy/policy.go`:
 
 1. Append the name to `coreObjects`. This is the closed set `Parse` validates
    against, so nothing outside it can ever be granted.
-2. Add one parameter to `objects(...)` — same name, same position — and one line
-   to the map it returns.
-3. Give **every one of the five system roles** its grant, in the same position,
-   in the `defaults` map: `admin`, `manager`, `rep`, `read_only`, `ops`.
+2. In `defaults.go`, decide for **each of the six system roles** — `admin`,
+   `management`, `manager`, `rep`, `read_only`, `ops` — whether the new object
+   matches that role's baseline. If it does, there is nothing to write: `grid`
+   gives every core object the base. If it does not, add one line naming the
+   object and its grant to that role's override map.
 
-**The argument list is positional.** `objects(...)` zips its arguments onto the
-map by declaration order, and a role's entry is a single line of bare `crud`,
-`readOnly` and `grant{}` values. Go's compiler catches a *missing* argument;
-nothing catches a *transposed* one, and a diff that shifts two grants one column
-apart is invisible in review. Write the new grant at the **end** of every list
-rather than in a "logical" middle position, and re-read the generated matrix in
-step 4 before you believe your own change.
+   **Silence is now the default, and that is the trap.** The old positional form
+   made a forgotten role a compile error — an argument was missing. `grid` gives
+   that role the base instead and tells nobody. So decide for all six
+   deliberately, and confirm the result in the regenerated matrix at step 4;
+   that page is the only thing that will tell you a role inherited a grant you
+   never thought about.
+
+**Nothing is positional.** `grid(base, overrides)` seeds every object in
+`coreObjects` with the base and then applies the overrides by NAME, so the
+object a grant governs is written beside it. An override naming an object that
+does not exist panics at package init rather than being ignored, which is what
+makes a typo a build failure instead of a role that silently governs nothing.
+
+A role's override map is therefore the list of places that role DEPARTS from its
+own posture, which is the sentence a reviewer wants: not "what does rep hold on
+all 44 objects" but "where is rep not the record posture". `managerObjects` is
+still one variable shared by `manager` and `management` so the two grids cannot
+drift; only their row scope differs.
 
 Pick the posture from an existing precedent rather than inventing one — the
 comment block above `defaults` records the reasoning for each family (record
@@ -129,9 +141,10 @@ go test ./internal/modules/identity/ -run RBAC -update
 The same test — **`TestPublishedRBACMatrixMatchesTheSeededRoleDocuments`** in
 `backend/internal/modules/identity/rbacmatrix_test.go` — runs on every build
 *without* `-update` and fails when the page and the seeded values disagree, so the
-two cannot drift apart unnoticed. Read the regenerated row: it is your best
-chance to catch a transposed argument from step 1, because it renders each role's
-grant as `CRUD` letters rather than as a position in a call.
+two cannot drift apart unnoticed. Read the regenerated row: it renders each
+role's grant as `CRUD` letters, which is the resolved answer rather than the
+base-plus-overrides you wrote — so it is where you confirm that the role you did
+NOT write a line for inherited the grant you meant it to.
 
 ## 5. Gate the store, then the UI
 


### PR DESCRIPTION
Groundwork for the settings redesign. The plan adds thirteen RBAC objects; doing that against a 44-argument positional list would make it a 57-argument one, so this lands first and alone.

## What was wrong

The seeded role defaults were built by a positional zip. Each role was one line of bare `crud`, `readOnly` and `grant{}` values, and which object a grant governed was decided by **counting**. A transposed pair typechecked, read identically in review, and would have been caught only by the replay fixture.

The function's own comment called the parameter list "the mechanism", and the how-to told authors to append at the end and re-read the generated matrix before believing their own change. That is what a mechanism nobody can read costs.

## What changed

`grid(base, overrides)` seeds every object in `coreObjects` with the role's baseline, then applies the rest **by name**. A role now states only where it departs from its own posture: twelve lines for admin, ten for read_only, twenty-eight for rep. That is the sentence a reviewer wants — not "what does rep hold on all forty-four" but "where is rep not the record posture".

An override naming an object that does not exist panics at package init, so a typo is a build failure rather than a role that silently governs nothing. The fourteen object names that repeat across role documents became constants, so a misspelling is a compile error there too.

## Nothing about the seed changed

Every role's every grant was dumped before and after and compared object by object: six roles, forty-four objects, identical. The replay fixture and the generated RBAC matrix both pass untouched, which is the real proof.

## One gate had to move with it

`search`'s join-table gate cross-checked the object literal against `objects()`'s parameter count — a second derivation, so an object appended somewhere other than the literal would be caught. That count no longer exists, and the property it stood in for is now the compiler's: a role cannot name an object the literal lacks.

The gate keeps a second reading by asserting the seed still derives from `coreObjects` at all. An edit that went back to spelling grants out object by object would restore exactly the drift the gate exists to catch, and now fails instead of passing silently. Mutation-checked in both directions.

`make check-backend` green. `make craft-static` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the 44-argument positional zip that seeded RBAC role defaults with a `grid(base, overrides)` builder, so each grant is written beside the object it governs and roles state only where they depart from their baseline. The seed values are unchanged; a typo in an override now panics at package init instead of silently governing nothing, and object names repeated across role documents are constants so a misspelling is a compile error.

**Refactors**
- Updated the search join-table gate to assert the seed still derives from `coreObjects`, since the old parameter-count check no longer exists.
- Updated the how-to doc for adding an RBAC object to describe the override-map approach.

<sup>Written for commit a0e1347319ec7c158de6c9873aac93ebd05ce0a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Improved default permission configuration across administrative, management, managerial, representative, read-only, and operations roles.
  * Added explicit handling for objects with no permissions.
  * Invalid permission override names now fail validation instead of being silently ignored.

* **Documentation**
  * Updated the RBAC guide with name-based permission override instructions and coverage for all supported roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->