### PR TITLE
The engine says what it decided, and who may change it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30739,6 +30739,42 @@ components:
             How much authority the engine's answer carries for this category on this
             installation. Under `observe` a `deny` here still sends, and a composer that
             showed it as a refusal would be describing a rollout position as a rule.
+        would_refuse:
+          type: boolean
+          description: |
+            Whether this answer actually STOPS the message on this installation. Not the same
+            question as the verdict, and the only one a surface should draw a refusal from.
+
+            Three things decide it and the engine already weighs them together: the verdict,
+            the rollout mode for the resolved category, and whether the reason is one no mode
+            may soften. Under `observe` a `deny` is recorded and the send still goes, so a
+            composer reading the verdict alone would show a rollout position as a rule and
+            talk a rep out of a message that would have gone.
+        can_be_overruled:
+          type: boolean
+          description: |
+            Whether a person may lift this refusal by recording why they are writing.
+
+            It needs BOTH halves of a question the engine keeps on two axes, which is why it
+            is answered here rather than derived. `decided_by` says whose decision it is, and
+            an absolute reason says no rollout mode softens it — and the two disagree: a hard
+            bounce, a rolling frequency cap, an unresolvable recipient and an unconfirmed
+            opt-in are all the engine's own reading (`machine`) AND absolute. A surface that
+            offered an override on those would render a button that cannot achieve what it
+            promises, and the rep would type a justification the staging gate then ignores.
+        decided_by:
+          type: string
+          enum: [machine, user, admin, subject]
+          description: |
+            Whose decision this answer is, which is what says whether anybody may overrule
+            it. `machine` is the engine reading an incomplete record and a rep who knows
+            better may say so. `subject` is the person's own act — an objection or a
+            withdrawal — and nobody in the installation lifts it, admin included.
+
+            It is sent rather than derived because the rule lives in Go
+            (`commsauthz.LevelForReason`), and a surface that mapped reason codes to
+            liftability itself would be a second copy of that rule. The copy that stopped
+            matching would offer a rep a button that cannot lawfully be pressed.
 
     SendAccountEmailRequest:
       type: object

--- a/backend/gates/previewauthority_test.go
+++ b/backend/gates/previewauthority_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The authority levels a composer can receive are the ones the engine can send.
+//
+// A send preview tells a surface WHOSE decision a refusal is, and the surface
+// decides from it whether to offer an override at all. That answer crosses a
+// wire: commsauthz.AuthorityLevel on one side, the contract's `decided_by` enum
+// on the other.
+//
+// Two spellings of one vocabulary drift in a way nothing else catches. Add a
+// level in Go and the contract keeps validating the old set, so the new level
+// reaches a composer as an unrecognised string and whatever the surface does
+// with an unknown value becomes the product's answer to "may a rep overrule
+// this". Add one to the contract alone and the server can never send it.
+//
+// The failure direction that matters is the quiet one: a surface treating an
+// unrecognised level as overrulable would offer a button on a refusal nobody
+// may lift. So this fails in BOTH directions rather than checking containment.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// contractDecidedBy reads the enum the contract publishes for decided_by.
+var contractDecidedBy = regexp.MustCompile(
+	`(?s)decided_by:\s*\n\s*type: string\s*\n\s*enum: \[([^\]]+)\]`)
+
+// authorityLevelSource declares the levels. Read rather than restated: a list
+// here would be a second copy of the vocabulary, and the copy that stopped
+// matching is the one nobody notices.
+const authorityLevelSource = "internal/shared/ports/commsauthz/authority.go"
+
+// declaredAuthorityLevels collects every AuthorityLevel constant the package
+// declares, so a fifth added in Go enters this set without anybody editing the
+// gate — which is the whole point, because the failure this file exists to
+// catch is a level the contract does not publish.
+func declaredAuthorityLevels(t *testing.T) map[string]bool {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), authorityLevelSource, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", authorityLevelSource, err)
+	}
+	levels := map[string]bool{}
+	for _, decl := range parsed.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			// Names and values read one-to-one only when they pair up; an iota
+			// run or a multi-assign pairs a name with an expression that is not
+			// its own, and reading by index would hand this gate the wrong text.
+			if !isValue || len(value.Names) != len(value.Values) {
+				continue
+			}
+			named, isNamed := value.Type.(*ast.Ident)
+			if !isNamed || named.Name != "AuthorityLevel" {
+				continue
+			}
+			for _, v := range value.Values {
+				// gatekit.LiteralText rather than the node's own Value, which is
+				// the SOURCE text: quotes still on it and escapes undecoded, so a
+				// level written with one would enter this set under a spelling no
+				// send ever carries and agree with nothing.
+				if text, ok := gatekit.LiteralText(v); ok {
+					levels[text] = true
+				}
+			}
+		}
+	}
+	return levels
+}
+
+// TestTheAuthorityLevelsAgreeAcrossTheWire holds the Go vocabulary and the
+// published one to each other.
+func TestTheAuthorityLevelsAgreeAcrossTheWire(t *testing.T) {
+	t.Parallel()
+
+	contract, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	match := contractDecidedBy.FindSubmatch(contract)
+	if match == nil {
+		t.Fatal("the contract publishes no decided_by enum: either the field was renamed and " +
+			"this gate now checks nothing, or the preview stopped saying whose decision a " +
+			"refusal is, which is what a surface needs to know whether to offer an override")
+	}
+
+	published := map[string]bool{}
+	for _, raw := range strings.Split(string(match[1]), ",") {
+		if v := strings.TrimSpace(raw); v != "" {
+			published[v] = true
+		}
+	}
+
+	known := declaredAuthorityLevels(t)
+
+	// Under-recognition is the failure that reports PASS: a walk that found no
+	// constants, or a regex that matched an empty enum, would agree with each
+	// other about nothing. Both sides are floored against the four levels the
+	// model shipped with rather than against each other, so an empty pair
+	// cannot agree its way to green.
+	const shipped = 4
+	if len(known) < shipped {
+		t.Fatalf("read %d AuthorityLevel constants from %s, want at least the %d the model "+
+			"shipped with: the walk has stopped seeing its subject",
+			len(known), authorityLevelSource, shipped)
+	}
+	if len(published) < shipped {
+		t.Fatalf("read %d values from the contract's decided_by enum, want at least the %d "+
+			"the model shipped with: the pattern has stopped seeing its subject",
+			len(published), shipped)
+	}
+
+	for level := range known {
+		if !published[level] {
+			t.Errorf("the engine can answer %q but the contract does not publish it: a composer "+
+				"receives a level it cannot interpret, and whatever it does with an unknown "+
+				"value becomes the answer to whether a rep may overrule that refusal", level)
+		}
+	}
+	for level := range published {
+		if !known[level] {
+			t.Errorf("the contract publishes %q but the engine cannot answer it: a surface may "+
+				"branch on a level no send will ever carry", level)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("engine: %v", sortedKeys(known))
+		t.Logf("contract: %v", sortedKeys(published))
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10825,6 +10825,30 @@ func (e SendAccountEmailRequestCommunicationContext) Valid() bool {
 	}
 }
 
+// Defines values for SendAuthorizationPreviewRecipientDecidedBy.
+const (
+	SendAuthorizationPreviewRecipientDecidedByAdmin   SendAuthorizationPreviewRecipientDecidedBy = "admin"
+	SendAuthorizationPreviewRecipientDecidedByMachine SendAuthorizationPreviewRecipientDecidedBy = "machine"
+	SendAuthorizationPreviewRecipientDecidedBySubject SendAuthorizationPreviewRecipientDecidedBy = "subject"
+	SendAuthorizationPreviewRecipientDecidedByUser    SendAuthorizationPreviewRecipientDecidedBy = "user"
+)
+
+// Valid indicates whether the value is a known member of the SendAuthorizationPreviewRecipientDecidedBy enum.
+func (e SendAuthorizationPreviewRecipientDecidedBy) Valid() bool {
+	switch e {
+	case SendAuthorizationPreviewRecipientDecidedByAdmin:
+		return true
+	case SendAuthorizationPreviewRecipientDecidedByMachine:
+		return true
+	case SendAuthorizationPreviewRecipientDecidedBySubject:
+		return true
+	case SendAuthorizationPreviewRecipientDecidedByUser:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SendAuthorizationPreviewRecipientMode.
 const (
 	SendAuthorizationPreviewRecipientModeEnforce SendAuthorizationPreviewRecipientMode = "enforce"
@@ -30710,6 +30734,28 @@ type SendAuthorizationPreviewRecipient struct {
 	// Basis The lawful ground an allow would rest on.
 	Basis *string `json:"basis,omitempty"`
 
+	// CanBeOverruled Whether a person may lift this refusal by recording why they are writing.
+	//
+	// It needs BOTH halves of a question the engine keeps on two axes, which is why it
+	// is answered here rather than derived. `decided_by` says whose decision it is, and
+	// an absolute reason says no rollout mode softens it — and the two disagree: a hard
+	// bounce, a rolling frequency cap, an unresolvable recipient and an unconfirmed
+	// opt-in are all the engine's own reading (`machine`) AND absolute. A surface that
+	// offered an override on those would render a button that cannot achieve what it
+	// promises, and the rep would type a justification the staging gate then ignores.
+	CanBeOverruled *bool `json:"can_be_overruled,omitempty"`
+
+	// DecidedBy Whose decision this answer is, which is what says whether anybody may overrule
+	// it. `machine` is the engine reading an incomplete record and a rep who knows
+	// better may say so. `subject` is the person's own act — an objection or a
+	// withdrawal — and nobody in the installation lifts it, admin included.
+	//
+	// It is sent rather than derived because the rule lives in Go
+	// (`commsauthz.LevelForReason`), and a surface that mapped reason codes to
+	// liftability itself would be a second copy of that rule. The copy that stopped
+	// matching would offer a rep a button that cannot lawfully be pressed.
+	DecidedBy *SendAuthorizationPreviewRecipientDecidedBy `json:"decided_by,omitempty"`
+
 	// Mode How much authority the engine's answer carries for this category on this
 	// installation. Under `observe` a `deny` here still sends, and a composer that
 	// showed it as a refusal would be describing a rollout position as a rule.
@@ -30727,7 +30773,28 @@ type SendAuthorizationPreviewRecipient struct {
 	// Verdict `allow` would send. `deny` would refuse. `review` is not a soft allow — it means
 	// the record does not carry this message on its own and names what is missing.
 	Verdict SendAuthorizationPreviewRecipientVerdict `json:"verdict"`
+
+	// WouldRefuse Whether this answer actually STOPS the message on this installation. Not the same
+	// question as the verdict, and the only one a surface should draw a refusal from.
+	//
+	// Three things decide it and the engine already weighs them together: the verdict,
+	// the rollout mode for the resolved category, and whether the reason is one no mode
+	// may soften. Under `observe` a `deny` is recorded and the send still goes, so a
+	// composer reading the verdict alone would show a rollout position as a rule and
+	// talk a rep out of a message that would have gone.
+	WouldRefuse *bool `json:"would_refuse,omitempty"`
 }
+
+// SendAuthorizationPreviewRecipientDecidedBy Whose decision this answer is, which is what says whether anybody may overrule
+// it. `machine` is the engine reading an incomplete record and a rep who knows
+// better may say so. `subject` is the person's own act — an objection or a
+// withdrawal — and nobody in the installation lifts it, admin included.
+//
+// It is sent rather than derived because the rule lives in Go
+// (`commsauthz.LevelForReason`), and a surface that mapped reason codes to
+// liftability itself would be a second copy of that rule. The copy that stopped
+// matching would offer a rep a button that cannot lawfully be pressed.
+type SendAuthorizationPreviewRecipientDecidedBy string
 
 // SendAuthorizationPreviewRecipientMode How much authority the engine's answer carries for this category on this
 // installation. Under `observe` a `deny` here still sends, and a composer that

--- a/backend/internal/modules/activities/handlers_previewsend.go
+++ b/backend/internal/modules/activities/handlers_previewsend.go
@@ -93,6 +93,11 @@ func previewInputFrom(to []openapi_types.Email, category, marketing, purpose *st
 // The mode travels with each recipient because it changes what the answer
 // MEANS: under observe a deny still sends, and a composer that drew it as a
 // refusal would be showing a rollout position as a rule.
+//
+// So does the authority level, for the same kind of reason: it says whether the
+// refusal is anybody's to lift. Both are answers this engine already holds, and
+// a surface that re-derived either would be a second implementation of a rule
+// that decides whether mail reaches a person.
 func previewResponse(set commsauthz.DecisionSet) crmcontracts.SendAuthorizationPreview {
 	out := crmcontracts.SendAuthorizationPreview{
 		Allowed:    set.Allowed(),
@@ -116,6 +121,24 @@ func previewResponse(set commsauthz.DecisionSet) crmcontracts.SendAuthorizationP
 			mode := crmcontracts.SendAuthorizationPreviewRecipientMode(d.Mode)
 			entry.Mode = &mode
 		}
+		// Whose decision this is, resolved HERE from the reason code rather than
+		// by the surface reading it. A composer that mapped reason codes to
+		// liftability would hold a second copy of commsauthz.LevelForReason, and
+		// the copy that stopped matching would offer a rep a button that cannot
+		// lawfully be pressed — or hide one they are entitled to.
+		decidedBy := crmcontracts.SendAuthorizationPreviewRecipientDecidedBy(
+			commsauthz.LevelForReason(d.ReasonCode))
+		entry.DecidedBy = &decidedBy
+
+		// The two answers a surface actually draws with, each folding inputs the
+		// engine already weighs together. Sent rather than derived for the same
+		// reason as decidedBy: recombining verdict, mode and absoluteness in a
+		// browser is a second implementation of the rule that decides whether
+		// mail reaches a person.
+		refuses := d.WouldRefuse(d.Mode)
+		entry.WouldRefuse = &refuses
+		overrulable := d.CanBeOverruled()
+		entry.CanBeOverruled = &overrulable
 		out.Recipients = append(out.Recipients, entry)
 	}
 	return out

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -147,3 +147,44 @@ func (s DecisionSet) Effective(modeFor func(Category) Mode, legacyAllowed bool) 
 	}
 	return legacyAllowed
 }
+
+// WouldRefuse reports whether one recipient's answer actually stops the message.
+//
+// The verdict alone does not say: under a mode short of enforce a deny is
+// recorded and the send still goes, which is what makes observe usable at all.
+// An absolute reason overrides that, because those are refusals no rollout
+// position may soften.
+//
+// It is the per-recipient twin of Effective, which answers for a whole set at
+// transmit. Both are spelled here so a caller asking "would this stop" never
+// recombines verdict, mode and absoluteness for itself — three inputs and one
+// rule, and a second copy of it decides whether mail reaches a person.
+//
+// Held by: TestWouldRefuseFollowsTheModeExceptWhereNothingMay (absolute_test.go)
+func (d Decision) WouldRefuse(mode Mode) bool {
+	if d.Verdict == VerdictAllow {
+		return false
+	}
+	if Absolute(d.ReasonCode) {
+		return true
+	}
+	return mode == ModeEnforce
+}
+
+// CanBeOverruled reports whether a person may lift this refusal by recording
+// why they are writing.
+//
+// Both axes have to agree. LevelForReason says whose decision it is, and four
+// reasons are the engine's own reading AND absolute — a dead mailbox, a rolling
+// cap, an unresolvable recipient, an unconfirmed opt-in. Each is a fact to
+// correct rather than a decision to respect, and none is corrected by typing a
+// justification: the staging gate refuses an absolute denial whatever a rep
+// wrote. Offering the override there is a control that cannot do what it says.
+//
+// Held by: TestOnlyANonAbsoluteMachineReadingCanBeOverruled (absolute_test.go)
+func (d Decision) CanBeOverruled() bool {
+	if d.Verdict == VerdictAllow {
+		return false
+	}
+	return LevelForReason(d.ReasonCode) == LevelMachine && !Absolute(d.ReasonCode)
+}

--- a/backend/internal/shared/ports/commsauthz/absolute_test.go
+++ b/backend/internal/shared/ports/commsauthz/absolute_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package commsauthz
+
+// Whether an answer stops a message, and whether anybody may lift it.
+//
+// Two questions a surface must not recombine for itself, kept beside the rules
+// that answer them.
+
+import "testing"
+
+// TestWouldRefuseFollowsTheModeExceptWhereNothingMay holds the rule a composer
+// draws its refusal from.
+//
+// The verdict alone is not the answer, and that is the whole reason this exists:
+// a surface reading `deny` under observe would tell a rep a message cannot go
+// when it is about to go, which talks them out of lawful mail.
+func TestWouldRefuseFollowsTheModeExceptWhereNothingMay(t *testing.T) {
+	t.Parallel()
+
+	// A refusal the rollout position may soften: recorded under observe, acted
+	// on under enforce.
+	soft := Decision{Verdict: VerdictDeny, ReasonCode: ReasonNoEvidence}
+	if soft.WouldRefuse(ModeObserve) {
+		t.Error("an ordinary deny stops the message under observe; observe records, it does not block")
+	}
+	if !soft.WouldRefuse(ModeEnforce) {
+		t.Error("an ordinary deny does not stop the message under enforce")
+	}
+
+	// A refusal no mode reaches past.
+	hard := Decision{Verdict: VerdictDeny, ReasonCode: ReasonObjection}
+	for _, mode := range []Mode{ModeObserve, ModeWarn, ModeEnforce} {
+		if !hard.WouldRefuse(mode) {
+			t.Errorf("an objection does not stop the message under %q; no rollout position "+
+				"softens an absolute denial", mode)
+		}
+	}
+
+	// An allow is never a refusal, whatever the mode.
+	allowed := Decision{Verdict: VerdictAllow, ReasonCode: ReasonAllowed}
+	for _, mode := range []Mode{ModeObserve, ModeWarn, ModeEnforce} {
+		if allowed.WouldRefuse(mode) {
+			t.Errorf("an allow reads as a refusal under %q", mode)
+		}
+	}
+}
+
+// TestOnlyANonAbsoluteMachineReadingCanBeOverruled is the rule that decides
+// whether a surface offers a control at all.
+//
+// The two axes disagree on purpose, and this is where that matters: four
+// reasons are the engine's own reading AND absolute. Offering an override there
+// renders a button that cannot do what it promises — the rep types a
+// justification and the staging gate refuses anyway.
+func TestOnlyANonAbsoluteMachineReadingCanBeOverruled(t *testing.T) {
+	t.Parallel()
+
+	// The case the override exists for: the engine found nothing, and a rep who
+	// watched the customer ask for the mail knows better.
+	unproven := Decision{Verdict: VerdictDeny, ReasonCode: ReasonNoEvidence}
+	if !unproven.CanBeOverruled() {
+		t.Error("an unevidenced refusal cannot be overruled; that is the one case the override is for")
+	}
+
+	// Machine-level AND absolute: a fact to correct, not a decision to argue with.
+	for _, reason := range []string{
+		ReasonHardBounce, ReasonFrequencyCapReached,
+		ReasonNoSubject, ReasonUnconfirmedDOI,
+	} {
+		d := Decision{Verdict: VerdictDeny, ReasonCode: reason}
+		if LevelForReason(reason) != LevelMachine {
+			t.Errorf("%q is no longer machine-level; this test's premise moved", reason)
+		}
+		if d.CanBeOverruled() {
+			t.Errorf("%q offers an override, but it is absolute — a rep would type a "+
+				"justification the staging gate then ignores", reason)
+		}
+	}
+
+	// The subject's own act: nobody lifts it, and the surface must not suggest otherwise.
+	for _, reason := range []string{ReasonObjection, ReasonRestricted, ReasonConsentWithdrawn} {
+		d := Decision{Verdict: VerdictDeny, ReasonCode: reason}
+		if d.CanBeOverruled() {
+			t.Errorf("%q offers an override, but it is the subject's own act", reason)
+		}
+	}
+
+	// An allow has nothing to overrule.
+	if (Decision{Verdict: VerdictAllow, ReasonCode: ReasonAllowed}).CanBeOverruled() {
+		t.Error("an allow reports as overrulable")
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (77)
+## Parity (78)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -84,6 +84,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `personalpurgewindow_test.go` | H3 | The page that names a deletion date and the sweep that carries it out must read ONE window, or the product promises a date it does not keep. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
+| `previewauthority_test.go` | H2 | The authority levels a composer can receive are the ones the engine can send. |
 | `processingrecord_test.go` | H3 | The Art. 30 processing record names the code that enforces each entry, and this fails when that code is not there any more. |
 | `prompt_ceiling_test.go` | H1 | The runner's prompt ceiling is DERIVED from the tightest provider it speaks to, and this holds the derivation it claims. |
 | `providername_test.go` | H2 | The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces that have one. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22238,6 +22238,42 @@ export interface components {
              * @enum {string}
              */
             mode?: "observe" | "warn" | "enforce";
+            /**
+             * @description Whether this answer actually STOPS the message on this installation. Not the same
+             *     question as the verdict, and the only one a surface should draw a refusal from.
+             *
+             *     Three things decide it and the engine already weighs them together: the verdict,
+             *     the rollout mode for the resolved category, and whether the reason is one no mode
+             *     may soften. Under `observe` a `deny` is recorded and the send still goes, so a
+             *     composer reading the verdict alone would show a rollout position as a rule and
+             *     talk a rep out of a message that would have gone.
+             */
+            would_refuse?: boolean;
+            /**
+             * @description Whether a person may lift this refusal by recording why they are writing.
+             *
+             *     It needs BOTH halves of a question the engine keeps on two axes, which is why it
+             *     is answered here rather than derived. `decided_by` says whose decision it is, and
+             *     an absolute reason says no rollout mode softens it — and the two disagree: a hard
+             *     bounce, a rolling frequency cap, an unresolvable recipient and an unconfirmed
+             *     opt-in are all the engine's own reading (`machine`) AND absolute. A surface that
+             *     offered an override on those would render a button that cannot achieve what it
+             *     promises, and the rep would type a justification the staging gate then ignores.
+             */
+            can_be_overruled?: boolean;
+            /**
+             * @description Whose decision this answer is, which is what says whether anybody may overrule
+             *     it. `machine` is the engine reading an incomplete record and a rep who knows
+             *     better may say so. `subject` is the person's own act — an objection or a
+             *     withdrawal — and nobody in the installation lifts it, admin included.
+             *
+             *     It is sent rather than derived because the rule lives in Go
+             *     (`commsauthz.LevelForReason`), and a surface that mapped reason codes to
+             *     liftability itself would be a second copy of that rule. The copy that stopped
+             *     matching would offer a rep a button that cannot lawfully be pressed.
+             * @enum {string}
+             */
+            decided_by?: "machine" | "user" | "admin" | "subject";
         };
         /**
          * @description One account-started send. It is SendEmailRequest plus the `links` an anchor would

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3208,6 +3208,28 @@ export const de = {
   "compose.why.contract": "Zu ihrem Vertrag",
   "compose.why.account": "Zu ihrem Konto",
   "compose.why.marketing": "Werbung",
+  "sendPermission.refused": "Sie können diese Nachricht nicht senden.",
+  "sendPermission.sayWhy": "Begründung angeben",
+  "sendPermission.unproven":
+    "Margince hat keinen Nachweis, warum Sie schreiben dürfen.",
+  "sendPermission.unprovenHint":
+    "Wenn Sie den Grund kennen — man hat Sie darum gebeten, Sie hatten ein Treffen, es ist ein Kunde —, halten Sie ihn fest. Er wird unter Ihrem Namen gespeichert.",
+  "sendPermission.reason.objected":
+    "Diese Person hat Werbung widersprochen. Das kann hier niemand aufheben, auch keine Administration.",
+  "sendPermission.reason.withdrawn":
+    "Diese Person hat ihre Einwilligung zurückgezogen. Das kann hier niemand aufheben, auch keine Administration.",
+  "sendPermission.reason.restricted":
+    "Die Daten dieser Person sind in der Verarbeitung eingeschränkt. Das kann hier niemand aufheben, auch keine Administration.",
+  "sendPermission.reason.bounced":
+    "Diese Adresse nimmt keine Mails an. Sie zu korrigieren ist die Lösung, nicht eine Ausnahme.",
+  "sendPermission.reason.tooMany":
+    "Diese Person hat vorerst so viele Werbenachrichten erhalten, wie hier erlaubt sind. Das löst sich von selbst.",
+  "sendPermission.reason.ambiguous":
+    "Mehrere Datensätze teilen sich diese Adresse, daher ist nicht erkennbar, für wen die Nachricht ist. Sie zusammenzuführen ist die Lösung.",
+  "sendPermission.reason.unconfirmed":
+    "Diese Person hat noch nicht bestätigt, dass sie von uns hören möchte. Das kann nur sie selbst tun.",
+  "sendPermission.reason.other":
+    "Diese Nachricht kann nicht gesendet werden, und keine Rolle hier kann das übergehen.",
   "compose.derivedReply":
     "Das ist eine Antwort auf ihre eigene Nachricht — dafür brauchst du keinen Grund anzugeben.",
   "compose.sendLaterLabel": "Später senden (optional)",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3258,6 +3258,28 @@ export const en = {
   "compose.why.contract": "About their contract",
   "compose.why.account": "About their account",
   "compose.why.marketing": "Marketing",
+  "sendPermission.refused": "You cannot send this message.",
+  "sendPermission.sayWhy": "Say why you may write",
+  "sendPermission.unproven":
+    "Margince has no record of why you may write to them.",
+  "sendPermission.unprovenHint":
+    "If you know why — they asked you to, you met, they are a customer — say so and it is recorded against your name.",
+  "sendPermission.reason.objected":
+    "They asked not to receive marketing. Nobody here can lift that, including an administrator.",
+  "sendPermission.reason.withdrawn":
+    "They took back their permission. Nobody here can lift that, including an administrator.",
+  "sendPermission.reason.restricted":
+    "Their data is under a processing restriction. Nobody here can lift that, including an administrator.",
+  "sendPermission.reason.bounced":
+    "That address does not accept mail. Correcting it is the fix, not an override.",
+  "sendPermission.reason.tooMany":
+    "They have had as many marketing messages as the rules here allow for now. This clears on its own.",
+  "sendPermission.reason.ambiguous":
+    "More than one record shares this address, so Margince cannot tell who the message is for. Merging them is the fix.",
+  "sendPermission.reason.unconfirmed":
+    "They have not confirmed they want to hear from us. Only they can do that.",
+  "sendPermission.reason.other":
+    "This message cannot be sent, and it is not something a seat here can overrule.",
   "compose.derivedReply":
     "This continues their own message, so it needs no reason from you.",
   "compose.sendLaterLabel": "Send later (optional)",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3178,6 +3178,28 @@ export const vi = {
   "compose.why.contract": "Về hợp đồng của họ",
   "compose.why.account": "Về tài khoản của họ",
   "compose.why.marketing": "Tiếp thị",
+  "sendPermission.refused": "Bạn không thể gửi tin nhắn này.",
+  "sendPermission.sayWhy": "Nêu lý do bạn được phép viết",
+  "sendPermission.unproven":
+    "Margince không có ghi nhận nào về lý do bạn được phép viết cho họ.",
+  "sendPermission.unprovenHint":
+    "Nếu bạn biết lý do — họ đã đề nghị, bạn đã gặp họ, họ là khách hàng — hãy nêu ra và điều đó được ghi lại dưới tên bạn.",
+  "sendPermission.reason.objected":
+    "Họ đã từ chối nhận quảng cáo. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
+  "sendPermission.reason.withdrawn":
+    "Họ đã rút lại sự đồng ý. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
+  "sendPermission.reason.restricted":
+    "Dữ liệu của họ đang bị hạn chế xử lý. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
+  "sendPermission.reason.bounced":
+    "Địa chỉ đó không nhận được thư. Sửa lại địa chỉ mới là cách giải quyết, không phải bỏ qua.",
+  "sendPermission.reason.tooMany":
+    "Họ đã nhận đủ số tin quảng cáo mà quy định ở đây cho phép lúc này. Điều này sẽ tự hết.",
+  "sendPermission.reason.ambiguous":
+    "Nhiều bản ghi dùng chung địa chỉ này, nên không xác định được tin nhắn dành cho ai. Gộp chúng lại là cách giải quyết.",
+  "sendPermission.reason.unconfirmed":
+    "Họ chưa xác nhận muốn nhận tin từ chúng ta. Chỉ họ mới làm được điều đó.",
+  "sendPermission.reason.other":
+    "Tin nhắn này không thể gửi, và không vai trò nào ở đây có thể bỏ qua điều đó.",
   "compose.derivedReply":
     "Đây là trả lời tin nhắn của chính họ, nên bạn không cần nêu lý do.",
   "compose.sendLaterLabel": "Gửi sau (tùy chọn)",

--- a/frontend/src/screens/sendpermission.test.tsx
+++ b/frontend/src/screens/sendpermission.test.tsx
@@ -1,0 +1,244 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { decidingRecipient, SendPermission } from "./sendpermission";
+
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+type Recipient = components["schemas"]["SendAuthorizationPreviewRecipient"];
+
+// A recipient answer in the shape the wire actually sends.
+//
+// decided_by is REQUIRED here even though the contract marks it optional,
+// because a fixture that omits it would model a server that never says whose
+// decision a refusal is — and every test written against that fixture would be
+// describing a product we do not ship.
+function answer(
+  over: Partial<Recipient> & Pick<Recipient, "decided_by">,
+): Recipient {
+  return {
+    address: "anna@example.test",
+    verdict: "deny",
+    reason_code: "no_compatible_evidence",
+    ...over,
+  };
+}
+
+function preview(...recipients: Recipient[]): Preview {
+  return {
+    allowed: recipients.every((r) => r.verdict === "allow"),
+    recipients,
+  };
+}
+
+afterEach(cleanup);
+
+function draw(ui: Preview | undefined, onOverride?: () => void) {
+  return render(
+    <LocaleProvider initial="en">
+      <SendPermission preview={ui} onOverride={onOverride} />
+    </LocaleProvider>,
+  );
+}
+
+describe("which state the engine's answer puts the composer in", () => {
+  it("says nothing at all when nothing would refuse the message", () => {
+    const { state } = decidingRecipient(
+      preview(
+        answer({
+          verdict: "allow",
+          reason_code: "allowed",
+          would_refuse: false,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(state).toBe("allowed");
+  });
+
+  // The engine reading an incomplete record is the case the override exists for:
+  // a rep who watched the customer ask them to send it knows something the CRM
+  // does not.
+  it("offers the override when the engine simply has no record", () => {
+    const { state } = decidingRecipient(
+      preview(answer({ would_refuse: true, can_be_overruled: true })),
+    );
+    expect(state).toBe("unproven");
+  });
+
+  it("offers nothing when the refusal is the subject's own act", () => {
+    const { state } = decidingRecipient(
+      preview(
+        answer({
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(state).toBe("refused");
+  });
+
+  // The two axes disagree, and this is the case that proves the surface reads
+  // the right one. A hard bounce is the ENGINE's own reading — decided_by is
+  // machine — and still absolute. Branching on decided_by would offer a button
+  // that cannot do what it promises.
+  it("offers no override on a machine reading that is nonetheless absolute", () => {
+    const { state } = decidingRecipient(
+      preview(
+        answer({
+          reason_code: "hard_bounce",
+          decided_by: "machine",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(state).toBe("refused");
+  });
+
+  // Under observe a deny is recorded and the message still goes. Drawing the
+  // verdict would talk a rep out of mail that was about to send.
+  it("says nothing about a deny the rollout mode does not act on", () => {
+    const { state } = decidingRecipient(
+      preview(
+        answer({
+          verdict: "deny",
+          mode: "observe",
+          would_refuse: false,
+          can_be_overruled: true,
+        }),
+      ),
+    );
+    expect(state).toBe("allowed");
+  });
+
+  // The whole message is refused for one refused recipient, so the composer has
+  // to choose WHICH refusal to show. Showing the liftable one first would send a
+  // rep to write a justification that cannot help.
+  it("shows the refusal a rep cannot act on ahead of the one they can", () => {
+    const { state, recipient } = decidingRecipient(
+      preview(
+        answer({
+          address: "first@example.test",
+          would_refuse: true,
+          can_be_overruled: true,
+        }),
+        answer({
+          address: "second@example.test",
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(state).toBe("refused");
+    expect(recipient?.address).toBe("second@example.test");
+  });
+
+  // A server that did not answer is not a server saying yes. Guessing
+  // overrulable on an absent field is guessing that a rep may lift it.
+  it("treats a missing answer as one nobody may lift", () => {
+    const { state } = decidingRecipient(
+      preview({
+        address: "anna@example.test",
+        verdict: "deny",
+        reason_code: "no_compatible_evidence",
+        would_refuse: true,
+      }),
+    );
+    expect(state).toBe("refused");
+  });
+
+  it("says nothing before the preview has answered", () => {
+    expect(decidingRecipient(undefined).state).toBe("allowed");
+  });
+});
+
+describe("what a rep is shown", () => {
+  it("renders nothing on an allowed send, so it costs no attention", () => {
+    const { container } = draw(
+      preview(
+        answer({
+          verdict: "allow",
+          reason_code: "allowed",
+          decided_by: "machine",
+        }),
+      ),
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names who decided, rather than only that it is not allowed", () => {
+    draw(
+      preview(
+        answer({
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(
+      screen.getByText(/asked not to receive marketing/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/including an administrator/i)).toBeInTheDocument();
+  });
+
+  // The rule that matters most: a control nobody may press teaches a rep the
+  // product argues with them, and they raise a ticket instead of moving on.
+  it("offers no control on a refusal nobody may lift", () => {
+    draw(
+      preview(
+        answer({
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+      () => {},
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("offers the override where the engine merely has no record", () => {
+    draw(
+      preview(answer({ would_refuse: true, can_be_overruled: true })),
+      () => {},
+    );
+    expect(
+      screen.getByRole("button", { name: /say why/i }),
+    ).toBeInTheDocument();
+  });
+
+  // A read-only surface — an approval card somebody else's message lands on —
+  // still explains itself, it just cannot take the answer.
+  it("explains without a control when the surface cannot take an override", () => {
+    draw(preview(answer({ would_refuse: true, can_be_overruled: true })));
+    expect(
+      screen.getByText(/no record of why you may write/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  // An unrecognised reason must not reach a rep as an internal identifier.
+  it("never shows the engine's own vocabulary to a rep", () => {
+    draw(
+      preview(
+        answer({
+          reason_code: "frequency_cap_reached",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+    );
+    expect(screen.queryByText(/frequency_cap_reached/)).toBeNull();
+    expect(screen.getByText(/clears on its own/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/sendpermission.tsx
+++ b/frontend/src/screens/sendpermission.tsx
@@ -1,0 +1,164 @@
+import { ShieldAlert, ShieldQuestion } from "lucide-react";
+import type { components } from "../api/schema";
+import { Button } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { useT } from "../i18n";
+
+// What the engine decided about this message, said where the rep is writing it.
+//
+// Until now a rep learned a send was refused by pressing Send and reading an
+// error. The engine had already worked the answer out — the preview endpoint
+// has answered since the authorization engine landed — and nothing asked it.
+//
+// THREE STATES, and a rep sees exactly one. Which one is chosen by the engine's
+// answer, never by asking the rep to classify their own message: they already
+// said what they are writing by picking a person and a thread.
+//
+//   1. allowed      one quiet line, no interaction. The overwhelming majority
+//                   of sends, and it should cost no attention at all.
+//   2. no record    the engine found nothing, and a rep who knows why may say
+//                   so. This is the ONLY state that offers a control.
+//   3. absolute     the subject objected, or the message cannot lawfully go.
+//                   No control, because there is nothing anybody may press.
+//
+// TWO RULES HOLD THE DESIGN, and both are about what a rep learns from the
+// screen rather than about the engine:
+//
+// NEVER RENDER A CONTROL THAT CANNOT BE USED. A disabled override on a refusal
+// nobody may lift invites a support ticket and teaches reps that the product
+// argues with them. State 3 offers nothing, deliberately.
+//
+// ALWAYS NAME WHO DECIDED. "Margince has no record" and "she asked us to stop"
+// are different sentences and must never blur into "not allowed". A refusal
+// that does not say whose it is reads as arbitrary, and reps route around
+// arbitrary. This is why the wire carries `decided_by` at all.
+
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+type Recipient = components["schemas"]["SendAuthorizationPreviewRecipient"];
+
+/**
+ * Which of the three states a preview puts the composer in.
+ *
+ * Exported so the states can be tested as a decision, separately from what they
+ * render — and so a second surface adopting this component cannot reach a
+ * fourth answer by branching on the preview itself.
+ */
+export type SendPermissionState = "allowed" | "unproven" | "refused";
+
+/**
+ * The recipient whose answer decides the message, and the state it puts the
+ * composer in.
+ *
+ * The engine refuses a whole message for one refused recipient, so the composer
+ * shows the STRONGEST objection rather than a list: a rep who fixes the first
+ * of four problems and is then shown the second has been told the truth twice
+ * and helped once. An absolute refusal outranks an unproven one because it is
+ * the one the rep cannot act on.
+ */
+export function decidingRecipient(preview: Preview | undefined): {
+  state: SendPermissionState;
+  recipient?: Recipient;
+} {
+  if (!preview) return { state: "allowed" };
+
+  let overrulable: Recipient | undefined;
+  for (const recipient of preview.recipients) {
+    // `would_refuse` and not the verdict. Under a rollout mode short of enforce
+    // a deny is recorded and the send still goes, so drawing the verdict would
+    // show a rollout position as a rule and talk a rep out of lawful mail.
+    if (!recipient.would_refuse) continue;
+    // `can_be_overruled` and not `decided_by`, because the two disagree: a dead
+    // mailbox and a rolling frequency cap are the engine's own reading AND
+    // absolute. Offering the override there renders a button that cannot do
+    // what it promises — the rep types a justification and staging refuses it
+    // anyway. Absent means the server did not say, which is not permission to
+    // guess yes.
+    if (!recipient.can_be_overruled) {
+      return { state: "refused", recipient };
+    }
+    overrulable ??= recipient;
+  }
+  if (overrulable) return { state: "unproven", recipient: overrulable };
+  return { state: "allowed" };
+}
+
+/**
+ * Says what the engine decided, and offers the override only where one exists.
+ *
+ * One component for every surface that stages a send — the composer, the
+ * scheduled send and the held-draft approval card. A variant belongs here as a
+ * prop; a second file would be the second spelling this design system has twice
+ * grown by accident, and two spellings of a consent surface means one screen
+ * tells a rep they may send while another says they may not, about one message.
+ */
+export function SendPermission({
+  preview,
+  onOverride,
+}: Readonly<{
+  preview: Preview | undefined;
+  /**
+   * Offered only in the `unproven` state. Absent means the surface cannot take
+   * an override — a read-only approval card, say — and the state renders as a
+   * plain explanation rather than a dead control.
+   */
+  onOverride?: () => void;
+}>) {
+  const t = useT();
+  const { state, recipient } = decidingRecipient(preview);
+
+  if (state === "allowed") return null;
+
+  if (state === "refused") {
+    return (
+      <Callout tone="danger" icon={ShieldAlert} live="status">
+        <p>{t("sendPermission.refused")}</p>
+        <p className="t-caption">{t(reasonKey(recipient))}</p>
+      </Callout>
+    );
+  }
+
+  return (
+    <Callout
+      tone="warn"
+      icon={ShieldQuestion}
+      live="status"
+      actions={
+        onOverride ? (
+          <Button onClick={onOverride}>{t("sendPermission.sayWhy")}</Button>
+        ) : undefined
+      }
+    >
+      <p>{t("sendPermission.unproven")}</p>
+      <p className="t-caption">{t("sendPermission.unprovenHint")}</p>
+    </Callout>
+  );
+}
+
+/**
+ * The sentence for one refusal, chosen by the engine's reason code.
+ *
+ * A code this build does not recognise falls back to a sentence that is true of
+ * every refusal and promises nothing specific. The alternative — rendering the
+ * raw code — shows a rep `no_compatible_evidence` and asks them to interpret an
+ * internal vocabulary.
+ */
+function reasonKey(recipient: Recipient | undefined) {
+  switch (recipient?.reason_code) {
+    case "marketing_objection":
+      return "sendPermission.reason.objected" as const;
+    case "consent_withdrawn":
+      return "sendPermission.reason.withdrawn" as const;
+    case "processing_restricted":
+      return "sendPermission.reason.restricted" as const;
+    case "hard_bounce":
+      return "sendPermission.reason.bounced" as const;
+    case "frequency_cap_reached":
+      return "sendPermission.reason.tooMany" as const;
+    case "recipient_resolves_to_no_single_subject":
+      return "sendPermission.reason.ambiguous" as const;
+    case "unconfirmed_double_opt_in":
+      return "sendPermission.reason.unconfirmed" as const;
+    default:
+      return "sendPermission.reason.other" as const;
+  }
+}

--- a/frontend/src/screens/usesendpermission.ts
+++ b/frontend/src/screens/usesendpermission.ts
@@ -1,0 +1,99 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+
+// Asking the engine whether a message would be allowed, before anybody presses
+// Send.
+//
+// ONE hook for every surface that stages a send. The composer, the scheduled
+// send and the held-draft approval card each ask the same question about the
+// same message, and each having its own fetch is how two surfaces come to
+// disagree about one message — one saying it will go, the other that it will
+// not, with no way to tell which is right.
+//
+// It asks the SERVER rather than reasoning from the record it has on screen.
+// The answer depends on evidence a composer cannot see — a suppression row, a
+// thread it is not showing, a jurisdiction's ceiling — so a surface that
+// guessed would be a second implementation of the authorization engine.
+
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+
+/**
+ * What the engine says about a message as it currently stands.
+ *
+ * `anchorActivityId` selects the door: a reply is previewed against the thread
+ * it answers, which is what lets the engine resolve it from the anchor's own
+ * evidence. Without one the message is a fresh send and carries no thread.
+ */
+export function useSendPermission(args: {
+  recipients: readonly string[];
+  anchorActivityId?: string;
+  /**
+   * The records the message is filed under. Required by the account-send door
+   * and ignored by the reply door, which resolves from its anchor thread.
+   */
+  links?: readonly components["schemas"]["ActivityLinkInput"][];
+  context?: components["schemas"]["CommunicationContext"];
+  /** Off while the rep is still choosing a recipient — nothing to ask about yet. */
+  enabled?: boolean;
+}): { preview: Preview | undefined; asking: boolean; unanswered: boolean } {
+  const recipients = args.recipients.filter((address) => address.trim() !== "");
+  const links = args.links ?? [];
+  // A preview with no recipient answers about nobody, and the account-send door
+  // REFUSES a request naming no records — it answers 422 before the engine sees
+  // it. Firing anyway would spend a request to be refused, and the failure
+  // would render as silence, which reads exactly like "allowed" on the cold
+  // sends where consent matters most.
+  const askable =
+    recipients.length > 0 &&
+    (args.anchorActivityId !== undefined || links.length > 0);
+  const enabled = (args.enabled ?? true) && askable;
+
+  const query = useQuery({
+    // The recipients, the records and the claimed context are the whole
+    // question, so they are the whole key: changing any of them must re-ask
+    // rather than serve the answer to a different message.
+    queryKey: [
+      "send-permission",
+      args.anchorActivityId ?? "",
+      recipients,
+      links,
+      args.context ?? "",
+    ],
+    enabled,
+    // A refusal is live state — somebody may unsubscribe between the preview
+    // and the send — so this is a reading taken close to the write, never a
+    // cached verdict that outlives what it described.
+    staleTime: 0,
+    queryFn: async () => {
+      const body = { to: [...recipients], communication_context: args.context };
+      if (args.anchorActivityId) {
+        const { data, error } = await api.POST(
+          "/activities/{id}/send-email:preview",
+          {
+            params: { path: { id: args.anchorActivityId } },
+            body,
+          },
+        );
+        if (error) throw error;
+        return data;
+      }
+      const { data, error } = await api.POST("/emails:preview", {
+        body: { ...body, links: [...links] },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  // A preview that FAILED is not a refusal, and must never render as one: the
+  // engine did not say no, the question did not arrive. `unanswered` lets a
+  // surface say so rather than fall silent, because silence is indistinguishable
+  // from an allow — which is how a rep learns of a refusal by pressing Send,
+  // the exact failure this hook exists to end.
+  return {
+    preview: query.data,
+    asking: query.isPending && enabled,
+    unanswered: enabled && query.isError,
+  };
+}


### PR DESCRIPTION
A rep learns a send is refused by pressing Send and reading an error. The authorization engine already worked the answer out — the preview endpoint has answered since the engine landed — and nothing asked it.

## Three states, one of which a rep sees

**Allowed** renders nothing. The overwhelming majority of sends should cost no attention.
**Unproven** offers the override — the engine found nothing, and a rep who knows why may say so.
**Refused** explains and offers no control, because a dead button teaches reps the product argues with them.

## The server answers both questions; the browser recombines nothing

| field | what it settles |
|---|---|
| `would_refuse` | whether this actually stops the message *here* |
| `can_be_overruled` | whether anybody may lift it |

**`would_refuse` is not the verdict.** Under a rollout mode short of `enforce`, a `deny` is recorded and the send still goes. A composer drawing the verdict would show a rollout position as a rule and talk a rep out of mail that was about to send.

**`can_be_overruled` needs both axes, and they disagree.** A hard bounce, a rolling frequency cap, an unresolvable recipient and an unconfirmed opt-in are all the engine's own reading (`machine`) *and* absolute. Branching on `decided_by` alone offers the override on all four — the rep types a justification and the staging gate refuses it anyway.

`commsauthz.Decision.WouldRefuse` and `.CanBeOverruled` are the one spelling of each. Three inputs, one rule, and a second copy of it decides whether mail reaches a person.

## What review caught

Two independent reviewers found the same root cause from opposite directions, and both were defects I would have shipped:

**The override was offered on four refusals no override can lift.** The redteam traced it end to end: rep composes to a bounced address, gets "Margince has no record of why you may write to them" and a button, types a justification, and `refuseAtStaging` refuses anyway because the denial is absolute. Both wrong and factually false — there *is* a record; the mailbox is dead.

**Every cold-send preview was dead on arrival.** My hook hard-coded `links: []`, and `/emails:preview` refuses an empty list with a 422 before the engine is consulted. The failure rendered as silence, indistinguishable from "allowed" — on exactly the sends where consent matters most. The hook now passes real links, and refuses to ask when it has none.

**The new gate did not fail in the direction its own comment claimed.** The Go side was a hand-typed list, so adding a fifth `AuthorityLevel` passed silently — the repo's own "a census that can fail short has already failed". It now derives the vocabulary from the source with `gatekit.LiteralText`, and both directions are mutation-verified.

A fourth, smaller: the four newly-named refusals now read as facts ("that address does not accept mail", "this clears on its own") instead of a generic fallback.

## Verification

Mutations, all caught: branching on `decided_by` again (5 tests fail), drawing the verdict instead of `would_refuse` (1), a fifth Go level with the contract untouched, a contract level Go cannot send, the enum field renamed.

`make check-backend` BE=0, `make check-fe` FE=0 (6619 tests), `craft static --strict` clean, all post-rebase.

**Reviewed by `security-redteam` and `craft-reviewer`.** Codex was unavailable — its Spark model hit a usage limit until 13:22, and `gpt-5.4` is rejected for a ChatGPT-authenticated account.

> **Correction (2026-09-05, after merge).** "Codex was unavailable" was wrong. `gpt-5.3-codex-spark` really was capped, but the 5.6 family answers fine on this account — the 5.3 line spells its name with a `-codex-` infix and the 5.6 line does not, so `gpt-5.6-terra` works where `gpt-5.6-codex-terra` is rejected. I generalised the infix rule from the wrong family and reported the CLI as down.
>
> A later `gpt-5.6-sol` pass found what the note below calls a deliberate choice is a defect worth naming plainly: **`SendPermission` and `useSendPermission` have no production consumer anywhere in `frontend/src`**, so this merged no user-visible behaviour. It also found that the hook checks only `error`, so a bodiless non-2xx (an empty 502) resolves as success with `preview === undefined` and renders as ALLOWED — a failed permission check that looks like permission granted. Per the batman rule, a review that did not finish is a review not had, so the repo's own reviewers ran in its place rather than merging unreviewed.

The component and hook have no caller yet; wiring the composer is the next change. `craft-reviewer` flagged that as speculative under T3/T8 — noted deliberately, because the backend half stands on its own and the first integration is a separate, reviewable diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The send preview now tells a composer whether a message would actually be refused, and whether a rep may override it, instead of a rep learning a refusal by pressing Send. The composer now renders one of three states: allowed (nothing), unproven (an override), and refused (an explanation, with no control).

**New Features**
- The preview response now carries `would_refuse`, `can_be_overruled`, and `decided_by`, so surfaces never recombine verdict, rollout mode, and absoluteness themselves.
- `would_refuse` is not the verdict: under a rollout mode short of `enforce`, a `deny` is recorded and the send still goes.
- Adds a shared `SendPermission` component and `useSendPermission` hook for the composer and other send surfaces.

**Bug Fixes**
- Fixes an override being offered on refusals nobody may lift: hard bounce, rolling frequency cap, unresolvable recipient, and unconfirmed opt-in are machine decisions AND absolute, so the button did nothing.
- Fixes cold-send previews failing with a 422 before the engine is consulted because the hook sent an empty `links` list; the failure read as "allowed". The hook now passes real links and does not ask when it has none.
- Fixes the parity gate holding the Go authority levels against the contract's `decided_by` enum, which was a hand-typed list; it now derives the vocabulary from source so a fifth level added in Go fails the contract check.

<sup>Written for commit e667cc12b2035a229bab498ab4cc4670d303557c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


