### PR TITLE
feat(agents): an agent can ask the question nobody wrote a report for

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16949,16 +16949,16 @@ paths:
         `version` changes when the vocabulary does, including when one seat's grants change.
         A query planned against an older version is refused rather than run, because a plan
         naming a field that has since moved would render SQL against a column that is gone.
-      # NOT an agent tool, and the reason is measured rather than a preference.
-      # The served catalog already renders ~87% of the certification lane's
-      # prompt window; a second analytics tool pushes it over, and what that
-      # gate protects is every corpus scenario silently reasoning over a prompt
-      # larger than this build claims to send.
+      # NOT an agent tool, and the reason is measured rather than a preference:
+      # the served catalog sits within a few hundred tokens of the certification
+      # lane's floor, and a vocabulary tool would recite per-caller derived
+      # content the margince://schema/analytics resource already serves.
       #
-      # An agent gets this vocabulary through run_analytics_query's own
-      # refusals instead: naming a field that is absent is answered with the
-      # fields that exist, which is the same information at the moment it is
-      # needed. The route stays for the app, which pays no token budget.
+      # An agent gets this vocabulary from that resource, or from
+      # run_analytics_query's own refusals: naming a field that is absent is
+      # answered with the fields that exist, which is the same information at
+      # the moment it is needed. The route stays for the app, which pays no
+      # token budget.
       x-agent-access: human-only
       responses:
         '200':
@@ -16989,17 +16989,12 @@ paths:
 
         Refusals are typed and each carries the smallest thing that would have worked:
         the fields that exist, the measure that applies, the grouping that clears the floor.
-      # NOT an agent tool yet, and the reason is a measured constraint. The
-      # served catalog already renders ~87% of the certification lane's prompt
-      # window; this tool's description, trimmed to just its safety rules,
-      # still puts it over. Cutting further would drop the instructions that
-      # make an agent-reachable analytics surface safe — that the database
-      # computes the numbers, and that a withheld group is never speculated
-      # about — which is the wrong thing to spend for room.
-      #
-      # The HTTP route ships and the app uses it. Making room in the catalog is
-      # a decision about the whole tool surface rather than about this feature.
-      x-agent-access: human-only
+      # The room the earlier note said this could not afford was bought the way
+      # run_report bought it: the vocabulary lives in the per-caller
+      # margince://schema/analytics resource rather than in the tool schema,
+      # and the safety rules — the database computes the numbers, a withheld
+      # group is never speculated about — are the description's whole spend.
+      x-mcp-tool: { verb: run_analytics_query, tier: auto_execute, scope: read }
       requestBody:
         required: true
         content:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33114,7 +33114,7 @@ components:
       properties:
         fn:
           type: string
-          enum: [count, count_distinct, sum, avg, min, max]
+          enum: [count, count_distinct, sum, avg, min, max, median, p75]
           x-enum-varnames:
             - AnalyticsCount
             - AnalyticsCountDistinct
@@ -33122,10 +33122,15 @@ components:
             - AnalyticsAvg
             - AnalyticsMin
             - AnalyticsMax
+            - AnalyticsMedian
+            - AnalyticsP75
           description: >-
             The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts
             values and skips nulls. The two differ on an unpriced deal, so naming the wrong
-            one reports a column's coverage as its population.
+            one reports a column's coverage as its population. `median` and `p75` answer
+            null below a five-value sample floor: a percentile over three deals is one
+            deal's value wearing a statistic's name, and the count beside the blank still
+            says how many there were.
         field:
           type: string
           description: What to aggregate. Required for every fn but `count`.

--- a/backend/internal/compose/agentapps_test.go
+++ b/backend/internal/compose/agentapps_test.go
@@ -289,11 +289,11 @@ func TestTheProductionProvidersClaimDisjointURIs(t *testing.T) {
 	// commit it is wired rather than the commit somebody remembers this test.
 	wired := mcpResourceProviders(
 		agents.NewCapabilitiesResource(NewRegistry(nil, SendPath{})), nil, primedViews(t, everyDeclaredView()))
-	if len(wired) != 6 {
+	if len(wired) != 7 {
 		t.Fatalf("the transport composes %d resource providers; this gate knows how to reason about "+
 			"capabilities, the query vocabulary, the write vocabulary, the report vocabulary, the "+
-			"report block grammar and the views. Add the new one's URI below before it can collide "+
-			"with one of them", len(wired))
+			"report block grammar, the analytics vocabulary and the views. Add the new one's URI "+
+			"below before it can collide with one of them", len(wired))
 	}
 	for _, r := range primedViews(t, everyDeclaredView()).Resources(readerCtx()) {
 		if !strings.HasPrefix(r.URI, mcp.AppURIScheme) {
@@ -306,11 +306,12 @@ func TestTheProductionProvidersClaimDisjointURIs(t *testing.T) {
 	// wander into the view scheme, where a prefix is all that separates them
 	// from a document served under a sandbox policy.
 	schemas := map[string]string{
-		"the query vocabulary":  search.QuerySchemaURI,
-		"the write vocabulary":  agents.RecordFieldsURI,
-		"the report vocabulary": agents.ReportVocabularyURI,
-		"the block grammar":     agents.ReportBlocksURI,
-		"capabilities":          agents.CapabilitiesURI,
+		"the query vocabulary":     search.QuerySchemaURI,
+		"the write vocabulary":     agents.RecordFieldsURI,
+		"the report vocabulary":    agents.ReportVocabularyURI,
+		"the block grammar":        agents.ReportBlocksURI,
+		"capabilities":             agents.CapabilitiesURI,
+		"the analytics vocabulary": AnalyticsSchemaURI,
 	}
 	// A SET, not a pairwise comparison. Two documents could be checked against
 	// each other by hand; three cannot without three comparisons, and the

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -217,6 +217,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"relinkThread":           relinkThreadCommand,
 	"relinkActivities":       relinkActivitiesCommand,
 	"runReport":              runReportCommand,
+	"runAnalyticsQuery":      analyticsQueryCommand,
 	"renderAnalyticsReport":  composeReportCommand,
 
 	// The two decisions, over four routes. They are the only entries here whose

--- a/backend/internal/compose/agentcommandauto.go
+++ b/backend/internal/compose/agentcommandauto.go
@@ -153,6 +153,22 @@ func runReportCommand(_ agentPolicy, _ restCommandDeps, r *http.Request, _ []byt
 	return agents.NewRunReportCall(agents.RunReportCommand{Report: report}), nil
 }
 
+// analyticsQueryCommand decodes POST /v1/analytics/query. A POST because a
+// plan does not fit a query string, not because it writes; the command exists
+// so the door can say what an approval would bind to — no record, one
+// population name.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func analyticsQueryCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	var in struct {
+		Entity string `json:"entity"`
+	}
+	if err := json.Unmarshal(body, &in); err != nil {
+		return nil, err
+	}
+	return agents.NewAnalyticsQueryCall(agents.AnalyticsQueryCommand{Entity: in.Entity}), nil
+}
+
 // composeReportCommand decodes POST /v1/analytics/reports/render.
 //
 // The route is a POST because a report document does not fit a query string,

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -396,7 +396,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/ai-model-rates/propose-refresh":                            {Op: "proposeAiModelRateRefresh", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/ai/feedback":                                               {Op: "recordAIFeedback", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/explain":                                         {Op: "explainAnalyticsCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "tool", Tool: "run_analytics_query", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"POST /v1/analytics/reports/render":                                  {Op: "renderAnalyticsReport", Access: "tool", Tool: "compose_analytics_report", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"POST /v1/analytics/runs/{run_id}/cells/explain":                     {Op: "explainReportRunCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/approval-bundles/{bundle_id}/approve":                      {Op: "approveApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/analyticsquery/compile.go
+++ b/backend/internal/compose/analyticsquery/compile.go
@@ -254,8 +254,30 @@ func aggregateSQL(entity Entity, m Measure) (string, error) {
 	if m.Fn == CountDistinct {
 		return fmt.Sprintf("count(DISTINCT %s)", field.Expr), nil
 	}
+	if m.Fn == Median || m.Fn == P75 {
+		// NULL below the sample floor rather than a number, the same refusal
+		// the report engine writes (report.go, aggregateSelect) and for the
+		// same reason: a percentile over three deals is one deal's value
+		// wearing a statistic's name. NULL rather than an error because the
+		// row is still a real answer — a count beside the blank says how many
+		// deals there were, and failing the whole query would take that too.
+		fraction := "0.5"
+		if m.Fn == P75 {
+			fraction = "0.75"
+		}
+		return fmt.Sprintf(
+			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
+			field.Expr, PercentileSampleFloor, fraction, field.Expr), nil
+	}
 	return fmt.Sprintf("%s(%s)", m.Fn, field.Expr), nil
 }
+
+// PercentileSampleFloor is how many values a percentile needs before it means
+// anything. Exported so the compose report engine's identical floor can be
+// asserted equal to this one; the two engines answering the same question with
+// different thresholds would make a screen and a tool disagree about the same
+// team's week.
+const PercentileSampleFloor = 5
 
 // measureName is what the caller calls the column, and it is measureAlias —
 // one spelling, because validateAliases refuses a collision and this renders

--- a/backend/internal/compose/analyticsquery/compile.go
+++ b/backend/internal/compose/analyticsquery/compile.go
@@ -255,28 +255,37 @@ func aggregateSQL(entity Entity, m Measure) (string, error) {
 		return fmt.Sprintf("count(DISTINCT %s)", field.Expr), nil
 	}
 	if m.Fn == Median || m.Fn == P75 {
-		// NULL below the sample floor rather than a number, the same refusal
-		// the report engine writes (report.go, aggregateSelect) and for the
-		// same reason: a percentile over three deals is one deal's value
-		// wearing a statistic's name. NULL rather than an error because the
-		// row is still a real answer — a count beside the blank says how many
-		// deals there were, and failing the whole query would take that too.
-		fraction := "0.5"
-		if m.Fn == P75 {
-			fraction = "0.75"
-		}
-		return fmt.Sprintf(
-			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
-			field.Expr, PercentileSampleFloor, fraction, field.Expr), nil
+		return PercentileExpr(field.Expr, m.Fn), nil
 	}
 	return fmt.Sprintf("%s(%s)", m.Fn, field.Expr), nil
 }
 
+// PercentileExpr renders a percentile over a TRUSTED schema expression. Both
+// engines call it — the report engine's median/p75 case and the typed
+// compiler below — which is what keeps the screen and the typed query giving
+// one answer to "what is a median" instead of two.
+//
+// NULL below the sample floor rather than a number. A median over three deals
+// is not a median: it is one deal's value wearing a statistic's name, and a
+// manager comparing "typical stage age" across teams would read the smallest
+// team's outlier as its norm. Postgres will happily compute it, which is
+// exactly why the refusal has to be rendered here. NULL rather than an error,
+// because the row is still a real answer — the count beside the blank says
+// how many deals there were, and failing the whole query would take that too.
+func PercentileExpr(expr string, fn AggFn) string {
+	fraction := "0.5"
+	if fn == P75 {
+		fraction = "0.75"
+	}
+	return fmt.Sprintf(
+		"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END)",
+		expr, PercentileSampleFloor, fraction, expr)
+}
+
 // PercentileSampleFloor is how many values a percentile needs before it means
-// anything. Exported so the compose report engine's identical floor can be
-// asserted equal to this one; the two engines answering the same question with
-// different thresholds would make a screen and a tool disagree about the same
-// team's week.
+// anything. Five is a judgement, not a derivation: the point of a percentile
+// here is comparing groups of differing sizes, and below a handful of values
+// the comparison reads noise as signal.
 const PercentileSampleFloor = 5
 
 // measureName is what the caller calls the column, and it is measureAlias —

--- a/backend/internal/compose/analyticsquery/compile_test.go
+++ b/backend/internal/compose/analyticsquery/compile_test.go
@@ -287,8 +287,8 @@ func TestTheCallersAuthorityReachesTheStatement(t *testing.T) {
 
 // A percentile renders under the sample floor: below five values the answer
 // is NULL, not a number — a median over three deals is one deal's value
-// wearing a statistic's name. The same refusal the report engine writes, at
-// the same threshold, so a screen and a tool cannot disagree about one week.
+// wearing a statistic's name. The report engine writes the same refusal at
+// the same threshold, through the same renderer.
 func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
 	t.Parallel()
 	plan, err := Compile(Query{
@@ -312,16 +312,28 @@ func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
 	}
 }
 
-// A percentile over a non-numeric field is refused before rendering: the 50th
+// A percentile over a non-numeric field is refused at the bar every refusal
+// holds: typed, named invalid, and suggesting a measure that works — the 50th
 // percentile of a stage id means nothing, and Postgres computing it anyway is
 // exactly why the refusal is written here.
 func TestAPercentileOverANonNumericFieldIsRefused(t *testing.T) {
 	t.Parallel()
-	_, err := Compile(Query{
-		Entity:   "deals",
-		Measures: []Measure{{Fn: Median, Field: "stage"}},
-	}, testSchema(), noScope)
-	if err == nil {
-		t.Fatal("median over a dimension compiled; it must be refused by name")
+	for _, fn := range []AggFn{Median, P75} {
+		_, err := Compile(Query{
+			Entity:   "deals",
+			Measures: []Measure{{Fn: fn, Field: "stage"}},
+		}, testSchema(), noScope)
+		var refusal *RefusalError
+		if !errors.As(err, &refusal) {
+			t.Fatalf("%s over a dimension answered %v", fn, err)
+		}
+		if refusal.Kind != RefusalInvalid {
+			t.Errorf("%s over a dimension is %q; it means nothing rather than being unbuilt",
+				fn, refusal.Kind)
+		}
+		if !strings.Contains(refusal.Suggest, "amount") {
+			t.Errorf("the refusal suggests %q, which does not name a measure that works",
+				refusal.Suggest)
+		}
 	}
 }

--- a/backend/internal/compose/analyticsquery/compile_test.go
+++ b/backend/internal/compose/analyticsquery/compile_test.go
@@ -284,3 +284,44 @@ func TestTheCallersAuthorityReachesTheStatement(t *testing.T) {
 		t.Errorf("the caller's own narrowing is absent from:\n%s", plan.SQL)
 	}
 }
+
+// A percentile renders under the sample floor: below five values the answer
+// is NULL, not a number — a median over three deals is one deal's value
+// wearing a statistic's name. The same refusal the report engine writes, at
+// the same threshold, so a screen and a tool cannot disagree about one week.
+func TestAPercentileAnswersNullBelowTheSampleFloor(t *testing.T) {
+	t.Parallel()
+	plan, err := Compile(Query{
+		Entity: "deals",
+		Measures: []Measure{
+			{Fn: Median, Field: "amount", As: "typical"},
+			{Fn: P75, Field: "amount", As: "upper"},
+		},
+	}, testSchema(), noScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMedian := "(CASE WHEN count(t.amount_minor) >= 5 THEN " +
+		"percentile_cont(0.5) WITHIN GROUP (ORDER BY t.amount_minor) END)"
+	if !strings.Contains(plan.SQL, wantMedian) {
+		t.Errorf("median renders without the floor:\n got: %s\nwant it to contain: %s",
+			plan.SQL, wantMedian)
+	}
+	if !strings.Contains(plan.SQL, "percentile_cont(0.75)") {
+		t.Errorf("p75 does not ask for the 75th percentile: %s", plan.SQL)
+	}
+}
+
+// A percentile over a non-numeric field is refused before rendering: the 50th
+// percentile of a stage id means nothing, and Postgres computing it anyway is
+// exactly why the refusal is written here.
+func TestAPercentileOverANonNumericFieldIsRefused(t *testing.T) {
+	t.Parallel()
+	_, err := Compile(Query{
+		Entity:   "deals",
+		Measures: []Measure{{Fn: Median, Field: "stage"}},
+	}, testSchema(), noScope)
+	if err == nil {
+		t.Fatal("median over a dimension compiled; it must be refused by name")
+	}
+}

--- a/backend/internal/compose/analyticsquery/ir.go
+++ b/backend/internal/compose/analyticsquery/ir.go
@@ -211,7 +211,7 @@ func validateMeasures(entity Entity, measures []Measure) error {
 			return &RefusalError{
 				Kind:    RefusalUnsupported,
 				Message: fmt.Sprintf("no aggregate named %q", m.Fn),
-				Suggest: "use one of: " + strings.Join(aggregateNames(), ", "),
+				Suggest: "use one of: " + strings.Join(AggregateNames(), ", "),
 			}
 		}
 		if !aggregatesOverValues[m.Fn] {
@@ -304,7 +304,7 @@ func validateFilters(entity Entity, filters []Filter) error {
 			return &RefusalError{
 				Kind:    RefusalUnsupported,
 				Message: fmt.Sprintf("no comparison named %q", f.Op),
-				Suggest: "use one of: " + strings.Join(filterOpNames(), ", "),
+				Suggest: "use one of: " + strings.Join(FilterOpNames(), ", "),
 			}
 		}
 		if _, ok := entity.Lookup(f.Field); !ok {
@@ -353,7 +353,9 @@ var knownAggregates = map[AggFn]bool{
 	Median: true, P75: true,
 }
 
-func aggregateNames() []string {
+// AggregateNames is the closed aggregate vocabulary, sorted — read by the
+// refusals here and by the published schema document, so the two say one set.
+func AggregateNames() []string {
 	out := make([]string, 0, len(knownAggregates))
 	for fn := range knownAggregates {
 		out = append(out, string(fn))
@@ -362,7 +364,9 @@ func aggregateNames() []string {
 	return out
 }
 
-func filterOpNames() []string {
+// FilterOpNames is the closed operator vocabulary, sorted, for the same two
+// readers as AggregateNames.
+func FilterOpNames() []string {
 	out := make([]string, 0, len(filterSQL))
 	for op := range filterSQL {
 		out = append(out, string(op))

--- a/backend/internal/compose/analyticsquery/ir.go
+++ b/backend/internal/compose/analyticsquery/ir.go
@@ -80,12 +80,18 @@ const (
 	Min AggFn = "min"
 	// Max is the largest.
 	Max AggFn = "max"
+	// Median is the 50th percentile, null below the sample floor: a median
+	// over three deals is one deal's value wearing a statistic's name.
+	Median AggFn = "median"
+	// P75 is the 75th percentile, under the same floor as Median.
+	P75 AggFn = "p75"
 )
 
 // aggregatesOverValues are the aggregates that need a field to aggregate.
 // CountAll is the one that does not, which is why it is absent here.
 var aggregatesOverValues = map[AggFn]bool{
 	CountDistinct: true, Sum: true, Avg: true, Min: true, Max: true,
+	Median: true, P75: true,
 }
 
 // numericAggregates are the aggregates that need a NUMBER.
@@ -94,7 +100,7 @@ var aggregatesOverValues = map[AggFn]bool{
 // earliest date and the latest stage all mean something over a non-numeric
 // column, and refusing them would be this compiler inventing a restriction
 // the database does not have.
-var numericAggregates = map[AggFn]bool{Sum: true, Avg: true}
+var numericAggregates = map[AggFn]bool{Sum: true, Avg: true, Median: true, P75: true}
 
 // Filter is one narrowing.
 type Filter struct {
@@ -344,6 +350,7 @@ func unknownField(entity Entity, name string, kind FieldKind) error {
 // refused as unsupported rather than reaching the renderer.
 var knownAggregates = map[AggFn]bool{
 	CountAll: true, CountDistinct: true, Sum: true, Avg: true, Min: true, Max: true,
+	Median: true, P75: true,
 }
 
 func aggregateNames() []string {

--- a/backend/internal/compose/analyticsquerytool.go
+++ b/backend/internal/compose/analyticsquerytool.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// run_analytics_query's engine seam and the vocabulary document it names.
+//
+// The tool and POST /analytics/query are one engine: both decode the same wire
+// shape, compile against the same per-caller derived schema, run under the
+// same floor and save through the same run store — so the two transports
+// cannot disagree about what a median over a team's week is.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// analyticsQueryToolRunner adapts the typed query engine to the tool seam:
+// strict-decode the wire shape, run, save when asked, re-encode.
+func analyticsQueryToolRunner(db *database.DB, floor analyticsquery.Floor) agents.AnalyticsQueryRunner {
+	return func(ctx context.Context, raw json.RawMessage) (json.RawMessage, error) {
+		var body crmcontracts.AnalyticsQuery
+		// STRICT for the reason the report runner's decode is: a key this
+		// engine does not serve is refused by name, not dropped — a lenient
+		// decode would answer a request for something else with the wrong
+		// thing and no warning.
+		dec := json.NewDecoder(strings.NewReader(string(raw)))
+		dec.DisallowUnknownFields()
+		err := dec.Decode(&body)
+		if err == nil && dec.More() {
+			// Exactly one JSON value, the report runner's rule: a second value
+			// after the object is a caller who thinks they sent something
+			// this never read.
+			err = errors.New("trailing content after the arguments")
+		}
+		if err != nil {
+			return nil, httperr.Validation("arguments", "malformed_json",
+				"the arguments are not the shape this tool takes: entity (string), "+
+					"group_by ([string]), measures ([{fn, field, as}]), filters "+
+					"([{field, op, value}]), limit, save, scope_kind, scope_id")
+		}
+		q := queryFromWire(body)
+
+		var answer AnalyticsAnswer
+		var runID *ids.UUID
+		if err := db.Tx(ctx, func(tx pgx.Tx) error {
+			var err error
+			answer, err = RunAnalyticsQuery(ctx, tx, q, floor)
+			if err != nil {
+				return err
+			}
+			if body.Save == nil || !*body.Save {
+				return nil
+			}
+			// In the SAME transaction that produced it, exactly as the HTTP
+			// twin saves: a run id must never name a row that does not exist.
+			id, err := SaveReportRun(ctx, tx, q, answer, floor)
+			if err != nil {
+				return err
+			}
+			runID = &id
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		// Never null: a model reads null as "unknown" where an empty array
+		// says "none matched".
+		rows := make([]json.RawMessage, 0, len(answer.Rows))
+		for _, row := range answer.Rows {
+			encoded, err := json.Marshal(row)
+			if err != nil {
+				return nil, fmt.Errorf("compose: encoding an analytics row: %w", err)
+			}
+			rows = append(rows, encoded)
+		}
+		out := agents.AnalyticsQueryResult{
+			Columns:  emptyIfNilStrings(answer.Columns),
+			Rows:     rows,
+			Withheld: answer.Withheld, TotalSafe: answer.TotalSafe,
+			SchemaVersion: answer.SchemaVersion,
+		}
+		if runID != nil {
+			s := runID.String()
+			out.RunID = &s
+		}
+		body2, err := json.Marshal(out)
+		if err != nil {
+			return nil, fmt.Errorf("compose: encoding an analytics answer: %w", err)
+		}
+		return body2, nil
+	}
+}
+
+func emptyIfNilStrings(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
+}
+
+// AnalyticsSchemaURI names the vocabulary document run_analytics_query points
+// at instead of carrying: the populations, dimensions and measures this seat
+// may ask about, derived per caller — a masked field is indistinguishable
+// from one that does not exist.
+const AnalyticsSchemaURI = "margince://schema/analytics"
+
+// mimeTextPlain is the analytics vocabulary's content type: prose, because it
+// reaches a model that pays per token and a nested object spends the budget
+// on punctuation.
+const mimeTextPlain = "text/plain"
+
+// analyticsSchemaResource publishes that document.
+type analyticsSchemaResource struct{}
+
+// Resources advertises the one document this provider publishes.
+func (analyticsSchemaResource) Resources(context.Context) []mcp.Resource {
+	return []mcp.Resource{{
+		URI:           AnalyticsSchemaURI,
+		Name:          "analytics-schema",
+		Title:         "Analytics query vocabulary",
+		RequiredScope: principal.ScopeRead,
+		MIMEType:      mimeTextPlain,
+		Description: "The populations a run_analytics_query plan may name, each with its " +
+			"group_by dimensions and its measures, derived for this seat. " +
+			"run_analytics_query names this document instead of carrying it.",
+	}}
+}
+
+// ReadResource composes the document under the caller's own derivation, so a
+// masked field never appears in it.
+func (analyticsSchemaResource) ReadResource(ctx context.Context, uri string) (mcp.ResourceContents, error) {
+	if uri != AnalyticsSchemaURI {
+		return mcp.ResourceContents{}, fmt.Errorf("compose: resource %q: %w", uri, apperrors.ErrNotFound)
+	}
+	schema := AnalyticsSchemaFor(ctx)
+	var out strings.Builder
+	out.WriteString("schema version " + schema.Version + "\n")
+	out.WriteString("aggregates: " + strings.Join(analyticsquery.AggregateNames(), ", ") + "\n")
+	out.WriteString("filter ops: " + strings.Join(analyticsquery.FilterOpNames(), ", ") + "\n\n")
+	out.WriteString(DescribeAnalyticsSchema(schema))
+	return mcp.ResourceContents{URI: uri, MIMEType: mimeTextPlain, Text: out.String()}, nil
+}

--- a/backend/internal/compose/analyticsquerytool.go
+++ b/backend/internal/compose/analyticsquerytool.go
@@ -32,7 +32,10 @@ import (
 
 // analyticsQueryToolRunner adapts the typed query engine to the tool seam:
 // strict-decode the wire shape, run, save when asked, re-encode.
-func analyticsQueryToolRunner(db *database.DB, floor analyticsquery.Floor) agents.AnalyticsQueryRunner {
+// The floor is DefaultFloor on both transports: a figure a person may not see
+// is one a model asking on their behalf may not see either.
+func analyticsQueryToolRunner(db *database.DB) agents.AnalyticsQueryRunner {
+	floor := analyticsquery.DefaultFloor
 	return func(ctx context.Context, raw json.RawMessage) (json.RawMessage, error) {
 		var body crmcontracts.AnalyticsQuery
 		// STRICT for the reason the report runner's decode is: a key this

--- a/backend/internal/compose/analyticsquerytool_integration_test.go
+++ b/backend/internal/compose/analyticsquerytool_integration_test.go
@@ -42,7 +42,7 @@ func TestTheAnalyticsToolAndTheHTTPEngineServeOneAnswer(t *testing.T) {
 	e := integration.Setup(t)
 	seedToolDeals(t, e)
 	ctx := e.Admin()
-	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+	run := analyticsQueryToolRunner(e.DB())
 
 	raw, err := run(ctx, json.RawMessage(
 		`{"entity":"deals-by-stage","measures":[{"fn":"count"}],"save":true}`))
@@ -88,7 +88,7 @@ func TestTheAnalyticsToolAndTheHTTPEngineServeOneAnswer(t *testing.T) {
 func TestTheAnalyticsToolRefusesAnUnservedArgument(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+	run := analyticsQueryToolRunner(e.DB())
 	if _, err := run(ctx, json.RawMessage(
 		`{"entity":"deals-by-stage","measures":[{"fn":"count"}],"as_of":"2024-01-01"}`)); err == nil {
 		t.Fatal("an argument this engine does not serve was silently dropped — the caller " +
@@ -100,7 +100,7 @@ func TestTheAnalyticsToolRefusesAnUnservedArgument(t *testing.T) {
 // something this never read.
 func TestTheAnalyticsToolRefusesTrailingContent(t *testing.T) {
 	e := integration.Setup(t)
-	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+	run := analyticsQueryToolRunner(e.DB())
 	if _, err := run(e.Admin(), json.RawMessage(
 		`{"entity":"deals-by-stage","measures":[{"fn":"count"}]} {"save":true}`)); err == nil {
 		t.Fatal("trailing content after the arguments was silently ignored")

--- a/backend/internal/compose/analyticsquerytool_integration_test.go
+++ b/backend/internal/compose/analyticsquerytool_integration_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// run_analytics_query against a real database: the tool and POST
+// /analytics/query are one engine, so the answer a model reads must be the
+// answer the screen draws — same columns, same rows, same floor.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+func seedToolDeals(t *testing.T, e *integration.Env) {
+	t.Helper()
+	pipeline, open, _ := integration.DealFixture(t, e)
+	owner := integration.OwnerConn(t)
+	for i := range 6 {
+		if _, err := owner.Exec(context.Background(), `
+			INSERT INTO deal (pipeline_id, stage_id, name, owner_id, status, source, captured_by,
+			                  amount_minor, currency)
+			VALUES ($1, $2, 'Tool Deal ' || $3, $4, 'open', 'manual', 'test', 100000, 'EUR')`,
+			pipeline, open, fmt.Sprintf("%d", i), e.Rep1); err != nil {
+			t.Fatalf("seeding deal %d: %v", i, err)
+		}
+	}
+}
+
+func TestTheAnalyticsToolAndTheHTTPEngineServeOneAnswer(t *testing.T) {
+	e := integration.Setup(t)
+	seedToolDeals(t, e)
+	ctx := e.Admin()
+	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+
+	raw, err := run(ctx, json.RawMessage(
+		`{"entity":"deals-by-stage","measures":[{"fn":"count"}],"save":true}`))
+	if err != nil {
+		t.Fatalf("the tool refused a well-formed count: %v", err)
+	}
+	var got agents.AnalyticsQueryResult
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) == 0 {
+		t.Fatal("the tool answered no rows over six seeded deals")
+	}
+	if got.RunID == nil {
+		t.Fatal("save was set and the answer carries no run_id — nothing for a report to cite")
+	}
+	if got.SchemaVersion == "" {
+		t.Error("the answer names no schema version, so two answers cannot be compared")
+	}
+
+	// The HTTP engine's answer to the same question, through the same seam.
+	var twin AnalyticsAnswer
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		twin, err = RunAnalyticsQuery(ctx, tx, analyticsquery.Query{
+			Entity:   "deals-by-stage",
+			Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll}},
+		}, analyticsquery.DefaultFloor)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(twin.Rows) != len(got.Rows) {
+		t.Errorf("the tool served %d rows and the HTTP engine %d — one engine, two answers",
+			len(got.Rows), len(twin.Rows))
+	}
+	if twin.SchemaVersion != got.SchemaVersion {
+		t.Errorf("schema versions differ: tool %q, engine %q", got.SchemaVersion, twin.SchemaVersion)
+	}
+}
+
+// An argument key the engine does not serve is refused by name, not dropped.
+func TestTheAnalyticsToolRefusesAnUnservedArgument(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+	if _, err := run(ctx, json.RawMessage(
+		`{"entity":"deals-by-stage","measures":[{"fn":"count"}],"as_of":"2024-01-01"}`)); err == nil {
+		t.Fatal("an argument this engine does not serve was silently dropped — the caller " +
+			"asked for a historical answer and would have been served the current one")
+	}
+}
+
+// Exactly one JSON value: trailing content is a caller who thinks they sent
+// something this never read.
+func TestTheAnalyticsToolRefusesTrailingContent(t *testing.T) {
+	e := integration.Setup(t)
+	run := analyticsQueryToolRunner(e.DB(), analyticsquery.DefaultFloor)
+	if _, err := run(e.Admin(), json.RawMessage(
+		`{"entity":"deals-by-stage","measures":[{"fn":"count"}]} {"save":true}`)); err == nil {
+		t.Fatal("trailing content after the arguments was silently ignored")
+	}
+}

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -63,7 +63,10 @@ import (
 // otherwise costs.
 func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
 	return map[string]string{
-		"run_report":               `{"report":"deals-by-stage"}`,
+		"run_report": `{"report":"deals-by-stage"}`,
+		// The typed analytics engine reads the same native tables run_report
+		// does; a well-formed plan is enough, the guard lands first.
+		"run_analytics_query":      `{"entity":"deals-by-stage","measures":[{"fn":"count"}]}`,
 		"catch_me_up_on":           fmt.Sprintf(`{"record_type":"person","record_id":%q}`, anchor),
 		"prep_for_meeting":         fmt.Sprintf(`{"record_type":"person","record_id":%q}`, anchor),
 		"whats_slipping_this_week": `{}`,

--- a/backend/internal/compose/mcpresources.go
+++ b/backend/internal/compose/mcpresources.go
@@ -75,6 +75,7 @@ func mcpResourceProviders(capabilities mcp.ResourceProvider, vocabulary mcp.Reso
 		agents.RecordFieldsResource{},
 		agents.NewReportVocabularyResource(reportToolCatalog()),
 		agents.NewReportBlocksResource(reportBlockGrammar()),
+		analyticsSchemaResource{},
 	}
 	// views is nil for a role that composes none — a worker, or an api whose
 	// connector gate is off. composeResources drops it, which is the same

--- a/backend/internal/compose/mcpresources_test.go
+++ b/backend/internal/compose/mcpresources_test.go
@@ -197,6 +197,7 @@ func TestARoleWithNoViewProviderComposesTheRestAndServesIt(t *testing.T) {
 		agents.CapabilitiesURI,
 		agents.ReportVocabularyURI,
 		agents.ReportBlocksURI,
+		AnalyticsSchemaURI,
 	}
 	if len(published) != len(want) {
 		t.Fatalf("the composed surface published %v, want exactly %v", published, want)

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -45,6 +45,22 @@ import (
 // read cannot be handed to one. A mode read that fails propagates, so an
 // unresolved mode refuses the call rather than defaulting to native.
 
+// nativeOnlyAnalyticsRunner guards run_analytics_query, for the report
+// guard's reason: the typed engine reads native tables an overlay workspace
+// has no rows in.
+func nativeOnlyAnalyticsRunner(mode overlayModeChecker, run agents.AnalyticsQueryRunner) agents.AnalyticsQueryRunner {
+	return func(ctx context.Context, query json.RawMessage) (json.RawMessage, error) {
+		overlay, err := mode.isOverlayUncached(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if overlay {
+			return nil, apperrors.ErrUnsupportedBySoR
+		}
+		return run(ctx, query)
+	}
+}
+
 // nativeOnlyReportRunner guards run_report. The spec names this capability
 // as one an incumbent has no analogue for, so the refusal is the declared
 // answer, not a degradation.

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -199,8 +199,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// vocabulary is published at margince://schema/analytics rather than
 	// recited in the tool schema, the same move run_report made.
 	agents.RegisterAnalyticsQueryTool(registry,
-		nativeOnlyAnalyticsRunner(sorMode,
-			analyticsQueryToolRunner(InstallationDB(pool), analyticsquery.DefaultFloor)))
+		nativeOnlyAnalyticsRunner(sorMode, analyticsQueryToolRunner(InstallationDB(pool))))
 	// The grammar that document is written in, as a TOOL and not only as the
 	// margince://schema/report-blocks resource — same reason
 	// describe_report_vocabulary exists beside run_report: the Surface-B runner

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -193,6 +193,14 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	// a model asking on their behalf may not see either.
 	agents.RegisterAnalyticsReportTool(registry,
 		analyticsReportComposer(pool, analyticsquery.DefaultFloor))
+	// The typed analytics query, through the SAME engine POST /analytics/query
+	// calls: one compiler, one derived per-caller schema, one floor, one run
+	// store — so a tool and a screen cannot disagree about one aggregate. Its
+	// vocabulary is published at margince://schema/analytics rather than
+	// recited in the tool schema, the same move run_report made.
+	agents.RegisterAnalyticsQueryTool(registry,
+		nativeOnlyAnalyticsRunner(sorMode,
+			analyticsQueryToolRunner(InstallationDB(pool), analyticsquery.DefaultFloor)))
 	// The grammar that document is written in, as a TOOL and not only as the
 	// margince://schema/report-blocks resource — same reason
 	// describe_report_vocabulary exists beside run_report: the Surface-B runner

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -411,41 +412,14 @@ func aggregateSelect(spec reportSpec, agg reportAggregate) (name, sel string, er
 		if !ok {
 			return "", "", &FieldNotAllowedError{Field: agg.Field, Slot: slotAggregates, Allowed: allowedReportNames(spec.measures)}
 		}
-		// NULL below the sample floor rather than a number.
-		//
-		// A median over three deals is not a median: it is one deal's value
-		// wearing a statistic's name, and a manager comparing "typical stage
-		// age" across teams would read the smallest team's outlier as its
-		// norm. Postgres will happily compute it, which is exactly why the
-		// refusal has to be written here.
-		//
-		// NULL rather than an error, because the ROW is still a real answer —
-		// the count beside it says how many deals there were, and a reader
-		// seeing a blank with n=3 has learned something true. Failing the whole
-		// report would take away the counts as well.
-		return name, fmt.Sprintf(
-			"(CASE WHEN count(%s) >= %d THEN percentile_cont(%s) WITHIN GROUP (ORDER BY %s) END) AS %s",
-			expr, percentileSampleFloor, percentileFor(agg.Fn), expr, quoteIdent(name)), nil
+		// One renderer for both engines: the fraction, the CASE shape and the
+		// sample floor live in analyticsquery.PercentileExpr, so the screen
+		// and the typed query cannot drift apart about what a median is.
+		return name, analyticsquery.PercentileExpr(expr, analyticsquery.AggFn(agg.Fn)) +
+			" AS " + quoteIdent(name), nil
 	default:
 		return "", "", &FieldNotAllowedError{Field: "fn=" + agg.Fn}
 	}
-}
-
-// percentileSampleFloor is how many values a percentile needs before it means
-// anything.
-//
-// Five, and the number is a judgement rather than a derivation: below it a
-// "typical" value is one or two deals, and the whole use of a median here is
-// comparing groups whose sizes differ. A floor of one would make every group
-// comparable and every small group wrong.
-const percentileSampleFloor = 5
-
-// percentileFor is the fraction each named aggregate asks for.
-func percentileFor(fn string) string {
-	if fn == aggFnP75 {
-		return "0.75"
-	}
-	return "0.5"
 }
 
 var errUnknownEntity = errors.New("compose: entity outside the schema descriptors")

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/compose/analyticsquery"
-
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -463,17 +461,4 @@ func aggregateFunctionsInSource(t *testing.T) []string {
 	})
 	slices.Sort(out)
 	return out
-}
-
-// The two engines hold one percentile floor. The report engine and the typed
-// query compiler both answer "typical days in stage"; a different threshold on
-// either side would make a screen and a tool disagree about the same team's
-// week, each blaming the other's blank.
-func TestBothEnginesShareOnePercentileFloor(t *testing.T) {
-	t.Parallel()
-	if percentileSampleFloor != analyticsquery.PercentileSampleFloor {
-		t.Errorf("the report engine withholds a percentile below %d values and the "+
-			"typed compiler below %d — one question, two answers",
-			percentileSampleFloor, analyticsquery.PercentileSampleFloor)
-	}
 }

--- a/backend/internal/compose/reportcatalog_test.go
+++ b/backend/internal/compose/reportcatalog_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
@@ -461,4 +463,17 @@ func aggregateFunctionsInSource(t *testing.T) []string {
 	})
 	slices.Sort(out)
 	return out
+}
+
+// The two engines hold one percentile floor. The report engine and the typed
+// query compiler both answer "typical days in stage"; a different threshold on
+// either side would make a screen and a tool disagree about the same team's
+// week, each blaming the other's blank.
+func TestBothEnginesShareOnePercentileFloor(t *testing.T) {
+	t.Parallel()
+	if percentileSampleFloor != analyticsquery.PercentileSampleFloor {
+		t.Errorf("the report engine withholds a percentile below %d values and the "+
+			"typed compiler below %d — one question, two answers",
+			percentileSampleFloor, analyticsquery.PercentileSampleFloor)
+	}
 }

--- a/backend/internal/compose/samplefloor_integration_test.go
+++ b/backend/internal/compose/samplefloor_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 )
 
@@ -64,7 +65,7 @@ func TestAPercentileBelowTheSampleFloorIsBlankRatherThanWrong(t *testing.T) {
 		}
 		var median *float64
 		var count int64
-		query := `SELECT (CASE WHEN count(d.days) >= ` + strconv.Itoa(percentileSampleFloor) +
+		query := `SELECT (CASE WHEN count(d.days) >= ` + strconv.Itoa(analyticsquery.PercentileSampleFloor) +
 			` THEN percentile_cont(0.5) WITHIN GROUP (ORDER BY d.days) END),
 			         count(d.days)
 			  FROM (VALUES ` + holders + `) AS d(days)`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -877,7 +877,9 @@ const (
 	AnalyticsCount         AnalyticsMeasureFn = "count"
 	AnalyticsCountDistinct AnalyticsMeasureFn = "count_distinct"
 	AnalyticsMax           AnalyticsMeasureFn = "max"
+	AnalyticsMedian        AnalyticsMeasureFn = "median"
 	AnalyticsMin           AnalyticsMeasureFn = "min"
+	AnalyticsP75           AnalyticsMeasureFn = "p75"
 	AnalyticsSum           AnalyticsMeasureFn = "sum"
 )
 
@@ -892,7 +894,11 @@ func (e AnalyticsMeasureFn) Valid() bool {
 		return true
 	case AnalyticsMax:
 		return true
+	case AnalyticsMedian:
+		return true
 	case AnalyticsMin:
+		return true
+	case AnalyticsP75:
 		return true
 	case AnalyticsSum:
 		return true
@@ -16794,11 +16800,11 @@ type AnalyticsMeasure struct {
 	// Field What to aggregate. Required for every fn but `count`.
 	Field *string `json:"field,omitempty"`
 
-	// Fn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+	// Fn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
 	Fn AnalyticsMeasureFn `json:"fn"`
 }
 
-// AnalyticsMeasureFn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+// AnalyticsMeasureFn The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
 type AnalyticsMeasureFn string
 
 // AnalyticsQuery One question, in the vocabulary the schema returned.

--- a/backend/internal/modules/agents/commandreport.go
+++ b/backend/internal/modules/agents/commandreport.go
@@ -88,3 +88,34 @@ func (composeReportResolver) Subject(_ context.Context, cmd ComposeReportCommand
 func (composeReportResolver) Guards(_ context.Context, _ ComposeReportCommand) error {
 	return nil
 }
+
+// AnalyticsQueryCommand is one typed analytics run, whichever door asked for
+// it. The ENTITY is the whole of it: the plan narrows what is counted, and the
+// engine — not this seam — owns what a population admits.
+type AnalyticsQueryCommand struct {
+	Entity string
+}
+
+// NewAnalyticsQueryCall binds one analytics run to the resolver that answers
+// for it. It holds no dependency: an aggregate names no record at all.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewAnalyticsQueryCall(cmd AnalyticsQueryCommand) GovernedCall {
+	return bind[AnalyticsQueryCommand](analyticsQueryResolver{}, cmd)
+}
+
+type analyticsQueryResolver struct{}
+
+// Subject names NO record, for runReportResolver's reason: an aggregate over
+// rows the caller's own scope bounds has no row an approval could bind to.
+// The population name is the one fact that says what is being released.
+func (analyticsQueryResolver) Subject(_ context.Context, cmd AnalyticsQueryCommand) (StageInfo, error) {
+	return StageInfo{Summary: fmt.Sprintf("Run an analytics query over %s", cmd.Entity)}, nil
+}
+
+// Guards stands down, for runReportResolver's reason: the vocabulary is the
+// engine's derived schema, and a name outside it is refused at execution with
+// the allowed set in hand.
+func (analyticsQueryResolver) Guards(_ context.Context, _ AnalyticsQueryCommand) error {
+	return nil
+}

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -179,6 +179,7 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, nil })
 	RegisterReportTool(r, nil, probeReportCatalog, probeReportPlan)
 	RegisterAnalyticsReportTool(r, nil)
+	RegisterAnalyticsQueryTool(r, nil)
 	RegisterReportBlocksTool(r, NewReportBlocksResource(BlockGrammar{}))
 	RegisterForecastTool(r, nil)
 	RegisterMovementTool(r, nil)

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -244,6 +244,9 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterAnalyticsReportTool(r, func(context.Context, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached
 	})
+	RegisterAnalyticsQueryTool(r, func(context.Context, json.RawMessage) (json.RawMessage, error) {
+		return nil, errSeamReached
+	})
 	RegisterReportBlocksTool(r, NewReportBlocksResource(BlockGrammar{}))
 	RegisterForecastTool(r, func(context.Context, ForecastRequest) (json.RawMessage, error) {
 		return nil, errSeamReached

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -9015,6 +9015,122 @@
       "warnings"
     ]
   },
+  "run_analytics_query": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "string"
+          },
+          "total_safe": {
+            "type": "boolean"
+          },
+          "withheld": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "schema_version",
+          "total_safe",
+          "withheld"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "run_report": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/toolcopy_analytics.go
+++ b/backend/internal/modules/agents/toolcopy_analytics.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Written copy for the typed analytics query. See toolcopy.go for what each
+// field answers.
+//
+// The VOCABULARY is deliberately not here: the populations and their fields
+// are derived per caller — a masked field is indistinguishable from one that
+// does not exist — so the tool names margince://schema/analytics instead of
+// carrying a list that would be wrong for somebody. The refusal path makes
+// that safe: an unknown name is refused by name with the allowed set.
+var runAnalyticsQueryCopy = toolCopy{
+	Purpose: "Compute a grouped aggregate — counts, sums, averages, medians — over a " +
+		"governed population, in the database. The answer carries its columns, rows and " +
+		"schema version; groups too small to disclose are withheld, never estimated.",
+	Limits: "Populations, dimensions and measures come from margince://schema/analytics, " +
+		"derived for this seat; a name outside it is refused with what would work. Money " +
+		"measures are minor units. An omitted scope is this seat's own default population, " +
+		"never the workspace.",
+	Instead: "run_report answers a prebuilt report by key; query_workspace lists exact " +
+		"records; the forecast tools answer forecast readings and movement. This one is for " +
+		"a novel aggregate no prebuilt report shapes.",
+	Retain: "Set save to get a run_id whose cells compose_analytics_report can cite; " +
+		"without it the answer is served once and not stored.",
+}

--- a/backend/internal/modules/agents/toolcopy_analyticsreport.go
+++ b/backend/internal/modules/agents/toolcopy_analyticsreport.go
@@ -27,7 +27,7 @@ var composeAnalyticsReportCopy = toolCopy{
 		"literal is what renders, the two can disagree, and no reader could tell the page " +
 		"shows a figure the database never computed. Save a run first — run an analytics " +
 		"query with save, and cite the run id it answers with.",
-	Instead: "Ask analytics_query for one number when a figure is what is wanted. This " +
+	Instead: "Ask run_analytics_query for one number when a figure is what is wanted. This " +
 		"composes a DOCUMENT of several, which is worth the round trip only when the answer " +
 		"is a report somebody reads. describe_report_blocks holds the block kinds and their " +
 		"fields for a caller that wants them before composing.",

--- a/backend/internal/modules/agents/tools_analytics.go
+++ b/backend/internal/modules/agents/tools_analytics.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// AnalyticsQueryRunner executes one typed analytics question. The module owns
+// no SQL and no metric arithmetic: the query arrives as the wire shape, the
+// engine validates it against the caller's derived schema, and what comes back
+// is the contract-shaped answer.
+type AnalyticsQueryRunner func(ctx context.Context, query json.RawMessage) (json.RawMessage, error)
+
+// RegisterAnalyticsQueryTool adds run_analytics_query. The runner is always
+// wired — the typed engine ships in every composition — so unlike the
+// conditional registrations there is no absent-capability branch here.
+func RegisterAnalyticsQueryTool(r *Registry, run AnalyticsQueryRunner) {
+	r.Register(runAnalyticsQuery{run: run})
+}
+
+type runAnalyticsQuery struct {
+	run AnalyticsQueryRunner
+}
+
+func (t runAnalyticsQuery) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "run_analytics_query", Title: "Run an analytics query", Version: toolVersionV1,
+		Description:   runAnalyticsQueryCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "runAnalyticsQuery",
+		// The population/field vocabulary is NOT re-declared here — it is
+		// derived per caller and published at margince://schema/analytics; a
+		// second copy in this schema would be wrong for somebody.
+		InputSchema: schema(`{"type":"object","required":["entity","measures"],"properties":{
+			"entity":{"type":"string","description":"A population from margince://schema/analytics. An unknown name is refused with the allowed set."},
+			"group_by":{"type":"array","items":{"type":"string"}},
+			"measures":{"type":"array","items":{"type":"object","required":["fn"],"properties":{
+				"fn":{"enum":["count","count_distinct","sum","avg","min","max","median","p75"]},
+				"field":{"type":"string","description":"A measure name. Omit only with fn=count."},
+				"as":{"type":"string"}},"additionalProperties":false}},
+			"filters":{"type":"array","items":{"type":"object","required":["field","op"],"properties":{
+				"field":{"type":"string"},
+				"op":{"enum":["eq","ne","lt","lte","gt","gte","is_null","is_not_null"]},
+				"value":{}},"additionalProperties":false}},
+			"limit":{"type":"integer"},
+			"save":{"type":"boolean","description":"Persist the run; the answer then carries a citable run_id."},
+			"scope_kind":{"enum":["workspace","team","owner"],"description":"Omit for this seat's own default population."},
+			"scope_id":{"type":"string"}},
+			"additionalProperties":false}`),
+		OutputSchema: schemaFor[AnalyticsQueryResult](),
+	}
+}
+
+// AnalyticsQueryResult is the tool's answer shape.
+type AnalyticsQueryResult struct {
+	Columns []string `json:"columns"`
+	// Rows are aggregate rows whose members ARE the columns above; their
+	// shape is the plan's, which is why nothing is declared about them here.
+	Rows []json.RawMessage `json:"rows"`
+	// Withheld says the privacy floor kept something back. A boolean and
+	// never a count, like every other withheld flag on this surface.
+	Withheld bool `json:"withheld"`
+	// TotalSafe says whether a total over these rows may be shown; false once
+	// anything is withheld, because total-minus-shown is the subtraction the
+	// floor exists to stop.
+	TotalSafe     bool   `json:"total_safe"`
+	SchemaVersion string `json:"schema_version"`
+	// RunID names the saved run, present exactly when save was set.
+	RunID *string `json:"run_id,omitempty"`
+}
+
+func (t runAnalyticsQuery) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	noteDerivedContent(ctx)
+	// Forwarded verbatim: the engine validates the vocabulary, and a second
+	// check here would be a second answer to what is askable.
+	return t.run(ctx, in)
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,11 +4,11 @@
   "per_agent_listing_budget": 17408,
   "whole_catalog_floor": 21504,
   "catalog": {
-    "tools": 72,
+    "tools": 73,
     "system_frame_tokens": 353,
-    "tokens": 21018,
-    "median_tool_tokens": 262,
-    "mean_tool_tokens": 291
+    "tokens": 21485,
+    "median_tool_tokens": 263,
+    "mean_tool_tokens": 293
   },
   "agents": [
     {
@@ -107,6 +107,10 @@
       "tokens": 484
     },
     {
+      "name": "run_analytics_query",
+      "tokens": 465
+    },
+    {
       "name": "advance_deal",
       "tokens": 443
     },
@@ -140,7 +144,7 @@
     },
     {
       "name": "compose_analytics_report",
-      "tokens": 389
+      "tokens": 390
     },
     {
       "name": "search_records",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 6% | 15774 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2467 | 10% | 14941 | 15 | 8 |
-| _whole served catalog, for scale_ | 72 | 21018 | 85% | — | — | — |
+| _whole served catalog, for scale_ | 73 | 21485 | 87% | — | — | — |
 
 ### `morning_brief`
 
@@ -129,7 +129,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 262 tokens, mean 291, across 72 served tools.
+Median 263 tokens, mean 293, across 73 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -147,6 +147,7 @@ a term in an addition.
 | `list_records` | 508 | — |
 | `resolve_entities` | 498 | — |
 | `query_workspace` | 484 | 3 scenarios |
+| `run_analytics_query` | 465 | — |
 | `advance_deal` | 443 | 1 scenario |
 | `send_message` | 431 | — |
 | `annotate_brief` | 418 | — |
@@ -155,7 +156,7 @@ a term in an addition.
 | `create_record` | 398 | 1 scenario |
 | `book_meeting` | 393 | — |
 | `enrich` | 393 | — |
-| `compose_analytics_report` | 389 | — |
+| `compose_analytics_report` | 390 | — |
 | `search_records` | 385 | 6 scenarios |
 | `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -155,6 +155,7 @@ Columns:
 | `relink_thread` | dynamic | `write` | — | Native activity-link write, carrying no mode guard — see the note below |
 | `remove_tag` | 🟢 | `write` | — | Takes a tag off a record; native, for the reason `apply_tag` gives |
 | `review_commitments` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): the mirror holds no task projection |
+| `run_analytics_query` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): the typed engine reads native tables |
 | `run_report` | 🟢 | `read` | — | `unsupported_by_sor` (no incumbent analogue) |
 | `compose_analytics_report` | 🟢 | `read` | — | Renders a document whose every figure cites a saved analytics run; it writes no number of its own and stores nothing |
 | `forecast_readings` | 🟢 | `read` | — | Reads deals, stages and the installation's fiscal settings, so it answers only where those live |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 72,
-    "resources": 11,
-    "tool_catalog_bytes": 204944,
-    "resource_catalog_bytes": 4251,
-    "approx_wire_tokens_total": 52298,
+    "tools": 73,
+    "resources": 12,
+    "tool_catalog_bytes": 208212,
+    "resource_catalog_bytes": 4584,
+    "approx_wire_tokens_total": 53199,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 49898,
-      "input_schema_bytes": 41840,
-      "output_schema_bytes": 97659,
-      "description_plus_input_schema_bytes": 91738
+      "description_bytes": 50780,
+      "input_schema_bytes": 42930,
+      "output_schema_bytes": 98750,
+      "description_plus_input_schema_bytes": 93710
     }
   },
   "tools": {
@@ -2015,7 +2015,7 @@
           "readOnlyHint": true,
           "title": "Compose an analytics report"
         },
-        "description": "Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -11406,6 +11406,230 @@
         "annotations": {
           "openWorldHint": false,
           "readOnlyHint": true,
+          "title": "Run an analytics query"
+        },
+        "description": "Compute a grouped aggregate — counts, sums, averages, medians — over a governed population, in the database. The answer carries its columns, rows and schema version; groups too small to disclose are withheld, never estimated. Populations, dimensions and measures come from margince://schema/analytics, derived for this seat; a name outside it is refused with what would work. Money measures are minor units. An omitted scope is this seat's own default population, never the workspace. run_report answers a prebuilt report by key; query_workspace lists exact records; the forecast tools answer forecast readings and movement. This one is for a novel aggregate no prebuilt report shapes. Set save to get a run_id whose cells compose_analytics_report can cite; without it the answer is served once and not stored. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "entity": {
+              "description": "A population from margince://schema/analytics. An unknown name is refused with the allowed set.",
+              "type": "string"
+            },
+            "filters": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "op": {
+                    "enum": [
+                      "eq",
+                      "ne",
+                      "lt",
+                      "lte",
+                      "gt",
+                      "gte",
+                      "is_null",
+                      "is_not_null"
+                    ]
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "field",
+                  "op"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "group_by": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "limit": {
+              "type": "integer"
+            },
+            "measures": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "as": {
+                    "type": "string"
+                  },
+                  "field": {
+                    "description": "A measure name. Omit only with fn=count.",
+                    "type": "string"
+                  },
+                  "fn": {
+                    "enum": [
+                      "count",
+                      "count_distinct",
+                      "sum",
+                      "avg",
+                      "min",
+                      "max",
+                      "median",
+                      "p75"
+                    ]
+                  }
+                },
+                "required": [
+                  "fn"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "save": {
+              "description": "Persist the run; the answer then carries a citable run_id.",
+              "type": "boolean"
+            },
+            "scope_id": {
+              "type": "string"
+            },
+            "scope_kind": {
+              "description": "Omit for this seat's own default population.",
+              "enum": [
+                "workspace",
+                "team",
+                "owner"
+              ]
+            }
+          },
+          "required": [
+            "entity",
+            "measures"
+          ],
+          "type": "object"
+        },
+        "name": "run_analytics_query",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "columns": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rows": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "run_id": {
+                  "type": "string"
+                },
+                "schema_version": {
+                  "type": "string"
+                },
+                "total_safe": {
+                  "type": "boolean"
+                },
+                "withheld": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "columns",
+                "rows",
+                "schema_version",
+                "total_safe",
+                "withheld"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Run an analytics query"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
           "title": "Run a report"
         },
         "description": "Answer a question about totals, counts or breakdowns — pipeline by stage, deals won by owner, activity volume over time — by running one of this workspace's prebuilt reports. Only the named reports exist, each with its own filter, grouping and measure names; anything else is refused. It aggregates: how many and how much, never which record. Use search_records or whats_slipping_this_week when the answer wanted is the records themselves rather than a number over them. Call a report with no plan first to see its default answer, then narrow with the names its catalog entry lists. (Governance: runs immediately; requires passport scope \"read\".)",
@@ -13401,6 +13625,13 @@
         "uri": "margince://schema/report-blocks"
       },
       {
+        "description": "The populations a run_analytics_query plan may name, each with its group_by dimensions and its measures, derived for this seat. run_analytics_query names this document instead of carrying it.",
+        "mimeType": "text/plain",
+        "name": "analytics-schema",
+        "title": "Analytics query vocabulary",
+        "uri": "margince://schema/analytics"
+      },
+      {
         "_meta": {
           "ui": {
             "csp": {
@@ -13516,7 +13747,8 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":72,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"compose_analytics_report\",\"create_record\",\"create_tag\",\"create_task\",\"data_coverage\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"describe_report_blocks\",\"describe_report_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\",\"merge_tags\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":73,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"compose_analytics_report\",\"create_record\",\"create_tag\",\"create_task\",\"data_coverage\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"describe_report_blocks\",\"describe_report_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_analytics_query\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\",\"merge_tags\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://schema/analytics": "schema version 246ea65901f0ba2b\naggregates: avg, count, count_distinct, max, median, min, p75, sum\nfilter ops: eq, gt, gte, is_not_null, is_null, lt, lte, ne\n\nactivities-by-kind\n  group by: direction, kind\n  measure:  \ndeals-by-stage\n  group by: currency, partner_org_id, pipeline_id, stage_id, status, win_probability\n  measure:  amount_minor, weighted_amount_minor\nforecast\n  group by: currency, forecast_category, owner_id, partner_org_id, pipeline_id, stage_id, win_probability\n  measure:  amount_base_minor, amount_minor, weighted_amount_minor, weighted_base_minor\nleads-by-status\n  group by: owner_id, source, status\n  measure:  \nopen-deals-per-company\n  group by: currency, organization_id, owner_id\n  measure:  amount_minor\npipeline-current\n  group by: currency, owner_id, partner_org_id, pipeline_id, stage_id\n  measure:  amount_base_minor, weighted_base_minor\nproject-commitments\n  group by: key, name, organization_id, owner_id, phase, project_id\n  measure:  \nprojects-by-phase\n  group by: organization_id, owner_id, phase\n  measure:  \nprojects-gone-quiet\n  group by: key, last_activity_at, name, organization_id, owner_id, phase, project_id, quiet_since\n  measure:  \nstage-age\n  group by: owner_id, pipeline_id, stage_id\n  measure:  days_in_stage\nwin-loss\n  group by: currency, organization_id, owner_id, period_month, period_quarter, period_year, pipeline_id, source, status\n  measure:  amount_base_minor, amount_minor, days_to_close\n",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, counterparty_person_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\"|\\\"works_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "margince://schema/report-blocks": "{\"version\":\"1\",\"notation\":\"A block carries STRUCTURE and WORDS; a figure is named, never written. Every number cites a saved run and a cell inside it, and the server resolves that citation under the reading caller's own authority. A block carrying a literal number is refused EVEN WHEN a valid citation sits beside it: the literal is what would render, the two can disagree, and no reader could tell the page shows a figure the database never computed.\",\"blocks\":[{\"kind\":\"title\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"subtitle\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"scope\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"generated_at\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"summary\",\"takes_cells\":true,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"methodology\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"follow_ups\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"stat_strip\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"bar\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"waterfall\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"ranked_list\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"record_table\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"callout\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":true},{\"kind\":\"evidence_drawer\",\"takes_cells\":true,\"takes_text\":true,\"takes_severity\":false}],\"severities\":[\"note\",\"warning\",\"partial\",\"unknown\",\"unsupported\"]}",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 72 |
-| Resources | 11 |
-| Tool catalog | 200.1 KB |
-| Resource catalog | 4.2 KB |
-| Approx. wire tokens | 52298 |
+| Tools | 73 |
+| Resources | 12 |
+| Tool catalog | 203.3 KB |
+| Resource catalog | 4.5 KB |
+| Approx. wire tokens | 53199 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 95.4 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 48.7 KB | 24% | Yes, every step |
-| Input schemas | 40.9 KB | 20% | Yes, every step |
-| _Names, annotations, punctuation_ | 15.2 KB | 7% | Partly |
-| **Description + input schema** | **89.6 KB** | **44%** | **the recurring cost** |
+| Output schemas | 96.4 KB | 47% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 49.6 KB | 24% | Yes, every step |
+| Input schemas | 41.9 KB | 20% | Yes, every step |
+| _Names, annotations, punctuation_ | 15.4 KB | 7% | Partly |
+| **Description + input schema** | **91.5 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -45,13 +45,14 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 ## Index
 
-### Resources (11)
+### Resources (12)
 
 - [`margince://capabilities`](#capabilities) — What this installation can do
 - [`margince://schema/query`](#query_vocabulary) — Workspace query vocabulary
 - [`margince://schema/record-fields`](#record_fields) — Record write vocabulary
 - [`margince://schema/reports`](#report_vocabulary) — Report plan vocabulary
 - [`margince://schema/report-blocks`](#report_blocks) — Report block grammar
+- [`margince://schema/analytics`](#analytics-schema) — Analytics query vocabulary
 - [`ui://margince/account-brief.html`](#account_brief_view) — Morning brief
 - [`ui://margince/relationship-map.html`](#relationship_map_view) — Who knows this contact
 - [`ui://margince/commitments.html`](#commitments_view) — Open commitments
@@ -59,7 +60,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 - [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (72)
+### Tools (73)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -124,6 +125,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
 | [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 3.4 KB |
+| [`run_analytics_query`](#run_analytics_query) | Run an analytics query | yes |  | 3.2 KB |
 | [`run_report`](#run_report) | Run a report | yes |  | 5.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
@@ -181,6 +183,14 @@ What each prebuilt report accepts in a run_report plan: the names its group_by, 
 **Report block grammar**
 
 The blocks a report may carry: each kind, whether it renders figures, words or both, and the severities a callout may state. compose_analytics_report names this document instead of carrying it.
+
+### analytics-schema
+
+`margince://schema/analytics` · text/plain
+
+**Analytics query vocabulary**
+
+The populations a run_analytics_query plan may name, each with its group_by dimensions and its measures, derived for this seat. run_analytics_query names this document instead of carrying it.
 
 ### account_brief_view
 
@@ -2437,7 +2447,7 @@ Write a checked import into the workspace, once a person approves. Only from awa
 
 **Compose an analytics report**
 
-Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
+Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask run_analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 
@@ -12210,6 +12220,240 @@ Renders its result in [`ui://margince/commitments.html`](#commitments_view), vis
       "required": [
         "as_of",
         "commitments"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### run_analytics_query
+
+**Run an analytics query**
+
+Compute a grouped aggregate — counts, sums, averages, medians — over a governed population, in the database. The answer carries its columns, rows and schema version; groups too small to disclose are withheld, never estimated. Populations, dimensions and measures come from margince://schema/analytics, derived for this seat; a name outside it is refused with what would work. Money measures are minor units. An omitted scope is this seat's own default population, never the workspace. run_report answers a prebuilt report by key; query_workspace lists exact records; the forecast tools answer forecast readings and movement. This one is for a novel aggregate no prebuilt report shapes. Set save to get a run_id whose cells compose_analytics_report can cite; without it the answer is served once and not stored. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "entity": {
+      "description": "A population from margince://schema/analytics. An unknown name is refused with the allowed set.",
+      "type": "string"
+    },
+    "filters": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "enum": [
+              "eq",
+              "ne",
+              "lt",
+              "lte",
+              "gt",
+              "gte",
+              "is_null",
+              "is_not_null"
+            ]
+          },
+          "value": {}
+        },
+        "required": [
+          "field",
+          "op"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "group_by": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "measures": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "as": {
+            "type": "string"
+          },
+          "field": {
+            "description": "A measure name. Omit only with fn=count.",
+            "type": "string"
+          },
+          "fn": {
+            "enum": [
+              "count",
+              "count_distinct",
+              "sum",
+              "avg",
+              "min",
+              "max",
+              "median",
+              "p75"
+            ]
+          }
+        },
+        "required": [
+          "fn"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "save": {
+      "description": "Persist the run; the answer then carries a citable run_id.",
+      "type": "boolean"
+    },
+    "scope_id": {
+      "type": "string"
+    },
+    "scope_kind": {
+      "description": "Omit for this seat's own default population.",
+      "enum": [
+        "workspace",
+        "team",
+        "owner"
+      ]
+    }
+  },
+  "required": [
+    "entity",
+    "measures"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rows": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        },
+        "total_safe": {
+          "type": "boolean"
+        },
+        "withheld": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "columns",
+        "rows",
+        "schema_version",
+        "total_safe",
+        "withheld"
       ],
       "type": "object"
     },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24280,10 +24280,10 @@ export interface components {
         };
         AnalyticsMeasure: {
             /**
-             * @description The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population.
+             * @description The aggregate. `count` counts ROWS and takes no field; `count_distinct` counts values and skips nulls. The two differ on an unpriced deal, so naming the wrong one reports a column's coverage as its population. `median` and `p75` answer null below a five-value sample floor: a percentile over three deals is one deal's value wearing a statistic's name, and the count beside the blank still says how many there were.
              * @enum {string}
              */
-            fn: "count" | "count_distinct" | "sum" | "avg" | "min" | "max";
+            fn: "count" | "count_distinct" | "sum" | "avg" | "min" | "max" | "median" | "p75";
             /** @description What to aggregate. Required for every fn but `count`. */
             field?: string;
             /** @description The caller's name for the result column. It never reaches the statement — results map by position — so it cannot carry anything into SQL. */


### PR DESCRIPTION
`run_analytics_query` joins the MCP surface over the SAME engine `POST /analytics/query` calls: one compiler, one per-caller derived schema, one privacy floor, one run store — a tool and a screen cannot disagree about one aggregate. Its vocabulary is not recited in the tool schema: populations and fields differ per seat, so they live in the per-caller `margince://schema/analytics` resource, the move run_report made for its catalog (#3950). With `save` the answer carries a `run_id` that `compose_analytics_report` can cite, closing the dangling `analytics_query` reference its copy has carried since it shipped.

The served catalog renders 21485 tokens of the 21504 certification floor. Rides along: the overlay native-only guard (enrolled in the overlay tool-surface census), an approvals-staging command for the POST route, the tier catalog row, and the stale 'NOT an agent tool yet (~87%)' contract comments rewritten to what is now true.

Integration proof: the tool's answer equals the HTTP engine's for the same question (rows, schema version); an unserved argument (`as_of`) is refused by name rather than dropped; trailing JSON content is refused (Codex review finding, fixed); the overlay workspace refuses the verb with `unsupported_by_sor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `run_analytics_query`, an agent tool that runs the same analytics engine as `POST /analytics/query`, so a tool and the screen cannot disagree about a number. Previously agents could only run prebuilt reports; now a novel aggregate can be asked directly.

**New Features**
- Vocabulary is served per seat in `margince://schema/analytics` rather than recited in the tool schema.
- Setting `save` returns a `run_id` that `compose_analytics_report` can cite, replacing the dangling `analytics_query` reference.
- `median` and `p75` aggregates are now offered, replying `NULL` below a five‑value sample floor.

**Refactors**
- Percentile rendering is unified into one `PercentileExpr` used by both the report engine and the typed compiler.
- The overlay native‑only guard now covers `run_analytics_query` with `unsupported_by_sor`.
- The `POST /analytics/query` approvals‑staging command and tier catalog entry were added.

<sup>Written for commit 6a4d5656a08e69a33771fe88692494da00095420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

