### PR TITLE
fix: restore seeded demo workflows and actionable evidence

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28059,9 +28059,8 @@ components:
       type: object
       description: |
         The one thing to do next, and what performing it means. `action` is one of
-        `draft_email`, `create_task`, `open_meeting_brief`, `none` — the same verbs
-        the retired next-best-action carried, so a client that already performs them
-        needs no new code. `arguments` is the body or operand the verb takes, ready
+        `draft_email`, `create_task`, `open_task`, `open_meeting_brief`, `none`.
+        `open_task` opens existing work without creating another task. `arguments` is the body or operand the verb takes, ready
         to send; absent for `none`.
       required: [action, reason, evidence]
       properties:
@@ -28070,7 +28069,7 @@ components:
         arguments:
           type: object
           additionalProperties: true
-          description: "`draft_email` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body."
+          description: "`draft_email`, `open_task` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body."
         evidence:
           type: array
           items: { $ref: '#/components/schemas/DealNextBestActionEvidence' }
@@ -40768,7 +40767,7 @@ components:
       properties:
         action:
           type: string
-          enum: [draft_reply, draft_email, create_task, open_meeting_brief, reconnect, none]
+          enum: [draft_reply, draft_email, create_task, open_task, open_meeting_brief, reconnect, none]
           description: |
             `draft_reply` answers the message in `activity_id` — offered only where the
             reader may READ that message, because there is no replying to words they
@@ -40777,7 +40776,7 @@ components:
             and no thread behind it.
 
             `draft_email` opens a new message, `create_task` agrees a next step,
-            `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
+            `open_task` opens existing work, `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
             sends the reader to reauthorize a source that stopped answering.
 
             `none` is a producer's answer that there is nothing to do — a closed deal has

--- a/backend/internal/compose/corpusask.go
+++ b/backend/internal/compose/corpusask.go
@@ -141,12 +141,14 @@ type askedAnswer struct {
 // The fence is minted per request: a boundary reused across calls is one some
 // uploaded document may already have been shown, and every passage in this
 // prompt is a third party's own writing.
+// Quoted answers budget for both reasoning and verbatim supporting spans.
+// The ordinary structured-output cap can expire before a grounded answer ends.
 func CorpusAskRequest(question string, passages []knowledge.Passage, lang string) model.Request {
 	fence := promptfence.New()
 	return model.Request{
 		System:         corpusAskSystemFor(fence, lang),
 		Messages:       []model.Message{{Role: chatRoleUser, Content: fence.Wrap(renderCorpusAsk(question, passages))}},
-		MaxTokens:      ai.ReasoningOutputMaxTokens,
+		MaxTokens:      2 * ai.ReasoningOutputMaxTokens,
 		ResponseSchema: corpusAskSchema(passageIDs(passages)),
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/dealstatus/input.go
+++ b/backend/internal/compose/dealstatus/input.go
@@ -27,7 +27,7 @@ import (
 // are rendered into, which is Go code and so the half a digest cannot reach. It
 // rides the fingerprint so a card built from the old shape is rewritten rather
 // than served forever.
-const projectionVersion = "deal-status-projection-3"
+const projectionVersion = "deal-status-projection-4"
 
 // promptVersion is DERIVED from the prompt as it is SENT — boundary rule
 // included — so rewording it rewrites the cards whether or not anybody

--- a/backend/internal/compose/dealstatus/input_test.go
+++ b/backend/internal/compose/dealstatus/input_test.go
@@ -119,3 +119,25 @@ func TestACitedTaskCarriesASubjectTheReaderCanRead(t *testing.T) {
 		t.Fatalf("kind = %q, want task", got.Kind)
 	}
 }
+
+func TestALongMailKeepsItsSignOffInTheModelsEvidence(t *testing.T) {
+	body := "Hello, the results improved. " + strings.Repeat("The customer measured the change. ", 30) + "\n\nRegards,\nAlex Kim"
+	got := excerpt(body)
+	if !strings.HasPrefix(got, "Hello, the results improved.") || !strings.HasSuffix(got, "Alex Kim") {
+		t.Fatalf("the bounded evidence lost the result or its author: %q", got)
+	}
+	if len([]rune(got)) > maxExcerptLen {
+		t.Fatal("retaining the sign-off exceeded the evidence budget")
+	}
+}
+
+func TestAnExcerptKeepsTheSenderAndDropsQuotedHistory(t *testing.T) {
+	body := "The results improved. " + strings.Repeat("More detail. ", 50) + "\nMetin Ergener\n\nOn Monday, Lena wrote:\nPrevious proposal\nLena Fischer"
+	got := excerpt(body)
+	if !strings.Contains(got, "Metin Ergener") || strings.Contains(got, "Lena Fischer") {
+		t.Fatalf("excerpt confused the sender with quoted history: %q", got)
+	}
+	if got := excerpt("> A quoted message only"); got != "" {
+		t.Fatalf("quoted-only message became authored evidence: %q", got)
+	}
+}

--- a/backend/internal/compose/dealstatus/model.go
+++ b/backend/internal/compose/dealstatus/model.go
@@ -24,13 +24,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/margince/margince/backend/internal/compose/promptlang"
 	"github.com/margince/margince/backend/internal/compose/promptvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
@@ -65,9 +65,10 @@ Each of "story", "blocker", "buyer", "verdict.because" and "move_reason" is a li
 "move_reason" — a LIST of exactly one {"text","evidence"} object saying why the recommended move is the right one now, the same shape as "story". The move itself is decided elsewhere and given to you in "recommended_move": explain it, never replace it. It rests on records like every other sentence, so it cites them.
 
 Every sentence lists the ids it rests on in its own "evidence", from the summary's "id" fields. Ids belong in "evidence" only — never in any "text" or in "opening".
+A named stakeholder is not automatically the author of a timeline entry. Attribute a statement to a person only when that entry names them; otherwise say the customer or the team.
 Ground every word in the summary. Never invent a person, a company, a date, a number or an event. If the summary does not say it, do not write it.
 Every timeline entry carries "when": "past" for something that has happened, "scheduled" for something booked and still ahead. A scheduled entry is a plan, never an event — never write that it took place, and never measure silence from it.
-"open_tasks" is work NOBODY HAS DONE YET, whatever its date says. A task there carries "state": "open" or "overdue". Never write that a task's work happened, was sent, was followed up or was delivered — an overdue task is a promise already broken, not a thing that took place, and it is the strongest reason to act rather than evidence that somebody already did. Completed work is on the timeline instead, as the event it became.
+"open_tasks" is work NOBODY HAS DONE YET, whatever its date says. A task there carries "state": "open" or "overdue". Only state "overdue" is late. State "open" is not overdue, regardless of dates, silence or the deal's age. Never write that a task's work happened, was sent, was followed up or was delivered — an overdue task is a promise already broken, not a thing that took place, and it is the strongest reason to act rather than evidence that somebody already did. Completed work is on the timeline instead, as the event it became.
 "health" scores four things from 0 to 1, where low is bad: activity_recency, stage_velocity, engagement (how many people are actually talking to us) and commitments (promises we have kept). They are signals to reason from, never facts to state — never write a score, a factor name or the word "health" in the card. A low score tells you where to look in "timeline"; the timeline's dates are what you write.
 Never write the same fact in two sections. Each one answers a different question.
 `
@@ -303,15 +304,17 @@ func ParseStatus(reply string, in StatusInput) (WrittenStatus, error) {
 	return sections, nil
 }
 
-// excerpt bounds one body's contribution, cutting on a rune so a multi-byte
-// character is never split into an invalid tail.
+// excerpt keeps the opening and sign-off within one bounded contribution.
+// A prefix alone loses the speaker's name at the end of a longer mail, leaving
+// the model to confuse the account's best-known contact with its author.
 func excerpt(body string) string {
-	trimmed := strings.TrimSpace(body)
+	trimmed := textlang.CurrentMessage(body)
 	runes := []rune(trimmed)
 	if len(runes) <= maxExcerptLen {
 		return trimmed
 	}
-	return string(runes[:maxExcerptLen]) + "…"
+	tail := maxExcerptLen / 3
+	return string(runes[:maxExcerptLen-tail-1]) + "…" + string(runes[len(runes)-tail:])
 }
 
 // dealIn projects the deal's own fields.

--- a/backend/internal/compose/dealstatus/move.go
+++ b/backend/internal/compose/dealstatus/move.go
@@ -14,14 +14,12 @@ package dealstatus
 // meeting outranks an unanswered mail because the meeting has a date; an
 // unanswered mail outranks a bare next step because somebody is waiting.
 //
-// An open task no longer ENDS the reasoning. It used to: the card read the
-// task's title back to the reader and said it had nothing to add, which is a
-// card telling you what you already know and then declining to help. An open
-// task is now evidence like any other, and the deal still gets a move.
 
 import (
 	"fmt"
 	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/dealrole"
@@ -33,6 +31,7 @@ import (
 const (
 	ActionDraftEmail       = "draft_email"
 	ActionCreateTask       = "create_task"
+	ActionOpenTask         = "open_task"
 	ActionOpenMeetingBrief = "open_meeting_brief"
 	ActionNone             = "none"
 )
@@ -66,6 +65,14 @@ func decideMove(f facts) crmcontracts.DealStatusCardMove {
 	}
 	if opening, ok := firstOutreach(f); ok {
 		return opening
+	}
+	// Existing work is the next step until somebody completes it. Creating
+	// another generic follow-up here duplicates the task the card just read.
+	if len(f.openTasks) > 0 {
+		task := f.openTasks[0]
+		activityID := openapi_types.UUID(task.ID)
+		return move(ActionOpenTask, "Complete the existing task: "+task.Subject, map[string]any{"activity_id": activityID},
+			crmcontracts.DealNextBestActionEvidence{ActivityId: &activityID, Text: task.Subject})
 	}
 	return move(ActionCreateTask, nextStepReason(f),
 		map[string]any{
@@ -171,6 +178,9 @@ func move(action, reason string, args map[string]any, evidence ...crmcontracts.D
 		args = map[string]any{}
 	}
 	out := crmcontracts.DealStatusCardMove{Action: action, Reason: reason, Arguments: &args}
+	if action == ActionNone {
+		out.Arguments = nil
+	}
 	out.Evidence = append([]crmcontracts.DealNextBestActionEvidence{}, evidence...)
 	return out
 }

--- a/backend/internal/compose/dealstatus/move_test.go
+++ b/backend/internal/compose/dealstatus/move_test.go
@@ -39,21 +39,19 @@ func inboundMail(at time.Time) crmcontracts.Activity {
 	return a
 }
 
-func TestAnOpenTaskNoLongerEndsTheReasoning(t *testing.T) {
-	// The card this replaces read the task's title back to the reader and
-	// said it had nothing to add. An open task is evidence now, not a reason
-	// to stay silent, so the deal still gets a move.
+func TestAnOpenTaskIsReusedInsteadOfDuplicated(t *testing.T) {
+	taskID := ids.NewV7()
 	f := facts{
 		deal: openDeal(), now: testNow,
 		timeline:  []crmcontracts.Activity{act(crmcontracts.ActivityKindEmail, testNow.AddDate(0, 0, -12))},
-		openTasks: []activities.OpenTask{{ID: ids.NewV7(), Subject: "Agree the next step"}},
+		openTasks: []activities.OpenTask{{ID: taskID, Subject: "Agree the next step"}},
 	}
 	mv := decideMove(f)
-	if mv.Action == ActionNone {
-		t.Fatalf("a deal with an open task got no move: %+v", mv)
+	if mv.Action != ActionOpenTask || mv.Arguments == nil {
+		t.Fatalf("existing work offered another write: %+v", mv)
 	}
-	if mv.Action != ActionCreateTask {
-		t.Fatalf("action = %q, want the next-step task", mv.Action)
+	if len(mv.Evidence) != 1 || mv.Evidence[0].ActivityId == nil || *mv.Evidence[0].ActivityId != openapi_types.UUID(taskID) {
+		t.Fatalf("move does not name the existing task: %+v", mv)
 	}
 }
 

--- a/backend/internal/compose/integration/automations_integration_test.go
+++ b/backend/internal/compose/integration/automations_integration_test.go
@@ -8,7 +8,7 @@ package integration
 // The automations surface (B-E15.1/.4, feedback/14): a closed catalog,
 // instance CRUD that validates params against it, created-paused,
 // If-Match on the enable flip, soft delete — and the workspace
-// bootstrap seeding exactly the six starter templates enabled
+// bootstrap seeding the six starters, with owner-dependent drafts paused
 // (UAT.md:72).
 
 import (
@@ -23,7 +23,7 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 	e.BootstrapWorkspace(t)
 
 	assertAutomationCatalogIsClosed(t, e)
-	assertBootstrapSeededStartersEnabled(t, e)
+	assertBootstrapSeededStarters(t, e)
 	assertAutomationCreateValidatesParams(t, e)
 	createdID := createPausedAutomation(t, e)
 
@@ -94,10 +94,10 @@ func assertAutomationCatalogIsClosed(t *testing.T, e *apptest.AppEnv) {
 	}
 }
 
-// assertBootstrapSeededStartersEnabled checks the workspace bootstrap
+// assertBootstrapSeededStarters checks the workspace bootstrap
 // seeded EXACTLY the six starter templates already enabled (UAT.md:72)
 // — the recorded deviation from the API path's created-paused rule.
-func assertBootstrapSeededStartersEnabled(t *testing.T, e *apptest.AppEnv) {
+func assertBootstrapSeededStarters(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// Bootstrap seeded the six starters ENABLED (system floor, recorded
 	// deviation from created-paused which governs the API path).
@@ -116,8 +116,12 @@ func assertBootstrapSeededStartersEnabled(t *testing.T, e *apptest.AppEnv) {
 		t.Fatalf("bootstrap seeded %d automations, want exactly 6", len(listed.Data))
 	}
 	for _, a := range listed.Data {
-		if a.Status != "enabled" {
-			t.Fatalf("seeded %s is %s, want enabled", a.Key, a.Status)
+		want := "enabled"
+		if a.Key == "post_meeting_recap" {
+			want = "paused"
+		}
+		if a.Status != want {
+			t.Fatalf("seeded %s is %s, want %s", a.Key, a.Status, want)
 		}
 	}
 }

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -74,12 +74,15 @@ func TestNotifyFiringWithNoTransportLandsAVisibleSkippedRun(t *testing.T) {
 	engine.RegisterSystemWorkflow(notifyNoTransportProbe{})
 
 	ctx := context.Background()
-	if err := engine.HandleEvent(ctx, kevents.Envelope{
+	event := kevents.Envelope{
 		EventID: ids.NewV7(), Type: "deal.stage_changed",
 		OccurredAt: time.Now().UTC(),
 		Entity:     kevents.EntityRef{Type: "deal", ID: dealID},
-	}); err != nil {
-		t.Fatal(err)
+	}
+	for range 2 {
+		if err := engine.HandleEvent(ctx, event); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	var status string
@@ -221,6 +224,14 @@ func TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord(t *testing.T) {
 	var status string
 	var appliedJSON []byte
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		var count int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM workflow_run
+			WHERE handler = 'task11a_draft_email_probe'`).Scan(&count); err != nil {
+			return err
+		}
+		if count != 1 {
+			t.Fatalf("redelivery created %d draft runs, want one", count)
+		}
 		return tx.QueryRow(
 			context.Background(),
 			`SELECT status, applied FROM workflow_run WHERE handler = 'task11a_draft_email_probe'`,

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13868,6 +13868,7 @@ const (
 	WorklistMoveActionDraftReply       WorklistMoveAction = "draft_reply"
 	WorklistMoveActionNone             WorklistMoveAction = "none"
 	WorklistMoveActionOpenMeetingBrief WorklistMoveAction = "open_meeting_brief"
+	WorklistMoveActionOpenTask         WorklistMoveAction = "open_task"
 	WorklistMoveActionReconnect        WorklistMoveAction = "reconnect"
 )
 
@@ -13883,6 +13884,8 @@ func (e WorklistMoveAction) Valid() bool {
 	case WorklistMoveActionNone:
 		return true
 	case WorklistMoveActionOpenMeetingBrief:
+		return true
+	case WorklistMoveActionOpenTask:
 		return true
 	case WorklistMoveActionReconnect:
 		return true
@@ -21960,14 +21963,13 @@ type DealStatusCard struct {
 }
 
 // DealStatusCardMove The one thing to do next, and what performing it means. `action` is one of
-// `draft_email`, `create_task`, `open_meeting_brief`, `none` — the same verbs
-// the retired next-best-action carried, so a client that already performs them
-// needs no new code. `arguments` is the body or operand the verb takes, ready
+// `draft_email`, `create_task`, `open_task`, `open_meeting_brief`, `none`.
+// `open_task` opens existing work without creating another task. `arguments` is the body or operand the verb takes, ready
 // to send; absent for `none`.
 type DealStatusCardMove struct {
 	Action string `json:"action"`
 
-	// Arguments `draft_email` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body.
+	// Arguments `draft_email`, `open_task` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body.
 	Arguments *map[string]interface{}      `json:"arguments,omitempty"`
 	Evidence  []DealNextBestActionEvidence `json:"evidence"`
 
@@ -34555,7 +34557,7 @@ type WorklistMove struct {
 	// and no thread behind it.
 	//
 	// `draft_email` opens a new message, `create_task` agrees a next step,
-	// `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
+	// `open_task` opens existing work, `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
 	// sends the reader to reauthorize a source that stopped answering.
 	//
 	// `none` is a producer's answer that there is nothing to do — a closed deal has
@@ -34592,7 +34594,7 @@ type WorklistMove struct {
 // and no thread behind it.
 //
 // `draft_email` opens a new message, `create_task` agrees a next step,
-// `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
+// `open_task` opens existing work, `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
 // sends the reader to reauthorize a source that stopped answering.
 //
 // `none` is a producer's answer that there is nothing to do — a closed deal has

--- a/backend/internal/modules/agents/runner/catalog.go
+++ b/backend/internal/modules/agents/runner/catalog.go
@@ -64,11 +64,13 @@ func Catalog() []AgentSpec {
 	return []AgentSpec{
 		{
 			Name: "morning_brief",
-			Goal: "Assemble the Morning Brief for this workspace: enumerate open deals, " +
-				"read the ones with recent activity, and produce a ranked list (at most 7) of " +
-				"deals the team can win this week. For each: why it is on the list, what changed " +
-				"recently, and one recommended next move — every claim grounded in a record you " +
-				"actually read, citing its id. A quiet day yields a short list; never pad it.",
+			Goal: "Prepare the acting person's existing Morning Brief. First call read_brief. " +
+				"Its items are the queue already ranked for this person; do not assemble a workspace-wide list. " +
+				"Read the evidence for those items, then call annotate_brief with one concise narrative " +
+				"and grounded findings: why each item matters, what changed and the next move. " +
+				"Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. " +
+				"Keep the existing order. If there are no items, finish without inventing a brief. " +
+				"A tool refusal means the findings were not saved: correct it before claiming completion.",
 			DueHourUTC: 6,
 		},
 		{

--- a/backend/internal/modules/automation/automations.go
+++ b/backend/internal/modules/automation/automations.go
@@ -262,6 +262,18 @@ func (s *AutomationStore) Update(ctx context.Context, id ids.AutomationID, in Up
 		if in.IfVersion != nil && *in.IfVersion != before.Version {
 			return apperrors.ErrVersionSkew
 		}
+		if in.Enabled != nil && *in.Enabled {
+			owner, err := claimDraftStarter(ctx, tx, before)
+			if err != nil {
+				return err
+			}
+			if !owner.IsZero() {
+				if _, err := storekit.Audit(ctx, tx, "update", "automation", id.UUID,
+					map[string]string{keyOwnerID: ""}, map[string]string{keyOwnerID: owner.String()}); err != nil {
+					return err
+				}
+			}
+		}
 		if in.Params != nil {
 			entry, ok := CatalogEntryByKey(before.Key)
 			if !ok {
@@ -332,19 +344,9 @@ func (s *AutomationStore) Archive(ctx context.Context, id ids.AutomationID) erro
 	})
 }
 
-// SeedStarterAutomationsTx enrolls EXACTLY the SIX seeded starter
-// templates (Catalog()'s Seeded entries — UAT.md:72) for a fresh
-// workspace inside the bootstrap transaction — ENABLED, deliberately:
-// the contract's created-paused rule governs user-configured instances;
-// a system-seeded floor ("no lead sits unseen") that arrived paused
-// would silently not exist. The authorable-but-unseeded entries
-// (assign_lead_owner, stage_change_create_task) are reachable through
-// the API but never land here unasked. Default params run through the
-// SAME entry.Validate a human author's create call does — an empty
-// params blob is what every seeded template's own handler reader
-// already treats as "use my own default" (e.g. DueInDays,
-// noActivityDays), so this seeds honestly-validated rows, never a blob
-// bypassing the catalog's own gate.
+// SeedStarterAutomationsTx enables the system-owned starters at bootstrap.
+// A draft needs a person's authority, so its template stays paused until an
+// authorized person enables it and takes ownership.
 func SeedStarterAutomationsTx(ctx context.Context, tx pgx.Tx) error {
 	for _, entry := range Catalog() {
 		if !entry.Seeded {
@@ -363,8 +365,12 @@ func SeedStarterAutomationsTx(ctx context.Context, tx pgx.Tx) error {
 		}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO automation (key, name, origin, trigger, action, params, enabled, tier)
-			VALUES ($1, $2, 'catalog', $3, $4, $5, true, $6)`,
-			entry.Key, entry.Name, triggerJSON, actionJSON, paramsJSON, entry.Tier); err != nil {
+			VALUES (@key, @name, 'catalog', @trigger, @action, @params, @enabled, @tier)`,
+			pgx.NamedArgs{
+				"key": entry.Key, "name": entry.Name, "trigger": triggerJSON,
+				"action": actionJSON, "params": paramsJSON, "tier": entry.Tier,
+				"enabled": entry.Action != string(ActionTypeDraftEmail),
+			}); err != nil {
 			return fmt.Errorf("seed automation %s: %w", entry.Key, err)
 		}
 	}

--- a/backend/internal/modules/automation/automations_catalog.go
+++ b/backend/internal/modules/automation/automations_catalog.go
@@ -30,7 +30,7 @@ type CatalogEntry struct {
 	Validate     func(params map[string]any) error
 	// Seeded marks the entry as one of the SIX starter templates
 	// SeedStarterAutomationsTx (automations.go) enrolls into a fresh
-	// workspace, enabled, on bootstrap (UAT.md:72 — "exactly the six
+	// workspace on bootstrap (UAT.md:72 — "exactly the six
 	// seeded templates"). An entry with Seeded false is still fully
 	// instantiable through the API (the catalog stays the closed,
 	// authorable set) — it just never lands in a workspace unasked.

--- a/backend/internal/modules/automation/draftstarter.go
+++ b/backend/internal/modules/automation/draftstarter.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// claimDraftStarter gives an unowned draft template the enabling person's
+// authority. Existing owners never change when somebody toggles the template.
+func claimDraftStarter(ctx context.Context, tx pgx.Tx, before Automation) (ids.UUID, error) {
+	entry, ok := CatalogEntryByKey(before.Key)
+	if !ok {
+		return ids.Nil, fmt.Errorf("automation %s names an unknown catalog key", before.ID)
+	}
+	if entry.Action != string(ActionTypeDraftEmail) {
+		return ids.Nil, nil
+	}
+	if err := requireAuthorCeiling(ctx, entry); err != nil {
+		return ids.Nil, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return ids.Nil, &MissingDraftOwnerError{}
+	}
+	updated, err := tx.Exec(ctx, `UPDATE automation SET owner_id = @owner
+		WHERE id = @id AND owner_id IS NULL`,
+		pgx.NamedArgs{"owner": actor.UserID, "id": before.ID})
+	if err != nil || updated.RowsAffected() == 0 {
+		return ids.Nil, err
+	}
+	return actor.UserID, nil
+}

--- a/backend/internal/modules/automation/draftstarter_integration_test.go
+++ b/backend/internal/modules/automation/draftstarter_integration_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package automation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestEnablingADraftStarterClaimsItsOwnerOnce(t *testing.T) {
+	fx := setupAutomationDB(t)
+	db := database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws))
+	ctx := fx.humanCtx(fx.rep1, principal.RowScopeAll)
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("fixture has no actor")
+	}
+	actor.Permissions.Objects["activity"] = principal.ObjectGrant{Read: true, Create: true}
+	ctx = principal.WithActor(ctx, actor)
+	if err := db.Tx(ctx, func(tx pgx.Tx) error { return SeedStarterAutomationsTx(ctx, tx) }); err != nil {
+		t.Fatal(err)
+	}
+	var id ids.AutomationID
+	var enabled bool
+	var owner *ids.UUID
+	if err := fx.owner.QueryRow(ctx, "SELECT id, enabled, owner_id FROM automation WHERE key = 'post_meeting_recap'").Scan(&id, &enabled, &owner); err != nil {
+		t.Fatal(err)
+	}
+	if enabled || owner != nil {
+		t.Fatal("draft starter starts enabled or invents an owner")
+	}
+	store := NewAutomationStore(db)
+	enable := true
+	denied := fx.humanCtx(fx.rep2, principal.RowScopeAll)
+	if _, err := store.Update(denied, id, UpdateAutomationInput{Enabled: &enable}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("enabling without draft authority: %v", err)
+	}
+	if _, err := store.Update(ctx, id, UpdateAutomationInput{Enabled: &enable}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fx.owner.QueryRow(ctx, "SELECT owner_id FROM automation WHERE id = $1", id).Scan(&owner); err != nil {
+		t.Fatal(err)
+	}
+	if owner == nil || *owner != fx.rep1 {
+		t.Fatal("enabler did not become draft owner")
+	}
+	actor.UserID = fx.rep2
+	if _, err := store.Update(principal.WithActor(ctx, actor), id, UpdateAutomationInput{Enabled: &enable}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fx.owner.QueryRow(context.Background(), "SELECT owner_id FROM automation WHERE id = $1", id).Scan(&owner); err != nil {
+		t.Fatal(err)
+	}
+	if owner == nil || *owner != fx.rep1 {
+		t.Fatal("a later toggle reassigned the draft's owner")
+	}
+	if count := fx.count(t, "SELECT count(*) FROM audit_log WHERE entity_id = $1 AND after ? 'owner_id'", id); count != 1 {
+		t.Fatalf("ownership was audited %d times, want once", count)
+	}
+}

--- a/backend/internal/modules/automation/taskeffect.go
+++ b/backend/internal/modules/automation/taskeffect.go
@@ -14,9 +14,11 @@ package automation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
@@ -79,13 +81,19 @@ func anchorReminderTaskEffect(
 // nobody to give it to, and the unassigned queue is where it belongs until
 // somebody claims the record.
 //
-// A record this read cannot reach mints an unassigned task too, rather than
-// failing the run. The reminder is the point; losing it entirely because its
-// owner could not be looked up trades a misfiled task for no task at all.
+// A deleted target skips the firing; other read failures must not create work
+// under an unknown owner.
 func ownedTaskEffect(
 	ctx context.Context, ex Executors, ev workflow.Event, subject string, dueAt time.Time,
 ) (workflow.Effect, error) {
-	return taskCreateEffectFor(ev, subject, dueAt, recordOwner(ctx, ex, ev))
+	if ex.Provider == nil {
+		return taskCreateEffectFor(ev, subject, dueAt, nil)
+	}
+	owner, err := recordOwner(ctx, ex, ev)
+	if err != nil {
+		return workflow.Effect{}, err
+	}
+	return taskCreateEffectFor(ev, subject, dueAt, owner)
 }
 
 // recordOwner reads who answers for the record that fired, or nil.
@@ -93,19 +101,20 @@ func ownedTaskEffect(
 // One shape for every record type the task-minting handlers fire on: deal,
 // lead, person and organization all spell their owner `owner_id`, so one decode
 // answers all four and a per-type switch would be four spellings of one fact.
-func recordOwner(ctx context.Context, ex Executors, ev workflow.Event) *ids.UUID {
-	if ex.Provider == nil {
-		return nil
-	}
+func recordOwner(ctx context.Context, ex Executors, ev workflow.Event) (*ids.UUID, error) {
 	rec, err := ex.Provider.Read(ctx, ev.Entity)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		// The event may outlive a promoted lead or an archived record.
+		return nil, declineFiring("the target record is no longer available")
+	}
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var owned struct {
 		OwnerID *ids.UUID `json:"owner_id"`
 	}
 	if err := json.Unmarshal(rec.Fields, &owned); err != nil {
-		return nil
+		return nil, fmt.Errorf("reading the task owner: %w", err)
 	}
-	return owned.OwnerID
+	return owned.OwnerID, nil
 }

--- a/backend/internal/modules/automation/taskeffect_test.go
+++ b/backend/internal/modules/automation/taskeffect_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+func TestATaskForADisappearedTargetIsSkipped(t *testing.T) {
+	ex := Executors{Provider: &fakeReadProvider{err: apperrors.ErrNotFound}}
+	effect, err := ownedTaskEffect(context.Background(), ex, workflow.Event{}, "Follow up", time.Time{})
+	var declined declinedFiring
+	if !errors.As(err, &declined) || len(effect.Actions) != 0 {
+		t.Fatalf("stale target planned work: %+v, %v", effect, err)
+	}
+}
+
+func TestAnUnreadableTaskOwnerIsNotTreatedAsUnassigned(t *testing.T) {
+	for name, provider := range map[string]*fakeReadProvider{
+		"permission denied": {err: apperrors.ErrPermissionDenied},
+		"malformed record":  {record: datasource.Record{Fields: []byte("not json")}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			effect, err := ownedTaskEffect(context.Background(), Executors{Provider: provider}, workflow.Event{}, "Follow up", time.Time{})
+			if err == nil || len(effect.Actions) != 0 {
+				t.Fatalf("unreadable owner planned an unassigned task: %+v, %v", effect, err)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/capture/offlinedemo/generate.go
+++ b/backend/internal/modules/capture/offlinedemo/generate.go
@@ -87,14 +87,14 @@ func (m message) record() connector.NormalizedRecord {
 		addresses = append(addresses, m.CCAddr)
 	}
 
-	// Links are explicit. The org always; the deal when the thread is about
-	// one. NOT the person: the sink's counterparty ladder resolves and links
+	// Meetings reach companies through their attendees, as live calendar capture
+	// does. Mail links the company directly; both may link a deal. Not the person: the sink's counterparty ladder resolves and links
 	// them, and a second link here would be a duplicate row.
 	// An id that will not parse costs its link rather than the message: the
 	// directory produced it from the database, so a bad one is a bug worth
 	// seeing as a missing link rather than a lost thread.
 	var links []datasource.EntityRef
-	if orgID, err := ids.Parse(m.OrgID); err == nil {
+	if orgID, err := ids.Parse(m.OrgID); err == nil && m.Kind != "meeting" {
 		links = append(links, datasource.EntityRef{Type: datasource.EntityOrganization, ID: orgID})
 	}
 	if m.DealID != "" {
@@ -136,7 +136,12 @@ func (m message) record() connector.NormalizedRecord {
 	// The cost is that a generated outbound reads as correspondence without
 	// T1 evidence, which is honest — nobody filed these in a Sent folder,
 	// because nobody sent them.
-	if m.Kind != "meeting" {
+	if m.Kind == "meeting" {
+		rec.Participants = []connector.MessageParticipant{
+			{Email: m.FromAddr, DisplayName: m.FromName, Role: connector.ParticipantRoleOrganizer},
+			{Email: m.ToAddr, DisplayName: m.ToName, Role: connector.ParticipantRoleAttendee},
+		}
+	} else {
 		rec.Counterparty = connector.Counterparty{
 			Email:       strings.ToLower(counterparty),
 			DisplayName: counterpartyName,

--- a/backend/internal/modules/capture/offlinedemo/meeting_test.go
+++ b/backend/internal/modules/capture/offlinedemo/meeting_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package offlinedemo
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+func TestGeneratedMeetingsFileThroughTheirAttendees(t *testing.T) {
+	box := demoMailbox()
+	meetings := 0
+	for _, message := range generate(box, box.Accounts[0]) {
+		if message.Kind != "meeting" {
+			continue
+		}
+		meetings++
+		record := message.record()
+		for _, link := range record.Links {
+			if link.Type == datasource.EntityOrganization {
+				t.Fatal("meeting links a company directly")
+			}
+		}
+		found := false
+		for _, party := range record.Participants {
+			if party.Email == box.Accounts[0].People[0].Email && party.Role == connector.ParticipantRoleAttendee {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("meeting lost its attendee: %+v", record.Participants)
+		}
+	}
+	if meetings == 0 {
+		t.Fatal("fixture generated no meetings")
+	}
+}

--- a/backend/internal/modules/capture/offlinedemo/offlinedemo_test.go
+++ b/backend/internal/modules/capture/offlinedemo/offlinedemo_test.go
@@ -181,9 +181,12 @@ func TestOutboundNamesItsRecipient(t *testing.T) {
 
 // TestRecordsLinkTheAccount — an activity that links nothing shows on no
 // company page, which is the failure the seeder's verify pass exists to catch.
-func TestRecordsLinkTheAccount(t *testing.T) {
+func TestMailRecordsLinkTheAccount(t *testing.T) {
 	box := demoMailbox()
 	for _, m := range generate(box, box.Accounts[0]) {
+		if m.Kind == "meeting" {
+			continue
+		}
 		rec := m.record()
 		found := false
 		for _, link := range rec.Links {

--- a/backend/internal/modules/knowledge/handbook/approvals.md
+++ b/backend/internal/modules/knowledge/handbook/approvals.md
@@ -155,9 +155,9 @@ Every step here is one you take yourself.
    routes the text through the normaliser that numbers the lines, and those line
    numbers are what the evidence below points at.
 4. **Log**.
-5. Open **History**, find the meeting, and click **Read transcript**. Margince
-   does not read it on upload — you ask for the read, and this is the step that
-   asks.
+5. Open **History** and find the meeting. Margince queues a reading when you
+   log a transcript. If no reading is underway or complete, click **Read
+   transcript** to request one.
 6. Wait for **Done**. It reports what it found: "{count} next steps waiting for
    your review", or "Read in full. This conversation states no next steps."
 7. Go to the **Worklist**, then **Decisions**. A busy queue can bury a new
@@ -168,9 +168,9 @@ Every step here is one you take yourself.
 9. **Approve** to create the task, or **Reject** with a reason. An approved
    proposal becomes an ordinary task on the contact and on their company.
 
-What this does **not** do: it does not send anything, and it does not act
-without the read in step 5 and the answer in step 9. A transcript sitting in an
-activity has proposed nothing until you ask it to.
+What this does **not** do: it does not send anything or create tasks without
+your approval. Reading the transcript proposes next steps; accepting a proposal
+is what creates its task.
 
 ## Where you see them
 

--- a/backend/internal/shared/kernel/textlang/replytext.go
+++ b/backend/internal/shared/kernel/textlang/replytext.go
@@ -311,3 +311,16 @@ func NewTextOnly(text string) string {
 	}
 	return strings.TrimSpace(string(runes))
 }
+
+// CurrentMessage retains the sender's signature but excludes quoted messages.
+// Unlike language detection's cutAt fallback, attribution must not substitute
+// somebody else's quoted words when the sender wrote little or nothing.
+// A forwarded original remains available in the full activity, not presented
+// here as the forwarding person's own statement.
+func CurrentMessage(text string) string {
+	runes := []rune(text)
+	if offset := quoteStart(runes); offset >= 0 {
+		runes = runes[:offset]
+	}
+	return strings.TrimSpace(string(runes))
+}

--- a/backend/migrations/core/1788610228_an_unowned_draft_starter_waits_for_an_author.down.sql
+++ b/backend/migrations/core/1788610228_an_unowned_draft_starter_waits_for_an_author.down.sql
@@ -1,0 +1,3 @@
+-- Re-enabling an unowned draft would restore a configuration that cannot run.
+-- A downgrade preserves the pause; an authorized person may enable it later.
+SET LOCAL lock_timeout = '3s';

--- a/backend/migrations/core/1788610228_an_unowned_draft_starter_waits_for_an_author.up.sql
+++ b/backend/migrations/core/1788610228_an_unowned_draft_starter_waits_for_an_author.up.sql
@@ -1,0 +1,15 @@
+-- A starter with no author cannot draft with anyone's authority. Pause old
+-- instances until an authorized person explicitly enables and claims them.
+SET LOCAL lock_timeout = '3s';
+
+WITH paused AS (
+    UPDATE automation
+       SET enabled = false, version = version + 1, updated_at = now()
+     WHERE enabled AND owner_id IS NULL AND archived_at IS NULL
+       AND action ->> 'kind' = 'draft_email'
+    RETURNING id
+)
+INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, before, after)
+SELECT 'system', 'migration', 'update', 'automation', id,
+       '{"status":"enabled"}'::jsonb, '{"status":"paused"}'::jsonb
+  FROM paused;

--- a/backend/migrations/draftstarter_integration_test.go
+++ b/backend/migrations/draftstarter_integration_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheDraftStarterUpgradePausesOnlyUnownedDrafts(t *testing.T) {
+	dsn, _ := dsns(t)
+	conn := connect(t, dsn)
+	headSchema(t, conn)
+	ctx := context.Background()
+	owner := ids.NewV7()
+	if _, err := conn.Exec(ctx, "INSERT INTO app_user(id,email,display_name) VALUES ($1,'author@example.test','Author')", owner); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Exec(ctx, `INSERT INTO automation(key,name,trigger,action,owner_id,enabled)
+ VALUES ('unowned','unowned','{}','{"kind":"draft_email"}',NULL,true),
+ ('owned','owned','{}','{"kind":"draft_email"}',$1,true),
+ ('system','system','{}','{"kind":"create_task"}',NULL,true)`, owner); err != nil {
+		t.Fatal(err)
+	}
+	sql, err := os.ReadFile("core/1788610228_an_unowned_draft_starter_waits_for_an_author.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if _, err := conn.Exec(ctx, string(sql)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := conn.Query(ctx, "SELECT key,enabled,version FROM automation WHERE key IN ('unowned','owned','system') ORDER BY key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for rows.Next() {
+		var key string
+		var enabled bool
+		var version int
+		if err := rows.Scan(&key, &enabled, &version); err != nil {
+			t.Fatal(err)
+		}
+		wantEnabled, wantVersion := key != "unowned", 1
+		if !wantEnabled {
+			wantVersion = 2
+		}
+		if enabled != wantEnabled || version != wantVersion {
+			t.Fatalf("%s is enabled=%v version=%d", key, enabled, version)
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	rows.Close()
+	if count != 3 {
+		t.Fatalf("read %d automations, want 3", count)
+	}
+	var audited int
+	if err := conn.QueryRow(ctx, "SELECT count(*) FROM audit_log WHERE entity_type='automation' AND entity_id IN (SELECT id FROM automation WHERE key='unowned')").Scan(&audited); err != nil {
+		t.Fatal(err)
+	}
+	if audited != 1 {
+		t.Fatalf("pause was audited %d times, want once", audited)
+	}
+}

--- a/backend/tools/seed-demo/consent.go
+++ b/backend/tools/seed-demo/consent.go
@@ -227,43 +227,7 @@ func seedFinanceLinks(ctx context.Context, conn *pgx.Conn, cfg demoConfig, orgID
 		linked += int(tag.RowsAffected())
 	}
 
-	if err := requestFinanceSync(ctx, conn); err != nil {
-		return linked, err
-	}
 	return linked, nil
-}
-
-// requestFinanceSync asks the worker to mirror the ledger now.
-//
-// Without this the demo has customers and no money. The links are only READ
-// by the sync, which the sweep fires every six hours — so a seed that lands
-// just after a sweep leaves every revenue card empty until the next one, and
-// the run reports success while the finance half of the product shows
-// nothing. That is exactly what happened: the sweep ran at 10:55, the seeder
-// wrote the links at 11:03, and 200 invoices existed only after the job was
-// enqueued by hand.
-//
-// A row on River's queue is how the sweep itself asks, so this asks the same
-// way rather than reaching into the finance module. The worker picks it up
-// within seconds; if no worker is running the row simply waits, which is the
-// right outcome for a stack that is not fully up.
-func requestFinanceSync(ctx context.Context, conn *pgx.Conn) error {
-	var workspaceID string
-	if err := conn.QueryRow(ctx, `SELECT id FROM workspace LIMIT 1`).Scan(&workspaceID); err != nil {
-		return fmt.Errorf("resolving the workspace for the finance sync: %w", err)
-	}
-	// Idempotent by intent rather than by key: an already-queued pass makes a
-	// second one a no-op that costs one job row, and the mirror writes nothing
-	// when the ledger has not changed.
-	_, err := conn.Exec(ctx,
-		`INSERT INTO river_job (state, kind, queue, priority, max_attempts, args, scheduled_at)
-		 VALUES ('available', 'finance_sync', 'default', 1, 3, jsonb_build_object('workspace_id', $1::text), now())`,
-		workspaceID)
-	if err != nil {
-		return fmt.Errorf("requesting a finance sync: %w", err)
-	}
-	fmt.Println("finance sync:  requested — invoices and payments arrive with the next worker pass")
-	return nil
 }
 
 // orgIDsByDomain re-reads the seeded organizations so the finance phase can

--- a/backend/tools/seed-demo/nightlypasses.go
+++ b/backend/tools/seed-demo/nightlypasses.go
@@ -3,33 +3,17 @@
 
 package main
 
-// Asking the nightly passes to run once, at the end of a seed.
-//
-// Three jobs fill the two surfaces a demo opens on. The close-date corrector
-// and the follow-up reconciler stage the worklist's cards: one asks a human to
-// confirm the real date on a deal that has gone quiet, the other proposes the
-// reply nobody sent. The morning brief ranks the deals themselves. All three
-// are nightly and all three read a deal's age — so on a freshly seeded
-// installation they have nothing to say for a day, and both surfaces are empty.
-//
-// That empty screen reads as a broken feature rather than a young database, and
-// it is not one somebody can wait out: the sweeps did already run, at boot,
-// against deals that did not exist yet. This is the same failure the finance
-// sync hit (see requestFinanceSync) and it is asked the same way — a row on
-// River's queue, which is how the scheduler itself asks. Reaching into the
-// deals module instead would be a second way to start a pass that already has
-// one.
-//
-// Ordering is the whole point of running this LAST. The passes read
-// last_activity_at, which the mailbox seeding sets when it writes the
-// correspondence; asked before that, they would look at deals whose newest
-// activity is their own creation and find nothing stale.
+// Request the scheduled readers after the seed has finished writing their inputs.
+// The scheduler may already have run against the empty installation at boot.
+// Queueing its declared jobs lets the production workers fill the demo surfaces.
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
 )
 
 // requestNightlyWorklistPasses opens the owner connection and asks for one run
@@ -53,7 +37,7 @@ func requestNightlyWorklistPasses(dsn string, mode runMode) (err error) {
 			err = fmt.Errorf("closing the connection that requested the worklist passes: %w", closeErr)
 		}
 	}()
-	// One transaction over all three requests. Half a worklist is worse than
+	// One transaction over all requests. Half a worklist is worse than
 	// none: the surface fills with close-date cards and silently lacks the
 	// follow-ups, which reads as a working feature with nothing to say rather
 	// than as a seed that failed. The brief's delete joins it for the same
@@ -82,16 +66,17 @@ func requestNightlyWorklistPasses(dsn string, mode runMode) (err error) {
 // true. Printing inside the transaction would announce passes that a failed
 // commit then threw away.
 func reportRequestedPasses(cleared int64) {
+	fmt.Println("weekly review: requested — existing frozen reviews are retained; new reviews use the seeded records")
+	fmt.Println("finance sync:  requested — invoices and payments arrive with the next worker pass")
 	fmt.Println("worklist:      close-date and follow-up passes requested — " +
 		"cards arrive with the next worker pass")
 	fmt.Printf("brief:         %d empty run(s) cleared, morning brief requested — "+
 		"it fills once the installation's morning hour has arrived\n", cleared)
 }
 
-// nightlyWorklistJobs are the passes that stage the worklist's cards. Both are
-// workspace-scoped fan-outs: the job layer expands them per workspace, which is
-// why neither takes a workspace id here.
-var nightlyWorklistJobs = []string{"close_date_sweep", "follow_up_reconcile"}
+// nightlyWorklistJobs populate finance and the worklist after all records and
+// customer links exist. Each dispatcher resolves its own workspace population.
+var nightlyWorklistJobs = []string{"finance_sync_sweep", "close_date_sweep", "follow_up_reconcile", "weekly_review_generate"}
 
 // requestNightlyPasses queues one run of each worklist pass.
 //
@@ -105,9 +90,7 @@ var nightlyWorklistJobs = []string{"close_date_sweep", "follow_up_reconcile"}
 // failing over a queue nobody is reading.
 func requestNightlyPasses(ctx context.Context, tx pgx.Tx) error {
 	for _, kind := range nightlyWorklistJobs {
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO river_job (state, kind, queue, priority, max_attempts, args, scheduled_at)
-			 VALUES ('available', $1, 'default', 1, 3, '{}'::jsonb, now())`, kind); err != nil {
+		if err := requestSeedPass(ctx, tx, kind); err != nil {
 			return fmt.Errorf("requesting the %s pass: %w", kind, err)
 		}
 	}
@@ -151,10 +134,22 @@ func requestTheMorningBrief(ctx context.Context, tx pgx.Tx) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("clearing the empty brief runs this seed outran: %w", err)
 	}
-	if _, err := tx.Exec(ctx,
-		`INSERT INTO river_job (state, kind, queue, priority, max_attempts, args, scheduled_at)
-		 VALUES ('available', 'brief_generate', 'default', 1, 3, '{}'::jsonb, now())`); err != nil {
+	if err := requestSeedPass(ctx, tx, "brief_generate"); err != nil {
 		return 0, fmt.Errorf("requesting the morning brief: %w", err)
 	}
 	return cleared.RowsAffected(), nil
+}
+
+// requestSeedPass refuses stale job names before the seed can announce success.
+// The declaration owns the queue and whether an empty payload is meaningful.
+func requestSeedPass(ctx context.Context, tx pgx.Tx, kind string) error {
+	spec, ok := jobs.SpecFor(kind)
+	if !ok || len(spec.Args) != 0 {
+		return fmt.Errorf("seed pass %q is not a declared, argument-free job", kind)
+	}
+	_, err := tx.Exec(ctx,
+		`INSERT INTO river_job (state, kind, queue, priority, max_attempts, args, scheduled_at)
+		 VALUES ('available', @kind, @queue, 1, 3, '{}'::jsonb, now())`,
+		pgx.NamedArgs{"kind": kind, "queue": spec.Queue})
+	return err
 }

--- a/backend/tools/seed-demo/nightlypasses_integration_test.go
+++ b/backend/tools/seed-demo/nightlypasses_integration_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+)
+
+func TestSeedPassesQueueRegisteredJobsAfterTheRecordsExist(t *testing.T) {
+	ctx := context.Background()
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("run through make test-it with a private database")
+	}
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := tx.Rollback(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	if _, err := tx.Exec(ctx, "DELETE FROM river_job"); err != nil {
+		t.Fatal(err)
+	}
+	if err := requestNightlyPasses(ctx, tx); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := tx.Query(ctx, "SELECT kind, queue, args::text FROM river_job ORDER BY kind")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for rows.Next() {
+		var kind, queue, args string
+		if err := rows.Scan(&kind, &queue, &args); err != nil {
+			t.Fatal(err)
+		}
+		spec, ok := jobs.SpecFor(kind)
+		if !ok || queue != spec.Queue || args != "{}" {
+			t.Fatalf("invalid seed job %s/%s/%s", kind, queue, args)
+		}
+		found[kind] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	rows.Close()
+	if !found["finance_sync_sweep"] || !found["weekly_review_generate"] {
+		t.Fatalf("seed omitted finance or weekly review: %v", found)
+	}
+	if err := requestSeedPass(ctx, tx, "finance_sync"); err == nil {
+		t.Fatal("retired job name was accepted")
+	}
+}

--- a/docs/handbook/approvals.md
+++ b/docs/handbook/approvals.md
@@ -155,9 +155,9 @@ Every step here is one you take yourself.
    routes the text through the normaliser that numbers the lines, and those line
    numbers are what the evidence below points at.
 4. **Log**.
-5. Open **History**, find the meeting, and click **Read transcript**. Margince
-   does not read it on upload — you ask for the read, and this is the step that
-   asks.
+5. Open **History** and find the meeting. Margince queues a reading when you
+   log a transcript. If no reading is underway or complete, click **Read
+   transcript** to request one.
 6. Wait for **Done**. It reports what it found: "{count} next steps waiting for
    your review", or "Read in full. This conversation states no next steps."
 7. Go to the **Worklist**, then **Decisions**. A busy queue can bury a new
@@ -168,9 +168,9 @@ Every step here is one you take yourself.
 9. **Approve** to create the task, or **Reject** with a reason. An approved
    proposal becomes an ordinary task on the contact and on their company.
 
-What this does **not** do: it does not send anything, and it does not act
-without the read in step 5 and the answer in step 9. A transcript sitting in an
-activity has proposed nothing until you ask it to.
+What this does **not** do: it does not send anything or create tasks without
+your approval. Reading the transcript proposes next steps; accepting a proposal
+is what creates its task.
 
 ## Where you see them
 

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -13,7 +13,7 @@
   "agents": [
     {
       "name": "morning_brief",
-      "goal": "Assemble the Morning Brief for this workspace: enumerate open deals, read the ones with recent activity, and produce a ranked list (at most 7) of deals the team can win this week. For each: why it is on the list, what changed recently, and one recommended next move — every claim grounded in a record you actually read, citing its id. A quiet day yields a short list; never pad it.",
+      "goal": "Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.",
       "tools": [
         "annotate_brief",
         "catch_me_up_on",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -36,7 +36,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 
 ### `morning_brief`
 
-> Assemble the Morning Brief for this workspace: enumerate open deals, read the ones with recent activity, and produce a ranked list (at most 7) of deals the team can win this week. For each: why it is on the list, what changed recently, and one recommended next move — every claim grounded in a record you actually read, citing its id. A quiet day yields a short list; never pad it.
+> Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.
 
 Attaches 5 tools for 1634 tokens, leaving 15774 of its budget and 22942 tokens of the
 window for the goal, the grounding and everything it reads.

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -1,9 +1,9 @@
 {
   "totals": {
     "sites": 40,
-    "sites_best_current": 31,
+    "sites_best_current": 30,
     "sites_best_partial": 0,
-    "sites_best_stale": 7,
+    "sites_best_stale": 8,
     "sites_absent": 2,
     "scenarios": 136,
     "records": 59,
@@ -17,9 +17,9 @@
         "env": "eu_hosted"
       },
       "sites": 20,
-      "sites_current": 15,
+      "sites_current": 14,
       "sites_partial": 1,
-      "sites_stale": 4,
+      "sites_stale": 5,
       "runs": 236,
       "passed": 215,
       "reliability": 0.9110169491525424,
@@ -157,9 +157,9 @@
         "env": "eu_hosted"
       },
       "sites": 6,
-      "sites_current": 6,
+      "sites_current": 5,
       "sites_partial": 0,
-      "sites_stale": 0,
+      "sites_stale": 1,
       "runs": 42,
       "passed": 39,
       "reliability": 0.9285714285714286,
@@ -1467,17 +1467,8 @@
       "key": "corpus_ask/corpus_ask",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "corpus_ask_answers_only_from_the_passage_that_says_it",
@@ -1502,7 +1493,7 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 3,
@@ -1517,7 +1508,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         },
         {
           "binding": {
@@ -1525,9 +1516,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -1540,7 +1531,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer"
         }
       ]
     },

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -25,9 +25,9 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | | |
 |---|---:|
 | Shipped invocation sites | 40 |
-| … best state `current` | 31 |
+| … best state `current` | 30 |
 | … best state `partial` | 0 |
-| … best state `stale` | 7 |
+| … best state `stale` | 8 |
 | … `absent` on every binding | 2 |
 | Scenarios in the corpus | 136 |
 | Committed records | 59 |
@@ -90,7 +90,7 @@ Which model to run each site on, and what that choice rests on.
 | [`cold_start/company_message`](#cold_startcompany_message) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
 | [`cold_start/field_extract`](#cold_startfield_extract) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
 | [`cold_start/sitereadmessage`](#cold_startsitereadmessage) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `supported_degraded` | 0.83 | `current` | 2 | 3 |
-| [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
+| [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | - | - | - | `stale` | 3 | 2 |
 | [`deal_health/deal_status`](#deal_healthdeal_status) | - | - | - | `stale` | 3 | 1 |
 | [`document_extract/fields`](#document_extractfields) | `gemini · gemini-3.5-flash · eu_hosted` | `certified` | 1.00 | `current` | 4 | 1 |
 | [`draft_reply/account`](#draft_replyaccount) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
@@ -141,14 +141,14 @@ verdict each reached. Each record's own p50 and p95 are in the site tables.
 
 | Provider | Model | Env | Sites | `current` | `partial` | `stale` | Runs | Passed | Reliability | Slowest p95 | `certified` | `supported_degraded` | `not_supported` |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 20 | 15 | 1 | 4 | 236 | 215 | 0.91 | 3370ms | 13 | 1 | 6 |
+| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 20 | 14 | 1 | 5 | 236 | 215 | 0.91 | 3370ms | 13 | 1 | 6 |
 | `gemini` | `gemini-3.1-pro-preview` | `eu_hosted` | 3 | 0 | 0 | 3 | 18 | 18 | 1.00 | 44515ms | 2 | 0 | 1 |
 | `gemini` | `gemini-3.5-flash` | `eu_hosted` | 9 | 6 | 0 | 3 | 63 | 59 | 0.94 | 20319ms | 7 | 0 | 2 |
 | `openai_compatible` | `anthropic/claude-haiku-4.5` | `eu_hosted` | 1 | 1 | 0 | 0 | 15 | 9 | 0.60 | 3731ms | 0 | 0 | 1 |
 | `openai_compatible` | `mistralai/ministral-14b-2512` | `cloud_frontier` | 11 | 0 | 0 | 11 | 160 | 113 | 0.71 | 20620ms | 8 | 0 | 3 |
 | `openai_compatible` | `mistralai/ministral-8b-2512` | `cloud_frontier` | 3 | 0 | 0 | 3 | 15 | 14 | 0.93 | 22390ms | 1 | 2 | 0 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
-| `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 6 | 0 | 0 | 42 | 39 | 0.93 | 4477ms | 5 | 0 | 1 |
+| `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 5 | 0 | 1 | 42 | 39 | 0.93 | 4477ms | 5 | 0 | 1 |
 | `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 31 | 23 | 0 | 8 | 333 | 269 | 0.81 | 68516ms | 12 | 7 | 12 |
 | `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
 
@@ -179,6 +179,8 @@ model, real network).
 | `cold_start/company_message` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/field_extract` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/sitereadmessage` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `corpus_ask/corpus_ask` | `gemini · gemini-3.1-flash-lite · eu_hosted` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `corpus_ask/corpus_ask` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer |
 | `deal_health/deal_status` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is |
 | `draft_reply/account` | `gemini · gemini-3.1-pro-preview · eu_hosted` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `draft_reply/account` | `gemini · gemini-3.5-flash · eu_hosted` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
@@ -479,8 +481,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | - | `certified` | 9 | 9 | 1.00 | 895ms | 1457ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1366ms | 4299ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | - | `certified` | 9 | 9 | 1.00 | 895ms | 1457ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1366ms | 4299ms | 9 | 0 | 0 | 0 |
 
 ### `deal_health`
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -122,6 +122,8 @@ describe("the custom-fields admin, at its address inside settings", () => {
   });
 
   it("mounts the field builder on the Data model page", async () => {
+    // Routing is under test; wait for the real lazy module before timing UI queries.
+    await import("./screens/settings");
     // Every query the surface fires must resolve, or QueryGate paints its error
     // card instead of the heading: /me (an admin holding the custom_field write
     // the entry is gated on), the per-object field list, and the audit rail.
@@ -218,6 +220,7 @@ describe("extension routes (vanilla registry)", () => {
 
 describe("locale switch", () => {
   it("mounts in English (A100) and flips the chrome to German on switch", async () => {
+    await import("./screens/settings");
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -19707,16 +19707,15 @@ export interface components {
         };
         /**
          * @description The one thing to do next, and what performing it means. `action` is one of
-         *     `draft_email`, `create_task`, `open_meeting_brief`, `none` — the same verbs
-         *     the retired next-best-action carried, so a client that already performs them
-         *     needs no new code. `arguments` is the body or operand the verb takes, ready
+         *     `draft_email`, `create_task`, `open_task`, `open_meeting_brief`, `none`.
+         *     `open_task` opens existing work without creating another task. `arguments` is the body or operand the verb takes, ready
          *     to send; absent for `none`.
          */
         DealStatusCardMove: {
             action: string;
             /** @description One sentence saying why this move and not another. */
             reason: string;
-            /** @description `draft_email` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body. */
+            /** @description `draft_email`, `open_task` and `open_meeting_brief` carry `{activity_id}`; `create_task` carries a `CreateTaskRequest` body. */
             arguments?: {
                 [key: string]: unknown;
             };
@@ -30875,7 +30874,7 @@ export interface components {
              *     and no thread behind it.
              *
              *     `draft_email` opens a new message, `create_task` agrees a next step,
-             *     `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
+             *     `open_task` opens existing work, `open_meeting_brief` reads the brief before a booked meeting, and `reconnect`
              *     sends the reader to reauthorize a source that stopped answering.
              *
              *     `none` is a producer's answer that there is nothing to do — a closed deal has
@@ -30885,7 +30884,7 @@ export interface components {
              *     client that meets one anyway draws nothing, which is the same outcome.
              * @enum {string}
              */
-            action: "draft_reply" | "draft_email" | "create_task" | "open_meeting_brief" | "reconnect" | "none";
+            action: "draft_reply" | "draft_email" | "create_task" | "open_task" | "open_meeting_brief" | "reconnect" | "none";
             /**
              * Format: uuid
              * @description The record the verb acts on, where the verb acts on one: the message for

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -241,6 +241,13 @@ export const de = {
   "search.tier.mirrored": "aus einem verbundenen System",
   "search.tier.unverified": "nicht verifiziert",
 
+  "context.recentTouches": "Letzte Gespräche",
+  "context.openTasks": "Offene Aufgaben",
+  "context.relatedPeople": "Zugehörige Personen",
+  "context.relatedCompanies": "Zugehörige Unternehmen",
+  "context.relatedProjects": "Verknüpfte Projekte",
+  "context.whoKnows": "Wer sie kennt",
+  "context.relatedDeals": "Zugehörige Deals",
   "context.title": "Verwandte Belege",
   "context.empty": "Noch nichts Verwandtes.",
 
@@ -3237,7 +3244,7 @@ export const de = {
     "Das ist eine Antwort auf ihre eigene Nachricht — dafür brauchst du keinen Grund anzugeben.",
   "compose.sendLaterLabel": "Später senden (optional)",
   "compose.send": "Senden",
-  "compose.sendConfirmTitle": "Diese E-Mail senden?",
+  "compose.sendConfirmTitle": "E-Mail entwerfen",
   "compose.threadHeading": "Dieser Verlauf",
   "compose.continueHeading": "Einen Verlauf fortsetzen?",
   "compose.threadLeave": "Anderen wählen",
@@ -3246,7 +3253,7 @@ export const de = {
   "compose.threadContinuing": "Der letzte Austausch, den dies fortsetzt",
   "compose.threadPending": "Verlauf wird geladen\u2026",
   "compose.sendBody":
-    "Sie senden diese E-Mail jetzt. Dies ist eine ausgehende, unwiderrufliche Aktion.",
+    "Prüfen und bearbeiten Sie Ihren Entwurf. Ein Klick auf Senden verschickt die E-Mail und kann nicht rückgängig gemacht werden.",
   "compose.schedule": "Einplanen",
   "compose.scheduleConfirmTitle": "Diese E-Mail einplanen?",
   // The composer computed that it had scheduled a send and said nothing —
@@ -4440,7 +4447,7 @@ export const de = {
   "overnightGrant.help":
     "Es liest deine Deals und E-Mails, um zu ordnen, was heute wichtig ist, und schreibt Notizen zurück. Senden kann es nicht: die Erlaubnis hier deckt Lesen und Schreiben ab, niemals Senden.",
   "overnightGrant.danger":
-    "ACHTUNG: Ohne diese Freigabe bleiben dein Morgen-Überblick, deine Arbeitsliste und dein Wochenrückblick leer. Das sind die Bildschirme, mit denen Margince startet — der größte Teil des Produkts wirkt dann, als würde er nicht funktionieren.",
+    "Ohne diese Berechtigung kann der Agent Ihren Brief über Nacht weder lesen noch kommentieren. Ihre Datensätze, Arbeitsliste und der geplante Wochenrückblick bleiben verfügbar.",
   "overnightGrant.saveFailed":
     "Deine Antwort auf die Nacht-Frage konnte nicht gespeichert werden. Alles andere ist verbunden — stelle es unter Einstellungen → Verbindungen ein, sobald du drin bist.",
   "overnightGrant.renew":
@@ -5657,6 +5664,7 @@ export const de = {
   "recordmail.send": "E-Mail schreiben",
   "deal360.rewrite": "Neu schreiben",
   "deal360.readFull": "Vollständige Einschätzung lesen",
+  "deal360.openTask": "Vorhandene Aufgabe öffnen",
   "deal360.createTask": "Aufgabe anlegen",
   "deal360.openBrief": "Meeting-Briefing öffnen",
   "deal360.unreadable":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -262,6 +262,13 @@ export const en = {
   "search.tier.mirrored": "from a connected system",
   "search.tier.unverified": "unverified",
 
+  "context.recentTouches": "Recent conversations",
+  "context.openTasks": "Open tasks",
+  "context.relatedPeople": "Related people",
+  "context.relatedCompanies": "Related companies",
+  "context.relatedProjects": "Related projects",
+  "context.whoKnows": "Who knows them",
+  "context.relatedDeals": "Related deals",
   "context.title": "Related evidence",
   "context.empty": "Nothing related yet.",
 
@@ -3301,7 +3308,7 @@ export const en = {
     "This continues their own message, so it needs no reason from you.",
   "compose.sendLaterLabel": "Send later (optional)",
   "compose.send": "Send",
-  "compose.sendConfirmTitle": "Send this email?",
+  "compose.sendConfirmTitle": "Draft email",
   "compose.threadHeading": "This conversation",
   "compose.continueHeading": "Continue a conversation?",
   "compose.threadLeave": "Choose another",
@@ -3310,7 +3317,7 @@ export const en = {
   "compose.threadContinuing": "The last exchange, which this will continue",
   "compose.threadPending": "Loading the conversation\u2026",
   "compose.sendBody":
-    "You are sending this email now. This is an outbound, irreversible action.",
+    "Review and edit your draft. Clicking Send sends this email and cannot be undone.",
   // A moment picked in the field above turns this dialog into a different
   // promise, so it says a different thing. The three sentences it replaces all
   // claim the send is happening NOW and is irreversible; a scheduled message is
@@ -4508,7 +4515,7 @@ export const en = {
   "overnightGrant.help":
     "It reads your deals and mail to rank what needs you today, and writes notes back. It cannot send: the permission you give here covers reading and writing only, never sending.",
   "overnightGrant.danger":
-    "Without this, your morning brief, your worklist lanes and your weekly review stay empty. These are the screens Margince opens on, so most of the product will look like it is not working.",
+    "Without this permission, the overnight agent cannot read or annotate your brief. Your records, worklist and scheduled weekly review remain available.",
   "overnightGrant.saveFailed":
     "Your answer to the overnight question could not be saved. Everything else is connected — set it under Settings → Connections when you are in.",
   "overnightGrant.renew":
@@ -5755,6 +5762,7 @@ export const en = {
   "recordmail.send": "Write email",
   "deal360.rewrite": "Write it again",
   "deal360.readFull": "Read the full briefing",
+  "deal360.openTask": "Open existing task",
   "deal360.createTask": "Add this task",
   "deal360.openBrief": "Open the meeting brief",
   "deal360.unreadable":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -247,6 +247,13 @@ export const vi = {
   "search.tier.mirrored": "từ hệ thống đã kết nối",
   "search.tier.unverified": "chưa xác minh",
 
+  "context.recentTouches": "Trao đổi gần đây",
+  "context.openTasks": "Công việc đang mở",
+  "context.relatedPeople": "Người liên quan",
+  "context.relatedCompanies": "Công ty liên quan",
+  "context.relatedProjects": "Dự án liên quan",
+  "context.whoKnows": "Ai biết họ",
+  "context.relatedDeals": "Cơ hội liên quan",
   "context.title": "Bằng chứng liên quan",
   "context.empty": "Chưa có gì liên quan.",
 
@@ -3207,7 +3214,7 @@ export const vi = {
     "Đây là trả lời tin nhắn của chính họ, nên bạn không cần nêu lý do.",
   "compose.sendLaterLabel": "Gửi sau (tùy chọn)",
   "compose.send": "Gửi",
-  "compose.sendConfirmTitle": "Gửi email này?",
+  "compose.sendConfirmTitle": "Soạn email",
   "compose.threadHeading": "Cuộc trao đổi này",
   "compose.continueHeading": "Tiếp nối một cuộc trao đổi?",
   "compose.threadLeave": "Chọn cuộc khác",
@@ -3216,7 +3223,7 @@ export const vi = {
   "compose.threadContinuing": "Lần trao đổi gần nhất, mà thư này tiếp nối",
   "compose.threadPending": "Đang tải cuộc trao đổi\u2026",
   "compose.sendBody":
-    "Bạn đang gửi email này ngay bây giờ. Đây là hành động gửi ra ngoài, không đảo ngược được.",
+    "Xem lại và chỉnh sửa bản nháp. Nhấn Gửi sẽ gửi email và không thể hoàn tác.",
   "compose.schedule": "Hẹn giờ",
   "compose.scheduleConfirmTitle": "Hẹn giờ gửi email này?",
   // The composer computed that it had scheduled a send and said nothing —
@@ -4390,7 +4397,7 @@ export const vi = {
   "overnightGrant.help":
     "Nó đọc thương vụ và email của bạn để sắp xếp việc gì cần bạn hôm nay, và ghi ghi chú trở lại. Nó không thể gửi: quyền bạn cấp ở đây chỉ gồm đọc và ghi, không bao giờ gửi.",
   "overnightGrant.danger":
-    "NGUY HIỂM: Không có quyền này, bản tóm tắt buổi sáng, danh sách công việc và bản đánh giá tuần của bạn sẽ trống. Đó là những màn hình Margince mở đầu tiên — phần lớn sản phẩm sẽ trông như không hoạt động.",
+    "Nếu không cấp quyền này, trợ lý không thể đọc hoặc thêm ghi chú vào bản tin qua đêm. Dữ liệu, danh sách công việc và bản tổng kết tuần theo lịch vẫn có sẵn.",
   "overnightGrant.saveFailed":
     "Không lưu được câu trả lời của bạn cho câu hỏi ban đêm. Mọi thứ khác đã được kết nối — hãy đặt lại trong Cài đặt → Kết nối khi bạn vào.",
   "overnightGrant.renew":
@@ -5603,6 +5610,7 @@ export const vi = {
   "recordmail.send": "Viết email",
   "deal360.rewrite": "Viết lại",
   "deal360.readFull": "Đọc bản tóm tắt đầy đủ",
+  "deal360.openTask": "Mở công việc hiện có",
   "deal360.createTask": "Thêm việc này",
   "deal360.openBrief": "Mở bản tóm tắt cuộc họp",
   "deal360.unreadable":

--- a/frontend/src/screens/analytics.coverage.test.tsx
+++ b/frontend/src/screens/analytics.coverage.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { viewerZone } from "../format/timezone";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { AnalyticsScreen } from "./analytics";
+
+afterEach(() => {
+  cleanup();
+  window.location.hash = "";
+  vi.unstubAllGlobals();
+});
+
+it("explains a bookmarked coverage page without fetching a forbidden panel", async () => {
+  const fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const body = url.endsWith("/me")
+      ? meFixture({ roles: ["rep"], allow: {} })
+      : url.includes("/analytics/context")
+        ? {
+            default_scope: { kind: "workspace", label: "Workspace" },
+            allowed_scopes: [{ kind: "workspace", label: "Workspace" }],
+            capabilities: {},
+            timezone: viewerZone(),
+            base_currency: "EUR",
+          }
+        : { data: [] };
+    return new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetch);
+  window.location.hash = "#/analytics/coverage";
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <AnalyticsScreen />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText(en["common.permissionDenied"])).toBeTruthy();
+  expect(
+    fetch.mock.calls.some(([input]) =>
+      String(input instanceof Request ? input.url : input).includes(
+        "/analytics/coverage",
+      ),
+    ),
+  ).toBe(false);
+});

--- a/frontend/src/screens/analytics.stories.tsx
+++ b/frontend/src/screens/analytics.stories.tsx
@@ -142,6 +142,18 @@ const derivation = {
 
 const routes: RouteMap = {
   "GET /me": meRoute({}),
+  "GET /analytics/context": () =>
+    jsonResponse({
+      default_scope: { kind: "workspace", label: "Whole workspace" },
+      allowed_scopes: [{ kind: "workspace", label: "Whole workspace" }],
+      capabilities: {
+        view_manager_forecast: true,
+        submit_manager_forecast: true,
+      },
+      as_of: "2026-09-04T00:00:00Z",
+      timezone: "Europe/Berlin",
+      base_currency: "EUR",
+    }),
   "GET /pipelines": () => jsonResponse(pipelines),
   "POST /reports/pipeline-current": () => run("pipeline-current", stageRows),
   "POST /reports/forecast": () => run("forecast", forecastRows),
@@ -236,9 +248,7 @@ export const Performance: Story = {
   play: clickButton("Performance"),
 };
 
-// The seat's own outcomes: pipeline and meetings under an owner lens. Its own
-// route map, because serving /analytics/context to every story above would
-// grow a scope picker into renders that exist to show something else.
+// The seat's own outcomes: pipeline and meetings under an owner lens.
 const ownLensRoutes: RouteMap = {
   ...routes,
   "GET /analytics/context": () =>
@@ -324,7 +334,10 @@ export const Delivery: Story = {
 
 export const DataCoverage: Story = {
   render: () => {
-    installFetchStub(coverageRoutes);
+    installFetchStub({
+      ...coverageRoutes,
+      "GET /me": meRoute({ data_coverage: ["read"] }),
+    });
     return (
       <StoryProviders>
         <AnalyticsScreen />

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
+import { meFixture } from "../app/mefixture";
 import { formatMoney, MONEY_ABSENT } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
@@ -87,6 +88,19 @@ function reportsStub(opts: ReportsStubOpts = {}) {
     // numbers cover, and whether this reader may publish a forecast. A stub
     // without it leaves the screen waiting and the assertions below looking
     // like a rendering bug.
+    if (url.endsWith("/me")) {
+      return jsonResponse(
+        meFixture({
+          roles: ["rep"],
+          allow: {
+            data_coverage:
+              opts.coverage !== undefined && opts.coverage.status !== 403
+                ? ["read"]
+                : [],
+          },
+        }),
+      );
+    }
     if (url.includes("/analytics/coverage")) {
       const cov = opts.coverage ?? { status: 403 };
       return jsonResponse(
@@ -337,8 +351,9 @@ describe("the data coverage section", () => {
     ).toBeTruthy();
   });
 
-  it("hides the tab from a seat the server refuses", async () => {
-    vi.stubGlobal("fetch", reportsStub({ coverage: { status: 403 } }));
+  it("does not request coverage without the ops grant", async () => {
+    const fetch = reportsStub({ coverage: { status: 403 } });
+    vi.stubGlobal("fetch", fetch);
     render(<AnalyticsScreen />);
     await screen.findByRole("button", { name: "Pipeline" });
     await waitFor(() =>
@@ -346,6 +361,13 @@ describe("the data coverage section", () => {
         screen.queryByRole("button", { name: "Data coverage" }),
       ).toBeNull(),
     );
+    expect(
+      fetch.mock.calls.some(([input]) =>
+        String(input instanceof Request ? input.url : input).includes(
+          "/analytics/coverage",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -1,7 +1,8 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCan } from "../app/capability";
 import { ENTITY } from "../app/entity";
 import { navigate, routeHash, useRoute } from "../app/router";
 import {
@@ -708,6 +709,7 @@ const DERIVATION_HEADERS: Readonly<Record<string, MessageKey>> = {
   owner_id: "explain.col.owner",
   pipeline_id: "explain.col.pipeline",
   organization_id: "analytics.company",
+  partner_org_id: "analytics.company",
 };
 
 // A column the vocabulary knows gets its word; anything else keeps the wire
@@ -762,10 +764,23 @@ function renderDerivationCell(
   row: Record<string, unknown>,
   baseCurrency: string | null,
   locale: Locale,
-): string {
+): ReactNode {
   const value = row[col];
   if (value == null) {
     return "";
+  }
+  if (typeof value === "string" && value !== "") {
+    if (col === "pipeline_id")
+      return <DerivationPipelineName pipelineId={value} />;
+    if (col === "stage_id" && typeof row.pipeline_id === "string") {
+      return (
+        <DerivationPipelineName pipelineId={row.pipeline_id} stageId={value} />
+      );
+    }
+    if (col === "owner_id") return <EntityRef kind="user" id={value} />;
+    if (col === "organization_id" || col === "partner_org_id") {
+      return <EntityRef kind="organization" id={value} />;
+    }
   }
   if (col.endsWith("_minor") && typeof value === "number") {
     return formatMoneyOrAbsent(
@@ -775,6 +790,33 @@ function renderDerivationCell(
     );
   }
   return String(value);
+}
+
+function DerivationPipelineName({
+  pipelineId,
+  stageId,
+}: Readonly<{ pipelineId: string; stageId?: string }>) {
+  const t = useT();
+  const pipeline = useQuery({
+    queryKey: ["pipeline", pipelineId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/pipelines/{id}", {
+        params: { path: { id: pipelineId } },
+      });
+      if (error) throwProblem(error);
+      return data;
+    },
+  });
+  if (pipeline.isPending) return <>{t("common.loading")}</>;
+  if (pipeline.isError) return <>{t("common.error")}</>;
+  return (
+    <>
+      {stageId
+        ? (pipeline.data?.stages?.find((stage) => stage.id === stageId)?.name ??
+          t("common.empty"))
+        : pipeline.data?.name}
+    </>
+  );
 }
 
 // The source rows the explained figure reconciles to. A section INSIDE the
@@ -1084,6 +1126,10 @@ function DataCoverageView({
 }: Readonly<{ locale: Locale; timezone: string }>) {
   const t = useT();
   const coverage = useDataCoverage();
+  const allowed = useCan("data_coverage", "read");
+  if (!allowed) {
+    return <EmptyState>{t("common.permissionDenied")}</EmptyState>;
+  }
   return (
     <QueryGate query={coverage} pendingLabel={t("analytics.sectionCoverage")}>
       {(run) =>
@@ -1135,7 +1181,9 @@ function DataCoverageView({
 type DataCoverageRow = components["schemas"]["DataCoverage"]["sources"][number];
 
 function useDataCoverage() {
+  const allowed = useCan("data_coverage", "read");
   return useQuery({
+    enabled: allowed,
     queryKey: ["analytics-coverage"],
     retry: false,
     queryFn: async () => {
@@ -1724,6 +1772,7 @@ export function AnalyticsScreen() {
   // Sharing sits beside the tabs rather than inside a section, because the
   // thing being shared is the SECTION the reader is on — a button that moved
   // with the content would read as sharing one card.
+  const canReadCoverage = useCan("data_coverage", "read");
   const coverageProbe = useDataCoverage();
   const header = (
     <div className="analytics-header">
@@ -1733,10 +1782,9 @@ export function AnalyticsScreen() {
             return context.data?.default_scope.kind === "owner";
           }
           if (candidate === "coverage") {
-            // The server gates this read on the ops grant. The tab appears
-            // when the probe ANSWERS — hidden while pending, so a seat the
-            // server refuses never sees it flicker in and out.
-            return coverageProbe.isSuccess;
+            // The read starts only with the ops grant; the tab appears
+            // after the server has answered.
+            return canReadCoverage && coverageProbe.isSuccess;
           }
           return true;
         })}

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1675,7 +1675,7 @@ describe("ComposeModal — channel reply", () => {
     // Confirming an irreversible send under the name of a channel this
     // message will never travel on is a lie the rep cannot check.
     expect(screen.getByText("Send this message?")).toBeTruthy();
-    expect(screen.queryByText("Send this email?")).toBeNull();
+    expect(screen.queryByText("Draft email")).toBeNull();
     // The heading is the only place the channel is named, so it cannot also
     // be the only place the irreversibility is: the modal chrome around it
     // is a tier dot and two buttons.
@@ -1779,7 +1779,7 @@ describe("TimelineActions", () => {
     stubRoutes();
     render(<TimelineActions activity={note} entityType="deal" entityId="d1" />);
     await userEvent.click(screen.getByRole("button", { name: "Reply" }));
-    expect(await screen.findByText("Send this email?")).toBeTruthy();
+    expect(await screen.findByText("Draft email")).toBeTruthy();
   });
 
   it("opens the composer when Reply is clicked", async () => {
@@ -1788,8 +1788,8 @@ describe("TimelineActions", () => {
       <TimelineActions activity={email} entityType="deal" entityId="d1" />,
     );
     await userEvent.click(screen.getByRole("button", { name: "Reply" }));
-    // The ConfirmModal titled "Send this email?" mounts only once Reply opens it.
-    expect(await screen.findByText("Send this email?")).toBeTruthy();
+    // The ConfirmModal titled "Draft email" mounts only once Reply opens it.
+    expect(await screen.findByText("Draft email")).toBeTruthy();
   });
 
   it("offers no reply when the person is unreachable", async () => {

--- a/frontend/src/screens/context.tsx
+++ b/frontend/src/screens/context.tsx
@@ -8,6 +8,7 @@ import { ENTITY_KINDS, type EntityKind } from "../app/entity";
 import { Card, EmptyState } from "../design-system/atoms";
 import { EvidenceChip, toEvidence } from "../design-system/trust";
 import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import {
   OverlayUnavailable,
   QueryGate,
@@ -25,6 +26,15 @@ import "./context.css";
 // ContextEntityRef.type but not a 360) renders as plain text, same convention
 // as SearchHit in search.tsx.
 type ContextResponse = components["schemas"]["ContextResponse"];
+const SECTION_LABELS: Readonly<Record<string, MessageKey>> = {
+  recent_touches: "context.recentTouches",
+  open_tasks: "context.openTasks",
+  related_people: "context.relatedPeople",
+  related_organizations: "context.relatedCompanies",
+  related_deals: "context.relatedDeals",
+  related_projects: "context.relatedProjects",
+  who_knows: "context.whoKnows",
+};
 const LINKABLE = new Set<EntityKind>(ENTITY_KINDS);
 
 // The walk starts at the anchor, so the anchor comes back inside it — and a row
@@ -99,7 +109,11 @@ export function RecordContextPanel({
             <div className="context-sections">
               {sections.map((section) => (
                 <div key={section.name} className="context-section">
-                  <h3 className="t-label">{section.name}</h3>
+                  <h3 className="t-label">
+                    {SECTION_LABELS[section.name]
+                      ? t(SECTION_LABELS[section.name])
+                      : section.name.replaceAll("_", " ")}
+                  </h3>
                   <ul className="context-items">
                     {section.items.map((item) => {
                       const self = `${item.ref.type}:${item.ref.id}`;

--- a/frontend/src/screens/dealstatus.stories.tsx
+++ b/frontend/src/screens/dealstatus.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DealStatusCardPanel } from "./dealstatus";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+const meta: Meta = { title: "Records/Deal next step" };
+export default meta;
+type Story = StoryObj;
+
+export const ExistingTask: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": meRoute({ activity: ["read", "update"] }),
+      "GET /deals/demo-deal/status": () =>
+        jsonResponse({
+          deal_id: "demo-deal",
+          story: {
+            sentences: [
+              { text: "The buyer is reviewing the proposal.", evidence: [] },
+            ],
+          },
+          verdict: { standing: "live", because: { sentences: [] } },
+          next: {
+            action: "open_task",
+            reason: "Complete the existing task: Follow up on the proposal",
+            arguments: { activity_id: "demo-task" },
+            evidence: [
+              { activity_id: "demo-task", text: "Follow up on the proposal" },
+            ],
+          },
+          generated_at: "2026-09-05T09:00:00Z",
+          generated_by: "model",
+        }),
+      "GET /deals/demo-deal/coverage": () =>
+        jsonResponse({ stakeholders: [], risks: [] }),
+    });
+    return (
+      <StoryProviders>
+        <DealStatusCardPanel dealId="demo-deal" dealName="Demo proposal" />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/dealstatus.tsx
+++ b/frontend/src/screens/dealstatus.tsx
@@ -3,6 +3,7 @@ import { ListChecks, RefreshCw, Sparkles } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCan } from "../app/capability";
 import { navigate } from "../app/router";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
@@ -20,6 +21,7 @@ import {
   TodayPanel,
   WrittenBy,
 } from "./record360";
+import { TaskDetailModal, useTaskUpdate } from "./taskactions";
 import "./dealstatus.css";
 
 // Deal360 — the deal page's written briefing, read before a call, in the
@@ -354,6 +356,7 @@ function hasMoveControl(move: DealStatusCardMove): boolean {
   switch (move.action) {
     case "create_task":
       return Boolean(move.arguments);
+    case "open_task":
     case "open_meeting_brief":
       return activityIdOf(move) !== null;
     default:
@@ -396,6 +399,13 @@ function MoveButton({
   const t = useT();
   const queryClient = useQueryClient();
   const [briefOpen, setBriefOpen] = useState(false);
+  const [taskOpen, setTaskOpen] = useState(false);
+  const canUpdateTask = useCan("activity", "update");
+  const taskUpdate = useTaskUpdate([
+    ["deal-status", dealId],
+    ["tasks"],
+    ["worklist"],
+  ]);
   const activityId = activityIdOf(move);
   const createTask = useMutation({
     mutationKey: ["deal-status-create-task"],
@@ -419,6 +429,23 @@ function MoveButton({
 
   const taskBody = move.arguments;
   switch (move.action) {
+    case "open_task":
+      if (!activityId) return null;
+      return (
+        <>
+          <Button small onClick={() => setTaskOpen(true)}>
+            {t("deal360.openTask")}
+          </Button>
+          {taskOpen && (
+            <TaskDetailModal
+              activityId={activityId}
+              readOnly={!canUpdateTask}
+              onClose={() => setTaskOpen(false)}
+              update={taskUpdate}
+            />
+          )}
+        </>
+      );
     case "create_task":
       // No body, no button: a click that sent {} would only be refused.
       if (!taskBody) {

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -300,7 +300,7 @@ describe("a moment action that opens the composer", () => {
     await user.click(within(header).getByRole("button", { name: "Email" }));
 
     expect(
-      await screen.findByRole("dialog", { name: /Send this email/ }),
+      await screen.findByRole("dialog", { name: /Draft email/ }),
     ).toBeTruthy();
     expect(
       screen.queryByRole("textbox", { name: "What should it be about?" }),

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -174,6 +174,15 @@ describe("the verbs the row can and cannot take a reader to", () => {
   // THE distinction the wider vocabulary made necessary. One hardcoded label
   // was right while draft_reply was the only verb; over an opening outreach it
   // names a conversation nobody has had.
+  it("names existing work without promising an email", () => {
+    const item: WorklistItem = {
+      ...movingRow("open_task", "task-1"),
+      subject: { type: "deal", id: "d-1" },
+    };
+    expect(moveLabel(item, t)).toBe("Open existing task");
+    expect(moveHref(item)).toBeDefined();
+  });
+
   it("names a first message as writing, not as replying", () => {
     expect(moveLabel(movingRow("draft_email"), t)).toBe("Draft the email");
     expect(moveLabel(movingRow("draft_reply"), t)).toBe("Draft the reply");

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -539,6 +539,7 @@ const NAVIGABLE_MOVES = new Set([
   "draft_reply",
   "draft_email",
   "open_meeting_brief",
+  "open_task",
 ]);
 
 /**
@@ -553,7 +554,10 @@ const NAVIGABLE_MOVES = new Set([
  * and there is no earlier record for it to name.
  */
 function moveIsComplete(move: NonNullable<WorklistItem["move"]>): boolean {
-  return move.action !== "draft_reply" || move.activity_id !== undefined;
+  return (
+    !["draft_reply", "open_task"].includes(move.action) ||
+    move.activity_id !== undefined
+  );
 }
 
 /**
@@ -582,6 +586,7 @@ export function moveHref(item: WorklistItem): string | undefined {
     return briefHref(item);
   }
   const record = subjectHref(item);
+  if (move.action === "open_task") return record;
   if (!record || item.subject?.type !== "person") {
     return record;
   }
@@ -613,6 +618,7 @@ export function moveOpensComposer(item: WorklistItem): boolean {
 // composer opens, the verb is the act; where the link only reaches the record,
 // it says so.
 export function moveLabel(item: WorklistItem, t: T): string {
+  if (item.move?.action === "open_task") return t("deal360.openTask");
   const opens = moveOpensComposer(item);
   if (item.move?.action === "draft_email") {
     return t(


### PR DESCRIPTION
Fresh demo seeds queued a retired finance job, offline meetings stopped mailbox capture, and enabled recap starters had no drafting owner. This repair queues supported jobs, files meetings through their participants, and leaves recap starters paused until an authorized person enables them and becomes their owner. Existing invalid starters are paused by an additive, audited migration.

The demo also gains a written Ask answer with enough reasoning budget, corrected transcript instructions, a morning agent that annotates the person’s actual brief items, readable evidence references, permission-aware coverage pages, and clear draft wording. Deals with open work now offer **Open existing task** across the deal card and Worklist instead of creating another generic follow-up. Attribution snippets retain the sender’s own signature while excluding quoted history; full messages remain available.

Validation: all local merge-gate lanes exercised; failures corrected and their narrow lanes rerun. Real Postgres capture/automation, migration, seed-job, currency/freeze and draft-redelivery checks; 7,186 frontend tests across 578 files passing in the complete final run; frontend build and extension-screen tests; Storybook light and dark renders; independent Claude Opus review and correction pass. Browser verification includes 240 imported invoices, seven completed offline mailbox syncs, cited Ask answers, saved morning annotations, a recap held for approval, and opening the existing Algolia task. No emails sent.

Known follow-ups: #4422 covers preservation/recovery across the already-shipped historical frozen-amount migration. #4423 covers safe rebuilding of a weekly review generated before seeding; existing snapshots remain intact and the seed says so. A genuinely quiet previous week was verified, not manufactured wins.

Also corrected stale Analytics stories and lazy Settings test setup exposed by the full local checks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the demo seed so it queues only declared jobs, files meetings through their attendees, and leaves recap draft starters paused until an authorized person enables and owns them. Deals with open work now offer opening the existing task instead of creating a duplicate follow-up.

**Demo seed and starter ownership**
- Seeds queue `finance_sync_sweep` and `weekly_review_generate` through the declared job registry instead of retired names.
- Meetings reach companies through their attendees, matching live calendar capture.
- A migration pauses unowned `draft_email` automations; enabling one claims the enabler as owner once, with an audit entry.

**Next step and evidence quality**
- Deal cards with open work return `open_task` with the existing task id instead of `create_task`.
- Worklist and deal card link to the existing task, labeled "Open existing task".
- Evidence excerpts keep the sender's sign-off and exclude quoted history.
- Corpus Ask doubles its reasoning budget; the morning brief agent annotates the person's own brief items.

<sup>Written for commit 334c20061cb4e79c2022bad772b579d02d8b515f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

