### PR TITLE
The horizon follows what the installation actually answers

### DIFF
--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -116,6 +116,16 @@ type ListActivitiesInput struct {
 	// in, never by a caller: it is one read's snapshot, not a request parameter,
 	// and a caller supplying it could widen or narrow who counts as a colleague.
 	ownDomains []string
+	// horizonDays is how far back a wait reaches and still counts, derived from
+	// this installation's own response spread (waitinghorizon.go). Unexported
+	// and set beside the transaction it was measured in, for ownDomains' exact
+	// reason: it is one read's snapshot rather than a request parameter, and a
+	// caller supplying it could widen or narrow what the queue calls work.
+	//
+	// Zero means unmeasured, which the clause reads as the compiled default —
+	// so a caller with no seam to measure through gets today's behaviour rather
+	// than a horizon of nothing.
+	horizonDays int
 	// OpenAndDueBy narrows to tasks still open and already due at an instant:
 	// the day's work, asked as one question.
 	//
@@ -173,6 +183,14 @@ func (s *Store) ListActivities(ctx context.Context, in ListActivitiesInput) ([]c
 		// no sender, which is the same open default WithOwnDomains documents.
 		if in.ownDomains, err = s.ownDomainList(ctx, tx); err != nil {
 			return err
+		}
+		// Measured only when the waiting filter is actually asked for. Every
+		// activity list runs through here, and the spread is a percentile over
+		// a year — a scan no read that never mentions waiting should pay for.
+		if in.WaitingReplyAsOf != nil {
+			if in.horizonDays, err = s.waitingHorizonFor(ctx, tx, *in.WaitingReplyAsOf); err != nil {
+				return err
+			}
 		}
 		activities, page, err = ListActivitiesTx(ctx, tx, in)
 		return err

--- a/backend/internal/modules/activities/hiddenbacklog.go
+++ b/backend/internal/modules/activities/hiddenbacklog.go
@@ -139,9 +139,17 @@ func (s *Store) HiddenWaiting(ctx context.Context, asOf time.Time) (HiddenBacklo
 	var out HiddenBacklog
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		reader := readerOrNobody(ctx)
+		// The queue's own horizon, measured once and handed to every relaxation
+		// below. Measured per count instead, the guardrail could report a
+		// difference between two scans that came from two different cutoffs
+		// rather than from the rule it was relaxing.
+		measured, err := s.waitingHorizonFor(ctx, tx, asOf)
+		if err != nil {
+			return err
+		}
 		// What the eligibility query finds under the rules as they stand — a
 		// near neighbour of the page's own count, for the reason Shown states.
-		shown, err := s.countWaiting(ctx, tx, asOf, waitingRelaxation{reader: reader})
+		shown, err := s.countWaiting(ctx, tx, asOf, waitingRelaxation{reader: reader}, measured)
 		if err != nil {
 			return err
 		}
@@ -168,7 +176,7 @@ func (s *Store) HiddenWaiting(ctx context.Context, asOf time.Time) (HiddenBacklo
 			{&out.Unlinked, waitingRelaxation{reader: reader, keepUnlinked: true}},
 			{&out.Colleagues, waitingRelaxation{reader: reader, keepColleagues: true}},
 		} {
-			widened, err := s.countWaiting(ctx, tx, asOf, relaxed.with)
+			widened, err := s.countWaiting(ctx, tx, asOf, relaxed.with, measured)
 			if err != nil {
 				return err
 			}
@@ -217,7 +225,7 @@ type waitingRelaxation struct {
 
 // countWaiting runs the waiting query under one relaxation and counts its rows.
 func (s *Store) countWaiting(
-	ctx context.Context, tx pgx.Tx, asOf time.Time, relax waitingRelaxation,
+	ctx context.Context, tx pgx.Tx, asOf time.Time, relax waitingRelaxation, measured int,
 ) (int, error) {
 	args := []any{}
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -233,7 +241,7 @@ func (s *Store) countWaiting(
 	if linkVisible == "" {
 		linkVisible = scopeUnbounded
 	}
-	horizon := waitingHorizonDays
+	horizon := horizonOrDefault(measured)
 	if relax.wholeHorizon {
 		horizon = hiddenHorizonDays
 	}

--- a/backend/internal/modules/activities/owedverdict.go
+++ b/backend/internal/modules/activities/owedverdict.go
@@ -110,7 +110,11 @@ func (s *Store) UnjudgedInbound(ctx context.Context, asOf time.Time, limit, body
 		//
 		// The rest of the partial index's predicate rides along, so the index
 		// and this query ask the same question and the planner can use it.
-		waiting, err := waitingReplyExistsClause(ctx, arg, asOf, nil, nil, own,
+		horizon, err := s.waitingHorizonFor(ctx, tx, asOf)
+		if err != nil {
+			return err
+		}
+		waiting, err := waitingReplyExistsClause(ctx, arg, asOf, nil, nil, own, horizon,
 			`a.owed_verdict IS NULL AND a.audience = 'workspace' AND a.restricted_at IS NULL`)
 		if err != nil {
 			return err

--- a/backend/internal/modules/activities/responsemetrics.go
+++ b/backend/internal/modules/activities/responsemetrics.go
@@ -65,10 +65,18 @@ type ResponseMetrics struct {
 //
 // The window is bounded by the caller. An unbounded read would answer "how fast
 // have we ever been", which no reader is asking and which grows without limit.
+//
+// The PERCENTILE is the caller's too, and there are exactly two askers. The
+// metrics window takes the median, which is what "how fast do we answer" means
+// to a person reading a number. The waiting horizon takes a high one, because
+// its question is the opposite end: the point past which this installation
+// essentially does not answer at all (waitinghorizon.go). Shared rather than
+// copied because what must not drift is the DEFINITION of an answered sales
+// thread, which is the whole body below.
 const firstResponseSQL = `
 	SELECT count(*),
 	       COALESCE(
-	         percentile_cont(0.5) WITHIN GROUP (
+	         percentile_cont(%[5]s) WITHIN GROUP (
 	           ORDER BY EXTRACT(EPOCH FROM (reply.occurred_at - inbound.occurred_at)) / 60
 	         )::bigint, 0)
 	  FROM activity inbound
@@ -242,7 +250,8 @@ func (s *Store) ResponseWindow(ctx context.Context, from, to time.Time) (Respons
 			content,
 			liveRecord(openDealPredicate, "d"),
 			liveRecord(workingLeadPredicate, "ld"),
-			ownDomainSenderSQL("inbound", arg(ownDomains))),
+			ownDomainSenderSQL("inbound", arg(ownDomains)),
+			medianPercentile),
 			args...).Scan(&out.Answered, &out.MedianMinutes); err != nil {
 			return fmt.Errorf("activities: reading first-response times: %w", err)
 		}

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -247,9 +247,16 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		if err != nil {
 			return err
 		}
+		// The horizon this installation's own answering implies, measured in
+		// the same transaction as the scan it bounds — so the cutoff and the
+		// rows it judges come from one snapshot.
+		horizon, err := s.waitingHorizonFor(ctx, tx, asOf)
+		if err != nil {
+			return err
+		}
 		rows, err := tx.Query(ctx,
 			fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
-				waitingHorizonDays,
+				horizon,
 				liveRecord(openDealPredicate, "d"),
 				liveRecord(workingLeadPredicate, "ld"),
 				liveRecord(openDealPredicate, "openDeal"),

--- a/backend/internal/modules/activities/waitinghorizon.go
+++ b/backend/internal/modules/activities/waitinghorizon.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// How far back a wait can reach and still be work, measured from what this
+// installation actually does rather than compiled in for everybody.
+//
+// One number judged every installation: an agency answering within the hour and
+// an enterprise seller working sixty-day cycles got the same ninety days. For
+// the agency that is a queue holding conversations everyone has forgotten; for
+// the enterprise it is a queue dropping live business on a date nobody chose.
+//
+// A SETTING was the obvious answer and it is the wrong one. Response
+// expectations plausibly differ per pipeline, per deal size, per customer tier,
+// so a single workspace number papers over that with an authoritative face —
+// and a number nobody revisits is the failure material_threshold_minor already
+// solved the same way: derive the bar from the data rather than ask for it.
+//
+// A derived horizon also makes no promise. Nothing escalates when work crosses
+// it, because nothing was committed to — which is why this needs no new lane
+// and no question about who is told.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// waitingHorizonSpread is what the derivation measures: how long this
+// installation took to answer, and over how many answers.
+type waitingHorizonSpread struct {
+	// Slow is the high percentile of first-response times — the point past
+	// which this installation essentially does not answer. The MEDIAN would be
+	// the wrong input: half of all answers arrive after it, so a horizon set
+	// there would drop conversations that routinely get replies.
+	Slow time.Duration
+	// Answered is how many first responses that percentile was taken over.
+	Answered int
+}
+
+const (
+	// waitingHorizonMinSample is how many answered threads the derivation needs
+	// before it will speak.
+	//
+	// A fresh installation has no history at all, and a thin one produces a
+	// wild number from a handful of conversations that happen to be slow. Below
+	// this the compiled ninety stands — stated here rather than left to emerge
+	// from a percentile over three rows.
+	waitingHorizonMinSample = 30
+
+	// waitingHorizonFloorDays and waitingHorizonCeilingDays bound what the
+	// measurement may produce.
+	//
+	// The ceiling is the queue's other failure mode: a derivation with none can
+	// answer "keep everything forever", which is not a queue. The floor is the
+	// mirror — an installation that answers everything within a day would
+	// otherwise derive a horizon that drops a customer who waited a week, and a
+	// week's silence is not history in any business.
+	waitingHorizonFloorDays   = 14
+	waitingHorizonCeilingDays = 365
+
+	// waitingHorizonSlack is how much longer than its slow answers an
+	// installation keeps waiting.
+	//
+	// The horizon is not "how long we take" — a wait exactly as old as our
+	// slowest answer is one still plausibly about to be answered. It is how
+	// long past that a thread stays worth looking at, and three times is the
+	// coarse reading this deliberately keeps coarse: the bands that separate an
+	// urgent wait from a stale one are the caller's, and a horizon precise to
+	// the hour would imply a judgement this measurement cannot make.
+	waitingHorizonSlack = 3
+)
+
+// derivedWaitingHorizonDays is the horizon this installation's own behaviour
+// implies, and waitingHorizonDays when it has not answered enough to say.
+//
+// Pure, and separate from the query that feeds it, because the arithmetic is
+// the part worth being able to read and test: what it measures, what it does
+// with too little data, and what it refuses to produce.
+func derivedWaitingHorizonDays(spread waitingHorizonSpread) int {
+	if spread.Answered < waitingHorizonMinSample || spread.Slow <= 0 {
+		return waitingHorizonDays
+	}
+	days := int(spread.Slow.Hours()/24) * waitingHorizonSlack
+	return min(max(days, waitingHorizonFloorDays), waitingHorizonCeilingDays)
+}
+
+const (
+	// medianPercentile is what the metrics window asks firstResponseSQL for:
+	// the middle answer, which is what "how fast do we answer" means to a
+	// person reading a number.
+	medianPercentile = "0.5"
+	// slowPercentile is what the horizon asks it for. Not the median — half of
+	// all answers arrive after that, so a horizon set there would drop
+	// conversations this installation routinely replies to. The ninety-fifth
+	// is the point past which it essentially does not answer, and the last five
+	// per cent are left out because one abandoned thread answered a year late
+	// would otherwise set the horizon for everybody.
+	slowPercentile = "0.95"
+
+	// waitingHorizonWindowDays is how far back the measurement looks.
+	//
+	// A year, so the derivation follows a business that has changed rather than
+	// one it used to be, and so a seasonal quarter cannot speak for the whole
+	// installation. It is deliberately longer than any horizon this can
+	// produce: the measurement's window and the horizon it derives are
+	// different things, and tying them together would make the horizon depend
+	// on its own previous value.
+	waitingHorizonWindowDays = 365
+)
+
+// waitingHorizonFor measures this installation's own response spread and
+// derives the horizon from it, inside the caller's transaction.
+//
+// UNGATED, and that is the one thing about this read worth arguing. Every other
+// figure in this package is taken under the caller's own visibility, because it
+// is about their work. The horizon is not: it decides which rows the queue
+// contains, so two colleagues reading one shared thread have to be judged by
+// one number. Derived per reader it would make the queue's contents depend on
+// who is looking, twice over and invisibly.
+//
+// What that costs is a duration and a count over the installation, and no
+// content: nothing here names a conversation, a person or a record.
+func (s *Store) waitingHorizonFor(ctx context.Context, tx pgx.Tx, asOf time.Time) (int, error) {
+	args := []any{asOf.AddDate(0, 0, -waitingHorizonWindowDays), asOf}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	ownDomains, err := s.ownDomainList(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	var spread waitingHorizonSpread
+	var slowMinutes int64
+	if err := tx.QueryRow(ctx, fmt.Sprintf(firstResponseSQL,
+		scopeUnbounded,
+		liveRecord(openDealPredicate, "d"),
+		liveRecord(workingLeadPredicate, "ld"),
+		ownDomainSenderSQL("inbound", arg(ownDomains)),
+		slowPercentile),
+		args...).Scan(&spread.Answered, &slowMinutes); err != nil {
+		return 0, fmt.Errorf("activities: measuring the response spread the horizon follows: %w", err)
+	}
+	spread.Slow = time.Duration(slowMinutes) * time.Minute
+	return derivedWaitingHorizonDays(spread), nil
+}
+
+// horizonOrDefault reads an unmeasured horizon as the compiled one.
+//
+// A clause builder is reached from paths that hold no transaction to measure
+// through, and the honest answer for those is today's behaviour rather than a
+// horizon of zero days — which would call every wait history and empty the
+// queue.
+func horizonOrDefault(days int) int {
+	if days <= 0 {
+		return waitingHorizonDays
+	}
+	return days
+}

--- a/backend/internal/modules/activities/waitinghorizon_test.go
+++ b/backend/internal/modules/activities/waitinghorizon_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"testing"
+	"time"
+)
+
+func days(n int) time.Duration { return time.Duration(n) * 24 * time.Hour }
+
+// The whole point of deriving: an agency and an enterprise seller stop getting
+// the same number. One compiled ninety judged both, and it was wrong in
+// opposite directions — a queue full of forgotten conversations for one, a
+// queue dropping live business for the other.
+func TestTheHorizonFollowsWhatTheInstallationActuallyDoes(t *testing.T) {
+	fast := derivedWaitingHorizonDays(waitingHorizonSpread{Slow: days(2), Answered: 500})
+	slow := derivedWaitingHorizonDays(waitingHorizonSpread{Slow: days(40), Answered: 500})
+
+	if fast >= waitingHorizonDays {
+		t.Errorf("an installation whose slow answers take two days derives %d days, which is no shorter "+
+			"than the compiled %d — the agency case is unserved", fast, waitingHorizonDays)
+	}
+	if slow <= waitingHorizonDays {
+		t.Errorf("an installation whose slow answers take forty days derives %d days, which is no longer "+
+			"than the compiled %d — the enterprise case is unserved", slow, waitingHorizonDays)
+	}
+	if fast >= slow {
+		t.Errorf("the faster installation derived %d and the slower %d — the horizon does not follow the "+
+			"behaviour it is measured from", fast, slow)
+	}
+}
+
+// Too little to say, so it does not say. A fresh installation has no history,
+// and a handful of conversations that happen to be slow is not a cadence.
+func TestATooThinSampleKeepsTheCompiledHorizon(t *testing.T) {
+	for _, spread := range []waitingHorizonSpread{
+		{},
+		{Slow: days(40), Answered: waitingHorizonMinSample - 1},
+		// Answered enough, but nothing measured — the percentile came back zero
+		// because every answer landed in the same instant it was asked, which is
+		// a shape to refuse rather than to derive a same-day horizon from.
+		{Slow: 0, Answered: 500},
+	} {
+		if got := derivedWaitingHorizonDays(spread); got != waitingHorizonDays {
+			t.Errorf("a spread of %+v derived %d days, want the compiled %d", spread, got, waitingHorizonDays)
+		}
+	}
+}
+
+// Both bounds, and each is a failure mode rather than a tidiness rule: with no
+// ceiling the derivation answers "keep everything forever", which is not a
+// queue; with no floor an installation that answers within the hour drops a
+// customer who waited a week.
+func TestTheDerivationRefusesToProduceAQueueThatIsNotOne(t *testing.T) {
+	if got := derivedWaitingHorizonDays(waitingHorizonSpread{Slow: days(900), Answered: 500}); got != waitingHorizonCeilingDays {
+		t.Errorf("an installation with very slow answers derived %d days, want the ceiling %d — a horizon "+
+			"that keeps everything forever is the queue's other failure mode", got, waitingHorizonCeilingDays)
+	}
+	if got := derivedWaitingHorizonDays(waitingHorizonSpread{Slow: time.Hour, Answered: 500}); got != waitingHorizonFloorDays {
+		t.Errorf("an installation answering within the hour derived %d days, want the floor %d — a week's "+
+			"silence is not history in any business", got, waitingHorizonFloorDays)
+	}
+}
+
+// Zero is the field's zero value, not a horizon, and reading it as one would
+// call every wait history and empty the queue.
+//
+// It is reachable rather than defensive: ListActivitiesTx is a public seam for
+// a caller that already holds a transaction, so it has no store to measure
+// through — and a caller that sets WaitingReplyAsOf on it hands this an
+// unmeasured horizon by construction. The honest answer for that path is
+// today's behaviour.
+func TestAnUnmeasuredHorizonIsTheCompiledOneAndNotNoDaysAtAll(t *testing.T) {
+	for _, unmeasured := range []int{0, -1} {
+		if got := horizonOrDefault(unmeasured); got != waitingHorizonDays {
+			t.Errorf("horizonOrDefault(%d) = %d, want the compiled %d — a horizon of no days calls every "+
+				"wait history and empties the queue", unmeasured, got, waitingHorizonDays)
+		}
+	}
+	// And a measured one is passed through, or the guard would pin every
+	// installation back to ninety and the derivation would reach nothing.
+	if got := horizonOrDefault(21); got != 21 {
+		t.Errorf("horizonOrDefault(21) = %d, want 21 — the guard is swallowing the measurement", got)
+	}
+}

--- a/backend/internal/modules/activities/waitingrecordscope.go
+++ b/backend/internal/modules/activities/waitingrecordscope.go
@@ -52,7 +52,7 @@ func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any
 // The subquery is uncorrelated — it computes its own candidate set rather
 // than reading the outer FROM — so its own `a` alias shadowing the outer
 // query's is harmless.
-func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID, ownDomains []string, alsoBeforeTheCap string) (string, error) {
+func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID, ownDomains []string, horizonDays int, alsoBeforeTheCap string) (string, error) {
 	instant := arg(asOf)
 	content, err := auth.ActivityContentClause(ctx, "a", arg)
 	if err != nil {
@@ -92,7 +92,7 @@ func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.
 	reader := arg(readerOrNobody(ctx))
 	return "a.id IN (SELECT id FROM (" +
 		fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
-			waitingHorizonDays,
+			horizonOrDefault(horizonDays),
 			liveRecord(openDealPredicate, "d"),
 			liveRecord(workingLeadPredicate, "ld"),
 			liveRecord(openDealPredicate, "openDeal"),
@@ -111,7 +111,7 @@ func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg f
 	if in.WaitingReplyAsOf == nil {
 		return where, nil
 	}
-	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID, in.ownDomains, "")
+	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID, in.ownDomains, in.horizonDays, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #3702, to the ruling recorded on it: derive the horizon from what the installation actually does, no setting.

## What it does

`waitingHorizonDays = 90` judged every installation. An agency answering within the hour got a queue full of conversations everyone has forgotten; an enterprise seller on sixty-day cycles got a queue dropping live business on a date nobody chose.

The horizon is now measured: the **ninety-fifth percentile** of this installation's own first-response times over a year, times a slack factor. Not the median — half of all answers arrive after that, so a horizon set there would drop conversations the installation routinely replies to.

## The four things the ruling asked for

1. **The derivation is written down beside it**, and it is a pure function so it can be read and tested on its own: what it measures, over what window, and what it does with too little data. Below **30 answered threads** the compiled 90 stands — a fresh installation has no history, and a handful of slow conversations is not a cadence.
2. **Bounded at both ends.** A ceiling of 365, because a derivation with none answers "keep everything forever", which is not a queue. And a floor of 14, which is the mirror the ruling did not name: an installation answering within the hour would otherwise derive a horizon that drops a customer who waited a week, and a week's silence is not history in any business.
3. **Inspectable** — the figure feeds `GET /worklist/hidden`'s `past_horizon` directly, which is where an operator asking "why did this drop off my queue" already looks, and which the ruling names as the evidence the derivation is falsifiable against.
4. `waitingLead` and `leadLead` are **left compiled in**, as the ruling says: how many of one kind lead the page is about a screen's shape, not an installation's cadence.

## Two decisions the ruling did not settle

**The measurement is ungated.** Every other figure in the package is taken under the caller's own visibility, because it is about their work. This one is not: the horizon decides which rows the queue *contains*, so two colleagues reading one shared thread must be judged by one number. Derived per reader, the queue's contents would depend on who is looking — twice over and invisibly. What it costs is a duration and a count over the installation, and no content: nothing in it names a conversation, a person or a record.

**The percentile is now `firstResponseSQL`'s parameter** rather than a second query. That file already says the sales-thread definition must not drift and is deliberately restated once; a third copy would be worse than sharing. The metrics window asks it for the median, the horizon asks for the ninety-fifth, and the body — what counts as an answered sales thread — is one statement.

## Measured where it is used

Five call sites judge against this horizon and they now take one value. The two that hold a transaction measure it there; the clause builders take it as a snapshot the way `ownDomains` already is — *"one read's snapshot, not a request parameter"*. The guardrail measures once and hands the same figure to all five relaxations, or it would report a difference between two scans that came from two cutoffs rather than from the rule it was relaxing.

## Verification

`make check-backend` green; the `activities` integration lane green.

The derivation's arithmetic is unit-tested and mutation-checked: no ceiling, no floor, and a thin sample derived from anyway — each fails with the case that names it.

`horizonOrDefault` is also held, and that one is worth a note. It was unheld when I first ran the mutations, which is the shape I deleted as speculative on #3725 — but the two differ. There the invalid state was impossible by construction; here `ListActivitiesTx` is a **public** seam for a caller holding its own transaction, so it has no store to measure through, and the field's zero value would read as a horizon of no days and empty the queue. Reachable by construction, so it is kept and tested rather than removed.

**What I could not do** is the ruling's fourth item — *"check `past_horizon` before and after on real data"* — which needs an installation with history. The mechanism makes it measurable and the figure is already on `GET /worklist/hidden`; the check itself is an operator's.
