### PR TITLE
The team board says what to do about the numbers

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -39740,9 +39740,9 @@ components:
     TeamBoardCounts:
       type: object
       description: |
-        Three counts of work somebody owes, all read under the CALLER's visibility rather
-        than the teammate's — so this is how much of their load the reader can see.
-      required: [waiting, at_risk, overdue]
+        Counts of work somebody owes, all read under the CALLER's visibility rather than the
+        teammate's — so this is how much of their load the reader can see.
+      required: [waiting, at_risk, overdue, promises_due]
       properties:
         waiting:
           type: integer
@@ -39756,6 +39756,15 @@ components:
         overdue:
           type: integer
           description: 'Open tasks whose due moment has already passed.'
+        promises_due:
+          type: integer
+          description: |
+            Commitments due by the instant the board was read, from the same extracted claims
+            the rep's own day counts — not from open tasks, which are a different question
+            wearing the same heading.
+
+            A zero here means they owe nothing, not that nobody asked: claims have a writer on
+            every installation, so this count is always read.
 
     WorklistBand:
       type: object

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -160,6 +160,11 @@ type Service struct {
 	// bounded listing reader the ranked queue uses. Optional, and its absence
 	// draws no column rather than a column of zeros.
 	overdueLoad OverdueLoad
+	// promiseLoad is the board's counting reader for commitments due, optional
+	// on the same terms: absent draws no column, because a column of zeros
+	// reads as a team owing nothing rather than as a question this installation
+	// cannot answer.
+	promiseLoad PromiseLoad
 	// decisionDepth is how many staged decisions a read takes. The lane feed's
 	// page is a prefetch for a surface that answers one at a time; the ranked
 	// queue takes a census, because a batch row that says "10" over a pile of

--- a/backend/internal/compose/attention/feedoptions.go
+++ b/backend/internal/compose/attention/feedoptions.go
@@ -115,6 +115,16 @@ func (s *Service) WithOverdueLoad(o OverdueLoad) *Service {
 	return s
 }
 
+// WithPromiseLoad binds the board's counting reader for commitments due.
+//
+// Unbound, the board draws no promises column — and here the zero would be
+// worse than elsewhere: an installation that extracts no claims would report a
+// team that promised nothing, when the truth is that nobody was listening.
+func (s *Service) WithPromiseLoad(p PromiseLoad) *Service {
+	s.promiseLoad = p
+	return s
+}
+
 // WithPins binds the reader's own pinned rows — an option for the reason
 // WithWaiting is one.
 //

--- a/backend/internal/compose/attention/teamboard.go
+++ b/backend/internal/compose/attention/teamboard.go
@@ -55,7 +55,7 @@ func (s *Service) TeamBoard(ctx context.Context) (crmcontracts.TeamBoard, error)
 		return crmcontracts.TeamBoard{}, err
 	}
 	asOf := s.now()
-	load, err := s.teamLoad(ctx, asOf)
+	load, err := s.teamLoad(ctx, roster, asOf)
 	if err != nil {
 		return crmcontracts.TeamBoard{}, err
 	}
@@ -102,7 +102,7 @@ type teamCounts struct {
 // has somewhere to say it; a board is nothing but numbers, and a zero that means
 // "you may not see this" is indistinguishable from one that means "they are
 // clear" — which is the reading that would tell a lead their team is fine.
-func (s *Service) teamLoad(ctx context.Context, asOf time.Time) (teamCounts, error) {
+func (s *Service) teamLoad(ctx context.Context, roster []TeamMember, asOf time.Time) (teamCounts, error) {
 	load := teamCounts{counts: map[ids.UUID]crmcontracts.TeamBoardCounts{}}
 	if s.waiting != nil {
 		// The SAME read the ranked queue takes, bucketed by owner. A count from
@@ -163,5 +163,51 @@ func (s *Service) teamLoad(ctx context.Context, asOf time.Time) (teamCounts, err
 		// total. The bound belongs to the reader that applied it.
 		load.truncated = load.truncated || cut
 	}
+	if err := s.addPromisesDue(ctx, &load, roster, asOf); err != nil {
+		return teamCounts{}, err
+	}
 	return load, nil
+}
+
+// addPromisesDue folds each teammate's due commitments into the tally.
+//
+// Its own function because it needs the ROSTER, which the sources above do not:
+// they answer for everybody at once, and this one asks per owner because who
+// owns a promise lives inside the store's query rather than on the claim.
+func (s *Service) addPromisesDue(
+	ctx context.Context, load *teamCounts, roster []TeamMember, asOf time.Time,
+) error {
+	if s.promiseLoad == nil {
+		// Unbound leaves the column at zero, which is what every required count
+		// on this board already does — `waiting` and `overdue` are nil-guarded
+		// the same way. Production binds all three, so an unbound source is a
+		// test that does not exercise the column rather than a deployment.
+		//
+		// The risk this shares with its two siblings is real and named here
+		// rather than fixed only for the newest: a source dropped from the
+		// composition would report a clean team instead of failing. Making that
+		// a hard error is one change across all three, with its own gate, and
+		// not something to do for one column while the other two keep the old
+		// behaviour — two rules on one board is worse than one wrong one.
+		// Tracked as its own change rather than left as a comment: issue 4444.
+		return nil
+	}
+	owners := make([]ids.UUID, 0, len(roster))
+	for _, member := range roster {
+		owners = append(owners, member.UserID)
+	}
+	// Due by the SAME instant the rest of the board is read at, so every column
+	// describes one moment. A promise lane bounded by end-of-day while the
+	// others read now would put a row in one column and not the next for no
+	// reason a lead could see.
+	due, err := s.promiseLoad.DuePerOwner(ctx, owners, asOf)
+	if err != nil {
+		return err
+	}
+	for owner, count := range due {
+		row := load.counts[owner]
+		row.PromisesDue = count
+		load.counts[owner] = row
+	}
+	return nil
 }

--- a/backend/internal/compose/attention/teamboard_test.go
+++ b/backend/internal/compose/attention/teamboard_test.go
@@ -381,3 +381,106 @@ func TestTheTeamScopeFailsClosedWithoutTheMembershipReader(t *testing.T) {
 		t.Fatalf("the team scope answered %d rows with no membership reader bound", len(got))
 	}
 }
+
+// promisesSaying is the counting reader over a fixed tally, recording which
+// owners it was asked about — the board passes its own roster, so a reader that
+// silently answered for somebody not on it would be counting a stranger's load
+// into a manager's team.
+type promisesSaying struct {
+	per   map[ids.UUID]int
+	asked []ids.UUID
+}
+
+func (p *promisesSaying) DuePerOwner(
+	_ context.Context, owners []ids.UUID, _ time.Time,
+) (map[ids.UUID]int, error) {
+	p.asked = append(p.asked, owners...)
+	return p.per, nil
+}
+
+func TestTheBoardCountsPromisesDuePerOwner(t *testing.T) {
+	t.Parallel()
+
+	svc := boardService(
+		TeamMember{UserID: theReader, DisplayName: "Aa Reader"},
+		TeamMember{UserID: theColleague, DisplayName: "Bb Colleague"},
+	)
+	svc.promiseLoad = &promisesSaying{per: map[ids.UUID]int{theColleague: 3}}
+
+	board, err := svc.TeamBoard(boardReaderAt(principal.RowScopeTeam))
+	if err != nil {
+		t.Fatalf("the board refused a team-scoped reader: %v", err)
+	}
+	if got := board.Members[1].Counts.PromisesDue; got != 3 {
+		t.Fatalf("the colleague's promises read %d, wanted 3", got)
+	}
+	// The reader owes none, and zero is the answer about them rather than a
+	// gap: the source was asked and said so.
+	if got := board.Members[0].Counts.PromisesDue; got != 0 {
+		t.Fatalf("a person the source did not name read %d, wanted 0", got)
+	}
+}
+
+// The board asks about the people it is drawing, and nobody else. A reader free
+// to answer for anyone would fold a stranger's promises into a team's row.
+func TestTheBoardAsksAboutItsOwnRosterAndNoOneElse(t *testing.T) {
+	t.Parallel()
+
+	svc := boardService(
+		TeamMember{UserID: theReader, DisplayName: "Aa Reader"},
+		TeamMember{UserID: theColleague, DisplayName: "Bb Colleague"},
+	)
+	asked := &promisesSaying{per: map[ids.UUID]int{}}
+	svc.promiseLoad = asked
+
+	if _, err := svc.TeamBoard(boardReaderAt(principal.RowScopeTeam)); err != nil {
+		t.Fatalf("the board refused a team-scoped reader: %v", err)
+	}
+	if len(asked.asked) != 2 {
+		t.Fatalf("the board asked about %d owners over a team of two", len(asked.asked))
+	}
+	for _, owner := range asked.asked {
+		if owner != theReader && owner != theColleague {
+			t.Fatalf("the board asked about %v, who is not on its roster", owner)
+		}
+	}
+}
+
+// An UNBOUND promise source leaves every count at zero, which is what the
+// contract now says: claims have a writer on every installation, so production
+// always binds this reader. Unbound is a test shape, not a deployment.
+func TestAnUnboundPromiseSourceLeavesTheColumnAtZero(t *testing.T) {
+	t.Parallel()
+
+	svc := boardService(TeamMember{UserID: theReader, DisplayName: "Aa Reader"})
+
+	board, err := svc.TeamBoard(boardReaderAt(principal.RowScopeTeam))
+	if err != nil {
+		t.Fatalf("the board refused a team-scoped reader: %v", err)
+	}
+	if got := board.Members[0].Counts.PromisesDue; got != 0 {
+		t.Fatalf("an unread source drew %d, wanted 0", got)
+	}
+}
+
+// A promise source that CANNOT answer fails the board, exactly as the other
+// three do. A column of zeros over a source that errored would tell a lead
+// their team is clear.
+func TestAPromiseSourceThatCouldNotAnswerFailsRatherThanReadingAsZero(t *testing.T) {
+	t.Parallel()
+
+	svc := boardService(TeamMember{UserID: theReader, DisplayName: "Aa Reader"})
+	svc.promiseLoad = promisesFailing{}
+
+	if _, err := svc.TeamBoard(boardReaderAt(principal.RowScopeTeam)); err == nil {
+		t.Fatal("a board built over a source that could not answer was served as though it had")
+	}
+}
+
+type promisesFailing struct{}
+
+func (promisesFailing) DuePerOwner(
+	context.Context, []ids.UUID, time.Time,
+) (map[ids.UUID]int, error) {
+	return nil, errors.New("counting promises due")
+}

--- a/backend/internal/compose/attention/teamlanes.go
+++ b/backend/internal/compose/attention/teamlanes.go
@@ -62,3 +62,22 @@ type TeamMember struct {
 type OverdueLoad interface {
 	OverduePerAssignee(ctx context.Context, asOf time.Time) (map[ids.UUID]int, error)
 }
+
+// PromiseLoad counts each person's commitments due by an instant.
+//
+// Read from extracted claims, like the rep's own commitments lane, so the board
+// and the rep's day count the same thing. A count taken from open tasks instead
+// would be a different question wearing the same column heading: a task carries
+// a date and no provenance, and a promise is a thing somebody SAID.
+//
+// Optional, and for a sharper reason than the others: an installation that
+// extracts no claims binds nothing here, and a zero column would tell a lead
+// their team promised nothing — when in truth nobody was listening.
+// It takes the OWNERS to count rather than answering for everyone, because the
+// promise store answers one owner at a time — the claim's owner is the owner of
+// the PERSON it was made to, and that ladder lives in the store's own query. A
+// board asking for a roster it already has is cheaper than a second aggregate
+// restating who owns a promise.
+type PromiseLoad interface {
+	DuePerOwner(ctx context.Context, owners []ids.UUID, by time.Time) (map[ids.UUID]int, error)
+}

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -386,7 +386,8 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// board. Counted rather than listed, because the task lane above stops
 		// at a dozen and a board built from it would call every loaded rep
 		// equally loaded.
-		WithOverdueLoad(attentionOverdue{store: activities.NewStore(db)})
+		WithOverdueLoad(attentionOverdue{store: activities.NewStore(db)}).
+		WithPromiseLoad(attentionPromiseLoad{store: people.NewStore(db)})
 }
 
 // attentionZone binds the feed's day boundary to the installation's timezone,

--- a/backend/internal/compose/attentionteamseam.go
+++ b/backend/internal/compose/attentionteamseam.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The readers behind the TEAM board, bound to the modules that own their rows.
+//
+// Their own file rather than beside the per-reader lanes, because they answer a
+// different question: each is about somebody OTHER than the caller, counted
+// under the caller's own visibility. The lane seam next door reads one person's
+// day and never needs a roster.
+
+import (
+	"context"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// attentionPromiseLoad counts each named person's commitments due, for the team
+// board.
+//
+// ONE query over every owner rather than one per teammate. A board reaches a
+// hundred people, and a hundred sequential round trips on a surface a lead
+// opens every morning is a slow page for no reason — and each in its own
+// transaction meant a person's records changing hands mid-loop could be counted
+// twice or not at all.
+//
+// The store shares every arm of that count with the page a rep opens, so a
+// lead's column and their colleague's own cards answer the same question.
+type attentionPromiseLoad struct{ store *people.Store }
+
+var _ attention.PromiseLoad = attentionPromiseLoad{}
+
+func (p attentionPromiseLoad) DuePerOwner(
+	ctx context.Context, owners []ids.UUID, by time.Time,
+) (map[ids.UUID]int, error) {
+	typed := make([]ids.UserID, 0, len(owners))
+	for _, owner := range owners {
+		typed = append(typed, ids.From[ids.UserKind](owner))
+	}
+	// Counted under the CALLER's own scopes, which is what the board promises:
+	// this is how much of a teammate's load the reader can see, not how much of
+	// it exists.
+	due, err := p.store.CountOpenCommitmentsDueByOwner(ctx, typed, by)
+	if err != nil {
+		return nil, err
+	}
+	// A person the query did not name owes nothing. Said explicitly, because
+	// the board draws a number for every member and an absent key would leave
+	// their column reading zero for a reason nobody chose.
+	for _, owner := range owners {
+		if _, counted := due[owner]; !counted {
+			due[owner] = 0
+		}
+	}
+	return due, nil
+}

--- a/backend/internal/compose/integration/commitmentlane_integration_test.go
+++ b/backend/internal/compose/integration/commitmentlane_integration_test.go
@@ -378,3 +378,62 @@ func TestTheCommitmentCountSeesPastTheLanesCap(t *testing.T) {
 			"five that they have two", total)
 	}
 }
+
+// The board's column and the rep's own lane answer the SAME question.
+//
+// They are two readers of one thing: a lead scans a table, then opens the day
+// behind a number that worried them. If the two disagree the lead is sent to a
+// desk where the work is not, and neither screen says which is right.
+//
+// The multi-owner count exists because a board reaches a hundred people and a
+// hundred sequential queries is a slow morning. What this holds is that making
+// it one query did not make it a different question.
+func TestTheBoardsPromiseColumnAgreesWithEachRepsOwnLane(t *testing.T) {
+	e := integration.Setup(t)
+	mine := e.SeedPerson(t, "Herr Vogt", &e.Rep1)
+	theirs := e.SeedPerson(t, "Frau Keller", &e.Rep2)
+	orphan := e.SeedPerson(t, "Niemands Kontakt", nil)
+	todayLater := laneClock.Add(6 * time.Hour)
+	nextWeek := laneClock.AddDate(0, 0, 7)
+
+	for range 3 {
+		seedPromise(t, e, mine, "Heute Nachmittag", &todayLater)
+	}
+	seedPromise(t, e, theirs, "Auch heute", &todayLater)
+	// Neither of these belongs on today's board: one is due next week, one is
+	// on a person nobody owns.
+	seedPromise(t, e, mine, "Nächste Woche", &nextWeek)
+	seedPromise(t, e, orphan, "Unterlagen nachreichen", &todayLater)
+
+	store := people.NewStore(e.DB())
+	bound := laneClock.Add(24 * time.Hour)
+	owners := []ids.UserID{
+		ids.From[ids.UserKind](e.Rep1),
+		ids.From[ids.UserKind](e.Rep2),
+	}
+	board, err := store.CountOpenCommitmentsDueByOwner(e.Admin(), owners, bound)
+	if err != nil {
+		t.Fatalf("counting the team's promises: %v", err)
+	}
+	for _, owner := range owners {
+		alone, err := store.CountOpenCommitmentsDue(e.Admin(), owner, bound)
+		if err != nil {
+			t.Fatalf("counting one rep's promises: %v", err)
+		}
+		if board[owner.UUID] != alone {
+			t.Fatalf("the board says %d for %v and their own lane says %d — "+
+				"a lead sent to that desk finds different work than the number promised",
+				board[owner.UUID], owner, alone)
+		}
+	}
+	// And the figures are the ones the fixture describes, so an agreement of
+	// two zeros could not pass for agreement.
+	if board[e.Rep1] != 3 || board[e.Rep2] != 1 {
+		t.Fatalf("the board read %d and %d, wanted 3 and 1", board[e.Rep1], board[e.Rep2])
+	}
+	// The unowned promise is on nobody's column, exactly as it is on nobody's
+	// lane.
+	if len(board) != 2 {
+		t.Fatalf("the board named %d owners over a roster of two", len(board))
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32173,19 +32173,27 @@ type TeamBoard struct {
 	// so here rather than presenting a floor as a total.
 	Truncated bool `json:"truncated"`
 
-	// Unassigned Three counts of work somebody owes, all read under the CALLER's visibility rather
-	// than the teammate's — so this is how much of their load the reader can see.
+	// Unassigned Counts of work somebody owes, all read under the CALLER's visibility rather than the
+	// teammate's — so this is how much of their load the reader can see.
 	Unassigned TeamBoardCounts `json:"unassigned"`
 }
 
-// TeamBoardCounts Three counts of work somebody owes, all read under the CALLER's visibility rather
-// than the teammate's — so this is how much of their load the reader can see.
+// TeamBoardCounts Counts of work somebody owes, all read under the CALLER's visibility rather than the
+// teammate's — so this is how much of their load the reader can see.
 type TeamBoardCounts struct {
 	// AtRisk Open deals gone quiet or already past their expected close date.
 	AtRisk int `json:"at_risk"`
 
 	// Overdue Open tasks whose due moment has already passed.
 	Overdue int `json:"overdue"`
+
+	// PromisesDue Commitments due by the instant the board was read, from the same extracted claims
+	// the rep's own day counts — not from open tasks, which are a different question
+	// wearing the same heading.
+	//
+	// A zero here means they owe nothing, not that nobody asked: claims have a writer on
+	// every installation, so this count is always read.
+	PromisesDue int `json:"promises_due"`
 
 	// Waiting Customers who wrote and have had no reply, attributed by the record the thread is
 	// filed under: deal, then lead, then person, then organization, first owner found.
@@ -32195,8 +32203,8 @@ type TeamBoardCounts struct {
 
 // TeamBoardMember One teammate and the work they are answerable for.
 type TeamBoardMember struct {
-	// Counts Three counts of work somebody owes, all read under the CALLER's visibility rather
-	// than the teammate's — so this is how much of their load the reader can see.
+	// Counts Counts of work somebody owes, all read under the CALLER's visibility rather than the
+	// teammate's — so this is how much of their load the reader can see.
 	Counts TeamBoardCounts `json:"counts"`
 
 	// DisplayName The teammate, as the roster names them.

--- a/backend/internal/modules/people/commitmentsdue.go
+++ b/backend/internal/modules/people/commitmentsdue.go
@@ -123,8 +123,12 @@ func (s *Store) OpenCommitmentsDue(ctx context.Context, owner ids.UserID, by tim
 // assembled from a second copy of these arms would answer a different question
 // from the cards under it, one arm at a time, and nothing would fail to say so.
 //
-// %[1]d is the owner, %[2]d the bound, %[3]s the activity-content scope and
-// %[4]s the person scope.
+// %[1]s is the OWNER TEST — `pr.owner_id = $n` for one rep, `= ANY($n)` for a
+// board counting several. A fragment rather than a fixed comparison because the
+// board would otherwise need its own copy of every arm below to change that one
+// term, and the count under a lead's table would drift from the cards a rep
+// opens. %[2]d is the bound, %[3]s the activity-content scope and %[4]s the
+// person scope.
 //
 // Held by: TestTheCommitmentCountAnswersTheSameQuestionAsThePage
 // (backend/internal/compose/integration/commitmentlane_integration_test.go)
@@ -140,7 +144,7 @@ const openCommitmentsDueFrom = `
 		   -- and again tomorrow. The task lane beside this one reads it the
 		   -- same way, and the two decide the same afternoon.
 		   AND c.due_at IS NOT NULL AND c.due_at < $%[2]d
-		   AND pr.owner_id = $%[1]d
+		   AND %[1]s
 		   AND (%[3]s) AND (%[4]s)`
 
 // CountOpenCommitmentsDue answers how many promises are due by an instant, with
@@ -179,7 +183,8 @@ func (s *Store) CountOpenCommitmentsDue(ctx context.Context, owner ids.UserID, b
 			personScope = sqlAlwaysVisible
 		}
 		return tx.QueryRow(ctx, fmt.Sprintf(`SELECT count(*)`+openCommitmentsDueFrom,
-			ownerPos, byPos, activityScope, personScope), args...).Scan(&total)
+			fmt.Sprintf("pr.owner_id = $%d", ownerPos), byPos, activityScope, personScope),
+			args...).Scan(&total)
 	})
 	if err != nil {
 		return 0, fmt.Errorf("count the rep's commitments coming due: %w", err)
@@ -215,7 +220,8 @@ func openCommitmentsDue(
 		       a.occurred_at, c.due_at`+openCommitmentsDueFrom+`
 		 ORDER BY c.due_at ASC, c.id
 		 LIMIT %[5]d`,
-		ownerPos, byPos, activityScope, personScope, commitmentsDueLimit(limit)), args...)
+		fmt.Sprintf("pr.owner_id = $%d", ownerPos), byPos, activityScope, personScope,
+		commitmentsDueLimit(limit)), args...)
 	if err != nil {
 		return nil, fmt.Errorf("read the rep's commitments coming due: %w", err)
 	}
@@ -233,4 +239,72 @@ func openCommitmentsDue(
 		return nil, fmt.Errorf("read the rep's commitments coming due: %w", err)
 	}
 	return out, nil
+}
+
+// CountOpenCommitmentsDueByOwner answers the same question as
+// CountOpenCommitmentsDue for several owners at once, for the team board.
+//
+// ONE query rather than one per teammate. A board is capped at a hundred
+// people, and a hundred sequential round trips on a surface a lead opens every
+// morning is a slow page for no reason — worse, each ran in its own transaction,
+// so a person's records changing hands mid-loop could have them counted twice or
+// not at all. This reads one snapshot.
+//
+// It shares openCommitmentsDueFrom with the single-owner count and the page, so
+// what a lead's column totals is what that rep's own cards show. Owners not
+// named in the result owe nothing; the caller fills the zero.
+func (s *Store) CountOpenCommitmentsDueByOwner(
+	ctx context.Context, owners []ids.UserID, by time.Time,
+) (map[ids.UUID]int, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	per := map[ids.UUID]int{}
+	if len(owners) == 0 {
+		return per, nil
+	}
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		var args []any
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		ownersPos := arg(owners)
+		byPos := arg(by)
+		activityScope, err := auth.ActivityContentClause(ctx, "a", arg)
+		if err != nil {
+			return err
+		}
+		if activityScope == "" {
+			activityScope = sqlAlwaysVisible
+		}
+		personScope, err := auth.ScopeClauseFor(ctx, "person", "pr", arg)
+		if err != nil {
+			return err
+		}
+		if personScope == "" {
+			personScope = sqlAlwaysVisible
+		}
+		rows, err := tx.Query(ctx, fmt.Sprintf(`SELECT pr.owner_id, count(*)`+
+			openCommitmentsDueFrom+` GROUP BY pr.owner_id`,
+			fmt.Sprintf("pr.owner_id = ANY($%d)", ownersPos), byPos, activityScope, personScope),
+			args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var owner ids.UUID
+			var due int
+			if err := rows.Scan(&owner, &due); err != nil {
+				return err
+			}
+			per[owner] = due
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("count the team's commitments coming due: %w", err)
+	}
+	return per, nil
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29953,8 +29953,8 @@ export interface components {
             counts: components["schemas"]["TeamBoardCounts"];
         };
         /**
-         * @description Three counts of work somebody owes, all read under the CALLER's visibility rather
-         *     than the teammate's — so this is how much of their load the reader can see.
+         * @description Counts of work somebody owes, all read under the CALLER's visibility rather than the
+         *     teammate's — so this is how much of their load the reader can see.
          */
         TeamBoardCounts: {
             /**
@@ -29967,6 +29967,15 @@ export interface components {
             at_risk: number;
             /** @description Open tasks whose due moment has already passed. */
             overdue: number;
+            /**
+             * @description Commitments due by the instant the board was read, from the same extracted claims
+             *     the rep's own day counts — not from open tasks, which are a different question
+             *     wearing the same heading.
+             *
+             *     A zero here means they owe nothing, not that nobody asked: claims have a writer on
+             *     every installation, so this count is always read.
+             */
+            promises_due: number;
         };
         /**
          * @description One outcome band and how much of it this page is showing — the headings a client draws,

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8221,6 +8221,14 @@ export const de = {
   "worklist.board.atRisk": "Gefährdete Deals",
   "worklist.board.overdue": "Überfällig",
   "worklist.board.nobody": "Noch niemand",
+  "worklist.coaching.title": "Heute früh ein Gespräch wert",
+  "worklist.coaching.promises":
+    "{name} schuldet {count} fällige Zusagen — die Kundschaft wartet bereits darauf.",
+  "worklist.coaching.waiting":
+    "{count} Kundinnen und Kunden warten auf {name}.",
+  "worklist.coaching.overdue":
+    "{name} hat {count} Aufgaben, deren Frist verstrichen ist.",
+  "worklist.board.promises": "Fällige Zusagen",
   "worklist.board.truncated":
     "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
   "worklist.readings.label": "Was heute auf dem Spiel steht",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8334,6 +8334,12 @@ export const en = {
   "worklist.board.atRisk": "Deals at risk",
   "worklist.board.overdue": "Past due",
   "worklist.board.nobody": "Nobody yet",
+  "worklist.coaching.title": "Worth a word this morning",
+  "worklist.coaching.promises":
+    "{name} owes {count} promises that are due — the customer is already expecting them.",
+  "worklist.coaching.waiting": "{count} customers are waiting on {name}.",
+  "worklist.coaching.overdue": "{name} has {count} tasks past their due date.",
+  "worklist.board.promises": "Promises due",
   "worklist.board.truncated":
     "There is more work than this could count. These are floors, not totals.",
   "worklist.readings.label": "What today is worth",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8126,6 +8126,12 @@ export const vi = {
   "worklist.board.atRisk": "Giao dịch có rủi ro",
   "worklist.board.overdue": "Quá hạn",
   "worklist.board.nobody": "Chưa có ai",
+  "worklist.coaching.title": "Đáng trao đổi sáng nay",
+  "worklist.coaching.promises":
+    "{name} còn {count} cam kết đã đến hạn — khách hàng đang chờ.",
+  "worklist.coaching.waiting": "{count} khách hàng đang chờ {name}.",
+  "worklist.coaching.overdue": "{name} có {count} công việc đã quá hạn.",
+  "worklist.board.promises": "Cam kết đến hạn",
   "worklist.board.truncated":
     "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
   "worklist.readings.label": "Hôm nay có gì đang bị đe dọa",

--- a/frontend/src/screens/personnetwork.css
+++ b/frontend/src/screens/personnetwork.css
@@ -375,6 +375,10 @@
   font-weight: var(--fw-medium);
 }
 .pn-moment p .badge {
+  /* ds:ignore a badge trailing a sentence is not a spacing role — it is the
+     gap between a word and the label after it, and none of gapActions,
+     gapCards or the pad roles describes that. Changing the primitive would
+     move every badge in the product, including the ones that sit alone. */
   margin-left: var(--space-2);
   vertical-align: 1px;
 }

--- a/frontend/src/screens/worklist.board.stories.tsx
+++ b/frontend/src/screens/worklist.board.stories.tsx
@@ -27,20 +27,20 @@ const aLoadedTeam: TeamBoardData = {
     {
       user_id: "00000000-0000-4000-8000-000000000001",
       display_name: "Lena Fischer",
-      counts: { waiting: 14, at_risk: 3, overdue: 6 },
+      counts: { waiting: 14, at_risk: 3, overdue: 6, promises_due: 2 },
     },
     {
       user_id: "00000000-0000-4000-8000-000000000002",
       display_name: "Marc Weber",
-      counts: { waiting: 2, at_risk: 0, overdue: 0 },
+      counts: { waiting: 2, at_risk: 0, overdue: 0, promises_due: 0 },
     },
     {
       user_id: "00000000-0000-4000-8000-000000000003",
       display_name: "Sofia Ruiz",
-      counts: { waiting: 0, at_risk: 1, overdue: 0 },
+      counts: { waiting: 0, at_risk: 1, overdue: 0, promises_due: 4 },
     },
   ],
-  unassigned: { waiting: 3, at_risk: 0, overdue: 1 },
+  unassigned: { waiting: 3, at_risk: 0, overdue: 1, promises_due: 0 },
   truncated: false,
 };
 

--- a/frontend/src/screens/worklist.board.tsx
+++ b/frontend/src/screens/worklist.board.tsx
@@ -12,6 +12,7 @@
 import { DataTable, Disclosure } from "../design-system/atoms";
 import { SurfaceState } from "../design-system/surfacestate";
 import { useT } from "../i18n";
+import { CoachingMoves } from "./worklist.coaching";
 import { type TeamBoardMember, useTeamBoard } from "./worklist.queries";
 
 // A row of the board, with the unassigned pile carried as one of them.
@@ -27,11 +28,17 @@ type BoardRow = Readonly<{
   waiting: number;
   atRisk: number;
   overdue: number;
+  promises: number;
 }>;
 
 function rowsOf(
   members: readonly TeamBoardMember[],
-  unassigned: { waiting: number; at_risk: number; overdue: number },
+  unassigned: {
+    waiting: number;
+    at_risk: number;
+    overdue: number;
+    promises_due: number;
+  },
   unassignedLabel: string,
 ): BoardRow[] {
   const rows = members.map((member) => ({
@@ -40,12 +47,23 @@ function rowsOf(
     waiting: member.counts.waiting,
     atRisk: member.counts.at_risk,
     overdue: member.counts.overdue,
+    promises: member.counts.promises_due,
   }));
   // Last, and only when it holds something. An always-drawn zero row would put
   // a permanent line under every team that has nothing unowned, and the reader
   // would learn to skip the place the unowned customer eventually appears.
+  // Summed through the same normaliser the cells render through, so a figure
+  // the server did not send behaves identically in both places. A raw addition
+  // gives NaN, and NaN > 0 is false — one missing column would silently take
+  // the whole unassigned pile off a lead's screen, which is the work with
+  // nobody on it.
   const nobody =
-    unassigned.waiting + unassigned.at_risk + unassigned.overdue > 0;
+    [
+      unassigned.waiting,
+      unassigned.at_risk,
+      unassigned.overdue,
+      unassigned.promises_due,
+    ].reduce((total, value) => total + held(value), 0) > 0;
   return nobody
     ? [
         ...rows,
@@ -55,9 +73,23 @@ function rowsOf(
           waiting: unassigned.waiting,
           atRisk: unassigned.at_risk,
           overdue: unassigned.overdue,
+          promises: unassigned.promises_due,
         },
       ]
     : rows;
+}
+
+// How much a count actually holds, with a missing figure read as none.
+//
+// A count is required on the wire, so an absent one is version skew rather than
+// a state the server means. Reading it as zero is the honest fallback for a
+// TABLE OF NUMBERS: the alternative — refusing the whole board because one
+// column of one row is missing — takes away four columns that arrived fine, on
+// a surface whose job is to tell a lead where to look.
+//
+// It is a floor, and `truncated` already tells the reader the figures may be.
+function held(value: number | undefined) {
+  return value ?? 0;
 }
 
 // A count of zero reads as a dash.
@@ -65,8 +97,11 @@ function rowsOf(
 // "0" and "—" say different things at a glance down a column: a reader scanning
 // for who is loaded wants the numbers to be the only digits on the page, and a
 // column of zeros hides the one 14 among them.
-function count(value: number) {
-  return value === 0 ? "—" : String(value);
+//
+// A MISSING count reads as a dash too, through held: "undefined" in a numeric
+// column is the one rendering that tells a lead nothing and looks like a bug.
+function count(value: number | undefined) {
+  return held(value) === 0 ? "—" : String(held(value));
 }
 
 // The team's load, above the reader's own queue.
@@ -103,6 +138,12 @@ export function TeamBoard({
       >
         {board.data && (
           <>
+            {/* WHAT to do about the table, above the table. A lead reading five
+                columns across six people is doing arithmetic before they can
+                act; these are the same numbers with the arithmetic done. Drawn
+                from board.data, so they add no request and cannot disagree with
+                the rows beneath them. */}
+            <CoachingMoves members={board.data.members} onOwner={onOwner} />
             <DataTable
               label={t("worklist.board.title")}
               rows={rowsOf(
@@ -144,6 +185,15 @@ export function TeamBoard({
                   key: "overdue",
                   header: t("worklist.board.overdue"),
                   render: (row) => count(row.overdue),
+                },
+                // The column the coaching lines above are drawn from. Without
+                // it a lead reads "Ana owes 3 promises" with nowhere on the
+                // page to check it — a suggestion they cannot verify is one
+                // they stop trusting.
+                {
+                  key: "promises_due",
+                  header: t("worklist.board.promises"),
+                  render: (row) => count(row.promises),
                 },
               ]}
             />

--- a/frontend/src/screens/worklist.coaching.test.tsx
+++ b/frontend/src/screens/worklist.coaching.test.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { COACHING_MOVES, CoachingMoves, movesFor } from "./worklist.coaching";
+import type { TeamBoardMember } from "./worklist.queries";
+
+// Which conversations a lead should have this morning.
+//
+// The board says who is carrying what. These say what to do about it, and the
+// claim that costs most if it is wrong is the ORDER: a rep behind on tasks is
+// late, and a rep who broke a promise has spent something the customer already
+// counted on. Getting that backwards sends a lead to the wrong desk.
+
+function member(
+  name: string,
+  counts: Partial<TeamBoardMember["counts"]>,
+): TeamBoardMember {
+  return {
+    user_id: `id-${name}`,
+    display_name: name,
+    counts: { waiting: 0, at_risk: 0, overdue: 0, promises_due: 0, ...counts },
+  };
+}
+
+function draw(members: readonly TeamBoardMember[], onOwner = vi.fn()) {
+  render(
+    <LocaleProvider initial="en">
+      <CoachingMoves members={members} onOwner={onOwner} />
+    </LocaleProvider>,
+  );
+  return onOwner;
+}
+
+afterEach(cleanup);
+
+describe("what a lead should do about the board", () => {
+  it("draws at most three moves, each carrying the number it was drawn from", () => {
+    draw([
+      member("Ana", { promises_due: 2 }),
+      member("Ben", { promises_due: 4 }),
+      member("Cara", { waiting: 9 }),
+      member("Dev", { overdue: 7 }),
+      member("Eve", { promises_due: 1 }),
+    ]);
+
+    const moves = screen.getAllByRole("button");
+    expect(moves).toHaveLength(COACHING_MOVES);
+    // Every line says a number. A suggestion a lead cannot check is one they
+    // stop reading.
+    for (const move of moves) {
+      expect(move.textContent).toMatch(/\d/);
+    }
+  });
+
+  it("puts a broken promise ahead of a bigger queue", () => {
+    draw([member("Ana", { waiting: 40 }), member("Ben", { promises_due: 1 })]);
+
+    const first = screen.getAllByRole("button")[0];
+    expect(first.textContent).toContain("Ben");
+  });
+
+  it("names a person once, however many thresholds they cross", () => {
+    const moves = movesFor([
+      member("Ana", { promises_due: 3, waiting: 20, overdue: 12 }),
+      member("Ben", { waiting: 9 }),
+    ]);
+
+    expect(moves.filter((m) => m.name === "Ana")).toHaveLength(1);
+    // And the second person still gets their line, which is what one-per-person
+    // is FOR: three lines about Ana would push Ben off a list of three.
+    expect(moves.map((m) => m.name)).toContain("Ben");
+  });
+
+  // A zero is a real answer, not a silence. Claims have a writer on every
+  // installation, so a rep at zero owes nothing — and a threshold of one keeps
+  // them off the list without the count having to be missing.
+  it("says nothing about a person who owes no promises", () => {
+    const moves = movesFor([member("Ana", { waiting: 2, overdue: 1 })]);
+    expect(moves).toHaveLength(0);
+  });
+
+  it("draws nothing at all when nobody is over a threshold", () => {
+    const { container } = render(
+      <LocaleProvider initial="en">
+        <CoachingMoves
+          members={[member("Ana", { waiting: 1 })]}
+          onOwner={vi.fn()}
+        />
+      </LocaleProvider>,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("routes a move to that person's own queue", async () => {
+    const user = userEvent.setup();
+    const onOwner = draw([member("Ana", { promises_due: 2 })]);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onOwner).toHaveBeenCalledWith("id-Ana");
+  });
+});

--- a/frontend/src/screens/worklist.coaching.tsx
+++ b/frontend/src/screens/worklist.coaching.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The three conversations a lead should have this morning.
+//
+// The board above says who is carrying what; it does not say what to DO about
+// it. A lead reading five columns across six people is doing arithmetic before
+// they can act, and the person most in trouble is not always the one with the
+// biggest number — a rep with fourteen waiting customers and nothing overdue is
+// having a busy week, and one with four waiting and six broken promises is
+// losing trust.
+//
+// DERIVED, not asked for. Every move here comes from counts the board already
+// fetched, so this adds no request and cannot disagree with the table it sits
+// under. There is no model in it: a suggestion a lead cannot check is a
+// suggestion they will stop reading, and each line carries the number it was
+// drawn from.
+
+import { Callout } from "../design-system/callout";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { TeamBoardMember } from "./worklist.queries";
+
+// How many moves a morning gets.
+//
+// Three, because this is a list a lead acts on before their own day starts. A
+// surface that named every teammate with a number over a threshold would be the
+// board again, sorted differently — and a lead who cannot get through it learns
+// to skip it, which costs them the one line that mattered.
+export const COACHING_MOVES = 3;
+
+// What each threshold means, and why it is where it is.
+//
+// These are the counts at which a number stops being a busy week and starts
+// being a person who needs help. They are deliberately not configurable yet:
+// one shipped set that a lead can argue with beats a settings page nobody fills
+// in, and the argument is what tells us where they really belong.
+const TOO_MANY_OVERDUE = 3;
+const TOO_MANY_WAITING = 5;
+const ANY_BROKEN_PROMISE = 1;
+
+// A move names a person, what is happening, and the number behind it.
+type CoachingMove = Readonly<{
+  ownerId: string;
+  name: string;
+  kind: "overdue" | "waiting" | "promises";
+  evidence: number;
+}>;
+
+// movesFor picks the moves worth making, most urgent kind first.
+//
+// ORDERED BY KIND, not by size, and that is the judgement in this file. A
+// broken promise outranks a big queue because the customer already noticed: a
+// rep behind on tasks is late, a rep who said "I'll send it Tuesday" and did
+// not has spent something that has to be earned back.
+//
+// One move per person. A teammate over every threshold has one problem — too
+// much work — and three lines about them would push two other people off a list
+// of three.
+export function movesFor(members: readonly TeamBoardMember[]): CoachingMove[] {
+  const moves: CoachingMove[] = [];
+  const named = new Set<string>();
+  const take = (
+    member: TeamBoardMember,
+    kind: CoachingMove["kind"],
+    evidence: number,
+  ) => {
+    if (named.has(member.user_id)) {
+      return;
+    }
+    named.add(member.user_id);
+    moves.push({
+      ownerId: member.user_id,
+      name: member.display_name,
+      kind,
+      evidence,
+    });
+  };
+  // Promises first, then the queue, then the task list — the order above.
+  for (const member of members) {
+    if (member.counts.promises_due >= ANY_BROKEN_PROMISE) {
+      take(member, "promises", member.counts.promises_due);
+    }
+  }
+  for (const member of members) {
+    if (member.counts.waiting > TOO_MANY_WAITING) {
+      take(member, "waiting", member.counts.waiting);
+    }
+  }
+  for (const member of members) {
+    if (member.counts.overdue > TOO_MANY_OVERDUE) {
+      take(member, "overdue", member.counts.overdue);
+    }
+  }
+  return moves.slice(0, COACHING_MOVES);
+}
+
+// The moves, above the board they are drawn from.
+//
+// Nothing at all when there is nothing to say. An empty "no coaching needed"
+// panel is a line a lead reads every morning to learn nothing, and the mornings
+// it does have something to say are the ones it would then be skipped on.
+export function CoachingMoves({
+  members,
+  onOwner,
+}: Readonly<{
+  members: readonly TeamBoardMember[];
+  onOwner: (userId: string) => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const moves = movesFor(members);
+  if (moves.length === 0) {
+    return null;
+  }
+  return (
+    <Callout tone="info" title={t("worklist.coaching.title")}>
+      <ul className="worklist-coaching">
+        {moves.map((move) => (
+          <li key={move.ownerId}>
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => onOwner(move.ownerId)}
+            >
+              {t(`worklist.coaching.${move.kind}` as const, {
+                name: move.name,
+                count: formatNumber(move.evidence, locale),
+              })}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Callout>
+  );
+}

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -452,3 +452,14 @@
     min-block-size: 44px;
   }
 }
+
+/* The coaching list inside its callout.
+   Unstyled markers and no indent: these are three sentences a lead reads, not
+   a nested outline, and the callout already carries the tone. */
+.worklist-coaching {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-1);
+}

--- a/frontend/src/screens/worklist.stories.tsx
+++ b/frontend/src/screens/worklist.stories.tsx
@@ -17,20 +17,20 @@ const aLoadedTeam: TeamBoard = {
     {
       user_id: "00000000-0000-4000-8000-000000000001",
       display_name: "Lena Fischer",
-      counts: { waiting: 14, at_risk: 3, overdue: 6 },
+      counts: { waiting: 14, at_risk: 3, overdue: 6, promises_due: 2 },
     },
     {
       user_id: "00000000-0000-4000-8000-000000000002",
       display_name: "Marc Weber",
-      counts: { waiting: 2, at_risk: 0, overdue: 0 },
+      counts: { waiting: 2, at_risk: 0, overdue: 0, promises_due: 0 },
     },
     {
       user_id: "00000000-0000-4000-8000-000000000003",
       display_name: "Sofia Ruiz",
-      counts: { waiting: 0, at_risk: 1, overdue: 0 },
+      counts: { waiting: 0, at_risk: 1, overdue: 0, promises_due: 4 },
     },
   ],
-  unassigned: { waiting: 3, at_risk: 0, overdue: 1 },
+  unassigned: { waiting: 3, at_risk: 0, overdue: 1, promises_due: 0 },
   truncated: false,
 };
 


### PR DESCRIPTION
A lead reading five columns across six people is doing arithmetic before they can act, and the person most in trouble is not always the one with the biggest number. A rep with fourteen waiting customers and nothing overdue is having a busy week; one with four waiting and six broken promises is losing trust.

## Two halves

**`promises_due` joins the board's counts.** Read through the same `CountOpenCommitmentsDue` the rep's own day counts, so the board and the day agree. Who owns a promise is not a column on the claim — it belongs to whoever owns the *person* it was made to, and that ladder lives inside the store's query.

**`CoachingMoves` draws at most three lines above the table**, each naming a person, what is happening, and the number behind it. Derived entirely from counts the board already fetched, so it adds no request and cannot disagree with the rows beneath it.

Ordered by **kind, not size**: a broken promise outranks a big queue because the customer already noticed. One line per person, so a teammate over every threshold cannot push two others off a list of three.

## What review changed

Codex reviewed twice and found five things. Three were real defects:

1. **The count was drawn nowhere.** It drove a coaching line — "Ana owes 3 promises" — with no column on the page to check it against. A suggestion a lead cannot verify is one they stop trusting. The column is now on the board.
2. **N+1 across the roster.** One `CountOpenCommitmentsDue` per teammate, up to the cap of 100, each in its own transaction — a slow morning page, and a person changing hands mid-loop could be counted twice or not at all. Replaced with `CountOpenCommitmentsDueByOwner`: one query, `owner_id = ANY($n) GROUP BY owner_id`, sharing every arm of `openCommitmentsDueFrom` with the page a rep opens. Held by `TestTheBoardsPromiseColumnAgreesWithEachRepsOwnLane`, mutation-checked.
3. **Absence machinery that could never fire.** I made the count optional so an installation without claim extraction would send nothing rather than a misleading zero. Claims have had a writer since #4290's predecessor, so the reader is always bound and "absent" was unreachable. The count is now `required`, and a zero honestly means they owe nothing.

## What is not here

**`meetings_unprepared`.** The plan asked for it. A meeting cannot be attributed to a rep: `assignee_id` is task-only, and in a seeded database only 31 of 500 meetings carry a human `captured_by` — the rest are connector provenance. The only workable attribution is the record-ownership ladder inside `waitingRepliesSQL`, which cannot be reused from there, and a second copy for meetings would be two answers to "whose meeting is this". Left out rather than guessed at.

## Filed rather than fixed

**#4444** — `teamLoad` nil-guards all three counting sources while all three counts are `required`, so a source dropped from the composition reports a clean team. That is the same risk for `waiting` and `overdue` as for the column added here; fixing it for the newest alone would leave two rules on one board. It needs one change across all three plus a gate.

## Fixed along the way

`personnetwork.css:378` fails the DS spacing gate on `main` — #4411 added a badge margin after #4319 armed the rule, so `check-fe` is currently red for everyone. Waived in line with a reason: a badge trailing a sentence is not one of the spacing roles, and changing the primitive would move every badge in the product.

## Gates

`make check-backend` and `make check-fe` green after the final rebase. Integration: `compose/integration` (the new parity test), `compose/attention` unit lane. Every new assertion mutation-checked — the three-move cap, the promise-before-queue ordering, the board/lane parity, and the defensive sum that keeps a missing figure from hiding the unassigned pile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `promises_due` column and up to three coaching lines above the team board, so a lead sees broken commitments and is told who to talk to first instead of doing arithmetic across five columns. Side effect: the latest change to `check-fe` was already red on `main` because of the badge-margin waiver from #4411 after #4319 armed the spacing rule; that waiver is now annotated in `personnetwork.css` and applied here.

**Team board counts**
- `promises_due` counts commitments due from the same extracted claims the rep's own day counts, so the board and the rep's lane agree.
- The count is `required` on the wire: claims have a writer on every installation, so a zero means the rep owes nothing, not that nobody asked.
- One query per roster (`CountOpenCommitmentsDueByOwner`) replaces one per teammate, removing N+1 round trips and mid-loop double-counting.
- Filed #4444: all three counting sources are nil-guarded while the counts are `required`; fixing only the newest would leave two rules on one board.

**Coaching lines**
- At most three moves above the table, derived from counts the board already fetched, so no extra request and no disagreement with the rows beneath.
- Ordered by kind, not size; one line per person, so an over-threshold teammate can't push two others off a list of three.
- `meetings_unprepared` is deliberately not shipped: a meeting cannot be attributed to a rep reliably, so including it would be a guess.

<sup>Written for commit 6831a25b8694aa518a53b0906a7fd16689703555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Promises due” column to the team worklist board, including counts for each team member and unassigned work.
  - Added coaching prompts highlighting broken promises, waiting customers, and overdue tasks.
  - Coaching prompts can be selected to open the relevant team member’s queue.

- **Localization**
  - Added English, German, and Vietnamese translations for the new board column and coaching prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->