### PR TITLE
The fold's order and its count are held

### DIFF
--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -433,28 +433,47 @@ describe("what the ranked queue tells a reader", () => {
     const { container } = renderWorklist();
 
     await screen.findByText("A buyer is waiting on a funded deal");
-    // The first three are said outright.
-    for (const kind of [
-      "buyer_wrote_last",
-      "stale",
-      "no_reply_history",
-    ] as const) {
-      expect(container.textContent).toContain(en[`worklist.because.${kind}`]);
+    const fold = container.querySelector("details.worklist-row-because-fold");
+    expect(fold).not.toBeNull();
+    // Read the two halves SEPARATELY. Asserting over the whole page cannot
+    // tell "in the summary" from "in the fold", so it passes just as well on a
+    // row that put the strongest reasons behind the tap — which is the exact
+    // inversion this component exists to prevent.
+    const summary = fold?.querySelector("summary")?.textContent ?? "";
+    const hidden = fold?.querySelector("p")?.textContent ?? "";
+
+    // THE SERVER'S ORDER, kept. `because` arrives "in the order they were
+    // weighed", so the head is the strongest three and the fold falls in the
+    // right place by construction. Nothing held that until now: reversing the
+    // list before the slice passed every test in this file, and a reversed
+    // fold buries the weak reasons and promotes the ones a reader already has.
+    // Positions, checked for PRESENCE first. indexOf answers -1 for a phrase
+    // that is not there, and -1 is less than every real index — so an ordering
+    // assertion alone passes when the reason it names has vanished entirely.
+    const at = (kind: "buyer_wrote_last" | "stale" | "no_reply_history") => {
+      const found = summary.indexOf(en[`worklist.because.${kind}`]);
+      expect(found, `${kind} is missing from the summary`).toBeGreaterThan(-1);
+      return found;
+    };
+    expect(at("buyer_wrote_last")).toBeLessThan(at("stale"));
+    expect(at("stale")).toBeLessThan(at("no_reply_history"));
+
+    // The rest are PRESENT — folded, never discarded — and specifically NOT in
+    // the summary. The one that decided the rank is in here, which is the whole
+    // reason a cap was wrong.
+    for (const kind of ["asks_nothing", "expected_revenue"] as const) {
+      expect(hidden).toContain(en[`worklist.because.${kind}`]);
+      expect(summary).not.toContain(en[`worklist.because.${kind}`]);
     }
-    // The rest are PRESENT — folded, never discarded. The one that decided the
-    // rank is in here, which is the whole reason a cap was wrong.
-    expect(container.textContent).toContain(
-      en["worklist.because.expected_revenue"],
+
+    // The count names how many are ACTUALLY hidden, so a reader can decide
+    // whether to spend the tap. Asserted as the whole rendered phrase against
+    // the summary alone: `toContain("2")` matched any digit 2 anywhere on the
+    // page, so a summary promising "+22 more reasons" over two hidden facts
+    // passed it.
+    expect(summary).toContain(
+      en["worklist.because.more_other"].replace("{count}", "2"),
     );
-    expect(container.textContent).toContain(
-      en["worklist.because.asks_nothing"],
-    );
-    // And the fold names HOW MANY, so a reader can decide whether to spend the
-    // tap. "+2 more reasons", not "more".
-    expect(container.textContent).toContain("2");
-    expect(
-      container.querySelector("details.worklist-row-because-fold"),
-    ).not.toBeNull();
   });
 
   // Three reasons still fit on one line at 390px, so folding them would cost a


### PR DESCRIPTION
## Why

Two assertions in the fold's test proved nothing. A review found both by **mutating the component** rather than reading it — neither is visible from the test's text.

**The order was not held.** Reversing the reason list before the slice passed all 39 tests in the file. A reversed fold buries the weak reasons and promotes the strong ones — the exact inversion the component exists to prevent, since its premise is that `because` arrives *"in the order they were weighed"* so the head is the strongest three by construction. That premise lived in a docstring and was held by nothing. The realistic regression is somebody adding a `.sort()` or a de-duplication step to the reason pipeline, and nothing failing.

**The count was not held.** `expect(container.textContent).toContain("2")` matches any digit `2` anywhere on the rendered page, so a summary promising *"+22 more reasons"* over two hidden facts passed. Since #4256 argued that naming the count is "the durable half", the count is the thing most worth pinning.

## What changed

Both assertions now read the two halves of the fold **separately** — the `<summary>` and the folded `<p>`. An assertion over the whole page cannot tell "in the summary" from "in the fold", which is precisely why the original passed on a reversed row.

- head reasons asserted in server order within the summary
- folded reasons asserted present in the `<p>` **and** absent from the summary
- count asserted as the whole rendered phrase from the catalog, not a bare digit

The ordering check asks **presence first**. `indexOf` returns `-1` for a phrase that isn't there, and `-1` is less than every real index — so an ordering assertion alone passes when the reason it names has vanished entirely.

## Evidence

| Obligation | Evidence |
|---|---|
| Order is held | Mutation: reverse the list before the slice → fails |
| Count is held | Mutation: render `folded.length + 20` → fails |
| Presence is held | Mutation: drop a head reason from the summary → fails with `stale is missing from the summary` |
| Fixture is not vacuous | The five reason phrases are distinct strings with no substring collisions, so no assertion can pass by accidental match |
| Review before commit | Codex (`gpt-5.3-codex-spark`) reviewed the uncommitted diff. Its one finding was the `indexOf` `-1` case; the guard was already in when it reported. It cleared the `querySelector` and catalog-string questions |
| Lanes | `make check-fe` 0 · `make craft-static` PASS 0/0/0 |

No production code changes. **The component was correct; the tests were not.**

## Note on a flaky neighbour

`onboarding-conversation/company-act.test.tsx` failed twice during this work — a *different* test each time, passing 3/3 in isolation with this change applied and 2/2 on clean main. Not caused by this diff, but worth knowing it is not deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the worklist fold test's two assertions that proved nothing: the fold's order and its hidden-reason count were never actually verified, so regressions like a `.sort()` on the reason pipeline or a wrong count passed all tests. The test now reads the `<summary>` and the folded `<p>` separately, checks presence before ordering, and matches the full rendered count phrase.

No production code changes; the component was correct.

<sup>Written for commit e22547aaa3b40dbbd9ce78a3df1ff6ed261b6019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

