### PR TITLE
feat(activities): a company meeting asks who was in the room

### DIFF
--- a/frontend/src/design-system/recordpicker.tsx
+++ b/frontend/src/design-system/recordpicker.tsx
@@ -47,6 +47,10 @@ export function RecordPicker({
   const t = useT();
   const [term, setTerm] = useState("");
   const [candidates, setCandidates] = useState<RecordPickerCandidate[]>([]);
+  // Whether the CURRENT term has an answer behind it. An empty candidate list
+  // means two different things without it — nothing matched, or nothing has
+  // been asked yet — and only one of them is worth telling the reader.
+  const [answered, setAnswered] = useState(false);
   // The FAILURE is held, not the sentence it becomes. A search runs inside a
   // debounced effect, and `useT` hands back a fresh closure on every render, so
   // a translator captured in that effect would either put it in the dependency
@@ -89,6 +93,7 @@ export function RecordPicker({
     setSearchSpace(() => searchTargets);
     setCandidates([]);
     setSearchFailure(null);
+    setAnswered(false);
   }
 
   useEffect(() => {
@@ -96,8 +101,12 @@ export function RecordPicker({
     if (!query) {
       setCandidates([]);
       setSearchFailure(null);
+      setAnswered(false);
       return;
     }
+    // The previous answer stops standing the moment the term moves: a list
+    // left on screen under a newly typed query describes the old one.
+    setAnswered(false);
     let cancelled = false;
     const timer = setTimeout(async () => {
       try {
@@ -105,11 +114,19 @@ export function RecordPicker({
         if (!cancelled) {
           setCandidates(results);
           setSearchFailure(null);
+          // A search that ANSWERED, so an empty answer can be told from a
+          // search that never ran. Both drew the same nothing before, and the
+          // reader looking at a company whose contacts are all archived could
+          // not tell "nobody here" from a field that had not responded yet.
+          setAnswered(true);
         }
       } catch (error) {
         if (!cancelled) {
           setCandidates([]);
           setSearchFailure({ cause: error });
+          // A refusal is not an empty answer: the failure line below says what
+          // went wrong, and "nothing matched" underneath it would contradict it.
+          setAnswered(false);
         }
       }
     }, SEARCH_DEBOUNCE_MS);
@@ -146,6 +163,11 @@ export function RecordPicker({
         <p className="recordpicker-selected" aria-live="polite">
           <Check className="recordpicker-selected-check" aria-hidden />
           {selected.name}
+        </p>
+      )}
+      {answered && candidates.length === 0 && (
+        <p className="t-caption" aria-live="polite">
+          {t("picker.noMatch")}
         </p>
       )}
       {candidates.length > 0 && (

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -516,6 +516,7 @@ export const de = {
   "common.loading": "Wird geladen…",
   "ref.nameLoadFailed": "Name konnte nicht geladen werden",
   "ref.notInRoster": "Aktuell zugeordnet (nicht mehr in der Nutzerliste)",
+  "picker.noMatch": "Kein Treffer",
 
   // "Funktioniert nicht mehr", nicht "Fehler aufgetreten": die Ansicht ist
   // stehengeblieben, und das ist die Beobachtung, die der Lesende selbst
@@ -3118,6 +3119,7 @@ export const de = {
   "log.transcriptUploadRejected": "Nur eine .txt-Datei wird akzeptiert.",
   "log.transcriptUploadFailed":
     "Die Datei konnte nicht gelesen werden — versuchen Sie stattdessen, den Text einzufügen.",
+  "log.attendee": "Wer war dabei",
   "log.subject": "Betreff",
   "log.body": "Details",
   "log.dueAt": "Fällig am",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -558,6 +558,11 @@ export const en = {
   "ref.nameLoadFailed": "Name didn't load",
   "ref.notInRoster": "Currently assigned (no longer in the user list)",
 
+  // A record search that ANSWERED and found nothing. Distinct from a search
+  // that has not run: both drew the same empty space before, and a reader
+  // could not tell "nobody here" from a field still thinking.
+  "picker.noMatch": "No match",
+
   // The app-level boundary's fallback. It says what happened and what to do
   // next, and nothing about the error itself: a render throw carries our own
   // internals, which the reader can neither read nor act on. Two sentences,
@@ -3157,6 +3162,7 @@ export const en = {
   "log.kindTask": "Task",
   "log.kindMeeting": "Meeting",
   "log.kindCall": "Call",
+  "log.attendee": "Who was there",
   "log.subject": "Subject",
   "log.body": "Details",
   "log.transcriptLabel": "Transcript",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -522,6 +522,7 @@ export const vi = {
   "ref.nameLoadFailed": "Không tải được tên",
   "ref.notInRoster":
     "Hiện đang được giao (không còn trong danh sách người dùng)",
+  "picker.noMatch": "Không có kết quả",
 
   "app.errorTitle": "Màn hình này đã ngừng hoạt động.",
   "app.errorBody": "Hãy thử lại. Nếu vẫn tiếp tục lỗi, hãy tải lại trang.",
@@ -3087,6 +3088,7 @@ export const vi = {
   "log.transcriptUploadRejected": "Chỉ chấp nhận tệp .txt.",
   "log.transcriptUploadFailed":
     "Không thể đọc tệp đó — hãy thử dán văn bản thay vào đó.",
+  "log.attendee": "Ai đã tham dự",
   "log.subject": "Tiêu đề",
   "log.body": "Nội dung",
   "log.dueAt": "Ngày đến hạn",

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -409,6 +409,100 @@ describe("log activity from a 360", () => {
     expect(calendarDay(occurred, INSTALLATION_ZONE)).toBe(noteDay.value);
   });
 
+  // A meeting and a call are WITH A PERSON, and the server refuses either one
+  // linked to a company — per link, so naming the company alongside the person
+  // is refused too. Opened on a company the form offered no way to say who was
+  // there, and the reader met a 422 with no field to correct.
+  describe("a meeting logged from a company", () => {
+    const contacts = {
+      // full_name, the field the contract sends — a fixture naming a person by
+      // display_name would pass here and find nothing against the real API.
+      data: [
+        { ...person, id: "p1", full_name: "Frédéric de Gombert" },
+        { ...person, id: "p2", full_name: "Marie Lefevre" },
+      ],
+      page: { next_cursor: null },
+    };
+
+    it("asks who was there, and refuses to send until it is answered", async () => {
+      const user = userEvent.setup();
+      stubApi({
+        "POST /activities": createdActivity,
+        "GET /people": () => jsonResponse(contacts),
+      });
+      render(<LogActivity entityType="organization" entityId="o1" />);
+      await pickOption(user, screen.getByLabelText("Type"), "Meeting");
+      await user.type(screen.getByLabelText("Subject *"), "Kickoff");
+
+      // The subject alone is not enough here, unlike every other kind.
+      const log = screen.getByRole("button", { name: "Log" });
+      expect(log.hasAttribute("disabled")).toBe(true);
+
+      await user.type(screen.getByLabelText("Who was there"), "Fré");
+      await user.click(
+        await screen.findByRole("button", { name: "Frédéric de Gombert" }),
+      );
+      await waitFor(() => expect(log.hasAttribute("disabled")).toBe(false));
+    });
+
+    it("links the person and NOT the company, which the server refuses", async () => {
+      const user = userEvent.setup();
+      const captured: Captured[] = [];
+      stubApi(
+        {
+          "POST /activities": createdActivity,
+          "GET /people": () => jsonResponse(contacts),
+        },
+        captured,
+      );
+      render(<LogActivity entityType="organization" entityId="o1" />);
+      await pickOption(user, screen.getByLabelText("Type"), "Meeting");
+      await user.type(screen.getByLabelText("Subject *"), "Kickoff");
+      await user.type(screen.getByLabelText("Who was there"), "Fré");
+      await user.click(
+        await screen.findByRole("button", { name: "Frédéric de Gombert" }),
+      );
+      await user.click(screen.getByRole("button", { name: "Log" }));
+
+      await waitFor(() =>
+        expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+          true,
+        ),
+      );
+      const post = captured.find((entry) => entry.key === "POST /activities");
+      if (!post) throw new Error("expected a POST /activities to be captured");
+      const links = (
+        post.body as { links: { entity_type: string; entity_id: string }[] }
+      ).links;
+      // One link, the person. An organization link alongside it is refused by
+      // the database trigger whatever else is present, and a frontend test
+      // whose POST is stubbed cannot see that refusal — so the shape is
+      // asserted here rather than trusted to a green submit.
+      expect(links).toEqual([{ entity_type: "person", entity_id: "p1" }]);
+    });
+
+    it("asks nobody for a note, which a company can hold on its own", async () => {
+      stubApi({ "POST /activities": createdActivity });
+      render(<LogActivity entityType="organization" entityId="o1" />);
+      expect(screen.queryByLabelText("Who was there")).toBeNull();
+    });
+
+    it("says the company has no contacts rather than offering none silently", async () => {
+      const user = userEvent.setup();
+      stubApi({
+        "POST /activities": createdActivity,
+        "GET /people": () =>
+          jsonResponse({ data: [], page: { next_cursor: null } }),
+      });
+      render(<LogActivity entityType="organization" entityId="o1" />);
+      await pickOption(user, screen.getByLabelText("Type"), "Meeting");
+      await user.type(screen.getByLabelText("Who was there"), "any");
+      // The picker's own empty-search wording, so a company with nobody on it
+      // reads as an answered question rather than a field that never responded.
+      expect(await screen.findByText(/no match/i)).toBeTruthy();
+    });
+  });
+
   it("files a note on the day the writer overrode to, when the record's clock already calls it yesterday", async () => {
     // The other side of the same boundary. At 16:00 in Los Angeles the record's
     // clock has already turned over, so the writer's own today is the record's

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -12,6 +12,10 @@ import {
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import {
+  RecordPicker,
+  type RecordPickerCandidate,
+} from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
 import { calendarDay, dueInstant, middayInstant } from "../format/calendarday";
 import { viewerZone } from "../format/timezone";
@@ -112,12 +116,49 @@ function occurredInstant(input: ActivityDraft, recordZone: string): string {
   return middayInstant(input.day, recordZone);
 }
 
+// A meeting and a call are WITH A PERSON, and the server refuses either one
+// filed against a company — per link, so naming the company alongside the
+// person is refused too, and the company is reached through the attendee's
+// employer instead (activities/activitylinks.go, migration
+// "a meeting is with a person again").
+//
+// So a form opened on a company has to ask WHO was in the room before it can
+// send one of these kinds at all. It offered no way to say, and the reader met
+// a 422 with no field to correct.
+const KINDS_WITH_A_PERSON = new Set(["meeting", "call"]);
+
+// The company's own contacts, narrowed by what the reader typed.
+//
+// Scoped to the company rather than searching every person in the installation:
+// the question is who from THIS account was in the room, and an unscoped search
+// would offer contacts of other companies as equally likely answers to it.
+async function searchCompanyContacts(
+  organizationID: string,
+  q: string,
+): Promise<RecordPickerCandidate[]> {
+  const { data, error } = await api.GET("/people", {
+    params: { query: { organization_id: organizationID, q, limit: 20 } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data.data.map((person) => ({
+    id: person.id,
+    // full_name, which the contract documents as always present. display_name
+    // belongs to a USER; a person has neither the field nor a fallback for it.
+    name: person.full_name,
+  }));
+}
+
 // The wire body one drafted entry becomes.
 function activityRequestBody(
   input: ActivityDraft,
   entityType: EntityKind,
   entityId: string,
   recordZone: string,
+  // Who was in the room, when the form is open on a company and the kind is one
+  // that needs a person. Null everywhere else.
+  attendee: RecordPickerCandidate | null,
 ) {
   // source_system: transcript is what routes the body through the
   // server's ADR-0058 normalizer and what the activity/transcript
@@ -153,7 +194,13 @@ function activityRequestBody(
     // today), and held is what the lead ladder reads as engagement.
     ...(input.kind === "meeting" ? { meeting_status: "held" as const } : {}),
     ...(isTranscript ? { source_system: "transcript" } : {}),
-    links: [{ entity_type: entityType, entity_id: entityId }],
+    // The attendee REPLACES the company link rather than joining it. The
+    // server refuses an organization link on a meeting or a call whichever
+    // else are present, and the company still reaches the activity: the
+    // employer walk carries it there through the person who was named.
+    links: attendee
+      ? [{ entity_type: "person" as const, entity_id: attendee.id }]
+      : [{ entity_type: entityType, entity_id: entityId }],
     source: "manual",
   };
 }
@@ -199,6 +246,11 @@ export function LogActivityForm({
     }
   }
   const [fileError, setFileError] = useState<string | null>(null);
+  // Who was in the room. Only ever asked on a company, and only for the kinds
+  // that are with a person — see KINDS_WITH_A_PERSON.
+  const [attendee, setAttendee] = useState<RecordPickerCandidate | null>(null);
+  const needsAttendee =
+    entityType === "organization" && KINDS_WITH_A_PERSON.has(draft.kind);
 
   const log = useMutation({
     // Keyed on entityId, the record this form is open on, not the created
@@ -210,13 +262,18 @@ export function LogActivityForm({
     // committed render held, and what this one decides with the zone is the
     // instant the entry is STORED at — so a stale read would not misdraw a
     // page, it would file the activity on the wrong day, permanently.
-    mutationFn: async (input: { draft: ActivityDraft; zone: string }) => {
+    mutationFn: async (input: {
+      draft: ActivityDraft;
+      zone: string;
+      attendee: RecordPickerCandidate | null;
+    }) => {
       const { data, error } = await api.POST("/activities", {
         body: activityRequestBody(
           input.draft,
           entityType,
           entityId,
           input.zone,
+          input.attendee,
         ),
       });
       if (error) {
@@ -232,7 +289,20 @@ export function LogActivityForm({
       for (const queryKey of keys) {
         queryClient.invalidateQueries({ queryKey });
       }
+      // The attendee's OWN timeline too. The activity is filed against the
+      // person, so the company screen this form sits on reaches it through the
+      // employer walk while the person's page holds it directly — and a reader
+      // who logs a meeting here and opens the contact expects to find it.
+      if (input.attendee) {
+        for (const queryKey of entityTimelineKeys(
+          "person",
+          input.attendee.id,
+        )) {
+          queryClient.invalidateQueries({ queryKey });
+        }
+      }
       setDraft(freshDraft(input.zone));
+      setAttendee(null);
       onLogged?.();
     },
   });
@@ -245,7 +315,7 @@ export function LogActivityForm({
       className="form-stack"
       onSubmit={(event) => {
         event.preventDefault();
-        log.mutate({ draft, zone: recordZone });
+        log.mutate({ draft, zone: recordZone, attendee });
       }}
     >
       <div className="form-row">
@@ -300,6 +370,19 @@ export function LogActivityForm({
           )}
         </Field>
       </div>
+      {/* WHO was in the room, asked before what was said. A meeting or a call
+          is with a person and the server refuses one filed against a company,
+          so on a company this is the field that decides whether the entry can
+          be sent at all — not a refinement of one that could. */}
+      {needsAttendee && (
+        <RecordPicker
+          label={t("log.attendee")}
+          searchTargets={(q) => searchCompanyContacts(entityId, q)}
+          selected={attendee}
+          onPick={setAttendee}
+          disabled={log.isPending}
+        />
+      )}
       <Field label={t("log.subject")} required>
         {(control) => (
           <TextInput
@@ -370,7 +453,15 @@ export function LogActivityForm({
           small
           variant="primary"
           type="submit"
-          disabled={!log.isPending && !draft.subject.trim()}
+          // An unnamed attendee is refused by the server with a 422 the reader
+          // cannot act on from here, so the button says no first. Never
+          // auto-selecting the company's first contact to make the submit
+          // work: filing a meeting against somebody who was not there is worse
+          // than refusing to file it.
+          disabled={
+            !log.isPending &&
+            (!draft.subject.trim() || (needsAttendee && !attendee))
+          }
           pending={log.isPending}
           busyLabel={t("log.saving")}
         >


### PR DESCRIPTION
Logging a meeting from a company was a dead end. The kind was offered, the form took a subject and a body, and the submit came back 422: *a meeting is with a person, not with a company*. The form had no field for a person, so the reader had nothing to correct.

## Why an extra link would not work

The refusal is per **link**, not per activity — naming the company alongside the person is refused too, by the application check and by a database trigger. So the fix is not an extra link but a different one.

On a company, a meeting or a call now asks who was there and files the activity against that person alone. The company still reaches it: the prep walks the attendee's employer edge, which is what made refusing the direct link safe when it was reinstated.

`call` is included because it carries the same server rule and is reachable as an opening kind, so a company header could open the form pre-set to a kind the server would reject.

## Nothing is auto-selected

The submit button says no before the server does. Filing a meeting against somebody who was not in the room is worse than refusing to file it.

## One thing found on the way

`RecordPicker` had no answered-and-empty state: a search that found nothing rendered exactly what a search that had not run rendered. A company whose contacts are all archived looked like a field still thinking. It now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logging a meeting or call from a company previously failed with a 422 because these kinds must be filed against a person, not a company. The form now asks who was there and files the activity against that person, keeping the company reachable through the attendee's employer link.

- The submit button stays disabled until a person is picked; nothing is auto-selected.
- `call` is covered too, since it shares the same server rule and can be selected on a company.
- `RecordPicker` now says "No match" when a search answers with nothing, instead of looking like a field that never responded.

<sup>Written for commit e0842510898c49ec50fea00a9f07b6a01ad4f16b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

