### PR TITLE
fix(test): the suppression seed names the level its row was decided at

### DIFF
--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -42,12 +42,19 @@ import (
 // that will own it lands with the preference centre. The row shape is the one
 // liveSuppression reads, and when that writer arrives this helper is what
 // should be repointed at it.
+//
+// decided_by_level is named rather than defaulted, because the column has no
+// default: the migration that added it dropped the scaffolding one on purpose,
+// so that a writer states who decided or the INSERT fails where its author can
+// see it. 'subject' is what this row IS — a marketing objection is the person's
+// own act under Art. 21, the one tier no seat in the installation may lift —
+// and it is the level that migration's own backfill gives the same kind.
 func suppressPerson(t *testing.T, e *apptest.AppEnv, personID string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
-			INSERT INTO communication_suppression (person_id, kind, source, captured_by)
-			VALUES ($1, 'marketing_objection', 'test', $2)`, personID, "test")
+			INSERT INTO communication_suppression (person_id, kind, source, captured_by, decided_by_level)
+			VALUES ($1, 'marketing_objection', 'test', $2, 'subject')`, personID, "test")
 		return err
 	}); err != nil {
 		t.Fatalf("recording the objection: %v", err)


### PR DESCRIPTION
## What

The `suppressPerson` seed helper in `stagingrefusal_integration_test.go` names
`decided_by_level` on its INSERT. That is the whole diff.

## Why

`main` has been red on the integration lane since https://github.com/margince/margince/pull/4294:
shards 2/6 and 4/6 fail in `stagingrefusal`, and `integration (RLS + erasure +
HTTP e2e)` fails as their fan-in — one cause, three red jobs.

https://github.com/margince/margince/pull/4294 added
`communication_suppression.decided_by_level` and deliberately dropped the
scaffolding `DEFAULT`, so a writer states who decided or the INSERT fails where
its author can see it. That is the right shape and it did exactly what it was
built to do. The one writer of this table outside a migration is this seed
helper, which names its columns explicitly and did not name the new one.

`'subject'` is what the row **is**, not a value picked to make the test pass: a
marketing objection is the person's own act under Art. 21 — the tier no seat in
the installation may lift — and it is the level
https://github.com/margince/margince/pull/4294's own backfill assigns every
existing row of that kind.

The other INSERT into this table, in migration `1788527759`, is ordered before the
column exists and its rows are classified by that same backfill. It needs nothing,
and was checked rather than assumed.

## How verified

- `make test-it DIR=backend/internal/compose/integration RUN='TestAMailSendToAnObjectingRecipientStagesNothing|TestAChannelSendToAnObjectingRecipientStagesNothing'`
  against a real Postgres: **both PASS** (they were the two failing tests).
- Swept every INSERT into `communication_suppression` across the whole tree, not
  just Go: exactly two, and the migration one is ordered before the column.
- `go test ./gates/...` green, including `suppressionauthority_test.go`.

- [x] `make check` is green
- [ ] `make test-integration` is green (the two tests this repairs are run directly, above, against a real Postgres)
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Generated. Traced from the red `main-health` run through the shard logs to the
single failing statement, then checked for sibling writers before fixing the one
that failed.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
