### PR TITLE
fix(migrations): classify activity_meeting_history's FK to activity

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -246,8 +246,15 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 		"it to the surviving person inside the merge's own gated path (people/mergerelink.go), and the only other " +
 		"statements are privacy's subject-addressed ones: erasure and the retention action delete WHERE person_id, " +
 		"and the subject-access read selects the subject's own rows",
-	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
-	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
+	"activity_link.activity_id": "child row: written only inside LogActivity for the new activity",
+	// A meeting's own status transitions (core 1788616400). Both writers pass
+	// through recordMeetingTransition's single chokepoint (activities/meetinghistory.go),
+	// held by TestEveryMeetingStatusWriterRecordsHistory — LogActivity for the
+	// activity id that same transaction just created, and UpdateActivity for the
+	// id auth.EnsureActivityWritableIn already admitted earlier in that same
+	// transaction. Neither path takes the id from anywhere else.
+	"activity_meeting_history.activity_id": "child row: written only through recordMeetingTransition, from an activity id its own transaction already created (LogActivity) or already admitted via auth.EnsureActivityWritableIn (UpdateActivity)",
+	"lead_score_history.lead_id":           "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a
 	// standalone record (comms/doc.go): StageTx writes only inside the
 	// caller's own transaction, alongside the activity write it reports on


### PR DESCRIPTION
## Summary
- #4439 added `activity_meeting_history.activity_id` (FK -> `activity`) without a visibility-decision entry in `rowScopedFKDecisions`, so `TestFK_rowScopedTargetsHaveVisibilityDecision` fails main-wide in the integration lane.
- Both writers of the column go through `recordMeetingTransition`'s single chokepoint (held by `TestEveryMeetingStatusWriterRecordsHistory`), from an activity id their own transaction already created (`LogActivity`) or already admitted through `auth.EnsureActivityWritableIn` (`UpdateActivity`) — the same child-row shape `activity_link.activity_id` already carries.
- Classified it as a child row, same as its sibling.

## Test plan
- [x] `make test-it DIR=backend/migrations RUN=TestFK_rowScopedTargetsHaveVisibilityDecision` — passes
- [x] `make check-go` — passes
- [x] `craft static --strict` on the changed file — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main-wide integration failure by classifying `activity_meeting_history.activity_id` as a child row, so `TestFK_rowScopedTargetsHaveVisibilityDecision` passes.

- #4439 added the FK without a visibility-decision entry, which failed the test on every PR's integration lane.
- The column is only written through `recordMeetingTransition` from an activity id its own transaction already created (`LogActivity`) or admitted (`UpdateActivity`), the same child-row shape as `activity_link.activity_id`.

<sup>Written for commit 2e831f81a37a8c151d2b91a630bdd222db07c9a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

