### PR TITLE
main is red: the morning's pipeline counter gets a mock to read

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -2253,6 +2253,36 @@ export async function mockApi(
         base_currency: "EUR",
       });
     }
+    // What the pipeline is worth. Analytics reads it, and so does the morning's
+    // own counter — one query, one cache entry, so an omission here is not one
+    // screen's problem.
+    //
+    // It needs a branch for the same reason `/analytics/context` above does,
+    // and the failure is worse than a blank card: the catch-all at the bottom
+    // answers an unmocked GET with `{data:[],page}`, a 200 whose `base_currency`
+    // is undefined, and the counter hands that straight to a money formatter.
+    // The throw takes the error boundary, the error boundary takes the shell,
+    // and every sweep over a route that draws the strip fails on a missing nav
+    // rail rather than on whatever it was measuring.
+    if (path === "/forecast") {
+      return json({
+        period_start: "2026-03-01",
+        period_end: "2026-03-31",
+        scope_kind: "workspace",
+        won_minor: 125000,
+        evidence_minor: 480000,
+        best_case_minor: 1240000,
+        open_minor: 960000,
+        weighted_minor: 520000,
+        eligible_count: 12,
+        priced_count: 11,
+        confirmed_date_count: 7,
+        fx_missing_count: 0,
+        as_of: "2026-03-04T09:00:00Z",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+      });
+    }
     if (path.startsWith("/reports/")) {
       return json({
         report: "deals-by-stage",


### PR DESCRIPTION
`main`'s UAT lane fails **fourteen** checks across `#/home`, `#/deals`, `#/analytics`, the palette and the agent panel — every one of them on a missing `nav.rail`, which is the shell rather than the thing each test was measuring. Eleven of the fourteen are one unmocked endpoint.

## What happens

The morning's pipeline counter reads `/forecast`. `e2e/seed.ts` does not serve it, so it falls to the catch-all at the bottom of the `/v1/` handler, which answers **`{data:[],page}` with status 200**. That is not an error the query can see: `base_currency` is simply undefined, the counter hands it to a money formatter, `undefined.trim()` throws, the error boundary takes the route and the shell goes with it.

Traced by sourcemapping the minified frame out of the built bundle, since the failure only reproduces against `vite preview`:

```
common-CkGS-ZVK.js:1:50876  ->  src/format/minorunits.ts:88   (currency.trim())
common-CkGS-ZVK.js:1:51308  ->  src/format/minorunits.ts:156  (toMajorUnits)
common-CkGS-ZVK.js:1:51590  ->  src/format/format.ts:97       (formatMoneyCompact)
home-DQVKtjB5.js:2:26034    ->  src/screens/home.readings.tsx:391
```

`ForecastReadings.base_currency` is required by the contract, so the counter is right to trust it. The fixture is what lies.

## The fix

`/forecast` gets its own branch, beside `/analytics/context` — which is in that file for exactly this reason and says so, having once been answered by a substring match with a 360's envelope carrying no `default_scope`, and taken every analytics screen to the same boundary. Same failure, same shape, third time the catch-all has done it.

## Verification

`playwright test e2e/ac.spec.ts`, Node 24, against the built app:

- before — **14 failed**, 181 passed
- after — **3 failed**, 192 passed

## What this does NOT fix

The three that remain are real defects rather than fixture gaps, both in screens today's work has been landing on, and neither is touched here:

- `scrollable-region-focusable` × 3 on `#/deals`, light and dark: `section[data-stage="s3"|"s4"|"s5"]`. `.board-col` is `overflow-y: auto` (`listtable.css`), so an empty stage is a scrollable region with nothing focusable in it. The fold control is deliberately per-column — `composed.tsx` says why — so a non-collapsing empty column has no control to reach.
- `#/analytics` scrolls sideways at 390px.

Left for the authors of those screens rather than folded into a red-main hotfix: one is a shared design-system board the leads board also draws, and neither is what is taking the shell down. `uat` is not in the required `ci` fan-in, so this can land ahead of them and `main` gets eleven of its fourteen back.

## Superseded

This branch also carried a fix for `personreadings.test.tsx`'s three `Activity` fixtures. https://github.com/margince/margince/pull/4407 landed the same fix while this was in review, so that commit is dropped and only the mock change remains.
