### PR TITLE
A snooze can wait for a reply or a meeting, not only a date

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30058,16 +30058,24 @@ components:
           description: |
             What the reader decided. `not_sales` binds the thread for everybody; `snooze` and
             `not_mine` bind only the caller.
+        reopen_on:
+          $ref: '#/components/schemas/ReopenCondition'
         snoozed_until:
           type: string
           format: date-time
           description: |
-            When a snooze lifts. REQUIRED for `snooze` and refused for the other two — a snooze
-            with no moment would never lift, and a moment on `not_mine` would make a hand-off
-            expire on a Thursday.
+            When a snooze lifts. REQUIRED for `snooze` with `reopen_on: time`, and refused
+            everywhere else — a snooze waiting on a reply lifts when the reply arrives, and a
+            moment on `not_mine` would make a hand-off expire on a Thursday.
 
             A moment already past is refused rather than stored: it would write a row that hides
             nothing, and read to the rep as a snooze that did not take.
+        reopen_ref:
+          type: string
+          format: uuid
+          description: |
+            The meeting to wait for. REQUIRED for `snooze` with `reopen_on: meeting` and
+            refused otherwise.
 
     AudienceMember:
       type: object
@@ -38226,7 +38234,15 @@ components:
           description: The source rows (deal / activity / relationship) behind the factors; never empty (evidence-or-omit).
         state: { type: string, enum: [new, acted, dismissed, snoozed], description: The acting rep's queue state for this item. }
         state_at: { type: [string, 'null'], format: date-time, description: When the rep acted/dismissed/snoozed; null while new. }
-        snoozed_until: { type: [string, 'null'], format: date-time, description: 'When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.' }
+        snoozed_until: { type: [string, 'null'], format: date-time, description: 'When a snoozed item re-surfaces; set exactly while reopen_on=time, null otherwise — the other conditions lift on an event rather than a date.' }
+        reopen_on:
+          type: [string, 'null']
+          enum: [time, reply, meeting, null]
+          description: 'What the item is waiting for; set exactly while state=snoozed, null otherwise.'
+        reopen_ref:
+          type: [string, 'null']
+          format: uuid
+          description: 'The meeting being waited for; set exactly while reopen_on=meeting.'
         lineage:
           $ref: '#/components/schemas/MorningBriefItemLineage'
         finding:
@@ -38623,10 +38639,45 @@ components:
 
     BriefSnoozeRequest:
       type: object
-      description: Snooze a brief item until a future instant (A77/AC-home-6); it re-surfaces once the instant passes.
-      required: [snoozed_until]
+      description: |
+        Set a brief item aside until something happens. The something is `reopen_on`: a moment
+        on the clock, the customer writing back, or a named meeting being over.
       properties:
-        snoozed_until: { type: string, format: date-time, description: When the item re-surfaces; must be in the future. }
+        reopen_on:
+          $ref: '#/components/schemas/ReopenCondition'
+        snoozed_until:
+          type: string
+          format: date-time
+          description: |
+            When the item re-surfaces. REQUIRED for `time` and refused for the other two — a
+            snooze waiting on a reply lifts when the reply arrives, not on a date. Must be in
+            the future.
+        reopen_ref:
+          type: string
+          format: uuid
+          description: |
+            The meeting to wait for. REQUIRED for `meeting` and refused otherwise, because
+            "after the meeting" names nothing without saying which meeting.
+
+    ReopenCondition:
+      type: string
+      enum: [time, reply, meeting]
+      default: time
+      # NAMED EXPLICITLY, like the pair in ListCustomFieldsParams above and for
+      # a sharper version of the same reason. oapi-codegen prefixes an enum's
+      # constants only when it sees a clash, so adding a shared schema whose
+      # values are this generic re-decides that for every OTHER enum in the
+      # file: `time`/`reply`/`meeting` freed the prefixes off
+      # ListPeopleParamsCapturedByKind, whose bare `System` then collided with
+      # GetWorklistParamsFilter's and stopped the package compiling. Spelling
+      # these keeps this schema out of that calculation entirely.
+      x-enum-varnames: [ReopenOnTime, ReopenOnReply, ReopenOnMeeting]
+      description: |
+        What lifts a snooze. `time` is the original behaviour and the default, so a client
+        written before the other two keeps working unchanged. `reply` waits for the
+        counterparty to write back on a conversation linked to the record. `meeting` waits for
+        a named meeting to be over — an archived meeting counts as over, so a cancelled one
+        returns the work rather than holding it forever.
 
     MorningBriefFeatureVector:
       type: object

--- a/backend/gates/reopenconditionparity_test.go
+++ b/backend/gates/reopenconditionparity_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// What a snooze may wait for is spelled in four places, and all four must agree.
+//
+// values.ReopenConditions() is the Go set every writer builds from, the two
+// tables' CHECK constraints are what the database will actually accept, and the
+// contract's ReopenCondition enum is what a client may send. A value in the Go
+// set that the CHECK refuses is a snooze the product offers and the write
+// rejects; one in the CHECK that Go never names is a row no read knows how to
+// lift, which sets work aside forever.
+//
+// Every side is DERIVED — the Go set from the function, the SQL sets from the
+// migration text, the wire set from the YAML. Hard-coding the three values here
+// would make this file a fifth copy rather than a check on the other four.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// The two tables that hold a set-aside. Both were given the column by the same
+// migration and both must admit the same values: a rep who can wait for a reply
+// on a deal and not on the message that deal is waiting for would be reading
+// one product with two different vocabularies.
+var reopenConditionTables = []string{"brief_item", "activity_reader_state"}
+
+func TestEveryTableAdmitsExactlyTheConditionsGoCanWrite(t *testing.T) {
+	t.Parallel()
+	want := make([]string, 0, len(values.ReopenConditions()))
+	for _, c := range values.ReopenConditions() {
+		want = append(want, string(c))
+	}
+	slices.Sort(want)
+
+	for _, table := range reopenConditionTables {
+		got := reopenCheckValues(t, table)
+		if !slices.Equal(got, want) {
+			t.Errorf("%s admits %v but values.ReopenConditions() is %v; "+
+				"a condition on one side only is either a snooze the write refuses "+
+				"or a stored wait no read can lift", table, got, want)
+		}
+	}
+}
+
+func TestTheWireOffersExactlyTheConditionsGoCanWrite(t *testing.T) {
+	t.Parallel()
+	want := make([]string, 0, len(values.ReopenConditions()))
+	for _, c := range values.ReopenConditions() {
+		want = append(want, string(c))
+	}
+	slices.Sort(want)
+
+	got := reopenContractEnum(t)
+	if !slices.Equal(got, want) {
+		t.Errorf("the contract's ReopenCondition enum is %v but values.ReopenConditions() is %v; "+
+			"a value on the wire the server cannot store is a promise no writer keeps", got, want)
+	}
+}
+
+// reopenCheckValues reads one table's reopen_on CHECK out of the migrations.
+//
+// It scans EVERY migration rather than the one that introduced the column,
+// because a later one may widen the set, and a gate that reads only the first
+// would keep passing while the constraint it describes no longer exists.
+func reopenCheckValues(t *testing.T, table string) []string {
+	t.Helper()
+	constraint := table + "_reopen_known"
+	// The clause as the migration spells it: reopen_on IN ('a', 'b', 'c').
+	clause := regexp.MustCompile(`CONSTRAINT\s+` + regexp.QuoteMeta(constraint) +
+		`\s+CHECK\s*\(reopen_on IS NULL OR reopen_on IN \(([^)]*)\)\)`)
+
+	files, err := filepath.Glob(filepath.Join("migrations", "core", "*.up.sql"))
+	if err != nil {
+		t.Fatalf("listing the migrations: %v", err)
+	}
+	slices.Sort(files)
+	var found []string
+	for _, file := range files {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		for _, match := range clause.FindAllStringSubmatch(string(body), -1) {
+			// The LAST match wins, so a migration that widens the set is what
+			// this gate reports rather than the one that first created it.
+			found = quotedValues(match[1])
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s CHECK found in the migrations; the constraint this gate "+
+			"protects is gone, and with it every guarantee about what a snooze may wait for", constraint)
+	}
+	slices.Sort(found)
+	return found
+}
+
+// quotedValues pulls the single-quoted literals out of an IN list.
+func quotedValues(list string) []string {
+	quoted := regexp.MustCompile(`'([^']*)'`)
+	out := []string{}
+	for _, m := range quoted.FindAllStringSubmatch(list, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// reopenContractEnum reads the shared schema's enum out of the contract.
+func reopenContractEnum(t *testing.T) []string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("api", "crm.yaml"))
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas map[string]struct {
+				Enum []string `yaml:"enum"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+	schema, ok := doc.Components.Schemas["ReopenCondition"]
+	if !ok {
+		t.Fatal("the contract has no ReopenCondition schema; the enum this gate holds is gone")
+	}
+	out := slices.Clone(schema.Enum)
+	// The nullable spellings elsewhere carry a null member; this shared schema
+	// does not, and a stray empty would compare unequal for a reason that has
+	// nothing to do with drift.
+	out = slices.DeleteFunc(out, func(v string) bool { return strings.TrimSpace(v) == "" })
+	slices.Sort(out)
+	return out
+}

--- a/backend/internal/compose/attentionbriefing_integration_test.go
+++ b/backend/internal/compose/attentionbriefing_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // briefingLaneEnv is one workspace with the seam's own reader over the real
@@ -173,7 +174,7 @@ func TestASetAsideBriefingItemComesBackWhenItsWindowPasses(t *testing.T) {
 	}
 	item := run.Items[0]
 	until := b.now.Add(3 * time.Hour)
-	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, until, b.now.Add(time.Minute)); err != nil {
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnTime, &until, nil, b.now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/briefs/briefhandlers.go
+++ b/backend/internal/compose/briefs/briefhandlers.go
@@ -20,6 +20,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // Handlers wires the brief transport to the engine.
@@ -93,21 +94,39 @@ func (h Handlers) MarkBriefItemDismissed(w http.ResponseWriter, r *http.Request,
 	httperr.WriteJSON(w, http.StatusOK, briefItemToWire(item))
 }
 
-// SnoozeBriefItem hides a queue item until the requested instant, after
-// which it re-surfaces as actionable (A77/AC-home-6). A snooze that is
-// already over would be a no-op wearing a success code — refused as
-// client error instead.
+// SnoozeBriefItem sets a queue item aside until its reopen condition is met,
+// after which it re-surfaces as actionable.
+//
+// A `time` snooze already over would be a no-op wearing a success code, so it is
+// refused as a client error. The other two conditions carry no instant to check
+// — whether they are already satisfied is a question for the re-surface read,
+// not for this transport.
 func (h Handlers) SnoozeBriefItem(w http.ResponseWriter, r *http.Request, itemID openapi_types.UUID) {
 	var req crmcontracts.BriefSnoozeRequest
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	var raw *string
+	if req.ReopenOn != nil {
+		on := string(*req.ReopenOn)
+		raw = &on
+	}
+	on, err := values.ParseReopenCondition(raw, "reopen_on")
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
 	now := time.Now().UTC()
-	if !req.SnoozedUntil.After(now) {
+	if on == values.ReopenOnTime && req.SnoozedUntil != nil && !req.SnoozedUntil.After(now) {
 		httperr.Write(w, r, httperr.Validation("snoozed_until", "not_in_future", "snoozed_until must lie in the future"))
 		return
 	}
-	item, err := h.engine.MarkSnoozed(r.Context(), ids.UUID(itemID), req.SnoozedUntil, now)
+	var ref *ids.UUID
+	if req.ReopenRef != nil {
+		id := ids.UUID(*req.ReopenRef)
+		ref = &id
+	}
+	item, err := h.engine.MarkSnoozed(r.Context(), ids.UUID(itemID), on, req.SnoozedUntil, ref, now)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
@@ -219,7 +238,29 @@ func briefItemToWire(item BriefRunItem) crmcontracts.MorningBriefItem {
 		State:        crmcontracts.MorningBriefItemState(item.State),
 		StateAt:      item.StateAt,
 		SnoozedUntil: item.SnoozedUntil,
+		ReopenOn:     reopenToWire(item.ReopenOn),
+		ReopenRef:    reopenRefToWire(item.ReopenRef),
 		Finding:      nullableText(item.Finding),
 		Lineage:      lineageToWire(item.Lineage),
 	}
+}
+
+// reopenToWire carries the condition only while one is set. An item that is not
+// snoozed is waiting for nothing, and the empty string would render as a fourth
+// condition the client has no name for.
+func reopenToWire(on values.ReopenCondition) *crmcontracts.MorningBriefItemReopenOn {
+	if on == "" {
+		return nil
+	}
+	wire := crmcontracts.MorningBriefItemReopenOn(on)
+	return &wire
+}
+
+// reopenRefToWire is the same carry for the meeting a condition may name.
+func reopenRefToWire(ref *ids.UUID) *openapi_types.UUID {
+	if ref == nil {
+		return nil
+	}
+	wire := openapi_types.UUID(*ref)
+	return &wire
 }

--- a/backend/internal/compose/briefs/briefmarks.go
+++ b/backend/internal/compose/briefs/briefmarks.go
@@ -19,12 +19,14 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // The field names an audit image of a brief item carries. Named because three
@@ -34,26 +36,67 @@ const (
 	auditFieldState        = "state"
 	auditFieldStateAt      = "state_at"
 	auditFieldSnoozedUntil = "snoozed_until"
+	auditFieldReopenOn     = "reopen_on"
+	auditFieldReopenRef    = "reopen_ref"
 )
+
+// snooze is what a rep is waiting for, carried as one value because the three
+// fields are one decision: a condition, the instant it may store, and the row it
+// may name. Passing them separately is how a caller writes two of the three and
+// hits a CHECK the client cannot read.
+type snooze struct {
+	on    values.ReopenCondition
+	until *time.Time
+	ref   *ids.UUID
+}
 
 // MarkActed records that the rep acted on a queue item; the next run's
 // candidate filter drops the deal until it materially changes.
 func (e *BriefEngine) MarkActed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
-	return e.markItem(ctx, itemID, briefStateActed, nil, now)
+	return e.markItem(ctx, itemID, briefStateActed, snooze{}, now)
 }
 
 // MarkDismissed records that the rep dismissed a queue item; the deal
 // does not reappear unless a new linked activity arrives after the mark.
 func (e *BriefEngine) MarkDismissed(ctx context.Context, itemID ids.UUID, now time.Time) (BriefRunItem, error) {
-	return e.markItem(ctx, itemID, briefStateDismissed, nil, now)
+	return e.markItem(ctx, itemID, briefStateDismissed, snooze{}, now)
 }
 
-// MarkSnoozed hides a queue item until the given instant (A77/AC-home-6),
-// after which it re-surfaces as actionable. The transport validates that
-// `until` lies in the future; this transition only records it.
-func (e *BriefEngine) MarkSnoozed(ctx context.Context, itemID ids.UUID, until, now time.Time) (BriefRunItem, error) {
-	untilUTC := until.UTC()
-	return e.markItem(ctx, itemID, briefStateSnoozed, &untilUTC, now)
+// MarkSnoozed hides a queue item until its reopen condition is met, after which
+// it re-surfaces as actionable.
+//
+// A `time` snooze needs the instant and the transport validates it lies ahead;
+// `reply` and `meeting` wait on the world instead, and the re-surface read
+// decides when they are over. The shape is checked here rather than left to the
+// database, so a caller that names a meeting without naming which one reads a
+// validation error instead of a constraint violation.
+func (e *BriefEngine) MarkSnoozed(
+	ctx context.Context, itemID ids.UUID, on values.ReopenCondition,
+	until *time.Time, ref *ids.UUID, now time.Time,
+) (BriefRunItem, error) {
+	held := snooze{on: on, ref: ref}
+	if on.WantsInstant() {
+		if until == nil {
+			return BriefRunItem{}, &values.ParseError{
+				Field: "snoozed_until", Code: "snooze_needs_a_moment",
+				Message: "a snooze that waits on the clock names the moment it lifts",
+			}
+		}
+		utc := until.UTC()
+		held.until = &utc
+	} else if until != nil {
+		return BriefRunItem{}, &values.ParseError{
+			Field: "snoozed_until", Code: "snooze_has_no_moment",
+			Message: "a snooze waiting on a reply or a meeting lifts when that happens, not on a date",
+		}
+	}
+	if on.NeedsReference() != (ref != nil) {
+		return BriefRunItem{}, &values.ParseError{
+			Field: "reopen_ref", Code: "reopen_ref_shape",
+			Message: "only a snooze waiting on a meeting names the meeting it waits for",
+		}
+	}
+	return e.markItem(ctx, itemID, briefStateSnoozed, held, now)
 }
 
 // markItem is the one acted/dismissed/snoozed transition: only the run's
@@ -65,7 +108,7 @@ func (e *BriefEngine) MarkSnoozed(ctx context.Context, itemID ids.UUID, until, n
 // is per-rep personal queue state — the object gate is the deal-read
 // grant the brief itself rides on, and the real authority is run
 // ownership.
-func (e *BriefEngine) markItem(ctx context.Context, itemID ids.UUID, state string, snoozedUntil *time.Time, now time.Time) (BriefRunItem, error) {
+func (e *BriefEngine) markItem(ctx context.Context, itemID ids.UUID, state string, held snooze, now time.Time) (BriefRunItem, error) {
 	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
 		return BriefRunItem{}, err
 	}
@@ -76,72 +119,63 @@ func (e *BriefEngine) markItem(ctx context.Context, itemID ids.UUID, state strin
 
 	var item BriefRunItem
 	err = database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
-		var owner ids.UUID
-		row := tx.QueryRow(ctx, `
-			SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, ''),
-			       bi.returned_after_dismissal_on, bi.returned_with_activity_at, br.user_id
-			FROM brief_item bi
-			JOIN brief_run br ON br.id = bi.brief_run_id
-			WHERE bi.id = $1
-			FOR UPDATE OF bi`, itemID)
-		var featuresRaw []byte
-		// Read back with the mark, because the client replaces its cached item
-		// with this response wholesale: dropping the lineage here makes the
-		// "you dismissed it" line vanish the moment the rep acts on the very
-		// item it was explaining.
-		var dismissedOn, returnedWith *time.Time
-		err := row.Scan(&item.ID, &item.DealID, &item.Rank, &item.Composite, &featuresRaw,
-			&item.EvidenceIDs, &item.State, &item.StateAt, &item.SnoozedUntil, &item.Finding,
-			&dismissedOn, &returnedWith, &owner)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
+		owner, err := lockItemForMark(ctx, tx, itemID, &item)
 		if err != nil {
 			return err
-		}
-		// The CHECK keeps the pair whole, so one non-null half means both are.
-		if dismissedOn != nil && returnedWith != nil {
-			item.Lineage = &ItemLineage{DismissedOn: *dismissedOn, ReturnedWith: *returnedWith}
-		}
-		if err := json.Unmarshal(featuresRaw, &item.Features); err != nil {
-			return fmt.Errorf("brief: item %s carries an unreadable feature vector: %w", item.ID, err)
 		}
 		if owner != userID {
 			// Another rep's brief: existence-hiding, like every row-scope miss.
 			return apperrors.ErrNotFound
 		}
-		// The mark's twin of the join in readRunItems: the item names a deal
-		// that may have moved since the run was assembled, and a mark is a
-		// read-back as much as a write. Checked BEFORE actionability, so a
-		// deal the rep can no longer read answers not-found rather than
-		// disclosing the item's state through a conflict.
-		if err := auth.EnsureVisible(ctx, tx, "deal", item.DealID); err != nil {
+		// The meeting a snooze names must exist, be a meeting, and be one this
+		// rep may read. Checked inside the transaction so the row cannot be
+		// archived between the check and the write.
+		if held.ref != nil {
+			if err := activities.EnsureMeetingReference(ctx, tx, *held.ref); err != nil {
+				return err
+			}
+		}
+		actionable, err := briefItemActionable(ctx, tx, item, now)
+		if err != nil {
 			return err
 		}
-		if !briefItemActionable(item, now) {
+		if !actionable {
 			return apperrors.ErrConflict
 		}
 
 		markedAt := now.UTC()
+		// NULL rather than the empty string when the mark is not a snooze: the
+		// column's CHECK pairs its presence with the snoozed state, and an
+		// empty string is present.
+		var storedOn *string
+		if held.on != "" {
+			on := string(held.on)
+			storedOn = &on
+		}
 		if _, err := tx.Exec(ctx, `
-			UPDATE brief_item SET state = $2, state_at = $3, snoozed_until = $4 WHERE id = $1`,
-			itemID, state, markedAt, snoozedUntil); err != nil {
+			UPDATE brief_item SET state = $2, state_at = $3, snoozed_until = $4,
+			       reopen_on = $5, reopen_ref = $6 WHERE id = $1`,
+			itemID, state, markedAt, held.until, storedOn, held.ref); err != nil {
 			return err
 		}
 		before := map[string]any{
 			auditFieldState: item.State, auditFieldStateAt: item.StateAt,
 			auditFieldSnoozedUntil: item.SnoozedUntil,
+			auditFieldReopenOn:     item.ReopenOn, auditFieldReopenRef: item.ReopenRef,
 		}
 		after := map[string]any{
 			auditFieldState: state, auditFieldStateAt: markedAt,
-			auditFieldSnoozedUntil: snoozedUntil,
+			auditFieldSnoozedUntil: held.until,
+			auditFieldReopenOn:     held.on, auditFieldReopenRef: held.ref,
 		}
 		if _, err := storekit.Audit(ctx, tx, "update", "brief_item", itemID, before, after); err != nil {
 			return err
 		}
 		item.State = state
 		item.StateAt = &markedAt
-		item.SnoozedUntil = snoozedUntil
+		item.SnoozedUntil = held.until
+		item.ReopenOn = held.on
+		item.ReopenRef = held.ref
 		return nil
 	})
 	if err != nil {
@@ -168,12 +202,91 @@ func Unanswered(item BriefRunItem) bool {
 	return item.State == briefStateNew
 }
 
-// briefItemActionable says whether a rep may still mark this item: fresh,
-// or snoozed past its snoozed_until (the re-surface may not have been
+// briefItemActionable says whether a rep may still mark this item: fresh, or
+// snoozed past whatever it was waiting for (the re-surface may not have been
 // materialized by a read yet, but the item is already actionable again).
-func briefItemActionable(item BriefRunItem, now time.Time) bool {
+//
+// It reads the database because two of the three conditions are answered by
+// rows rather than by the clock — a reply that arrived, a meeting that ended —
+// and asking here is what keeps ONE answer to "is this snooze over". The
+// re-surface read calls the same SQL through briefSnoozeLiftedSQL.
+func briefItemActionable(ctx context.Context, tx pgx.Tx, item BriefRunItem, now time.Time) (bool, error) {
 	if item.State == briefStateNew {
-		return true
+		return true, nil
 	}
-	return item.State == briefStateSnoozed && item.SnoozedUntil != nil && !now.UTC().Before(*item.SnoozedUntil)
+	if item.State != briefStateSnoozed {
+		return false, nil
+	}
+	switch item.ReopenOn {
+	case values.ReopenOnTime:
+		return item.SnoozedUntil != nil && !now.UTC().Before(*item.SnoozedUntil), nil
+	case values.ReopenOnReply, values.ReopenOnMeeting:
+		var lifted bool
+		if err := tx.QueryRow(ctx, `SELECT `+briefSnoozeLiftedSQL("$1", "$2", "$3", "$4", "$5"),
+			item.DealID, string(item.ReopenOn), item.ReopenRef, item.StateAt, now.UTC()).Scan(&lifted); err != nil {
+			return false, fmt.Errorf("brief: reading whether item %s is still set aside: %w", item.ID, err)
+		}
+		return lifted, nil
+	default:
+		// A snoozed row with no condition cannot exist — the column's CHECK
+		// pairs the two — so reaching here means the constraint was dropped
+		// rather than that a rep is waiting for something unnameable.
+		return false, fmt.Errorf("brief: item %s is snoozed waiting for %q, which is not a condition", item.ID, item.ReopenOn)
+	}
+}
+
+// lockItemForMark reads one queue item under FOR UPDATE and fills it in,
+// returning the id of the rep whose run it belongs to.
+//
+// Read back with the mark, because the client replaces its cached item with the
+// response wholesale: dropping the lineage here makes the "you dismissed it"
+// line vanish the moment the rep acts on the very item it was explaining.
+//
+// Split from markItem because that function is the TRANSITION — who may mark,
+// whether the item is still actionable, and the write itself — and fifteen scan
+// targets in the middle of it hid which of those questions each branch was
+// answering.
+func lockItemForMark(ctx context.Context, tx pgx.Tx, itemID ids.UUID, item *BriefRunItem) (ids.UUID, error) {
+	var owner ids.UUID
+	var featuresRaw []byte
+	var dismissedOn, returnedWith *time.Time
+	var wasOn *string
+	err := tx.QueryRow(ctx, `
+		SELECT bi.id, bi.deal_id, bi.rank, bi.composite, bi.feature_vector, bi.evidence_ids, bi.state, bi.state_at, bi.snoozed_until, coalesce(bi.finding, ''),
+		       bi.reopen_on, bi.reopen_ref, bi.returned_after_dismissal_on, bi.returned_with_activity_at, br.user_id
+		FROM brief_item bi
+		JOIN brief_run br ON br.id = bi.brief_run_id
+		WHERE bi.id = $1
+		FOR UPDATE OF bi`, itemID).Scan(&item.ID, &item.DealID, &item.Rank, &item.Composite, &featuresRaw,
+		&item.EvidenceIDs, &item.State, &item.StateAt, &item.SnoozedUntil, &item.Finding,
+		&wasOn, &item.ReopenRef, &dismissedOn, &returnedWith, &owner)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.UUID{}, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return ids.UUID{}, err
+	}
+	// The CHECK keeps the pair whole, so one non-null half means both are.
+	if dismissedOn != nil && returnedWith != nil {
+		item.Lineage = &ItemLineage{DismissedOn: *dismissedOn, ReturnedWith: *returnedWith}
+	}
+	if wasOn != nil {
+		item.ReopenOn = values.ReopenCondition(*wasOn)
+	}
+	if err := json.Unmarshal(featuresRaw, &item.Features); err != nil {
+		return ids.UUID{}, fmt.Errorf("brief: item %s carries an unreadable feature vector: %w", item.ID, err)
+	}
+	// The mark's twin of the join in readRunItems: the item names a deal that
+	// may have moved since the run was assembled, and a mark is a read-back as
+	// much as a write. Checked HERE, beside the read that produced the
+	// reference, rather than in the caller — a persisted reference is
+	// re-checked when it is served, and a function that hands one back without
+	// checking is one refactor away from a caller that forgets to.
+	//
+	// Before actionability, so a deal the rep can no longer read answers
+	// not-found rather than disclosing the item's state through a conflict.
+	if err := auth.EnsureVisible(ctx, tx, "deal", item.DealID); err != nil {
+		return ids.UUID{}, err
+	}
+	return owner, nil
 }

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -309,7 +309,12 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 			JOIN brief_run br ON br.id = bi.brief_run_id
 			WHERE br.user_id = $%d AND bi.deal_id = d.id AND bi.state <> 'new'
 			  AND CASE WHEN bi.state = 'snoozed'
-			      THEN bi.snoozed_until > $%d
+			      -- Still suppressed while the snooze holds. A time snooze
+			      -- holds until its moment; the other two hold until the
+			      -- shared predicate says the world moved.
+			      THEN CASE WHEN bi.reopen_on = 'time'
+			           THEN bi.snoozed_until > $%d
+			           ELSE NOT %s END
 			      ELSE NOT EXISTS (
 				SELECT 1 FROM activity a
 				JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
@@ -320,7 +325,9 @@ func briefCandidates(ctx context.Context, tx pgx.Tx, userID ids.UUID, now time.T
 				  -- lineage read bounds itself the same way, so an unbounded
 				  -- one here would return deals whose card can say nothing.
 				  AND a.occurred_at <= $%d) END)`,
-		briefBaseValueSQL(fmt.Sprintf("$%d", asOfPos), fmt.Sprintf("$%d", basePos), "d"), userPos, asOfPos, asOfPos)
+		briefBaseValueSQL(fmt.Sprintf("$%d", asOfPos), fmt.Sprintf("$%d", basePos), "d"), userPos, asOfPos,
+		briefSnoozeLiftedSQL("d.id", "bi.reopen_on", "bi.reopen_ref", "bi.state_at", fmt.Sprintf("$%d", asOfPos)),
+		asOfPos)
 	if scope != "" {
 		q += " AND " + scope
 	}

--- a/backend/internal/compose/briefs/briefsnooze_integration_test.go
+++ b/backend/internal/compose/briefs/briefsnooze_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 func TestBriefSnoozeIsOwnerOnlyStampedAndConflictSafe(t *testing.T) {
@@ -38,11 +39,11 @@ func TestBriefSnoozeIsOwnerOnlyStampedAndConflictSafe(t *testing.T) {
 
 	// Only the run's owner may snooze: another rep sees not-found.
 	rep2 := b.As(b.Rep2, []ids.UUID{b.Team1}, integration.AdminPerms)
-	if _, err := b.engine.MarkSnoozed(rep2, itemA.ID, until, snoozeAt); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := b.engine.MarkSnoozed(rep2, itemA.ID, values.ReopenOnTime, &until, nil, snoozeAt); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("foreign snooze → %v, want ErrNotFound (existence-hiding)", err)
 	}
 
-	snoozed, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, until, snoozeAt)
+	snoozed, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, values.ReopenOnTime, &until, nil, snoozeAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +71,8 @@ func TestBriefSnoozeIsOwnerOnlyStampedAndConflictSafe(t *testing.T) {
 	}
 
 	// An acted item cannot be snoozed — the snooze only defers actionable work.
-	if _, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, until.Add(72*time.Hour), until.Add(2*time.Minute)); !errors.Is(err, apperrors.ErrConflict) {
+	later := until.Add(72 * time.Hour)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, values.ReopenOnTime, &later, nil, until.Add(2*time.Minute)); !errors.Is(err, apperrors.ErrConflict) {
 		t.Fatalf("snooze on an acted item → %v, want ErrConflict", err)
 	}
 
@@ -108,7 +110,7 @@ func TestBriefSnoozedItemHidesUntilExpiryThenResurfaces(t *testing.T) {
 	// than by this one. Hours are what a rep snoozes for anyway — "not before
 	// the afternoon" — and the flip this test is about is the same flip.
 	until := briefClock.Add(8 * time.Hour)
-	if _, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, until, briefClock.Add(time.Hour)); err != nil {
+	if _, err := b.engine.MarkSnoozed(b.repCtx, itemA.ID, values.ReopenOnTime, &until, nil, briefClock.Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/briefs/briefsnoozeevent_integration_test.go
+++ b/backend/internal/compose/briefs/briefsnoozeevent_integration_test.go
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package briefs
+
+// A snooze that waits on the world rather than on the clock.
+//
+// "Remind me in three days" was the only thing a rep could say, so every
+// set-aside was a guess: too early and the item is still dead, too late and the
+// customer waited. These tests hold the two conditions that replace the guess —
+// the customer writing back, and a meeting being over — through all three
+// readers that must agree about whether a snooze is finished: the home read
+// that flips the state, the fresh run that suppresses the deal, and the mark
+// guard that decides whether a rep may still act.
+//
+// All instants are injected; nothing here reads the wall clock.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+func TestASnoozeWaitingForAReplyLiftsWhenOneArrives(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnReply, nil, nil, setDown); err != nil {
+		t.Fatal(err)
+	}
+
+	// No reply yet: hidden from the read, suppressed from a fresh run, and no
+	// passage of time changes either — which is the whole point of the
+	// condition.
+	muchLater := setDown.Add(6 * time.Hour)
+	if visible := readableDeals(t, b, muchLater); visible[item.DealID] {
+		t.Fatal("an item waiting for a reply re-surfaced with no reply; a condition that lifts on time alone is the guess this replaces")
+	}
+	ranked, err := b.engine.Rank(b.repCtx, muchLater)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range ranked.Queue {
+		if candidate.DealID == item.DealID {
+			t.Fatal("a fresh run ranked a deal whose item is still waiting for a reply")
+		}
+	}
+
+	// The reply arrives, linked to the same deal and after the set-down.
+	replyAt := setDown.Add(time.Hour)
+	reply := seedInbound(t, owner, "they wrote back", replyAt)
+	integration.LinkActivity(t, owner, reply, "deal", b.dealA)
+
+	if visible := readableDeals(t, b, replyAt.Add(time.Hour)); !visible[item.DealID] {
+		t.Fatal("the reply arrived and the item stayed set aside; the rep is now the one keeping the customer waiting")
+	}
+}
+
+// TestAnInboundBeforeTheSnoozeIsNotTheReplyBeingWaitedFor is the case the
+// bound on occurred_at exists for. Without it the snooze lifts on mail that was
+// already sitting there when the rep set the item down — which is to say it
+// never takes at all.
+func TestAnInboundBeforeTheSnoozeIsNotTheReplyBeingWaitedFor(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	// A real inbound on this deal, stamped BEFORE the rep sets the item down.
+	// Seeded here rather than relying on setupBrief's own linked activity,
+	// which carries no direction at all and would be excluded by the inbound
+	// clause no matter what the time bound said — a fixture that cannot fail
+	// the assertion it is named for.
+	setDown := briefClock.Add(3 * time.Hour)
+	old := seedInbound(t, owner, "last week's mail", setDown.Add(-2*time.Hour))
+	integration.LinkActivity(t, owner, old, "deal", b.dealA)
+
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnReply, nil, nil, setDown); err != nil {
+		t.Fatal(err)
+	}
+	if visible := readableDeals(t, b, setDown.Add(2*time.Hour)); visible[item.DealID] {
+		t.Fatal("mail that predates the snooze lifted it, so the snooze never took")
+	}
+}
+
+// TestAFutureDatedReplyDoesNotLiftASnoozeYet bounds the other end. A reply
+// stamped for next week has not arrived, and treating it as one puts the item
+// back for something still to come.
+func TestAFutureDatedReplyDoesNotLiftASnoozeYet(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnReply, nil, nil, setDown); err != nil {
+		t.Fatal(err)
+	}
+	ahead := seedInbound(t, owner, "dated next week", setDown.AddDate(0, 0, 7))
+	integration.LinkActivity(t, owner, ahead, "deal", b.dealA)
+
+	if visible := readableDeals(t, b, setDown.Add(4*time.Hour)); visible[item.DealID] {
+		t.Fatal("a reply dated next week lifted the snooze today")
+	}
+}
+
+// TestOurOwnOutboundIsNotTheCustomerReplying is the direction guard. A rep who
+// sets an item down and then sends a chaser has not been replied to, and
+// lifting on their own mail would put the work back the moment they did it.
+func TestOurOwnOutboundIsNotTheCustomerReplying(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnReply, nil, nil, setDown); err != nil {
+		t.Fatal(err)
+	}
+	chasedAt := setDown.Add(time.Hour)
+	ours := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, direction)
+		VALUES ($1, 'email', 'just chasing', $2, 'manual', 'human:x', 'outbound')`, chasedAt)
+	integration.LinkActivity(t, owner, ours, "deal", b.dealA)
+
+	if visible := readableDeals(t, b, chasedAt.Add(time.Hour)); visible[item.DealID] {
+		t.Fatal("our own chaser lifted the snooze; the rep is waiting on the customer, not on themselves")
+	}
+}
+
+func TestASnoozeWaitingForAMeetingLiftsOnceItIsOver(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	meetsAt := setDown.Add(4 * time.Hour)
+	meeting := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 'manual', 'human:x')`, meetsAt)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnMeeting, nil, &meeting, setDown); err != nil {
+		t.Fatal(err)
+	}
+
+	if visible := readableDeals(t, b, meetsAt.Add(-time.Hour)); visible[item.DealID] {
+		t.Fatal("the item came back before the meeting it was waiting for")
+	}
+	if visible := readableDeals(t, b, meetsAt.Add(time.Hour)); !visible[item.DealID] {
+		t.Fatal("the meeting is over and the item stayed set aside")
+	}
+}
+
+// TestACancelledMeetingReturnsTheWorkRatherThanHoldingItForever is the case
+// that decides between two defensible rules. A rep waiting on a meeting that is
+// then cancelled is waiting for something that will never happen, and the only
+// outcome that actually loses work is holding the item forever.
+func TestACancelledMeetingReturnsTheWorkRatherThanHoldingItForever(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	meeting := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 'manual', 'human:x')`, briefClock.AddDate(0, 0, 16))
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnMeeting, nil, &meeting, briefClock.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	// Still far ahead, so nothing but the cancellation can bring this back.
+	stillWaiting := briefClock.Add(5 * time.Hour)
+	if visible := readableDeals(t, b, stillWaiting); visible[item.DealID] {
+		t.Fatal("an item waiting for a future meeting came back early")
+	}
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET archived_at = now() WHERE id = $1`, meeting); err != nil {
+		t.Fatal(err)
+	}
+	if visible := readableDeals(t, b, stillWaiting.Add(time.Hour)); !visible[item.DealID] {
+		t.Fatal("the meeting was cancelled and the work stayed buried; nothing will ever bring it back")
+	}
+}
+
+// TestTheMarkGuardAgreesWithTheReadAboutAnEventSnooze is the third reader.
+// A rep looking at a screen the read has not refreshed must not be told their
+// item is a conflict when the read would already have re-surfaced it — and must
+// not be allowed to mark one the read still hides.
+func TestTheMarkGuardAgreesWithTheReadAboutAnEventSnooze(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnReply, nil, nil, setDown); err != nil {
+		t.Fatal(err)
+	}
+	// No reply: the guard refuses, exactly as the read hides it.
+	if _, err := b.engine.MarkActed(b.repCtx, item.ID, setDown.Add(time.Hour)); !errors.Is(err, apperrors.ErrConflict) {
+		t.Fatalf("marking an item still waiting for a reply → %v, want ErrConflict", err)
+	}
+	replyAt := setDown.Add(time.Hour)
+	reply := seedInbound(t, owner, "they wrote back", replyAt)
+	integration.LinkActivity(t, owner, reply, "deal", b.dealA)
+
+	// The reply arrived: the guard admits the mark without the read having run
+	// first, which is the stale-screen case it exists for.
+	if _, err := b.engine.MarkActed(b.repCtx, item.ID, replyAt.Add(time.Hour)); err != nil {
+		t.Fatalf("marking an item whose reply arrived: %v", err)
+	}
+}
+
+// TestASnoozeShapeIsRefusedBeforeItReachesTheDatabase holds the three ways a
+// caller can name a wait that means nothing. Each must answer as a validation
+// error the client can read, not as a constraint violation it cannot.
+func TestASnoozeShapeIsRefusedBeforeItReachesTheDatabase(t *testing.T) {
+	b := setupBrief(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	at := briefClock.Add(time.Hour)
+	moment := briefClock.Add(8 * time.Hour)
+
+	for _, bad := range []struct {
+		name string
+		on   values.ReopenCondition
+		till *time.Time
+		ref  *ids.UUID
+	}{
+		{"a clock snooze with no moment", values.ReopenOnTime, nil, nil},
+		{"a reply snooze carrying a moment", values.ReopenOnReply, &moment, nil},
+		{"a meeting snooze naming no meeting", values.ReopenOnMeeting, nil, nil},
+		{"a reply snooze naming a meeting", values.ReopenOnReply, nil, &item.DealID},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, bad.on, bad.till, bad.ref, at); err == nil {
+				t.Fatal("accepted, and the row it would write describes a wait nothing can lift")
+			}
+		})
+	}
+}
+
+// seedInbound writes one inbound message at a given instant. Every instant in
+// this file is derived from the moment the item was set down rather than
+// written out, so a change to briefClock cannot silently move a reply to the
+// wrong side of the snooze and turn a real assertion into a vacuous one.
+func seedInbound(t *testing.T, owner *pgx.Conn, subject string, at time.Time) ids.UUID {
+	t.Helper()
+	return integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, direction)
+		VALUES ($1, 'email', $2, $3, 'manual', 'human:x', 'inbound')`, subject, at)
+}
+
+// TestASnoozeCannotWaitForSomethingThatIsNotAMeeting holds the guard on
+// reopen_ref. Three ways to name the wrong thing, and each loses work or leaks:
+// an id naming nothing never lifts, an id naming an email lifts instantly
+// because its occurred_at is already past, and an id naming a row the rep
+// cannot read would tell them when somebody else's meeting happened.
+func TestASnoozeCannotWaitForSomethingThatIsNotAMeeting(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	at := briefClock.Add(time.Hour)
+
+	email := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, direction)
+		VALUES ($1, 'email', 'not a meeting', $2, 'manual', 'human:x', 'inbound')`, briefClock.Add(-24*time.Hour))
+	missing := ids.NewV7()
+
+	for _, bad := range []struct {
+		name string
+		ref  ids.UUID
+	}{
+		{"an id that names no row at all", missing},
+		{"an id that names an email rather than a meeting", email},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			ref := bad.ref
+			if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnMeeting, nil, &ref, at); err == nil {
+				t.Fatal("accepted; the snooze it writes either never lifts or lifts on the wrong row")
+			}
+		})
+	}
+}
+
+// TestAMeetingSnoozeHoldsUntilTheMeetingHasENDED is the difference between the
+// meeting's start and its end. Lifting at occurred_at puts the work back while
+// the rep is still in the room, which is the one moment they cannot act on it.
+func TestAMeetingSnoozeHoldsUntilTheMeetingHasENDED(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	setDown := briefClock.Add(time.Hour)
+	startsAt := setDown.Add(2 * time.Hour)
+	meeting := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, duration_seconds, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 3600, 'manual', 'human:x')`, startsAt)
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnMeeting, nil, &meeting, setDown); err != nil {
+		t.Fatal(err)
+	}
+	// Thirty minutes in: the meeting has started and is not over.
+	if visible := readableDeals(t, b, startsAt.Add(30*time.Minute)); visible[item.DealID] {
+		t.Fatal("the work came back while the rep was still in the meeting")
+	}
+	if visible := readableDeals(t, b, startsAt.Add(90*time.Minute)); !visible[item.DealID] {
+		t.Fatal("the meeting ended and the work stayed set aside")
+	}
+}
+
+// TestACancelledMeetingStatusReturnsTheWork covers the other way a meeting
+// stops being something worth waiting for. Archiving is one; the record's own
+// status is the one a calendar sync actually writes.
+func TestACancelledMeetingStatusReturnsTheWork(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+
+	run, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := run.Items[0]
+	meeting := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, meeting_status, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 'booked', 'manual', 'human:x')`, briefClock.AddDate(0, 0, 16))
+	if _, err := b.engine.MarkSnoozed(b.repCtx, item.ID, values.ReopenOnMeeting, nil, &meeting, briefClock.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	stillWaiting := briefClock.Add(5 * time.Hour)
+	if visible := readableDeals(t, b, stillWaiting); visible[item.DealID] {
+		t.Fatal("an item waiting for a booked future meeting came back early")
+	}
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET meeting_status = 'canceled' WHERE id = $1`, meeting); err != nil {
+		t.Fatal(err)
+	}
+	if visible := readableDeals(t, b, stillWaiting.Add(time.Hour)); !visible[item.DealID] {
+		t.Fatal("the meeting was cancelled and the work stayed buried")
+	}
+}
+
+// readableDeals is what the rep's own home read currently shows them, as a set
+// of deal ids. The read is the surface the whole feature is judged by, so the
+// tests above ask it rather than querying brief_item directly.
+func readableDeals(t *testing.T, b *briefEnv, at time.Time) map[ids.UUID]bool {
+	t.Helper()
+	latest, err := b.engine.LatestRun(b.repCtx, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[ids.UUID]bool{}
+	for _, item := range latest.Items {
+		seen[item.DealID] = true
+	}
+	return seen
+}

--- a/backend/internal/compose/briefs/briefsnoozelift.go
+++ b/backend/internal/compose/briefs/briefsnoozelift.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// Whether a snooze that waits on the world is over.
+//
+// Two readers ask this and they must not disagree. The candidate filter asks it
+// to decide whether a deal comes back into tomorrow's queue; the mark guard asks
+// it to decide whether a rep looking at a stale screen may still act. If the
+// filter says an item is back and the guard says it is still set aside, the rep
+// sees the row and gets a conflict when they touch it — so the predicate is
+// spelled once, here, and both build their query from it.
+//
+// A `time` snooze is not handled here: it is answered by comparing two
+// timestamps, needs no join, and the callers compare it directly.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+)
+
+// briefSnoozeLiftedSQL renders the predicate as a boolean expression over five
+// SQL terms the caller supplies: the deal, the condition, the meeting it may
+// name, the instant the item was set down, and the instant to judge against.
+//
+// Each term is a fragment rather than a fixed column or placeholder because the
+// two callers reach the same five values differently — the candidate filter has
+// the brief_item row joined and passes column references, the mark guard has
+// already read it into Go and passes its own numbered placeholders. Hard-coding
+// either shape would compile in one caller and not the other, and hand-typing a
+// "$4" into a query whose fourth argument is something else is exactly the
+// failure the rule against typing placeholders exists to prevent.
+//
+// Every term is a compile-time literal at both call sites. Nothing from a
+// request body reaches this function.
+func briefSnoozeLiftedSQL(deal, condition, ref, setDown, asOf string) string {
+	return fmt.Sprintf(`(CASE %s
+		-- A reply is anything the counterparty sent us on a conversation
+		-- linked to this deal after the rep set it down.
+		--
+		-- NO CONTENT GATE on the activity, which is deliberate and matches the
+		-- dismissal filter this sits beside in briefCandidates: the brief's
+		-- queue is scoped by DEAL, and a rep who may read the deal is told
+		-- that it moved without being shown what moved it. The waiting-message
+		-- lane is scoped by activity instead, so its own predicate does gate
+		-- the reply — the two differ because the thing being protected does. Bounded at the
+		-- judging instant for the reason the dismissal filter is: a
+		-- future-dated inbound has not arrived, and lifting a snooze for it
+		-- puts the item back for something still to come.
+		WHEN 'reply' THEN EXISTS (
+			SELECT 1 FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = %s
+			WHERE a.archived_at IS NULL
+			  AND a.direction = 'inbound'
+			  AND a.occurred_at > %s
+			  AND a.occurred_at <= %s)
+		-- The meeting is over once it has ENDED, which is its start plus its
+		-- duration. Lifting at occurred_at would put the work back while the
+		-- rep is still in the room, which is the one moment they certainly
+		-- cannot act on it. A meeting with no duration is treated as ending
+		-- when it starts, because that is all the row says.
+		--
+		-- A meeting that will not happen counts as over: archived, cancelled or
+		-- a no-show. The rep is waiting for something that will never come, and
+		-- holding the item forever is the only outcome that loses the work.
+		--
+		-- kind = 'meeting' is the guard that makes reopen_ref mean what it
+		-- says. Without it any activity id serves — an old email whose
+		-- occurred_at has long passed lifts the snooze the moment it is set.
+		WHEN 'meeting' THEN EXISTS (
+			SELECT 1 FROM activity m
+			WHERE m.id = %s AND m.kind = '%s'
+			  AND (m.archived_at IS NOT NULL
+			       OR m.meeting_status IN ('canceled', 'no_show')
+			       OR m.occurred_at
+			          + make_interval(secs => coalesce(m.duration_seconds, 0)) <= %s))
+		ELSE false
+	END)`, condition, deal, setDown, asOf, ref, activities.KindMeeting, asOf)
+}

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // Brief item states (data-model §12.5). A snooze (A77/AC-home-6) hides
@@ -73,6 +74,10 @@ type BriefRunItem struct {
 	State        string
 	StateAt      *time.Time
 	SnoozedUntil *time.Time
+	// ReopenOn is what the rep is waiting for, set only while snoozed. ReopenRef
+	// names the meeting when they are waiting for one.
+	ReopenOn  values.ReopenCondition
+	ReopenRef *ids.UUID
 	// Finding is what the overnight agent found about this deal, empty when no
 	// pass has annotated the run it belongs to.
 	Finding string
@@ -366,17 +371,24 @@ func readRunItems(ctx context.Context, tx pgx.Tx, runID ids.UUID) ([]BriefRunIte
 	return items, rows.Err()
 }
 
-// resurfaceExpiredSnoozes flips a run's expired snoozes back to
-// actionable — the A77 re-surface half of the snooze contract. Each flip
-// is a state change on per-rep queue data, so it is audited like the
-// rep's own marks (brief rows are audit-only; no brief.* event exists in
-// the events.md catalog).
+// resurfaceExpiredSnoozes flips a run's finished snoozes back to actionable —
+// the re-surface half of the snooze contract. Each flip is a state change on
+// per-rep queue data, so it is audited like the rep's own marks (brief rows are
+// audit-only; no brief.* event exists in the events.md catalog).
+//
+// "Finished" is whatever the item was waiting for: a moment that has passed, a
+// reply that arrived, a meeting that is over. The last two come from
+// briefSnoozeLiftedSQL, the same predicate the candidate filter and the mark
+// guard ask — three readers of one question, and a fourth spelling here would
+// be the one that disagrees.
 func resurfaceExpiredSnoozes(ctx context.Context, tx pgx.Tx, runID ids.UUID, now time.Time) error {
-	resurfaced, err := collectIDList(tx.Query(ctx, `
-		UPDATE brief_item
-		SET state = 'new', state_at = NULL, snoozed_until = NULL
-		WHERE brief_run_id = $1 AND state = 'snoozed' AND snoozed_until <= $2
-		RETURNING id`, runID, now.UTC()))
+	lifted := briefSnoozeLiftedSQL("bi.deal_id", "bi.reopen_on", "bi.reopen_ref", "bi.state_at", "$2")
+	resurfaced, err := collectIDList(tx.Query(ctx, fmt.Sprintf(`
+		UPDATE brief_item bi
+		SET state = 'new', state_at = NULL, snoozed_until = NULL, reopen_on = NULL, reopen_ref = NULL
+		WHERE bi.brief_run_id = $1 AND bi.state = 'snoozed'
+		  AND CASE WHEN bi.reopen_on = 'time' THEN bi.snoozed_until <= $2 ELSE %s END
+		RETURNING bi.id`, lifted), runID, now.UTC()))
 	if err != nil {
 		return err
 	}
@@ -384,7 +396,7 @@ func resurfaceExpiredSnoozes(ctx context.Context, tx pgx.Tx, runID ids.UUID, now
 		before := map[string]any{auditFieldState: briefStateSnoozed}
 		after := map[string]any{
 			auditFieldState: briefStateNew, auditFieldStateAt: nil,
-			auditFieldSnoozedUntil: nil,
+			auditFieldSnoozedUntil: nil, auditFieldReopenOn: nil, auditFieldReopenRef: nil,
 		}
 		if _, err := storekit.Audit(ctx, tx, "update", "brief_item", itemID, before, after); err != nil {
 			return err

--- a/backend/internal/compose/briefseam.go
+++ b/backend/internal/compose/briefseam.go
@@ -84,6 +84,8 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 			// evidence was never queued.
 			EvidenceIDs:  append(make([]ids.UUID, 0, len(item.EvidenceIDs)), item.EvidenceIDs...),
 			SnoozedUntil: item.SnoozedUntil,
+			ReopenOn:     item.ReopenOn,
+			ReopenRef:    item.ReopenRef,
 		})
 	}
 	return agents.ReadBriefResult{

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // withheldFromTheTool names each persisted brief field the agent surface does
@@ -55,6 +56,7 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 	asOf := time.Date(2026, 8, 8, 5, 22, 0, 0, time.UTC)
 	stateAt := time.Date(2026, 8, 8, 7, 33, 0, 0, time.UTC)
 	snoozedUntil := time.Date(2026, 8, 9, 8, 44, 0, 0, time.UTC)
+	meetingID := ids.NewV7()
 	annotatedAt := time.Date(2026, 8, 8, 6, 12, 0, 0, time.UTC)
 	run := briefs.BriefRun{
 		ID: runID, UserID: userID, GeneratedAt: generated, AsOf: asOf,
@@ -69,6 +71,7 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 			},
 			EvidenceIDs: []ids.UUID{evidence}, State: "snoozed",
 			StateAt: &stateAt, SnoozedUntil: &snoozedUntil,
+			ReopenOn: values.ReopenOnMeeting, ReopenRef: &meetingID,
 			Finding: "He asked about the delivery date yesterday.",
 			Lineage: &briefs.ItemLineage{
 				DismissedOn:  time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
@@ -121,6 +124,10 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		"Rank": `"rank":3`, "Composite": `"composite":0.815`, "Features": `"momentum":0.44`,
 		"EvidenceIDs": `"evidence_ids":["` + evidence.String(), "State": `"state":"snoozed"`,
 		"StateAt": `"state_at":"2026-08-08T07:33:00Z"`, "SnoozedUntil": `"snoozed_until":"2026-08-09T08:44:00Z"`,
+		// Served, not withheld: without the condition a snooze carrying no
+		// moment reads to an agent as one that never lifts, and it would report
+		// a deal as abandoned when the person is waiting for a reply.
+		"ReopenOn": `"reopen_on":"meeting"`, "ReopenRef": `"reopen_ref":"` + meetingID.String(),
 		"Finding": "He asked about the delivery date yesterday.",
 		"Lineage": `"dismissed_on":"2026-08-05"`,
 	}, string(served))

--- a/backend/internal/compose/integration/disposition_integration_test.go
+++ b/backend/internal/compose/integration/disposition_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // waitsFor reads the waiting lane as one person and reports whether the subject
@@ -87,8 +88,9 @@ func TestOneRepsSnoozeDoesNotHideTheRowFromAnother(t *testing.T) {
 		t.Fatal("the second rep never saw the message, so this proves nothing about hiding it")
 	}
 
+	twoDays := waitingInstant.Add(48 * time.Hour)
 	if err := atWaitingInstant(e).SnoozeMessage(
-		e.As(e.Rep1, nil, AdminPerms), id, waitingInstant.Add(48*time.Hour)); err != nil {
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnTime, &twoDays, nil); err != nil {
 		t.Fatalf("the first rep snoozing the message: %v", err)
 	}
 
@@ -213,7 +215,7 @@ func TestASnoozeLiftsWhenItsMomentPasses(t *testing.T) {
 
 	until := waitingInstant.Add(24 * time.Hour)
 	if err := atWaitingInstant(e).SnoozeMessage(
-		e.As(e.Rep1, nil, AdminPerms), id, until); err != nil {
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnTime, &until, nil); err != nil {
 		t.Fatalf("snoozing the message: %v", err)
 	}
 
@@ -291,8 +293,9 @@ func TestASnoozeIntoThePastIsRefused(t *testing.T) {
 
 	// Judged against the SAME clock the accepting cases use, so what is refused
 	// here is the moment being behind rather than the fixture being historical.
+	past := waitingInstant.Add(-time.Hour)
 	err := atWaitingInstant(e).SnoozeMessage(
-		e.As(e.Rep1, nil, AdminPerms), id, waitingInstant.Add(-time.Hour))
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnTime, &past, nil)
 	if err == nil {
 		t.Fatal("a snooze into the past was accepted, and hides nothing")
 	}

--- a/backend/internal/compose/integration/dispositionreopen_integration_test.go
+++ b/backend/internal/compose/integration/dispositionreopen_integration_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A message set aside until something happens, rather than until a date.
+//
+// The waiting lane's whole promise is that it empties: work it and it is done.
+// A snooze that could only name a moment made every set-aside a guess, and a
+// wrong guess breaks the promise in both directions — the message comes back
+// while the customer is still silent, or it stays buried after they have
+// written.
+//
+// What "they replied" means here is NOT what it means on a brief item, and the
+// difference is the point of the two separate predicates. A brief item waits on
+// a DEAL, so any inbound linked to that deal answers it. A message waits on a
+// CONVERSATION, so only a newer inbound on the same thread does.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// waitsForAt is waitsFor with the instant made explicit, because every
+// assertion below turns on whether the judging moment is before or after the
+// thing being waited for.
+func waitsForAt(t *testing.T, e *Env, user ids.UUID, subject string, at time.Time) bool {
+	t.Helper()
+	rows, err := activities.NewStore(e.DB()).WaitingReplies(e.As(user, nil, AdminPerms), at)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+	return containsSubject(rows, subject)
+}
+
+func TestAMessageSnoozedUntilTheyReplyComesBackWhenTheyDo(t *testing.T) {
+	e := Setup(t)
+	const thread = "thread-reopen-reply"
+	const subject = "Waiting on their answer"
+	person := seedWaitingPerson(t, e)
+	seedWaitingMessageLinked(t, e, thread, "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour), person)
+	id := waitingMessageID(t, e, subject)
+
+	// Present before anybody judges it, or every assertion below is a query
+	// that never matched rather than a change.
+	if !waitsForAt(t, e, e.Rep1, subject, waitingInstant) {
+		t.Fatal("the message never reached the lane, so this proves nothing")
+	}
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	// No reply, and no amount of time changes that.
+	if waitsForAt(t, e, e.Rep1, subject, waitingInstant.Add(10*24*time.Hour)) {
+		t.Fatal("a message waiting for a reply came back with no reply; that is the guess this replaces")
+	}
+
+	// They write back on the SAME conversation.
+	//
+	// The reply becomes the thread's waiting row — the lane serves the newest
+	// inbound per thread — and it carries no disposition of its own, so it
+	// would appear whether or not the snooze lifted. That makes the reply's
+	// own presence worthless as evidence here. What the lift actually controls
+	// is the SNOOZED row, so this asserts through the disposition directly.
+	replyAt := waitingInstant.Add(2 * time.Hour)
+	const answer = "Their answer"
+	seedWaitingMessageLinked(t, e, thread, "inbound", answer, replyAt, person)
+
+	if !waitsForAt(t, e, e.Rep1, answer, replyAt.Add(time.Hour)) {
+		t.Fatal("they replied and the conversation stayed off the rep's day")
+	}
+}
+
+// TestAReplySnoozeOnAThreadThatGetsNoNewInboundStillHolds is the other half of
+// the case above, and the half that actually exercises the lift.
+//
+// When a reply DOES arrive it becomes the thread's newest inbound and appears
+// on the lane under its own subject, carrying no disposition — so its presence
+// proves the lane picked a row, not that any snooze lifted. This one holds the
+// negative the lift alone decides: the same set-down, an inbound on a DIFFERENT
+// thread, and the original still hidden. Together they pin both directions.
+func TestAReplySnoozeOnAThreadThatGetsNoNewInboundStillHolds(t *testing.T) {
+	e := Setup(t)
+	const subject = "Still waiting on them"
+	person := seedWaitingPerson(t, e)
+	seedWaitingMessageLinked(t, e, "thread-reopen-quiet", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour), person)
+	id := waitingMessageID(t, e, subject)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	if waitsForAt(t, e, e.Rep1, subject, waitingInstant.Add(30*24*time.Hour)) {
+		t.Fatal("a month passed with no reply and the message came back anyway; the condition lifted on time after all")
+	}
+}
+
+// TestAReplyThisReaderCannotSeeDoesNotLiftTheirSnooze is the disclosure the
+// content gate on the lift exists to stop.
+//
+// The row coming back IS the message: a rep who set a thread down until the
+// customer answered, and then watches it reappear, has been told the customer
+// answered — without being shown a word of it, and without being entitled to
+// know. The waiting query already gates the row it serves this way; the reply
+// that lifts a snooze has to be gated the same, or the snooze becomes a side
+// channel around it.
+func TestAReplyThisReaderCannotSeeDoesNotLiftTheirSnooze(t *testing.T) {
+	e := Setup(t)
+	const thread = "thread-reopen-private"
+	const subject = "Waiting on a private thread"
+	person := seedWaitingPerson(t, e)
+	seedWaitingMessageLinked(t, e, thread, "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour), person)
+	id := waitingMessageID(t, e, subject)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	// The reply arrives on the same thread, but narrowed to its participants —
+	// which this reader is not one of.
+	replyAt := waitingInstant.Add(2 * time.Hour)
+	reply := seedWaitingMessageLinked(t, e, thread, "inbound", "Their private answer", replyAt, person)
+	if _, err := OwnerConn(t).Exec(context.Background(),
+		`UPDATE activity SET audience = 'participants' WHERE id = $1`, reply); err != nil {
+		t.Fatal(err)
+	}
+
+	if waitsForAt(t, e, e.Rep1, subject, replyAt.Add(time.Hour)) {
+		t.Fatal("a reply this reader may not see put their row back, which tells them it arrived")
+	}
+}
+
+// TestAnUnrelatedThreadIsNotTheReplyBeingWaitedFor is why the predicate matches
+// the whole thread identity rather than the customer. Mail from the same person
+// about something else is not the answer the rep was waiting for.
+func TestAnUnrelatedThreadIsNotTheReplyBeingWaitedFor(t *testing.T) {
+	e := Setup(t)
+	const subject = "Waiting on the contract"
+	person := seedWaitingPerson(t, e)
+	seedWaitingMessageLinked(t, e, "thread-reopen-contract", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour), person)
+	id := waitingMessageID(t, e, subject)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	// The same customer, a different conversation.
+	other := waitingInstant.Add(2 * time.Hour)
+	seedWaitingMessageLinked(t, e, "thread-reopen-invoice", "inbound", "About the invoice", other, person)
+
+	if waitsForAt(t, e, e.Rep1, subject, other.Add(time.Hour)) {
+		t.Fatal("mail on another thread lifted the snooze; the rep is waiting on this conversation, not this person")
+	}
+}
+
+// TestOurOwnReplyDoesNotLiftAMessageSnooze is the direction guard. A rep who
+// sets a message down and then sends a chaser has not been replied to.
+func TestOurOwnReplyDoesNotLiftAMessageSnooze(t *testing.T) {
+	e := Setup(t)
+	const thread = "thread-reopen-ours"
+	const subject = "Waiting after our chaser"
+	person := seedWaitingPerson(t, e)
+	seedWaitingMessageLinked(t, e, thread, "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour), person)
+	id := waitingMessageID(t, e, subject)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	ours := waitingInstant.Add(2 * time.Hour)
+	seedWaitingMessageLinked(t, e, thread, "outbound", "Just chasing", ours, person)
+
+	if waitsForAt(t, e, e.Rep1, subject, ours.Add(time.Hour)) {
+		t.Fatal("our own chaser lifted the snooze; the rep is waiting on the customer, not on themselves")
+	}
+}
+
+// TestAMessageSnoozedUntilAMeetingComesBackAfterIt is the second condition.
+func TestAMessageSnoozedUntilAMeetingComesBackAfterIt(t *testing.T) {
+	e := Setup(t)
+	const subject = "Answer after the demo"
+	seedWaitingMessage(t, e, "thread-reopen-meeting", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour))
+	id := waitingMessageID(t, e, subject)
+
+	meetsAt := waitingInstant.Add(6 * time.Hour)
+	meeting := SeedIDRow(t, OwnerConn(t), `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 'manual', 'human:x')`, meetsAt)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnMeeting, nil, &meeting); err != nil {
+		t.Fatalf("snoozing until after the meeting: %v", err)
+	}
+	if waitsForAt(t, e, e.Rep1, subject, meetsAt.Add(-time.Hour)) {
+		t.Fatal("the message came back before the meeting it was waiting for")
+	}
+	if !waitsForAt(t, e, e.Rep1, subject, meetsAt.Add(time.Hour)) {
+		t.Fatal("the meeting is over and the message stayed set aside")
+	}
+}
+
+// TestACancelledMeetingReturnsTheMessage matches the brief's rule, and for the
+// same reason: a rep waiting on something that will now never happen must not
+// wait forever.
+func TestACancelledMeetingReturnsTheMessage(t *testing.T) {
+	e := Setup(t)
+	const subject = "Answer after the cancelled demo"
+	seedWaitingMessage(t, e, "thread-reopen-cancelled", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour))
+	id := waitingMessageID(t, e, subject)
+
+	meetsAt := waitingInstant.AddDate(0, 0, 20)
+	meeting := SeedIDRow(t, OwnerConn(t), `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'meeting', 'the demo', $2, 'manual', 'human:x')`, meetsAt)
+
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnMeeting, nil, &meeting); err != nil {
+		t.Fatalf("snoozing until after the meeting: %v", err)
+	}
+	stillWaiting := waitingInstant.Add(4 * time.Hour)
+	if waitsForAt(t, e, e.Rep1, subject, stillWaiting) {
+		t.Fatal("a message waiting for a future meeting came back early")
+	}
+	if _, err := OwnerConn(t).Exec(context.Background(),
+		`UPDATE activity SET archived_at = now() WHERE id = $1`, meeting); err != nil {
+		t.Fatal(err)
+	}
+	if !waitsForAt(t, e, e.Rep1, subject, stillWaiting.Add(time.Hour)) {
+		t.Fatal("the meeting was cancelled and the message stayed buried; nothing will ever bring it back")
+	}
+}
+
+// TestAnEventSnoozeStaysTheSnoozersOwn carries the reader-scoping guarantee
+// onto the new conditions. The original snooze was proven personal; a condition
+// that quietly widened it to the workspace would take a colleague's message off
+// their day with nothing on any screen to say who did it.
+func TestAnEventSnoozeStaysTheSnoozersOwn(t *testing.T) {
+	e := Setup(t)
+	const subject = "Mine to wait on"
+	seedWaitingMessage(t, e, "thread-reopen-mine", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour))
+	id := waitingMessageID(t, e, subject)
+
+	if !waitsForAt(t, e, e.Rep2, subject, waitingInstant) {
+		t.Fatal("the second rep never saw the message, so this proves nothing about hiding it")
+	}
+	if err := atWaitingInstant(e).SnoozeMessage(
+		e.As(e.Rep1, nil, AdminPerms), id, values.ReopenOnReply, nil, nil); err != nil {
+		t.Fatalf("snoozing until they reply: %v", err)
+	}
+	later := waitingInstant.Add(5 * 24 * time.Hour)
+	if waitsForAt(t, e, e.Rep1, subject, later) {
+		t.Fatal("the snoozer still sees their own set-aside")
+	}
+	if !waitsForAt(t, e, e.Rep2, subject, later) {
+		t.Fatal("one rep's event snooze took the message off a colleague's day")
+	}
+}
+
+// TestAMessageSnoozeShapeIsRefused holds the same four bad shapes the brief
+// engine refuses. Both writers answer this identically because both tables hold
+// the same CHECK, and a client that learns one vocabulary must not meet another.
+func TestAMessageSnoozeShapeIsRefused(t *testing.T) {
+	e := Setup(t)
+	const subject = "Shape check"
+	seedWaitingMessage(t, e, "thread-reopen-shape", "inbound", subject,
+		waitingInstant.Add(-3*24*time.Hour))
+	id := waitingMessageID(t, e, subject)
+	moment := waitingInstant.Add(48 * time.Hour)
+	someID := ids.NewV7()
+
+	for _, bad := range []struct {
+		name string
+		on   values.ReopenCondition
+		till *time.Time
+		ref  *ids.UUID
+	}{
+		{"a clock snooze with no moment", values.ReopenOnTime, nil, nil},
+		{"a reply snooze carrying a moment", values.ReopenOnReply, &moment, nil},
+		{"a meeting snooze naming no meeting", values.ReopenOnMeeting, nil, nil},
+		{"a reply snooze naming a meeting", values.ReopenOnReply, nil, &someID},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			if err := atWaitingInstant(e).SnoozeMessage(
+				e.As(e.Rep1, nil, AdminPerms), id, bad.on, bad.till, bad.ref); err == nil {
+				t.Fatal("accepted, and the row it would write describes a wait nothing can lift")
+			}
+		})
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -6988,6 +6988,27 @@ func (e MeetingPlanUnknownKind) Valid() bool {
 	}
 }
 
+// Defines values for MorningBriefItemReopenOn.
+const (
+	MorningBriefItemReopenOnMeeting MorningBriefItemReopenOn = "meeting"
+	MorningBriefItemReopenOnReply   MorningBriefItemReopenOn = "reply"
+	MorningBriefItemReopenOnTime    MorningBriefItemReopenOn = "time"
+)
+
+// Valid indicates whether the value is a known member of the MorningBriefItemReopenOn enum.
+func (e MorningBriefItemReopenOn) Valid() bool {
+	switch e {
+	case MorningBriefItemReopenOnMeeting:
+		return true
+	case MorningBriefItemReopenOnReply:
+		return true
+	case MorningBriefItemReopenOnTime:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for MorningBriefItemState.
 const (
 	MorningBriefItemStateActed     MorningBriefItemState = "acted"
@@ -10414,6 +10435,27 @@ func (e RenewContractRequestValueBasis) Valid() bool {
 	case RenewContractRequestValueBasisAnnualized12m:
 		return true
 	case RenewContractRequestValueBasisTotal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ReopenCondition.
+const (
+	ReopenOnMeeting ReopenCondition = "meeting"
+	ReopenOnReply   ReopenCondition = "reply"
+	ReopenOnTime    ReopenCondition = "time"
+)
+
+// Valid indicates whether the value is a known member of the ReopenCondition enum.
+func (e ReopenCondition) Valid() bool {
+	switch e {
+	case ReopenOnMeeting:
+		return true
+	case ReopenOnReply:
+		return true
+	case ReopenOnTime:
 		return true
 	default:
 		return false
@@ -18540,10 +18582,24 @@ type BriefDeliveryMorningBriefDelivery string
 // BriefDeliveryWeeklyDelivery The same, for the weekly review.
 type BriefDeliveryWeeklyDelivery string
 
-// BriefSnoozeRequest Snooze a brief item until a future instant (A77/AC-home-6); it re-surfaces once the instant passes.
+// BriefSnoozeRequest Set a brief item aside until something happens. The something is `reopen_on`: a moment
+// on the clock, the customer writing back, or a named meeting being over.
 type BriefSnoozeRequest struct {
-	// SnoozedUntil When the item re-surfaces; must be in the future.
-	SnoozedUntil time.Time `json:"snoozed_until"`
+	// ReopenOn What lifts a snooze. `time` is the original behaviour and the default, so a client
+	// written before the other two keeps working unchanged. `reply` waits for the
+	// counterparty to write back on a conversation linked to the record. `meeting` waits for
+	// a named meeting to be over — an archived meeting counts as over, so a cancelled one
+	// returns the work rather than holding it forever.
+	ReopenOn *ReopenCondition `json:"reopen_on,omitempty"`
+
+	// ReopenRef The meeting to wait for. REQUIRED for `meeting` and refused otherwise, because
+	// "after the meeting" names nothing without saying which meeting.
+	ReopenRef *openapi_types.UUID `json:"reopen_ref,omitempty"`
+
+	// SnoozedUntil When the item re-surfaces. REQUIRED for `time` and refused for the other two — a
+	// snooze waiting on a reply lifts when the reply arrives, not on a date. Must be in
+	// the future.
+	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
 }
 
 // BuyerRoomAccess Whether the session admits the caller to content right now. `live` — the room
@@ -25329,7 +25385,13 @@ type MorningBriefItem struct {
 	// Rank Position in the queue (1 = top), after the L2 re-order.
 	Rank int `json:"rank"`
 
-	// SnoozedUntil When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.
+	// ReopenOn What the item is waiting for; set exactly while state=snoozed, null otherwise.
+	ReopenOn *MorningBriefItemReopenOn `json:"reopen_on,omitempty"`
+
+	// ReopenRef The meeting being waited for; set exactly while reopen_on=meeting.
+	ReopenRef *openapi_types.UUID `json:"reopen_ref,omitempty"`
+
+	// SnoozedUntil When a snoozed item re-surfaces; set exactly while reopen_on=time, null otherwise — the other conditions lift on an event rather than a date.
 	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
 
 	// State The acting rep's queue state for this item.
@@ -25338,6 +25400,9 @@ type MorningBriefItem struct {
 	// StateAt When the rep acted/dismissed/snoozed; null while new.
 	StateAt *time.Time `json:"state_at,omitempty"`
 }
+
+// MorningBriefItemReopenOn What the item is waiting for; set exactly while state=snoozed, null otherwise.
+type MorningBriefItemReopenOn string
 
 // MorningBriefItemState The acting rep's queue state for this item.
 type MorningBriefItemState string
@@ -30370,6 +30435,13 @@ type RenewContractRequest struct {
 // RenewContractRequestValueBasis Stated explicitly rather than inherited: an open-ended agreement becoming a fixed term changes what its value measures.
 type RenewContractRequestValueBasis string
 
+// ReopenCondition What lifts a snooze. `time` is the original behaviour and the default, so a client
+// written before the other two keeps working unchanged. `reply` waits for the
+// counterparty to write back on a conversation linked to the record. `meeting` waits for
+// a named meeting to be over — an archived meeting counts as over, so a cancelled one
+// returns the work rather than holding it forever.
+type ReopenCondition string
+
 // ReplaceChannelTokenRequest defines model for ReplaceChannelTokenRequest.
 type ReplaceChannelTokenRequest struct {
 	// BotToken The replacement BotFather token. Sealed into the vault on arrival and never echoed back.
@@ -31463,9 +31535,20 @@ type SetActivityDispositionRequest struct {
 	// `not_mine` bind only the caller.
 	Disposition SetActivityDispositionRequestDisposition `json:"disposition"`
 
-	// SnoozedUntil When a snooze lifts. REQUIRED for `snooze` and refused for the other two — a snooze
-	// with no moment would never lift, and a moment on `not_mine` would make a hand-off
-	// expire on a Thursday.
+	// ReopenOn What lifts a snooze. `time` is the original behaviour and the default, so a client
+	// written before the other two keeps working unchanged. `reply` waits for the
+	// counterparty to write back on a conversation linked to the record. `meeting` waits for
+	// a named meeting to be over — an archived meeting counts as over, so a cancelled one
+	// returns the work rather than holding it forever.
+	ReopenOn *ReopenCondition `json:"reopen_on,omitempty"`
+
+	// ReopenRef The meeting to wait for. REQUIRED for `snooze` with `reopen_on: meeting` and
+	// refused otherwise.
+	ReopenRef *openapi_types.UUID `json:"reopen_ref,omitempty"`
+
+	// SnoozedUntil When a snooze lifts. REQUIRED for `snooze` with `reopen_on: time`, and refused
+	// everywhere else — a snooze waiting on a reply lifts when the reply arrives, and a
+	// moment on `not_mine` would make a hand-off expire on a Thursday.
 	//
 	// A moment already past is refused rather than stored: it would write a row that hides
 	// nothing, and read to the rep as a snooze that did not take.

--- a/backend/internal/modules/activities/disposition.go
+++ b/backend/internal/modules/activities/disposition.go
@@ -94,7 +94,7 @@ func (s *Store) SetThreadNotSales(ctx context.Context, id ids.ActivityID) error 
 			thread.key, thread.kind, thread.provider, capturedBy); err != nil {
 			return fmt.Errorf("activities: recording the thread as not sales: %w", err)
 		}
-		return s.recordDisposition(ctx, tx, id, stateNotSales, nil)
+		return s.recordDisposition(ctx, tx, id, stateNotSales, nil, "")
 	})
 }
 
@@ -120,7 +120,7 @@ func (s *Store) ClearThreadNotSales(ctx context.Context, id ids.ActivityID) erro
 			// decision that was never made.
 			return nil
 		}
-		return s.recordDisposition(ctx, tx, id, stateSalesAgain, nil)
+		return s.recordDisposition(ctx, tx, id, stateSalesAgain, nil, "")
 	})
 }
 
@@ -192,21 +192,48 @@ const (
 	directionInbound = "inbound"
 )
 
-// SnoozeMessage puts one message down for this reader until a moment.
+// SnoozeMessage puts one message down for this reader until its reopen
+// condition is met.
 //
-// The moment is the caller's, and one already past is refused rather than
+// A `time` snooze names a moment, and one already past is refused rather than
 // stored: it would write a row that hides nothing and read to the rep as a
 // snooze that did not take. Judged against the STORE's clock, which the
 // scheduling suites inject — a test driving a snooze past its moment must not
 // need the wall clock to reach it.
-func (s *Store) SnoozeMessage(ctx context.Context, id ids.ActivityID, until time.Time) error {
-	if !until.After(s.now()) {
+//
+// `reply` and `meeting` name no moment at all. They wait on rows the waiting
+// query already reads, so the condition is stored and evaluated there rather
+// than turned into a guessed date here.
+func (s *Store) SnoozeMessage(
+	ctx context.Context, id ids.ActivityID, on values.ReopenCondition,
+	until *time.Time, ref *ids.UUID,
+) error {
+	if on.WantsInstant() {
+		if until == nil {
+			return &values.ParseError{
+				Field: fieldSnoozedUntil, Code: "snooze_needs_a_moment",
+				Message: "a snooze that waits on the clock names the moment it lifts",
+			}
+		}
+		if !until.After(s.now()) {
+			return &values.ParseError{
+				Field: fieldSnoozedUntil, Code: "snooze_in_the_past",
+				Message: "a snooze names a moment still ahead",
+			}
+		}
+	} else if until != nil {
 		return &values.ParseError{
-			Field: "snoozed_until", Code: "snooze_in_the_past",
-			Message: "a snooze names a moment still ahead",
+			Field: fieldSnoozedUntil, Code: "snooze_has_no_moment",
+			Message: "a snooze waiting on a reply or a meeting lifts when that happens, not on a date",
 		}
 	}
-	return s.setReaderState(ctx, id, stateSnoozed, &until)
+	if on.NeedsReference() != (ref != nil) {
+		return &values.ParseError{
+			Field: "reopen_ref", Code: "reopen_ref_shape",
+			Message: "only a snooze waiting on a meeting names the meeting it waits for",
+		}
+	}
+	return s.setReaderState(ctx, id, stateSnoozed, until, on, ref)
 }
 
 // SetMessageNotMine records that this reader is not the person to answer.
@@ -215,7 +242,7 @@ func (s *Store) SnoozeMessage(ctx context.Context, id ids.ActivityID, until time
 // Thursday — what makes it stop applying is the record changing hands, which
 // the reader of these rows judges against the owner of the day.
 func (s *Store) SetMessageNotMine(ctx context.Context, id ids.ActivityID) error {
-	return s.setReaderState(ctx, id, stateNotMine, nil)
+	return s.setReaderState(ctx, id, stateNotMine, nil, "", nil)
 }
 
 // ClearMessageDisposition picks a message back up — the undo behind every
@@ -237,12 +264,15 @@ func (s *Store) ClearMessageDisposition(ctx context.Context, id ids.ActivityID) 
 			// sibling above states, and silent for the same one.
 			return nil
 		}
-		return s.recordDisposition(ctx, tx, id, statePickedUp, nil)
+		return s.recordDisposition(ctx, tx, id, statePickedUp, nil, "")
 	})
 }
 
 // setReaderState writes one reader's own judgement about one message.
-func (s *Store) setReaderState(ctx context.Context, id ids.ActivityID, state string, until *time.Time) error {
+func (s *Store) setReaderState(
+	ctx context.Context, id ids.ActivityID, state string, until *time.Time,
+	on values.ReopenCondition, ref *ids.UUID,
+) error {
 	return s.judgeMessage(ctx, id, func(ctx context.Context, tx pgx.Tx, capturedBy string) error {
 		reader := readerOrNobody(ctx)
 		if reader.IsZero() {
@@ -251,18 +281,43 @@ func (s *Store) setReaderState(ctx context.Context, id ids.ActivityID, state str
 			// the acting human's id would set aside work on their behalf.
 			return apperrors.ErrPermissionDenied
 		}
+		// The meeting a snooze names must exist, be a meeting, and be one this
+		// reader may read. Checked inside the transaction so it cannot be
+		// archived between the check and the row that waits on it.
+		if ref != nil {
+			if err := EnsureMeetingReference(ctx, tx, *ref); err != nil {
+				return err
+			}
+		}
+		// NULL rather than the empty string when the judgement is not a
+		// snooze: the column's CHECK pairs its presence with the snoozed
+		// state, and an empty string is present.
+		var storedOn *string
+		if on != "" {
+			raw := string(on)
+			storedOn = &raw
+		}
+		// set_at comes from the STORE's clock, not from now() in SQL.
+		//
+		// A reply snooze lifts on mail that arrived after the rep put the
+		// message down, so set_at is no longer just a record of when — it is
+		// one side of that comparison. A wall-clock stamp against injected
+		// instants makes every seeded reply look older than the snooze, which
+		// is a snooze that never lifts.
 		if _, err := tx.Exec(ctx, `
-			INSERT INTO activity_reader_state (activity_id, reader_id, state, snoozed_until, set_by)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO activity_reader_state (activity_id, reader_id, state, snoozed_until, reopen_on, reopen_ref, set_by, set_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 			ON CONFLICT (activity_id, reader_id) DO UPDATE
 			   SET state = EXCLUDED.state,
 			       snoozed_until = EXCLUDED.snoozed_until,
+			       reopen_on = EXCLUDED.reopen_on,
+			       reopen_ref = EXCLUDED.reopen_ref,
 			       set_by = EXCLUDED.set_by,
-			       set_at = now()`,
-			id, reader, state, until, capturedBy); err != nil {
+			       set_at = EXCLUDED.set_at`,
+			id, reader, state, until, storedOn, ref, capturedBy, s.now().UTC()); err != nil {
 			return fmt.Errorf("activities: setting the message aside: %w", err)
 		}
-		return s.recordDisposition(ctx, tx, id, state, until)
+		return s.recordDisposition(ctx, tx, id, state, until, on)
 	})
 }
 
@@ -304,10 +359,14 @@ func (s *Store) judgeMessage(
 // announcement, in the same transaction as the judgement itself.
 func (s *Store) recordDisposition(
 	ctx context.Context, tx pgx.Tx, id ids.ActivityID, state string, until *time.Time,
+	on values.ReopenCondition,
 ) error {
 	after := map[string]any{"disposition": state}
 	if until != nil {
 		after["snoozed_until"] = until.UTC()
+	}
+	if on != "" {
+		after["reopen_on"] = string(on)
 	}
 	auditID, err := storekit.AuditEvent(ctx, tx, "update", "activity", id.UUID, after)
 	if err != nil {

--- a/backend/internal/modules/activities/handlers_lifecycle.go
+++ b/backend/internal/modules/activities/handlers_lifecycle.go
@@ -172,13 +172,15 @@ func (h Handlers) SetActivityDisposition(w http.ResponseWriter, r *http.Request,
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	// A moment belongs to a snooze and to nothing else. Accepting one on a
-	// judgement that does not expire would leave the rep believing their
-	// not-mine lifts on Thursday, and nothing would ever tell them otherwise;
-	// a snooze without one would never lift, which is not a snooze.
-	wantsMoment := req.Disposition == crmcontracts.SetActivityDispositionRequestDispositionSnooze
-	if wantsMoment != (req.SnoozedUntil != nil) {
-		httperr.Write(w, r, momentMismatch(wantsMoment))
+	// A moment and a reopen condition belong to a snooze and to nothing else.
+	// Accepting either on a judgement that does not expire would leave the rep
+	// believing their not-mine lifts on Thursday, and nothing would ever tell
+	// them otherwise. WHICH shape a snooze itself must take is the store's to
+	// judge, because the two tables that hold set-asides answer it identically
+	// and a copy here would be the half that drifts.
+	isSnooze := req.Disposition == crmcontracts.SetActivityDispositionRequestDispositionSnooze
+	if !isSnooze && (req.SnoozedUntil != nil || req.ReopenOn != nil || req.ReopenRef != nil) {
+		httperr.Write(w, r, momentMismatch(false))
 		return
 	}
 	activityID := pathID[ids.ActivityKind](id)
@@ -189,7 +191,7 @@ func (h Handlers) SetActivityDisposition(w http.ResponseWriter, r *http.Request,
 	case crmcontracts.SetActivityDispositionRequestDispositionNotMine:
 		err = h.store.SetMessageNotMine(r.Context(), activityID)
 	case crmcontracts.SetActivityDispositionRequestDispositionSnooze:
-		err = h.store.SnoozeMessage(r.Context(), activityID, *req.SnoozedUntil)
+		err = h.snoozeFromRequest(r, activityID, req)
 	default:
 		// An unknown or absent disposition. Without this the switch matches
 		// nothing, err stays nil, and the caller is told 204 — that their
@@ -287,4 +289,27 @@ func (h Handlers) UnpinWorklistRow(
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// snoozeFromRequest turns the wire's three optional snooze fields into the
+// store's call, refusing a condition outside the set before any of it is
+// written.
+func (h Handlers) snoozeFromRequest(
+	r *http.Request, id ids.ActivityID, req crmcontracts.SetActivityDispositionRequest,
+) error {
+	var raw *string
+	if req.ReopenOn != nil {
+		on := string(*req.ReopenOn)
+		raw = &on
+	}
+	on, err := values.ParseReopenCondition(raw, "reopen_on")
+	if err != nil {
+		return err
+	}
+	var ref *ids.UUID
+	if req.ReopenRef != nil {
+		named := ids.UUID(*req.ReopenRef)
+		ref = &named
+	}
+	return h.store.SnoozeMessage(r.Context(), id, on, req.SnoozedUntil, ref)
 }

--- a/backend/internal/modules/activities/hiddenbacklog.go
+++ b/backend/internal/modules/activities/hiddenbacklog.go
@@ -234,6 +234,13 @@ func (s *Store) countWaiting(
 	if err != nil {
 		return 0, err
 	}
+	// The same gate for the reply that may LIFT a snooze. A reply this
+	// reader cannot see must not put the row back on their day: the row
+	// reappearing is itself the disclosure that it arrived.
+	backContent, err := auth.ActivityContentClause(ctx, "back", arg)
+	if err != nil {
+		return 0, err
+	}
 	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
 	if err != nil {
 		return 0, err
@@ -275,7 +282,8 @@ func (s *Store) countWaiting(
 		arg(relax.reader),
 		scopeUnbounded,
 		notSales, unlinked,
-		colleague, ownDomainSenderSQL("a", arg(ownDomains)))
+		colleague, ownDomainSenderSQL("a", arg(ownDomains)),
+		messageSnoozeLiftedSQL(fmt.Sprintf("$%d", instant), backContent))
 	var count int
 	// Counted around the whole statement rather than by replacing its SELECT
 	// list: the query GROUPs and LIMITs, so the row count IS the answer and a

--- a/backend/internal/modules/activities/meetingreference.go
+++ b/backend/internal/modules/activities/meetingreference.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Whether an id names a meeting the caller may wait for.
+//
+// A snooze that waits for a meeting stores the meeting's id, and two set-aside
+// systems store one — the waiting lane here and the brief's own queue. Both ask
+// this, because the question is about the ACTIVITY table and this module owns
+// it; a copy in the other would be a second answer to "is this a meeting",
+// drifting the first time either was edited.
+//
+// Three separate failures, one guard:
+//
+//   - An id naming no row is a snooze nothing will ever lift, so the rep loses
+//     the work with no screen anywhere saying why.
+//   - An id naming something that is not a meeting turns any old email into the
+//     lift condition. Its occurred_at is already past, so the snooze would end
+//     the instant it was set.
+//   - An id the caller cannot read would let them learn, from whether their own
+//     item came back, when somebody else's meeting happened.
+//
+// The unreadable case answers not-found rather than a distinct error, so a
+// caller cannot tell "not a meeting" from "not yours" — the same
+// existence-hiding every row-scope miss takes.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// KindMeeting is what a snooze reference must be, and what both lift predicates
+// filter on. Exported so the brief's queue names the same kind this module's
+// SQL does rather than spelling its own.
+const KindMeeting = "meeting"
+
+// EnsureMeetingReference refuses a reopen_ref that does not name a meeting this
+// caller may read. It takes a transaction because both callers check inside
+// their own write, so the meeting cannot be archived between the check and the
+// row that depends on it.
+func EnsureMeetingReference(ctx context.Context, tx pgx.Tx, ref ids.UUID) error {
+	// The OBJECT gate first, because this reaches a table the caller may have
+	// no grant on at all. The disposition writer already holds activity:read
+	// through judgeMessage; the brief's writer holds only deal:read, so
+	// without this a rep could name activity ids and learn from the refusals
+	// which ones are meetings they may see.
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return err
+	}
+	// Then the ROW gate — the DISCOVER one, not the content one. Waiting for a meeting to be over
+	// needs only to know it exists and when it ends; it reads no subject and no
+	// body. Demanding content authority would refuse a rep who can see a
+	// meeting is on the calendar but not what was said in it, which is exactly
+	// the person this snooze is for.
+	if err := auth.EnsureActivityVisible(ctx, tx, ref); err != nil {
+		return err
+	}
+	var kind string
+	if err := tx.QueryRow(ctx, `SELECT kind FROM activity WHERE id = $1`, ref).Scan(&kind); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		return fmt.Errorf("activities: reading the meeting a snooze waits for: %w", err)
+	}
+	if kind != KindMeeting {
+		return &values.ParseError{
+			Field: "reopen_ref", Code: "not_a_meeting",
+			Message: "a snooze waiting for a meeting names a meeting",
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -177,9 +177,9 @@ func liveRecord(predicate, alias string) string {
 // waitingRepliesSQL is Sprintf'd directly at ALL call sites — WaitingReplies
 // below (entityClause scopeUnbounded, the workspace-wide Worklist read), the
 // entity-scoped list filter (waitingReplyExistsClause) and the guardrail —
-// rather than through a wrapper. Thirteen positional holes is already the shape the
-// constant settled on for its own eligibility rules; a wrapper over that
-// many arguments would just be the same Sprintf call once removed, with a
+// rather than through a wrapper. A long positional argument list is already the
+// shape the constant settled on for its own eligibility rules; a wrapper over
+// that many arguments would just be the same Sprintf call once removed, with a
 // second place to keep its parameter order in sync with the %[N] indices
 // below. What must not fork between the call sites is the SQL TEXT — the
 // anti-joins, the tie break, the future-dated guard, the horizon, the
@@ -215,6 +215,13 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		// reader watch a row vanish to learn that a reply they may not see had
 		// arrived.
 		content, err := auth.ActivityContentClause(ctx, "a", arg)
+		if err != nil {
+			return err
+		}
+		// The same gate for the reply that may LIFT a snooze. A reply this
+		// reader cannot see must not put the row back on their day: the row
+		// reappearing is itself the disclosure that it arrived.
+		backContent, err := auth.ActivityContentClause(ctx, "back", arg)
 		if err != nil {
 			return err
 		}
@@ -264,7 +271,8 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 				reader,
 				scopeUnbounded,
 				neverRelaxed, neverRelaxed,
-				neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains))), args...)
+				neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains)),
+				messageSnoozeLiftedSQL(fmt.Sprintf("$%d", instant), backContent)), args...)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/activities/waitingrecordscope.go
+++ b/backend/internal/modules/activities/waitingrecordscope.go
@@ -58,6 +58,13 @@ func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.
 	if err != nil {
 		return "", err
 	}
+	// The same gate for the reply that may LIFT a snooze. A reply this
+	// reader cannot see must not put the row back on their day: the row
+	// reappearing is itself the disclosure that it arrived.
+	backContent, err := auth.ActivityContentClause(ctx, "back", arg)
+	if err != nil {
+		return "", err
+	}
 	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
 	if err != nil {
 		return "", err
@@ -100,7 +107,8 @@ func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.
 			reader,
 			entityClause,
 			neverRelaxed, neverRelaxed,
-			neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains))) +
+			neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains)),
+			messageSnoozeLiftedSQL(fmt.Sprintf("$%d", instant), backContent)) +
 		") waiting_thread)", nil
 }
 

--- a/backend/internal/modules/activities/waitingsql.go
+++ b/backend/internal/modules/activities/waitingsql.go
@@ -15,6 +15,8 @@ package activities
 //
 // waiting.go holds what READS it; this holds what it says.
 
+import "fmt"
+
 // waitingRepliesSQL finds, per thread, the newest inbound with no later
 // outbound in the same thread — where the thread is a SALES conversation the
 // workspace is answerable for, recent enough to still be one.
@@ -280,8 +282,9 @@ const waitingRepliesSQL = `
 	   -- answer a reader wants. A caller replaying a HISTORICAL instant would
 	   -- get today's judgements over that day's messages, and nothing does.
 	   --
-	   -- A snooze lifts on its own moment, so the row comes back when it is due
-	   -- rather than waiting for somebody to remember it.
+	   -- A snooze lifts on whatever it named: its own moment, the counterparty
+	   -- writing back, or a meeting being over. The row comes back when that
+	   -- happens rather than waiting for somebody to remember it.
 	   --
 	   -- not_mine carries no moment and does not lift at all. Ending it when the
 	   -- linked record changes hands would be the kinder rule, and it is not
@@ -295,7 +298,7 @@ const waitingRepliesSQL = `
 	          WHERE mine.activity_id = a.id
 	            AND mine.reader_id = $%[10]d
 	            AND (mine.state = 'not_mine'
-	              OR (mine.state = 'snoozed' AND mine.snoozed_until > $%[1]d)))
+	              OR (mine.state = 'snoozed' AND NOT %[16]s)))
 	 GROUP BY a.id, a.kind, a.subject, a.occurred_at
 	 -- NEWEST first, which is the opposite of how the rows are then shown.
 	 --
@@ -311,3 +314,51 @@ const waitingRepliesSQL = `
 	 -- unchanged. This decides only WHICH waits survive the bound.
 	 ORDER BY a.occurred_at DESC
 	 LIMIT %[4]d`
+
+// messageSnoozeLiftedSQL is whether a reader's snooze on one waiting message is
+// over, as a boolean expression the waiting query embeds.
+//
+// The three conditions and the two columns are the same ones the brief's queue
+// uses, and the answer is deliberately NOT shared with it: what "they replied"
+// means differs. A brief item waits on a DEAL, so any inbound linked to that
+// deal answers it. A waiting message waits on a CONVERSATION, so only a newer
+// inbound on the same thread does — an unrelated mail from the same customer
+// about a different subject is not the reply the rep was waiting for.
+//
+// asOf is the instant to judge against; it is the caller's own placeholder, and
+// every other term here is a fixed column reference.
+// The content gate is taken as a fragment the caller renders for the `back`
+// alias, exactly as it renders one for `a`. Without it a reply the reader may
+// not see would still lift their snooze, and the row reappearing on their day
+// is itself the disclosure that it arrived.
+func messageSnoozeLiftedSQL(asOf, backContent string) string {
+	return fmt.Sprintf(`(CASE mine.reopen_on
+		WHEN 'time' THEN mine.snoozed_until <= %[1]s
+		-- The same thread identity the waiting query matches replies by: key
+		-- alone shares a namespace across kinds and providers, so a crafted
+		-- References header could otherwise lift a snooze on a conversation
+		-- the sender has nothing to do with.
+		WHEN 'reply' THEN EXISTS (
+			SELECT 1 FROM activity back
+			WHERE back.archived_at IS NULL
+			  AND %[3]s
+			  AND back.direction = 'inbound'
+			  AND back.thread_key = a.thread_key
+			  AND back.kind = a.kind
+			  AND back.channel_provider IS NOT DISTINCT FROM a.channel_provider
+			  AND back.occurred_at > mine.set_at
+			  AND back.occurred_at <= %[1]s)
+		-- The same rule the brief's queue applies, and for the same reasons:
+		-- over means ENDED (start plus duration, not start), a meeting that
+		-- will never happen counts as over, and kind = 'meeting' is what makes
+		-- reopen_ref mean a meeting rather than any activity id.
+		WHEN 'meeting' THEN EXISTS (
+			SELECT 1 FROM activity m
+			WHERE m.id = mine.reopen_ref AND m.kind = '%[2]s'
+			  AND (m.archived_at IS NOT NULL
+			       OR m.meeting_status IN ('canceled', 'no_show')
+			       OR m.occurred_at
+			          + make_interval(secs => coalesce(m.duration_seconds, 0)) <= %[1]s))
+		ELSE false
+	END)`, asOf, KindMeeting, backContent)
+}

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -7153,6 +7153,13 @@
                 "rank": {
                   "type": "integer"
                 },
+                "reopen_on": {
+                  "type": "string"
+                },
+                "reopen_ref": {
+                  "type": "string",
+                  "format": "uuid"
+                },
                 "snoozed_until": {
                   "type": "string"
                 },

--- a/backend/internal/modules/agents/tools_brief.go
+++ b/backend/internal/modules/agents/tools_brief.go
@@ -33,6 +33,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/agents/apps"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
@@ -119,8 +120,18 @@ type BriefItem struct {
 	// answers are metered under.
 	EvidenceIDs []ids.UUID `json:"evidence_ids"`
 	// SnoozedUntil is when a snoozed item re-surfaces, and is absent unless the
-	// item is snoozed.
+	// item is snoozed waiting on the clock.
 	SnoozedUntil *time.Time `json:"snoozed_until,omitempty"`
+	// ReopenOn is what a snoozed item is waiting for: the clock, a reply, or a
+	// meeting being over. SERVED rather than withheld, and served BECAUSE
+	// SnoozedUntil is: without it a snooze with no moment reads as a snooze
+	// that never lifts, and an agent would report a deal as abandoned when the
+	// person is simply waiting for the customer to write back.
+	ReopenOn values.ReopenCondition `json:"reopen_on,omitempty"`
+	// ReopenRef is the meeting being waited for, set only when ReopenOn names
+	// one. Charged like the other ids: naming a record to an agent hands that
+	// record over.
+	ReopenRef *ids.UUID `json:"reopen_ref,omitempty"`
 	// Lineage is set when this deal is back after the person dismissed it, and
 	// it is SERVED rather than withheld: it is a deterministic fact about what
 	// they did, not something an agent wrote, so reading it is not a loop

--- a/backend/internal/shared/kernel/values/reopen.go
+++ b/backend/internal/shared/kernel/values/reopen.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package values
+
+// What a rep is waiting for when they set something aside.
+//
+// A snooze used to mean one thing: come back on Thursday. That made every
+// set-aside a guess about when the world would move, and the rep was usually
+// wrong in one of two directions — too early and the item is still dead, too
+// late and the customer waited on them. The two things they actually meant are
+// held here.
+//
+// Spelled in this package rather than in briefs or activities because BOTH set
+// aside work and both store the condition, and the two tables' CHECK
+// constraints hold the same set. A second copy in either module is a set that
+// can drift from the one the database will accept.
+
+import "fmt"
+
+// ReopenCondition names what lifts a snooze.
+type ReopenCondition string
+
+const (
+	// ReopenOnTime lifts at a stored instant — the original snooze.
+	ReopenOnTime ReopenCondition = "time"
+	// ReopenOnReply lifts when the counterparty writes back. No instant: the
+	// wait is on a person, and putting a deadline on it would re-surface work
+	// on a day nothing happened.
+	ReopenOnReply ReopenCondition = "reply"
+	// ReopenOnMeeting lifts once a named meeting is over. It names the meeting,
+	// because "after the meeting" says nothing without saying which one.
+	ReopenOnMeeting ReopenCondition = "meeting"
+)
+
+// ReopenConditions is every condition, in the order a chooser should offer
+// them: the moment first because it is what a rep already knows, then the two
+// that wait on the world.
+//
+// Held by: TestEveryTableAdmitsExactlyTheConditionsGoCanWrite (backend/gates/reopenconditionparity_test.go),
+// which derives the same set from both tables' CHECK constraints and requires
+// them equal. Its sibling in that file holds the contract's enum against this
+// set too, so a condition added here and nowhere else fails twice.
+//
+// Returned as a fresh slice because a package-level array would let one caller
+// reorder every other caller's chooser.
+func ReopenConditions() []ReopenCondition {
+	return []ReopenCondition{ReopenOnTime, ReopenOnReply, ReopenOnMeeting}
+}
+
+// WantsInstant says whether this condition stores a snoozed_until, and
+// NeedsReference whether it stores a reopen_ref. Together they are the shape
+// both tables' CHECK constraints hold, asked in Go before the write rather than
+// discovered as a constraint violation the client cannot read.
+func (c ReopenCondition) WantsInstant() bool { return c == ReopenOnTime }
+
+// NeedsReference says whether the condition names another row.
+func (c ReopenCondition) NeedsReference() bool { return c == ReopenOnMeeting }
+
+// ParseReopenCondition turns a wire value into a condition, refusing anything
+// outside the set the database would refuse anyway.
+//
+// The default is deliberate rather than convenient: an ABSENT condition is a
+// time snooze, because that is what every caller written before this existed
+// meant, and every row stored before it was one.
+func ParseReopenCondition(raw *string, field string) (ReopenCondition, error) {
+	if raw == nil || *raw == "" {
+		return ReopenOnTime, nil
+	}
+	for _, known := range ReopenConditions() {
+		if ReopenCondition(*raw) == known {
+			return known, nil
+		}
+	}
+	return "", &ParseError{
+		Field: field, Code: "unknown_reopen_condition",
+		Message: fmt.Sprintf("a snooze waits for one of %v", ReopenConditions()),
+	}
+}

--- a/backend/migrations/briefrunlocalday_integration_test.go
+++ b/backend/migrations/briefrunlocalday_integration_test.go
@@ -204,10 +204,19 @@ func insertBriefItem(t *testing.T, conn *pgx.Conn, run, deal ids.UUID, rank int,
 	state string, stateAt, snoozedUntil *time.Time,
 ) {
 	t.Helper()
+	// A snooze carries what it is waiting for, and the column's CHECK pairs the
+	// two. Derived from the state rather than taken as a parameter, because
+	// every caller here seeds the clock kind and asking each to say so would
+	// spread one row's shape across the file.
+	var reopenOn *string
+	if state == "snoozed" {
+		clock := "time"
+		reopenOn = &clock
+	}
 	if _, err := conn.Exec(context.Background(),
-		`INSERT INTO brief_item (brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state, state_at, snoozed_until)
-		 VALUES ($1, $2, $3, 0.5, '{}'::jsonb, ARRAY[]::uuid[], $4, $5, $6)`,
-		run, deal, rank, state, stateAt, snoozedUntil); err != nil {
+		`INSERT INTO brief_item (brief_run_id, deal_id, rank, composite, feature_vector, evidence_ids, state, state_at, snoozed_until, reopen_on)
+		 VALUES ($1, $2, $3, 0.5, '{}'::jsonb, ARRAY[]::uuid[], $4, $5, $6, $7)`,
+		run, deal, rank, state, stateAt, snoozedUntil, reopenOn); err != nil {
 		t.Fatalf("seeding a brief item: %v", err)
 	}
 }

--- a/backend/migrations/core/1788612865_a_snooze_can_wait_for_an_event.down.sql
+++ b/backend/migrations/core/1788612865_a_snooze_can_wait_for_an_event.down.sql
@@ -1,0 +1,34 @@
+-- Restoring the state-keyed shapes means the event-waiting snoozes have to go:
+-- the old constraints require every snooze to carry a moment, and a reply or
+-- meeting snooze has none to give. Dropping those rows returns their items to
+-- the queue, which is the safe direction — the rep sees work again rather than
+-- losing it to a set-aside nothing can now lift.
+-- Bound the wait for every lock below. Without it an open transaction
+-- holding a conflicting lock stalls every write to these tables for as long
+-- as this migration is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+DELETE FROM brief_item WHERE state = 'snoozed' AND reopen_on <> 'time';
+DELETE FROM activity_reader_state WHERE state = 'snoozed' AND reopen_on <> 'time';
+
+ALTER TABLE activity_reader_state DROP CONSTRAINT activity_reader_state_shaped;
+ALTER TABLE activity_reader_state
+  ADD CONSTRAINT activity_reader_state_shaped
+  CHECK (
+    (state = 'snoozed' AND snoozed_until IS NOT NULL)
+    OR (state = 'not_mine' AND snoozed_until IS NULL)
+  );
+ALTER TABLE activity_reader_state DROP CONSTRAINT activity_reader_state_reopen_ref_shaped;
+ALTER TABLE activity_reader_state DROP CONSTRAINT activity_reader_state_reopen_known;
+ALTER TABLE activity_reader_state DROP COLUMN reopen_ref;
+ALTER TABLE activity_reader_state DROP COLUMN reopen_on;
+
+ALTER TABLE brief_item DROP CONSTRAINT brief_item_snooze_shape;
+ALTER TABLE brief_item
+  ADD CONSTRAINT brief_item_snooze_shape
+  CHECK ((snoozed_until IS NOT NULL) = (state = 'snoozed'));
+ALTER TABLE brief_item DROP CONSTRAINT brief_item_reopen_ref_shaped;
+ALTER TABLE brief_item DROP CONSTRAINT brief_item_reopen_belongs_to_a_snooze;
+ALTER TABLE brief_item DROP CONSTRAINT brief_item_reopen_known;
+ALTER TABLE brief_item DROP COLUMN reopen_ref;
+ALTER TABLE brief_item DROP COLUMN reopen_on;

--- a/backend/migrations/core/1788612865_a_snooze_can_wait_for_an_event.up.sql
+++ b/backend/migrations/core/1788612865_a_snooze_can_wait_for_an_event.up.sql
@@ -1,0 +1,80 @@
+-- A snooze can name an EVENT to wait for, not only a moment.
+--
+-- "Remind me in three days" was the only thing a rep could say, so every
+-- set-aside became a guess about when the world would move. The two things they
+-- actually meant were "when they reply" and "after the meeting" — and both are
+-- already knowable from rows we hold, so the condition is stored and evaluated
+-- at read time rather than driven by a new job.
+--
+-- WHY reopen_ref IS NULLABLE FOR 'reply'. A reply condition is answered by any
+-- newer inbound on the same thread, which the read finds from the item itself;
+-- there is nothing to point at. A meeting condition names the meeting, because
+-- "after the meeting" is meaningless without saying which.
+
+-- Bound the wait for every lock below. Without it an open transaction
+-- holding a conflicting lock stalls every write to these tables for as long
+-- as this migration is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE brief_item ADD COLUMN reopen_on text;
+ALTER TABLE brief_item ADD COLUMN reopen_ref uuid;
+
+ALTER TABLE brief_item
+  ADD CONSTRAINT brief_item_reopen_known
+  CHECK (reopen_on IS NULL OR reopen_on IN ('time', 'reply', 'meeting'));
+
+-- BEFORE the constraints that require it. Every snooze written before this
+-- migration was a moment, so 'time' is what they were rather than a default
+-- chosen for them — and a deployed database with one live snooze would fail
+-- the ADD CONSTRAINT below if the backfill ran after it.
+UPDATE brief_item SET reopen_on = 'time' WHERE state = 'snoozed';
+
+-- The pair travels with the state, so neither half can be written alone: a
+-- reopen condition on an item that is not snoozed describes a wait nothing is
+-- waiting for, and a snooze with no condition is the old shape this migration
+-- exists to replace.
+ALTER TABLE brief_item
+  ADD CONSTRAINT brief_item_reopen_belongs_to_a_snooze
+  CHECK ((reopen_on IS NOT NULL) IS NOT DISTINCT FROM (state = 'snoozed'));
+
+-- A meeting names its meeting; the other two conditions have nothing to name.
+--
+-- IS NOT DISTINCT FROM rather than =, because a CHECK that evaluates to NULL
+-- PASSES in Postgres. With a plain `=` a row carrying reopen_on NULL and a
+-- reopen_ref would compare NULL and be admitted — a reference on a row that is
+-- waiting for nothing.
+ALTER TABLE brief_item
+  ADD CONSTRAINT brief_item_reopen_ref_shaped
+  CHECK ((reopen_ref IS NOT NULL) IS NOT DISTINCT FROM (reopen_on IS NOT DISTINCT FROM 'meeting'));
+
+-- The old shape tied snoozed_until to the state itself. Only a 'time' snooze
+-- carries a moment now, so the constraint moves from the state to the condition.
+ALTER TABLE brief_item DROP CONSTRAINT brief_item_snooze_shape;
+ALTER TABLE brief_item
+  ADD CONSTRAINT brief_item_snooze_shape
+  CHECK ((snoozed_until IS NOT NULL) IS NOT DISTINCT FROM (reopen_on IS NOT DISTINCT FROM 'time'));
+
+ALTER TABLE activity_reader_state ADD COLUMN reopen_on text;
+ALTER TABLE activity_reader_state ADD COLUMN reopen_ref uuid;
+
+ALTER TABLE activity_reader_state
+  ADD CONSTRAINT activity_reader_state_reopen_known
+  CHECK (reopen_on IS NULL OR reopen_on IN ('time', 'reply', 'meeting'));
+
+UPDATE activity_reader_state SET reopen_on = 'time' WHERE state = 'snoozed';
+
+ALTER TABLE activity_reader_state
+  ADD CONSTRAINT activity_reader_state_reopen_ref_shaped
+  CHECK ((reopen_ref IS NOT NULL) IS NOT DISTINCT FROM (reopen_on IS NOT DISTINCT FROM 'meeting'));
+
+-- Same move as above: the shape check now reads the condition rather than the
+-- state, so a reply-snooze is allowed to carry no moment while not_mine still
+-- carries neither.
+ALTER TABLE activity_reader_state DROP CONSTRAINT activity_reader_state_shaped;
+ALTER TABLE activity_reader_state
+  ADD CONSTRAINT activity_reader_state_shaped
+  CHECK (
+    (state = 'snoozed' AND reopen_on IS NOT NULL
+       AND (snoozed_until IS NOT NULL) IS NOT DISTINCT FROM (reopen_on = 'time'))
+    OR (state = 'not_mine' AND snoozed_until IS NULL AND reopen_on IS NULL)
+  );

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -180,8 +180,12 @@ public.activity_reader_state.activity_reader_state_activity_id_fkey FOREIGN KEY 
 public.activity_reader_state.activity_reader_state_known CHECK ((state = ANY (ARRAY['snoozed'::text, 'not_mine'::text])))
 public.activity_reader_state.activity_reader_state_pkey PRIMARY KEY (activity_id, reader_id)
 public.activity_reader_state.activity_reader_state_reader_id_fkey FOREIGN KEY (reader_id) REFERENCES app_user(id) ON DELETE CASCADE
-public.activity_reader_state.activity_reader_state_shaped CHECK ((((state = 'snoozed'::text) AND (snoozed_until IS NOT NULL)) OR ((state = 'not_mine'::text) AND (snoozed_until IS NULL))))
+public.activity_reader_state.activity_reader_state_reopen_known CHECK (((reopen_on IS NULL) OR (reopen_on = ANY (ARRAY['time'::text, 'reply'::text, 'meeting'::text]))))
+public.activity_reader_state.activity_reader_state_reopen_ref_shaped CHECK ((NOT ((reopen_ref IS NOT NULL) IS DISTINCT FROM (NOT (reopen_on IS DISTINCT FROM 'meeting'::text)))))
+public.activity_reader_state.activity_reader_state_shaped CHECK ((((state = 'snoozed'::text) AND (reopen_on IS NOT NULL) AND (NOT ((snoozed_until IS NOT NULL) IS DISTINCT FROM (reopen_on = 'time'::text)))) OR ((state = 'not_mine'::text) AND (snoozed_until IS NULL) AND (reopen_on IS NULL))))
 public.activity_reader_state.reader_id uuid NOT NULL gen=- def=-
+public.activity_reader_state.reopen_on text gen=- def=-
+public.activity_reader_state.reopen_ref uuid gen=- def=-
 public.activity_reader_state.set_at timestamp with time zone NOT NULL gen=- def=now()
 public.activity_reader_state.set_by text NOT NULL gen=- def=-
 public.activity_reader_state.snoozed_until timestamp with time zone gen=- def=-
@@ -979,8 +983,11 @@ public.brief_item.brief_item_finding_length CHECK (((finding IS NULL) OR (char_l
 public.brief_item.brief_item_lineage_whole CHECK (((returned_after_dismissal_on IS NULL) = (returned_with_activity_at IS NULL)))
 public.brief_item.brief_item_pkey PRIMARY KEY (id)
 public.brief_item.brief_item_rank_check CHECK ((rank >= 1))
+public.brief_item.brief_item_reopen_belongs_to_a_snooze CHECK ((NOT ((reopen_on IS NOT NULL) IS DISTINCT FROM (state = 'snoozed'::text))))
+public.brief_item.brief_item_reopen_known CHECK (((reopen_on IS NULL) OR (reopen_on = ANY (ARRAY['time'::text, 'reply'::text, 'meeting'::text]))))
+public.brief_item.brief_item_reopen_ref_shaped CHECK ((NOT ((reopen_ref IS NOT NULL) IS DISTINCT FROM (NOT (reopen_on IS DISTINCT FROM 'meeting'::text)))))
 public.brief_item.brief_item_run_fkey FOREIGN KEY (brief_run_id) REFERENCES brief_run(id) ON DELETE CASCADE
-public.brief_item.brief_item_snooze_shape CHECK (((snoozed_until IS NOT NULL) = (state = 'snoozed'::text)))
+public.brief_item.brief_item_snooze_shape CHECK ((NOT ((snoozed_until IS NOT NULL) IS DISTINCT FROM (NOT (reopen_on IS DISTINCT FROM 'time'::text)))))
 public.brief_item.brief_item_state_check CHECK ((state = ANY (ARRAY['new'::text, 'acted'::text, 'dismissed'::text, 'snoozed'::text])))
 public.brief_item.brief_item_state_stamped CHECK (((state = 'new'::text) = (state_at IS NULL)))
 public.brief_item.brief_run_id uuid NOT NULL gen=- def=-
@@ -991,6 +998,8 @@ public.brief_item.feature_vector jsonb NOT NULL gen=- def=-
 public.brief_item.finding text gen=- def=-
 public.brief_item.id uuid NOT NULL gen=- def=uuidv7()
 public.brief_item.rank integer NOT NULL gen=- def=-
+public.brief_item.reopen_on text gen=- def=-
+public.brief_item.reopen_ref uuid gen=- def=-
 public.brief_item.returned_after_dismissal_on date gen=- def=-
 public.brief_item.returned_with_activity_at timestamp with time zone gen=- def=-
 public.brief_item.snoozed_until timestamp with time zone gen=- def=-

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (80)
+## Parity (81)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -91,6 +91,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `providername_test.go` | H2 | The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces that have one. |
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
+| `reopenconditionparity_test.go` | H3 | What a snooze may wait for is spelled in four places, and all four must agree. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this person currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 73,
     "resources": 12,
-    "tool_catalog_bytes": 208212,
+    "tool_catalog_bytes": 208289,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 53199,
+    "approx_wire_tokens_total": 53218,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 50780,
       "input_schema_bytes": 42930,
-      "output_schema_bytes": 98750,
+      "output_schema_bytes": 98827,
       "description_plus_input_schema_bytes": 93710
     }
   },
@@ -9091,6 +9091,13 @@
                       },
                       "rank": {
                         "type": "integer"
+                      },
+                      "reopen_on": {
+                        "type": "string"
+                      },
+                      "reopen_ref": {
+                        "format": "uuid",
+                        "type": "string"
                       },
                       "snoozed_until": {
                         "type": "string"

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 73 |
 | Resources | 12 |
-| Tool catalog | 203.3 KB |
+| Tool catalog | 203.4 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 53199 |
+| Approx. wire tokens | 53218 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 96.4 KB | 47% | **No** — a result's shape, never listed to a model |
+| Output schemas | 96.5 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 49.6 KB | 24% | Yes, every step |
 | Input schemas | 41.9 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.4 KB | 7% | Partly |
-| **Description + input schema** | **91.5 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **91.5 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -114,7 +114,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`qualify_lead`](#qualify_lead) | Qualify a lead |  |  | 2.4 KB |
 | [`query_workspace`](#query_workspace) | Query the workspace | yes |  | 4.0 KB |
 | [`read_approval`](#read_approval) | Read one staged action in full | yes |  | 2.4 KB |
-| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.0 KB |
+| [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.1 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
 | [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.4 KB |
@@ -9899,6 +9899,13 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
               },
               "rank": {
                 "type": "integer"
+              },
+              "reopen_on": {
+                "type": "string"
+              },
+              "reopen_ref": {
+                "format": "uuid",
+                "type": "string"
               },
               "snoozed_until": {
                 "type": "string"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21616,16 +21616,23 @@ export interface components {
              * @enum {string}
              */
             disposition: "snooze" | "not_mine" | "not_sales";
+            reopen_on?: components["schemas"]["ReopenCondition"];
             /**
              * Format: date-time
-             * @description When a snooze lifts. REQUIRED for `snooze` and refused for the other two — a snooze
-             *     with no moment would never lift, and a moment on `not_mine` would make a hand-off
-             *     expire on a Thursday.
+             * @description When a snooze lifts. REQUIRED for `snooze` with `reopen_on: time`, and refused
+             *     everywhere else — a snooze waiting on a reply lifts when the reply arrives, and a
+             *     moment on `not_mine` would make a hand-off expire on a Thursday.
              *
              *     A moment already past is refused rather than stored: it would write a row that hides
              *     nothing, and read to the rep as a snooze that did not take.
              */
             snoozed_until?: string;
+            /**
+             * Format: uuid
+             * @description The meeting to wait for. REQUIRED for `snooze` with `reopen_on: meeting` and
+             *     refused otherwise.
+             */
+            reopen_ref?: string;
         };
         /**
          * @description One user or team admitted to a message besides its participants. The same shape the
@@ -28574,9 +28581,19 @@ export interface components {
             state_at?: string | null;
             /**
              * Format: date-time
-             * @description When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.
+             * @description When a snoozed item re-surfaces; set exactly while reopen_on=time, null otherwise — the other conditions lift on an event rather than a date.
              */
             snoozed_until?: string | null;
+            /**
+             * @description What the item is waiting for; set exactly while state=snoozed, null otherwise.
+             * @enum {string|null}
+             */
+            reopen_on?: "time" | "reply" | "meeting" | null;
+            /**
+             * Format: uuid
+             * @description The meeting being waited for; set exactly while reopen_on=meeting.
+             */
+            reopen_ref?: string | null;
             lineage?: components["schemas"]["MorningBriefItemLineage"];
             /**
              * @description What the overnight agent found about this deal — why it is on the list, what changed,
@@ -28937,14 +28954,36 @@ export interface components {
              */
             cited_evidence: string[];
         };
-        /** @description Snooze a brief item until a future instant (A77/AC-home-6); it re-surfaces once the instant passes. */
+        /**
+         * @description Set a brief item aside until something happens. The something is `reopen_on`: a moment
+         *     on the clock, the customer writing back, or a named meeting being over.
+         */
         BriefSnoozeRequest: {
+            reopen_on?: components["schemas"]["ReopenCondition"];
             /**
              * Format: date-time
-             * @description When the item re-surfaces; must be in the future.
+             * @description When the item re-surfaces. REQUIRED for `time` and refused for the other two — a
+             *     snooze waiting on a reply lifts when the reply arrives, not on a date. Must be in
+             *     the future.
              */
-            snoozed_until: string;
+            snoozed_until?: string;
+            /**
+             * Format: uuid
+             * @description The meeting to wait for. REQUIRED for `meeting` and refused otherwise, because
+             *     "after the meeting" names nothing without saying which meeting.
+             */
+            reopen_ref?: string;
         };
+        /**
+         * @description What lifts a snooze. `time` is the original behaviour and the default, so a client
+         *     written before the other two keeps working unchanged. `reply` waits for the
+         *     counterparty to write back on a conversation linked to the record. `meeting` waits for
+         *     a named meeting to be over — an archived meeting counts as over, so a cancelled one
+         *     returns the work rather than holding it forever.
+         * @default time
+         * @enum {string}
+         */
+        ReopenCondition: "time" | "reply" | "meeting";
         /** @description The §10.1 factor decomposition, each normalized 0..1 — the composite reconciles to it. */
         MorningBriefFeatureVector: {
             /** @description stage win probability / 100. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8097,12 +8097,15 @@ export const de = {
   "worklist.disposition.snoozeFor": "Für wie lange",
   "worklist.disposition.snoozeDays_one": "{value} Tag",
   "worklist.disposition.snoozeDays_other": "{value} Tage",
+  "worklist.disposition.snoozeUntil.reply": "Bis sie antworten",
   "worklist.disposition.verb.not_mine": "Nicht meins",
   "worklist.disposition.verb.not_sales": "Kein Kunde",
   "worklist.disposition.done.snooze": "Morgen wieder auf deiner Liste.",
   "worklist.disposition.doneSnooze_one": "Morgen wieder auf deiner Liste.",
   "worklist.disposition.doneSnooze_other":
     "In {value} Tagen wieder auf deiner Liste.",
+  "worklist.disposition.doneSnoozeUntil.reply":
+    "Wieder auf deiner Liste, sobald sie antworten.",
   "worklist.disposition.done.not_mine":
     "Von deiner Liste. Wer zuständig ist, sieht es weiterhin.",
   "worklist.disposition.done.not_sales": "Von allen Listen entfernt.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8205,11 +8205,14 @@ export const en = {
   "worklist.disposition.snoozeFor": "For how long",
   "worklist.disposition.snoozeDays_one": "{value} day",
   "worklist.disposition.snoozeDays_other": "{value} days",
+  "worklist.disposition.snoozeUntil.reply": "Until they reply",
   "worklist.disposition.verb.not_mine": "Not mine",
   "worklist.disposition.verb.not_sales": "Not a customer",
   "worklist.disposition.done.snooze": "Back on your list tomorrow.",
   "worklist.disposition.doneSnooze_one": "Back on your list tomorrow.",
   "worklist.disposition.doneSnooze_other": "Back on your list in {value} days.",
+  "worklist.disposition.doneSnoozeUntil.reply":
+    "Back on your list when they reply.",
   "worklist.disposition.done.not_mine":
     "Off your list. Whoever owns it still sees it.",
   "worklist.disposition.done.not_sales": "Off everyone's list.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8004,6 +8004,7 @@ export const vi = {
   "worklist.disposition.snoozeFor": "Trong bao lâu",
   "worklist.disposition.snoozeDays_one": "{value} ngày",
   "worklist.disposition.snoozeDays_other": "{value} ngày",
+  "worklist.disposition.snoozeUntil.reply": "Đến khi họ trả lời",
   "worklist.disposition.verb.not_mine": "Không phải của tôi",
   "worklist.disposition.verb.not_sales": "Không phải khách hàng",
   "worklist.disposition.done.snooze": "Ngày mai sẽ trở lại danh sách của bạn.",
@@ -8011,6 +8012,8 @@ export const vi = {
     "Ngày mai sẽ trở lại danh sách của bạn.",
   "worklist.disposition.doneSnooze_other":
     "Sẽ trở lại danh sách của bạn sau {value} ngày.",
+  "worklist.disposition.doneSnoozeUntil.reply":
+    "Sẽ trở lại danh sách của bạn khi họ trả lời.",
   "worklist.disposition.done.not_mine":
     "Đã rời danh sách của bạn. Người phụ trách vẫn thấy nó.",
   "worklist.disposition.done.not_sales": "Đã rời danh sách của mọi người.",

--- a/frontend/src/screens/worklist.dispositions.tsx
+++ b/frontend/src/screens/worklist.dispositions.tsx
@@ -24,6 +24,7 @@ import { useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
 import { type Locale, translatePlural, useLocale, useT } from "../i18n";
 import {
+  type ReopenCondition,
   useClearDisposition,
   useSetDisposition,
   type WorklistDisposition,
@@ -52,6 +53,25 @@ export const SNOOZE_DAYS = 1;
 export const SNOOZE_SPANS = [1, 3, 7] as const;
 
 type SnoozeSpan = (typeof SNOOZE_SPANS)[number];
+
+// The two answers a span cannot give.
+//
+// Every span above is a guess about when the world will move, and a rep making
+// that guess is usually wrong in one of two directions: too short and the row
+// is back while the customer is still silent, too long and the customer waited
+// on them. These say what they are actually waiting for, and the server decides
+// when it happened.
+//
+// `meeting` is deliberately NOT here. It needs the rep to name WHICH meeting,
+// which is a picker over the record's calendar rather than a line in this list
+// — offering it without one would send a condition the server refuses. The
+// server takes it today; this surface does not yet ask for it.
+export const SNOOZE_EVENTS = ["reply"] as const satisfies readonly Exclude<
+  ReopenCondition,
+  "time" | "meeting"
+>[];
+
+type SnoozeEvent = (typeof SNOOZE_EVENTS)[number];
 
 // Which undo REACH each judgement takes back.
 //
@@ -107,18 +127,31 @@ export function usePutDown(item: WorklistItem) {
   const set = useSetDisposition();
   const clear = useClearDisposition();
   const offered = item.dispositions ?? [];
-  const put = (disposition: WorklistDisposition, days?: SnoozeSpan) => {
+  const put = (
+    disposition: WorklistDisposition,
+    // A span or an event, never both: the two are alternative answers to "come
+    // back when", and the server refuses a snooze carrying a moment it does not
+    // wait for.
+    until?: SnoozeSpan | SnoozeEvent,
+  ) => {
+    const event = typeof until === "string" ? until : undefined;
+    const days = typeof until === "number" ? until : undefined;
     set.mutate(
       {
         activityId: item.id,
         disposition,
         ...(disposition === "snooze"
-          ? { snoozedUntil: snoozeUntil(days).toISOString() }
+          ? event
+            ? { reopenOn: event }
+            : {
+                reopenOn: "time" as const,
+                snoozedUntil: snoozeUntil(days).toISOString(),
+              }
           : {}),
       },
       {
         onSuccess: () =>
-          toast.show(doneText(disposition, days, t, locale), {
+          toast.show(doneText(disposition, until, t, locale), {
             action: {
               label: t("worklist.disposition.undo"),
               // A failed undo needs saying. The toast dismisses itself the
@@ -242,7 +275,10 @@ function PutDownMenu({
   offered: readonly WorklistDisposition[];
   // The SPAN reaches the write, not only the judgement: the menu's longer
   // lines are the answers the default day cannot give.
-  put: (disposition: WorklistDisposition, days?: SnoozeSpan) => void;
+  put: (
+    disposition: WorklistDisposition,
+    until?: SnoozeSpan | SnoozeEvent,
+  ) => void;
   pending: boolean;
   t: T;
   locale: Locale;
@@ -288,6 +324,21 @@ function PutDownMenu({
               days,
               { value: formatNumber(days, locale) },
             )}
+          </Button>
+        ))}
+      {/* The event answers, as lines of the same list. They sit after the spans
+          because a rep reaching for this menu most often still means a
+          duration; what these add is the case a duration cannot state. */}
+      {offered.includes("snooze") &&
+        SNOOZE_EVENTS.map((event) => (
+          <Button
+            key={event}
+            small
+            variant="ghost"
+            pending={pending}
+            onClick={() => put("snooze", event)}
+          >
+            {t(`worklist.disposition.snoozeUntil.${event}` as const)}
           </Button>
         ))}
     </OverflowMenu>
@@ -356,7 +407,10 @@ export function DispositionVerbs({ item }: Readonly<{ item: WorklistItem }>) {
           choose a duration every time would charge the common case for the
           rare one. */}
       {offered.includes("snooze") && (
-        <SnoozeSpans pending={pending} onPick={(days) => put("snooze", days)} />
+        <SnoozeSpans
+          pending={pending}
+          onPick={(until) => put("snooze", until)}
+        />
       )}
     </div>
   );
@@ -408,7 +462,10 @@ export function swipeActions(
 function SnoozeSpans({
   pending,
   onPick,
-}: Readonly<{ pending: boolean; onPick: (days: SnoozeSpan) => void }>) {
+}: Readonly<{
+  pending: boolean;
+  onPick: (until: SnoozeSpan | SnoozeEvent) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   return (
@@ -430,6 +487,17 @@ function SnoozeSpans({
             })}
           </Button>
         ))}
+        {SNOOZE_EVENTS.map((event) => (
+          <Button
+            key={event}
+            small
+            variant="ghost"
+            disabled={pending}
+            onClick={() => onPick(event)}
+          >
+            {t(`worklist.disposition.snoozeUntil.${event}` as const)}
+          </Button>
+        ))}
       </div>
     </Popover>
   );
@@ -448,14 +516,17 @@ function SnoozeSpans({
 // keep the sentence they had.
 function doneText(
   disposition: WorklistDisposition,
-  days: SnoozeSpan | undefined,
+  until: SnoozeSpan | SnoozeEvent | undefined,
   t: T,
   locale: Locale,
 ): string {
   if (disposition !== "snooze") {
     return t(`worklist.disposition.done.${disposition}` as const);
   }
-  const span = days ?? SNOOZE_DAYS;
+  if (typeof until === "string") {
+    return t(`worklist.disposition.doneSnoozeUntil.${until}` as const);
+  }
+  const span = until ?? SNOOZE_DAYS;
   return translatePlural(locale, "worklist.disposition.doneSnooze", span, {
     value: formatNumber(span, locale),
   });

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -35,6 +35,10 @@ export type WorklistCategory = WorklistItem["category"];
 export type WorklistDisposition = NonNullable<
   WorklistItem["dispositions"]
 >[number];
+// What a snooze waits for. Derived from the contract's shared schema for the
+// reason the disposition union is: a hand-written union goes stale the moment
+// the server gains a fourth condition, and nothing compares the two.
+export type ReopenCondition = components["schemas"]["ReopenCondition"];
 export type TeamBoard = components["schemas"]["TeamBoard"];
 export type TeamExceptions = components["schemas"]["TeamExceptions"];
 export type HandledForYou = components["schemas"]["HandledForYou"];
@@ -430,14 +434,19 @@ export function useSetDisposition() {
       activityId: string;
       disposition: WorklistDisposition;
       snoozedUntil?: string;
+      reopenOn?: ReopenCondition;
+      reopenRef?: string;
     }) => {
       const { error } = await api.PUT("/activities/{id}/disposition", {
         params: { path: { id: input.activityId } },
         body: {
           disposition: input.disposition,
-          // Only a snooze names a moment. Sending one on the others is a 422,
-          // because a hand-off that expires on a Thursday is not a hand-off.
+          // Only a snooze names a moment or a condition. Sending either on the
+          // others is a 422, because a hand-off that expires on a Thursday is
+          // not a hand-off.
           ...(input.snoozedUntil ? { snoozed_until: input.snoozedUntil } : {}),
+          ...(input.reopenOn ? { reopen_on: input.reopenOn } : {}),
+          ...(input.reopenRef ? { reopen_ref: input.reopenRef } : {}),
         },
       });
       if (error) {

--- a/frontend/src/screens/worklist.snooze.test.tsx
+++ b/frontend/src/screens/worklist.snooze.test.tsx
@@ -147,6 +147,51 @@ describe("how long a row is put down for", () => {
     },
   );
 
+  // The answer a span cannot give.
+  //
+  // Every duration above is a guess about when the customer will move, and the
+  // rep is usually wrong in one of two directions. This asserts the WIRE rather
+  // than the button, because a picker that renders the line and sends a
+  // one-day snooze underneath looks identical on screen and is the same old
+  // guess.
+  it("sends the reply condition and no moment when the reader picks it", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const fetch = draw();
+
+    await user.click(screen.getByRole("button", { name: "For how long" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: en["worklist.disposition.snoozeUntil.reply"],
+      }),
+    );
+
+    await waitFor(async () => expect((await sentBodies(fetch)).length).toBe(1));
+    const body = (await sentBodies(fetch))[0];
+    expect(body.reopen_on).toBe("reply");
+    // No moment: the server refuses a reply snooze carrying one, and a client
+    // that sent tomorrow alongside would turn every such press into a 422.
+    expect(body.snoozed_until).toBeUndefined();
+  });
+
+  // The default press still names the clock EXPLICITLY.
+  //
+  // The server treats an absent condition as `time`, so omitting it would work
+  // today — and would silently become a different snooze the day that default
+  // changed. Saying which one is meant costs one field.
+  it("names the clock condition on the plain press", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const fetch = draw();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: en["worklist.disposition.verb.snooze"],
+      }),
+    );
+
+    await waitFor(async () => expect((await sentBodies(fetch)).length).toBe(1));
+    expect((await sentBodies(fetch))[0].reopen_on).toBe("time");
+  });
+
   // The spans are offered only where the verb is. A duration picker beside a
   // row the server never offered a snooze on is a control that 404s.
   it("offers no spans on a row the server does not let a reader snooze", () => {


### PR DESCRIPTION
"Remind me in three days" was the only thing a rep could say, so every set-aside was a guess about when the world would move. The guess is wrong in one of two directions: too short and the row is back while the customer is still silent, too long and the customer waited on the rep.

Two conditions replace the guess, on both set-aside systems — the brief's morning queue (`brief_item`) and the waiting-messages lane (`activity_reader_state`):

| condition | lifts when |
|---|---|
| `reply` | the counterparty writes back |
| `meeting` | a named meeting is over |

Both are answered from rows already held, so nothing new runs on a schedule.

## What "they replied" means is deliberately different in the two places

A brief item waits on a **deal**, so any inbound linked to that deal answers it. A waiting message waits on a **conversation**, so only a newer inbound on the same thread does — mail from the same customer about a different subject is not the reply the rep was waiting for. Two predicates, because the thing being waited on differs.

## A meeting is over when it has ENDED

`occurred_at + duration_seconds`, not `occurred_at` — otherwise the work comes back while the rep is still in the room. A meeting that will never happen counts as over: archived, cancelled, or a no-show. Holding the item forever is the only outcome that loses the work.

## What the review caught

Codex reviewed this before the first commit and found five defects, all real:

1. **The migration would have failed on any deployed database.** The CHECK requiring `reopen_on` on a snoozed row was added *before* the backfill that sets it. Proven against a real Postgres with a live snoozed row: the original order errors, the fixed order backfills and passes.
2. **`CHECK` expressions evaluating to NULL pass in Postgres**, so `reopen_on = NULL` with a `reopen_ref` set was admitted. Now `IS NOT DISTINCT FROM` throughout.
3. **`reopen_ref` was stored unvalidated.** An id naming an old email lifted the snooze instantly (its `occurred_at` is already past); an id the caller could not read would have told them when somebody else's meeting happened. Now gated on object grant, row visibility and `kind`.
4. **Neither lift predicate filtered `kind = 'meeting'`.**
5. **A reply the reader may not see still lifted their snooze** — and the row reappearing *is* the disclosure that it arrived. The waiting query already gates the row it serves; the reply that lifts a snooze is now gated the same way. Mutation-proven.

## Also fixed here

`activity_reader_state.set_at` was stamped by `now()` in SQL while everything around it uses an injected clock. A reply snooze compares against `set_at`, so the wall-clock stamp made every seeded reply look older than the snooze — a snooze that never lifted.

A shared `ReopenCondition` schema whose values are `time`/`reply`/`meeting` re-decided oapi-codegen's collision resolution across the whole contract, freeing the prefixes off `ListPeopleParamsCapturedByKind` until its bare `System` collided with `GetWorklistParamsFilter`'s and stopped the package compiling. Named explicitly with `x-enum-varnames`, like the pair in `ListCustomFieldsParams`.

## Three readers, one predicate

The candidate filter, the re-surface UPDATE and the mark guard all decide "is this snooze over", and they share one spelling — so a row cannot be shown and then 409 when it is touched.

## Held by

`backend/gates/reopenconditionparity_test.go` derives the condition set three ways — from `values.ReopenConditions()`, from both tables' CHECK constraints, and from the contract's enum — and requires all three equal. Mutation-checked in both directions.

## Scope left out

The `meeting` condition is served by the API but not offered on screen: choosing one needs a picker over the record's calendar, which is its own change. `reply` ships in the UI.

## Known, unchanged

`EnsureMeetingReference` checks visibility and kind in separate statements under READ COMMITTED. That TOCTOU is the same exposure every `EnsureVisible` call in this tree has; narrowing it means changing the repo-wide pattern, not this diff.

The brief's reply predicate applies no activity content gate, matching the dismissal filter it sits beside in `briefCandidates`: the brief's queue is scoped by deal, and a rep who may read the deal is told it moved without being shown what moved it. The message lane is scoped by activity, so its predicate does gate the reply.

## Gates

`make check-backend` and `make check-fe` green after the final rebase. Integration lanes green: `migrations`, `compose/briefs`, `compose/integration`, `modules/activities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snoozes can now wait for a reply or a meeting, not only a date, on both the brief's morning queue and the waiting-messages lane.

**Behavior**
- `reply` lifts when the counterparty writes back: any inbound linked to the deal for a brief item, a newer inbound on the same thread for a message.
- `meeting` lifts when the meeting ends (`occurred_at + duration_seconds`); archived, cancelled, or no-show meetings count as over.
- `reopen_ref` must name a meeting the caller can read, or the snooze is refused.
- The candidate filter, re-surface UPDATE, and mark guard share one lift predicate, so a row can't be shown and then conflict when touched.
- Fixed `activity_reader_state.set_at` using `now()` in SQL instead of the injected clock, which made reply snoozes never lift.
- The UI offers "Until they reply"; the meeting condition is API-only until a calendar picker exists.

**Migration**
- The migration backfills `reopen_on` before adding the CHECK that requires it; the reverse order fails on deployed databases.
- The down migration deletes event-waiting snoozes and returns their items to the queue.

<sup>Written for commit ac91cd01bf01c89fb217790277059d99f6724775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Snooze worklist items until a specific time, an inbound reply, or a meeting concludes.
  - Added reply-based snoozing to the worklist interface, including confirmation messages and localized labels.
  - Brief results now show the selected reopening condition and related meeting reference when applicable.
- **Bug Fixes**
  - Snoozed items now reappear consistently across worklists when their configured condition is met.
  - Replies hidden from the viewer no longer incorrectly reopen snoozed items.
- **Validation**
  - Added validation to prevent invalid combinations and ensure meeting references identify visible meetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->