### PR TITLE
fix(compose): the last owner to share a two-mailbox message is told it opened

### DIFF
--- a/backend/internal/compose/threadaudience.go
+++ b/backend/internal/compose/threadaudience.go
@@ -231,19 +231,39 @@ func readableActivityIDsTx(ctx context.Context, tx pgx.Tx, ids0 []ids.UUID) ([]i
 // It is also the honest number: the caller is owed how many colleagues co-hold
 // THEIR messages, not how many hold a stranger's message that happens to carry
 // the same header value.
+//
+// Whether one row holds is activities' question, answered by the same
+// predicate the audience derivation runs (activities.ImportRowHolds). The
+// count and the recompute read the same rows, so a second spelling here is a
+// second answer, and the one time this had one they disagreed: the last owner
+// to share a two-mailbox message was told a colleague still held it while the
+// recompute opened it to the workspace.
 func othersHoldingTx(ctx context.Context, tx pgx.Tx, messages []ids.UUID, user ids.UUID) (int, error) {
 	if len(messages) == 0 {
 		return 0, nil
 	}
-	var held int
-	if err := tx.QueryRow(ctx, `
-		SELECT count(DISTINCT i.user_id)
+	rows, err := tx.Query(ctx, `
+		SELECT i.user_id, i.posture_at_import, i.verdict_status
 		  FROM capture_import i
-		 WHERE i.activity_id = ANY($1) AND i.user_id <> $2
-		   AND (coalesce(i.posture_at_import, 'shared') <> 'shared'
-		        OR i.verdict_status IN ('held', 'unsure', 'held_by_owner', 'pending'))`,
-		messages, user).Scan(&held); err != nil {
+		 WHERE i.activity_id = ANY($1) AND i.user_id <> $2`,
+		messages, user)
+	if err != nil {
 		return 0, fmt.Errorf("compose: counting the seats still holding a thread: %w", err)
 	}
-	return held, nil
+	defer rows.Close()
+	holding := map[ids.UUID]struct{}{}
+	for rows.Next() {
+		var seat ids.UUID
+		var posture, status *string
+		if err := rows.Scan(&seat, &posture, &status); err != nil {
+			return 0, fmt.Errorf("compose: counting the seats still holding a thread: %w", err)
+		}
+		if activities.ImportRowHolds(posture, status) {
+			holding[seat] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("compose: counting the seats still holding a thread: %w", err)
+	}
+	return len(holding), nil
 }

--- a/backend/internal/compose/threadaudience_integration_test.go
+++ b/backend/internal/compose/threadaudience_integration_test.go
@@ -93,6 +93,38 @@ func TestOneOwnersShareCannotPublishAColleaguesHeldMessage(t *testing.T) {
 	}
 }
 
+func TestTheLastOwnersShareReportsTheMessageOpen(t *testing.T) {
+	// One message, two mailboxes, both `classified` at import — the default
+	// posture, so this is the ordinary two-importer case. The first owner's
+	// share is refused honestly: the colleague still holds. The second owner's
+	// share releases the LAST hold, and the answer must say so on both fields —
+	// a posture is what the mailbox asked of mail in general, and a seat's
+	// explicit shared_by_owner ends its say. The recompute already opens the
+	// message here; an answer still counting the posture as a hold tells the
+	// person who just published a conversation that it stayed private.
+	e := integration.Setup(t)
+	id := seedHeldThreadOn(t, e, "thread-last-holder", "kunde@example.test", e.Rep1)
+	addImportRowFor(t, e, id, e.Rep2)
+
+	first := decideThread(t, e, e.Rep1, "thread-last-holder", true)
+	if first.Shared || first.HeldByOthers != 1 {
+		t.Fatalf("first share: shared=%v held_by_others=%d, want false and 1 — the colleague is still holding",
+			first.Shared, first.HeldByOthers)
+	}
+
+	last := decideThread(t, e, e.Rep2, "thread-last-holder", true)
+	if last.HeldByOthers != 0 {
+		t.Fatalf("held_by_others=%d after both owners shared, want 0 — a shared_by_owner seat is not holding, "+
+			"whatever posture the message arrived under", last.HeldByOthers)
+	}
+	if !last.Shared {
+		t.Fatal("the last holder's share reported the message private while it opened to the workspace")
+	}
+	if got := activityAudience(t, e, id); got != "workspace" {
+		t.Fatalf("the message is %q after both owners shared, want workspace", got)
+	}
+}
+
 func TestAThreadYouDidNotImportIsNotFound(t *testing.T) {
 	// A thread key is the sender-controlled References root in a namespace the
 	// whole workspace shares, so it is guessable. Answering not-found rather

--- a/backend/internal/modules/activities/importrowholds.go
+++ b/backend/internal/modules/activities/importrowholds.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// ImportRowHolds answers whether ONE importing seat's row, on its own, still
+// asks for the message to be held.
+//
+// It is contributionOf restated as a boolean, and exists so that the seam
+// reporting "how many colleagues still hold this" counts by the same rule this
+// module derives the audience from. The rule's non-obvious half is that an
+// explicit verdict outranks the posture in BOTH directions: a mailbox that was
+// `classified` at import holds only until its seat decides, so a seat whose
+// verdict is `shared_by_owner` or `cleared` is not holding, whatever posture
+// the message arrived under. A count that read the posture as a standing hold
+// told the last owner to share a two-mailbox message that it was still private
+// at the moment the recompute opened it to the workspace.
+func ImportRowHolds(posture, status *string) bool {
+	audience, _ := contributionOf(posture, status, nil)
+	return audience != audienceWorkspace
+}


### PR DESCRIPTION
Fixes #4342.

## What was wrong

`othersHoldingTx` in `backend/internal/compose/threadaudience.go` spelled its own copy of the "is this seat holding" rule, and its posture arm counted `posture_at_import <> 'shared'` as a standing hold. A posture is a fact about the mailbox at import and never changes, so any seat whose mailbox was `classified` (the default) counted as holding forever — even after that seat's verdict said `shared_by_owner`. The recompute (`activities.RecomputeAudienceTx`) reads the same rows with the correct rule and opened the message, while the response told the last owner to share that a colleague was still holding it.

## The fix

The holding rule now has one spelling. `activities.ImportRowHolds` (new, in `backend/internal/modules/activities/importrowholds.go`) restates `contributionOf` — the function the audience derivation runs — as a boolean. `othersHoldingTx` fetches the other seats' import rows and counts holders through it, so the count and the derivation cannot disagree again.

## Tests

`TestTheLastOwnersShareReportsTheMessageOpen` replays the issue's scenario: one message, two `classified` importers, both share. The first share is refused with `held_by_others: 1` (correct — the colleague still holds); the second must answer `shared: true, held_by_others: 0` with the activity at `workspace`. Mutation-checked: restoring the old posture arm makes it fail.

Ran `make check-backend` green and `make test-it DIR=backend/internal/compose` over the whole thread-audience suite. `check-fe` had two flakes in `App.test.tsx` and `analytics.test.tsx` (no frontend files in this diff); both pass on a direct re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4342. The last owner to share a two-mailbox message was told a colleague still held it, while the recompute opened it to the workspace. `othersHoldingTx` spelled the holding rule itself and counted `posture_at_import` as a standing hold; a posture never changes, so a `classified` mailbox held forever even after its seat's verdict said `shared_by_owner`.

**Bug Fixes**
- The holding rule now has one spelling: `activities.ImportRowHolds` restates `contributionOf` as a boolean, and `othersHoldingTx` counts holders through it.
- `TestTheLastOwnersShareReportsTheMessageOpen` replays the two-importer scenario and fails if the old posture arm is restored.

<sup>Written for commit a44cbb6202b36ce793676387f48bd11740addd28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

