### PR TITLE
A decision is answered in a drawer, not in the row

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -766,9 +766,7 @@ test("AC-book-public-409: a taken slot degrades honestly — no fabricated confi
     ),
   ).toBeVisible();
   await expect(page.getByText("slot no longer available")).toBeVisible();
-  await expect(
-    page.getByText("Gebucht."),
-  ).toHaveCount(0);
+  await expect(page.getByText("Gebucht.")).toHaveCount(0);
 });
 
 test("AC-onboarding-1: onboarding is the rail-less conversational shell", async ({
@@ -1219,24 +1217,18 @@ test.describe("§3.8: 390px mobile", () => {
   // Measured against the VIEWPORT rather than a fixed pixel budget, because the
   // number that matters is whether a thumb can reach it without scrolling. The
   // page is not scrolled first: this asserts the arriving screen.
-  // FAILS TODAY, and is left failing on purpose.
+  // PASSES since the decision moved into a drawer.
   //
-  // MEASURED 2026-09-05, after the Review split (#4182) moved `approval` to
-  // destinationReview: "Übernehmen" ends at 921px on an 844px screen. The
-  // first seeded row is still an approval drawing its whole decision inline —
-  // evidence, draft and three answers — at 657px against its own 208px
-  // ceiling. Moving the SOURCE to another destination did not move the seeded
-  // row off this queue, so the drawer this note has always pointed at is still
-  // the fix and is still unbuilt.
+  // It failed for as long as the first seeded row was an approval drawing its
+  // whole decision inline — evidence, draft and three answers — 440px of card
+  // inside a row whose ceiling is 208. "Übernehmen" ended at 920px on an 844px
+  // screen and a rep had to scroll past one decision to reach their work.
   //
-  // An earlier version of this comment said 864px and blamed the last 20px on
-  // the row alone. Both numbers were stale; the row is the whole of it.
-  //
-  // Marked `fixme` rather than relaxed to 950px: a ceiling tuned to today's
-  // failure is a test that agrees with the defect, and this one has to go
-  // GREEN when the drawer lands rather than be tightened by somebody who
-  // remembers to.
-  test.fixme("AC-WORKLIST-SDR-01: the first primary action is above the fold at 390x844", async ({
+  // The row now offers the verb and the drawer holds the card, so the row is
+  // 205px and the first action is inside the fold. It was left failing rather
+  // than relaxed to 950px through several sessions, which is why it could go
+  // green on the fix instead of being quietly tightened to agree with it.
+  test("AC-WORKLIST-SDR-01: the first primary action is above the fold at 390x844", async ({
     page,
   }) => {
     await page.goto("/#/worklist");
@@ -1296,6 +1288,33 @@ test.describe("§3.8: 390px mobile", () => {
     ).toBeLessThanOrEqual(seen.fold);
   });
 
+  // The drawer itself, on the screen size it was built for.
+  //
+  // SDR-01 above proves the row got shorter, and a row that lost its card and
+  // gained a button that opens nothing would pass it. This asserts the other
+  // half: the decision is still answerable, and only once the reader asks.
+  test("AC-WORKLIST-SDR-03: a decision is answered in a drawer, not in the row", async ({
+    page,
+  }) => {
+    await page.goto("/#/worklist");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator(".worklist-list li").first()).toBeVisible();
+
+    // Nothing to answer until it is opened: the queue draws no verdict button.
+    await expect(page.getByRole("button", { name: "Übernehmen" })).toHaveCount(
+      0,
+    );
+
+    await page.getByRole("button", { name: "Entscheiden" }).first().click();
+
+    const decision = page.getByRole("dialog");
+    await expect(decision).toBeVisible();
+    // The same card the record page draws, with its verdicts on it.
+    await expect(
+      decision.getByRole("button", { name: "Übernehmen" }),
+    ).toBeVisible();
+  });
+
   // The height a row is allowed to take before it has to fold.
   //
   // The fold test above measures the FIRST row's reach; this one measures every
@@ -1310,8 +1329,8 @@ test.describe("§3.8: 390px mobile", () => {
   // FAILS TODAY on TWO rows, and they have different causes — which is why
   // this note no longer says "the same one cause" as it once did.
   //
-  // The approval draws 657px against 208px, and the drawer AC-01 waits for
-  // fixes that one.
+  // The approval is FIXED: its decision moved into a drawer, and the row went
+  // from 657px to 205px, inside its 208px ceiling.
   //
   // The second is an ORDINARY TASK at 284px against 176px, and no drawer
   // touches it. Measured 2026-09-05, its parts are: rank 19, title 49 (it
@@ -1323,6 +1342,14 @@ test.describe("§3.8: 390px mobile", () => {
   // is a product decision rather than a fix. Left failing rather than
   // relaxed, so the decision is made by someone rather than by a number
   // quietly rising.
+  //
+  // RE-MEASURED 2026-09-05 after the drawer landed, and the four buttons are
+  // the whole of what is left: Später 65, Nicht meins 97, Für wie lange 83,
+  // Anheften 81. That is 326px of control against 308px of usable row width,
+  // so they wrap to two 44px bands and no layout rule can undo it — the groups
+  // were made to share a line in the same change, and this row still cannot
+  // fit. Dropping or folding a verb is the only way under 176px, and which
+  // verb is Lars's call.
   test.fixme("AC-WORKLIST-SDR-07: no row outgrows its ceiling at 390x844", async ({
     page,
   }) => {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8232,6 +8232,11 @@ export const de = {
   "worklist.untitled.introduction_request":
     "Ein Kollege bittet dich um eine Vorstellung",
   "worklist.verb.decide": "Entscheiden",
+  // Die Schublade, in der entschieden wird.
+  "worklist.decision.title": "Deine Entscheidung",
+  "worklist.decision.loading": "Der Vorschlag wird geladen…",
+  "worklist.decision.unavailable":
+    "Dieser Vorschlag konnte nicht gelesen werden. Beantworte ihn in der Freigabeliste.",
   "worklist.verb.merge": "Zusammenführen",
   "worklist.verb.open": "Öffnen",
   "worklist.verb.complete": "Öffnen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8317,6 +8317,12 @@ export const en = {
   "worklist.untitled.introduction_request":
     "A colleague asked you for an introduction",
   "worklist.verb.decide": "Decide",
+  // The drawer the decision is answered in. The row shows what is being decided
+  // and this names the act, so the heading does not repeat the row's sentence.
+  "worklist.decision.title": "Your decision",
+  "worklist.decision.loading": "Fetching what is being proposed…",
+  "worklist.decision.unavailable":
+    "This proposal could not be read. Open the approvals queue to answer it.",
   "worklist.verb.merge": "Merge",
   "worklist.verb.open": "Open",
   "worklist.verb.complete": "Open",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8137,6 +8137,11 @@ export const vi = {
   "worklist.untitled.introduction_request":
     "Một đồng nghiệp nhờ bạn giới thiệu",
   "worklist.verb.decide": "Quyết định",
+  // Ngăn kéo nơi đưa ra quyết định.
+  "worklist.decision.title": "Quyết định của bạn",
+  "worklist.decision.loading": "Đang tải đề xuất…",
+  "worklist.decision.unavailable":
+    "Không đọc được đề xuất này. Hãy trả lời trong danh sách phê duyệt.",
   "worklist.verb.merge": "Gộp",
   "worklist.verb.open": "Mở",
   "worklist.verb.complete": "Mở",

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -187,7 +187,12 @@
   padding: 0;
 }
 
-.worklist-row-verbs {
+.worklist-row-verbs,
+/* The dispositions are laid out like the verbs beside them because they ARE a
+   group of controls beside the verbs. Left as a bare block it filled its line
+   whatever it held, so on a phone it could never share a row with the verbs and
+   the two spent 88px on four small buttons. */
+.worklist-row-dispositions {
   display: flex;
   flex: 0 0 auto;
   gap: var(--space-2);
@@ -349,13 +354,21 @@
     min-width: 0;
   }
 
-  /* Every group of verbs below the text, at full width and free to wrap. They
-     are separate elements — the row's own, the ways to put it down, the
-     hand-off — and each has to yield, or the one that does not squeezes the
-     others back onto a sliver. */
+  /* Every group of verbs below the text, and free to wrap. They are separate
+     elements — the row's own, the ways to put it down, the hand-off — and each
+     has to yield, or the one that does not squeezes the others back onto a
+     sliver.
+
+     They SHARE a line where they fit, and take one each only when they do not.
+     `1 1 100%` gave every group a full-width band of its own, so a row with
+     verbs AND dispositions spent two 44px lines on four small buttons and stood
+     284px tall against a 176px ceiling — measured at 390x844, with no decision
+     card on it. `auto` asks for the width the buttons actually need and the
+     wrap does the rest, which is the same behaviour for a group too wide to
+     share and a shorter row for every group that is not. */
   .worklist-row-verbs,
   .worklist-row-dispositions {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
     flex-wrap: wrap;
   }
 

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -8,7 +8,8 @@
 // decides how one piece of work reads and where each of its verbs goes, and
 // that is the half a reader of either question does not need the other for.
 
-import { Badge, Button } from "../design-system/atoms";
+import { useId, useRef, useState } from "react";
+import { Badge, Button, Modal } from "../design-system/atoms";
 import { PanelRow } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
@@ -494,20 +495,72 @@ function decidable(item: WorklistItem): boolean {
   return item.actions.includes("decide") && item.source === "approval";
 }
 
-// The decision itself, fetched whole because a row cannot carry it.
+// The decision itself, fetched whole because a row cannot carry it — and
+// answered in a DRAWER rather than in the row.
+//
+// It used to render inline, and that is what made the queue unusable on a
+// phone. The card carries evidence, a draft and three answers; measured at
+// 390x844 it stood 440px tall inside a row whose ceiling is 208, which pushed
+// the first primary action of the whole page to 920px down an 844px screen.
+// The reader had to scroll past one decision to reach the work.
+//
+// The row keeps the decision's SUMMARY and one button. The drawer holds the
+// card — the same ApprovalRow the record page draws, posting to the same
+// endpoint — so the queue still adds no authority of its own. What it adds is
+// that the decision is answerable where it was ranked.
+//
+// Held by: AC-WORKLIST-SDR-01 and AC-WORKLIST-SDR-07 (frontend/e2e/ac.spec.ts),
+// which measure the closed row and the first action against the phone fold.
 function RowDecision({ item }: Readonly<{ item: WorklistItem }>) {
-  const approval = useApproval(item.id, true);
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const opener = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  // Fetched only once the reader asks. A queue of decisions would otherwise
+  // fire one read per row on arrival to fill cards nobody has opened, and the
+  // row above needs none of it to draw its button.
+  const approval = useApproval(item.id, open);
   // A body with no `kind` is not a proposal this card can draw: the kind
   // chooses the label, the tool chip and the autonomy dot. Treated as a failed
   // read rather than rendered, because the alternative is a throw that takes
   // the whole day's page down over one malformed answer.
   const usable = approval.data?.kind ? approval.data : undefined;
-  if (!usable) {
-    return null;
-  }
   return (
     <div className="worklist-row-decision">
-      <ApprovalRow approval={usable} extraInvalidateKeys={[worklistKey]} />
+      <Button
+        ref={opener}
+        variant="primary"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+      >
+        {t("worklist.verb.decide")}
+      </Button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        labelledBy={titleId}
+        placement="right"
+        size="wide"
+        returnFocusTo={() => opener.current}
+      >
+        <h2 id={titleId}>{t("worklist.decision.title")}</h2>
+        {usable ? (
+          <ApprovalRow
+            approval={usable}
+            extraInvalidateKeys={[worklistKey]}
+            onAlreadyDecided={() => setOpen(false)}
+          />
+        ) : (
+          // The read has not landed, or landed unusable. Said rather than left
+          // blank: a drawer that opens onto nothing reads as a broken button,
+          // and the reader has already committed a tap to get here.
+          <p>
+            {approval.isPending
+              ? t("worklist.decision.loading")
+              : t("worklist.decision.unavailable")}
+          </p>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -569,15 +569,24 @@ describe("what the ranked queue tells a reader", () => {
     );
     const { container } = renderWorklist();
 
-    // The row arrives first; the decision it carries is a second read, so the
-    // card appears after it.
     await screen.findByText(/Send the follow-up/);
     // A queue that can rank a decision and not answer it sends the reader to a
     // second screen to do what the row already described. The card is the same
     // one the record page draws, posting to the same endpoint.
+    //
+    // ANSWERED IN A DRAWER, not in the row. The card is 440px of evidence,
+    // draft and three answers; inline it made the row 657px against a 208px
+    // ceiling and pushed the page's first action off a phone screen. So the row
+    // offers the verb and the drawer holds the card, and this asserts both
+    // halves — a row that opened nothing would pass on the button alone.
     await waitFor(() => {
       expect(container.querySelector(".worklist-row-decision")).toBeTruthy();
     });
+    // Not answerable until the reader asks: the queue draws no Accept.
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Decide" }),
+    );
     expect(await screen.findByRole("button", { name: "Accept" })).toBeTruthy();
   });
 


### PR DESCRIPTION
The first thing a rep saw on their phone was somebody else's approval, and they had to scroll past it to reach their own work.

The row drew the whole decision inline — evidence, a draft and three answers. Measured at 390x844 that card is 440px inside a row whose ceiling is 208, which made the row 657px and put the page's first primary action 920px down an 844px screen.

The row now offers the verb and a drawer holds the card. It is the same `ApprovalRow` the record page draws, posting to the same endpoint, so the queue still adds no authority of its own. The card is fetched only once the reader asks, so a queue of decisions no longer fires a read per row on arrival to fill cards nobody opened.

The drawer is the existing right-placement `Modal`, not a new primitive — a generic drawer would need two production callers in the same change to earn its place.

## What the numbers did

| | before | after | ceiling |
|---|---|---|---|
| first primary action, from the top | 920px | inside the fold | 844px |
| the approval row | 657px | 205px | 208px |

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `AC-WORKLIST-SDR-01` passes — first action inside the 844px fold. Was `test.fixme`, now green on the fix. |
| The other half | `AC-WORKLIST-SDR-03` is new: the queue draws no verdict button until "Entscheiden" is clicked, then the dialog shows "Übernehmen". A row that lost its card and gained a button opening nothing would pass SDR-01; this one catches that. |
| Failure behavior | The drawer says the proposal is being fetched, or that it could not be read and where to answer it. A drawer opening onto nothing reads as a broken button. |
| Mobile | Both AC tests above run at 390x844. |
| Accessibility | Reuses `Modal`'s focus trap and `returnFocusTo`, so focus returns to the opening button. `worklist` is already in the axe light/dark sweep. |
| Mutation strength | Forcing the drawer open by default (`useState(true)`) makes `worklist.test.tsx` fail on the "draws no Accept inline" clause. |
| Full lane | `make check-fe` green; `playwright -g "AC-WORKLIST"` → 2 passed, 1 skipped. |

## What is deliberately still failing

`AC-WORKLIST-SDR-07` stays `test.fixme`, and its comment now says why with numbers. The approval half is fixed. What still fails is an ordinary task row at 284px against a 176px ceiling, and its four buttons are the whole of it: 65 + 97 + 83 + 81 = 326px of control against 308px of row width, so they wrap to two 44px bands. No layout rule can undo that — the two verb groups were made to share a line in this same change and this row still cannot fit. Dropping or folding a verb is a product decision, so the test is left failing rather than relaxed.

## Also

The dispositions were a bare `div` with no layout rule, so they filled their own line whatever they held and could never share one with the verbs beside them. They are a group of controls next to a group of controls, so they are laid out like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves worklist decisions into a drawer so the first primary action fits above the fold on mobile. The row previously drew the whole decision inline — evidence, draft, and three answers — which made the row 657px tall and pushed the page's first action to 920px down an 844px screen; it now offers a "Decide" button that opens the card in a drawer.

**Changes**
- The drawer holds the same `ApprovalRow` card the record page draws, posting to the same endpoint, so the queue adds no authority of its own.
- The card is fetched only when the drawer opens, so a queue no longer fires a read per row on arrival.
- Reuses the existing right-placement `Modal` with its focus trap and `returnFocusTo`, so focus returns to the opening button.
- The dispositions are now laid out like the verbs beside them and share a line where they fit, instead of always taking a full band.

**Test status**
- `AC-WORKLIST-SDR-01` is now green; new test `AC-WORKLIST-SDR-03` asserts the queue draws no verdict button until the reader asks.
- `AC-WORKLIST-SDR-07` stays skipped: an ordinary task row's four buttons total 326px against 308px of row width, so they wrap regardless of layout. Folding or dropping a verb is a product decision.

<sup>Written for commit ddd4e6341708a9b1ffd203e25d6707429100935e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

