### PR TITLE
test(worklist): a row claims no verb it cannot perform

### DIFF
--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -39,6 +39,16 @@ import (
 // The brief itself is still its own surface with its own cited sections. This
 // names the way in; a queue that tried to summarise it here would be a second
 // answer to "prepare me for this".
+//
+// It offers no OUTCOME either, and that is the same fact rather than a second
+// gap. Recording what a meeting came to is a write on the activity —
+// `meeting_status` on PATCH /activities/{id} takes booked, held, no_show and
+// canceled, and the log-activity screen already sends `held` — so the write
+// exists and it is the row that has nowhere to put it: the card's subject is a
+// timeline entry with no page, which is why it carries no `open`. Giving the
+// outcome a verb here means either a control that answers inline, the way the
+// approval card does, or a destination for an activity that has none. Both are
+// larger than wiring, and neither is decided.
 func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 	subject := meeting.Subject
 	starts := meeting.StartsAt

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -31,6 +31,13 @@ func readerAt(tier principal.RowScope) context.Context {
 // A rep sees their own work. The default matters more than it looks: an admin
 // account can read every deal in the installation, and a queue that showed all
 // of them would hand a rep several hundred colleagues' rows and call it a day.
+//
+// EVERY tier, managers included. A design proposed landing a manager on their
+// team's exceptions instead, on the reasoning that a manager's job is the team;
+// it was declined, and this test is what holds the decision. A manager is also
+// a seller — their own promises and their own buyers are waiting too — and a
+// queue that opened on somebody else's work would bury that behind a switch.
+// The team view is a scope this reader can reach, not the one they land in.
 func TestEveryReaderDefaultsToTheirOwnWork(t *testing.T) {
 	for _, tier := range []principal.RowScope{principal.RowScopeOwn, principal.RowScopeTeam, principal.RowScopeAll} {
 		scope, err := resolveScope(readerAt(tier), "")

--- a/frontend/src/screens/worklist.verbcensus.test.ts
+++ b/frontend/src/screens/worklist.verbcensus.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { WorklistItem } from "./worklist.queries";
+
+// A row claims no verb it cannot perform.
+//
+// The rule is NOT "every row offers something": two rows deliberately offer
+// nothing, because the queue can send a reader somewhere and cannot fix a rule,
+// and a row the server named no verb for is still real work with nothing to
+// press. Drawing a control on either would promise a repair this surface does
+// not perform.
+//
+// What must hold is the other direction. Every verb the contract can send has
+// to be ANSWERED somewhere — routed to a destination, or drawn inline by the
+// component that owns it — or the row draws a button that goes nowhere, which
+// is worse than no button at all.
+//
+// Nothing enforced that. `VERB_DESTINATION` is a partial map on purpose, so a
+// tenth verb added to the contract would simply fall out of it and be silently
+// undrawn, and the six answered inline are named nowhere. This is that list,
+// and it fails rather than drifts.
+
+const SCREENS = join(__dirname);
+
+// Every verb the contract offers, read from the generated types rather than
+// retyped: a census that names its own subjects proves only that they were
+// named.
+type Verb = WorklistItem["actions"][number];
+
+// Where each verb is answered. ROUTED means VERB_DESTINATION carries it to the
+// record the row is about; INLINE names the file that draws its control on the
+// row itself. Exhaustive over the union, so a verb added to `crm.yaml` fails to
+// compile here until somebody says where a reader answers it.
+const ANSWERED_BY = {
+  open: { how: "routed" },
+  complete: { how: "routed" },
+  snooze: { how: "routed" },
+  // Answered on this page, so a link would send the reader where they already
+  // are — except an introduction ask, which routes to the colleague's own
+  // Network tab through decideDestination.
+  decide: { how: "inline", file: "worklist.row.tsx" },
+  merge: { how: "inline", file: "worklist.pair.tsx" },
+  act: { how: "inline", file: "worklist.row.tsx" },
+  set_aside: { how: "inline", file: "worklist.row.tsx" },
+  dismiss: { how: "inline", file: "worklist.row.tsx" },
+  acknowledge: { how: "inline", file: "worklist.row.tsx" },
+} as const satisfies Record<
+  Verb,
+  { how: "routed" } | { how: "inline"; file: string }
+>;
+
+describe("a row claims no verb it cannot perform", () => {
+  const row = readFileSync(join(SCREENS, "worklist.row.tsx"), "utf8");
+
+  // The routed verbs, read from VERB_DESTINATION's own body. Read as source
+  // rather than imported, because the map is not exported and exporting it to
+  // satisfy a test would widen the module's surface for the test's convenience.
+  //
+  // SLICED TO THE MAP FIRST, so the pattern does not have to tell one top-level
+  // arrow-valued map from another: VERB_LABEL sits beside it with the same
+  // shape, and a census that told them apart by their parameter name would gain
+  // members the day somebody renamed one.
+  const map = row.match(/const VERB_DESTINATION\b[\s\S]*?\n};/)?.[0] ?? "";
+  const routed = new Set(
+    [...map.matchAll(/^ {2}(\w+): /gm)].map(([, verb]) => verb),
+  );
+
+  // A corpus that read NOTHING reports the same silence as one that found
+  // nothing wrong, so the census says out loud that it found its subject.
+  // Today three verbs are routed, so an empty parse would fail the arms below
+  // by accident; that stops the day the last routed verb moves inline, which
+  // the map's own comment anticipates.
+  //
+  // Asserted inside a test rather than at module scope: a bare expect there
+  // aborts the file, and a suite reporting "no tests" reads as a configuration
+  // problem rather than as this census losing the thing it audits.
+  it("finds the destination map it reads as text", () => {
+    expect(
+      map,
+      "VERB_DESTINATION is no longer a top-level const ending in `};` — this " +
+        "census reads it as source and can no longer find it",
+    ).not.toBe("");
+    expect(
+      routed.size,
+      "the destination map parsed as empty, so this census read nothing " +
+        "rather than found nothing",
+    ).toBeGreaterThan(0);
+  });
+
+  it("routes exactly the verbs the destination map claims", () => {
+    const declared = Object.entries(ANSWERED_BY)
+      .filter(([, where]) => where.how === "routed")
+      .map(([verb]) => verb)
+      .sort();
+
+    expect([...routed].sort()).toEqual(declared);
+  });
+
+  // THE CENSUS. A verb answered nowhere is a verb a reader is offered and
+  // cannot use.
+  it("answers every verb the contract can send", () => {
+    const unanswered = Object.entries(ANSWERED_BY).filter(([verb, where]) => {
+      if (where.how === "routed") {
+        return !routed.has(verb);
+      }
+      // GUARDED, not merely mentioned. The named file has to ASK whether the
+      // row offers this verb, in one of the two spellings the call sites use —
+      // `offered("x")` through the helper, or `includes("x")` direct. A file
+      // that merely contains the word satisfies nothing: deleting a control's
+      // condition leaves the verb's name behind in the click handler, in
+      // VERB_LABEL and in the prose, so a mention test stays green over a row
+      // that draws nothing.
+      const source = readFileSync(join(SCREENS, where.file), "utf8");
+      return !(
+        source.includes(`offered("${verb}")`) ||
+        source.includes(`includes("${verb}")`)
+      );
+    });
+
+    expect(
+      unanswered.map(([verb]) => verb),
+      "these verbs reach the row and nothing answers them, so a reader is " +
+        "offered a control that does nothing",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
The worklist row can be sent nine verbs. Three are routed to the record the row is about; six are answered inline. **Nothing said so**, so a tenth verb added to `crm.yaml` would fall out of the partial destination map and be silently undrawn.

The narrowed rule, as decided: **not** "every row offers something" — two rows offer nothing on purpose, because the queue can send a reader somewhere and cannot fix a rule, and a row the server named no verb for is still real work with nothing to press. Both keep their tests. What must hold is the other direction: a verb that reaches the row and is answered nowhere is a control that does nothing.

## Why this is a census and not a list

Three things make it fail rather than drift, and each was put there because a mutation got past the version before it.

**1. Its subjects come from the contract.** `ANSWERED_BY` is `satisfies Record<Verb, …>` where `Verb` resolves through the generated schema to a closed union of the nine. A tenth verb stops this file compiling until somebody says where a reader answers it.

**2. An inline claim must find a GUARD, not a mention.** Reviewer mutation: change `{offered("act") && (` to `{false && (`. The control is gone, `act` reaches the row, nothing draws — and the first version of this census **passed green**, because the word `act` survives in the click handler, in `VERB_LABEL` and in prose. It now requires `offered("x")` or `includes("x")` and fails on exactly that mutation.

**3. It says out loud that it found its subject.** The routed arm reads `VERB_DESTINATION` as source. My own first fix for the empty-corpus rule was itself blind: renaming the map to `VERB_DESTINATION_RENAMED` left the census **green**, because the pattern matched the new name as a prefix. Anchored on a word boundary, all three arms now fail on that rename with a named reason.

## Evidence

| Obligation | Evidence |
|---|---|
| The invariant | `answers every verb the contract can send` — fails listing any verb no file guards on |
| Under-recognition | `finds the destination map it reads as text` — fails when the map is renamed, reformatted, or parses empty |
| Mutation strength | Delete `snooze: (href) => href,` → two arms fail. Point `acknowledge` at a file that does not answer it → census fails naming it. `{offered("act") && (` → `{false && (` → census fails naming `act`. Rename the map → all three fail |
| Full lane | `make check-backend` green; `make check-fe` green, **6646 tests** |
| Review | `craft-reviewer`, which found finding 2 by mutation and predicted finding 3. **Codex was rate-limited for this whole session** (`gpt-5.3-codex-spark` is the only model this account accepts; reset 13:22), retried before commit and before merge |

## Two decisions recorded where the code can see them

**A manager lands on their own work, every tier.** A design proposed landing them on their team's exceptions; declined, because a manager is also a seller whose own promises and buyers are waiting, and a queue that opened on somebody else's work would bury that behind a switch. `TestEveryReaderDefaultsToTheirOwnWork` holds it.

**A meeting row has nowhere to record the outcome** (#4321). The write exists — `meeting_status` on `PATCH /activities/{id}`, which `logactivity.tsx` already sends — so this was scoped as wiring and is not. The card's subject is an activity, a timeline entry with no page, which is why it carries no `open` at all. An outcome verb needs an inline control or a destination that does not exist; neither is decided.

All five factual claims in those two comments were verified against source by the reviewer rather than taken on trust.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test census that enforces every verb a worklist row can receive is answered, so a future verb added to the contract can't be silently undrawn.

- The census reads verbs from the generated union, so a new verb fails compilation until someone says where it's answered.
- Inline claims must find an `offered("x")` or `includes("x")` guard in the owning file, not just the verb's name.
- The routed arm reads `VERB_DESTINATION` as source and fails if the map is renamed, reformatted, or parses empty.
- Documents two decisions in code comments: managers land on their own work at every tier, and a meeting row deliberately offers no outcome verb.

<sup>Written for commit b29580cf70d6c897f002f2e7fad5c8f78dfb8895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified supported meeting outcome recording and the availability of related worklist actions.
  - Documented default work-queue scope behavior for all role levels, including managers.

- **Tests**
  - Added automated coverage to verify that worklist actions are consistently routed or guarded.
  - Improved detection of missing or incomplete action handling as the worklist evolves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->