### PR TITLE
fix(frontend): the restore-callback gate states the budget a tree scan needs

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -122,6 +122,14 @@ describe("the custom-fields admin, at its address inside settings", () => {
   });
 
   it("mounts the field builder on the Data model page", async () => {
+    // The settings screen is a lazy chunk, and since the shell stopped importing
+    // the screen module for its route constants it is loaded for the first time
+    // HERE. Under vitest that first load is the on-demand transform of every
+    // settings card, which runs longer than the finder below waits — and a
+    // finder that expires on a chunk still being compiled says nothing about
+    // whether the address mounts the builder. Warming the module first leaves
+    // the routing as the only thing being timed.
+    await import("./screens/settings");
     // Every query the surface fires must resolve, or QueryGate paints its error
     // card instead of the heading: /me (an admin holding the custom_field write
     // the entry is gated on), the per-object field list, and the audit rail.

--- a/frontend/src/screens/recordwritekeys.test.ts
+++ b/frontend/src/screens/recordwritekeys.test.ts
@@ -35,7 +35,15 @@ describe("recordWriteKeys", () => {
 // that never used it. Every restore callback in this tree hand-spelled ONE
 // key, and each picked a different one, so the gate is derived from the tree
 // rather than from a list kept beside it.
-describe("every restore callback goes through the helper", () => {
+//
+// A generous budget, stated rather than defaulted, as every gate that parses
+// the whole tree declares: this is synchronous CPU work over several hundred
+// files, about two seconds alone and past vitest's default ten under a loaded
+// runner. There is no hang for a tight timeout to catch, so the ceiling is the
+// floor under a slow runner and nothing else.
+const scanBudget = { timeout: 60_000 };
+
+describe("every restore callback goes through the helper", scanBudget, () => {
   it("finds no onRestored that invalidates by hand", () => {
     const offenders: string[] = [];
     for (const file of sourceFiles()) {


### PR DESCRIPTION
## What

`fe-unit` is red on `main`: `recordwritekeys.test.ts › every restore callback goes through the helper › finds no onRestored that invalidates by hand` times out at vitest's default ten seconds under a loaded runner. The suite now declares the same generous scan budget every other tree-parsing gate in this tree declares.

(This PR opened with a second fix, for the Data model mount test in `App.test.tsx`; #4427 landed the same warm-up on `main` first, so after merging `main` that change is gone from the diff and only the gate remains.)

## Why

The gate parses every source file under `src` with the TypeScript compiler: about two seconds alone, and past ten under a loaded runner (it took 10.4s on this PR's own first run). That is synchronous CPU work with no hang for a tight timeout to catch, which is exactly why `conformance.test.ts`, `native-controls.test.ts` and the other tree scans declare `{ timeout: 60_000 }` on their suites. This one had defaulted, and the tree has grown past it. The budget guard (`scripts/test-budget.test.ts`) folds the literal and passes.

## How verified

- `pnpm exec vitest run src/App.test.tsx src/screens/recordwritekeys.test.ts scripts/test-budget.test.ts`: 31 pass on the merged head.
- `biome check` on the file is clean.

- [x] `make check` is green — the frontend half; no Go files change
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers — no Go files in the diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Diagnosed and written in a Claude Code session while driving #4387, which merged `main` and inherited the red lane.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uo4JEvQcJemsi4osSv5qpD