### PR TITLE
fix(deals): a base currency absent from the digits table is not a missing scale

### DIFF
--- a/backend/migrations/core/1788865447_a_two_digit_base_currency_is_not_a_missing_one.down.sql
+++ b/backend/migrations/core/1788865447_a_two_digit_base_currency_is_not_a_missing_one.down.sql
@@ -1,0 +1,6 @@
+-- Irreversible by design: the values this restored are the correct ones, and
+-- the state it replaced was a column of NULLs. Reinstating that loss is not a
+-- rollback anybody wants, so the down migration leaves the corrected amounts
+-- in place. The schema is untouched either way — this migration writes values
+-- only.
+SELECT 1;

--- a/backend/migrations/core/1788865447_a_two_digit_base_currency_is_not_a_missing_one.up.sql
+++ b/backend/migrations/core/1788865447_a_two_digit_base_currency_is_not_a_missing_one.up.sql
@@ -1,0 +1,63 @@
+-- The frozen-base backfill emptied the column it was written to correct.
+--
+-- 1788583500 dropped the generated deal.amount_minor_base, added a plain
+-- column and recomputed every closed row. Its deal-side scale read
+--
+--   coalesce((SELECT dd.digits FROM currency_minor_digits dd WHERE ...), 2)
+--
+-- but its BASE-side scale put the coalesce INSIDE the subquery:
+--
+--   (SELECT coalesce(bd.digits, 2) FROM currency_minor_digits bd WHERE ...)
+--
+-- A coalesce inside a scalar subquery never sees a missing row. It defaults a
+-- NULL digits COLUMN, which cannot happen — the column is NOT NULL — while an
+-- absent row still yields NULL and takes the whole expression with it.
+--
+-- currency_minor_digits holds only the currencies that DEVIATE from ISO's two
+-- decimals, so EUR, USD and GBP are absent by design. Every installation whose
+-- base is an ordinary two-decimal currency therefore backfilled its entire
+-- closed book to NULL: not the foreign-currency rows alone, but every closed
+-- deal including base-currency ones converting at a rate of 1.
+--
+-- The readers treat NULL as "no frozen figure", so the loss is silent. Closed
+-- revenue, the projects rollup, the organization won-lifetime figure and the
+-- weekly comparison each drop the row rather than reporting a wrong number.
+--
+-- The runtime SQL (compose.BaseValueSQL, briefs.briefBaseValueSQL) always had
+-- the coalesce in the right place, which is why open-pipeline figures stayed
+-- correct while the frozen column emptied underneath them.
+--
+-- This recomputes the same rows with the same arithmetic and the coalesce
+-- outside, where it answers the question actually being asked. A row the
+-- arithmetic cannot answer for stays NULL exactly as before: no rate, no
+-- amount, no base-currency setting, or a product too large for bigint.
+--
+-- Rows the freeze writer has already filled since 1788583500 ran are recomputed
+-- to the identical value: the writer uses this same arithmetic, so a correct
+-- row survives the pass unchanged.
+
+SET LOCAL lock_timeout = '5s';
+
+UPDATE deal d
+   SET amount_minor_base = CASE
+         WHEN round(d.amount_minor * d.fx_rate_to_base
+                * power(10::numeric, coalesce(
+                    (SELECT bd.digits FROM currency_minor_digits bd
+                      WHERE bd.currency = base.code), 2))
+                / power(10::numeric, coalesce(
+                    (SELECT dd.digits FROM currency_minor_digits dd
+                      WHERE dd.currency = d.currency), 2)))
+              BETWEEN -9223372036854775808 AND 9223372036854775807
+         THEN round(d.amount_minor * d.fx_rate_to_base
+                * power(10::numeric, coalesce(
+                    (SELECT bd.digits FROM currency_minor_digits bd
+                      WHERE bd.currency = base.code), 2))
+                / power(10::numeric, coalesce(
+                    (SELECT dd.digits FROM currency_minor_digits dd
+                      WHERE dd.currency = d.currency), 2)))::bigint
+         ELSE NULL
+       END
+  FROM (SELECT value #>> '{}' AS code FROM setting
+         WHERE key = 'installation.base_currency') AS base
+ WHERE d.fx_rate_to_base IS NOT NULL
+   AND d.amount_minor IS NOT NULL;

--- a/backend/migrations/frozenbasebackfill_integration_test.go
+++ b/backend/migrations/frozenbasebackfill_integration_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// The frozen-base backfill, replayed over the state it was written for.
+//
+// currency_minor_digits lists only the currencies that DEVIATE from ISO's two
+// decimals, so an ordinary base currency — EUR, USD, GBP — has no row there.
+// 1788583500 wrote its base-side scale as
+//
+//	(SELECT coalesce(bd.digits, 2) FROM currency_minor_digits bd WHERE ...)
+//
+// which defaults a NULL digits COLUMN rather than a missing ROW, and the column
+// is NOT NULL so that can never happen. An absent row still returned NULL and
+// carried the whole conversion with it, emptying the frozen amount of every
+// closed deal on such an installation — the base-currency ones converting at a
+// rate of 1 along with the foreign ones.
+//
+// The loss is silent: every reader treats NULL as "no frozen figure" and drops
+// the row, so closed revenue and the rollups shrink without reporting an error.
+//
+// Both migration texts are replayed from the shipped FILES, so this cannot pass
+// against SQL that no longer ships.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+var (
+	frozenFixturePipeline = ids.MustParse("01920000-0000-7000-8000-0000000000e1")
+	frozenFixtureStage    = ids.MustParse("01920000-0000-7000-8000-0000000000e2")
+	frozenDealEUR         = ids.MustParse("01920000-0000-7000-8000-0000000000e3")
+	frozenDealVND         = ids.MustParse("01920000-0000-7000-8000-0000000000e4")
+	frozenDealJPY         = ids.MustParse("01920000-0000-7000-8000-0000000000e5")
+)
+
+// replayMigration runs one shipped migration's up text over whatever the test
+// seeded. The FILE, not a copy of its statements.
+func replayMigration(t *testing.T, conn *pgx.Conn, name string) {
+	t.Helper()
+	up, err := os.ReadFile(filepath.Join("core", name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	if _, err := conn.Exec(context.Background(), string(up)); err != nil {
+		t.Fatalf("replaying %s: %v", name, err)
+	}
+}
+
+// rewindFrozenBaseMigration puts deal.amount_minor_base back the way
+// 1788583500 found it — the generated column, with its scale-blind expression —
+// so the test can seed closed deals and replay the migration over them.
+func rewindFrozenBaseMigration(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	if _, err := conn.Exec(context.Background(), `
+		ALTER TABLE deal DROP COLUMN amount_minor_base;
+		ALTER TABLE deal ADD COLUMN amount_minor_base bigint
+			GENERATED ALWAYS AS ((round(((amount_minor)::numeric * fx_rate_to_base)))::bigint) STORED`); err != nil {
+		t.Fatalf("undoing the frozen-base migration: %v", err)
+	}
+}
+
+// seedFrozenBaseFixture writes a EUR-base installation and three closed deals:
+// one in the base currency, one in a zero-decimal currency that HAS a
+// currency_minor_digits row, and one more of the same to prove the base side
+// rather than the deal side is what was broken.
+func seedFrozenBaseFixture(t *testing.T, conn *pgx.Conn) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO setting (key, value) VALUES ('installation.base_currency', '"EUR"')
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
+		t.Fatalf("seeding the base currency: %v", err)
+	}
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO pipeline (id, name) VALUES ($1, 'Frozen')`, frozenFixturePipeline); err != nil {
+		t.Fatalf("seeding the fixture pipeline: %v", err)
+	}
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		 VALUES ($1, $2, 'Won', 1, 'won', 100)`,
+		frozenFixtureStage, frozenFixturePipeline); err != nil {
+		t.Fatalf("seeding the fixture stage: %v", err)
+	}
+	for _, d := range []struct {
+		id       ids.UUID
+		currency string
+		amount   int64
+		rate     string
+	}{
+		{frozenDealEUR, "EUR", 1800000, "1.0000000000"},
+		{frozenDealVND, "VND", 2400000000, "0.0000350000"},
+		{frozenDealJPY, "JPY", 15000000, "0.0060000000"},
+	} {
+		if _, err := conn.Exec(ctx,
+			`INSERT INTO deal (id, pipeline_id, stage_id, name, status, closed_at,
+			                   amount_minor, currency, fx_rate_to_base, source, captured_by)
+			 VALUES ($1, $2, $3, 'Closed', 'won', now(), $4, $5, $6::numeric, 'manual', 'test')`,
+			d.id, frozenFixturePipeline, frozenFixtureStage, d.amount, d.currency, d.rate); err != nil {
+			t.Fatalf("seeding the %s deal: %v", d.currency, err)
+		}
+	}
+}
+
+func frozenBaseOf(t *testing.T, conn *pgx.Conn, deal ids.UUID) *int64 {
+	t.Helper()
+	var v *int64
+	if err := conn.QueryRow(context.Background(),
+		`SELECT amount_minor_base FROM deal WHERE id = $1`, deal).Scan(&v); err != nil {
+		t.Fatalf("reading the frozen base amount: %v", err)
+	}
+	return v
+}
+
+func TestTheFrozenBaseBackfillSurvivesATwoDecimalBaseCurrency(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+
+	rewindFrozenBaseMigration(t, conn)
+	seedFrozenBaseFixture(t, conn)
+
+	replayMigration(t, conn, "1788583500_a_frozen_base_amount_knows_both_scales.up.sql")
+	replayMigration(t, conn, "1788865447_a_two_digit_base_currency_is_not_a_missing_one.up.sql")
+
+	// EUR against a EUR base at a rate of 1: the amount is already in the base
+	// currency and both scales are two, so the conversion must be the identity.
+	// This is the case that shows the defect was never about foreign currency —
+	// a base-side NULL empties the plainest row in the book.
+	for _, want := range []struct {
+		deal   ids.UUID
+		label  string
+		amount int64
+	}{
+		{frozenDealEUR, "a EUR deal against a EUR base", 1800000},
+		// VND 2,400,000,000 (zero decimals = ₫2,400,000,000) at 0.000035
+		// EUR/VND is €84,000, which is 8,400,000 EUR minor units.
+		{frozenDealVND, "a VND deal against a EUR base", 8400000},
+		// JPY 15,000,000 (zero decimals = ¥15,000,000) at 0.006 EUR/JPY is
+		// €90,000 = 9,000,000 EUR minor units.
+		{frozenDealJPY, "a JPY deal against a EUR base", 9000000},
+	} {
+		got := frozenBaseOf(t, conn, want.deal)
+		if got == nil {
+			t.Fatalf("%s froze NULL, want %d — a base currency absent from currency_minor_digits is an ordinary two-decimal currency, not a missing scale, and every closed deal on such an installation drops out of closed revenue and the rollups",
+				want.label, want.amount)
+		}
+		if *got != want.amount {
+			t.Fatalf("%s froze %d, want %d", want.label, *got, want.amount)
+		}
+	}
+}
+
+func TestTheFrozenBaseBackfillLeavesARowItCannotConvert(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	headSchema(t, conn)
+	ctx := context.Background()
+
+	rewindFrozenBaseMigration(t, conn)
+	seedFrozenBaseFixture(t, conn)
+
+	// No base-currency setting: the destination scale is genuinely unknown, and
+	// guessing two is the assumption both migrations exist to remove.
+	if _, err := conn.Exec(ctx, `DELETE FROM setting WHERE key = 'installation.base_currency'`); err != nil {
+		t.Fatal(err)
+	}
+
+	replayMigration(t, conn, "1788583500_a_frozen_base_amount_knows_both_scales.up.sql")
+	replayMigration(t, conn, "1788865447_a_two_digit_base_currency_is_not_a_missing_one.up.sql")
+
+	if got := frozenBaseOf(t, conn, frozenDealVND); got != nil {
+		t.Fatalf("with no base currency configured the frozen amount is %d, want NULL — a converted figure against an unknown destination scale is a guess presented as a stored fact", *got)
+	}
+}

--- a/frontend/src/design-system/recordtabs.css
+++ b/frontend/src/design-system/recordtabs.css
@@ -17,14 +17,16 @@
      both. Without the `work` container the fallback is the reading column's
      own gutter, which is the narrower, safe answer. */
   margin-inline: calc(-1 * var(--pageGutter));
-  /* AND it may shrink, which is what makes the strip's own scrolling reachable.
+  /* IT MAY SHRINK, which is what makes the strip's own scrolling reachable.
      A flex or grid item is `min-inline-size: auto`, so it refuses to go narrower
      than its content — and this element's content is every tab laid end to end.
      Inside a `work` container that never shows, because the block below pins an
      explicit `inline-size` and the strip scrolls within it. Outside one, on a
      screen whose header is a flex row, the strip's `overflow-x: auto` could
      never engage: the tabs pushed the page sideways instead, which is the one
-     thing this component is built not to do. */
+     thing this component is built not to do. Analytics lays its header out as a
+     flex row and is where the 390px sweep caught it, eleven pixels past the
+     viewport; the record pages place the strip in a block and never saw it. */
   min-inline-size: 0;
 }
 

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -509,6 +509,46 @@ describe("log activity from a 360", () => {
       expect(links).toEqual([{ entity_type: "person", entity_id: "p1" }]);
     });
 
+    it("files a note on the company after a meeting's attendee was picked", async () => {
+      const user = userEvent.setup();
+      const captured: Captured[] = [];
+      stubApi(
+        {
+          "POST /activities": createdActivity,
+          "GET /people": () => jsonResponse(contacts),
+        },
+        captured,
+      );
+      render(<LogActivity entityType="organization" entityId="o1" />);
+      await pickOption(user, screen.getByLabelText("Type"), "Meeting");
+      await user.type(screen.getByLabelText("Who was there"), "Fré");
+      await user.click(
+        await screen.findByRole("button", { name: "Frédéric de Gombert" }),
+      );
+
+      // Switching kind hides the picker but does not forget the person: the
+      // reader answered a question the form stopped asking.
+      await pickOption(user, screen.getByLabelText("Type"), "Note");
+      expect(screen.queryByLabelText("Who was there")).toBeNull();
+      await user.type(screen.getByLabelText("Subject *"), "Pricing thoughts");
+      await user.click(screen.getByRole("button", { name: "Log" }));
+
+      await waitFor(() =>
+        expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+          true,
+        ),
+      );
+      const post = captured.find((entry) => entry.key === "POST /activities");
+      if (!post) throw new Error("expected a POST /activities to be captured");
+      const links = (
+        post.body as { links: { entity_type: string; entity_id: string }[] }
+      ).links;
+      // The company, not the contact. A note carries no person rule, so a
+      // stale attendee would file it against the contact and take it off the
+      // company screen the reader wrote it on.
+      expect(links).toEqual([{ entity_type: "organization", entity_id: "o1" }]);
+    });
+
     it("asks nobody for a note, which a company can hold on its own", async () => {
       stubApi({ "POST /activities": createdActivity });
       render(<LogActivity entityType="organization" entityId="o1" />);

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -196,9 +196,15 @@ function activityRequestBody(
     // server refuses an organization link on a meeting or a call whichever
     // else are present, and the company still reaches the activity: the
     // employer walk carries it there through the person who was named.
-    links: attendee
-      ? [{ entity_type: "person" as const, entity_id: attendee.id }]
-      : [{ entity_type: entityType, entity_id: entityId }],
+    //
+    // Only for the kinds that ask for one. The picker stops rendering when the
+    // reader switches to a note or a task, but the person they had already
+    // chosen stays in state — and filing a company note against that person
+    // takes it off the company screen it was written on.
+    links:
+      attendee && KINDS_WITH_A_PERSON.has(input.kind)
+        ? [{ entity_type: "person" as const, entity_id: attendee.id }]
+        : [{ entity_type: entityType, entity_id: entityId }],
     source: "manual",
   };
 }


### PR DESCRIPTION
1788583500 recomputed every closed deal's frozen base amount and emptied the
column instead. Its base-side scale read

    (SELECT coalesce(bd.digits, 2) FROM currency_minor_digits bd WHERE ...)

with the coalesce INSIDE the subquery, where it defaults a NULL digits column
rather than a missing row — and the column is NOT NULL, so it never fired. An
absent row returned NULL and took the whole conversion with it. The deal-side
scale three lines below has the coalesce outside, which is the correct spelling
and the one the runtime SQL already used.

currency_minor_digits lists only the currencies that DEVIATE from two decimals,
so EUR, USD and GBP are absent by design. Every installation on an ordinary base
currency therefore backfilled its entire closed book to NULL — not the foreign
rows alone but every closed deal, including base-currency ones converting at a
rate of 1. Readers treat NULL as "no frozen figure" and drop the row, so closed
revenue, the projects rollup, the organization won-lifetime figure and the
weekly comparison each shrank without reporting an error.

Measured on the demo database: 30 of 32 convertible closed deals held NULL, 20
of them EUR against a EUR base. The two survivors were written by the freeze
writer after the migration ran, which is why the live pipeline figures stayed
right while the frozen column emptied underneath them.

The repair is additive — the shipped migration is not edited — and recomputes
the same rows with the same arithmetic. A row already correct is recomputed to
the identical value, and a row the arithmetic cannot answer for still stays
NULL: no rate, no amount, no base-currency setting, or a product too large for
bigint.

The backfill had no test asserting a value; the schema fitness test only holds
that the column has one writer, which stayed true throughout. The new
integration test replays both shipped migration FILES over seeded closed deals
and asserts literal amounts, including a EUR deal at a rate of 1 — the plainest
row in the book, and the one that shows the defect was never about foreign
currency.

Two further fixes found in the same pass:

A company note filed against the contact of a meeting. logactivity's link rule
read `attendee ? [person] : [company]` with no kind check, and the picker's
state survives a change of kind — so picking an attendee for a Meeting, then
switching to Note, filed the note on the person and took it off the company
screen it was written on. The existing "asks nobody for a note" test never
picked a person first, which is why it passed.

fe-lint was red on main: recordtabs.css declared min-inline-size twice in one
rule, from two authors writing the same value with different comments. The
comments are merged; the declaration is unchanged.

Lanes: make check-backend (green), make test-it DIR=backend/migrations (whole
lane, including applyReverseReapply over the down migration), fe-lint, and
1016 frontend tests across the touched screens and the design system. Both new
guards were mutation-checked: reverting each fix fails its own test and no
other.

Not fixed here: App.test.tsx "mounts the field builder on the Data model page"
fails on clean main, from the settings-catalog split in #4419. The settings body
renders empty. It is unrelated to this change and reported rather than widened
into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the frozen-base backfill that set `amount_minor_base` to NULL on every closed deal when the base currency has no row in `currency_minor_digits` (EUR, USD, and GBP are absent by design), silently shrinking closed revenue and rollup figures. The new migration recomputes the same rows with the scale lookup corrected; rows the arithmetic can't answer still stay NULL.

**Bug Fixes**
- The base-side scale read `(SELECT coalesce(bd.digits, 2) ...)` with the coalesce inside the subquery, where it never defaults a missing row; the fix moves it outside, matching the deal-side and runtime SQL.
- The down migration is a no-op by design: reinstating the NULLs would be a loss, not a rollback.
- Adds an integration test that replays both shipped migration files over seeded closed deals and asserts literal amounts, including a EUR deal at a rate of 1.
- A company note was filed against the contact of a meeting when an attendee had been picked for a previous kind; the link rule now only uses the attendee for kinds that ask for one.
- Merges duplicate comments on the `min-inline-size` declaration in `recordtabs.css`.

<sup>Written for commit 4c4849fcfc21d30a7c30518867ec09b701770d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected frozen base amounts for deals using two-decimal base currencies.
  * Prevented notes and tasks from being incorrectly linked to a previously selected contact.
  * Ensured notes and tasks remain linked to the relevant company or record.

* **Tests**
  * Added coverage for currency amount backfills and activity-linking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->