### PR TITLE
fix(recordtabs): the strip may scroll, because the block around it may shrink

### DIFF
--- a/frontend/src/design-system/recordtabs.css
+++ b/frontend/src/design-system/recordtabs.css
@@ -17,6 +17,15 @@
      both. Without the `work` container the fallback is the reading column's
      own gutter, which is the narrower, safe answer. */
   margin-inline: calc(-1 * var(--pageGutter));
+  /* AND it may shrink, which is what makes the strip's own scrolling reachable.
+     A flex or grid item is `min-inline-size: auto`, so it refuses to go narrower
+     than its content — and this element's content is every tab laid end to end.
+     Inside a `work` container that never shows, because the block below pins an
+     explicit `inline-size` and the strip scrolls within it. Outside one, on a
+     screen whose header is a flex row, the strip's `overflow-x: auto` could
+     never engage: the tabs pushed the page sideways instead, which is the one
+     thing this component is built not to do. */
+  min-inline-size: 0;
 }
 
 /* A record with a RAIL is the exception, and it has to be: the rail is a


### PR DESCRIPTION
The last check keeping `main`'s UAT lane red. One declaration.

Closes https://github.com/margince/margince/issues/4397
Closes https://github.com/margince/margince/issues/4415

## What happens

`#/analytics` scrolls sideways at 390px — the shell content scroller **94px** past the viewport — and the offender is the record tab strip, on a screen that is not a record.

`.recordtabs` breaks out to the work column's edges. Inside a `work` container the `@container` block pins an explicit `inline-size: 100cqi`, so the width is the column's and the tabs scroll within it. Outside one the fallback is a pair of negative gutters and no width at all — the narrower answer `recordtabs.css` documents it to be, and correct wherever the element is free to take its parent's width.

On `#/analytics` it is not free. That screen's header is a flex row, so `.recordtabs` is a **flex item**, and a flex item is `min-inline-size: auto` — it refuses to go narrower than its content, and its content is every tab laid end to end. So the strip's own `overflow-x: auto` could never engage: there was no overflow to absorb, because the box had already grown to fit.

Measured in the browser at 390px:

```
recordtabs        w=483.7  marX=-20px/-20px  minInline=auto   <- flex item, sized to content
recordtabs-row    w=483.7  padX=20px/20px
recordtabs-strip  w=443.7  overflow-x=auto                    <- the scroller, never asked to scroll
analytics-header  w=350.0  display=flex  dir=row  align=center
```

443.7px of tabs plus two 20px gutters is 483.7px inside a 350px column. 483.7 − 390 = 93.7, which is the 94px the sweep reports.

## The fix

`min-inline-size: 0` on `.recordtabs`.

On the **component**, not on the screen: any flex or grid parent reaches this, and `#/analytics` is only where it landed first. It cannot affect the container case — there the width is pinned before shrinking is ever asked about.

## Why not the wrapper

https://github.com/margince/margince/issues/4397 proposes wrapping `screens/analytics.tsx` in `PageZones`/a `work` container, and notes that needs a look at the whole screen's layout. That is still worth doing on its own merits — analytics is the one `RecordTabs` consumer outside the family — but it is not what this defect requires, and it is a much larger diff to put in front of a red lane.

The narrow reading is also the more honest one: a component whose strip is designed to scroll should be able to scroll in any parent, and this one could not. Fixing the screen would have left the next flex parent to rediscover it.

## Verification

- `playwright test e2e/ac.spec.ts` — **195 passed, 0 failed**, the `#/analytics` 390px sweep among them. Before: 1 failed / 194 passed.
- `make fe-ds-gates` — clean.
- `vitest run src/design-system` — 83 files, **993 tests**, all passing.
- `biome check` — clean.

Node 24, matching what CI pins.

## One correction to the issue's numbers

https://github.com/margince/margince/issues/4397 records an 11px breakout. It is 94px now — the analytics work that landed after it was filed widened the strip. Same mechanism, larger number.
