### PR TITLE
fix(people): the network moment's badge says why it re-spaces a primitive

### DIFF
--- a/frontend/src/screens/personnetwork.css
+++ b/frontend/src/screens/personnetwork.css
@@ -375,6 +375,8 @@
   font-weight: var(--fw-medium);
 }
 .pn-moment p .badge {
+  /* ds:ignore a badge trailing a sentence takes the word gap after it; no
+     role names an inline interval */
   margin-left: var(--space-2);
   vertical-align: 1px;
 }


### PR DESCRIPTION
## What

One line: the margin on the badge inside a person-network moment's sentence carries the spacing-roles gate's in-line waiver and its reason. `main` is green on `fe-quality` again.

## Why

#4319 armed `check-ds-spacing-roles.sh` at 21:20 and #4411 landed at 21:39 with `.pn-moment p .badge { margin-left: var(--space-2) }`, which the gate reads as a screen re-spacing a design-system primitive. Both PRs were green on their own heads; the union is red, and every frontend PR since inherits it through the required `ci` context.

A badge trailing a sentence takes the word gap after it. No role names an inline interval (`--gapActions`, `--gapCards`, `--padCard`, `--padPanel` are all block-level), so this is the genuine one-off the gate's own message routes to a waiver with a reason rather than a role.

## How verified

- `frontend/scripts/check-ds-spacing-roles.sh`: FAIL on `main` at 76f02a4, PASS with this line.
- `biome check` clean on the file.
- No behaviour change: the declaration and its value are untouched, only the comment is added.

- [x] `make check` is green — only `fe-quality`'s spacing-roles gate was red, and this is its fix; no other lane reads this file differently
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers (no Go files changed)
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Diagnosed and written in a Claude Code session while driving #4383, which inherited the red lane after merging `main`. The same commit is carried on that branch so it goes green without waiting for this one.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWPcWxB9CNtBVS4hwXt6w4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWPcWxB9CNtBVS4hwXt6w4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `ds:ignore` comment to the badge margin in `frontend/src/screens/personnetwork.css` so the spacing-roles check passes on `main`. The declaration and value are behaviorally unchanged; the comment records why this one-off inline interval has no corresponding design-system role.

<sup>Written for commit 792e26d5e64d307e34d6849182ddfa804a3757e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

