### PR TITLE
How full the installation is, without what it pays

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11019,6 +11019,43 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /installation/seat-usage:
+    get:
+      tags: [Identity]
+      operationId: getSeatUsage
+      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
+      x-agent-access: human-only
+      summary: How many full seats this installation is using (capacity, not entitlement).
+      description: |
+        The seat COUNT on its own, without what the license grants or what it cost.
+
+        This exists because those are two questions with two readers. How many seats are in
+        use is capacity, which whoever plans headcount needs; what the installation is
+        entitled to and what it paid is its commercial standing. `GET /installation/license`
+        answers both together and is governed by the `license` object, so a role could not be
+        shown the first without also being handed the second. This one is governed by
+        `seat_usage`, which management holds and license does not accompany.
+
+        It is the SAME meter, not a second one: this and the entitlement surface run one
+        statement, which is also the ceiling that refuses the next full seat at `POST /users`.
+        A count that could disagree with the ceiling it measures would be a meter nobody is
+        held to.
+
+        `seats_used` counts every full seat the installation has not withdrawn — neither
+        deactivated nor suspended. Read seats are unlimited and never metered (A62/ADR-0047),
+        and agent seats count, because a first-party runner acts on the estate as a human does.
+
+        No seat cap is reported here. A cap is entitlement, which is what the other surface is
+        for and what `seat_usage` deliberately does not carry.
+      responses:
+        '200':
+          description: The seats in use.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SeatUsage' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   # -------- /me/agent-grants (the rep's own standing overnight authority) --------
   # A rep says once whether an agent may work as them overnight. The answer is
   # THEIRS: the path is /me/..., the acting principal names the rep, and there is
@@ -20961,6 +20998,24 @@ components:
           description: 'Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam | personal | advisor. The last two belong to the mailbox owner rather than to the business: personal is a private correspondent, advisor a professional they engage personally.'
         resolved_at: { type: [string, 'null'], format: date-time }
 
+    SeatUsage:
+      type: object
+      description: |
+        How many full seats the installation is using, without what it is entitled to.
+
+        Deliberately NOT a subset of LicenseEntitlement: it carries no cap and no posture,
+        because those are the commercial facts `seat_usage` exists to leave out. A client
+        needing both reads the entitlement surface, which requires the `license` grant.
+      required: [seats_used]
+      properties:
+        seats_used:
+          type: integer
+          minimum: 0
+          description: |
+            Full seats in use: every one the installation has not withdrawn — neither
+            deactivated nor suspended — agent seats included. Read seats are unlimited and
+            never counted (A62/ADR-0047). This is the same number the entitlement surface
+            reports and the same one a seat creation is refused against; there is one meter.
     LicenseEntitlement:
       type: object
       description: |

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -242,6 +242,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/imports/{id}/report":                                        {Op: "getImportRunReport", Access: "tool", Tool: "read_import_report", RecordType: "import_run", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/installation/license":                                       {Op: "getLicenseEntitlement", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/installation/oauth-apps/{provider}":                         {Op: "getOauthApp", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/installation/seat-usage":                                    {Op: "getSeatUsage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/installation/setup":                                         {Op: "getInstallationSetup", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/knowledge/corpora":                                          {Op: "listCorpora", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/knowledge/corpora/{id}":                                     {Op: "readCorpus", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/handlers_license.go
+++ b/backend/internal/compose/handlers_license.go
@@ -31,6 +31,22 @@ type licenseHandlers struct {
 	posture func() licensecheck.Posture
 }
 
+// withPosture adds the license half to a handler that already carries the seat
+// count, and is the ONLY way the entitlement surface is completed.
+//
+// It takes the receiver's store rather than building a second one. The two
+// halves genuinely come from different places — the count from the assembly,
+// because app_user rows exist whether or not a license was configured; the
+// posture from the option, because only that caller has one — and a struct
+// literal restating both would let an edit to either drop the other silently.
+//
+// Held by: TestWithLicensePostureKeepsTheSeatCountItWasGiven, which fails when
+// this rebuilds the struct instead of adding to it.
+func (h licenseHandlers) withPosture(posture func() licensecheck.Posture) licenseHandlers {
+	h.posture = posture
+	return h
+}
+
 // GetLicenseEntitlement answers the entitlement and the usage measured against
 // it.
 //
@@ -55,6 +71,33 @@ func (h licenseHandlers) GetLicenseEntitlement(w http.ResponseWriter, r *http.Re
 		return
 	}
 	httperr.WriteJSON(w, http.StatusOK, toContractLicenseEntitlement(h.posture(), used))
+}
+
+// GetSeatUsage answers the seat count without the entitlement beside it.
+//
+// The posture is not read here at all, and that is the split: this surface
+// exists so a reader who may see capacity is not thereby handed what the
+// installation pays. Its gate is the store's — `seat_usage` rather than
+// `license` — so the two surfaces differ in exactly one thing, which grant
+// opens them.
+func (h licenseHandlers) GetSeatUsage(w http.ResponseWriter, r *http.Request) {
+	if h.seats == nil {
+		httperr.NotImplemented(w, r, "GetSeatUsage")
+		return
+	}
+	// Human-only for the same reason the entitlement is: how much of an
+	// installation is in use is capacity planning, not something an agent asks
+	// for, even one carrying its holder's passport.
+	if err := auth.RequireHuman(r.Context()); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	used, err := h.seats.SeatsInUse(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.SeatUsage{SeatsUsed: used})
 }
 
 // renewalWindow is how long before expiry the surface asks for a renewal.

--- a/backend/internal/compose/handlers_license_test.go
+++ b/backend/internal/compose/handlers_license_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/licensecheck"
 )
 
@@ -153,6 +154,35 @@ func TestWithLicensePostureReachesTheEntitlementHandler(t *testing.T) {
 	// and the exposition cannot disagree about what this process resolved.
 	if srv.licensePosture == nil {
 		t.Error("the option did not reach the /metrics accessor")
+	}
+}
+
+// The option ADDS the posture and keeps the seat count, which is the invariant
+// that lets the two halves be wired in two places.
+//
+// The count comes from the assembly and the posture from the option, so a
+// WithLicensePosture that rebuilt the struct instead of adding to it would drop
+// the store — and the drop is silent: both entitlement and capacity would answer
+// 501 for the life of the process, in the one role that applies this option.
+// Nothing else covers that branch, because the harness that exercises the
+// capacity endpoint wires no posture and so never runs this code.
+func TestWithLicensePostureKeepsTheSeatCountItWasGiven(t *testing.T) {
+	t.Parallel()
+	// Stand in for the assembly, which is what puts the store here. A real one
+	// needs a pool; what this asserts is only that the option does not discard
+	// whatever it found, so a non-nil marker is the whole fixture.
+	srv := Server{}
+	srv.licenseHandlers = licenseHandlers{seats: &identity.SeatUsageStore{}}
+
+	WithLicensePosture(func() licensecheck.Posture {
+		return licensecheck.Posture{State: licensecheck.StateAbsent, CheckedAt: resolvedAt}
+	})(&srv, nil)
+
+	if srv.seats == nil {
+		t.Fatal("the option dropped the seat count; both license surfaces would answer 501")
+	}
+	if srv.posture == nil {
+		t.Fatal("the option did not add the posture")
 	}
 }
 

--- a/backend/internal/compose/integration/seat_usage_split_integration_test.go
+++ b/backend/internal/compose/integration/seat_usage_split_integration_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The seat COUNT read apart from the entitlement it normally sits beside.
+//
+// `GET /installation/license` answers capacity and commercial standing together
+// and is governed by `license`, so a role could not be shown how many seats are
+// in use without also being handed what the installation pays. Management needs
+// the first and not the second, which is what `seat_usage` is for.
+//
+// What has to be true, and what these prove against a real database:
+//
+//   a seat_usage holder is admitted and a license holder still is
+//   a rep holding neither is refused, by the STORE and not the transport
+//   both doors report the SAME number
+//
+// That last one is the reason this is an integration test rather than a unit
+// one. Two counts of one installation's seats would drift, and the one that
+// drifted would be the one nobody was refused a seat by — a meter disagreeing
+// with the ceiling it measures. The doors run one statement; a change that gave
+// either its own query fails here.
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seatUsage is the wire shape, read back rather than restated, so a renamed
+// field fails here instead of decoding into a zero that looks like an empty
+// installation.
+type seatUsage struct {
+	SeatsUsed int `json:"seats_used"`
+}
+
+// seatUsageOnlyPerms is the reader this split exists for: the capacity grant and
+// nothing commercial. `license` is absent on purpose — with it the case would
+// pass through the OLD gate and prove nothing about the new one.
+var seatUsageOnlyPerms = principal.Permissions{
+	RoleKeys: []string{"management"},
+	Objects:  map[string]principal.ObjectGrant{"seat_usage": {Read: true}},
+	RowScope: principal.RowScopeAll,
+}
+
+// noSeatGrantPerms is a rep: neither grant, so both doors must refuse. Spelled
+// here rather than reusing the entitlement file's licenseReaderPerms, whose name
+// says the opposite of what this case means — a reader who HOLDS the license
+// grant is precisely what it is not.
+var noSeatGrantPerms = principal.Permissions{
+	RoleKeys: []string{"rep"},
+	Objects:  map[string]principal.ObjectGrant{"person": {Create: true, Read: true, Update: true}},
+	RowScope: principal.RowScopeTeam,
+}
+
+// licenseOnlyPerms is the opposite reader, and it is here to prove the split did
+// not quietly move the entitlement surface onto the new object: a holder of
+// `license` alone must still read it.
+var licenseOnlyPerms = principal.Permissions{
+	RoleKeys: []string{"admin"},
+	Objects:  map[string]principal.ObjectGrant{"license": {Read: true}},
+	RowScope: principal.RowScopeAll,
+}
+
+func TestSeatUsageAdmitsTheCapacityGrantAndRefusesAReader(t *testing.T) {
+	e := Setup(t)
+	store := identity.NewSeatUsage(e.DB())
+
+	// Admitted: the grant this endpoint was split out for.
+	management := e.As(e.Rep1, []ids.UUID{e.Team1}, seatUsageOnlyPerms)
+	used, err := store.SeatsInUse(management)
+	if err != nil {
+		t.Fatalf("a seat_usage holder was refused the seat count: %v", err)
+	}
+	if used < 1 {
+		// A zero would pass an assertion of "no error" while proving the count
+		// never ran. The harness seeds users, so the meter has something to see.
+		t.Fatalf("seats in use = %d, want at least the seeded users", used)
+	}
+
+	// Refused: a rep holds neither grant. The refusal is the STORE's, so no row
+	// is counted before it happens.
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, noSeatGrantPerms)
+	if got, err := store.SeatsInUse(rep); err == nil {
+		t.Fatalf("a rep counted the installation's seats and got %d", got)
+	} else if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("refusal = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// The capacity grant does NOT open the entitlement surface, which is the whole
+// point of splitting rather than widening: a reader who may see how full the
+// installation is still may not see what it pays.
+func TestSeatUsageDoesNotAdmitTheEntitlement(t *testing.T) {
+	e := Setup(t)
+	management := e.As(e.Rep1, []ids.UUID{e.Team1}, seatUsageOnlyPerms)
+
+	if got, err := identity.NewSeatUsage(e.DB()).FullSeatsInUse(management); err == nil {
+		t.Fatalf("a seat_usage holder read the entitlement count and got %d", got)
+	} else if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("refusal = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// One meter, two doors. If either entry point ever grows a statement of its own
+// this is what fails, and it fails on the number rather than on the shape — the
+// drift a second query causes is silent everywhere else.
+func TestBothDoorsReportOneMeter(t *testing.T) {
+	e := Setup(t)
+	store := identity.NewSeatUsage(e.DB())
+
+	viaLicense, err := store.FullSeatsInUse(e.As(e.Rep1, []ids.UUID{e.Team1}, licenseOnlyPerms))
+	if err != nil {
+		t.Fatalf("a license holder was refused the entitlement count: %v", err)
+	}
+	viaSeatUsage, err := store.SeatsInUse(e.As(e.Rep1, []ids.UUID{e.Team1}, seatUsageOnlyPerms))
+	if err != nil {
+		t.Fatalf("a seat_usage holder was refused the seat count: %v", err)
+	}
+	if viaLicense != viaSeatUsage {
+		t.Errorf("the two doors disagree: license says %d, seat_usage says %d", viaLicense, viaSeatUsage)
+	}
+}
+
+// The endpoint over the wire, because the store test above proves the gate and
+// not the route: a handler wired to the wrong store, or not wired at all, is
+// invisible to every case above it.
+func TestTheSeatUsageEndpointAnswersItsHolder(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	var got seatUsage
+	if status := e.Call(t, "GET", "/v1/installation/seat-usage", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /installation/seat-usage = %d, want 200", status)
+	}
+	if got.SeatsUsed < 1 {
+		t.Errorf("seats_used = %d, want at least the seeded users", got.SeatsUsed)
+	}
+}

--- a/backend/internal/compose/license.go
+++ b/backend/internal/compose/license.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
@@ -157,15 +156,20 @@ func WithLicensePosture(posture func() licensecheck.Posture) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		s.licensePosture = posture
 		// The entitlement surface is built HERE rather than in the assembly, and
-		// both halves together: the assembly runs BEFORE the options, so a handler
-		// wired there would have captured a nil posture and answered 501 for the
-		// life of the process. One wiring point also means one answer to "does this
-		// role report entitlement at all" — a role that never applies this option
-		// serves no /metrics section and no surface, declared or absent in both.
-		s.licenseHandlers = licenseHandlers{
-			seats:   identity.NewSeatUsage(InstallationDB(pool)),
-			posture: posture,
-		}
+		// the posture half: the assembly runs BEFORE the options, so a handler wired
+		// there would have captured a nil posture and answered 501 for the life of
+		// the process. One wiring point also means one answer to "does this role
+		// report entitlement at all" — a role that never applies this option serves
+		// no /metrics section and no entitlement surface, declared or absent in both.
+		//
+		// The seat COUNT is not rebuilt here. It came from the assembly, because it
+		// is a fact about app_user rows that holds whether or not a license was ever
+		// configured, and adding the posture is the only thing this option has to
+		// say about it. Spelling the store a second time would put one invariant in
+		// two places, and dropping it from that second literal — reasonably, on the
+		// grounds that the assembly already wired it — would take the entitlement
+		// surface down with it.
+		s.licenseHandlers = s.withPosture(posture)
 		// The same posture reaches identity's seat writer as a ceiling, from the
 		// same call: a role that reports what a license grants must not be able to
 		// show an admin a number it does not hold them to. The posture is read at

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -160,6 +160,15 @@ func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
 	// domain control, and the only way an operator corrects a shipped
 	// baseline that is wrong about one of their customers.
 	s.consumerMailDomainHandlers = consumerMailDomainHandlers{store: capture.NewFreemailDomains(InstallationDB(pool))}
+	// The seat COUNT, wired here rather than with the entitlement, because how
+	// many seats an installation is USING is a fact about app_user rows and holds
+	// whether or not a license was ever configured. A deployment that wires no
+	// posture still answers the capacity surface.
+	//
+	// The entitlement is the half that needs the option: WithLicensePosture adds
+	// the posture to this handler through withPosture rather than rebuilding it,
+	// so the store is spelled once and neither half can drop the other.
+	s.licenseHandlers = licenseHandlers{seats: identity.NewSeatUsage(InstallationDB(pool))}
 }
 
 // wireExportSurface binds the two export transports.

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1027,6 +1027,10 @@ func (stubs) SetOauthApp(w nethttp.ResponseWriter, r *nethttp.Request, provider 
 	httperr.NotImplemented(w, r, "SetOauthApp")
 }
 
+func (stubs) GetSeatUsage(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetSeatUsage")
+}
+
 func (stubs) GetInstallationSettings(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetInstallationSettings")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31031,6 +31031,19 @@ type SearchResultTrustTier string
 // SearchResultType defines model for SearchResult.Type.
 type SearchResultType string
 
+// SeatUsage How many full seats the installation is using, without what it is entitled to.
+//
+// Deliberately NOT a subset of LicenseEntitlement: it carries no cap and no posture,
+// because those are the commercial facts `seat_usage` exists to leave out. A client
+// needing both reads the entitlement surface, which requires the `license` grant.
+type SeatUsage struct {
+	// SeatsUsed Full seats in use: every one the installation has not withdrawn — neither
+	// deactivated nor suspended — agent seats included. Read seats are unlimited and
+	// never counted (A62/ADR-0047). This is the same number the entitlement surface
+	// reports and the same one a seat creation is refused against; there is one meter.
+	SeatsUsed int `json:"seats_used"`
+}
+
 // SendAccountEmailRequest One account-started send. It is SendEmailRequest plus the `links` an anchor would
 // otherwise have supplied — the records this new conversation belongs to.
 type SendAccountEmailRequest struct {
@@ -49039,6 +49052,9 @@ type ServerInterface interface {
 	// Store one vendor's OAuth app for this installation (admin/ops).
 	// (PUT /installation/oauth-apps/{provider})
 	SetOauthApp(w http.ResponseWriter, r *http.Request, provider string)
+	// How many full seats this installation is using (capacity, not entitlement).
+	// (GET /installation/seat-usage)
+	GetSeatUsage(w http.ResponseWriter, r *http.Request)
 	// The installation's own settings.
 	// (GET /installation/settings)
 	GetInstallationSettings(w http.ResponseWriter, r *http.Request)
@@ -51574,6 +51590,12 @@ func (_ Unimplemented) GetOauthApp(w http.ResponseWriter, r *http.Request, provi
 // Store one vendor's OAuth app for this installation (admin/ops).
 // (PUT /installation/oauth-apps/{provider})
 func (_ Unimplemented) SetOauthApp(w http.ResponseWriter, r *http.Request, provider string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// How many full seats this installation is using (capacity, not entitlement).
+// (GET /installation/seat-usage)
+func (_ Unimplemented) GetSeatUsage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -63699,6 +63721,26 @@ func (siw *ServerInterfaceWrapper) SetOauthApp(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SetOauthApp(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSeatUsage operation middleware
+func (siw *ServerInterfaceWrapper) GetSeatUsage(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSeatUsage(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -79857,6 +79899,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/installation/oauth-apps/{provider}", wrapper.SetOauthApp)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/installation/seat-usage", wrapper.GetSeatUsage)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/installation/settings", wrapper.GetInstallationSettings)

--- a/backend/internal/modules/identity/seatusage.go
+++ b/backend/internal/modules/identity/seatusage.go
@@ -25,6 +25,14 @@ import (
 // rep reads their own seat elsewhere (UC-ADMIN-03 F1).
 const licenseObject = "license"
 
+// seatUsageObject gates the seat COUNT on its own, apart from the entitlement it
+// is normally read beside. The two answer different questions to different
+// readers: how many seats are in use is capacity, which a manager plans against,
+// while what the license grants and what it cost is the installation's
+// commercial standing. One object for both meant a role could not be shown the
+// first without also being handed the second.
+const seatUsageObject = "seat_usage"
+
 // SeatUsageStore counts the seats an entitlement is measured against.
 type SeatUsageStore struct {
 	db *database.DB
@@ -58,6 +66,29 @@ func (s *SeatUsageStore) FullSeatsInUse(ctx context.Context) (int, error) {
 	if err := auth.Require(ctx, licenseObject, principal.ActionRead); err != nil {
 		return 0, err
 	}
+	return s.countFullSeats(ctx)
+}
+
+// SeatsInUse answers the same count for a reader holding `seat_usage` rather
+// than `license`: the capacity question without the commercial one.
+//
+// It runs countFullSeats rather than a statement of its own, and that is the
+// point of splitting the GRANT instead of writing a second store. Two counts of
+// one installation's seats would drift, and the one that drifted would be the
+// one nobody was refused a seat by — a meter disagreeing with the ceiling it
+// measures. There is one meter; this is a second door onto it, and the doors
+// differ only in which grant opens them.
+func (s *SeatUsageStore) SeatsInUse(ctx context.Context) (int, error) {
+	if err := auth.Require(ctx, seatUsageObject, principal.ActionRead); err != nil {
+		return 0, err
+	}
+	return s.countFullSeats(ctx)
+}
+
+// countFullSeats runs the meter. It carries no gate of its own, which is why it
+// is unexported: both entry points above check one first, and a caller reaching
+// the count without checking would be the defect this shape prevents.
+func (s *SeatUsageStore) countFullSeats(ctx context.Context) (int, error) {
 	var used int
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, fullSeatsInUseQuery).Scan(&used)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7485,6 +7485,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/installation/seat-usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * How many full seats this installation is using (capacity, not entitlement).
+         * @description The seat COUNT on its own, without what the license grants or what it cost.
+         *
+         *     This exists because those are two questions with two readers. How many seats are in
+         *     use is capacity, which whoever plans headcount needs; what the installation is
+         *     entitled to and what it paid is its commercial standing. `GET /installation/license`
+         *     answers both together and is governed by the `license` object, so a role could not be
+         *     shown the first without also being handed the second. This one is governed by
+         *     `seat_usage`, which management holds and license does not accompany.
+         *
+         *     It is the SAME meter, not a second one: this and the entitlement surface run one
+         *     statement, which is also the ceiling that refuses the next full seat at `POST /users`.
+         *     A count that could disagree with the ceiling it measures would be a meter nobody is
+         *     held to.
+         *
+         *     `seats_used` counts every full seat the installation has not withdrawn — neither
+         *     deactivated nor suspended. Read seats are unlimited and never metered (A62/ADR-0047),
+         *     and agent seats count, because a first-party runner acts on the estate as a human does.
+         *
+         *     No seat cap is reported here. A cap is entitlement, which is what the other surface is
+         *     for and what `seat_usage` deliberately does not carry.
+         */
+        get: operations["getSeatUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/agent-grants": {
         parameters: {
             query?: never;
@@ -14189,6 +14228,22 @@ export interface components {
             /** Format: date-time */
             resolved_at?: string | null;
         } | null;
+        /**
+         * @description How many full seats the installation is using, without what it is entitled to.
+         *
+         *     Deliberately NOT a subset of LicenseEntitlement: it carries no cap and no posture,
+         *     because those are the commercial facts `seat_usage` exists to leave out. A client
+         *     needing both reads the entitlement surface, which requires the `license` grant.
+         */
+        SeatUsage: {
+            /**
+             * @description Full seats in use: every one the installation has not withdrawn — neither
+             *     deactivated nor suspended — agent seats included. Read seats are unlimited and
+             *     never counted (A62/ADR-0047). This is the same number the entitlement surface
+             *     reports and the same one a seat creation is refused against; there is one meter.
+             */
+            seats_used: number;
+        };
         /**
          * @description What the license grants and how much of it is used, as this process last resolved it.
          *     Read by admin/ops only.
@@ -43027,6 +43082,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LicenseEntitlement"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    getSeatUsage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The seats in use. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeatUsage"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
`GET /installation/license` answers two questions at once: how many full seats are in use, and what the license grants, what state it is in, whether the installation is over its limit. It is governed by `license`, so a role could not be shown the first without being handed the second. Management plans headcount and has no business reading the commercial standing.

`GET /installation/seat-usage` answers the count alone, governed by `seat_usage`. The response carries `seats_used` and nothing else — no cap, no posture, no licensee. A cap is entitlement, which is what the other surface is for and what this object exists to leave out.

I proved the payoff from runtime values rather than from reading the grant table: **management holds `seat_usage:read` and not `license:read`**, admin and ops hold both, manager/rep/read_only hold neither. That is exactly the reader the split exists for.

## One meter, two doors

`FullSeatsInUse` and the new `SeatsInUse` differ only in which grant opens them, and both call `countFullSeats` rather than each carrying a statement. Two counts of one installation's seats would drift, and the one that drifted would be the meter nobody is refused a seat by — the ceiling at `POST /users` runs that same `fullSeatsInUseQuery`. `TestBothDoorsReportOneMeter` fails on the number if either ever grows its own query.

`countFullSeats` is unexported and carries no gate, which the security review confirmed is structurally covered rather than merely conventional: `rbacgate_test.go` requires every exported method on a module store to reach an auth gate and resolves that transitively over same-package calls, so a future third caller fails the gate unless someone writes a waiver with a rationale.

## The wiring defect the store tests could not see

The seat store was built only inside `WithLicensePosture`. That is right for the entitlement — it pairs the count with a posture only that option carries — but wrong for capacity, which is a fact about `app_user` rows that holds whether or not a license was configured. **The three store tests passed while the endpoint answered 501**, and only the over-the-wire case caught it.

The store now comes from the assembly, and the option adds the posture through `withPosture` instead of rebuilding the struct. That was craft-reviewer's finding: rebuilding meant `identity.NewSeatUsage(...)` was spelled in two places, and dropping it from the option's literal — reasonably, on the grounds the assembly already wired it — would have taken both license surfaces down to 501 in the one role that applies the option, silently. `TestWithLicensePostureKeepsTheSeatCountItWasGiven` now fails on exactly that edit.

## Verification

- `make check-backend` **green, exit 0**
- 7 integration tests pass, including the three pre-existing entitlement ones — the assembly change does not disturb the option that overwrites it
- frontend `tsc --noEmit` clean against the regenerated contract
- five mutations checked one at a time: removing the `seat_usage` gate, swapping it for `license`, removing the assembly wiring, and rebuilding the struct in `withPosture` each failed the right test

## No migration

`seat_usage` was seeded and backfilled in #4298, ahead of the endpoint that uses it. The backfill grants read to admin, management and ops, and writes explicit all-false rows for the other three so nothing inherits it silently.

Reviewed by `security-redteam` (no exploitable finding; it also caught an unheld "spelled once" claim in a doc comment, now naming its holder) and `craft-reviewer` (two findings, both fixed: the second store spelling above, and a comment describing a 501 state that never shipped). Codex is quota-blocked until Sep 12.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /installation/seat-usage` so management can read the seat count without the license entitlement. The old `GET /installation/license` answered both together and required the `license` grant, so a role couldn't see capacity without also seeing the installation's commercial standing. The new endpoint returns only `seats_used` and is governed by `seat_usage`, which management already holds.

- Both `FullSeatsInUse` and `SeatsInUse` run the same `countFullSeats` query, so the two surfaces share one meter and can't drift.
- The seat store now comes from the assembly instead of `WithLicensePosture`, since the count is a fact about `app_user` rows that holds whether or not a license was configured.
- `WithLicensePosture` now adds the posture through `withPosture` rather than rebuilding the struct, so the store is spelled once and neither half can drop the other.

No migration: `seat_usage` was seeded and backfilled in #4298.

<sup>Written for commit 9d9516c8f72dbada3c3c2d5be2c13798d83c78a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to view the number of full seats currently in use.
  * Seat usage access is separated from licensing entitlement access, allowing authorized capacity readers to view counts without exposing licensing details.
  * Seat usage is available even when license posture information is not configured.

* **Bug Fixes**
  * Preserved configured seat usage data when adding license posture settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->