### PR TITLE
fix(ci): the merge alarm reads the last word before the merge, not the first

### DIFF
--- a/scripts/check-merge-verdict.sh
+++ b/scripts/check-merge-verdict.sh
@@ -80,12 +80,29 @@ if [[ -z "$pr_number" ]]; then
 	exit 1
 fi
 
-# The oldest matching run, not the newest. A re-run after the merge answers
-# about a tree that had already landed, and taking the latest verdict would let
-# one clear the record of the merge it was not present for.
-verdict="$(jq -r --arg name "$required" '
-	[.check_runs // [] | .[] | select(.name == $name)]
-	| sort_by(.completed_at // "9999") | .[0] // {}' <<<"$checks")"
+# THE LAST WORD BEFORE THE MERGE — not the newest run, and not the oldest.
+#
+# A re-run AFTER the merge answers about a tree that had already landed, so it
+# must not clear the record of the merge it was absent for. That is why this was
+# the oldest run, and that half is still true.
+#
+# But "oldest" only stands in for "before the merge" while there is one run
+# before it. A red lane cleared by a re-run and then merged by a human has TWO,
+# and the oldest is the run the merger looked at and correctly disregarded — so
+# the alarm accused a merge whose required check was green at the moment it was
+# made. Re-running is how a flaky lane is legitimately cleared, which made this
+# fire on the ordinary repair rather than on anything.
+#
+# So: the latest verdict that had completed by merge time. Falling back to the
+# oldest overall when none had, which is the fan-in's usual shape — `ci` posts
+# minutes after the merge, and reading that run is the whole point of the alarm.
+merged_at="$(jq -r 'if type == "array" and length > 0 then (min_by(.number).merged_at // "") else "" end' <<<"$pulls")"
+verdict="$(jq -r --arg name "$required" --arg merged "$merged_at" '
+	[.check_runs // [] | .[] | select(.name == $name)] as $named
+	| ([$named[] | select($merged != "" and (.completed_at // "9999") <= $merged)]
+	   | sort_by(.completed_at) | last)
+	// ($named | sort_by(.completed_at // "9999") | .[0])
+	// {}' <<<"$checks")"
 
 if [[ "$(jq -r 'length' <<<"$verdict")" -eq 0 ]]; then
 	echo "ok: $sha has no \`$required\` verdict to read (pull request #$pr_number) — an absent verdict is the shape of a decision that was taken, not a finding"

--- a/scripts/test-check-merge-verdict.sh
+++ b/scripts/test-check-merge-verdict.sh
@@ -75,6 +75,23 @@ case_is "a later re-run does not overwrite the verdict at merge time" "$pr" \
 	'{"check_runs":[{"name":"ci","status":"completed","conclusion":"failure","completed_at":"2026-08-24T02:29:56Z"},{"name":"ci","status":"completed","conclusion":"success","completed_at":"2026-08-25T09:00:00Z"}]}' \
 	1 'reported `failure`'
 
+# THE OTHER SIDE OF THAT RULE, and the case it was missing: BOTH runs before the
+# merge. A red lane cleared by a re-run and then merged by a human is the
+# ordinary way a flake is repaired, and the required check was green at the
+# moment the merge was made — the red is the run the merger looked at and
+# correctly disregarded. Judging the oldest accused that merge of landing over a
+# verdict that had already been superseded, which is the alarm firing on the
+# repair rather than on anything.
+case_is "a re-run BEFORE the merge is the verdict the merger saw" "$pr" \
+	'{"check_runs":[{"name":"ci","status":"completed","conclusion":"failure","completed_at":"2026-08-24T02:29:56Z"},{"name":"ci","status":"completed","conclusion":"success","completed_at":"2026-08-24T02:40:00Z"}]}' \
+	0 "merged behind a green"
+
+# And the pair either side of it, which is the shape that must still accuse: red
+# before, green only after. The merge was made over the red one.
+case_is "a re-run after the merge cannot clear a red the merger saw" "$pr" \
+	'{"check_runs":[{"name":"ci","status":"completed","conclusion":"failure","completed_at":"2026-08-24T02:29:56Z"},{"name":"ci","status":"completed","conclusion":"success","completed_at":"2026-08-24T03:10:00Z"}]}' \
+	1 'reported `failure`'
+
 # The other finding, and the loudest: nothing reviewed this at all.
 case_is "no pull request at all" '[]' '{"check_runs":[]}' 1 "no pull request naming it"
 


### PR DESCRIPTION
The merge alarm fired on a merge whose required check was green when it was made. https://github.com/margince/margince/issues/4434 is that false alarm — it names my own https://github.com/margince/margince/pull/4426, which merged CLEAN.

Closes https://github.com/margince/margince/issues/4434

## What it judged

The alarm reads the **oldest** `ci` run on the merged head, deliberately:

> The oldest matching run, not the newest. A re-run after the merge answers about a tree that had already landed, and taking the latest verdict would let one clear the record of the merge it was not present for.

That is right about the case it was written for. It is wrong about the one nobody had: **both runs before the merge.**

```
PR #4426   ci failure  13:18:46
           ci success  13:36:34   <- the re-run that made it mergeable
           merged      13:45:17
```

`ci` was green at the moment the merge was made. The red is the run the merger looked at and correctly disregarded — re-running is how a flaky lane is legitimately cleared, and https://github.com/margince/margince/issues/4435 is a flake that requires exactly that. So the alarm fired on the ordinary repair, which is the failure its own header warns about:

> An alarm that fires on the expected state is an alarm that gets turned off, and it would have buried the two findings above.

## The rule now

The latest verdict that had **completed by merge time**, falling back to the oldest overall when none had.

The fallback is not a convenience. `ci` is a fan-in that posts minutes after the merge, so a verdict arriving late is the alarm's main subject — dropping it would silence the thing this exists for.

## Replayed against the three merges that alarmed today

Real payloads, pulled from the API with `filter=all` (the default `latest` hides the duplicate runs entirely, which is why this is easy to miss):

| PR | `ci` runs | merged | before | after |
|---|---|---|---|---|
| https://github.com/margince/margince/pull/4426 | fail 13:18, **success 13:36** | 13:45 | ✗ accused | ✓ silent |
| https://github.com/margince/margince/pull/4418 | **fail 12:33**, success 13:51 | 13:48 | ✓ accused | ✓ accused |
| https://github.com/margince/margince/pull/4431 | fail 13:38 only | 13:21 | ✓ accused | ✓ accused |

The two genuine findings — a merge over a red `ci` whose green came afterwards, and a fan-in that landed red — still report. Only the false one stops.

## Held

Two cases, either side of the merge instant and otherwise identical, so neither can be traded for the other unnoticed:

- `a re-run BEFORE the merge is the verdict the merger saw` — exit 0
- `a re-run after the merge cannot clear a red the merger saw` — exit 1

Mutation-tested: restoring `sort_by(.completed_at) | .[0]` fails the first and leaves the second green, which is what says the pair is measuring the boundary rather than one side of it.

All 13 pre-existing cases still hold — `make test-merge-verdict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Merge verdict checks now evaluate the latest completed run available before the pull request was merged.
  - Correctly distinguish between checks that passed before merging and reruns completed afterward.
  - Improved handling when no pre-merge check run is available, ensuring a consistent fallback verdict.

- **Tests**
  - Added coverage for reruns occurring both before and after merge completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->