### PR TITLE
fix(worklist): the deal card says whether anybody is carrying the deal

### DIFF
--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -96,6 +96,10 @@ func dealFactsOf(item crmcontracts.AttentionItem) *crmcontracts.WorklistDealFact
 		OwnerId:     item.Deal.OwnerId,
 		AmountMinor: item.Deal.AmountMinor,
 		Currency:    item.Deal.Currency,
+		// Copied verbatim: absent is not false. A committee this reader could
+		// not read in full arrives nil, and normalizing it to false would tell
+		// a rep nobody is carrying a deal whose champion they simply cannot see.
+		NoChampion: item.Deal.NoChampion,
 	}
 	// The close date rides on the lane item's own due moment, and the idle
 	// count on its own typed field. Both were already resolved; only this projection

--- a/backend/internal/compose/attention/nochampion_test.go
+++ b/backend/internal/compose/attention/nochampion_test.go
@@ -99,3 +99,67 @@ func withDealFacts(deal RiskyDeal) RiskyDeal {
 	deal.AmountMinor, deal.Currency = &minor, &currency
 	return deal
 }
+
+// The reason and the fact are two answers, and a client reads both.
+//
+// The tests above prove the `because` line fires; this proves the typed field
+// beside it says the same thing. They are separate code paths — classifyRisk
+// appends the reason from the lane item, dealFactsOf projects the facts object
+// — so one carrying the tri-state proves nothing about the other. A card
+// drawing a champion-coverage badge reads the field, not the reason.
+func TestTheDealCardSaysNobodyIsCarryingIt(t *testing.T) {
+	uncovered := true
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Fleet retrofit",
+		QuietDays: 19, NoChampion: &uncovered,
+	}))
+	if row.Deal == nil {
+		t.Fatal("the row carries no deal facts at all")
+	}
+	if row.Deal.NoChampion == nil || !*row.Deal.NoChampion {
+		t.Errorf("the card states no_champion=%v, want a stated true", row.Deal.NoChampion)
+	}
+}
+
+// Absent, never false — the distinction the contract spells out at length.
+//
+// `false` here would be the card claiming the committee is covered, over a
+// read that never saw the committee. A rep reading that stops looking for a
+// champion on a deal whose champion they simply may not see.
+func TestTheCardMakesNoChampionClaimAboutAWithheldCommittee(t *testing.T) {
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Fleet retrofit",
+		QuietDays: 19, NoChampion: nil,
+	}))
+	if row.Deal == nil {
+		t.Fatal("the row carries no deal facts at all")
+	}
+	if row.Deal.NoChampion != nil {
+		t.Errorf("the card answers %v about a committee it could not read, want no answer", *row.Deal.NoChampion)
+	}
+}
+
+// The third input, and the one the contract's prose and its schema disagree on.
+//
+// `noChampionOf` never returns a stated false today — a covered committee
+// arrives absent — so this pins the projection's behaviour if one ever does.
+// It passes it through rather than swallowing it, because a stated false is
+// the coverage seam's answer to give: this row copies, it does not judge. The
+// schema permits `false`; the field's prose says it is "sent only when the
+// answer is both known and negative". Resolving that is the contract's work,
+// and until it is resolved a silent change of behaviour here should cost
+// somebody this test.
+func TestTheCardRepeatsAStatedFalseRatherThanInventingAnAnswer(t *testing.T) {
+	covered := false
+	row := oneRiskRow(t, withDealFacts(RiskyDeal{
+		DealID: ids.NewV7(), Name: "Fleet retrofit",
+		QuietDays: 19, NoChampion: &covered,
+	}))
+	if row.Deal == nil {
+		t.Fatal("the row carries no deal facts at all")
+	}
+	if row.Deal.NoChampion == nil || *row.Deal.NoChampion {
+		t.Errorf("the card states no_champion=%v over a seam that answered false",
+			row.Deal.NoChampion)
+	}
+}

--- a/backend/internal/compose/attention/ownerscope_test.go
+++ b/backend/internal/compose/attention/ownerscope_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// One row, two owner answers, and nothing holding them together.
+//
+// A ranked row states its owner twice: `ownerRef` answers the CLIENT, and
+// `owner` answers the SCOPE FILTERS through answersTo. The split is deliberate
+// — a zero `owner` is a row the filters simply keep, where a client told
+// `unassigned` would read a confident claim nobody owes it — and only `owner`
+// decides whose Mine queue a row lands on.
+//
+// So a producer that names a person in `ownerRef` and leaves `owner` zero puts
+// a row on nobody's queue while the card beside it prints that person's name.
+// The existing census (TestEveryProducerStatesAnOwner) cannot see that: it reads
+// `ownerRef` alone, which is the half that would still be right.
+//
+// Today the three producers that name a person set both. This test is what
+// makes that stay true.
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestANamedOwnerIsOneTheScopeFiltersCanRead(t *testing.T) {
+	t.Parallel()
+	holder := ids.NewV7()
+	rows := classifyDay(dayWhoseRowsNameAnOwner(holder), rankInstant, dayMoney{})
+	rows = append(rows,
+		classifyWaiting(WaitingCustomer{Since: rankInstant, OwnerID: holder}, rankInstant),
+		classifyLead(OwedLead{OwnerID: holder}, rankInstant))
+	named := 0
+	for _, row := range rows {
+		if row.ownerRef.kind != ownerNamed {
+			continue
+		}
+		named++
+		answers, readable := answersTo(row)
+		if !readable {
+			t.Errorf("a %q row names %v to the reader and answersTo sees nobody, so the row "+
+				"prints an owner and lands on no Mine queue: set `owner` in its classifier too",
+				row.item.Source, row.ownerRef.user)
+			continue
+		}
+		if answers != row.ownerRef.user {
+			t.Errorf("a %q row names %v to the reader and %v to the scope filters, so the card "+
+				"and the queue it sits on disagree about who owes it",
+				row.item.Source, row.ownerRef.user, answers)
+		}
+	}
+	// Without this the census passes over a day whose producers all answered
+	// `unassigned` or `whoever is reading` — every arm above skipped, nothing
+	// compared, and PASS. The fixture must actually reach the paired answer.
+	if named < 3 {
+		t.Fatalf("only %d row named a person, so this census compared almost nothing: "+
+			"give dayWhoseRowsNameAnOwner a row for each producer that calls ownedBy", named)
+	}
+}
+
+// dayWhoseRowsNameAnOwner is dayOfEveryLane with a person on the rows that can
+// carry one, so the pairing above is exercised rather than skipped.
+func dayWhoseRowsNameAnOwner(holder ids.UUID) crmcontracts.Attention {
+	day := dayOfEveryLane()
+	assignee := openapi_types.UUID(holder)
+	day.Planned = []crmcontracts.AttentionItem{
+		item("task", "task", func(row *crmcontracts.AttentionItem) { row.AssigneeId = &assignee }),
+	}
+	return day
+}

--- a/backend/internal/compose/attention/ownerscope_test.go
+++ b/backend/internal/compose/attention/ownerscope_test.go
@@ -73,3 +73,36 @@ func dayWhoseRowsNameAnOwner(holder ids.UUID) crmcontracts.Attention {
 	}
 	return day
 }
+
+// A folded row can name a person the scope filters will never see.
+//
+// ownerOfTheGroup speaks where the members agree, and a synthesized row has no
+// record of its own to take `owner` from — so a group whose members all name
+// one person carries ownerNamed with a zero `owner`. That is the mis-scoping
+// the census above describes, reached directly because no producer that folds
+// can currently produce it: classifyDecision, the only classifier the fold
+// consumes, answers unassigned() for every row and ignores AssigneeId, by a
+// deliberate rule of its own.
+//
+// So this is the shape waiting rather than a defect today, and testing it here
+// rather than through a fixture keeps the claim honest: the census above cannot
+// reach this, and pretending otherwise with a hand-forced pile would assert a
+// path through classifyDecision that does not exist.
+func TestAFoldedRowNamingAPersonWouldNotBeScopedToThem(t *testing.T) {
+	t.Parallel()
+	holder := ids.NewV7()
+	members := []ranked{{ownerRef: ownedBy(holder)}, {ownerRef: ownedBy(holder)}}
+	group := ownerOfTheGroup(members)
+	if group.kind != ownerNamed || group.user != holder {
+		t.Fatalf("a pile agreeing on one owner says %v, so this test no longer reaches "+
+			"the shape it was written for", group)
+	}
+	// The gap itself: the group names a person and carries no `owner` for
+	// answersTo to read. If a foldable producer ever names one, this is the line
+	// that has to change with it.
+	folded := ranked{ownerRef: group}
+	if _, readable := answersTo(folded); readable {
+		t.Error("a folded row now answers the scope filters — fold its owner into the " +
+			"census above rather than leaving this test to describe a gap that closed")
+	}
+}


### PR DESCRIPTION
`dealFactsOf` builds the worklist row's `WorklistDealFacts` and copied every
field except `NoChampion`, so `no_champion` was absent on every row regardless
of what the champion-coverage read actually found. The lane's own projection
(`dealFacts` in `rendersilence.go`) carries it deliberately; this one dropped
it. The `because: no_champion` reason fires from a separate code path, which is
why nothing on screen read wrong and the gap stayed invisible.

**No screen changes today** — nothing in `frontend/` reads
`WorklistDealFacts.no_champion` yet, only the reason beside it. What changes is
that a client drawing champion coverage from the facts object now gets the same
answer the reason already gave.

Second, smaller fix in the same area: **a named owner is one the scope filters
can read.** A ranked row states its owner twice — `ownerRef` answers the
client, `owner` answers the scope filters through `answersTo` — and only the
second decides whose Mine queue a row lands on. `TestEveryProducerStatesAnOwner`
reads `ownerRef` alone, so a producer naming a person to the reader while
leaving `owner` zero would print that name on the card and put the row on
nobody's queue, with the census green. Latent today (the three producers that
call `ownedBy` set both); the new census keeps it that way.

Closes #4304.

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestTheDealCardSaysNobodyIsCarryingIt` — the row's `deal.no_champion` is a stated `true` where the coverage read found an uncovered committee. Field-only; no rendered change yet. |
| Permission/row scope | Unchanged. The tri-state is resolved by the coverage seam under the caller's own read; this projection copies and never re-decides, which is what keeps a withheld committee absent rather than reported. |
| Failure behavior | `TestTheCardMakesNoChampionClaimAboutAWithheldCommittee` — a committee the reader could not read in full stays absent, never `false`. |
| Idempotency/concurrency | n/a — pure projection, no write. |
| Mobile | n/a — no rendered change. |
| Storybook | n/a — no component change. |
| Accessibility | n/a — no component change. |
| Contract | No contract edit. `make check-backend` drift + composition reproducibility green. |
| Write shape | n/a — read path only. |
| Mutation strength | Three mutations, three distinct failures, no redundant test: (1) drop the field → `TestTheDealCardSaysNobodyIsCarryingIt` + `TestTheCardRepeatsAStatedFalse…`; (2) round `nil` down to `false` → `TestTheCardMakesNoChampionClaimAboutAWithheldCommittee`; (3) swallow a stated `false` into absent → `TestTheCardRepeatsAStatedFalse…`. For the census: dropping `owner:` from the task producer fails `TestANamedOwnerIsOneTheScopeFiltersCanRead` while `TestEveryProducerStatesAnOwner` stays green — which is the proof the gap was uncovered. Emptying the fixture trips its own count guard. |
| Full lane | `make check-backend` EXIT=0, zero failures, on `570c4661ef`. |

Reviewed by `craft-reviewer`, which found four things, all fixed here: a
duplicate absent-case test whose comment claimed a route it never travelled
(deleted), a comment that paraphrased its sibling instead of stating the
invariant (rewritten to the one fact that matters — absent is not false), the
missing stated-`false` input (now a test), and a floating section comment
(folded into the doc comment).

Codex review not run: out of quota for `gpt-5.3-codex-spark` until Sep 12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the worklist deal card to carry the `no_champion` field from the coverage read, so the facts object now matches the reason line. Also guards that named owners are set in the scope-filter field, not just the client-facing one.

- `dealFactsOf` now copies `NoChampion` verbatim, preserving the tri-state: absent stays absent, stated true and false are passed through.
- `TestANamedOwnerIsOneTheScopeFiltersCanRead` enforces that producers naming an owner also set the `owner` field used by `answersTo`, so rows land on the right Mine queue.
- `TestAFoldedRowNamingAPersonWouldNotBeScopedToThem` pins the one gap the census cannot reach: a folded row naming a person would carry a zero `owner`, so it fails if a foldable producer ever names one.

<sup>Written for commit b63fdff14a34e93b07463a058d46493ad3fa276d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deal cards now accurately reflect whether a champion is confirmed, explicitly absent, or unknown because committee information is unavailable.
  - Attention rows with named owners now maintain consistent owner information, improving owner-based filtering and visibility.

- **Tests**
  - Added coverage for champion-status handling and owner assignment to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->