### PR TITLE
fix(worklist): silence is the only negative a champion answer has

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -39361,10 +39361,14 @@ components:
           type: [boolean, 'null']
           description: |
             `true` when the account has a buying committee and nobody engaged on it holds
-            the champion seat. Null is not `false`: it is sent only when the answer is both
-            known and negative, and stays absent for a committee the caller may not read in
-            full, for a deal carrying no seats at all, and for a server that does not assess
-            coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
+            the champion seat. There is no other value: `false` is NEVER sent, and absent
+            is the answer in every case that is not that finding — a committee whose
+            champion seat IS held, a committee the caller may not read in full, a deal
+            carrying no seats at all, and a server that does not assess coverage.
+
+            So absence does not mean "covered". It means this endpoint is making no claim,
+            and a client MUST NOT read it as one. See `WorklistDealFacts.no_champion`,
+            which carries the same fact out under the same rule.
 
     AttentionRelationshipFacts:
       type: object
@@ -41002,12 +41006,15 @@ components:
             the champion seat — a deal drifting because nobody INSIDE is arguing for it,
             which needs a different move from the rep than a deal nobody outside has touched.
 
-            Null is not `false`. It is sent only when the answer is both known and negative,
-            and stays absent in the three cases that would otherwise be rounded down to a
-            finding: a committee the caller may not read in full (a champion they cannot see
-            is still a champion), a deal carrying no seats at all (no committee, so no gap),
-            and a server that does not assess coverage. A client MUST NOT render an absent
-            value as "nobody is carrying this".
+            `false` is NEVER sent. The field carries a finding or it carries nothing, and
+            absent is the answer in all FOUR cases that are not the finding: a committee
+            whose champion seat IS held, a committee the caller may not read in full (a
+            champion they cannot see is still a champion), a deal carrying no seats at all
+            (no committee, so no gap), and a server that does not assess coverage.
+
+            Absence therefore says nothing either way. A client MUST NOT render it as
+            "nobody is carrying this", and MUST NOT render it as "somebody is": the four
+            cases are indistinguishable on the wire by design.
 
     WorklistSourceUnavailable:
       type: object

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -96,10 +96,11 @@ func dealFactsOf(item crmcontracts.AttentionItem) *crmcontracts.WorklistDealFact
 		OwnerId:     item.Deal.OwnerId,
 		AmountMinor: item.Deal.AmountMinor,
 		Currency:    item.Deal.Currency,
-		// Copied verbatim: absent is not false. A committee this reader could
-		// not read in full arrives nil, and normalizing it to false would tell
-		// a rep nobody is carrying a deal whose champion they simply cannot see.
-		NoChampion: item.Deal.NoChampion,
+		// A finding or nothing. `false` is never sent, so a covered committee
+		// reaches the wire absent alongside the unreadable and the seatless one
+		// — a reader who cannot see the seats must not be able to tell those
+		// apart, because telling them apart is the disclosure.
+		NoChampion: aFindingOnly(item.Deal.NoChampion),
 	}
 	// The close date rides on the lane item's own due moment, and the idle
 	// count on its own typed field. Both were already resolved; only this projection
@@ -113,6 +114,19 @@ func dealFactsOf(item crmcontracts.AttentionItem) *crmcontracts.WorklistDealFact
 		facts.QuietDays = &quiet
 	}
 	return facts
+}
+
+// aFindingOnly drops a stated false, so absence is this field's only negative.
+//
+// Both producers of the champion answer call it, because one rule spelled twice
+// drifts: a covered committee, an unreadable one and a seatless deal must reach
+// the wire alike, and a reader able to tell them apart is the disclosure the
+// rule exists to refuse.
+func aFindingOnly(answer *bool) *bool {
+	if answer == nil || !*answer {
+		return nil
+	}
+	return answer
 }
 
 // expectedRevenue is what the deal is worth times how likely it is to land.

--- a/backend/internal/compose/attention/nochampion_test.go
+++ b/backend/internal/compose/attention/nochampion_test.go
@@ -138,28 +138,3 @@ func TestTheCardMakesNoChampionClaimAboutAWithheldCommittee(t *testing.T) {
 		t.Errorf("the card answers %v about a committee it could not read, want no answer", *row.Deal.NoChampion)
 	}
 }
-
-// The third input, and the one the contract's prose and its schema disagree on.
-//
-// `noChampionOf` never returns a stated false today — a covered committee
-// arrives absent — so this pins the projection's behaviour if one ever does.
-// It passes it through rather than swallowing it, because a stated false is
-// the coverage seam's answer to give: this row copies, it does not judge. The
-// schema permits `false`; the field's prose says it is "sent only when the
-// answer is both known and negative". Resolving that is the contract's work,
-// and until it is resolved a silent change of behaviour here should cost
-// somebody this test.
-func TestTheCardRepeatsAStatedFalseRatherThanInventingAnAnswer(t *testing.T) {
-	covered := false
-	row := oneRiskRow(t, withDealFacts(RiskyDeal{
-		DealID: ids.NewV7(), Name: "Fleet retrofit",
-		QuietDays: 19, NoChampion: &covered,
-	}))
-	if row.Deal == nil {
-		t.Fatal("the row carries no deal facts at all")
-	}
-	if row.Deal.NoChampion == nil || *row.Deal.NoChampion {
-		t.Errorf("the card states no_champion=%v over a seam that answered false",
-			row.Deal.NoChampion)
-	}
-}

--- a/backend/internal/compose/attention/nochampionsilence_test.go
+++ b/backend/internal/compose/attention/nochampionsilence_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// `false` is never sent, so silence is the only negative.
+//
+// `no_champion` carries a finding or it carries nothing. The contract says a
+// covered committee is absent alongside the three other non-findings, which
+// makes the four indistinguishable on the wire on purpose: a reader who cannot
+// see the seats must not be able to tell a covered committee from one they were
+// refused, because telling them apart IS the disclosure.
+//
+// That rule lives in two places — the field's description in crm.yaml and
+// noChampionOf, which maps Covered to nil — and a description enforces nothing.
+// This is the half that fails.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// Both answers the seam can give, and neither may reach the wire as a false.
+//
+// The loop is the point: a covered committee (false) and an uncovered one (true)
+// take different routes through noChampionOf, and only the second may surface.
+// Asserting the covered case alone would leave a projection free to invert the
+// finding, which is the same defect wearing the other sign.
+func TestTheCoverageSeamMintsNoStatedFalse(t *testing.T) {
+	t.Parallel()
+	for _, covered := range []bool{true, false} {
+		row := oneRiskRow(t, withDealFacts(RiskyDeal{
+			DealID: ids.NewV7(), Name: "Fleet retrofit", QuietDays: 19,
+			NoChampion: &covered,
+		}))
+		if row.Deal == nil {
+			t.Fatal("the row carries no deal facts at all")
+		}
+		if row.Deal.NoChampion != nil && !*row.Deal.NoChampion {
+			t.Errorf("a stated false reached the wire from a %v answer", covered)
+		}
+	}
+}
+
+// The same rule on the lane's own projection, which is the other producer.
+//
+// `AttentionDealFacts` and `WorklistDealFacts` carry one field under one rule,
+// and two functions build them. Holding only the worklist side would leave the
+// lane free to send the `false` its own contract text says is never sent — the
+// shape where a rule is fixed at one call site and the sibling keeps the defect.
+func TestTheLaneSendsNoStatedFalseEither(t *testing.T) {
+	t.Parallel()
+	for _, covered := range []bool{true, false} {
+		minor, currency := int64(4_000_000), "EUR"
+		item := riskItem(RiskyDeal{
+			DealID: ids.NewV7(), Name: "Fleet retrofit", QuietDays: 19,
+			AmountMinor: &minor, Currency: &currency, NoChampion: &covered,
+		})
+		if item.Deal == nil {
+			t.Fatal("the lane row carries no deal facts at all")
+		}
+		if item.Deal.NoChampion != nil && !*item.Deal.NoChampion {
+			t.Errorf("the lane sent a stated false from a %v answer", covered)
+		}
+	}
+}

--- a/backend/internal/compose/attention/rendersilence.go
+++ b/backend/internal/compose/attention/rendersilence.go
@@ -158,11 +158,11 @@ func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
 	facts := &crmcontracts.AttentionDealFacts{
 		AmountMinor: deal.AmountMinor,
 		Currency:    deal.Currency,
-		// Carried through, not re-decided. The seam that read the committee
-		// already resolved the tri-state — a withheld or seatless read arrives
-		// absent — and a renderer that reapplied the rule would be a second
-		// judgement over a fact it cannot see the evidence for.
-		NoChampion: deal.NoChampion,
+		// A finding or nothing, the same rule the worklist projection applies:
+		// `false` is never sent, so a covered committee reaches the wire absent
+		// alongside the unreadable and the seatless one. Both sides of this
+		// field spell one rule, so they share the helper that holds it.
+		NoChampion: aFindingOnly(deal.NoChampion),
 	}
 	if deal.StageID != nil {
 		stage := openapi_types.UUID(*deal.StageID)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17767,10 +17767,14 @@ type AttentionDealFacts struct {
 	Currency    *string `json:"currency,omitempty"`
 
 	// NoChampion `true` when the account has a buying committee and nobody engaged on it holds
-	// the champion seat. Null is not `false`: it is sent only when the answer is both
-	// known and negative, and stays absent for a committee the caller may not read in
-	// full, for a deal carrying no seats at all, and for a server that does not assess
-	// coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
+	// the champion seat. There is no other value: `false` is NEVER sent, and absent
+	// is the answer in every case that is not that finding — a committee whose
+	// champion seat IS held, a committee the caller may not read in full, a deal
+	// carrying no seats at all, and a server that does not assess coverage.
+	//
+	// So absence does not mean "covered". It means this endpoint is making no claim,
+	// and a client MUST NOT read it as one. See `WorklistDealFacts.no_champion`,
+	// which carries the same fact out under the same rule.
 	NoChampion *bool               `json:"no_champion,omitempty"`
 	OwnerId    *openapi_types.UUID `json:"owner_id,omitempty"`
 
@@ -34168,12 +34172,15 @@ type WorklistDealFacts struct {
 	// the champion seat — a deal drifting because nobody INSIDE is arguing for it,
 	// which needs a different move from the rep than a deal nobody outside has touched.
 	//
-	// Null is not `false`. It is sent only when the answer is both known and negative,
-	// and stays absent in the three cases that would otherwise be rounded down to a
-	// finding: a committee the caller may not read in full (a champion they cannot see
-	// is still a champion), a deal carrying no seats at all (no committee, so no gap),
-	// and a server that does not assess coverage. A client MUST NOT render an absent
-	// value as "nobody is carrying this".
+	// `false` is NEVER sent. The field carries a finding or it carries nothing, and
+	// absent is the answer in all FOUR cases that are not the finding: a committee
+	// whose champion seat IS held, a committee the caller may not read in full (a
+	// champion they cannot see is still a champion), a deal carrying no seats at all
+	// (no committee, so no gap), and a server that does not assess coverage.
+	//
+	// Absence therefore says nothing either way. A client MUST NOT render it as
+	// "nobody is carrying this", and MUST NOT render it as "somebody is": the four
+	// cases are indistinguishable on the wire by design.
 	NoChampion     *bool               `json:"no_champion,omitempty"`
 	OwnerId        *openapi_types.UUID `json:"owner_id,omitempty"`
 	QuietDays      *int                `json:"quiet_days,omitempty"`

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29579,10 +29579,14 @@ export interface components {
             owner_id?: string | null;
             /**
              * @description `true` when the account has a buying committee and nobody engaged on it holds
-             *     the champion seat. Null is not `false`: it is sent only when the answer is both
-             *     known and negative, and stays absent for a committee the caller may not read in
-             *     full, for a deal carrying no seats at all, and for a server that does not assess
-             *     coverage. See `WorklistDealFacts.no_champion`, which carries the same fact out.
+             *     the champion seat. There is no other value: `false` is NEVER sent, and absent
+             *     is the answer in every case that is not that finding — a committee whose
+             *     champion seat IS held, a committee the caller may not read in full, a deal
+             *     carrying no seats at all, and a server that does not assess coverage.
+             *
+             *     So absence does not mean "covered". It means this endpoint is making no claim,
+             *     and a client MUST NOT read it as one. See `WorklistDealFacts.no_champion`,
+             *     which carries the same fact out under the same rule.
              */
             no_champion?: boolean | null;
         };
@@ -31094,12 +31098,15 @@ export interface components {
              *     the champion seat — a deal drifting because nobody INSIDE is arguing for it,
              *     which needs a different move from the rep than a deal nobody outside has touched.
              *
-             *     Null is not `false`. It is sent only when the answer is both known and negative,
-             *     and stays absent in the three cases that would otherwise be rounded down to a
-             *     finding: a committee the caller may not read in full (a champion they cannot see
-             *     is still a champion), a deal carrying no seats at all (no committee, so no gap),
-             *     and a server that does not assess coverage. A client MUST NOT render an absent
-             *     value as "nobody is carrying this".
+             *     `false` is NEVER sent. The field carries a finding or it carries nothing, and
+             *     absent is the answer in all FOUR cases that are not the finding: a committee
+             *     whose champion seat IS held, a committee the caller may not read in full (a
+             *     champion they cannot see is still a champion), a deal carrying no seats at all
+             *     (no committee, so no gap), and a server that does not assess coverage.
+             *
+             *     Absence therefore says nothing either way. A client MUST NOT render it as
+             *     "nobody is carrying this", and MUST NOT render it as "somebody is": the four
+             *     cases are indistinguishable on the wire by design.
              */
             no_champion?: boolean | null;
         };


### PR DESCRIPTION
Lars decided option **2A** on #4433.

`no_champion` was declared `[boolean, 'null']` while the producer could only
ever emit `true` or absent, and the field's prose listed three absent-cases
without the fourth — a committee whose champion seat IS held. A client author
had no way to know whether `false` was a value they must handle.

The rule is now stated and held: **`false` is never sent**, and absence is the
answer in all four cases that are not the finding. The four are
indistinguishable on the wire on purpose — a reader who cannot see the seats
must not be able to tell a covered committee from one they were refused,
because telling those apart is the disclosure the tri-state exists to prevent.

**Both producers, not one.** The field is built by two functions —
`dealFactsOf` for `WorklistDealFacts` and `dealFacts` for `AttentionDealFacts`
— and both contract descriptions were rewritten, so both call sites now share
`aFindingOnly`. `craft-reviewer` caught that my first version fixed only the
worklist side and left the lane's own projection copying a stated false, with a
comment still arguing for the rule this decision inverts.

The test that pinned pass-through of a stated false is deleted. It was the
honest reading before this decision and is the defect after it.

Closes #4433.

| Obligation | Evidence |
|---|---|
| User-visible outcome | No rendered change. Nothing in `frontend/` reads this field; the `because: no_champion` reason is a separate path and is untouched. What changes is what a client may rely on. |
| Permission/row scope | Unchanged, and this narrows rather than widens: a covered committee now reaches the wire identically to one the reader was refused. |
| Failure behavior | `TestTheCoverageSeamMintsNoStatedFalse` — both answers the seam can give, neither surfaces as a false. |
| Idempotency/concurrency | n/a — pure projection, no write. |
| Mobile | n/a — no rendered change. |
| Storybook | n/a — no component change. |
| Accessibility | n/a — no component change. |
| Contract | `backend/api/crm.yaml` edited; `make gen` and `pnpm gen:api` both re-run, `api_gen.go` and `schema.d.ts` committed. The `contract-frontend-drift` gate passes. Schema type left as `[boolean, 'null']` deliberately: narrowing it would be a breaking wire change for existing clients, so the tests hold the invariant. |
| Write shape | n/a — read path only. |
| Mutation strength | Copying verbatim (the old behaviour) fails `TestTheCoverageSeamMintsNoStatedFalse`; inverting the helper to swallow the `true` fails it *and* `TestTheDealCardSaysNobodyIsCarryingIt`; reverting **only** the sibling in `rendersilence.go` fails `TestTheLaneSendsNoStatedFalseEither` alone, which is what proves the two sides are held independently. |
| Full lane | `make check` (both halves) EXIT=0, zero failures. |

`craft-reviewer` raised four findings, all addressed: the sibling producer
above (BLOCKER), a redundant second test I had already cut after
mutation-checking it myself, a helper comment that speculated about a future
refactor rather than stating today's rule, and an explanatory aside in the
contract text that no client could act on.

One note for whoever reads CI: `worklist.today.test.tsx > submits once however
fast the reader presses` failed on an earlier full-gate run under load and
passes alone and in the clean run above. It is not in this diff — the change is
six files, none of them that test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements option 2A from #4433: `no_champion` now never sends `false`, and absence is the only negative. The contract previously allowed `false` while the producers only intended `true` or absent, so clients couldn't rely on what absence meant; now both producers map a stated `false` to absent, making a covered committee indistinguishable on the wire from an unreadable one, a seatless deal, and a no-assessment server.

**Contract**
- Rewrites the `no_champion` description in `crm.yaml` and regenerated `api_gen.go` and `schema.d.ts`.
- Leaves the schema type as `[boolean, 'null']`; narrowing it would be a breaking wire change.
- Replaces the pass-through test with tests covering both producers.
- No rendered change; `frontend/` doesn't read this field.

<sup>Written for commit 45658f7ddab2d2618d1ffb4d5b07a10e5c73768b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

