### PR TITLE
The record panel asks the deciding half, not the reading one

### DIFF
--- a/backend/internal/modules/approvals/pendingfortarget.go
+++ b/backend/internal/modules/approvals/pendingfortarget.go
@@ -29,12 +29,24 @@ import (
 // package, and re-deriving the effective status (lazy expiry) outside this
 // module is exactly the drift the type keeps unexported to prevent.
 //
-// Every row here shares ONE target, so the target-visibility half of
-// decidable is asked once for the record rather than once per row — the
-// inbox's per-row probe exists because its rows point at different records.
-// The two halves that vary by row stay in the loop: the per-kind grant check,
-// and the self-only narrowing (withheldFromOtherSeats), which compares the
-// caller against the seat each ROW was staged for and not against the target.
+// It IS decidable, evaluated in the order this shape allows rather than by a
+// second rule. Every row shares ONE target, so decidable's target half is asked
+// once for the record instead of once per row — the inbox's per-row probe
+// exists because its rows point at different records — and the two halves that
+// vary by row stay in the loop: the per-kind grant check, and the self-only
+// narrowing (withheldFromOtherSeats), which compares the caller against the
+// seat each ROW was staged for and not against the target.
+//
+// The hoisted half is targetDecidable, the WRITE one, and not targetVisible.
+// They differ in exactly the arms a manual grant can widen, so reading-scope
+// was enough to put a pending proposal on the panel — and the panel renders the
+// proposal, summary and proposed change included, not merely the fact that one
+// exists. A read-scoped share therefore received a staged change the inbox
+// withholds from the same seat.
+//
+// decidable's own doc is why that cannot stand: it backs List, Get and Decide
+// alike so triage visibility and the decision gate can never drift apart. A
+// record page answering differently is that drift, wearing a fourth caller.
 //
 // The scan is bounded at PendingScanCap rows so one record page cannot pay
 // for an unbounded backlog. A caller counting rather than listing must treat
@@ -48,15 +60,15 @@ func (s *Service) PendingForTarget(ctx context.Context, tx pgx.Tx, targetType st
 	if limit <= 0 || limit > PendingScanCap {
 		limit = PendingScanCap
 	}
-	visible, err := targetVisible(ctx, tx, &targetType, &targetID)
+	decidableTarget, err := targetDecidable(ctx, tx, &targetType, &targetID)
 	if err != nil {
 		return nil, err
 	}
-	if !visible {
-		// The record itself is one this caller could not read — an ungranted
-		// type or an out-of-scope row — so nothing staged against it is
-		// decidable, and saying so is the same existence-hiding answer the
-		// record read gives.
+	if !decidableTarget {
+		// The record is one this caller could not decide against — an ungranted
+		// type, an out-of-scope row, or a share that only ever let them read —
+		// so nothing staged against it is decidable, and saying so is the same
+		// existence-hiding answer the record read gives.
 		return []crmcontracts.Approval{}, nil
 	}
 	now := s.now()

--- a/backend/internal/modules/approvals/pendingtargetscope_integration_test.go
+++ b/backend/internal/modules/approvals/pendingtargetscope_integration_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// The record panel and the inbox answer ONE question about a target.
+//
+// decidable exists so they cannot drift: it backs List, Get and Decide alike,
+// "so triage visibility and the decision gate can never drift apart — you see
+// exactly what you could act on, and what you cannot see you cannot decide (in
+// either direction)". The panel was a fourth caller answering differently — it
+// hoisted targetVisible, the READ half, where the inbox takes targetDecidable,
+// the WRITE one.
+//
+// The two differ in exactly the arms a manual grant can widen, so a read-only
+// SHARE was enough. And the panel renders the proposal — summary and proposed
+// change, not merely that one exists — so what reached that seat was the staged
+// content itself.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// sharedSeat is a colleague whose reach over ONE record comes from a grant
+// rather than from row scope: the object grants a decision needs, and no scope
+// of their own. What the share says — read or write — is then the whole
+// difference between the two predicates.
+func sharedSeat(ws, user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			RowScope: principal.RowScopeOwn,
+			Objects: map[string]principal.ObjectGrant{
+				tableOrganization: {Create: true, Read: true, Update: true, Delete: true},
+			},
+		},
+	})
+}
+
+func TestAReadOnlyShareIsNotEnoughToSeeAPendingDecision(t *testing.T) {
+	e := setupStaging(t)
+	ctx := context.Background()
+
+	sharee := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Sharee')`,
+		sharee, "sharee-"+sharee.String()+"@st.test"); err != nil {
+		t.Fatalf("seeding the sharee: %v", err)
+	}
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO organization (id, display_name, source, captured_by, owner_id)
+		VALUES ($1, 'Gitex', 'test', 'human:seed', $2)`, target, e.rep); err != nil {
+		t.Fatalf("seeding the account: %v", err)
+	}
+	// A shared kind, so the self-only narrowing is not what answers this: the
+	// only thing between the sharee and the row is which half of the target
+	// predicate the panel hoists.
+	if _, err := e.svc.Stage(e.asAgent(t), StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: []byte(`{"proposed_name":"Gitex Global"}`),
+		DiffHash:       "promotion-" + target.String(),
+		TargetType:     tableOrganization,
+		TargetID:       target,
+		Summary:        "Rename Gitex?",
+	}); err != nil {
+		t.Fatalf("staging the proposal: %v", err)
+	}
+
+	share := func(t *testing.T, access string) {
+		t.Helper()
+		// Replaced rather than inserted-if-absent: the two calls below are the
+		// SAME share widened, and an ON CONFLICT DO NOTHING would silently keep
+		// the read grant — which passes the first assertion and then fails the
+		// control for a reason that has nothing to do with the panel.
+		if _, err := e.owner.Exec(ctx,
+			`DELETE FROM record_grant WHERE record_id = $1 AND subject_id = $2`, target, sharee); err != nil {
+			t.Fatalf("clearing the previous share: %v", err)
+		}
+		if _, err := e.owner.Exec(ctx, `
+			INSERT INTO record_grant (record_type, record_id, subject_type, subject_id, access, granted_by)
+			VALUES ('organization', $1, 'user', $2, $3, $4)`, target, sharee, access, e.rep); err != nil {
+			t.Fatalf("granting %s: %v", access, err)
+		}
+	}
+	panelRows := func(t *testing.T, as context.Context) int {
+		t.Helper()
+		var n int
+		if err := e.svc.db.Tx(as, func(tx pgx.Tx) error {
+			out, err := e.svc.PendingForTarget(as, tx, tableOrganization, target, PendingScanCap)
+			n = len(out)
+			return err
+		}); err != nil {
+			t.Fatalf("PendingForTarget: %v", err)
+		}
+		return n
+	}
+
+	share(t, "read")
+	if got := panelRows(t, sharedSeat(e.ws, sharee)); got != 0 {
+		t.Errorf("a read-only share put %d pending proposal(s) on the record panel — the panel renders "+
+			"the summary and the proposed change, so this seat received a staged change the inbox "+
+			"withholds from them", got)
+	}
+
+	// THE POSITIVE CONTROL, and it is what makes the assertion above mean
+	// anything: without it this test passes just as well when the panel is
+	// broken and shows nobody anything.
+	share(t, "write")
+	if got := panelRows(t, sharedSeat(e.ws, sharee)); got != 1 {
+		t.Errorf("a write share read %d pending proposal(s), want 1 — narrowing the panel to the "+
+			"deciding half has taken it from the seat that CAN decide", got)
+	}
+}


### PR DESCRIPTION
Closes #3707.

## Half of it is already fixed

The ticket reports two divergences between `PendingForTarget` and the inbox. Measuring against current `main`, **the self-only one is gone** — `PendingForTarget` calls `withheldFromOtherSeats` per row, and its doc explains why the target half is hoisted while the two row-varying halves stay in the loop. `TestASelfOnlyStagingIsAbsentFromAColleaguesTargetFilteredReads` holds it.

The second one stands, and it is the one this closes.

## A read-only share was enough

The panel hoisted `targetVisible` — the READ half — where the inbox takes `targetDecidable`, the WRITE one. They differ in *"exactly the arms whose table a manual grant can widen"*, so a read-scoped record grant put a pending proposal on the record page.

And the panel does not merely say one exists: it returns `crmcontracts.Approval`, **summary and proposed change included**. So what reached that seat was the staged change itself, which the inbox withholds from the same person.

`decidable`'s own doc is why that cannot stand:

> It backs List, Get and Decide alike, so triage visibility and the decision gate can never drift apart — you see exactly what you could act on, and what you cannot see you cannot decide (in either direction).

A record page answering differently is that drift wearing a fourth caller.

## What changed

One predicate: the hoisted half is now `targetDecidable`. The hoist itself stays, and the ticket's suggested `decidable`-per-row would undo it for nothing — every row here shares one target, so the inbox's per-row probe (its rows point at different records) would re-ask the same question N times.

So the panel **is** `decidable`, evaluated in the order this shape allows: the target once, then the per-kind grants and the self-only narrowing per row. The doc now says which half is hoisted and why, so the next reader is not left to infer it from which helper was reached for.

## Verification

`make check-backend` green.

`TestAReadOnlyShareIsNotEnoughToSeeAPendingDecision` drives the difference through a real `record_grant`, widened from `read` to `write` on the same share — and the write case is a **positive control**, without which the test passes just as well when the panel is broken and shows nobody anything.

That control earned its keep twice while I wrote it: first an `ON CONFLICT DO NOTHING` silently kept the read grant so the widening never happened, then the kind I picked needed `organization.update` while the seat held only person grants — so both cases were empty for a reason that had nothing to do with the panel. Neither would have been visible from the passing half alone.

Mutation-checked: restoring `targetVisible` fails with the message that names it, and the self-only test stays green throughout — the narrowing did not swallow the gate beside it.
