### PR TITLE
fix(frontend): personreadings' task fixture answers the Activity contract

### DIFF
--- a/frontend/src/screens/personreadings.test.tsx
+++ b/frontend/src/screens/personreadings.test.tsx
@@ -206,6 +206,11 @@ describe("what we owe them", () => {
           data: [
             {
               id: "t1",
+              kind: "task",
+              source: "manual",
+              captured_by: "human:u1",
+              created_at: AS_OF,
+              updated_at: AS_OF,
               subject: "Prepare the translation checklist",
               due_at: "2026-08-05T09:00:00Z",
               is_done: false,
@@ -240,6 +245,11 @@ describe("what we owe them", () => {
           data: [
             {
               id: "t1",
+              kind: "task",
+              source: "manual",
+              captured_by: "human:u1",
+              created_at: AS_OF,
+              updated_at: AS_OF,
               subject: "Already sent",
               is_done: true,
               occurred_at: AS_OF,
@@ -265,6 +275,11 @@ describe("what we owe them", () => {
           data: [
             {
               id: "t1",
+              kind: "task",
+              source: "manual",
+              captured_by: "human:u1",
+              created_at: AS_OF,
+              updated_at: AS_OF,
               subject: "Prepare the checklist",
               is_done: false,
               occurred_at: AS_OF,


### PR DESCRIPTION
## Summary
\`fe-build\`/\`fe-quality\` are red on \`main\` right now, independent of anything else in flight: \`screens/personreadings.test.tsx\`'s three \`next_steps.data\` literals supplied only the fields their assertions read (\`id\`, \`subject\`, \`due_at\`/\`is_done\`, \`occurred_at\`). That compiled against the \`Activity\` shape #4395 wrote them against; #4398's schema regen widened the required fields on that same shape, and \`tsc -b\` now fails on all three literals with:

\`\`\`
error TS2739: ... is missing the following properties ...: kind, source, captured_by, created_at, updated_at
\`\`\`

Confirmed pre-existing by reproducing against a clean \`origin/main\` checkout (4dcf69bcb) before this branch's one-line-per-object change.

## Fix
Adds the five missing required fields to each literal, matching the pattern other \`Activity\` fixtures already use elsewhere in the tree (\`kind: "task"\`, \`source: "manual"\`, \`captured_by: "human:u1"\`, plus \`created_at\`/\`updated_at\`).

## Test plan
- [x] \`pnpm exec tsc -b\`: EXIT:0
- [x] \`pnpm exec vitest run src/screens/personreadings.test.tsx\`: 15/15 passed
- [x] \`make check-fe\`: EXIT:0
- [x] No backend files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RSPfhkYwWQ5yMDQaJz3ao

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing type check in `personreadings.test.tsx` by adding the required fields the regenerated `Activity` schema now expects. The three task fixtures only supplied the fields their assertions read, so `tsc -b` failed on `main`; they now include `kind: "task"`, `source: "manual"`, `captured_by: "human:u1"`, and `created_at`/`updated_at`, matching other `Activity` fixtures.

<sup>Written for commit a54c950e7fcfab3d258b752a0ebda3e0fa7d95e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

