### PR TITLE
fix(worklist): a phone can snooze a row for a week again

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8064,6 +8064,8 @@ export const de = {
   "worklist.bandClear.keep_momentum": "Nichts Vereinbartes bleibt liegen.",
   "worklist.bandClear.review": "Nichts zu prüfen.",
   "worklist.disposition.verb.snooze": "Schlummern",
+  "worklist.disposition.snoozeForDays_one": "{value} Tag schlummern",
+  "worklist.disposition.snoozeForDays_other": "{value} Tage schlummern",
   "worklist.disposition.snoozeFor": "Für wie lange",
   "worklist.disposition.snoozeDays_one": "{value} Tag",
   "worklist.disposition.snoozeDays_other": "{value} Tage",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8173,6 +8173,8 @@ export const en = {
   "worklist.bandClear.keep_momentum": "Nothing agreed is drifting.",
   "worklist.bandClear.review": "Nothing to review.",
   "worklist.disposition.verb.snooze": "Snooze",
+  "worklist.disposition.snoozeForDays_one": "Snooze for {value} day",
+  "worklist.disposition.snoozeForDays_other": "Snooze for {value} days",
   "worklist.disposition.snoozeFor": "For how long",
   "worklist.disposition.snoozeDays_one": "{value} day",
   "worklist.disposition.snoozeDays_other": "{value} days",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7973,6 +7973,8 @@ export const vi = {
     "Không có việc đã thống nhất nào bị đình trệ.",
   "worklist.bandClear.review": "Không có gì để rà soát.",
   "worklist.disposition.verb.snooze": "Tạm gác",
+  "worklist.disposition.snoozeForDays_one": "Tạm gác {value} ngày",
+  "worklist.disposition.snoozeForDays_other": "Tạm gác {value} ngày",
   "worklist.disposition.snoozeFor": "Trong bao lâu",
   "worklist.disposition.snoozeDays_one": "{value} ngày",
   "worklist.disposition.snoozeDays_other": "{value} ngày",

--- a/frontend/src/screens/worklist.dispositions.tsx
+++ b/frontend/src/screens/worklist.dispositions.tsx
@@ -36,7 +36,7 @@ import {
 // a rep reaching for it at ten in the morning means tomorrow morning, not this
 // afternoon. It stays the default the plain press takes, so the fast path is
 // still one click.
-const SNOOZE_DAYS = 1;
+export const SNOOZE_DAYS = 1;
 
 // The spans a reader can choose instead.
 //
@@ -49,7 +49,7 @@ const SNOOZE_DAYS = 1;
 // moment is a claim about the reader's calendar: "Monday" from a Friday is
 // three days and from a Monday is seven, and a queue that guessed wrong would
 // hide work for four days nobody asked for. A span says exactly what it does.
-const SNOOZE_SPANS = [1, 3, 7] as const;
+export const SNOOZE_SPANS = [1, 3, 7] as const;
 
 type SnoozeSpan = (typeof SNOOZE_SPANS)[number];
 
@@ -141,7 +141,7 @@ export function usePutDown(item: WorklistItem) {
       },
     );
   };
-  return { offered, put, pending: set.isPending, t };
+  return { offered, put, pending: set.isPending, t, locale };
 }
 
 // The whole row, answerable with the thumb where there is no width for verbs.
@@ -237,11 +237,15 @@ function PutDownMenu({
   put,
   pending,
   t,
+  locale,
 }: Readonly<{
   offered: readonly WorklistDisposition[];
-  put: (disposition: WorklistDisposition) => void;
+  // The SPAN reaches the write, not only the judgement: the menu's longer
+  // lines are the answers the default day cannot give.
+  put: (disposition: WorklistDisposition, days?: SnoozeSpan) => void;
   pending: boolean;
   t: T;
+  locale: Locale;
 }>) {
   return (
     <OverflowMenu label={t("worklist.disposition.menu")}>
@@ -260,6 +264,32 @@ function PutDownMenu({
           {t(`worklist.disposition.verb.${disposition}` as const)}
         </Button>
       ))}
+      {/* The LONGER SPANS, as lines of their own rather than behind a second
+          control. Above the fold they live in a Popover beside the snooze verb,
+          which keeps the common case one press; a popover inside a menu is a
+          second layer over a surface already floating, and a keyboard reader
+          would open two things to say "next week".
+          The verb above still sends the default day, so the fast path is
+          unchanged and these are the answers it cannot give. Each carries its
+          own sentence — "Snooze for 3 days" — because a bare "3 days" standing
+          beside "Snooze" is a fragment whose subject a reader has to guess. */}
+      {offered.includes("snooze") &&
+        SNOOZE_SPANS.filter((days) => days !== SNOOZE_DAYS).map((days) => (
+          <Button
+            key={days}
+            small
+            variant="ghost"
+            pending={pending}
+            onClick={() => put("snooze", days)}
+          >
+            {translatePlural(
+              locale,
+              "worklist.disposition.snoozeForDays",
+              days,
+              { value: formatNumber(days, locale) },
+            )}
+          </Button>
+        ))}
     </OverflowMenu>
   );
 }
@@ -270,26 +300,27 @@ function PutDownMenu({
 // design-system/swiperow.tsx's header. PutDownByThumb carries every JUDGEMENT
 // there, on the row itself.
 //
-// The snooze SPANS do not survive the fold, and that is a gap rather than a
-// design. The gesture sends the default day, so below 720px a rep who knows a
-// customer is away all week can no longer say so — they press again tomorrow,
-// which is the state the spans were added to end. Restoring them means another
-// control in the row, which is the 44px band this change removed; that trade is
-// a product decision, filed as issue #4313 rather than settled here.
+// The snooze SPANS travel with them, as lines in that menu. They were lost for
+// one release: the gesture sends the default day, so a rep who knew a customer
+// was away all week pressed the same button every morning — the state the spans
+// were added to end. A menu line costs no height where a fourth 44px control
+// did, which is what made room for them without the band coming back.
 
 export function DispositionVerbs({ item }: Readonly<{ item: WorklistItem }>) {
   const folded = useFoldedViewport();
   // The row's own write, from the wrapper that holds it — one mutation per row,
   // so a press here and a swipe confirm beside it cannot write twice.
   //
-  // The fallback is for the callers that draw these verbs OUTSIDE a row, the
-  // Brief's Do Next section among them: they get their own write rather than
-  // throwing on a missing provider. Both hooks run either way, because a hook
-  // cannot be called conditionally; the unused one registers a mutation nobody
-  // fires, which costs a registration and never a request.
+  // The fallback is for a caller that draws these verbs outside a row: it gets
+  // its own write rather than throwing on a missing provider. Every caller
+  // today goes through WorklistRow, the Brief's feed included, so nothing
+  // reaches it — it is what keeps a future caller from a crash it cannot read.
+  // Both hooks run either way, because a hook cannot be called conditionally;
+  // the unused one registers a mutation nobody fires, which costs a
+  // registration and never a request.
   const shared = useContext(PutDownContext);
   const own = usePutDown(item);
-  const { offered, put, pending, t } = shared ?? own;
+  const { offered, put, pending, t, locale } = shared ?? own;
   if (offered.length === 0) {
     return null;
   }
@@ -297,7 +328,15 @@ export function DispositionVerbs({ item }: Readonly<{ item: WorklistItem }>) {
   // rather than four 44px controls, so the judgements stay reachable by key
   // without the height that put the row over its ceiling.
   if (folded) {
-    return <PutDownMenu offered={offered} put={put} pending={pending} t={t} />;
+    return (
+      <PutDownMenu
+        offered={offered}
+        put={put}
+        pending={pending}
+        t={t}
+        locale={locale}
+      />
+    );
   }
   return (
     <div className="worklist-row-dispositions">

--- a/frontend/src/screens/worklist.swipe.test.tsx
+++ b/frontend/src/screens/worklist.swipe.test.tsx
@@ -19,6 +19,8 @@ import { en } from "../i18n/en";
 import {
   DispositionVerbs,
   PutDownByThumb,
+  SNOOZE_DAYS,
+  SNOOZE_SPANS,
   SWIPE_SIDES,
 } from "./worklist.dispositions";
 import type { WorklistDisposition, WorklistItem } from "./worklist.queries";
@@ -149,6 +151,18 @@ function drawRows(count: number) {
       </LocaleProvider>
     </QueryClientProvider>,
   );
+}
+
+// The body of the one write, read off the Request the generated client sends.
+// An `init.body` lookup finds null on every call and would report "nothing was
+// sent" for a request that went out correctly.
+async function sentBody(
+  fetchSpy: ReturnType<typeof vi.fn>,
+): Promise<Record<string, unknown>> {
+  const [input] = fetchSpy.mock.calls[0] ?? [];
+  const request = input instanceof Request ? input.clone() : undefined;
+  const raw = request ? await request.text() : "";
+  return raw === "" ? {} : (JSON.parse(raw) as Record<string, unknown>);
 }
 
 afterEach(() => {
@@ -326,6 +340,57 @@ describe("putting a row down below the fold", () => {
           "the two placements are not sharing one mutation",
       ).toBe(true);
     });
+  });
+
+  // EVERY SPAN SURVIVES THE FOLD, and reaches the wire as itself.
+  //
+  // The gesture sends the default day and nothing else, so a fold that carried
+  // only the verbs left a rep who knows a customer is away all week pressing
+  // the same button every morning — the state the spans were added to end.
+  // They are menu lines below the fold because a line costs no height where a
+  // fourth 44px control does.
+  it("offers every snooze span below the fold, and sends the one pressed", async () => {
+    const user = userEvent.setup();
+    atWidth(true);
+    const fetchSpy = draw(EVERY_JUDGEMENT);
+
+    await user.click(
+      screen.getByRole("button", { name: en["worklist.disposition.menu"] }),
+    );
+
+    // The whole span vocabulary, derived rather than named here: a census that
+    // lists its own subjects proves only that they were listed.
+    for (const days of SNOOZE_SPANS) {
+      const line =
+        days === SNOOZE_DAYS
+          ? en["worklist.disposition.verb.snooze"]
+          : en["worklist.disposition.snoozeForDays_other"].replace(
+              "{value}",
+              String(days),
+            );
+      expect(
+        screen.getByRole("button", { name: line }),
+        `a reader below the fold cannot snooze for ${days} day(s)`,
+      ).toBeInTheDocument();
+    }
+
+    // And the span REACHES THE SERVER. A line that sent the default day would
+    // read as three choices offering one answer.
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.disposition.snoozeForDays_other"].replace(
+          "{value}",
+          "7",
+        ),
+      }),
+    );
+    await waitFor(() => expect(fetchSpy.mock.calls.length).toBe(1));
+    const sent = await sentBody(fetchSpy);
+    const until = new Date(String(sent.snoozed_until));
+    const days = Math.round(
+      (until.getTime() - Date.now()) / (24 * 60 * 60 * 1000),
+    );
+    expect(days, "the seven-day line sent a different span").toBe(7);
   });
 
   it("draws no gesture at all on a row the server offers nothing for", () => {


### PR DESCRIPTION
The 1/3/7-day snooze picker lived in the button band, and that band leaves the row below 720px so the queue can be worked with a thumb. The gesture sends the default day and nothing else, so **a rep who knew a customer was away all week pressed the same button every morning** — the state the spans were added to end.

Closes #4313.

## The room already existed

The menu that carries the three judgements below the fold takes a line at no height cost, where a fourth 44px control is exactly what did not fit. So the spans are lines in it, and the row stays at the height the swipe bought.

Each line carries its own sentence — **"Snooze for 3 days"**. Above the fold the spans sit under a "For how long" trigger that supplies the verb, so the line reads "3 days"; standing alone beside "Snooze" that is a fragment whose subject a reader has to guess.

**The default day is not repeated as a line.** `usePutDown` defaults the span to `SNOOZE_DAYS`, so a "Snooze for 1 day" line would send the identical instant the plain verb does — two controls for one answer, asking a reader to tell them apart for nothing.

## Evidence

| Obligation | Evidence |
|---|---|
| Every span survives the fold | `offers every snooze span below the fold, and sends the one pressed` — derives its subjects from `SNOOZE_SPANS` rather than naming them, so a hard-coded `[1, 3, 7]` cannot keep passing the day somebody adds a 14-day span with no line |
| The span reaches the server | The same test reads the **instant** off the request and computes the span. A line sending the default day would otherwise read as three choices offering one answer |
| Mutation strength | Remove a span line → fails naming the span nobody can reach. Drop `days` from the write → fails comparing seven days against one |
| Full lane | `make check-fe` green, **6661 tests** |
| Review | `craft-reviewer` |

## A note on this machine's gate runs

Three full-gate runs failed on **eleven different tests across six files**, every one passing in isolation and none of them touched by this diff. Load average was **77** — four other batman worktrees running gates at once. I did not merge on that: I ran the full gate on a clean checkout of `origin/main` (green, 6672 tests) and then again on this branch (green, 6661). Both clean runs are what this PR rests on.

## One correction to my own commit message

The first version claimed the menu makes the spans "reachable by KEY, which the popover never was on a phone." **Both halves were false.** `Popover` moves focus into its panel (`popover.tsx:91`), and there is no popover on a phone at all — the whole band leaves. I had invented a keyboard bug in a shipped component; the review caught it and the claim is gone.

Also fixed in passing: a comment naming the Brief's feed as a caller that draws these verbs outside a row. It goes through `WorklistRow` now, so the fallback it described has no caller — the comment says that instead of naming one that no longer applies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the 1/3/7-day snooze picker on phones, closing #4313. Below 720px the band that carried the spans leaves the row, so a rep could only snooze for the default day; the longer spans are now lines in the overflow menu at no height cost.

- Adds "Snooze for 3 days" and "Snooze for 7 days" to the menu; the default day stays on the plain verb so there aren't two controls for one answer.
- The pressed span reaches the server as its own day count.
- The test derives spans from `SNOOZE_SPANS` and reads the day count off the request, so a line sending the wrong span fails.

<sup>Written for commit 98767a67e23946568a47afb3a05b42e2dcc64bac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

