### PR TITLE
run_report advertises every aggregate the engine answers

### DIFF
--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -462,19 +462,26 @@ func renderPredicates(preds []boundPredicate) string {
 }
 
 func aggregatePhrase(agg reportAggregate) (string, error) {
+	// Keyed off the engine's own constants, and covering ALL of them. This map
+	// once listed five of seven as bare strings, so stage-age and win-loss
+	// minted derivation links whose default percentile aggregates this very
+	// function then refused. TestEveryEngineAggregateRendersAPhrase holds the
+	// two sides equal in both directions.
 	verbs := map[string]string{
-		"count": "the number of matching records",
-		"sum":   "the sum of",
-		"avg":   "the average of",
-		"min":   "the minimum of",
-		"max":   "the maximum of",
+		aggFnCount:  "the number of matching records",
+		aggFnSum:    "the sum of",
+		aggFnAvg:    "the average of",
+		aggFnMin:    "the minimum of",
+		aggFnMax:    "the maximum of",
+		aggFnMedian: "the median of",
+		aggFnP75:    "the 75th percentile of",
 	}
 	verb, ok := verbs[agg.Fn]
 	if !ok {
 		return "", &FieldNotAllowedError{Field: "fn=" + agg.Fn}
 	}
 	phrase := verb
-	if agg.Fn != "count" {
+	if agg.Fn != aggFnCount {
 		phrase += " " + agg.Field
 	}
 	if agg.As != "" {

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -462,11 +462,10 @@ func renderPredicates(preds []boundPredicate) string {
 }
 
 func aggregatePhrase(agg reportAggregate) (string, error) {
-	// Keyed off the engine's own constants, and covering ALL of them. This map
-	// once listed five of seven as bare strings, so stage-age and win-loss
-	// minted derivation links whose default percentile aggregates this very
-	// function then refused. TestEveryEngineAggregateRendersAPhrase holds the
-	// two sides equal in both directions.
+	// Keyed off the engine's own constants and covering ALL of them: five of
+	// seven as bare strings once left the percentile defaults of stage-age and
+	// win-loss minting links this very function then refused. Held equal to the
+	// engine by TestEveryEngineAggregateRendersAPhrase.
 	verbs := map[string]string{
 		aggFnCount:  "the number of matching records",
 		aggFnSum:    "the sum of",

--- a/backend/internal/compose/derivation_test.go
+++ b/backend/internal/compose/derivation_test.go
@@ -80,7 +80,7 @@ func TestRenderDefinitionTellsUnsetApartFromEmptyText(t *testing.T) {
 
 func TestRenderDefinitionRejectsUnknownAggregate(t *testing.T) {
 	_, err := renderDefinition(prebuiltReports["forecast"], nil, nil,
-		[]reportAggregate{{Fn: "median", Field: "amount_minor"}})
+		[]reportAggregate{{Fn: "p90", Field: "amount_minor"}})
 	var notAllowed *FieldNotAllowedError
 	if !errors.As(err, &notAllowed) {
 		t.Fatalf("unknown fn → %v, want FieldNotAllowedError", err)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -170,7 +170,9 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// call was staged in. Nothing here decides anything the person behind the
 	// passport could not decide in the app.
 	agents.RegisterApprovalTools(registry, approvalQueue(approvalsSvc))
-	agents.RegisterReportTool(registry, nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))), reportToolCatalog())
+	agents.RegisterReportTool(registry,
+		nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))),
+		reportToolCatalog(), reportPlanVocabulary())
 	// The vocabulary that plan is written in, as a TOOL and not only as the
 	// margince://schema/reports resource — same reason describe_query_vocabulary
 	// exists next to query_workspace, and one reason more: the Surface-B runner

--- a/backend/internal/compose/reportcatalog.go
+++ b/backend/internal/compose/reportcatalog.go
@@ -160,3 +160,21 @@ func unservedPlanArguments(planArgs json.RawMessage) []string {
 	slices.Sort(unserved)
 	return unserved
 }
+
+// reportPlanVocabulary is what the engine accepts from a plan beyond the
+// per-report names: the aggregate functions.
+//
+// DERIVED from the engine's own vocabulary for the reason the catalog above is.
+// The tool listed these five by hand, and when the engine grew median and p75
+// the list stayed at five — so stage-age and win-loss came to DEFAULT to a
+// percentile that no agent could ask for, and nothing failed, because a
+// hand-written list cannot notice what it does not contain.
+//
+// Sorted, so the rendered schema is byte-stable across processes.
+func reportPlanVocabulary() agents.ReportPlanVocabulary {
+	functions := []string{
+		aggFnCount, aggFnSum, aggFnAvg, aggFnMin, aggFnMax, aggFnMedian, aggFnP75,
+	}
+	slices.Sort(functions)
+	return agents.ReportPlanVocabulary{Functions: functions}
+}

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -380,50 +380,40 @@ func TestThePublishedAggregateFunctionsAreTheOnesTheEngineSwitchesOn(t *testing.
 	}
 }
 
+// Every function the engine switches on renders a derivation phrase.
+//
+// aggregatePhrase is the second hand-written spelling of this closed set the
+// tree grew: it too listed five of seven, so the product minted derivation
+// links for stage-age and win-loss whose default percentile aggregates its own
+// resolver then refused with a 422.
+func TestEveryEngineAggregateRendersAPhrase(t *testing.T) {
+	t.Parallel()
+	engine := aggregateFunctionsInSource(t)
+	if len(engine) == 0 {
+		t.Fatal("read no aggregate functions out of aggregateSelect — the scan is " +
+			"looking in the wrong place, and would prove nothing over an empty set")
+	}
+	for _, fn := range engine {
+		if _, err := aggregatePhrase(reportAggregate{Fn: fn, Field: "days_in_stage"}); err != nil {
+			t.Errorf("the engine answers fn=%q and aggregatePhrase refuses it: %v. "+
+				"Every report row's derivation link renders through that phrase, so "+
+				"a report defaulting to this function mints links it cannot follow.", fn, err)
+		}
+	}
+}
+
 // aggregateFunctionsInSource reads the case values of aggregateSelect's switch
-// — the closed set the engine actually implements.
+// — the closed set the engine actually implements. One parse serves both the
+// aggFn* constant table and the switch walk. A case spelled as a bare string
+// literal FAILS the census rather than shrinking it: a scan that silently read
+// a smaller switch would report agreement between two smaller sets.
 func aggregateFunctionsInSource(t *testing.T) []string {
 	t.Helper()
 	file, err := parser.ParseFile(token.NewFileSet(), "report.go", nil, parser.SkipObjectResolution)
 	if err != nil {
 		t.Fatalf("parsing report.go: %v", err)
 	}
-	constants := aggregateFunctionConstants(t)
-	var out []string
-	ast.Inspect(file, func(n ast.Node) bool {
-		fn, ok := n.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "aggregateSelect" {
-			return true
-		}
-		ast.Inspect(fn.Body, func(inner ast.Node) bool {
-			clause, ok := inner.(*ast.CaseClause)
-			if !ok {
-				return true
-			}
-			for _, expr := range clause.List {
-				if name, ok := expr.(*ast.Ident); ok {
-					if value, isAggregate := constants[name.Name]; isAggregate {
-						out = append(out, value)
-					}
-				}
-			}
-			return true
-		})
-		return false
-	})
-	slices.Sort(out)
-	return out
-}
-
-// aggregateFunctionConstants maps each aggFn* identifier to the wire word it
-// holds, so the switch's case names resolve to what a caller writes.
-func aggregateFunctionConstants(t *testing.T) map[string]string {
-	t.Helper()
-	file, err := parser.ParseFile(token.NewFileSet(), "report.go", nil, parser.SkipObjectResolution)
-	if err != nil {
-		t.Fatalf("parsing report.go: %v", err)
-	}
-	out := map[string]string{}
+	constants := map[string]string{}
 	ast.Inspect(file, func(n ast.Node) bool {
 		spec, ok := n.(*ast.ValueSpec)
 		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
@@ -437,9 +427,38 @@ func aggregateFunctionConstants(t *testing.T) map[string]string {
 			if err != nil {
 				t.Fatalf("unquoting %s: %v", spec.Names[0].Name, err)
 			}
-			out[spec.Names[0].Name] = value
+			constants[spec.Names[0].Name] = value
 		}
 		return true
 	})
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "aggregateSelect" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			clause, ok := inner.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				switch e := expr.(type) {
+				case *ast.Ident:
+					if value, isAggregate := constants[e.Name]; isAggregate {
+						out = append(out, value)
+					}
+				case *ast.BasicLit:
+					if e.Kind == token.STRING {
+						t.Errorf("aggregateSelect cases %s as a bare literal; use an "+
+							"aggFn* constant so the published vocabulary derives from it", e.Value)
+					}
+				}
+			}
+			return true
+		})
+		return false
+	})
+	slices.Sort(out)
 	return out
 }

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -6,7 +6,11 @@ package compose
 import (
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -339,4 +343,103 @@ func TestAFilterRefusalNamesTheThresholdsToo(t *testing.T) {
 	if thresholded == 0 {
 		t.Fatal("no prebuilt report declares a threshold, so this test proved nothing")
 	}
+}
+
+// The published aggregate functions are the ones aggregateSelect switches on.
+//
+// This is the gap that made the change: the tool listed five by hand, the
+// engine grew median and p75, and nothing noticed — so stage-age and win-loss
+// came to DEFAULT to a percentile no agent could ask for, while the HTTP path
+// accepted it happily.
+//
+// The engine's side is read from aggregateSelect's own source rather than from
+// a list beside it. A list would be a third spelling of the same closed set,
+// free to drift from the switch exactly as the tool's enum did — and this test
+// would then compare two copies of the mistake.
+func TestThePublishedAggregateFunctionsAreTheOnesTheEngineSwitchesOn(t *testing.T) {
+	t.Parallel()
+	engine := aggregateFunctionsInSource(t)
+	if len(engine) == 0 {
+		t.Fatal("read no aggregate functions out of aggregateSelect — the scan is " +
+			"looking in the wrong place, and would report agreement between two empty sets")
+	}
+	published := reportPlanVocabulary().Functions
+
+	for _, fn := range engine {
+		if !slices.Contains(published, fn) {
+			t.Errorf("the engine accepts fn=%q and run_report does not publish it. "+
+				"An agent cannot ask for a function it is never told about, however "+
+				"willingly the engine would answer.", fn)
+		}
+	}
+	for _, fn := range published {
+		if !slices.Contains(engine, fn) {
+			t.Errorf("run_report publishes fn=%q and the engine refuses it. A caller "+
+				"reading the schema would spend a call to learn that.", fn)
+		}
+	}
+}
+
+// aggregateFunctionsInSource reads the case values of aggregateSelect's switch
+// — the closed set the engine actually implements.
+func aggregateFunctionsInSource(t *testing.T) []string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "report.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing report.go: %v", err)
+	}
+	constants := aggregateFunctionConstants(t)
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "aggregateSelect" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			clause, ok := inner.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				if name, ok := expr.(*ast.Ident); ok {
+					if value, isAggregate := constants[name.Name]; isAggregate {
+						out = append(out, value)
+					}
+				}
+			}
+			return true
+		})
+		return false
+	})
+	slices.Sort(out)
+	return out
+}
+
+// aggregateFunctionConstants maps each aggFn* identifier to the wire word it
+// holds, so the switch's case names resolve to what a caller writes.
+func aggregateFunctionConstants(t *testing.T) map[string]string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "report.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing report.go: %v", err)
+	}
+	out := map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
+			return true
+		}
+		if !strings.HasPrefix(spec.Names[0].Name, "aggFn") {
+			return true
+		}
+		if lit, ok := spec.Values[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatalf("unquoting %s: %v", spec.Names[0].Name, err)
+			}
+			out[spec.Names[0].Name] = value
+		}
+		return true
+	})
+	return out
 }

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -177,7 +177,7 @@ func fullRegistry(t *testing.T) *Registry {
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
 	RegisterCoreTools(r, nil, nil, nil, nil, nil, nil)
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, nil })
-	RegisterReportTool(r, nil, probeReportCatalog)
+	RegisterReportTool(r, nil, probeReportCatalog, probeReportPlan)
 	RegisterAnalyticsReportTool(r, nil)
 	RegisterReportBlocksTool(r, NewReportBlocksResource(BlockGrammar{}))
 	RegisterForecastTool(r, nil)
@@ -705,6 +705,14 @@ var probeReportCatalog = []ReportCatalogEntry{{
 	Aggregates: []string{"amount_minor"},
 	Defaults:   "count as deals grouped by stage_id",
 }}
+
+// probeReportPlan stands in for the engine's plan vocabulary, and carries the
+// REAL function names for the reason the catalog above carries a real entry:
+// an empty set takes the branch that omits the enum, so a registry built on
+// nil would conformance-check a schema no deployment serves.
+var probeReportPlan = ReportPlanVocabulary{
+	Functions: []string{"avg", "count", "max", "median", "min", "p75", "sum"},
+}
 
 // A result that misses its own declared schema is OUR defect, and the client
 // must not be handed structuredContent that violates what this server just

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -240,7 +240,7 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, errSeamReached })
 	RegisterReportTool(r, func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached
-	}, probeReportCatalog)
+	}, probeReportCatalog, probeReportPlan)
 	RegisterAnalyticsReportTool(r, func(context.Context, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached
 	})

--- a/backend/internal/modules/agents/tools_report.go
+++ b/backend/internal/modules/agents/tools_report.go
@@ -56,13 +56,14 @@ type ReportCatalogEntry struct {
 // vocabularies were documented as "the report's vocabulary" — a phrase naming
 // something no tool on this surface yielded. A caller had to guess a key, then
 // guess the words that key accepts, and read a refusal for each miss.
-func RegisterReportTool(r *Registry, run ReportRunner, catalog []ReportCatalogEntry) {
-	r.Register(runReport{run: run, catalog: catalog})
+func RegisterReportTool(r *Registry, run ReportRunner, catalog []ReportCatalogEntry, plan ReportPlanVocabulary) {
+	r.Register(runReport{run: run, catalog: catalog, plan: plan})
 }
 
 type runReport struct {
 	run     ReportRunner
 	catalog []ReportCatalogEntry
+	plan    ReportPlanVocabulary
 }
 
 func (t runReport) Spec() mcp.ToolSpec {
@@ -76,13 +77,47 @@ func (t runReport) Spec() mcp.ToolSpec {
 			"filters":{"type":"object","description":"Equality predicates keyed by this report's filter names — {\"owner_id\":\"<uuid>\"}. A key outside the report's list is refused."},
 			"group_by":{"type":"array","items":{"type":"string"},"description":"Dimension names from this report's list. Omit for the report's own default grouping."},
 			"aggregates":{"type":"array","items":{"type":"object","required":["fn"],"properties":{
-				"fn":{"type":"string","enum":["count","sum","avg","min","max"]},
+				"fn":` + aggregateFunctionProperty(t.plan.Functions) + `,
 				"field":{"type":"string","description":"A measure name from this report's list. Omit only with fn=count."},
 				"as":{"type":"string","description":"Output column name for this aggregate"}},"additionalProperties":false},
 				"description":"Omit for the report's own default aggregates."}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[RunReportResult](),
 	}
+}
+
+// ReportPlanVocabulary is what the engine accepts from a plan BEYOND the
+// per-report names: the aggregate functions, which are the same for every
+// report because the engine applies them rather than a spec declaring them.
+//
+// Handed over rather than restated here, for the reason the catalog is. The
+// list was written out in this file once, and the engine grew median and p75
+// without it — so two reports came to DEFAULT to a percentile no agent could
+// ask for, because the only document naming the functions listed five of seven.
+type ReportPlanVocabulary struct {
+	// Functions are the aggregate names, sorted by the producer so the
+	// rendered schema is byte-stable across processes — a schema that
+	// reshuffles per boot reads as a changed tool to a client that caches it.
+	Functions []string
+}
+
+// aggregateFunctionProperty renders the `fn` argument, closed to the functions
+// the ENGINE implements.
+//
+// An empty set omits the enum for the reason reportProperty does: `"enum":[]`
+// is a schema no value can satisfy, so it would advertise an argument nothing
+// can fill.
+func aggregateFunctionProperty(functions []string) string {
+	const described = `"type":"string","description":"How to aggregate the field. ` +
+		`count takes no field; every other function names one from this report's aggregates list."`
+	if len(functions) == 0 {
+		return "{" + described + "}"
+	}
+	quoted := make([]string, 0, len(functions))
+	for _, fn := range functions {
+		quoted = append(quoted, jsonString(fn))
+	}
+	return `{"enum":[` + strings.Join(quoted, ",") + `],` + described + `}`
 }
 
 // reportProperty renders the `report` argument, closing it to the catalog's own

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,7 +6,7 @@
   "catalog": {
     "tools": 72,
     "system_frame_tokens": 353,
-    "tokens": 20981,
+    "tokens": 21018,
     "median_tool_tokens": 262,
     "mean_tool_tokens": 291
   },
@@ -72,7 +72,7 @@
   "tool_cost": [
     {
       "name": "run_report",
-      "tokens": 880
+      "tokens": 917
     },
     {
       "name": "preview_import",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 6% | 15774 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2467 | 10% | 14941 | 15 | 8 |
-| _whole served catalog, for scale_ | 72 | 20981 | 85% | — | — | — |
+| _whole served catalog, for scale_ | 72 | 21018 | 85% | — | — | — |
 
 ### `morning_brief`
 
@@ -138,7 +138,7 @@ a term in an addition.
 
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
-| `run_report` | 880 | 3 scenarios |
+| `run_report` | 917 | 3 scenarios |
 | `preview_import` | 677 | — |
 | `send_account_email` | 655 | — |
 | `log_activity` | 635 | 1 scenario |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 72,
     "resources": 11,
-    "tool_catalog_bytes": 204796,
+    "tool_catalog_bytes": 204944,
     "resource_catalog_bytes": 4251,
-    "approx_wire_tokens_total": 52261,
+    "approx_wire_tokens_total": 52298,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 49898,
-      "input_schema_bytes": 41692,
+      "input_schema_bytes": 41840,
       "output_schema_bytes": 97659,
-      "description_plus_input_schema_bytes": 91590
+      "description_plus_input_schema_bytes": 91738
     }
   },
   "tools": {
@@ -11426,12 +11426,15 @@
                     "type": "string"
                   },
                   "fn": {
+                    "description": "How to aggregate the field. count takes no field; every other function names one from this report's aggregates list.",
                     "enum": [
-                      "count",
-                      "sum",
                       "avg",
+                      "count",
+                      "max",
+                      "median",
                       "min",
-                      "max"
+                      "p75",
+                      "sum"
                     ],
                     "type": "string"
                   }

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 72 |
 | Resources | 11 |
-| Tool catalog | 200.0 KB |
+| Tool catalog | 200.1 KB |
 | Resource catalog | 4.2 KB |
-| Approx. wire tokens | 52261 |
+| Approx. wire tokens | 52298 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,9 +31,9 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 95.4 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 48.7 KB | 24% | Yes, every step |
-| Input schemas | 40.7 KB | 20% | Yes, every step |
+| Input schemas | 40.9 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.2 KB | 7% | Partly |
-| **Description + input schema** | **89.4 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **89.6 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -124,7 +124,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 3.4 KB |
-| [`run_report`](#run_report) | Run a report | yes |  | 4.8 KB |
+| [`run_report`](#run_report) | Run a report | yes |  | 5.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
 | [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.9 KB |
@@ -12321,12 +12321,15 @@ Answer a question about totals, counts or breakdowns — pipeline by stage, deal
             "type": "string"
           },
           "fn": {
+            "description": "How to aggregate the field. count takes no field; every other function names one from this report's aggregates list.",
             "enum": [
-              "count",
-              "sum",
               "avg",
+              "count",
+              "max",
+              "median",
               "min",
-              "max"
+              "p75",
+              "sum"
             ],
             "type": "string"
           }


### PR DESCRIPTION
The run_report tool's `fn` enum was hand-written at five functions; when the report engine grew `median` and `p75` the list stayed at five, so stage-age and win-loss defaulted to a percentile no agent could ask for by name. The vocabulary is now handed over from the engine's own constant set (`reportPlanVocabulary()`), and a census test reads `aggregateSelect`'s switch and holds the published set equal to the engine's in both directions.

Tool budget after the change: 21018 tokens of the 21504 certification floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
run_report now advertises every aggregate function the engine answers, so agents can ask for `median` and `p75` by name. The `fn` enum was a hand-written list of five; when the engine grew `median` and `p75`, stage-age and win-loss defaulted to a percentile no agent could ask for. The vocabulary is now handed over from the engine's own constants, and census tests hold the published set and the derivation phrases equal to the engine's switch in both directions.

- `aggregatePhrase` rendered only five verbs, so default percentile aggregates minted derivation links the resolver then refused with a 422; it now keys off the engine constants and covers all seven.
- `RegisterReportTool` now takes a `ReportPlanVocabulary` argument; callers pass `reportPlanVocabulary()`.
- The `fn` schema gains a description; the enum now lists all seven functions, sorted.
- Tool budget rises from 20,981 to 21,018 catalog tokens; `run_report` goes from 880 to 917.

<sup>Written for commit 135899685e11fa99aa72ff7fe7bb22c0f812bf73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the `run_report` tool to support `median` and `p75` aggregate functions.
  - The available aggregate-function options now reflect the functions supported by the reporting engine.

- **Documentation**
  - Clarified aggregate-function guidance, including that `count` does not require a field while other functions do.
  - Updated MCP catalog references and tool size estimates to reflect the expanded schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->