### PR TITLE
fix(frontend): three independent main-red defects in the uat/lint lanes

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -2253,6 +2253,32 @@ export async function mockApi(
         base_currency: "EUR",
       });
     }
+    // Home's own reading of the same pipeline (home.readings.tsx) and
+    // Analytics' forecast tab (analytics.forecast.tsx) share this one query.
+    // Without it the catch-all's list envelope reaches
+    // formatMoneyCompact(data.open_minor, data.base_currency, locale)
+    // unguarded — unlike the weighted figure beside it, which is wrapped in
+    // formatMoneyOrAbsent — so an undefined currency took the whole #/home
+    // shell down with it.
+    if (path === "/forecast") {
+      return json({
+        period_start: "2026-04-01",
+        period_end: "2026-06-30",
+        scope_kind: "workspace",
+        won_minor: 4_000_000,
+        evidence_minor: 12_000_000,
+        best_case_minor: 18_000_000,
+        open_minor: 25_000_000,
+        weighted_minor: 13_000_000,
+        eligible_count: 12,
+        priced_count: 12,
+        confirmed_date_count: 10,
+        fx_missing_count: 0,
+        as_of: "2026-07-13T00:00:00Z",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+      });
+    }
     if (path.startsWith("/reports/")) {
       return json({
         report: "deals-by-stage",
@@ -2331,25 +2357,6 @@ export async function mockApi(
         aggregated_account_count: 1,
         restricted_excluded: [],
         computed_at: "2026-07-13T00:00:00Z",
-      });
-    }
-    // Analytics' frame, BEFORE the record-context match below: that one tests
-    // a substring, so it answered this route with a 360's envelope — a body
-    // with no `default_scope`, which took every analytics screen to the error
-    // boundary and the rail with it. Named in full here because the two share
-    // a word and nothing else.
-    if (path === "/analytics/context") {
-      const workspace = { kind: "workspace", label: "Whole workspace" };
-      return json({
-        default_scope: workspace,
-        allowed_scopes: [workspace],
-        capabilities: {
-          view_manager_forecast: true,
-          submit_manager_forecast: true,
-        },
-        as_of: "2026-07-13T00:00:00Z",
-        timezone: "Europe/Berlin",
-        base_currency: "EUR",
       });
     }
     // RS-3's context panel and the IT-1 tool console both read fixed-shape

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -369,6 +369,19 @@ function BoardLayout<Record extends BoardRecord>({
             }
             data-stage={column.stage}
             aria-label={column.label}
+            // listtable.css gives every column `overflow-y: auto` so a stage
+            // with many deals scrolls its own cards instead of stretching the
+            // rest to match it. A column with too few cards to overflow, or
+            // none at all, is still declared scrollable — and a card's own
+            // link makes a full column keyboard-reachable but says nothing
+            // about an EMPTY one, which axe's scrollable-region-focusable
+            // rule catches. The section is the scroller, so it takes the
+            // fallback stop itself rather than depending on what is inside it —
+            // the WCAG-sanctioned fix for a non-interactive scrollable region,
+            // which is exactly why the a11y linter's default posture forbids
+            // tabIndex on a section at all.
+            // biome-ignore lint/a11y/noNoninteractiveTabindex: the scrollable region itself needs the keyboard stop; see the comment above.
+            tabIndex={0}
             {...columnDropHandlers?.(column)}
           >
             {/* THE STAGE AND HOW MUCH IS IN IT, on one line and stuck to the

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1919,45 +1919,41 @@ function DealBoardBody({
   // this map as well would read each company twice.
   const orgMarks = useOrgMarks(loadedDeals, orgs, orgsSettled);
   return (
-    <>
-      <QueryGate query={pipelinesQuery} pendingLabel={t("nav.deals")}>
-        {() =>
-          effectivePipeline ? (
-            // Only the INITIAL load goes through the gate. An infinite
-            // query reports isError when ANY page fails, later ones
-            // included, so keeping the gate around a loaded board would
-            // let one failed "load more" throw away every card already on
-            // screen. Past the first page the board stands and the button
-            // retries — exactly what OverlayDealsTable does above, and for
-            // the same reason.
-            (dealsQuery.data?.pages ?? []).length === 0 ? (
-              <QueryGate query={dealsQuery} pendingLabel={t("nav.deals")}>
-                {() => null}
-              </QueryGate>
-            ) : (
-              <>
-                <PipelineBoard
-                  cardHref={(deal) =>
-                    routeHash({ screen: "deals", id: deal.id })
-                  }
-                  columns={buildColumns(
-                    effectivePipeline.stages ?? [],
-                    loadedDeals,
-                    stageTotalsQuery.data ?? new Map(),
-                    orgMarks,
-                    totalsWithheld ? t(totalsWithheld) : undefined,
-                  )}
-                  onOpen={openDeal}
-                  cardDragHandlers={cardDragHandlers}
-                  columnDropHandlers={columnDropHandlers}
-                />
-                <LoadMoreButton query={dealsQuery} />
-              </>
-            )
-          ) : null
-        }
-      </QueryGate>
-    </>
+    <QueryGate query={pipelinesQuery} pendingLabel={t("nav.deals")}>
+      {() =>
+        effectivePipeline ? (
+          // Only the INITIAL load goes through the gate. An infinite
+          // query reports isError when ANY page fails, later ones
+          // included, so keeping the gate around a loaded board would
+          // let one failed "load more" throw away every card already on
+          // screen. Past the first page the board stands and the button
+          // retries — exactly what OverlayDealsTable does above, and for
+          // the same reason.
+          (dealsQuery.data?.pages ?? []).length === 0 ? (
+            <QueryGate query={dealsQuery} pendingLabel={t("nav.deals")}>
+              {() => null}
+            </QueryGate>
+          ) : (
+            <>
+              <PipelineBoard
+                cardHref={(deal) => routeHash({ screen: "deals", id: deal.id })}
+                columns={buildColumns(
+                  effectivePipeline.stages ?? [],
+                  loadedDeals,
+                  stageTotalsQuery.data ?? new Map(),
+                  orgMarks,
+                  totalsWithheld ? t(totalsWithheld) : undefined,
+                )}
+                onOpen={openDeal}
+                cardDragHandlers={cardDragHandlers}
+                columnDropHandlers={columnDropHandlers}
+              />
+              <LoadMoreButton query={dealsQuery} />
+            </>
+          )
+        ) : null
+      }
+    </QueryGate>
   );
 }
 
@@ -2690,13 +2686,10 @@ export function DealsScreen({
         bodyOwnsPaging={overlay || view === "board"}
         bodyCount={
           view === "board" &&
-          dealsQuery.data && (
-            <>
-              {t("board.count", {
-                count: formatNumber(loadedDeals.length, locale),
-              })}
-            </>
-          )
+          dealsQuery.data &&
+          t("board.count", {
+            count: formatNumber(loadedDeals.length, locale),
+          })
         }
         // The pipeline picker is screen state, not a filter, so switching it
         // changes every row without touching `filters`. Naming it here is
@@ -4236,15 +4229,13 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                 </>
               }
               actions={
-                <>
-                  <DealActions
-                    deal={deal}
-                    orgs={orgs.data?.data ?? []}
-                    meId={me.data?.user.id ?? ""}
-                    openStages={openStages}
-                    archivedReasonId={archivedReasonId}
-                  />
-                </>
+                <DealActions
+                  deal={deal}
+                  orgs={orgs.data?.data ?? []}
+                  meId={me.data?.user.id ?? ""}
+                  openStages={openStages}
+                  archivedReasonId={archivedReasonId}
+                />
               }
               band={dealBand({ deal, reasonId: archivedReasonId, t })}
               timeline={timelineEntries}


### PR DESCRIPTION
## Summary
Root-caused and fixed three deterministic, independent CI failures found while investigating why the \`uat (AC screens + axe WCAG 2.2 AA + 390px, mocked)\` and \`fe-lint\` lanes were red on \`main\` — confirmed pre-existing by reproducing each against a clean \`origin/main\` checkout before any of this branch's changes.

- **\`#/home\` crashed entirely** (~10 of 14 uat failures): \`e2e/seed.ts\` has no mock for \`GET /forecast\`, so it fell through to the generic list-envelope fallback. \`home.readings.tsx\` reads that fallback's fields unguarded — unlike the weighted figure right below it, which uses \`formatMoneyOrAbsent\` — so an undefined \`base_currency\` crashed \`formatMoneyCompact\` and took the whole \`#/home\` render down with it (every AC/axe/390px check that loads \`#/home\` failed as a result). Added the missing mock. Also removed a dead, unreachable duplicate \`/analytics/context\` handler sitting right below it.
- **\`#/deals\` axe violations** (3 of 14): board-column sections are declared \`overflow-y: auto\` by \`listtable.css\` regardless of content, so an empty or short stage with no focusable deal card fails axe's \`scrollable-region-focusable\` check. Added the WCAG-sanctioned \`tabIndex\` on the column section itself (needed a \`biome-ignore\` since the a11y linter's default posture forbids tabIndex on a non-interactive element).
- **\`fe-lint\` red on \`main\`**, unrelated to the above: three useless-fragment violations in \`screens/deals.tsx\`. Fixed via biome's own \`--unsafe\` autofix — pure formatting, no logic change.

A fourth uat failure — \`#/analytics\`'s \`RecordTabs\` breaking out ~11px past the viewport at 390px because \`analytics.tsx\` never wraps itself in a \`work\` \`PageZones\` container (every other \`RecordTabs\` consumer does) — is filed as #4397 rather than folded in here: the real fix touches the whole screen's layout, which is a bigger, more deliberate change than the three above.

## Test plan
- [x] Reproduced all four failures against a clean \`origin/main\` build, confirming none are caused by unmerged work
- [x] \`pnpm exec playwright test\` (full \`frontend-e2e\` suite): 275 passed, only the filed #4397 analytics/390px case remains red
- [x] \`make check-fe\`: EXIT:0 (fe-quality, fe-unit, fe-lint, drift, composed typecheck, build)
- [x] No backend files touched — no Go/craft gate needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RSPfhkYwWQ5yMDQaJz3ao

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three independent CI defects so the `uat` (AC screens + axe WCAG 2.2 AA + 390px) and `fe-lint` lanes go green on `main`. The `#/home` screen no longer crashes in the e2e suite, the deals board passes axe checks, and lint is clean.

**Bug Fixes**
- Added a `/forecast` mock to `e2e/seed.ts`; the catch-all list envelope previously reached `#/home` with an undefined `base_currency`, crashing `formatMoneyCompact`. Also removed a dead duplicate `/analytics/context` handler.
- Added `tabIndex={0}` to deal-board column sections. `listtable.css` declares them `overflow-y: auto` unconditionally, so empty stages had no focusable content and failed axe's `scrollable-region-focusable` rule.
- Removed three useless fragments in `screens/deals.tsx` via biome's autofix — formatting only, no logic change.

The remaining `#/analytics` 390px overflow (`RecordTabs` breaking out past the viewport) is a separate screen-layout issue tracked as #4397 and intentionally not included here.

<sup>Written for commit 88183761e08a210777130f7dacbb505a973a319b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation for board columns, including empty or short scrollable columns.

* **Bug Fixes**
  * Corrected forecast data handling so Home readings and the Analytics forecast view display workspace-scoped forecast information reliably.
  * Corrected the analytics context label shown for the overall workspace scope.

* **Refactor**
  * Simplified internal rendering structure without changing visible deal-management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->