### PR TITLE
ci(merge-attest): the alarm reports a bad verdict, not an absent one

### DIFF
--- a/.github/workflows/merge-attest.yml
+++ b/.github/workflows/merge-attest.yml
@@ -12,11 +12,19 @@
 # It is NOT a gate and will never be one. It runs AFTER the merge, on the tip,
 # and blocks nothing. Prevention is a branch-protection decision (#2496).
 #
-# It runs no lane. That is what makes a push trigger affordable at ~85 merges a
-# day: two API reads and a jq. `main-health` still owns the question of whether
-# main actually works, at its own cadence and its own cost — this one answers
-# only whether the merge had an answer, which is the question that was going
-# unasked for two hours at a time.
+# It reports ONE thing: a merge whose required check then reported an adverse
+# verdict, or a commit no pull request names at all. It deliberately says nothing
+# about an ABSENT verdict — merging past `ci` is a standing decision here, and an
+# alarm that fires on the expected state is one that gets muted. Seventeen issues
+# in under five hours, each describing the bypass working as intended, is what
+# that looked like.
+#
+# It runs no lane, but it does WAIT: `ci` is a fan-in and lands minutes after the
+# merge, so the verdict has to be waited for rather than sampled at push time.
+# That is the cost — a runner held for up to the budget below, per merge, on a
+# repository whose minutes are free. `main-health` still owns whether main
+# actually works, at its own cadence; this one attributes a bad verdict to the
+# merge that carried it, roughly two hours before the health check would.
 name: merge-attest
 
 on:
@@ -37,8 +45,14 @@ concurrency:
 jobs:
   verdict:
     name: verdict
-    timeout-minutes: 10
+    # The wait below is bounded at 20 minutes; this bounds the job around it.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    # ONE name for the required check, read by the step that waits for it and by
+    # the judge that reads its conclusion. Spelled twice, the wait could settle
+    # on one check while the judge reported on another.
+    env:
+      MERGE_VERDICT_REQUIRED: ci
     permissions:
       contents: read
       # The pull request that carried this commit, and the checks that ran on
@@ -84,47 +98,66 @@ jobs:
             echo "EOF"
             echo "head=$(jq -r '.[0].head_sha // ""' <<<"$pulls")"
           } >>"$GITHUB_OUTPUT"
-      - name: The checks that ran on its head
+      - name: The verdict on its head, waited for rather than sampled
         id: checks
         if: steps.pulls.outputs.head != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pulls.outputs.head }}
         run: |
+          # WAITED FOR, not sampled. `ci` is a fan-in that starts only once every
+          # lane has finished, so it posts minutes after the merge — on every
+          # merge measured when this was written, between three and twelve of
+          # them. Reading once at push time therefore sees no verdict on nearly
+          # every merge, and an absent verdict is precisely what this alarm no
+          # longer reports: without the wait it would judge nothing, ever, while
+          # going on printing a clean record. A census that can fail short has
+          # already failed.
+          #
+          # Bounded, and reaching the bound is not itself a finding: a verdict
+          # that never arrives is an absent one. The loop stops and the judge
+          # says so.
+          #
+          # filter=all, not the endpoint's default of `latest`. The judge
+          # deliberately reads the OLDEST attempt, so that a re-run after the
+          # merge cannot clear the record of the merge it was absent for — and
+          # `latest` returns only the most recent attempt per check, which is
+          # exactly the one that would clear it.
+          #
+          # PAGINATED. per_page caps at 100, and with filter=all every ATTEMPT
+          # of every check counts toward it — a pull request re-run a few times
+          # passes 100 easily. Truncating drops the tail, and the tail is what
+          # the judge reads.
+          #
+          # --slurp because --paginate alone emits one JSON document per page,
+          # which is not a value jq can fold; slurped, the pages arrive as an
+          # array and .[].check_runs[] flattens them into the one list the judge
+          # expects. The filter runs in a SEPARATE jq because gh refuses
+          # `--slurp` together with `--jq` and exits 1.
+          #
+          # A KNOWN CEILING remains, and is GitHub's rather than ours: this
+          # endpoint stops at the 1000 most recent check SUITES for a ref.
+          # Reaching it would need a commit re-run into four figures. Named
+          # rather than silently inherited.
+          deadline=$(( SECONDS + 20 * 60 ))
+          while :; do
+            runs="$(gh api --paginate --slurp "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs?per_page=100&filter=all" \
+              | jq -c '{check_runs: [.[].check_runs[] | {name, status, conclusion, completed_at}]}')"
+            settled="$(jq -r --arg n "$MERGE_VERDICT_REQUIRED" \
+              '[.check_runs[] | select(.name == $n and .status == "completed")] | length' <<<"$runs")"
+            [ "$settled" -gt 0 ] && break
+            [ "$SECONDS" -ge "$deadline" ] && {
+              echo "no completed \`$MERGE_VERDICT_REQUIRED\` within the budget — judging what is there"
+              break
+            }
+            sleep 30
+          done
+          # The payload is the LAST fetch the loop made, not a fresh one. A
+          # second call here would be a second answer to the same question, and
+          # the two could disagree across the seconds between them.
           {
             echo "runs<<EOF"
-            # filter=all, not the endpoint's default of `latest`. The judge
-            # deliberately reads the OLDEST attempt, so that a re-run after the
-            # merge cannot clear the record of the merge it was absent for —
-            # and `latest` returns only the most recent attempt per check,
-            # which is exactly the one that would clear it. The default would
-            # have made that rule silently unenforceable.
-            # PAGINATED. per_page caps at 100, and with filter=all every
-            # ATTEMPT of every check counts toward it — a pull request that was
-            # re-run a few times passes 100 easily. Truncating drops the tail,
-            # and the tail is precisely what the judge reads: it takes the
-            # OLDEST attempt so a re-run after the merge cannot clear the
-            # record of the merge it was absent for.
-            #
-            # --slurp because --paginate alone emits one JSON document per
-            # page, which is not a value jq can fold; slurped, the pages arrive
-            # as an array and .[].check_runs[] flattens them into the one list
-            # the judge expects.
-            #
-            # The filter runs in a SEPARATE jq rather than gh's --jq: gh
-            # refuses `--slurp` together with `--jq` ("the --slurp option is
-            # not supported with --jq or --template") and exits 1, which is
-            # what this step had been doing on every merge — writing no
-            # delimiter and taking the judge down with it. Piping keeps the
-            # slurped array and the filter exactly as they were.
-            #
-            # A KNOWN CEILING remains and is GitHub's rather than ours: this
-            # endpoint stops at the 1000 most recent check SUITES for a ref.
-            # Reaching that would need a commit re-run into four figures, and
-            # the alternative is walking the check-suites endpoint instead —
-            # more request budget on every push to cover a case nothing here
-            # has approached. Named rather than silently inherited.
-            gh api --paginate --slurp "repos/${{ github.repository }}/commits/${{ steps.pulls.outputs.head }}/check-runs?per_page=100&filter=all" \
-              | jq -c '{check_runs: [.[].check_runs[] | {name, status, conclusion, completed_at}]}'
+            echo "$runs"
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
       - name: Was there a verdict behind this merge?

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -535,21 +535,23 @@ beside the gate, deliberately outside it:
   [The shared Go build cache](#the-shared-go-build-cache) for why it is scheduled
   rather than per-push.
 
-- **`merge-attest.yml`** — on every push to `main`, and it runs no lane: two API
-  reads and a jq, which is what makes a push trigger affordable at ~85 merges a
-  day. It asks one question the health check cannot — not *is `main` red*, but
-  *did what just landed have a verdict behind it*: a pull request that named the
-  commit, and a `ci` check that reported, was green, and finished **before** the
-  merge. A required check that never reported is the case it exists for, because
-  an absent verdict is not a red one and nothing asking "was it green?" can tell
-  them apart.
+- **`merge-attest.yml`** — on every push to `main`. It runs no lane, but it does
+  **wait**: `ci` is a fan-in that starts only once every other lane has finished,
+  so it posts minutes after the merge and a read at push time would see nothing.
+  The wait is bounded at 20 minutes, and reaching that bound is not a finding.
 
-  **Gates nothing, and never will.** It runs after the merge. A repository role
-  merging past `ci` is deliberate — an infrastructure outage that reds every
-  pull request, a revert that has to land now — and what this changes is only
-  that the fact is loud and attributed at push time instead of surfacing two
-  hours later as somebody else's pull request going red against a base they did
-  not break. Prevention is a branch-protection decision (#2496). Judged by
+  It reports exactly two things: a commit **no pull request names** at all, and a
+  required check that **reported an adverse verdict** — the tree on `main` does
+  not pass its own required check. It says nothing about a verdict that was
+  merely *absent* at merge time. A repository role merging past `ci` is a
+  standing decision here, so an absent verdict is the expected shape of that
+  decision and not an incident; an alarm that fires on the expected state is one
+  that gets muted, and it would bury the two findings above.
+
+  **Gates nothing, and never will.** It runs after the merge. What it changes is
+  that a bad verdict is loud and attributed at push time, instead of surfacing
+  two hours later as somebody else's pull request going red against a base they
+  did not break. Prevention is a branch-protection decision (#2496). Judged by
   [`scripts/check-merge-verdict.sh`](../scripts/check-merge-verdict.sh), which
   reads its evidence from the environment so every arm is drivable from a
   fixture (`make test-merge-verdict`); a finding is filed as one issue per

--- a/scripts/check-merge-verdict.sh
+++ b/scripts/check-merge-verdict.sh
@@ -20,12 +20,17 @@
 #
 #   - nothing merged it. No pull request names this commit, so no review and no
 #     check ever applied to it.
-#   - the check never reported. It was still running, or never started, when the
-#     merge landed — #2504's own case, and the one a "was it green?" question
-#     cannot see, because an absent verdict is not a red one.
-#   - the check reported and was not green.
-#   - the check went green AFTER the merge. The merge was decided on an earlier,
-#     unfinished state; that the answer turned out well is luck, not a gate.
+#   - the check reported, and the verdict was adverse. The tree that landed does
+#     not pass its own required check.
+#
+# WHAT IT DELIBERATELY DOES NOT REPORT: an ABSENT verdict. Merging past `ci` is a
+# standing decision here, not an incident, and `ci` is a fan-in that only starts
+# once every lane has finished — so it posts roughly ten minutes after a run
+# begins and a merge inside that window sees nothing. Reporting that was
+# reporting the decision back to the people who made it: seventeen issues in
+# under five hours, every one of them describing a bypass working as intended.
+# An alarm that fires on the expected state is an alarm that gets turned off,
+# and it would have buried the two findings above.
 #
 # Reads its evidence from the environment rather than fetching it, so every arm
 # above is drivable from a fixture — the same shape ci-verdict.sh uses, and for
@@ -75,8 +80,6 @@ if [[ -z "$pr_number" ]]; then
 	exit 1
 fi
 
-merged_at="$(jq -r --arg n "$pr_number" '[.[] | select((.number|tostring) == $n)] | .[0].merged_at // ""' <<<"$pulls")"
-
 # The oldest matching run, not the newest. A re-run after the merge answers
 # about a tree that had already landed, and taking the latest verdict would let
 # one clear the record of the merge it was not present for.
@@ -85,24 +88,25 @@ verdict="$(jq -r --arg name "$required" '
 	| sort_by(.completed_at // "9999") | .[0] // {}' <<<"$checks")"
 
 if [[ "$(jq -r 'length' <<<"$verdict")" -eq 0 ]]; then
-	emit "pull request #$pr_number merged before its required \`$required\` check reported at all — an absent verdict, which is not the same as a green one"
-	exit 1
+	echo "ok: $sha has no \`$required\` verdict to read (pull request #$pr_number) — an absent verdict is the shape of a decision that was taken, not a finding"
+	exit 0
 fi
 
+# `success` passes; the three below are the OTHER ways to have no answer, and
+# they are not adverse ones. A cancelled run is the case that would otherwise
+# accuse: deleting the branch on merge cancels whatever was still running on it,
+# so treating `cancelled` as a red verdict would report the tidy-up rather than
+# the tree.
 conclusion="$(jq -r '.conclusion // ""' <<<"$verdict")"
-if [[ "$conclusion" != "success" ]]; then
-	emit "pull request #$pr_number merged while its required \`$required\` check was \`${conclusion:-still running}\`"
+case "$conclusion" in
+success)
+	echo "ok: $sha merged behind a green \`$required\` (pull request #$pr_number)"
+	;;
+"" | cancelled | skipped | neutral)
+	echo "ok: $sha has no \`$required\` verdict to read (pull request #$pr_number) — \`${conclusion:-still running}\` is an absent answer, not an adverse one"
+	;;
+*)
+	emit "pull request #$pr_number landed, and its required \`$required\` check then reported \`$conclusion\` — the tree on main does not pass its own required check"
 	exit 1
-fi
-
-completed_at="$(jq -r '.completed_at // ""' <<<"$verdict")"
-# Compared as STRINGS, which is right for these two and only these two: the API
-# writes both as ISO-8601 in UTC with the same fixed width, so lexical order is
-# chronological order. It would not be for a mixed-offset timestamp, and neither
-# field is ever one.
-if [[ -n "$merged_at" && -n "$completed_at" && "$completed_at" > "$merged_at" ]]; then
-	emit "pull request #$pr_number merged at $merged_at, before its required \`$required\` check finished at $completed_at — the merge was decided on an unfinished run"
-	exit 1
-fi
-
-echo "ok: $sha merged behind a green \`$required\` (pull request #$pr_number)"
+	;;
+esac

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -441,7 +441,16 @@ fi
 # a recurring finding becomes a stale one.
 
 if [[ "${MERGE_VERDICT_RESULT:-}" = "failure" ]]; then
-  report "A merge landed on main against a failing verdict${MERGE_VERDICT_PR:+ (#$MERGE_VERDICT_PR)}" bug \
+  # TWO findings, two titles. The judge reports a commit no pull request names
+  # BEFORE any verdict exists, so titling that one "against a failing verdict"
+  # would describe a check that never ran — and the two are told apart by
+  # exactly the thing the title would otherwise name, the pull request number.
+  if [[ -n "${MERGE_VERDICT_PR:-}" ]]; then
+    merge_title="A merge landed on main against a failing verdict (#$MERGE_VERDICT_PR)"
+  else
+    merge_title="A merge landed on main with no pull request behind it"
+  fi
+  report "$merge_title" bug \
 "${MERGE_VERDICT_WHY:-a merge landed on \`main\` whose required check reported an adverse verdict; the run below says which}
 
 Found by the push-time check on \`main\`: $RUN_URL

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -441,28 +441,22 @@ fi
 # a recurring finding becomes a stale one.
 
 if [[ "${MERGE_VERDICT_RESULT:-}" = "failure" ]]; then
-  report "A merge landed on main without a verdict behind it${MERGE_VERDICT_PR:+ (#$MERGE_VERDICT_PR)}" bug \
-"${MERGE_VERDICT_WHY:-a merge landed on \`main\` without a green required check; the run below says which}
+  report "A merge landed on main against a failing verdict${MERGE_VERDICT_PR:+ (#$MERGE_VERDICT_PR)}" bug \
+"${MERGE_VERDICT_WHY:-a merge landed on \`main\` whose required check reported an adverse verdict; the run below says which}
 
 Found by the push-time check on \`main\`: $RUN_URL
 
-**This is not an accusation of bad faith, and not a request to remove bypass.**
-There are real cases for it — an infrastructure outage that reds every pull
-request, a revert that has to land now. What there was no case for is the fact
-being invisible: the pull request closes green-looking in the list,
-\`main-health\` is two-hourly and goes on reporting the last green it saw, and
-the next signal anybody gets is somebody else's pull request going red against a
-base they did not break. That is how #2504's four merges were found — twice,
-independently, each finder spending a rebase and a full local lane to rule their
-own diff out.
+**This is not about the bypass.** Merging past \`ci\` is a standing decision here
+and this alarm says nothing about it — a verdict that was merely ABSENT at merge
+time is not reported at all. What is reported is a verdict that came back and was
+BAD: the tree now on \`main\` does not pass its own required check, or no pull
+request names the commit at all.
 
-**What to do with this issue.** If the tree is fine, say why the bypass was
-right and close it; the record is the point. If it is not, \`main\` is red now
-and this issue names the commit, which is roughly two hours earlier than
-\`main-health\` would have.
-
-Prevention is a branch-protection decision (#2496), not something this alarm
-can or should do."\
+**What to do with this issue.** \`main\` is red now, and this issue names the
+commit that made it so — roughly two hours earlier than \`main-health\` would,
+and without the rebase-and-full-local-lane that ruling out your own diff costs.
+Fix forward or revert. If the verdict was wrong rather than the tree, say why and
+close it; the record is the point."\
     || unreported=1
 fi
 

--- a/scripts/test-check-merge-verdict.sh
+++ b/scripts/test-check-merge-verdict.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# test-check-merge-verdict.sh — prove the merge alarm still tells an absent
-# verdict from a green one.
+# test-check-merge-verdict.sh — prove the merge alarm still tells an ADVERSE
+# verdict from an absent one.
 #
 # It runs beside the judge for the reason `test-ci-verdict.sh` runs beside the
 # verdict: this thing is silent when it is working, so "the alarm did not go
-# off" is exactly the signal that was already untrustworthy. The case that
-# matters most is the check that is MISSING rather than red — #2504's own shape,
-# and the one an "is it green?" question cannot see, because jq reading an
-# absent field and jq reading a passing one both answer with something falsy if
-# the script is written carelessly.
+# off" is exactly the signal that was already untrustworthy. Silence is now the
+# answer to far more inputs than it used to be — every absent verdict — which
+# makes the half of this suite that asserts exit 0 the half that matters. An
+# alarm rewritten to say less is one keystroke from saying nothing, and only a
+# case that FAILS when it goes quiet can tell those apart.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -45,31 +45,37 @@ check() { printf '{"check_runs":[{"name":"ci","status":"completed","conclusion":
 # script exits non-zero.
 case_is "green before the merge" "$pr" "$(check success 2026-08-24T02:29:56Z)" 0 "#2516"
 
-# #2504's four merges. An absent verdict is not a red one, and nothing that asks
-# "was it green?" can see the difference.
-case_is "the required check never reported" "$pr" '{"check_runs":[]}' 1 "before its required \`ci\` check reported at all"
+# THE ONE FINDING THAT REMAINS about a check: it reported, and the answer was
+# adverse. Merging past `ci` is a standing decision, so the alarm is silent about
+# a verdict that is merely absent — but never about one that came back bad.
+case_is "the required check reported red" "$pr" "$(check failure 2026-08-24T02:29:56Z)" 1 'reported `failure`'
+case_is "the required check timed out" "$pr" "$(check timed_out 2026-08-24T02:29:56Z)" 1 'reported `timed_out`'
+
+# Green, and green only afterwards. The merge was decided on an unfinished run;
+# under a bypass that is the expected shape, not a finding.
+case_is "green AFTER the merge landed" "$pr" "$(check success 2026-08-24T03:10:00Z)" 0 "merged behind a green"
+
+# THE SILENT ARMS. Each is a way to have NO answer, and each must exit 0 — but
+# each is asserted on its message too, so a judge that has stopped reading the
+# verdict at all cannot pass this by falling through to a bare exit 0.
+case_is "the required check never reported" "$pr" '{"check_runs":[]}' 0 "no \`ci\` verdict to read"
 case_is "some other check reported, ci did not" "$pr" \
 	'{"check_runs":[{"name":"deterministic-gates","status":"completed","conclusion":"success","completed_at":"2026-08-24T02:16:58Z"}]}' \
-	1 "before its required \`ci\` check reported at all"
-
-case_is "merged over a red ci" "$pr" "$(check failure 2026-08-24T02:29:56Z)" 1 'was `failure`'
-case_is "merged over a cancelled ci" "$pr" "$(check cancelled 2026-08-24T02:29:56Z)" 1 'was `cancelled`'
-# GitHub counts a skipped required check as passing. This does not.
-case_is "merged over a skipped ci" "$pr" "$(check skipped 2026-08-24T02:29:56Z)" 1 'was `skipped`'
-case_is "ci still running at merge time" "$pr" \
-	'{"check_runs":[{"name":"ci","status":"in_progress","conclusion":null}]}' 1 'was `still running`'
-
-# Green, but only afterwards. The merge was decided on an unfinished run and the
-# answer arriving later is luck, not a gate — invisible to anything that reads
-# the conclusion alone.
-case_is "green AFTER the merge landed" "$pr" "$(check success 2026-08-24T03:10:00Z)" 1 "before its required \`ci\` check finished"
+	0 "no \`ci\` verdict to read"
+# Deleting the branch on merge cancels what was still running on it. That is the
+# tidy-up, not the tree.
+case_is "the required check was cancelled" "$pr" "$(check cancelled 2026-08-24T02:29:56Z)" 0 'is an absent answer'
+case_is "the required check was skipped" "$pr" "$(check skipped 2026-08-24T02:29:56Z)" 0 'is an absent answer'
+case_is "ci still running when read" "$pr" \
+	'{"check_runs":[{"name":"ci","status":"in_progress","conclusion":null}]}' 0 'is an absent answer'
 
 # A re-run after the merge must not clear the record of the merge it was absent
 # for, so the OLDEST run is the one judged.
 case_is "a later re-run does not overwrite the verdict at merge time" "$pr" \
 	'{"check_runs":[{"name":"ci","status":"completed","conclusion":"failure","completed_at":"2026-08-24T02:29:56Z"},{"name":"ci","status":"completed","conclusion":"success","completed_at":"2026-08-25T09:00:00Z"}]}' \
-	1 'was `failure`'
+	1 'reported `failure`'
 
+# The other finding, and the loudest: nothing reviewed this at all.
 case_is "no pull request at all" '[]' '{"check_runs":[]}' 1 "no pull request naming it"
 
 # A commit with no pull request and a lookup that did not happen are different

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -281,8 +281,13 @@ expect_health "a failed publish with no range still files" \
 # the offending pull request exactly, which is the whole difference between this
 # alarm and the two-hourly one above.
 
+# The REASON is a parameter, not a constant, because the two findings do not
+# share one: a commit no pull request names is reported before any verdict
+# exists. Pinning the failing-verdict sentence onto both cases would test the
+# no-pull-request arm against a reason the judge never emits for it.
 expect_merge() {
 	local name="$1" pr="$2" want_title="$3" must_say="$4" out status got body
+	local why="${5:-pull request #2516 landed, and its required \`ci\` check then reported \`failure\`}"
 	export ACTION_LOG="$stub_dir/actions"
 	export BODY_LOG="$stub_dir/body"
 	: >"$ACTION_LOG"
@@ -290,7 +295,7 @@ expect_merge() {
 	set +e
 	out="$(env OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
 		MERGE_VERDICT_RESULT=failure MERGE_VERDICT_PR="$pr" \
-		MERGE_VERDICT_WHY="pull request #2516 landed, and its required \`ci\` check then reported \`failure\`" \
+		MERGE_VERDICT_WHY="$why" \
 		"$root/scripts/scheduled-report.sh" 2>&1)"
 	status=$?
 	set -e
@@ -326,9 +331,13 @@ expect_merge "a merge over a red check is filed against its pull request" \
 
 # A commit with no pull request has no number to name, and the title must still
 # be a title rather than one ending in an empty parenthesis.
-expect_merge "a merge with no pull request still files under a legible title" \
-	"" "A merge landed on main against a failing verdict" \
-	"its required"
+# The OTHER finding, and it must not borrow the first one's title: a commit no
+# pull request names is reported before any verdict exists, so "against a failing
+# verdict" would describe a check that never ran.
+expect_merge "a merge with no pull request is titled for what it found" \
+	"" "A merge landed on main with no pull request behind it" \
+	"no pull request naming it" \
+	"abc1234 landed on main with no pull request naming it, so no review and no required check ever applied to it"
 
 # --- the census -----------------------------------------------------------------
 #

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -290,7 +290,7 @@ expect_merge() {
 	set +e
 	out="$(env OPEN_TITLES="" GH_TOKEN=stub REPO=owner/repo RUN_URL=https://example.test/run/1 \
 		MERGE_VERDICT_RESULT=failure MERGE_VERDICT_PR="$pr" \
-		MERGE_VERDICT_WHY="pull request #2516 merged while its required \`ci\` check was \`failure\`" \
+		MERGE_VERDICT_WHY="pull request #2516 landed, and its required \`ci\` check then reported \`failure\`" \
 		"$root/scripts/scheduled-report.sh" 2>&1)"
 	status=$?
 	set -e
@@ -321,14 +321,14 @@ expect_merge() {
 # which is the dedupe above working exactly as designed against a subject it does
 # not fit.
 expect_merge "a merge over a red check is filed against its pull request" \
-	2516 "A merge landed on main without a verdict behind it (#2516)" \
-	'merged while its required `ci` check was `failure`'
+	2516 "A merge landed on main against a failing verdict (#2516)" \
+	'its required `ci` check then reported `failure`'
 
 # A commit with no pull request has no number to name, and the title must still
 # be a title rather than one ending in an empty parenthesis.
 expect_merge "a merge with no pull request still files under a legible title" \
-	"" "A merge landed on main without a verdict behind it" \
-	"merged while its required"
+	"" "A merge landed on main against a failing verdict" \
+	"its required"
 
 # --- the census -----------------------------------------------------------------
 #


### PR DESCRIPTION
## What

`merge-attest` stops reporting an **absent** verdict and reports only an
**adverse** one: a required check that came back bad, or a commit no pull request
names at all. `cancelled`, `skipped`, `neutral` and a run still in flight join
"never reported" on the silent side.

To see an adverse verdict the judge has to wait for one, so the workflow now
waits for `ci` to reach a conclusion rather than sampling the instant of the
push, bounded at 20 minutes. Reaching the bound is not a finding.

## Why

Merging past `ci` is a standing decision here, and `ci` is a fan-in that starts
only once every other lane has finished — so it posts minutes after the merge and
**every** bypassed merge looked, at push time, exactly like a merge with no
verdict behind it. The alarm reported that faithfully: seventeen issues in under
five hours, each describing the decision working as intended.

An alarm that fires on the expected state is an alarm that gets muted, and muting
this one would have taken its two real findings with it. So the noise goes and
the findings stay.

The wait is what that costs — a runner held per merge instead of two API reads,
on a repository whose minutes are free. Stated rather than hidden: without it the
judge would reach its remaining arm on almost no merge, pass silently, and print
a clean record while checking nothing. A census that can fail short has already
failed, which is why the bound is documented as an absent answer rather than as a
pass.

Measured on the seventeen merges that prompted this: `ci` completed between three
and twelve minutes after the merge on every one of them, and none was already red
at merge time.

## How verified

- `make test-merge-verdict` — the judge's arms, rewritten. Both findings still
  exit 1; each of the five silent arms is asserted **on its message**, not merely
  on exit 0, so a judge that has stopped reading the verdict cannot pass by
  falling through.
- `make test-scheduled-report` — including the census that asks `merge-attest.yml`
  and the reporter the same wiring question from both sides.
- `make ci-doc-parity`, `make test-ci-verdict` green.
- `make check` green on the branch this was developed on.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Generated. The policy change is the repository owner's decision; the shape of it —
which conclusions count as absent, that the fetch is reused rather than repeated,
and that the required check is named once at job level so the waiter and the judge
cannot settle on different checks — was worked out against the seventeen real
merges.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Merge verification now waits up to 20 minutes for the required CI check to finish before evaluating results.
  - Missing, running, cancelled, skipped, or neutral checks no longer create merge-attestation findings.
  - Reports and issues are now generated only for merges associated with an adverse CI verdict.
  - Failure messages provide clearer guidance to fix forward or revert affected changes.

- **Documentation**
  - Updated CI documentation to reflect the revised wait and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->