### PR TITLE
fix(worklist): a keyboard can put a row down at phone width

### DIFF
--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -1771,6 +1771,25 @@ export function OverflowMenu({
     trigger.current?.focus();
   }, [chosen]);
 
+  // FOCUS GOES IN. The panel is portalled to the body, so it sits at the end of
+  // the document rather than after its trigger: without this a reader who opens
+  // a menu Tabs to the NEXT row's trigger, then through every control on the
+  // page, and reaches the items they opened it for last. On a list drawing one
+  // menu per row that is dozens of stops, which is a menu no keyboard reaches.
+  //
+  // The same hook the dialogs use, and for the same reason its own header
+  // gives: a surface that keeps its chrome private still owes the keyboard one
+  // answer to "where is focus now". Escape and the click-outside stay below,
+  // because this menu closes on a third thing a dialog does not have — an item
+  // being chosen — and that path has to leave the dialog it may have opened
+  // holding focus.
+  useDialogFocus({
+    open,
+    onClose: () => setOpen(false),
+    container: panel,
+    returnFocusTo: () => trigger.current,
+  });
+
   useEffect(() => {
     if (!open) {
       return;

--- a/frontend/src/design-system/swiperow.tsx
+++ b/frontend/src/design-system/swiperow.tsx
@@ -109,7 +109,15 @@ export function SwipeRow({
     // A primary pointer only. A second finger arriving mid-scroll would
     // otherwise restart the measurement from its own landing point and turn a
     // two-finger scroll into a drag that travelled the width of the hand.
-    if (!event.isPrimary) {
+    //
+    // AND NOT A PRESS THAT LANDED ON A CONTROL. The caller mounts this around
+    // a whole row, so its buttons and links are inside the surface and their
+    // pointer events bubble here: a thumb that slips 56px while reaching for a
+    // menu or a verb would otherwise stage a judgement nobody asked for, and
+    // the staged bar would then stand over the control that was actually being
+    // pressed. A row's own controls answer their own presses.
+    const on = event.target instanceof Element ? event.target : null;
+    if (!event.isPrimary || on?.closest("button, a, [role='button']")) {
       return;
     }
     from.current = { x: event.clientX, y: event.clientY };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8015,6 +8015,7 @@ export const de = {
     "Von deiner Liste. Wer zuständig ist, sieht es weiterhin.",
   "worklist.disposition.done.not_sales": "Von allen Listen entfernt.",
   "worklist.disposition.swipeCancel": "Behalten",
+  "worklist.disposition.menu": "Aus der Liste nehmen",
   "worklist.disposition.undo": "Rückgängig",
   "worklist.disposition.undoFailed":
     "Das konnte nicht rückgängig gemacht werden. Die Nachricht ist weiterhin von deiner Liste.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8115,6 +8115,7 @@ export const en = {
     "Off your list. Whoever owns it still sees it.",
   "worklist.disposition.done.not_sales": "Off everyone's list.",
   "worklist.disposition.swipeCancel": "Keep it",
+  "worklist.disposition.menu": "Take off the list",
   "worklist.disposition.undo": "Undo",
   "worklist.disposition.undoFailed":
     "That could not be undone. The message is still off your list.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7927,6 +7927,7 @@ export const vi = {
     "Đã rời danh sách của bạn. Người phụ trách vẫn thấy nó.",
   "worklist.disposition.done.not_sales": "Đã rời danh sách của mọi người.",
   "worklist.disposition.swipeCancel": "Giữ lại",
+  "worklist.disposition.menu": "Đưa khỏi danh sách",
   "worklist.disposition.undo": "Hoàn tác",
   "worklist.disposition.undoFailed":
     "Không thể hoàn tác. Tin nhắn vẫn nằm ngoài danh sách của bạn.",

--- a/frontend/src/screens/worklist.dispositions.tsx
+++ b/frontend/src/screens/worklist.dispositions.tsx
@@ -14,10 +14,10 @@
 // disappearance needs its way back offered at the moment of the disappearance;
 // finding it again afterwards means knowing which of three judgements you made.
 
-import { useState } from "react";
+import { createContext, useContext, useState } from "react";
 
 import { useFoldedViewport } from "../app/viewport";
-import { Button } from "../design-system/atoms";
+import { Button, OverflowMenu } from "../design-system/atoms";
 import { Popover } from "../design-system/popover";
 import { SwipeRow } from "../design-system/swiperow";
 import { useToast } from "../design-system/toast";
@@ -160,13 +160,20 @@ export function PutDownByThumb({
   children,
 }: Readonly<{ item: WorklistItem; children: React.ReactNode }>) {
   const folded = useFoldedViewport();
+  // ONE MUTATION PER ROW, held here because this is the component both
+  // placements sit inside. Two `usePutDown` calls on one row are two mutations
+  // with two `pending` flags, and neither disables the other: a menu press
+  // followed by a swipe confirm wrote the same judgement twice and raised two
+  // toasts, each offering an Undo for a state the other had already cleared.
+  // Measured before this was lifted — two PUTs from one row.
   // PER SIDE, because the walk is a position in one direction's list. A single
   // counter shared by both would be moved by a flick the other way, so a reader
   // alternating directions would never step through either side's judgements.
   const [walked, setWalked] = useState({ start: 0, end: 0 });
-  const { offered, put, t } = usePutDown(item);
+  const write = usePutDown(item);
+  const { offered, put, t } = write;
   if (!folded || offered.length === 0) {
-    return children;
+    return <PutDown value={write}>{children}</PutDown>;
   }
   return (
     <SwipeRow
@@ -180,8 +187,80 @@ export function PutDownByThumb({
       }
       {...swipeActions(offered, t, put, walked)}
     >
-      {children}
+      <PutDown value={write}>{children}</PutDown>
     </SwipeRow>
+  );
+}
+
+// The row's one write, handed to whichever control the width leaves standing.
+//
+// A context rather than a prop, because the verbs are drawn deep inside the
+// row's own tree — the caller composes them beside the title and the rank, and
+// threading the write through every one of those would make the row's shape
+// the write's business.
+const PutDownContext = createContext<PutDown | null>(null);
+
+function PutDown({
+  value,
+  children,
+}: Readonly<{ value: PutDown; children: React.ReactNode }>) {
+  return (
+    <PutDownContext.Provider value={value}>{children}</PutDownContext.Provider>
+  );
+}
+
+type PutDown = ReturnType<typeof usePutDown>;
+
+// The same judgements, reachable without a pointer.
+//
+// A swipe is not a control a keyboard, a switch or a screen reader can operate,
+// so below the fold the three judgements had exactly one route and it needed a
+// finger. The staged bar the gesture opens carries real buttons, but only a
+// drag opens it.
+//
+// A MENU rather than the buttons back. Restoring them is the 44px band that was
+// removed to bring the row under its ceiling, so the fix would undo the change
+// it is fixing; a menu is one tab stop and one line of text, and it is what the
+// design system already offers for "the verbs a record offers but a reader
+// rarely wants". The swipe stays the fast path for a thumb and this is the one
+// that answers to a key.
+//
+// Its children mount on first open, which is the default and matters here: a
+// queue draws one of these per row.
+//
+// It takes the WRITE rather than opening its own. A second usePutDown on the
+// same row is a second mutation with its own `pending`, so a press here and a
+// swipe confirm beside it both fire: two writes for one judgement, and two
+// toasts each offering an Undo for a state the other already cleared.
+function PutDownMenu({
+  offered,
+  put,
+  pending,
+  t,
+}: Readonly<{
+  offered: readonly WorklistDisposition[];
+  put: (disposition: WorklistDisposition) => void;
+  pending: boolean;
+  t: T;
+}>) {
+  return (
+    <OverflowMenu label={t("worklist.disposition.menu")}>
+      {offered.map((disposition) => (
+        <Button
+          key={disposition}
+          small
+          variant="ghost"
+          // PENDING, never disabled. A disabled control leaves the tab order,
+          // so a keyboard reader who presses one is dropped to the body — the
+          // exact failure this menu exists to fix. The atom refuses the press
+          // through aria-disabled and keeps the control reachable.
+          pending={pending}
+          onClick={() => put(disposition)}
+        >
+          {t(`worklist.disposition.verb.${disposition}` as const)}
+        </Button>
+      ))}
+    </OverflowMenu>
   );
 }
 
@@ -197,15 +276,28 @@ export function PutDownByThumb({
 // which is the state the spans were added to end. Restoring them means another
 // control in the row, which is the 44px band this change removed; that trade is
 // a product decision, filed as issue #4313 rather than settled here.
-//
-// The same fold leaves these three judgements reachable by pointer alone — the
-// staged bar's buttons are tabbable, but only after a drag opens it. Issue
-// #4314 carries that, and the shape of its answer is the same trade.
+
 export function DispositionVerbs({ item }: Readonly<{ item: WorklistItem }>) {
   const folded = useFoldedViewport();
-  const { offered, put, pending, t } = usePutDown(item);
-  if (folded || offered.length === 0) {
+  // The row's own write, from the wrapper that holds it — one mutation per row,
+  // so a press here and a swipe confirm beside it cannot write twice.
+  //
+  // The fallback is for the callers that draw these verbs OUTSIDE a row, the
+  // Brief's Do Next section among them: they get their own write rather than
+  // throwing on a missing provider. Both hooks run either way, because a hook
+  // cannot be called conditionally; the unused one registers a mutation nobody
+  // fires, which costs a registration and never a request.
+  const shared = useContext(PutDownContext);
+  const own = usePutDown(item);
+  const { offered, put, pending, t } = shared ?? own;
+  if (offered.length === 0) {
     return null;
+  }
+  // Below the fold the band goes and the menu stands in its place: one tab stop
+  // rather than four 44px controls, so the judgements stay reachable by key
+  // without the height that put the row over its ceiling.
+  if (folded) {
+    return <PutDownMenu offered={offered} put={put} pending={pending} t={t} />;
   }
   return (
     <div className="worklist-row-dispositions">

--- a/frontend/src/screens/worklist.swipe.test.tsx
+++ b/frontend/src/screens/worklist.swipe.test.tsx
@@ -4,7 +4,14 @@
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
@@ -54,17 +61,37 @@ function atWidth(folded: boolean) {
   }));
 }
 
-function draw(dispositions: readonly WorklistDisposition[]) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(
-      async () =>
-        new Response(JSON.stringify({}), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-    ),
+// The row as worklist.row.tsx mounts it, without the fetch stub — for the tests
+// that need to control the response themselves.
+function rowUnderTest(dispositions: readonly WorklistDisposition[]) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const item = row(dispositions);
+  return (
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          <PutDownByThumb item={item}>
+            <p>Anna Weber is waiting</p>
+            <DispositionVerbs item={item} />
+          </PutDownByThumb>
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>
   );
+}
+
+function draw(dispositions: readonly WorklistDisposition[]) {
+  const fetchSpy = vi.fn(
+    async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", fetchSpy);
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -80,6 +107,43 @@ function draw(dispositions: readonly WorklistDisposition[]) {
             <p>Anna Weber is waiting</p>
             <DispositionVerbs item={item} />
           </PutDownByThumb>
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+  return fetchSpy;
+}
+
+// Two rows of the same shape, for the assertions that only fail on a page with
+// more than one menu in it.
+function drawRows(count: number) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          {Array.from({ length: count }, (_, at) => {
+            const item = { ...row(EVERY_JUDGEMENT), id: `row-${at}` };
+            return (
+              <PutDownByThumb key={item.id} item={item}>
+                <p>{item.title}</p>
+                <DispositionVerbs item={item} />
+              </PutDownByThumb>
+            );
+          })}
           <ToastRegion />
         </ToastProvider>
       </LocaleProvider>
@@ -180,6 +244,88 @@ describe("putting a row down below the fold", () => {
     expect(
       screen.getByRole("button", { name: verb("not_mine") }),
     ).toBeInTheDocument();
+  });
+
+  // THE KEYBOARD PATH. A swipe is not a control a keyboard, a switch or a
+  // screen reader can operate, so a fold that left the gesture as the only
+  // route would take the three judgements away from every reader who does not
+  // point. The menu is one tab stop carrying all three — not the 44px band
+  // back, which is the height the fold removed.
+  it("offers every judgement to a keyboard below the fold", async () => {
+    const user = userEvent.setup();
+    atWidth(true);
+    // TWO rows, because one hides the defect: with a single menu the portalled
+    // panel happens to be next in document order, and a test that tabs once
+    // passes over a page where every other row's trigger comes first.
+    drawRows(2);
+
+    // Reachable by TAB, not merely present: a control a keyboard cannot land
+    // on is the gap this closes, not a fix for it.
+    await user.tab();
+    const trigger = screen.getAllByRole("button", {
+      name: en["worklist.disposition.menu"],
+    })[0];
+    expect(document.activeElement).toBe(trigger);
+
+    await user.keyboard("{Enter}");
+
+    // FOCUS IS INSIDE THE PANEL, which is the whole claim. The panel is
+    // portalled to the body, so asserting the items merely RENDER proves
+    // nothing about reaching them: a reader would Tab to the next row's
+    // trigger, then through the rest of the page, and meet these last.
+    const first = screen.getByRole("button", {
+      name: verb(EVERY_JUDGEMENT[0]),
+    });
+    expect(document.activeElement).toBe(first);
+
+    // And Tab walks the rest of them rather than leaving for the page.
+    for (const disposition of EVERY_JUDGEMENT.slice(1)) {
+      await user.tab();
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: verb(disposition) }),
+      );
+    }
+  });
+
+  // BOTH PLACEMENTS SHARE THE ROW'S ONE WRITE.
+  //
+  // The menu and the swipe are two placements of one capability. Held apart
+  // they are two mutations with two `pending` flags and neither disables the
+  // other, so a row being written from one placement looks idle to the other.
+  //
+  // The flag is what the two share, so the flag is what this reads: a write
+  // started from the GESTURE has to reach the MENU'S item. A second mutation
+  // leaves each placement reading its own, and the menu offers a fresh press
+  // over a row already going to the server.
+  it("shows the menu a write the gesture started", async () => {
+    const user = userEvent.setup();
+    atWidth(true);
+    // A write that does not settle, so `pending` is observable rather than a
+    // state the assertion races.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    render(rowUnderTest(EVERY_JUDGEMENT));
+
+    // Start a write from the gesture and confirm it.
+    swipe(...FORWARD);
+    await user.click(
+      screen.getAllByRole("button", { name: verb("snooze") })[0],
+    );
+
+    // The menu's own item now reads that write as in flight.
+    await user.click(
+      screen.getByRole("button", { name: en["worklist.disposition.menu"] }),
+    );
+    await waitFor(() => {
+      const items = screen.getAllByRole("button", { name: verb("snooze") });
+      expect(
+        items.some((one) => one.getAttribute("aria-disabled") === "true"),
+        "the menu offers a fresh press over a row already being written, so " +
+          "the two placements are not sharing one mutation",
+      ).toBe(true);
+    });
   });
 
   it("draws no gesture at all on a row the server offers nothing for", () => {


### PR DESCRIPTION
Below the fold the worklist's three set-aside judgements — snooze, not mine, not a customer — were reachable **only by a pointer drag**. The staged bar the gesture opens carries real tabbable buttons, but only a drag opens it. A keyboard, a switch and a screen reader lost all three at that width, while a wider screen offered them as ordinary buttons.

Closes #4314.

## A menu, not the buttons back

Restoring the button band is the 44px of height removed to bring the row under its ceiling — the obvious fix undoes the change it repairs. `OverflowMenu` is one tab stop, and it is what this design system already offers for *"the verbs a record offers but a reader rarely wants."* The swipe stays the fast path for a thumb; this answers to a key.

## The fix was not accessible, so that is fixed too

**`OverflowMenu` never moved focus into its panel.** It is portalled to `document.body`, so it sits at the end of the document rather than after its trigger. A reader who opened one Tabbed to the **next row's trigger**, then through every control on the page, and met the items they opened it for last. On a list drawing one menu per row that is dozens of stops.

It now uses `useDialogFocus` — the hook whose own header describes this exact failure — so **all 16 callers** are fixed rather than this one row worked around.

## Three more defects the review found

| | |
|---|---|
| **A drag landing on a control staged a judgement** | The gesture wraps the row, so its buttons' pointer events bubbled to the surface. A thumb slipping 56px toward the menu filed a snooze nobody asked for, and the staged bar then stood over the control actually being pressed. Also closes the same hole for the row's own verbs and its pin |
| **Two mutations per row** | Each placement read its own `pending`, so a row being written from one looked idle to the other — **measured at 2 PUTs from one row**. The write is lifted to the wrapper both placements sit inside |
| **`disabled` dropped focus to the body** | On the menu's items — in the accessibility fix. A disabled control leaves the tab order, which is the exact failure being repaired. Now `pending`, which refuses the press through `aria-disabled` and keeps the control reachable |

Also: the German menu was named *"Zurückstellen"*, which **is** snooze and so misnamed the other two items; the Vietnamese one was named the same words as its own first item. Both now say what all three do.

## Evidence

| Obligation | Evidence |
|---|---|
| Keyboard reach | `offers every judgement to a keyboard below the fold` — tabs to the trigger, presses Enter, asserts focus lands **inside** the panel, then Tabs through every item. Rendered across **two rows**, because one hides the defect: with a single menu the panel happens to be next in document order |
| Shared write | `shows the menu a write the gesture started` — starts a write from the gesture against an unsettled request and asserts the **menu's own item** reads it as in flight |
| Mutation strength | Remove `useDialogFocus` → the keyboard test fails on the wrong element. Revert the lifted mutation → the shared-write test fails naming the defect. Remove the menu → only the keyboard test fails |
| Height | The row is **205px with the menu, exactly as without** — the trigger sits on the verbs' existing line rather than adding a band |
| Full lane | `make check-fe` green, **6660 tests**, including every existing `OverflowMenu` caller |
| Review | `craft-reviewer`. **Codex was rate-limited for this entire session** — the 13:22 window passed and reset straight to 18:24 |

## One thing I caught in my own work

My first version of the shared-write test **passed with the fix reverted**. It counted writes, and two deliberate presses are honestly two writes either way. It now reads the shared `pending` flag, and reverting the lift fails it with a message naming what broke.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Below the fold, the worklist's three set-aside judgements (snooze, not mine, not a customer) were reachable only by dragging the row open. They now sit in an `OverflowMenu` on the row — one tab stop with no height cost — so keyboard, switch, and screen-reader users get the same choices a wide screen shows as buttons. Closes #4314.

**Bug Fixes**

- Focus now moves into the `OverflowMenu`'s panel and returns to the trigger on close; the panel is portalled to `document.body`, so previously the items sat at the end of the document behind every other control. This fixes all 16 callers of `OverflowMenu`.
- A drag that lands on a control no longer stages a judgement; the swipe ignores pointer events on `button`, `a`, and `[role='button']` elements.
- The row now has one shared write. The swipe and the menu each had their own `usePutDown`, so a row being written from one looked idle to the other — two PUTs from one row.
- Menu items use `pending` (`aria-disabled`) rather than `disabled`, which would have dropped focus to the body.
- German and Vietnamese menu labels now describe all three judgements; the German one named only snooze and the Vietnamese one repeated its own first item's words.

<sup>Written for commit 904af9cc9ebc3032b06fdfd568e028a5dfa2ae18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

