### PR TITLE
fix(reports): a reference scope narrows only what the query names

### DIFF
--- a/backend/gates/analyticsscope_test.go
+++ b/backend/gates/analyticsscope_test.go
@@ -73,6 +73,10 @@ var composesItsOwnNarrowing = gatekit.Waive(map[string]string{
 	"referenceScopeClauses": "a DIFFERENT question: the row scope over the records a " +
 		"population POINTS AT, asked per declared reference rather than over the " +
 		"population's own rows. It is called alongside specScopeClauses, never instead",
+	"maskedDerivationSelects": "not a narrowing at all: it decides which COLUMN of a row " +
+		"the drill-through already returns comes back NULL, and adds no predicate. The rows " +
+		"it selects over are derivationWhere's, unchanged — a row whose reference this blanks " +
+		"is still counted by the aggregate beside it, which is the point",
 })
 
 func TestEveryPopulationsNarrowingsAreComposedInOnePlace(t *testing.T) {

--- a/backend/internal/compose/analyticsexplain.go
+++ b/backend/internal/compose/analyticsexplain.go
@@ -68,7 +68,7 @@ func ExplainAnalyticsCell(
 	// whole query, scope included. A drill-through narrowed differently from
 	// its own headline opens records the number never counted.
 	plan, err := analyticsquery.CompileExplain(
-		in, schema, analyticsScope(ctx, tx, spec, requestedFromQuery(in.Query)))
+		in, schema, analyticsScope(ctx, tx, spec, in.Query))
 	if err != nil {
 		return AnalyticsExplanation{}, err
 	}

--- a/backend/internal/compose/analyticsqueryrun.go
+++ b/backend/internal/compose/analyticsqueryrun.go
@@ -67,7 +67,7 @@ func RunAnalyticsQuery(
 	}
 
 	schema := AnalyticsSchemaFor(ctx)
-	plan, err := analyticsquery.Compile(q, schema, analyticsScope(ctx, tx, spec, requestedFromQuery(q)))
+	plan, err := analyticsquery.Compile(q, schema, analyticsScope(ctx, tx, spec, q))
 	if err != nil {
 		return AnalyticsAnswer{}, err
 	}
@@ -155,11 +155,60 @@ func refuseIfTheFilterHidesTooLittle(
 // is invisible to it. Written inline, swapping the whole composer for its scope
 // half passed the gate — which is the defect the gate exists to catch.
 func analyticsScope(
-	ctx context.Context, tx pgx.Tx, spec reportSpec, requested RequestedScope,
+	ctx context.Context, tx pgx.Tx, spec reportSpec, q analyticsquery.Query,
 ) analyticsquery.ScopeClauses {
+	named := namedByAnalyticsQuery(spec, q)
 	return func(arg func(any) int) ([]string, error) {
-		return specNarrowings(ctx, tx, spec, requested, arg)
+		return specNarrowings(ctx, tx, spec, requestedFromQuery(q), named, arg)
 	}
+}
+
+// namedByAnalyticsQuery is namedByReport for the typed grammar: every field the
+// query groups by, filters on or measures, resolved to the SQL the compiler
+// will render for it.
+//
+// EVERY field goes through one lookup, and that is the correction rather than a
+// tidy-up. The analytics schema a caller's field name is validated against is
+// the spec's dimensions and measures (analyticsqueryseam.go), NOT spec.filters
+// — those are the report engine's own filter vocabulary and a different map.
+// Resolving a filter through spec.filters therefore missed wherever the two
+// disagree, and open-deals-per-company is that spec: organization_id is a
+// dimension there and not a filter, so `filter organization_id eq <id>` bound
+// with no reference scope and answered whether a capture-private company
+// exists and how many deals point at it.
+//
+// One set serves both the answer and its explanation. CompileExplain selects
+// the group-bys and the measure fields — nothing wider — so the drill-through
+// cannot name a reference the headline did not, and the two read one row set
+// (explain.go: the explanation must not out-see the number).
+func namedByAnalyticsQuery(spec reportSpec, q analyticsquery.Query) referencedColumns {
+	named := make(referencedColumns, len(q.GroupBy)+len(q.Filters)+len(q.Measures))
+	// The compiler resolves a field name through the schema, which is built
+	// from these two maps and nothing else.
+	name := func(field string) {
+		if expr, ok := spec.dimensions[field]; ok {
+			named[expr] = true
+		}
+		if expr, ok := spec.measures[field]; ok {
+			named[expr] = true
+		}
+	}
+	for _, field := range q.GroupBy {
+		name(field)
+	}
+	for _, f := range q.Filters {
+		name(f.Field)
+	}
+	for _, m := range q.Measures {
+		// A measure's field may be a DIMENSION: count_distinct is not a
+		// numeric aggregate, so validateMeasures does not require KindMeasure
+		// for it, and count_distinct over a reference puts that reference in
+		// front of the caller through the explain's select list.
+		if m.Field != "" {
+			name(m.Field)
+		}
+	}
+	return named
 }
 
 // requestedFromQuery carries the stored question's scope words across to the

--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -102,113 +101,6 @@ type derivationOutcome struct {
 	AsOfPinned bool
 }
 
-// derivationURL mints the handle for one aggregate row (or, with a nil
-// row, for the whole filtered result). parseDerivationQuery is its exact
-// inverse; the round trip is unit-tested so a handle we mint always
-// resolves.
-func derivationURL(
-	report string, filters map[string]any, groupBy []string,
-	aggregates []reportAggregate, row map[string]any, asOf time.Time,
-) string {
-	values := url.Values{}
-	if !asOf.IsZero() {
-		values.Set(asOfKey, asOf.UTC().Format(time.RFC3339Nano))
-	}
-	for _, agg := range aggregates {
-		values.Add("agg", agg.Fn+":"+agg.Field+":"+agg.As)
-	}
-	filterKeys := make([]string, 0, len(filters))
-	for key := range filters {
-		filterKeys = append(filterKeys, key)
-	}
-	sort.Strings(filterKeys)
-	for _, key := range filterKeys {
-		setPredicate(values, key, filters[key])
-	}
-	if row != nil {
-		for _, dim := range groupBy {
-			values.Add("by", dim)
-			setPredicate(values, dim, row[dim])
-		}
-	}
-	return "/v1/reports/" + url.PathEscape(report) + "/derivation?" + values.Encode()
-}
-
-// setPredicate writes one bound field into the handle: an unset column is named
-// under nullPredicateKey, anything else carries its rendered value. Keeping the
-// two apart is what stops the empty string from reading as NULL.
-//
-//craft:ignore naked-any handle values arrive from JSON plan echoes and wire-shaped report rows — schemaless by design
-func setPredicate(values url.Values, key string, v any) {
-	if v == nil {
-		values.Add(nullPredicateKey, key)
-		return
-	}
-	values.Set(key, predicateString(v))
-}
-
-// predicateString renders a bound value for the handle's query string. Never
-// called with nil — setPredicate spells that case separately.
-//
-//craft:ignore naked-any handle values arrive from JSON plan echoes and wire-shaped report rows — schemaless by design
-func predicateString(v any) string {
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return fmt.Sprint(v)
-}
-
-// parseDerivationQuery reads a handle's query string back into the
-// typed form: `by` and `agg` are the reserved plan keys, every other
-// parameter is an equality predicate to be validated against the
-// report's closed vocabulary.
-func parseDerivationQuery(values url.Values) (derivationQuery, error) {
-	q := derivationQuery{Predicates: map[string]string{}, Unset: map[string]bool{}}
-	for key, vals := range values {
-		switch key {
-		case "by":
-			q.GroupBy = append(q.GroupBy, vals...)
-		case nullPredicateKey:
-			for _, field := range vals {
-				q.Unset[field] = true
-			}
-		case asOfKey:
-			if len(vals) != 1 {
-				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey}
-			}
-			at, err := time.Parse(time.RFC3339Nano, vals[0])
-			if err != nil {
-				return derivationQuery{}, &FieldNotAllowedError{Field: asOfKey + "=" + vals[0]}
-			}
-			q.AsOf = at
-		case "agg":
-			for _, v := range vals {
-				parts := strings.SplitN(v, ":", 3)
-				if len(parts) != 3 || parts[0] == "" {
-					return derivationQuery{}, &FieldNotAllowedError{Field: "agg=" + v}
-				}
-				q.Aggregates = append(q.Aggregates, reportAggregate{Fn: parts[0], Field: parts[1], As: parts[2]})
-			}
-		default:
-			if len(vals) != 1 {
-				// One cell binds one value per field; a repeated key is
-				// not a plan this engine ever minted.
-				return derivationQuery{}, &FieldNotAllowedError{Field: key}
-			}
-			q.Predicates[key] = vals[0]
-		}
-	}
-	sort.Strings(q.GroupBy)
-	for field := range q.Unset {
-		// One field cannot be both unset and equal to something; a handle
-		// saying both is not one this engine ever minted.
-		if _, ok := q.Predicates[field]; ok {
-			return derivationQuery{}, &FieldNotAllowedError{Field: field}
-		}
-	}
-	return q, nil
-}
-
 // boundExpr is one validated predicate: the vocabulary field, its fixed
 // SQL expression, and the bound value ("" = SQL NULL).
 type boundExpr struct {
@@ -236,6 +128,10 @@ type derivationPlan struct {
 	selects    []string
 	aggColumns []string
 	aggSelects []string
+	// groupBy names the dimensions the headline grouped by, from the handle's
+	// `by` keys — which is what tells this plan which references the number it
+	// explains was scoped by. A row handle also BINDS each one, in preds.
+	groupBy []string
 	// asOf is the instant the headline was computed at, from the handle. Zero
 	// for a handle minted before this key existed.
 	asOf time.Time
@@ -315,6 +211,7 @@ func compileDerivation(spec reportSpec, q derivationQuery) (derivationPlan, erro
 			return derivationPlan{}, &FieldNotAllowedError{Field: dim}
 		}
 		grouped[dim] = true
+		plan.groupBy = append(plan.groupBy, dim)
 	}
 	// Predicates admit the union of the report's dimensions and filters:
 	// a group-key value pins the cell, a filter value replays the plan.

--- a/backend/internal/compose/derivationfetch.go
+++ b/backend/internal/compose/derivationfetch.go
@@ -11,6 +11,8 @@ package compose
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -64,9 +66,25 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		}
 		whereSQL := strings.Join(where, " AND ")
 
+		// A reference this reader cannot open comes back NULL, and its row
+		// stays. That is what a normal deal read does with the same column
+		// (deals/fieldmask.go blanks the reference and keeps the deal), so the
+		// drill-through and the list its link opens describe one population.
+		//
+		// On its OWN argument slice, forked from the shared one. The mask binds
+		// the reader's scope values, and only the rows statement names them —
+		// Postgres rejects a parameter a statement never references, so letting
+		// these land in `args` would break the aggregate recompute below, which
+		// selects no reference at all.
+		rowArgs := slices.Clone(args)
+		rowArg := func(v any) int { rowArgs = append(rowArgs, v); return len(rowArgs) }
+		selects, err := maskedDerivationSelects(ctx, spec, plan, rowArg)
+		if err != nil {
+			return err
+		}
 		rowsSQL, rowsArgs, err := bindReportTokens(ctx, frame, fmt.Sprintf(
 			"SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %d",
-			strings.Join(plan.selects, ", "), spec.fromClause(), whereSQL, reportRowLimit), args)
+			strings.Join(selects, ", "), spec.fromClause(), whereSQL, reportRowLimit), rowArgs)
 		if err != nil {
 			return err
 		}
@@ -109,6 +127,95 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		}
 		return nil
 	})
+}
+
+// maskedDerivationSelects is plan.selects with each REFERENCE column wrapped so
+// that a row pointing at a record this caller cannot open returns NULL there
+// instead of the id.
+//
+// Masking rather than excluding, and the difference is the whole of it. The
+// drill-through returns every dimension the spec declares — that is deliberate,
+// so a reader can see why each record is in this group — which means it hands
+// back the partner id even when the number above it was a stage total. Dropping
+// those rows to avoid naming the partner would make the explanation smaller
+// than the number it explains. Blanking the column keeps both true: the row is
+// one this caller may read, and the reference is one they may not.
+//
+// It mirrors what an ordinary read of the same record already does
+// (deals/fieldmask.go blanks partner_org_id and keeps the deal), so a reader
+// who follows the link sees the same rows with the same holes.
+//
+// The aggregate recompute does NOT take this treatment and must not: it counts
+// rows, names no reference, and wrapping a column it never returns would only
+// make the two halves read different SQL for one row set.
+func maskedDerivationSelects(
+	ctx context.Context, spec reportSpec, plan derivationPlan, arg func(any) int,
+) ([]string, error) {
+	if len(spec.referenceScopes) == 0 {
+		return plan.selects, nil
+	}
+	// Only the references this plan actually RETURNS. A spec may scope a column
+	// it exposes as a filter alone (deals-by-stage scopes organization_id for
+	// that reason), and no select mentions it — while ScopeClauseFor registers a
+	// bind parameter for every column it is asked about. A parameter the
+	// finished statement never names is a Postgres error, not a no-op.
+	returned := make(map[string]bool, len(plan.columns))
+	for _, name := range plan.columns {
+		if expr, ok := spec.dimensions[name]; ok {
+			returned[expr] = true
+		}
+		if expr, ok := spec.measures[name]; ok {
+			returned[expr] = true
+		}
+	}
+	masks := make(map[string]string, len(spec.referenceScopes))
+	// Sorted, so one request renders one statement. Each mask binds its own
+	// parameter through arg, and map order would hand the same two references
+	// different positions from run to run — an irreproducible statement in a
+	// log, and no plan cache. referenceScopeClauses sorts for the same reason.
+	for _, column := range slices.Sorted(maps.Keys(spec.referenceScopes)) {
+		if !returned[column] {
+			continue
+		}
+		table := spec.referenceScopes[column]
+		scope, err := auth.ScopeClauseFor(ctx, table, "ref", arg)
+		if err != nil {
+			return nil, err
+		}
+		if scope == "" {
+			// An unbounded reader of that table: nothing to blank.
+			continue
+		}
+		masks[column] = fmt.Sprintf(
+			"(CASE WHEN EXISTS (SELECT 1 FROM %s ref WHERE ref.id = %s AND %s) THEN %s END)",
+			table, column, scope, column)
+	}
+	if len(masks) == 0 {
+		return plan.selects, nil
+	}
+	// plan.columns and plan.selects are built in one pass and stay aligned, so
+	// the column name at index i names the expression selected at index i.
+	//
+	// A column is a dimension or a measure (derivation.go appends both), and
+	// both are looked up: a spec that exposed a reference as a measure would
+	// otherwise return the id unmasked, which is a disclosure and not an error.
+	// TestNoMeasureCarriesAReference refuses that spec at the gate, and this
+	// stays honest either way rather than assuming the gate.
+	out := make([]string, len(plan.selects))
+	copy(out, plan.selects)
+	for i, name := range plan.columns {
+		expr, named := spec.dimensions[name]
+		if !named {
+			expr, named = spec.measures[name]
+		}
+		if !named {
+			continue
+		}
+		if mask, isReference := masks[expr]; isReference {
+			out[i] = mask + " AS " + name
+		}
+	}
+	return out, nil
 }
 
 // derivationWhere renders the drill-through's WHERE side: the report's
@@ -161,10 +268,11 @@ func derivationWhere(
 			where = append(where, population)
 		}
 	}
-	// The drill-through puts every dimension on its rows, so every reference
-	// the spec carries takes its row scope here too — the explanation must
-	// not out-see the number it explains.
-	refs, err := referenceScopeClauses(ctx, spec, arg)
+	// The drill-through puts every dimension on its rows, so a reference this
+	// plan RETURNS takes its row scope here — the explanation must not
+	// out-see the number it explains. A reference the plan never mentions is
+	// left alone, on the same terms as the headline (reportwhere.go).
+	refs, err := referenceScopeClauses(ctx, spec, namedByDerivation(spec, plan), arg)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/derivationhandle.go
+++ b/backend/internal/compose/derivationhandle.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The derivation handle's WIRE form: minting the URL that rides beside every
+// aggregate, and reading it back.
+//
+// Split from derivation.go, which resolves a parsed handle against a report's
+// vocabulary. The two change for unrelated reasons — a new query-string key is
+// this file, a new validation rule is that one — and the round trip is the
+// invariant this half owns: parseDerivationQuery is derivationURL's exact
+// inverse, and a handle the product mints always resolves.
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// derivationURL mints the handle for one aggregate row (or, with a nil
+// row, for the whole filtered result). parseDerivationQuery is its exact
+// inverse; the round trip is unit-tested so a handle we mint always
+// resolves.
+func derivationURL(
+	report string, filters map[string]any, groupBy []string,
+	aggregates []reportAggregate, row map[string]any, asOf time.Time,
+) string {
+	values := url.Values{}
+	if !asOf.IsZero() {
+		values.Set(asOfKey, asOf.UTC().Format(time.RFC3339Nano))
+	}
+	for _, agg := range aggregates {
+		values.Add("agg", agg.Fn+":"+agg.Field+":"+agg.As)
+	}
+	filterKeys := make([]string, 0, len(filters))
+	for key := range filters {
+		filterKeys = append(filterKeys, key)
+	}
+	sort.Strings(filterKeys)
+	for _, key := range filterKeys {
+		setPredicate(values, key, filters[key])
+	}
+	// The dimensions are NAMED whether or not a row pins their values, so that a
+	// drill-through scopes the same references its headline did. A result handle
+	// silent about its grouping could not tell a report grouped BY partner —
+	// which excludes the partners its reader cannot open — from one grouped by
+	// stage, which keeps them, and then opened rows the count never counted.
+	for _, dim := range groupBy {
+		values.Add("by", dim)
+		if row != nil {
+			setPredicate(values, dim, row[dim])
+		}
+	}
+	return "/v1/reports/" + url.PathEscape(report) + "/derivation?" + values.Encode()
+}
+
+// setPredicate writes one bound field into the handle: an unset column is named
+// under nullPredicateKey, anything else carries its rendered value. Keeping the
+// two apart is what stops the empty string from reading as NULL.
+//
+//craft:ignore naked-any handle values arrive from JSON plan echoes and wire-shaped report rows — schemaless by design
+func setPredicate(values url.Values, key string, v any) {
+	if v == nil {
+		values.Add(nullPredicateKey, key)
+		return
+	}
+	values.Set(key, predicateString(v))
+}
+
+// predicateString renders a bound value for the handle's query string. Never
+// called with nil — setPredicate spells that case separately.
+//
+//craft:ignore naked-any handle values arrive from JSON plan echoes and wire-shaped report rows — schemaless by design
+func predicateString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+// parseDerivationQuery reads a handle's query string back into the
+// typed form: `by` and `agg` are the reserved plan keys, every other
+// parameter is an equality predicate to be validated against the
+// report's closed vocabulary.
+func parseDerivationQuery(values url.Values) (derivationQuery, error) {
+	q := derivationQuery{Predicates: map[string]string{}, Unset: map[string]bool{}}
+	for key, vals := range values {
+		switch key {
+		case "by":
+			q.GroupBy = append(q.GroupBy, vals...)
+		case nullPredicateKey:
+			for _, field := range vals {
+				q.Unset[field] = true
+			}
+		case asOfKey:
+			at, err := parseHandleAsOf(vals)
+			if err != nil {
+				return derivationQuery{}, err
+			}
+			q.AsOf = at
+		case "agg":
+			aggregates, err := parseHandleAggregates(vals)
+			if err != nil {
+				return derivationQuery{}, err
+			}
+			q.Aggregates = append(q.Aggregates, aggregates...)
+		default:
+			if len(vals) != 1 {
+				// One cell binds one value per field; a repeated key is
+				// not a plan this engine ever minted.
+				return derivationQuery{}, &FieldNotAllowedError{Field: key}
+			}
+			q.Predicates[key] = vals[0]
+		}
+	}
+	sort.Strings(q.GroupBy)
+	for field := range q.Unset {
+		// One field cannot be both unset and equal to something; a handle
+		// saying both is not one this engine ever minted.
+		if _, ok := q.Predicates[field]; ok {
+			return derivationQuery{}, &FieldNotAllowedError{Field: field}
+		}
+	}
+	return q, nil
+}
+
+// parseHandleAsOf reads the instant the headline was computed at. One value,
+// RFC3339 with nanoseconds — the format derivationURL writes.
+func parseHandleAsOf(vals []string) (time.Time, error) {
+	if len(vals) != 1 {
+		return time.Time{}, &FieldNotAllowedError{Field: asOfKey}
+	}
+	at, err := time.Parse(time.RFC3339Nano, vals[0])
+	if err != nil {
+		return time.Time{}, &FieldNotAllowedError{Field: asOfKey + "=" + vals[0]}
+	}
+	return at, nil
+}
+
+// parseHandleAggregates reads the `fn:field:as` triples. The field may be empty
+// (count takes none); the function may not, or the handle names no aggregate.
+func parseHandleAggregates(vals []string) ([]reportAggregate, error) {
+	out := make([]reportAggregate, 0, len(vals))
+	for _, v := range vals {
+		parts := strings.SplitN(v, ":", 3)
+		if len(parts) != 3 || parts[0] == "" {
+			return nil, &FieldNotAllowedError{Field: "agg=" + v}
+		}
+		out = append(out, reportAggregate{Fn: parts[0], Field: parts[1], As: parts[2]})
+	}
+	return out, nil
+}

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -280,17 +280,27 @@ func (e *reportEngine) runSpec(ctx context.Context, report string, spec reportSp
 	}
 
 	req.Filters = withThresholdDefaults(spec, req.Filters)
-	groupBy := req.GroupBy
-	if len(groupBy) == 0 {
-		groupBy = spec.defaultBy
+	// What the caller asked for by name, kept before the defaults land: the
+	// grant check below refuses a field the caller NAMED and must not start
+	// refusing one the spec supplied for them.
+	asked := req.GroupBy
+	// The default group-by becomes the REQUEST's. Everything downstream that
+	// asks what this query groups by — the plan echo, the derivation handle,
+	// and the reference-scope set deciding which referenced records the answer
+	// may name — reads req. A default held only in a local answered "nothing"
+	// to the last of those while the SQL grouped by an organization id, and
+	// open-deals-per-company then named companies its reader cannot open.
+	if len(req.GroupBy) == 0 {
+		req.GroupBy = spec.defaultBy
 	}
+	groupBy := req.GroupBy
 	aggregates := req.Aggregates
 	if len(aggregates) == 0 {
 		aggregates = grantedDefaultAggregates(ctx, spec)
 	}
 	// What the caller asked for by name is refused by name; what they did not
 	// ask for was narrowed above.
-	if err := requireVocabularyGrants(ctx, spec, slices.Concat(req.GroupBy, aggregateFields(req.Aggregates))); err != nil {
+	if err := requireVocabularyGrants(ctx, spec, slices.Concat(asked, aggregateFields(req.Aggregates))); err != nil {
 		return reportOutcome{}, err
 	}
 

--- a/backend/internal/compose/reportadhoc.go
+++ b/backend/internal/compose/reportadhoc.go
@@ -16,6 +16,20 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
+// adHocReferenceTables are the descriptor field NAMES that point at a
+// row-scoped record, mapped to the table each names.
+//
+// Keyed by field name where the prebuilt catalog's referenceScopes are keyed by
+// SQL expression, because this vocabulary renders its own expressions
+// (`t.` + name) and there is no spec author to write one.
+// TestTheAdHocVocabularyScopesEveryReferenceTheCatalogDoes holds the two
+// together, so a reference the catalog learns about cannot stay unknown here.
+var adHocReferenceTables = map[string]string{
+	fieldOrganizationID: tableOrganization,
+	fieldPartnerOrgID:   tableOrganization,
+	fieldProjectID:      tableProject,
+}
+
 // runAdHocPlan serves the datasource seam's RunReport: the plan's
 // vocabulary is the schema descriptors (every declared field may group
 // or filter; count is the aggregate). Used by overlay tooling and the
@@ -42,6 +56,20 @@ func (e *reportEngine) runAdHocPlan(ctx context.Context, plan datasource.ReportP
 		spec.filters[f.Name] = expr
 		if f.Type == "bigint" || f.Type == "integer" {
 			spec.measures[f.Name] = expr
+		}
+		// A descriptor field that POINTS AT a row-scoped record carries the same
+		// obligation here as in the prebuilt catalog: grouping by it hands back
+		// an id the caller's own read of the same row masks.
+		//
+		// Derived from the schema rather than written per spec, because this
+		// vocabulary is. A hand-kept list would go stale the next time a
+		// descriptor grows a reference, and the failure is a disclosure rather
+		// than an error.
+		if table, isReference := adHocReferenceTables[f.Name]; isReference {
+			if spec.referenceScopes == nil {
+				spec.referenceScopes = map[string]string{}
+			}
+			spec.referenceScopes[expr] = table
 		}
 	}
 	req := reportRequest{GroupBy: plan.GroupBy, Filters: map[string]any{}}

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -53,7 +53,7 @@ func (h reportHandlers) RunReport(w http.ResponseWriter, r *http.Request, report
 	// The whole-result handle pins the same instant its rows do: it explains the
 	// same answer, over every row rather than one group's.
 	resultURL := derivationURL(
-		outcome.Report, outcome.Filters, nil, outcome.Aggregates, nil, outcome.GeneratedAt)
+		outcome.Report, outcome.Filters, outcome.GroupBy, outcome.Aggregates, nil, outcome.GeneratedAt)
 	totalRows := len(rows)
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ReportResult{
 		Report:               outcome.Report,

--- a/backend/internal/compose/reportreferencescope_integration_test.go
+++ b/backend/internal/compose/reportreferencescope_integration_test.go
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A reference scope narrows only what the query NAMES.
+//
+// A report row can point at a record the reader cannot open — a deal's partner
+// organization is the case that exists, because a connector mints a captured
+// company as `visibility='owner'` and it stays the importing user's until a
+// human promotes it. Grouping by that partner would name it, so those rows
+// leave the population. Summing by STAGE names no partner at all, and dropping
+// the same rows there reports less money than the reader's own deal list shows
+// them, for a reason nothing on screen states.
+//
+// The two halves of one answer have to describe one population: a count and the
+// records its drill-through link opens, or the link is not a drill-through.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// hiddenPartnerEnv is the failing scenario from the report that prompted this:
+// two open deals in one stage, both readable, one of them naming a partner
+// organization the reader cannot open.
+type hiddenPartnerEnv struct {
+	*forecastEnv
+	hidden ids.UUID
+	open   ids.UUID
+}
+
+// seedHiddenPartner stands up that scenario. The amounts differ by an order of
+// magnitude so a total can never be read two ways: 90000 is the hidden
+// partner's deal and 10000 the open one, and no sum of a subset collides with
+// the sum of another.
+func seedHiddenPartner(t *testing.T) hiddenPartnerEnv {
+	t.Helper()
+	e := setupForecast(t)
+	// Capture-private to Rep3, exactly as a connector-captured company is until
+	// a human promotes it: readable to its owner, invisible to every other seat
+	// including an admin's.
+	hidden := e.seedID(t, `INSERT INTO organization (id, owner_id, display_name, visibility, source, captured_by)
+		VALUES ($1, $2, 'Hidden Partners', 'owner', 'manual', 'human:x')`, e.Rep3)
+	open := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Open Partners', 'manual', 'human:x')`)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, expected_close_date, source, captured_by)
+		VALUES ($1, 'From the hidden partner', $2, $3, $4, 'sourced', 90000, 'EUR', (now() + interval '30 days')::date, 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], hidden)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, partner_org_id, partner_attribution, amount_minor, currency, expected_close_date, source, captured_by)
+		VALUES ($1, 'From the open partner', $2, $3, $4, 'sourced', 10000, 'EUR', (now() + interval '30 days')::date, 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], open)
+	return hiddenPartnerEnv{forecastEnv: e, hidden: hidden, open: open}
+}
+
+// blindReader reads every deal and holds no organization grant, so the hidden
+// partner is out of reach for them and the open one is not.
+func (e hiddenPartnerEnv) blindReader() context.Context {
+	return e.dealReadCtx(ids.NewV7(), nil, principal.RowScopeAll)
+}
+
+// A stage total counts both deals. The partner is never named by this
+// question, so excluding its deal buys no privacy and costs the reader 90000
+// of their own pipeline.
+func TestAStageTotalKeepsADealWhosePartnerTheReaderCannotOpen(t *testing.T) {
+	e := seedHiddenPartner(t)
+
+	result := e.runReport(e.blindReader(), t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
+
+	if got := wireInt(t, row, "deals"); got != 2 {
+		t.Errorf("deals = %d, want 2 — the reader may open both, and this question names no partner", got)
+	}
+	if got := wireInt(t, row, "amount_minor_sum"); got != 100000 {
+		t.Errorf("amount_minor_sum = %d, want 100000 (90000 + 10000)", got)
+	}
+	// The exclusion this replaces was not reported either, which is what made
+	// it unreadable: a short count with nothing beside it saying so.
+	if result.ExcludedByPermission != nil {
+		t.Errorf("excluded_by_permission = %d, want null — nothing was withheld from this total",
+			*result.ExcludedByPermission)
+	}
+}
+
+// The same reader grouping BY partner still never sees the partner they cannot
+// open. This is the case the exclusion exists for, and the change must not
+// widen it: an aggregate has no per-row place to write "withheld", and folding
+// those deals under a null key would still say that some partner brought them.
+func TestGroupingByPartnerStillExcludesThePartnerTheReaderCannotOpen(t *testing.T) {
+	e := seedHiddenPartner(t)
+
+	result := e.runReport(e.blindReader(), t, "deals-by-stage",
+		`{"group_by":["partner_org_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
+
+	var sawOpen bool
+	for _, row := range result.Rows {
+		id, ok := row["partner_org_id"].(string)
+		if !ok {
+			continue
+		}
+		if id == e.hidden.String() {
+			t.Errorf("the report named partner %s, which this caller's own deal read masks", id)
+		}
+		if id == e.open.String() {
+			sawOpen = true
+			if got := wireInt(t, row, "amount_minor_sum"); got != 10000 {
+				t.Errorf("open partner total = %d, want 10000", got)
+			}
+		}
+	}
+	if !sawOpen {
+		t.Error("the readable partner vanished too; the clause excluded more than it should")
+	}
+}
+
+// Filtering BY a partner is scoped like grouping by one, even though it prints
+// no id. The answer's SHAPE discloses the reference: "how much did this partner
+// bring" answered over a partner the caller cannot open confirms which deals
+// are theirs.
+//
+// Both arms, because the refusal alone is green against an engine that answers
+// nobody: the readable partner's own filter must still return their deal.
+func TestFilteringByAPartnerIsScopedLikeGroupingByOne(t *testing.T) {
+	e := seedHiddenPartner(t)
+	reader := e.blindReader()
+
+	hidden := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],`+
+			`"filters":{"partner_org_id":"`+e.hidden.String()+`"}}`)
+	for _, row := range hidden.Rows {
+		if got := wireInt(t, row, "deals"); got != 0 {
+			t.Errorf("deals = %d, want 0 — filtering on an unreadable partner must not confirm their deals", got)
+		}
+	}
+
+	open := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}],`+
+			`"filters":{"partner_org_id":"`+e.open.String()+`"}}`)
+	if len(open.Rows) == 0 {
+		t.Fatal("filtering on the READABLE partner returned nothing; the refusal above would pass against an engine that answers nobody")
+	}
+	for _, row := range open.Rows {
+		if got := wireInt(t, row, "deals"); got != 1 {
+			t.Errorf("deals = %d, want 1 for the partner this reader may open", got)
+		}
+		if got := wireInt(t, row, "amount_minor_sum"); got != 10000 {
+			t.Errorf("amount_minor_sum = %d, want 10000", got)
+		}
+	}
+}
+
+// A report answering with its DEFAULT plan is scoped by what that plan groups
+// by, not by what the caller happened to type.
+//
+// open-deals-per-company groups by organization_id when the request names no
+// group-by, and organization_id is a reference. A narrowing derived from the
+// request alone reads "this query names nothing", and the answer then keys a
+// row on every organization in the installation — including one captured into
+// a colleague's mailbox and never promoted.
+func TestADefaultGroupByIsScopedLikeAnAskedForOne(t *testing.T) {
+	e := setupForecast(t)
+	hidden := e.seedID(t, `INSERT INTO organization (id, owner_id, display_name, visibility, source, captured_by)
+		VALUES ($1, $2, 'Hidden Customer', 'owner', 'manual', 'human:x')`, e.Rep3)
+	open := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Open Customer', 'manual', 'human:x')`)
+	for _, org := range []ids.UUID{hidden, open} {
+		e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, expected_close_date, source, captured_by)
+			VALUES ($1, 'Deal', $2, $3, $4, 50000, 'EUR', (now() + interval '30 days')::date, 'manual', 'human:x')`,
+			e.pipeline, e.stages[60], org)
+	}
+
+	// The empty request: no group_by, so the spec's default decides.
+	result := e.runReport(e.dealReadCtx(ids.NewV7(), nil, principal.RowScopeAll), t,
+		"open-deals-per-company", `{}`)
+
+	var sawOpen bool
+	for _, row := range result.Rows {
+		id, ok := row["organization_id"].(string)
+		if !ok {
+			continue
+		}
+		if id == hidden.String() {
+			t.Errorf("the default plan named organization %s, which this caller cannot open", id)
+		}
+		if id == open.String() {
+			sawOpen = true
+		}
+	}
+	if !sawOpen {
+		t.Error("the readable organization vanished too; the default plan narrowed more than it should")
+	}
+}
+
+// The RESULT-level handle explains the same population its headline reported,
+// including when that headline grouped by a reference.
+//
+// A report grouped by partner excludes the partners its reader cannot open, so
+// the answer covers fewer deals than the reader's own list. The handle beside
+// that answer explains every cell at once and binds no group value — so unless
+// it also NAMES the dimension, the drill-through cannot tell this report from
+// one grouped by stage, and opens deals the count never counted.
+func TestTheResultHandleExplainsThePopulationItsHeadlineReported(t *testing.T) {
+	e := seedHiddenPartner(t)
+	reader := e.blindReader()
+
+	result := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["partner_org_id"],"aggregates":[{"fn":"count","as":"deals"}],"filters":{"partner_sourced":true}}`)
+
+	var counted int64
+	for _, row := range result.Rows {
+		counted += wireInt(t, row, "deals")
+	}
+	if counted != 1 {
+		t.Fatalf("the headline counted %d deals, want 1 — only the open partner's is nameable", counted)
+	}
+
+	detail := e.explainReport(reader, t, "deals-by-stage", result.DerivationURL)
+	if int64(detail.TotalRows) != counted {
+		t.Errorf("the answer counted %d deals and its result handle opens %d; "+
+			"a count and the records its link opens are one population",
+			counted, detail.TotalRows)
+	}
+	for _, row := range detail.Rows {
+		if id, ok := row["partner_org_id"].(string); ok && id == e.hidden.String() {
+			t.Errorf("the drill-through named partner %s, which the headline excluded", id)
+		}
+	}
+}
+
+// The typed analytics grammar scopes a filter on a reference the same way.
+//
+// Its filter field is resolved against the analytics schema — the spec's
+// dimensions and measures — so a narrowing that looked the field up in the
+// report engine's own filter map missed wherever the two disagree.
+// open-deals-per-company is that spec: organization_id is a dimension there and
+// not a filter, which made a filtered count answer whether a capture-private
+// company exists and how many deals point at it.
+func TestAnAnalyticsFilterOnAReferenceIsScoped(t *testing.T) {
+	e := setupForecast(t)
+	hidden := e.seedID(t, `INSERT INTO organization (id, owner_id, display_name, visibility, source, captured_by)
+		VALUES ($1, $2, 'Hidden Customer', 'owner', 'manual', 'human:x')`, e.Rep3)
+	open := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Open Customer', 'manual', 'human:x')`)
+	// Above the privacy floor on both sides, so a refusal can never stand in
+	// for the scope and pass this test for the wrong reason.
+	for i := 0; i < 6; i++ {
+		for _, org := range []ids.UUID{hidden, open} {
+			e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, expected_close_date, source, captured_by)
+				VALUES ($1, 'Deal', $2, $3, $4, 50000, 'EUR', (now() + interval '30 days')::date, 'manual', 'human:x')`,
+				e.pipeline, e.stages[60], org)
+		}
+	}
+
+	ask := func(org ids.UUID) AnalyticsAnswer {
+		t.Helper()
+		answer, err := e.askAnalytics(e.reportReaderCtx(), t, analyticsquery.Query{
+			Entity:   "open-deals-per-company",
+			Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "n"}},
+			Filters: []analyticsquery.Filter{
+				{Field: "organization_id", Op: analyticsquery.OpEq, Value: org.String()},
+			},
+		})
+		if err != nil {
+			t.Fatalf("analytics query: %v", err)
+		}
+		return answer
+	}
+
+	for _, row := range ask(hidden).Rows {
+		if got, ok := row["n"]; ok && got != nil {
+			t.Errorf("filtering on a capture-private organization answered n = %v; "+
+				"a count over an unreadable reference confirms it exists and how many deals name it", got)
+		}
+	}
+	// The readable organization still answers, or the arm above proves only
+	// that this engine refuses everybody.
+	var answered bool
+	for _, row := range ask(open).Rows {
+		if got, ok := row["n"]; ok && got != nil {
+			answered = true
+		}
+	}
+	if !answered {
+		t.Error("filtering on the READABLE organization answered nothing; the refusal above would be vacuous")
+	}
+}
+
+// The count and the records its link opens are one population.
+//
+// This is the half the report that prompted the change could see: the stage
+// said 1 and clicking it opened 2. Both numbers are now 2, and they are read
+// from the same handle the response minted.
+func TestTheDrillThroughOpensExactlyWhatTheStageCounted(t *testing.T) {
+	e := seedHiddenPartner(t)
+	reader := e.blindReader()
+
+	result := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
+	counted := wireInt(t, row, "deals")
+
+	detail := e.explainReport(reader, t, "deals-by-stage", result.DerivationURL)
+	if int64(detail.TotalRows) != counted {
+		t.Fatalf("the stage counted %d deals and its drill-through opens %d; a count and its link are one population",
+			counted, detail.TotalRows)
+	}
+	if got := wireInt(t, detail.Aggregates, "amount_minor_sum"); got != 100000 {
+		t.Errorf("drill-through amount_minor_sum = %d, want 100000 — the recompute must reconcile to the headline", got)
+	}
+}
+
+// The drill-through returns every dimension, so it hands back the partner id
+// even when the headline grouped by stage. The unreadable one comes back NULL
+// and its ROW STAYS — which is what an ordinary read of the same deal does
+// (deals/fieldmask.go blanks the reference and keeps the deal).
+func TestTheDrillThroughBlanksAnUnreadablePartnerAndKeepsItsRow(t *testing.T) {
+	e := seedHiddenPartner(t)
+	reader := e.blindReader()
+
+	result := e.runReport(reader, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
+	detail := e.explainReport(reader, t, "deals-by-stage", result.DerivationURL)
+
+	if len(detail.Rows) != 2 {
+		t.Fatalf("drill-through returned %d rows, want 2 — the reader may open both deals", len(detail.Rows))
+	}
+	var blanked, named int
+	for _, row := range detail.Rows {
+		partner, present := row["partner_org_id"]
+		if !present {
+			t.Fatal("the drill-through dropped the partner_org_id column entirely; it returns every dimension")
+		}
+		switch id, isString := partner.(string); {
+		case partner == nil:
+			blanked++
+		case isString && id == e.open.String():
+			named++
+		case isString && id == e.hidden.String():
+			t.Errorf("the drill-through named partner %s, which this caller's own deal read masks", id)
+		default:
+			t.Errorf("unexpected partner_org_id %v (%T)", partner, partner)
+		}
+	}
+	if blanked != 1 {
+		t.Errorf("%d rows came back with a blank partner, want exactly 1 (the hidden one)", blanked)
+	}
+	if named != 1 {
+		t.Errorf("%d rows named the readable partner, want exactly 1 — masking must not blank what the reader may open", named)
+	}
+}
+
+// The owner of the captured organization sees their own partner named, in the
+// same drill-through that blanks it for everybody else. Without this the suite
+// above would pass against an engine that blanked partner_org_id for every
+// caller, which is a different product and not a privacy boundary.
+func TestTheOwnerOfACapturedPartnerStillSeesItNamed(t *testing.T) {
+	e := seedHiddenPartner(t)
+	owner := e.dealReadCtx(e.Rep3, nil, principal.RowScopeAll)
+
+	result := e.runReport(owner, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`)
+	detail := e.explainReport(owner, t, "deals-by-stage", result.DerivationURL)
+
+	var sawHidden bool
+	for _, row := range detail.Rows {
+		if id, ok := row["partner_org_id"].(string); ok && id == e.hidden.String() {
+			sawHidden = true
+		}
+	}
+	if !sawHidden {
+		t.Error("the capturing user's own partner was blanked from them; capture privacy is theirs, not a mask on everyone")
+	}
+}

--- a/backend/internal/compose/reportreferencescope_test.go
+++ b/backend/internal/compose/reportreferencescope_test.go
@@ -12,6 +12,8 @@ package compose
 // keeping a second list of which ones were remembered.
 
 import (
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -50,6 +52,125 @@ func TestEveryReferenceDimensionDeclaresItsScope(t *testing.T) {
 	}
 }
 
+// A FILTER over a reference column is defended, by one of the two mechanisms
+// that can defend it.
+//
+// The dimension case is obvious: the id is printed. A filter discloses the same
+// fact through the answer's SHAPE — `count deals where organization_id =
+// <guess>` returns 1 for a company that exists with a deal and 0 for one that
+// does not, so a caller who cannot open that company learns it is there, one
+// guess at a time.
+//
+// Two defences, and either suffices:
+//
+//   - filterScopes refuses the VALUE. requireFilterScopes runs auth.Require and
+//     auth.EnsureVisibleLive on the id the caller sent, so an unreadable one is
+//     404 before any row is counted. This is the stronger of the two — the
+//     question is refused rather than answered narrowly — and it is what
+//     project_id carries on every spec that offers it.
+//   - referenceScopes narrows the ROWS. The filter binds, but only rows whose
+//     referenced record the caller can open are counted, so the answer is 0
+//     for a company they cannot see.
+//
+// A spec offering the filter with neither is the finding. deals-by-stage and
+// pipeline-current offered organization_id with neither, and a filtered count
+// there confirmed a capture-private company one guess at a time.
+func TestEveryReferenceFilterIsDefended(t *testing.T) {
+	judged := 0
+	for name, spec := range prebuiltReports {
+		for field, expr := range spec.filters {
+			table, isReference := referenceColumns[expr]
+			if !isReference {
+				continue
+			}
+			judged++
+			if _, refused := spec.filterScopes[field]; refused {
+				continue
+			}
+			declared, narrowed := spec.referenceScopes[expr]
+			if !narrowed {
+				t.Errorf("%s filters by %q, which selects rows by a %s the caller may not be "+
+					"able to open, and declares neither a filterScopes entry to refuse the "+
+					"value nor a referenceScopes entry to narrow the rows — the count then "+
+					"answers whether that record exists",
+					name, field, table)
+				continue
+			}
+			if declared != table {
+				t.Errorf("%s scopes filter %q against %q, want %q", name, field, declared, table)
+			}
+		}
+	}
+	if judged == 0 {
+		t.Fatal("no reference filters were read; this gate proves nothing about the specs it means to cover")
+	}
+}
+
+// The ad-hoc vocabulary knows every reference the prebuilt catalog does.
+//
+// runAdHocPlan builds a spec from the schema descriptors, so every declared
+// field becomes a dimension and a filter with no author to declare a scope for
+// it. adHocReferenceTables is what supplies them, and a second list of the same
+// facts is two answers to one question — this keeps them one.
+//
+// The two are keyed differently on purpose: the catalog by SQL expression,
+// because a spec writes its own; the ad-hoc map by field name, because that
+// vocabulary renders `t.` + name. So the comparison is over the column name
+// both spellings end in.
+func TestTheAdHocVocabularyScopesEveryReferenceTheCatalogDoes(t *testing.T) {
+	judged := 0
+	for column, table := range referenceColumns {
+		// Only the plain columns: a reference the catalog reads through a
+		// subselect (the activity's project) is not a descriptor field, and the
+		// ad-hoc vocabulary cannot name it.
+		name, isPlainColumn := strings.CutPrefix(column, "t.")
+		if !isPlainColumn {
+			continue
+		}
+		judged++
+		declared, ok := adHocReferenceTables[name]
+		if !ok {
+			t.Errorf("the catalog scopes %s against %s, and adHocReferenceTables does not name it — "+
+				"the datasource seam would group by it and hand back an id the caller's own read masks",
+				column, table)
+			continue
+		}
+		if declared != table {
+			t.Errorf("adHocReferenceTables scopes %q against %q, want %q", name, declared, table)
+		}
+	}
+	if judged == 0 {
+		t.Fatal("no plain reference columns were read; this gate proves nothing")
+	}
+}
+
+// A reference belongs in a spec's dimensions, never its measures.
+//
+// A measure is a number to aggregate, and the drill-through selects every
+// measure onto its rows beside every dimension. A reference exposed as one
+// would be handed back as an id by a path built to render sums — masked today
+// only because maskedDerivationSelects looks measures up too, and countable
+// nowhere as an aggregate: count over a partner id counts rows, sum over one
+// is meaningless. So the honest place for it is a dimension, and this refuses
+// the other spelling rather than leaving a spec free to choose the one whose
+// only protection is a lookup somebody could simplify away.
+func TestNoMeasureCarriesAReference(t *testing.T) {
+	judged := 0
+	for name, spec := range prebuiltReports {
+		for field, expr := range spec.measures {
+			judged++
+			if table, isReference := referenceColumns[expr]; isReference {
+				t.Errorf("%s measures %q, which names a row in %s rather than a number — "+
+					"a reference is a dimension, and aggregating one answers no question",
+					name, field, table)
+			}
+		}
+	}
+	if judged == 0 {
+		t.Fatal("no measures were read; this gate proves nothing about the specs it means to cover")
+	}
+}
+
 // The reverse direction: a declared scope must name a table the row-scope
 // helpers actually know, or the clause it renders would fail at query time on
 // a path no unit test reaches.
@@ -66,5 +187,43 @@ func TestEveryDeclaredReferenceScopeNamesARowScopedTable(t *testing.T) {
 				t.Errorf("%s scopes %q against no table", name, column)
 			}
 		}
+	}
+}
+
+// Every reference a caller can SELECT BY resolves through the vocabulary
+// namedByReport reads, so that naming one applies its scope.
+//
+// namedByReport (reportwhere.go) looks a group-by key up in spec.dimensions and
+// a filter key in spec.filters. Those are the two maps whose values are SQL
+// expressions comparable against spec.referenceScopes. This asserts the
+// converse: every scoped reference IS reachable that way, so a spec cannot
+// declare a scope for a column no caller can name — a scope that never renders
+// reads exactly like one that does.
+//
+// It says nothing about spec.thresholds, and that is the point of writing it
+// this way rather than scanning threshold SQL for column names: a threshold
+// renders its own clause from a bind position, so a reference inside one would
+// be spelled however its author spelled it, and a substring scan would miss the
+// case it exists to catch. What holds instead is that a threshold takes a
+// NUMBER from the caller (thresholdValue) and compares it — it cannot carry a
+// caller-supplied reference id at all, so there is nothing for a scope to gate.
+func TestEveryScopedReferenceIsReachableThroughTheVocabulary(t *testing.T) {
+	judged := 0
+	for name, spec := range prebuiltReports {
+		for column := range spec.referenceScopes {
+			judged++
+			reachable := slices.Contains(slices.Collect(maps.Values(spec.dimensions)), column) ||
+				slices.Contains(slices.Collect(maps.Values(spec.filters)), column)
+			if !reachable {
+				t.Errorf("%s scopes %s, which is neither a dimension nor a filter — "+
+					"namedByReport resolves a caller's key through those two maps, so this "+
+					"scope renders for no question anybody can ask",
+					name, column)
+			}
+		}
+	}
+	// A census that reads no references would pass over nothing at all.
+	if judged == 0 {
+		t.Fatal("no reference scopes were read; this gate proves nothing about the specs it means to cover")
 	}
 }

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -195,10 +195,16 @@ var prebuiltReports = map[string]reportSpec{
 			fieldProjectID:    colProjectID,
 		},
 		filterScopes: projectFilterScope,
-		// partner_org_id points at an organization, which a normal deal read
-		// masks per row when the caller cannot open it.
-		referenceScopes: map[string]string{colPartnerOrgID: tableOrganization},
-		defaultBy:       moneyDefaultBy(fieldStageID),
+		// Both organization references, which a normal deal read masks per row
+		// when the caller cannot open them. organization_id is a FILTER here
+		// and not a dimension, and it needs the scope for that alone: a count
+		// filtered to one company answers whether that company exists and has
+		// a deal, which is the disclosure whether or not the id is printed.
+		referenceScopes: map[string]string{
+			colPartnerOrgID:   tableOrganization,
+			colOrganizationID: tableOrganization,
+		},
+		defaultBy: moneyDefaultBy(fieldStageID),
 		defaultAggs: []reportAggregate{
 			{Fn: aggFnCount, As: aliasDeals},
 			{Fn: aggFnSum, Field: fieldAmountMinor, As: "amount_minor_sum"},

--- a/backend/internal/compose/reportspecs_pipeline.go
+++ b/backend/internal/compose/reportspecs_pipeline.go
@@ -66,8 +66,15 @@ func pipelineCurrentSpec() reportSpec {
 			fieldPartnerOrgID:   colPartnerOrgID,
 			fieldProjectID:      colProjectID,
 		},
-		filterScopes:    projectFilterScope,
-		referenceScopes: map[string]string{colPartnerOrgID: tableOrganization},
+		filterScopes: projectFilterScope,
+		// Both organization references. organization_id is a filter and not a
+		// dimension here, and a count filtered to one company answers whether
+		// that company exists and has a deal — the disclosure does not need
+		// the id to be printed.
+		referenceScopes: map[string]string{
+			colPartnerOrgID:   tableOrganization,
+			colOrganizationID: tableOrganization,
+		},
 		// By STAGE alone. deals-by-stage groups by stage and currency, so a
 		// stage trading in three currencies draws three rows and no total —
 		// which is honest while the money is unconverted and pointless once it

--- a/backend/internal/compose/reportwhere.go
+++ b/backend/internal/compose/reportwhere.go
@@ -99,7 +99,7 @@ func buildReportWhere(
 			where = append(where, population)
 		}
 	}
-	refs, err := referenceScopeClauses(ctx, spec, arg)
+	refs, err := referenceScopeClauses(ctx, spec, namedByReport(spec, req), arg)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,8 @@ func specScopeClauses(ctx context.Context, spec reportSpec, arg func(any) int) (
 // TestEveryPopulationsNarrowingsAreComposedInOnePlace ratifies it by name.
 // Every other path takes the whole set from here.
 func specNarrowings(
-	ctx context.Context, tx pgx.Tx, spec reportSpec, requested RequestedScope, arg func(any) int,
+	ctx context.Context, tx pgx.Tx, spec reportSpec, requested RequestedScope,
+	named referencedColumns, arg func(any) int,
 ) ([]string, error) {
 	out, err := specScopeClauses(ctx, spec, arg)
 	if err != nil {
@@ -191,22 +192,107 @@ func specNarrowings(
 	}
 	// And the records the population POINTS AT: grouping by a reference column
 	// would otherwise name ids the caller's ordinary read of the same row masks.
-	refs, err := referenceScopeClauses(ctx, spec, arg)
+	refs, err := referenceScopeClauses(ctx, spec, named, arg)
 	if err != nil {
 		return nil, err
 	}
 	return append(append(out, masks...), refs...), nil
 }
 
+// referencedColumns is the set of SQL expressions one query SELECTS BY — the
+// columns it groups on or filters on, whose values therefore shape the answer
+// whether or not any id is printed.
+//
+// Not the columns it merely returns: those are masked per row where a caller
+// could reach one (maskedDerivationSelects), because blanking a column keeps
+// the row in a population that both halves of an answer have to agree on.
+//
+// Keyed by the same expression string spec.referenceScopes uses, so a lookup is
+// a comparison and not a second spelling of the mapping.
+type referencedColumns map[string]bool
+
+// namedByReport is what a prebuilt report exposes: the dimensions it groups by
+// and the filters it was given.
+//
+// A filter counts even though it prints nothing. Filtering on a partner the
+// caller cannot open would confirm which deals that partner brought — the
+// answer's SHAPE discloses the reference even when its id never appears.
+//
+// A spec may instead defend a filter with filterScopes, which refuses the VALUE
+// (auth.EnsureVisibleLive, so an unreadable id is 404 before a row is counted)
+// and is the stronger of the two — project_id carries that on every spec that
+// offers it, and declares no reference scope. Naming a column here that no
+// referenceScopes entry covers renders nothing, so this set stays the same
+// question for both families.
+func namedByReport(spec reportSpec, req reportRequest) referencedColumns {
+	named := make(referencedColumns, len(req.GroupBy)+len(req.Filters))
+	for _, field := range req.GroupBy {
+		if expr, ok := spec.dimensions[field]; ok {
+			named[expr] = true
+		}
+	}
+	for field := range req.Filters {
+		if expr, ok := spec.filters[field]; ok {
+			named[expr] = true
+		}
+	}
+	return named
+}
+
+// namedByDerivation is what a drill-through SELECTS ON: the predicates the
+// handle carries, whether they came from the headline's filters or from the
+// group this cell belongs to.
+//
+// Its output columns are deliberately not here. A drill-through returns every
+// dimension the spec declares, so taking the columns would scope every
+// reference on every drill-through and put back the exclusion this change
+// removes. maskedDerivationSelects (derivationfetch.go) covers the output side
+// instead, by blanking the reference and keeping the row — which is what an
+// ordinary read of the same record does.
+//
+// So the two halves divide the obligation: a reference a predicate SELECTS BY
+// narrows the rows, and a reference a column merely RETURNS is masked. Both
+// leave the drill-through reading the same population as its headline.
+func namedByDerivation(spec reportSpec, plan derivationPlan) referencedColumns {
+	named := make(referencedColumns, len(plan.preds)+len(plan.groupBy))
+	for _, p := range plan.preds {
+		named[p.expr] = true
+	}
+	// And what the HEADLINE grouped by, which the handle names even where it
+	// pins no value. A result-level handle explains every cell of one answer at
+	// once, so it binds no group key — but the answer it explains was still
+	// narrowed by grouping over a reference, and a drill-through that forgot
+	// that opened records the count above it never counted.
+	for _, field := range plan.groupBy {
+		if expr, ok := spec.dimensions[field]; ok {
+			named[expr] = true
+		}
+	}
+	return named
+}
+
 // referenceScopeClauses narrows a report to the rows whose REFERENCED records
-// the caller could open, for every reference the spec declares.
+// the caller could open, for every reference the query NAMES.
 //
 // The engine's own gate covers the report's entity and nothing it points at, so
 // a dimension over a reference column would otherwise hand back ids that the
 // same caller's ordinary read of the same row masks. Excluding the row is the
-// only honest aggregate answer: there is no per-row place to write "withheld",
-// and folding those deals under a null key would still say that SOME partner
-// brought them.
+// only honest aggregate answer there: there is no per-row place to write
+// "withheld", and folding those deals under a null key would still say that
+// SOME partner brought them.
+//
+// `named` is what bounds it: the columns this query groups by, filters on or
+// returns. A reference the answer never mentions discloses nothing, so
+// excluding its rows buys no privacy and costs correctness — a stage total that
+// drops the deals whose partner is capture-private reports less money than the
+// same reader's own deal list shows them, for a reason nothing on screen
+// states, and its drill-through link then opens more records than the count
+// counted.
+//
+// The two callers therefore pass different sets, and the difference is the
+// point. A report names its group-bys and its filters. A drill-through puts
+// every dimension on its rows, so it names its output columns as well —
+// an explanation must not out-see the number it explains.
 //
 // This is the ROW-SCOPE obligation only. A reference that also takes the
 // referenced table's OBJECT grant before it may be named at all (the project
@@ -216,12 +302,17 @@ func specNarrowings(
 // nothing about the grant, which is why the two are asked separately.
 // TestGroupingByPartnerDoesNotNameAPartnerTheCallerCannotOpen pins the
 // partner dimension to the row scope alone.
-func referenceScopeClauses(ctx context.Context, spec reportSpec, arg func(any) int) ([]string, error) {
+func referenceScopeClauses(
+	ctx context.Context, spec reportSpec, named referencedColumns, arg func(any) int,
+) ([]string, error) {
 	if len(spec.referenceScopes) == 0 {
 		return nil, nil
 	}
 	clauses := make([]string, 0, len(spec.referenceScopes))
 	for _, column := range slices.Sorted(maps.Keys(spec.referenceScopes)) {
+		if !named[column] {
+			continue
+		}
 		table := spec.referenceScopes[column]
 		scope, err := auth.ScopeClauseFor(ctx, table, "ref", arg)
 		if err != nil {


### PR DESCRIPTION
Closes #4102.

## What was wrong

A deal can point at a company its reader cannot open. That happens when a
connector captured the company out of somebody's mailbox and no human has
promoted it yet — it stays private to the capturing user, and not even an admin
sees it (rowscope.go, `ownerPrivateTables`).

Naming such a company in an answer would disclose it, so the report engine
excluded those rows. From every query, though — including ones that never
mention the company at all. A stage total therefore reported less money than the
same reader's own deal list showed them, for a reason nothing on screen stated,
and clicking the count opened more deals than the count had counted.

## What changed

The reference scope now applies to what a query actually SELECTS BY: the
dimensions it groups on, the fields it filters on. A reference a drill-through
merely returns is blanked to NULL with its row kept — which is what an ordinary
read of the same deal already does (`deals/fieldmask.go`) — so a count and the
records its link opens describe one population again.

Grouping by the partner still excludes partners the reader cannot open. That is
the case the exclusion exists for and it is unchanged.

## Four disclosures found while proving it

Each has an integration test that reproduces it when the fix is reverted.

1. **A report's DEFAULT plan was scoped by what the caller typed, not what the
   engine ran.** `open-deals-per-company` groups by `organization_id` given an
   empty body, so `POST /v1/reports/open-deals-per-company` with `{}` listed
   every capture-private company to any `deal.read` seat.
2. **The typed analytics grammar resolved a filter field through the wrong
   map.** The compiler validates against the analytics schema — the spec's
   dimensions and measures — while the narrowing looked in `spec.filters`. Where
   the two disagree the scope never rendered, and `filter organization_id eq
   <guess>` answered how many deals point at a company the caller cannot open.
   The privacy floor does not cover this: it only refuses filters isolating
   fewer records than the floor.
3. **`deals-by-stage` and `pipeline-current` offered `organization_id` as a
   filter** with neither a `filterScopes` entry to refuse the value nor a
   `referenceScopes` entry to narrow the rows. Predates this change.
4. **The datasource seam's ad-hoc vocabulary declared no reference scopes at
   all**, so grouping by `organization_id` through it returned the ids unmasked.
   Predates this change.

## Held by

Five gates that derive their obligation from the catalog rather than listing
what somebody remembered: every reference dimension and every reference filter
is defended (by `filterScopes` refusing the value, or `referenceScopes`
narrowing the rows), no measure carries a reference, every declared scope is
reachable through the vocabulary, and the ad-hoc map knows every reference the
catalog does.

Nine integration tests, each mutation-checked — the guard reverted, the test
watched to fail for the right reason.

## Verified live

On a dev stack with a capture-private company seeded: the 777000 deal now
appears in admin's stage total; its drill-through opens exactly one row with the
partner blanked; the capturing user still sees their own company named; both
oracles answer nothing.

## Incidental

`derivation.go` sat one line under the 500-line cap, so the handle's wire form —
minting the URL and reading it back — moves to `derivationhandle.go`, and
`parseDerivationQuery`'s as-of and aggregate parsing become their own functions
to clear the complexity cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The reference scope now applies only to the references a query selects by — its group-bys and filters — so a stage total keeps deals whose partner the reader cannot open. Previously those deals were dropped from every query, making a count and its drill-through describe different populations.

**Bug Fixes**
- A reference a drill-through only returns is blanked to NULL, keeping the row it belongs to.
- The default plan is now scoped by what the engine runs, not by what the caller typed.
- The analytics grammar now resolves filter fields through the same map the compiler uses.
- `deals-by-stage` and `pipeline-current` now scope `organization_id` as a filter.
- The ad-hoc datasource vocabulary now declares reference scopes for fields that point at row-scoped records.

**Refactors**
- The derivation handle's wire form moves to `derivationhandle.go`; as-of and aggregate parsing become their own functions.

<sup>Written for commit 1fcd770663bbd0c40a6f6a292a5c7fb26ae4a6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

