### PR TITLE
fix(reports): activities-by-kind no longer crashes for a non-workspace-scope seat

### DIFF
--- a/backend/internal/compose/integration/report_activitiesbykind_runreport_integration_test.go
+++ b/backend/internal/compose/integration/report_activitiesbykind_runreport_integration_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// activities-by-kind's population opt-out, over the governed run_report
+// tool — a real migrated Postgres, a real team-scoped reader.
+//
+// `activity` carries no owner_id column, so the report engine's population
+// default (measureCallersOwn, which appends a hardcoded `owner_id = caller`
+// clause) rendered invalid SQL for any caller whose row scope was not
+// RowScopeAll — a 500, not a wrong answer. Row scope alone already narrows
+// this report correctly (activityWalk routes it through
+// auth.ActivityContentClause, real per-row narrowing, not the TRUE an
+// identity table's row scope renders), so opting the spec out of the
+// population default is a complete fix on its own.
+//
+// The saved-analytics door onto the same spec (RunAnalyticsQuery /
+// specNarrowings) is covered separately, in
+// backend/internal/compose/report_activitypopulation_integration_test.go,
+// since it lives in a different package with a different harness.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// teamReaderWith mints a RowScopeTeam reader on Team1 holding exactly the
+// named read grants — the tier that actually reaches the population
+// resolver (an all-scope reader's lens never does), as against the
+// RowScopeAll readers the rest of this package's report tests use.
+func (e *Env) teamReaderWith(objects ...string) context.Context {
+	grants := map[string]principal.ObjectGrant{"installation_settings": {Read: true}}
+	for _, object := range objects {
+		grants[object] = principal.ObjectGrant{Read: true}
+	}
+	return e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{Objects: grants, RowScope: principal.RowScopeTeam})
+}
+
+func TestActivitiesByKindDoesNotCrashForATeamScopedReader(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	fileActivity(admin, t, e, "call", time.Now().UTC().Add(-time.Hour), nil)
+
+	reader := e.teamReaderWith("activity")
+	rows, err := tryPrebuiltReport(reader, e, "activities-by-kind", "")
+	if err != nil {
+		t.Fatalf("activities-by-kind for a team-scoped reader errored (want a real answer, not the owner_id crash): %v", err)
+	}
+	if len(rows) != 1 || cell(rows[0], "activities") != "1" {
+		t.Errorf("activities-by-kind for a team-scoped reader = %v, want the one call counted", rows)
+	}
+}

--- a/backend/internal/compose/report_activitypopulation_integration_test.go
+++ b/backend/internal/compose/report_activitypopulation_integration_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// activities-by-kind's population opt-out, over the saved-analytics door
+// (RunAnalyticsQuery / specNarrowings) as well as the run_report one —
+// report_projectgrant_integration_test.go already covers this key's project
+// grant over this same door, with a RowScopeAll reader that never reaches
+// the population resolver at all (an all-scope lens skips it). This is the
+// other half: a non-all-scope reader, the shape that used to render the
+// engine's hardcoded `owner_id = caller` clause against a table that has no
+// such column.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// teamScopedActivityReader is activityReader's RowScopeTeam twin: the tier
+// that actually reaches AnalyticsPopulationClause's owner_id resolution,
+// which an all-scope reader's lens never does.
+func (e *forecastEnv) teamScopedActivityReader() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		TeamIDs: []ids.UUID{e.Team1},
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"activity": {Read: true}, "forecast": {Read: true}, "installation_settings": {Read: true},
+			},
+			RowScope: principal.RowScopeTeam,
+		},
+	})
+}
+
+// A team-scoped reader asking activities-by-kind through the saved-analytics
+// door must get a real count, not the 500 the population default's
+// hardcoded owner_id clause produced against a table with no such column.
+func TestActivitiesByKindAnalyticsQueryDoesNotCrashForATeamScopedReader(t *testing.T) {
+	e := setupForecast(t)
+	// Above analyticsquery.DefaultFloor (5): a count at or below the floor is
+	// WITHHELD by design (a separate mechanism from the population crash this
+	// test is about), and a withheld answer would read like this one too.
+	for i := 0; i < 6; i++ {
+		e.seedID(t, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+			VALUES ($1, 'call', 'checking in', now() - interval '1 hour', 'manual', 'human:x')`)
+	}
+
+	answer, err := e.askAnalytics(e.teamScopedActivityReader(), t, analyticsquery.Query{
+		Entity:   "activities-by-kind",
+		Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "activities"}},
+	})
+	if err != nil {
+		t.Fatalf("activities-by-kind for a team-scoped reader errored (want a real answer, not the owner_id crash): %v", err)
+	}
+	if answer.Withheld {
+		t.Fatalf("answer withheld: %+v, want it above the floor", answer)
+	}
+	if len(answer.Rows) != 1 || answer.Rows[0]["activities"] != int64(6) && answer.Rows[0]["activities"] != float64(6) {
+		t.Errorf("activities-by-kind for a team-scoped reader = %+v, want the six calls counted", answer.Rows)
+	}
+}

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -237,8 +237,16 @@ var prebuiltReports = map[string]reportSpec{
 			"and this is the one lead key that still counts them",
 	},
 	"activities-by-kind": {
-		entity:       datasource.EntityActivity,
-		table:        tableActivity,
+		entity: datasource.EntityActivity,
+		table:  tableActivity,
+		// `activity` has no owner_id column at all, so the population
+		// default's hardcoded `owner_id = caller` clause does not narrow this
+		// report for a non-workspace-scope caller — it renders invalid SQL,
+		// a 500 rather than a wrong answer. Row scope alone (activityWalk
+		// below, through ActivityContentClause) already narrows this
+		// correctly, since an activity's discoverability is real per-row
+		// scope and not the identity-table TRUE a deal's is.
+		population:   measureEveryReadableRow,
 		baseWhere:    whereArchivedNull,
 		basePlain:    "live (unarchived) activities",
 		activityWalk: true,

--- a/backend/internal/compose/reportwhere.go
+++ b/backend/internal/compose/reportwhere.go
@@ -167,12 +167,21 @@ func specNarrowings(
 	// and appended it would be the second partial answer the gate exists to
 	// refuse, and it would pass, because the gate reads the clause builders
 	// and not what a caller does after them.
-	_, population, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg)
-	if err != nil {
-		return nil, err
-	}
-	if population != "" {
-		out = append(out, population)
+	//
+	// Gated on spec.population like buildReportWhere's own population half:
+	// a spec that opts out (measureEveryReadableRow) means it, on every door
+	// onto it — the saved-analytics path this composes for must not narrow a
+	// report the run_report path already answers unnarrowed, and for a spec
+	// with no owner_id column (activities-by-kind) resolving this
+	// unconditionally is not a narrower answer, it is a crash.
+	if spec.population == measureCallersOwn {
+		_, population, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg)
+		if err != nil {
+			return nil, err
+		}
+		if population != "" {
+			out = append(out, population)
+		}
 	}
 	// An aggregate over a masked column would disclose it through the total,
 	// so the row leaves the population entirely.


### PR DESCRIPTION
## Summary

Fixes the `activities-by-kind` crash from margince#4211, part of a QC-tracked cluster of 10 reports affected by commit #4170's population-narrowing default. The other 9 in that cluster are **not** fixed here — see below.

**The crash.** The report engine's population default (`measureCallersOwn`) appends a hardcoded `owner_id = caller` clause on top of a report's row scope unless the spec opts out. `activities-by-kind` never opted out, and `activity` has no `owner_id` column at all, so any caller whose row scope was not `RowScopeAll` got a `500` (Postgres `42703`) instead of an answer — on both doors onto the report (the governed `run_report` tool, and the saved-analytics query path).

Row scope alone already narrows this report correctly: `activityWalk` routes it through `auth.ActivityContentClause`, real per-row narrowing, unlike the `TRUE` an identity table's row scope renders for `deal`/`lead`/`project`. Opting the spec out (`population: measureEveryReadableRow`) is a complete, uncontroversial fix on its own.

**A second bug the fix exposed.** `specNarrowings` (the composer the saved-analytics path and ad-hoc explain use) called the population clause builder unconditionally, ignoring `spec.population` entirely — unlike `buildReportWhere`, which already gated on it. Before this change no catalog entry had ever set the opt-out, so the inconsistency was latent; fixed to match `buildReportWhere`'s own guard. Without this half, the activities-by-kind fix only moves the crash to the saved-analytics door instead of closing it.

## What's deliberately NOT in this PR

An earlier pass of this fix set `population: measureEveryReadableRow` on the same 9 other reports the QC cluster names (`deals-by-stage`, `open-deals-per-company`, `stage-age`, `leads-by-status`, `pipeline-current`, `win-loss`, `projects-by-phase`, `project-commitments`, `projects-gone-quiet`). Two independent reviews (Fable, Codex) and a run of the existing integration suite surfaced that `TestDealsByStageMeasuresTheReadersOwnPopulation` and `TestADealOutsideThePopulationIsNotAPermissionExclusion` pin the caller-narrowed default as a **shipped, deliberately-tested product decision** for at least `deals-by-stage`/`open-deals-per-company` — not a bug. The real defect is that one report key serves two screens (a board wanting the unnarrowed population, an Analytics tab wanting the caller's own lens) with no way to ask for one or the other. That's a product/architecture call, filed separately: **margince#4316** (`status: needs-decision`), rather than shipped silently by flipping a spec default that has its own tests.

## Review

Both Fable and Codex reviewed the (then-10-report) diff. Codex found no issues. Fable found the conflict above by actually running the existing integration suite — the finding that led to re-scoping this PR down to just the safe, uncontroversial fix.

## Test plan

- [x] `make check-go` — green
- [x] `craft static --strict` / `make lint` — 0 findings
- [x] New regression tests on both access paths, mutation-verified (revert → the exact `column t.owner_id does not exist` crash reproduces; restore → green):
  - `backend/internal/compose/integration/report_activitiesbykind_runreport_integration_test.go` (`run_report` tool door)
  - `backend/internal/compose/report_activitypopulation_integration_test.go` (saved-analytics door, `specNarrowings`)
- [x] Full `backend/internal/compose` and `backend/internal/compose/integration` suites green, including the two pre-existing tests that pin `deals-by-stage`/`open-deals-per-company`'s current behavior as correct
- [x] Rebased onto current `origin/main`, re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `activities-by-kind` report crashing with a 500 for any non-workspace-scope user, on both the governed `run_report` tool and the saved-analytics query path. The population default appended a hardcoded `owner_id = caller` clause to a table that has no `owner_id` column; the report now opts out of that default, relying on row scope alone, which already narrows correctly.

Also fixes `specNarrowings` (the saved-analytics composer) to respect the population opt-out, matching `buildReportWhere`'s existing guard — without this, the fix only moves the crash to a different door.

The same change is deliberately not applied to 9 other reports that share a similar pattern, because existing tests pin the current behavior as a product decision; that conflict is filed separately.

<sup>Written for commit 7cca4bce1ebf9eaa3db613e16428a101758123bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “activities by kind” report for team-scoped readers.
  * Reports now return activity counts without triggering server errors or invalid filtering.
  * Ensured report results are narrowed correctly according to the reader’s access scope.
* **Tests**
  * Added coverage for team-scoped report access and activity count accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->