### PR TITLE
fix(analytics): the coverage section waits for the frame it renders in

### DIFF
--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -1547,12 +1547,11 @@ function SectionBody({
 }>) {
   switch (section) {
     case "coverage":
-      return (
-        <DataCoverageView
-          locale={locale}
-          timezone={context?.timezone ?? null}
-        />
-      );
+      // Like the other context-bearing sections: nothing renders before the
+      // frame arrives, so the view never has to guess a zone.
+      return context ? (
+        <DataCoverageView locale={locale} timezone={context.timezone} />
+      ) : null;
     case "outcomes":
       return context ? (
         <MyOutcomesView defaultScope={context.default_scope} locale={locale} />


### PR DESCRIPTION
#4375 shipped half of its final review fix: `DataCoverageView`'s `timezone` prop became required while `SectionBody` still passed `context?.timezone ?? null`, leaving the composed typecheck red on main. The coverage branch now gates on the loaded context like the outcomes and forecast branches beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red typecheck on main by making the coverage section wait for the loaded context before rendering, matching the outcomes and forecast sections.

- `DataCoverageView` now only renders when `context` is available, so it never receives a null `timezone`.
- The coverage section no longer passes `context?.timezone ?? null` as a fallback.

<sup>Written for commit b866b3f683f864d981edc72664c7bd518aeed103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

