### PR TITLE
A compact money figure gets the unit test that would have caught it — merge after #4414

### DIFF
--- a/frontend/src/format/format.test.ts
+++ b/frontend/src/format/format.test.ts
@@ -8,6 +8,7 @@ import {
   formatDayMonth,
   formatDuration,
   formatMoney,
+  formatMoneyCompact,
   formatMoneyOrAbsent,
   formatNumber,
   formatSignedMoney,
@@ -79,6 +80,43 @@ describe("money formatting (B-EP09.17)", () => {
 
   it("still scales two-decimal currencies under vi", () => {
     expect(formatMoney(128_400, "EUR", "vi")).toBe("1.284,00\u00a0€");
+  });
+});
+
+// The KPI-slot formatter had no test of its own, and that is how it came to
+// render one stored figure two ways. `maximumFractionDigits: 1` with no minimum
+// leaves the minimum to Intl, whose default under `style: "currency"` is the
+// currency's own digit count — so a round €420,000 kept a forced ".0" on one
+// ICU build and dropped it on another. One figure, two renderings, decided by
+// the reader's browser rather than by this file.
+//
+// EXACT strings for that reason. `toContain("420")` is satisfied by both
+// spellings AND by the uncompacted "€420,000.00", which is the assertion shape
+// that let the divergence run: it could not tell the three apart.
+describe("a money figure abbreviated for a KPI slot", () => {
+  it("drops a decimal a round figure does not need", () => {
+    expect(formatMoneyCompact(42_000_000, "EUR", "en")).toBe("€420k");
+  });
+
+  // The maximum earns its keep here: rounded to whole thousands these two
+  // figures are the same number on the page.
+  it("keeps the decimal that tells two figures apart", () => {
+    expect(formatMoneyCompact(18_640_000, "EUR", "en")).toBe("€186.4k");
+    expect(formatMoneyCompact(18_690_000, "EUR", "en")).toBe("€186.9k");
+  });
+
+  // Below the threshold the long form is no wider and carries every digit, so
+  // abbreviating buys nothing — and the currency's own decimals go with it,
+  // because "€8,332.00" is what the slot has no room for.
+  it("stays exact under ten thousand", () => {
+    expect(formatMoneyCompact(833_200, "EUR", "en")).toBe("€8,332");
+  });
+
+  // The scale is the SERVER's ISO table, not Intl's CLDR one. VND carries no
+  // minor unit, so 420,000 minor units is ₫420k; dividing by Intl's count
+  // instead would draw ₫4.2k, a figure the record does not hold.
+  it("abbreviates on the stored scale, not Intl's own count", () => {
+    expect(formatMoneyCompact(420_000, "VND", "en")).toBe("₫420k");
   });
 });
 


### PR DESCRIPTION
## What

Adds the unit test `formatMoneyCompact` never had. Four cases in `frontend/src/format/format.test.ts`, nothing else in the diff.

**This must land after #4414 and not before.** #4414 fixes the helper; this only pins the fix. On its own it is red for anyone whose ICU forces the decimal.

### History of this PR

It opened as a change to two assertions in `home.readings.test.tsx`, on the premise that `formatMoneyCompact` deterministically renders `€420.0k` and the test was wrong to expect `€420k`. That premise was false, and this PR's own CI disproved it: the runner rendered `€420k` while this container rendered `€420.0k`, off the same commit. The assertion change went red on CI for exactly the reason it was meant to fix.

The real defect was in the formatter, and #4414 — opened independently, 24 minutes after this one — has it, with a better account of the mechanism and a stronger fix for the second half. So the formatter change and the per-file `cleanup()` that were here have been dropped rather than duplicated:

- **The formatter.** #4414's `minimumFractionDigits: 0` is the same line this carried, and its comment is the better one: it names the clamp direction and catches a case missed here — in German, where 420k does not abbreviate at all, the figure rendered `420.000,0 €`.
- **The cleanup.** #4414 registers Testing Library's `cleanup()` globally in `vitest.setup.ts`, with a behavioural gate, so no file can forget. This PR fixed the one file that had — strictly the smaller fix.

What is left is the one thing neither #4414 nor `main` has.

## Why

`maximumFractionDigits: 1` with no minimum leaves the minimum to Intl, whose default under `style: "currency"` is the currency's own digit count — two for EUR — and ECMA-402 only clamps that DOWN to the maximum. So the option reads as "at most one digit" and resolved to *exactly* one on some ICU builds and to none on others. One stored figure, two renderings, decided by the reader's browser.

Nothing caught it because nothing tested the helper. The screen tests that did touch the figure asserted `/420k|420,000/`, which cannot tell the three spellings apart: it passes on `€420k`, on `€420.0k`, and on the uncompacted `€420,000.00` — three different claims to a reader, one match to the regex. That is why these assertions are exact strings.

The four cases, and what each would catch:

- A round figure drops the decimal — the divergence itself.
- A remainder keeps it: `€186.4k` and `€186.9k` are the same number on the page if the maximum ever goes to zero.
- Under the ten-thousand threshold the figure stays exact (`€8,332`), so the compact form is never used where it buys nothing.
- The abbreviation rides the **server's** ISO scale, not Intl's CLDR count: VND carries no minor unit, so 420,000 minor units is `₫420k`. Dividing by Intl's count instead would draw `₫4.2k`, a figure the record does not hold.

## How verified

- `pnpm exec vitest run src/format/format.test.ts` — 39 passed, with #4414's `format.ts` applied locally to stand in for the merged state.
- Mutation-checked in both directions, which is the point of a gate: without the fix the round-figure case fails `expected '€420.0k' to be '€420k'`; with it, green. Removing the fix from a tree carrying only these tests reproduces it.
- `pnpm exec biome check` clean on the one changed file.

CI on this branch alone will go green *for the wrong reason* — the runner's ICU already defaults the minimum to zero, so the gate passes there whether or not the helper is fixed. That is precisely why it should not merge ahead of #4414: landing first would put a test in `main` that is red on every newer ICU.

- [x] `make check` is green — `fe-unit` green (576 files); the backend lanes are untouched by a one-file frontend test change
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — test-only frontend change
- [x] `make craft-static` reports no new blockers — `craft static` sweeps the Go trees; this diff is TypeScript
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Agent-written throughout: the original wrong diagnosis, the CI evidence that overturned it, the four test cases and their comments, the mutation check, and this description. The decision to slim this PR to the gate rather than duplicate #4414 was the human's.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWXrbtjmkFfmHhZnw84j7F