### PR TITLE
fix(compose): three schema-conformance/RBAC gaps from the same main-red episode

### DIFF
--- a/backend/internal/compose/integration/agentaccess/passports_integration_test.go
+++ b/backend/internal/compose/integration/agentaccess/passports_integration_test.go
@@ -85,8 +85,24 @@ func setupPassports(t *testing.T) *passportsEnv {
 	return e
 }
 
+// identityFor builds the identity ListPassports actually reads. Since
+// 8996cef8e ("A settings surface is gated on the grant it named, not on
+// being an admin") the admin widening asks auth.Require(ctx, "user_admin",
+// ActionRead) against id.Permissions, not id.hasRole("admin") against
+// id.Roles — Roles still rides along (other identity verbs' escalation
+// ceiling reads it), but a caller here meaning "admin" has to grant the
+// object too, or the check the production code runs sees nobody.
 func (e *passportsEnv) identityFor(user ids.UUID, roles []string) identity.Identity {
-	return identity.Identity{UserID: ids.From[ids.UserKind](user), WorkspaceID: ids.From[ids.WorkspaceKind](e.WS), Roles: roles}
+	perms := principal.Permissions{RowScope: principal.RowScopeAll}
+	for _, r := range roles {
+		if r == "admin" {
+			perms.Objects = map[string]principal.ObjectGrant{"user_admin": {Read: true}}
+		}
+	}
+	return identity.Identity{
+		UserID: ids.From[ids.UserKind](user), WorkspaceID: ids.From[ids.WorkspaceKind](e.WS),
+		Roles: roles, Permissions: perms,
+	}
 }
 
 func (e *passportsEnv) ctx() context.Context {

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -17,7 +17,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -69,13 +72,27 @@ func seedRollupOpenDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID, amo
 
 // seedRollupWonDeal closes a deal with the frozen FX rate the
 // deal_closed_fx CHECK demands — the rate the quarter sum must reuse.
+//
+// amount_minor_base is set alongside it rather than left to a trigger: since
+// 1788583500 the column is filled by the real close path (deals.freezeBaseRate),
+// never generated — a generated expression cannot reach the base currency's own
+// minor-unit scale. Computed here with deals.ConvertToBase, the same exported
+// arithmetic that writer calls, rather than a second copy of the formula.
 func seedRollupWonDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID,
 	amountMinor int64, currency, fxRateToBase string, closedAt time.Time,
 ) {
 	t.Helper()
-	e.WsExec(t, `INSERT INTO deal (id, name, amount_minor, currency, fx_rate_to_base, pipeline_id, stage_id, organization_id, status, closed_at, source, captured_by)
-		VALUES ($1, 'Won Deal', $2, $3, $4, $5, $6, $7, 'won', $8, 'manual', 'human:test')`,
-		ids.NewV7(), amountMinor, currency, fxRateToBase, st.pipeline, st.won, org, closedAt)
+	var rate pgtype.Numeric
+	if err := rate.Scan(fxRateToBase); err != nil {
+		t.Fatalf("rate %q is not a number: %v", fxRateToBase, err)
+	}
+	amountMinorBase, err := deals.ConvertToBase(amountMinor, rate, currency, "EUR")
+	if err != nil {
+		t.Fatalf("converting %d %s to base: %v", amountMinor, currency, err)
+	}
+	e.WsExec(t, `INSERT INTO deal (id, name, amount_minor, currency, fx_rate_to_base, amount_minor_base, pipeline_id, stage_id, organization_id, status, closed_at, source, captured_by)
+		VALUES ($1, 'Won Deal', $2, $3, $4, $5, $6, $7, $8, 'won', $9, 'manual', 'human:test')`,
+		ids.NewV7(), amountMinor, currency, fxRateToBase, amountMinorBase, st.pipeline, st.won, org, closedAt)
 }
 
 func seedRollupFxRate(t *testing.T, e *Env, fromCurrency, rate string, day time.Time) {

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -141,6 +141,10 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		{"list_records", `{"record_type":"deal","filters":{"pipeline_id":"` + pipeline.String() + `"}}`},
 		{"list_records", `{"record_type":"person","limit":5}`},
 		{"run_report", `{"report":"deals-by-stage"}`},
+		// The typed engine's own door, over the same pipeline the fixture above
+		// already holds a deal in — so the count answers 1 rather than an
+		// unproven empty page.
+		{"run_analytics_query", `{"entity":"pipeline-current","measures":[{"fn":"count","as":"deals"}]}`},
 		// No arguments: the directory answers what the installation composed, so
 		// there is nothing for a caller to narrow by — and the empty object is
 		// the shape the schema declares.


### PR DESCRIPTION
## Summary

Three distinct breaks from the same main-red episode (a fourth, a stale `mcp-info.json`, was already fixed in #4356):

1. **`run_analytics_query` never invoked in the schema-conformance sweep.** #4346 registered the typed analytics engine's MCP door but never added it to `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas`'s coverage sweep. Fix: added the call, over `pipeline-current`.

2. **The org-rollup fixture never froze `amount_minor_base`.** Migration `1788583500` turned `deal.amount_minor_base` from a GENERATED column into one the real close path fills (`deals.freezeBaseRate`). `seedRollupWonDeal` seeds a closed deal by raw INSERT and never set the new column, so `TestOrgRollupReconcilesTreeToSelves` read `SUM(amount_minor_base)` as `0` instead of the frozen `30000`. Fix: computed with `deals.ConvertToBase`, the same exported arithmetic the real writer calls.

3. **The passports fixture claimed "admin" without the grant that now means it.** `8996cef8e` ("A settings surface is gated on the grant it named, not on being an admin") moved `ListPassports`'s admin widening off `id.hasRole("admin")` (reading `Identity.Roles`) onto `auth.Require(ctx, "user_admin", ActionRead)` (reading `Identity.Permissions`) — but never touched this test's `identityFor`, which still only set `Roles`. `TestListPassportsScopesToOwnerUnlessAdmin`'s "admin" identity carried the label and no grant, so the production check saw nobody and the admin case silently degraded to owner-only scope. Fix: grant `user_admin: {Read: true}` when the fixture means "admin".

All four confirmed reproducing on a clean `origin/main` checkout, independent of any other branch and of each other — four separate authors' recent PRs each shipped a real behavior change without updating one sibling copy (a generated doc, a coverage sweep, a test fixture computing money, a test fixture's permission grant).

## Test plan

- [x] All four named tests pass individually and as part of their packages
- [x] `make check-go` — green
- [x] `craft static --strict` — 0 blocker/major/minor
- [x] Full `make test-integration` run in progress locally as an extra check beyond the CI shards
- [x] Based on latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RSPfhkYwWQ5yMDQaJz3ao