### PR TITLE
fix(meetingbrief): a withheld conversation no longer dates the arc or reaches the model

### DIFF
--- a/backend/internal/compose/meetingbrief/arc.go
+++ b/backend/internal/compose/meetingbrief/arc.go
@@ -184,6 +184,18 @@ func titleOf(moment ArcMoment) string {
 // rather than titled: it has no readable subject to name and no citation they
 // could open. Its existence is still reported, in the activity_history
 // omission, which is the honest place for "there is more here you cannot see".
+//
+// A thread with nothing this caller may read carries the zero time in its
+// First/Last (threadsOf never sets them from a withheld row), and none of
+// Inbound/OnDeal/HasMeeting either. The zero time sorts before every real
+// activity, so such a thread always opens its own moment here — the gap back
+// to any real date is enormous — scored on recency alone against a
+// millennium-old instant, which is the floor every real moment already
+// meets or beats and never loses a tie against (a real moment's own instant
+// is always after the zero time). It cannot outrank, and so cannot displace,
+// a moment built from anything this caller may read — before the loop below
+// drops it for holding no readable IDs at all. Its existence still counts;
+// it never gets to date, weigh or size a moment a reader is shown.
 func accountArc(in Input) []ArcMoment {
 	if len(in.History) == 0 {
 		return nil

--- a/backend/internal/compose/meetingbrief/arc_test.go
+++ b/backend/internal/compose/meetingbrief/arc_test.go
@@ -145,8 +145,11 @@ func TestTheArcReadsInDateOrder(t *testing.T) {
 	}
 }
 
-// A conversation this caller may not read still dates the arc and says
-// nothing. Its subject must not reach the reader by any path.
+// A conversation this caller may not read says nothing and must not date the
+// arc either. The arc's own `omitted` line tells the reader "the account arc
+// is built from the rest"; a withheld conversation's own instant reaching
+// plan.account_arc[].to (or its count) makes that sentence false, and handed
+// the reader the withheld message's date by subtraction.
 func TestAWithheldConversationNamesNothing(t *testing.T) {
 	in := fullInput()
 	withheld := mail(dealID, 5, "", "inbound")
@@ -155,10 +158,20 @@ func TestAWithheldConversationNamesNothing(t *testing.T) {
 		mail(activityID, 3, "Readable subject", "inbound"),
 		withheld,
 	}
-	for _, moment := range accountArc(in) {
+	arc := accountArc(in)
+	for _, moment := range arc {
 		if strings.Contains(moment.Title, "withheld") {
 			t.Errorf("a withheld conversation named itself in the arc title %q", moment.Title)
 		}
+	}
+	if len(arc) != 1 {
+		t.Fatalf("moments = %d, want 1 — the withheld-only thread has its own moment, dropped", len(arc))
+	}
+	if got, want := arc[0].To, at(3); !got.Equal(want) {
+		t.Errorf("moment.To = %s, want %s — the withheld message's own date must not extend it", got, want)
+	}
+	if got := conversationCount(arc[0]); got != 1 {
+		t.Errorf("conversation count = %d, want 1 — the withheld conversation is not this reader's to count", got)
 	}
 	if got := withheldCount(in.History); got != 1 {
 		t.Errorf("withheld count = %d, want 1 — the omission is built from it", got)
@@ -185,10 +198,114 @@ func TestAWithheldRowIsNotCitedEvenInsideAReadableThread(t *testing.T) {
 			t.Error("a withheld row is citable through the thread it shares with a readable one")
 		}
 	}
-	// It still COUNTS: the thread holds two conversations, and the arc's dates
-	// are right because of it.
+	// It still COUNTS in Rows — a withheld row still happened — but must not
+	// move First/Last: the hidden reply landed on day 4, a day later than the
+	// readable message it replies to, and the thread's dates must stay at the
+	// readable message's own day, not stretch to the hidden reply's.
 	if threads[0].Rows != 2 {
 		t.Errorf("rows = %d, want 2 — a withheld row still happened", threads[0].Rows)
+	}
+	if got, want := threads[0].Last, at(3); !got.Equal(want) {
+		t.Errorf("last = %s, want %s — a withheld reply must not date the thread", got, want)
+	}
+}
+
+// The history reader hands threadsOf rows newest first (history.go's
+// ORDER BY occurred_at DESC), the opposite order the test above uses. The fix
+// must hold either way: the guard is "was this row readable", not "was it the
+// first one seen for this key".
+func TestAWithheldRowIsNotCitedRegardlessOfScanOrder(t *testing.T) {
+	readable := mail(activityID, 3, "Requirements", "inbound")
+	readable.ThreadKey = "abc"
+	hidden := mail(dealID, 4, "", "outbound")
+	hidden.ThreadKey = "abc"
+	hidden.Withheld = true
+
+	threads := threadsOf([]HistoryIn{hidden, readable})
+	if len(threads) != 1 {
+		t.Fatalf("threads = %d, want 1 — one thread key is one thread", len(threads))
+	}
+	for _, id := range threads[0].IDs {
+		if id == dealID {
+			t.Error("a withheld row is citable through the thread it shares with a readable one")
+		}
+	}
+	if got, want := threads[0].Last, at(3); !got.Equal(want) {
+		t.Errorf("last = %s, want %s — a withheld reply scanned FIRST must still not date the thread", got, want)
+	}
+}
+
+// A withheld row's own nature — that it was a meeting, was on the deal, got
+// a reply — must not bias which readable moment ranks highest or which
+// readable subject becomes a moment's title. Either would let hidden content
+// steer what the reader is shown through a channel the audience narrowing
+// cannot see.
+func TestAWithheldRowsNatureDoesNotBiasRankingOrTitle(t *testing.T) {
+	plain := mail(activityID, 3, "Ordinary note", "outbound")
+	plain.ThreadKey = "abc"
+	loudButHidden := HistoryIn{
+		ID: dealID, Kind: "meeting", Subject: "Should never be the title",
+		Direction: "inbound", At: at(4), OnDeal: true, Withheld: true,
+	}
+	loudButHidden.ThreadKey = "abc"
+
+	threads := threadsOf([]HistoryIn{plain, loudButHidden})
+	if len(threads) != 1 {
+		t.Fatalf("threads = %d, want 1", len(threads))
+	}
+	got := threads[0]
+	if got.HasMeeting {
+		t.Error("a withheld meeting made the thread read as a meeting")
+	}
+	if got.OnDeal {
+		t.Error("a withheld on-deal row made the thread read as on-deal")
+	}
+	if got.Inbound != 0 {
+		t.Errorf("inbound = %d, want 0 — the only inbound row is withheld", got.Inbound)
+	}
+	if got.Subject != "Ordinary note" {
+		t.Errorf("subject = %q, want the readable row's own subject, not the withheld row's louder one", got.Subject)
+	}
+}
+
+// An all-withheld moment must never outrank, and so never displace, a moment
+// built from anything this caller may read — not even when the withheld
+// content looks maximally important (a meeting, on the deal, replied to).
+// Six moments compete for the five-slot cap; the sixth, weakest readable one
+// must still beat the loud-but-hidden moment, proving the floor holds under
+// real competition rather than only in an uncapped fixture.
+func TestALoudWithheldMomentNeverDisplacesAWeakReadableOne(t *testing.T) {
+	in := fullInput()
+	var history []HistoryIn
+	loud := HistoryIn{
+		ID: dealID, Kind: "meeting", Subject: "Loud but hidden",
+		Direction: "inbound", At: at(1), OnDeal: true, Withheld: true,
+	}
+	history = append(history, loud)
+	// Six ordinary, weak, single-message moments — no deal, no meeting, no
+	// reply, nothing to score beyond recency — each a silence-closing gap
+	// apart so they never merge into one.
+	for i := range arcCap + 1 {
+		history = append(history, mail(
+			fmt.Sprintf("0198f000-0000-7000-8000-0000000%05d", i+400),
+			40+i*30, fmt.Sprintf("Weak %d", i), "outbound"))
+	}
+	in.History = history
+	in.Now = at(40 + arcCap*30)
+
+	arc := accountArc(in)
+	if len(arc) != arcCap {
+		t.Fatalf("moments = %d, want %d — the cap, filled entirely from readable moments", len(arc), arcCap)
+	}
+	for _, moment := range arc {
+		if strings.Contains(moment.Title, "Loud but hidden") {
+			t.Fatal("the withheld moment's title reached the reader")
+		}
+		for _, current := range moment.Threads {
+			if current.HasMeeting && len(current.IDs) == 0 {
+				t.Fatal("the withheld moment occupied a slot in the capped arc")
+			}
+		}
 	}
 }
 

--- a/backend/internal/compose/meetingbrief/history.go
+++ b/backend/internal/compose/meetingbrief/history.go
@@ -17,10 +17,11 @@ package meetingbrief
 // would have bought a bigger prompt and no more understanding: what makes a
 // history useful is knowing which parts of it to read closely.
 //
-// A row this caller may not READ still counts. It keeps its date and its
-// thread key, so the shape of the relationship is right, and it contributes no
-// subject and no body. The count of such rows becomes an omission, because a
-// thin arc that does not say it is thin reads exactly like a quiet account.
+// A row this caller may not READ still counts and still keeps its date and
+// thread key on the row itself, but contributes neither to the arc it is
+// folded into (threads.go) nor a subject or body here. The count of such rows
+// becomes an omission, because a thin arc that does not say it is thin reads
+// exactly like a quiet account.
 
 import (
 	"context"
@@ -161,8 +162,8 @@ func (s *Service) readHistory(
 		row.ID = id.String()
 		row.Withheld = !readableRow
 		if row.Withheld {
-			// What it was called is content. The row still counts and still
-			// shapes the arc's dates; it says nothing.
+			// What it was called is content. The row still counts; it says
+			// nothing and, per threads.go, does not shape the arc either.
 			row.Subject = ""
 		}
 		history = append(history, row)

--- a/backend/internal/compose/meetingbrief/input.go
+++ b/backend/internal/compose/meetingbrief/input.go
@@ -143,7 +143,11 @@ type ClaimIn struct {
 	OccurredAt *time.Time
 }
 
-// ActIn is one recent conversation as the brief reads it.
+// ActIn is one recent conversation as the brief reads it. Every field here is
+// marshalled straight into the model's prompt (encodeInput), so this struct
+// carries only what a reader may already see — WithCounterpart is where a
+// conversation outside this caller's audience is kept out, not a flag on it
+// here that the prompt would then have to be trusted to honour.
 type ActIn struct {
 	ID        string
 	Kind      string
@@ -241,6 +245,19 @@ func WithCounterpart(in *Input, view crmcontracts.Person360) {
 	for _, activity := range view.Activities.Data {
 		if len(in.Recent) == recentCap {
 			break
+		}
+		// A row outside this caller's audience is kept out of Recent the same
+		// way an unreadable row is kept out of History's citable set — it
+		// reached this read as a date and a count, on the person's own page,
+		// and it must not go on to be the model's or the floor's evidence for
+		// a sentence about it. Skipped rather than counted against recentCap,
+		// so a withheld row never costs the section a readable one's slot.
+		//
+		// Spelled as an allow-list, not a deny-list: this feeds the model's
+		// prompt, so an unrecognised future content_state must be excluded by
+		// default rather than let through because it didn't spell "withheld".
+		if activity.ContentState == nil || *activity.ContentState != crmcontracts.ActivityContentStateAvailable {
+			continue
 		}
 		folded := ActIn{
 			ID:   ids.UUID(activity.Id).String(),

--- a/backend/internal/compose/meetingbrief/input_test.go
+++ b/backend/internal/compose/meetingbrief/input_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+// WithCounterpart folds the lead attendee's own 360 read into the brief's
+// input. A row outside this caller's audience must never reach Recent at
+// all: Recent is marshalled straight into the model's prompt, and a citation
+// to a withheld conversation sends the reader to a record they cannot open,
+// so the one place this is enforced is here, at the fold, rather than
+// trusted downstream in every section that reads Recent.
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestWithCounterpartExcludesAWithheldActivity(t *testing.T) {
+	withheld := crmcontracts.ActivityContentStateWithheld
+	available := crmcontracts.ActivityContentStateAvailable
+	view := crmcontracts.Person360{
+		Activities: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{
+			Data: []crmcontracts.Activity{
+				{
+					Id:           openapi_types.UUID(ids.NewV7()),
+					Kind:         crmcontracts.ActivityKindEmail,
+					OccurredAt:   at(9),
+					ContentState: &withheld,
+				},
+				{
+					Id:           openapi_types.UUID(ids.NewV7()),
+					Kind:         crmcontracts.ActivityKindEmail,
+					OccurredAt:   at(7),
+					Subject:      ptr("Contract redlines"),
+					ContentState: &available,
+				},
+				// content_state carries only two known values today, but the
+				// exclusion is spelled as an allow-list precisely so a third
+				// one nobody has written a case for yet is excluded too — this
+				// row carries no content_state at all, the shape a future
+				// unnamed state (or a stale caller) would also produce.
+				{
+					Id:         openapi_types.UUID(ids.NewV7()),
+					Kind:       crmcontracts.ActivityKindEmail,
+					OccurredAt: at(6),
+					Subject:    ptr("No content_state at all"),
+				},
+			},
+		},
+	}
+	in := &Input{}
+	WithCounterpart(in, view)
+	if len(in.Recent) != 1 {
+		t.Fatalf("recent = %d, want 1 — only the row explicitly marked available may reach Recent", len(in.Recent))
+	}
+	if in.Recent[0].Subject != "Contract redlines" {
+		t.Errorf("recent[0] = %+v, want the readable conversation, not the withheld or unmarked one", in.Recent[0])
+	}
+}
+
+// A withheld row must not cost a readable one its slot: recentCap bounds what
+// the reader actually sees, and a withheld row contributes nothing to see. A
+// count-only check would pass even if the withheld row displaced the LAST
+// readable one rather than being skipped outright, so this also names which
+// one made it in.
+func TestAWithheldActivityDoesNotSpendARecentSlot(t *testing.T) {
+	data := make([]crmcontracts.Activity, 0, recentCap+1)
+	withheld := crmcontracts.ActivityContentStateWithheld
+	available := crmcontracts.ActivityContentStateAvailable
+	data = append(data, crmcontracts.Activity{
+		Id: openapi_types.UUID(ids.NewV7()), Kind: crmcontracts.ActivityKindEmail,
+		OccurredAt: at(20), ContentState: &withheld,
+	})
+	lastReadableID := openapi_types.UUID(ids.NewV7())
+	for i := range recentCap {
+		id := openapi_types.UUID(ids.NewV7())
+		if i == recentCap-1 {
+			id = lastReadableID
+		}
+		data = append(data, crmcontracts.Activity{
+			Id: id, Kind: crmcontracts.ActivityKindEmail, OccurredAt: at(10 - i),
+			ContentState: &available,
+		})
+	}
+	view := crmcontracts.Person360{
+		Activities: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{Data: data},
+	}
+	in := &Input{}
+	WithCounterpart(in, view)
+	if len(in.Recent) != recentCap {
+		t.Fatalf("recent = %d, want %d readable conversations, none of them spent on the withheld one", len(in.Recent), recentCap)
+	}
+	if got, want := in.Recent[recentCap-1].ID, ids.UUID(lastReadableID).String(); got != want {
+		t.Errorf("last recent id = %s, want %s — the withheld row displaced the last readable one instead of being skipped", got, want)
+	}
+}

--- a/backend/internal/compose/meetingbrief/threads.go
+++ b/backend/internal/compose/meetingbrief/threads.go
@@ -30,19 +30,26 @@ type thread struct {
 	First   time.Time
 	Last    time.Time
 	// IDs are the conversation's activities this caller may READ, newest
-	// first. A withheld row is counted in Rows and never listed here: it still
-	// dates the thread, and citing it would send a reader to a record they
-	// cannot open — which also tells them a limited conversation belongs to
-	// this thread, a fact the audience narrowing exists to keep.
+	// first. A withheld row is counted in Rows and never listed here: citing
+	// it would send a reader to a record they cannot open — which also tells
+	// them a limited conversation belongs to this thread, a fact the audience
+	// narrowing exists to keep.
 	IDs []string
 	// Rows is how many conversations the thread holds, readable or not.
-	Rows       int
+	Rows int
+	// Inbound/Outbound/OnDeal/HasMeeting describe only the READABLE rows.
+	// They feed the moment's score and its title, so a withheld row's own
+	// nature — that it was a meeting, was on the deal, got a reply — must not
+	// bias which readable moment ranks highest or which readable subject
+	// becomes the title: either would let hidden content steer what the
+	// reader is shown, through a channel the audience narrowing cannot see.
 	Inbound    int
 	Outbound   int
 	OnDeal     bool
 	HasMeeting bool
 	// Readable is how many of the thread's rows this caller may read. A thread
-	// that is entirely withheld still exists and still dates the arc.
+	// that is entirely withheld (Readable == 0) still exists in Rows, but its
+	// First/Last stay at the zero time — it does not date the arc.
 	Readable int
 }
 
@@ -87,37 +94,39 @@ func threadsOf(history []HistoryIn) []thread {
 		key := threadKeyOf(row)
 		found, ok := byKey[key]
 		if !ok {
-			found = &thread{Key: key, Kind: row.Kind, First: row.At, Last: row.At}
+			found = &thread{Key: key, Kind: row.Kind}
 			byKey[key] = found
 			order = append(order, key)
 		}
 		found.Rows++
 		if !row.Withheld {
 			found.IDs = append(found.IDs, row.ID)
-		}
-		if row.At.Before(found.First) {
-			found.First = row.At
-		}
-		if row.At.After(found.Last) {
-			found.Last = row.At
-		}
-		// The newest readable subject names the thread: a later message in a
-		// chain carries the subject the participants settled on.
-		if !row.Withheld {
+			// First/Last date the arc, so only a row this caller may read may
+			// set them — a withheld row still counts in Rows above, but its
+			// instant must never surface as when the thread started or ended.
+			if found.Readable == 0 || row.At.Before(found.First) {
+				found.First = row.At
+			}
+			if found.Readable == 0 || row.At.After(found.Last) {
+				found.Last = row.At
+			}
+			found.Readable++
+			// The newest readable subject names the thread: a later message in a
+			// chain carries the subject the participants settled on.
 			if found.Subject == "" || row.At.Equal(found.Last) {
 				if row.Subject != "" {
 					found.Subject = row.Subject
 				}
 			}
+			switch row.Direction {
+			case "inbound":
+				found.Inbound++
+			case "outbound":
+				found.Outbound++
+			}
+			found.OnDeal = found.OnDeal || row.OnDeal
+			found.HasMeeting = found.HasMeeting || row.Kind == "meeting"
 		}
-		switch row.Direction {
-		case "inbound":
-			found.Inbound++
-		case "outbound":
-			found.Outbound++
-		}
-		found.OnDeal = found.OnDeal || row.OnDeal
-		found.HasMeeting = found.HasMeeting || row.Kind == "meeting"
 	}
 	threads := make([]thread, 0, len(order))
 	for _, key := range order {

--- a/backend/internal/compose/modelroutedeadline.go
+++ b/backend/internal/compose/modelroutedeadline.go
@@ -25,6 +25,11 @@ var modelRouteSuffixes = []string{
 	"/draft-email",
 	"/dossier",
 	"/growth-fit",
+	"/meeting-brief",
+	"/ask",
+	"/intro-note-draft",
+	"/intro-request-draft",
+	"/role-proposals",
 }
 
 // extendDeadlineForModelRoutes gives a handler that calls a model long enough

--- a/backend/internal/compose/modelroutedeadline_test.go
+++ b/backend/internal/compose/modelroutedeadline_test.go
@@ -27,12 +27,18 @@ func TestOnlyTheModelRoutesTakeTheLongerDeadline(t *testing.T) {
 	// without a real server sees. The route DECISION is what is asserted here,
 	// and it is the half that decides which endpoints are exposed.
 	for path, wantsModelTime := range map[string]bool{
-		"/v1/activities/01a0-4cd3/draft-email":   true,
-		"/v1/organizations/01a0-4cd2/dossier":    true,
-		"/v1/organizations/01a0-4cd2/growth-fit": true,
-		"/v1/people":                             false,
-		"/v1/me":                                 false,
-		"/v1/organizations/01a0-4cd2":            false,
+		"/v1/activities/01a0-4cd3/draft-email":            true,
+		"/v1/organizations/01a0-4cd2/dossier":             true,
+		"/v1/organizations/01a0-4cd2/growth-fit":          true,
+		"/v1/activities/01a0-4cd3/meeting-brief":          true,
+		"/v1/organizations/01a0-4cd2/ask":                 true,
+		"/v1/knowledge/corpora/01a0-4cd2/ask":             true,
+		"/v1/people/01a0-4cd2/intro-note-draft":           true,
+		"/v1/organizations/01a0-4cd2/intro-request-draft": true,
+		"/v1/deals/01a0-4cd2/role-proposals":              true,
+		"/v1/people":                                      false,
+		"/v1/me":                                          false,
+		"/v1/organizations/01a0-4cd2":                     false,
 		// A path that merely CONTAINS a slow route's name is not one: the
 		// suffix is the whole match, or a list endpoint beside it inherits a
 		// deadline it has no work for.


### PR DESCRIPTION
## Summary

Fixes two QC-tracked defects in `compose/meetingbrief/` (margince#3657, margince#3633):

**#3657 — a privacy leak.** The meeting brief's account arc tells the reader "N conversations are not yours to read, so the arc is built from the rest," then built its date range, conversation count, ranking and title selection from those same withheld rows anyway — handing a colleague a limited message's existence and date by subtraction. Separately, a withheld activity could reach the model's prompt through `Input.Recent` (JSON-marshalled straight into it) and get cited as evidence for a generated sentence, which the frontend renders as a clickable link to the record the reader was told they could not open. Live-measured by the QC harness: 2–6 leaking responses out of ~18 probes, because the model chooses whether to cite it.

**#3633 — a slow-model 502.** `/meeting-brief`'s model call had no deadline extension, so a slow-but-live answer could exceed the server's 30s write timeout and surface as a raw 502 instead of falling back to the deterministic composition the code already does on an outright model error.

## What changed

- `threads.go` — a thread's `First`/`Last`/`Inbound`/`Outbound`/`OnDeal`/`HasMeeting` now come only from rows this caller may read. An entirely-withheld thread keeps the zero time and the floor ranking score, so it can neither date the arc nor win a ranking slot away from a readable moment (found by two independent reviews below — the first pass only fixed the dates, not the ranking bias).
- `input.go` — `WithCounterpart` now drops a withheld (or content-state-unmarked) activity before it ever reaches `Input.Recent`, spelled as an allow-list (only `available` gets through) rather than a deny-list, since this feeds the model's prompt directly. This closes the citation-leak path at its one source instead of trusting every downstream reader of `Recent` to re-check it.
- `history.go`, `arc.go` — stale comments that asserted the old (buggy) behavior as intentional, corrected.
- `modelroutedeadline.go` — added `/meeting-brief` plus 5 more routes (`/ask` — both org-ask and corpus-ask, `/intro-note-draft`, `/intro-request-draft`, `/role-proposals`) that all call `ai.Ask` synchronously and shared the same 502 exposure as the 3 already-patched routes.

No AI prompt text or request schema changed — `ActIn`'s shape is unchanged, only which entries `WithCounterpart` includes — so no aicert re-run is needed.

## Review

Two independent reviews (Fable model + Codex) both found the same real gap in the first version of this fix: `Inbound`/`OnDeal`/`HasMeeting` still leaked from withheld rows into ranking/title selection, letting a withheld thread's *nature* (was it a meeting, was it on the deal) bias which readable moment/title the reader sees, and letting an all-withheld moment consume one of the capped top-5 ranking slots before being dropped — silently handing the reader fewer moments than intended. Fixed in this same commit (see `threads.go`'s per-row guard) and covered by new mutation-verified tests (`TestAWithheldRowsNatureDoesNotBiasRankingOrTitle`, `TestALoudWithheldMomentNeverDisplacesAWeakReadableOne`).

Every new/changed regression assertion was mutation-tested by hand: reverting the relevant guard makes the corresponding test fail red before the fix, and pass green after.

## Test plan

- [x] `make check-go` — full backend gate, green
- [x] `craft static --strict` — 0 blocker/major/minor on all 8 changed files
- [x] Unit + mutation tests for every guard (see commit)
- [x] Live UAT on a running dev stack (slug `tinng-mbrief`): rep logs two emails with a contact, limits the second one's audience to `participants`, books a meeting, reads the meeting brief as a colleague outside that audience — confirmed via `GET /activities/{id}/meeting-brief` that the withheld email's id appears nowhere in the response, `plan.account_arc[0].to` stops at the last *readable* email's date, and the "conversations since then" count in `what_changed` correctly excludes it (4, not 5, cross-checked against the raw `/people/{id}/360` read). Screenshot walkthrough of the same scenario in the actual Meeting Brief panel attached below.

Meeting Brief panel showing the corrected "account arc" (ends 3 Sep, not the withheld message's 4 Sep) and the honest omission line ("1 conversation in this account is not yours to read, so the account arc is built from the rest"):


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a privacy leak in the meeting brief where a withheld conversation could still date the account arc, bias ranking and title selection, and reach the model's prompt as citable evidence. Also extends the slow-model deadline to six more routes so a slow answer falls back to deterministic composition instead of surfacing as a 502.

**Bug Fixes**
- Threads now build `First`/`Last`/`Inbound`/`Outbound`/`OnDeal`/`HasMeeting` only from rows the caller may read; an entirely withheld thread keeps the zero time and floor ranking score.
- `WithCounterpart` drops a withheld or unmarked activity before it reaches `Recent`, spelled as an allow-list so a future unknown content state is excluded by default.
- Added `/meeting-brief`, `/ask`, `/intro-note-draft`, `/intro-request-draft`, and `/role-proposals` to the slow-model deadline list.

No AI prompt text or request schema changed — `ActIn`'s shape is unchanged, only which entries `WithCounterpart` includes.

<sup>Written for commit c7ba9c77832519a55df36f1d94832bfb89666a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Withheld or unavailable conversation activity is excluded from meeting brief recency, dates, counts, citations, rankings, subjects, and summaries.
  * Readable activity is no longer displaced by withheld content when recent-item or arc limits apply.
  * Unmarked activity is treated as unavailable and excluded from meeting brief results.
  * Meeting brief and other AI-powered responses now receive sufficient time to complete without being cut off by server write-time limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->