### PR TITLE
fix(dealstatus): an overdue task is work owed, not work done

### DIFF
--- a/backend/internal/compose/aicert/corpus/deal_health/deal_status_overdue_task_is_not_done_01.yaml
+++ b/backend/internal/compose/aicert/corpus/deal_health/deal_status_overdue_task_is_not_done_01.yaml
@@ -1,0 +1,60 @@
+name: deal_status_an_overdue_task_is_not_done_work
+task: deal_health
+site: deal_status
+source: hand_authored
+sanitized_by: hand_authored/claude-fable-5
+fixture:
+  deal:
+    name: "Ostsee Handel — Suchqualität"
+    status: open
+    amount: "4500000 EUR (minor units)"
+    expected_close: "2026-10-15"
+  move: "create_task: The follow-up on the offer is three days overdue — do it or agree a new date."
+  timeline:
+    # The offer WAS sent. That is a real event and the card may say so.
+    - label: offer_sent
+      kind: email
+      direction: outbound
+      subject: "Angebot — Suchqualitäts-Audit"
+      at: "2026-09-01"
+      when: past
+      excerpt: "Attached is the audit proposal we discussed. Happy to walk through it whenever suits."
+    - label: scoping_call
+      kind: call
+      direction: outbound
+      subject: "Call — audit scope"
+      at: "2026-08-26"
+      when: past
+      excerpt: "They want the relevance audit before committing to the wider rollout."
+  # The follow-up was NEVER made. It is a task, it is overdue, and it is the
+  # exact shape that produced a card claiming "I followed up on the proposal"
+  # while the task sat open in the worklist — the model read an overdue task's
+  # own date as the date the work happened.
+  open_tasks:
+    - label: chase_the_offer
+      subject: "Angebot Suchqualitäts-Audit nachfassen"
+      due: "2026-09-05"
+      state: overdue
+expect:
+  outcome: accepted
+  # The card rests on the sent offer, which is what actually happened. The
+  # overdue task may be cited as WORK STILL OWED — never as a thing done.
+  answer: [offer_sent]
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40
+  rubric: >
+    Score whether the briefing tells the truth about what has and has not
+    happened. The offer WAS sent on 1 September and the card may say so. The
+    follow-up was NOT: it is an open task, three days overdue, and any sentence
+    stating or implying that it was made — "I followed up", "we chased it",
+    "the proposal was followed up on" — fails the scenario outright, whatever
+    else the card gets right. This is the whole point of the case. "blocker"
+    should name the overdue follow-up as work still owed, which is the honest
+    reading and the one a rep can act on. "verdict" should be drifting or
+    blocked; live scores low, because a promise three days past its date is not
+    a deal running to plan. "buyer" must read what Ostsee Handel want from their
+    own words — the relevance audit before a wider rollout — and score low if it
+    invents a motive. "move_reason" must explain the given move rather than
+    proposing another. Any invented person, meeting, discount or figure fails.

--- a/backend/internal/compose/certcase_dealstatus.go
+++ b/backend/internal/compose/certcase_dealstatus.go
@@ -45,6 +45,19 @@ type dealStatusFixture struct {
 	// model explains the move rather than choosing one, so a case that omitted
 	// it would certify the lane against a prompt production never sends.
 	Move string `json:"move"`
+	// OpenTasks is work nobody has done yet, which production always sends
+	// alongside the timeline. A fixture that omitted it could not certify the
+	// rule that matters most here — that an overdue task is a promise still
+	// owed rather than evidence the work happened.
+	OpenTasks []dealStatusTaskFixture `json:"open_tasks"`
+}
+
+type dealStatusTaskFixture struct {
+	Label   string `json:"label"`
+	Subject string `json:"subject"`
+	Due     string `json:"due"`
+	// State is "open" or "overdue"; empty reads as open, the ordinary case.
+	State string `json:"state"`
 }
 
 type dealStatusDealFixture struct {
@@ -123,6 +136,20 @@ func dealStatusInput(f dealStatusFixture) (dealstatus.StatusInput, map[string]st
 		in.Timeline = append(in.Timeline, dealstatus.ActIn{
 			ID: id, Kind: act.Kind, Direction: act.Direction,
 			Subject: act.Subject, At: act.At, When: when, Excerpt: act.Excerpt,
+		})
+	}
+	for _, task := range f.OpenTasks {
+		if err := refuseUnnameable(task.Label, "open task", label); err != nil {
+			return in, nil, err
+		}
+		id := ids.NewV7().String()
+		label[task.Label] = id
+		state := task.State
+		if state == "" {
+			state = dealstatus.TaskStateOpen
+		}
+		in.OpenTasks = append(in.OpenTasks, dealstatus.TaskIn{
+			ID: id, Subject: task.Subject, Due: task.Due, State: state,
 		})
 	}
 	return in, label, nil

--- a/backend/internal/compose/dealstatus/input.go
+++ b/backend/internal/compose/dealstatus/input.go
@@ -17,6 +17,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
@@ -26,7 +27,7 @@ import (
 // are rendered into, which is Go code and so the half a digest cannot reach. It
 // rides the fingerprint so a card built from the old shape is rewritten rather
 // than served forever.
-const projectionVersion = "deal-status-projection-2"
+const projectionVersion = "deal-status-projection-3"
 
 // promptVersion is DERIVED from the prompt as it is SENT — boundary rule
 // included — so rewording it rewrites the cards whether or not anybody
@@ -52,10 +53,23 @@ func project(f facts, move crmcontracts.DealStatusCardMove) StatusInput {
 		if len(in.Timeline) == maxTimelineRows {
 			break
 		}
+		// An UNFINISHED task is not something that happened, and the timeline
+		// is the list of things that did. It reached here labelled "past" the
+		// moment its due date went by — and the prompt defines "past" as
+		// "something that has happened" — so an overdue follow-up read as
+		// evidence the follow-up was made. That is how a card came to say "I
+		// followed up on the proposal" about a task still sitting open in the
+		// worklist, citing the task as its proof.
+		//
+		// It is not dropped from the model's view, only from the list of
+		// EVENTS: open_tasks carries it, as the work it still is.
+		if unfinishedTask(a) {
+			continue
+		}
 		in.Timeline = append(in.Timeline, actIn(a, f.now))
 	}
 	for _, t := range f.openTasks {
-		in.OpenTasks = append(in.OpenTasks, taskIn(t))
+		in.OpenTasks = append(in.OpenTasks, taskIn(t, f.now))
 	}
 	in.Room = roomIn(f)
 	if inbound, ok := unansweredInbound(f); ok {
@@ -103,6 +117,17 @@ func actIn(a crmcontracts.Activity, now time.Time) ActIn {
 	return out
 }
 
+// unfinishedTask reports whether a timeline row is a task nobody has completed.
+//
+// A COMPLETED task stays: finishing a promise is an event, and a card that
+// could not see it would have no way to say the work was done. `is_done` is
+// nil on every kind but task, so the check is the kind and the flag together
+// rather than the flag alone.
+func unfinishedTask(a crmcontracts.Activity) bool {
+	return a.Kind == crmcontracts.ActivityKindTask &&
+		(a.IsDone == nil || !*a.IsDone)
+}
+
 // whenOf says whether a row has happened. The deal's timeline holds booked
 // meetings alongside past contact, and only this tells them apart.
 func whenOf(a crmcontracts.Activity, now time.Time) string {
@@ -116,10 +141,17 @@ func withheld(a crmcontracts.Activity) bool {
 	return a.ContentState != nil && *a.ContentState == crmcontracts.ActivityContentStateWithheld
 }
 
-func taskIn(t activities.OpenTask) TaskIn {
-	out := TaskIn{ID: t.ID.String(), Subject: t.Subject}
+func taskIn(t activities.OpenTask, now time.Time) TaskIn {
+	out := TaskIn{ID: t.ID.String(), Subject: t.Subject, State: TaskStateOpen}
 	if t.DueAt != nil {
 		out.Due = t.DueAt.Format("2006-01-02")
+	}
+	// deadline.Passed, not a comparison of our own: whether a promise due at
+	// this instant is already late is ONE decision, and the surfaces that
+	// answered it separately disagreed with each other in front of the same
+	// reader.
+	if deadline.Passed(t.DueAt, now) {
+		out.State = TaskStateOverdue
 	}
 	return out
 }

--- a/backend/internal/compose/dealstatus/model.go
+++ b/backend/internal/compose/dealstatus/model.go
@@ -67,6 +67,7 @@ Each of "story", "blocker", "buyer", "verdict.because" and "move_reason" is a li
 Every sentence lists the ids it rests on in its own "evidence", from the summary's "id" fields. Ids belong in "evidence" only — never in any "text" or in "opening".
 Ground every word in the summary. Never invent a person, a company, a date, a number or an event. If the summary does not say it, do not write it.
 Every timeline entry carries "when": "past" for something that has happened, "scheduled" for something booked and still ahead. A scheduled entry is a plan, never an event — never write that it took place, and never measure silence from it.
+"open_tasks" is work NOBODY HAS DONE YET, whatever its date says. A task there carries "state": "open" or "overdue". Never write that a task's work happened, was sent, was followed up or was delivered — an overdue task is a promise already broken, not a thing that took place, and it is the strongest reason to act rather than evidence that somebody already did. Completed work is on the timeline instead, as the event it became.
 "health" scores four things from 0 to 1, where low is bad: activity_recency, stage_velocity, engagement (how many people are actually talking to us) and commitments (promises we have kept). They are signals to reason from, never facts to state — never write a score, a factor name or the word "health" in the card. A low score tells you where to look in "timeline"; the timeline's dates are what you write.
 Never write the same fact in two sections. Each one answers a different question.
 `
@@ -178,7 +179,25 @@ type TaskIn struct {
 	ID      string `json:"id"`
 	Subject string `json:"subject"`
 	Due     string `json:"due,omitempty"`
+	// State is "open" or "overdue" — never "done", because a done task is not
+	// in this list at all.
+	//
+	// Said rather than left to be worked out from `due` against today: the
+	// model has no clock, and "overdue" is the whole difference between a
+	// promise still in hand and one already broken.
+	State string `json:"state"`
 }
+
+// The two states a task in this list can be in. A third would mean a task that
+// is not open, which belongs on the timeline as the event it became.
+//
+// Exported because the certification fixture builds this same input, and a
+// case that spelled the state itself could grade a value production never
+// sends.
+const (
+	TaskStateOpen    = "open"
+	TaskStateOverdue = "overdue"
+)
 
 // RoomIn is the Deal Room's state and what the buyer said in it.
 type RoomIn struct {

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -1,11 +1,11 @@
 {
   "totals": {
     "sites": 40,
-    "sites_best_current": 33,
+    "sites_best_current": 32,
     "sites_best_partial": 0,
-    "sites_best_stale": 5,
+    "sites_best_stale": 6,
     "sites_absent": 2,
-    "scenarios": 135,
+    "scenarios": 136,
     "records": 59,
     "bindings": 10
   },
@@ -177,9 +177,9 @@
         "env": "eu_hosted"
       },
       "sites": 31,
-      "sites_current": 25,
+      "sites_current": 24,
       "sites_partial": 0,
-      "sites_stale": 6,
+      "sites_stale": 7,
       "runs": 333,
       "passed": 269,
       "reliability": 0.8078078078078078,
@@ -1550,18 +1550,14 @@
       "key": "deal_health/deal_status",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
+        {
+          "name": "deal_status_an_overdue_task_is_not_done_work",
+          "expects": "accepted",
+          "file": "backend/internal/compose/aicert/corpus/deal_health/deal_status_overdue_task_is_not_done_01.yaml"
+        },
         {
           "name": "deal_status_offer_left_hanging",
           "expects": "accepted",
@@ -1580,10 +1576,10 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
-          "scenarios_total": 2,
+          "scenarios_measured": 0,
+          "scenarios_total": 3,
           "runs": 6,
           "passed": 6,
           "reliability": 1,
@@ -1595,7 +1591,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is"
         }
       ]
     },

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -25,11 +25,11 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | | |
 |---|---:|
 | Shipped invocation sites | 40 |
-| … best state `current` | 33 |
+| … best state `current` | 32 |
 | … best state `partial` | 0 |
-| … best state `stale` | 5 |
+| … best state `stale` | 6 |
 | … `absent` on every binding | 2 |
-| Scenarios in the corpus | 135 |
+| Scenarios in the corpus | 136 |
 | Committed records | 59 |
 | Bindings measured | 10 |
 
@@ -91,7 +91,7 @@ Which model to run each site on, and what that choice rests on.
 | [`cold_start/field_extract`](#cold_startfield_extract) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
 | [`cold_start/sitereadmessage`](#cold_startsitereadmessage) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `supported_degraded` | 0.83 | `current` | 2 | 3 |
 | [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
-| [`deal_health/deal_status`](#deal_healthdeal_status) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 2 | 1 |
+| [`deal_health/deal_status`](#deal_healthdeal_status) | - | - | - | `stale` | 3 | 1 |
 | [`document_extract/fields`](#document_extractfields) | `gemini · gemini-3.5-flash · eu_hosted` | `certified` | 1.00 | `current` | 4 | 1 |
 | [`draft_reply/account`](#draft_replyaccount) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
 | [`draft_reply/first`](#draft_replyfirst) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `supported_degraded` | 1.00 | `current` | 1 | 2 |
@@ -149,7 +149,7 @@ verdict each reached. Each record's own p50 and p95 are in the site tables.
 | `openai_compatible` | `mistralai/ministral-8b-2512` | `cloud_frontier` | 3 | 0 | 0 | 3 | 15 | 14 | 0.93 | 22390ms | 1 | 2 | 0 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 6 | 0 | 0 | 42 | 39 | 0.93 | 4477ms | 5 | 0 | 1 |
-| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 31 | 25 | 0 | 6 | 333 | 269 | 0.81 | 68516ms | 12 | 7 | 12 |
+| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 31 | 24 | 0 | 7 | 333 | 269 | 0.81 | 68516ms | 12 | 7 | 12 |
 | `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
 
 ## Stale records, and why
@@ -179,6 +179,7 @@ model, real network).
 | `cold_start/company_message` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/field_extract` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/sitereadmessage` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `deal_health/deal_status` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is |
 | `draft_reply/account` | `gemini · gemini-3.1-pro-preview · eu_hosted` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `draft_reply/account` | `gemini · gemini-3.5-flash · eu_hosted` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `draft_reply/intro_note` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario intro_note_is_written_to_the_customer_not_about_the_request — or the prompt this build now builds from it — has changed since the record scored it |
@@ -486,10 +487,11 @@ Records (2):
 
 Scope a run of it can claim: `full_invocation`.
 
-Scenarios (2):
+Scenarios (3):
 
 | Scenario | Expects | Case |
 |---|---|---|
+| `deal_status_an_overdue_task_is_not_done_work` | `accepted` | [deal_status_overdue_task_is_not_done_01.yaml](../../backend/internal/compose/aicert/corpus/deal_health/deal_status_overdue_task_is_not_done_01.yaml) |
 | `deal_status_offer_left_hanging` | `accepted` | [deal_status_offer_left_hanging_01.yaml](../../backend/internal/compose/aicert/corpus/deal_health/deal_status_offer_left_hanging_01.yaml) |
 | `deal_status_says_nothing_is_wrong_when_nothing_is` | `accepted` | [deal_status_quiet_after_proposal_01.yaml](../../backend/internal/compose/aicert/corpus/deal_health/deal_status_quiet_after_proposal_01.yaml) |
 
@@ -497,7 +499,7 @@ Records (1):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 1139ms | 1778ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `certified` | 6 | 6 | 1.00 | 1139ms | 1778ms | 6 | 0 | 0 | 0 |
 
 ### `document_extract`
 


### PR DESCRIPTION
The Algolia card said **"I followed up on the proposal on 5 September"** and cited the follow-up task as its evidence. That task was open, three days overdue, and sitting in the worklist with a Done button nobody had pressed.

## The mechanism

Every activity reaches the model's timeline, tasks included, and `whenOf` labels a row `past` once its date is behind the clock. The prompt defines `past` as *"something that has happened"*.

So a task became evidence of its own completion the moment it went overdue. The later it got, the more confidently the card claimed the work was done.

## What changed

An unfinished task leaves the timeline. It is not hidden — `open_tasks` carries it, as the work it still is, and it gains an explicit `state` of `open` or `overdue` rather than leaving the model to work that out from a date against a clock it does not have.

A **completed** task stays on the timeline. Finishing a promise is an event, and a card that could not see it would have no way to say the work was done.

The prompt now says what `open_tasks` means, in the terms the failure took: never write that a task's work happened, was sent, was followed up or was delivered.

## The fixture could not have caught this

It carried no open tasks at all, so no certification case could exercise any of it. It carries them now, and `deal_status_an_overdue_task_is_not_done_work` is the Algolia shape: an offer that **was** sent, a follow-up that was not, and a rubric that fails the scenario outright for any sentence claiming the follow-up happened.

## Two things the gates caught

Lateness goes through `deadline.Passed` rather than a comparison of its own — the gate holding one answer to "is this late" caught the second one I wrote.

The projection version is bumped, so cards cached against the old shape regenerate rather than standing. `ai-certification.json` records `deal_status` as stale, which it now is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deal status card treating an overdue task as evidence the work was done. Unfinished tasks now leave the timeline into `open_tasks` with an explicit `open` or `overdue` state; completed tasks stay on the timeline.

- The prompt now forbids writing that a task's work happened, was sent, was followed up, or was delivered.
- Added a certification fixture for the overdue-task shape that fails any sentence claiming the follow-up happened.
- Bumped the projection version so cached cards regenerate against the new shape.
- `deal_status` is recorded as stale until the changed prompt is re-certified.

<sup>Written for commit c80524d7be729cc164aeb31770f5fa27f90f6a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

