### PR TITLE
fix(deals): a stage header states no number it did not measure

### DIFF
--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -338,6 +338,25 @@ const absentMoneyColumns: BoardMoneyColumn[] = [
     ],
   },
   {
+    // A sum hidden for a reason of the CALLER's, not the mixed-currency one
+    // above. The deals board withholds its totals when its card list and its
+    // totals query would measure different populations, and a column that drew
+    // the mixed-currency sentence there would state a reason that is not true.
+    stage: "withheld",
+    label: "Total withheld",
+    probabilityPct: 50,
+    rawMinor: null,
+    weightedMinor: null,
+    currency: null,
+    sumHidden: true,
+    sumHiddenReason: "No total — filter to My deals",
+    count: 2,
+    deals: [
+      boardDeal("a6", "Northwind renewal", 12_000, 3),
+      boardDeal("a7", "Tailspin expansion", 45_000, 9),
+    ],
+  },
+  {
     stage: "loading",
     label: "Totals in flight",
     probabilityPct: 60,

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -349,7 +349,7 @@ const absentMoneyColumns: BoardMoneyColumn[] = [
     weightedMinor: null,
     currency: null,
     sumHidden: true,
-    sumHiddenReason: "No total — filter to My deals",
+    sumHiddenReason: "Loaded only — filter to My deals for the total",
     count: 2,
     deals: [
       boardDeal("a6", "Northwind renewal", 12_000, 3),

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -120,6 +120,18 @@ export type BoardColumn<Record extends BoardRecord = BoardDeal> = {
    */
   sumHidden?: boolean;
   /**
+   * WHY the sum is hidden, as the words to print in its place.
+   *
+   * The default says the stage mixes currencies, which was the only reason a
+   * total could go missing when this column was written. It is not the only one
+   * now: a board whose card list and whose totals query measure DIFFERENT
+   * populations has no figure it may honestly print either, and printing the
+   * mixed-currency sentence there would state a reason that is not true.
+   *
+   * A caller that hides a sum for its own reason passes its own words.
+   */
+  sumHiddenReason?: string;
+  /**
    * Draw the column narrow: its head and its count, and none of its cards.
    *
    * For a stage that is a DESTINATION more than a queue — a lead board's
@@ -440,7 +452,7 @@ function BoardLayout<Record extends BoardRecord>({
                   euros, dollars and dong, five of six columns are this state. */}
               {money && column.sumHidden && (
                 <span className="board-col-weighted">
-                  {t("board.mixedCurrencies")}
+                  {column.sumHiddenReason ?? t("board.mixedCurrencies")}
                 </span>
               )}
             </div>

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2358,6 +2358,7 @@ export const de = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Nur ins Stocken geraten",
   "deals.filterOwnerMe": "Meine Deals",
+  "deals.totalsNeedOwnerFilter": "Keine Summe — auf Meine Deals filtern",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Alle Partner",
   "deals.filterForecast": "Forecast",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2358,7 +2358,9 @@ export const de = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Nur ins Stocken geraten",
   "deals.filterOwnerMe": "Meine Deals",
-  "deals.totalsNeedOwnerFilter": "Keine Summe — auf Meine Deals filtern",
+  "deals.totalsNeedOwnerFilter":
+    "Nur geladene — für die Summe auf Meine Deals filtern",
+  "deals.totalsNoTagFilter": "Nur geladene — keine Summe bei Tag-Filter",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Alle Partner",
   "deals.filterForecast": "Forecast",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2399,6 +2399,7 @@ export const en = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Stalled only",
   "deals.filterOwnerMe": "My deals",
+  "deals.totalsNeedOwnerFilter": "No total — filter to My deals",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Any partner",
   "deals.filterForecast": "Forecast",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2399,7 +2399,13 @@ export const en = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Stalled only",
   "deals.filterOwnerMe": "My deals",
-  "deals.totalsNeedOwnerFilter": "No total — filter to My deals",
+  // Both reasons say "loaded only" rather than naming the sum alone: with no
+  // server aggregate the column's figure is the cards LOADED, and the board
+  // pages on demand, so that number grows as the reader presses Load more.
+  // Naming only the total would leave the count reading as final.
+  "deals.totalsNeedOwnerFilter":
+    "Loaded only — filter to My deals for the total",
+  "deals.totalsNoTagFilter": "Loaded only — no total while a tag filters",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Any partner",
   "deals.filterForecast": "Forecast",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2338,7 +2338,9 @@ export const vi = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Chỉ deal đình trệ",
   "deals.filterOwnerMe": "Deal của tôi",
-  "deals.totalsNeedOwnerFilter": "Không có tổng — lọc theo Deal của tôi",
+  "deals.totalsNeedOwnerFilter":
+    "Chỉ phần đã tải — chọn Deal của tôi để xem tổng",
+  "deals.totalsNoTagFilter": "Chỉ phần đã tải — không có tổng khi lọc theo thẻ",
   "deals.filterPartner": "Đối tác",
   "deals.filterPartnerAnyOne": "Mọi đối tác",
   "deals.filterForecast": "Dự báo",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2338,6 +2338,7 @@ export const vi = {
   "deals.pipeline": "Pipeline",
   "deals.filterStalled": "Chỉ deal đình trệ",
   "deals.filterOwnerMe": "Deal của tôi",
+  "deals.totalsNeedOwnerFilter": "Không có tổng — lọc theo Deal của tôi",
   "deals.filterPartner": "Đối tác",
   "deals.filterPartnerAnyOne": "Mọi đối tác",
   "deals.filterForecast": "Dự báo",

--- a/frontend/src/screens/deals-views.test.tsx
+++ b/frontend/src/screens/deals-views.test.tsx
@@ -238,6 +238,11 @@ describe("a saved view over the deals board", () => {
   });
 
   it("keeps the board's own count, its stage totals and its archived toggle", async () => {
+    // Stage totals are asked for only while the owner filter names the viewer:
+    // `GET /deals` returns every deal the reader may see while the report
+    // measures the caller's own population, so any other selection would put a
+    // number over cards it did not count.
+    window.location.hash = "#/deals?owner_id=u-me";
     const dealUrls: string[] = [];
     const user = userEvent.setup();
     vi.stubGlobal(

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1063,7 +1063,17 @@ describe("DealsScreen", () => {
   // cards. The seeded card's own amount×probability would give a different,
   // WRONG figure if the board still computed it client-side — this proves
   // it renders the server's number instead.
+  // The board asks for stage totals only while the owner filter names the
+  // viewer, because that is the only selection under which the report's
+  // population and the board's card list are the same set of deals. Every test
+  // below whose subject IS the totals request has to put the board in that
+  // state first, the way a reader does by choosing "My deals".
+  function narrowToMyDeals() {
+    window.location.hash = "#/deals?owner_id=u-me";
+  }
+
   it("renders the board's column total from the deals-by-stage report, not from the loaded cards", async () => {
+    narrowToMyDeals();
     vi.stubGlobal(
       "fetch",
       stubBackend([deal({ id: "a", stage_id: "s1", amount_minor: 1 })], {
@@ -1091,7 +1101,38 @@ describe("DealsScreen", () => {
     expect(screen.getByText("250 deals")).toBeTruthy();
   });
 
+  // The defect this guard exists for: `GET /deals` returns every deal the
+  // reader may SEE, while the deals-by-stage report measures the caller's OWN
+  // population. A Qualified column said "1 deal" over eight cards because the
+  // header counted the reader's one and the board drew all eight.
+  //
+  // With no owner filter the two sets differ, so the board asks for no total
+  // and says why, rather than printing a number it did not measure.
+  it("asks for no stage total, and says so, until the owner filter names the viewer", async () => {
+    let totalsAsked = false;
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({ id: "a", stage_id: "s1" })], {
+        onStageTotalsBody: () => {
+          totalsAsked = true;
+        },
+      }),
+    );
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    expect(totalsAsked).toBe(false);
+    // Once per stage column: each one owes the reader a reason where its
+    // figure would be, not a blank that reads as a stage worth nothing.
+    expect(
+      screen.getAllByText("No total — filter to My deals").length,
+    ).toBeGreaterThan(0);
+  });
+
   it("sends the board's active filters to the deals-by-stage totals request", async () => {
+    narrowToMyDeals();
     let sentBody: unknown;
     vi.stubGlobal(
       "fetch",
@@ -2427,10 +2468,15 @@ describe("the partner filter", () => {
       return stubBackend([d], { single: d })(request);
     });
 
+    // Totals are asked for only while the owner filter names the viewer: it is
+    // the one selection under which the report's population and the board's
+    // card list are the same deals. Set on the address, because a filter
+    // already applied opens the bar as a chip rather than as the "Filter"
+    // button this test then clicks.
+    window.location.hash = "#/deals?owner_id=u-me";
     render(<DealsScreen />);
     await screen.findByText("Fleet retrofit");
     await userEvent.click(screen.getByRole("button", { name: "Table" }));
-    await userEvent.click(screen.getByRole("button", { name: "Filter" }));
     const menu = screen.getByRole("group", { name: "Filter" });
     await userEvent.click(
       within(menu).getByRole("button", { name: "Partner" }),

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1124,11 +1124,32 @@ describe("DealsScreen", () => {
     );
 
     expect(totalsAsked).toBe(false);
-    // Once per stage column: each one owes the reader a reason where its
-    // figure would be, not a blank that reads as a stage worth nothing.
+    // Once per stage column, exactly. Each one owes the reader a reason where
+    // its figure would be, and "more than zero" would pass with one column
+    // explaining itself while the rest drew blanks.
     expect(
-      screen.getAllByText("No total — filter to My deals").length,
-    ).toBeGreaterThan(0);
+      screen.getAllByText("Loaded only — filter to My deals for the total")
+        .length,
+    ).toBe(stages.length);
+  });
+
+  // A tag filter withholds totals too — the report has no tag field and sending
+  // one is a 422 — and it must say THAT, not tell the reader to press an owner
+  // filter they may already have pressed.
+  it("names the tag filter, not the owner filter, when a tag is what withheld the total", async () => {
+    window.location.hash = "#/deals?owner_id=u-me&tag_id=t1";
+    vi.stubGlobal("fetch", stubBackend([deal({ id: "a", stage_id: "s1" })]));
+    render(<DealsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+
+    expect(
+      screen.getAllByText("Loaded only — no total while a tag filters").length,
+    ).toBe(stages.length);
+    expect(
+      screen.queryByText("Loaded only — filter to My deals for the total"),
+    ).toBeNull();
   });
 
   it("sends the board's active filters to the deals-by-stage totals request", async () => {
@@ -2468,15 +2489,17 @@ describe("the partner filter", () => {
       return stubBackend([d], { single: d })(request);
     });
 
-    // Totals are asked for only while the owner filter names the viewer: it is
-    // the one selection under which the report's population and the board's
-    // card list are the same deals. Set on the address, because a filter
-    // already applied opens the bar as a chip rather than as the "Filter"
-    // button this test then clicks.
+    // The owner filter comes from the address rather than from a click,
+    // because it is this test's PRECONDITION and not its subject: totals are
+    // asked for only while it names the viewer, so without it there is no
+    // report body for the partner assertion to inspect. A reader reaches the
+    // same state by choosing "My deals", and the case that covers that choice
+    // is the withheld-total one above.
     window.location.hash = "#/deals?owner_id=u-me";
     render(<DealsScreen />);
     await screen.findByText("Fleet retrofit");
     await userEvent.click(screen.getByRole("button", { name: "Table" }));
+    // The partner dial itself IS the subject, so it is pressed, not addressed.
     const menu = screen.getByRole("group", { name: "Filter" });
     await userEvent.click(
       within(menu).getByRole("button", { name: "Partner" }),

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -386,7 +386,31 @@ function dealsByStageReportFilters(f: DealFilters): Record<string, unknown> {
 // row, which buildStageTotals reads as "hide the sum" — the report never
 // includes archived deals (like every report), so the totals reflect the
 // live pipeline regardless of the board's "show archived" toggle.
-function useStageTotals(f: DealFilters) {
+// measuresTheSamePopulation reports whether the totals query would count the
+// same deals the board is showing.
+//
+// It does not, unless the owner filter names the viewer. `GET /deals` returns
+// every deal the reader may SEE — a deal is readable by every seat, plus
+// anything shared with them — while `POST /reports/{report}` carries no scope
+// parameter at all, so the report engine measures the caller's OWN population:
+// their records, or their teams' if they manage any. The two sets differ for
+// every rep who can read a colleague's deal, which is all of them.
+//
+// That is how a Qualified column came to say "1 deal" above eight cards. The
+// header was counting the reader's own one; the board was drawing every deal
+// the reader could see.
+//
+// Naming the viewer in the owner filter collapses the difference: both queries
+// then ask for the same person's deals, and the report's own narrowing becomes
+// a no-op rather than a second, invisible filter.
+function measuresTheSamePopulation(
+  f: DealFilters,
+  viewerID: string | undefined,
+): boolean {
+  return viewerID !== undefined && f.filters.owner_id === viewerID;
+}
+
+function useStageTotals(f: DealFilters, viewerID: string | undefined) {
   return useQuery({
     // Under ["deals"] on purpose, so the ONE invalidation every deal mutation
     // already fires refreshes the column headers along with the cards. Keyed
@@ -401,7 +425,16 @@ function useStageTotals(f: DealFilters) {
     // under it is a number the reader has no way to reconcile. Withheld is the
     // honest answer, and buildStageTotals already draws the no-sum column for
     // the mixed-currency case.
-    enabled: !f.overlay && parseTagIDs(f.filters.tag_id).length === 0,
+    //
+    // Nor unless the owner filter names the viewer, for the same reason in a
+    // different clause: the report measures the caller's own population and the
+    // board draws everything they may read, so any other owner selection — or
+    // none — puts a number over cards it did not count. See
+    // measuresTheSamePopulation.
+    enabled:
+      !f.overlay &&
+      parseTagIDs(f.filters.tag_id).length === 0 &&
+      measuresTheSamePopulation(f, viewerID),
     queryFn: async () => {
       const { data, error } = await api.POST("/reports/{report}", {
         params: { path: { report: "deals-by-stage" } },
@@ -1307,6 +1340,10 @@ export function buildColumns(
   deals: Deal[],
   totals: Map<string, StageTotals>,
   naming: CompanyNaming,
+  // What to say where a stage total would go when the totals query was not
+  // asked at all — see measuresTheSamePopulation. Undefined when totals are in
+  // play, which is the ordinary case.
+  totalsWithheld?: string,
 ): BoardMoneyColumn[] {
   return [...stages]
     .sort((a, b) => a.position - b.position)
@@ -1328,7 +1365,11 @@ export function buildColumns(
         // count while totals are still loading, so the column shows SOME
         // number rather than a misleading 0.
         count: stageTotals?.count ?? stageDeals.length,
-        sumHidden: stageTotals?.sumHidden ?? false,
+        // Withheld totals hide the sum for their own reason, which is NOT the
+        // mixed-currency one the column says by default.
+        sumHidden:
+          totalsWithheld !== undefined || (stageTotals?.sumHidden ?? false),
+        sumHiddenReason: totalsWithheld,
       };
     });
 }
@@ -1895,6 +1936,14 @@ function DealBoardBody({
                     loadedDeals,
                     stageTotalsQuery.data ?? new Map(),
                     orgMarks,
+                    // A query that was never enabled has no data and never
+                    // will, which is a different state from one still loading.
+                    // Saying so is the point: the alternative is a column
+                    // sitting silently over cards it did not count.
+                    stageTotalsQuery.fetchStatus === "idle" &&
+                      !stageTotalsQuery.isSuccess
+                      ? t("deals.totalsNeedOwnerFilter")
+                      : undefined,
                   )}
                   onOpen={openDeal}
                   cardDragHandlers={cardDragHandlers}
@@ -2476,7 +2525,7 @@ export function DealsScreen({
   // over EVERY matching deal, not just the capped page useDeals fetches —
   // built from the SAME filter dials so cards and totals never disagree
   // about which deals are in view.
-  const stageTotalsQuery = useStageTotals(dealFilters);
+  const stageTotalsQuery = useStageTotals(dealFilters, meQuery.data?.user.id);
   // A stage-keyed board cannot place a mirror deal (its pipeline/stage is the
   // null pipeline/stage), so overlay mode opens on the flat table and hides the toggle
   // (below) — the mode is fixed for the page's life, so a static initial value

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -386,28 +386,41 @@ function dealsByStageReportFilters(f: DealFilters): Record<string, unknown> {
 // row, which buildStageTotals reads as "hide the sum" — the report never
 // includes archived deals (like every report), so the totals reflect the
 // live pipeline regardless of the board's "show archived" toggle.
-// measuresTheSamePopulation reports whether the totals query would count the
-// same deals the board is showing.
+// Why the board may not state a stage total, or undefined when it may.
 //
-// It does not, unless the owner filter names the viewer. `GET /deals` returns
-// every deal the reader may SEE — a deal is readable by every seat, plus
-// anything shared with them — while `POST /reports/{report}` carries no scope
-// parameter at all, so the report engine measures the caller's OWN population:
-// their records, or their teams' if they manage any. The two sets differ for
-// every rep who can read a colleague's deal, which is all of them.
+// ONE function for both the decision and the words. The query's `enabled` keys
+// on this answering undefined, and the column prints what it answers — so a
+// reason cannot be added to one without the other, and the column can never
+// explain a total by a rule that is not the one that withheld it.
 //
-// That is how a Qualified column came to say "1 deal" above eight cards. The
-// header was counting the reader's own one; the board was drawing every deal
-// the reader could see.
+// Derived from the FILTERS, never from the query's own status. A query that
+// errored also settles to idle-and-not-successful, and reading status would
+// have told a reader whose report answered 422 to press a filter instead of
+// showing them the failure.
 //
-// Naming the viewer in the owner filter collapses the difference: both queries
-// then ask for the same person's deals, and the report's own narrowing becomes
-// a no-op rather than a second, invisible filter.
-function measuresTheSamePopulation(
+// The two reasons:
+//
+// A TAG has no filter field on the report — sending one is a 422 — so the
+// totals would count deals the board is not showing.
+//
+// The POPULATION differs unless the owner filter names the viewer. `GET /deals`
+// returns every deal the reader may SEE, a deal being readable by every seat,
+// while the report engine narrows to the caller's OWN records (reportwhere.go
+// applies a population clause on top of row scope, precisely because a deal is
+// an identity table whose row scope renders TRUE). On the demo installation
+// that is 35 open deals as cards against 7 in the header — the "1 deal" over
+// eight cards the rehearsal found.
+function totalsWithheldBecause(
   f: DealFilters,
   viewerID: string | undefined,
-): boolean {
-  return viewerID !== undefined && f.filters.owner_id === viewerID;
+): MessageKey | undefined {
+  if (parseTagIDs(f.filters.tag_id).length > 0) {
+    return "deals.totalsNoTagFilter";
+  }
+  if (viewerID === undefined || f.filters.owner_id !== viewerID) {
+    return "deals.totalsNeedOwnerFilter";
+  }
+  return undefined;
 }
 
 function useStageTotals(f: DealFilters, viewerID: string | undefined) {
@@ -419,22 +432,13 @@ function useStageTotals(f: DealFilters, viewerID: string | undefined) {
     // single-currency stage left the old sum standing, which is the mixed-
     // currency refusal not happening.
     queryKey: ["deals", "by-stage-totals", f],
-    // Not while a tag narrows the board. The report's filter vocabulary has no
-    // tag field — sending one is a 422 — so the totals would count deals the
-    // board is not showing, and a column header reporting more than the cards
-    // under it is a number the reader has no way to reconcile. Withheld is the
-    // honest answer, and buildStageTotals already draws the no-sum column for
-    // the mixed-currency case.
+    // Asked only when the report would count the deals the board is drawing.
+    // totalsWithheldBecause owns that decision and the words for it both, so
+    // the column cannot explain a missing total by the wrong rule.
     //
-    // Nor unless the owner filter names the viewer, for the same reason in a
-    // different clause: the report measures the caller's own population and the
-    // board draws everything they may read, so any other owner selection — or
-    // none — puts a number over cards it did not count. See
-    // measuresTheSamePopulation.
-    enabled:
-      !f.overlay &&
-      parseTagIDs(f.filters.tag_id).length === 0 &&
-      measuresTheSamePopulation(f, viewerID),
+    // Overlay is separate and not a reason: the board does not render at all
+    // there, so there is no column to explain anything to.
+    enabled: !f.overlay && totalsWithheldBecause(f, viewerID) === undefined,
     queryFn: async () => {
       const { data, error } = await api.POST("/reports/{report}", {
         params: { path: { report: "deals-by-stage" } },
@@ -1886,12 +1890,17 @@ function DealBoardBody({
   openDeal,
   cardDragHandlers,
   columnDropHandlers,
+  totalsWithheld,
 }: Readonly<{
   dealsQuery: ReturnType<typeof useDeals>;
   pipelinesQuery: ReturnType<typeof usePipelines>;
   effectivePipeline?: Pipeline;
   loadedDeals: Deal[];
   stageTotalsQuery: ReturnType<typeof useStageTotals>;
+  // Why no stage total is coming, or undefined when one is. Decided by
+  // totalsWithheldBecause where the query's own `enabled` reads it, so the
+  // column's explanation and the query's absence cannot disagree.
+  totalsWithheld?: MessageKey;
   orgs: Organization[];
   orgsSettled: boolean;
   openDeal: ComponentProps<typeof PipelineBoard>["onOpen"];
@@ -1936,14 +1945,7 @@ function DealBoardBody({
                     loadedDeals,
                     stageTotalsQuery.data ?? new Map(),
                     orgMarks,
-                    // A query that was never enabled has no data and never
-                    // will, which is a different state from one still loading.
-                    // Saying so is the point: the alternative is a column
-                    // sitting silently over cards it did not count.
-                    stageTotalsQuery.fetchStatus === "idle" &&
-                      !stageTotalsQuery.isSuccess
-                      ? t("deals.totalsNeedOwnerFilter")
-                      : undefined,
+                    totalsWithheld ? t(totalsWithheld) : undefined,
                   )}
                   onOpen={openDeal}
                   cardDragHandlers={cardDragHandlers}
@@ -2526,6 +2528,12 @@ export function DealsScreen({
   // built from the SAME filter dials so cards and totals never disagree
   // about which deals are in view.
   const stageTotalsQuery = useStageTotals(dealFilters, meQuery.data?.user.id);
+  // The same answer the query keys its `enabled` on, so the column explains the
+  // absence by the rule that caused it.
+  const totalsWithheld = totalsWithheldBecause(
+    dealFilters,
+    meQuery.data?.user.id,
+  );
   // A stage-keyed board cannot place a mirror deal (its pipeline/stage is the
   // null pipeline/stage), so overlay mode opens on the flat table and hides the toggle
   // (below) — the mode is fixed for the page's life, so a static initial value
@@ -2646,6 +2654,7 @@ export function DealsScreen({
         effectivePipeline={effectivePipeline}
         loadedDeals={loadedDeals}
         stageTotalsQuery={stageTotalsQuery}
+        totalsWithheld={totalsWithheld}
         orgs={orgsQuery.data?.data ?? []}
         orgsSettled={orgsQuery.isSuccess}
         openDeal={openDeal}


### PR DESCRIPTION
The Qualified column said **1 deal** above **eight** cards.

`GET /deals` returns every deal the reader may SEE — a deal is readable by every seat, plus anything shared with them. `POST /reports/{report}` carries no scope parameter at all, so the report engine measures the caller's OWN population: their records, or their teams' if they manage any.

The board drew one set and its headers counted the other. The two differ for every rep who can read a colleague's deal, which is all of them.

## What changed

The board asks for stage totals only while the owner filter names the viewer — the one selection under which both queries ask about the same person's deals. Under any other selection it draws no figure and says why, the way it already withholds a sum for a stage that mixes currencies.

That reason is now the caller's rather than a fixed sentence. Printing "mixed currencies" over a column withheld for a different reason states something untrue.

## Why withhold rather than widen

Adding a scope parameter to the report endpoint reaches `crm.yaml`, both generators and the analytics population resolver. A number over the wrong cards is worse than an honest absence in the meantime. If the product wants board-wide totals later, that is the contract change to make.

## Tests

The three existing tests that assert the totals request now put the board in the state that asks for one. A new case holds the withheld state itself: no request made, and a reason rendered where the figure would be. Reverting the guard fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deals board drawing a stage count that didn't match the cards under it. The Qualified column said "1 deal" above eight cards because the board lists every deal the reader can see, while the totals report counts only the caller's own deals.

- Stage totals are requested only when the owner filter names the viewer and no tag filter is active — the selections where both queries count the same deals.
- One function owns both the withhold decision and the words printed in its place, so a column cannot explain a missing total by the wrong rule; a tag filter gets its own reason rather than the owner-filter one.
- The hidden-sum reason is caller-provided now, so a withheld column no longer says "mixed currencies"; both reasons say "loaded only" since the figure falls back to the cards loaded.
- Existing totals tests set the board to the requesting state; new tests cover the withheld owner-filter and tag-filter states.

<sup>Written for commit 85a8987f0e20c955016af5dae7cb4d2308051d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deal stage totals are now shown only when the “My deals” filter is applied.
  * When totals are unavailable, each stage explains that filtering to “My deals” is required.
  * Added localized messaging in English, German, and Vietnamese.
* **Bug Fixes**
  * Prevented potentially misleading totals from appearing when viewing deals outside the current user’s ownership filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->