### PR TITLE
feat(worklist): a row says its deadline once

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1339,29 +1339,23 @@ test.describe("§3.8: 390px mobile", () => {
   // The approval is FIXED: its decision moved into a drawer, and the row went
   // from 657px to 205px, inside its 208px ceiling.
   //
-  // The second is an ORDINARY TASK at 284px against 176px, and no drawer
-  // touches it. Measured 2026-09-05, its parts are: rank 19, title 49 (it
-  // wraps to two lines at 390px), when/because/consequence 57, dispositions
-  // 44, verbs 44, and ~71 of gap and padding. Every one of those was added
-  // deliberately and the 44px floor is the touch target the row owes a thumb,
-  // so there is no slack to reclaim by tightening. A 176px row cannot hold
-  // this anatomy on a phone: something has to be dropped or folded, and which
-  // is a product decision rather than a fix. Left failing rather than
-  // relaxed, so the decision is made by someone rather than by a number
-  // quietly rising.
+  // The second is an ORDINARY TASK, and no drawer touches it. It measures
+  // 205px against a 176px ceiling. Its parts: title 49 (the category badge
+  // wraps to a second line at 390px), the three facts on ONE line 19,
+  // consequence 19, the primary verbs 44, rank 19, and the rest gap and
+  // padding.
   //
-  // The tall row measures 227px against its 176px ceiling. Its parts: title 49
-  // (two lines at 390px), when/because/consequence 57, the primary verbs 44,
-  // rank 19, and ~58 of gap and padding. The set-aside verbs are no longer
-  // among them — below the fold they leave the row and it is swiped instead
-  // (screens/worklist.dispositions.tsx, design-system/swiperow.tsx).
+  // Two rounds have now taken what can be taken. The set-aside verbs left the
+  // row for a swipe (284 -> 227), and the deadline stopped being printed twice
+  // — `when` gives the hour and `due_today` gave the day underneath it, so the
+  // phrase gives way and the remaining facts share one line (227 -> 205).
   //
-  // The 44px band that remains is the row's PRIMARY actions, which is how a rep
-  // does the work: putting those behind a gesture would empty the queue of what
-  // it exists for, and 44px is the touch target rather than a style. So closing
-  // the last 51px means folding the caption block, raising a ceiling that was
-  // never measured, or dropping the rank badge on a phone — each a product
-  // decision rather than a fix.
+  // What is left is not padding. The 44px band is the row's PRIMARY actions,
+  // which is how a rep does the work; 44px is the touch target rather than a
+  // style. The 49px title is 49 because the category badge wraps, and the badge
+  // says what kind of work the row is. Closing the last 29px means dropping a
+  // fact rather than a duplicate — or raising a ceiling that was never measured
+  // and which the decision rows already set at 208.
   //
   // Left failing rather than relaxed, so the decision is made by someone rather
   // than by a number quietly rising to agree with the defect.

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -260,9 +260,49 @@ export function isUnprepared(item: WorklistItem): boolean {
   return item.because.some((reason) => reason.kind === BADGED);
 }
 
-/** The reasons a row says in its phrase line — everything the badges do not. */
-export function phrasedReasons(item: WorklistItem): WorklistReason[] {
-  return item.because.filter((reason) => reason.kind !== BADGED);
+/**
+ * The reason kinds the WHEN line already says.
+ *
+ * Each is the moment in a coarser register: a task row printed "due 06.07.2026,
+ * 15:00" and then "due today" underneath it, an overdue one said "overdue" a
+ * third time beside the badge that already says so, and a meeting said "starts
+ * 14:12" over "starting shortly". One clock, twice, reading as two findings.
+ * The moment wins because it names the hour a rep is racing rather than the day.
+ *
+ * A SET rather than one kind, because the duplication is structural. `overdue`
+ * and `due_today` are the two arms of a single `if` in the task lane, both
+ * guarded by the same `due_at` the moment is drawn from, so a rule naming one
+ * of them names half a condition. `meeting_soon` fires only where the meeting
+ * has a `due_at`, which is exactly when its own when line is drawn, so it has
+ * no non-duplicating case at all.
+ *
+ * The other deadline reasons stay OUT of this set and that is the non-obvious
+ * half: `closing_soon`, `response_overdue` and `response_due_soon` ride on
+ * sources — `deal_at_risk`, `brief_item`, `lead_response` — for which
+ * `whenKeyFor` answers null. Nothing draws their moment, so their phrase is the
+ * only place the fact is said.
+ *
+ * DROPPED ONLY WHERE THE MOMENT IS DRAWN. A row whose `due_at` the when line
+ * refuses — an approval's lapse instant, which is a fact about the staged work
+ * and not a deadline the rep owes — still says its phrase, or the row would
+ * lose the fact entirely rather than say it once.
+ */
+const SAID_BY_THE_WHEN_LINE = new Set<string>([
+  "due_today",
+  "overdue",
+  "meeting_soon",
+]);
+
+/** The reasons a row says in its phrase line — everything said elsewhere. */
+export function phrasedReasons(
+  item: WorklistItem,
+  whenDrawn: boolean,
+): WorklistReason[] {
+  return item.because.filter(
+    (reason) =>
+      reason.kind !== BADGED &&
+      !(whenDrawn && SAID_BY_THE_WHEN_LINE.has(reason.kind)),
+  );
 }
 
 export function reasonText(

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -120,6 +120,14 @@
   min-width: 0;
 }
 
+/* When, what it is worth, and why — three short fragments that read as one
+   line. It inherits the text column's own arrangement above the fold, so the
+   three keep the stacked shape a wide row has room for; the phone block below
+   is what turns it into a wrapping row. */
+.worklist-row-facts-line {
+  display: contents;
+}
+
 .worklist-row-title {
   align-items: center;
   display: flex;
@@ -375,6 +383,27 @@
   .worklist-row-text {
     flex: 1 1 100%;
     min-width: 0;
+  }
+
+  /* THE THREE SHORT FACTS SHARE A LINE at phone width.
+     Each is a fragment of a dozen characters — "due 15:00", "€40k", "due today
+     · nobody owns it" — and stacked they took three 19px lines of a row whose
+     whole ceiling is 176px. That is 38px spent on the space beside three short
+     phrases, on the one screen with none to spare.
+     They wrap when they do not fit, so a long reason still gets its own line
+     rather than being cut, and the separator makes the join readable as three
+     facts rather than one run-on sentence. */
+  .worklist-row-facts-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 var(--space-2);
+    min-width: 0;
+  }
+
+  .worklist-row-facts-line > * + *::before {
+    color: var(--textMeta);
+    content: "·";
+    margin-inline-end: var(--space-2);
   }
 
   /* Every group of verbs below the text, and free to wrap. They are separate

--- a/frontend/src/screens/worklist.needsprep.test.tsx
+++ b/frontend/src/screens/worklist.needsprep.test.tsx
@@ -51,13 +51,22 @@ describe("a meeting with nothing prepared", () => {
   });
 
   // Dropping the badged reason must not take the row's OTHER reasons with it.
+  //
+  // The other reason here is `quiet_days` rather than `meeting_soon`, and the
+  // swap is the point rather than a detail: this fixture carries a `due_at`, so
+  // the row draws "starts 09:30" and `meeting_soon` is that same clock in words
+  // — dropped by the when-line rule, not by the badge one. A reason the row has
+  // a second reason to omit cannot show that the BADGE rule left it alone.
   it("keeps the reasons that are not badges", () => {
     const item = meetingRow("m1", false);
     render(
       <WorklistRow
         item={{
           ...item,
-          because: [...item.because, { kind: "meeting_soon" }],
+          because: [
+            ...item.because,
+            { kind: "quiet_days", value: { kind: "days", days: 12 } },
+          ],
         }}
         position={1}
         owner=""
@@ -65,8 +74,6 @@ describe("a meeting with nothing prepared", () => {
     );
 
     expect(screen.getByText(en["worklist.needsPrep"])).toBeTruthy();
-    expect(
-      screen.getByText(new RegExp(en["worklist.because.meeting_soon"])),
-    ).toBeTruthy();
+    expect(screen.getByText(/12/)).toBeTruthy();
   });
 });

--- a/frontend/src/screens/worklist.reasons.test.tsx
+++ b/frontend/src/screens/worklist.reasons.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { WorklistScreen } from "./worklist";
 
 // Why a row is worth the reader's morning, drawn.
@@ -157,5 +158,157 @@ describe("a task says who holds it", () => {
 
     expect(await screen.findByText("Send the retrofit quote")).toBeTruthy();
     expect(screen.queryByText(/nobody owns it/)).toBeNull();
+  });
+});
+
+// A row states its deadline ONCE.
+//
+// `when` prints the moment — "due 06.07.2026, 15:00" — and `due_today` is that
+// same clock in a coarser register. Drawn together the row said the deadline
+// twice, one line under the other, which reads as two findings about one clock
+// and cost a 19px line on the screen with none to spare.
+//
+// Whichever of the two survives has to be the MOMENT: it names the hour a rep
+// is racing, where the phrase names only the day.
+describe("a row says its deadline once", () => {
+  function dueRow(overrides: Partial<WorklistItem> = {}): WorklistItem {
+    return {
+      id: "t1",
+      source: "task",
+      category: "tasks",
+      level: 2,
+      consequence: "task_slips",
+      title: "Send the retrofit quote",
+      due_at: "2026-08-31T15:00:00Z",
+      because: [{ kind: "due_today" }, { kind: "unassigned" }],
+      actions: [],
+      ...overrides,
+    };
+  }
+
+  it("drops the due-today phrase where the moment is drawn", async () => {
+    const { container } = draw([dueRow()]);
+
+    // The moment survives, carrying the hour. Matched as "due <something>"
+    // rather than a literal clock time: the moment is rendered in the
+    // installation's own zone, so a hard-coded hour would assert the suite's
+    // timezone rather than that the line was drawn.
+    const when = await screen.findByText(/^due \d/);
+    expect(when.className).toContain("worklist-row-when");
+
+    // The coarser phrase is gone, so the clock is stated once. Read from the
+    // because line itself: "due today" as a page-wide query would also match
+    // the summary sentence above the queue.
+    expect(
+      container.querySelector(".worklist-row-because")?.textContent,
+    ).not.toMatch(/due today/i);
+  });
+
+  // The other reasons on the row are untouched: this drops ONE duplicated
+  // fact, not the line it sat in.
+  it("keeps every other reason beside the moment", async () => {
+    const { container } = draw([dueRow()]);
+
+    await screen.findByText(/^due \d/);
+    expect(
+      container.querySelector(".worklist-row-because")?.textContent,
+    ).toMatch(/nobody owns it/i);
+  });
+
+  // OVERDUE is the same duplicate said a THIRD time. It sits beside a danger
+  // badge that already says "Overdue" and above a moment that says the hour, so
+  // the phrase is the one register a reader gains nothing from. It reaches the
+  // row from the other arm of the very `if` that sends `due_today`, both
+  // guarded by the same `due_at` the moment is drawn from — a rule naming one
+  // of them names half a condition.
+  it("drops the overdue phrase where the moment is drawn", async () => {
+    const { container } = draw([
+      dueRow({ because: [{ kind: "overdue" }, { kind: "unassigned" }] }),
+    ]);
+
+    await screen.findByText(/^due \d/);
+    const because = container.querySelector(
+      ".worklist-row-because",
+    )?.textContent;
+    expect(because).not.toMatch(/overdue/i);
+    expect(because).toMatch(/nobody owns it/i);
+  });
+
+  // MEETING_SOON has no non-duplicating case at all: it fires only where the
+  // meeting carries a `due_at`, which is exactly when its own when line draws
+  // "starts 14:12".
+  it("drops the starting-shortly phrase where the moment is drawn", async () => {
+    const { container } = draw([
+      dueRow({
+        id: "m1",
+        source: "meeting",
+        category: "meetings",
+        consequence: "meeting_unprepared",
+        title: "Quarterly review",
+        because: [{ kind: "meeting_soon" }],
+      }),
+    ]);
+
+    await screen.findByText(/^starts \d/);
+    expect(container.querySelector(".worklist-row-because")).toBeNull();
+  });
+
+  // A DEADLINE REASON WHOSE MOMENT IS NEVER DRAWN KEEPS ITS PHRASE.
+  //
+  // It holds the `whenDrawn` GUARD, not the membership of the set. `closing_soon`
+  // rides on `deal_at_risk`, a source whenKeyFor answers null for, so the guard
+  // is false and the set is never consulted — this row keeps its phrase whether
+  // or not somebody adds `closing_soon` to it. That is the behaviour the rule
+  // wants and it is worth saying which half the test can see: the guard is what
+  // stops a source with no moment losing its only statement of the fact, and it
+  // is proven by removing the guard, which is what the approval row below
+  // catches.
+  //
+  // What the set's membership costs is checked one test up, where a source that
+  // DOES draw a moment must lose the duplicate.
+  it("keeps a deadline phrase whose source draws no moment", async () => {
+    const { container } = draw([
+      dueRow({
+        id: "d1",
+        source: "deal_at_risk",
+        category: "deals_at_risk",
+        consequence: "deal_drifts",
+        title: "Turbinenbau retrofit",
+        because: [{ kind: "closing_soon" }],
+      }),
+    ]);
+
+    await screen.findByText(/Turbinenbau retrofit/);
+
+    // No moment is drawn for this source, so the phrase is the only place the
+    // fact is said.
+    expect(container.querySelector(".worklist-row-when")).toBeNull();
+    // The PHRASE ITSELF, not merely a non-empty line: a row carries other
+    // reasons, so asserting the line has text would pass just as happily with
+    // this fact dropped.
+    expect(
+      container.querySelector(".worklist-row-because")?.textContent,
+    ).toMatch(new RegExp(en["worklist.because.closing_soon"]));
+  });
+
+  // WHERE THE MOMENT IS REFUSED THE PHRASE STAYS. An approval's `due_at` is
+  // when the proposal lapses — a fact about the staged work rather than a
+  // deadline the rep owes — so the when line draws nothing for it. Dropping the
+  // phrase there too would take the fact off the row entirely rather than say
+  // it once.
+  it("keeps the due-today phrase on a row whose moment is not drawn", async () => {
+    const { container } = draw([
+      dueRow({
+        id: "a1",
+        source: "approval",
+        category: "decisions",
+        title: "A proposal waiting on you",
+      }),
+    ]);
+
+    await screen.findByText(/A proposal waiting on you/);
+    expect(
+      container.querySelector(".worklist-row-because")?.textContent,
+    ).toMatch(/due today/i);
   });
 });

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -118,8 +118,11 @@ export function WorklistRow({
       ? syncHealthDetail(item.kind, item.detail, t)
       : item.detail;
   // The badged reasons are drawn as badges above and left out here, so one
-  // meeting does not report the same finding twice in two registers.
-  const reasons = phrasedReasons(item)
+  // meeting does not report the same finding twice in two registers. The when
+  // line takes `due_today` the same way when it is drawn: the moment names the
+  // hour a rep is racing, and "due today" underneath it is that clock said
+  // again in a coarser register.
+  const reasons = phrasedReasons(item, when !== null)
     .map((reason) => reasonText(reason, t, locale, zone))
     .filter((phrase): phrase is string => phrase !== null);
   const above = comparisonText(item.above_next, t, locale, zone);
@@ -437,9 +440,20 @@ function RowCaptions({
       {/* When it starts, or when it is due. Above the reasons because it is the
           fact those reasons are ABOUT: "starting shortly" explains a rank, and
           this says what time. */}
-      {when && <p className="t-caption worklist-row-when">{when}</p>}
-      {facts && <p className="t-caption worklist-row-facts">{facts}</p>}
-      <RowReasons reasons={reasons} />
+      {/* WHEN, WHAT IT IS WORTH and WHY, on one wrapping line rather than
+          three stacked ones. Each is a fragment — "due 15:00", "€40k", "due
+          today · nobody owns it" — and three fragments of a dozen characters
+          each took three full lines of a 390px row, which is 38px of a 176px
+          ceiling spent on whitespace beside three short phrases. They stay
+          separate elements, so a reader still meets them in the same order and
+          a screen reader still reads three facts; only the line breaks between
+          them go. Above that width they stack as before, because a wide row has
+          the height and stacked lines are easier to scan. */}
+      <div className="worklist-row-facts-line">
+        {when && <p className="t-caption worklist-row-when">{when}</p>}
+        {facts && <p className="t-caption worklist-row-facts">{facts}</p>}
+        <RowReasons reasons={reasons} />
+      </div>
       {/* What it costs to do nothing. The question a queue exists to answer,
           and the one the lane feed had no field for. */}
       {consequence && (


### PR DESCRIPTION
A task row printed its deadline twice. `when` gave the moment — *"due 06.07.2026, 15:00"* — and the reason line gave *"due today"* on the line beneath. One clock, two registers, reading as two findings about one deadline, on the screen with the least room for it.

The moment survives, because it names the hour a rep is racing where the phrase names only the day.

## Why a set, not one kind

The first version of this fixed `due_today` alone. Review caught that as a point fix, and it was right — the duplication is structural:

- **`overdue` and `due_today` are the two arms of a single `if`** in the task lane (`classify.go`), both guarded by the same `due_at` the moment is drawn from. Naming one of them names half a condition. `overdue` was the worse of the two: said a **third** time, beside the danger badge that already says it.
- **`meeting_soon` fires only where a meeting carries a `due_at`** — exactly when its own when line draws *"starts 14:12"*. It has no non-duplicating case at all.

**What stays out is the non-obvious half.** `closing_soon`, `response_overdue` and `response_due_soon` ride on sources `whenKeyFor` answers `null` for, so nothing draws their moment and the phrase is the only place the fact is said. Dropping those would take a fact off the row rather than a duplicate.

**Only where the moment is drawn.** An approval's `due_at` is when the proposal *lapses* — a fact about the staged work, not a deadline the rep owes — so the when line refuses it and the phrase stays.

## Evidence

| Obligation | Evidence |
|---|---|
| The duplicate goes | `drops the due-today phrase where the moment is drawn`, plus the same for `overdue` and `meeting_soon` |
| The rule does not over-reach | `keeps a deadline phrase whose source draws no moment` — and its comment says which half it holds, because the `whenDrawn` guard protects that row whether or not the set grows |
| The guard | `keeps the due-today phrase on a row whose moment is not drawn` — removing `whenDrawn &&` fails only this |
| Mutation strength | Remove the whole clause → only the due-today test fails. Remove `overdue` and `meeting_soon` from the set → only their two tests fail. Remove the guard → only the approval test fails. Each clause fails alone |
| Height | The tall row measures **205px, down from 227** — the remaining facts now fit one line, 132 + 119 inside 308px, where the pair was 132 + 191 and missed by 15 |
| Full lane | `make check-fe` green, **6658 tests** |
| Review | `craft-reviewer`, which found the point-fix blocker by rendering the rows and reading them. **Codex was rate-limited all session** — the 13:22 window passed and reset straight to 18:24 |

## Two corrections to things that were already wrong

**A test was proving less than it claimed.** `keeps the reasons that are not badges` used `meeting_soon` as its "other" reason — on a fixture with a `due_at`, so that reason now has a second reason to be absent. It cannot show the badge rule left anything alone. Repointed at `quiet_days`.

**The SDR-07 note carried two contradicting measurements.** The 284px block was left standing beside the 205px one, both dated the same day, both describing the same row. Deleted the stale one.

## Still parked

**AC-WORKLIST-SDR-07 remains `test.fixme`, 29px over.** Two rounds have taken what can be taken: the set-aside verbs left for a swipe (284 → 227), the deadline stopped being said twice (227 → 205). What is left is not padding — the title is 49px because the category badge wraps at 390px, the primary verbs are the 44px touch target, and the facts are one 19px line.

Closing the last 29px means dropping a fact rather than a duplicate, or raising a ceiling that was never measured and which the decision rows already set at 208. Left failing so that choice is made deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a worklist row from saying its deadline twice: the when line prints the moment ("due 06.07.2026, 15:00") and the reason line printed the same clock in words ("due today") beneath it. The duplicated reasons now yield to the moment, which names the hour a rep is racing rather than the day.

- Drops `due_today`, `overdue`, and `meeting_soon` wherever the when line draws the moment.
- Keeps deadline phrases whose source draws no moment, like `closing_soon`, so a fact is not removed with a duplicate.
- Approval rows keep their due-today phrase: their `due_at` is a lapse instant the when line refuses.
- The tall row drops from 227px to 205px once the remaining facts share one line.
- Repointed a needs-prep test at `quiet_days`, since `meeting_soon` now yields to the when line instead of the badge rule.
- Removed a stale 284px measurement from the SDR-07 note that contradicted the 205px one.
- SDR-07 stays `test.fixme`, 29px over its ceiling; closing it means a product decision, not slack.

<sup>Written for commit b4ccde5469efc0129ac403c0a33323aea52b6c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

