### PR TITLE
main is red: two settings assertions wait for a chunk, not for a request

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -172,8 +172,25 @@ describe("the custom-fields admin, at its address inside settings", () => {
     // The SURFACE's own section header, at level 2. The shell's page head titles
     // the PAGE — "Data model" — so anchoring at level 1 would pass even if this
     // section never mounted.
+    // WAITING FOR A CHUNK, not for a request. The settings screen arrives on a
+    // chunk of its own and the shell no longer carries it — the catalog, the
+    // addresses and the visibility predicate moved out so that src/app/** could
+    // ask its three questions without pulling every settings card into the
+    // always-loaded bundle. What the shell stopped paying for on every page, a
+    // settings route now pays once on arrival, and in jsdom that import is
+    // resolved by the test runner rather than served from a browser cache.
+    //
+    // It lands just past the 1000ms default: this passes at 1500ms on an idle
+    // machine and failed at the default on a loaded runner, which is the wrong
+    // way round for a threshold to sit. Stated as a literal because
+    // scripts/test-budget.test.ts folds these numbers to check them against the
+    // per-test ceiling, and a timeout it cannot read is a budget nobody checked.
     expect(
-      await screen.findByRole("heading", { level: 2, name: "Custom fields" }),
+      await screen.findByRole(
+        "heading",
+        { level: 2, name: "Custom fields" },
+        { timeout: 3000 },
+      ),
     ).toBeTruthy();
   });
 });
@@ -235,9 +252,15 @@ describe("locale switch", () => {
     // also what makes this an app-level claim: the choice is made on one route
     // and has to hold on the next one, not just inside the card that made it.
     window.location.hash = "#/settings/account";
+    // The settings chunk again, for the reason spelled out on the Data model
+    // case above: this waits for the module to arrive, not for a request.
     await pickOption(
       userEvent.setup(),
-      await screen.findByRole("combobox", { name: "Language" }),
+      await screen.findByRole(
+        "combobox",
+        { name: "Language" },
+        { timeout: 3000 },
+      ),
       "Deutsch",
     );
 


### PR DESCRIPTION
`fe-unit` fails on `main`, and every open pull request inherits it. Both failures are in `App.test.tsx`, and both are the same wait.

Closes https://github.com/margince/margince/issues/4421

## What fails

```
App.test.tsx:176  Unable to find role="heading" and name "Custom fields"
App.test.tsx:240  Unable to find role="combobox" and name "Language"
```

Both are a `findByRole` issued straight after a `#/settings/...` route is opened. Reproduced on the tip before changing anything.

## Why, and why it is not a regression

The page is not erroring — it is still **`Loading…`** when the assertion gives up. Dumped from the failing render:

```
HEADINGS   H2 :: Settings | H3 :: You | H3 :: Admin settings | H1 :: Data model
MAIN       Settings/Data model … Data modelLoading…
```

The settings screen arrives on a chunk of its own, and the shell no longer carries it: https://github.com/margince/margince/pull/4419 moved the catalog, the addresses and the visibility predicate to `screens/settingsnav.tsx` so `src/app/**` could ask its three questions without pulling every settings card into the always-loaded bundle. What the shell stopped paying for on **every** page, a settings route now pays **once** on arrival — and in jsdom that import is resolved by the test runner rather than served from a browser cache.

It lands just past testing-library's 1000ms default. Bisected rather than guessed:

| timeout | result |
|---|---|
| 1000 (default) | fails |
| 1500 | 21 passed |
| 2500 | 21 passed |
| 8000 | 21 passed |

Which is the wrong way round for a threshold to sit: passing on a quiet laptop and failing on a loaded runner.

## The fix

`{ timeout: 3000 }` on both assertions — twice what the measurement asks for, and low enough that both tests stay inside the population `scripts/test-budget.test.ts` measures its ceiling over.

**As literals, and that is not a style choice.** My first attempt shared one named constant between the two sites, on the reasoning that two bare numbers invite someone to tune one of them. `scripts/test-budget.test.ts` rejected it, and it is right to:

> a timeout this reader cannot fold is the one that matters: the budget it hides is the budget nobody checked

That gate folds every waiter's timeout out of the syntax tree to hold it against the per-test ceiling, so a number it cannot resolve is a budget nobody checked. The nicer-reading version is exactly the shape it exists to refuse. The reason lives in a comment at the first site instead, and the second points at it.

## Verification

- `vitest run src/App.test.tsx` — **21 passed**.
- `vitest run scripts/test-budget.test.ts` — **6 passed**: both tests still fit the ceiling, and both timeouts are readable to the gate.
- `biome check` — clean.
- CI `fe-unit` — **578 test files passed**.

Node 24, matching what CI pins.

## Not this PR

The `fe-unit` job failed once more after the fix landed, on an unhandled `ReferenceError: window is not defined` — React's scheduler firing after jsdom teardown, originating while `src/screens/worklist.email.test.tsx` runs. Every test passed; the unhandled error fails the job on its own. It has now hit twice today on unrelated branches and is a flake worth its own issue rather than a re-run each time.
