### PR TITLE
feat(assurance): a finding whose condition cleared says so

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -417,7 +417,7 @@ func oneFinishedInputCheck(ctx context.Context, t *testing.T, e *Env) {
 		}); err != nil {
 			return err
 		}
-		return store.FinishRun(ctx, tx, run, 1, 0, assurance.StatusComplete, "ready")
+		return store.FinishRun(ctx, tx, run, 1, 0, 0, assurance.StatusComplete, "ready")
 	}); err != nil {
 		t.Fatalf("recording a finished input check for the forecast tools: %v", err)
 	}

--- a/backend/internal/compose/jobs_assurance.go
+++ b/backend/internal/compose/jobs_assurance.go
@@ -120,7 +120,7 @@ func (w *assuranceWorkspaceWorker) check(ctx context.Context, ws ids.UUID) error
 	}
 	w.log.InfoContext(ctx, "the forecast's inputs were checked",
 		"workspace_id", ws, "run_id", result.RunID,
-		"eligible_deals", result.EligibleDeals, "findings", result.Findings,
+		"eligible_deals", result.EligibleDeals, "findings", result.Findings, "cleared", result.Cleared,
 		"readiness", result.Readiness, "status", result.Status)
 	return nil
 }

--- a/backend/internal/modules/assurance/needs_test.go
+++ b/backend/internal/modules/assurance/needs_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package assurance
+
+import (
+	"slices"
+	"testing"
+)
+
+// Every source a rule declares it Needs is one the coverage vocabulary can
+// actually report. The two sides live on opposite ends of a seam — the rule in
+// this module, the source name in the compose coverage reader — and a typo
+// ("mailbox") would make the rule's findings permanently un-clearable while
+// every test that watches the guard hold kept passing.
+//
+// The list is the assurance_source_coverage_source_check constraint's, which
+// owns the vocabulary; a source added there is added here in the same change.
+func TestEveryDeclaredNeedIsACoverageSource(t *testing.T) {
+	t.Parallel()
+	sources := []string{"mail", "calendar", "documents", "contracts", "offers", "incumbent"}
+	for _, rule := range Rules() {
+		for _, need := range rule.Needs {
+			if !slices.Contains(sources, need) {
+				t.Errorf("rule %s needs %q, which no coverage row can ever report — "+
+					"its findings would be permanently un-clearable", rule.Type, need)
+			}
+		}
+	}
+}

--- a/backend/internal/modules/assurance/rules.go
+++ b/backend/internal/modules/assurance/rules.go
@@ -107,7 +107,13 @@ type Rule struct {
 	// or vanishing because a rule moved is not the business moving, and a
 	// reader comparing two nights has to be able to tell.
 	Version string
-	Ask     func(asOf time.Time, s Subject, cfg Config) *Finding
+	// Needs names the coverage sources this rule's absence claim stands on.
+	// A rule that reads only the deal graph needs none: the subjects read
+	// itself proves the graph was reachable. buyerSilent needs the mailbox —
+	// its finding must NOT be auto-cleared on a night the mailbox was not
+	// read, because "no silence observed" would then mean "nothing observed".
+	Needs []string
+	Ask   func(asOf time.Time, s Subject, cfg Config) *Finding
 }
 
 // Config is what an installation decides rather than the product.
@@ -198,13 +204,16 @@ func closePushed() Rule {
 // The deal says one number and the offer that was sent says another. The buyer
 // is looking at the offer.
 func amountVsOffer() Rule {
-	return Rule{Type: TypeAmountVsOffer, Version: "v1", Ask: func(_ time.Time, s Subject, cfg Config) *Finding {
+	return Rule{Type: TypeAmountVsOffer, Version: "v1", Needs: []string{"offers"}, Ask: func(_ time.Time, s Subject, cfg Config) *Finding {
 		return amountDisagreement(TypeAmountVsOffer, s, s.OfferTotalMinor, "offer_total", cfg)
 	}}
 }
 
 // The deal says one number and the signed contract says another. Worse than
 // the offer case: this one has a signature on it.
+// No Needs: the contract table is native to the run's own database, so the
+// subjects read succeeding is what proves it was reachable — there is no
+// graded coverage source for it to stand on.
 func amountVsContract() Rule {
 	return Rule{Type: TypeAmountVsContract, Version: "v1", Ask: func(_ time.Time, s Subject, cfg Config) *Finding {
 		f := amountDisagreement(TypeAmountVsContract, s, s.ContractTotalMinor, "contract_total", cfg)
@@ -282,7 +291,7 @@ func noEconomicBuyer() Rule {
 // answered in ninety days — and the deal looks alive to every screen reading
 // it. This rule reads the buyer's own side.
 func buyerSilent() Rule {
-	return Rule{Type: TypeBuyerSilent, Version: "v1", Ask: func(asOf time.Time, s Subject, cfg Config) *Finding {
+	return Rule{Type: TypeBuyerSilent, Version: "v1", Needs: []string{"mail"}, Ask: func(asOf time.Time, s Subject, cfg Config) *Finding {
 		if s.LastInboundAt == nil {
 			// Nobody has ever heard from them. A different finding from
 			// silence after a conversation, and not one this rule claims: a

--- a/backend/internal/modules/assurance/scan.go
+++ b/backend/internal/modules/assurance/scan.go
@@ -39,8 +39,11 @@ type Result struct {
 	RunID         ids.UUID
 	EligibleDeals int
 	Findings      int
-	Readiness     string
-	Status        string
+	// Cleared counts formerly open findings this pass closed because their
+	// condition is no longer present.
+	Cleared   int64
+	Readiness string
+	Status    string
 }
 
 // Scan asks every rule of every live open deal, once.
@@ -77,11 +80,13 @@ func (s *Scanner) Scan(ctx context.Context, now time.Time) (Result, error) {
 			// which is the night worth reporting.
 			out.Status = StatusIncomplete
 			out.Readiness = ReadinessChecksIncomplete
-			return s.store.FinishRun(ctx, tx, runID, 0, 0, out.Status, out.Readiness)
+			return s.store.FinishRun(ctx, tx, runID, 0, 0, 0, out.Status, out.Readiness)
 		}
 
 		var findings []Finding
+		var seen, walked []string
 		for _, subject := range subjects {
+			walked = append(walked, subject.DealID)
 			// Counted in the LOOP, one per deal actually evaluated. Taken from
 			// len(subjects) it would be the same number the query returned,
 			// which makes the census assert x == x and leaves a loop that
@@ -93,22 +98,55 @@ func (s *Scanner) Scan(ctx context.Context, now time.Time) (Result, error) {
 					continue
 				}
 				findings = append(findings, *found)
+				seen = append(seen, LogicalKey(*found))
 				if err := s.store.UpsertException(ctx, tx, *found, subject.Owner); err != nil {
 					return err
 				}
 			}
 		}
 		out.Findings = len(findings)
+		// A finding this complete walk did not re-mint has no condition left to
+		// report — close it, but only for rules whose required sources were
+		// read tonight. Absence is a claim, and it stands on what was looked at.
+		cleared, err := s.store.CloseCleared(ctx, tx, clearableTypes(coverage), walked, seen)
+		if err != nil {
+			return err
+		}
+		out.Cleared = cleared
 		out.Readiness = Readiness(coverage, findings, s.cfg)
 		out.Status = StatusComplete
 		if out.Readiness == ReadinessChecksIncomplete {
 			out.Status = StatusIncomplete
 		}
-		return s.store.FinishRun(ctx, tx, runID, out.EligibleDeals, 0,
+		return s.store.FinishRun(ctx, tx, runID, out.EligibleDeals, 0, out.Cleared,
 			out.Status, out.Readiness)
 	})
 	if err != nil {
 		return Result{}, err
 	}
 	return out, nil
+}
+
+// clearableTypes names the rule types whose findings tonight's pass may close
+// in absence: every source the rule needs was actually read. A rule with no
+// declared needs stands on the subjects read alone, which succeeding is what
+// got us here.
+func clearableTypes(coverage []SourceCoverage) []string {
+	checked := map[string]bool{}
+	for _, c := range coverage {
+		checked[c.Source] = c.State == CoverageChecked
+	}
+	var out []string
+	for _, rule := range Rules() {
+		clearable := true
+		for _, need := range rule.Needs {
+			if !checked[need] {
+				clearable = false
+			}
+		}
+		if clearable {
+			out = append(out, rule.Type)
+		}
+	}
+	return out
 }

--- a/backend/internal/modules/assurance/scan_integration_test.go
+++ b/backend/internal/modules/assurance/scan_integration_test.go
@@ -86,7 +86,10 @@ func (e *scanEnv) as() context.Context {
 		Permissions: principal.Permissions{
 			RoleKeys: []string{"manager"},
 			Objects: map[string]principal.ObjectGrant{
-				"forecast": {Read: true, Create: true},
+				// Update is real: the scan WRITES as well as mints — closing a
+				// cleared finding is an update, the same grant a human answer
+				// spends. In production the job's system principal bypasses this.
+				"forecast": {Read: true, Create: true, Update: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},
@@ -242,5 +245,140 @@ func TestARunWithUnreadableInputsStillExists(t *testing.T) {
 	}
 	if status != StatusIncomplete {
 		t.Errorf("the stored run says %q", status)
+	}
+}
+
+// checkedCoverage is a night on which every source was read.
+func checkedCoverage(context.Context, pgx.Tx, time.Time) []SourceCoverage {
+	now := time.Now().UTC()
+	return []SourceCoverage{
+		{Source: "mail", State: CoverageChecked, CheckedThrough: &now},
+		{Source: "offers", State: CoverageChecked, CheckedThrough: &now},
+	}
+}
+
+// Fixing the record closes the finding, as condition_cleared and not as
+// resolved: nobody answered it, the record changed, and the two must stay
+// tellable apart later.
+func TestAFixedRecordClearsItsFindingOnTheNextScan(t *testing.T) {
+	t.Parallel()
+	e := setupScan(t)
+	ctx := e.as()
+
+	past := time.Now().UTC().AddDate(0, 0, -10)
+	sick := Subject{
+		DealID: ids.NewV7().String(), Owner: e.rep.String(),
+		ExpectedClose: &past, Category: "commit", HasNextStep: true, HasEconomicBuyer: true,
+	}
+	subjects := []Subject{sick}
+	scanner := NewScanner(e.store,
+		func(context.Context, pgx.Tx) ([]Subject, error) { return subjects, nil },
+		checkedCoverage, DefaultConfig())
+
+	if _, err := scanner.Scan(ctx, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The rep moves the close date forward; tonight the condition is gone.
+	future := time.Now().UTC().AddDate(0, 0, 20)
+	subjects[0].ExpectedClose = &future
+	got, err := scanner.Scan(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cleared != 1 {
+		t.Errorf("the pass cleared %d findings, want 1", got.Cleared)
+	}
+
+	var status string
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status FROM assurance_exception WHERE subject_id = $1 AND type = $2`,
+			sick.DealID, TypeClosePast).Scan(&status)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if status != ExceptionConditionCleared {
+		t.Errorf("the fixed record's finding is %q, want %q — left open it nags about "+
+			"a condition that is gone; folded into resolved it forges an answer nobody gave",
+			status, ExceptionConditionCleared)
+	}
+}
+
+// A finding whose rule needs a source that went unread tonight stays open:
+// on such a night "not observed" means "not looked", not "not there".
+func TestAFindingWhoseSourceWentUnreadStaysOpen(t *testing.T) {
+	t.Parallel()
+	e := setupScan(t)
+	ctx := e.as()
+
+	long := time.Now().UTC().AddDate(0, 0, -120)
+	amount := int64(100_000_00)
+	silent := Subject{
+		DealID: ids.NewV7().String(), Owner: e.rep.String(),
+		AmountMinor: &amount, Currency: "EUR", Category: "commit",
+		LastInboundAt: &long, HasNextStep: true, HasEconomicBuyer: true,
+	}
+	subjects := []Subject{silent}
+	coverage := checkedCoverage
+	scanner := NewScanner(e.store,
+		func(context.Context, pgx.Tx) ([]Subject, error) { return subjects, nil },
+		func(ctx context.Context, tx pgx.Tx, now time.Time) []SourceCoverage {
+			return coverage(ctx, tx, now)
+		},
+		DefaultConfig())
+	if _, err := scanner.Scan(ctx, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tonight the mailbox cannot be read, and the deal row alone no longer
+	// shows the silence — LastInboundAt is what the mailbox feeds.
+	subjects[0].LastInboundAt = nil
+	coverage = func(context.Context, pgx.Tx, time.Time) []SourceCoverage {
+		now := time.Now().UTC()
+		return []SourceCoverage{
+			{Source: "mail", State: CoverageUnavailable},
+			{Source: "offers", State: CoverageChecked, CheckedThrough: &now},
+		}
+	}
+	if _, err := scanner.Scan(ctx, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	var status string
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status FROM assurance_exception WHERE subject_id = $1 AND type = $2`,
+			silent.DealID, TypeBuyerSilent).Scan(&status)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if status != "open" {
+		t.Errorf("the silence finding is %q after a night the mailbox went unread, want "+
+			"open — clearing it would read an unread mailbox as an all-clear", status)
+	}
+
+	// The admit arm: the NEXT night the mailbox is read again and the buyer
+	// has answered. Now absence is a looked-at fact, and the finding clears.
+	recent := time.Now().UTC().AddDate(0, 0, -2)
+	subjects[0].LastInboundAt = &recent
+	coverage = checkedCoverage
+	got, err := scanner.Scan(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cleared != 1 {
+		t.Errorf("the read-again night cleared %d findings, want 1", got.Cleared)
+	}
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status FROM assurance_exception WHERE subject_id = $1 AND type = $2`,
+			silent.DealID, TypeBuyerSilent).Scan(&status)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if status != ExceptionConditionCleared {
+		t.Errorf("after a checked night with the buyer answering, the finding is %q, "+
+			"want %q", status, ExceptionConditionCleared)
 	}
 }

--- a/backend/internal/modules/assurance/store.go
+++ b/backend/internal/modules/assurance/store.go
@@ -49,6 +49,14 @@ const (
 	ReadinessChecksIncomplete    = "checks_incomplete"
 )
 
+// ExceptionConditionCleared is a finding the SCAN closed: the condition it
+// reported is no longer present in the record. Distinct from resolved on
+// purpose — nobody answered this one, the record changed — because a reason
+// that cannot be told apart later cannot be audited later. The same word as
+// OutcomeConditionCleared deliberately: one fact, spelled once, landing in the
+// status column here and in the outcome column when a resolution row exists.
+const ExceptionConditionCleared = OutcomeConditionCleared
+
 // Source coverage states.
 const (
 	CoverageChecked           = "checked"
@@ -174,12 +182,18 @@ func (s *Store) UpsertException(ctx context.Context, tx pgx.Tx, f Finding, owner
 		ON CONFLICT (logical_key) DO UPDATE
 		SET last_seen_at = now(),
 		    updated_at = now(),
+		    -- A cleared row REOPENS on re-detection: the scan closed it because
+		    -- the condition left the record, so the condition being back is a
+		    -- new fact for a person. A resolved row does not — somebody
+		    -- answered that one, and re-detection must not un-ask them.
+		    status = CASE WHEN assurance_exception.status = 'condition_cleared'
+		                  THEN 'open' ELSE assurance_exception.status END,
 		    -- Only while it is still somebody's problem. A resolved row keeps
 		    -- the value it was resolved against, which is what lets a later
 		    -- scan tell "still true" from "changed since you answered".
-		    observed = CASE WHEN assurance_exception.status = 'open'
+		    observed = CASE WHEN assurance_exception.status IN ('open', 'condition_cleared')
 		                    THEN EXCLUDED.observed ELSE assurance_exception.observed END,
-		    severity = CASE WHEN assurance_exception.status = 'open'
+		    severity = CASE WHEN assurance_exception.status IN ('open', 'condition_cleared')
 		                    THEN EXCLUDED.severity ELSE assurance_exception.severity END`,
 		LogicalKey(f), f.Type, subjectID, claim, observed,
 		f.Severity, f.AffectedMinor, nullIfEmpty(f.Currency),
@@ -189,10 +203,61 @@ func (s *Store) UpsertException(ctx context.Context, tx pgx.Tx, f Finding, owner
 	return nil
 }
 
+// CloseCleared closes every open finding of the named types, on the named
+// subjects, that this pass no longer observes. Both bounds carry meaning: the
+// types are the rules whose required sources were actually read tonight — for
+// the others "not observed" means "not looked" — and the subjects are the
+// deals this pass actually evaluated, because absence is only a fact about
+// what was walked. A deal that left the eligible set is deliberately NOT
+// cleared here; its findings are a different question with a different answer.
+//
+// A finding under a LIVE deferral is left alone: "remind me next week" is an
+// answer about when, and a condition that dips out for one night — a push
+// count rolling off its window does this on its own — must not eat the
+// reminder. If the condition is truly gone next week, the reminder fires over
+// a clean record and clears then.
+//
+// No per-finding resolution row is written: assurance_resolution attributes an
+// answer to a person (actor_id is NOT NULL because an answer is BY somebody),
+// and the scan is not one. The night's clearing is recorded once, on the run's
+// own audit row, where FinishRun carries the cleared count.
+func (s *Store) CloseCleared(ctx context.Context, tx pgx.Tx, types []string, subjects, seen []string) (int64, error) {
+	if err := auth.Require(ctx, "forecast", principal.ActionUpdate); err != nil {
+		return 0, err
+	}
+	if len(types) == 0 || len(subjects) == 0 {
+		return 0, nil
+	}
+	if seen == nil {
+		// A pass that found NOTHING has an empty seen set, not an absent one.
+		// pgx encodes a nil slice as SQL NULL, and `NOT (x = ANY(NULL))` is
+		// NULL — which silently filters every row and clears nothing, on
+		// exactly the night everything should clear.
+		seen = []string{}
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE assurance_exception
+		SET status = $1, updated_at = now()
+		WHERE status = 'open'
+		  AND subject_kind = 'deal'
+		  AND subject_id = ANY($2::uuid[])
+		  AND type = ANY($3)
+		  AND NOT (logical_key = ANY($4))
+		  AND NOT EXISTS (SELECT 1 FROM assurance_resolution r
+		                   WHERE r.exception_id = assurance_exception.id
+		                     AND r.outcome = 'deferred'
+		                     AND r.remind_at > now())`,
+		ExceptionConditionCleared, subjects, types, seen)
+	if err != nil {
+		return 0, fmt.Errorf("assurance: closing cleared findings: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // FinishRun closes a pass with what it found and what it could reach.
 func (s *Store) FinishRun(
 	ctx context.Context, tx pgx.Tx, runID ids.UUID,
-	eligibleDeals, eligibleSignals int, status, readiness string,
+	eligibleDeals, eligibleSignals int, cleared int64, status, readiness string,
 ) error {
 	if err := auth.Require(ctx, "forecast", principal.ActionCreate); err != nil {
 		return err
@@ -226,6 +291,10 @@ func (s *Store) FinishRun(
 			"readiness":        readiness,
 			"eligible_deals":   eligibleDeals,
 			"eligible_signals": eligibleSignals,
+			// How many findings this pass closed in absence. A night that
+			// silently retired four hundred findings must not read like one
+			// that retired none.
+			"cleared": cleared,
 		})
 	if err != nil {
 		return err

--- a/backend/internal/modules/assurance/store.go
+++ b/backend/internal/modules/assurance/store.go
@@ -52,9 +52,9 @@ const (
 // ExceptionConditionCleared is a finding the SCAN closed: the condition it
 // reported is no longer present in the record. Distinct from resolved on
 // purpose — nobody answered this one, the record changed — because a reason
-// that cannot be told apart later cannot be audited later. The same word as
-// OutcomeConditionCleared deliberately: one fact, spelled once, landing in the
-// status column here and in the outcome column when a resolution row exists.
+// that cannot be told apart later cannot be audited later. The status column
+// here and the outcome column on a resolution row carry the same word for the
+// same event, which is why this is an alias rather than a second literal.
 const ExceptionConditionCleared = OutcomeConditionCleared
 
 // Source coverage states.

--- a/backend/migrations/core/1788583398_a_finding_whose_condition_cleared_says_so.down.sql
+++ b/backend/migrations/core/1788583398_a_finding_whose_condition_cleared_says_so.down.sql
@@ -1,0 +1,9 @@
+-- Rows in the finer vocabulary fold into resolved before the old constraint
+-- returns; losing the who-closed-it distinction is the price of going back.
+SET LOCAL lock_timeout = '3s';
+UPDATE assurance_exception SET status = 'resolved' WHERE status = 'condition_cleared';
+ALTER TABLE assurance_exception
+    DROP CONSTRAINT assurance_exception_status_check;
+ALTER TABLE assurance_exception
+    ADD CONSTRAINT assurance_exception_status_check CHECK (
+        status IN ('open', 'resolved', 'expired'));

--- a/backend/migrations/core/1788583398_a_finding_whose_condition_cleared_says_so.up.sql
+++ b/backend/migrations/core/1788583398_a_finding_whose_condition_cleared_says_so.up.sql
@@ -1,0 +1,10 @@
+-- A finding the scan itself closed — the condition it reported is no longer in
+-- the record — is a different fact from one a person answered. Folding both
+-- into 'resolved' makes them indistinguishable forever, so the status gains
+-- its own word. The reason is split at the writer, where it is still known.
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE assurance_exception
+    DROP CONSTRAINT assurance_exception_status_check;
+ALTER TABLE assurance_exception
+    ADD CONSTRAINT assurance_exception_status_check CHECK (
+        status IN ('open', 'resolved', 'expired', 'condition_cleared'));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -752,7 +752,7 @@ public.assurance_exception.assurance_exception_amount_currency_pair CHECK (((aff
 public.assurance_exception.assurance_exception_pkey PRIMARY KEY (id)
 public.assurance_exception.assurance_exception_seen_ordered CHECK ((last_seen_at >= first_seen_at))
 public.assurance_exception.assurance_exception_severity_check CHECK ((severity = ANY (ARRAY['low'::text, 'medium'::text, 'high'::text])))
-public.assurance_exception.assurance_exception_status_check CHECK ((status = ANY (ARRAY['open'::text, 'resolved'::text, 'expired'::text])))
+public.assurance_exception.assurance_exception_status_check CHECK ((status = ANY (ARRAY['open'::text, 'resolved'::text, 'expired'::text, 'condition_cleared'::text])))
 public.assurance_exception.assurance_exception_subject_kind_check CHECK ((subject_kind = ANY (ARRAY['deal'::text, 'signal'::text, 'offer'::text, 'contract'::text])))
 public.assurance_exception.captured_by text NOT NULL gen=- def=-
 public.assurance_exception.claim jsonb NOT NULL gen=- def='{}'::jsonb


### PR DESCRIPTION
The nightly scan never closed a finding: a fixed record's exception stayed open forever, nagging about a condition that was gone. The pass now reconciles what it walked — an open finding it did not re-mint closes as `condition_cleared`, a status of its own because nobody answered it, and a reason that cannot be told apart later cannot be audited later.

Absence is a claim about what was looked at, so the clear is bounded three ways: to the subjects this pass actually evaluated, to rule types whose declared sources (`Rule.Needs`) were all read tonight — buyerSilent needs the mailbox, so its findings survive a night the mailbox went unread — and away from findings under a live deferral, so a one-night dip cannot eat a reminder. A cleared finding reopens on re-detection; a resolved one still does not. The run's audit row and the job log carry the cleared count.

Review round (fallback reviewers; Codex rate-limited): terminal-status reopen path, deferral guard, cleared-count auditability, Needs on the offer rule plus a vocabulary census, and an admit-arm test — which caught a real defect: a nil seen-set encoded as SQL NULL and `NOT (x = ANY(NULL))` filtered every row, so the night everything should clear cleared nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The nightly assurance scan now closes findings whose condition has disappeared, instead of leaving fixed records nagging on open findings forever.

- A finding the pass no longer observes closes as `condition_cleared`, a status distinct from `resolved` because the scan, not a person, closed it.
- Clearing is bounded to the subjects this pass actually walked and to rule types whose declared coverage sources were all read tonight.
- Findings under a live deferral are never cleared by a one-night dip.
- A cleared finding reopens on re-detection; a resolved one does not.
- The run's audit row and the job log now carry the cleared count.

**Migration**
- Adds `condition_cleared` to the `assurance_exception` status check; the down migration folds those rows into `resolved`.

<sup>Written for commit bf26ffdfdf0c702e614b46f2c8c85c72943d3b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

