### PR TITLE
A message a page draws in full is a message it opens

### DIFF
--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -1358,9 +1358,9 @@ function TimelineGroupRow({
             summary={newest.emailSummary}
             timestamp={formatTimeOfDay(newest.atIso, locale, zone)}
             onOpen={newest.onOpenEmail}
-            // The entry carries an opener on every surface that mounts a
-            // drawer. Where it does not, the surface itself has no reader to
-            // open into — the Brief is the one such page.
+            // Absent on the reply composer, whose rows are the thread being
+            // answered rather than a place to act from. Every other surface
+            // that draws this timeline mounts a drawer and passes an opener.
             whyNotOpenable="noReader"
           />
         ) : (
@@ -1494,7 +1494,7 @@ export function TimelineRow({
             summary={entry.emailSummary}
             timestamp={formatTimeOfDay(entry.atIso, locale, zone)}
             onOpen={entry.onOpenEmail}
-            // As above: absent only where the surface mounts no drawer.
+            // As above: absent on the reply composer and nowhere else.
             whyNotOpenable="noReader"
           />
           {flag}

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -1358,6 +1358,10 @@ function TimelineGroupRow({
             summary={newest.emailSummary}
             timestamp={formatTimeOfDay(newest.atIso, locale, zone)}
             onOpen={newest.onOpenEmail}
+            // The entry carries an opener on every surface that mounts a
+            // drawer. Where it does not, the surface itself has no reader to
+            // open into — the Brief is the one such page.
+            whyNotOpenable="noReader"
           />
         ) : (
           <>
@@ -1490,6 +1494,8 @@ export function TimelineRow({
             summary={entry.emailSummary}
             timestamp={formatTimeOfDay(entry.atIso, locale, zone)}
             onOpen={entry.onOpenEmail}
+            // As above: absent only where the surface mounts no drawer.
+            whyNotOpenable="noReader"
           />
           {flag}
         </div>

--- a/frontend/src/design-system/emailentry.test.tsx
+++ b/frontend/src/design-system/emailentry.test.tsx
@@ -98,7 +98,13 @@ afterEach(() => {
 
 describe("EmailEntry", () => {
   it("says who wrote, what about, and whose move it is", () => {
-    wrap(<EmailEntry summary={READABLE} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={READABLE}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     expect(screen.getByText(/Ana Sommer \+2/)).toBeInTheDocument();
     expect(screen.getByText("Angebot Q4")).toBeInTheDocument();
     expect(
@@ -110,7 +116,13 @@ describe("EmailEntry", () => {
   });
 
   it("keeps a withheld row visible and says nothing in it", () => {
-    wrap(<EmailEntry summary={WITHHELD} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={WITHHELD}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     // Visible, so a reader can tell a limited conversation from one that never
     // happened.
     expect(screen.getByText("1 Sep 09:12")).toBeInTheDocument();
@@ -135,7 +147,13 @@ describe("EmailEntry", () => {
   // was every withheld row and every row whose summary carries no
   // counterparty, on every 360 timeline.
   it("never ends the direction on a preposition", () => {
-    wrap(<EmailEntry summary={WITHHELD} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={WITHHELD}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     expect(screen.getByText("Received")).toBeInTheDocument();
     expect(screen.queryByText("Received from")).not.toBeInTheDocument();
   });
@@ -148,6 +166,7 @@ describe("EmailEntry", () => {
       <EmailEntry
         summary={{ ...READABLE, counterparty: "   " }}
         timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
       />,
     );
     expect(screen.getByText("Received")).toBeInTheDocument();
@@ -155,7 +174,13 @@ describe("EmailEntry", () => {
   });
 
   it("says the direction WITH the name when there is one", () => {
-    wrap(<EmailEntry summary={READABLE} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={READABLE}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     // One sentence from one string, so the two forms cannot drift and a
     // locale can put the name where its grammar wants it.
     expect(screen.getByText(/^Received from Ana Sommer/)).toBeInTheDocument();
@@ -169,6 +194,7 @@ describe("EmailEntry", () => {
       <EmailEntry
         summary={{ ...WITHHELD, direction: "outbound" }}
         timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
       />,
     );
     expect(screen.getByText("Sent")).toBeInTheDocument();
@@ -182,7 +208,13 @@ describe("EmailEntry", () => {
   // "email" in an icon alone, so a screen reader was told what happened
   // without being told what kind of thing it was.
   it("announces that the row is an email", () => {
-    wrap(<EmailEntry summary={READABLE} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={READABLE}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     // Asked of the sr-only span itself: "Email" appearing SOMEWHERE on the row
     // would still pass after the announcement was removed.
     expect(
@@ -205,7 +237,13 @@ describe("EmailEntry", () => {
   });
 
   it("is not a control when there is nothing to open", () => {
-    wrap(<EmailEntry summary={READABLE} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={READABLE}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });
@@ -249,7 +287,13 @@ describe("EmailDetail", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     // A row on its own costs nothing: the summary it draws came with the list.
-    wrap(<EmailEntry summary={READABLE} timestamp="1 Sep 09:12" />);
+    wrap(
+      <EmailEntry
+        summary={READABLE}
+        timestamp="1 Sep 09:12"
+        whyNotOpenable="noDetail"
+      />,
+    );
     expect(fetchSpy).not.toHaveBeenCalled();
     cleanup();
 

--- a/frontend/src/design-system/emailentry.tsx
+++ b/frontend/src/design-system/emailentry.tsx
@@ -112,22 +112,44 @@ function rowFields(summary: EmailSummary, t: ReturnType<typeof useT>) {
   };
 }
 
+/**
+ * Why a row does not open, for the two cases where that is the honest answer.
+ *
+ * `noDetail` — the row has no message to open: a thread projection standing
+ * for several messages, or an entry the server gave no activity id.
+ * `noReader` — the surface itself mounts no drawer, so there is nowhere to
+ * open INTO. The Brief is the one such surface.
+ *
+ * Naming the reason is the point. An optional opener could not tell these
+ * apart from a surface that simply forgot to pass one, and a forgotten opener
+ * renders a full-fidelity preview that does nothing — the defect this union
+ * exists to make unwritable.
+ */
+type NoOpenReason = "noDetail" | "noReader";
+
 export function EmailEntry({
   summary,
   timestamp,
-  onOpen,
+  ...opener
 }: Readonly<{
   /** The server's own row model. Nothing here is derived in the browser. */
   summary: EmailSummary;
   /** Formatted by the caller, which owns the reader's timezone. */
   timestamp: string;
-  /**
-   * Opens the canonical detail. Omitted only where there is no detail to open;
-   * a row that looks openable and is not teaches a reader the product does not
-   * work.
-   */
-  onOpen?: () => void;
-}>) {
+}> &
+  Readonly<
+    /**
+     * Openable, or explicitly not — never silently neither.
+     *
+     * A caller threading a callback it cannot guarantee (an optional prop, a
+     * row that may carry no activity id) takes the first branch and states the
+     * fallback reason too: `onOpen` undefined then means what the caller says
+     * it means, rather than meaning nobody thought about it.
+     */
+    | { onOpen: () => void }
+    | { onOpen: undefined; whyNotOpenable: NoOpenReason }
+    | { whyNotOpenable: NoOpenReason }
+  >) {
   const t = useT();
   const { locale } = useLocale();
   const row = rowFields(summary, t);
@@ -166,6 +188,7 @@ export function EmailEntry({
     </>
   );
 
+  const onOpen = "onOpen" in opener ? opener.onOpen : undefined;
   if (!onOpen) {
     return <div className="emailentry">{content}</div>;
   }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1836,7 +1836,6 @@ export const de = {
   "co.recent.emptyDetail":
     "Sobald Sie eine E-Mail senden, einen Anruf festhalten oder sich treffen, steht der Austausch hier, mit dem, was jede Seite getan hat.",
   "co.recent.empty": "Noch nichts mit ihnen erfasst.",
-  "co.recent.viewHistory": "Verlauf ansehen",
   "co.recent.kind.email": "E-Mail",
   "co.recent.kind.call": "Anruf",
   "co.recent.kind.meeting": "Termin",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1888,7 +1888,6 @@ export const en = {
   "co.recent.emptyDetail":
     "Once you send an email, log a call or hold a meeting, the exchange appears here, with who did what on each side.",
   "co.recent.empty": "Nothing logged with them yet.",
-  "co.recent.viewHistory": "View history",
   "co.recent.kind.email": "Email",
   "co.recent.kind.call": "Call",
   "co.recent.kind.meeting": "Meeting",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1824,7 +1824,6 @@ export const vi = {
   "co.recent.emptyDetail":
     "Khi bạn gửi email, ghi lại cuộc gọi hoặc họp, trao đổi đó sẽ xuất hiện ở đây, kèm việc mỗi bên đã làm gì.",
   "co.recent.empty": "Chưa ghi nhận trao đổi nào.",
-  "co.recent.viewHistory": "Xem lịch sử",
   "co.recent.kind.email": "Email",
   "co.recent.kind.call": "Cuộc gọi",
   "co.recent.kind.meeting": "Cuộc họp",

--- a/frontend/src/screens/brief.donext.test.tsx
+++ b/frontend/src/screens/brief.donext.test.tsx
@@ -180,4 +180,38 @@ describe("do next", () => {
     rerender(<DoNext day={undefined} state="failed" />);
     expect(screen.queryByText(en["brief.donext.clear"])).toBeNull();
   });
+
+  // The section draws a waiting message in FULL — sender, subject, preview,
+  // access badge — and shipped with no way to open it: a reader was shown the
+  // message and then refused it. A drawer needs no second column, only a
+  // dialog, so the absence was never about this page's shape.
+  it("opens a waiting message it drew in full", () => {
+    render(
+      <DoNext
+        day={day([
+          item({
+            id: "e1",
+            title: "Aster Handel",
+            email_summary: {
+              activity_id: "01a05500-0000-7000-8000-00000000ee01",
+              occurred_at: "2026-06-09T09:15:00Z",
+              version: 2,
+              subject: "Re: the renewal quote",
+              preview: "Can you hold the price until Friday?",
+              counterparty: "Dana Buyer",
+              direction: "inbound",
+              display_status: "team",
+              move: "needs_reply",
+              attachment_count: 0,
+            },
+          }),
+        ])}
+        state="ready"
+      />,
+    );
+
+    // A control, not a paragraph: the row says it opens a dialog.
+    const row = screen.getByRole("button", { name: /Re: the renewal quote/ });
+    expect(row.getAttribute("aria-haspopup")).toBe("dialog");
+  });
 });

--- a/frontend/src/screens/brief.donext.tsx
+++ b/frontend/src/screens/brief.donext.tsx
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { useState } from "react";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { Panel } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { leadRows, waitingRows } from "./brief.sentence";
 import type { Worklist } from "./worklist.queries";
@@ -41,6 +44,7 @@ export function DoNext({
 }: Readonly<{ day: Worklist | undefined; state: SectionState }>) {
   const t = useT();
   const { locale } = useLocale();
+  const [openEmail, setOpenEmail] = useState<string | null>(null);
   // The optional chain reaches the FIELD, not just the payload. A worklist
   // answer that carried no queue crashed the whole page — the same mistake the
   // team gate above made, and a page that throws is a worse answer than one
@@ -94,6 +98,7 @@ export function DoNext({
                     // No pane and no filter on this surface, so the rank draws
                     // as a number rather than as a control that opens nothing.
                     // WorklistRow leaves both out when they are absent.
+                    onOpenEmail={setOpenEmail}
                   />
                 </li>
               ))}
@@ -101,6 +106,16 @@ export function DoNext({
           )}
         </SurfaceState>
       </Panel>
+      {/* The section's own reader. A waiting row here draws the whole message
+          — sender, subject, preview, access badge — and a row that shows a
+          reader the message and refuses to open it is the defect this mount
+          removes. One drawer for the section, at its level rather than inside
+          a row, so two rows can never mount two dialogs. */}
+      <OpenEmailDrawer
+        activityId={openEmail}
+        zone={viewerZone()}
+        onClose={() => setOpenEmail(null)}
+      />
     </section>
   );
 }

--- a/frontend/src/screens/company/glance.test.tsx
+++ b/frontend/src/screens/company/glance.test.tsx
@@ -3,9 +3,14 @@
 
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
-import { MoneyPane } from "./glance";
+import { MoneyPane, ThreadFold } from "./glance";
+
+type Organization360 = components["schemas"]["Organization360"];
+type Activity = components["schemas"]["Activity"];
 
 afterEach(cleanup);
 
@@ -42,5 +47,92 @@ describe("the money pane's projects group", () => {
     drawMoney(false);
     expect(screen.queryByRole("button", { name: "Attach project" })).toBeNull();
     expect(screen.queryByText("No projects yet")).toBeNull();
+  });
+});
+
+// The fold draws the account's messages in FULL — sender, subject, preview,
+// access badge — so a reader who can see the message expects to open it. It
+// shipped without an opener, which is the one failure a full-fidelity preview
+// must not have: the row said "there is a message here" and answered nothing.
+describe("the folded thread on the account's 360", () => {
+  const EMAIL_ID = "01a05500-0000-7000-8000-00000000dd01";
+
+  const emailRow: Activity = {
+    id: EMAIL_ID,
+    kind: "email",
+    occurred_at: "2026-08-29T09:15:00Z",
+    subject: "Re: the renewal quote",
+    body: "Can you hold the price until Friday?",
+    direction: "inbound",
+    content_state: "available",
+    source: "manual",
+    captured_by: "human:u-1",
+    created_at: "2026-08-29T09:15:00Z",
+    updated_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    is_done: false,
+    email_summary: {
+      activity_id: EMAIL_ID,
+      occurred_at: "2026-08-29T09:15:00Z",
+      version: 4,
+      subject: "Re: the renewal quote",
+      preview: "Can you hold the price until Friday?",
+      counterparty: "Dana Buyer",
+      direction: "inbound",
+      display_status: "team",
+      move: "needs_reply",
+      attachment_count: 0,
+    },
+  };
+
+  function threadView(): Organization360 {
+    return {
+      as_of: "2026-08-29T10:00:00Z",
+      organization: {
+        id: "o-1",
+        name: "Nordwind Logistik",
+        display_name: "Nordwind Logistik",
+        source: "manual",
+        captured_by: "human:u-1",
+        version: 1,
+        created_at: "2026-01-05T09:00:00Z",
+        updated_at: "2026-08-29T09:15:00Z",
+      },
+      activities: { data: [emailRow], page: { has_more: false } },
+      sections_omitted: [],
+    };
+  }
+
+  function drawThread(onOpenRecord?: (kind: string, id: string) => void) {
+    return render(
+      <LocaleProvider initial="en">
+        <ThreadFold
+          view={threadView()}
+          loading={false}
+          onOpenRecord={onOpenRecord}
+        />
+      </LocaleProvider>,
+    );
+  }
+
+  it("opens the message it shows, through the page's own router", async () => {
+    const user = userEvent.setup();
+    const onOpenRecord = vi.fn();
+    drawThread(onOpenRecord);
+
+    // The row is a control, not a paragraph — the distinction the defect erased.
+    const row = screen.getByRole("button", { name: /Re: the renewal quote/ });
+    expect(row.getAttribute("aria-haspopup")).toBe("dialog");
+    await user.click(row);
+
+    // The same door every cited chip on this account takes, so the fold cannot
+    // drift from the spine beside it.
+    expect(onOpenRecord).toHaveBeenCalledWith("activity", EMAIL_ID);
+  });
+
+  it("still draws the message when the host mounts no reader", () => {
+    drawThread(undefined);
+    expect(screen.getByText("Re: the renewal quote")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /renewal quote/ })).toBeNull();
   });
 });

--- a/frontend/src/screens/company/glance.tsx
+++ b/frontend/src/screens/company/glance.tsx
@@ -39,10 +39,15 @@ export function ThreadFold({
   view,
   loading,
   onOpenHistory,
+  onOpenRecord,
 }: Readonly<{
   view?: Organization360;
   loading: boolean;
   onOpenHistory?: () => void;
+  // The page's own router, the same door the spine above this fold takes. The
+  // fold draws the account's messages in full — sender, subject, preview — so
+  // without this it shows a reader the message and refuses to open it.
+  onOpenRecord?: (entityType: string, entityId: string) => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -67,6 +72,7 @@ export function ThreadFold({
           <CompanyRecentList
             activities={logged.slice(0, THREAD_LIMIT)}
             nameOf={recordNamesIn(view)}
+            onOpenRecord={onOpenRecord}
           />
         ) : (
           <PanelBody>

--- a/frontend/src/screens/company360.stories.tsx
+++ b/frontend/src/screens/company360.stories.tsx
@@ -7,7 +7,6 @@ import {
   CommercialPanel,
   DealsCard,
   NextSteps,
-  RecentActivityPanel,
   StateStrip,
 } from "./company360";
 import { CompanyContractState } from "./companycommercial";
@@ -357,7 +356,6 @@ function Cards({ view }: Readonly<{ view: View }>) {
           view={view}
           extra={<CompanyContractState view={view} />}
         />
-        <RecentActivityPanel view={view} />
         <DealsCard view={view} />
         <NextSteps view={view} />
       </div>

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -6,7 +6,6 @@ import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge, Button, Skeleton, StatCard } from "../design-system/atoms";
-import { type TimelineEntry, TimelineRow } from "../design-system/composed";
 import { Eyebrow } from "../design-system/eyebrow";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import {
@@ -40,12 +39,10 @@ import {
   problemMessageOf,
   throwProblem,
   useFinanceSummary,
-  useViewerId,
 } from "./common";
 import type { CompanyTab } from "./companytab";
 import { dealsFilteredBy } from "./dealsaddress";
 import "./company360.css";
-import { activityTimeline } from "../design-system/activitytimeline";
 import { FactList } from "../design-system/factlist";
 import { HEALTH_DIMENSION_LABEL, HEALTH_RATING_LABEL } from "./companylookups";
 import { EntityRef } from "./entityref";
@@ -493,129 +490,6 @@ function CommercialFigure({
           missing rather than a shorter row that reads as complete. */}
       <span className="co-figure-value">{value}</span>
     </div>
-  );
-}
-
-// How many entries the overview's chronology carries. The full history is the
-// History tab; this is "what happened lately" without leaving Overview.
-const RECENT_ACTIVITY_LIMIT = 5;
-
-// One run of the timeline under the day it happened. Consecutive rather than
-// grouped-by-key, because `entries` arrives newest-first from the server and a
-// day is never revisited later in the same page.
-type ActivityDay = { key: string; entries: TimelineEntry[] };
-
-function groupByDay(
-  entries: readonly TimelineEntry[],
-  locale: Locale,
-  recordZone: string,
-) {
-  const days: ActivityDay[] = [];
-  for (const entry of entries) {
-    const key = formatDate(entry.atIso, locale, recordZone);
-    const last = days.at(-1);
-    if (last?.key === key) {
-      last.entries.push(entry);
-    } else {
-      days.push({ key, entries: [entry] });
-    }
-  }
-  return days;
-}
-
-/**
- * RecentActivityPanel is the overview's chronology: the same activities
- * section the rail used to carry, grouped under the day they happened rather
- * than as a flat list — a day is one thing that happened, several messages
- * are how it happened.
- *
- * Reads the SAME activities section the account's Suggestions and health
- * cards read, so the story here cannot disagree with what they cite.
- */
-export function RecentActivityPanel({
-  view,
-  onOpenHistory,
-  loading = false,
-  bare = false,
-}: Readonly<{
-  view?: Organization360;
-  // Where the header's link leads. Absent for a caller with no History tab
-  // of its own (the stories file).
-  onOpenHistory?: () => void;
-  // The composite read's own pending flag — see sectionState's own doc.
-  loading?: boolean;
-  // Render the BODY without this card's own header band, for a caller that
-  // holds the Panel itself and labels the section. One implementation, two
-  // mounts: the Deals tab still draws the whole card, and the Company 360
-  // card draws this section inside its own chrome — a second copy of the
-  // timeline is how two surfaces come to disagree about what happened.
-  bare?: boolean;
-}>) {
-  const t = useT();
-  const { locale } = useLocale();
-  const viewerId = useViewerId();
-  const recordZone = useRecordZone();
-  // Every logged activity, not only the ones with a subject: a call or a note
-  // often has none, and filtering them out here would under-report the
-  // chronology and — because the count feeds sectionState — draw "nothing
-  // logged with them yet" on an account that has been called five times.
-  const logged = view?.activities?.data ?? [];
-  const state = sectionState(
-    view,
-    "activities",
-    Boolean(view?.activities),
-    logged.length,
-    loading,
-  );
-  const days = groupByDay(
-    activityTimeline(logged.slice(0, RECENT_ACTIVITY_LIMIT), viewerId),
-    locale,
-    recordZone,
-  );
-  const body =
-    state === "ready" ? (
-      days.map((day) => (
-        <div key={day.key} className="co-timeline-day">
-          {/* One level under whatever names this timeline: the card's own
-              title when it stands alone, the section subhead when it is a
-              section of the Company 360 card. */}
-          <Eyebrow as={bare ? "h4" : "h3"} className="co-timeline-day-heading">
-            {day.key}
-          </Eyebrow>
-          <ul className="timeline">
-            {day.entries.map((entry) => (
-              <TimelineRow key={entry.id} entry={entry} zone={recordZone} />
-            ))}
-          </ul>
-        </div>
-      ))
-    ) : (
-      <PanelBody>
-        <SurfaceState
-          state={state}
-          emptyLabel={t("co.recent.empty")}
-          loadingLabel={t("co.recent.title")}
-        >
-          {null}
-        </SurfaceState>
-      </PanelBody>
-    );
-  if (bare) {
-    return <>{body}</>;
-  }
-  return (
-    <Panel
-      title={t("co.recent.title")}
-      titleAction={
-        onOpenHistory && (
-          <Button small variant="ghost" onClick={onOpenHistory}>
-            {t("co.recent.viewHistory")}
-          </Button>
-        )
-      }
-    >
-      {body}
-    </Panel>
   );
 }
 

--- a/frontend/src/screens/companyrecent.tsx
+++ b/frontend/src/screens/companyrecent.tsx
@@ -175,6 +175,9 @@ function RecentRow({
                 ? () => onOpenRecord("activity", activity.id)
                 : undefined
             }
+            // Absent only for a host that mounts no drawer. Every account
+            // surface that draws this list routes `activity` to the reader.
+            whyNotOpenable="noReader"
           />
         ) : (
           <>

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -2439,6 +2439,7 @@ function CompanyOverviewStack({
             view={view}
             loading={loading}
             onOpenHistory={onOpenHistory}
+            onOpenRecord={onOpenRecord}
           />
         </Company360Call>
       )}

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -108,6 +108,11 @@ export function PersonMemory({
               summary={row.emailSummary}
               timestamp={row.time}
               onOpen={openerFor(row, onOpenEmail)}
+              // `openerFor` withholds an opener on two honest grounds: a page
+              // that mounts no drawer, and a row the projection gave no
+              // activity id. The second is the narrower claim, so it is the
+              // one stated.
+              whyNotOpenable="noDetail"
             />
           ) : (
             <span>

--- a/frontend/src/screens/worklist.emailtitle.tsx
+++ b/frontend/src/screens/worklist.emailtitle.tsx
@@ -37,11 +37,13 @@ export function WaitingEmailLine({
 }: Readonly<{
   item: WorklistItem;
   /**
-   * Opens the message. Omitted on a surface with no drawer to open it into —
-   * the row then shows the message and does not pretend to open it, which is
-   * better than a control that answers nothing.
+   * Opens the message. REQUIRED: this line draws the whole message — sender,
+   * subject, preview, access badge — so a surface that draws it and cannot
+   * open it shows a reader something and then refuses it. Both surfaces that
+   * draw a waiting row mount a drawer; a surface that cannot should not draw
+   * this line at all.
    */
-  onOpen?: (activityId: string) => void;
+  onOpen: (activityId: string) => void;
 }>) {
   const { locale } = useLocale();
   const summary = item.email_summary;
@@ -52,7 +54,7 @@ export function WaitingEmailLine({
     <EmailEntry
       summary={summary}
       timestamp={formatDateTime(summary.occurred_at, locale, viewerZone())}
-      onOpen={onOpen ? () => onOpen(summary.activity_id) : undefined}
+      onOpen={() => onOpen(summary.activity_id)}
     />
   );
 }

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -123,11 +123,11 @@ export function WorklistRow({
     .filter((phrase): phrase is string => phrase !== null);
   const above = comparisonText(item.above_next, t, locale, zone);
   const consequence = consequenceText(item, t);
-  // Whether this row NAMES ITSELF with the canonical email row. It needs both
-  // the summary and somewhere to open it: the line is only drawn when it can
-  // be opened, so a caller with no drawer must fall back to the title line
-  // below rather than losing the row's name along with its opener.
-  const emailRow = item.email_summary != null && onOpenEmail !== undefined;
+  // How this row NAMES ITSELF: the canonical email row when there is a message
+  // AND somewhere to open it, the title line otherwise. Held as the opener
+  // rather than as a flag, so the row cannot be drawn without one — a caller
+  // with no drawer keeps the title instead of losing the row's name with it.
+  const emailOpener = item.email_summary != null ? onOpenEmail : undefined;
   return (
     <PanelRow
       className={
@@ -146,11 +146,9 @@ export function WorklistRow({
             sentence about it. Everything else keeps the title line it had, and
             the badges below stay on both: they say where the row sits in the
             day, which the email row does not answer. */}
-        {emailRow && onOpenEmail && (
-          <WaitingEmailLine item={item} onOpen={onOpenEmail} />
-        )}
+        {emailOpener && <WaitingEmailLine item={item} onOpen={emailOpener} />}
         <p className="t-body worklist-row-title">
-          {emailRow ? null : href ? (
+          {emailOpener ? null : href ? (
             <a className="entity-link" href={href}>
               {title}
             </a>

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -90,9 +90,12 @@ export function WorklistRow({
   // Where a grouped row is reviewed. Also a filter change the Brief cannot
   // make: it shows a fixed cut and has no filter to move.
   onReview?: () => void;
-  // Opens a waiting email. Absent on a surface with no drawer — the Brief
-  // draws the message and does not offer to open it, rather than drawing a
-  // control that answers nothing.
+  // Opens a waiting email. Unlike the pane above, this one is carried by every
+  // surface that draws a waiting row, the Brief included: a drawer needs no
+  // second column, only a dialog, and the row draws the whole message —
+  // sender, subject, preview, access badge. A row that shows a reader the
+  // message and refuses to open it teaches them the product does not work.
+  // Optional only for a caller that draws no waiting row at all.
   onOpenEmail?: (activityId: string) => void;
 }>) {
   const t = useT();
@@ -120,7 +123,11 @@ export function WorklistRow({
     .filter((phrase): phrase is string => phrase !== null);
   const above = comparisonText(item.above_next, t, locale, zone);
   const consequence = consequenceText(item, t);
-  const emailRow = item.email_summary != null;
+  // Whether this row NAMES ITSELF with the canonical email row. It needs both
+  // the summary and somewhere to open it: the line is only drawn when it can
+  // be opened, so a caller with no drawer must fall back to the title line
+  // below rather than losing the row's name along with its opener.
+  const emailRow = item.email_summary != null && onOpenEmail !== undefined;
   return (
     <PanelRow
       className={
@@ -139,7 +146,9 @@ export function WorklistRow({
             sentence about it. Everything else keeps the title line it had, and
             the badges below stay on both: they say where the row sits in the
             day, which the email row does not answer. */}
-        <WaitingEmailLine item={item} onOpen={onOpenEmail} />
+        {emailRow && onOpenEmail && (
+          <WaitingEmailLine item={item} onOpen={onOpenEmail} />
+        )}
         <p className="t-body worklist-row-title">
           {emailRow ? null : href ? (
             <a className="entity-link" href={href}>


### PR DESCRIPTION
An email preview and the reader that opens it were wired together on almost every surface and silently apart on three. `EmailEntry` rendered an inert `div` when its opener was undefined and a `button` when it was not, with identical pixels either way — so a surface that forgot to pass one drew a full-fidelity message (sender, subject, preview, access badge) that answered nothing when clicked.

The component's own doc comment already named the failure: *"a row that looks openable and is not teaches a reader the product does not work."*

## The reported case

The company 360's folded thread. Its host mounts the drawer, and the record spine directly beside it routes an activity to that drawer — but `ThreadFold` had no `onOpenRecord` prop at all, so the fold could not reach the door its sibling was already using.

## What changed

**`EmailEntry`'s props became a union.** Either an opener, or a named reason there is none: `noDetail` for a row with no message to open, `noReader` for a surface that mounts no dialog. Omitting both is now a compile error, which is what makes the two honest cases distinguishable from an oversight rather than identical to one.

**The Daily Brief was the honest `noReader` case and is no longer one.** A drawer needs a dialog, not a second column, so the section mounts its own and `WaitingEmailLine`'s opener became required. `WorklistRow` now holds the opener rather than a flag, so the canonical email row cannot be drawn without somewhere to open it and a caller with no drawer keeps its title line instead of losing the row's name along with its opener.

**`RecentActivityPanel` carried the same defect and no longer had a mount** outside its stories file — the Company 360 card it names as its second mount draws `ThreadFold` now. Deleted rather than wired, along with the `co.recent.viewHistory` key its header owned.

## Verified in the browser

On a seeded dev stack, not only in tests:

- Company page: all three email rows are `button`s with `aria-haspopup="dialog"`; clicking opens the reader with the same body the person page shows for the same message.
- Daily Brief: the waiting message opens.
- Worklist and Brief: zero inert email rows, and no row left without a name.

## Tests

Both new tests were mutation-checked — each fails with its own fix reverted and passes with it restored. The i18n orphan gate caught the now-unused translation key from the deletion, which is the gate doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes every email row that draws a full message openable. Some surfaces rendered a full preview — sender, subject, access badge — that answered nothing when clicked; the company 360 folded thread and the Daily Brief could not open the reader at all.

**Bug Fixes**
- `EmailEntry` now requires either an `onOpen` callback or a named `whyNotOpenable` reason; omitting both is a compile error.
- The folded thread on the company 360 accepts `onOpenRecord` and routes to the same drawer as the record spine beside it.
- The Daily Brief mounts its own open-email drawer, and `WaitingEmailLine` now requires an opener.
- `WorklistRow` holds the opener instead of a flag, so a caller without a drawer keeps a title line rather than a dead row.
- Deleted `RecentActivityPanel`, which had no mount left outside stories, with its `co.recent.viewHistory` translation key.

<sup>Written for commit 565db946699afaff8f372c741dc4938377acc16e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waiting emails in the Brief worklist can now open in a dialog.
  * Email activity in company threads and cited records can open through the shared record viewer.
* **Bug Fixes**
  * Improved handling and accessibility of email rows that cannot be opened, with clearer non-interactive states.
  * Person memory and timeline entries now accurately indicate when no detail or reader is available.
* **Removals**
  * Removed the Recent Activity chronology panel from company pages.
  * Removed the “View history” translation from supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->