### PR TITLE
fix(forecast): the unread-sources line names sources, not tables

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3347,6 +3347,8 @@ export const de = {
   "review.needsReview": "Prüfung nötig",
   "review.checksIncomplete": "Prüfung unvollständig",
   "review.allSourcesRead": "Alle Quellen wurden gelesen.",
+  "review.source.mail": "das Postfach",
+  "review.source.offers": "Angebote",
   "review.sourcesUnread":
     "Nicht gelesen: {sources}. Die Befunde unten decken nur ab, was geprüft werden konnte.",
   "review.notCheckedYet":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3408,6 +3408,12 @@ export const en = {
   "review.needsReview": "Needs review",
   "review.checksIncomplete": "Checks incomplete",
   "review.allSourcesRead": "Every source was read.",
+  // The sources a run reads, named for the reader rather than by the server's
+  // own vocabulary. The unread line printed the wire keys verbatim, so a German
+  // reader was told "mail, offers" in English — words that name a table, not a
+  // thing they would go and fix.
+  "review.source.mail": "the mailbox",
+  "review.source.offers": "offers",
   "review.sourcesUnread":
     "Not read: {sources}. Findings below cover only what could be checked.",
   "review.notCheckedYet":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3314,6 +3314,8 @@ export const vi = {
   "review.needsReview": "Cần xem lại",
   "review.checksIncomplete": "Kiểm tra chưa đầy đủ",
   "review.allSourcesRead": "Đã đọc mọi nguồn.",
+  "review.source.mail": "hộp thư",
+  "review.source.offers": "báo giá",
   "review.sourcesUnread":
     "Chưa đọc: {sources}. Các phát hiện bên dưới chỉ bao gồm những gì kiểm tra được.",
   "review.notCheckedYet":

--- a/frontend/src/screens/analytics.forecast.review.tsx
+++ b/frontend/src/screens/analytics.forecast.review.tsx
@@ -156,10 +156,31 @@ function CoverageLine({ run }: Readonly<{ run: Assurance }>) {
   return (
     <p className="sub">
       {t("review.sourcesUnread", {
-        sources: unread.map((source) => source.source).join(", "),
+        sources: unread
+          .map((source) => sourceName(source.source, t))
+          .join(", "),
       })}
     </p>
   );
+}
+
+// A source's name in the reader's language.
+//
+// The wire carries the server's own vocabulary — "mail", "offers" — and the
+// line printed it verbatim, so a German reader was told which sources went
+// unread in English, in words that name a table rather than a thing they
+// recognise. An unknown source falls back to its wire key: a source this
+// release has not heard of is better named badly than not named at all, since
+// the whole point of the line is which one to go and fix.
+function sourceName(source: string, t: ReturnType<typeof useT>): string {
+  switch (source) {
+    case "mail":
+      return t("review.source.mail");
+    case "offers":
+      return t("review.source.offers");
+    default:
+      return source;
+  }
 }
 
 // One finding, and the way to answer it.


### PR DESCRIPTION
"Not read: mail, offers" printed the server's own vocabulary verbatim, in English, whatever the reader's language. Those are table names, not things a rep would go and fix — and the line's own comment says naming the sources rather than counting them is the whole point of it.

They travel through i18n now, with the wire key as the fallback: a source this release has not heard of is better named badly than not named at all.

## The other half needed no change

The plan called for `offerCoverage` to stop grading the offers table by its newest row's age — the reading that made a static installation report "not read: offers" forever. Main already does this: it reports checked at the observation time, because the table lives in the same database as the run, so if the code executes at all the source was readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the unread-sources line in the forecast review screen so source names appear in the reader's language instead of the server's English table names.

- Adds `review.source.mail` and `review.source.offers` translations for German, English, and Vietnamese.
- Unknown sources fall back to their wire key so the line still names something the rep can go and fix.

<sup>Written for commit e39b1684ae98e0d0157d97e03fcb4006efde6914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

