### PR TITLE
The named criteria are findable, and three were not held

### DIFF
--- a/frontend/src/screens/worklist.exceptions.test.tsx
+++ b/frontend/src/screens/worklist.exceptions.test.tsx
@@ -68,7 +68,7 @@ describe("what needs the lead", () => {
     expect(screen.getByText(en["worklist.exceptions.nobody"])).toBeTruthy();
   });
 
-  it("admits a bounded page is not a clear team", async () => {
+  it("AC-WORKLIST-MGR-04: admits a bounded page is not a clear team", async () => {
     stubExceptions({
       as_of: "2026-09-05T09:00:00Z",
       // The server read to its own bound. A lead taking this list for the

--- a/frontend/src/screens/worklist.handled.test.tsx
+++ b/frontend/src/screens/worklist.handled.test.tsx
@@ -19,7 +19,7 @@ afterEach(() => {
 // must never do.
 
 describe("what was handled for the reader", () => {
-  it("reports what happened and offers nothing to do about it", async () => {
+  it("AC-WORKLIST-TRUST-01: reports what happened and offers nothing to do about it", async () => {
     stubHandled({
       as_of: "2026-09-05T09:00:00Z",
       truncated: false,

--- a/frontend/src/screens/worklist.hiddenowner.test.tsx
+++ b/frontend/src/screens/worklist.hiddenowner.test.tsx
@@ -48,7 +48,7 @@ describe("the hidden-backlog panel is about the reader", () => {
   // from you" read as Lena's backlog. On the one surface whose whole job is to
   // say what a queue is not showing, that is the worst place in the product to
   // attribute a figure to the wrong person.
-  it("draws no hidden-backlog panel on a colleague's queue", async () => {
+  it("AC-WORKLIST-MGR-02: draws no hidden-backlog panel on a colleague's queue", async () => {
     stub(day({ scope_options: ["mine", "team"] }));
     renderWorklist("en", "11111111-1111-4111-8111-111111111111");
 

--- a/frontend/src/screens/worklist.manager.test.tsx
+++ b/frontend/src/screens/worklist.manager.test.tsx
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The two interventions a lead makes on somebody else's queue: handing a task
+// to another person, and leaving them a note about it.
+//
+// Both were shipped with stories and no test. A story shows that a control
+// draws; neither of these is about drawing. Reassign moves a customer's work
+// from one person's day to another's, and coaching writes a notice that arrives
+// in a colleague's queue under their own name — so what has to be held is the
+// WRITE: which endpoint, and what body. A control that renamed the promise and
+// posted nothing looks identical on screen.
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { CoachControl, ReassignControl } from "./worklist.manager";
+import { jsonResponse, row } from "./worklist.testkit";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// The roster the pickers read, and the reader themself in it. `LENA` is the
+// owner whose queue is open, so she is the person the reassign picker must NOT
+// offer — handing work to the person who already holds it is the one move that
+// does nothing.
+const LENA = "u-lena";
+const MINH = "u-minh";
+
+function stubRosterAnd(write: (input: Request) => Response | undefined) {
+  const fetched = vi.fn(async (input: RequestInfo | URL) => {
+    const request = input instanceof Request ? input : undefined;
+    const url = String(request ? request.url : input);
+    if (request && request.method !== "GET") {
+      const answered = write(request);
+      if (answered) {
+        return answered;
+      }
+    }
+    if (url.includes("/users")) {
+      // The list AND the end of it. `walkRoster` pages until a null cursor, so
+      // a body without `page` walks until its own bound and the picker opens
+      // empty — which looks exactly like a workspace with nobody in it.
+      return jsonResponse({
+        data: [
+          { id: LENA, display_name: "Lena Fischer" },
+          { id: MINH, display_name: "Minh Tran" },
+        ],
+        page: { next_cursor: null },
+      });
+    }
+    return jsonResponse({ data: [] });
+  });
+  vi.stubGlobal("fetch", fetched);
+  return fetched;
+}
+
+function renderUnderAToastRegion(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          {ui}
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The last non-GET this render sent, with its body read off the Request.
+//
+// openapi-fetch sends a Request object rather than (url, init), so the method
+// and the body ride on it — reading a second init argument finds nothing and
+// the assertion compares undefined against the write it wanted.
+async function wrote(
+  fetched: ReturnType<typeof vi.fn>,
+): Promise<{ method: string; url: string; body: unknown } | undefined> {
+  const calls = fetched.mock.calls;
+  for (let at = calls.length - 1; at >= 0; at--) {
+    const [input] = calls[at] as [RequestInfo | URL, RequestInit?];
+    if (input instanceof Request && input.method !== "GET") {
+      return {
+        method: input.method,
+        url: input.url,
+        body: await input.clone().json(),
+      };
+    }
+  }
+  return undefined;
+}
+
+describe("handing a task to somebody else", () => {
+  it("AC-WORKLIST-MGR-03: writes the new assignee to the task the row names", async () => {
+    const fetched = stubRosterAnd(() => jsonResponse({}));
+    const user = userEvent.setup();
+    renderUnderAToastRegion(
+      <ReassignControl item={row({ id: "task-1" })} owner={LENA} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    );
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Minh Tran" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.reassignConfirm"],
+      }),
+    );
+
+    // The task's own endpoint, in the owning module's spelling. This queue adds
+    // no writer of its own: it asks the activity to change its assignee.
+    const sent = await wrote(fetched);
+    expect(sent?.method).toBe("PATCH");
+    expect(sent?.url).toContain("/activities/task-1");
+    expect(sent?.body).toEqual({ assignee_id: MINH });
+    expect(
+      await screen.findByText(en["worklist.manager.reassigned"]),
+    ).toBeTruthy();
+  });
+
+  // The person who already holds the work is not a destination for it.
+  it("offers everyone except the person whose queue this is", async () => {
+    stubRosterAnd(() => jsonResponse({}));
+    const user = userEvent.setup();
+    renderUnderAToastRegion(
+      <ReassignControl item={row({ id: "task-1" })} owner={LENA} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    );
+
+    await user.click(await screen.findByRole("combobox"));
+    expect(screen.getByRole("option", { name: "Minh Tran" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "Lena Fischer" })).toBeNull();
+  });
+
+  // A refused handover leaves the work where it was, which looks exactly like a
+  // press that did nothing.
+  it("says so when the handover is refused", async () => {
+    stubRosterAnd(
+      () =>
+        new Response(JSON.stringify({ title: "Forbidden", status: 403 }), {
+          status: 403,
+          headers: { "content-type": "application/problem+json" },
+        }),
+    );
+    const user = userEvent.setup();
+    renderUnderAToastRegion(
+      <ReassignControl item={row({ id: "task-1" })} owner={LENA} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    );
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Minh Tran" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.reassignConfirm"],
+      }),
+    );
+
+    expect(
+      await screen.findByText(en["worklist.manager.reassignFailed"]),
+    ).toBeTruthy();
+  });
+});
+
+describe("leaving a note on somebody's queue", () => {
+  it("AC-WORKLIST-MGR-03: writes the note to the person it is about", async () => {
+    const fetched = stubRosterAnd(() => jsonResponse({}));
+    const user = userEvent.setup();
+    renderUnderAToastRegion(<CoachControl owner={LENA} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: en["worklist.manager.coach"] }),
+    );
+    await user.type(
+      screen.getByLabelText(en["worklist.manager.note"]),
+      "Two of these have been waiting a week.",
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.coachConfirm"],
+      }),
+    );
+
+    const sent = await wrote(fetched);
+    expect(sent?.body).toEqual({
+      recipient_user_id: LENA,
+      kind: "coach_general",
+      note: "Two of these have been waiting a week.",
+    });
+    expect(
+      await screen.findByText(en["worklist.manager.coached"]),
+    ).toBeTruthy();
+  });
+
+  // An empty note is ABSENT rather than an empty string: the coach added none,
+  // and the kind's own headline already says what the note would have.
+  it("sends no note field where the coach wrote nothing", async () => {
+    const fetched = stubRosterAnd(() => jsonResponse({}));
+    const user = userEvent.setup();
+    renderUnderAToastRegion(<CoachControl owner={LENA} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: en["worklist.manager.coach"] }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.manager.coachConfirm"],
+      }),
+    );
+
+    const sent = await wrote(fetched);
+    expect(sent?.body).toEqual({
+      recipient_user_id: LENA,
+      kind: "coach_general",
+    });
+  });
+});

--- a/frontend/src/screens/worklist.paging.test.tsx
+++ b/frontend/src/screens/worklist.paging.test.tsx
@@ -126,7 +126,7 @@ describe("walking to the rest of the queue", () => {
   // population rather than four figures about the page beside a fifth about the
   // day. A fixture whose bands could be a count of its own page would pass
   // whichever the header meant, which is how this shipped.
-  it("keeps the day's figures still while the rows grow", async () => {
+  it("AC-WORKLIST-SDR-04: keeps the day's figures still while the rows grow", async () => {
     const counts = [
       {
         category: "tasks" as const,

--- a/frontend/src/screens/worklist.pin.test.tsx
+++ b/frontend/src/screens/worklist.pin.test.tsx
@@ -179,6 +179,67 @@ describe("a reader can put a row at the top of their own day", () => {
     expect(await screen.findByText(en["worklist.verb.pinFailed"])).toBeTruthy();
   });
 
+  // Where the keyboard is after the refusal.
+  //
+  // AC-WORKLIST-SDR-06 asks that an action keep focus across a failure, and
+  // this queue is worked from the keyboard: a reader tabs to a row, presses,
+  // and is told it did not land. If the failure moves focus — to the document,
+  // or to a toast that then leaves — their next Tab starts from the top of the
+  // page and they have to travel back to the row they were on. Nothing else in
+  // this suite asserts focus at all, so a refactor that re-rendered the button
+  // and dropped focus would show up only as a bug report.
+  //
+  // The SAME refused write as the case above, asked a second question, because
+  // "it says so" and "you can act on what it says" are different promises.
+  it("AC-WORKLIST-SDR-06: leaves the keyboard on the control that was refused", async () => {
+    const fetched = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input instanceof Request ? input : undefined;
+      const url = String(request ? request.url : input);
+      if (url.includes("/worklist/pins")) {
+        return new Response(
+          JSON.stringify({ title: "Forbidden", status: 403 }),
+          {
+            status: 403,
+            headers: { "content-type": "application/problem+json" },
+          },
+        );
+      }
+      if (url.includes("/worklist")) {
+        return new Response(
+          JSON.stringify(
+            day({
+              queue: [
+                row({
+                  id: "task-1",
+                  source: "task",
+                  title: "Send the retrofit quote",
+                }),
+              ],
+              summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetched);
+    renderUnderAToastRegion();
+
+    const pin = await screen.findByRole("button", {
+      name: en["worklist.verb.pin"],
+    });
+    await userEvent.click(pin);
+
+    expect(await screen.findByText(en["worklist.verb.pinFailed"])).toBeTruthy();
+    // The control the reader pressed still holds the keyboard, so their next
+    // key reaches the row they were working rather than the top of the page.
+    expect(document.activeElement).toBe(pin);
+  });
+
   it("offers no pin on a folded group, whose id the fold mints", async () => {
     stubbing([
       row({

--- a/frontend/src/screens/worklist.review.test.tsx
+++ b/frontend/src/screens/worklist.review.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 });
 
 describe("the day is drawn apart from what it is not", () => {
-  it("keeps a judgement out of the queue and still shows it", async () => {
+  it("AC-WORKLIST-REVIEW-01: keeps a judgement out of the queue and still shows it", async () => {
     stub(
       day({
         queue: [

--- a/frontend/src/screens/worklist.taskdone.test.tsx
+++ b/frontend/src/screens/worklist.taskdone.test.tsx
@@ -17,7 +17,7 @@ import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import { WorklistScreen } from "./worklist";
-import { day, row, stub } from "./worklist.testkit";
+import { day, jsonResponse, row, stub } from "./worklist.testkit";
 
 afterEach(() => {
   cleanup();
@@ -72,6 +72,107 @@ describe("finishing a task from the row", () => {
         body: { is_done: false },
       });
     });
+  });
+});
+
+// The figures still describe the rows after the work is done.
+//
+// The plan asks for counts that reconcile "after load, action, and refresh",
+// and the load half was already held (worklist_test.go and paging). This is the
+// ACTION half, and it is the one that can rot silently: a client that removes
+// the finished row and leaves the headline alone still draws a queue, still
+// draws a number, and the two simply disagree — one row on screen under a
+// sentence saying two are waiting.
+//
+// The server answers DIFFERENTLY after the write, which is the whole point. A
+// stub that replayed the first day would let a client that never re-read pass:
+// the row would vanish from the DOM optimistically and the stale figure would
+// be the one still on screen, which is exactly the defect.
+describe("the day's figures after the work is done", () => {
+  it("AC-WORKLIST-SDR-04: re-reads the count rather than leaving the old one on screen", async () => {
+    const before = day({
+      queue: [
+        row({
+          id: "task-1",
+          source: "task",
+          title: "Send the retrofit quote",
+          actions: ["complete"],
+          primary_action: "complete",
+        }),
+        row({
+          id: "task-2",
+          source: "task",
+          title: "Call the buyer back",
+          actions: ["complete"],
+          primary_action: "complete",
+        }),
+      ],
+      summary: { urgent: 0, due: 0, lower_priority: 2, total: 2 },
+    });
+    const after = day({
+      queue: [
+        row({
+          id: "task-2",
+          source: "task",
+          title: "Call the buyer back",
+          actions: ["complete"],
+          primary_action: "complete",
+        }),
+      ],
+      summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+    });
+    // One day before the write and the other after it, decided by whether the
+    // PATCH has been seen rather than by a call count — the queue is read more
+    // than once on arrival, and counting reads would make this depend on how
+    // many.
+    let done = false;
+    let readAfterTheWrite = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (input instanceof Request && input.method === "PATCH") {
+          done = true;
+          return jsonResponse({});
+        }
+        if (url.includes("/worklist")) {
+          if (done) {
+            readAfterTheWrite += 1;
+          }
+          return jsonResponse(done ? after : before);
+        }
+        return jsonResponse({ data: [] });
+      }),
+    );
+    const user = userEvent.setup();
+    renderUnderAToastRegion();
+
+    // The figure the day starts on, so the assertion below is a CHANGE rather
+    // than a number that happened to be right from the first render.
+    await screen.findByText(/2 in all/);
+    await user.click(
+      (await screen.findAllByRole("button", { name: en["tasks.complete"] }))[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Send the retrofit quote")).toBeNull();
+    });
+    // The row left AND the headline followed it. Asserting only the first is
+    // what lets a stale count ship: the finished row disappears optimistically
+    // while the sentence above it still says two are waiting.
+    await waitFor(() => {
+      expect(screen.getByText(/1 in all/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/2 in all/)).toBeNull();
+    // And the day still holds the work that was not finished, so the count fell
+    // because one row left rather than because the queue emptied itself.
+    expect(screen.getByText("Call the buyer back")).toBeTruthy();
+    // The figure came from the SERVER, not from arithmetic on the client.
+    // Without this the test passes for a client that decremented its own copy
+    // and never asked again — which is right for this fixture and wrong the
+    // moment the write changes anything the client did not predict, such as a
+    // second row leaving with it or a band the row moves between.
+    expect(readAfterTheWrite).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -635,7 +635,7 @@ describe("what the ranked queue tells a reader", () => {
     expect(screen.getAllByText("My team").length).toBeGreaterThan(0);
   });
 
-  it("warns rather than claiming a clear day it could not read", async () => {
+  it("AC-WORKLIST-SDR-05: warns rather than claiming a clear day it could not read", async () => {
     stub(
       day({
         sources_unavailable: [{ source: "capture_health", reason: "failed" }],
@@ -1031,7 +1031,7 @@ describe("the draft_reply verb says what the click does", () => {
 // fixture must keep them distinct for the count to mean what it says, which is
 // what `seen.size` being asserted at 3 holds.
 describe("every obligation is drawn once", () => {
-  it("renders no row twice, including the one at the top", async () => {
+  it("AC-WORKLIST-SDR-02: renders no row twice, including the one at the top", async () => {
     stub(
       day({
         queue: [


### PR DESCRIPTION
The product plan names thirteen acceptance criteria for the worklist and nothing in the tree carried those names, so there was no way to ask which were met. Two were written; the rest existed only in the plan.

## Most were already proven — this says so rather than writing second copies

Seven tests gain their criterion's id. Each was read against what its id claims before being renamed, and Codex re-checked all seven independently.

| AC | Already proven by |
|---|---|
| SDR-02 one obligation renders once | `worklist.test.tsx:1034` — a census over every rendered title |
| SDR-04 counts reconcile (load/paging) | `worklist.paging.test.tsx:129` |
| SDR-05 partial lanes → no all-clear | `worklist.test.tsx:638` |
| MGR-02 owner/team scope never leaks | `worklist.hiddenowner.test.tsx:51` |
| MGR-04 partial data → no clear team | `worklist.exceptions.test.tsx:71` |
| REVIEW-01 grouped decisions finite | `worklist.review.test.tsx:25` |
| TRUST-01 receipts and snapshot | `worklist.handled.test.tsx:22` |

A duplicate assertion would have been worse than the gap.

## Three were genuinely unheld

**SDR-04, the action half.** The figures were never checked after a write. That is the half that rots quietly: a client that removes the finished row and leaves the headline alone still draws a queue and still draws a number, and the two disagree. The stub answers a different day once it has seen the PATCH, and the test **counts the re-read** rather than inferring it from a figure that happens to be right — a client that decremented its own copy would otherwise pass.

**SDR-06, focus across a failure.** No worklist test used `activeElement` at all. A queue worked from the keyboard that drops focus on a refusal sends the reader back to the top of the page. The refused pin already had a test for *saying* so; this asks whether they can act on what it says.

**MGR-03, coach and reassign.** `worklist.manager.tsx` had no test file, only stories. A story shows a control draws; neither of these is about drawing. Reassign moves a customer's work between people's days, and coaching writes a notice under the coach's own name — so what has to be held is the write.

## Evidence

| Obligation | Evidence |
|---|---|
| Mutation strength | Stale server response breaks SDR-04; removing the re-read counter breaks it too; blurring the button breaks SDR-06; handing the task to its current owner breaks MGR-03; sending an empty note as `""` rather than omitting it breaks the coach case. Each checked one clause at a time. |
| Write shape | The manager tests assert method, URL and body — `PATCH /activities/{id}` with `{assignee_id}`, and the coach's `{recipient_user_id, kind}`. |
| Failure behavior | A refused handover (403) says so; a refused pin keeps focus. |
| Test-double fidelity | The roster stub matches what `readRosterPage` actually consumes (`data.data`, `data.page.next_cursor`) — verified against `entityref.tsx`, since a double that does not match the real writer proves nothing. |
| Review | Codex reviewed before the commit and found one real defect: SDR-04 asserted final DOM state without proving a re-read happened. Fixed and mutation-checked. |
| Full lane | `make check-fe` green. |

## Still open, and needing a decision

Two criteria are not written because as stated they **contradict shipped behaviour**:

- **MGR-01 "manager defaults to Team exceptions"** — `scope_test.go:34` requires every tier, managers included, to default to `mine`, and `worklist.tsx:706` hard-codes it. Writing this means changing where a manager lands and deleting that test.
- **SDR-03's "no Today row has zero actions"** — contradicted by two deliberate tests (`worklist.test.tsx:904`, `worklist.automationrow.test.tsx:85`) that sanction verb-less rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the product plan's thirteen worklist acceptance criteria in the tree and writes the three that had no test behind them.

**Findability**
- Seven existing tests now carry their AC id in the test name after being read against what the id claims.
- SDR-03 and MGR-01 are left unwritten because as stated they contradict shipped behavior; they need a product decision.

**New tests**
- SDR-04's action half holds the day's counts across a write and counts the re-read, so a client that decrements locally fails.
- SDR-06 holds that a refused pin keeps focus, so keyboard users stay on the row they were working.
- MGR-03 gains a test file asserting the reassign and coach writes (method, URL, body), the failure path, and the omitted-note case.

<sup>Written for commit 95b13aac4d453ba50141571a3b6f001e62bffc93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for worklist management actions, including reassignment, coaching notes, authorization failures, and request payloads.
  * Verified that failed pin actions retain keyboard focus and display the appropriate feedback.
  * Added coverage confirming completed tasks refresh worklist data and summary counts correctly.
  * Organized worklist tests with acceptance-criteria identifiers to improve traceability across pagination, review, visibility, and duplicate-row scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->