### PR TITLE
The shell asks where a setting lives without drawing it

### DIFF
--- a/frontend/src/app/account.tsx
+++ b/frontend/src/app/account.tsx
@@ -13,7 +13,7 @@ import { Avatar } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
 import { problemMessageOf, useLogout, useMe } from "../screens/common";
-import { SETTINGS_SCREEN } from "../screens/settings";
+import { SETTINGS_SCREEN } from "../screens/settingsnav";
 import { usePopoverDismiss } from "./popover";
 import { routeHash } from "./router";
 import {

--- a/frontend/src/app/mefixture.ts
+++ b/frontend/src/app/mefixture.ts
@@ -42,6 +42,7 @@ export function meFixture({
   seat = "full",
   allow = {},
   rowScope = "own",
+  settingsAvailability = { company_context: true },
 }: {
   roles?: string[];
   seat?: "full" | "read";
@@ -53,6 +54,19 @@ export function meFixture({
    * make every test agree with a widening nobody wrote.
    */
   rowScope?: RowScope;
+  /**
+   * Which settings surfaces exist in this installation. Defaults to the company
+   * page being available, because that is the compiled default the deployment
+   * config resolves to — a fixture omitting it should describe an ordinary
+   * installation, not one with the rollout switched off.
+   *
+   * Pass `null` for the third state, which is neither of those: a server older
+   * than the field, or a snapshot cached before it shipped, answers /me with no
+   * `settings_availability` at all. That is not the same record as one saying
+   * the surface is off, and a reader has to fail closed on both — so the
+   * absence needs its own spelling rather than riding the default.
+   */
+  settingsAvailability?: MeResponse["settings_availability"] | null;
 } = {}): MeResponse {
   const objects: Record<string, RbacObjectGrant> = {};
   for (const [object, actions] of Object.entries(allow)) {
@@ -78,6 +92,7 @@ export function meFixture({
     data_reset_available: false,
     admin_password_link: false,
     authorization: { seat_type: seat, objects, row_scope: rowScope },
+    settings_availability: settingsAvailability ?? undefined,
   };
   return me;
 }

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -424,6 +424,64 @@ describe("useBuiltinCommands", () => {
     return render(<Probe />);
   }
 
+  // The company page rides a deployment flag as well as a grant, and the
+  // palette used to answer that half of the question differently from the rail:
+  // it passed `probeCompanyFlag: false` to avoid a network read, so the flag
+  // resolved to false here and to its real value there. One installation, two
+  // answers, and no test could see it because each surface was asserted alone.
+  //
+  // These three hold the claim that they now agree. The knob is the same
+  // `meFixture` field `settings-nav.test.tsx` drives, so a predicate that
+  // stopped reading it fails on both sides at once.
+  function renderProbeWithCompany(opts: { companyContext: boolean | null }) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          meFixture({
+            roles: [],
+            allow: { organization: ["read"] },
+            settingsAvailability:
+              opts.companyContext === null
+                ? null
+                : { company_context: opts.companyContext },
+          }),
+        ),
+      ),
+    );
+    return render(<Probe />);
+  }
+
+  it("offers the company shortcut when the installation has that surface", async () => {
+    const user = userEvent.setup();
+    renderProbeWithCompany({ companyContext: true });
+    await user.type(screen.getByRole("searchbox"), "general");
+    await waitFor(() => {
+      expect(screen.getAllByRole("button")[0].textContent).toContain("General");
+    });
+  });
+
+  it("withholds it when the installation does not, matching the rail", async () => {
+    const user = userEvent.setup();
+    renderProbeWithCompany({ companyContext: false });
+    // The grant is held and the flag is not, which is exactly the state the old
+    // palette got wrong: it never read the flag, so it fell back to the grants
+    // beside it and offered a page this installation may not have.
+    await user.type(screen.getByRole("searchbox"), "general");
+    await waitFor(() => {
+      expect(screen.queryByText("General")).toBeNull();
+    });
+  });
+
+  it("withholds it when /me carries no availability at all", async () => {
+    const user = userEvent.setup();
+    renderProbeWithCompany({ companyContext: null });
+    await user.type(screen.getByRole("searchbox"), "general");
+    await waitFor(() => {
+      expect(screen.queryByText("General")).toBeNull();
+    });
+  });
+
   it("reaches the filter builder by the name the screen prints", async () => {
     const user = userEvent.setup();
     renderProbe();

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -13,7 +13,7 @@ import {
   type SettingsTabId,
   settingsAddress,
   useSettingsEntryVisibility,
-} from "../screens/settings";
+} from "../screens/settingsnav";
 import {
   CUSTOM_SCREEN,
   customPaletteScreens,
@@ -85,10 +85,12 @@ const SETTINGS_ALIASES: Readonly<
 export function useBuiltinCommands(): Command[] {
   const t = useT();
   const { locale } = useLocale();
-  // Without the company rollout probe: the palette offers no shortcut to General,
-  // and that probe is a network read this hook would otherwise fire on every
-  // screen (see useSettingsEntryVisibility).
-  const visible = useSettingsEntryVisibility(false);
+  // The same snapshot the settings rail reads, so the two cannot disagree about
+  // which pages exist. This used to pass `false` to skip a network probe the
+  // hook fired for the company-rollout fact alone — which meant the palette
+  // answered that question differently from the rail. The fact rides /me now,
+  // so there is no request to skip and no parameter to pass.
+  const visible = useSettingsEntryVisibility();
   return useMemo(() => {
     const screens: Command[] = NAV.map((item) => ({
       id: `screen:${item.screen}`,

--- a/frontend/src/app/searchkinds.ts
+++ b/frontend/src/app/searchkinds.ts
@@ -3,7 +3,7 @@
 
 import type { components } from "../api/schema";
 import type { MessageKey } from "../i18n/en";
-import { settingsAddress } from "../screens/settings";
+import { settingsAddress } from "../screens/settingsnav";
 import { ENTITY, type EntityKind, isEntityKind } from "./entity";
 import type { Route } from "./router";
 

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -14,7 +14,7 @@ import { CompanyLogo } from "../design-system/companylogo";
 import { Logomark } from "../design-system/logomark";
 import { useLocale, useT } from "../i18n";
 import { useCompany } from "../screens/onboarding";
-import { SETTINGS_SCREEN, useSettingsSection } from "../screens/settings";
+import { SETTINGS_SCREEN, useSettingsSection } from "../screens/settingsnav";
 import { AgentEdge } from "./agent-edge";
 import { AgentRail } from "./agentrail";
 import { EconomyBanner } from "./economybanner";

--- a/frontend/src/app/topbar.tsx
+++ b/frontend/src/app/topbar.tsx
@@ -1,7 +1,7 @@
 import { PanelLeftClose, PanelLeftOpen, Search } from "lucide-react";
 import { Breadcrumb, type Crumb } from "../design-system/breadcrumb";
 import { useLocale, useT } from "../i18n";
-import { SETTINGS_SCREEN } from "../screens/settings";
+import { SETTINGS_SCREEN } from "../screens/settingsnav";
 import { AccountMenu } from "./account";
 import { SCREEN_ENTITY } from "./entity";
 import { EXTENSION_SCREEN, findExtension } from "./extensions";

--- a/frontend/src/screens/settings-imports.test.ts
+++ b/frontend/src/screens/settings-imports.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// The settings catalog is split in two so the shell can ask where a settings
+// entry lives without paying to draw it. `settingsnav.tsx` answers the address
+// and visibility questions; `settings.tsx` renders the cards and pulls in every
+// mutation hook and roughly a hundred and fifty imports to do it.
+//
+// That split only buys anything while it holds TRANSITIVELY. A direct-import
+// grep would pass the day someone adds `settingsnav -> somecard -> settings`,
+// and the shell would silently go back to loading the whole settings screen to
+// render a nav rail. So this walks the graph from each entry point and fails on
+// the reachable set, not on the first hop.
+//
+// Two obligations, both real failures we would otherwise ship blind:
+//
+//  1. No file under `src/app/**` may reach `settings.tsx`. Those are the always-
+//     loaded shell modules; reaching the screen defeats its lazy chunk for every
+//     page in the product, not only settings.
+//  2. `settingsnav.tsx` may not reach `settings.tsx`. It is the light half by
+//     construction, and a cycle through it re-couples every one of its readers.
+
+const screensDir = dirname(fileURLToPath(import.meta.url));
+const srcRoot = resolve(screensDir, "..");
+const settingsScreen = join(screensDir, "settings.tsx");
+const settingsNav = join(screensDir, "settingsnav.tsx");
+
+/** Resolve a relative specifier to a real file, trying the extensions Vite does. */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) {
+    return null; // a package, not our source
+  }
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ]) {
+    // `isFile` rather than mere existence: a bare specifier can name a
+    // DIRECTORY that also has an `index.tsx`, and treating the directory as the
+    // resolved module would end the walk one hop early — a silent under-read,
+    // which is the one way this gate must not fail.
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Every module specifier `file` imports, including `import type` and dynamic
+ * `import()`. Type-only edges count: a type import that names a card module
+ * still says the two halves are one unit, and a later value import across the
+ * same edge would not show up as a new dependency in review.
+ */
+function importsOf(file: string): string[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const out: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      out.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      out.push(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return out;
+}
+
+/**
+ * The shortest import path from `entry` to `target`, or null when unreachable.
+ * Returning the path rather than a boolean is what makes a failure actionable:
+ * the offending edge is usually three hops in and invisible from the entry.
+ */
+function pathTo(entry: string, target: string): string[] | null {
+  const seen = new Set([entry]);
+  const queue: string[][] = [[entry]];
+  while (queue.length > 0) {
+    const trail = queue.shift() as string[];
+    const head = trail[trail.length - 1];
+    for (const specifier of importsOf(head)) {
+      const next = resolveSpecifier(head, specifier);
+      if (next === null || seen.has(next)) {
+        continue;
+      }
+      if (next === target) {
+        return [...trail, next].map((file) => relative(srcRoot, file));
+      }
+      seen.add(next);
+      queue.push([...trail, next]);
+    }
+  }
+  return null;
+}
+
+/**
+ * Every production module that must not reach the settings screen, DERIVED
+ * rather than listed. A hand-kept list is a second copy of "who asks a settings
+ * question", and it goes stale the first time somebody adds a module — silently,
+ * because a gate that reads a smaller tree still reports PASS.
+ *
+ * Two trees qualify. `src/app/**` is the always-loaded shell. `src/screens/**`
+ * is every other screen: a screen that only wants an ADDRESS must not drag the
+ * settings cards into its own chunk, which is what `worklist.copy.ts` did —
+ * putting the whole settings screen behind Home, the default landing page.
+ *
+ * Tests, stories and the testkit are excluded on purpose: they ask this module
+ * for both halves, that is what they are for, and they ship in no chunk.
+ */
+function productionModulesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return productionModulesUnder(path);
+    }
+    if (!/\.tsx?$/.test(entry.name)) {
+      return [];
+    }
+    return /\.(test|stories)\.tsx?$|\.testkit\.tsx$/.test(entry.name)
+      ? []
+      : [path];
+  });
+}
+
+const settingsOwnModules = new Set([settingsScreen, settingsNav]);
+const shellEntryPoints = [
+  ...productionModulesUnder(join(srcRoot, "app")),
+  ...productionModulesUnder(join(srcRoot, "screens")),
+]
+  .filter((file) => !settingsOwnModules.has(file))
+  .map((file) => relative(srcRoot, file))
+  .sort();
+
+describe("the settings nav split holds transitively", () => {
+  it.each(shellEntryPoints)("%s does not reach settings.tsx", (entry) => {
+    const trail = pathTo(join(srcRoot, entry), settingsScreen);
+    expect(
+      trail,
+      trail === null ? "" : `import path: ${trail.join(" -> ")}`,
+    ).toBeNull();
+  });
+
+  it("settingsnav.tsx does not reach settings.tsx", () => {
+    const trail = pathTo(settingsNav, settingsScreen);
+    expect(
+      trail,
+      trail === null ? "" : `import path: ${trail.join(" -> ")}`,
+    ).toBeNull();
+  });
+
+  // The walk is only worth its runtime if it can actually see an edge. Without
+  // this, a resolver that silently returned null for every specifier would
+  // report PASS on a tree where the split had completely collapsed.
+  it("finds a path that does exist, so a green result means something", () => {
+    const trail = pathTo(settingsScreen, join(srcRoot, "i18n/index.tsx"));
+    expect(trail).not.toBeNull();
+    expect(trail?.[0]).toBe("screens/settings.tsx");
+  });
+});

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -3,7 +3,6 @@ import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { translate } from "../i18n";
-import { companyContextCapabilitiesQueryKey } from "./company-context";
 import {
   SETTINGS_TABS,
   SettingsScreen,
@@ -136,6 +135,10 @@ function adminNavBackend(opts: {
   // and expect the nav not to narrow.
   seat?: "full" | "read";
   companyReadEnabled?: boolean;
+  // A server that predates `settings_availability` answers /me without it.
+  // The predicate has to read that as "the surface does not exist" rather than
+  // as permission, so a case can ask for the field to be absent entirely.
+  omitAvailability?: true;
 }) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
@@ -145,6 +148,9 @@ function adminNavBackend(opts: {
           roles: opts.roles,
           seat: opts.seat ?? "full",
           allow: opts.allow ?? {},
+          settingsAvailability: opts.omitAvailability
+            ? null
+            : { company_context: opts.companyReadEnabled ?? false },
         }),
       );
     }
@@ -162,28 +168,6 @@ function adminNavBackend(opts: {
       page: { next_cursor: null, has_more: false },
     });
   });
-}
-
-// The same backend with the rollout answer on a valve the test opens. The nav
-// can then be read at two named moments — flag unanswered, flag answered "off"
-// — instead of whichever of the two the event loop happens to serve first.
-function adminNavBackendHoldingCapabilities(opts: {
-  roles: string[];
-  allow?: GrantSpec;
-}) {
-  const answer = adminNavBackend({ ...opts, companyReadEnabled: false });
-  let release: (() => void) | undefined;
-  const held = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-    const url = String(input instanceof Request ? input.url : input);
-    if (url.includes("/company/context/capabilities")) {
-      await held;
-    }
-    return answer(input);
-  });
-  return { fetchMock, answerCapabilities: () => release?.() };
 }
 
 // The settings entries currently in the nav, in render order — personal group
@@ -680,41 +664,61 @@ describe("SettingsScreen Admin settings group", () => {
     expect(await screen.findByRole("link", { name: "General" })).toBeTruthy();
   });
 
-  it("withholds General from that same admin while the rollout flag is off — before the flag answers and after", async () => {
+  it("withholds General from that same admin while the rollout flag is off", async () => {
     // The flag is a deployment posture, not a permission, so it ANDs with the
     // grant beside it: the company profile may simply not exist on this
-    // installation. An unknown flag therefore reads as "off" — an entry that
-    // appears while the answer is in flight and then vanishes has already offered
-    // a surface this installation may not have.
+    // installation.
+    //
+    // This used to assert two moments — the nav composed while the flag was
+    // still in flight, then again once it answered — because the fact arrived
+    // over its own request and an entry could appear and then vanish. It rides
+    // /me now, so there is no in-flight window to hold open: the nav cannot
+    // render before the snapshot it reads. The race is gone rather than
+    // untested, which is why the second moment went with it.
     //
     // The organization read is the ONLY term of General's predicate this fixture
     // grants, which is what leaves the flag decisive. On a seeded installation
     // every role also holds `installation_settings:read` and General opens on
-    // that regardless — so this case is about the flag's contribution to the
-    // union, not a claim that General is ever unreachable in practice.
-    const { fetchMock, answerCapabilities } =
-      adminNavBackendHoldingCapabilities({
+    // that regardless — so this is about the flag's contribution to the union,
+    // not a claim that General is ever unreachable in practice.
+    vi.stubGlobal(
+      "fetch",
+      adminNavBackend({
         roles: ["admin"],
         allow: readOn("organization"),
-      });
-    vi.stubGlobal("fetch", fetchMock);
-    const { client } = renderNav();
+        companyReadEnabled: false,
+      }),
+    );
+    renderNav();
 
-    // Moment one: the nav is fully composed from /me — its role-gated entries
-    // are on screen — while the flag is still unanswered, because this test
-    // holds the answer.
     await screen.findByRole("link", { name: "Maintenance" });
     expect(navTabs()).toEqual(ADMIN_TABS_WITH_MAINTENANCE);
+    expect(screen.queryByRole("link", { name: "General" })).toBeNull();
+  });
 
-    // Moment two: the answer is in the cache, which is the fact the emptiness
-    // claim needs — the request having been SENT proves nothing about what the
-    // nav has rendered.
-    answerCapabilities();
-    await waitFor(() =>
-      expect(
-        client.getQueryState(companyContextCapabilitiesQueryKey)?.status,
-      ).toBe("success"),
+  it("withholds General when /me carries no availability at all", async () => {
+    // The absent case, which is a DIFFERENT fact from the flag reading false:
+    // a server older than `settings_availability` answers /me without the
+    // object, and a browser holding a cached snapshot from before the field
+    // shipped does the same. Both are states a running deployment reaches
+    // during a rollout, and neither says the company profile exists.
+    //
+    // Without this case the predicate's `?? false` is unheld — flipping it to
+    // `?? true` passes every other test in this file, because they all supply
+    // the field. What that flip ships is an entry offered on an installation
+    // that may not have the surface, which is the one direction a deployment
+    // fact must not fail.
+    vi.stubGlobal(
+      "fetch",
+      adminNavBackend({
+        roles: ["admin"],
+        allow: readOn("organization"),
+        omitAvailability: true,
+      }),
     );
-    expect(navTabs()).toEqual(ADMIN_TABS_WITH_MAINTENANCE);
+    renderNav();
+
+    await screen.findByRole("link", { name: "Maintenance" });
+    expect(screen.queryByRole("link", { name: "General" })).toBeNull();
   });
 });

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -4,26 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import {
-  Activity,
-  BadgeCheck,
-  Blocks,
-  BookOpen,
-  Building2,
-  ChevronDown,
-  Database,
-  KeyRound,
-  type LucideIcon,
-  Mail,
-  Mic,
-  Plug,
-  ShieldCheck,
-  Sparkles,
-  UserRound,
-  UsersRound,
-  Webhook,
-  Wrench,
-} from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -35,10 +16,8 @@ import {
 import { api, FIRST_PAGE } from "../api/client";
 import type { components, operations } from "../api/schema";
 import { dotTier } from "../app/autonomy";
-import { useCan, useCanWrite, useHoldsAdminRole } from "../app/capability";
+import { useCanWrite, useHoldsAdminRole } from "../app/capability";
 import { isEntityKind } from "../app/entity";
-import { unitsForSecretScope } from "../app/extensions";
-import type { NavLevelEntry, NavLevelGroup, NavSection } from "../app/nav";
 import { useRecordZone } from "../app/recordzone";
 import { navigateReplacing, type Route } from "../app/router";
 import { useUnsavedGuard } from "../app/unsaved";
@@ -97,10 +76,7 @@ import {
   useLogout,
   useMe,
 } from "./common";
-import {
-  CompanyContextCard,
-  useCompanyContextCapabilities,
-} from "./company-context";
+import { CompanyContextCard } from "./company-context";
 import { ConnectedAgentsCard } from "./connected-agents";
 import { ConnectorsCard } from "./connectors";
 import { ConsumerMailDomainsCard } from "./consumer-mail-domains";
@@ -147,6 +123,38 @@ import { VoiceDnaCard } from "./voice-dna";
 import { WebhooksCard } from "./webhooks";
 import "./settings.css";
 
+// The catalog, the addresses and the visibility predicate moved to
+// ./settingsnav so `src/app/**` can read them without pulling in every card.
+// Re-exported here because this module's own consumers — the tests, the stories,
+// the testkit — ask for both halves, and splitting their imports would be churn
+// that proves nothing.
+import {
+  ADMIN_SEGMENT,
+  SETTINGS_SCREEN,
+  SETTINGS_TABS,
+  type SettingsTabId,
+  settingsAddress,
+  settingsRouteTab,
+  useSettingsEntryVisibility,
+  useSettingsSection,
+  useVisibleSettingsTabs,
+} from "./settingsnav";
+
+// Re-exported so this module's own consumers — the tests, the stories, the
+// testkit — keep asking one module for both halves. Splitting their imports
+// would be churn that proves nothing about the split that matters, which is
+// `src/app/**` no longer reaching the cards.
+export {
+  ADMIN_SEGMENT,
+  SETTINGS_SCREEN,
+  SETTINGS_TABS,
+  type SettingsTabId,
+  settingsAddress,
+  settingsRouteTab,
+  useSettingsEntryVisibility,
+  useSettingsSection,
+};
+
 // Settings governance surface (B-EP09.13b): renders FROM the live seams —
 // /me (identity + effective roles), passports (mint + the metadata list,
 // token shown once and never re-disclosed), consent purposes (DOI flags),
@@ -155,111 +163,6 @@ import "./settings.css";
 // and the automations the installation runs unattended. EP09 renders
 // governance; it never authors policy.
 
-// The entry register: one section nav entry per settings SUBJECT. Only surfaces
-// this app actually renders get one — the mockup's Booking / Flow /
-// Connected-surfaces tabs have no live seam here, so they are omitted rather
-// than stubbed (STATE-5). The entry is selected by the route id
-// (#/settings/<id>), so it is linkable and the palette can deep-link one.
-//
-// It used to be fifteen tabs plus nine routes outside them. What collapsed and
-// why: two surfaces both called "Capture" became one; the
-// installation and the company profile were always the same organization;
-// currency rates joined the base currency they convert to while model prices
-// joined the AI runtime they price; user administration and extension
-// permissions are one question about authority; the field editor, pipeline
-// designer, product list and offer templates all define the shape a record
-// takes; and the operational verbs that were hiding beside the field editor — a
-// reindex, job health, the danger zone — became a place of their own.
-//
-// One of those merges was later UNDONE: connectors and the overlay both answer
-// "what are we connected to" and were merged on that reading, but the question
-// has two different owners — see the split below. Capture activity is newer and
-// additive: it answers what those connections DID, which no existing entry
-// could say.
-//
-// No sentence here counts the entries. Three of them used to, and by the time
-// anyone looked they said eleven, twelve and thirteen for a register holding
-// fourteen — a number in prose beside a list is a second source of truth that
-// nothing updates and no test can check. The list below is the count.
-//
-// Two groups: "you" (per-user, every member) and "admin" (installation
-// posture). The group NAMES the subject, not an audience — every entry in it
-// carries its own predicate, which is the grant the cards on it actually ask
-// for, and the heading renders when at least one member survives.
-//
-// There is no second gate above those predicates. One used to sit here — a
-// seat check for admin-or-ops — and it answered false for the whole group
-// whatever the entry underneath had decided. That is a guess about a
-// heterogeneous set: it spans surfaces with clean object grants (data model,
-// organization, knowledge) and surfaces the server gates on the role itself
-// (users, extensions). Every seeded role holds `pipeline`, `custom_field`,
-// `knowledge_corpus`, `automation`, `product`, `offer_template` and `tag`
-// reads, so the server answered those seats 200 while the product showed them
-// nothing — and showed it by ABSENCE, so nobody could see the disagreement.
-// A role edited to drop `license:read` loses that row and keeps the rest,
-// which is the same rule applied to everyone rather than to two role names.
-// The server stays the RBAC authority on every card within.
-//
-// The personal group is where a credential or a connection the PERSON holds
-// lives: `agents` carries the caller's own passports, so gating it would regress
-// passport minting for every seat that is not an admin, and `connections` carries
-// their own mailbox and their own LinkedIn network.
-//
-// `connections` and `integrations` were ONE row, and that row was the reason the
-// list had an entry with no predicate at all: it held a rep's own mailbox and the
-// installation's webhooks together, so any honest gate on it took a personal task
-// away from whoever it hid it from. The seam was never a missing group — it was
-// one entry belonging to both. Split by WHOSE thing each surface is, they both get
-// an honest predicate, and the ungated special case is gone rather than moved.
-//
-// Width is NOT an entry's business. Every page takes the whole column, so they
-// line up with each other and with the rest of the app: a reader
-// moving between two settings pages sees the content start and end where the
-// last one did. A per-page measure buys a nicer form column at the cost of the
-// page appearing to change size as you navigate, and of a knob each new entry
-// has to answer for. Where a single control would otherwise stretch to the full
-// column, the control constrains itself (`.settingrow-measure`, and each
-// surface's own field widths) — that is a property of the control, which knows
-// how wide it wants to be, not of the page, which does not.
-// Exported for the nav suite, which derives its expected label list from THIS
-// register rather than restating it. A restated list is a second source of truth
-// that nothing updates: the copy in the test omitted `license` for as long as
-// that entry existed, so a fully wired fourteenth tab — register, predicate,
-// content, sidebar deep link, two locales — was invisible to every assertion in
-// the file, including the two that claim to check the whole level.
-export const SETTINGS_TABS = [
-  { id: "account", icon: UserRound, group: "you" },
-  { id: "voice", icon: Mic, group: "you" },
-  { id: "agents", icon: KeyRound, group: "you" },
-  { id: "connections", icon: Plug, group: "you" },
-  { id: "capture-activity", icon: Activity, group: "you" },
-  { id: "general", icon: Building2, group: "admin" },
-  { id: "users", icon: UsersRound, group: "admin" },
-  { id: "integrations", icon: Webhook, group: "admin" },
-  { id: "extensions", icon: Blocks, group: "admin" },
-  { id: "capture", icon: Mail, group: "admin" },
-  { id: "data-model", icon: Database, group: "admin" },
-  { id: "ai", icon: Sparkles, group: "admin" },
-  { id: "knowledge", icon: BookOpen, group: "admin" },
-  { id: "privacy", icon: ShieldCheck, group: "admin" },
-  { id: "license", icon: BadgeCheck, group: "admin" },
-  { id: "maintenance", icon: Wrench, group: "admin" },
-] as const satisfies readonly {
-  id: string;
-  icon: LucideIcon;
-  group: "you" | "admin";
-}[];
-
-// Exported alongside the register: a caller that needs the label for an entry
-// builds the key from this, and `settings.tab.${SettingsTabId}` is then a
-// literal union TypeScript can check against MessageKey — no assertion, so a
-// typo is a compile error rather than a lookup that silently falls back to the
-// raw key and lets a test validate a label that does not exist.
-export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
-
-// Exported for the placement gate below the register: a settings card that
-// configures the INSTALLATION has to sit on an admin entry, and the only way to
-// check that without rendering every tab is to walk what each one returns.
 export function tabContent(id: SettingsTabId): ReactNode {
   switch (id) {
     case "account":
@@ -495,8 +398,6 @@ function DataModelTab() {
   );
 }
 
-const SETTINGS_GROUPS = ["you", "admin"] as const;
-
 /**
  * The route segment every Admin settings entry sits under.
  *
@@ -511,361 +412,6 @@ const SETTINGS_GROUPS = ["you", "admin"] as const;
  * is rewritten to the address above, so nothing that exists today lands
  * nowhere.
  */
-export const ADMIN_SEGMENT = "admin";
-
-// The route this screen answers, named once: the shell mounts the settings level
-// by matching it, and the section published below declares it.
-export const SETTINGS_SCREEN = "settings";
-
-type AdminTabId = Extract<
-  (typeof SETTINGS_TABS)[number],
-  { group: "admin" }
->["id"];
-
-// Which Organization entries this principal can use, one answer per entry, each
-// asking for the grant the cards on it ask for. The nav then describes the seat
-// instead of the role name it was assigned: a principal granted product writes by
-// an edited role reaches the data model, and nobody is offered a page whose every
-// card would refuse them.
-//
-// TWO GATES, and they answer different questions.
-//
-// The SEAT decides whether this half of settings exists for the reader at all:
-// installation posture is an operator's work, so `admin` and `ops` reach it and
-// nobody else does. That is a product decision about who configures an
-// installation, not a claim about what the server would answer — and it is worth
-// being precise about the difference, because the server has NOT changed: `GET
-// /users`, the automations read and the consent registry still answer 200 to
-// every authenticated seat. A REST or MCP caller holding a rep's passport reads
-// them exactly as before. What this gate scopes is the product's own navigation.
-//
-// The GRANT then decides whether a page an operator may open has anything in it,
-// and OPENING AN ENTRY IS A READ — so every predicate below asks for a READ
-// grant. They asked for write grants once, because each was written to answer
-// "can you USE this", and the cost was measured against the live API: a
-// read-only seat was hidden from eight of eleven entries the server answers 200
-// on, including three surfaces (products, offer templates, custom fields) that
-// were ungated routes of their own before the merge. Within the section that
-// lesson still holds in full: the entry opens if the principal may READ any part
-// of it, and the write affordances inside say for themselves who may use them.
-//
-// A read grant is not a formality even where every seeded role holds it. The
-// predicate asks the live grant, so a role edited to drop `custom_field:read`
-// loses the Data model row — which `true` could never express, and which is the
-// difference between a predicate that happens to be satisfied and no predicate.
-//
-// A merged entry takes the UNION of what its parts asked for, never the
-// intersection: an entry that opened before this change must still open, or a
-// restructure quietly becomes a permission change. Where a part is narrower than
-// its page, that part gates itself inside — and a part withheld by a PERMISSION
-// says so rather than vanishing (design-system/README.md).
-//
-// The licensing seat is deliberately not folded in (see capability.ts): a read
-// seat still reads the pages behind these entries.
-//
-// EVERY predicate is evaluated here, unconditionally, before anything composes
-// them. The number of hooks a render runs must not depend on which grants came
-// back — so the `||` sits on the results, never around the calls, and no hook
-// may move into the filter over the tab list.
-/**
- * Which Organization entries this principal may open.
- *
- * Exported because the command palette must answer the SAME question: it offers a
- * shortcut to two of these entries, and a shortcut that lands on the Account
- * fallback is a command that lied. One predicate map, two readers.
- *
- * `probeCompanyFlag` is false for that caller. The company rollout flag is a
- * network read, and the palette is mounted on every screen while the settings rail
- * is mounted on one — firing it app-wide to answer a question the palette never
- * asks (it offers no shortcut to General) would spend a request per session for
- * nothing. With the flag unread, `general` falls back to the installation and
- * currency reads beside it, which is the honest answer for a caller that has not
- * asked whether the company profile exists.
- */
-export function useSettingsEntryVisibility(
-  probeCompanyFlag = true,
-): Readonly<Record<AdminTabId, boolean>> {
-  const capabilities = useCompanyContextCapabilities(probeCompanyFlag);
-  const pipeline = useCan("pipeline", "read");
-  const product = useCan("product", "read");
-  const offerTemplate = useCan("offer_template", "read");
-  const knowledgeCorpus = useCan("knowledge_corpus", "read");
-  const customField = useCan("custom_field", "read");
-  const tag = useCan("tag", "read");
-  const fxRate = useCan("fx_rate", "read");
-  const aiModelRate = useCan("ai_model_rate", "read");
-  const embeddingReindex = useCan("embedding_reindex", "read");
-  const organization = useCan("organization", "read");
-  const installation = useCan("installation_settings", "read");
-  const captureSettings = useCan("capture_settings", "read");
-  const licenseRead = useCan("license", "read");
-  const automation = useCan("automation", "read");
-  const webhook = useCan("webhook_subscription", "read");
-  // The consent registry's server gate, which is not a role and not "any member":
-  // consent/store.go's ListPurposes calls auth.Require(ctx, "person", read).
-  const person = useCan("person", "read");
-  const overlay = useCan("overlay_connection", "read");
-  // The one predicate below that is a ROLE rather than a grant. `GET /admin/reset-data`
-  // and the job-health read are gated on the literal admin role server-side and no
-  // RBAC object describes them — a `role` object would encode a constant, and an
-  // admin who revoked their own grant on it could never restore it (capability.ts).
-  // Everything else above is a `read`, because opening a page is reading it.
-  const isAdmin = useHoldsAdminRole();
-  // Each entry's own read predicate, and the whole answer. There is no second
-  // gate above these: a reader reaches an entry when they hold what it asks
-  // for, which is the same question the SERVER answers on every route behind
-  // it. The seat check that used to sit here returned false for every one of
-  // these entries unless the reader held `admin` or `ops`, so a seat holding
-  // `pipeline:read` — which every seeded role holds — was shown nothing while
-  // the API answered it 200. That is the client disagreeing with the authority,
-  // and the disagreement was invisible: the page was absent rather than
-  // refused. What an entry offers once opened is still each card's own
-  // question, and the cards ask their own writes.
-  const granted = {
-    // The organization, its profile and its currency table are one entry now, so
-    // the predicate is the union of what they each asked for. Each is gated on
-    // the SAME live grant the card inside asks for rather than on a role name:
-    // deriving it from admin/ops would disagree with the cards in both
-    // directions — an admin whose installation_settings grant was removed would
-    // get a page of disabled fields, and a principal holding the grant under an
-    // edited role could not reach the surface they may use.
-    //
-    // The company profile carries a second condition that is a rollout FLAG
-    // rather than a permission, so its grant ANDs with it: PUT /company is gated
-    // on organization writes, and the flag says whether the surface exists on
-    // this installation at all.
-    general:
-      installation ||
-      (organization && (capabilities.data?.read_enabled ?? false)) ||
-      fxRate,
-    // The member roster, the roles on it, and what a role may reach. No RBAC
-    // object describes identity administration and none can — a `role` object
-    // would encode a constant, and an admin who revoked their own grant on it
-    // could never restore it (capability.ts) — so the server gates the VERBS on
-    // the role directly and serves the roster itself to anyone signed in.
-    //
-    // `true` matches that: `GET /users` answers 200 to any authenticated
-    // principal, and "who is on my team" is not an admin's private question.
-    // The same handler decides what the answer CONTAINS — role keys and the
-    // inactive view are an admin's, everyone else gets the active roster the
-    // share and assignee pickers already show them (handlers_roster.go).
-    //
-    // The invite form and every role control below withhold themselves on their
-    // own authority, so a reader without them sees the roster and none of the
-    // controls.
-    users: true,
-    // `GET /extensions` is admin-only server-side, so the entry follows the
-    // role rather than a grant: any reader who is not an admin would open a
-    // page whose only read answers 403.
-    extensions: isAdmin,
-    capture: captureSettings,
-    // The installation's own outside wiring — the shared provider credential, the
-    // outbound subscriptions, the incumbent mirror. Either read opens it, and the
-    // provider card carries no grant of its own because the server answers for it.
-    //
-    // The system-of-record chip in the topbar is shown to EVERY seat and points
-    // here, so an entry this narrow would strand whoever follows it on the Account
-    // fallback — the overlay read every seeded role holds is what keeps that link
-    // honest, and it is a live grant rather than an exemption.
-    //
-    // The composed units are the third card, and they open the entry on their
-    // own PRESENCE rather than on a grant: this page is the only place a
-    // workspace-scoped unit is offered at all — it has no rail row and the
-    // palette never carried one — so a role holding neither read would lose the
-    // unit itself, not merely the two cards above it. Presence is the honest
-    // predicate because the card asks for no grant; the unit's own screen is
-    // what refuses, on the object it declares.
-    integrations:
-      webhook || overlay || unitsForSecretScope("workspace").length > 0,
-    // Everything that defines the shape a record takes: the field editor, the
-    // pipeline designer, the product list, the offer templates. Any one of their
-    // reads opens the page; the authoring controls inside each ask for their own
-    // write.
-    // Tags joined this entry, so the union widens: a seat holding `tag:read`
-    // and none of the other three must still find the vocabulary. A merged
-    // entry takes the union of what its parts ask for, never the intersection.
-    "data-model": customField || pipeline || product || offerTemplate || tag,
-    // The automations the installation runs, what it spent, and what it charges
-    // per model. The automations read is the one every seeded role holds, and it
-    // is what keeps this page reachable for manager, rep and read_only — the
-    // server answers their automations read 200, and the editor was a route of
-    // its own before this page absorbed it.
-    ai: automation || aiModelRate,
-    // The consent purpose registry, the retention ladder, the subject-request
-    // queue and the audit trail. `consent_config` is a governed object upstream and
-    // absent from the shipped RBAC vocabulary, so there is no grant NAMED for the
-    // registry — but the server does not gate it on a role either: ListPurposes
-    // demands `person:read`, so that is the grant to ask for, and asking it is what
-    // keeps this from being `true` standing in for a permission. Every seeded role
-    // holds it, and a role edited to drop it would otherwise reach a page of four
-    // refusals. The three surfaces below the registry are narrower and each says so.
-    privacy: person,
-    // The document sets a person can ask questions of, and the files in them.
-    // `knowledge_corpus:read` is the ASK, and the RBAC migration grants it to
-    // every seeded role — so this entry opens for a manager or a rep, and the
-    // card inside shows them the sets with no verbs. That is deliberate and is
-    // the same shape as the automations read on `ai` above: a page that lists
-    // what a reader may ask is not an administrator's page merely because
-    // creating one is.
-    knowledge: knowledgeCorpus,
-    // The operational verbs, and the one entry that genuinely narrows. The reindex
-    // read is admin/ops; job health and the danger zone are admin-ONLY (the server
-    // spells both with RequireAdmin), so an ops seat reaches this page for the
-    // reindex and finds the other two withheld. Nobody below ops has anything to
-    // read here at all. The reindex is an ordinary grant an edited role can hold, so
-    // the entry opens on either and the cards inside decide.
-    // What the license grants and how much of it is used. Admin/ops-only, read
-    // included — the narrowest predicate on the rail beside Maintenance's,
-    // because a seat meter is the installation's commercial standing and a rep
-    // reads their own seat elsewhere (UC-ADMIN-03 F1). A live grant rather than a
-    // role name, like every other entry here: an ops principal whose license read
-    // was removed by an edited role loses the row, which is the difference
-    // between asking the grant and asking who somebody is.
-    license: licenseRead,
-    maintenance: isAdmin || embeddingReindex,
-  } satisfies Readonly<Record<AdminTabId, boolean>>;
-  return granted;
-}
-
-/**
- * Which entry an address names, and whether that address is the current one.
- *
- * Two shapes reach here. `#/settings/admin/privacy` is what the product mints
- * today; `#/settings/privacy` is what every link written before the admin half
- * had a segment of its own says, and it still resolves — a bookmark, a pasted
- * link and a docs page must not land nowhere because the IA grew a level of
- * naming. `legacy` is what tells `SettingsScreen` to rewrite the address it was
- * given, so the two spellings do not both stay in circulation.
- *
- * A personal entry addressed THROUGH the admin segment (`#/settings/admin/voice`)
- * is not resolved: it is not an address the product ever minted, and answering
- * it would make two live addresses for one page.
- */
-/**
- * Entry ids this product used to mint, and the entry each one is now.
- *
- * A renamed tab keeps answering under its old id so a bookmark, a pasted link
- * and the two handbook copies do not land nowhere — and it resolves through
- * `legacy`, so the address bar is rewritten to the current spelling rather than
- * leaving both in circulation. The map is the only place the old id survives;
- * `SETTINGS_TABS` carries the current one alone.
- */
-const RENAMED_TABS: Readonly<Record<string, SettingsTabId>> = {
-  people: "users",
-};
-
-export function settingsRouteTab(route: Route): {
-  readonly tab: string | undefined;
-  readonly legacy: boolean;
-} {
-  if (route.id === ADMIN_SEGMENT) {
-    const renamed =
-      route.id2 === undefined ? undefined : RENAMED_TABS[route.id2];
-    if (renamed !== undefined) {
-      return { tab: renamed, legacy: true };
-    }
-    // Only an ADMIN entry answers under the admin segment. A personal id here
-    // resolves to nothing rather than to its page: the page already has an
-    // address, and serving it under a second one puts a spelling in circulation
-    // that nothing mints and nothing rewrites. Unresolved, it falls back like any
-    // other address the register does not answer.
-    const deep = SETTINGS_TABS.find((candidate) => candidate.id === route.id2);
-    return {
-      tab: deep?.group === "admin" ? deep.id : undefined,
-      legacy: false,
-    };
-  }
-  const renamed = route.id === undefined ? undefined : RENAMED_TABS[route.id];
-  if (renamed !== undefined) {
-    return { tab: renamed, legacy: true };
-  }
-  const entry = SETTINGS_TABS.find((candidate) => candidate.id === route.id);
-  return { tab: route.id, legacy: entry?.group === "admin" };
-}
-
-/**
- * The address one settings entry lives at.
- *
- * Every caller that mints a settings link goes through this — the redirect
- * below, the command palette's two shortcuts, the test kit's rail. The admin
- * group's extra segment is a property of the ENTRY, so a caller that knew only
- * the tab id would have to look the group up to build the link, and one of them
- * would eventually not bother.
- *
- * An id no entry answers keeps the shallow shape: it is the address a reader
- * typed, and `useVisibleSettingsTabs` is what decides what it lands on.
- */
-export function settingsAddress(tab?: string): Route {
-  const entry = SETTINGS_TABS.find((candidate) => candidate.id === tab);
-  return entry?.group === "admin"
-    ? { screen: SETTINGS_SCREEN, id: ADMIN_SEGMENT, id2: entry.id }
-    : { screen: SETTINGS_SCREEN, id: tab };
-}
-
-// Which tabs this principal may use, and which of them the route selects. The
-// nav in the sidebar and the content on the page both read this, so the two
-// cannot disagree about what is current — including on the fallback below.
-function useVisibleSettingsTabs(tab?: string) {
-  const adminTabVisible = useSettingsEntryVisibility();
-  const tabs = SETTINGS_TABS.filter(
-    (entry) => entry.group !== "admin" || adminTabVisible[entry.id],
-  );
-  // Unknown / absent id (or one this principal cannot see) falls back to the
-  // first visible tab — a stale deep-link lands on Account, never a blank
-  // screen. A rep who follows somebody's link to an admin page lands there too,
-  // silently: the section is absent for them, and a page announcing that it
-  // exists but is not theirs would be the one thing an absent section is chosen
-  // to avoid saying.
-  return { tabs, active: tabs.find((entry) => entry.id === tab) ?? tabs[0] };
-}
-
-/**
- * The settings level, as data the sidebar can render.
- *
- * The shell asks for this and renders it as the second navigation level; it
- * never learns what a grant is. The two groups are the ones this screen has
- * always had — "You" is per-user work, "Organization" is posture an admin
- * curates — and a group with no visible member is dropped rather than printed
- * empty. They are named for the SUBJECT rather than repeating the word the level
- * above them already carries: "Settings / Your settings / …" said it twice in a
- * 200px column.
- */
-export function useSettingsSection(route: Route): NavSection {
-  const { tabs, active } = useVisibleSettingsTabs(settingsRouteTab(route).tab);
-  // Both message keys are composed from the ids, and both annotations are what
-  // make them KEYS: a template literal narrows to the catalog's union only where
-  // something expects one, and unannotated it would compile as any old string —
-  // an unknown key has to stay a compile error.
-  const groups = SETTINGS_GROUPS.map(
-    (group): NavLevelGroup => ({
-      headingKey: `settings.group.${group}`,
-      items: tabs
-        .filter((entry) => entry.group === group)
-        .map(
-          (entry): NavLevelEntry => ({
-            id: entry.id,
-            // Where the row actually points. The admin group sits a segment
-            // deeper than the personal one, and the panel shows both under one
-            // pair of headings — so the depth is the ENTRY's, not the level's.
-            prefix: entry.group === "admin" ? [ADMIN_SEGMENT] : undefined,
-            labelKey: `settings.tab.${entry.id}`,
-            icon: entry.icon,
-          }),
-        ),
-    }),
-  ).filter((group) => group.items.length > 0);
-  return {
-    screen: SETTINGS_SCREEN,
-    titleKey: "nav.settings",
-    // No row is current on a route that is not one of the tabs. An extension
-    // unit's page keeps this level in the sidebar — it is reached from here and
-    // its trail says so — but it is not a settings tab, and `settingsRouteTab`
-    // answers with the default one for any address it cannot read. Marking
-    // Account current there would point at a page the reader is not on.
-    activeId: route.screen === SETTINGS_SCREEN ? active.id : "",
-    groups,
-  };
-}
 
 export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
   const { tab, legacy } = settingsRouteTab(route);

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -1,0 +1,510 @@
+// The settings catalog, its addresses, and who may open each entry.
+//
+// Split from the screen so `src/app/**` can ask those three questions without
+// importing the cards. The shell, the topbar, the palette, the account menu and
+// the search kinds each need an address or a visibility answer; none of them
+// renders a settings page, and every one was pulling in a hundred and fifty
+// imports — every card, every mutation, the whole lucide set — to get one.
+//
+// Nothing here renders and nothing here imports a card. That is what keeps the
+// cost of asking "where does this go" separate from the cost of drawing it, and
+// it is the property settings-imports.test.ts holds.
+
+import {
+  Activity,
+  BadgeCheck,
+  Blocks,
+  BookOpen,
+  Building2,
+  Database,
+  KeyRound,
+  type LucideIcon,
+  Mail,
+  Mic,
+  Plug,
+  ShieldCheck,
+  Sparkles,
+  UserRound,
+  UsersRound,
+  Webhook,
+  Wrench,
+} from "lucide-react";
+import { useCan, useHoldsAdminRole } from "../app/capability";
+import { unitsForSecretScope } from "../app/extensions";
+import type { NavLevelEntry, NavLevelGroup, NavSection } from "../app/nav";
+import type { Route } from "../app/router";
+import { useMe } from "./common";
+
+// The entry register: one section nav entry per settings SUBJECT. Only surfaces
+// this app actually renders get one — the mockup's Booking / Flow /
+// Connected-surfaces tabs have no live seam here, so they are omitted rather
+// than stubbed (STATE-5). The entry is selected by the route id
+// (#/settings/<id>), so it is linkable and the palette can deep-link one.
+//
+// It used to be fifteen tabs plus nine routes outside them. What collapsed and
+// why: two surfaces both called "Capture" became one; the
+// installation and the company profile were always the same organization;
+// currency rates joined the base currency they convert to while model prices
+// joined the AI runtime they price; user administration and extension
+// permissions are one question about authority; the field editor, pipeline
+// designer, product list and offer templates all define the shape a record
+// takes; and the operational verbs that were hiding beside the field editor — a
+// reindex, job health, the danger zone — became a place of their own.
+//
+// One of those merges was later UNDONE: connectors and the overlay both answer
+// "what are we connected to" and were merged on that reading, but the question
+// has two different owners — see the split below. Capture activity is newer and
+// additive: it answers what those connections DID, which no existing entry
+// could say.
+//
+// No sentence here counts the entries. Three of them used to, and by the time
+// anyone looked they said eleven, twelve and thirteen for a register holding
+// fourteen — a number in prose beside a list is a second source of truth that
+// nothing updates and no test can check. The list below is the count.
+//
+// Two groups: "you" (per-user, every member) and "admin" (installation
+// posture). The group NAMES the subject, not an audience — every entry in it
+// carries its own predicate, which is the grant the cards on it actually ask
+// for, and the heading renders when at least one member survives.
+//
+// There is no second gate above those predicates. One used to sit here — a
+// seat check for admin-or-ops — and it answered false for the whole group
+// whatever the entry underneath had decided. That is a guess about a
+// heterogeneous set: it spans surfaces with clean object grants (data model,
+// organization, knowledge) and surfaces the server gates on the role itself
+// (users, extensions). Every seeded role holds `pipeline`, `custom_field`,
+// `knowledge_corpus`, `automation`, `product`, `offer_template` and `tag`
+// reads, so the server answered those seats 200 while the product showed them
+// nothing — and showed it by ABSENCE, so nobody could see the disagreement.
+// A role edited to drop `license:read` loses that row and keeps the rest,
+// which is the same rule applied to everyone rather than to two role names.
+// The server stays the RBAC authority on every card within.
+//
+// The personal group is where a credential or a connection the PERSON holds
+// lives: `agents` carries the caller's own passports, so gating it would regress
+// passport minting for every seat that is not an admin, and `connections` carries
+// their own mailbox and their own LinkedIn network.
+//
+// `connections` and `integrations` were ONE row, and that row was the reason the
+// list had an entry with no predicate at all: it held a rep's own mailbox and the
+// installation's webhooks together, so any honest gate on it took a personal task
+// away from whoever it hid it from. The seam was never a missing group — it was
+// one entry belonging to both. Split by WHOSE thing each surface is, they both get
+// an honest predicate, and the ungated special case is gone rather than moved.
+//
+// Width is NOT an entry's business. Every page takes the whole column, so they
+// line up with each other and with the rest of the app: a reader
+// moving between two settings pages sees the content start and end where the
+// last one did. A per-page measure buys a nicer form column at the cost of the
+// page appearing to change size as you navigate, and of a knob each new entry
+// has to answer for. Where a single control would otherwise stretch to the full
+// column, the control constrains itself (`.settingrow-measure`, and each
+// surface's own field widths) — that is a property of the control, which knows
+// how wide it wants to be, not of the page, which does not.
+// Exported for the nav suite, which derives its expected label list from THIS
+// register rather than restating it. A restated list is a second source of truth
+// that nothing updates: the copy in the test omitted `license` for as long as
+// that entry existed, so a fully wired fourteenth tab — register, predicate,
+// content, sidebar deep link, two locales — was invisible to every assertion in
+// the file, including the two that claim to check the whole level.
+// The two audience groups the rail renders, in order. Beside the register they
+// group, so a group added to one is visible from the other.
+const SETTINGS_GROUPS = ["you", "admin"] as const;
+
+export const SETTINGS_TABS = [
+  { id: "account", icon: UserRound, group: "you" },
+  { id: "voice", icon: Mic, group: "you" },
+  { id: "agents", icon: KeyRound, group: "you" },
+  { id: "connections", icon: Plug, group: "you" },
+  { id: "capture-activity", icon: Activity, group: "you" },
+  { id: "general", icon: Building2, group: "admin" },
+  { id: "users", icon: UsersRound, group: "admin" },
+  { id: "integrations", icon: Webhook, group: "admin" },
+  { id: "extensions", icon: Blocks, group: "admin" },
+  { id: "capture", icon: Mail, group: "admin" },
+  { id: "data-model", icon: Database, group: "admin" },
+  { id: "ai", icon: Sparkles, group: "admin" },
+  { id: "knowledge", icon: BookOpen, group: "admin" },
+  { id: "privacy", icon: ShieldCheck, group: "admin" },
+  { id: "license", icon: BadgeCheck, group: "admin" },
+  { id: "maintenance", icon: Wrench, group: "admin" },
+] as const satisfies readonly {
+  id: string;
+  icon: LucideIcon;
+  group: "you" | "admin";
+}[];
+
+// Exported alongside the register: a caller that needs the label for an entry
+// builds the key from this, and `settings.tab.${SettingsTabId}` is then a
+// literal union TypeScript can check against MessageKey — no assertion, so a
+// typo is a compile error rather than a lookup that silently falls back to the
+// raw key and lets a test validate a label that does not exist.
+export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
+
+// Exported for the placement gate below the register: a settings card that
+// configures the INSTALLATION has to sit on an admin entry, and the only way to
+// check that without rendering every tab is to walk what each one returns.
+
+export const ADMIN_SEGMENT = "admin";
+
+// The route this screen answers, named once: the shell mounts the settings level
+// by matching it, and the section published below declares it.
+export const SETTINGS_SCREEN = "settings";
+
+type AdminTabId = Extract<
+  (typeof SETTINGS_TABS)[number],
+  { group: "admin" }
+>["id"];
+
+// Which Organization entries this principal can use, one answer per entry, each
+// asking for the grant the cards on it ask for. The nav then describes the seat
+// instead of the role name it was assigned: a principal granted product writes by
+// an edited role reaches the data model, and nobody is offered a page whose every
+// card would refuse them.
+//
+// TWO GATES, and they answer different questions.
+//
+// The SEAT decides whether this half of settings exists for the reader at all:
+// installation posture is an operator's work, so `admin` and `ops` reach it and
+// nobody else does. That is a product decision about who configures an
+// installation, not a claim about what the server would answer — and it is worth
+// being precise about the difference, because the server has NOT changed: `GET
+// /users`, the automations read and the consent registry still answer 200 to
+// every authenticated seat. A REST or MCP caller holding a rep's passport reads
+// them exactly as before. What this gate scopes is the product's own navigation.
+//
+// The GRANT then decides whether a page an operator may open has anything in it,
+// and OPENING AN ENTRY IS A READ — so every predicate below asks for a READ
+// grant. They asked for write grants once, because each was written to answer
+// "can you USE this", and the cost was measured against the live API: a
+// read-only seat was hidden from eight of eleven entries the server answers 200
+// on, including three surfaces (products, offer templates, custom fields) that
+// were ungated routes of their own before the merge. Within the section that
+// lesson still holds in full: the entry opens if the principal may READ any part
+// of it, and the write affordances inside say for themselves who may use them.
+//
+// A read grant is not a formality even where every seeded role holds it. The
+// predicate asks the live grant, so a role edited to drop `custom_field:read`
+// loses the Data model row — which `true` could never express, and which is the
+// difference between a predicate that happens to be satisfied and no predicate.
+//
+// A merged entry takes the UNION of what its parts asked for, never the
+// intersection: an entry that opened before this change must still open, or a
+// restructure quietly becomes a permission change. Where a part is narrower than
+// its page, that part gates itself inside — and a part withheld by a PERMISSION
+// says so rather than vanishing (design-system/README.md).
+//
+// The licensing seat is deliberately not folded in (see capability.ts): a read
+// seat still reads the pages behind these entries.
+//
+// EVERY predicate is evaluated here, unconditionally, before anything composes
+// them. The number of hooks a render runs must not depend on which grants came
+// back — so the `||` sits on the results, never around the calls, and no hook
+// may move into the filter over the tab list.
+/**
+ * Which Organization entries this principal may open.
+ *
+ * Exported because the command palette must answer the SAME question: it offers a
+ * shortcut to two of these entries, and a shortcut that lands on the Account
+ * fallback is a command that lied. One predicate map, two readers.
+ *
+ * Both readers now resolve one cached snapshot, so they cannot disagree about
+ * which pages exist. They could before: the rail probed the company-context
+ * rollout over the network and the palette deliberately did not, which made
+ * General reachable from one and absent from the other for a caller whose only
+ * readable part of that page was the company profile.
+ */
+export function useSettingsEntryVisibility(): Readonly<
+  Record<AdminTabId, boolean>
+> {
+  // Read off /me rather than probed. The company-context capabilities endpoint
+  // is a screen's own hook, and importing it here dragged twenty-two imports
+  // into a module whose whole reason for existing is to stay light. The same
+  // fact rides /me as settings_availability.company_context, computed from the
+  // rollout the endpoints themselves gate on.
+  //
+  // It also removes the reason probeCompanyFlag existed. The palette passed
+  // false to avoid spending a request per session on a question it never asked;
+  // there is no request now, so both callers read one cached snapshot and can no
+  // longer disagree about which pages exist.
+  const availability = useMe().data?.settings_availability;
+  const companyContext = availability?.company_context ?? false;
+  const pipeline = useCan("pipeline", "read");
+  const product = useCan("product", "read");
+  const offerTemplate = useCan("offer_template", "read");
+  const knowledgeCorpus = useCan("knowledge_corpus", "read");
+  const customField = useCan("custom_field", "read");
+  const tag = useCan("tag", "read");
+  const fxRate = useCan("fx_rate", "read");
+  const aiModelRate = useCan("ai_model_rate", "read");
+  const embeddingReindex = useCan("embedding_reindex", "read");
+  const organization = useCan("organization", "read");
+  const installation = useCan("installation_settings", "read");
+  const captureSettings = useCan("capture_settings", "read");
+  const licenseRead = useCan("license", "read");
+  const automation = useCan("automation", "read");
+  const webhook = useCan("webhook_subscription", "read");
+  // The consent registry's server gate, which is not a role and not "any member":
+  // consent/store.go's ListPurposes calls auth.Require(ctx, "person", read).
+  const person = useCan("person", "read");
+  const overlay = useCan("overlay_connection", "read");
+  // The one predicate below that is a ROLE rather than a grant. `GET /admin/reset-data`
+  // and the job-health read are gated on the literal admin role server-side and no
+  // RBAC object describes them — a `role` object would encode a constant, and an
+  // admin who revoked their own grant on it could never restore it (capability.ts).
+  // Everything else above is a `read`, because opening a page is reading it.
+  const isAdmin = useHoldsAdminRole();
+  // Each entry's own read predicate, and the whole answer. There is no second
+  // gate above these: a reader reaches an entry when they hold what it asks
+  // for, which is the same question the SERVER answers on every route behind
+  // it. The seat check that used to sit here returned false for every one of
+  // these entries unless the reader held `admin` or `ops`, so a seat holding
+  // `pipeline:read` — which every seeded role holds — was shown nothing while
+  // the API answered it 200. That is the client disagreeing with the authority,
+  // and the disagreement was invisible: the page was absent rather than
+  // refused. What an entry offers once opened is still each card's own
+  // question, and the cards ask their own writes.
+  const granted = {
+    // The organization, its profile and its currency table are one entry now, so
+    // the predicate is the union of what they each asked for. Each is gated on
+    // the SAME live grant the card inside asks for rather than on a role name:
+    // deriving it from admin/ops would disagree with the cards in both
+    // directions — an admin whose installation_settings grant was removed would
+    // get a page of disabled fields, and a principal holding the grant under an
+    // edited role could not reach the surface they may use.
+    //
+    // The company profile carries a second condition that is a rollout FLAG
+    // rather than a permission, so its grant ANDs with it: PUT /company is gated
+    // on organization writes, and the flag says whether the surface exists on
+    // this installation at all.
+    general: installation || (organization && companyContext) || fxRate,
+    // The member roster, the roles on it, and what a role may reach. No RBAC
+    // object describes identity administration and none can — a `role` object
+    // would encode a constant, and an admin who revoked their own grant on it
+    // could never restore it (capability.ts) — so the server gates the VERBS on
+    // the role directly and serves the roster itself to anyone signed in.
+    //
+    // `true` matches that: `GET /users` answers 200 to any authenticated
+    // principal, and "who is on my team" is not an admin's private question.
+    // The same handler decides what the answer CONTAINS — role keys and the
+    // inactive view are an admin's, everyone else gets the active roster the
+    // share and assignee pickers already show them (handlers_roster.go).
+    //
+    // The invite form and every role control below withhold themselves on their
+    // own authority, so a reader without them sees the roster and none of the
+    // controls.
+    users: true,
+    // `GET /extensions` is admin-only server-side, so the entry follows the
+    // role rather than a grant: any reader who is not an admin would open a
+    // page whose only read answers 403.
+    extensions: isAdmin,
+    capture: captureSettings,
+    // The installation's own outside wiring — the shared provider credential, the
+    // outbound subscriptions, the incumbent mirror. Either read opens it, and the
+    // provider card carries no grant of its own because the server answers for it.
+    //
+    // The system-of-record chip in the topbar is shown to EVERY seat and points
+    // here, so an entry this narrow would strand whoever follows it on the Account
+    // fallback — the overlay read every seeded role holds is what keeps that link
+    // honest, and it is a live grant rather than an exemption.
+    //
+    // The composed units are the third card, and they open the entry on their
+    // own PRESENCE rather than on a grant: this page is the only place a
+    // workspace-scoped unit is offered at all — it has no rail row and the
+    // palette never carried one — so a role holding neither read would lose the
+    // unit itself, not merely the two cards above it. Presence is the honest
+    // predicate because the card asks for no grant; the unit's own screen is
+    // what refuses, on the object it declares.
+    integrations:
+      webhook || overlay || unitsForSecretScope("workspace").length > 0,
+    // Everything that defines the shape a record takes: the field editor, the
+    // pipeline designer, the product list, the offer templates. Any one of their
+    // reads opens the page; the authoring controls inside each ask for their own
+    // write.
+    // Tags joined this entry, so the union widens: a seat holding `tag:read`
+    // and none of the other three must still find the vocabulary. A merged
+    // entry takes the union of what its parts ask for, never the intersection.
+    "data-model": customField || pipeline || product || offerTemplate || tag,
+    // The automations the installation runs, what it spent, and what it charges
+    // per model. The automations read is the one every seeded role holds, and it
+    // is what keeps this page reachable for manager, rep and read_only — the
+    // server answers their automations read 200, and the editor was a route of
+    // its own before this page absorbed it.
+    ai: automation || aiModelRate,
+    // The consent purpose registry, the retention ladder, the subject-request
+    // queue and the audit trail. `consent_config` is a governed object upstream and
+    // absent from the shipped RBAC vocabulary, so there is no grant NAMED for the
+    // registry — but the server does not gate it on a role either: ListPurposes
+    // demands `person:read`, so that is the grant to ask for, and asking it is what
+    // keeps this from being `true` standing in for a permission. Every seeded role
+    // holds it, and a role edited to drop it would otherwise reach a page of four
+    // refusals. The three surfaces below the registry are narrower and each says so.
+    privacy: person,
+    // The document sets a person can ask questions of, and the files in them.
+    // `knowledge_corpus:read` is the ASK, and the RBAC migration grants it to
+    // every seeded role — so this entry opens for a manager or a rep, and the
+    // card inside shows them the sets with no verbs. That is deliberate and is
+    // the same shape as the automations read on `ai` above: a page that lists
+    // what a reader may ask is not an administrator's page merely because
+    // creating one is.
+    knowledge: knowledgeCorpus,
+    // The operational verbs, and the one entry that genuinely narrows. The reindex
+    // read is admin/ops; job health and the danger zone are admin-ONLY (the server
+    // spells both with RequireAdmin), so an ops seat reaches this page for the
+    // reindex and finds the other two withheld. Nobody below ops has anything to
+    // read here at all. The reindex is an ordinary grant an edited role can hold, so
+    // the entry opens on either and the cards inside decide.
+    // What the license grants and how much of it is used. Admin/ops-only, read
+    // included — the narrowest predicate on the rail beside Maintenance's,
+    // because a seat meter is the installation's commercial standing and a rep
+    // reads their own seat elsewhere (UC-ADMIN-03 F1). A live grant rather than a
+    // role name, like every other entry here: an ops principal whose license read
+    // was removed by an edited role loses the row, which is the difference
+    // between asking the grant and asking who somebody is.
+    license: licenseRead,
+    maintenance: isAdmin || embeddingReindex,
+  } satisfies Readonly<Record<AdminTabId, boolean>>;
+  return granted;
+}
+
+/**
+ * Which entry an address names, and whether that address is the current one.
+ *
+ * Two shapes reach here. `#/settings/admin/privacy` is what the product mints
+ * today; `#/settings/privacy` is what every link written before the admin half
+ * had a segment of its own says, and it still resolves — a bookmark, a pasted
+ * link and a docs page must not land nowhere because the IA grew a level of
+ * naming. `legacy` is what tells `SettingsScreen` to rewrite the address it was
+ * given, so the two spellings do not both stay in circulation.
+ *
+ * A personal entry addressed THROUGH the admin segment (`#/settings/admin/voice`)
+ * is not resolved: it is not an address the product ever minted, and answering
+ * it would make two live addresses for one page.
+ */
+/**
+ * Entry ids this product used to mint, and the entry each one is now.
+ *
+ * A renamed tab keeps answering under its old id so a bookmark, a pasted link
+ * and the two handbook copies do not land nowhere — and it resolves through
+ * `legacy`, so the address bar is rewritten to the current spelling rather than
+ * leaving both in circulation. The map is the only place the old id survives;
+ * `SETTINGS_TABS` carries the current one alone.
+ */
+const RENAMED_TABS: Readonly<Record<string, SettingsTabId>> = {
+  people: "users",
+};
+
+export function settingsRouteTab(route: Route): {
+  readonly tab: string | undefined;
+  readonly legacy: boolean;
+} {
+  if (route.id === ADMIN_SEGMENT) {
+    const renamed =
+      route.id2 === undefined ? undefined : RENAMED_TABS[route.id2];
+    if (renamed !== undefined) {
+      return { tab: renamed, legacy: true };
+    }
+    // Only an ADMIN entry answers under the admin segment. A personal id here
+    // resolves to nothing rather than to its page: the page already has an
+    // address, and serving it under a second one puts a spelling in circulation
+    // that nothing mints and nothing rewrites. Unresolved, it falls back like any
+    // other address the register does not answer.
+    const deep = SETTINGS_TABS.find((candidate) => candidate.id === route.id2);
+    return {
+      tab: deep?.group === "admin" ? deep.id : undefined,
+      legacy: false,
+    };
+  }
+  const renamed = route.id === undefined ? undefined : RENAMED_TABS[route.id];
+  if (renamed !== undefined) {
+    return { tab: renamed, legacy: true };
+  }
+  const entry = SETTINGS_TABS.find((candidate) => candidate.id === route.id);
+  return { tab: route.id, legacy: entry?.group === "admin" };
+}
+
+/**
+ * The address one settings entry lives at.
+ *
+ * Every caller that mints a settings link goes through this — the redirect
+ * below, the command palette's two shortcuts, the test kit's rail. The admin
+ * group's extra segment is a property of the ENTRY, so a caller that knew only
+ * the tab id would have to look the group up to build the link, and one of them
+ * would eventually not bother.
+ *
+ * An id no entry answers keeps the shallow shape: it is the address a reader
+ * typed, and `useVisibleSettingsTabs` is what decides what it lands on.
+ */
+export function settingsAddress(tab?: string): Route {
+  const entry = SETTINGS_TABS.find((candidate) => candidate.id === tab);
+  return entry?.group === "admin"
+    ? { screen: SETTINGS_SCREEN, id: ADMIN_SEGMENT, id2: entry.id }
+    : { screen: SETTINGS_SCREEN, id: tab };
+}
+
+// Which tabs this principal may use, and which of them the route selects. The
+// nav in the sidebar and the content on the page both read this, so the two
+// cannot disagree about what is current — including on the fallback below.
+// Exported for SettingsScreen, which lives beside the cards and still has to
+// resolve which entry an address lands on.
+export function useVisibleSettingsTabs(tab?: string) {
+  const adminTabVisible = useSettingsEntryVisibility();
+  const tabs = SETTINGS_TABS.filter(
+    (entry) => entry.group !== "admin" || adminTabVisible[entry.id],
+  );
+  // Unknown / absent id (or one this principal cannot see) falls back to the
+  // first visible tab — a stale deep-link lands on Account, never a blank
+  // screen. A rep who follows somebody's link to an admin page lands there too,
+  // silently: the section is absent for them, and a page announcing that it
+  // exists but is not theirs would be the one thing an absent section is chosen
+  // to avoid saying.
+  return { tabs, active: tabs.find((entry) => entry.id === tab) ?? tabs[0] };
+}
+
+/**
+ * The settings level, as data the sidebar can render.
+ *
+ * The shell asks for this and renders it as the second navigation level; it
+ * never learns what a grant is. The two groups are the ones this screen has
+ * always had — "You" is per-user work, "Organization" is posture an admin
+ * curates — and a group with no visible member is dropped rather than printed
+ * empty. They are named for the SUBJECT rather than repeating the word the level
+ * above them already carries: "Settings / Your settings / …" said it twice in a
+ * 200px column.
+ */
+export function useSettingsSection(route: Route): NavSection {
+  const { tabs, active } = useVisibleSettingsTabs(settingsRouteTab(route).tab);
+  // Both message keys are composed from the ids, and both annotations are what
+  // make them KEYS: a template literal narrows to the catalog's union only where
+  // something expects one, and unannotated it would compile as any old string —
+  // an unknown key has to stay a compile error.
+  const groups = SETTINGS_GROUPS.map(
+    (group): NavLevelGroup => ({
+      headingKey: `settings.group.${group}`,
+      items: tabs
+        .filter((entry) => entry.group === group)
+        .map(
+          (entry): NavLevelEntry => ({
+            id: entry.id,
+            // Where the row actually points. The admin group sits a segment
+            // deeper than the personal one, and the panel shows both under one
+            // pair of headings — so the depth is the ENTRY's, not the level's.
+            prefix: entry.group === "admin" ? [ADMIN_SEGMENT] : undefined,
+            labelKey: `settings.tab.${entry.id}`,
+            icon: entry.icon,
+          }),
+        ),
+    }),
+  ).filter((group) => group.items.length > 0);
+  return {
+    screen: SETTINGS_SCREEN,
+    titleKey: "nav.settings",
+    // No row is current on a route that is not one of the tabs. An extension
+    // unit's page keeps this level in the sidebar — it is reached from here and
+    // its trail says so — but it is not a settings tab, and `settingsRouteTab`
+    // answers with the default one for any address it cannot read. Marking
+    // Account current there would point at a page the reader is not on.
+    activeId: route.screen === SETTINGS_SCREEN ? active.id : "",
+    groups,
+  };
+}

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -11,7 +11,7 @@ import {
 import type { Locale, useT } from "../i18n";
 import { translatePlural } from "../i18n";
 import { BRIEF_PARAM, COMPOSE_PARAM } from "./personpage.address";
-import { settingsAddress } from "./settings";
+import { settingsAddress } from "./settingsnav";
 import type {
   Worklist,
   WorklistComparison,


### PR DESCRIPTION
`src/app/**` needed three answers from settings — where does this entry address, may this reader see it, what is the nav section — and getting them meant importing `screens/settings.tsx`, which carries every card, every mutation hook and the whole lucide set into the always-loaded shell chunk.

The catalog, the addresses and the visibility predicate move to `screens/settingsnav.tsx`: eight imports, renders nothing. The shell, topbar, palette, account menu and search kinds read that instead. `settings.tsx` re-exports the same names, so its own tests, stories and testkit are untouched.

## The gate

A direct-import grep would miss `settingsnav -> somecard -> settings`, so `settings-imports.test.ts` walks the graph with the TypeScript compiler API and fails on the reachable set, printing the offending trail. It found `topbar -> palette -> settings.tsx` while being written — three hops from an entry point I had already checked by hand.

Its first version hand-listed five entry points, which made it a second copy of "who asks a settings question" and left it blind to `screens/worklist.copy.ts`. That file imported the address from `settings.tsx` and so put the whole settings screen behind **Home, the default landing page** — the exact cost this change claims to remove, relocated rather than removed. The corpus is derived from the tree now (every production module under `src/app/**` and `src/screens/**`, tests and stories excluded), walking 498 pairs where the list walked 7. Restoring that one import fails it in twelve places.

## One behaviour changes

`useSettingsEntryVisibility` decided whether the company page exists by calling `useCompanyContextCapabilities`, an HTTP probe, and the palette passed `probeCompanyFlag: false` to avoid spending a request per session on a question it never asked. **So the rail and the palette could disagree about which pages exist.** Both now read `settings_availability.company_context` off `/me`, so one cached snapshot answers both and the parameter is gone.

Every other term of the predicate is byte-identical to main — same objects, same actions, same structure. No entry widens for any role.

`useCompanyContextCapabilities` stays: onboarding branches on a different field of the same payload, and the company-context card does its own read.

## The state that had no test

Absent availability was untestable: `meFixture` replaced an absent field with the enabled one through a destructuring default, so `?? false` could be flipped to `?? true` with every test still green. That is a real deployment state — a server older than the field, or a snapshot cached before it shipped — and it must fail closed. The fixture takes `null` for it now, spelled apart from both "on" and "off", and both the rail and the palette assert it.

The claim that the two surfaces cannot disagree was held on the rail side only; `palette.test.tsx` now drives the same fixture knob through the palette in all three states. Each guard was mutation-checked one clause at a time.

## Verification

- `vitest run`: **7183 passed, 577 files, 0 failed**
- `tsc --noEmit` clean; `pnpm build` clean
- biome clean on all 12 changed files

`make check-fe` fails one leg on `src/design-system/recordtabs.css`, which is **pre-existing on main** (arrived with #4392, byte-identical to main's copy here) and already owned by #4405. Not touched by this change.

Reviewed by `security-redteam` (no exploitable findings; independently confirmed the fail-closed behaviour and that `company.go` and `companycontextrollout.go` derive from one `companyContextReadEnabled`) and `craft-reviewer`, whose three findings are all fixed above. Codex was unavailable — its weekly quota resets Sep 12.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the shell ask where a settings entry lives without drawing it: the catalog, addresses, and visibility predicate move from `screens/settings.tsx` into a new light `screens/settingsnav.tsx`, so the always-loaded shell, topbar, palette, account menu, and search kinds no longer pull in every settings card, mutation hook, and lucide icon.

- `settings.tsx` re-exports the same names, leaving its tests, stories, and testkit untouched.
- `useSettingsEntryVisibility` no longer takes `probeCompanyFlag`; both the settings rail and the palette now read `settings_availability.company_context` off `/me`, so they can no longer disagree about whether the company page exists.
- Absent availability now fails closed — a server older than the field hides General — and `meFixture` takes `null` to spell that state out; both surfaces assert all three states.
- New `settings-imports.test.ts` walks the import graph from every production module under `src/app` and `src/screens`, failing on any transitive path back to `settings.tsx`; it caught `worklist.copy.ts`, which would have shipped the whole settings screen behind the default landing page.

<sup>Written for commit 5f30b66a48b5868c8612ceacd8e7903c07e37ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

