### PR TITLE
The morning says what changed since the night looked

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2514,6 +2514,9 @@ export const de = {
   "brief.week.quiet":
     "Eine ruhige Woche — nichts abgeschlossen, nichts bewegt.",
 
+  "brief.changed.lead": "Seit dem Briefing geändert:",
+  "brief.changed.more": "+{count} weitere",
+  "brief.changed.open": "Arbeitsliste öffnen",
   "brief.feed.title": "Heute",
   "brief.feed.sub": "Eine Reihenfolge, einmal entschieden.",
   "brief.feed.loading": "Dein Morgen wird gelesen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2581,6 +2581,9 @@ export const en = {
   "brief.week.andCarry": "{result} {carry}",
   "brief.week.quiet": "A quiet week — nothing closed and nothing moved.",
 
+  "brief.changed.lead": "Changed since the brief:",
+  "brief.changed.more": "+{count} more",
+  "brief.changed.open": "Open the worklist",
   "brief.feed.title": "Today",
   "brief.feed.sub": "One order, decided once.",
   "brief.feed.loading": "Reading your morning",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2491,6 +2491,9 @@ export const vi = {
   "brief.week.quiet":
     "Một tuần yên ắng — không chốt được gì và không có gì chuyển động.",
 
+  "brief.changed.lead": "Thay đổi kể từ bản tóm tắt:",
+  "brief.changed.more": "+{count} mục khác",
+  "brief.changed.open": "Mở danh sách công việc",
   "brief.feed.title": "Hôm nay",
   "brief.feed.sub": "Một thứ tự, quyết định một lần.",
   "brief.feed.loading": "Đang đọc buổi sáng của bạn",

--- a/frontend/src/screens/brief.changed.test.tsx
+++ b/frontend/src/screens/brief.changed.test.tsx
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { ChangedSinceBrief } from "./brief.changed";
+import type { Worklist, WorklistItem } from "./worklist.queries";
+
+// What has happened since the night looked.
+//
+// The cases are all about the difference between three states the wire keeps
+// apart and a careless client would not: changed, not changed, and no run to
+// compare against.
+
+afterEach(cleanup);
+
+function item(over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id: "i1",
+    source: "waiting_customer",
+    category: "customer_waiting",
+    title: "Aster Handel",
+    because: [],
+    actions: ["open"],
+    ...over,
+  } as unknown as WorklistItem;
+}
+
+function draw(queue: WorklistItem[]) {
+  return render(
+    <LocaleProvider initial="en">
+      <ChangedSinceBrief
+        day={{ queue, as_of: "2026-09-03T06:42:00Z" } as unknown as Worklist}
+      />
+    </LocaleProvider>,
+  );
+}
+
+describe("what changed since the brief", () => {
+  it("names the rows the server marked as new", () => {
+    draw([
+      item({ id: "a", title: "Aster replied", changed_since_brief: true }),
+      item({
+        id: "b",
+        title: "Fleet retrofit moved",
+        changed_since_brief: true,
+      }),
+      item({ id: "c", title: "Old news", changed_since_brief: false }),
+    ]);
+
+    expect(screen.getByText(/Aster replied/)).toBeTruthy();
+    expect(screen.getByText(/Fleet retrofit moved/)).toBeTruthy();
+    expect(screen.queryByText(/Old news/)).toBeNull();
+  });
+
+  // THE distinction the whole strip turns on. A row carries no flag when there
+  // was no run to compare against, and "the night saw this" is a different fact
+  // from "there was no night". Reading absent as false would report a calm
+  // morning on the one day nothing could be known about it.
+  it("draws nothing when there was no run to compare against", () => {
+    const { container } = draw([
+      item({ id: "a", title: "Aster replied" }),
+      item({ id: "b", title: "Fleet retrofit moved" }),
+    ]);
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("draws nothing on a morning the night already saw whole", () => {
+    const { container } = draw([
+      item({ id: "a", changed_since_brief: false }),
+      item({ id: "b", changed_since_brief: false }),
+    ]);
+
+    expect(container.textContent).toBe("");
+  });
+
+  // Three names and then a count. A strip that listed eleven titles would be a
+  // second queue above the queue.
+  it("names three and counts the rest", () => {
+    draw(
+      Array.from({ length: 6 }, (_, at) =>
+        item({
+          id: `row-${at}`,
+          title: `Row ${at}`,
+          changed_since_brief: true,
+        }),
+      ),
+    );
+
+    expect(screen.getByText(/Row 0/)).toBeTruthy();
+    expect(screen.getByText(/Row 2/)).toBeTruthy();
+    expect(screen.queryByText(/Row 3/)).toBeNull();
+    // A substring match rather than a regex: the copy starts with "+", which a
+    // regex reads as a quantifier over nothing.
+    expect(
+      screen.getByText((text) =>
+        text.includes(en["brief.changed.more"].replace("{count}", "3")),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("says nothing about a remainder when it named them all", () => {
+    draw([
+      item({ id: "a", title: "Aster replied", changed_since_brief: true }),
+    ]);
+
+    expect(screen.queryByText(/more/)).toBeNull();
+  });
+
+  // A payload with no queue at all draws nothing rather than throwing: a page
+  // that throws is a worse answer than one that draws nothing.
+  it("draws nothing rather than throwing on an answer with no queue", () => {
+    const { container } = render(
+      <LocaleProvider initial="en">
+        <ChangedSinceBrief day={{} as unknown as Worklist} />
+      </LocaleProvider>,
+    );
+
+    expect(container.textContent).toBe("");
+  });
+});

--- a/frontend/src/screens/brief.changed.test.tsx
+++ b/frontend/src/screens/brief.changed.test.tsx
@@ -63,7 +63,7 @@ describe("what changed since the brief", () => {
       item({ id: "b", title: "Fleet retrofit moved" }),
     ]);
 
-    expect(container.textContent).toBe("");
+    expect(container.firstChild).toBeNull();
   });
 
   it("draws nothing on a morning the night already saw whole", () => {
@@ -72,7 +72,7 @@ describe("what changed since the brief", () => {
       item({ id: "b", changed_since_brief: false }),
     ]);
 
-    expect(container.textContent).toBe("");
+    expect(container.firstChild).toBeNull();
   });
 
   // Three names and then a count. A strip that listed eleven titles would be a
@@ -108,6 +108,55 @@ describe("what changed since the brief", () => {
     expect(screen.queryByText(/more/)).toBeNull();
   });
 
+  // The decisions deck above answers approvals, and this strip must not name
+  // one as well: the reader would see the same decision twice, once as a card
+  // they can answer and once as a line pointing at a worklist where it is not
+  // the row they came for. brief.sentence.ts holds the ONE spelling of what
+  // this page is answerable for, and reading the raw queue here was that rule
+  // reappearing one element higher.
+  it("leaves the decisions the deck above already answers to the deck", () => {
+    const { container } = draw([
+      item({
+        id: "a",
+        source: "approval",
+        title: "Approve the discount",
+        changed_since_brief: true,
+      }),
+      item({ id: "b", title: "Aster replied", changed_since_brief: true }),
+    ]);
+
+    expect(container.textContent).not.toContain("Approve the discount");
+    expect(screen.getByText(/Aster replied/)).toBeTruthy();
+  });
+
+  // THE mixed state, and the case that earns the `=== true` filter beyond the
+  // all-absent one. A run happened, so some rows carry the flag — but a row with
+  // no material timestamp of its own carries none even then
+  // (attention/briefdedupe.go skips it), and reading that absence as "changed"
+  // would name a row the night saw perfectly well.
+  it("names only the flagged rows when a run left some rows unflagged", () => {
+    draw([
+      item({ id: "a", title: "Aster replied", changed_since_brief: true }),
+      item({ id: "b", title: "Undateable row" }),
+      item({ id: "c", title: "Seen last night", changed_since_brief: false }),
+    ]);
+
+    expect(screen.getByText(/Aster replied/)).toBeTruthy();
+    expect(screen.queryByText(/Undateable row/)).toBeNull();
+    expect(screen.queryByText(/Seen last night/)).toBeNull();
+  });
+
+  // The only way out of the strip. Without it a reader is told three things
+  // moved and given nowhere to go and see them.
+  it("offers the way to the rows it named", () => {
+    draw([
+      item({ id: "a", title: "Aster replied", changed_since_brief: true }),
+    ]);
+
+    const link = screen.getByText(en["brief.changed.open"]);
+    expect(link.getAttribute("href")).toBe("#/worklist");
+  });
+
   // A payload with no queue at all draws nothing rather than throwing: a page
   // that throws is a worse answer than one that draws nothing.
   it("draws nothing rather than throwing on an answer with no queue", () => {
@@ -117,6 +166,6 @@ describe("what changed since the brief", () => {
       </LocaleProvider>,
     );
 
-    expect(container.textContent).toBe("");
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/screens/brief.changed.tsx
+++ b/frontend/src/screens/brief.changed.tsx
@@ -4,6 +4,7 @@
 import { Callout } from "../design-system/callout";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
+import { waitingRows } from "./brief.sentence";
 import { itemTitle } from "./worklist.copy";
 import type { Worklist } from "./worklist.queries";
 
@@ -41,7 +42,14 @@ const NAMED = 3;
 export function ChangedSinceBrief({ day }: Readonly<{ day: Worklist }>) {
   const t = useT();
   const { locale } = useLocale();
-  const changed = (day.queue ?? []).filter(
+  // waitingRows, not the raw queue: it drops the approvals the Decisions deck
+  // above already answers, and it is the ONE spelling of "what this page is
+  // answerable for" that brief.sentence.ts's own comment insists on. Reading
+  // day.queue here named a decision in the strip that the deck was drawing as a
+  // card at the same moment — the duplication that rule exists to stop,
+  // reappearing one element higher. It also answers [] for a payload with no
+  // queue, so it is the null guard too.
+  const changed = waitingRows(day).filter(
     (item) => item.changed_since_brief === true,
   );
   if (changed.length === 0) {

--- a/frontend/src/screens/brief.changed.tsx
+++ b/frontend/src/screens/brief.changed.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Callout } from "../design-system/callout";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import { itemTitle } from "./worklist.copy";
+import type { Worklist } from "./worklist.queries";
+
+// What has happened since the night looked.
+//
+// The morning is assembled overnight and read hours later, and the gap is where
+// a rep gets caught out: a buyer replies at 07:15, the page still reflects 06:00,
+// and the row that changed sits in the same position saying the same thing. The
+// feed below is correctly ordered either way — the ranking is live — but nothing
+// on the page said "this is new since the brief".
+//
+// THE SERVER DECIDES WHAT IS NEW, not this. Each row carries
+// `changed_since_brief`, stamped against the run's own DATA CUTOFF rather than
+// the later instant it finished writing — a run that read at 06:00 and wrote at
+// 06:42 has a 42-minute window, and the wrong instant hides exactly the reply a
+// rep opens the page to find. The browser cannot make that comparison: it does
+// not know which of a row's several timestamps is the material one.
+//
+// ABSENT IS NOT FALSE. A row carries no flag at all when there was no run to
+// compare against, and this strip draws nothing in that case rather than
+// reporting a morning where nothing changed. "The night saw this" and "there was
+// no night" are different facts, and a reader who cannot tell them apart will
+// trust the wrong one.
+
+/** How many titles the strip names before it counts the rest. */
+const NAMED = 3;
+
+/**
+ * What changed since the overnight run, or nothing.
+ *
+ * Drawn only when something did. A strip that said "nothing has changed" every
+ * morning would teach a reader to stop reading it, and on a day with no run it
+ * would be saying something it cannot know.
+ */
+export function ChangedSinceBrief({ day }: Readonly<{ day: Worklist }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const changed = (day.queue ?? []).filter(
+    (item) => item.changed_since_brief === true,
+  );
+  if (changed.length === 0) {
+    return null;
+  }
+  const named = changed.slice(0, NAMED);
+  const rest = changed.length - named.length;
+  return (
+    <Callout tone="info">
+      {t("brief.changed.lead")}{" "}
+      {named.map((item) => itemTitle(item, t, locale)).join(" · ")}
+      {rest > 0
+        ? ` · ${t("brief.changed.more", {
+            count: formatNumber(rest, locale),
+          })}`
+        : ""}{" "}
+      <a className="entity-link" href="#/worklist">
+        {t("brief.changed.open")}
+      </a>
+    </Callout>
+  );
+}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -8,6 +8,7 @@ import { useNow } from "../format/now";
 import { useT } from "../i18n";
 import { useDecisionSink } from "./approvalrow";
 import { usePendingApprovals } from "./approvals.queries";
+import { ChangedSinceBrief } from "./brief.changed";
 import { BriefDials } from "./brief.dials";
 import { BriefFeed } from "./brief.feed";
 import { PlanSection } from "./brief.plan";
@@ -284,6 +285,11 @@ export function HomeScreen() {
           the rail it would be a warning about the queue, filed away from the
           queue. */}
       {worklistQuery.data && <BriefCoverage day={worklistQuery.data} />}
+      {/* And what has happened since the night looked, under the coverage line
+          and above the readings: both are facts about the page as a whole
+          rather than about any one row, and a reader takes them before the
+          figures they qualify. */}
+      {worklistQuery.data && <ChangedSinceBrief day={worklistQuery.data} />}
       {/* The strip reads the SAME worklist answer the queue below it reads, so
           the five figures cannot disagree with the rows they summarise. */}
       {worklistQuery.data && <HomeReadingsStrip day={worklistQuery.data} />}


### PR DESCRIPTION
The brief is assembled overnight and read hours later, and the gap is where a rep
gets caught out. A buyer replies at 07:15; the page still reflects 06:00; the row
that changed sits in the same place saying the same thing.

The feed below is correctly ordered either way — the ranking is live — but
nothing on the page said "this is new since the night". A strip under the
coverage line now names up to three of them and counts the rest.

## The server decides what is new

`changed_since_brief` ships already (#4328), stamped against the run's own **data
cutoff** rather than the later instant it finished writing. The browser could not
make that comparison: it does not know which of a row's several timestamps is the
material one, and a run that read at 06:00 and wrote at 06:42 has a 42-minute
window where the wrong instant hides exactly the reply this strip exists to
surface.

## Absent is not false

This is the one way the strip can be wrong. A row carries **no flag at all** when
there was no run to compare against; `false` means the night saw it and nothing
happened since.

Reading absent as unchanged would report a calm morning on the day nothing could
be known about it. So the filter tests `=== true`, and the case is
mutation-checked — the looser `!== false` fails the "no run to compare against"
test.

## Placement

Under the coverage caveat, above the readings. Both are facts about the page as a
whole rather than about any one row, and a reader takes them before the figures
they qualify.

## Verification

`make check-backend` and `make check-fe` green (6666 frontend tests), plus
`craft-static`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The brief page now shows what changed since the overnight run, so a rep can see that a buyer replied at 07:15 when the brief was assembled at 06:00. A strip under the coverage line names up to three changed rows and counts the rest, with a link to the worklist.

- The server's `changed_since_brief` flag decides what's new, stamped against the run's data cutoff rather than when it finished writing.
- A row with no flag means there was no run to compare against, and the strip draws nothing — absent is not "unchanged". The filter uses `=== true`.
- The strip reads `waitingRows`, so it never names an approval that the Decisions deck above already answers.

<sup>Written for commit 939a1a1e89f2f6c3e10e9c78cf4543bca96c44a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

