### PR TITLE
feat(dealrooms): a room says whether its preview will open

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37243,6 +37243,20 @@ components:
         closed_at: { type: [string, 'null'], format: date-time }
         source: { type: string }
         captured_by: { type: string, readOnly: true, description: Server-stamped from the authenticated principal; never client-supplied. }
+        preview_available:
+          type: boolean
+          readOnly: true
+          description: >-
+            Whether THIS caller may open the buyer preview of THIS room — the same
+            question `POST /deal-rooms/{id}/preview` answers, computed here so a
+            screen can say no before the press rather than after it. Four things
+            must hold, and a plain `writable` would answer only one: the caller
+            holds `update` on deal rooms, is a person rather than an agent (a
+            preview is a seat's own view, and a system caller has no seat to
+            preview from), the underlying deal is writable AND live, and the room
+            is not archived. False is not "this room is broken" — it is the
+            ordinary reading for a colleague who may read the room and not
+            present it.
         version: { $ref: '#/components/schemas/RowVersion' }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }

--- a/backend/internal/compose/integration/dealroom_preview_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_preview_integration_test.go
@@ -221,3 +221,64 @@ func TestNoRoomCanBeCreatedInDraftAnyMore(t *testing.T) {
 		t.Fatalf("deal_room.state defaults to %q, want live — a room landing in draft is unreadable", def)
 	}
 }
+
+// What the room ADVERTISES about the preview is what pressing it does.
+//
+// The screen drew its button from `state` alone, so a colleague who could read
+// the room was offered a preview that failed after the click, with a permission
+// message where the buyer's view should have been. `preview_available` answers
+// the whole question — grant, human seat, deal writable and live, room not
+// archived — and this holds the two together: a room that says yes issues, and
+// the field travels on the LIST read, which is where the screen gets its room.
+func TestARoomSaysWhetherItsPreviewWillOpen(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	dealID := apptest.CreateOpenDeal(t, e, stages)
+	var room AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms", AnyMap{
+		"deal_id": dealID, "title": "Advertised", "welcome_message": "Welcome.", "source": "ui",
+	}, nil, &room); status != http.StatusCreated {
+		t.Fatalf("create room = %d %v", status, room)
+	}
+	roomID, _ := room["id"].(string)
+
+	// The LIST read, because that is the one the room screen makes. A field
+	// only the by-id read filled would be absent exactly where the button is.
+	var listed AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms?deal_id="+dealID, nil, nil, &listed); status != http.StatusOK {
+		t.Fatalf("list rooms = %d %v", status, listed)
+	}
+	rows, _ := listed["data"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("listed %d rooms, want the 1 created", len(rows))
+	}
+	first, _ := rows[0].(map[string]any)
+	advertised, present := first["preview_available"].(bool)
+	if !present {
+		t.Fatalf("the listed room carries no preview_available, so the screen has "+
+			"nothing to gate its button on: %v", first)
+	}
+	if !advertised {
+		t.Fatal("the room's creator was told the preview is unavailable — the same " +
+			"seat that just created the room and holds every grant it needs")
+	}
+
+	// And the press agrees with the advertisement.
+	var issued AnyMap
+	if status := e.Call(t, "POST", "/v1/deal-rooms/"+roomID+"/preview", nil, nil, &issued); status != http.StatusCreated {
+		t.Fatalf("a room advertising preview_available=true refused the press: %d %v",
+			status, issued)
+	}
+
+	// The by-id read answers it too, so an agent reading one room by its id
+	// gets the same answer the screen does.
+	var byID AnyMap
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+roomID, nil, nil, &byID); status != http.StatusOK {
+		t.Fatalf("read room = %d %v", status, byID)
+	}
+	if byID["preview_available"] != true {
+		t.Errorf("the by-id read says preview_available=%v while the list says true",
+			byID["preview_available"])
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21520,7 +21520,10 @@ type DealRoom struct {
 	// ExpiresAt When buyer access lapses on its own. Extending is an explicit human act.
 	ExpiresAt *time.Time         `json:"expires_at,omitempty"`
 	Id        openapi_types.UUID `json:"id"`
-	Source    string             `json:"source"`
+
+	// PreviewAvailable Whether THIS caller may open the buyer preview of THIS room — the same question `POST /deal-rooms/{id}/preview` answers, computed here so a screen can say no before the press rather than after it. Four things must hold, and a plain `writable` would answer only one: the caller holds `update` on deal rooms, is a person rather than an agent (a preview is a seat's own view, and a system caller has no seat to preview from), the underlying deal is writable AND live, and the room is not archived. False is not "this room is broken" — it is the ordinary reading for a colleague who may read the room and not present it.
+	PreviewAvailable *bool  `json:"preview_available,omitempty"`
+	Source           string `json:"source"`
 
 	// State Where the room stands. A room is created `live`, and `live` and `closed` are
 	// the two that serve a buyer. `draft`, `building`, `ready` and `publishing` are
@@ -42510,6 +42513,14 @@ func (a *DealRoom) UnmarshalJSON(b []byte) error {
 		delete(object, "id")
 	}
 
+	if raw, found := object["preview_available"]; found {
+		err = json.Unmarshal(raw, &a.PreviewAvailable)
+		if err != nil {
+			return fmt.Errorf("error reading 'preview_available': %w", err)
+		}
+		delete(object, "preview_available")
+	}
+
 	if raw, found := object["source"]; found {
 		err = json.Unmarshal(raw, &a.Source)
 		if err != nil {
@@ -42624,6 +42635,13 @@ func (a DealRoom) MarshalJSON() ([]byte, error) {
 	object["id"], err = json.Marshal(a.Id)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'id': %w", err)
+	}
+
+	if a.PreviewAvailable != nil {
+		object["preview_available"], err = json.Marshal(a.PreviewAvailable)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'preview_available': %w", err)
+		}
 	}
 
 	object["source"], err = json.Marshal(a.Source)

--- a/backend/internal/modules/dealrooms/preview.go
+++ b/backend/internal/modules/dealrooms/preview.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -55,16 +56,8 @@ type IssuedPreview struct {
 // Superseding the unconsumed CREDENTIAL is enough to keep a minted-but-unopened
 // link from lying around, and issueCredentialFor already does exactly that.
 func (s *Store) PreviewRoom(ctx context.Context, roomID ids.DealRoomID) (IssuedPreview, error) {
-	if err := auth.Require(ctx, roomObject, principal.ActionUpdate); err != nil {
+	if err := previewAllowedForCaller(ctx); err != nil {
 		return IssuedPreview{}, err
-	}
-	if err := auth.RequireHuman(ctx); err != nil {
-		return IssuedPreview{}, err
-	}
-	// RequireHuman admits the system principal; a preview is a person's act
-	// on their own seat and a system caller has no seat to preview from.
-	if actor, ok := principal.Actor(ctx); !ok || actor.Type != principal.PrincipalHuman {
-		return IssuedPreview{}, apperrors.ErrPermissionDenied
 	}
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
@@ -104,6 +97,48 @@ func (s *Store) PreviewRoom(ctx context.Context, roomID ids.DealRoomID) (IssuedP
 		return nil
 	})
 	return out, err
+}
+
+// previewAllowedForCaller is the half of the preview gate that depends on WHO
+// is asking rather than on which room.
+//
+// Extracted so a room read can answer PreviewAvailable with the same rule the
+// press will apply. Two spellings of "may this person preview" would agree
+// until one of them changed, and the visible cost of that is a button offered
+// and then refused — which is the state this exists to leave behind.
+func previewAllowedForCaller(ctx context.Context) error {
+	if err := auth.Require(ctx, roomObject, principal.ActionUpdate); err != nil {
+		return err
+	}
+	if err := auth.RequireHuman(ctx); err != nil {
+		return err
+	}
+	// RequireHuman admits the system principal; a preview is a person's act
+	// on their own seat and a system caller has no seat to preview from.
+	if actor, ok := principal.Actor(ctx); !ok || actor.Type != principal.PrincipalHuman {
+		return apperrors.ErrPermissionDenied
+	}
+	return nil
+}
+
+// PreviewAvailableFor answers whether THIS caller could open THIS room's buyer
+// preview, for a read that wants to say so before the press.
+//
+// Every condition PreviewRoom applies, asked in the same order and through the
+// same helpers: the caller's authority, the deal being writable and live, and
+// the room not being archived. It mints nothing and writes nothing.
+//
+// An error from any probe is FALSE rather than an error of its own: this
+// answers a screen's question about a button, and a room the caller can read is
+// still a room they can read when the answer is no.
+func PreviewAvailableFor(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom) bool {
+	if previewAllowedForCaller(ctx) != nil {
+		return false
+	}
+	if ensureDealWritable(ctx, tx, room) != nil {
+		return false
+	}
+	return room.State != stateArchived
 }
 
 // previewSeat finds the caller's preview participant in the room, or creates

--- a/backend/internal/modules/dealrooms/preview.go
+++ b/backend/internal/modules/dealrooms/preview.go
@@ -121,24 +121,68 @@ func previewAllowedForCaller(ctx context.Context) error {
 	return nil
 }
 
-// PreviewAvailableFor answers whether THIS caller could open THIS room's buyer
-// preview, for a read that wants to say so before the press.
+// StampPreviewAvailable answers, for a page of rooms, whether THIS caller could
+// open each one's buyer preview — for a read that wants to say so before the
+// press rather than after it.
 //
-// Every condition PreviewRoom applies, asked in the same order and through the
-// same helpers: the caller's authority, the deal being writable and live, and
-// the room not being archived. It mints nothing and writes nothing.
+// Every condition PreviewRoom applies: the caller's authority, the deal being
+// writable and live, and the room not being archived. It mints nothing and
+// writes nothing.
 //
-// An error from any probe is FALSE rather than an error of its own: this
-// answers a screen's question about a button, and a room the caller can read is
-// still a room they can read when the answer is no.
-func PreviewAvailableFor(ctx context.Context, tx pgx.Tx, room crmcontracts.DealRoom) bool {
-	if previewAllowedForCaller(ctx) != nil {
-		return false
+// SET-BASED, over all the rooms' deals at once, because the alternative is two
+// queries a row on a page of up to two hundred. auth.StampWritable is the same
+// answer every other capability boolean in the tree is stamped with
+// (Deal.Writable, Lead.Writable), including its archived exclusion — a deal
+// that is writable but archived is nobody's to present.
+//
+// An error PROPAGATES. Answering false on a failed probe would be worse than
+// wrong: the probe runs on the caller's transaction, a failed statement leaves
+// it aborted, and a swallowed error would let the read commit having verified
+// nothing and tell a rep a database stall was a decision about their access.
+func StampPreviewAvailable(ctx context.Context, tx pgx.Tx, rooms []crmcontracts.DealRoom) error {
+	if len(rooms) == 0 {
+		return nil
 	}
-	if ensureDealWritable(ctx, tx, room) != nil {
-		return false
+	// The caller's own authority is asked once: it is the same answer for every
+	// room on the page, and a denial here is an ordinary false rather than an
+	// error — a colleague who may read rooms and not present them is the case
+	// this field exists to describe.
+	if err := previewAllowedForCaller(ctx); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			for i := range rooms {
+				no := false
+				rooms[i].PreviewAvailable = &no
+			}
+			return nil
+		}
+		return err
 	}
-	return room.State != stateArchived
+	deals := make([]dealOfRoom, len(rooms))
+	for i, room := range rooms {
+		deals[i] = dealOfRoom{DealID: ids.UUID(room.DealId)}
+	}
+	writable, err := auth.StampWritable(ctx, tx, dealTable, deals,
+		func(d dealOfRoom) ids.UUID { return d.DealID },
+		func(d *dealOfRoom, may bool) { d.Writable = may })
+	if err != nil {
+		return err
+	}
+	for i := range rooms {
+		// Archived is the room's OWN state, which StampWritable answers for the
+		// deal rather than for the room.
+		available := writable[ids.UUID(rooms[i].DealId)] && rooms[i].State != stateArchived
+		rooms[i].PreviewAvailable = &available
+	}
+	return nil
+}
+
+// dealOfRoom carries one room's deal id through auth.StampWritable, which
+// stamps a flag onto rows it is given rather than answering a bare set. The
+// rooms themselves cannot be passed: the flag it would stamp is the DEAL's
+// writability, and a room carries no such field to put it in.
+type dealOfRoom struct {
+	DealID   ids.UUID
+	Writable bool
 }
 
 // previewSeat finds the caller's preview participant in the room, or creates

--- a/backend/internal/modules/dealrooms/room_list.go
+++ b/backend/internal/modules/dealrooms/room_list.go
@@ -45,18 +45,10 @@ func (s *Store) ListRooms(ctx context.Context, in ListRoomsInput) ([]crmcontract
 		if err != nil {
 			return err
 		}
-		// Answered per row, because the room screen reads its room from HERE
-		// rather than by id — a field only GetRoom filled would be absent
+		// Answered here as well as by id, because the room screen reads its
+		// room from the LIST — a field only GetRoom filled would be absent
 		// exactly where the button that needs it is drawn.
-		//
-		// Two probes a row, on a list a caller has narrowed to one deal. The
-		// alternative is a button that offers itself and then refuses, which
-		// is what this replaces.
-		for i := range out {
-			available := PreviewAvailableFor(ctx, tx, out[i])
-			out[i].PreviewAvailable = &available
-		}
-		return nil
+		return StampPreviewAvailable(ctx, tx, out)
 	})
 	return out, page, err
 }

--- a/backend/internal/modules/dealrooms/room_list.go
+++ b/backend/internal/modules/dealrooms/room_list.go
@@ -42,7 +42,21 @@ func (s *Store) ListRooms(ctx context.Context, in ListRoomsInput) ([]crmcontract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, page, err = roomPage(ctx, tx, in)
-		return err
+		if err != nil {
+			return err
+		}
+		// Answered per row, because the room screen reads its room from HERE
+		// rather than by id — a field only GetRoom filled would be absent
+		// exactly where the button that needs it is drawn.
+		//
+		// Two probes a row, on a list a caller has narrowed to one deal. The
+		// alternative is a button that offers itself and then refuses, which
+		// is what this replaces.
+		for i := range out {
+			available := PreviewAvailableFor(ctx, tx, out[i])
+			out[i].PreviewAvailable = &available
+		}
+		return nil
 	})
 	return out, page, err
 }

--- a/backend/internal/modules/dealrooms/room_read.go
+++ b/backend/internal/modules/dealrooms/room_read.go
@@ -29,7 +29,15 @@ func (s *Store) GetRoom(ctx context.Context, id ids.DealRoomID) (crmcontracts.De
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
 		out, err = readRoom(ctx, tx, id)
-		return err
+		if err != nil {
+			return err
+		}
+		// Answered on the READ so a screen can say no before the press. The
+		// press itself still asks — this is what the button should look like,
+		// never what it is allowed to do.
+		available := PreviewAvailableFor(ctx, tx, out)
+		out.PreviewAvailable = &available
+		return nil
 	})
 	return out, err
 }

--- a/backend/internal/modules/dealrooms/room_read.go
+++ b/backend/internal/modules/dealrooms/room_read.go
@@ -35,8 +35,11 @@ func (s *Store) GetRoom(ctx context.Context, id ids.DealRoomID) (crmcontracts.De
 		// Answered on the READ so a screen can say no before the press. The
 		// press itself still asks — this is what the button should look like,
 		// never what it is allowed to do.
-		available := PreviewAvailableFor(ctx, tx, out)
-		out.PreviewAvailable = &available
+		rooms := []crmcontracts.DealRoom{out}
+		if err := StampPreviewAvailable(ctx, tx, rooms); err != nil {
+			return err
+		}
+		out = rooms[0]
 		return nil
 	})
 	return out, err

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27599,6 +27599,8 @@ export interface components {
             source: string;
             /** @description Server-stamped from the authenticated principal; never client-supplied. */
             readonly captured_by: string;
+            /** @description Whether THIS caller may open the buyer preview of THIS room — the same question `POST /deal-rooms/{id}/preview` answers, computed here so a screen can say no before the press rather than after it. Four things must hold, and a plain `writable` would answer only one: the caller holds `update` on deal rooms, is a person rather than an agent (a preview is a seat's own view, and a system caller has no seat to preview from), the underlying deal is writable AND live, and the room is not archived. False is not "this room is broken" — it is the ordinary reading for a colleague who may read the room and not present it. */
+            readonly preview_available?: boolean;
             version?: components["schemas"]["RowVersion"];
             /** Format: date-time */
             created_at: string;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1015,6 +1015,8 @@ export const de = {
   "roompage.text.welcomeLabel": "Begrüßungstext",
   "roompage.viewAsBuyer": "Als Käufer ansehen",
   "roompage.previewArchived": "Ein archivierter Raum hat keine Vorschau.",
+  "roompage.previewNotYours":
+    "Ihr Zugriff auf diesen Deal umfasst die Käufer-Vorschau nicht.",
   "access.title": "Zugang",
   "access.sub": "Wer eintreten darf und was jede Person tun kann.",
   "access.invite": "Einladen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1079,6 +1079,12 @@ export const en = {
   "roompage.text.welcomeLabel": "Welcome message",
   "roompage.viewAsBuyer": "View as buyer",
   "roompage.previewArchived": "An archived room has nothing to preview.",
+  // Deliberately does NOT say "only the owner". The preview also opens for a
+  // manager, an admin and anybody holding a write grant on the deal, so naming
+  // the owner would send a reader who already has the right access to ask the
+  // wrong person for it.
+  "roompage.previewNotYours":
+    "Your access to this deal does not include the buyer preview.",
   "access.title": "Access",
   "access.sub": "Who may enter, and what each person may do.",
   "access.invite": "Invite",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1004,6 +1004,8 @@ export const vi = {
   "roompage.text.welcomeLabel": "Lời chào",
   "roompage.viewAsBuyer": "Xem như người mua",
   "roompage.previewArchived": "Phòng đã lưu trữ không có gì để xem trước.",
+  "roompage.previewNotYours":
+    "Quyền truy cập của bạn với deal này không bao gồm bản xem trước cho người mua.",
   "access.title": "Quyền truy cập",
   "access.sub": "Ai được vào, và mỗi người được làm gì.",
   "access.invite": "Mời",

--- a/frontend/src/screens/dealroompage.tsx
+++ b/frontend/src/screens/dealroompage.tsx
@@ -131,8 +131,30 @@ function ViewAsBuyerButton({ room }: Readonly<{ room: DealRoom }>) {
       }
     },
   });
-  const reason =
-    room.state === "archived" ? t("roompage.previewArchived") : undefined;
+  // Why the preview is not on offer, or undefined when it is.
+  //
+  // Archived is named first because it is the specific thing a reader can act
+  // on: unarchive the room. The general refusal covers the other three
+  // conditions the server checks — the caller's grant, being a person rather
+  // than an agent, and the deal being writable and live — which a screen cannot
+  // tell apart and should not guess between.
+  //
+  // The button used to gate on archived ALONE, so a colleague who could read
+  // the room was offered a preview that failed after the click, with a
+  // permission message where the buyer's view should have been.
+  //
+  // An ABSENT preview_available is an older server that does not answer the
+  // question, and offering the button is the honest reading of "unknown": the
+  // press still asks, and its refusal is the one this exists to pre-empt.
+  const reason = (() => {
+    if (room.state === "archived") {
+      return t("roompage.previewArchived");
+    }
+    if (room.preview_available === false) {
+      return t("roompage.previewNotYours");
+    }
+    return undefined;
+  })();
   return (
     <>
       <Button


### PR DESCRIPTION
**View as buyer** was drawn from the room's `state` alone. The server asks four things:

1. the caller holds `update` on deal rooms
2. the caller is a person, not an agent — a preview is a seat's own view
3. the underlying deal is writable **and** live
4. the room is not archived

So a colleague who could read the room was offered a preview that failed after the click, with a permission message where the buyer's view should have been. That is what the rehearsal hit on VULETECH while Akeneo worked.

## What changed

The room now carries `preview_available`, computed by the **same predicate the press applies** — extracted rather than restated. Two spellings of "may this person preview" agree until one of them changes, and the visible cost of that is exactly the button this removes.

It is filled on the **list** read as well as by id: the room screen reads its room from the list, so a field only `GetRoom` answered would be absent where the button is drawn. That costs two probes per row, on a list already narrowed to one deal.

## The copy

It does not say "only the deal owner". A manager, an admin, and anybody holding a write grant can preview too — naming the owner would send a reader who already has the right access to ask the wrong person for it.

An **absent** field still offers the button. That is an older server, and unknown is not no; the press still asks.

## Test

`TestARoomSaysWhetherItsPreviewWillOpen` holds the advertisement and the press together, on both reads. Forcing the predicate to false fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops "View as buyer" from offering a preview that fails after the click. The room now carries `preview_available`, answered by the same predicate the press applies, and the button hides with a reason when it's false.

- `preview_available` is filled on both list and by-id reads, because the room screen reads its room from the list.
- The predicate checks the caller's `update` grant, a human seat, a writable and live deal, and a non-archived room.
- Probe failures now propagate instead of reading as "no" — a swallowed failure could commit an aborted transaction and return 200 OK having verified nothing.
- The probe is set-based via `auth.StampWritable`, one query per page instead of two per row.
- An absent field (older server) still shows the button, since unknown is not no and the press still asks.
- The refusal copy avoids naming the owner, because managers, admins, and write-grant holders can preview too.

<sup>Written for commit 3cfc95417e629a2bc9a96e7c785ffb26a97b7997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

