### PR TITLE
feat(analytics): the nightly check's coverage has a screen

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3314,6 +3314,21 @@ export const de = {
   "analytics.sectionPerformance": "Ergebnisse",
   "analytics.noClosedDeals": "Es wurden noch keine Deals abgeschlossen.",
   "analytics.sectionOutcomes": "Meine Ergebnisse",
+  "analytics.sectionCoverage": "Datenabdeckung",
+  "analytics.coverageSub":
+    "Welche Quellen die nächtliche Prüfung lesen konnte, und wie weit. Eine stille, aber gelesene Quelle gilt als geprüft; eine ungelesene sagt warum.",
+  "analytics.covSource": "Quelle",
+  "analytics.covState": "Zustand",
+  "analytics.covThrough": "Geprüft bis",
+  "analytics.covChecked": "Geprüft",
+  "analytics.covStale": "Veraltet — zuletzt nichts gelesen",
+  "analytics.covUnavailable":
+    "Nicht verfügbar — die Prüfung konnte nicht lesen",
+  "analytics.covPermissionLimited": "Zugriff muss neu erteilt werden",
+  "analytics.covNotConnected":
+    "Nicht verbunden — nichts zu reparieren, etwas zu entscheiden",
+  "analytics.coverageInputsElsewhere":
+    "Probleme auf Datensatzebene werden in der Forecast-Eingangsprüfung gelistet und gelöst.",
   "analytics.myPipeline": "Meine offene Pipeline",
   "analytics.myMeetings": "Meine Termine",
   "analytics.meetingsAsTheyStand":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3385,6 +3385,12 @@ export const de = {
   "review.checksIncomplete": "Prüfung unvollständig",
   "review.allSourcesRead": "Alle Quellen wurden gelesen.",
   "review.source.mail": "das Postfach",
+  "review.source.calendar": "der Kalender",
+  "review.source.documents": "Dokumente",
+  "review.source.contracts": "Verträge",
+  "review.source.incumbent": "das Altsystem",
+  "analytics.coverageNeverRun":
+    "Noch keine Prüfung gelaufen. Eine frische Installation wurde noch nicht angesehen — etwas anderes als eine, die geprüft und für gesund befunden wurde.",
   "review.source.offers": "Angebote",
   "review.sourcesUnread":
     "Nicht gelesen: {sources}. Die Befunde unten decken nur ab, was geprüft werden konnte.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3455,6 +3455,12 @@ export const en = {
   // reader was told "mail, offers" in English — words that name a table, not a
   // thing they would go and fix.
   "review.source.mail": "the mailbox",
+  "review.source.calendar": "the calendar",
+  "review.source.documents": "documents",
+  "review.source.contracts": "contracts",
+  "review.source.incumbent": "the incumbent system",
+  "analytics.coverageNeverRun":
+    "No check has run yet. A fresh installation has not been looked at — different from one that was looked at and found healthy.",
   "review.source.offers": "offers",
   "review.sourcesUnread":
     "Not read: {sources}. Findings below cover only what could be checked.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3381,6 +3381,20 @@ export const en = {
   "analytics.sectionPerformance": "Performance",
   "analytics.noClosedDeals": "No deals have closed yet.",
   "analytics.sectionOutcomes": "My outcomes",
+  "analytics.sectionCoverage": "Data coverage",
+  "analytics.coverageSub":
+    "Which sources the nightly check could read, and how far. A quiet source that was read is checked; an unread one says why.",
+  "analytics.covSource": "Source",
+  "analytics.covState": "State",
+  "analytics.covThrough": "Checked through",
+  "analytics.covChecked": "Checked",
+  "analytics.covStale": "Stale — nothing read recently",
+  "analytics.covUnavailable": "Unavailable — the check could not read it",
+  "analytics.covPermissionLimited": "Access needs re-granting",
+  "analytics.covNotConnected":
+    "Not connected — nothing to fix, something to decide",
+  "analytics.coverageInputsElsewhere":
+    "Record-level input problems are listed and resolved in the Forecast input review.",
   "analytics.myPipeline": "My open pipeline",
   "analytics.myMeetings": "My meetings",
   "analytics.meetingsAsTheyStand":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3351,6 +3351,12 @@ export const vi = {
   "review.checksIncomplete": "Kiểm tra chưa đầy đủ",
   "review.allSourcesRead": "Đã đọc mọi nguồn.",
   "review.source.mail": "hộp thư",
+  "review.source.calendar": "lịch",
+  "review.source.documents": "tài liệu",
+  "review.source.contracts": "hợp đồng",
+  "review.source.incumbent": "hệ thống cũ",
+  "analytics.coverageNeverRun":
+    "Chưa có lần kiểm tra nào chạy. Bản cài đặt mới chưa được xem xét — khác với bản đã được xem và thấy ổn.",
   "review.source.offers": "báo giá",
   "review.sourcesUnread":
     "Chưa đọc: {sources}. Các phát hiện bên dưới chỉ bao gồm những gì kiểm tra được.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3281,6 +3281,20 @@ export const vi = {
   "analytics.sectionPerformance": "Hiệu suất",
   "analytics.noClosedDeals": "Chưa có deal nào được chốt.",
   "analytics.sectionOutcomes": "Kết quả của tôi",
+  "analytics.sectionCoverage": "Độ phủ dữ liệu",
+  "analytics.coverageSub":
+    "Những nguồn nào kiểm tra hằng đêm đọc được, và đến đâu. Nguồn im ắng nhưng đã đọc là đã kiểm tra; nguồn chưa đọc sẽ nói lý do.",
+  "analytics.covSource": "Nguồn",
+  "analytics.covState": "Trạng thái",
+  "analytics.covThrough": "Đã kiểm tra đến",
+  "analytics.covChecked": "Đã kiểm tra",
+  "analytics.covStale": "Cũ — gần đây không đọc được gì",
+  "analytics.covUnavailable": "Không khả dụng — kiểm tra không đọc được",
+  "analytics.covPermissionLimited": "Cần cấp lại quyền truy cập",
+  "analytics.covNotConnected":
+    "Chưa kết nối — không có gì để sửa, có việc cần quyết định",
+  "analytics.coverageInputsElsewhere":
+    "Vấn đề ở cấp bản ghi được liệt kê và xử lý trong phần rà soát đầu vào của Forecast.",
   "analytics.myPipeline": "Pipeline đang mở của tôi",
   "analytics.myMeetings": "Cuộc họp của tôi",
   "analytics.meetingsAsTheyStand":

--- a/frontend/src/screens/analytics.forecast.review.tsx
+++ b/frontend/src/screens/analytics.forecast.review.tsx
@@ -172,12 +172,22 @@ function CoverageLine({ run }: Readonly<{ run: Assurance }>) {
 // recognise. An unknown source falls back to its wire key: a source this
 // release has not heard of is better named badly than not named at all, since
 // the whole point of the line is which one to go and fix.
-function sourceName(source: string, t: ReturnType<typeof useT>): string {
+// Exported for the Data coverage table, which draws the same source enum:
+// two screens naming one vocabulary share one translator.
+export function sourceName(source: string, t: ReturnType<typeof useT>): string {
   switch (source) {
     case "mail":
       return t("review.source.mail");
     case "offers":
       return t("review.source.offers");
+    case "calendar":
+      return t("review.source.calendar");
+    case "documents":
+      return t("review.source.documents");
+    case "contracts":
+      return t("review.source.contracts");
+    case "incumbent":
+      return t("review.source.incumbent");
     default:
       return source;
   }

--- a/frontend/src/screens/analytics.stories.tsx
+++ b/frontend/src/screens/analytics.stories.tsx
@@ -261,6 +261,43 @@ const ownLensRoutes: RouteMap = {
     ]),
 };
 
+// Source health under the ops grant: one read source with its instant, and
+// every unread state in its own words.
+const coverageRoutes: RouteMap = {
+  ...routes,
+  "GET /analytics/coverage": () =>
+    jsonResponse({
+      run_id: "r1",
+      as_of: "2026-09-05T02:00:00Z",
+      sources: [
+        {
+          source: "mail",
+          state: "checked",
+          checked_through: "2026-09-05T01:30:00Z",
+        },
+        {
+          source: "offers",
+          state: "checked",
+          checked_through: "2026-09-05T02:00:00Z",
+        },
+        { source: "calendar", state: "stale" },
+        { source: "documents", state: "not_connected" },
+      ],
+    }),
+};
+
+export const DataCoverage: Story = {
+  render: () => {
+    installFetchStub(coverageRoutes);
+    return (
+      <StoryProviders>
+        <AnalyticsScreen />
+      </StoryProviders>
+    );
+  },
+  play: clickButton("Data coverage"),
+};
+
 export const MyOutcomes: Story = {
   render: () => {
     installFetchStub(ownLensRoutes);

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -67,6 +67,9 @@ type ReportsStubOpts = {
   winLossRows?: Record<string, unknown>[];
   stageAgeRows?: Record<string, unknown>[];
   meetingRows?: Record<string, unknown>[];
+  // The coverage read: a payload, a status (403 for a seat without the ops
+  // grant, 404 for a fresh installation), or omitted for the default 403.
+  coverage?: { status: number; body?: unknown };
   derivation?: Record<string, unknown>;
   onDerivation?: (url: string) => void;
   context?: Record<string, unknown>;
@@ -81,6 +84,13 @@ function reportsStub(opts: ReportsStubOpts = {}) {
     // numbers cover, and whether this reader may publish a forecast. A stub
     // without it leaves the screen waiting and the assertions below looking
     // like a rendering bug.
+    if (url.includes("/analytics/coverage")) {
+      const cov = opts.coverage ?? { status: 403 };
+      return jsonResponse(
+        cov.body ?? { title: "Forbidden", status: cov.status },
+        cov.status,
+      );
+    }
     if (url.includes("/analytics/context")) {
       return jsonResponse(
         opts.context ?? {
@@ -186,6 +196,53 @@ async function openPerformance() {
     .setup()
     .click(await screen.findByRole("button", { name: "Performance" }));
 }
+
+describe("the data coverage section", () => {
+  it("names each source's state in words, with the instant a read one reached", async () => {
+    vi.stubGlobal(
+      "fetch",
+      reportsStub({
+        coverage: {
+          status: 200,
+          body: {
+            run_id: "r1",
+            as_of: "2026-09-05T02:00:00Z",
+            sources: [
+              {
+                source: "mail",
+                state: "checked",
+                checked_through: "2026-09-05T01:30:00Z",
+              },
+              { source: "offers", state: "not_connected" },
+            ],
+          },
+        },
+      }),
+    );
+    render(<AnalyticsScreen />);
+    await userEvent
+      .setup()
+      .click(await screen.findByRole("button", { name: "Data coverage" }));
+    expect(await screen.findByText("Checked")).toBeTruthy();
+    // An unconnected source is a decision, not a repair — its words say so.
+    expect(
+      screen.getByText("Not connected — nothing to fix, something to decide"),
+    ).toBeTruthy();
+    // Only the read source carries a date; the unread one shows absence.
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("hides the tab from a seat the server refuses", async () => {
+    vi.stubGlobal("fetch", reportsStub({ coverage: { status: 403 } }));
+    render(<AnalyticsScreen />);
+    await screen.findByRole("button", { name: "Pipeline" });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Data coverage" }),
+      ).toBeNull(),
+    );
+  });
+});
 
 // A context whose default lens is one seat: the rep's own.
 const ownLensContext = {

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -224,12 +224,27 @@ describe("the data coverage section", () => {
       .setup()
       .click(await screen.findByRole("button", { name: "Data coverage" }));
     expect(await screen.findByText("Checked")).toBeTruthy();
+    // The source column speaks the reader's words, not the wire's.
+    expect(screen.getByText("the mailbox")).toBeTruthy();
     // An unconnected source is a decision, not a repair — its words say so.
     expect(
       screen.getByText("Not connected — nothing to fix, something to decide"),
     ).toBeTruthy();
     // Only the read source carries a date; the unread one shows absence.
     expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("says a fresh installation was never looked at, in words", async () => {
+    vi.stubGlobal("fetch", reportsStub({ coverage: { status: 404 } }));
+    render(<AnalyticsScreen />);
+    await userEvent
+      .setup()
+      .click(await screen.findByRole("button", { name: "Data coverage" }));
+    expect(
+      await screen.findByText(
+        "No check has run yet. A fresh installation has not been looked at — different from one that was looked at and found healthy.",
+      ),
+    ).toBeTruthy();
   });
 
   it("hides the tab from a seat the server refuses", async () => {

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -30,6 +30,7 @@ import {
   useAnalyticsSelection,
 } from "./analytics.context";
 import { ForecastView } from "./analytics.forecast";
+import { sourceName } from "./analytics.forecast.review";
 import { AnalyticsScopePicker } from "./analytics.scope";
 import { ShareViewButton } from "./analytics.share";
 import {
@@ -1058,50 +1059,53 @@ const COVERAGE_STATE_KEY: Readonly<Record<string, MessageKey>> = {
 function DataCoverageView({
   locale,
   timezone,
-}: Readonly<{ locale: Locale; timezone: string | null }>) {
+}: Readonly<{ locale: Locale; timezone: string }>) {
   const t = useT();
   const coverage = useDataCoverage();
   return (
     <QueryGate query={coverage} pendingLabel={t("analytics.sectionCoverage")}>
-      {(run) => (
-        <Card title={t("analytics.sectionCoverage")}>
-          <p className="sub">{t("analytics.coverageSub")}</p>
-          <DataTable
-            label={t("analytics.sectionCoverage")}
-            columns={[
-              {
-                key: "source",
-                header: t("analytics.covSource"),
-                render: (row: DataCoverageRow) => row.source,
-              },
-              {
-                key: "state",
-                header: t("analytics.covState"),
-                render: (row: DataCoverageRow) =>
-                  COVERAGE_STATE_KEY[row.state]
-                    ? t(COVERAGE_STATE_KEY[row.state])
-                    : row.state,
-              },
-              {
-                key: "through",
-                header: t("analytics.covThrough"),
-                render: (row: DataCoverageRow) =>
-                  // The instant renders only once the frame's own zone is
-                  // known — a screen must not name a zone of its own, and a
-                  // date placed in a guessed one is worse than a beat of "—".
-                  row.checked_through && timezone
-                    ? formatDateTime(row.checked_through, locale, timezone)
-                    : "—",
-              },
-            ]}
-            rows={run.sources}
-            rowKey={(row) => row.source}
-          />
-          {/* Record-level input problems live where they are answered: the
+      {(run) =>
+        run == null ? (
+          <Card title={t("analytics.sectionCoverage")}>
+            <EmptyState>{t("analytics.coverageNeverRun")}</EmptyState>
+          </Card>
+        ) : (
+          <Card title={t("analytics.sectionCoverage")}>
+            <p className="sub">{t("analytics.coverageSub")}</p>
+            <DataTable
+              label={t("analytics.sectionCoverage")}
+              columns={[
+                {
+                  key: "source",
+                  header: t("analytics.covSource"),
+                  render: (row: DataCoverageRow) => sourceName(row.source, t),
+                },
+                {
+                  key: "state",
+                  header: t("analytics.covState"),
+                  render: (row: DataCoverageRow) =>
+                    COVERAGE_STATE_KEY[row.state]
+                      ? t(COVERAGE_STATE_KEY[row.state])
+                      : row.state,
+                },
+                {
+                  key: "through",
+                  header: t("analytics.covThrough"),
+                  render: (row: DataCoverageRow) =>
+                    row.checked_through
+                      ? formatDateTime(row.checked_through, locale, timezone)
+                      : "—",
+                },
+              ]}
+              rows={run.sources}
+              rowKey={(row) => row.source}
+            />
+            {/* Record-level input problems live where they are answered: the
               Forecast input review. One resolution surface, not two. */}
-          <p className="sub">{t("analytics.coverageInputsElsewhere")}</p>
-        </Card>
-      )}
+            <p className="sub">{t("analytics.coverageInputsElsewhere")}</p>
+          </Card>
+        )
+      }
     </QueryGate>
   );
 }
@@ -1115,9 +1119,11 @@ function useDataCoverage() {
     queryFn: async () => {
       const { data, error, response } = await api.GET("/analytics/coverage");
       if (response.status === 404) {
-        // A fresh installation: no run has completed. The gate renders the
-        // typed empty state rather than an error.
-        return { run_id: "", as_of: "", sources: [] };
+        // A fresh installation: no run has completed yet. Null, so the view
+        // says that in words rather than drawing headers over blank space —
+        // "nothing has looked yet" and "everything looked fine" are opposite
+        // instructions about whether to trust the numbers elsewhere.
+        return null;
       }
       if (error) {
         throwProblem(error);

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -25,6 +25,7 @@ import {
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
+  type AnalyticsSelection,
   useAnalyticsContext,
   useAnalyticsSelection,
 } from "./analytics.context";
@@ -79,7 +80,12 @@ type ReportKey =
 // held exactly one report, and keeping them the same would have meant the
 // address changing the day a section grew a second result — breaking every
 // link anyone had saved to it.
-type Section = "forecast" | "pipeline" | "performance" | "outcomes";
+type Section =
+  | "forecast"
+  | "pipeline"
+  | "performance"
+  | "outcomes"
+  | "coverage";
 
 // Which results each section holds, in the order they are drawn. The tab strip
 // and the bodies both read this, so a section cannot come to list a report it
@@ -99,6 +105,8 @@ const SECTION_REPORTS = {
   performance: ["win-loss", "stage-age"],
   // The rep's own week: a composed view like the forecast, not report cards.
   outcomes: [],
+  // Source health: an ops view over the nightly check's own coverage rows.
+  coverage: [],
 } as const satisfies Record<Section, readonly ReportKey[]>;
 
 const SECTIONS = Object.keys(SECTION_REPORTS) as readonly Section[];
@@ -1033,6 +1041,92 @@ function StageAgeTable({
   );
 }
 
+// Every word a coverage row's state can carry, spelled per state so an
+// unread source never borrows a read one's copy. A hand-kept mirror of the
+// server's own vocabulary; an unknown state renders its raw word rather than
+// a wrong sentence.
+const COVERAGE_STATE_KEY: Readonly<Record<string, MessageKey>> = {
+  checked: "analytics.covChecked",
+  stale: "analytics.covStale",
+  unavailable: "analytics.covUnavailable",
+  permission_limited: "analytics.covPermissionLimited",
+  not_connected: "analytics.covNotConnected",
+};
+
+// Which connectors the nightly check could read, and how far. Ops-facing: the
+// server gates the read, and a seat without the grant never sees the tab.
+function DataCoverageView({
+  locale,
+  timezone,
+}: Readonly<{ locale: Locale; timezone: string | null }>) {
+  const t = useT();
+  const coverage = useDataCoverage();
+  return (
+    <QueryGate query={coverage} pendingLabel={t("analytics.sectionCoverage")}>
+      {(run) => (
+        <Card title={t("analytics.sectionCoverage")}>
+          <p className="sub">{t("analytics.coverageSub")}</p>
+          <DataTable
+            label={t("analytics.sectionCoverage")}
+            columns={[
+              {
+                key: "source",
+                header: t("analytics.covSource"),
+                render: (row: DataCoverageRow) => row.source,
+              },
+              {
+                key: "state",
+                header: t("analytics.covState"),
+                render: (row: DataCoverageRow) =>
+                  COVERAGE_STATE_KEY[row.state]
+                    ? t(COVERAGE_STATE_KEY[row.state])
+                    : row.state,
+              },
+              {
+                key: "through",
+                header: t("analytics.covThrough"),
+                render: (row: DataCoverageRow) =>
+                  // The instant renders only once the frame's own zone is
+                  // known — a screen must not name a zone of its own, and a
+                  // date placed in a guessed one is worse than a beat of "—".
+                  row.checked_through && timezone
+                    ? formatDateTime(row.checked_through, locale, timezone)
+                    : "—",
+              },
+            ]}
+            rows={run.sources}
+            rowKey={(row) => row.source}
+          />
+          {/* Record-level input problems live where they are answered: the
+              Forecast input review. One resolution surface, not two. */}
+          <p className="sub">{t("analytics.coverageInputsElsewhere")}</p>
+        </Card>
+      )}
+    </QueryGate>
+  );
+}
+
+type DataCoverageRow = components["schemas"]["DataCoverage"]["sources"][number];
+
+function useDataCoverage() {
+  return useQuery({
+    queryKey: ["analytics-coverage"],
+    retry: false,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET("/analytics/coverage");
+      if (response.status === 404) {
+        // A fresh installation: no run has completed. The gate renders the
+        // typed empty state rather than an error.
+        return { run_id: "", as_of: "", sources: [] };
+      }
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
 type AnalyticsScopeWire = components["schemas"]["AnalyticsScope"];
 
 // The current standing a meeting can hold, in the order a week reads: what is
@@ -1367,14 +1461,22 @@ export function AnalyticsScreen() {
   // Sharing sits beside the tabs rather than inside a section, because the
   // thing being shared is the SECTION the reader is on — a button that moved
   // with the content would read as sharing one card.
+  const coverageProbe = useDataCoverage();
   const header = (
     <div className="analytics-header">
       <RecordTabs
-        options={SECTIONS.filter(
-          (candidate) =>
-            candidate !== "outcomes" ||
-            context.data?.default_scope.kind === "owner",
-        )}
+        options={SECTIONS.filter((candidate) => {
+          if (candidate === "outcomes") {
+            return context.data?.default_scope.kind === "owner";
+          }
+          if (candidate === "coverage") {
+            // The server gates this read on the ops grant. The tab appears
+            // when the probe ANSWERS — hidden while pending, so a seat the
+            // server refuses never sees it flicker in and out.
+            return coverageProbe.isSuccess;
+          }
+          return true;
+        })}
         value={section}
         onChange={setSection}
         labels={{
@@ -1382,6 +1484,7 @@ export function AnalyticsScreen() {
           pipeline: t("analytics.sectionPipeline"),
           performance: t("analytics.sectionPerformance"),
           outcomes: t("analytics.sectionOutcomes"),
+          coverage: t("analytics.sectionCoverage"),
         }}
         label={t("analytics.sections")}
       />
@@ -1410,30 +1513,63 @@ export function AnalyticsScreen() {
   return (
     <div className="wrap">
       {header}
-      {section === "outcomes" ? (
-        context.data ? (
-          <MyOutcomesView
-            defaultScope={context.data.default_scope}
-            locale={locale}
-          />
-        ) : null
-      ) : section === "forecast" ? (
-        selection && context.data ? (
-          <ForecastView
-            selection={selection}
-            canSubmit={context.data.capabilities.submit_manager_forecast}
-          />
-        ) : null
-      ) : (
-        SECTION_REPORTS[section].map((report) => (
-          <ReportCard
-            key={report}
-            report={report}
-            stages={pipelineQuery.data?.stages ?? []}
-            locale={locale}
-          />
-        ))
-      )}
+      <SectionBody
+        section={section}
+        locale={locale}
+        context={context.data}
+        selection={selection}
+        stages={pipelineQuery.data?.stages ?? []}
+      />
     </div>
   );
+}
+
+// One section's body, chosen in its own component so the screen's own render
+// stays a header plus a choice rather than a ladder of ternaries.
+function SectionBody({
+  section,
+  locale,
+  context,
+  selection,
+  stages,
+}: Readonly<{
+  section: Section;
+  locale: Locale;
+  context: components["schemas"]["AnalyticsContext"] | undefined;
+  selection: AnalyticsSelection | null;
+  stages: readonly Stage[];
+}>) {
+  switch (section) {
+    case "coverage":
+      return (
+        <DataCoverageView
+          locale={locale}
+          timezone={context?.timezone ?? null}
+        />
+      );
+    case "outcomes":
+      return context ? (
+        <MyOutcomesView defaultScope={context.default_scope} locale={locale} />
+      ) : null;
+    case "forecast":
+      return selection && context ? (
+        <ForecastView
+          selection={selection}
+          canSubmit={context.capabilities.submit_manager_forecast}
+        />
+      ) : null;
+    default:
+      return (
+        <>
+          {SECTION_REPORTS[section].map((report) => (
+            <ReportCard
+              key={report}
+              report={report}
+              stages={stages}
+              locale={locale}
+            />
+          ))}
+        </>
+      );
+  }
 }


### PR DESCRIPTION
`GET /analytics/coverage` shipped with the nightly assurance job and had no UI. A **Data coverage** tab now renders it for the seats the server admits (admin/ops): each source the check tried, its state in its own words — a quiet source that was read is *checked*; an unconnected one is *a decision, not a repair* — and the instant a read source reached, in the installation's own zone.

The tab appears only when the probe answers, so a refused seat never sees it; a fresh installation's 404 renders as 'no check has run yet' rather than an error or an empty grid. Record-level input problems stay where they are resolved — the Forecast input review — and the card says so instead of growing a second resolution surface. Source names go through the same translator the input review uses, widened to the full six-source vocabulary.

The team-review half of this plan item already shipped as the team weekly brief (#4263), so this PR is the coverage half. Verified live: the endpoint answers on a seeded stack with mail `not_connected` and offers `checked`.

Reviewed by the fallback pair (Codex at its limit): security clean; craft's findings (raw wire words in the source column, the fabricated empty payload, an unreachable zone guard) fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a **Data coverage** tab that renders `GET /analytics/coverage` for admin/ops seats, showing which sources the nightly check could read, each state in plain words, and the instant a read source reached.

**New Features**
- The tab appears only when the probe answers; a seat the server refuses never sees it.
- A fresh installation's 404 renders as "no check has run yet" instead of an error or empty grid.
- Source names use the Forecast input review's translator, widened to the full six-source vocabulary.
- Record-level input problems stay in the Forecast input review; the card points there rather than adding a second resolution surface.

<sup>Written for commit cf38d769d3984d64e796cc12fb8ee0d8c029ee1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

