### PR TITLE
fix(weekly): a week that closed three deals is not a quiet week

### DIFF
--- a/backend/internal/compose/certcase_weeklynarrative.go
+++ b/backend/internal/compose/certcase_weeklynarrative.go
@@ -113,7 +113,7 @@ func (c *weeklyNarrativeCase) Run(ctx context.Context, completer aitasks.Complet
 // judge, and scoring it against the expectation would credit or blame a model
 // for prose the product would have thrown away.
 func (c *weeklyNarrativeCase) Evaluate(trace aitasks.Trace) aitasks.Outcome {
-	sentence, err := narrative.Parse(trace.Output)
+	sentence, err := narrative.Parse(trace.Output, c.in)
 	if err != nil {
 		return aitasks.Outcome{
 			Result: aitasks.OutcomeInvalid,

--- a/backend/internal/compose/weekly/narrative/narrative.go
+++ b/backend/internal/compose/weekly/narrative/narrative.go
@@ -61,6 +61,20 @@ type Counts struct {
 	BriefItemsDismissed int `json:"brief_items_dismissed"`
 }
 
+// quiet reports whether the week did nothing worth a sentence.
+//
+// EVERY count, not a chosen few. A week that closed nothing but carried three
+// promises over is not quiet to the person carrying them, and one that only
+// dismissed brief items still spent somebody's attention. The one question
+// this answers is whether "nothing happened" could be true, and any non-zero
+// count settles it.
+func (c Counts) quiet() bool {
+	return c.TasksDue == 0 && c.TasksDone == 0 && c.TasksCarriedOver == 0 &&
+		c.DealsMoved == 0 && c.DealsWon == 0 && c.DealsLost == 0 &&
+		c.ProposalsAccepted == 0 && c.ProposalsRejected == 0 &&
+		c.BriefItemsActed == 0 && c.BriefItemsDismissed == 0
+}
+
 // Deal is one line from the week, by the name it carried then.
 type Deal struct {
 	Label   string `json:"label"`
@@ -80,9 +94,28 @@ Every number and every name you write must appear in the summary. Never add a fa
 
 Do not restate the whole summary. The reader has the counts and the deal list in front of them; you are saying what they add up to. A sentence that only repeats two numbers has told them nothing.
 
-Say when a week was quiet. "A quiet week — nothing closed and nothing slipped" is a true and useful sentence, and inventing significance to fill the space is the one failure that costs the reader their trust in every other week.
-
 Never advise, never congratulate, never scold. State it.
+`
+
+// quietWeekRule is added ONLY to a week whose counts are all zero.
+//
+// It used to be part of the standing prompt, which handed the model "A quiet
+// week — nothing closed and nothing slipped" as a ready sentence on every
+// week, including one that closed three deals for EUR 12,500. The greeting
+// above it said so and the metric beside it said so, and the prose said
+// nothing had happened.
+//
+// An exemplar is the most quotable line in a prompt. Offering it where it
+// cannot be true is asking for it back.
+const quietWeekRule = `
+Say when a week was quiet. "A quiet week — nothing closed and nothing slipped" is a true and useful sentence, and inventing significance to fill the space is the one failure that costs the reader their trust in every other week.
+`
+
+// happenedRule is its opposite, for a week that did something. It names the
+// contradiction rather than the wording, because the wording is only one way
+// of writing it.
+const happenedRule = `
+THIS WEEK WAS NOT QUIET: the counts below are not all zero. Never write that nothing closed, nothing moved, nothing slipped or that the week was quiet — the reader is looking at the numbers that say otherwise, in the same panel.
 `
 
 // systemFor names THIS call's data boundary; see promptfence.Fence.Rule.
@@ -105,11 +138,22 @@ func systemFor(fence promptfence.Fence, lang string) string {
 func Request(in Input, lang string) model.Request {
 	fence := promptfence.New()
 	return model.Request{
-		System:         systemFor(fence, lang),
+		System:         systemFor(fence, lang) + weekShapeRule(in),
 		Messages:       []model.Message{{Role: "user", Content: fence.Wrap(encodeInput(in))}},
 		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		SecretStripper: ai.NewSecretStripper(),
 	}
+}
+
+// weekShapeRule is the half of the prompt that depends on what the week held.
+//
+// One of the two, never both and never neither: a week either did something or
+// it did not, and the model is told which before it is asked to describe it.
+func weekShapeRule(in Input) string {
+	if in.Counts.quiet() {
+		return quietWeekRule
+	}
+	return happenedRule
 }
 
 // encodeInput renders the week as the JSON the prompt reads. Every field is a
@@ -129,7 +173,7 @@ func encodeInput(in Input) string {
 // A refusal is not a failure of the week — the caller keeps the deterministic
 // review and records that no sentence was written. So every rejection here is
 // silent to the reader and loud in the log.
-func Parse(reply string) (string, error) {
+func Parse(reply string, in Input) (string, error) {
 	// A POINTER, so a missing field and a present-but-empty one are different
 	// answers. Decoded into a plain string, `{}` and `{"narrative":null}` both
 	// land as "" — and the caller stores that as "a pass ran and found the week
@@ -155,5 +199,56 @@ func Parse(reply string) (string, error) {
 		return "", fmt.Errorf("weekly narrative: %d characters, over the %d the column holds",
 			n, MaxNarrativeRunes)
 	}
+	if err := refuseContradiction(sentence, in); err != nil {
+		return "", err
+	}
 	return sentence, nil
+}
+
+// quietClaims are the ways a sentence says the week held nothing.
+//
+// A CLOSED list of phrases, and deliberately not a general check that every
+// number in the prose appears in the input. That was the other option and it
+// is worse than nothing: dates, localised amounts, percentages and numbers
+// inside company names all read as figures, so it refuses honest sentences
+// while a wrong number attached to the right metric still passes.
+//
+// This is narrower and it holds. One claim, "the week was quiet", checked
+// against the one fact that settles it. English only, matching the corpus this
+// prompt is certified against — a sentence written in another language is not
+// caught here, which is why the prompt states the rule as well.
+var quietClaims = []string{
+	"quiet week",
+	"a quiet one",
+	"nothing closed",
+	"nothing moved",
+	"nothing slipped",
+	"nothing happened",
+}
+
+// refuseContradiction rejects a sentence that says the week held nothing when
+// the counts beside it say otherwise.
+//
+// The reader sees both at once: the greeting says "You closed 3 deals", the Won
+// metric says "3 · €12,500", and the prose said "A quiet week — nothing closed
+// and nothing slipped". One panel disagreeing with itself about the same week
+// costs the reader their trust in every week, including the ones that were
+// right.
+//
+// Refusing keeps the deterministic review and drops the sentence, which is what
+// every other rejection here does. A week with no prose reads as a week nobody
+// wrote about; a week whose prose contradicts its own numbers reads as a
+// product that does not know what happened.
+func refuseContradiction(sentence string, in Input) error {
+	if in.Counts.quiet() {
+		return nil
+	}
+	folded := strings.ToLower(sentence)
+	for _, claim := range quietClaims {
+		if strings.Contains(folded, claim) {
+			return fmt.Errorf(
+				"weekly narrative: the sentence says %q about a week that was not quiet", claim)
+		}
+	}
+	return nil
 }

--- a/backend/internal/compose/weekly/narrative/narrative_test.go
+++ b/backend/internal/compose/weekly/narrative/narrative_test.go
@@ -69,6 +69,10 @@ func TestTheRequestCarriesTheLanguageAndTheVoice(t *testing.T) {
 	}
 }
 
+// quietWeek holds nothing, so a case about the reply's SHAPE is not also a
+// case about whether the sentence contradicts the week.
+var quietWeek = Input{WeekStart: "2026-08-24"}
+
 func TestParseRefusesWhatTheLaneCannotStore(t *testing.T) {
 	long := strings.Repeat("x", MaxNarrativeRunes+1)
 	cases := []struct {
@@ -81,7 +85,7 @@ func TestParseRefusesWhatTheLaneCannotStore(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Parse(tc.reply)
+			got, err := Parse(tc.reply, quietWeek)
 			if err == nil {
 				t.Fatalf("Parse accepted %s and returned %q", tc.name, got)
 			}
@@ -93,7 +97,7 @@ func TestParseRefusesWhatTheLaneCannotStore(t *testing.T) {
 // caller stores the stamp without prose. Reporting it as an error would make
 // the honest quiet week indistinguishable from a broken pass.
 func TestAnEmptySentenceIsAnAnswerRatherThanAFailure(t *testing.T) {
-	got, err := Parse(`{"narrative":"   "}`)
+	got, err := Parse(`{"narrative":"   "}`, quietWeek)
 	if err != nil {
 		t.Fatalf("Parse refused an empty sentence: %v", err)
 	}
@@ -108,7 +112,7 @@ func TestAnEmptySentenceIsAnAnswerRatherThanAFailure(t *testing.T) {
 func TestTheBoundCountsCharactersNotBytes(t *testing.T) {
 	// 600 umlauts: at the ceiling in characters, well over it in bytes.
 	sentence := strings.Repeat("ü", MaxNarrativeRunes)
-	got, err := Parse(`{"narrative":"` + sentence + `"}`)
+	got, err := Parse(`{"narrative":"`+sentence+`"}`, quietWeek)
 	if err != nil {
 		t.Fatalf("Parse refused %d characters that the column holds: %v", MaxNarrativeRunes, err)
 	}
@@ -123,12 +127,82 @@ func TestTheBoundCountsCharactersNotBytes(t *testing.T) {
 // worth saying, which the model never said.
 func TestAMissingFieldIsNotAQuietWeek(t *testing.T) {
 	for _, reply := range []string{`{}`, `{"narrative":null}`} {
-		if _, err := Parse(reply); err == nil {
+		if _, err := Parse(reply, quietWeek); err == nil {
 			t.Errorf("Parse accepted %s as an honest quiet week", reply)
 		}
 	}
 	// And the present-but-empty case still IS one.
-	if _, err := Parse(`{"narrative":""}`); err != nil {
+	if _, err := Parse(`{"narrative":""}`, quietWeek); err != nil {
 		t.Errorf("Parse refused an explicitly empty sentence: %v", err)
+	}
+}
+
+// A week that closed three deals is not a quiet week, and the sentence may not
+// say it was.
+//
+// The stored week of 24 August said all three things at once: the greeting
+// "You closed 3 deals", the Won metric "3 · €12,500", and the prose "A quiet
+// week — nothing closed and nothing slipped". One panel, one week, two answers.
+//
+// The prompt had handed the model that exact sentence as an exemplar, on every
+// week, including this one.
+func TestASentenceMayNotCallABusyWeekQuiet(t *testing.T) {
+	busy := Input{
+		WeekStart: "2026-08-24",
+		Counts:    Counts{DealsWon: 3},
+	}
+	for _, said := range []string{
+		"A quiet week — nothing closed and nothing slipped.",
+		"Nothing closed this week.",
+		"A quiet one, with nothing moved.",
+		"NOTHING HAPPENED worth reporting.",
+	} {
+		if _, err := Parse(`{"narrative":"`+said+`"}`, busy); err == nil {
+			t.Errorf("the lane accepted %q about a week that closed three deals", said)
+		}
+	}
+
+	// The same sentences are the honest answer for a week that held nothing.
+	for _, said := range []string{
+		"A quiet week — nothing closed and nothing slipped.",
+		"Nothing moved.",
+	} {
+		if _, err := Parse(`{"narrative":"`+said+`"}`, quietWeek); err != nil {
+			t.Errorf("the lane refused %q about a week that genuinely held nothing: %v",
+				said, err)
+		}
+	}
+}
+
+// A busy week's ordinary sentence still passes. Without this the check above is
+// satisfied by a lane that refuses everything.
+func TestABusyWeeksOwnSentenceIsAccepted(t *testing.T) {
+	busy := Input{WeekStart: "2026-08-24", Counts: Counts{DealsWon: 3}}
+	said := "Three closes and two promises carried into next week."
+	got, err := Parse(`{"narrative":"`+said+`"}`, busy)
+	if err != nil {
+		t.Fatalf("the lane refused an honest sentence about a busy week: %v", err)
+	}
+	if got != said {
+		t.Errorf("the sentence came back as %q, want it unchanged", got)
+	}
+}
+
+// The prompt itself stops offering the quiet-week wording to a week that was
+// not quiet. The check above is the floor; this is what keeps the model from
+// reaching for the sentence in the first place.
+func TestTheQuietWeekExemplarIsOfferedOnlyToAQuietWeek(t *testing.T) {
+	quiet := Request(quietWeek, "en").System
+	busy := Request(Input{Counts: Counts{DealsWon: 3}}, "en").System
+
+	if !strings.Contains(quiet, "A quiet week") {
+		t.Error("a week that held nothing is not told it may say so")
+	}
+	if strings.Contains(busy, "A quiet week") {
+		t.Error("a week that closed three deals is handed the quiet-week sentence " +
+			"as an exemplar, which is where the contradiction came from")
+	}
+	if !strings.Contains(busy, "THIS WEEK WAS NOT QUIET") {
+		t.Error("a busy week is not told that it was busy")
 	}
 }

--- a/backend/internal/compose/weeklyjobs.go
+++ b/backend/internal/compose/weeklyjobs.go
@@ -305,7 +305,7 @@ func (w *weeklyGenerateWorkspaceWorker) narrate(ctx context.Context, review week
 	bounded, cancel := context.WithTimeout(ctx, narrateBudget)
 	defer cancel()
 	reply, err := ai.Ask(bounded, w.narrator, narrative.Request(in, lang), func(text string) error {
-		_, err := narrative.Parse(text)
+		_, err := narrative.Parse(text, in)
 		return err
 	})
 	if err != nil {
@@ -313,7 +313,7 @@ func (w *weeklyGenerateWorkspaceWorker) narrate(ctx context.Context, review week
 			"week", review.LocalWeekStart.Format(time.DateOnly), "cause", err)
 		return
 	}
-	sentence, err := narrative.Parse(reply.Text)
+	sentence, err := narrative.Parse(reply.Text, in)
 	if err != nil {
 		w.log.WarnContext(ctx, "the weekly review has no sentence: the reply was refused",
 			"week", review.LocalWeekStart.Format(time.DateOnly), "cause", err)

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -1,9 +1,9 @@
 {
   "totals": {
     "sites": 40,
-    "sites_best_current": 32,
+    "sites_best_current": 31,
     "sites_best_partial": 0,
-    "sites_best_stale": 6,
+    "sites_best_stale": 7,
     "sites_absent": 2,
     "scenarios": 136,
     "records": 59,
@@ -177,9 +177,9 @@
         "env": "eu_hosted"
       },
       "sites": 31,
-      "sites_current": 24,
+      "sites_current": 23,
       "sites_partial": 0,
-      "sites_stale": 7,
+      "sites_stale": 8,
       "runs": 333,
       "passed": 269,
       "reliability": 0.8078078078078078,
@@ -3857,17 +3857,8 @@
       "key": "weekly_review/narrative",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.4444444444444444,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_deal_named_like_an_instruction_is_read_as_a_name",
@@ -3892,9 +3883,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 4,
@@ -3907,7 +3898,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count"
         }
       ]
     }

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -25,9 +25,9 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | | |
 |---|---:|
 | Shipped invocation sites | 40 |
-| … best state `current` | 32 |
+| … best state `current` | 31 |
 | … best state `partial` | 0 |
-| … best state `stale` | 6 |
+| … best state `stale` | 7 |
 | … `absent` on every binding | 2 |
 | Scenarios in the corpus | 136 |
 | Committed records | 59 |
@@ -119,7 +119,7 @@ Which model to run each site on, and what that choice rests on.
 | [`voice_build/derive`](#voice_buildderive) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
 | [`voice_build/eval_draft`](#voice_buildeval_draft) | - | - | - | `stale` | 1 | 3 |
 | [`voice_build/eval_scores`](#voice_buildeval_scores) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`weekly_review/narrative`](#weekly_reviewnarrative) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.44 | `current` | 3 | 1 |
+| [`weekly_review/narrative`](#weekly_reviewnarrative) | - | - | - | `stale` | 3 | 1 |
 
 **Best model tested** is the strongest result that still describes what ships.
 Only a `current` or `partial` record is eligible; among those the pick is the
@@ -149,7 +149,7 @@ verdict each reached. Each record's own p50 and p95 are in the site tables.
 | `openai_compatible` | `mistralai/ministral-8b-2512` | `cloud_frontier` | 3 | 0 | 0 | 3 | 15 | 14 | 0.93 | 22390ms | 1 | 2 | 0 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 6 | 0 | 0 | 42 | 39 | 0.93 | 4477ms | 5 | 0 | 1 |
-| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 31 | 24 | 0 | 7 | 333 | 269 | 0.81 | 68516ms | 12 | 7 | 12 |
+| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 31 | 23 | 0 | 8 | 333 | 269 | 0.81 | 68516ms | 12 | 7 | 12 |
 | `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
 
 ## Stale records, and why
@@ -202,6 +202,7 @@ model, real network).
 | `voice_build/eval_draft` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario held_out_draft_sits_close_to_the_author — or the prompt this build now builds from it — has changed since the record scored it |
 | `voice_build/eval_scores` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario judge_ranks_the_author_rhythm_above_generic_ai_prose — or the prompt this build now builds from it — has changed since the record scored it |
 | `voice_build/eval_scores` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `weekly_review/narrative` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
 
 ## Sites, their scenarios and their records
 
@@ -1051,5 +1052,5 @@ Records (1):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 4 | 0.44 | 779ms | 1315ms | 4 | 5 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 4 | 0.44 | 779ms | 1315ms | 4 | 5 | 0 | 0 |
 


### PR DESCRIPTION
The stored week of 24 August said three things at once:

- the greeting: **"You closed 3 deals. 2 promises carried over."**
- the Won metric: **"3 · €12,500"**
- the prose, directly beneath both: **"A quiet week — nothing closed and nothing slipped."**

## Where the sentence came from

The prompt handed the model that exact sentence as an exemplar, on every week, unconditionally. An exemplar is the most quotable line in a prompt, and offering it where it cannot be true is asking for it back.

It is conditional now. A week whose counts are all zero is told it may say the week was quiet; a week that did something is told plainly that it did not, and that the reader is looking at the numbers which say so in the same panel.

## The check

`Parse` takes the input, so a sentence can be checked against the week it describes rather than only for its shape.

It is narrow on purpose: a closed list of ways to say "nothing happened", refused only when the counts say otherwise. The general version — every number in the prose must appear in the input — was the other option and it is **worse than nothing**. Dates, localised amounts, percentages and numbers inside company names all read as figures, so it refuses honest sentences while a wrong number attached to the right metric still passes.

Refusing drops the sentence and keeps the deterministic review, which is what every other rejection in this lane does. A week with no prose reads as a week nobody wrote about. A week whose prose contradicts its own numbers reads as a product that does not know what happened.

## Mutation-checked both ways

Removing the check accepts the quiet sentence about three closes. Making the exemplar unconditional hands it back to a busy week. A busy week's own honest sentence still passes, so neither test is satisfied by a lane that refuses everything.

## Certification

`weekly_review/narrative` is recorded stale — the prompt changed. Its last measured reliability on this site was **0.44**, band `not_supported`, which is the shape of the defect above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the weekly narrative so a week that closed three deals can no longer be described as "a quiet week — nothing closed and nothing slipped." The prompt previously offered that sentence as an exemplar on every week; now it is conditional on all counts being zero, and `Parse` rejects quiet claims about busy weeks.

**Bug Fixes**
- `Parse` now takes the week's counts and refuses sentences claiming nothing happened when any count is non-zero.
- The contradiction check uses a closed list of quiet phrases; a general number-matching check was rejected as worse than nothing.
- Certification records for `weekly_review/narrative` are marked stale since the prompt changed.

<sup>Written for commit cfdd8912cabeaa4c12d52e36e00d44aac8a395c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

