### PR TITLE
The capture chip sits at the column's foot, the ring hugs the ball, and the edge lights thin for an import

### DIFF
--- a/frontend/src/app/agent-edge-gl.ts
+++ b/frontend/src/app/agent-edge-gl.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { EDGE_FRAG, EDGE_VERT } from "./agent-edge-shader";
+import type { AgentEdgeRegister } from "./agent-edge-signal";
 
 /**
  * The edge's renderer: one program, one quad, one draw call per frame.
@@ -23,11 +24,22 @@ export type EdgeFrame = Readonly<{
   /** 0 while dark, 1 while fully lit: the fade lives here, not in CSS opacity. */
   level: number;
   /**
-   * How much of the travelling head to draw: 1 normally, 0 under reduced motion.
+   * The rim's resting thickness this frame, in CSS pixels: a register's own, or
+   * a point between two while the loop eases from one to the other.
+   */
+  thick: number;
+  /**
+   * How much the rim breathes: how far the crests swell it and how far the
+   * halo reaches with them. 1 is the amplitude the shader was tuned at.
+   */
+  wave: number;
+  /**
+   * How much of the travelling head to draw: the register's share normally, 0
+   * under reduced motion.
    *
    * Per frame rather than fixed at construction because it is the loop that knows
-   * about motion preference, and because a test can then read what the loop
-   * asked for without a GPU.
+   * about motion preference and which register is wanted, and because a test can
+   * then read what the loop asked for without a GPU.
    */
   beam: number;
 }>;
@@ -39,15 +51,39 @@ export type EdgeRenderer = Readonly<{
   dispose: () => void;
 }>;
 
+/** What the rim draws at in one register: the three dials the loop turns. */
+export type EdgeDress = Readonly<{
+  /** Resting thickness in CSS pixels, before the wave swells it. */
+  thick: number;
+  /** How much of the travelling head to draw, 0..1. */
+  beam: number;
+  /** How much the rim breathes, 1 being the amplitude the shader was tuned at. */
+  wave: number;
+}>;
+
 /**
- * The rim's resting thickness in CSS pixels, before the wave swells it.
+ * The two registers, side by side so the difference between them can be read as
+ * a difference: the numbers only mean anything relative to each other.
  *
- * It is a floor rather than the whole width: the wave adds better than half of
- * this again at a crest, so the visible rim breathes either side of it. Anything
- * under about one and a half is mostly its own anti-aliasing, since the shader's
- * `smoothstep` spends most of a pixel on each side of the boundary.
+ * The thickness is a floor rather than the whole width: the wave adds better
+ * than half of it again at a crest, so the visible rim breathes either side of
+ * it. Anything under about one and a half is mostly its own anti-aliasing, since
+ * the shader's `smoothstep` spends most of a pixel on each side of the boundary,
+ * which is what puts the import's thickness where it is: as thin as a rim can be
+ * and still be a rim. The agent's is a little over what one register used to
+ * draw at, and a little livelier, because two registers only read as two if the
+ * louder one is unmistakably the louder one.
+ *
+ * The import keeps a faint head and half the swell rather than none of either.
+ * A rim that does not move at all is the fallback a host without WebGL2 wears,
+ * and it says the work is happening without being able to say it is happening
+ * NOW; the import is a run that can stall, so it keeps the part of the picture
+ * that only a live loop can draw.
  */
-const THICKNESS = 2.6;
+export const EDGE_REGISTERS: Readonly<Record<AgentEdgeRegister, EdgeDress>> = {
+  agent: { thick: 3, beam: 1, wave: 1.15 },
+  capture: { thick: 1.6, beam: 0.35, wave: 0.45 },
+};
 
 /**
  * Above 1.5 this costs fill for nothing a reader can see. The rim is a soft
@@ -148,7 +184,7 @@ export function createEdgeRenderer(
   const uTime = gl.getUniformLocation(program, "uTime");
   const uLevel = gl.getUniformLocation(program, "uLevel");
   const uThick = gl.getUniformLocation(program, "uThick");
-  gl.uniform1f(uThick, THICKNESS);
+  const uWave = gl.getUniformLocation(program, "uWave");
   const uBeam = gl.getUniformLocation(program, "uBeam");
   // Through a Float32Array rather than casting the tuples: `uniform3fv` wants a
   // mutable float list, and an assertion to get one would be a claim about a
@@ -191,9 +227,11 @@ export function createEdgeRenderer(
       gl.uniform2f(uRes, width, height);
       gl.uniform1f(uDpr, ratio);
     },
-    draw({ time, level, beam }) {
+    draw({ time, level, thick, wave, beam }) {
       gl.uniform1f(uTime, time);
       gl.uniform1f(uLevel, level);
+      gl.uniform1f(uThick, thick);
+      gl.uniform1f(uWave, wave);
       gl.uniform1f(uBeam, beam);
       // No clear: every fragment is written, and the blend is over transparent
       // black, so clearing would be a full-screen write for nothing.

--- a/frontend/src/app/agent-edge-loop.test.ts
+++ b/frontend/src/app/agent-edge-loop.test.ts
@@ -4,7 +4,12 @@
 /** @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { EdgeFrame, EdgeHues, EdgeRenderer } from "./agent-edge-gl";
+import {
+  EDGE_REGISTERS,
+  type EdgeFrame,
+  type EdgeHues,
+  type EdgeRenderer,
+} from "./agent-edge-gl";
 import { FADE, FRAME_MS, runEdgeLoop } from "./agent-edge-loop";
 
 // The loop's contract with the GPU, which is a contract about WHEN and not about
@@ -284,6 +289,85 @@ describe("the edge's draw loop", () => {
     paint.run(1000, 1000 / 60);
 
     expect(renderer.frames.at(-1)?.beam).toBe(1);
+  });
+
+  it("opens in the agent's register, which is the one every reading used to be", () => {
+    const paint = clock();
+    const renderer = recorder();
+    start(renderer);
+    paint.run(FADE * 1000 * 2, 1000 / 60);
+
+    expect(renderer.frames.at(-1)).toMatchObject(EDGE_REGISTERS.agent);
+  });
+
+  it("takes the import's register at once while still dark", () => {
+    // The first frame a reader sees should already be in the right register.
+    // A fresh loop is dark, and a dark edge has nothing to ease from, so the
+    // register is taken rather than approached: every frame of the fade-in is
+    // already thin.
+    const paint = clock();
+    const renderer = recorder();
+    const { loop } = start(renderer);
+    loop?.setRegister("capture");
+    paint.run(FADE * 1000 * 2, 1000 / 60);
+
+    expect(renderer.frames.length).toBeGreaterThan(5);
+    for (const frame of renderer.frames) {
+      expect(frame).toMatchObject(EDGE_REGISTERS.capture);
+    }
+  });
+
+  it("is thinner, calmer and dimmer of head in the import's register, not merely different", () => {
+    // The whole point of the second register, stated as the ORDER between the
+    // two rather than as either's numbers: an import that drew a thicker or
+    // livelier rim than a run would have the two registers the wrong way round.
+    const { agent, capture } = EDGE_REGISTERS;
+
+    expect(capture.thick).toBeLessThan(agent.thick);
+    expect(capture.wave).toBeLessThan(agent.wave);
+    expect(capture.beam).toBeLessThan(agent.beam);
+    // And still lit, still moving: a rim with no head and no breath is the
+    // fallback a host without WebGL2 wears, and it cannot say NOW.
+    expect(capture.beam).toBeGreaterThan(0);
+    expect(capture.wave).toBeGreaterThan(0);
+  });
+
+  it("eases between registers while lit, at the light's own pace", () => {
+    // A run starting mid-import thickens the rim rather than swapping it, and
+    // a swap is exactly the cut the fade exists to avoid.
+    const paint = clock();
+    const renderer = recorder();
+    const { loop } = start(renderer);
+    loop?.setRegister("capture");
+    paint.run(FADE * 1000 * 2, 1000 / 60);
+    expect(renderer.frames.at(-1)?.thick).toBe(EDGE_REGISTERS.capture.thick);
+
+    loop?.setRegister("agent");
+    const mid = renderer.frames.length;
+    paint.run(FADE * 1000 * 4, 1000 / 60);
+    const after = renderer.frames.slice(mid);
+
+    expect(after.at(0)?.thick ?? 0).toBeLessThan(EDGE_REGISTERS.agent.thick);
+    expect(after.at(-1)).toMatchObject(EDGE_REGISTERS.agent);
+    for (const [i, frame] of after.slice(1).entries()) {
+      expect(frame.thick).toBeGreaterThanOrEqual(after[i]?.thick ?? 0);
+    }
+  });
+
+  it("keeps the head off in the import's register for a reader who asked for less movement", () => {
+    // The register's faint head is still a head, and parked in a corner it is
+    // still a hotspot. Reduced motion wins over the register.
+    const paint = clock();
+    const renderer = recorder();
+    const { loop } = start(renderer, { reduced: true });
+    loop?.setRegister("capture");
+    paint.run(1000, 1000 / 60);
+
+    expect(renderer.frames.length).toBeGreaterThan(5);
+    for (const frame of renderer.frames) {
+      expect(frame.beam).toBe(0);
+      expect(frame.thick).toBe(EDGE_REGISTERS.capture.thick);
+    }
   });
 
   it("opens dark when the caller is already leaving", () => {

--- a/frontend/src/app/agent-edge-loop.ts
+++ b/frontend/src/app/agent-edge-loop.ts
@@ -3,9 +3,12 @@
 
 import {
   createEdgeRenderer,
+  EDGE_REGISTERS,
+  type EdgeDress,
   type EdgeHues,
   type EdgeRenderer,
 } from "./agent-edge-gl";
+import type { AgentEdgeRegister } from "./agent-edge-signal";
 
 /**
  * The edge's draw loop, separated from the component that mounts it.
@@ -42,6 +45,16 @@ export type EdgeLoop = Readonly<{
    * that dims reads as finishing. The caller keeps this mounted until `onDark`.
    */
   setLit: (lit: boolean) => void;
+  /**
+   * Changes which register the light is in.
+   *
+   * Eased while lit, at the light's own pace: a run that starts mid-import
+   * thickens the rim rather than swapping it, and swapping is exactly the cut
+   * the fade exists to avoid. Taken at once while dark, because a dark edge has
+   * nothing to ease from and the first frame a reader sees should already be in
+   * the right register.
+   */
+  setRegister: (register: AgentEdgeRegister) => void;
 }>;
 
 export type EdgeLoopOptions = Readonly<{
@@ -58,6 +71,29 @@ export type EdgeLoopOptions = Readonly<{
     hues: EdgeHues,
   ) => EdgeRenderer | null;
 }>;
+
+/** One step toward a target, never past it. Shared by the light and the register
+ *  so the two move at the same pace, which is what makes a register change read
+ *  as the same light changing rather than as a second one arriving. */
+function approach(value: number, target: number, step: number): number {
+  return value < target
+    ? Math.min(value + step, target)
+    : Math.max(value - step, target);
+}
+
+/** The dress at a point between the two registers: 0 is the agent's, 1 the import's. */
+function dressAt(weight: number): EdgeDress {
+  const { agent, capture } = EDGE_REGISTERS;
+  // Two products rather than one difference, so both ends are exact: a rim
+  // asked for the import's register should draw the import's numbers, not a
+  // float a rounding error away from them.
+  const mix = (from: number, to: number) => from * (1 - weight) + to * weight;
+  return {
+    thick: mix(agent.thick, capture.thick),
+    beam: mix(agent.beam, capture.beam),
+    wave: mix(agent.wave, capture.wave),
+  };
+}
 
 /**
  * Starts drawing, and returns null when the host cannot.
@@ -91,6 +127,11 @@ export function runEdgeLoop(
   // way, and the way it could not go is the one a reader notices.
   let level = 0;
   let target = 1;
+  // Where between the two registers the light is, and where it is going. The
+  // same integration as the light, for the same reason: reading it off the
+  // register alone could only ever cut.
+  let worn = 0;
+  let wanted = 0;
   let wentDark = false;
 
   const measure = () => {
@@ -143,13 +184,17 @@ export function runEdgeLoop(
     const step = (now - lastAt) / 1000 / FADE;
     lastAt = now;
     drawnAt = now;
-    level = Math.min(Math.max(level + (target === 1 ? step : -step), 0), 1);
+    level = approach(level, target, step);
+    worn = approach(worn, wanted, step);
+    const dress = dressAt(worn);
     renderer.draw({
       time: options.reduced ? 0 : (now - born) / 1000,
       level,
+      thick: dress.thick,
+      wave: dress.wave,
       // Holding the clock still parks the travelling head in a corner rather
       // than stopping it, so the head has to be turned off explicitly.
-      beam: options.reduced ? 0 : 1,
+      beam: options.reduced ? 0 : dress.beam,
     });
     if (target === 0 && level === 0 && !wentDark) {
       // Once. The caller unmounts on this, and a second call would arrive after
@@ -207,6 +252,12 @@ export function runEdgeLoop(
       // the report is armed again rather than being spent for the loop's life.
       if (lit) {
         wentDark = false;
+      }
+    },
+    setRegister(register) {
+      wanted = register === "capture" ? 1 : 0;
+      if (level === 0) {
+        worn = wanted;
       }
     },
   };

--- a/frontend/src/app/agent-edge-shader.ts
+++ b/frontend/src/app/agent-edge-shader.ts
@@ -35,7 +35,8 @@ uniform float uDpr;      // device pixels per CSS pixel, so widths stay in CSS p
 uniform float uTime;     // seconds since the edge lit
 uniform float uLevel;    // 0..1 fade in and out, so nothing appears or cuts
 uniform float uThick;    // the rim's resting thickness, CSS px
-uniform float uBeam;     // 1 normally, 0 for a reader who asked for less movement
+uniform float uWave;     // how much the rim breathes: 1 as tuned, less for an import
+uniform float uBeam;     // the head's share: the register's, 0 under reduced motion
 uniform vec3  uHueA;     // cool
 uniform vec3  uHueB;
 uniform vec3  uHueC;
@@ -190,10 +191,13 @@ void main() {
 
   // The rim's thickness undulates with the wave, so the crests are visible as
   // the edge swelling and thinning rather than as a stripe moving inside it.
-  // Amplitude, and it is generous on purpose: the rim nearly doubles at a crest
-  // and thins to well under its resting width in a trough, which is what makes
-  // the wave legible on something only a few pixels across.
-  float thick = uThick * max(0.25, 1.0 + 1.15 * w + 0.85 * beam) + 1.0;
+  // Amplitude, and it is generous on purpose: at full breath the rim nearly
+  // doubles at a crest and thins to well under its resting width in a trough,
+  // which is what makes the wave legible on something only a few pixels across.
+  // uWave scales that breath, and the halo's with it below: it is the one dial
+  // that turns the whole picture calmer without turning it off.
+  float swell = w * uWave;
+  float thick = uThick * max(0.25, 1.0 + 1.15 * swell + 0.85 * beam) + 1.0;
 
   // The whole reason this is a shader: one pixel of smoothstep across the
   // boundary, computed per fragment. There is no raster to displace and nothing
@@ -204,9 +208,13 @@ void main() {
   // Two halos, both exponential falloffs rather than blurs: the near one seats
   // the rim, the far one is the light it throws onto the page. An exponential is
   // what a real falloff looks like and costs two instructions.
-  float reach = mix(4.0, 22.0, clamp(0.5 + 0.5 * w, 0.0, 1.0));
+  float reach = mix(4.0, 22.0, clamp(0.5 + 0.5 * swell, 0.0, 1.0));
   float near = exp(-max(dist - thick, 0.0) / reach);
   float far = exp(-max(dist - thick, 0.0) / 46.0);
+  // A calmer rim throws less light onto the page. Not none: the halo is what
+  // seats the rim against the window, and a thin rim with no seat reads as a
+  // hairline border rather than as light.
+  float glow = mix(0.55, 1.0, clamp(uWave, 0.0, 1.0));
 
   // The gradient MOVES inside the waves, and slower than they do: hue drifting
   // at the wave's own speed would read as one object sliding past.
@@ -220,7 +228,8 @@ void main() {
   // than as a different colour arriving.
   tint = mix(tint, uHueC, 0.55 * beam);
 
-  float alpha = (core * 0.95 + near * (0.34 + 0.30 * beam) + far * (0.13 + 0.10 * beam))
+  float alpha = (core * 0.95
+                 + (near * (0.34 + 0.30 * beam) + far * (0.13 + 0.10 * beam)) * glow)
               * uLevel;
   alpha = clamp(alpha, 0.0, 1.0);
 

--- a/frontend/src/app/agent-edge-signal.ts
+++ b/frontend/src/app/agent-edge-signal.ts
@@ -19,7 +19,24 @@ import { useSyncExternalStore } from "react";
  */
 
 /**
- * The one fact the margins draw: whether work is in flight.
+ * Which register the margins speak in.
+ *
+ * Both are work in flight and the margin lights for both, but they are not the
+ * same kind of work and were not being read as the same kind. An agent run is
+ * seconds to a minute: a rim that swells and sends a head of light round the
+ * frame says NOW, and is gone before it can become wallpaper. A mailbox import
+ * is minutes to hours, and the same rim over that span is a lamp left on in the
+ * corner of every screen a person works in. So the import takes a thinner,
+ * calmer register — still lit, still moving, still saying mail is arriving —
+ * and the agent's own register is a little thicker and livelier, so the two
+ * read as two things rather than as one thing at two volumes. What each draws
+ * at is in `agent-edge-gl.ts`.
+ */
+export type AgentEdgeRegister = "agent" | "capture";
+
+/**
+ * The one fact the margins draw: whether work is in flight, and in which
+ * register.
  *
  * A STAGED DECISION IS NOT PUBLISHED HERE. It used to be, as a second boolean
  * closing the margin into a still contour, and on any installation with an
@@ -31,10 +48,19 @@ import { useSyncExternalStore } from "react";
 export type AgentEdgeReading = Readonly<{
   /** Work is in flight: the agent is reading or acting THIS moment. */
   reading: boolean;
+  /**
+   * Which register the light is in. It means nothing while dark, so a dark
+   * reading always wears the agent's: one spelling for rest, whatever the light
+   * was doing before it went out.
+   */
+  register: AgentEdgeRegister;
 }>;
 
 /** Nothing is happening, which is the honest answer whenever no rail is mounted. */
-export const AGENT_EDGE_STILL: AgentEdgeReading = { reading: false };
+export const AGENT_EDGE_STILL: AgentEdgeReading = {
+  reading: false,
+  register: "agent",
+};
 
 let shown: AgentEdgeReading = AGENT_EDGE_STILL;
 const listeners = new Set<() => void>();
@@ -48,10 +74,16 @@ const listeners = new Set<() => void>();
  * already on screen.
  */
 export function publishAgentEdge(next: AgentEdgeReading): void {
-  if (next.reading === shown.reading) {
+  const settled: AgentEdgeReading = next.reading
+    ? { reading: true, register: next.register }
+    : AGENT_EDGE_STILL;
+  if (
+    settled.reading === shown.reading &&
+    settled.register === shown.register
+  ) {
     return;
   }
-  shown = { reading: next.reading };
+  shown = settled;
   for (const listener of listeners) {
     listener();
   }

--- a/frontend/src/app/agent-edge.css
+++ b/frontend/src/app/agent-edge.css
@@ -60,3 +60,9 @@
 .agentedge-still {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--orbMid) 80%, transparent);
 }
+/* The import's register on the same fallback. A pixel is the thinnest rim there
+   is, so the difference the shader draws as thickness is drawn here as
+   strength: the same hairline, further back. */
+.agentedge-still[data-register="capture"] {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--orbMid) 45%, transparent);
+}

--- a/frontend/src/app/agent-edge.stories.tsx
+++ b/frontend/src/app/agent-edge.stories.tsx
@@ -35,11 +35,11 @@ type Story = StoryObj<typeof AgentEdge>;
  * (agent-edge-signal.ts). So a story has to say what the agent is doing the same
  * way the rail does, and clear it on the way out or the next story inherits it.
  */
-function Edge({ reading }: AgentEdgeReading) {
+function Edge({ reading, register }: AgentEdgeReading) {
   useEffect(() => {
-    publishAgentEdge({ reading });
+    publishAgentEdge({ reading, register });
     return clearAgentEdge;
-  }, [reading]);
+  }, [reading, register]);
   return (
     <>
       <AgentEdge />
@@ -58,14 +58,25 @@ function Edge({ reading }: AgentEdgeReading) {
 
 /** Nothing at all, which is the resting state and most of the working day. */
 export const Still: Story = {
-  render: () => <Edge reading={false} />,
+  render: () => <Edge reading={false} register="agent" />,
 };
 
 /**
- * Work in flight. The whole rim is lit, the light billows in place, and one soft
- * arc laps the perimeter. This is the only state that moves, which is what makes
- * movement here mean something.
+ * The agent's own work in flight: a run, or a call this tab holds open. The
+ * whole rim is lit, the light billows in place, and one soft arc laps the
+ * perimeter. Movement here means something is happening, and this is the louder
+ * of the two registers it can happen in.
  */
 export const Reading: Story = {
-  render: () => <Edge reading={true} />,
+  render: () => <Edge reading={true} register="agent" />,
+};
+
+/**
+ * A mailbox import in flight, and nothing else. The same rim in the thin
+ * register: about half the thickness, half the breath, a faint head still making
+ * its lap. Open this beside `Reading` — the difference is the whole design, and
+ * it should be unmistakable at a glance and unremarkable over an afternoon.
+ */
+export const Importing: Story = {
+  render: () => <Edge reading={true} register="capture" />,
 };

--- a/frontend/src/app/agent-edge.test.tsx
+++ b/frontend/src/app/agent-edge.test.tsx
@@ -36,19 +36,39 @@ describe("the agent edge signal", () => {
 
   it("keeps one object per reading, so a subscriber can compare by identity", () => {
     const first = currentAgentEdge();
-    publishAgentEdge({ reading: false });
+    publishAgentEdge({ reading: false, register: "agent" });
 
     expect(currentAgentEdge()).toBe(first);
   });
 
   it("carries the reading it was published with", () => {
-    publishAgentEdge({ reading: true });
+    publishAgentEdge({ reading: true, register: "agent" });
 
-    expect(currentAgentEdge()).toEqual({ reading: true });
+    expect(currentAgentEdge()).toEqual({ reading: true, register: "agent" });
+  });
+
+  it("carries the import's register, and drops it the moment the light goes out", () => {
+    // A register means nothing while dark, so rest has ONE spelling whatever
+    // the light was doing: a subscriber comparing by identity sees the still
+    // object, and a test asserting rest need not know what ran before it.
+    publishAgentEdge({ reading: true, register: "capture" });
+    expect(currentAgentEdge()).toEqual({ reading: true, register: "capture" });
+
+    publishAgentEdge({ reading: false, register: "capture" });
+    expect(currentAgentEdge()).toBe(AGENT_EDGE_STILL);
+  });
+
+  it("publishes a change of register as a change, so a run starting mid-import reaches the margins", () => {
+    publishAgentEdge({ reading: true, register: "capture" });
+    const thin = currentAgentEdge();
+    publishAgentEdge({ reading: true, register: "agent" });
+
+    expect(currentAgentEdge()).not.toBe(thin);
+    expect(currentAgentEdge().register).toBe("agent");
   });
 
   it("goes still when cleared, so a reading cannot outlive its session", () => {
-    publishAgentEdge({ reading: true });
+    publishAgentEdge({ reading: true, register: "agent" });
     clearAgentEdge();
 
     expect(currentAgentEdge()).toEqual(AGENT_EDGE_STILL);
@@ -73,10 +93,10 @@ describe("the agent edge", () => {
     // an element that only exists while work is in flight cannot fall out of
     // step with the fact it reports.
     const { container } = render(<AgentEdge />);
-    act(() => publishAgentEdge({ reading: true }));
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
     expect(container.querySelector("canvas")).not.toBeNull();
 
-    act(() => publishAgentEdge({ reading: false }));
+    act(() => publishAgentEdge({ reading: false, register: "agent" }));
     expect(container.querySelector("canvas")).toBeNull();
   });
 
@@ -86,10 +106,10 @@ describe("the agent edge", () => {
     const { container } = render(<AgentEdge />);
     expect(container.querySelector("canvas")).toBeNull();
 
-    act(() => publishAgentEdge({ reading: true }));
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
     expect(container.querySelector("canvas")).not.toBeNull();
 
-    act(() => publishAgentEdge({ reading: false }));
+    act(() => publishAgentEdge({ reading: false, register: "agent" }));
     expect(container.querySelector("canvas")).toBeNull();
   });
 
@@ -99,9 +119,26 @@ describe("the agent edge", () => {
     // the agent is working, so the fallback is a plain lit rim rather than
     // nothing: a decoration that vanishes takes a reading with it.
     const { container } = render(<AgentEdge />);
-    act(() => publishAgentEdge({ reading: true }));
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
 
     expect(container.querySelector(".agentedge-still")).not.toBeNull();
+  });
+
+  it("tells the rim which register it is in, so the fallback can wear it too", () => {
+    // The shader's frames never reach the DOM, so this attribute is the one
+    // place the register is legible outside the loop: the static rim draws
+    // its thinner spelling from it, and this test reads it the same way.
+    const { container } = render(<AgentEdge />);
+    act(() => publishAgentEdge({ reading: true, register: "capture" }));
+    expect(
+      container.querySelector("canvas")?.getAttribute("data-register"),
+    ).toBe("capture");
+
+    // A run starting mid-import is the agent's own work, and the rim says so.
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
+    expect(
+      container.querySelector("canvas")?.getAttribute("data-register"),
+    ).toBe("agent");
   });
 
   it("takes no pointer and is hidden from a screen reader", () => {
@@ -118,7 +155,7 @@ describe("the agent edge", () => {
     // here: it has to serve every subscriber, not the last one to arrive.
     const first = render(<AgentEdge />);
     const second = render(<AgentEdge />);
-    act(() => publishAgentEdge({ reading: true }));
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
 
     expect(first.container.querySelector("canvas")).not.toBeNull();
     expect(second.container.querySelector("canvas")).not.toBeNull();
@@ -131,7 +168,7 @@ describe("the agent edge", () => {
     const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     const { unmount } = render(<AgentEdge />);
     unmount();
-    act(() => publishAgentEdge({ reading: true }));
+    act(() => publishAgentEdge({ reading: true, register: "agent" }));
 
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();

--- a/frontend/src/app/agent-edge.tsx
+++ b/frontend/src/app/agent-edge.tsx
@@ -6,7 +6,7 @@ import { readHue } from "../design-system/margince-core-gl";
 import { usePrefersReducedMotion } from "../design-system/motion";
 import type { EdgeHues } from "./agent-edge-gl";
 import { type EdgeLoop, runEdgeLoop } from "./agent-edge-loop";
-import { useAgentEdge } from "./agent-edge-signal";
+import { type AgentEdgeRegister, useAgentEdge } from "./agent-edge-signal";
 import "./agent-edge.css";
 
 /**
@@ -24,6 +24,15 @@ import "./agent-edge.css";
  * acting, with the colour drifting inside them, and they stop when the work
  * does — so movement here always means something is happening.
  *
+ * In two registers, because two kinds of work light it and they are not read
+ * the same way. The agent's own — a run, a call — is seconds to a minute, and
+ * the rim is a little thicker and livelier for it. A mailbox import is minutes
+ * to hours, and the same rim over that span was a lamp left on in the corner of
+ * every screen; it takes a thinner, calmer rim that still travels, so mail
+ * arriving is still visibly happening without being the loudest thing on the
+ * page all afternoon. Which register is the rail's call, published with the
+ * reading (agent-edge-signal.ts).
+ *
  * At rest it draws nothing at all.
  *
  * A STAGED DECISION IS NOT DRAWN HERE. It used to close the margin into a
@@ -38,7 +47,7 @@ import "./agent-edge.css";
  * loses nothing.
  */
 export function AgentEdge() {
-  const { reading } = useAgentEdge();
+  const { reading, register } = useAgentEdge();
   // The edge outlives the reading that lit it, by exactly as long as it takes to
   // go out. Unmounting on `reading` alone cut the light dead the instant the work
   // finished, and a light that vanishes reads as something breaking; the shader
@@ -53,7 +62,11 @@ export function AgentEdge() {
   return (
     <div className="agentedge" aria-hidden="true">
       {(reading || lingering) && (
-        <LitEdge lit={reading} onDark={() => setLingering(false)} />
+        <LitEdge
+          lit={reading}
+          register={register}
+          onDark={() => setLingering(false)}
+        />
       )}
     </div>
   );
@@ -81,7 +94,15 @@ export function AgentEdge() {
  * test can reach it. What stays here is the mounting: read the hues off the
  * document, start the loop, and wear the static rim if the host cannot run it.
  */
-function LitEdge({ lit, onDark }: { lit: boolean; onDark: () => void }) {
+function LitEdge({
+  lit,
+  register,
+  onDark,
+}: {
+  lit: boolean;
+  register: AgentEdgeRegister;
+  onDark: () => void;
+}) {
   const canvas = useRef<HTMLCanvasElement>(null);
   const loop = useRef<EdgeLoop | null>(null);
   const [live, setLive] = useState(false);
@@ -98,6 +119,8 @@ function LitEdge({ lit, onDark }: { lit: boolean; onDark: () => void }) {
   // without taking it as a dependency.
   const litRef = useRef(lit);
   litRef.current = lit;
+  const registerRef = useRef(register);
+  registerRef.current = register;
 
   useEffect(() => {
     const element = canvas.current;
@@ -136,6 +159,9 @@ function LitEdge({ lit, onDark }: { lit: boolean; onDark: () => void }) {
       onDark: () => onDarkRef.current(),
     });
     loop.current = started;
+    // The register before the light: a fresh loop takes its register at once
+    // while dark, so the first lit frame is already in the right one.
+    started?.setRegister(registerRef.current);
     // A fresh loop opens with its light asked for. When this rebuild happened
     // while the edge was already on its way out (a motion-preference change
     // mid-fade), the replacement relit and stayed lit, because the effect below
@@ -147,6 +173,15 @@ function LitEdge({ lit, onDark }: { lit: boolean; onDark: () => void }) {
       loop.current = null;
     };
   }, [reduced]);
+
+  // Only while the light is asked for. The signal wears the agent's register
+  // the moment the work stops, whatever it was lit in, and taking that word
+  // while the light is going out would thicken a rim on its way to nothing.
+  useEffect(() => {
+    if (lit && live) {
+      loop.current?.setRegister(register);
+    }
+  }, [register, lit, live]);
 
   // `live` is a dependency, not decoration: losing the context clears the loop
   // while `lit` may already be false, and without re-running here nothing would
@@ -175,6 +210,10 @@ function LitEdge({ lit, onDark }: { lit: boolean; onDark: () => void }) {
       // which is honest: the fallback says the agent is working without claiming
       // to show how.
       className={live ? "agentedge-canvas" : "agentedge-canvas agentedge-still"}
+      // For the static rim, which has no loop to ease and wears its register
+      // from here; and it is the one place a test can read which register the
+      // edge was told, since the shader's frames never reach the DOM.
+      data-register={register}
     />
   );
 }

--- a/frontend/src/app/agentrail.capture.test.tsx
+++ b/frontend/src/app/agentrail.capture.test.tsx
@@ -8,7 +8,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { currentAgentEdge } from "./agent-edge-signal";
+import { AGENT_EDGE_STILL, currentAgentEdge } from "./agent-edge-signal";
 import { AgentRail } from "./agentrail";
 import { LABELS } from "./agentrail-copy";
 import { meFixture } from "./mefixture";
@@ -16,9 +16,10 @@ import { meFixture } from "./mefixture";
 // A mailbox import is the one long run the AI-activity feed cannot carry, so
 // the rail reads it off the connections list instead (capture-progress.ts).
 // These cases prove that reading reaches every surface the rail owns: the
-// orb's state, the ring around it, the line under it, and the lit edge. They
-// live apart from agentrail.test.tsx because that file is past the size a test
-// file may grow to.
+// orb's state, the ring around it, the line under it, and the lit edge — in
+// the import's own register, which is the thin one, unless the agent's own work
+// is under way at the same time. They live apart from agentrail.test.tsx
+// because that file is past the size a test file may grow to.
 
 type Connector = components["schemas"]["CaptureConnection"];
 type BackfillStatus = components["schemas"]["BackfillStatus"];
@@ -130,13 +131,15 @@ afterEach(() => {
 });
 
 describe("a mailbox import", () => {
-  it("puts the orb in ingest, draws its share as the ring, and lights the edge", async () => {
+  it("puts the orb in ingest, draws its share as the ring, and lights the edge in the import's register", async () => {
     const { container } = mount({ connectors: [mailbox(IMPORTING)] });
     await waitFor(() =>
       expect(block(container).getAttribute("data-core-state")).toBe("ingest"),
     );
     expect(ringShare(container)).toBe("42 100");
-    expect(currentAgentEdge().reading).toBe(true);
+    // Thin and calm: an import runs for hours, and the agent's own rim over
+    // that span is a lamp left on.
+    expect(currentAgentEdge()).toEqual({ reading: true, register: "capture" });
   });
 
   it("says so under the orb, with the share", async () => {
@@ -186,10 +189,10 @@ describe("a mailbox import", () => {
     );
     expect(block(container).getAttribute("data-core-state")).toBe("idle");
     expect(container.querySelector(".core-progress")).toBeNull();
-    expect(currentAgentEdge().reading).toBe(false);
+    expect(currentAgentEdge()).toEqual(AGENT_EDGE_STILL);
   });
 
-  it("keeps its ring under a run the feed names, because the import did not stop", async () => {
+  it("keeps its ring under a run the feed names, and the edge takes the agent's register", async () => {
     const { container } = mount({
       connectors: [mailbox(IMPORTING)],
       running: [
@@ -205,8 +208,11 @@ describe("a mailbox import", () => {
     await waitFor(() =>
       expect(block(container).getAttribute("data-core-state")).toBe("working"),
     );
-    // ...and the ring is still the import's.
+    // ...and the ring is still the import's...
     expect(ringShare(container)).toBe("42 100");
+    // ...while the margin lights for the run: a named run is the agent's own
+    // work whatever the orb is showing, and it gets the thicker, livelier rim.
+    expect(currentAgentEdge()).toEqual({ reading: true, register: "agent" });
   });
 
   it("drops the ring under a fault: a red orb cannot also be going well", async () => {

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -26,7 +26,11 @@ import {
 } from "../api/model-inflight";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { clearAgentEdge, currentAgentEdge } from "./agent-edge-signal";
+import {
+  AGENT_EDGE_STILL,
+  clearAgentEdge,
+  currentAgentEdge,
+} from "./agent-edge-signal";
 import { AgentRail } from "./agentrail";
 import { LABELS, TASK_SAID, VOCABULARY } from "./agentrail-copy";
 import { type GrantSpec, meFixture } from "./mefixture";
@@ -964,12 +968,12 @@ describe("AgentRail", () => {
     // long as the queue does is a ring around the window on any installation
     // with work in it.
     await settlesOnLine(view.container, `1 ${LABELS.waiting}`);
-    expect(currentAgentEdge()).toEqual({ reading: false });
+    expect(currentAgentEdge()).toEqual(AGENT_EDGE_STILL);
 
     // Sign out mid-read and the login screen would otherwise inherit a lit
     // margin belonging to a session that has ended.
     view.unmount();
-    expect(currentAgentEdge()).toEqual({ reading: false });
+    expect(currentAgentEdge()).toEqual(AGENT_EDGE_STILL);
   });
 
   // The Core's own tone rule is the only place a state's colour is declared

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -30,7 +30,11 @@ import type { MessageKey } from "../i18n/en";
 import { usePendingApprovals } from "../screens/approvals.queries";
 import { useConnectors } from "../screens/connectors";
 import { useLicenseEntitlement } from "../screens/license";
-import { clearAgentEdge, publishAgentEdge } from "./agent-edge-signal";
+import {
+  type AgentEdgeRegister,
+  clearAgentEdge,
+  publishAgentEdge,
+} from "./agent-edge-signal";
 import { type AgentFault, useAgentFault } from "./agent-fault";
 import {
   IDLE_ORDER,
@@ -890,6 +894,12 @@ type Reading = Readonly<{
   state: MarginceCoreState;
   /** The occurrence the state is ABOUT, or null when no occurrence caused it. */
   cause: AiActivityItem | null;
+  /**
+   * Which register the margins light in. The import's only when the import is
+   * the ONLY work in flight: a named run or a call this tab holds open is the
+   * agent's own work whatever the orb is showing, and the margin says so.
+   */
+  register: AgentEdgeRegister;
 }>;
 
 function derive(
@@ -898,13 +908,13 @@ function derive(
   fault: AgentFault | null,
 ): Reading {
   if (signals.ai === "unconfigured" || signals.offline.length > 0) {
-    return { state: "error", cause: null };
+    return { state: "error", cause: null, register: "agent" };
   }
   // A run that broke, and that this reader has not been shown yet. It outranks
   // the licence because it is a thing that HAPPENED rather than a standing
   // condition, and it clears by being read rather than by being repaired.
   if (fault !== null) {
-    return { state: fault.severity, cause: fault.item };
+    return { state: fault.severity, cause: fault.item, register: "agent" };
   }
   // A live run past the lease its own source declared. The server derives it, so
   // a worker that died without saying so cannot go on being displayed as busy,
@@ -912,7 +922,7 @@ function derive(
   // the reader to do but know.
   const stalled = server.running.find((item) => item.state === "stalled");
   if (stalled) {
-    return { state: "warning", cause: stalled };
+    return { state: "warning", cause: stalled, register: "agent" };
   }
   // REFUSED only, and it stays amber rather than escalating, because escalating
   // would make the chrome a sales surface.
@@ -930,7 +940,7 @@ function derive(
   // names both absences and says what each one costs — instead of spending the
   // chrome's only ambient warning channel on something that is permanently true.
   if (signals.license === "refused") {
-    return { state: "warning", cause: null };
+    return { state: "warning", cause: null, register: "agent" };
   }
   // The agent's own live work, and which half of the lifecycle it is in comes
   // from the KIND of work rather than from how far along it is: evidence
@@ -941,13 +951,22 @@ function derive(
   // already has for every state.
   const live = server.running.find((item) => item.state !== "stalled");
   if (live) {
-    return { state: laneFor(live), cause: live };
+    return { state: laneFor(live), cause: live, register: "agent" };
   }
   // Mail being imported. No cause travels with it because it is not an
   // occurrence the feed can name; the line under the orb is the import's own,
   // from the signals (`barLine`), with its share where a preview gave it one.
+  // The margins take the import's register unless this tab has a call open
+  // underneath it: the orb keeps the import (the ask below cannot say which
+  // half of the lifecycle it is in, and this can), but a model call in flight
+  // is the agent's own work, and the margin lights for THAT in the register it
+  // always has.
   if (signals.capture !== null) {
-    return { state: "ingest", cause: null };
+    return {
+      state: "ingest",
+      cause: null,
+      register: server.asking ? "agent" : "capture",
+    };
   }
   // This tab's own ask, which the feed has not caught up with yet. `working`
   // rather than a lane read from the kind, because the kind is exactly what is
@@ -959,14 +978,14 @@ function derive(
   // run, and the moment the feed carries the occurrence the branch above wins
   // and names it.
   if (server.asking) {
-    return { state: "working", cause: null };
+    return { state: "working", cause: null, register: "agent" };
   }
   // A request that failed a moment ago does NOT colour the orb. One dropped
   // request on a flaky connection would otherwise flash the corner of every
   // screen red and green and red again, and a light that does that is a light
   // nobody reads. What the orb reports is standing state; the screen that made
   // the request reports the request.
-  return { state: "idle", cause: null };
+  return { state: "idle", cause: null, register: "agent" };
 }
 
 /**
@@ -1181,7 +1200,7 @@ export function AgentRail({
   const spend = useAiSpend();
   const { locale } = useLocale();
   const { fault, acknowledge } = useAgentFault(server.recent);
-  const { state, cause } = derive(signals, server, fault);
+  const { state, cause, register } = derive(signals, server, fault);
 
   // What the screen's margins draw, published rather than re-derived: the reads
   // above are all local to this component, so a second consumer calling the same
@@ -1191,8 +1210,8 @@ export function AgentRail({
   // that stands for as long as the queue does.
   const reading = RUNNING.has(state);
   useEffect(() => {
-    publishAgentEdge({ reading });
-  }, [reading]);
+    publishAgentEdge({ reading, register });
+  }, [reading, register]);
   // The last word belongs to the unmount: a reading left behind would outlive the
   // session that made it, and the signed-out screen would inherit a lit margin.
   useEffect(() => clearAgentEdge, []);

--- a/frontend/src/app/capture-chip.css
+++ b/frontend/src/app/capture-chip.css
@@ -1,14 +1,18 @@
 /*
- * The capture chip: the import's gauge, top-centre of the content column.
+ * The capture chip: the import's gauge, bottom-centre of the content column.
  *
  * Positioned against `.main` (which is `position: relative` for exactly this
  * kind of thing) rather than the viewport, so it stands over the page a reader
- * is working in and not over the sidebar. Under the top bar, because the bar's
- * centre is the search affordance and a chip on top of it would be two centred
- * things fighting for one line. Above the page (z-index 50 is the bar's own
- * layer in shell.css) and below the lit edge (90) and the toast (60): the chip
- * reports and the toast confirms, and a confirmation must not be hidden by a
- * gauge.
+ * is working in and not over the sidebar. At the FOOT of the column, on the
+ * same ledge the toast uses: the top of the column is the top bar, whose centre
+ * is the search affordance, and a chip under it read as a second bar. The foot
+ * is where this product already puts what passes through, and `--stickyBottomInset`
+ * is the shell's own word for where that foot is — `--space-2` on a desktop and
+ * the phone bar's clearance on a phone, so the chip never lands on the bar.
+ * Above the page (z-index 50 is the bar's own layer in shell.css) and below the
+ * lit edge (90) and the toast (60): the chip reports and the toast confirms, and
+ * a confirmation must not be hidden by a gauge, so a toast covers it for the
+ * seconds it is up.
  *
  * Dressed like the toast — the rail's dark ground, the pop shadow — because it
  * is the same kind of thing: something passing through, not part of the page.
@@ -17,7 +21,7 @@
  */
 .capturechip {
   position: absolute;
-  top: calc(var(--topbarH) + var(--space-2));
+  bottom: calc(var(--stickyBottomInset) + var(--space-2));
   left: 50%;
   transform: translateX(-50%);
   z-index: 55;
@@ -90,7 +94,7 @@
 @keyframes capturechip-in {
   from {
     opacity: 0;
-    transform: translate(-50%, -6px);
+    transform: translate(-50%, 6px);
   }
   to {
     opacity: 1;

--- a/frontend/src/app/capture-chip.tsx
+++ b/frontend/src/app/capture-chip.tsx
@@ -18,7 +18,7 @@ const CONNECTIONS_HREF = "#/settings/connections";
  * A connect-time import runs for minutes to hours and the person who started
  * it goes back to work while it does. The orb in the rail carries its ring, but
  * the rail is the corner of the window and at phone width a cell in the bar;
- * this puts the same reading top-centre of the content, small, for as long as
+ * this puts the same reading bottom-centre of the content, small, for as long as
  * mail is arriving, and takes itself away the moment it stops. A chip rather
  * than a banner: a banner is a sentence about the workspace, and this is a
  * gauge.

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -902,7 +902,7 @@ export function Shell({
             railless; these advisories belong only here. */}
           <EconomyBanner />
           <EmbedReindexBanner />
-          {/* The import's gauge, floating top-centre of this column for as
+          {/* The import's gauge, floating bottom-centre of this column for as
             long as mail is arriving. Inside `.main` rather than beside the
             edge below, because it is positioned against the content column
             and not the window. */}

--- a/frontend/src/design-system/margince-core.css
+++ b/frontend/src/design-system/margince-core.css
@@ -391,13 +391,33 @@
 
 /* ---- progress (WDS-CORE-2's optional half) ------------------------------ */
 /* A ring around the glass rather than a bar beside it: the Core is already the
-   thing being waited on, and a second widget would compete with it. */
+   thing being waited on, and a second widget would compete with it.
+
+   It hugs the ball that is actually DRAWN. The shader's camera sits 3.2 radii
+   from a unit sphere behind a 1.05 lens, so the silhouette it paints spans
+   tan(asin(1 / 3.2)) / 1.05 of the canvas's half-height on either side —
+   about 63% of the glass box — and the rest of the box is the halo's room. A
+   ring drawn at the box's edge therefore floated a third of the ball's width
+   away from it, which read as a separate dial rather than as the orb's own
+   progress. `--coreBall` is that share, and it is the shader's constant
+   restated rather than a tuning: move the camera and this moves with it. */
 .core-progress {
+  --coreBall: 0.627;
+  --coreRingGap: 4px;
   position: absolute;
-  inset: calc((var(--coreSize) - var(--coreGlass)) / 2 - 6px);
+  inset: calc(
+    (var(--coreSize) - var(--coreGlass) * var(--coreBall)) /
+    2 -
+    var(--coreRingGap)
+  );
   z-index: 3;
   pointer-events: none;
   transform: rotate(-90deg);
+}
+/* The still dress fills the whole glass box, so on a host without WebGL2 the
+   ring keeps the box's edge — the same ring, around the ball that host has. */
+.core-still .core-progress {
+  inset: calc((var(--coreSize) - var(--coreGlass)) / 2 - 6px);
 }
 .core-progress circle {
   fill: none;


### PR DESCRIPTION
## What

Three follow-ups to #4387 from looking at it on a real screen:

1. The capture chip moves from under the top bar to bottom-centre of the content column, on the ledge the toast already uses.
2. The Core's progress ring now sits on the ball the shader actually draws, instead of at the glass box's edge a third of the ball's width away.
3. The lit edge speaks in two registers. A mailbox import alone lights a thin, calm rim; the agent's own work (a named run, or a call this tab holds open) lights a rim a little thicker and livelier than the one register used to be.

## Why

**The chip.** The top of the content column is the top bar, whose centre is the search affordance; a chip under it read as a second bar. The foot of the column is where this product already puts what passes through. Its offset is read from `--stickyBottomInset`, the shell's own word for where that foot is (`--space-2` on a desktop, the phone bar's clearance on a phone), so the chip never lands on the phone bar. It keeps z-index 55, under the toast's 60: a confirmation covers the gauge for the seconds it is up, never the other way round.

**The ring.** The shader's camera sits 3.2 radii from a unit sphere behind a 1.05 lens, so the silhouette it paints spans `tan(asin(1/3.2)) / 1.05` of the canvas's half-height on either side, about 63% of the glass box, with the rest of the box kept for the halo. The ring was drawn 6px outside the box, so on the rail it floated well clear of the ball and read as a separate dial rather than as the orb's own progress. `--coreBall` restates that share from the shader's constants rather than tuning by eye, so moving the camera moves the ring. The still dress (a host without WebGL2) fills the whole box, so under `.core-still` the ring keeps the box's edge: the same ring, around the ball that host has.

**The edge.** An import runs for minutes to hours, and #4387 lit the edge for it in the same register as a run: the rim that says NOW for a thirty-second brief was a lamp left on in the corner of every screen for an afternoon. The design asked for was one thin edge for an import and a slightly thicker one for AI actions, and that is what this does:

- `AgentEdgeReading` gains `register: "agent" | "capture"`. The rail derives it with the state: the import's register only when the import is the ONLY work in flight. A named run, or `asking` (a model call this tab holds open), is the agent's own work whatever the orb shows, so the margin lights for that. A dark reading always wears the agent's register, so rest keeps one spelling and identity comparisons keep working.
- `EDGE_REGISTERS` in `agent-edge-gl.ts` holds the two dresses side by side: agent `{thick 3, beam 1, wave 1.15}` (the one register was 2.6 and 1.0), capture `{thick 1.6, beam 0.35, wave 0.45}`, 1.6 being just above the anti-aliasing floor the file already documents. The import keeps a faint head and half the breath rather than none: a rim that does not move is the WebGL-less fallback, and it cannot say NOW.
- The loop eases between registers at the light's own pace (`FADE`), so a run starting mid-import thickens the rim rather than swapping it; while dark it takes the register at once so the first lit frame is already right. Thickness is now a per-frame uniform, and a new `uWave` scales the swell, the halo's reach and how much light the rim throws.
- The static rim reads the register off `data-register` and draws the import's fainter; that attribute is also the one place a DOM test can read which register the edge was told.
- A third story, `Importing`, sits beside `Reading` so the two registers can be compared in one Storybook.

## How verified

- `make fe-lint` (biome + the design-system gates) and `tsc --noEmit` are clean.
- `agent-edge-loop` (23), `agent-edge` (16), `agentrail.capture` and `agentrail` suites pass; new cases cover the register table's ordering, taking a register while dark, easing while lit, reduced motion winning over the register's head, the signal normalising rest, the rim's attribute, and the rail publishing `capture` for an import alone and `agent` under a run.
- `make fe-unit` locally: everything green except two cases in `home.readings.test.tsx`, which fail identically with this diff stashed, are byte-identical to `main`, and passed in this PR's CI run on the previous head, so they are this container's environment, not this change.
- No Go files change.

- [x] `make check` is green — the frontend half; no Go files change
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers — no Go files in the diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Written in a Claude Code session from the product owner's screenshot and notes; the ring geometry was derived from the shader's camera constants rather than eyeballed, and the two-register design was the owner's call after a discussion of alternatives.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uo4JEvQcJemsi4osSv5qpD