### PR TITLE
/me says how far a caller's grants reach, and which settings pages exist

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32491,6 +32491,8 @@ components:
             mode: { type: string, enum: [native, overlay] }
         authorization:
           $ref: '#/components/schemas/Authorization'
+        settings_availability:
+          $ref: '#/components/schemas/SettingsAvailability'
         passport:
           type: [object, 'null']
           deprecated: true
@@ -33549,7 +33551,7 @@ components:
     Authorization:
       type: object
       additionalProperties: false
-      required: [seat_type, objects]
+      required: [seat_type, objects, row_scope]
       description: >
         What this principal may do, as the server itself computed it — never a client-side
         re-derivation from role keys, which drifts the moment an installation's stored grants
@@ -33561,9 +33563,9 @@ components:
 
         This is a snapshot, not an authority. A role change does not revoke live sessions, so a
         client refetches on window focus and after any 403, and treats the server's answer as
-        the only one that counts. It does NOT express row scope, nor the human-principal and
-        admin-role gates some routes carry independently of any grant — a permitted grant here
-        is necessary, never sufficient.
+        the only one that counts. It does not express the human-principal gate, nor the few
+        routes that still key on the literal admin role independently of any grant — a
+        permitted grant here is necessary, never sufficient.
       properties:
         seat_type:
           type: string
@@ -33579,6 +33581,57 @@ components:
             unknown object to the zero grant, and a client must do the same rather than treat a
             missing entry as unrestricted.
           additionalProperties: { $ref: '#/components/schemas/RbacObjectGrant' }
+        row_scope:
+          type: string
+          enum: [own, team, all]
+          description: >
+            How far the grants above reach: the caller's own rows, every row belonging to a
+            live team they share, or every row in the workspace. Widened to the maximum any of
+            the caller's roles holds, the same union the server applies.
+
+            It is a THIRD axis, independent of the seat ceiling and the object grants, and a
+            client that ignores it will describe a team lead's reach as if it were an admin's.
+
+            The server never sends a value outside this enum: an unresolved scope is narrowed
+            to `own` before it reaches the wire, so a client reading a value it does not
+            recognize is reading a newer server and should narrow it the same way.
+
+            This does not let a client decide which rows it gets — the server's scope clauses
+            do that on every query. It is what a client needs to EXPLAIN the answer it got, and
+            to label a setting as reaching only the reader, their team, or the company.
+
+    SettingsAvailability:
+      type: object
+      additionalProperties: false
+      required: [company_context]
+      description: >
+        Which settings surfaces EXIST in this installation, independently of whether this
+        caller may read them. A surface can be absent for two unrelated reasons — the
+        installation never enabled it, or this caller holds no grant on it — and settings
+        navigation has to tell them apart: the first is not a destination at all, the second
+        is a destination that explains itself.
+
+        Deployment facts only, never per-caller ones. Nothing here narrows with a role, so it
+        discloses no more than the deployment file already tells every seat. A caller
+        capability belongs beside `admin_password_link` instead, which folds the caller's role
+        into its answer for exactly that reason.
+
+        Carried on `/me` so navigation, the command palette, settings home and settings search
+        can resolve from ONE cached snapshot. Each of those surfaces has to agree about which
+        pages exist, and a screen-specific probe alongside them is how they came to disagree:
+        the rail asked, the palette did not, and a page appeared in one and not the other.
+
+        The whole object is optional, and a client that cannot read it should treat every
+        surface here as unavailable — the fail-closed direction hides a page that exists
+        rather than offering one that does not.
+      properties:
+        company_context:
+          type: boolean
+          description: >
+            True when the installation's company-context rollout has typed reads active — the
+            same predicate `GET /company-context/capabilities` reports as `read_enabled`, and
+            the same one its own endpoints gate on. False leaves the Company page to the
+            installation and currency settings beside it.
 
     # ---- Role administration (the /roles editor) ----
 

--- a/backend/internal/compose/companycontextavailability_test.go
+++ b/backend/internal/compose/companycontextavailability_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+)
+
+// One writer decides whether the Company settings page exists, and it resolves
+// the same rollout the endpoints gate on.
+//
+// The failure is silent in both directions. A stack advertising a page its own
+// endpoints refuse sends the reader to a surface that 404s; one hiding a page
+// they would serve loses a feature the operator paid to enable. Neither shows up
+// as an error anywhere, and both are what a second writer produces.
+//
+// Read from SOURCE, because the defect is invisible in the result: both sides
+// are booleans, so any two expressions agreeing on the five stages this package
+// can produce build an identical Server. What has to hold is that there is ONE
+// expression, which is a property of the text.
+//
+// The corpus is every non-test source in the package, not the one file the
+// writer lives in today. A gate naming its own subject's file passes beside a
+// rival writer in the file next door — which is the exact scenario this test's
+// reason for existing names.
+func TestOneWriterDecidesWhetherTheCompanyPageExists(t *testing.T) {
+	call := regexp.MustCompile(`(?m)^\s*s\.authHandlers = s\.WithCompanyContextAvailable\((.*)\)$`)
+
+	writers := map[string]string{}
+	for name := range composeSourceFiles(t) {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		for _, found := range call.FindAllStringSubmatch(readSource(t, name), -1) {
+			writers[name] = found[1]
+		}
+	}
+
+	const owner = "companycontextrollout.go"
+	const want = "companyContextReadEnabled(s.companyContextRollout)"
+
+	if len(writers) != 1 {
+		t.Fatalf("%d files set /me's company-context availability (%v), want exactly one. "+
+			"Two writers of one question drift, and the drift is a page a client offers that "+
+			"the server refuses.", len(writers), writers)
+	}
+	got, ok := writers[owner]
+	if !ok {
+		t.Fatalf("/me's company-context availability is set from %v, not from %s — "+
+			"either it moved, in which case this gate needs to follow it, or a rival writer "+
+			"replaced the owner", writers, owner)
+	}
+	if got != want {
+		t.Errorf("/me's company-context availability is set from %q, but the endpoints gate on "+
+			"%q. Two expressions for one question agree until they do not, and nothing fails "+
+			"when they stop.", got, want)
+	}
+
+	// The endpoints' own side. Without this the comparison above could keep
+	// passing against a predicate that no longer gates anything.
+	if !regexp.MustCompile(`func companyContextReadEnabled\(`).MatchString(readSource(t, owner)) {
+		t.Errorf("companyContextReadEnabled is gone from %s, so the expression checked above no "+
+			"longer names the predicate the endpoints use", owner)
+	}
+}
+
+// A server composed with NO rollout option agrees with itself.
+//
+// This is the case the earlier wiring got wrong, and it got it wrong invisibly.
+// An unset rollout means every stage is on — companyContextReadEnabled says so
+// and GetCompanyContextCapabilities re-derives it — while the injected boolean
+// was the zero value, false. So /me reported the Company page absent on a server
+// whose endpoints served it, and only a server that HAD the option agreed.
+//
+// Asked of the predicate rather than of a booted Server, because booting one
+// needs a pool. What the fix moved is WHERE the value is resolved: reading
+// s.companyContextRollout after the option loop means the unset case resolves
+// through the same predicate as every other, which is what this pins.
+func TestAnUnsetRolloutResolvesThroughTheSamePredicate(t *testing.T) {
+	for _, ran := range []bool{false, true} {
+		srv := &Server{authHandlers: identity.NewHandlers(&identity.Service{})}
+		if ran {
+			WithCompanyContextRollout("")(srv, nil)
+		}
+		srv.publishCompanyContextAvailability()
+
+		advertised := srv.CompanyContextAvailable()
+		gated := companyContextReadEnabled(srv.companyContextRollout)
+		if advertised != gated {
+			t.Errorf("rollout option ran=%v: /me advertises the Company page as available=%v "+
+				"while the endpoints admit=%v — the reader is sent to a page that 404s, or a "+
+				"page that works is hidden", ran, advertised, gated)
+		}
+	}
+}

--- a/backend/internal/compose/companycontextrollout.go
+++ b/backend/internal/compose/companycontextrollout.go
@@ -24,6 +24,24 @@ func WithCompanyContextRollout(rollout string) Option {
 	}
 }
 
+// publishCompanyContextAvailability tells /me whether the Company settings page
+// exists here, from the SAME rollout the endpoints gate on.
+//
+// Called after every option has run rather than inside the option above, and
+// that ordering is the whole point. The endpoints do not depend on the option
+// running — an unset rollout means every stage is on, which
+// companyContextReadEnabled says and GetCompanyContextCapabilities re-derives —
+// while the injected boolean would be the zero value, false. So setting it
+// inside the option made the two agree only for a server that HAD the option,
+// and a server without one advertised the page as absent while serving it.
+//
+// Reading s.companyContextRollout here instead means both sides resolve the same
+// field through the same predicate, whatever ran. The agreement is then a
+// property of the code rather than of an operator remembering a second switch.
+func (s *Server) publishCompanyContextAvailability() {
+	s.authHandlers = s.WithCompanyContextAvailable(companyContextReadEnabled(s.companyContextRollout))
+}
+
 func companyContextReadEnabled(rollout string) bool {
 	return rollout == "" || rollout == companyContextRolloutRead || rollout == companyContextRolloutTasks || rollout == companyContextRolloutOnboarding
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -89,6 +89,9 @@ func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	// first_run for it rather than only for a role that wired one. Reuses
 	// identitySvc — see its own comment below for why the process holds one.
 	srv.authHandlers = srv.WithFirstRunFn(srv.firstRunAnswer(identitySvc))
+	// After the option loop, so /me's answer and the endpoints' gate resolve one
+	// rollout value whether or not WithCompanyContextRollout ran.
+	srv.publishCompanyContextAvailability()
 
 	api := contractAPI(srv, pool, identitySvc)
 	// ONE identity.Service for the whole process: contractAPI's admission

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1846,6 +1846,27 @@ func (e AuditLogEntryActorType) Valid() bool {
 	}
 }
 
+// Defines values for AuthorizationRowScope.
+const (
+	AuthorizationRowScopeAll  AuthorizationRowScope = "all"
+	AuthorizationRowScopeOwn  AuthorizationRowScope = "own"
+	AuthorizationRowScopeTeam AuthorizationRowScope = "team"
+)
+
+// Valid indicates whether the value is a known member of the AuthorizationRowScope enum.
+func (e AuthorizationRowScope) Valid() bool {
+	switch e {
+	case AuthorizationRowScopeAll:
+		return true
+	case AuthorizationRowScopeOwn:
+		return true
+	case AuthorizationRowScopeTeam:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AuthorizationSeatType.
 const (
 	AuthorizationSeatTypeFull AuthorizationSeatType = "full"
@@ -14988,31 +15009,31 @@ func (e ListOrganizationsParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListOrganizationsParamsLifecycle.
 const (
-	ListOrganizationsParamsLifecycleCustomer       ListOrganizationsParamsLifecycle = "customer"
-	ListOrganizationsParamsLifecycleDisqualified   ListOrganizationsParamsLifecycle = "disqualified"
-	ListOrganizationsParamsLifecycleFormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
-	ListOrganizationsParamsLifecycleOpportunity    ListOrganizationsParamsLifecycle = "opportunity"
-	ListOrganizationsParamsLifecycleProspect       ListOrganizationsParamsLifecycle = "prospect"
-	ListOrganizationsParamsLifecycleTarget         ListOrganizationsParamsLifecycle = "target"
-	ListOrganizationsParamsLifecycleUnknown        ListOrganizationsParamsLifecycle = "unknown"
+	Customer       ListOrganizationsParamsLifecycle = "customer"
+	Disqualified   ListOrganizationsParamsLifecycle = "disqualified"
+	FormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
+	Opportunity    ListOrganizationsParamsLifecycle = "opportunity"
+	Prospect       ListOrganizationsParamsLifecycle = "prospect"
+	Target         ListOrganizationsParamsLifecycle = "target"
+	Unknown        ListOrganizationsParamsLifecycle = "unknown"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationsParamsLifecycle enum.
 func (e ListOrganizationsParamsLifecycle) Valid() bool {
 	switch e {
-	case ListOrganizationsParamsLifecycleCustomer:
+	case Customer:
 		return true
-	case ListOrganizationsParamsLifecycleDisqualified:
+	case Disqualified:
 		return true
-	case ListOrganizationsParamsLifecycleFormerCustomer:
+	case FormerCustomer:
 		return true
-	case ListOrganizationsParamsLifecycleOpportunity:
+	case Opportunity:
 		return true
-	case ListOrganizationsParamsLifecycleProspect:
+	case Prospect:
 		return true
-	case ListOrganizationsParamsLifecycleTarget:
+	case Target:
 		return true
-	case ListOrganizationsParamsLifecycleUnknown:
+	case Unknown:
 		return true
 	default:
 		return false
@@ -18027,14 +18048,26 @@ type AuthCapabilities struct {
 
 // Authorization What this principal may do, as the server itself computed it — never a client-side re-derivation from role keys, which drifts the moment an installation's stored grants differ from the compiled-in defaults.
 // Two independent axes, both of which must permit an action: the licensing seat ceiling (A62/ADR-0047), checked BEFORE RBAC and clamped on HTTP method, and the object grants. A client that collapses them into one predicate will be wrong in both directions.
-// This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does NOT express row scope, nor the human-principal and admin-role gates some routes carry independently of any grant — a permitted grant here is necessary, never sufficient.
+// This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does not express the human-principal gate, nor the few routes that still key on the literal admin role independently of any grant — a permitted grant here is necessary, never sufficient.
 type Authorization struct {
 	// Objects Effective grants keyed by RbacObject. An absent key denies — the server resolves an unknown object to the zero grant, and a client must do the same rather than treat a missing entry as unrestricted.
 	Objects map[string]RbacObjectGrant `json:"objects"`
 
+	// RowScope How far the grants above reach: the caller's own rows, every row belonging to a live team they share, or every row in the workspace. Widened to the maximum any of the caller's roles holds, the same union the server applies.
+	// It is a THIRD axis, independent of the seat ceiling and the object grants, and a client that ignores it will describe a team lead's reach as if it were an admin's.
+	// The server never sends a value outside this enum: an unresolved scope is narrowed to `own` before it reaches the wire, so a client reading a value it does not recognize is reading a newer server and should narrow it the same way.
+	// This does not let a client decide which rows it gets — the server's scope clauses do that on every query. It is what a client needs to EXPLAIN the answer it got, and to label a setting as reaching only the reader, their team, or the company.
+	RowScope AuthorizationRowScope `json:"row_scope"`
+
 	// SeatType The licensing seat. A read seat may read but never mutate over REST, whatever its role grants. A client that cannot read a recognized value MUST assume a read seat: the ceiling fails closed, so an omission never buys the ability to mutate.
 	SeatType AuthorizationSeatType `json:"seat_type"`
 }
+
+// AuthorizationRowScope How far the grants above reach: the caller's own rows, every row belonging to a live team they share, or every row in the workspace. Widened to the maximum any of the caller's roles holds, the same union the server applies.
+// It is a THIRD axis, independent of the seat ceiling and the object grants, and a client that ignores it will describe a team lead's reach as if it were an admin's.
+// The server never sends a value outside this enum: an unresolved scope is narrowed to `own` before it reaches the wire, so a client reading a value it does not recognize is reading a newer server and should narrow it the same way.
+// This does not let a client decide which rows it gets — the server's scope clauses do that on every query. It is what a client needs to EXPLAIN the answer it got, and to label a setting as reaching only the reader, their team, or the company.
+type AuthorizationRowScope string
 
 // AuthorizationSeatType The licensing seat. A read seat may read but never mutate over REST, whatever its role grants. A client that cannot read a recognized value MUST assume a read seat: the ceiling fails closed, so an omission never buys the ability to mutate.
 type AuthorizationSeatType string
@@ -24457,7 +24490,7 @@ type MeResponse struct {
 
 	// Authorization What this principal may do, as the server itself computed it — never a client-side re-derivation from role keys, which drifts the moment an installation's stored grants differ from the compiled-in defaults.
 	// Two independent axes, both of which must permit an action: the licensing seat ceiling (A62/ADR-0047), checked BEFORE RBAC and clamped on HTTP method, and the object grants. A client that collapses them into one predicate will be wrong in both directions.
-	// This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does NOT express row scope, nor the human-principal and admin-role gates some routes carry independently of any grant — a permitted grant here is necessary, never sufficient.
+	// This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does not express the human-principal gate, nor the few routes that still key on the literal admin role independently of any grant — a permitted grant here is necessary, never sufficient.
 	Authorization *Authorization `json:"authorization,omitempty"`
 
 	// DataResetAvailable True when this installation armed `operations.allow_data_reset` in its deployment file. It is the SAME value `POST /admin/reset-data` gates on, so a client never renders an action for a route that would answer 404. Absent or false means the capability does not exist here — the compiled default in every posture, dev included.
@@ -24477,6 +24510,12 @@ type MeResponse struct {
 
 	// Roles Effective role keys for this principal, and the one authority for them — `user.roles` is deliberately left unset here rather than repeating the same fact.
 	Roles []string `json:"roles"`
+
+	// SettingsAvailability Which settings surfaces EXIST in this installation, independently of whether this caller may read them. A surface can be absent for two unrelated reasons — the installation never enabled it, or this caller holds no grant on it — and settings navigation has to tell them apart: the first is not a destination at all, the second is a destination that explains itself.
+	// Deployment facts only, never per-caller ones. Nothing here narrows with a role, so it discloses no more than the deployment file already tells every seat. A caller capability belongs beside `admin_password_link` instead, which folds the caller's role into its answer for exactly that reason.
+	// Carried on `/me` so navigation, the command palette, settings home and settings search can resolve from ONE cached snapshot. Each of those surfaces has to agree about which pages exist, and a screen-specific probe alongside them is how they came to disagree: the rail asked, the palette did not, and a page appeared in one and not the other.
+	// The whole object is optional, and a client that cannot read it should treat every surface here as unavailable — the fail-closed direction hides a page that exists rather than offering one that does not.
+	SettingsAvailability *SettingsAvailability `json:"settings_availability,omitempty"`
 
 	// SystemOfRecord The installation's active system-of-record mode (overlay_mode.sor_mode). `native` is the
 	// default and full-capability mode. In `overlay` mode the data is served from a read-only
@@ -31243,6 +31282,15 @@ type SetRoleObjectGrantRequest struct {
 type SetSignatureEnrichmentRequest struct {
 	// Enabled true or false is this mailbox's own answer; null follows the tenant default.
 	Enabled *bool `json:"enabled"`
+}
+
+// SettingsAvailability Which settings surfaces EXIST in this installation, independently of whether this caller may read them. A surface can be absent for two unrelated reasons — the installation never enabled it, or this caller holds no grant on it — and settings navigation has to tell them apart: the first is not a destination at all, the second is a destination that explains itself.
+// Deployment facts only, never per-caller ones. Nothing here narrows with a role, so it discloses no more than the deployment file already tells every seat. A caller capability belongs beside `admin_password_link` instead, which folds the caller's role into its answer for exactly that reason.
+// Carried on `/me` so navigation, the command palette, settings home and settings search can resolve from ONE cached snapshot. Each of those surfaces has to agree about which pages exist, and a screen-specific probe alongside them is how they came to disagree: the rail asked, the palette did not, and a page appeared in one and not the other.
+// The whole object is optional, and a client that cannot read it should treat every surface here as unavailable — the fail-closed direction hides a page that exists rather than offering one that does not.
+type SettingsAvailability struct {
+	// CompanyContext True when the installation's company-context rollout has typed reads active — the same predicate `GET /company-context/capabilities` reports as `read_enabled`, and the same one its own endpoints gate on. False leaves the Company page to the installation and currency settings beside it.
+	CompanyContext bool `json:"company_context"`
 }
 
 // ShareCaptureHoldHistoryResponse defines model for ShareCaptureHoldHistoryResponse.

--- a/backend/internal/modules/identity/handlers.go
+++ b/backend/internal/modules/identity/handlers.go
@@ -106,6 +106,12 @@ type Handlers struct {
 	// endpoint gates on, so an offered action and a served route agree. False
 	// is the fail-closed default for a role that wired nothing.
 	dataResetAvailable bool
+
+	// companyContextAvailable is whether the installation's company-context
+	// rollout has typed reads active. Injected rather than read, because the
+	// rollout lives in the composition root and identity may not import it —
+	// the same shape as dataResetAvailable above, and for the same reason.
+	companyContextAvailable bool
 	// mcpResource is the canonical MCP server URL (public_base_url +
 	// "/mcp"), injected by the composition root from deployment config.
 	// The RFC 9728 protected-resource document advertises this verbatim

--- a/backend/internal/modules/identity/handlers_teams.go
+++ b/backend/internal/modules/identity/handlers_teams.go
@@ -150,7 +150,7 @@ func wireAccess(a Access) crmcontracts.AccessPreview {
 	identityRead := crmcontracts.AccessPreviewIdentityReadWorkspace
 	return crmcontracts.AccessPreview{
 		Role:         a.Role,
-		RowScope:     crmcontracts.AccessPreviewRowScope(a.Permissions.RowScope),
+		RowScope:     accessPreviewRowScope(a.Permissions.RowScope),
 		IdentityRead: &identityRead,
 		Objects:      objects,
 		FieldMasks:   masks,

--- a/backend/internal/modules/identity/meresponse.go
+++ b/backend/internal/modules/identity/meresponse.go
@@ -64,6 +64,10 @@ func (h Handlers) meResponse(
 		Authorization: &crmcontracts.Authorization{
 			SeatType: contractSeatType(id.SeatType),
 			Objects:  contractObjectGrants(id.Permissions.Objects),
+			RowScope: contractRowScope(id.Permissions.RowScope),
+		},
+		SettingsAvailability: &crmcontracts.SettingsAvailability{
+			CompanyContext: h.companyContextAvailable,
 		},
 	}
 }
@@ -92,6 +96,46 @@ func contractSeatType(seat string) crmcontracts.AuthorizationSeatType {
 		return crmcontracts.AuthorizationSeatTypeFull
 	}
 	return crmcontracts.AuthorizationSeatTypeRead
+}
+
+// contractRowScope maps the merged row scope onto the contract enum, failing
+// closed on anything it does not recognize.
+//
+// The zero value is the reason this is a function. principal.RowScope is a
+// string, and a principal whose scope never got resolved carries "" — which a
+// cast would put on the wire as an empty enum value the client reads as absent.
+// Absent is the client's cue to assume `own`, so the two agree in the end; but
+// they agree by accident, through a value the contract does not declare, and the
+// next reader has no way to tell an unresolved scope from a deliberate one. Any
+// unrecognized value therefore becomes `own` HERE, so what the server sends is
+// always a value the enum names.
+func contractRowScope(scope principal.RowScope) crmcontracts.AuthorizationRowScope {
+	switch scope {
+	case principal.RowScopeAll:
+		return crmcontracts.AuthorizationRowScopeAll
+	case principal.RowScopeTeam:
+		return crmcontracts.AuthorizationRowScopeTeam
+	default:
+		return crmcontracts.AuthorizationRowScopeOwn
+	}
+}
+
+// accessPreviewRowScope is contractRowScope for the access-preview enum, which
+// oapi-codegen renders as a separate Go type over the same three values.
+//
+// The two spellings are the reason this is a second function rather than a
+// second cast: the preview used to cast, so a principal whose scope never
+// resolved previewed as an empty enum value the contract does not declare. One
+// column, one mapping, and both readers narrow the same way.
+func accessPreviewRowScope(scope principal.RowScope) crmcontracts.AccessPreviewRowScope {
+	switch contractRowScope(scope) {
+	case crmcontracts.AuthorizationRowScopeAll:
+		return crmcontracts.AccessPreviewRowScopeAll
+	case crmcontracts.AuthorizationRowScopeTeam:
+		return crmcontracts.AccessPreviewRowScopeTeam
+	default:
+		return crmcontracts.AccessPreviewRowScopeOwn
+	}
 }
 
 // contractObjectGrants maps the merged permissions onto the wire shape.

--- a/backend/internal/modules/identity/nonproduction.go
+++ b/backend/internal/modules/identity/nonproduction.go
@@ -24,3 +24,40 @@ func (h Handlers) WithDataResetAvailable(available bool) Handlers {
 	h.dataResetAvailable = available
 	return h
 }
+
+// WithCompanyContextAvailable injects whether the installation's company-context
+// rollout has typed reads active — the same predicate the company-context
+// endpoints gate on, so a settings page a client offers and the route behind it
+// cannot disagree.
+//
+// Held by: TestOneWriterDecidesWhetherTheCompanyPageExists
+// (backend/internal/compose/companycontextavailability_test.go), which scans
+// every non-test source in the composition root and fails on a second writer or
+// on a different expression. The claim is about the TEXT, not the value: two
+// expressions agreeing on today's five rollout stages produce an identical
+// server, so nothing but the source can tell them apart.
+//
+// TestAnUnsetRolloutResolvesThroughTheSamePredicate holds the other half — that
+// a server which ran no rollout option agrees with itself. It did not, once: the
+// value was written inside the option, so an unset rollout left the endpoints
+// serving a page /me reported as absent.
+//
+// It rides /me rather than a probe of its own so that navigation, the command
+// palette, settings home and settings search resolve one cached snapshot. They
+// each have to agree about which pages exist, and a screen-specific probe beside
+// them is how they came to disagree.
+//
+// Without it /me reports unavailable, the fail-closed default that hides a page
+// that exists rather than offering one that does not.
+func (h Handlers) WithCompanyContextAvailable(available bool) Handlers {
+	h.companyContextAvailable = available
+	return h
+}
+
+// CompanyContextAvailable reports what /me will say about the Company settings
+// page. Exported so the composition root can assert its own wiring agrees with
+// the endpoints it gates, which is a claim about two packages and cannot be made
+// inside either one alone.
+func (h Handlers) CompanyContextAvailable() bool {
+	return h.companyContextAvailable
+}

--- a/backend/internal/modules/identity/settingsavailability_test.go
+++ b/backend/internal/modules/identity/settingsavailability_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// /me reports the company-context availability it was injected with, and reports
+// unavailable when nothing injected one.
+//
+// The fail-closed direction is the half worth a test. An installation that
+// never wired the rollout must hide the Company page rather than offer one its
+// own endpoints would refuse, and the way that breaks is a struct default
+// flipping or the field being read from somewhere else — neither of which
+// surfaces as an error.
+func TestMeReportsTheCompanyContextAvailabilityItWasGiven(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		build func() Handlers
+		want  bool
+	}{
+		{"nothing injected", func() Handlers { return NewHandlers(&Service{}) }, false},
+		{"injected available", func() Handlers {
+			return NewHandlers(&Service{}).WithCompanyContextAvailable(true)
+		}, true},
+		{"injected unavailable", func() Handlers {
+			return NewHandlers(&Service{}).WithCompanyContextAvailable(false)
+		}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build().meResponse(Identity{}, crmcontracts.Native)
+			if got.SettingsAvailability == nil {
+				t.Fatal("/me carries no settings_availability, so every client reading it fails " +
+					"closed and the Company page disappears whatever the installation configured")
+			}
+			if got.SettingsAvailability.CompanyContext != tt.want {
+				t.Errorf("company_context = %v, want %v",
+					got.SettingsAvailability.CompanyContext, tt.want)
+			}
+		})
+	}
+}
+
+// The row scope /me publishes is the one the principal actually holds, and an
+// unresolved scope publishes the narrowest rather than an empty enum value.
+//
+// A cast would put "" on the wire for a principal whose scope never resolved.
+// The client reads absent as `own` and so agrees in the end — but by accident,
+// through a value the contract does not declare, and the next reader cannot tell
+// an unresolved scope from a deliberate one.
+func TestMePublishesTheRowScopeAndFailsClosedOnAnUnknownOne(t *testing.T) {
+	for _, tt := range []struct {
+		scope string
+		want  crmcontracts.AuthorizationRowScope
+	}{
+		{"own", crmcontracts.AuthorizationRowScopeOwn},
+		{"team", crmcontracts.AuthorizationRowScopeTeam},
+		{"all", crmcontracts.AuthorizationRowScopeAll},
+		{"", crmcontracts.AuthorizationRowScopeOwn},
+		{"workspace", crmcontracts.AuthorizationRowScopeOwn},
+	} {
+		t.Run("scope "+tt.scope, func(t *testing.T) {
+			id := Identity{}
+			id.Permissions.RowScope = principal.RowScope(tt.scope)
+			got := NewHandlers(&Service{}).meResponse(id, crmcontracts.Native)
+			if got.Authorization == nil {
+				t.Fatal("/me carries no authorization block")
+			}
+			if got.Authorization.RowScope != tt.want {
+				t.Errorf("row_scope = %q, want %q", got.Authorization.RowScope, tt.want)
+			}
+			if !got.Authorization.RowScope.Valid() {
+				t.Errorf("row_scope %q is not a value the contract enum declares",
+					got.Authorization.RowScope)
+			}
+		})
+	}
+}
+
+// The access preview narrows an unresolved scope exactly as /me does.
+//
+// One column, two wire shapes: oapi-codegen renders the same three values as two
+// Go types, and the preview used to cast where /me maps. A cast puts "" on the
+// wire for a principal whose scope never resolved, so the same defect had one
+// fixed side and one open one — which is the shape review-loop rule 1 exists to
+// close.
+func TestTheAccessPreviewNarrowsAnUnknownScopeLikeMeDoes(t *testing.T) {
+	for _, tt := range []struct {
+		scope string
+		want  crmcontracts.AccessPreviewRowScope
+	}{
+		{"own", crmcontracts.AccessPreviewRowScopeOwn},
+		{"team", crmcontracts.AccessPreviewRowScopeTeam},
+		{"all", crmcontracts.AccessPreviewRowScopeAll},
+		{"", crmcontracts.AccessPreviewRowScopeOwn},
+		{"workspace", crmcontracts.AccessPreviewRowScopeOwn},
+	} {
+		t.Run("scope "+tt.scope, func(t *testing.T) {
+			got := accessPreviewRowScope(principal.RowScope(tt.scope))
+			if got != tt.want {
+				t.Errorf("row_scope = %q, want %q", got, tt.want)
+			}
+			if !got.Valid() {
+				t.Errorf("row_scope %q is not a value the contract enum declares", got)
+			}
+			// The two shapes carry the same decision, so a change to one that
+			// does not reach the other is the drift this pins.
+			if string(got) != string(contractRowScope(principal.RowScope(tt.scope))) {
+				t.Errorf("the preview says %q where /me says %q for the same stored scope",
+					got, contractRowScope(principal.RowScope(tt.scope)))
+			}
+		})
+	}
+}
+
+// Every wire shape carrying a row scope maps it; none casts.
+//
+// The test above proves accessPreviewRowScope narrows correctly, which is not
+// the same claim: reverting the handler to a cast leaves that test green,
+// because it calls the helper directly. What has to hold is that no producer
+// bypasses the mapping, and that is a property of the call sites.
+//
+// A cast is invisible in the result for every scope the store actually holds —
+// the three values map to themselves — and wrong only for the unresolved one,
+// which is exactly the case no fixture thinks to write.
+func TestNoWireShapeCastsARowScope(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing the package: %v", err)
+	}
+	cast := regexp.MustCompile(`crmcontracts\.\w*RowScope\((?:a|id|h)?\.?\w*\.?Permissions\.RowScope\)`)
+	var found []string
+	for _, name := range sources {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, readErr := os.ReadFile(name)
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", name, readErr)
+		}
+		for _, hit := range cast.FindAllString(string(body), -1) {
+			found = append(found, name+": "+hit)
+		}
+	}
+	if len(found) > 0 {
+		t.Errorf("a stored row scope is cast onto a contract enum at %v — a cast puts the "+
+			"unresolved \"\" on the wire, which the enum does not declare. Use contractRowScope "+
+			"or accessPreviewRowScope, which narrow it to `own`.", found)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23833,6 +23833,7 @@ export interface components {
                 mode: "native" | "overlay";
             };
             authorization?: components["schemas"]["Authorization"];
+            settings_availability?: components["schemas"]["SettingsAvailability"];
             /**
              * @deprecated
              * @description Always null. This endpoint is reachable only by a human session: a passport bearer is admitted as an agent principal and never binds the session identity this operation reads, so an agent receives 401 here rather than a passport claim. The field is retained because removing a response property breaks published clients; a client MUST NOT branch on it. An agent's own scopes are what the MCP surface advertises in tools/list, which is the honest place to ask.
@@ -24515,7 +24516,7 @@ export interface components {
         /**
          * @description What this principal may do, as the server itself computed it — never a client-side re-derivation from role keys, which drifts the moment an installation's stored grants differ from the compiled-in defaults.
          *     Two independent axes, both of which must permit an action: the licensing seat ceiling (A62/ADR-0047), checked BEFORE RBAC and clamped on HTTP method, and the object grants. A client that collapses them into one predicate will be wrong in both directions.
-         *     This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does NOT express row scope, nor the human-principal and admin-role gates some routes carry independently of any grant — a permitted grant here is necessary, never sufficient.
+         *     This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does not express the human-principal gate, nor the few routes that still key on the literal admin role independently of any grant — a permitted grant here is necessary, never sufficient.
          */
         Authorization: {
             /**
@@ -24527,6 +24528,24 @@ export interface components {
             objects: {
                 [key: string]: components["schemas"]["RbacObjectGrant"];
             };
+            /**
+             * @description How far the grants above reach: the caller's own rows, every row belonging to a live team they share, or every row in the workspace. Widened to the maximum any of the caller's roles holds, the same union the server applies.
+             *     It is a THIRD axis, independent of the seat ceiling and the object grants, and a client that ignores it will describe a team lead's reach as if it were an admin's.
+             *     The server never sends a value outside this enum: an unresolved scope is narrowed to `own` before it reaches the wire, so a client reading a value it does not recognize is reading a newer server and should narrow it the same way.
+             *     This does not let a client decide which rows it gets — the server's scope clauses do that on every query. It is what a client needs to EXPLAIN the answer it got, and to label a setting as reaching only the reader, their team, or the company.
+             * @enum {string}
+             */
+            row_scope: "own" | "team" | "all";
+        };
+        /**
+         * @description Which settings surfaces EXIST in this installation, independently of whether this caller may read them. A surface can be absent for two unrelated reasons — the installation never enabled it, or this caller holds no grant on it — and settings navigation has to tell them apart: the first is not a destination at all, the second is a destination that explains itself.
+         *     Deployment facts only, never per-caller ones. Nothing here narrows with a role, so it discloses no more than the deployment file already tells every seat. A caller capability belongs beside `admin_password_link` instead, which folds the caller's role into its answer for exactly that reason.
+         *     Carried on `/me` so navigation, the command palette, settings home and settings search can resolve from ONE cached snapshot. Each of those surfaces has to agree about which pages exist, and a screen-specific probe alongside them is how they came to disagree: the rail asked, the palette did not, and a page appeared in one and not the other.
+         *     The whole object is optional, and a client that cannot read it should treat every surface here as unavailable — the fail-closed direction hides a page that exists rather than offering one that does not.
+         */
+        SettingsAvailability: {
+            /** @description True when the installation's company-context rollout has typed reads active — the same predicate `GET /company-context/capabilities` reports as `read_enabled`, and the same one its own endpoints gate on. False leaves the Company page to the installation and currency settings beside it. */
+            company_context: boolean;
         };
         /** @description One role as `role.permissions` stores it. This is a ROLE's document, not a principal's — unlike `Authorization.objects` nothing here is merged, because the thing being edited is the single role. */
         Role: {

--- a/frontend/src/app/mefixture.ts
+++ b/frontend/src/app/mefixture.ts
@@ -16,6 +16,9 @@ import type { RbacAction, RbacObject } from "./capability";
 
 type MeResponse = components["schemas"]["MeResponse"];
 type RbacObjectGrant = components["schemas"]["RbacObjectGrant"];
+type RowScope = NonNullable<
+  components["schemas"]["Authorization"]
+>["row_scope"];
 
 const NO_GRANT: RbacObjectGrant = {
   create: false,
@@ -38,10 +41,18 @@ export function meFixture({
   roles = ["admin"],
   seat = "full",
   allow = {},
+  rowScope = "own",
 }: {
   roles?: string[];
   seat?: "full" | "read";
   allow?: GrantSpec;
+  /**
+   * How far the grants reach. Defaults to `own`, the narrowest, for the same
+   * reason the server does: a fixture that does not state a scope describes a
+   * principal whose scope was never resolved, and reading that as `all` would
+   * make every test agree with a widening nobody wrote.
+   */
+  rowScope?: RowScope;
 } = {}): MeResponse {
   const objects: Record<string, RbacObjectGrant> = {};
   for (const [object, actions] of Object.entries(allow)) {
@@ -66,7 +77,7 @@ export function meFixture({
     non_production: false,
     data_reset_available: false,
     admin_password_link: false,
-    authorization: { seat_type: seat, objects },
+    authorization: { seat_type: seat, objects, row_scope: rowScope },
   };
   return me;
 }

--- a/frontend/src/screens/company-context.test.tsx
+++ b/frontend/src/screens/company-context.test.tsx
@@ -124,7 +124,11 @@ function meResponse(seat: SeatType, organization: Grant): Me {
     admin_password_link: false,
     roles: [],
     teams: [],
-    authorization: { seat_type: seat, objects: { organization } },
+    authorization: {
+      seat_type: seat,
+      objects: { organization },
+      row_scope: "own",
+    },
   };
 }
 

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -69,7 +69,11 @@ function meResponse(seat: SeatType, integrations: Grant): Me {
     admin_password_link: false,
     roles: [],
     teams: [],
-    authorization: { seat_type: seat, objects: { integrations } },
+    authorization: {
+      seat_type: seat,
+      objects: { integrations },
+      row_scope: "own",
+    },
   };
 }
 


### PR DESCRIPTION
Stage two of the settings redesign. `/me` gains two fields the settings catalog will consume.

**`authorization.row_scope`** is the third axis. The seat ceiling and the object grants were already published; how far those grants *reach* was not, so a client describing a team lead's access had to describe it as an admin's. Required in the contract: a fixture omitting it models a principal whose scope was never resolved, and reading that as `all` would make every test agree with a widening nobody wrote.

**`settings_availability`** says which settings surfaces *exist* here, independently of whether the caller may read them. A surface can be absent for two unrelated reasons — the installation never enabled it, or this caller holds no grant — and settings navigation has to tell them apart: the first is not a destination, the second is a destination that explains itself. One boolean today, `company_context`.

It rides `/me` rather than a probe of its own so navigation, the command palette, settings home and settings search resolve one cached snapshot. They each have to agree about which pages exist, and a screen-specific probe beside them is how they came to disagree: the rail asked, the palette did not, and a page appeared in one and not the other.

Deployment facts only, never per-caller ones. Nothing in the object narrows with a role, so it discloses no more than the deployment file already tells every seat. A caller capability belongs beside `admin_password_link`, which folds the caller's role into its answer for exactly that reason.

## Two defects a review caught, both mine

**The "cannot disagree" claim was false for an unconfigured server.** The availability was set inside `WithCompanyContextRollout`, but the endpoints do not depend on that option running — an unset rollout means every stage is on, while the injected boolean would be the zero value, `false`. So a server composed without the option advertised the Company page as absent while serving it, and the two agreed only for a server that *had* the option. `cmd/api` always passes a concrete stage, so production was never wrong; the invariant was stated unconditionally and held by an option's presence rather than by the code. It is now published after the option loop, so both sides resolve one field through one predicate whatever ran.

**The gate meant to catch divergence read one file.** Its first draft called `readSource("companycontextrollout.go")`, so a rival writer in the file next door left it green — the exact scenario its own comment named as the thing it guards. It now scans every non-test source in the package and fails on a second writer or a different expression.

A third finding, raised by both reviewers: `handlers_teams.go` cast where `/me` maps. oapi-codegen renders the same three values as two Go types, and the access preview put an undeclared `""` on the wire for a principal whose scope never resolved. One column, one narrowing, both readers.

## Four tests, each mutation-checked against the defect it names

- `TestMePublishesTheRowScopeAndFailsClosedOnAnUnknownOne` covers the empty scope and an unrecognized one, and asserts the result is a value the enum declares — so a future enum member mapped wrongly still fails.
- `TestOneWriterDecidesWhetherTheCompanyPageExists` scans the composition root's sources. Read from source because the defect is invisible in the result: both sides are booleans, so two expressions agreeing on today's five rollout stages build an identical server.
- `TestAnUnsetRolloutResolvesThroughTheSamePredicate` holds the other half — a server that ran no option agrees with itself. Reverting the fix makes it fail with the exact divergence above.
- `TestNoWireShapeCastsARowScope` pins the call sites. Testing the mapping helper alone leaves a reverted call site green, because the test calls the helper directly, and a cast is invisible for every scope the store actually holds — wrong only for the unresolved one no fixture writes.

## Worth knowing

Neither field has a reader yet. The consumer is the settings catalog in the next stage, which the plan specifies as `{ kind: "availability"; key: SettingsAvailabilityKey }`. Landing it here would be the whole frontend redesign in one PR. The contract descriptions were trimmed of MUST-clauses about client behaviour that nothing holds — what remains states what the server guarantees.

Three frontend fixtures gained `row_scope`, all defaulting to `own`, matching the server's fail-closed direction. The two screen tests keep their own local `meResponse` helpers rather than converting to `meFixture`: they build a specific grant shape that `meFixture`'s `GrantSpec` parameterizes differently, and converting them expands the diff past the job.

## Gates

`make check-backend` exit 0, `make check-fe` exit 0, `make craft-static` zero findings, plus `make rls-store-path` and `make no-jurisdiction`. One frontend run failed on `worklist.today.test.tsx`, a file this diff touches nothing near; it passes in isolation and passed on a clean re-run — the documented load-timing flake family, not this change.

Reviewed adversarially for security and for craftsmanship. Security found nothing exploitable, having verified `Authorization` has exactly one producer in the tree. Every craft finding is fixed in this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`/me` now publishes `authorization.row_scope` (required, `own`/`team`/`all`, narrowing to `own` when unresolved) and `settings_availability` (currently one boolean, `company_context`), so clients can tell how far a caller's grants reach and which settings pages exist in the installation.

**Bug Fixes**
- The Company page availability was set inside the rollout option, so a server without the option advertised the page as absent while serving it; it now resolves after the option loop.
- The access preview cast the row scope, putting an undeclared `""` on the wire for an unresolved scope; both wire shapes now narrow through a shared mapping.

<sup>Written for commit 7609674994d3c67a14a050b759137fcd7e70f435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

