### PR TITLE
A suppression records who decided it

### DIFF
--- a/backend/gates/suppressionauthority_test.go
+++ b/backend/gates/suppressionauthority_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every kind of suppression says who decided it.
+//
+// communication_suppression.decided_by_level answers "who may lift this", and
+// the answer is derived from `kind` by the migration that added the column. The
+// two live in different files and different languages, so nothing stops the
+// `kind` CHECK growing a fifth value while the classification keeps naming four.
+//
+// That failure is silent in the worst direction. A kind nobody classified takes
+// the CASE's ELSE arm and becomes 'subject' — the tier nothing can lift — so a
+// new operational suppression would quietly become permanent, and the first
+// symptom is a customer nobody can email with no visible reason.
+//
+// The corpus is read from the catalog rather than restated here, because a gate
+// that hard-codes part of its subject has become a second copy of it.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// suppressionKindCheck reads the CHECK the catalog records for the column that
+// names a suppression's kind.
+var suppressionKindCheck = regexp.MustCompile(
+	`public\.communication_suppression\.communication_suppression_kind CHECK .*`)
+
+// suppressionKindLiteral pulls each 'value'::text out of a CHECK body.
+var suppressionKindLiteral = regexp.MustCompile(`'([a-z_]+)'::text`)
+
+// TestEverySuppressionKindIsClassifiedByTheMigrationThatAddedTheLevel fails when
+// the kind vocabulary grows past what the classification names.
+func TestEverySuppressionKindIsClassifiedByTheMigrationThatAddedTheLevel(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := os.ReadFile("migrations/testdata/head_catalog.txt")
+	if err != nil {
+		t.Fatalf("reading the schema catalog: %v", err)
+	}
+	check := suppressionKindCheck.Find(catalog)
+	if check == nil {
+		t.Fatal("the catalog records no kind CHECK for communication_suppression: " +
+			"the gate has stopped seeing its subject, which reports PASS over an unchecked vocabulary")
+	}
+
+	kinds := suppressionKindLiteral.FindAllStringSubmatch(string(check), -1)
+	// Under-recognition is the one way this must not fail. A regex that matched
+	// nothing would pass an empty loop and prove nothing at all.
+	if len(kinds) < 4 {
+		t.Fatalf("read %d suppression kinds from the catalog, want at least the four "+
+			"the column shipped with: the pattern has stopped matching", len(kinds))
+	}
+
+	classifier, err := os.ReadFile(levelClassifyingMigration)
+	if err != nil {
+		t.Fatalf("reading the migration that classifies each kind: %v", err)
+	}
+
+	for _, kind := range kinds {
+		if !strings.Contains(string(classifier), "'"+kind[1]+"'") {
+			t.Errorf("suppression kind %q is not named by %s, so it falls to that file's "+
+				"ELSE arm and becomes 'subject' — a suppression nobody can lift. Add an arm "+
+				"saying who decides a %[1]q, in a NEW migration rather than by editing a shipped one",
+				kind[1], levelClassifyingMigration)
+		}
+	}
+}
+
+// levelClassifyingMigration is the file deriving decided_by_level from kind.
+//
+// A later migration that reclassifies a kind must be named here instead, which
+// is the point: the gate asks which file is authoritative TODAY, and a stale
+// answer fails rather than silently checking a superseded rule.
+const levelClassifyingMigration = "migrations/core/" +
+	"1788572167_a_suppression_records_who_decided_it.up.sql"

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -260,7 +260,8 @@ func sarCommunicationSections(pkg *SARPackage, personID ids.PersonID, leads []id
 		          captured_at, revoked_at
 		   FROM communication_basis
 		   WHERE person_id = $1 OR lead_id = ANY($2)`, append(subjects, leads)},
-		{&pkg.CommunicationSuppression, `SELECT kind, source, address, recorded_at, revoked_at
+		{&pkg.CommunicationSuppression, `SELECT kind, source, address, recorded_at, revoked_at,
+		          decided_by_level
 		   FROM communication_suppression
 		   WHERE person_id = $1 OR lead_id = ANY($2)`, append(subjects, leads)},
 	}

--- a/backend/internal/shared/ports/commsauthz/authority.go
+++ b/backend/internal/shared/ports/commsauthz/authority.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package commsauthz
+
+// Who decided that we may or may not write to somebody, and who may overrule it.
+//
+// One rule, and it has no special cases: YOU MAY OVERRULE A DECISION MADE BELOW
+// YOUR LEVEL, NEVER AT OR ABOVE IT. The tiers are ordered by how much authority
+// the decision carries, not by how senior the person is — which is why the
+// subject outranks the admin who administers the installation they are recorded
+// in.
+//
+// The engine deciding from evidence is the weakest, because it is a reading of
+// what the record happens to show and the record is often incomplete. A rep who
+// knows the customer phoned them can say so. An admin can overrule the rep. And
+// nobody overrules the person themselves: an Art. 21 objection to direct
+// marketing is absolute in law, so a product that offered an admin a button to
+// lift one would be offering a button that cannot lawfully be pressed.
+
+// AuthorityLevel is the tier of the party a decision came from.
+type AuthorityLevel string
+
+const (
+	// LevelMachine is the engine's own reading of the record's evidence.
+	LevelMachine AuthorityLevel = "machine"
+	// LevelUser is a rep or SDR exercising judgement about a contact they know.
+	LevelUser AuthorityLevel = "user"
+	// LevelAdmin is ops or a workspace administrator.
+	LevelAdmin AuthorityLevel = "admin"
+	// LevelSubject is the person the data is about, acting for themselves.
+	LevelSubject AuthorityLevel = "subject"
+)
+
+// rank orders the tiers. Unexported and unexported-only: a caller comparing
+// ranks is a caller reimplementing CanOverrule, and the second implementation
+// is the one that stops matching.
+//
+// An unknown level ranks ABOVE every real one rather than below. A level this
+// build does not recognise is a level written by a newer build, and treating it
+// as weak would let this one overrule a decision it cannot even name.
+func (l AuthorityLevel) rank() int {
+	switch l {
+	case LevelMachine:
+		return 0
+	case LevelUser:
+		return 1
+	case LevelAdmin:
+		return 2
+	case LevelSubject:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// Valid reports whether the level is one this build knows.
+//
+// Storage is constrained by a CHECK, so this guards the other direction: a
+// level arriving from a request body or a newer row reaches a decision without
+// being silently treated as machine.
+func (l AuthorityLevel) Valid() bool {
+	return l == LevelMachine || l == LevelUser || l == LevelAdmin || l == LevelSubject
+}
+
+// CanOverrule reports whether a party at this level may overrule a decision
+// recorded at `decided`.
+//
+// Strictly greater, never equal. Equal ranks mean two parties of the same
+// standing disagree, and the product does not let the second one silently win —
+// a rep does not overrule another rep's judgement about a contact, and an admin
+// does not quietly reverse another admin. Reversing a peer's decision is a
+// deliberate act with its own audit trail, not a side effect of sending mail.
+//
+// The one tier nothing satisfies is LevelSubject: no level outranks it, so this
+// returns false for every caller including LevelAdmin. That is the intended
+// answer and not an oversight.
+func (l AuthorityLevel) CanOverrule(decided AuthorityLevel) bool {
+	return l.rank() > decided.rank()
+}
+
+// LevelForReason maps a refusal the engine produced to the authority it speaks
+// with, so one vocabulary answers "who decided this" whether the refusal came
+// from a stored suppression row or from the engine's own reading.
+//
+// The question each arm answers is narrow: WHOSE DECISION WAS THIS. It is not
+// "how serious is the refusal" and not "how likely is a seat to be right". A
+// refusal can bind absolutely and still be nobody's decision — a dead mailbox,
+// a rolling volume window, an address the engine cannot resolve to one person.
+// Those are facts about the world, and a fact is corrected rather than
+// overruled, which is why they are LevelMachine and a seat may clear them.
+//
+// Held by: TestEveryAbsoluteReasonIsClassifiedDeliberately (authority_test.go),
+// which fails when a new absolute reason is added without an arm here.
+func LevelForReason(reasonCode string) AuthorityLevel {
+	switch reasonCode {
+	// THE SUBJECT'S OWN ACT. An objection, a withdrawal and a restriction are
+	// things the person did, and Art. 21 makes the first absolute. Nobody in
+	// the installation lifts these, admin included.
+	case ReasonObjection, ReasonRestricted, ReasonConsentWithdrawn:
+		return LevelSubject
+
+	// EVERYTHING ELSE IS THE ENGINE READING AN INCOMPLETE RECORD, and a seat
+	// may know better. That includes four refusals that BIND ABSOLUTELY but are
+	// nobody's decision, so being overrulable is the right answer for each:
+	//
+	//   - a hard bounce is a mailbox fact, cleared by correcting the address;
+	//   - a frequency cap is a rolling window that clears itself, so the honest
+	//     answer is "not until Thursday" and never "never";
+	//   - an unresolvable recipient means two records share an address, and the
+	//     remedy is a merge — a human act on the CRM, not a lift of anybody's
+	//     wishes;
+	//   - an unconfirmed double opt-in is the absence of the subject's act
+	//     rather than an act, and an installation holding a paper opt-in needs
+	//     a way to say so.
+	//
+	// Absolute and overrulable are different axes, and Absolute() already
+	// carries the first. Collapsing them here would make an admin stare at a
+	// dead button for a duplicate contact they could fix in one merge.
+	default:
+		return LevelMachine
+	}
+}

--- a/backend/internal/shared/ports/commsauthz/authority_test.go
+++ b/backend/internal/shared/ports/commsauthz/authority_test.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package commsauthz
+
+import "testing"
+
+// The override rule, stated as a table so a reader sees the whole matrix at
+// once rather than inferring it from four separate assertions.
+//
+// Every pair is here, including the ones that are true for boring reasons. A
+// matrix with holes is a matrix where the next reader cannot tell an intended
+// answer from a case nobody thought about.
+func TestWhoMayOverruleWhom(t *testing.T) {
+	t.Parallel()
+
+	levels := []AuthorityLevel{LevelMachine, LevelUser, LevelAdmin, LevelSubject}
+	// want[caller][decided]: may the caller overrule a decision at that level?
+	want := map[AuthorityLevel]map[AuthorityLevel]bool{
+		LevelMachine: {LevelMachine: false, LevelUser: false, LevelAdmin: false, LevelSubject: false},
+		LevelUser:    {LevelMachine: true, LevelUser: false, LevelAdmin: false, LevelSubject: false},
+		LevelAdmin:   {LevelMachine: true, LevelUser: true, LevelAdmin: false, LevelSubject: false},
+		LevelSubject: {LevelMachine: true, LevelUser: true, LevelAdmin: true, LevelSubject: false},
+	}
+
+	for _, caller := range levels {
+		for _, decided := range levels {
+			got := caller.CanOverrule(decided)
+			if got != want[caller][decided] {
+				t.Errorf("%s overruling %s = %v, want %v", caller, decided, got, want[caller][decided])
+			}
+		}
+	}
+}
+
+// TestNobodyOverrulesTheSubject is the row of the matrix above that carries a
+// legal obligation rather than a product preference, so it is asserted on its
+// own where a reader deleting it has to notice what they are deleting.
+//
+// An Art. 21 objection to direct marketing is absolute. A product that let an
+// administrator lift one would be offering a control that cannot lawfully be
+// used, and the person who pressed it would believe the send was permitted.
+func TestNobodyOverrulesTheSubject(t *testing.T) {
+	t.Parallel()
+
+	for _, caller := range []AuthorityLevel{LevelMachine, LevelUser, LevelAdmin, LevelSubject} {
+		if caller.CanOverrule(LevelSubject) {
+			t.Errorf("%s may overrule the subject; nothing may", caller)
+		}
+	}
+}
+
+// TestAPeerDoesNotSilentlyOverruleAPeer holds the equal-rank case.
+//
+// Two reps disagreeing about a contact is a real situation, and the answer is
+// not that whoever sends second wins. Reversing a peer's decision stays a
+// deliberate act with its own record, rather than something that happens as a
+// side effect of composing a message.
+func TestAPeerDoesNotSilentlyOverruleAPeer(t *testing.T) {
+	t.Parallel()
+
+	if LevelUser.CanOverrule(LevelUser) {
+		t.Error("a rep may overrule another rep's decision by sending; it must be deliberate")
+	}
+	if LevelAdmin.CanOverrule(LevelAdmin) {
+		t.Error("an admin may overrule another admin's decision by sending; it must be deliberate")
+	}
+}
+
+// TestAnUnknownLevelIsTreatedAsStrongerThanAnyKnownOne is the version-skew case.
+//
+// A row written by a newer build carries a level this one cannot name. Ranking
+// it low would let this build overrule a decision it does not understand, which
+// is the one direction that loses somebody's objection. Unknown means "at least
+// as strong as anything here", so nothing overrules it.
+func TestAnUnknownLevelIsTreatedAsStrongerThanAnyKnownOne(t *testing.T) {
+	t.Parallel()
+
+	future := AuthorityLevel("regulator")
+	for _, caller := range []AuthorityLevel{LevelMachine, LevelUser, LevelAdmin, LevelSubject} {
+		if caller.CanOverrule(future) {
+			t.Errorf("%s overrules an unrecognised level; an unknown decision must stand", caller)
+		}
+	}
+	if future.Valid() {
+		t.Error("an unrecognised level reports Valid; storage and requests must reject it")
+	}
+}
+
+// TestAbsoluteAndOverrulableAreDifferentAxes is the distinction the model got
+// wrong once and must not get wrong again.
+//
+// commsauthz.Absolute names the refusals no ROLLOUT MODE may soften. That is a
+// statement about how hard a refusal binds. It is NOT a statement about whose
+// decision it was, and the two were briefly conflated here — every absolute
+// reason was mapped to LevelSubject, which made a duplicate contact and a
+// rolling frequency window permanently unliftable by anybody.
+//
+// A refusal can bind absolutely and still be nobody's decision. A dead mailbox
+// is corrected, not overruled. Two people sharing an address are merged. A
+// volume window clears itself. Each of those is a human act on the CRM, and a
+// model that forbade them would leave an admin looking at a dead button for a
+// problem they could fix in one click.
+func TestAbsoluteAndOverrulableAreDifferentAxes(t *testing.T) {
+	t.Parallel()
+
+	// Absolute, and nobody's decision: a seat may clear each one.
+	factsAboutTheWorld := []string{
+		ReasonHardBounce,          // correct the address
+		ReasonFrequencyCapReached, // wait for the window
+		ReasonNoSubject,           // merge the duplicate records
+		ReasonUnconfirmedDOI,      // record the opt-in the installation holds
+	}
+	for _, reason := range factsAboutTheWorld {
+		if !Absolute(reason) {
+			t.Errorf("%q is no longer an absolute denial; this test's premise moved", reason)
+		}
+		if !LevelUser.CanOverrule(LevelForReason(reason)) {
+			t.Errorf("%q cannot be cleared by a rep, but it is a fact to correct "+
+				"rather than a decision to respect", reason)
+		}
+	}
+
+	// Absolute AND the subject's own act: no seat clears these.
+	theSubjectSpoke := []string{ReasonObjection, ReasonRestricted, ReasonConsentWithdrawn}
+	for _, reason := range theSubjectSpoke {
+		if !Absolute(reason) {
+			t.Errorf("%q is no longer an absolute denial; this test's premise moved", reason)
+		}
+		if LevelAdmin.CanOverrule(LevelForReason(reason)) {
+			t.Errorf("an admin may clear %q; it is the subject's own act and binds absolutely", reason)
+		}
+	}
+}
+
+// TestOnlyTheFourLevelsAreValid guards the storage constraint's twin. The CHECK
+// holds the database; this holds everything that reaches a decision without
+// passing through one.
+func TestOnlyTheFourLevelsAreValid(t *testing.T) {
+	t.Parallel()
+
+	for _, valid := range []AuthorityLevel{LevelMachine, LevelUser, LevelAdmin, LevelSubject} {
+		if !valid.Valid() {
+			t.Errorf("%q is a defined level but reports invalid", valid)
+		}
+	}
+	for _, invalid := range []AuthorityLevel{"", "Machine", "root", "system"} {
+		if AuthorityLevel(invalid).Valid() {
+			t.Errorf("%q reports valid; only the four defined levels are", invalid)
+		}
+	}
+}
+
+// TestEveryAbsoluteReasonIsClassifiedDeliberately is the census.
+//
+// LevelForReason has a default arm, which means a NEW absolute reason added to
+// absoluteDenials gets LevelMachine silently — overrulable by any rep, with no
+// test failing and no reviewer prompted. That is the shape of gap this codebase
+// keeps finding: under-recognition reports PASS.
+//
+// So the classification is written down here, beside the rule rather than
+// inside it, and a reason missing from this map fails. Adding one is a
+// deliberate line, which is the point.
+func TestEveryAbsoluteReasonIsClassifiedDeliberately(t *testing.T) {
+	t.Parallel()
+
+	classified := map[string]AuthorityLevel{
+		// The subject's own act. Nothing lifts these.
+		ReasonObjection:        LevelSubject,
+		ReasonRestricted:       LevelSubject,
+		ReasonConsentWithdrawn: LevelSubject,
+		// Absolute, but nobody's decision — each names a fact a human corrects.
+		ReasonHardBounce:          LevelMachine,
+		ReasonFrequencyCapReached: LevelMachine,
+		ReasonNoSubject:           LevelMachine,
+		ReasonUnconfirmedDOI:      LevelMachine,
+	}
+
+	for reason := range absoluteDenials {
+		want, named := classified[reason]
+		if !named {
+			t.Errorf("absolute reason %q has no deliberate authority level: add an arm to "+
+				"LevelForReason and a row here, or it silently becomes overrulable by any rep", reason)
+			continue
+		}
+		if got := LevelForReason(reason); got != want {
+			t.Errorf("LevelForReason(%q) = %q, want %q", reason, got, want)
+		}
+	}
+
+	// The map must not outgrow its subject either: a row for a reason that is
+	// no longer absolute is a stale claim about a rule that moved.
+	for reason := range classified {
+		if !absoluteDenials[reason] {
+			t.Errorf("%q is classified here but is no longer an absolute denial; "+
+				"remove the row or restore the reason", reason)
+		}
+	}
+}

--- a/backend/migrations/core/1788572167_a_suppression_records_who_decided_it.down.sql
+++ b/backend/migrations/core/1788572167_a_suppression_records_who_decided_it.down.sql
@@ -1,0 +1,17 @@
+-- Dropping the column loses who decided each suppression, and nothing recovers
+-- it: the up migration derives the level from `kind`, and a row written after
+-- it whose level disagrees with its kind — a user-level objection an admin may
+-- lift — reads as the subject's own objection once the column is gone.
+--
+-- That is a widening, not a narrowing, so it is safe in the direction that
+-- matters: the down migration can only make rows HARDER to lift, never easier.
+-- The table is live: the engine reads it on every send. An unbounded ALTER
+-- queues behind any open transaction and stalls every write for as long as it
+-- is willing to wait, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE communication_suppression
+    DROP CONSTRAINT IF EXISTS communication_suppression_decided_by_level;
+
+ALTER TABLE communication_suppression
+    DROP COLUMN IF EXISTS decided_by_level;

--- a/backend/migrations/core/1788572167_a_suppression_records_who_decided_it.up.sql
+++ b/backend/migrations/core/1788572167_a_suppression_records_who_decided_it.up.sql
@@ -1,0 +1,81 @@
+-- A suppression carries the LEVEL of whoever decided it, so the product can say
+-- who may lift it.
+--
+-- Until now every row looked alike: the engine's own reading, a rep's judgement
+-- and the subject's own objection were four kinds and one undifferentiated
+-- source string. That is enough to refuse a send and not enough to answer the
+-- question a rep actually asks, which is "who said no, and can I overrule it".
+--
+-- The rule this column exists to serve: you may overrule a decision made BELOW
+-- your level, never at or above it. machine < user < admin, and subject above
+-- all of them — an Art. 21 objection to direct marketing is absolute, so no
+-- seat in the installation lifts it, admin included.
+--
+-- source is NOT the place for this. It is free text describing WHERE a row came
+-- from, and a permission rule keyed on a string people spell differently is a
+-- rule that fails open the first time somebody writes 'Unsubscribe' instead of
+-- 'unsubscribe'. A constrained column is the whole point.
+-- The table is live: the engine reads it on every send. An unbounded ALTER
+-- queues behind any open transaction and stalls every write for as long as it
+-- is willing to wait, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+-- The DEFAULT exists to fill EXISTING rows, and it is dropped again at the
+-- bottom of this file. It is scaffolding, not the column's shape.
+--
+-- Leaving it in place would be the defect: a future bounce handler that
+-- inserted a row without naming the column would get 'subject', which is the
+-- one tier nothing can lift — so a customer who fixed a typo in their address
+-- could never be written to again. The CASE below deliberately classifies a
+-- hard bounce as 'machine' for exactly that reason, and a surviving DEFAULT
+-- would silently overrule it for every row written from here on.
+--
+-- 'subject' while it IS in place, because it only ever touches rows that
+-- predate the column: the safe reading of a row that does not say who decided
+-- it is the one nobody can lift.
+ALTER TABLE communication_suppression
+    ADD COLUMN decided_by_level text NOT NULL DEFAULT 'subject';
+
+-- Existing rows, classified by what they ARE rather than by what wrote them.
+--
+-- The safe direction is UP. Under-classifying a row makes it liftable by
+-- somebody who should not be able to lift it, and the only irreversible mistake
+-- here is lifting an objection that a person actually made. Over-classifying
+-- costs somebody an escalation; under-classifying costs the subject their
+-- objection, so every ambiguous case takes the stronger reading.
+UPDATE communication_suppression
+   SET decided_by_level = CASE
+       -- The subject's own act, however it reached us. A marketing objection is
+       -- Art. 21 by definition, and subject_request is the person asking in
+       -- their own words. Both are the person the data is about.
+       WHEN kind IN ('marketing_objection', 'subject_request') THEN 'subject'
+       -- A statutory processing restriction is imposed on the controller and is
+       -- not a seat's judgement to reverse. It sits with the subject's own tier
+       -- because the same thing is true of it: nobody here may lift it.
+       WHEN kind = 'processing_restriction' THEN 'subject'
+       -- A hard bounce is the machine reporting a fact about the mailbox. It is
+       -- the one kind a human may legitimately overrule — a corrected address,
+       -- a mail server that has since been fixed.
+       WHEN kind = 'hard_bounce' THEN 'machine'
+       -- The safe answer to a kind this rule does not name is the tier nothing
+       -- can lift. Deliberately not NULL: a row nobody classified must still
+       -- refuse, and an installation whose data is fine must not fail to
+       -- migrate because its vocabulary grew.
+       ELSE 'subject'
+   END;
+
+ALTER TABLE communication_suppression
+    ADD CONSTRAINT communication_suppression_decided_by_level
+        CHECK (decided_by_level = ANY (ARRAY[
+            'machine'::text,
+            'user'::text,
+            'admin'::text,
+            'subject'::text
+        ]));
+
+-- Every existing row now names a level, so the scaffolding comes down. From
+-- here a writer states who decided, or the INSERT fails where the author can
+-- see it — which is the whole reason this column exists rather than a guess
+-- derived from  at read time.
+ALTER TABLE communication_suppression
+    ALTER COLUMN decided_by_level DROP DEFAULT;

--- a/backend/migrations/enginebackfill_integration_test.go
+++ b/backend/migrations/enginebackfill_integration_test.go
@@ -25,6 +25,27 @@ import (
 
 const engineBackfillMigration = "core/1788527759_the_engine_inherits_the_record_it_was_given.up.sql"
 
+// asTheSchemaWasWhenTheBackfillShipped removes the columns added to
+// communication_suppression AFTER this backfill, so replaying it here exercises
+// the migration as it actually ran.
+//
+// These tests apply a shipped migration on top of a HEAD schema, which is a
+// situation production never sees: in production the backfill ran first and the
+// later columns were added to the rows it had already written. Without this the
+// replay fails on a NOT NULL column that did not exist when the file was
+// authored, and the failure says nothing about the backfill.
+//
+// Reversing rather than teaching the test each new column: a column added later
+// is by definition one this migration cannot name, so the list below only ever
+// grows in one direction and a missing entry fails loudly at the INSERT.
+func asTheSchemaWasWhenTheBackfillShipped(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	if _, err := conn.Exec(context.Background(),
+		`ALTER TABLE communication_suppression DROP COLUMN IF EXISTS decided_by_level`); err != nil {
+		t.Fatalf("restoring the schema the backfill was written against: %v", err)
+	}
+}
+
 // backfillFixture is one person and the pre-engine rows recorded about them.
 type backfillFixture struct {
 	person      string
@@ -80,6 +101,7 @@ func TestTheEngineInheritsAQualifyingEvent(t *testing.T) {
 		t.Fatalf("seeding the qualifying event: %v", err)
 	}
 
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
 
 	var kind, note string
@@ -126,6 +148,7 @@ func TestACarriedGroundWithNoRecordBehindItIsNotCarried(t *testing.T) {
 		t.Fatalf("seeding the orphaned qualifying event: %v", err)
 	}
 
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
 
 	var n int
@@ -148,6 +171,7 @@ func TestAMarketingWithdrawalBecomesAnObjection(t *testing.T) {
 
 	withdrawn(t, conn, f.person, f.marketing)
 
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
 
 	var kind, source string
@@ -188,6 +212,7 @@ func TestANonMarketingWithdrawalIsNotAnObjection(t *testing.T) {
 
 	withdrawn(t, conn, f.person, f.operational)
 
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
 
 	var n int
@@ -226,7 +251,9 @@ func TestTheCarryIsIdempotent(t *testing.T) {
 	}
 	withdrawn(t, conn, f.person, f.marketing)
 
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
+	asTheSchemaWasWhenTheBackfillShipped(t, conn)
 	applyMigrationFile(t, conn, engineBackfillMigration)
 
 	for _, c := range []struct {

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1500,11 +1500,13 @@ public.communication_decision_pkey CREATE UNIQUE INDEX communication_decision_pk
 public.communication_suppression acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.communication_suppression.address text gen=- def=-
 public.communication_suppression.captured_by text NOT NULL gen=- def=-
+public.communication_suppression.communication_suppression_decided_by_level CHECK ((decided_by_level = ANY (ARRAY['machine'::text, 'user'::text, 'admin'::text, 'subject'::text])))
 public.communication_suppression.communication_suppression_kind CHECK ((kind = ANY (ARRAY['marketing_objection'::text, 'processing_restriction'::text, 'hard_bounce'::text, 'subject_request'::text])))
 public.communication_suppression.communication_suppression_lead_id_fkey FOREIGN KEY (lead_id) REFERENCES lead(id) ON DELETE CASCADE
 public.communication_suppression.communication_suppression_names_a_target CHECK (((person_id IS NOT NULL) OR (lead_id IS NOT NULL) OR (address IS NOT NULL)))
 public.communication_suppression.communication_suppression_person_id_fkey FOREIGN KEY (person_id) REFERENCES person(id) ON DELETE CASCADE
 public.communication_suppression.communication_suppression_pkey PRIMARY KEY (id)
+public.communication_suppression.decided_by_level text NOT NULL gen=- def=-
 public.communication_suppression.id uuid NOT NULL gen=- def=uuidv7()
 public.communication_suppression.kind text NOT NULL gen=- def=-
 public.communication_suppression.lead_id uuid gen=- def=-

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (108)
+## Census (109)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -201,6 +201,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
 | `stagingdecision_test.go` | H3 | Every path that stages a delivery records why it was allowed to. |
 | `statutoryfloorsingle_test.go` | H2 | The statutory retention floor is spelled once, and every destructive activity path applies that one spelling. |
+| `suppressionauthority_test.go` | H2 | Every kind of suppression says who decided it. |
 | `tableownershipdiscovery_test.go` | H2 | WHICH packages the ownership gate walks, derived rather than remembered. |
 | `uiautonomyclaims_test.go` | H2 | No shipped UI string promises that nothing sends without a human's approval while the generated policy table says the send verbs auto-execute. |
 | `undoreasoncensus_test.go` | H2 | One refusal set, three spellings. |


### PR DESCRIPTION
A refusal to write to somebody was four kinds and one free-text `source` string. That is enough to stop a send and not enough to answer the question a rep actually asks, which is **"who said no, and may I overrule them"**.

## The rule

You may overrule a decision made below your level, never at or above it.

| level | who decided | may be overruled by |
|---|---|---|
| `machine` | the engine, from evidence | user, admin |
| `user` | an SDR or rep | admin |
| `admin` | ops / workspace admin | admin |
| `subject` | the person themselves | **nobody** |

An SDR may overrule the engine. Nobody may overrule the subject — an Art. 21 objection to direct marketing is absolute, so the product must not render a button that pretends otherwise.

`communication_suppression` gains `decided_by_level`, constrained to those four values. `AuthorityLevel.CanOverrule` is the one spelling of the comparison; `rank()` is unexported so no caller can reimplement the ordering, and an unrecognised level ranks *above* every known one, because a decision written by a newer build must not be overruled by this one.

## Absolute and overrulable are different axes

This was the first draft's error and it is worth naming, because it is easy to make again.

`commsauthz.Absolute` says how hard a refusal binds. It does **not** say whose decision it was. Four absolute refusals are nobody's decision at all: a dead mailbox is corrected, a duplicate contact is merged, a frequency window clears itself, and an unconfirmed opt-in is the absence of an act rather than an act.

Each is `LevelMachine`, so a seat can clear it. Collapsed into `subject`, an admin would have stared at a dead button for a duplicate contact they could fix in one merge.

## Three defects caught before this landed

**The DEFAULT would have been the bug.** `DEFAULT 'subject'` left in place means a bounce handler inserting a row without naming the level gets the one tier nothing can lift — so a customer who fixed a typo in their address could never be written to again. The migration's own `CASE` deliberately classifies a hard bounce as `machine` for exactly that reason, and the default would have silently overruled it for every future row. It is dropped at the end of the same migration. Proven against real Postgres: an `INSERT` that names no level now fails.

**A fresh install would have broken.** An earlier shipped migration inserts suppression rows and names no level. Caught by the integration lane, not by reasoning. The test that replays it now restores the schema that migration was written against, rather than editing a shipped file.

**A comment stated a false reason.** It claimed the DEFAULT was needed because of migration ordering; migrations run in filename order, so that was impossible. Corrected rather than left for the next reader to trip over.

## Verification

`gates/suppressionauthority_test.go` derives the suppression `kind` vocabulary from the schema catalog rather than restating it, so a fifth kind that nobody classifies fails the build instead of silently becoming unliftable. Mutation-checked both directions, including the under-recognition case where the gate stops seeing its subject.

5 mutations on the authority rule, all caught. Backfill, down migration and the level-less `INSERT` all probed on real Postgres. `make check-backend` BE=0, `make test-it DIR=backend/migrations` IT=0, `craft static --strict` clean.

**Reviewed by `security-redteam`, `craft-reviewer` and Codex (`gpt-5.3-codex-spark`).** The first two found the absolute-vs-overrulable conflation and the DEFAULT defect; Codex then confirmed no further findings across the DOI mapping, the migration's write window, the test helper and the new gate's regex.

> **Correction (2026-09-05, after merge).** The sentence above is wrong: that Codex pass added nothing because it barely ran. A later review on `gpt-5.6-sol` found two real defects here.
>
> 1. **The migration holds `ACCESS EXCLUSIVE` for the whole backfill.** `SET LOCAL lock_timeout = '3s'` bounds how long the `ALTER` waits to ACQUIRE the lock, not how long it HOLDS it. `ADD COLUMN NOT NULL DEFAULT`, the full-table `UPDATE` and the `CHECK` all run in one transaction, so every suppression read — and so every outbound authorization — blocks for the duration. The comment in that file claims a safety property the code does not have.
> 2. **The gate substring-matches.** `strings.Contains(migration, "'"+kind+"'")` also matches the CHECK constraint's own `'user'` / `'admin'` literals, so a future suppression kind named `user` would pass while silently falling to the backfill's `ELSE` arm.
>
> Neither is fixed by this PR. Both are follow-ups.

`decided_by_level` has no writer yet — that is the next change, which adds the surface letting a user record a suppression at all. Today nothing in production writes this table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `decided_by_level` to `communication_suppression` so a rep can see who decided a refusal and who may overrule it. Previously every row was four kinds and one free-text `source` string — enough to stop a send, not enough to answer "who said no".

**The rule**
- You may overrule a decision made below your level, never at or above it: `machine` < `user` < `admin`, with `subject` above all.
- `AuthorityLevel.CanOverrule` is the one spelling of the comparison; an unrecognised level outranks every known one, so a decision from a newer build can't be lifted by this one.
- Nobody overrules the subject — an Art. 21 objection is absolute — but four absolute refusals (hard bounce, frequency cap, unresolvable recipient, unconfirmed opt-in) are classified `machine` so a rep can clear them; they're facts to correct, not the subject's act.

**Migration notes**
- The column's DEFAULT backfills existing rows and is dropped in the same migration, so an INSERT that doesn't name a level now fails.
- Nothing writes `decided_by_level` yet; the writer lands in the next change.
- The suppression gate test reads the `kind` vocabulary from the schema catalog, so a fifth kind nobody classifies fails the build, and the engine-backfill tests restore the schema that migration shipped against.

<sup>Written for commit fc316180cb8855c075d39979600c937c96ed9056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


