### PR TITLE
One deal is one row, and the night breaks the tie

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -40149,6 +40149,59 @@ components:
             rather than a gap: a dedupe pair genuinely asks the reader to choose.
         verdict:
           $ref: '#/components/schemas/WorklistDealVerdict'
+        brief_item_id:
+          type: string
+          format: uuid
+          description: |
+            The overnight brief entry this row also stands for, where the night
+            surfaced the same deal the day's own lanes did.
+
+            One deal is ONE row. The brief ranks deals and the at-risk lane raises
+            them, so a deal the night picked and the day also found arrived twice —
+            the same name, the same figures, two places to answer it. The rows are
+            folded into one, and this carries the brief entry's id so the verbs that
+            belong to the brief (`/brief/items/{id}/act`, and its set-aside and
+            dismiss) still reach it. Absent on a row the night did not raise.
+        brief_section:
+          type: string
+          enum: [respond_now, prepare_conversations, move_revenue, build_pipeline, review_and_repair]
+          x-enum-varnames:
+            - BriefSectionRespondNow
+            - BriefSectionPrepareConversations
+            - BriefSectionMoveRevenue
+            - BriefSectionBuildPipeline
+            - BriefSectionReviewAndRepair
+          description: |
+            Which part of the morning this row belongs to, as a LABEL and never as an
+            order.
+
+            The server has already ranked the page, and this says nothing about where a
+            row sits. A client may draw the label, and may group runs of consecutive
+            rows that share it — but partitioning the page by this field and
+            concatenating the parts would be a second ranking, and the two would
+            disagree the first time a `respond_now` row ranked below a `move_revenue`
+            one, which is ordinary and correct.
+
+            Derived on the server from the row's own category, source and band, so
+            every surface reads one answer. Exhaustive over the categories:
+            `backend/internal/compose/attention/briefsections.go` names every one, and
+            a gate derives that census from the generated contract.
+        changed_since_brief:
+          type: boolean
+          description: |
+            Whether the thing this row reports happened AFTER the overnight run's data
+            cutoff — the run's `as_of`, not its `generated_at`, which is only when the
+            row was written.
+
+            The distinction is the whole of this field's value: a run generated at 06:42
+            over data read at 06:00 has a 42-minute window in which a buyer can reply,
+            and comparing against the wrong instant either hides that reply or reports
+            every row as new. Stamped from the material timestamp each producer already
+            owns rather than from one generic `occurred_at`, so the browser never guesses
+            freshness.
+
+            Absent when there is no run today to compare against, which is different from
+            false: false says the night saw this, absent says there was no night.
 
     WorklistDealVerdict:
       type: object
@@ -40251,7 +40304,7 @@ components:
       properties:
         comparator:
           type: string
-          enum: [pin, crowded, level, deadline, expected_revenue, waiting_days, relationship, order]
+          enum: [pin, crowded, level, deadline, expected_revenue, opportunity, waiting_days, relationship, order]
           description: |
             What decided it. `order` means every comparator tied and the ids broke it, which the
             client renders as no reason at all.
@@ -40272,12 +40325,24 @@ components:
         client's to apply.
       required: [kind]
       properties:
-        kind: { type: string, enum: [date, money, days, level, none] }
+        kind: { type: string, enum: [date, money, days, level, score, none] }
         date: { type: string, format: date-time }
         minor: { type: integer, format: int64, description: 'Money in minor units of `currency`.' }
         currency: { type: string, pattern: '^[A-Z]{3}$' }
         days: { type: integer }
         level: { type: integer, minimum: 0, maximum: 6 }
+        score:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: |
+            A ranking judgement between 0 and 1 — today, the overnight brief's composite
+            for a deal.
+
+            Drawn as a BAND rather than as a number. The value orders the queue, and a
+            client printing "0.72 against 0.68" would be offering a precision the score
+            does not carry and a reader cannot check; the same two rows read honestly as
+            "the night rated this one higher".
 
     WorklistMove:
       type: object

--- a/backend/gates/briefsectioncensus_test.go
+++ b/backend/gates/briefsectioncensus_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every worklist category reaches a section of the morning.
+//
+// BriefSectionOf labels each row with the part of the day it belongs to, and the
+// morning feed groups runs of rows by that label. A category the mapping does not
+// place gets whatever the default arm returns, which is a real answer for the
+// categories that were considered and a wrong one for a category nobody thought
+// about — the row is drawn under "move revenue" because that is the fall-through,
+// not because anybody decided it belongs there.
+//
+// THE CORPUS IS DERIVED, NOT LISTED. A gate holding its own copy of the seven
+// categories is a second spelling of the enum, and it goes stale the same way the
+// mapping would (AGENTS.md, "Reuse before you build" rule 5). So the list comes
+// out of crm.yaml, and adding an eighth category fails this gate until somebody
+// decides which part of the morning it belongs to.
+//
+// It cannot fail short: the second test requires the parse to find at least the
+// seven the product ships, so a reworded schema that yielded an empty corpus is
+// loud rather than green (AGENTS.md rule 8).
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+func TestEveryWorklistCategoryIsPlacedInTheMorning(t *testing.T) {
+	t.Parallel()
+	for _, category := range worklistCategories(t) {
+		item := crmcontracts.WorklistItem{
+			Category: crmcontracts.WorklistItemCategory(category),
+			Actions:  []crmcontracts.WorklistItemActions{},
+		}
+		if section := attention.BriefSectionOf(item); section == "" {
+			t.Errorf("category %q reaches no brief section.\n"+
+				"align: backend/internal/compose/attention/briefsections.go — every category must "+
+				"reach a section, because a row drawn with no section is one a grouping client "+
+				"cannot place.", category)
+		}
+	}
+}
+
+// The census must not be able to pass by reading nothing.
+func TestTheCategoryCorpusIsTheContractsOwn(t *testing.T) {
+	t.Parallel()
+	found := worklistCategories(t)
+
+	if len(found) < 7 {
+		t.Fatalf("parsed %d worklist categories out of crm.yaml (%v), want at least the seven the "+
+			"product ships. The schema's shape changed and this gate is now judging a smaller "+
+			"subject than it thinks.", len(found), found)
+	}
+}
+
+// worklistCategories reads WorklistItem.category's enum out of the contract.
+func worklistCategories(t *testing.T) []string {
+	t.Helper()
+	var doc struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]struct {
+					Enum []string `yaml:"enum"`
+				} `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	raw, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	return doc.Components.Schemas["WorklistItem"].Properties["category"].Enum
+}

--- a/backend/gates/briefsectioncensus_test.go
+++ b/backend/gates/briefsectioncensus_test.go
@@ -51,14 +51,34 @@ func TestEveryWorklistCategoryIsPlacedInTheMorning(t *testing.T) {
 }
 
 // The census must not be able to pass by reading nothing.
+//
+// The floor is not a number typed here. An earlier version said `< 7`, a
+// constant that agrees with today's answer and would keep agreeing after an
+// eighth category shipped — the guard loosening silently at the moment it was
+// most needed, and a second copy of the enum's size besides.
+//
+// What replaces it is two checks that need no list: the parse must find
+// something, and every word it finds must be one the GENERATED validator admits.
+// The second is what catches a reworded schema that yields junk. It does NOT
+// catch a schema that yields a strict subset — for that the gate would need to
+// know how many categories exist, which is the copy being avoided. The census
+// above is the guard for that case: a category dropped from crm.yaml is one
+// BriefSectionOf still places, and nothing here is judging it any more, but the
+// same drop fails the frontend's own generated types loudly.
 func TestTheCategoryCorpusIsTheContractsOwn(t *testing.T) {
 	t.Parallel()
 	found := worklistCategories(t)
 
-	if len(found) < 7 {
-		t.Fatalf("parsed %d worklist categories out of crm.yaml (%v), want at least the seven the "+
-			"product ships. The schema's shape changed and this gate is now judging a smaller "+
-			"subject than it thinks.", len(found), found)
+	if len(found) == 0 {
+		t.Fatal("parsed no worklist categories out of crm.yaml: the schema's shape changed and " +
+			"this gate is now judging nothing at all. Fix the parse before trusting the census above.")
+	}
+	for _, category := range found {
+		if !crmcontracts.WorklistItemCategory(category).Valid() {
+			t.Errorf("crm.yaml declares category %q, which the generated validator does not know.\n"+
+				"align: run `make gen` — the contract and the generated enum have drifted, and this "+
+				"gate is judging a corpus the code cannot represent.", category)
+		}
 	}
 }
 

--- a/backend/internal/compose/attention/briefdedupe.go
+++ b/backend/internal/compose/attention/briefdedupe.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// One deal is ONE row, however many lanes found it.
+//
+// The brief ranks deals overnight and the at-risk lane raises them during the
+// day, and the two agree far more often than they disagree — that is what makes
+// them both right, and what put the same deal on the morning twice: the same
+// name, the same figures, two places to answer it, and two rows counted in every
+// reading above them.
+//
+// THE AT-RISK ROW SURVIVES, NOT THE BRIEF ROW. It is the one with the day's
+// facts on it: the figures pass filled its amount and close date, the classifier
+// gave it a level from those facts, and the move pass may have put a next step on
+// it. The brief row carries a rank and a deal id. Folding the other way would
+// keep the poorer row and lose the reason it was ranked where it was.
+//
+// WHAT THE BRIEF ROW LEAVES BEHIND is its id, on `brief_item_id`. The brief's
+// own verbs — act, set aside, dismiss — route to `/brief/items/{id}/…`, and a
+// reader answering the surviving row must still be able to tell the night it was
+// answered. Without the id the fold would silently take those verbs away, which
+// is a worse outcome than the duplicate.
+//
+// AND ITS COMPOSITE, which is what makes the fold more than tidying. The night's
+// score is the only ordering signal that knows how this deal compares to every
+// other deal the night considered, and ranksteps.go's `opportunity` step reads it
+// to break a tie INSIDE a level. Dropping the row without it would throw that
+// away.
+//
+// WHAT THE FOLD MUST NOT CHANGE is the surviving row's level, its band, or any
+// count derived from them. semanticLevelOf has three readers — the summary's
+// signals, bucketsOf's partition, and the partition a walk freezes — and its own
+// comment warns that a fourth spelling of that precedence is the defect to
+// avoid. So this touches none of them: it removes a row and copies two fields
+// onto another, and TestFoldingABriefItemMovesNoBucketCount holds that.
+
+import (
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// foldBriefIntoRisk drops each brief row whose deal another row already reports,
+// carrying the brief's id and its composite onto the row that survives.
+//
+// Rows the fold does not touch keep their order and their contents exactly, so
+// this is safe to call before the ranking: it is a filter, not a re-sort.
+func foldBriefIntoRisk(rows []ranked) []ranked {
+	kept := make([]ranked, 0, len(rows))
+	// Where each surviving row ended up in KEPT, not in rows. The brief entries
+	// are dropped as the walk goes, so the two indexes diverge the moment one
+	// is — and writing the brief's id at the row's old position would put it on
+	// whatever row slid into that slot, or past the end.
+	survivingAt := map[ids.UUID]int{}
+	folded := make([]ranked, 0, 4)
+	for _, row := range rows {
+		if _, isBrief := briefRowsDeal(row.item); isBrief {
+			folded = append(folded, row)
+			continue
+		}
+		if row.item.Subject != nil && row.item.Subject.Type == subjectDeal {
+			deal := ids.UUID(row.item.Subject.Id)
+			// The FIRST row about a deal wins: it is the one the ranking shows
+			// highest, and the brief's verbs must land where the reader looks.
+			if _, seen := survivingAt[deal]; !seen {
+				survivingAt[deal] = len(kept)
+			}
+		}
+		kept = append(kept, row)
+	}
+	for _, brief := range folded {
+		deal, _ := briefRowsDeal(brief.item)
+		at, found := survivingAt[deal]
+		if !found {
+			// The night surfaced a deal the day's own lanes did not. Its row
+			// stays as itself — this fold removes duplicates and never rows.
+			kept = append(kept, brief)
+			continue
+		}
+		carryBriefOnto(&kept[at], brief)
+	}
+	return kept
+}
+
+// briefRowsDeal answers which deal a brief row is about, where the row is one.
+func briefRowsDeal(item crmcontracts.WorklistItem) (ids.UUID, bool) {
+	if item.Source != crmcontracts.WorklistItemSourceBriefItem {
+		return ids.UUID{}, false
+	}
+	if item.Subject == nil || item.Subject.Type != subjectDeal {
+		return ids.UUID{}, false
+	}
+	return ids.UUID(item.Subject.Id), true
+}
+
+// carryBriefOnto moves what the folded row was carrying onto the survivor: the
+// brief's own id, so its verbs still reach it, and the night's composite, so the
+// opportunity tie-break can still read it.
+//
+// The survivor's level, band and every other field are untouched, which is the
+// invariant this fold is allowed to keep and nothing more.
+func carryBriefOnto(survivor *ranked, brief ranked) {
+	id, err := ids.Parse(brief.item.Id)
+	if err != nil {
+		// A brief row whose own id will not parse is a row whose verbs could not
+		// be addressed anyway. The duplicate is still folded away; what is lost
+		// is the routing, which was already lost.
+		return
+	}
+	named := openapi_types.UUID(id)
+	survivor.item.BriefItemId = &named
+	survivor.opportunity = brief.opportunity
+}
+
+// stampOpportunity puts the night's score on every row about a deal it ranked.
+//
+// EVERY row, not only the brief's own: the fold below keeps the at-risk row, and
+// a score reaching only the row that disappears would be a tie-break nothing
+// could read. A deal the night never saw keeps zero and loses the step to any
+// deal it did, which is the honest answer — the night has an opinion about one
+// and none about the other.
+func stampOpportunity(rows []ranked, scores map[ids.UUID]float64) []ranked {
+	if len(scores) == 0 {
+		return rows
+	}
+	for at := range rows {
+		item := rows[at].item
+		if item.Subject == nil || item.Subject.Type != subjectDeal {
+			continue
+		}
+		if score, ranked := scores[ids.UUID(item.Subject.Id)]; ranked {
+			rows[at].opportunity = score
+		}
+	}
+	return rows
+}
+
+// markChangedSinceBrief says which rows report something the night did not see.
+//
+// AGAINST THE RUN'S DATA CUTOFF, never its generated_at. A run written at 06:42
+// over records read at 06:00 has a 42-minute window, and judging freshness by
+// when the rows were written would call every one of them old — hiding exactly
+// the reply a rep opens the page to find.
+//
+// The row's own material moment is what is compared: `occurredAt`, which each
+// producer already set to the instant the thing it reports actually happened.
+// The alternative — the browser comparing some timestamp on the wire — is a
+// second answer to "is this new", in a place that cannot see which of a row's
+// several instants is the material one.
+//
+// NO RUN MEANS NO ANSWER, not a false one. A zero cutoff leaves every row's flag
+// absent, because "the night saw this" and "there was no night" are different
+// facts and a client showing a changed-since strip must be able to tell them
+// apart.
+func markChangedSinceBrief(rows []ranked, cutoff time.Time) []ranked {
+	if cutoff.IsZero() {
+		return rows
+	}
+	for at := range rows {
+		if rows[at].occurredAt.IsZero() {
+			// A row with no material moment cannot answer this question. Absent
+			// rather than false: false would claim the night saw something the
+			// row cannot date.
+			continue
+		}
+		changed := rows[at].occurredAt.After(cutoff)
+		rows[at].item.ChangedSinceBrief = &changed
+	}
+	return rows
+}

--- a/backend/internal/compose/attention/briefdedupe_test.go
+++ b/backend/internal/compose/attention/briefdedupe_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// One deal, one row — and the fold that gets there without moving anything else.
+//
+// The morning it exists for showed the same deal twice: once because the night
+// ranked it and once because the day's at-risk lane raised it. Same name, same
+// figures, two places to answer it, and both counted in the readings above.
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func rankedBriefRow(itemID, dealID ids.UUID) ranked {
+	return ranked{item: crmcontracts.WorklistItem{
+		Id:       itemID.String(),
+		Source:   crmcontracts.WorklistItemSourceBriefItem,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+		Actions:  []crmcontracts.WorklistItemActions{"act", "set_aside", "dismiss"},
+		Subject: &crmcontracts.AttentionSubject{
+			Type: subjectDeal, Id: openapi_types.UUID(dealID),
+		},
+	}}
+}
+
+func atRiskRow(dealID ids.UUID) ranked {
+	return ranked{
+		item: crmcontracts.WorklistItem{
+			Id:       dealID.String(),
+			Source:   crmcontracts.WorklistItemSourceDealAtRisk,
+			Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+			Level:    3,
+			Actions:  []crmcontracts.WorklistItemActions{"open"},
+			Subject: &crmcontracts.AttentionSubject{
+				Type: subjectDeal, Id: openapi_types.UUID(dealID),
+			},
+		},
+		semanticLevel: 3,
+	}
+}
+
+// THE case the fold exists for.
+func TestADealSurfacedByTheNightIsOneRowNotTwo(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+	rows := []ranked{atRiskRow(deal), rankedBriefRow(briefItem, deal)}
+
+	kept := foldBriefIntoRisk(rows)
+
+	if len(kept) != 1 {
+		t.Fatalf("kept %d rows, want the one at-risk row", len(kept))
+	}
+	if kept[0].item.Source != crmcontracts.WorklistItemSourceDealAtRisk {
+		t.Errorf("the surviving row is %q — the at-risk row carries the day's figures "+
+			"and is the one that must survive", kept[0].item.Source)
+	}
+}
+
+// The brief's verbs answer to the brief's endpoints, so the surviving row has to
+// carry its id or the fold silently takes act, set-aside and dismiss away.
+func TestTheFoldedRowKeepsTheBriefMarkVerbs(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+
+	kept := foldBriefIntoRisk([]ranked{atRiskRow(deal), rankedBriefRow(briefItem, deal)})
+
+	if kept[0].item.BriefItemId == nil {
+		t.Fatal("the surviving row names no brief item — the night can never be told it was answered")
+	}
+	if ids.UUID(*kept[0].item.BriefItemId) != briefItem {
+		t.Errorf("brief_item_id = %v, want the folded entry %v", *kept[0].item.BriefItemId, briefItem)
+	}
+}
+
+// The night's score is the reason the fold is more than tidying: it is the only
+// signal that knows how this deal compares to every other deal the night weighed.
+func TestTheFoldedRowInheritsTheNightsScore(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+	brief := rankedBriefRow(briefItem, deal)
+	brief.opportunity = 0.81
+
+	kept := foldBriefIntoRisk([]ranked{atRiskRow(deal), brief})
+
+	if kept[0].opportunity != 0.81 {
+		t.Errorf("opportunity = %v, want the night's own score", kept[0].opportunity)
+	}
+}
+
+// A deal the night surfaced and the day's lanes did not keeps its row. This fold
+// removes duplicates, never rows.
+func TestADealOnlyTheNightFoundKeepsItsRow(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+
+	kept := foldBriefIntoRisk([]ranked{rankedBriefRow(briefItem, deal)})
+
+	if len(kept) != 1 {
+		t.Fatalf("kept %d rows, want the brief's own row", len(kept))
+	}
+	if kept[0].item.Source != crmcontracts.WorklistItemSourceBriefItem {
+		t.Error("a deal only the night found lost its row")
+	}
+}
+
+// THE invariant the fold is allowed to keep and nothing more. semanticLevelOf
+// has three readers — the summary's signals, bucketsOf's partition, and the
+// partition a walk freezes — and a fold that moved a level would move a figure
+// a manager reads.
+func TestFoldingABriefItemMovesNoBucketCount(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+	before := bucketsOf([]ranked{atRiskRow(deal)})
+
+	kept := foldBriefIntoRisk([]ranked{atRiskRow(deal), rankedBriefRow(briefItem, deal)})
+	after := bucketsOf(kept)
+
+	if before != after {
+		t.Errorf("the buckets moved from %+v to %+v — the fold changed what a row MEANS, "+
+			"not just how many rows say it", before, after)
+	}
+	if kept[0].semanticLevel != 3 {
+		t.Errorf("semantic level = %d, want the survivor's own 3", kept[0].semanticLevel)
+	}
+}
+
+// Two rows about one deal, and the FIRST is the one the brief attaches to: it is
+// the one the ranking shows highest, and the verbs must land where the reader
+// will actually look.
+func TestTheBriefAttachesToTheHighestRowAboutItsDeal(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+	first, second := atRiskRow(deal), atRiskRow(deal)
+	second.item.Id = "second"
+
+	kept := foldBriefIntoRisk([]ranked{first, second, rankedBriefRow(briefItem, deal)})
+
+	if len(kept) != 2 {
+		t.Fatalf("kept %d rows, want both at-risk rows", len(kept))
+	}
+	if kept[0].item.BriefItemId == nil {
+		t.Fatal("the first row did not receive the brief's id")
+	}
+	if kept[1].item.BriefItemId != nil {
+		t.Error("a second row about the same deal also claimed the brief's verbs")
+	}
+}
+
+// The night's score reaches the row that SURVIVES, which is why it is stamped
+// before the fold rather than after it.
+func TestTheNightsScoreReachesTheRowThatSurvives(t *testing.T) {
+	deal := ids.NewV7()
+	rows := []ranked{atRiskRow(deal)}
+
+	rows = stampOpportunity(rows, map[ids.UUID]float64{deal: 0.64})
+
+	if rows[0].opportunity != 0.64 {
+		t.Errorf("opportunity = %v, want the score for this deal", rows[0].opportunity)
+	}
+}
+
+// A deal the night never weighed keeps zero and therefore loses the step to any
+// deal it did — the honest answer, not a missing one.
+func TestADealTheNightNeverWeighedScoresZero(t *testing.T) {
+	rows := []ranked{atRiskRow(ids.NewV7())}
+
+	rows = stampOpportunity(rows, map[ids.UUID]float64{ids.NewV7(): 0.9})
+
+	if rows[0].opportunity != 0 {
+		t.Errorf("opportunity = %v, want zero for a deal the night did not rank", rows[0].opportunity)
+	}
+}
+
+// THE distinction the whole field turns on: the run's DATA CUTOFF, not the later
+// instant at which it finished writing its rows down.
+func TestChangedSinceBriefUsesTheRunsAsOfNotItsGeneratedAt(t *testing.T) {
+	readAt := time.Date(2026, 9, 4, 6, 0, 0, 0, time.UTC)
+	// The reply landed after the night READ the records and before it finished
+	// writing them. Judged by generated_at it would read as old.
+	row := atRiskRow(ids.NewV7())
+	row.occurredAt = time.Date(2026, 9, 4, 6, 20, 0, 0, time.UTC)
+
+	marked := markChangedSinceBrief([]ranked{row}, readAt)
+
+	if marked[0].item.ChangedSinceBrief == nil {
+		t.Fatal("the row carries no answer at all")
+	}
+	if !*marked[0].item.ChangedSinceBrief {
+		t.Error("a reply that landed after the run's cutoff reads as something the night saw")
+	}
+}
+
+// Something the night did read is not new.
+func TestSomethingTheNightSawIsNotChanged(t *testing.T) {
+	readAt := time.Date(2026, 9, 4, 6, 0, 0, 0, time.UTC)
+	row := atRiskRow(ids.NewV7())
+	row.occurredAt = time.Date(2026, 9, 3, 17, 0, 0, 0, time.UTC)
+
+	marked := markChangedSinceBrief([]ranked{row}, readAt)
+
+	if marked[0].item.ChangedSinceBrief == nil || *marked[0].item.ChangedSinceBrief {
+		t.Errorf("changed = %v, want false for a record the night read", marked[0].item.ChangedSinceBrief)
+	}
+}
+
+// No run means no answer. Absent and false are different facts: one says there
+// was no night, the other says the night saw this.
+func TestWithNoRunNoRowClaimsTheNightSawIt(t *testing.T) {
+	row := atRiskRow(ids.NewV7())
+	row.occurredAt = time.Date(2026, 9, 4, 6, 20, 0, 0, time.UTC)
+
+	marked := markChangedSinceBrief([]ranked{row}, time.Time{})
+
+	if marked[0].item.ChangedSinceBrief != nil {
+		t.Errorf("changed = %v with no run to compare against — absent is the only honest answer",
+			*marked[0].item.ChangedSinceBrief)
+	}
+}
+
+// A row that cannot date what it reports says nothing rather than claiming the
+// night saw it.
+func TestARowWithNoMaterialMomentClaimsNothing(t *testing.T) {
+	readAt := time.Date(2026, 9, 4, 6, 0, 0, 0, time.UTC)
+
+	marked := markChangedSinceBrief([]ranked{atRiskRow(ids.NewV7())}, readAt)
+
+	if marked[0].item.ChangedSinceBrief != nil {
+		t.Error("a row with no material moment claimed an answer it cannot support")
+	}
+}
+
+// The fold is a FILTER, not a re-sort: the rows it keeps stay in the order they
+// arrived, so it is safe to run before the ranking.
+//
+// A brief row the fold cannot match is appended after the rows it walked past,
+// which is the one place order could move. It cannot matter — every caller
+// sorts afterwards, and sortByRank is total over these rows — but a reader of
+// this file should not have to take that on trust.
+func TestTheFoldKeepsTheRowsItDoesNotTouchInOrder(t *testing.T) {
+	first, second, third := atRiskRow(ids.NewV7()), atRiskRow(ids.NewV7()), atRiskRow(ids.NewV7())
+
+	kept := foldBriefIntoRisk([]ranked{first, second, third})
+
+	if len(kept) != 3 {
+		t.Fatalf("kept %d rows, want all three", len(kept))
+	}
+	for at, want := range []ranked{first, second, third} {
+		if kept[at].item.Id != want.item.Id {
+			t.Errorf("row %d is %s, want %s — the fold re-ordered rows it does not touch",
+				at, kept[at].item.Id, want.item.Id)
+		}
+	}
+}
+
+// A page with no brief rows at all comes back untouched.
+func TestAPageWithNoBriefRowsIsUnchanged(t *testing.T) {
+	deal := ids.NewV7()
+
+	kept := foldBriefIntoRisk([]ranked{atRiskRow(deal)})
+
+	if len(kept) != 1 || kept[0].item.BriefItemId != nil {
+		t.Errorf("a page with no brief rows came back changed: %+v", kept)
+	}
+}
+
+// The opportunity step breaks a tie INSIDE a level and never crosses one.
+//
+// This is the invariant that keeps the one feed one feed. The night ranks deals
+// against each other on facts the day's lanes do not gather; the levels are the
+// product's hard rule about what kind of work outranks what. A composite that
+// could lift a row past a level would be the second ranking system this whole
+// change exists to end.
+func TestTheOpportunityStepNeverChangesARowsSemanticLevel(t *testing.T) {
+	// A level-4 deal the night loved, against a level-3 deal it never saw.
+	loved := atRiskRow(ids.NewV7())
+	loved.item.Level = 4
+	loved.semanticLevel = 4
+	loved.opportunity = 0.99
+	unseen := atRiskRow(ids.NewV7())
+
+	ranked := rankAllFor([]ranked{loved, unseen}, ids.UUID{})
+
+	if ranked[0].Id != unseen.item.Id {
+		t.Errorf("the level-4 row the night scored 0.99 outranked a level-3 row — " +
+			"the composite crossed a level, which is the second ranking system this feed ends")
+	}
+}
+
+// Two rows at ONE level, and the night's score decides between them.
+func TestTwoRiskRowsAtOneLevelOrderByOpportunity(t *testing.T) {
+	quiet, promising := atRiskRow(ids.NewV7()), atRiskRow(ids.NewV7())
+	promising.opportunity = 0.8
+
+	ranked := rankAllFor([]ranked{quiet, promising}, ids.UUID{})
+
+	if ranked[0].Id != promising.item.Id {
+		t.Error("two rows at one level did not order by the night's score")
+	}
+}
+
+// And it says so, with both sides, so a reader can check the claim.
+func TestTheOpportunityStepExplainsItselfWithBothScores(t *testing.T) {
+	quiet, promising := atRiskRow(ids.NewV7()), atRiskRow(ids.NewV7())
+	promising.opportunity = 0.8
+	quiet.opportunity = 0.2
+
+	ranked := rankAllFor([]ranked{quiet, promising}, ids.UUID{})
+
+	above := ranked[0].AboveNext
+	if above == nil {
+		t.Fatal("the top row explains nothing")
+	}
+	if above.Comparator != crmcontracts.WorklistComparisonComparatorOpportunity {
+		t.Fatalf("comparator = %q, want opportunity", above.Comparator)
+	}
+	if above.Mine == nil || above.Mine.Score == nil || above.Theirs == nil || above.Theirs.Score == nil {
+		t.Fatalf("the comparison carries no scores: %+v", above)
+	}
+	if *above.Mine.Score <= *above.Theirs.Score {
+		t.Errorf("mine %v is not above theirs %v", *above.Mine.Score, *above.Theirs.Score)
+	}
+}

--- a/backend/internal/compose/attention/briefdedupe_test.go
+++ b/backend/internal/compose/attention/briefdedupe_test.go
@@ -322,3 +322,159 @@ func TestTheOpportunityStepExplainsItselfWithBothScores(t *testing.T) {
 		t.Errorf("mine %v is not above theirs %v", *above.Mine.Score, *above.Theirs.Score)
 	}
 }
+
+// A brief row AHEAD of the row it folds into.
+//
+// THE case the fold's index bookkeeping exists for, and the one every other test
+// in this file cannot see. The fold walks once, dropping brief rows and
+// recording where each survivor landed; the input index and the output index
+// diverge the moment a row is dropped. Every fixture above puts the brief row
+// LAST, so nothing is dropped before a survivor is recorded and the two indexes
+// stay equal — which means all of them pass against a version that records the
+// input position and writes at it.
+//
+// This one puts the brief row first. The at-risk row is then at input position 1
+// and output position 0, and a fold that confused them writes the brief's id
+// past the end of a one-row slice or onto the wrong row.
+//
+// Mutation-checked: recording `inputAt` instead of `len(kept)` fails this test
+// and passes every other one in the file.
+func TestABriefRowAheadOfItsSurvivorStillLandsOnIt(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+
+	kept := foldBriefIntoRisk([]ranked{
+		rankedBriefRow(briefItem, deal),
+		atRiskRow(deal),
+	})
+
+	if len(kept) != 1 {
+		t.Fatalf("kept %d rows, want the one at-risk row", len(kept))
+	}
+	if kept[0].item.BriefItemId == nil {
+		t.Fatal("the survivor lost the brief's id — the fold wrote it at an input position " +
+			"while the survivors live in the output slice")
+	}
+	if ids.UUID(*kept[0].item.BriefItemId) != briefItem {
+		t.Errorf("brief_item_id = %v, want %v", *kept[0].item.BriefItemId, briefItem)
+	}
+}
+
+// The same divergence, with several rows dropped before the survivor. Two brief
+// rows ahead of it push the input and output indexes two apart.
+func TestSeveralFoldedRowsAheadOfASurvivorStillLandOnIt(t *testing.T) {
+	first, second, deal := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	briefItem := ids.NewV7()
+
+	kept := foldBriefIntoRisk([]ranked{
+		rankedBriefRow(ids.NewV7(), first),
+		rankedBriefRow(ids.NewV7(), second),
+		rankedBriefRow(briefItem, deal),
+		atRiskRow(deal),
+	})
+
+	// The two unmatched brief rows keep their own rows; the third folds.
+	if len(kept) != 3 {
+		t.Fatalf("kept %d rows, want the at-risk row and the two unmatched brief rows", len(kept))
+	}
+	var survivor *ranked
+	for at := range kept {
+		if kept[at].item.Source == crmcontracts.WorklistItemSourceDealAtRisk {
+			survivor = &kept[at]
+		}
+	}
+	if survivor == nil {
+		t.Fatal("the at-risk row is gone")
+	}
+	if survivor.item.BriefItemId == nil || ids.UUID(*survivor.item.BriefItemId) != briefItem {
+		t.Errorf("brief_item_id = %v, want %v — the fold lost track of where the survivor landed",
+			survivor.item.BriefItemId, briefItem)
+	}
+}
+
+// The brief's verbs survive the pass that removes the row they were attached to.
+//
+// THE defect that made this fold run last. A deal can be both in the night's
+// brief and carrying an unanswered message. The at-risk row took the brief's id;
+// dropDealsAlreadyWaiting then deleted that row, because one unanswered message
+// is one row; and the waiting row that absorbs it inherits the deal's figures
+// and reasons but not the brief's id. The entry vanished from the page, and with
+// it the act, set-aside and dismiss verbs that answer the night — which the
+// fold's own header calls a worse outcome than the duplicate it prevents.
+//
+// Written over the two passes IN THE ORDER worklist.go runs them, because the
+// order is the fix: neither pass alone is wrong.
+func TestTheBriefsVerbsSurviveTheRowTheyWereAttachedTo(t *testing.T) {
+	deal, briefItem := ids.NewV7(), ids.NewV7()
+	waiting := waitingRowAbout(deal)
+
+	rows := dropDealsAlreadyWaiting([]ranked{atRiskRow(deal), waiting})
+	rows = foldBriefIntoRisk(append(rows, rankedBriefRow(briefItem, deal)))
+
+	var carrier *ranked
+	for at := range rows {
+		if rows[at].item.BriefItemId != nil {
+			carrier = &rows[at]
+		}
+	}
+	if carrier == nil {
+		t.Fatal("no row on the page names the brief entry — the night can never be told it was " +
+			"answered, and act, set aside and dismiss are gone with it")
+	}
+	if ids.UUID(*carrier.item.BriefItemId) != briefItem {
+		t.Errorf("brief_item_id = %v, want %v", *carrier.item.BriefItemId, briefItem)
+	}
+}
+
+// waitingRowAbout is the customer_waiting row that absorbs a deal's at-risk row.
+func waitingRowAbout(dealID ids.UUID) ranked {
+	return ranked{item: crmcontracts.WorklistItem{
+		Id:       ids.NewV7().String(),
+		Source:   sourceWaiting,
+		Category: crmcontracts.WorklistItemCategoryCustomerWaiting,
+		Level:    1,
+		Actions:  []crmcontracts.WorklistItemActions{"open"},
+		Subject: &crmcontracts.AttentionSubject{
+			Type: subjectDeal, Id: openapi_types.UUID(dealID),
+		},
+	}}
+}
+
+// One reader's night never reaches another reader's page.
+//
+// THE property the predecessor of this branch got wrong, in the same shape: it
+// kept per-read state on the Service, which one process shares across every
+// request, and a reader whose own brief ran empty inherited the last reader's.
+//
+// Written against readingScores rather than against scoresOf, and the
+// distinction is the whole point. scoresOf is pure — it has nowhere to leave a
+// previous caller's answer, so a test over it proves the easy half. The scores
+// and the cutoff are FIELDS on the Service, which is exactly the shape that
+// leaked, so the assertion has to be that the shared value is untouched.
+//
+// Mutation-checked: making readingScores assign through `s` rather than a copy
+// fails both halves.
+func TestOneReadersNightDoesNotReachAnothersPage(t *testing.T) {
+	theirDeal := ids.NewV7()
+	theirCutoff := time.Date(2026, 9, 4, 6, 0, 0, 0, time.UTC)
+	shared := &Service{
+		briefScores: map[ids.UUID]float64{theirDeal: 0.9},
+		briefCutoff: theirCutoff,
+	}
+
+	// The next reader's brief ran empty: no scores, no run, no cutoff.
+	mine := shared.readingScores(nil, time.Time{})
+
+	if len(shared.briefScores) != 1 || shared.briefScores[theirDeal] != 0.9 {
+		t.Errorf("the shared service's scores became %v — one read wrote through the value "+
+			"every request shares", shared.briefScores)
+	}
+	if !shared.briefCutoff.Equal(theirCutoff) {
+		t.Errorf("the shared service's cutoff became %v, want %v", shared.briefCutoff, theirCutoff)
+	}
+	if len(mine.briefScores) != 0 {
+		t.Errorf("my page carries %v — another reader's night", mine.briefScores)
+	}
+	if !mine.briefCutoff.IsZero() {
+		t.Errorf("my page carries cutoff %v, and my brief never ran", mine.briefCutoff)
+	}
+}

--- a/backend/internal/compose/attention/briefsections.go
+++ b/backend/internal/compose/attention/briefsections.go
@@ -38,17 +38,53 @@ import (
 // move. The FIRST matching rule wins, and the order below is the product
 // decision — the general category answer is last, after the specific ones.
 func BriefSectionOf(item crmcontracts.WorklistItem) crmcontracts.WorklistItemBriefSection {
+	// The specific rules first, because they cut ACROSS the categories: a lead
+	// owed a reply is somebody waiting rather than pipeline to build, and a deal
+	// whose next step is the meeting brief is a conversation to prepare whatever
+	// lane raised it. Each is a product decision and none of them is derivable
+	// from the category alone.
 	switch {
 	case respondsNow(item):
 		return crmcontracts.BriefSectionRespondNow
 	case preparesAConversation(item):
 		return crmcontracts.BriefSectionPrepareConversations
-	case repairsSomething(item):
-		return crmcontracts.BriefSectionReviewAndRepair
 	case sectionBuildsPipeline(item):
 		return crmcontracts.BriefSectionBuildPipeline
-	default:
+	}
+	return sectionOfCategory(item.Category)
+}
+
+// sectionOfCategory places a row that no specific rule claimed, by its category
+// alone.
+//
+// EVERY CATEGORY IS NAMED and there is no default, which is the whole point of
+// this function existing separately. With a `default` arm the placement was
+// total but not considered: a category nobody had thought about fell through to
+// `move_revenue` and was drawn under a heading that happened to be plausible,
+// and backend/gates/briefsectioncensus_test.go passed because it could only ask
+// whether a section came back at all.
+//
+// Here an eighth category returns the empty string, and that gate fails on it.
+// The gate's question is unchanged; what changed is that this function can now
+// answer it wrongly, which is what makes asking it worth anything.
+func sectionOfCategory(category crmcontracts.WorklistItemCategory) crmcontracts.WorklistItemBriefSection {
+	switch category {
+	case crmcontracts.WorklistItemCategoryCustomerWaiting:
+		return crmcontracts.BriefSectionRespondNow
+	case crmcontracts.WorklistItemCategoryLeads:
+		return crmcontracts.BriefSectionBuildPipeline
+	case crmcontracts.WorklistItemCategoryMeetings:
+		return crmcontracts.BriefSectionPrepareConversations
+	case crmcontracts.WorklistItemCategoryDecisions, crmcontracts.WorklistItemCategorySystem:
+		return crmcontracts.BriefSectionReviewAndRepair
+	case crmcontracts.WorklistItemCategoryDealsAtRisk, crmcontracts.WorklistItemCategoryTasks:
+		// The two that are revenue to move: a deal drifting, and the work
+		// somebody agreed to do about one.
 		return crmcontracts.BriefSectionMoveRevenue
+	default:
+		// A category this build does not place. Empty rather than a guess, so
+		// the census gate says so out loud.
+		return ""
 	}
 }
 
@@ -94,33 +130,22 @@ func preparesAConversation(item crmcontracts.WorklistItem) bool {
 	return item.Move != nil && item.Move.Action == crmcontracts.WorklistMoveActionOpenMeetingBrief
 }
 
-// repairsSomething: a judgement to make or a source to restore, rather than
-// customer work to do.
-func repairsSomething(item crmcontracts.WorklistItem) bool {
-	switch item.Category {
-	case crmcontracts.WorklistItemCategoryDecisions, crmcontracts.WorklistItemCategorySystem:
-		return true
-	}
-	return false
-}
-
 // sectionBuildsPipeline: work that creates future revenue rather than
 // protecting booked revenue.
 //
-// The BAND is asked first, because it is the server's own answer to "what is the
-// reader being asked to do today" and it already carries rows this section wants
-// that no subject test would find. bands.go's buildsPipeline answers the
-// narrower question — is the row filed under a lead — and is reused rather than
-// restated: two spellings of "this builds pipeline" would drift, and the band
-// this file reads is itself derived from that function.
+// bands.go's buildsPipeline is CALLED rather than restated — two spellings of
+// "this builds pipeline" would drift — and the band is deliberately NOT read
+// here, though an earlier version of this function read it first. That version
+// was dead code with a paragraph of justification on top: bandOfRow reaches
+// bandBuildPipeline only through this same buildsPipeline, so the band arm could
+// never be true where the call below is false. Deleting it changed no test,
+// which is how it was found.
 //
-// A relationship going quiet is the third arm and belongs to neither: there is
-// no lead yet and the band is about momentum, but reconnecting is exactly how
-// pipeline gets built.
+// The two arms it does have are the ones buildsPipeline does not answer. A lead
+// row is pipeline by its category even where its subject resolves elsewhere. And
+// a relationship going quiet has no lead and no deal at risk, yet reconnecting is
+// exactly how pipeline gets built.
 func sectionBuildsPipeline(item crmcontracts.WorklistItem) bool {
-	if item.Band != nil && *item.Band == crmcontracts.BuildPipeline {
-		return true
-	}
 	if item.Source == crmcontracts.WorklistItemSourceRelationshipDecay {
 		return true
 	}

--- a/backend/internal/compose/attention/briefsections.go
+++ b/backend/internal/compose/attention/briefsections.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Which part of the morning a row belongs to.
+//
+// A LABEL, NEVER AN ORDER, and that is the whole rule this file exists to hold.
+// The queue arrives ranked by one policy — the levels, then the tie-breaks in
+// ranksteps.go — and a section says nothing about where a row sits. A client may
+// draw the label and may group runs of consecutive rows that share it. It may
+// not partition the page by section and concatenate the parts: that is a second
+// ranking, and the two disagree the first time a `respond_now` row ranks below a
+// `move_revenue` one, which is ordinary and correct.
+//
+// So this is computed on the SERVER, once, and travels as presentation metadata.
+// The alternative — a browser deriving it from category and source — is the same
+// mapping in a second place, in a language where nothing can check it, and the
+// day it drifts the page groups a row under a heading the readings counted
+// elsewhere.
+//
+// EXHAUSTIVE over WorklistItemCategory, and held that way: every category
+// reaches a section, because a row drawn with no section at all is a row a
+// grouping client cannot place. backend/gates/briefsectioncensus_test.go derives
+// the category list from the generated contract rather than keeping a second
+// copy of it, so a category added to crm.yaml fails here until somebody decides
+// which part of the morning it belongs to.
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// BriefSectionOf answers which part of the morning this row belongs to.
+//
+// Read in this order, because the questions are not independent. A lead that is
+// overdue for a reply is somebody waiting, not pipeline to build; a deal row
+// whose move is a meeting brief is a conversation to prepare, not revenue to
+// move. The FIRST matching rule wins, and the order below is the product
+// decision — the general category answer is last, after the specific ones.
+func BriefSectionOf(item crmcontracts.WorklistItem) crmcontracts.WorklistItemBriefSection {
+	switch {
+	case respondsNow(item):
+		return crmcontracts.BriefSectionRespondNow
+	case preparesAConversation(item):
+		return crmcontracts.BriefSectionPrepareConversations
+	case repairsSomething(item):
+		return crmcontracts.BriefSectionReviewAndRepair
+	case sectionBuildsPipeline(item):
+		return crmcontracts.BriefSectionBuildPipeline
+	default:
+		return crmcontracts.BriefSectionMoveRevenue
+	}
+}
+
+// respondsNow: somebody is waiting for an answer from this rep.
+//
+// A bounce and an undelivered message belong here too, and they are the arm a
+// reader would not guess: the customer never received what we sent, so they are
+// waiting without knowing it, and nothing else about the day will surface that.
+func respondsNow(item crmcontracts.WorklistItem) bool {
+	switch item.Source {
+	case crmcontracts.WorklistItemSourceBounce, crmcontracts.WorklistItemSourceUndelivered:
+		return true
+	}
+	if item.Category == crmcontracts.WorklistItemCategoryCustomerWaiting {
+		return true
+	}
+	// A lead is pipeline UNTIL its reply clock is running, and then it is
+	// somebody waiting. The reasons are what carry that, because the lane
+	// already computed it and a second reading here would be a second answer.
+	return item.Category == crmcontracts.WorklistItemCategoryLeads && owedAReply(item)
+}
+
+// owedAReply reads the response clock the lead lane already stamped.
+func owedAReply(item crmcontracts.WorklistItem) bool {
+	for _, because := range item.Because {
+		switch because.Kind {
+		case crmcontracts.WorklistReasonKindResponseOverdue,
+			crmcontracts.WorklistReasonKindResponseDueSoon:
+			return true
+		}
+	}
+	return false
+}
+
+// preparesAConversation: a meeting is coming and somebody has to walk in ready.
+//
+// The deal arm matters as much as the meeting one: a deal row whose next step is
+// "open the meeting brief" is preparation, whatever lane raised it.
+func preparesAConversation(item crmcontracts.WorklistItem) bool {
+	if item.Source == crmcontracts.WorklistItemSourceMeeting || item.Category == crmcontracts.WorklistItemCategoryMeetings {
+		return true
+	}
+	return item.Move != nil && item.Move.Action == crmcontracts.WorklistMoveActionOpenMeetingBrief
+}
+
+// repairsSomething: a judgement to make or a source to restore, rather than
+// customer work to do.
+func repairsSomething(item crmcontracts.WorklistItem) bool {
+	switch item.Category {
+	case crmcontracts.WorklistItemCategoryDecisions, crmcontracts.WorklistItemCategorySystem:
+		return true
+	}
+	return false
+}
+
+// sectionBuildsPipeline: work that creates future revenue rather than
+// protecting booked revenue.
+//
+// The BAND is asked first, because it is the server's own answer to "what is the
+// reader being asked to do today" and it already carries rows this section wants
+// that no subject test would find. bands.go's buildsPipeline answers the
+// narrower question — is the row filed under a lead — and is reused rather than
+// restated: two spellings of "this builds pipeline" would drift, and the band
+// this file reads is itself derived from that function.
+//
+// A relationship going quiet is the third arm and belongs to neither: there is
+// no lead yet and the band is about momentum, but reconnecting is exactly how
+// pipeline gets built.
+func sectionBuildsPipeline(item crmcontracts.WorklistItem) bool {
+	if item.Band != nil && *item.Band == crmcontracts.BuildPipeline {
+		return true
+	}
+	if item.Source == crmcontracts.WorklistItemSourceRelationshipDecay {
+		return true
+	}
+	return buildsPipeline(item) || item.Category == crmcontracts.WorklistItemCategoryLeads
+}

--- a/backend/internal/compose/attention/briefsections_test.go
+++ b/backend/internal/compose/attention/briefsections_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Which part of the morning a row belongs to.
+//
+// Every case here is about the ORDER of the rules, because that is where the
+// mapping is a product decision rather than a lookup: a lead owed a reply is
+// somebody waiting, and a deal whose next step is a meeting brief is a
+// conversation to prepare.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+func sectioned(over crmcontracts.WorklistItem) crmcontracts.WorklistItemBriefSection {
+	if over.Actions == nil {
+		over.Actions = []crmcontracts.WorklistItemActions{}
+	}
+	return BriefSectionOf(over)
+}
+
+func TestACustomerWaitingIsAnsweredFirst(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceCustomerWaiting,
+		Category: crmcontracts.WorklistItemCategoryCustomerWaiting,
+	})
+
+	if got != crmcontracts.BriefSectionRespondNow {
+		t.Errorf("section = %q, want respond_now", got)
+	}
+}
+
+// THE ordering case for leads. A lead is pipeline until its reply clock is
+// running, and then somebody is waiting on us.
+func TestALeadOwedAReplyIsSomebodyWaitingNotPipelineToBuild(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceLeadResponse,
+		Category: crmcontracts.WorklistItemCategoryLeads,
+		Because: []crmcontracts.WorklistReason{
+			{Kind: crmcontracts.WorklistReasonKindResponseOverdue},
+		},
+	})
+
+	if got != crmcontracts.BriefSectionRespondNow {
+		t.Errorf("section = %q, want respond_now for a lead past its reply clock", got)
+	}
+}
+
+func TestALeadWithNoReplyClockIsPipelineToBuild(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceLeadResponse,
+		Category: crmcontracts.WorklistItemCategoryLeads,
+	})
+
+	if got != crmcontracts.BriefSectionBuildPipeline {
+		t.Errorf("section = %q, want build_pipeline", got)
+	}
+}
+
+// A message the customer never received. They are waiting without knowing it,
+// and nothing else about the day surfaces that.
+func TestABouncedMessageIsSomebodyWaiting(t *testing.T) {
+	for _, source := range []crmcontracts.WorklistItemSource{
+		crmcontracts.WorklistItemSourceBounce,
+		crmcontracts.WorklistItemSourceUndelivered,
+	} {
+		got := sectioned(crmcontracts.WorklistItem{
+			Source: source, Category: crmcontracts.WorklistItemCategorySystem,
+		})
+		if got != crmcontracts.BriefSectionRespondNow {
+			t.Errorf("%s: section = %q, want respond_now", source, got)
+		}
+	}
+}
+
+// THE ordering case for deals: a deal row whose next step is the meeting brief
+// is preparation, whatever lane raised it.
+func TestADealWhoseNextStepIsAMeetingBriefIsPreparation(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceDealAtRisk,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+		Move: &crmcontracts.WorklistMove{
+			Action: crmcontracts.WorklistMoveActionOpenMeetingBrief,
+		},
+	})
+
+	if got != crmcontracts.BriefSectionPrepareConversations {
+		t.Errorf("section = %q, want prepare_conversations", got)
+	}
+}
+
+func TestAMeetingIsAConversationToPrepare(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceMeeting,
+		Category: crmcontracts.WorklistItemCategoryMeetings,
+	})
+
+	if got != crmcontracts.BriefSectionPrepareConversations {
+		t.Errorf("section = %q, want prepare_conversations", got)
+	}
+}
+
+func TestADecisionAndASystemFailureAreBothReviewAndRepair(t *testing.T) {
+	for _, category := range []crmcontracts.WorklistItemCategory{
+		crmcontracts.WorklistItemCategoryDecisions,
+		crmcontracts.WorklistItemCategorySystem,
+	} {
+		got := sectioned(crmcontracts.WorklistItem{
+			Source: crmcontracts.WorklistItemSourceApproval, Category: category,
+		})
+		if got != crmcontracts.BriefSectionReviewAndRepair {
+			t.Errorf("%s: section = %q, want review_and_repair", category, got)
+		}
+	}
+}
+
+// A relationship going quiet has no lead and no deal at risk, and reconnecting
+// is exactly how pipeline gets built.
+func TestARelationshipGoingQuietIsPipelineToBuild(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceRelationshipDecay,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+	})
+
+	if got != crmcontracts.BriefSectionBuildPipeline {
+		t.Errorf("section = %q, want build_pipeline", got)
+	}
+}
+
+func TestADriftingDealIsRevenueToMove(t *testing.T) {
+	got := sectioned(crmcontracts.WorklistItem{
+		Source:   crmcontracts.WorklistItemSourceDealAtRisk,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+	})
+
+	if got != crmcontracts.BriefSectionMoveRevenue {
+		t.Errorf("section = %q, want move_revenue", got)
+	}
+}
+
+// EVERY category reaches a section. A row drawn with no section is a row a
+// grouping client cannot place, and the default arm is what guarantees it —
+// this is the test that would fail if somebody made the mapping partial.
+func TestEveryWorklistCategoryHasABriefSection(t *testing.T) {
+	for _, category := range []crmcontracts.WorklistItemCategory{
+		crmcontracts.WorklistItemCategoryCustomerWaiting,
+		crmcontracts.WorklistItemCategoryLeads,
+		crmcontracts.WorklistItemCategoryDealsAtRisk,
+		crmcontracts.WorklistItemCategoryMeetings,
+		crmcontracts.WorklistItemCategoryTasks,
+		crmcontracts.WorklistItemCategoryDecisions,
+		crmcontracts.WorklistItemCategorySystem,
+	} {
+		got := sectioned(crmcontracts.WorklistItem{Category: category})
+		if got == "" {
+			t.Errorf("category %q reaches no section", category)
+		}
+	}
+}

--- a/backend/internal/compose/attention/briefsections_test.go
+++ b/backend/internal/compose/attention/briefsections_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 func sectioned(over crmcontracts.WorklistItem) crmcontracts.WorklistItemBriefSection {
@@ -142,22 +143,49 @@ func TestADriftingDealIsRevenueToMove(t *testing.T) {
 	}
 }
 
-// EVERY category reaches a section. A row drawn with no section is a row a
-// grouping client cannot place, and the default arm is what guarantees it —
-// this is the test that would fail if somebody made the mapping partial.
-func TestEveryWorklistCategoryHasABriefSection(t *testing.T) {
-	for _, category := range []crmcontracts.WorklistItemCategory{
-		crmcontracts.WorklistItemCategoryCustomerWaiting,
-		crmcontracts.WorklistItemCategoryLeads,
-		crmcontracts.WorklistItemCategoryDealsAtRisk,
-		crmcontracts.WorklistItemCategoryMeetings,
-		crmcontracts.WorklistItemCategoryTasks,
-		crmcontracts.WorklistItemCategoryDecisions,
-		crmcontracts.WorklistItemCategorySystem,
-	} {
-		got := sectioned(crmcontracts.WorklistItem{Category: category})
-		if got == "" {
-			t.Errorf("category %q reaches no section", category)
-		}
+// A category this build cannot place carries NO section rather than an empty one.
+//
+// sectionOfCategory returns "" for a category nobody has placed, which is what
+// makes the census gate fail loudly instead of drawing the row under whatever
+// the fall-through happened to be. That empty string must not reach the wire:
+// the field is an enum, and a client reading "" has a value its own generated
+// types do not carry.
+//
+// The gate is what keeps this arm unreachable in a shipped build. This is what
+// keeps a build where it IS reachable from serving a value no client can read.
+func TestAnUnplaceableRowCarriesNoSectionRatherThanAnEmptyOne(t *testing.T) {
+	unplaced := ranked{item: crmcontracts.WorklistItem{
+		Id:       ids.NewV7().String(),
+		Source:   crmcontracts.WorklistItemSourceTask,
+		Category: "renewals",
+		Actions:  []crmcontracts.WorklistItemActions{},
+	}}
+
+	drawn := renderInOrder([]ranked{unplaced}, ids.UUID{})
+
+	if drawn[0].BriefSection != nil {
+		t.Errorf("brief_section = %q reached the wire for a category this build does not place — "+
+			"a client reading it has an enum value its generated types do not carry",
+			*drawn[0].BriefSection)
+	}
+}
+
+// And a row this build DOES place still carries its section, so the guard above
+// cannot be satisfied by drawing nothing at all.
+func TestAPlaceableRowStillCarriesItsSection(t *testing.T) {
+	placed := ranked{item: crmcontracts.WorklistItem{
+		Id:       ids.NewV7().String(),
+		Source:   crmcontracts.WorklistItemSourceDealAtRisk,
+		Category: crmcontracts.WorklistItemCategoryDealsAtRisk,
+		Actions:  []crmcontracts.WorklistItemActions{},
+	}}
+
+	drawn := renderInOrder([]ranked{placed}, ids.UUID{})
+
+	if drawn[0].BriefSection == nil {
+		t.Fatal("a placeable row carries no section — the guard is drawing nothing at all")
+	}
+	if *drawn[0].BriefSection != crmcontracts.BriefSectionMoveRevenue {
+		t.Errorf("section = %q, want move_revenue", *drawn[0].BriefSection)
 	}
 }

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -130,6 +130,13 @@ type Service struct {
 	// to do and not how the deal is standing, which is what every deal row did
 	// before this seam. dealstanding.go states the three-source order.
 	dealStandings DealStandings
+	// briefScores is one read's answer, on the per-request copy readingScores
+	// makes. The classifier reads it to stamp `opportunity`, which is why it
+	// cannot travel as an argument the way the findings do.
+	briefScores map[ids.UUID]float64
+	// briefCutoff is the same read's brief run data cutoff, on the same copy and
+	// for the same reason.
+	briefCutoff time.Time
 	// fx is OPTIONAL in the same way, and money is one read's answer from it,
 	// written per read onto the request's own copy the way taskScope is.
 	// basemoney.go states what each means and why the copy matters.
@@ -251,16 +258,14 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 // brief ran empty would inherit them because nothing would overwrite what
 // nothing wrote. That is another rep's mail-derived prose on this rep's row,
 // and an unsynchronised map write under concurrent requests besides.
-func (s *Service) assembleDay(
-	ctx context.Context,
-) (crmcontracts.Attention, map[ids.UUID]string, error) {
+func (s *Service) assembleDay(ctx context.Context) (crmcontracts.Attention, theNight, error) {
 	asOf := s.now().UTC()
 	// The day's end, resolved ONCE for the whole assembly: every due-dated lane
 	// is judged against the same instant, and the installation is asked for its
 	// timezone once rather than per lane.
 	until, err := s.endOfDay(ctx, asOf)
 	if err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
 	// Every lane starts as an empty slice, never nil. The contract declares
 	// them as arrays, and a withheld lane leaves its field unset — which
@@ -275,14 +280,14 @@ func (s *Service) assembleDay(
 	}
 	var omitted []crmcontracts.AttentionLanesOmitted
 
-	morning, morningState, findings, err := s.thisMorning(ctx)
+	night, err := s.thisMorning(ctx)
 	omitted, err = fill(omitted, "this_morning", err, func() {
-		out.ThisMorning = morning
-		out.Counts.ThisMorning = len(morning)
-		out.ThisMorningState = &morningState
+		out.ThisMorning = night.items
+		out.Counts.ThisMorning = len(night.items)
+		out.ThisMorningState = &night.state
 	})
 	if err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
 
 	needsYou, count, err := s.decisionsToDepth(ctx, s.decisionsDepth())
@@ -295,7 +300,7 @@ func (s *Service) assembleDay(
 		}
 	})
 	if err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
 
 	planned, plannedTotal, err := s.planned(ctx, asOf, until, s.taskScope)
@@ -304,7 +309,7 @@ func (s *Service) assembleDay(
 		out.Counts.Planned = plannedTotal
 	})
 	if err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
 
 	// The three OPTIONAL lanes, each bound or absent. optionalLane holds the
@@ -312,14 +317,14 @@ func (s *Service) assembleDay(
 	for _, lane := range s.optionalLanes(ctx, asOf, until, &out) {
 		omitted, err = lane.collect(omitted)
 		if err != nil {
-			return crmcontracts.Attention{}, nil, err
+			return crmcontracts.Attention{}, theNight{}, err
 		}
 	}
 
 	done, err := s.done(ctx, asOf)
 	omitted, err = fill(omitted, "done_for_you", err, func() { out.DoneForYou = done })
 	if err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
 
 	if len(omitted) > 0 {
@@ -328,9 +333,9 @@ func (s *Service) assembleDay(
 	// Last, over the assembled lanes: every card that names a record gets its
 	// display name under this reader's own grants (labels.go).
 	if err := s.fillSubjectLabels(ctx, &out); err != nil {
-		return crmcontracts.Attention{}, nil, err
+		return crmcontracts.Attention{}, theNight{}, err
 	}
-	return out, findings, nil
+	return out, night, nil
 }
 
 // laneCount carries the totals behind a lane the reader only sees a slice of.

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -243,12 +243,13 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 	return day, err
 }
 
-// assembleDay is Assemble, plus the night's finding per deal.
+// assembleDay is Assemble, plus everything else the night knows: its finding
+// per deal, its score per deal, and the run's data cutoff.
 //
 // The two are one pass because the brief lane is read ONCE: asking it again
 // after the page is cut would be a second read of a queue this already has in
-// hand. Assemble above discards the findings because /attention draws the brief
-// as its own rows; only the worklist folds a finding onto a deal row.
+// hand. Assemble above discards all three because /attention draws the brief as
+// its own rows; only the worklist reads a finding, a score or the cutoff.
 //
 // A RETURN VALUE AND NOT A FIELD on the Service, which is the point. Written
 // onto the Service the map would be SHARED — Assemble is reached on the

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -183,11 +183,14 @@ type stubBriefing struct {
 	// entries is ran=true, a night that produced nothing is ran=false. The
 	// zero value is the no-run morning, so a test must opt in to a run.
 	ran bool
-	err error
+	// asOf is the run's DATA CUTOFF, and the zero value is the no-run morning —
+	// which is what leaves a row's changed_since_brief absent rather than false.
+	asOf time.Time
+	err  error
 }
 
-func (s stubBriefing) Queue(context.Context) ([]BriefEntry, bool, error) {
-	return s.rows, s.ran || len(s.rows) > 0, s.err
+func (s stubBriefing) Queue(context.Context) ([]BriefEntry, bool, time.Time, error) {
+	return s.rows, s.ran || len(s.rows) > 0, s.asOf, s.err
 }
 
 func approval(summary string) crmcontracts.Approval {

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -247,7 +247,16 @@ type Briefing interface {
 	// with no entries means every item is answered. The two render as the
 	// same empty lane, and only the second has earned a tick — so the seam
 	// states which rather than leaving the feed to infer it from emptiness.
-	Queue(ctx context.Context) (entries []BriefEntry, ran bool, err error)
+	// Queue answers the unanswered entries, whether a run exists at all, and the
+	// run's DATA CUTOFF — its as_of, which is the instant the night read the
+	// records, not the later instant at which it finished writing them down.
+	//
+	// The cutoff is what "changed since the brief" means. A run generated at
+	// 06:42 over data read at 06:00 has a 42-minute window in which a buyer can
+	// reply, and judging freshness by generated_at would hide exactly the replies
+	// a rep most wants to see. Zero when no run exists, which is why `ran` is a
+	// separate answer: absent is not the same as false.
+	Queue(ctx context.Context) (entries []BriefEntry, ran bool, asOf time.Time, err error)
 }
 
 // BriefEntry is one UNANSWERED queue entry: what it is about, and where it
@@ -265,6 +274,9 @@ type BriefEntry struct {
 	ID     ids.UUID
 	DealID ids.UUID
 	Rank   int
+	// Composite is the night's own score for this deal, between 0 and 1, and
+	// what ranksteps.go's `opportunity` step breaks a tie by.
+	Composite float64
 	// Finding is what the overnight pass wrote about this deal, empty when no
 	// pass annotated the run. Grounded and citation-checked when it was written
 	// (briefs.AnnotateCurrentRun refuses one that cites outside the run), which

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -116,10 +116,20 @@ type ranked struct {
 	// reader's ordering preference move a figure their manager reads.
 	pinned        bool
 	semanticLevel int
-	waitingDays   int
-	waitingRank   int
-	strength      int
-	occurredAt    time.Time
+	// opportunity is the overnight brief's own composite for this deal, between
+	// 0 and 1, and zero where the night did not rank it.
+	//
+	// A TIE-BREAK INSIDE A LEVEL and never a level of its own. The night ranks
+	// deals against each other on facts the day's lanes do not gather; the
+	// levels are the product's hard rule about what kind of work outranks what.
+	// Letting this cross a level would be the second ranking system the one feed
+	// exists to end, so ranksteps.go reads it only after every earlier step has
+	// tied, and TestTheOpportunityStepNeverChangesARowsSemanticLevel holds it.
+	opportunity float64
+	waitingDays int
+	waitingRank int
+	strength    int
+	occurredAt  time.Time
 	// asOf is the one instant every row in the same page was classified
 	// against, carried onto the row rather than threaded through every step
 	// signature. The occurrence step reads it to turn occurredAt into how many
@@ -248,6 +258,13 @@ func renderInOrder(rows []ranked, reader ids.UUID) []crmcontracts.WorklistItem {
 		// describes a row's place on the page it is actually on.
 		band := crmcontracts.WorklistItemBand(bandOfRow(row))
 		item.Band = &band
+		// Which part of the morning it belongs to — a LABEL, not an order.
+		// Stamped after the band because it reads the band, and after the sort
+		// for the same reason the band is: it describes a row's place on the
+		// page it is actually on. briefsections.go states why a client may draw
+		// this and may not partition by it.
+		section := BriefSectionOf(item)
+		item.BriefSection = &section
 		// Who answers for it, as the PRODUCER said. Stamped here beside the
 		// band and the primary action, and for the same reason those are: a
 		// source added later carries it by arriving in this loop rather than by
@@ -395,6 +412,16 @@ func deadlineValue(at time.Time) *crmcontracts.WorklistValue {
 func daysValue(days int) *crmcontracts.WorklistValue {
 	value := days
 	return &crmcontracts.WorklistValue{Kind: "days", Days: &value}
+}
+
+// scoreValue carries a ranking judgement between 0 and 1 onto a comparison.
+//
+// Typed as its own kind rather than reused as a day count or a level, because a
+// client draws it differently: the number orders the queue and is not a figure a
+// reader can check, so the copy for it is a band and not a decimal.
+func scoreValue(score float64) *crmcontracts.WorklistValue {
+	value := float32(score)
+	return &crmcontracts.WorklistValue{Kind: "score", Score: &value}
 }
 
 // overdueAt reports whether a due moment is behind the read instant, through the

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -263,8 +263,18 @@ func renderInOrder(rows []ranked, reader ids.UUID) []crmcontracts.WorklistItem {
 		// for the same reason the band is: it describes a row's place on the
 		// page it is actually on. briefsections.go states why a client may draw
 		// this and may not partition by it.
-		section := BriefSectionOf(item)
-		item.BriefSection = &section
+		// An unplaced category yields no section, and no section is DRAWN rather
+		// than sent empty: the field is optional on the wire, and a client
+		// reading "" would have an enum value its own generated types do not
+		// carry. Absent is the honest answer — the row is still ranked, still
+		// explained, and simply carries no heading.
+		//
+		// backend/gates/briefsectioncensus_test.go is what makes this arm
+		// unreachable in a shipped build; this is what keeps a build where it is
+		// reachable from putting a value on the wire that no client can read.
+		if section := BriefSectionOf(item); section != "" {
+			item.BriefSection = &section
+		}
 		// Who answers for it, as the PRODUCER said. Stamped here beside the
 		// band and the primary action, and for the same reason those are: a
 		// source added later carries it by arriving in this loop rather than by

--- a/backend/internal/compose/attention/ranksteps.go
+++ b/backend/internal/compose/attention/ranksteps.go
@@ -160,6 +160,30 @@ var rankSteps = []rankStep{
 		},
 	},
 	{
+		// The night's own reading of which deal is worth the morning, read AFTER
+		// money and before age.
+		//
+		// Money first because a bigger deal at risk is the product's rule and not
+		// a model's opinion. Age after, because "this one has waited longer" is a
+		// fact about the reader's own queue and the composite is a judgement about
+		// the deal — where the night has an opinion, it should outrank the clock.
+		//
+		// Rows the night never ranked carry zero and therefore lose this step to
+		// any row it did, which is correct: a deal the brief considered and scored
+		// is one it has something to say about, and a deal it never saw is not.
+		name: "opportunity",
+		decides: func(a, b ranked) (bool, bool) {
+			return a.opportunity != b.opportunity, a.opportunity > b.opportunity
+		},
+		explain: func(a, b ranked) crmcontracts.WorklistComparison {
+			return crmcontracts.WorklistComparison{
+				Comparator: crmcontracts.WorklistComparisonComparatorOpportunity,
+				Mine:       scoreValue(a.opportunity),
+				Theirs:     scoreValue(b.opportunity),
+			}
+		},
+	},
+	{
 		name: "waiting_days",
 		// Ordered on the BOUNDED age and reported as the TRUE one: the bounded
 		// value is what decided, and the true value is what the row itself says

--- a/backend/internal/compose/attention/thismorning.go
+++ b/backend/internal/compose/attention/thismorning.go
@@ -58,12 +58,12 @@ func (s *Service) thisMorning(ctx context.Context) (theNight, error) {
 
 // theNight is everything one read of the brief lane yields.
 //
-// A struct rather than four return values, because only the first two are a
-// LANE. The other two are facts about deals that no lane draws: the findings
-// stand in as a deal's reading where no status card is cached, and the scores
-// break a tie inside a level. Both are consumed by the worklist long after the
-// lane itself has been rendered, and naming them here is what keeps the brief
-// read once for all four.
+// A struct rather than five return values, because only the first two are a
+// LANE. The rest are facts no lane draws: the findings stand in as a deal's
+// reading where no status card is cached, the scores break a tie inside a level,
+// and the cutoff says what the night had already seen. All three are consumed by
+// the worklist long after the lane itself has been rendered, and naming them
+// here is what keeps the brief read once for all of them.
 type theNight struct {
 	items    []crmcontracts.AttentionItem
 	state    crmcontracts.AttentionThisMorningState

--- a/backend/internal/compose/attention/thismorning.go
+++ b/backend/internal/compose/attention/thismorning.go
@@ -12,6 +12,7 @@ package attention
 
 import (
 	"context"
+	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -26,12 +27,10 @@ import (
 // this lane is a worklist that must be finishable and a row that cannot be
 // removed is the opposite of finishing. Home still shows what was answered,
 // which is where a rep looks to see what she did.
-func (s *Service) thisMorning(
-	ctx context.Context,
-) ([]crmcontracts.AttentionItem, crmcontracts.AttentionThisMorningState, map[ids.UUID]string, error) {
-	queue, ran, err := s.briefing.Queue(ctx)
+func (s *Service) thisMorning(ctx context.Context) (theNight, error) {
+	queue, ran, asOf, err := s.briefing.Queue(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return theNight{}, err
 	}
 	items := make([]crmcontracts.AttentionItem, 0, len(queue))
 	for _, entry := range queue {
@@ -48,5 +47,47 @@ func (s *Service) thisMorning(
 	case len(items) == 0:
 		state = crmcontracts.AllAnswered
 	}
-	return items, state, findingsOf(queue), nil
+	return theNight{
+		items:    items,
+		state:    state,
+		findings: findingsOf(queue),
+		scores:   scoresOf(queue),
+		cutoff:   asOf,
+	}, nil
+}
+
+// theNight is everything one read of the brief lane yields.
+//
+// A struct rather than four return values, because only the first two are a
+// LANE. The other two are facts about deals that no lane draws: the findings
+// stand in as a deal's reading where no status card is cached, and the scores
+// break a tie inside a level. Both are consumed by the worklist long after the
+// lane itself has been rendered, and naming them here is what keeps the brief
+// read once for all four.
+type theNight struct {
+	items    []crmcontracts.AttentionItem
+	state    crmcontracts.AttentionThisMorningState
+	findings map[ids.UUID]string
+	scores   map[ids.UUID]float64
+	// cutoff is the instant the night read the records — the run's as_of, not
+	// its generated_at. Zero when there was no run, which is why a row's
+	// `changed_since_brief` is ABSENT rather than false in that case: "the night
+	// saw this" and "there was no night" are different answers.
+	cutoff time.Time
+}
+
+// scoresOf collects the night's composite per deal.
+//
+// A pure function of the queue handed in and returned to its caller, for the
+// reason findingsOf gives: anything per-read left on the Service crosses
+// readers.
+func scoresOf(queue []BriefEntry) map[ids.UUID]float64 {
+	scores := make(map[ids.UUID]float64, len(queue))
+	for _, entry := range queue {
+		if entry.Composite == 0 {
+			continue
+		}
+		scores[entry.DealID] = entry.Composite
+	}
+	return scores
 }

--- a/backend/internal/compose/attention/walk.go
+++ b/backend/internal/compose/attention/walk.go
@@ -481,3 +481,15 @@ func (s *Service) readingWalk(walk worklistsnap.Snapshot, walking bool) *Service
 	}
 	return &reading
 }
+
+// readingScores carries this read's overnight composites onto a copy of the
+// service, the way readingWalk carries the walk.
+//
+// A COPY, always. One Service serves every request, and a score map left on the
+// shared one would rank the next reader's page by the last reader's night.
+func (s *Service) readingScores(scores map[ids.UUID]float64, cutoff time.Time) *Service {
+	reading := *s
+	reading.briefScores = scores
+	reading.briefCutoff = cutoff
+	return &reading
+}

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -110,11 +110,11 @@ func (s *Service) Worklist(
 	case resolved == scopeUnassigned:
 		reader = reader.forUnowned()
 	}
-	// The day AND the night's finding per deal, from one read of the brief
-	// lane. The findings travel as a value rather than on the service: feed.go's
-	// assembleDay states why a field there would carry one reader's findings
-	// onto the next reader's page.
-	day, findings, err := reader.assembleDay(ctx)
+	// The day AND what the night knows about each deal — its finding and its
+	// score — from one read of the brief lane. Both travel as values rather than
+	// on the service: feed.go's assembleDay states why a field there would carry
+	// one reader's night onto the next reader's page.
+	day, night, err := reader.assembleDay(ctx)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
@@ -164,6 +164,12 @@ func (s *Service) Worklist(
 		return crmcontracts.Worklist{}, err
 	}
 	withPins = withPins.readingWalk(walk, walking)
+	// The night's scores, on the same per-read copy the pins and the walk ride.
+	// They are read by the classifier, which runs inside the projection below,
+	// so they cannot travel as an argument the way the findings do — and they
+	// must not sit on the shared service, for the reason feed.go's assembleDay
+	// gives about the findings.
+	withPins = withPins.readingScores(night.scores, night.cutoff)
 	out := withPins.worklistFrom(
 		ctx, day, resolved, filter, limit, waiting, leads, cursor,
 		[]*crmcontracts.WorklistSourceUnavailable{waitingErr, leadsErr})
@@ -181,7 +187,7 @@ func (s *Service) Worklist(
 	// row can carry a move and no verdict, or a verdict and no move, and neither
 	// absence is a reason to withhold the other. dealstanding.go states the
 	// three-source order and why its floor is no verdict at all.
-	if err := reader.nameTheStanding(ctx, out.Queue, findings); err != nil {
+	if err := reader.nameTheStanding(ctx, out.Queue, night.findings); err != nil {
 		return crmcontracts.Worklist{}, err
 	}
 	// And the name beside each owner id, over the same cut page and for the same
@@ -213,6 +219,14 @@ func (s *Service) worklistFrom(
 	rows := classifyDay(day, day.AsOf, s.money)
 	rows = append(rows, s.rankedWaits(ctx, waiting, day.AsOf, scope)...)
 	rows = append(rows, rankedLeads(leads, day.AsOf)...)
+	// What the night thought of each deal, onto whichever row is about it — the
+	// brief's own row, and the at-risk row the fold below keeps. Stamped BEFORE
+	// the fold so the surviving row can inherit a score even where the night's
+	// own row is the one that goes.
+	rows = stampOpportunity(rows, s.briefScores)
+	// One deal is ONE row: a deal the night surfaced and the day also found
+	// arrives twice, and the at-risk row keeps the brief's id and its score.
+	rows = foldBriefIntoRisk(rows)
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
@@ -324,6 +338,9 @@ func (s *Service) worklistFrom(
 	// cut from the ranking above; a frozen walk's sequence is a previous run of
 	// that same comparator, and running it again here would return the reader's
 	// own rows in today's order rather than the one they were shown.
+	// Which of these the night had not seen, against the run's own data cutoff.
+	// Over the CUT page, because it is drawn and never ranked.
+	shown = markChangedSinceBrief(shown, s.briefCutoff)
 	ordered := renderInOrder(stampAsOf(shown, day.AsOf), readerOf(ctx))
 	bands := bandsOf(ordered)
 	out := crmcontracts.Worklist{

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -224,9 +224,6 @@ func (s *Service) worklistFrom(
 	// the fold so the surviving row can inherit a score even where the night's
 	// own row is the one that goes.
 	rows = stampOpportunity(rows, s.briefScores)
-	// One deal is ONE row: a deal the night surfaced and the day also found
-	// arrives twice, and the at-risk row keeps the brief's id and its score.
-	rows = foldBriefIntoRisk(rows)
 	// One unanswered message is one row: the deal it belongs to does not also
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
@@ -244,6 +241,19 @@ func (s *Service) worklistFrom(
 	// it judges against is the same wherever it sits. A fourth pass that
 	// removed waiting rows would break that, and would have to run last.
 	rows = dropDecayAlreadyWaiting(rows)
+	// One deal is ONE row: a deal the night surfaced and the day also found
+	// arrives twice, and the row that survives keeps the brief's id and score.
+	//
+	// LAST of the folds, and the three comments above say why. Each of those
+	// drops rows of a source none of the others reads, so their order among
+	// themselves does not matter. This one is different: it attaches the brief's
+	// id to a row the others may then REMOVE. Run earlier, a deal that is both in
+	// the night's brief and has an unanswered message lost its brief verbs
+	// entirely — the at-risk row took the id and dropDealsAlreadyWaiting then
+	// deleted that row, and the waiting row it was absorbed into inherits the
+	// deal's figures and reasons but not the brief's id. So this runs against
+	// whatever actually survives.
+	rows = foldBriefIntoRisk(rows)
 	// The reader's own override, raised AFTER the dedupe passes and before the
 	// ranking. After, because a pin on a row those passes remove is a pin on a
 	// row that is not on the page — the day decides what it holds, and the pin

--- a/backend/internal/compose/attentionbriefing_integration_test.go
+++ b/backend/internal/compose/attentionbriefing_integration_test.go
@@ -66,7 +66,7 @@ func TestAMorningWithNoRunReadsAsAnEmptyLaneNotARefusal(t *testing.T) {
 	// The rep has never had a brief. The engine answers not-found, and this
 	// lane must turn that into "nothing this morning" — reporting it as a
 	// refusal would tell her something was hidden when nothing was.
-	entries, ran, err := b.reader.Queue(b.repCtx)
+	entries, ran, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatalf("a rep with no run got an error rather than an empty morning: %v", err)
 	}
@@ -75,6 +75,48 @@ func TestAMorningWithNoRunReadsAsAnEmptyLaneNotARefusal(t *testing.T) {
 	}
 	if ran {
 		t.Fatal("ran = true for a rep with no run — the feed would tick a morning that never happened")
+	}
+}
+
+// The run's DATA CUTOFF reaches the feed, and it is the run's as_of.
+//
+// WHAT THIS DOES AND DOES NOT PROVE, stated plainly because the difference
+// matters to the next person who edits it. It proves the lane carries as_of. It
+// does NOT prove as_of was preferred over generated_at, and no test here can:
+// briefrank.go:242 and briefstore.go:133 both take the same `now`, so today the
+// two columns always hold the same instant and a fixture cannot tell them apart.
+//
+// The field is still read from as_of deliberately. The two are separate columns
+// because they answer different questions — when the night READ the records, and
+// when it finished writing them down — and the day a pass reads at 06:00 and
+// writes at 06:42, generated_at would call every reply in that window old. This
+// test pins the wiring so the value cannot silently become something else; the
+// day the two instants diverge, it starts telling them apart on its own.
+func TestTheLaneCarriesTheRunsDataCutoff(t *testing.T) {
+	b := setupBriefingLane(t)
+	seedBriefingLaneDeals(t, b)
+	// Seeded through the real writer, which is what puts both instants on the
+	// row: a hand-inserted run could carry any as_of this test liked and would
+	// prove nothing about what the night actually writes.
+	run, err := b.engine.SnapshotRun(b.repCtx, b.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ran, cutoff, err := b.reader.Queue(b.repCtx)
+	if err != nil {
+		t.Fatalf("reading the lane: %v", err)
+	}
+	if !ran {
+		t.Fatal("the seeded run did not read as a run")
+	}
+	if cutoff.IsZero() {
+		t.Fatal("the lane answers no cutoff for a run that has one — every row's " +
+			"changed_since_brief would be absent and the strip would never draw")
+	}
+
+	if !cutoff.Equal(run.AsOf) {
+		t.Errorf("cutoff = %v, want the run's as_of %v", cutoff, run.AsOf)
 	}
 }
 
@@ -90,7 +132,7 @@ func TestAnAnsweredBriefingItemLeavesTheLane(t *testing.T) {
 		t.Fatalf("the fixture queued %d items, and this test needs 2 to tell removal from emptiness", len(run.Items))
 	}
 
-	before, ran, err := b.reader.Queue(b.repCtx)
+	before, ran, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +148,7 @@ func TestAnAnsweredBriefingItemLeavesTheLane(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after, _, err := b.reader.Queue(b.repCtx)
+	after, _, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +179,7 @@ func TestASetAsideBriefingItemComesBackWhenItsWindowPasses(t *testing.T) {
 
 	// While the window runs, the item is out of the lane.
 	b.now = b.now.Add(time.Hour)
-	during, _, err := b.reader.Queue(b.repCtx)
+	during, _, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +193,7 @@ func TestASetAsideBriefingItemComesBackWhenItsWindowPasses(t *testing.T) {
 	// The engine's own read resurfaces it, which is why the lane asks the
 	// engine rather than deciding what a state means for itself.
 	b.now = until.Add(time.Minute)
-	after, _, err := b.reader.Queue(b.repCtx)
+	after, _, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +226,7 @@ func TestADeletedDealTakesItsBriefingRowWithIt(t *testing.T) {
 		t.Fatalf("the fixture queued %d items, and this test needs 2 to tell removal from emptiness", len(run.Items))
 	}
 
-	before, ran, err := b.reader.Queue(b.repCtx)
+	before, ran, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +242,7 @@ func TestADeletedDealTakesItsBriefingRowWithIt(t *testing.T) {
 		t.Fatalf("deleting the deal: %v", err)
 	}
 
-	after, ran, err := b.reader.Queue(b.repCtx)
+	after, ran, _, err := b.reader.Queue(b.repCtx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/attentionbriefingseam.go
+++ b/backend/internal/compose/attentionbriefingseam.go
@@ -9,6 +9,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/margince/margince/backend/internal/compose/attention"
 	"github.com/margince/margince/backend/internal/compose/briefs"
@@ -54,13 +55,13 @@ type attentionBriefing struct {
 // no amount, no close date, no reason and no name, still offering act, set
 // aside and dismiss over a deal that has been deleted, and counting toward the
 // day's total. A row that can name nothing is not a suggestion.
-func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, bool, error) {
+func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, bool, time.Time, error) {
 	run, err := a.engine.LatestRun(ctx, a.now())
 	if errors.Is(err, apperrors.ErrNotFound) {
-		return nil, false, nil
+		return nil, false, time.Time{}, nil
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, false, time.Time{}, err
 	}
 	unanswered := make([]attention.BriefEntry, 0, len(run.Items))
 	named := make([]ids.UUID, 0, len(run.Items))
@@ -70,13 +71,13 @@ func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, b
 		}
 		unanswered = append(unanswered, attention.BriefEntry{
 			ID: item.ID, DealID: item.DealID, Rank: item.Rank,
-			Finding: item.Finding,
+			Composite: item.Composite, Finding: item.Finding,
 		})
 		named = append(named, item.DealID)
 	}
 	resolvable, err := a.figures.Figures(ctx, named)
 	if err != nil {
-		return nil, false, err
+		return nil, false, time.Time{}, err
 	}
 	entries := make([]attention.BriefEntry, 0, len(unanswered))
 	for _, entry := range unanswered {
@@ -84,5 +85,5 @@ func (a attentionBriefing) Queue(ctx context.Context) ([]attention.BriefEntry, b
 			entries = append(entries, entry)
 		}
 	}
-	return entries, true, nil
+	return entries, true, run.AsOf, nil
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13351,6 +13351,7 @@ const (
 	WorklistComparisonComparatorDeadline        WorklistComparisonComparator = "deadline"
 	WorklistComparisonComparatorExpectedRevenue WorklistComparisonComparator = "expected_revenue"
 	WorklistComparisonComparatorLevel           WorklistComparisonComparator = "level"
+	WorklistComparisonComparatorOpportunity     WorklistComparisonComparator = "opportunity"
 	WorklistComparisonComparatorOrder           WorklistComparisonComparator = "order"
 	WorklistComparisonComparatorPin             WorklistComparisonComparator = "pin"
 	WorklistComparisonComparatorRelationship    WorklistComparisonComparator = "relationship"
@@ -13367,6 +13368,8 @@ func (e WorklistComparisonComparator) Valid() bool {
 	case WorklistComparisonComparatorExpectedRevenue:
 		return true
 	case WorklistComparisonComparatorLevel:
+		return true
+	case WorklistComparisonComparatorOpportunity:
 		return true
 	case WorklistComparisonComparatorOrder:
 		return true
@@ -13513,6 +13516,33 @@ func (e WorklistItemBand) Valid() bool {
 	case Now:
 		return true
 	case Review:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WorklistItemBriefSection.
+const (
+	BriefSectionBuildPipeline        WorklistItemBriefSection = "build_pipeline"
+	BriefSectionMoveRevenue          WorklistItemBriefSection = "move_revenue"
+	BriefSectionPrepareConversations WorklistItemBriefSection = "prepare_conversations"
+	BriefSectionRespondNow           WorklistItemBriefSection = "respond_now"
+	BriefSectionReviewAndRepair      WorklistItemBriefSection = "review_and_repair"
+)
+
+// Valid indicates whether the value is a known member of the WorklistItemBriefSection enum.
+func (e WorklistItemBriefSection) Valid() bool {
+	switch e {
+	case BriefSectionBuildPipeline:
+		return true
+	case BriefSectionMoveRevenue:
+		return true
+	case BriefSectionPrepareConversations:
+		return true
+	case BriefSectionRespondNow:
+		return true
+	case BriefSectionReviewAndRepair:
 		return true
 	default:
 		return false
@@ -13997,6 +14027,7 @@ const (
 	WorklistValueKindLevel WorklistValueKind = "level"
 	WorklistValueKindMoney WorklistValueKind = "money"
 	WorklistValueKindNone  WorklistValueKind = "none"
+	WorklistValueKindScore WorklistValueKind = "score"
 )
 
 // Valid indicates whether the value is a known member of the WorklistValueKind enum.
@@ -14011,6 +14042,8 @@ func (e WorklistValueKind) Valid() bool {
 	case WorklistValueKindMoney:
 		return true
 	case WorklistValueKindNone:
+		return true
+	case WorklistValueKindScore:
 		return true
 	default:
 		return false
@@ -15057,31 +15090,31 @@ func (e ListOrganizationsParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListOrganizationsParamsLifecycle.
 const (
-	Customer       ListOrganizationsParamsLifecycle = "customer"
-	Disqualified   ListOrganizationsParamsLifecycle = "disqualified"
-	FormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
-	Opportunity    ListOrganizationsParamsLifecycle = "opportunity"
-	Prospect       ListOrganizationsParamsLifecycle = "prospect"
-	Target         ListOrganizationsParamsLifecycle = "target"
-	Unknown        ListOrganizationsParamsLifecycle = "unknown"
+	ListOrganizationsParamsLifecycleCustomer       ListOrganizationsParamsLifecycle = "customer"
+	ListOrganizationsParamsLifecycleDisqualified   ListOrganizationsParamsLifecycle = "disqualified"
+	ListOrganizationsParamsLifecycleFormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
+	ListOrganizationsParamsLifecycleOpportunity    ListOrganizationsParamsLifecycle = "opportunity"
+	ListOrganizationsParamsLifecycleProspect       ListOrganizationsParamsLifecycle = "prospect"
+	ListOrganizationsParamsLifecycleTarget         ListOrganizationsParamsLifecycle = "target"
+	ListOrganizationsParamsLifecycleUnknown        ListOrganizationsParamsLifecycle = "unknown"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationsParamsLifecycle enum.
 func (e ListOrganizationsParamsLifecycle) Valid() bool {
 	switch e {
-	case Customer:
+	case ListOrganizationsParamsLifecycleCustomer:
 		return true
-	case Disqualified:
+	case ListOrganizationsParamsLifecycleDisqualified:
 		return true
-	case FormerCustomer:
+	case ListOrganizationsParamsLifecycleFormerCustomer:
 		return true
-	case Opportunity:
+	case ListOrganizationsParamsLifecycleOpportunity:
 		return true
-	case Prospect:
+	case ListOrganizationsParamsLifecycleProspect:
 		return true
-	case Target:
+	case ListOrganizationsParamsLifecycleTarget:
 		return true
-	case Unknown:
+	case ListOrganizationsParamsLifecycleUnknown:
 		return true
 	default:
 		return false
@@ -15375,19 +15408,19 @@ func (e ListPeopleParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListPeopleParamsTagMode.
 const (
-	All  ListPeopleParamsTagMode = "all"
-	Any  ListPeopleParamsTagMode = "any"
-	None ListPeopleParamsTagMode = "none"
+	ListPeopleParamsTagModeAll  ListPeopleParamsTagMode = "all"
+	ListPeopleParamsTagModeAny  ListPeopleParamsTagMode = "any"
+	ListPeopleParamsTagModeNone ListPeopleParamsTagMode = "none"
 )
 
 // Valid indicates whether the value is a known member of the ListPeopleParamsTagMode enum.
 func (e ListPeopleParamsTagMode) Valid() bool {
 	switch e {
-	case All:
+	case ListPeopleParamsTagModeAll:
 		return true
-	case Any:
+	case ListPeopleParamsTagModeAny:
 		return true
-	case None:
+	case ListPeopleParamsTagModeNone:
 		return true
 	default:
 		return false
@@ -33911,6 +33944,33 @@ type WorklistItem struct {
 	// Because The facts that put this item at this level, in the order they were weighed.
 	Because []WorklistReason `json:"because"`
 
+	// BriefItemId The overnight brief entry this row also stands for, where the night
+	// surfaced the same deal the day's own lanes did.
+	//
+	// One deal is ONE row. The brief ranks deals and the at-risk lane raises
+	// them, so a deal the night picked and the day also found arrived twice —
+	// the same name, the same figures, two places to answer it. The rows are
+	// folded into one, and this carries the brief entry's id so the verbs that
+	// belong to the brief (`/brief/items/{id}/act`, and its set-aside and
+	// dismiss) still reach it. Absent on a row the night did not raise.
+	BriefItemId *openapi_types.UUID `json:"brief_item_id,omitempty"`
+
+	// BriefSection Which part of the morning this row belongs to, as a LABEL and never as an
+	// order.
+	//
+	// The server has already ranked the page, and this says nothing about where a
+	// row sits. A client may draw the label, and may group runs of consecutive
+	// rows that share it — but partitioning the page by this field and
+	// concatenating the parts would be a second ranking, and the two would
+	// disagree the first time a `respond_now` row ranked below a `move_revenue`
+	// one, which is ordinary and correct.
+	//
+	// Derived on the server from the row's own category, source and band, so
+	// every surface reads one answer. Exhaustive over the categories:
+	// `backend/internal/compose/attention/briefsections.go` names every one, and
+	// a gate derives that census from the generated contract.
+	BriefSection *WorklistItemBriefSection `json:"brief_section,omitempty"`
+
 	// Category The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
 	Category WorklistItemCategory `json:"category"`
 
@@ -33925,6 +33985,21 @@ type WorklistItem struct {
 	// failures of one thing into one row. Opaque identity, never rendered and never
 	// parsed. Absent on a row that reports no shared condition.
 	CauseRef *string `json:"cause_ref,omitempty"`
+
+	// ChangedSinceBrief Whether the thing this row reports happened AFTER the overnight run's data
+	// cutoff — the run's `as_of`, not its `generated_at`, which is only when the
+	// row was written.
+	//
+	// The distinction is the whole of this field's value: a run generated at 06:42
+	// over data read at 06:00 has a 42-minute window in which a buyer can reply,
+	// and comparing against the wrong instant either hides that reply or reports
+	// every row as new. Stamped from the material timestamp each producer already
+	// owns rather than from one generic `occurred_at`, so the browser never guesses
+	// freshness.
+	//
+	// Absent when there is no run today to compare against, which is different from
+	// false: false says the night saw this, absent says there was no night.
+	ChangedSinceBrief *bool `json:"changed_since_brief,omitempty"`
 
 	// Consequence What happens if the reader does nothing. Derived per ITEM rather than per
 	// source, because one source has several honest answers: a deal past its close
@@ -34125,6 +34200,22 @@ type WorklistItemActions string
 // the queue arrives already sorted, and every row of one band is contiguous. A client
 // draws a heading when the band changes and never re-sorts.
 type WorklistItemBand string
+
+// WorklistItemBriefSection Which part of the morning this row belongs to, as a LABEL and never as an
+// order.
+//
+// The server has already ranked the page, and this says nothing about where a
+// row sits. A client may draw the label, and may group runs of consecutive
+// rows that share it — but partitioning the page by this field and
+// concatenating the parts would be a second ranking, and the two would
+// disagree the first time a `respond_now` row ranked below a `move_revenue`
+// one, which is ordinary and correct.
+//
+// Derived on the server from the row's own category, source and band, so
+// every surface reads one answer. Exhaustive over the categories:
+// `backend/internal/compose/attention/briefsections.go` names every one, and
+// a gate derives that census from the generated contract.
+type WorklistItemBriefSection string
 
 // WorklistItemCategory The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
 type WorklistItemCategory string
@@ -34497,6 +34588,15 @@ type WorklistValue struct {
 
 	// Minor Money in minor units of `currency`.
 	Minor *int64 `json:"minor,omitempty"`
+
+	// Score A ranking judgement between 0 and 1 — today, the overnight brief's composite
+	// for a deal.
+	//
+	// Drawn as a BAND rather than as a number. The value orders the queue, and a
+	// client printing "0.72 against 0.68" would be offering a precision the score
+	// does not carry and a reader cannot check; the same two rows read honestly as
+	// "the night rated this one higher".
+	Score *float32 `json:"score,omitempty"`
 }
 
 // WorklistValueKind defines model for WorklistValue.Kind.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -99,7 +99,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (109)
+## Census (110)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -118,6 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `auditbeforeimage_test.go` | H2 | An audited update says what it changed FROM. |
 | `basecurrencyguard_test.go` | H2 | The base-currency lock as a fitness function. |
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
+| `briefsectioncensus_test.go` | H2 | Every worklist category reaches a section of the morning. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
 | `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -30373,6 +30373,53 @@ export interface components {
              */
             primary_action?: "decide" | "merge" | "complete" | "snooze" | "open" | "act" | "dismiss" | "set_aside" | "acknowledge";
             verdict?: components["schemas"]["WorklistDealVerdict"];
+            /**
+             * Format: uuid
+             * @description The overnight brief entry this row also stands for, where the night
+             *     surfaced the same deal the day's own lanes did.
+             *
+             *     One deal is ONE row. The brief ranks deals and the at-risk lane raises
+             *     them, so a deal the night picked and the day also found arrived twice —
+             *     the same name, the same figures, two places to answer it. The rows are
+             *     folded into one, and this carries the brief entry's id so the verbs that
+             *     belong to the brief (`/brief/items/{id}/act`, and its set-aside and
+             *     dismiss) still reach it. Absent on a row the night did not raise.
+             */
+            brief_item_id?: string;
+            /**
+             * @description Which part of the morning this row belongs to, as a LABEL and never as an
+             *     order.
+             *
+             *     The server has already ranked the page, and this says nothing about where a
+             *     row sits. A client may draw the label, and may group runs of consecutive
+             *     rows that share it — but partitioning the page by this field and
+             *     concatenating the parts would be a second ranking, and the two would
+             *     disagree the first time a `respond_now` row ranked below a `move_revenue`
+             *     one, which is ordinary and correct.
+             *
+             *     Derived on the server from the row's own category, source and band, so
+             *     every surface reads one answer. Exhaustive over the categories:
+             *     `backend/internal/compose/attention/briefsections.go` names every one, and
+             *     a gate derives that census from the generated contract.
+             * @enum {string}
+             */
+            brief_section?: "respond_now" | "prepare_conversations" | "move_revenue" | "build_pipeline" | "review_and_repair";
+            /**
+             * @description Whether the thing this row reports happened AFTER the overnight run's data
+             *     cutoff — the run's `as_of`, not its `generated_at`, which is only when the
+             *     row was written.
+             *
+             *     The distinction is the whole of this field's value: a run generated at 06:42
+             *     over data read at 06:00 has a 42-minute window in which a buyer can reply,
+             *     and comparing against the wrong instant either hides that reply or reports
+             *     every row as new. Stamped from the material timestamp each producer already
+             *     owns rather than from one generic `occurred_at`, so the browser never guesses
+             *     freshness.
+             *
+             *     Absent when there is no run today to compare against, which is different from
+             *     false: false says the night saw this, absent says there was no night.
+             */
+            changed_since_brief?: boolean;
         };
         /**
          * @description How the deal behind a row is STANDING, beside the move that acts on it.
@@ -30471,7 +30518,7 @@ export interface components {
              *     when the two rows share a level.
              * @enum {string}
              */
-            comparator: "pin" | "crowded" | "level" | "deadline" | "expected_revenue" | "waiting_days" | "relationship" | "order";
+            comparator: "pin" | "crowded" | "level" | "deadline" | "expected_revenue" | "opportunity" | "waiting_days" | "relationship" | "order";
             mine?: components["schemas"]["WorklistValue"];
             theirs?: components["schemas"]["WorklistValue"];
         };
@@ -30482,7 +30529,7 @@ export interface components {
          */
         WorklistValue: {
             /** @enum {string} */
-            kind: "date" | "money" | "days" | "level" | "none";
+            kind: "date" | "money" | "days" | "level" | "score" | "none";
             /** Format: date-time */
             date?: string;
             /**
@@ -30493,6 +30540,16 @@ export interface components {
             currency?: string;
             days?: number;
             level?: number;
+            /**
+             * @description A ranking judgement between 0 and 1 — today, the overnight brief's composite
+             *     for a deal.
+             *
+             *     Drawn as a BAND rather than as a number. The value orders the queue, and a
+             *     client printing "0.72 against 0.68" would be offering a precision the score
+             *     does not carry and a reader cannot check; the same two rows read honestly as
+             *     "the night rated this one higher".
+             */
+            score?: number;
         };
         /**
          * @description The next step this row suggests, and what it would act on.


### PR DESCRIPTION
The morning showed the same deal twice. The overnight brief ranks deals and the
at-risk lane raises them, and the two agree far more often than they disagree —
which is what makes them both right, and what put one deal on the page as two
rows: same name, same figures, two places to answer it, both counted in the
readings above.

## The fold

The at-risk row survives. It is the one carrying the day's facts — the figures
pass filled its amount and close date, the classifier gave it a level from those
facts, the move pass may have put a next step on it. The brief row carries a rank
and a deal id.

What the folded row leaves behind is its own id, on `brief_item_id`, so the
brief's verbs still reach the night; and its composite, so the ordering can still
read it.

## The composite is a tie-break inside a level

Never a level of its own. The night ranks deals against each other on facts the
day's lanes do not gather; the levels are the product's hard rule about what kind
of work outranks what. The new `opportunity` step sits after `expected_revenue`
and before `waiting_days` — money first because a bigger deal at risk is the
product's rule and not a model's opinion, age after because "this one waited
longer" is a fact about the queue while the composite is a judgement about the
deal.

Two invariants, both mutation-checked:

- `TestTheOpportunityStepNeverChangesARowsSemanticLevel` — moving the step above
  the level comparator fails it.
- `TestFoldingABriefItemMovesNoBucketCount` — `semanticLevelOf` has three readers
  and its own comment warns that a fourth spelling of that precedence is the
  defect to avoid, so the fold removes a row and copies two fields and touches no
  level, band or count.

## Two new fields

`brief_section` labels which part of the morning a row belongs to. **A label,
never an order.** A client may draw it and may group consecutive rows that share
it; partitioning the page by it would be a second ranking that disagrees with the
first the moment a `respond_now` row ranks below a `move_revenue` one, which is
ordinary and correct.

`changed_since_brief` says whether a row reports something the night did not see,
against the run's **data cutoff** and not its `generated_at`. A run written at
06:42 over records read at 06:00 has a 42-minute window, and judging by
`generated_at` hides exactly the reply a rep opens the page to find. Absent when
there was no run, which is a different fact from false.

## The gate

`backend/gates/briefsectioncensus_test.go` derives the category list from
`crm.yaml` rather than keeping a second copy, so an eighth category fails until
somebody decides where in the morning it belongs. Its second test fails when the
parse finds fewer than the seven that ship — a census that can fail short has
already failed. Both clauses mutation-checked.

## Verification

`make check-backend` and `make check-fe` green, plus `craft-static`,
`rls-store-path`, `no-jurisdiction`, and the integration lane for the briefing
seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds deals the overnight brief and the at-risk lane both surfaced into one row, so the morning feed no longer shows the same deal twice, each counted in the readings above.

- The at-risk row survives; the brief's id moves to `brief_item_id` so its act, set-aside, and dismiss verbs still reach it. The fold runs after the other dedupe passes so a deal both in the brief and waiting on a reply keeps its verbs.
- The night's composite becomes an `opportunity` tie-break inside a level, read after `expected_revenue` and before `waiting_days`.
- New `brief_section` labels which part of the morning a row belongs to — a label, never an ordering. A category nobody has placed draws no section at all.
- New `changed_since_brief` compares against the run's data cutoff (`as_of`), not `generated_at`, and is absent when there was no run.
- A new gate derives the category census from `crm.yaml`, so an eighth category fails until it is mapped to a section.

<sup>Written for commit 35557ba70b10a1e6c3ea255faf68ceea5df1c7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

