### PR TITLE
Two fixtures main left behind

### DIFF
--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -45,9 +45,14 @@ import (
 func suppressPerson(t *testing.T, e *apptest.AppEnv, personID string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
+		// decided_by_level is stated rather than defaulted, because the column
+		// deliberately has no default: a writer names who decided or the INSERT
+		// fails where the author can see it. `subject` is what this row IS — a
+		// marketing objection is Art. 21 by definition, which is the same
+		// classification the migration gave the rows that predate the column.
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO communication_suppression (person_id, kind, source, captured_by)
-			VALUES ($1, 'marketing_objection', 'test', $2)`, personID, "test")
+			INSERT INTO communication_suppression (person_id, kind, source, captured_by, decided_by_level)
+			VALUES ($1, 'marketing_objection', 'test', $2, 'subject')`, personID, "test")
 		return err
 	}); err != nil {
 		t.Fatalf("recording the objection: %v", err)

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -565,13 +565,20 @@ test("AC-inbox: the staged decision is on the day's queue", async ({
   // and a queue that has to rank things across producers names each one by
   // what it actually is. Answering it stays the approvals surface's own job,
   // so the verbs are asserted where they live rather than here.
-  // The sentence appears twice on purpose: once as the row, and once on the
-  // card the row opens to answer it. That the decision is ANSWERABLE here is
-  // the claim worth making, so this asserts the verb rather than the text.
+  // That the decision is ANSWERABLE here is the claim worth making, so this
+  // asserts the verb rather than the text.
+  //
+  // The verb is "Entscheiden" and not a verdict: a decision is answered in a
+  // drawer now, so the queue draws the way IN to the answer rather than the
+  // answers themselves (AC-WORKLIST-SDR-03, which walks the drawer and asserts
+  // the verdicts inside it). Asserting "Übernehmen" here would be asserting the
+  // shape the row deliberately stopped having.
   await expect(
     page.getByText(/Send the follow-up to Anna Weber/).first(),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Übernehmen" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Entscheiden" }).first(),
+  ).toBeVisible();
 });
 
 test("AC-book: the booking page renders rail-less with live slots", async ({


### PR DESCRIPTION
**main is red on two lanes**, and every open pull request fails on both having touched nothing near them. Neither had an open PR fixing it.

## uat: the day's queue offers the way into a decision, not the verdict

`AC-inbox: the staged decision is on the day's queue` asserts `Übernehmen` is visible on `/#/worklist`. #4283 moved the verdicts into a drawer — the row draws `Entscheiden` now, and the queue deliberately draws **no** verdict button, which `AC-WORKLIST-SDR-03` (added by that same change) asserts from the other side:

```ts
// Nothing to answer until it is opened: the queue draws no verdict button.
await expect(page.getByRole("button", { name: "Übernehmen" })).toHaveCount(0);
```

The two tests contradicted each other and the older one was left behind, asserting the shape the row had just stopped having.

Its claim is unchanged and still worth making — the decision is on the day's queue and answerable from there — so it asserts the verb that opens it. The verdicts inside the drawer stay SDR-03's, which walks the drawer to reach them; repeating them here would make one change break two tests for one reason.

## integration: the objection fixture names who decided it

#4294 gave `communication_suppression` a `decided_by_level` and **dropped the default on purpose**:

> From here a writer states who decided, or the INSERT fails where the author can see it — which is the whole reason this column exists rather than a guess derived at read time.

The one fixture that writes the table directly was left behind, so `TestAMailSendToAnObjectingRecipientStagesNothing` and `TestAChannelSendToAnObjectingRecipientStagesNothing` fail on a NOT NULL violation.

`subject` is what the row **is** rather than a value picked to satisfy the column: a marketing objection is Art. 21 by definition, the same classification #4294's own migration gave the rows that predate it.

## Verified both ways, locally

- uat: pristine `origin/main` gives 1 failed / 275 passed; with this, **276 passed**.
- integration: both send-preflight tests fail on pristine main and pass with this.