### PR TITLE
fix(person): the promise counter counts promises, not just claims

### DIFF
--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -461,6 +461,13 @@ export function hasCommitments(view: Person360): boolean {
 // Tasks lead: one was typed or confirmed by a person, a claim was inferred.
 // The task list arrives ordered by urgency (the next-steps read), and that
 // order is kept.
+//
+// WIDER than personowed.owedPromises, deliberately, and not a second spelling
+// of it. This list is what the record has open in both directions — it carries
+// `commitment_theirs` and an `open_question` too, and keeps a done loop so the
+// card can strike it through. The counter next to it measures only what WE owe
+// and only while it is unfinished, which is the server's own owedPromises
+// rule. Two questions, two answers.
 function openLoops(
   view: Person360,
   viewerId: string | undefined,

--- a/frontend/src/screens/personowed.ts
+++ b/frontend/src/screens/personowed.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+
+type Person360 = components["schemas"]["Person360"];
+
+// What this record owes, from BOTH places a promise is written down.
+//
+// The server's own rule, in one place the screens can share:
+// compose/person360.owedPromises unions the open next-step TASKS with the open
+// `commitment_ours` CLAIMS, and the headline that says "You owe them" is
+// computed from exactly that union. A card counting one half contradicts the
+// headline above it — which is what "You owe them" over "0 · nothing owed" was.
+//
+// It is a UNION, NOT A JOIN, for the reason the server gives: nothing writes
+// conversation_claim.task_activity_id, so an extracted commitment and a task
+// filed for the same thing are two unlinked rows. A reader who did both may
+// see two. Guessing which pairs mean one promise is the alternative, and it
+// would be a guess.
+
+/** One thing owed, whichever side it was written down on. */
+export type OwedPromise = {
+  readonly key: string;
+  /** When it is due, or null where nobody said. */
+  readonly dueAt: string | null;
+  /** What was promised, in the words the record holds. */
+  readonly body: string;
+  /** Where it was written down, for a card that shows its working. */
+  readonly note?: string;
+};
+
+/**
+ * The open promises this record owes.
+ *
+ * A task counts only while it is NOT done — a completed promise is not owed —
+ * and a claim only while it is `commitment_ours` and still open. The other
+ * claim kinds are deliberately absent: `commitment_theirs` is what the other
+ * side owes US, and an `open_question` is a question nobody promised anything
+ * about. Counting either would tell a rep they owe work that is not theirs.
+ */
+export function owedPromises(view: Person360): readonly OwedPromise[] {
+  const tasks = (view.next_steps?.data ?? [])
+    .filter((task) => task.is_done !== true)
+    .map((task) => ({
+      key: task.id,
+      dueAt: task.due_at ?? null,
+      // A task can arrive without a subject — one filed without one, and one
+      // whose content this reader may not see, which the server nulls. Both
+      // are still owed.
+      body: task.subject ?? "",
+    }));
+  const claims = (view.claims ?? [])
+    .filter(
+      (claim) => claim.kind === "commitment_ours" && claim.status === "open",
+    )
+    .map((claim) => ({
+      key: claim.id,
+      dueAt: claim.due_at ?? null,
+      body: claim.body,
+      note: claim.source_label ?? undefined,
+    }));
+  return [...tasks, ...claims];
+}
+
+/**
+ * Whether the count above is a floor rather than a total.
+ *
+ * `next_steps` is a page. A card reporting its length as "3 promises" when the
+ * server holds more states a number it did not measure, which is the one thing
+ * a count must not do.
+ */
+export function owedPromisesTruncated(view: Person360): boolean {
+  return view.next_steps?.page.has_more === true;
+}

--- a/frontend/src/screens/personreadings.test.tsx
+++ b/frontend/src/screens/personreadings.test.tsx
@@ -193,6 +193,91 @@ describe("what we owe them", () => {
       within(card(grid, "Open promises")).getByText("nothing owed"),
     ).toBeTruthy();
   });
+
+  // A task IS a promise. An accepted transcript proposal becomes one, and the
+  // record's headline ("You owe them") counts it — so a counter reading claims
+  // alone put "0 · nothing owed" directly under a line saying the opposite,
+  // about the same person, on the same screen.
+  it("counts an open task, which is what an accepted transcript promise becomes", () => {
+    const grid = show(
+      view({
+        claims: [],
+        next_steps: {
+          data: [
+            {
+              id: "t1",
+              subject: "Prepare the translation checklist",
+              due_at: "2026-08-05T09:00:00Z",
+              is_done: false,
+              occurred_at: AS_OF,
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        },
+      }),
+    );
+    const promises = card(grid, "Open promises");
+    expect(within(promises).getByText("1")).toBeTruthy();
+    expect(within(promises).getByText("overdue 19 days")).toBeTruthy();
+  });
+
+  // A finished promise is not owed, and the other party's promise is not ours.
+  it("counts neither a done task nor what they owe us", () => {
+    const grid = show(
+      view({
+        claims: [
+          {
+            id: "c1",
+            kind: "commitment_theirs",
+            body: "Confirm the plan",
+            status: "open",
+            source_activity_id: "a1",
+            source_quote: "",
+            needs_review: false,
+          },
+        ],
+        next_steps: {
+          data: [
+            {
+              id: "t1",
+              subject: "Already sent",
+              is_done: true,
+              occurred_at: AS_OF,
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        },
+      }),
+    );
+    expect(
+      within(card(grid, "Open promises")).getByText("nothing owed"),
+    ).toBeTruthy();
+  });
+
+  // The count is a FLOOR when the server holds more than it sent: next_steps
+  // is a page, and "1" over a record with more open tasks is a number the card
+  // did not measure.
+  it("says at least, rather than a total, when the page was cut", () => {
+    const grid = show(
+      view({
+        claims: [],
+        next_steps: {
+          data: [
+            {
+              id: "t1",
+              subject: "Prepare the checklist",
+              is_done: false,
+              occurred_at: AS_OF,
+            },
+          ],
+          page: { next_cursor: "next", has_more: true },
+        },
+      }),
+    );
+    expect(
+      within(card(grid, "Open promises")).getByText("at least 1"),
+    ).toBeTruthy();
+  });
 });
 
 describe("what they decide and when we next meet", () => {

--- a/frontend/src/screens/personreadings.tsx
+++ b/frontend/src/screens/personreadings.tsx
@@ -13,6 +13,7 @@ import {
 import { daysPast } from "../format/lateness";
 import { type Locale, useLocale, usePlural, useT } from "../i18n";
 import { buyingRoleLabel } from "./companypeople/summary";
+import { owedPromises, owedPromisesTruncated } from "./personowed";
 import { daysSinceInbound, isQuiet } from "./personquiet";
 import type { PersonTab } from "./persontab";
 
@@ -249,9 +250,11 @@ function PromisesCard({
     return withheldCard(label, t);
   }
   const asOf = Date.parse(view.as_of);
-  const ours = (view.claims ?? []).filter(
-    (claim) => claim.kind === "commitment_ours" && claim.status === "open",
-  );
+  // BOTH places a promise is written down, which is the rule the headline
+  // above this card already applies. Counting claims alone put "0 · nothing
+  // owed" directly under "You owe them" — the same page contradicting itself
+  // about the same person, on a record whose only open promise was a task.
+  const ours = owedPromises(view);
   if (ours.length === 0) {
     return (
       <StatCard
@@ -264,8 +267,8 @@ function PromisesCard({
   }
   // The most overdue promise decides the card's tone: one late promise is the
   // thing the reader came to be told about, however many are on time.
-  const lateness = ours.flatMap((claim) => {
-    const late = claim.due_at ? daysPast(Date.parse(claim.due_at), asOf) : null;
+  const lateness = ours.flatMap((owed) => {
+    const late = owed.dueAt ? daysPast(Date.parse(owed.dueAt), asOf) : null;
     return late?.late ? [late.days] : [];
   });
   const worst = Math.max(0, ...lateness);
@@ -273,7 +276,16 @@ function PromisesCard({
   return (
     <StatCard
       label={label}
-      value={formatNumber(ours.length, locale)}
+      // A FLOOR where the server holds more than it sent: next_steps is a
+      // page, and a card reporting its length as the total states a number it
+      // did not measure.
+      value={
+        owedPromisesTruncated(view)
+          ? t("person.loops.atLeast", {
+              count: formatNumber(ours.length, locale),
+            })
+          : formatNumber(ours.length, locale)
+      }
       numeric
       detail={
         overdue
@@ -288,11 +300,11 @@ function PromisesCard({
       dot={overdue}
       basis={
         <FactList
-          facts={ours.map((claim) => ({
-            key: claim.id,
+          facts={ours.map((owed) => ({
+            key: owed.key,
             term: t("person.loops.ours"),
-            value: claim.body,
-            note: claim.source_label ?? undefined,
+            value: owed.body,
+            note: owed.note,
           }))}
         />
       }


### PR DESCRIPTION
The contact header said **"You owe them"** while the counter directly under it said **"0 · nothing owed"** — same person, same screen, same records. Only one of them was reading all of it.

## Why

The headline applies the server's rule (`compose/person360.owedPromises`): open next-step **tasks** unioned with open `commitment_ours` **claims**. The counter read claims alone.

So a record whose only open promise was a task counted nothing. A task is exactly what an accepted transcript proposal becomes, which is how the rehearsal produced both readings at once on Frédéric's page.

## What changed

One selector, `personowed.owedPromises`, spelling the server's rule where both screens share it:

- a **task** counts only while it is not done
- a **claim** only while it is `commitment_ours` and open

`commitment_theirs` is what the other side owes us; an `open_question` is a question nobody promised anything about. Counting either would tell a rep they owe work that is not theirs.

The count is a **floor** where the page was cut. `next_steps` is paged, and "1" over a record holding more open tasks is a number the card did not measure.

## What stays separate

`personcards.openLoops` answers a wider question — everything open in both directions, done loops included so the card can strike them through. Merging the two would make one of them wrong, and the comment now says so on both sides.

## Tests

Three new cases: an open task counts, a done task and the other party's promise do not, and a cut page says "at least". Each clause was mutation-checked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Open promises" counter so it agrees with the "You owe them" header: it now counts open tasks plus open `commitment_ours` claims, not claims alone. Previously a record whose only open promise was a task showed "0 · nothing owed" directly under "You owe them".

- Both screens share one selector (`owedPromises`) that spells the server's rule: a task counts only while not done, a claim only while `commitment_ours` and open.
- `commitment_theirs` and `open_question` are excluded — the other side's promises and open questions are not owed by this person.
- When `next_steps` is paged, the card shows "at least N" because the count is a floor, not a total.
- `personcards.openLoops` stays separate and now explains why: it answers a wider question, and merging the two would make one of them wrong.
- Adds three tests: an open task counts, done tasks and the other party's promises do not, and a cut page reads "at least".

<sup>Written for commit aacbf986d2a88a93334d547dc9afb096d077e2f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

