### PR TITLE
Dress the live mail import in the AI family

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4418,6 +4418,7 @@ export const de = {
     "Der Import-Status ist gerade nicht lesbar — die Erfassung selbst läuft weiter.",
   "backfill.queuedTitle": "Import eingereiht",
   "backfill.runningTitle": "E-Mail-Verlauf wird importiert",
+  "backfill.readingBadge": "Margince liest",
   "backfill.doneTitle": "Verlaufs-Import abgeschlossen",
   "backfill.errorTitle": "Der Import hat ein Problem",
   "backfill.cancelledTitle": "Import abgebrochen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4490,6 +4490,9 @@ export const en = {
     "The import status can't be read right now — capture itself keeps running.",
   "backfill.queuedTitle": "Import queued",
   "backfill.runningTitle": "Importing your mail history",
+  // The pill beside a live title: the indigo on the card is a claim that a
+  // machine is doing the reading, and this is the same claim in words.
+  "backfill.readingBadge": "Margince is reading",
   "backfill.doneTitle": "History import complete",
   "backfill.errorTitle": "The import hit a problem",
   "backfill.cancelledTitle": "Import cancelled",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4364,6 +4364,7 @@ export const vi = {
     "Hiện chưa đọc được trạng thái nhập — bản thân việc thu thập vẫn chạy.",
   "backfill.queuedTitle": "Đã xếp hàng lượt nhập",
   "backfill.runningTitle": "Đang nhập lịch sử thư của bạn",
+  "backfill.readingBadge": "Margince đang đọc",
   "backfill.doneTitle": "Đã nhập xong lịch sử",
   "backfill.errorTitle": "Lượt nhập gặp trục trặc",
   "backfill.cancelledTitle": "Đã huỷ lượt nhập",

--- a/frontend/src/screens/backfill.css
+++ b/frontend/src/screens/backfill.css
@@ -30,9 +30,6 @@
   font-weight: var(--fw-semibold);
   color: var(--textPrimary);
 }
-.capture-hero.done .backfill-h svg {
-  color: var(--success);
-}
 /* The window choices wrap rather than overflow: three labelled radios plus the
    control-label gap outgrow a narrow or zoomed column, and a horizontal
    scrollbar is not an acceptable way to reach the third option. */
@@ -71,69 +68,207 @@
   margin-top: var(--space-3);
 }
 
-/* The capture hero: the three headline figures a newly-connected mailbox
-   grows, climbing live as the backfill pages. */
-.capture-stats {
+/* The capture hero: the three headline figures a newly-connecte/* ---- the run view ----------------------------------------------------- */
+/* While Margince is reading the mailbox, the card wears the product's one mark
+   of machine work — the indigo family (tokens.css --ai): a wash of --aiLight
+   rising from the head, an --aiMed edge, the glyphs and the title in --aiText.
+   That is a claim rather than a mood: every figure on the card was put there by
+   the machine reading mail, and the light goes out the moment that stops. A
+   stalled run, a queued one, a failed one and a cancelled one all sit on the
+   plain card, because outcome is not provenance ("Indigo says a machine did
+   it", design-system/README.md); the finished run reads as arrival in the
+   success family instead. The words carry the same claim — the badge beside
+   the title says who is reading — so the colour is never the only signal. */
+.capture-hero {
+  position: relative;
+  /* The wash is painted past the padding and the card clips it to its own
+     corner. */
+  overflow: hidden;
+  transition:
+    border-color var(--dur-move) var(--ease-out),
+    background-color var(--dur-move) var(--ease-out);
+}
+.capture-hero.reading {
+  border-color: var(--aiMed);
+  background:
+    radial-gradient(70% 90% at 0% 0%, var(--aiLight), transparent 70%),
+    var(--bgElevated);
+}
+
+.capture-head {
   display: flex;
-  gap: var(--space-4);
-  margin: var(--space-3) 0;
   flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.capture-head .backfill-h {
+  margin: 0;
+}
+.capture-hero.reading .backfill-h {
+  color: var(--aiText);
+}
+/* The badge keeps to the far end of the head, so a long title on a narrow card
+   wraps under the mark rather than around the pill. */
+.capture-head-tag {
+  margin-inline-start: auto;
+}
+/* The state's glyph on its own disc: the one place a reader's eye lands first,
+   so it is the one place the state's colour is loudest. */
+.capture-mark {
+  display: inline-grid;
+  place-items: center;
+  flex: none;
+  inline-size: 32px;
+  block-size: 32px;
+  border-radius: var(--r-full);
+  corner-shape: round;
+  background: var(--bgCard);
+  color: var(--textSecondary);
+  transition:
+    background-color var(--dur-move) var(--ease-out),
+    color var(--dur-move) var(--ease-out),
+    box-shadow var(--dur-move) var(--ease-out);
+}
+.capture-mark svg {
+  width: 18px;
+  height: 18px;
+}
+.capture-hero.reading .capture-mark {
+  background: var(--aiLight);
+  color: var(--aiText);
+  box-shadow: 0 0 0 4px var(--aiLight);
+}
+.capture-hero.done .capture-mark {
+  background: var(--successBg);
+  color: var(--success);
+}
+
+/* The three headline figures a newly-connected mailbox grows, each on its own
+   plate: a figure and its caption are one reading, and a plate is what keeps
+   three readings from running into one line of numbers. */
+.capture-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-3);
+  margin: var(--space-3) 0;
 }
 .capture-stat {
   display: grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: auto minmax(0, 1fr);
   grid-template-rows: auto auto;
   align-items: center;
-  gap: 2px var(--space-2); /* ds:ignore a figure and its caption are one reading; --space-1's 4px floor splits them */
-  min-width: 84px;
+  column-gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  corner-shape: round;
+  background: var(--bgElevated);
 }
-.capture-stat svg {
+.capture-stat-glyph {
   grid-row: 1 / 3;
-  width: 20px;
-  height: 20px;
+  display: inline-grid;
+  place-items: center;
+  inline-size: 36px;
+  block-size: 36px;
+  border-radius: var(--r-sm);
+  corner-shape: round;
+  background: var(--accentLight);
   color: var(--accentText);
+  transition:
+    background-color var(--dur-move) var(--ease-out),
+    color var(--dur-move) var(--ease-out);
 }
+.capture-stat-glyph svg {
+  width: 18px;
+  height: 18px;
+}
+.capture-hero.reading .capture-stat-glyph {
+  background: var(--aiLight);
+  color: var(--aiText);
+}
+.capture-hero.done .capture-stat-glyph {
+  background: var(--successBg);
+  color: var(--success);
+}
+/* The display face, because these three are the card's headline; tabular, so a
+   figure climbing under CountUp changes its digits without moving its caption. */
 .capture-stat-value {
-  font-family: var(--f-body);
+  font-family: var(--f-display);
   font-size: var(--fs-h1);
   line-height: var(--lh-tight);
   font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-display);
+  font-variant-numeric: tabular-nums;
   color: var(--textPrimary);
 }
-.capture-stat span {
+.capture-stat-label {
   grid-column: 2;
   font-size: var(--fs-eyebrow);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
   /* textContent, not textSecondary — clears AA over the done-state green tint. */
   color: var(--textContent);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-eyebrow);
 }
-.capture-hero progress {
-  width: 100%;
-  margin: var(--space-2) 0;
+
+/* The bar draws the fraction the line under it states in words. Its fill is
+   the AI hue outright — the bar exists only while the machine is reading. */
+.capture-bar {
+  block-size: 6px;
+  margin-top: var(--space-2);
+  border-radius: var(--r-full);
+  corner-shape: round;
+  background: var(--bgCard);
+  overflow: hidden;
+}
+.capture-bar-fill {
+  position: relative;
+  display: block;
+  block-size: 100%;
+  border-radius: var(--r-full);
+  corner-shape: round;
+  background: var(--ai);
+  overflow: hidden;
+  transition: inline-size var(--dur-move) var(--ease-out);
+}
+/* The sheen travelling along the fill is the only thing on the card that says
+   "now" rather than "so far": a poll every few seconds moves the edge in
+   steps, and between two steps a still bar and a stalled one look the same.
+   Mixed from the hue and the card's own ground so it lightens the fill in the
+   light theme and deepens it in the dark one — a sheen either way, with no
+   literal of its own. */
+.capture-bar-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--ai) 40%, var(--bgElevated)) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: capture-sheen 1.8s var(--ease-in-out) infinite;
 }
 .capture-scanned {
-  margin: var(--space-1) 0 0;
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin: var(--space-2) 0 0;
   color: var(--textContent);
+  font-variant-numeric: tabular-nums;
 }
-/* Each increment re-keys the value node, replaying this pop. */
-.capture-stat-value {
-  animation: capture-pop 0.42s ease-out;
+.capture-pct {
+  font-weight: var(--fw-semibold);
+  color: var(--aiText);
 }
 .spin-slow {
   animation: capture-spin 1.6s linear infinite;
 }
-@keyframes capture-pop {
-  0% {
-    transform: scale(0.72);
-    opacity: 0.35;
-  }
-  60% {
-    transform: scale(1.12);
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
+@keyframes capture-sheen {
+  to {
+    transform: translateX(100%);
   }
 }
 @keyframes capture-spin {
@@ -142,8 +277,14 @@
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .capture-stat-value,
+  .capture-bar-fill::after,
   .spin-slow {
     animation: none;
+  }
+  .capture-hero,
+  .capture-mark,
+  .capture-stat-glyph,
+  .capture-bar-fill {
+    transition: none;
   }
 }

--- a/frontend/src/screens/backfill.stories.tsx
+++ b/frontend/src/screens/backfill.stories.tsx
@@ -23,7 +23,14 @@ function panelStory(
   routes: Record<string, (body: unknown) => Response> = {},
 ) {
   return () => {
-    installFetchStub(routes);
+    // The poll a live run starts must answer with the same row it was seeded
+    // from: left to the stub's fallback it came back as an empty page, and a
+    // couple of seconds into the story every live variant collapsed into a
+    // finished run with no counts.
+    installFetchStub({
+      [`GET /connectors/${provider}/backfill`]: () => jsonResponse(initial),
+      ...routes,
+    });
     return (
       <StoryProviders>
         <BackfillPanel provider={provider} initial={initial} />
@@ -84,11 +91,11 @@ export const Running: Story = { render: panelStory("gmail", RUNNING) };
 
 export const Done: Story = { render: panelStory("gmail", DONE) };
 
-// The live run in dark. The bar is a bare `<progress>` element with nothing but
-// a width in the sheet, so its track and fill are whatever the browser paints —
-// the one control on these screens that does not get its colour from a token and
-// therefore cannot be reasoned about from the CSS. The stat values are `--accent`
-// on the panel ground beside it.
+// The live run in dark. The card is in the AI family here — an `--aiLight` wash
+// under the head, an `--aiMed` edge, `--aiText` glyphs and a bar filled in
+// `--ai` — and the dark theme lifts `--aiText` while the tint stays at the same
+// alpha, so this is where the title over the wash and the percentage beside the
+// bar have to be checked for contrast rather than assumed from the light run.
 export const RunningDark: Story = {
   globals: { theme: "dark" },
   render: panelStory("gmail", RUNNING),
@@ -103,9 +110,10 @@ export const DoneDark: Story = {
   render: panelStory("gmail", DONE),
 };
 
-// The live run at 390px. The counts sit in a two-column grid with an 84px floor
-// per stat and wrap outside it, and the progress bar takes the full width — this
-// is where a four-stat grid either becomes two rows or overflows the card.
+// The live run at 390px. The three stat plates auto-fit at a 150px floor, so at
+// this width they stack to one column and the head's badge wraps under the title
+// — this is where a plate either holds its figure and caption on one line or
+// overflows the card.
 export const RunningPhone: Story = {
   globals: { viewport: { value: "phone" } },
   tags: ["uat-phone"],

--- a/frontend/src/screens/backfill.test.tsx
+++ b/frontend/src/screens/backfill.test.tsx
@@ -116,7 +116,25 @@ function requestsTo(calls: Request[], suffix: string, method: string) {
   );
 }
 
+// The live figures count UP over a second of real time, and these cases are
+// about the number rather than the climb. Reduced motion renders the end state
+// at once, which is both the honest thing for the component to do and the only
+// way to assert on a figure without a test whose cost is wall-clock.
+function preferNoMotion() {
+  vi.stubGlobal("matchMedia", ((query: string) => ({
+    matches: query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia);
+}
+
 beforeEach(() => {
+  preferNoMotion();
   vi.stubGlobal("scrollTo", vi.fn());
 });
 

--- a/frontend/src/screens/backfill.tsx
+++ b/frontend/src/screens/backfill.tsx
@@ -3,9 +3,15 @@ import { Building2, CheckCircle2, History, Mail, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { Button } from "../design-system/atoms";
+import { Badge, Button } from "../design-system/atoms";
 import { ChoiceList } from "../design-system/choicelist";
-import { formatDuration, formatMoney, formatNumber } from "../format/format";
+import { CountUp } from "../design-system/countup";
+import {
+  formatDuration,
+  formatMoney,
+  formatNumber,
+  formatPercent,
+} from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -413,9 +419,11 @@ function EstimateCard({
 }
 
 // The three headline figures of a capture run — captured mail and the two
-// record kinds it grows. Each is a live persisted-row count; the value's
-// `key` changes with the number so the CSS pop fires on every increment
-// (reduced-motion users get the number without the motion).
+// record kinds it grows. Each is a live persisted-row count. While the run is
+// still reading, the figure is a `CountUp`: a number still being earned climbs
+// to where the poll put it instead of jumping there. Once the run has settled
+// it is the plain number, because a figure the server has finished with has
+// nothing left to count towards.
 const CAPTURE_STATS: {
   key: "captured" | "people_created" | "organizations_created";
   label: MessageKey;
@@ -435,19 +443,27 @@ function CaptureStat({
   label,
   icon: Icon,
   locale,
+  counting,
 }: {
   value: number;
   label: string;
   icon: typeof Mail;
   locale: Locale;
+  counting: boolean;
 }) {
   return (
     <div className="capture-stat">
-      <Icon aria-hidden />
-      <b key={value} className="capture-stat-value">
-        {formatNumber(value, locale)}
+      <span className="capture-stat-glyph" aria-hidden>
+        <Icon />
+      </span>
+      <b className="capture-stat-value">
+        {counting ? (
+          <CountUp value={value} locale={locale} />
+        ) : (
+          formatNumber(value, locale)
+        )}
       </b>
-      <span>{label}</span>
+      <span className="capture-stat-label">{label}</span>
     </div>
   );
 }
@@ -467,37 +483,33 @@ function RunView({
   const { locale } = useLocale();
   const counts = run.counts;
   const scanned = counts?.messages_scanned ?? 0;
-  const live = run.state === "running" || run.state === "queued";
+  const live = isLiveState(run.state);
   const done = run.state === "done";
+  const { stale, agoMs } = staleness(run, live);
+  // The card wears the AI family only while the machine is actually reading:
+  // indigo is a claim about who is doing the work, so a queued run that has
+  // not started and a stalled one that has stopped both stay on plain ground.
+  const reading = run.state === "running" && !stale;
   // A percentage needs a denominator that is still true. The provider-side
   // count is a FLOOR — Gmail's exact count is capped at a page budget, and a
   // multi-year window reaches that cap far more often than a 12-month one —
   // so a run can scan past its own estimate. Clamping to 100% there would
   // show a full bar for an hour while the import kept going; the honest move
   // is the absolute counts this screen already falls back to when there is no
-  // estimate at all, because at that moment there effectively is none.
+  // estimate at all, because at that moment there effectively is none. A run
+  // that is not moving forward does not get a bar that implies otherwise.
   const denominator = run.estimated_messages ?? 0;
   const fraction =
-    denominator > 0 && scanned <= denominator ? scanned / denominator : null;
-  const { stale, agoMs } = staleness(run, live);
+    live && !stale && denominator > 0 && scanned <= denominator
+      ? scanned / denominator
+      : null;
+  const heroClass = ["capture-hero", done && "done", reading && "reading"]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div className={`capture-hero${done ? " done" : ""}`} aria-live="polite">
-      <h3 className="backfill-h">
-        {done ? (
-          <>
-            <CheckCircle2 aria-hidden /> {t("backfill.doneTitle")}
-          </>
-        ) : (
-          <>
-            <History
-              aria-hidden
-              className={live && !stale ? "spin-slow" : ""}
-            />{" "}
-            {t(stateTitle(run.state))}
-          </>
-        )}
-      </h3>
+    <div className={heroClass}>
+      <RunHead state={run.state} reading={reading} />
       <div className="capture-stats">
         {CAPTURE_STATS.map((stat) => (
           <CaptureStat
@@ -506,18 +518,15 @@ function RunView({
             label={t(stat.label)}
             icon={stat.icon}
             locale={locale}
+            counting={reading}
           />
         ))}
       </div>
       <RunProgress
-        live={live}
-        stale={stale}
+        scanned={scanned}
         fraction={fraction}
-        agoMs={agoMs}
+        staleForMs={stale ? agoMs : null}
       />
-      <p className="t-small capture-scanned">
-        {t("backfill.countScanned")} {formatNumber(scanned, locale)}
-      </p>
       {run.state === "error" && (
         <p className="t-small backfill-error">
           {t("backfill.errorNote")}
@@ -541,36 +550,97 @@ function RunView({
   );
 }
 
-// Either the live progress bar or the staleness note, never both: a run that
-// isn't moving forward doesn't get to keep the bar that implies otherwise.
-function RunProgress({
-  live,
-  stale,
-  fraction,
-  agoMs,
+// The state's glyph on its disc, the title, and — only while the machine is
+// reading — the pill that says so in words, because the indigo the card wears
+// then is a claim about who is doing the work and colour is never the only
+// signal.
+function RunHead({
+  state,
+  reading,
 }: {
-  live: boolean;
-  stale: boolean;
+  state: BackfillStatus["state"];
+  reading: boolean;
+}) {
+  const t = useT();
+  return (
+    <div className="capture-head" aria-live="polite">
+      <span className="capture-mark" aria-hidden>
+        {state === "done" ? (
+          <CheckCircle2 />
+        ) : (
+          <History className={reading ? "spin-slow" : ""} />
+        )}
+      </span>
+      <h3 className="backfill-h">{t(stateTitle(state))}</h3>
+      {reading && (
+        <span className="capture-head-tag">
+          <Badge tone="ai">{t("backfill.readingBadge")}</Badge>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Either the bar or the staleness note over the scanned line, never both: a run
+// that is not moving forward does not get to keep the bar that implies
+// otherwise. The percentage rides the line only when the bar is drawn — the two
+// state one number twice, in a shape and in words.
+function RunProgress({
+  scanned,
+  fraction,
+  staleForMs,
+}: {
+  scanned: number;
   fraction: number | null;
-  agoMs: number;
+  // How long a live run has gone without moving, or null while it moves.
+  staleForMs: number | null;
 }) {
   const t = useT();
   const { locale } = useLocale();
-  if (stale) {
-    return (
-      <p className="t-small backfill-stale">
-        {t("backfill.staleUpdated", {
-          duration: formatDuration(agoMs, locale),
-        })}
+  return (
+    <>
+      {staleForMs !== null && (
+        <p className="t-small backfill-stale">
+          {t("backfill.staleUpdated", {
+            duration: formatDuration(staleForMs, locale),
+          })}
+        </p>
+      )}
+      {fraction !== null && <RunBar fraction={fraction} />}
+      <p className="t-small capture-scanned" aria-live="polite">
+        <span>
+          {t("backfill.countScanned")} {formatNumber(scanned, locale)}
+        </span>
+        {fraction !== null && (
+          <span className="capture-pct">{formatPercent(fraction, locale)}</span>
+        )}
       </p>
-    );
-  }
-  if (fraction !== null && live) {
-    return (
-      <progress value={fraction} aria-label={t("backfill.progressLabel")} />
-    );
-  }
-  return null;
+    </>
+  );
+}
+
+// The bar draws the fraction the line under it states in words, and exposes
+// the same number to assistive tech through the progressbar role rather than
+// through a native `<progress>`, whose track and fill are the browser's colours
+// and the one thing on this card no token could reach.
+function RunBar({ fraction }: { fraction: number }) {
+  const t = useT();
+  const percent = Math.round(fraction * 100);
+  return (
+    <div
+      className="capture-bar"
+      role="progressbar"
+      aria-label={t("backfill.progressLabel")}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percent}
+    >
+      <span
+        className="capture-bar-fill"
+        style={{ inlineSize: `${percent}%` }}
+      />
+    </div>
+  );
 }
 
 function stateTitle(state: BackfillStatus["state"]): MessageKey {


### PR DESCRIPTION
## What

The history-import card in Settings → Connections drew a live run as a grey `<progress>` bar and three loose numbers. While Margince is reading a mailbox it now wears the product's AI family: an `--aiLight` wash under the head, an `--aiMed` edge, the glyph and title in `--aiText`, a "Margince is reading" badge beside the title, and a tokenized progress bar filled in `--ai` with a travelling sheen. The three figures sit on their own plates in the display face and climb through `CountUp` while the run is live; the percentage the bar draws is also stated beside the scanned count.

The indigo holds only while the machine is actually reading. A queued, stalled, failed or cancelled run stays on plain ground, and a finished one keeps its arrival in the success family.

## Why

Indigo is the product's one mark of machine authorship (`design-system/README.md`, "Indigo says a machine did it"), and a mailbox import is exactly that: every figure on the card was put there by the machine reading mail. Outcome is not provenance, so the light goes out when the reading stops. The bare `<progress>` was the one control on the card whose colours no token could reach; it is a `progressbar`-role element now, with the same label and the fraction exposed as `aria-valuenow`.

Fixed along the way: the Storybook stories' fetch stub answered a live run's first poll with the fallback's empty page, so every live variant collapsed into a finished run with no counts a couple of seconds in. `panelStory` now routes that GET to the seeded row.

## How verified

- `pnpm exec tsc --noEmit`, `pnpm lint` (the one warning and three infos are in files this change does not touch)
- `pnpm exec vitest run` — 582 of 583 files green; `worklist.email.test.tsx` timed out under full-suite load and passes in isolation, and this change does not touch it
- DS gates: `check-ds-purity`, `check-ds-spacing`, `check-ds-spacing-roles`, `check-space-tokens`, `check-font-lock`, `check-icon-glyph` all PASS; `conformance.test.ts` (reduced-motion coverage of the new infinite sheen), `catalog.test.ts`, `i18n.test.ts` (key parity for the new badge string in en/de/vi) green
- Rendered the `Running`, `RunningDark`, `RunningPhone`, `Done`, `Stale` and `Setup` stories in Storybook via Playwright and checked them by eye: light, dark, 390px stacking, and that the setup view is unchanged
- The backend is untouched, so `make check`'s Go half and `make test-integration` were not run

- [x] frontend half of `make check` is green (see above)
- [x] `make test-integration` — this change does not touch tenant data / RLS / the write shape
- [x] `make craft-static` — no Go files changed
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

The whole change was AI-generated from a screenshot and a one-line request, against the design-system catalog and the indigo provenance rule, and reviewed by rendering the stories.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKB4PPQZXqjXGdUaGGa3ub

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKB4PPQZXqjXGdUaGGa3ub)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The live mail-import card now wears the AI/indigo family while Margince is reading, and keeps plain styling for queued, stalled, failed, or cancelled runs.

- While a run is live, the card gets the indigo wash, edge, glyph, and title, a "Margince is reading" badge, and a tokenized progress bar with a travelling sheen.
- The bar is now a `progressbar`-role element so its colors come from tokens, and the percentage is stated beside the scanned count.
- The three headline figures sit on plates in the display face and climb via `CountUp`; once the run settles they render as plain numbers.
- Fixed the Storybook fetch stub so live-run stories no longer collapse into a finished run a few seconds in.
- Tests stub reduced motion to assert on final counts without waiting on the animation.
- Added the reading badge string to en, de, and vi.

<sup>Written for commit babc93c51824288e58a1aa381869e5abb93a7a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

