### PR TITLE
feat(analytics): the typed query answers a median under the same floor as the screen

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33114,7 +33114,7 @@ components:
       properties:
         fn:
           type: string
-          enum: [count, count_distinct, sum, avg, min, max]
+          enum: [count, count_distinct, sum, avg, min, max, median, p75]
           x-enum-varnames:
             - AnalyticsCount
             - AnalyticsCountDistinct
@@ -33122,10 +33122,15 @@ components:
             - AnalyticsAvg
             - AnalyticsMin
             - AnalyticsMax
+            - AnalyticsMedian
+            - AnalyticsP75
           description: >-
             The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts
             values and skips nulls. The two differ on an unpriced deal, so naming the wrong
-            one reports a column's coverage as its population.
+            one reports a column's coverage as its population. `median` and `p75` answer
+            null below a five-value sample floor: a percentile over three deals is one
+            deal's value wearing a statistic's name, and the count beside the blank still
+            says how many there were.
         field:
           type: string
           description: What to aggregate. Required for every fn but `count`.

--- a/backend/internal/compose/analyticsquery/compile.go
+++ b/backend/internal/compose/analyticsquery/compile.go
@@ -254,8 +254,30 @@ func aggregateSQL(entity Entity, m Measure) (string, error) {
 	if m.Fn == CountDistinct {
 		return fmt.Sprintf("count(DISTINCT %s)", field.Expr), nil
 	}
+	if m.Fn == Median || m.Fn == P75 {
+		// NULL below the sample floor rather than a number, the same refusal
+		// the report engine writes (report.go, aggregateSelect) and for the
+		// same reason: a percentile over three deals is one deal's value
+		// wearing a statistic's name. NULL rather than an error because the
+		// row is still a real answer — a count beside the blank says how many
+		// deals there were, and failing the whole query would take that too.
+		fraction := "0.5"
+		if m.Fn == P75 {
+			fraction = "0.75"
+		}
+		return fmt.Sprintf(
+			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
+			field.Expr, PercentileSampleFloor, fraction, field.Expr), nil
+	}
 	return fmt.Sprintf("%s(%s)", m.Fn, field.Expr), nil
 }
+
+// PercentileSampleFloor is how many values a percentile needs before it means
+// anything. Exported so the compose report engine's identical floor can be
+// asserted equal to this one; the two engines answering the same question with
+// different thresholds would make a screen and a tool disagree about the same
+// team's week.
+const PercentileSampleFloor = 5
 
 // measureName is what the caller calls the column, and it is measureAlias —
 // one spelling, because validateAliases refuses a collision and this renders

--- a/backend/internal/compose/analyticsquery/compile.go
+++ b/backend/internal/compose/analyticsquery/compile.go
@@ -255,28 +255,37 @@ func aggregateSQL(entity Entity, m Measure) (string, error) {
 		return fmt.Sprintf("count(DISTINCT %s)", field.Expr), nil
 	}
 	if m.Fn == Median || m.Fn == P75 {
-		// NULL below the sample floor rather than a number, the same refusal
-		// the report engine writes (report.go, aggregateSelect) and for the
-		// same reason: a percentile over three deals is one deal's value
-		// wearing a statistic's name. NULL rather than an error because the
-		// row is still a real answer — a count beside the blank says how many
-		// deals there were, and failing the whole query would take that too.
-		fraction := "0.5"
-		if m.Fn == P75 {
-			fraction = "0.75"
-		}
-		return fmt.Sprintf(
-			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
-			field.Expr, PercentileSampleFloor, fraction, field.Expr), nil
+		return PercentileExpr(field.Expr, m.Fn), nil
 	}
 	return fmt.Sprintf("%s(%s)", m.Fn, field.Expr), nil
 }
 
+// PercentileExpr renders a percentile over a TRUSTED schema expression. Both
+// engines call it — the report engine's median/p75 case and the typed
+// compiler below — which is what keeps the screen and the typed query giving
+// one answer to "what is a median" instead of two.
+//
+// NULL below the sample floor rather than a number. A median over three deals
+// is not a median: it is one deal's value wearing a statistic's name, and a
+// manager comparing "typical stage age" across teams would read the smallest
+// team's outlier as its norm. Postgres will happily compute it, which is
+// exactly why the refusal has to be rendered here. NULL rather than an error,
+// because the row is still a real answer — the count beside the blank says
+// how many deals there were, and failing the whole query would take that too.
+func PercentileExpr(expr string, fn AggFn) string {
+	fraction := "0.5"
+	if fn == P75 {
+		fraction = "0.75"
+	}
+	return fmt.Sprintf(
+		"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
+		expr, PercentileSampleFloor, fraction, expr)
+}
+
 // PercentileSampleFloor is how many values a percentile needs before it means
-// anything. Exported so the compose report engine's identical floor can be
-// asserted equal to this one; the two engines answering the same question with
-// different thresholds would make a screen and a tool disagree about the same
-// team's week.
+// anything. Five is a judgement, not a derivation: the point of a percentile
+// here is comparing groups of differing sizes, and below a handful of values
+// the comparison reads noise as signal.
 const PercentileSampleFloor = 5
 
 // measureName is what the caller calls the column, and it is measureAlias —

--- a/backend/internal/compose/analyticsquery/compile_test.go
+++ b/backend/internal/compose/analyticsquery/compile_test.go
@@ -287,8 +287,8 @@ func TestTheCallersAuthorityReachesTheStatement(t *testing.T) {
 
 // A percentile renders under the sample floor: below five values the answer
 // is NULL, not a number — a median over three deals is one deal's value
-// wearing a statistic's name. The same refusal the report engine writes, at
-// the same threshold, so a screen and a tool cannot disagree about one week.
+// wearing a statistic's name. The report engine writes the same refusal at
+// the same threshold, through the same renderer.
 func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
 	t.Parallel()
 	plan, err := Compile(Query{
@@ -312,16 +312,28 @@ func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
 	}
 }
 
-// A percentile over a non-numeric field is refused before rendering: the 50th
+// A percentile over a non-numeric field is refused at the bar every refusal
+// holds: typed, named invalid, and suggesting a measure that works — the 50th
 // percentile of a stage id means nothing, and Postgres computing it anyway is
 // exactly why the refusal is written here.
 func TestAPercentileOverANonNumericFieldIsRefused(t *testing.T) {
 	t.Parallel()
-	_, err := Compile(Query{
-		Entity:   "deals",
-		Measures: []Measure{{Fn: Median, Field: "stage"}},
-	}, testSchema(), noScope)
-	if err == nil {
-		t.Fatal("median over a dimension compiled; it must be refused by name")
+	for _, fn := range []AggFn{Median, P75} {
+		_, err := Compile(Query{
+			Entity:   "deals",
+			Measures: []Measure{{Fn: fn, Field: "stage"}},
+		}, testSchema(), noScope)
+		var refusal *RefusalError
+		if !errors.As(err, &refusal) {
+			t.Fatalf("%s over a dimension answered %v", fn, err)
+		}
+		if refusal.Kind != RefusalInvalid {
+			t.Errorf("%s over a dimension is %q; it means nothing rather than being unbuilt",
+				fn, refusal.Kind)
+		}
+		if !strings.Contains(refusal.Suggest, "amount") {
+			t.Errorf("the refusal suggests %q, which does not name a measure that works",
+				refusal.Suggest)
+		}
 	}
 }

--- a/backend/internal/compose/analyticsquery/compile_test.go
+++ b/backend/internal/compose/analyticsquery/compile_test.go
@@ -284,3 +284,44 @@ func TestTheCallersAuthorityReachesTheStatement(t *testing.T) {
 		t.Errorf("the caller's own narrowing is absent from:\n%s", plan.SQL)
 	}
 }
+
+// A percentile renders under the sample floor: below five values the answer
+// is NULL, not a number — a median over three deals is one deal's value
+// wearing a statistic's name. The same refusal the report engine writes, at
+// the same threshold, so a screen and a tool cannot disagree about one week.
+func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
+	t.Parallel()
+	plan, err := Compile(Query{
+		Entity: "deals",
+		Measures: []Measure{
+			{Fn: Median, Field: "amount", As: "typical"},
+			{Fn: P75, Field: "amount", As: "upper"},
+		},
+	}, testSchema(), noScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMedian := "(CASE WHEN count(t.amount_minor) >= 5 THEN " +
+		"percentile_cont(0.5) WITHIN GROUP (ORDER BY t.amount_minor) END)"
+	if !strings.Contains(plan.SQL, wantMedian) {
+		t.Errorf("median renders without the floor:\n got: %s\nwant it to contain: %s",
+			plan.SQL, wantMedian)
+	}
+	if !strings.Contains(plan.SQL, "percentile_cont(0.75)") {
+		t.Errorf("p75 does not ask for the 75th percentile: %s", plan.SQL)
+	}
+}
+
+// A percentile over a non-numeric field is refused before rendering: the 50th
+// percentile of a stage id means nothing, and Postgres computing it anyway is
+// exactly why the refusal is written here.
+func TestAPercentileOverANonNumericFieldIsRefused(t *testing.T) {
+	t.Parallel()
+	_, err := Compile(Query{
+		Entity:   "deals",
+		Measures: []Measure{{Fn: Median, Field: "stage"}},
+	}, testSchema(), noScope)
+	if err == nil {
+		t.Fatal("median over a dimension compiled; it must be refused by name")
+	}
+}

--- a/backend/internal/compose/analyticsquery/ir.go
+++ b/backend/internal/compose/analyticsquery/ir.go
@@ -80,12 +80,18 @@ const (
 	Min AggFn = "min"
 	// Max is the largest.
 	Max AggFn = "max"
+	// Median is the 50th percentile, null below the sample floor: a median
+	// over three deals is one deal's value wearing a statistic's name.
+	Median AggFn = "median"
+	// P75 is the 75th percentile, under the same floor as Median.
+	P75 AggFn = "p75"
 )
 
 // aggregatesOverValues are the aggregates that need a field to aggregate.
 // CountAll is the one that does not, which is why it is absent here.
 var aggregatesOverValues = map[AggFn]bool{
 	CountDistinct: true, Sum: true, Avg: true, Min: true, Max: true,
+	Median: true, P75: true,
 }
 
 // numericAggregates are the aggregates that need a NUMBER.
@@ -94,7 +100,7 @@ var aggregatesOverValues = map[AggFn]bool{
 // earliest date and the latest stage all mean something over a non-numeric
 // column, and refusing them would be this compiler inventing a restriction
 // the database does not have.
-var numericAggregates = map[AggFn]bool{Sum: true, Avg: true}
+var numericAggregates = map[AggFn]bool{Sum: true, Avg: true, Median: true, P75: true}
 
 // Filter is one narrowing.
 type Filter struct {
@@ -344,6 +350,7 @@ func unknownField(entity Entity, name string, kind FieldKind) error {
 // refused as unsupported rather than reaching the renderer.
 var knownAggregates = map[AggFn]bool{
 	CountAll: true, CountDistinct: true, Sum: true, Avg: true, Min: true, Max: true,
+	Median: true, P75: true,
 }
 
 func aggregateNames() []string {

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -411,41 +412,14 @@ func aggregateSelect(spec reportSpec, agg reportAggregate) (name, sel string, er
 		if !ok {
 			return "", "", &FieldNotAllowedError{Field: agg.Field, Slot: slotAggregates, Allowed: allowedReportNames(spec.measures)}
 		}
-		// NULL below the sample floor rather than a number.
-		//
-		// A median over three deals is not a median: it is one deal's value
-		// wearing a statistic's name, and a manager comparing "typical stage
-		// age" across teams would read the smallest team's outlier as its
-		// norm. Postgres will happily compute it, which is exactly why the
-		// refusal has to be written here.
-		//
-		// NULL rather than an error, because the ROW is still a real answer —
-		// the count beside it says how many deals there were, and a reader
-		// seeing a blank with n=3 has learned something true. Failing the whole
-		// report would take away the counts as well.
-		return name, fmt.Sprintf(
-			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END) AS %s",
-			expr, percentileSampleFloor, percentileFor(agg.Fn), expr, quoteIdent(name)), nil
+		// One renderer for both engines: the fraction, the CASE shape and the
+		// sample floor live in analyticsquery.PercentileExpr, so the screen
+		// and the typed query cannot drift apart about what a median is.
+		return name, analyticsquery.PercentileExpr(expr, analyticsquery.AggFn(agg.Fn)) +
+			" AS " + quoteIdent(name), nil
 	default:
 		return "", "", &FieldNotAllowedError{Field: "fn=" + agg.Fn}
 	}
-}
-
-// percentileSampleFloor is how many values a percentile needs before it means
-// anything.
-//
-// Five, and the number is a judgement rather than a derivation: below it a
-// "typical" value is one or two deals, and the whole use of a median here is
-// comparing groups whose sizes differ. A floor of one would make every group
-// comparable and every small group wrong.
-const percentileSampleFloor = 5
-
-// percentileFor is the fraction each named aggregate asks for.
-func percentileFor(fn string) string {
-	if fn == aggFnP75 {
-		return "0.75"
-	}
-	return "0.5"
 }
 
 var errUnknownEntity = errors.New("compose: entity outside the schema descriptors")

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/compose/analyticsquery"
-
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -463,17 +461,4 @@ func aggregateFunctionsInSource(t *testing.T) []string {
 	})
 	slices.Sort(out)
 	return out
-}
-
-// The two engines hold one percentile floor. The report engine and the typed
-// query compiler both answer "typical days in stage"; a different threshold on
-// either side would make a screen and a tool disagree about the same team's
-// week, each blaming the other's blank.
-func TestBothEnginesShareOnePercentileFloor(t *testing.T) {
-	t.Parallel()
-	if percentileSampleFloor != analyticsquery.PercentileSampleFloor {
-		t.Errorf("the report engine withholds a percentile below %d values and the "+
-			"typed compiler below %d — one question, two answers",
-			percentileSampleFloor, analyticsquery.PercentileSampleFloor)
-	}
 }

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -461,4 +463,17 @@ func aggregateFunctionsInSource(t *testing.T) []string {
 	})
 	slices.Sort(out)
 	return out
+}
+
+// The two engines hold one percentile floor. The report engine and the typed
+// query compiler both answer "typical days in stage"; a different threshold on
+// either side would make a screen and a tool disagree about the same team's
+// week, each blaming the other's blank.
+func TestBothEnginesShareOnePercentileFloor(t *testing.T) {
+	t.Parallel()
+	if percentileSampleFloor != analyticsquery.PercentileSampleFloor {
+		t.Errorf("the report engine withholds a percentile below %d values and the "+
+			"typed compiler below %d — one question, two answers",
+			percentileSampleFloor, analyticsquery.PercentileSampleFloor)
+	}
 }

--- a/backend/internal/compose/samplefloor_integration_test.go
+++ b/backend/internal/compose/samplefloor_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 )
 
@@ -64,7 +65,7 @@ func TestAPercentileBelowTheSampleFloorIsBlankRatherThanWrong(t *testing.T) {
 		}
 		var median *float64
 		var count int64
-		query := `SELECT (CASE WHEN count(d.days) >= ` + strconv.Itoa(percentileSampleFloor) +
+		query := `SELECT (CASE WHEN count(d.days) >= ` + strconv.Itoa(analyticsquery.PercentileSampleFloor) +
 			` THEN percentile_cont(0.5) WITHIN GROUP (ORDER BY d.days) END),
 			         count(d.days)
 			  FROM (VALUES ` + holders + `) AS d(days)`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -877,7 +877,9 @@ const (
 	AnalyticsCount         AnalyticsMeasureFn = "count"
 	AnalyticsCountDistinct AnalyticsMeasureFn = "count_distinct"
 	AnalyticsMax           AnalyticsMeasureFn = "max"
+	AnalyticsMedian        AnalyticsMeasureFn = "median"
 	AnalyticsMin           AnalyticsMeasureFn = "min"
+	AnalyticsP75           AnalyticsMeasureFn = "p75"
 	AnalyticsSum           AnalyticsMeasureFn = "sum"
 )
 
@@ -892,7 +894,11 @@ func (e AnalyticsMeasureFn) Valid() bool {
 		return true
 	case AnalyticsMax:
 		return true
+	case AnalyticsMedian:
+		return true
 	case AnalyticsMin:
+		return true
+	case AnalyticsP75:
 		return true
 	case AnalyticsSum:
 		return true
@@ -16794,11 +16800,11 @@ type AnalyticsMeasure struct {
 	// Field What to aggregate. Required for every fn but `count`.
 	Field *string `json:"field,omitempty"`
 
-	// Fn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+	// Fn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
 	Fn AnalyticsMeasureFn `json:"fn"`
 }
 
-// AnalyticsMeasureFn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+// AnalyticsMeasureFn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
 type AnalyticsMeasureFn string
 
 // AnalyticsQuery One question, in the vocabulary the schema returned.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24280,10 +24280,10 @@ export interface components {
         };
         AnalyticsMeasure: {
             /**
-             * @description The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+             * @description The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
              * @enum {string}
              */
-            fn: "count" | "count_distinct" | "sum" | "avg" | "min" | "max";
+            fn: "count" | "count_distinct" | "sum" | "avg" | "min" | "max" | "median" | "p75";
             /** @description What to aggregate. Required for every fn but `count`. */
             field?: string;
             /** @description The caller's name for the result column. It never reaches the statement — results map by position — so it cannot carry anything into SQL. */


### PR DESCRIPTION
The report engine has answered `median` and `p75` since the percentile work, but the typed analytics grammar refused both — an agent asking 'typical days in stage' through `POST /analytics/query` was told no aggregate by that name while the screen beside it drew one.

The IR, compiler and wire enum now carry both. Both engines render through one `analyticsquery.PercentileExpr`: the CASE shape, the five-value sample floor and the fraction mapping have one home, so the screen and the typed query give one answer to what a median is. Below the floor the answer is NULL, not a number — the count beside the blank still says how many deals there were. A percentile over a non-numeric field is refused with the grammar's typed refusal and a suggestion that names a measure that works.

Reviewed by the fallback pair (Codex rate-limited): security clean; craft found the duplicated fraction mapping, which this PR consolidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `median` and `p75` to the typed analytics grammar so `POST /analytics/query` accepts the same percentiles the report screen already draws. Both engines now render through one shared percentile expression, so they answer identically under the same five-value sample floor — below the floor the result is NULL, not a number, and the count beside the blank still says how many rows there were. A percentile over a non-numeric field is refused with a typed error that suggests a working measure.

<sup>Written for commit 23aea25de25572c5b3a05c9977fa7881ffc2b155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

