### PR TITLE
fix: small independent QC batch — tag retire+recoin, held-thread anchor, captured-thread visibility, priced-deals count

### DIFF
--- a/backend/internal/compose/integration/capture/capture_posture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_posture_integration_test.go
@@ -149,6 +149,51 @@ func TestASharedMailboxBirthsAMessageOpen(t *testing.T) {
 	}
 }
 
+// TestAnOwnerHoldOnAMessageBornOpenStillShowsItsEvidence is margince#4183: a
+// thread a SHARED mailbox births open never runs EnsureTx, so its ledger row
+// (if one exists at all) starts with no first_activity_id — and DecideAsOwner
+// used to leave it that way. heldthreadslist's existence check joins on that
+// column, so an owner who held such a thread was told their own intact
+// message had been erased.
+func TestAnOwnerHoldOnAMessageBornOpenStillShowsItsEvidence(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	allowSharedPosture(t, e)
+	setPosture(t, env, e.Rep1, capturemod.PostureShared)
+
+	sync(t, customerMail("owner-hold-open-1@acme.example"))
+	activityID := oneActivityID(t, e)
+	var threadKey string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, activityID).Scan(&threadKey)
+	}); err != nil {
+		t.Fatalf("reading the thread to hold: %v", err)
+	}
+
+	// The hold path, not the share one: this thread never went through
+	// EnsureTx (a shared mailbox births its messages open, with no verdict
+	// row at all), so DecideAsOwner is the row's very first writer.
+	if _, err := compose.NewThreadAudienceSetter(e.Pool).Decide(sharingContext(e, e.Rep1), threadKey, false); err != nil {
+		t.Fatalf("holding the thread as its owner: %v", err)
+	}
+
+	held, err := capturemod.HeldThreadsFor(seatContext(e, e.Rep1), e.DB())
+	if err != nil {
+		t.Fatalf("listing held threads: %v", err)
+	}
+	if len(held) != 1 {
+		t.Fatalf("want exactly one held thread, got %d", len(held))
+	}
+	if !held[0].HasActivity {
+		t.Fatalf("an owner's hold on a message born open reads HasActivity=false, " +
+			"want true: the message is intact, only its ledger row was")
+	}
+	if held[0].ActivityID == nil || *held[0].ActivityID != activityID {
+		t.Fatalf("held thread activity id = %v, want %s", held[0].ActivityID, activityID)
+	}
+}
+
 func TestTheWorkspaceFloorOutranksASharedMailbox(t *testing.T) {
 	env := newCaptureEnv(t)
 	e, sync := env.e, env.sync

--- a/backend/internal/modules/capture/threadownerdecision.go
+++ b/backend/internal/modules/capture/threadownerdecision.go
@@ -47,21 +47,31 @@ func (s *ThreadVerdictStore) DecideAsOwner(
 	if share {
 		status = VerdictSharedByOwner
 	}
+	// A thread this call opens fresh (never through EnsureTx — a message born
+	// open under a `shared` mailbox never did) needs an anchor of its own, or
+	// heldthreadslist's existence check has nothing to join against and reports
+	// an intact message as erased. The earliest of the seat's own live
+	// messages in the thread, the same messages ThreadActivityIDsTx names.
+	anchor, err := firstThreadActivityTx(ctx, tx, threadKey, actor.UserID)
+	if err != nil {
+		return err
+	}
 	// Upserted, because a thread the owner decides about may have no ledger row
 	// at all: a message born open under a `shared` mailbox never opened a
 	// question, and its owner may still want it held.
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO capture_thread_verdict
-		  (thread_key, user_id, status, disposition_reason, resolved_at, next_attempt_at)
-		VALUES ($1, $2, $3, $4, now(), NULL)
+		  (thread_key, user_id, first_activity_id, status, disposition_reason, resolved_at, next_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, now(), NULL)
 		ON CONFLICT (thread_key, user_id) DO UPDATE
-		   SET status = EXCLUDED.status,
+		   SET first_activity_id = coalesce(capture_thread_verdict.first_activity_id, EXCLUDED.first_activity_id),
+		       status = EXCLUDED.status,
 		       disposition_reason = EXCLUDED.disposition_reason,
 		       resolved_at = now(),
 		       next_attempt_at = NULL,
 		       claimed_by = NULL, claimed_until = NULL,
 		       updated_at = now()`,
-		threadKey, actor.UserID, status, ownerDecisionReason); err != nil {
+		threadKey, actor.UserID, anchor, status, ownerDecisionReason); err != nil {
 		return fmt.Errorf("capture: recording the owner's decision about a thread: %w", err)
 	}
 	// The seat's own import rows for the thread, which is what the audience
@@ -89,6 +99,26 @@ func (s *ThreadVerdictStore) DecideAsOwner(
 // ownerDecisionReason marks a ledger row a person settled, so a reader can tell
 // it from one a classifier reached.
 const ownerDecisionReason = "owner_decision"
+
+// firstThreadActivityTx names the earliest of the seat's own live messages in
+// a thread, for a ledger row that needs an anchor and does not have one yet.
+// Built over ThreadActivityIDsTx rather than a hand-rolled query: it already
+// reads exactly this seat's own thread and ids sort chronologically (ids.UUID
+// is a v7). The store re-derives its own answer rather than trusting a
+// caller's — DecideAsOwner's one caller happens to have already run this same
+// read, but a store that assumed so would break the day a second caller did
+// not. A thread with nothing to anchor to answers nil rather than the zero
+// UUID, which heldthreadslist reads as "no message" if it were ever written.
+func firstThreadActivityTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) (*ids.UUID, error) {
+	activityIDs, err := ThreadActivityIDsTx(ctx, tx, threadKey, user)
+	if err != nil {
+		return nil, err
+	}
+	if len(activityIDs) == 0 {
+		return nil, nil //nolint:nilnil // deliberate: no message to anchor to is not an error
+	}
+	return &activityIDs[0], nil
+}
 
 // ThreadActivityIDsTx lists the messages of one thread this seat imported.
 //

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3319,6 +3319,7 @@ export const de = {
   "analytics.count": "Deals",
   "analytics.unweighted": "Ungewichtet",
   "analytics.weighted": "Gewichtet",
+  "analytics.priced": "{priced} von {total} bepreist",
   "analytics.planNote":
     "der ausgeführte Plan und die Zeilen, auf die sich die Zahl zurückrechnet",
   "analytics.reportDeals": "Offene Pipeline nach Phase",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3386,6 +3386,7 @@ export const en = {
   "analytics.count": "Deals",
   "analytics.unweighted": "Unweighted",
   "analytics.weighted": "Weighted",
+  "analytics.priced": "{priced} of {total} priced",
   "analytics.planNote":
     "the executed plan and the rows this number reconciles to",
   "analytics.reportDeals": "Open pipeline by stage",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3286,6 +3286,7 @@ export const vi = {
   "analytics.count": "Deal",
   "analytics.unweighted": "Chưa trọng số",
   "analytics.weighted": "Có trọng số",
+  "analytics.priced": "{priced}/{total} đã định giá",
   "analytics.planNote":
     "kế hoạch đã chạy và những dòng mà con số này đối chiếu về",
   "analytics.reportDeals": "Pipeline đang mở theo giai đoạn",

--- a/frontend/src/screens/analytics.css
+++ b/frontend/src/screens/analytics.css
@@ -13,3 +13,12 @@
      on its own line rather than letting the strip scroll away from it. */
   flex-wrap: wrap;
 }
+
+/* A money cell that also carries the priced-of-total footnote: stacked rather
+   than inline, or the two texts run together with no space between them
+   (`.t-caption`/`.t-mono` are typography-only, and a table cell does not
+   stack its children on its own). */
+.analytics-money-cell {
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -1048,6 +1048,24 @@ describe("reports never sum money across currencies", () => {
     expect(row.pricedDeals).toBe(1);
   });
 
+  // A row that omits priced_deals answers "the server did not say", not "zero
+  // deals were priced" — folding the two together would print a claim nobody
+  // made.
+  it("answers null rather than zero when a stage row omits priced_deals", () => {
+    const [row] = buildStageAggregates(
+      [
+        {
+          stage_id: "pl-s1",
+          raw_minor: 100,
+          weighted_minor: 90,
+          deal_count: 2,
+        },
+      ],
+      STAGES,
+    );
+    expect(row.pricedDeals).toBeNull();
+  });
+
   it("shows a stage row's money is short a deal the rate sheet cannot price", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1069,6 +1087,26 @@ describe("reports never sum money across currencies", () => {
     expect(
       screen.getByText((text) => text.includes("1 of 2 priced")),
     ).toBeTruthy();
+  });
+
+  it("shows no priced footnote when the row omits priced_deals entirely", async () => {
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        stageRows: [
+          {
+            stage_id: "pl-s1",
+            raw_minor: 100,
+            weighted_minor: 90,
+            deal_count: 2,
+          },
+        ],
+      }),
+    );
+    render(<AnalyticsScreen />);
+    await openPipeline();
+    await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
+    expect(screen.queryByText((text) => text.includes("priced"))).toBeNull();
   });
 
   it("shows no priced footnote once every counted deal was priced", async () => {

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -868,6 +868,7 @@ describe("reports never sum money across currencies", () => {
       { fn: "sum", field: "amount_base_minor", as: "raw_minor" },
       { fn: "sum", field: "weighted_base_minor", as: "weighted_minor" },
       { fn: "count", as: "deal_count" },
+      { fn: "count", field: "amount_base_minor", as: "priced_deals" },
     ]);
   });
 
@@ -1028,6 +1029,69 @@ describe("reports never sum money across currencies", () => {
     expect(row.count).toBe(3);
   });
 
+  // priced_deals answers how many of `deal_count` the sums above actually
+  // cover — a deal in a currency the rate sheet cannot price is counted but
+  // priced nowhere in either total (margince#4201).
+  it("carries how many of a stage's deals the money actually covers", () => {
+    const [row] = buildStageAggregates(
+      [
+        {
+          stage_id: "pl-s1",
+          raw_minor: 100,
+          weighted_minor: 90,
+          deal_count: 2,
+          priced_deals: 1,
+        },
+      ],
+      STAGES,
+    );
+    expect(row.pricedDeals).toBe(1);
+  });
+
+  it("shows a stage row's money is short a deal the rate sheet cannot price", async () => {
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        stageRows: [
+          {
+            stage_id: "pl-s1",
+            raw_minor: 100,
+            weighted_minor: 90,
+            deal_count: 2,
+            priced_deals: 1,
+          },
+        ],
+      }),
+    );
+    render(<AnalyticsScreen />);
+    await openPipeline();
+    await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
+    expect(
+      screen.getByText((text) => text.includes("1 of 2 priced")),
+    ).toBeTruthy();
+  });
+
+  it("shows no priced footnote once every counted deal was priced", async () => {
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        stageRows: [
+          {
+            stage_id: "pl-s1",
+            raw_minor: 100,
+            weighted_minor: 90,
+            deal_count: 2,
+            priced_deals: 2,
+          },
+        ],
+      }),
+    );
+    render(<AnalyticsScreen />);
+    await openPipeline();
+    await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
+    expect(screen.queryByText((text) => text.includes("priced"))).toBeNull();
+  });
+
   // The wire allows a deal to carry no forecast category — nobody has said which
   // way it is going — and the five named categories match none of it. A tile set
   // built from the enum alone drops those deals off the screen entirely: the
@@ -1141,6 +1205,7 @@ describe("reports never sum money across currencies", () => {
             raw_minor: 2_500_000,
             weighted_minor: 250_000,
             deal_count: 2,
+            priced_deals: 1,
           },
         ],
       }),
@@ -1153,6 +1218,11 @@ describe("reports never sum money across currencies", () => {
     ).toBeTruthy();
     // The count rides on the tile's second line beside the weighted figure.
     expect(screen.getByText((text) => text.includes("Deals: 2"))).toBeTruthy();
+    // The priced count reaches the screen too (margince#4201) — without it
+    // the €2,500,000 total reads as covering both deals when it covers one.
+    expect(
+      screen.getByText((text) => text.includes("1 of 2 priced")),
+    ).toBeTruthy();
   });
 
   // An installation whose deals are all categorised should not be shown an empty

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -70,6 +70,9 @@ type StageAgg = {
   count: number;
   rawMinor: number | null;
   weightedMinor: number | null;
+  // How many of `count` the two sums above cover — a deal in a currency the
+  // rate sheet cannot price is counted but priced nowhere in the money.
+  pricedDeals: number;
 };
 
 type ReportKey =
@@ -226,6 +229,24 @@ function rowCount(row: ReportRow, key: string): number {
   return Number(row[key] ?? 0);
 }
 
+// The footnote for a money figure a currency the rate sheet cannot price left
+// short. Null when every counted deal was priced, which is the common case and
+// not worth a caption nobody needs to read.
+function pricedFootnote(
+  pricedDeals: number,
+  total: number,
+  locale: Locale,
+  t: ReturnType<typeof useT>,
+): string | null {
+  if (pricedDeals >= total) {
+    return null;
+  }
+  return t("analytics.priced", {
+    priced: formatNumber(pricedDeals, locale),
+    total: formatNumber(total, locale),
+  });
+}
+
 // A report's own name, spelled once: the segment picker and the heading of the
 // card that segment opens read the same key, so the tab and the surface behind
 // it cannot drift into two names for one report.
@@ -260,11 +281,17 @@ const REPORT_AGGREGATES: Record<ReportKey, ReportAggregate[]> = {
     { fn: "sum", field: "amount_base_minor", as: "raw_minor" },
     { fn: "sum", field: "weighted_base_minor", as: "weighted_minor" },
     { fn: "count", as: "deal_count" },
+    // How many of deal_count the sums above actually cover — a deal in a
+    // currency the rate sheet cannot price is counted but contributes nothing
+    // to either total, so a row printing only the money reads as complete when
+    // it is short (margince#4201).
+    { fn: "count", field: "amount_base_minor", as: "priced_deals" },
   ],
   forecast: [
     { fn: "sum", field: "amount_base_minor", as: "raw_minor" },
     { fn: "sum", field: "weighted_base_minor", as: "weighted_minor" },
     { fn: "count", as: "deal_count" },
+    { fn: "count", field: "amount_base_minor", as: "priced_deals" },
   ],
   "open-deals-per-company": [
     { fn: "sum", field: "amount_minor", as: "raw_minor" },
@@ -332,6 +359,7 @@ export function ForecastTile({
   amountMinor,
   weightedMinor,
   dealCount,
+  pricedDeals,
   currency,
   locale,
 }: Readonly<{
@@ -349,6 +377,10 @@ export function ForecastTile({
   // worth less than it is, with nothing on screen to suggest otherwise.
   // Optional: a caller with no count to hand shows none rather than a zero.
   dealCount?: number | null;
+  // How many of `dealCount` the money above actually covers (margince#4201).
+  // Optional and paired with dealCount: a caller with no count has nothing
+  // this could qualify either.
+  pricedDeals?: number | null;
   currency: string | null;
   locale: Locale;
 }>) {
@@ -359,7 +391,7 @@ export function ForecastTile({
       numeric
       value={formatMoneyOrAbsent(amountMinor, currency, locale)}
       detail={forecastTileDetail(
-        { weightedMinor, dealCount, currency, locale },
+        { weightedMinor, dealCount, pricedDeals, currency, locale },
         t,
       )}
     />
@@ -373,11 +405,13 @@ function forecastTileDetail(
   {
     weightedMinor,
     dealCount,
+    pricedDeals,
     currency,
     locale,
   }: Readonly<{
     weightedMinor?: number | null;
     dealCount?: number | null;
+    pricedDeals?: number | null;
     currency: string | null;
     locale: Locale;
   }>,
@@ -391,6 +425,12 @@ function forecastTileDetail(
   }
   if (dealCount != null) {
     parts.push(`${t("analytics.count")}: ${formatNumber(dealCount, locale)}`);
+  }
+  if (dealCount != null && pricedDeals != null) {
+    const footnote = pricedFootnote(pricedDeals, dealCount, locale, t);
+    if (footnote) {
+      parts.push(footnote);
+    }
   }
   return parts.length > 0 ? parts.join(" · ") : undefined;
 }
@@ -456,6 +496,7 @@ function ForecastStrip({
                   amountMinor={row ? rowMoney(row, "raw_minor") : null}
                   weightedMinor={row ? rowMoney(row, "weighted_minor") : null}
                   dealCount={row ? rowCount(row, "deal_count") : null}
+                  pricedDeals={row ? rowCount(row, "priced_deals") : null}
                   currency={baseCurrency}
                   locale={locale}
                 />
@@ -615,6 +656,7 @@ export function buildStageAggregates(
           // (weighted_amount_minor), never round(rawMinor × p / 100)
           // — that rounds the column sum once instead of every deal.
           weightedMinor: rowMoney(row, "weighted_minor"),
+          pricedDeals: rowCount(row, "priced_deals"),
         };
       })
       // Stage position alone orders the ladder now. The old tiebreak on currency
@@ -674,11 +716,22 @@ function StageTable({
         {
           key: "raw",
           header: t("analytics.unweighted"),
-          render: (row: StageAgg) => (
-            <span className="t-mono">
-              {formatMoneyOrAbsent(row.rawMinor, baseCurrency, locale)}
-            </span>
-          ),
+          render: (row: StageAgg) => {
+            const footnote = pricedFootnote(
+              row.pricedDeals,
+              row.count,
+              locale,
+              t,
+            );
+            return (
+              <span className="t-mono analytics-money-cell">
+                {formatMoneyOrAbsent(row.rawMinor, baseCurrency, locale)}
+                {footnote && (
+                  <span className="t-caption t-mono">{footnote}</span>
+                )}
+              </span>
+            );
+          },
         },
         {
           key: "weighted",

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -72,7 +72,10 @@ type StageAgg = {
   weightedMinor: number | null;
   // How many of `count` the two sums above cover — a deal in a currency the
   // rate sheet cannot price is counted but priced nowhere in the money.
-  pricedDeals: number;
+  // Null, not zero, when the server left the aggregate out of the row: that
+  // is "we do not know", and folding it into 0 would print "0 of 2 priced"
+  // for a stage nobody actually finished pricing.
+  pricedDeals: number | null;
 };
 
 type ReportKey =
@@ -496,7 +499,10 @@ function ForecastStrip({
                   amountMinor={row ? rowMoney(row, "raw_minor") : null}
                   weightedMinor={row ? rowMoney(row, "weighted_minor") : null}
                   dealCount={row ? rowCount(row, "deal_count") : null}
-                  pricedDeals={row ? rowCount(row, "priced_deals") : null}
+                  // Not rowCount: an absent aggregate here means the server
+                  // did not answer, and rowCount's 0 default would print
+                  // that as "0 priced" instead of leaving the detail out.
+                  pricedDeals={row ? rowMoney(row, "priced_deals") : null}
                   currency={baseCurrency}
                   locale={locale}
                 />
@@ -656,7 +662,10 @@ export function buildStageAggregates(
           // (weighted_amount_minor), never round(rawMinor × p / 100)
           // — that rounds the column sum once instead of every deal.
           weightedMinor: rowMoney(row, "weighted_minor"),
-          pricedDeals: rowCount(row, "priced_deals"),
+          // Not rowCount: an absent aggregate here means the server did not
+          // answer the question, and rowCount's 0 default would print that
+          // as an answer.
+          pricedDeals: rowMoney(row, "priced_deals"),
         };
       })
       // Stage position alone orders the ladder now. The old tiebreak on currency
@@ -717,12 +726,10 @@ function StageTable({
           key: "raw",
           header: t("analytics.unweighted"),
           render: (row: StageAgg) => {
-            const footnote = pricedFootnote(
-              row.pricedDeals,
-              row.count,
-              locale,
-              t,
-            );
+            const footnote =
+              row.pricedDeals == null
+                ? null
+                : pricedFootnote(row.pricedDeals, row.count, locale, t);
             return (
               <span className="t-mono analytics-money-cell">
                 {formatMoneyOrAbsent(row.rawMinor, baseCurrency, locale)}

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1956,6 +1956,34 @@ describe("TimelineActions", () => {
     expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
   });
 
+  // A successfully-linked connector message is born `workspace` with no
+  // `audience_reason` at all — decideBirthTx only stamps one when something
+  // holds the row, and limitLinkLessAudience only for a link-less one — yet
+  // the server's own `activityWasImported` test still refuses a direct write
+  // on it, because an import row exists regardless of what it derived. Gating
+  // only on `audience_reason` missed exactly this row: Visibility opened,
+  // took an answer, and the write came back refused with no working control on
+  // the page (margince#4152).
+  it("offers no audience control on a captured message with no audience_reason at all", () => {
+    stubRoutes();
+    render(
+      <TimelineActions
+        activity={{
+          ...activity202,
+          id: "a10",
+          kind: "message",
+          captured_by: "connector:ext:openchannel:1",
+          thread_key: "openchannel:abc",
+          audience_reason: null,
+        }}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
+  });
+
   // `manual` is a HUMAN's own answer, not the system's, so it stays theirs to
   // change. Without this the fix above would read as "any reason at all hides
   // the control", which withholds it from every row somebody has already set.

--- a/frontend/src/screens/timelineactions.tsx
+++ b/frontend/src/screens/timelineactions.tsx
@@ -103,7 +103,8 @@ export function TimelineActions({
           having somewhere better to ask, and the drawer is that.
 
           Every other kind is offered it, and AudienceAction itself withholds
-          it where the server says the audience was derived. That claim used to
+          it where the server says the audience was derived, or where
+          `captured_by` says an import wrote the row at all. That claim used to
           live here as "its audience is never derived", which was false for a
           connector-captured `message` and is the defect this comment now
           records rather than repeats. */}
@@ -185,6 +186,29 @@ export function AudienceAction({
   // derived. The field is withheld with the content, which is why this sits
   // BELOW the withheld guard — above it, a held row would read as editable.
   if (audienceIsDerived(activity)) {
+    return null;
+  }
+  // A row a mailbox or connector imported refuses this write EVEN WHEN
+  // `audience_reason` is empty: a successfully-linked message is born
+  // `workspace` with no reason stamped at all (decideBirthTx only stamps one
+  // for a hold, and limitLinkLessAudience only for a link-less row), yet the
+  // server's own `activityWasImported` test — the one SetAudience runs —
+  // answers yes for it regardless. Offering the button anyway opened this
+  // exact dialog on a captured conversation and had the write refused with no
+  // control on the page able to do what it asked (margince#4152).
+  //
+  // `captured_by`'s own prefix — `connector:<name>:<uuid>`, never
+  // `human:<uuid>` or `agent:<id>` — is a PROXY for "an import row exists",
+  // not the same fact: an importing seat that later deleted their connection
+  // leaves the prefix with no import row behind it, and a sync that declined
+  // to record itself as the importer (mailboxWasARecipientTx false) can leave
+  // a `connector:`-stamped row with none at all. Both hide a control that
+  // would in fact succeed — the safe direction, and cheaper than the
+  // authoritative per-row check (`change_mode`, deliberately not carried on
+  // the list summary — see #4023's own comment) — but it is a known gap, not
+  // an exact mirror. Reading the prefix here is not the guess #4023 removed:
+  // that guess picked between two WRITE ENDPOINTS; this only hides a button.
+  if (activity.captured_by.startsWith("connector:")) {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

Three small, independent fixes from the QC backlog, bundled into one PR per the "group multiple issues -> 1 pr" plan. Two more were dropped from this branch after it was already in flight:

- **margince#3725** landed on `main` as #4312 while this branch was in flight.
- **margince#3756** (`archiveTag` `auto_execute` letting an agent retire+recoin a tag name) was implemented, then **reverted**: CI's `TestConfirmFirstArchivesAreDecidableForEveryTargetArm` caught that moving `archiveTag` to `confirmation_required` directly contradicts Lars's explicit passport-authority ruling (commit `f6de12b1b`, 2026-08-23) — *"if I can do an action as a user then I can do the same via MCP"* — which deliberately took `archive_record` off confirm-first by default and named only `enrich`, `custom_field` and `webhook_subscription` as the exceptions. A human tag-admin can already retire+recoin unaided today with no confirmation, so the QC finding may be working-as-intended rather than a bug. Filed **margince#4347** (`status: needs-decision`) rather than shipping a contract change that fights a recent, deliberate architecture decision. (Codex's review of the implemented version separately caught the replay-scope 500 that change would also have introduced — moot now that it's reverted, but recorded in the issue for whoever picks it up.)

Remaining:

- **margince#4183** — `DecideAsOwner`'s insert never set `first_activity_id`, so a thread whose ledger row it alone created (a message born open under a `shared` mailbox) had nothing for `heldthreadslist`'s existence check to join against, and read as erased. Anchors it to the seat's earliest live message in the thread. New test: `TestAnOwnerHoldOnAMessageBornOpenStillShowsItsEvidence`, mutation-verified.
- **margince#4152** — the Visibility control's dispatch (`audience_reason` alone) missed a connector-captured, successfully-linked message: it's born `workspace` with no reason stamped, yet the server's own `activityWasImported` test still refuses a direct write on it. The control now also hides on `captured_by`'s `connector:` prefix — a documented proxy, not an exact mirror of the backend test. **margince#4332** tracks the residual gap (a rare false-hide edge case, and the deeper product question that a captured non-email message has no audience control anywhere after this fix) and the exact server-computed-boolean fix, per both reviewers' recommendation.
- **margince#4201** — `pipeline-current`/`forecast` compute `priced_deals` server-side (how many of the counted deals the money actually covers) but `analytics.tsx` never asked for it, so a row missing an unpriced currency read as complete. Requested and surfaced as a footnote. **A CSS bug where the footnote fused into the money figure with no separator was caught by review and fixed** (stacked via a new `.analytics-money-cell` flex-column class) — confirmed visually in a live UAT (see below).

## Review

Independently reviewed by both Fable and Codex. Both caught the fused priced-deals footnote (no visual separation) before merge — fixed, confirmed live in Chrome. Both also raised the `archiveTag` change (from different angles: Codex on replay-scope correctness, Fable on the #4023 precedent it partly echoed) — that whole change is now reverted for the deeper architectural reason above, which neither reviewer had visibility into (the passport-authority ruling isn't in the diff they saw).

## Test plan

- [x] `make check-go` — green (build, vet, lint, arch-lint, tests incl. gates, contract drift, composition reproducibility)
- [x] `make check-fe` — green (composed typecheck, ds-gates, drift, lint, unit, build)
- [x] `craft static --strict` — 0 blocker/major/minor on every changed Go file
- [x] Each fix has a new regression test, mutation-verified (reverted the fix, confirmed the test fails with the exact expected error, restored it):
  - `TestAnOwnerHoldOnAMessageBornOpenStillShowsItsEvidence` (margince#4183, real Postgres integration test)
  - Frontend RTL tests for margince#4152 (`compose.test.tsx`) and margince#4201 (`analytics.test.tsx`)
- [x] Live UAT (Chrome, local dev stack): seeded a deal in an unpriced currency (JPY, no seeded FX rate) and confirmed the "N of M priced" footnote renders stacked under the money figure, not fused into it — GIF attached below.
- [x] Based on the last known-good `main` (94ad3039e) — a later merge (#4346, 344fbbd81) went red on its own required checks after landing; not rebasing onto it until that clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RSPfhkYwWQ5yMDQaJz3ao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics now shows priced-deal coverage for forecast tiles and stage-table values, including clear handling when pricing data is unavailable.
  - Added German, English, and Vietnamese translations for new and updated interface text.

- **Bug Fixes**
  - Improved held-thread evidence so captured messages display the correct activity details.
  - Connector-captured messages no longer show an unavailable audience control, while relinking remains accessible.

- **Style**
  - Pricing coverage details now appear beneath the primary monetary value for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->