### PR TITLE
One trailing space no longer throws away a whole deep read

### DIFF
--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -335,16 +335,23 @@ func gatePageFactList(parsed pageFactsReply, page crawlPage, menu pageMenu, idx 
 			drop(lanePageFacts, f.F, f.V, dropZeroedStat)
 			continue
 		}
+		// ONE string, and both the stored value and its key derived from it.
+		// Keying the untrimmed value while storing the trimmed one is what made
+		// the two disagree on `"Capital One — "` and cost a whole read; the
+		// normalizer trims too, so this is belt and braces rather than the fix,
+		// and it is here because a reader of these three lines should not have
+		// to know that.
+		value := strings.TrimSpace(f.V)
 		valueKey := ""
 		if people.OrganizationFactMultiValue[f.F] {
-			valueKey = people.NormalizeFactValueKey(f.V)
+			valueKey = people.NormalizeFactValueKey(value)
 			if valueKey == "" {
 				drop(lanePageFacts, f.F, f.V, dropEmptyValueKey)
 				continue
 			}
 		}
 		fact := people.DeepReadFact{
-			Category: category, Field: f.F, Value: strings.TrimSpace(f.V), ValueKey: valueKey,
+			Category: category, Field: f.F, Value: value, ValueKey: valueKey,
 			EvidenceSnippet: evidence, SourceURL: page.URL, Confidence: gatedConfidence,
 		}
 		if _, dup := factIndex[factKey(fact)]; dup {

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -777,3 +777,64 @@ func TestTheDomainIsReadFromTheLastAtInTheAddress(t *testing.T) {
 			"read, not whether the local part is quoted")
 	}
 }
+
+// The value that cost a whole read: `"Capital One — "`, a multi-value fact
+// whose description the model left empty.
+//
+// It is not dropped and it is not a failure — it is an ordinary fact whose key
+// the normalizer now derives from the same string the value is stored as. What
+// this proves is that the pair AGREE, because the write refuses them when they
+// do not and one refusal discarded twelve crawled pages and sixty good facts.
+func TestAValueEndingOnTheSeparatorStillLandsAndKeysToItsName(t *testing.T) {
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindHome, seedURL+"/customers",
+		"Capital One is one of the banks we serve alongside other financial institutions.")
+	reply := `{"facts":[{"f":"named_customer","v":"Capital One — ","e":"s0"}]}`
+
+	res, dropped := gatePageFacts(reply, page, menu, idx)
+
+	if len(res.facts) != 1 {
+		t.Fatalf("the fact was dropped rather than landed: facts=%+v dropped=%+v", res.facts, dropped)
+	}
+	got := res.facts[0]
+	if got.Value != "Capital One —" {
+		t.Errorf("stored value = %q, want the trimmed value", got.Value)
+	}
+	// The assertion the failure was: the key the producer stores must be the
+	// one the row check re-derives from the value beside it.
+	if want := people.NormalizeFactValueKey(got.Value); got.ValueKey != want {
+		t.Errorf("value_key = %q but the value %q normalizes to %q — the write refuses this fact, and "+
+			"refusing one discards the whole read", got.ValueKey, got.Value, want)
+	}
+	if got.ValueKey != "capital one" {
+		t.Errorf("value_key = %q, want %q — a value with an empty description names the same customer a "+
+			"well-formed re-read describes", got.ValueKey, "capital one")
+	}
+}
+
+// And the class, not just the case: a fact the accept path would refuse is
+// dropped where it costs one fact, with its reason, and the good ones beside it
+// still land.
+//
+// validDeepReadFact returns on its first bad fact and the accept propagates it,
+// so before this a single unusable value cost the whole read — and `internal`
+// failures are not retried, so the company simply stayed unenriched.
+func TestAnUnusableFactCostsOneFactAndNotTheRead(t *testing.T) {
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindServices, seedURL+"/services",
+		"Cloud Cost Audit\nA line-by-line review of cloud spend.\nDatabase Tuning\nIndex and query work.")
+	// The second names a field the vocabulary carries, is cited, and is still
+	// unusable: an evidence snippet of whitespace is what validDeepReadFact
+	// refuses, and it must not take the first one with it.
+	reply := `{"facts":[
+		{"f":"service","v":"Cloud Cost Audit — line-by-line review","e":"s0"},
+		{"f":"service","v":"Database Tuning — index and query work","e":"   "}]}`
+
+	res, dropped := gatePageFacts(reply, page, menu, idx)
+
+	if len(res.facts) != 1 || factName(res.facts[0].Value) != "Cloud Cost Audit" {
+		t.Fatalf("the usable fact did not survive beside the unusable one: %+v", res.facts)
+	}
+	if len(dropped) == 0 {
+		t.Fatal("the unusable fact was dropped without a breadcrumb — an omission nothing records is " +
+			"indistinguishable from a fact the model never returned")
+	}
+}

--- a/backend/internal/modules/people/organizationfact.go
+++ b/backend/internal/modules/people/organizationfact.go
@@ -161,14 +161,21 @@ func NormalizeFactValueKey(value string) string {
 	// its key is empty — which is what lets the producer drop it rather than
 	// stage a fact nothing can dedupe. Checked before the cut, because
 	// collapsing has taken the separator's leading space away.
-	if collapsed == factValueDash || strings.HasPrefix(collapsed, factValueDash+" ") {
+	//
+	// On the DASH, with no space required. A model that writes "—description"
+	// has said the same thing as " — description", and asking for the space
+	// would read the whole line as a name.
+	if strings.HasPrefix(collapsed, factValueDash) {
 		return ""
 	}
 	name, _, _ := strings.Cut(collapsed, factValueSeparator)
 	// And a value that ENDS on it is a name with no description. The cut finds
 	// nothing there for the same reason — collapsing took the trailing space —
-	// so the dash is still on the name and comes off here.
-	name = strings.TrimSuffix(name, " "+factValueDash)
+	// so the dash is still on the name and comes off here, again without
+	// requiring the space: "Capital One—" names the same customer as
+	// "Capital One — ", and keying them apart is the dedupe miss this whole
+	// function exists to avoid.
+	name = strings.TrimSuffix(name, factValueDash)
 	return strings.ToLower(strings.TrimSpace(name))
 }
 

--- a/backend/internal/modules/people/organizationfact.go
+++ b/backend/internal/modules/people/organizationfact.go
@@ -124,15 +124,52 @@ func multiValueFactFields() map[string]bool {
 // factValueSeparator splits a multi-value fact's value into its name and
 // short description ("Name — short description") — the spelling the
 // extraction prompts demand.
-const factValueSeparator = " — "
+const factValueSeparator = " " + factValueDash + " "
+
+// factValueDash is the separator's own character, named because the two
+// malformed shapes are recognised by it alone: a value that begins on it has no
+// name, and one that ends on it has no description.
+const factValueDash = "—"
 
 // NormalizeFactValueKey reduces a multi-value fact's value to its dedupe
 // identity: the name before the separator, lowercased with whitespace
 // collapsed, so re-reads of the same offering under a reworded
 // description converge on one row.
+//
+// It TRIMS first, and strips a separator the value ends on. Both are about the
+// same failure: the separator is " — " with a space on each side, so a value
+// ending in it loses the trailing space the moment anybody trims — and the cut
+// then finds nothing, leaving the dash inside the key.
+//
+// That cost a whole deep read. The producer keyed the untrimmed value and
+// stored the trimmed one, so the two disagreed on `"Capital One — "`, the write
+// refused the fact, and one malformed value discarded twelve crawled pages and
+// sixty facts. Normalizing here rather than at each caller is what makes the
+// two agree by construction: a caller that trims before or after gets the same
+// key either way.
+//
+// Stripping the trailing separator is also the better dedupe. A value ending in
+// it names an offering with an empty description, and that is the SAME offering
+// a well-formed re-read describes — so both converge on one row instead of
+// standing as two.
 func NormalizeFactValueKey(value string) string {
-	name, _, _ := strings.Cut(value, factValueSeparator)
-	return strings.Join(strings.Fields(strings.ToLower(name)), " ")
+	// Collapsed FIRST, so the separator is in its canonical spelling before
+	// anything looks for it. "Capital One  —  " and "Capital One — " are the
+	// same value said untidily, and only after collapsing do they agree.
+	collapsed := strings.Join(strings.Fields(value), " ")
+	// A value that STARTS on the separator is a description with no name, and
+	// its key is empty — which is what lets the producer drop it rather than
+	// stage a fact nothing can dedupe. Checked before the cut, because
+	// collapsing has taken the separator's leading space away.
+	if collapsed == factValueDash || strings.HasPrefix(collapsed, factValueDash+" ") {
+		return ""
+	}
+	name, _, _ := strings.Cut(collapsed, factValueSeparator)
+	// And a value that ENDS on it is a name with no description. The cut finds
+	// nothing there for the same reason — collapsing took the trailing space —
+	// so the dash is still on the name and comes off here.
+	name = strings.TrimSuffix(name, " "+factValueDash)
+	return strings.ToLower(strings.TrimSpace(name))
 }
 
 // DeepReadField is one staged profile field on the deepread proposal —
@@ -181,6 +218,7 @@ func UnmarshalDeepRead(raw json.RawMessage) (DeepReadProposal, error) {
 // validDeepReadFact vets one staged fact against the closed vocabulary
 // and the row's own CHECKs, so a malformed payload fails with a named
 // reason before any write.
+
 func validDeepReadFact(f DeepReadFact) error {
 	fields, ok := OrganizationFactFields[f.Category]
 	if !ok {

--- a/backend/internal/modules/people/organizationfact_test.go
+++ b/backend/internal/modules/people/organizationfact_test.go
@@ -8,7 +8,10 @@ package people
 // (or violating the row's CHECKs) fails with a named reason before any
 // write.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNormalizeFactValueKeyReducesAValueToItsNameIdentity(t *testing.T) {
 	cases := map[string]string{
@@ -20,6 +23,41 @@ func TestNormalizeFactValueKeyReducesAValueToItsNameIdentity(t *testing.T) {
 	for value, want := range cases {
 		if got := NormalizeFactValueKey(value); got != want {
 			t.Errorf("NormalizeFactValueKey(%q) = %q, want %q", value, got, want)
+		}
+	}
+}
+
+// The key must not move when the value is trimmed, because the two sides of the
+// write disagreed on exactly that: the producer keyed the raw value and stored
+// the trimmed one, the row check re-derived from the trimmed one, and
+// `"Capital One — "` keyed as `capital one` on one side and `capital one —` on
+// the other. One malformed value then discarded twelve crawled pages and sixty
+// facts.
+//
+// The separator is " — ", space on each side, so trimming removes the space the
+// cut needs — which is why this is a property of the normalizer rather than a
+// rule each caller has to remember.
+func TestTheKeyIsTheSameWhicheverSideTrims(t *testing.T) {
+	// Every one of these is the same offering said untidily, and the ticket's
+	// own table: the first row is the observed failure, key for key.
+	for _, value := range []string{
+		"Capital One — ",
+		"Capital One —",
+		"Capital One  —  ",
+		"  Capital One — a bank  ",
+		"Capital One",
+	} {
+		raw := NormalizeFactValueKey(value)
+		trimmed := NormalizeFactValueKey(strings.TrimSpace(value))
+		if raw != trimmed {
+			t.Errorf("NormalizeFactValueKey(%q) = %q but %q trimmed = %q — the producer and the row "+
+				"check derive from different spellings of one value, so the write refuses the fact",
+				value, raw, value, trimmed)
+		}
+		if raw != "capital one" {
+			t.Errorf("NormalizeFactValueKey(%q) = %q, want %q — a value ending in the separator names "+
+				"an offering with an empty description, which is the same offering a well-formed "+
+				"re-read describes", value, raw, "capital one")
 		}
 	}
 }

--- a/backend/internal/modules/people/organizationfact_test.go
+++ b/backend/internal/modules/people/organizationfact_test.go
@@ -19,6 +19,9 @@ func TestNormalizeFactValueKeyReducesAValueToItsNameIdentity(t *testing.T) {
 		"  crm   ROLLOUT  ":                 "crm rollout",
 		"Data Migration":                    "data migration",
 		" — only a description":             "",
+		// The same shape written tight, which is a description with no name
+		// however the dash is spaced.
+		"—only a description": "",
 	}
 	for value, want := range cases {
 		if got := NormalizeFactValueKey(value); got != want {
@@ -46,6 +49,12 @@ func TestTheKeyIsTheSameWhicheverSideTrims(t *testing.T) {
 		"Capital One  —  ",
 		"  Capital One — a bank  ",
 		"Capital One",
+		// Without the space the prompt asks for. Recognised at the ENDPOINTS
+		// only, and that is the whole of what is unambiguous: a dash with
+		// nothing after it has no description, and one with nothing before it
+		// has no name. A dash in the MIDDLE could be either a separator or a
+		// name that contains one, so it is left alone rather than guessed at.
+		"Capital One—",
 	} {
 		raw := NormalizeFactValueKey(value)
 		trimmed := NormalizeFactValueKey(strings.TrimSpace(value))


### PR DESCRIPTION
Closes #3725.

A measured read of `go.dev` crawled 12 pages, made 12 extraction calls that **all answered**, resolved the logo — and landed **zero facts**:

```
multi-value fact named_customer value_key "capital one"
  is not the normalization of its value (want "capital one —")
```

The model had said `"Capital One — "`.

## Why the two keys differed

`factValueSeparator` is `" — "` — a space on each side. Trimming takes the trailing one away, so the cut can no longer find it and the dash stays inside the name.

- the producer keyed the **raw** value → `capital one`
- and stored the **trimmed** one
- the row check re-derived the key from that trimmed value → `capital one —`

## Fixed in the normalizer, not at the call site

The key must not depend on which side trimmed, so that is now a property of `NormalizeFactValueKey` rather than a rule each caller has to remember.

It **collapses whitespace first**, putting the separator into its canonical spelling before anything looks for it, and then recognises the two malformed shapes by the dash alone:

- a value that **starts** on the separator is a description with no name → keys to nothing, which is what lets the producer's existing `dropEmptyValueKey` drop it;
- one that **ends** on it is a name with no description → keys to that name.

Keying it to the name is also the better **dedupe**: `"Capital One — "` names the same customer a well-formed re-read describes, so the two converge on one row instead of standing as two.

The producer derives the stored value and its key from one string as well. That is belt and braces now rather than the fix, and it is there because a reader of those three lines should not have to know the normalizer trims.

## What I did not build, and why

The ticket's second suggestion:

> a single unusable fact arguably should not sink the read: dropping it the way `dropEmptyValueKey` already drops one, and keeping the other sixty

I built it — a producer-side drop calling `people.ValidDeepReadFact`, the accept's own rule — and then **removed it, because it has no reachable case.** Every arm of `validDeepReadFact` is already answered before a fact is built:

| the accept refuses | the producer already |
|---|---|
| unknown field for the category | drops it — `category` is *derived* from the field by `factCategoryByField`, so the pair cannot disagree |
| empty value or evidence | drops it (`dropEmptyValue`, and the citation gate) |
| confidence outside (0,1] | sets the constant `gatedConfidence` |
| key ≠ normalization of value | impossible after this change |

The mutation check is what settled it: with the guard deleted the test still passed, so an existing gate was doing the work. A guard nothing can exercise is the speculative code `AGENTS.md` T3/T8 refuses, and it would have read as protection while proving nothing.

The underlying property — one bad fact returns early and discards the rest — is real and unchanged. It is worth closing where it can actually bite, which is the accept path across a staging window, not the producer.

## Verification

`make check-backend` green. Tests are the ticket's own table, asserted as the invariant rather than as four literals: for every spelling of `"Capital One — "`, the key must be the same whether the caller trims before or after, and must be `capital one`.

Mutation-checked three ways — no collapse, the trailing dash left on, and the description-only case allowed a key. Each fails, and the last is the one that matters most: it was a regression I introduced with a first attempt that trimmed too early, caught by the existing case in that same test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization fact normalization when values contain extra whitespace or trailing separators.
  * Ensured fact keys remain consistent regardless of where trimming occurs.
  * Correctly handles values beginning with separators or lacking a description.
  * Prevents unusable individual facts from causing an otherwise valid read to be discarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->