### PR TITLE
fix(e2e): the UAT fixture answers /forecast, so the home strip stops taking the shell down

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -2253,6 +2253,35 @@ export async function mockApi(
         base_currency: "EUR",
       });
     }
+    // The readings the home strip and the forecast screen both read. Unmocked,
+    // the catch-all below answered it with a LIST envelope — `{data: [], page}`
+    // — which is truthy, so the screen walked past its own "did the read land"
+    // guard and formatted an undefined currency. `formatMoneyCompact` trims it,
+    // the trim throws, and the whole shell goes with it: every sweep then fails
+    // on a missing nav rail rather than on what it was measuring. Same failure
+    // as `/analytics/context` above, and the same reason it is named in full.
+    if (path === "/forecast") {
+      return json({
+        period_start: "2026-01-01",
+        period_end: "2026-03-31",
+        scope_kind: "workspace",
+        won_minor: 1_200_000,
+        evidence_minor: 900_000,
+        best_case_minor: 2_400_000,
+        open_minor: 4_200_000,
+        weighted_minor: 1_890_000,
+        // Eleven of twelve priced: the gap is what the card's second line is
+        // about, so a fixture where every deal carries a figure would leave
+        // that sentence unmeasured.
+        eligible_count: 12,
+        priced_count: 11,
+        confirmed_date_count: 8,
+        fx_missing_count: 0,
+        as_of: "2026-03-04T09:00:00Z",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+      });
+    }
     if (path.startsWith("/reports/")) {
       return json({
         report: "deals-by-stage",


### PR DESCRIPTION
## Why

Thirteen UAT cases fail on `main`, all of them waiting for `nav.rail` that never appears:

```
Error: expect(locator).toBeVisible() failed
Locator: locator('nav.rail')
- alert:
  - paragraph: Diese Ansicht funktioniert nicht mehr.
```

The home screen hits its error boundary and takes the whole shell with it, so every sweep — 390px, axe AA in both palettes, the one-h1 census — reports a missing rail rather than what it was measuring.

## What was actually wrong

`/forecast` has no branch in `e2e/seed.ts`, and the catch-all answers an unmatched path with a **list envelope**. `{data: [], page}` is truthy, so `home.readings.tsx` walks straight past its own "did the read land" guard:

```ts
if (readings.isError || !readings.data) { … }   // passes: data is {data: [], page}
const data = readings.data;
value={formatMoneyCompact(data.open_minor, data.base_currency, locale)}
```

`base_currency` is `undefined`, `formatMoneyCompact` → `toMajorUnits` → `minorUnitDigits(currency)` → `currency.trim()`, and the trim throws. Traced from the minified frame through the build's own sourcemap:

```
common.js:1:50876 -> src/format/minorunits.ts:88:40   (currency.trim())
common.js:1:51590 -> src/format/format.ts:97:16       (formatMoneyCompact)
home.js:2:26034   -> src/screens/home.readings.tsx:391 (the pipeline StatCard)
```

A read that never landed looked exactly like one that did. **The same shape is already written down two branches above this one**, for `/analytics/context` — an unmocked route answered with the wrong envelope takes the shell down and the sweep then fails on the rail. This is that, for the route the morning readings added.

## What this does not fix

Three failures remain, and none of them takes the shell down — each needs its own fix from whoever owns that surface:

- `#/analytics` scrolls sideways at 390px
- `#/deals` carries axe AA contrast findings, light and dark

So this takes UAT from **13 failures to 3**. It does not turn the lane green on its own.

## The deeper weakness, named rather than fixed

The catch-all returning `json(page([]))` for *every* unmatched path is what makes a missing mock indistinguishable from a successful read — the fixture answers a shape the caller then trusts. Hardening it (a 404 for unknown routes, say) would surface every other gap at once and is a decision about the harness rather than a fix to this defect, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/forecast` mock to the e2e seed fixture so the home readings screen stops crashing the shell. The catch-all previously answered unmatched paths with a list envelope, which the screen treated as a successful read and then errored on formatting, taking down the whole shell and making 13 UAT sweeps fail on a missing nav rail instead of what they measured. With this mock, those 13 cases pass; 3 unrelated failures remain (`#/analytics` scrolls at 390px, `#/deals` has axe AA contrast issues).

<sup>Written for commit 068d08c8da70491591bd3d959354e4703baf57a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

