### PR TITLE
fix(shell): the sidebar's tooltips stay above the page

### DIFF
--- a/frontend/src/app/chrome-layering.test.ts
+++ b/frontend/src/app/chrome-layering.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { withoutComments } from "../testing/css";
+
+// Fitness function for the chrome disappearing behind the page.
+//
+// The shell is two boxes side by side: the sidebar and the work column. The
+// sidebar's collapsed tooltips hang PAST its right edge, over the column — the
+// only part of the chrome that overlaps the page at all, and therefore the one
+// place a layering mistake shows.
+//
+// It showed. Screens stack freely inside their own column — the list table
+// alone declares 1 for its sticky header, 2 for the frozen identity column, 3
+// for that column's shade and 20 for a menu — and while the column formed no
+// stacking context, those numbers were not internal at all: they competed in
+// the ROOT context against the sidebar's 2, where the column, being later in
+// the tree, won every tie. A rail tooltip was cut off at the table's left edge,
+// behind the frozen column, on every list screen in the product.
+//
+// The fix is an invariant with two ends, and either end alone is green while
+// the defect is on screen: `.main` isolates, so a screen's layers stay the
+// screen's, and the sidebar takes a layer above the column's own. This holds
+// both, and reads the numbers from the sheet rather than repeating them —
+// a gate that carries its own copy of its subject stops being a gate the day
+// somebody restyles the real thing.
+//
+// WHAT IT CANNOT SEE, deliberately:
+//
+//   - Paint. It reads what the sheet declares; no test in this suite renders a
+//     stacking context, because jsdom applies no stylesheet. What decays here
+//     is the SPELLING of the rule, which is what actually went missing.
+//   - Anything portalled to `document.body` — a select popup, a dialog, the
+//     design system's own tooltip. Those leave the column altogether and are
+//     layered against the stack in design-system/, not against this one.
+//   - A new sibling of `.main` inside `.app` given a layer of its own. There is
+//     no census of siblings here; there are three, and they are in shell.tsx.
+
+const shellSheet = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "shell.css",
+);
+
+type Rule = Readonly<{
+  /** The selectors this block is declared against, one per entry. */
+  selectors: readonly string[];
+  body: string;
+  /** Inside an `@media` or `@supports`, rather than at the top level. */
+  nested: boolean;
+}>;
+
+/**
+ * Every innermost rule block in a stylesheet.
+ *
+ * Innermost is what the pattern matches — a prelude and a body that contain no
+ * braces of their own — and a block inside a media query is innermost too. That
+ * is the half a scan loses first: this sheet declares the sidebar TWICE, once
+ * as a desktop column and once as a phone bar inside `@media`, and a scan that
+ * stopped at the top level would read one of the two layers and pass.
+ */
+function rules(css: string): Rule[] {
+  const text = withoutComments(css);
+  const found: Rule[] = [];
+  for (const match of text.matchAll(/([^{}]*)\{([^{}]*)\}/g)) {
+    found.push({
+      selectors: match[1]
+        .split(",")
+        .map((one) => one.trim().replace(/\s+/g, " "))
+        .filter(Boolean),
+      body: match[2],
+      nested: openBlocks(text.slice(0, match.index)) > 0,
+    });
+  }
+  return found;
+}
+
+function openBlocks(before: string): number {
+  let depth = 0;
+  for (const character of before) {
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+    }
+  }
+  return depth;
+}
+
+function declared(rule: Rule, property: string): string | undefined {
+  const match = new RegExp(`(?:^|[;{\\s])${property}\\s*:\\s*([^;}]+)`).exec(
+    rule.body,
+  );
+  return match?.[1].trim();
+}
+
+/**
+ * The layer a rule sits on. An element with no `z-index` is `auto`, which
+ * against a positive layer loses exactly as 0 does — the question this asks is
+ * only ever "does the chrome outrank it".
+ */
+function layer(rule: Rule): number {
+  const value = declared(rule, "z-index");
+  return value === undefined ? 0 : Number(value);
+}
+
+const sheet = readFileSync(shellSheet, "utf8");
+const shell = rules(sheet);
+const workColumn = shell.filter((rule) => rule.selectors.includes(".main"));
+// The panel itself in either state, not the rows and tooltips inside it: those
+// are layered within whatever context the panel makes, which is the point.
+const sidebar = shell.filter((rule) =>
+  rule.selectors.some((one) => /^\.rail(\.(collapsed|expanded))?$/.test(one)),
+);
+
+describe("the work column never paints over the chrome", () => {
+  // A census that fails short reports PASS over a sheet it could not read, and
+  // there is no failing assertion to notice. Both boxes are named, and the
+  // sidebar is asserted to have been found on BOTH layouts — the phone one
+  // lives inside a media query, so this is also what proves the scan descends
+  // into at-rules.
+  it("finds both boxes, on both layouts", () => {
+    expect(workColumn.length).toBeGreaterThanOrEqual(1);
+    expect(
+      sidebar.filter((rule) => !rule.nested).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      sidebar.some((rule) => rule.nested && declared(rule, "z-index")),
+      "the scan did not reach the phone bar's layer inside its media query",
+    ).toBe(true);
+  });
+
+  it("isolates the column, so a screen's layers stay the screen's", () => {
+    expect(
+      workColumn.map((rule) => declared(rule, "isolation")),
+      "`.main` must form a stacking context: without one, a sticky table header " +
+        "and a rail tooltip are two numbers in the SAME context, and the column " +
+        "wins the tie by being later in the tree",
+    ).toContain("isolate");
+  });
+
+  it("gives the sidebar a layer above the column's", () => {
+    const column = Math.max(...workColumn.map(layer));
+    const layers = sidebar
+      .filter((rule) => declared(rule, "z-index"))
+      .map(layer);
+    expect(layers.length).toBeGreaterThanOrEqual(2);
+    for (const above of layers) {
+      expect(above).toBeGreaterThan(column);
+    }
+  });
+
+  // `z-index` on a static element is inert, and inert in the quietest way: the
+  // declaration is right there in the sheet for the next reader to trust.
+  it("positions the sidebar, so its layer is not inert", () => {
+    for (const rule of sidebar.filter((one) => declared(one, "z-index"))) {
+      expect(declared(rule, "position")).not.toBe("static");
+      expect(declared(rule, "position")).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -180,6 +180,17 @@
   /* The agent dock stands at the foot of THIS column rather than of the
      viewport, so the column is what it is positioned against. */
   position: relative;
+  /* The column's layering is the column's own business. Screens stack plenty
+     inside it — the list table alone declares 1 for a sticky header, 2 for the
+     frozen identity column, 3 for its shade and 20 for a menu — and with no
+     stacking context here every one of those numbers competed in the ROOT
+     context against the sidebar's, where the column, being later in the tree,
+     won each tie. What that looked like: a collapsed rail's tooltip cut off at
+     the table's left edge, behind the frozen column, on every list screen.
+     `isolation`, not a z-index of its own: it makes the context WITHOUT making
+     this element a containing block, so the fixed-position descendants the note
+     below is about are still laid out against the viewport. */
+  isolation: isolate;
   /* No `contain: layout` here, tempting as it is for the collapse animation's
      relayout cost: containment makes this element the containing block for every
      fixed-position descendant. The overlays are portalled to the body and so are
@@ -355,8 +366,12 @@
 .rail.collapsed {
   overflow: visible;
   /* Above the work column it is a sibling of: the tooltips below hang past the
-     rail's right edge, and the column, painted later with its own stacking
-     context, covered them. A tooltip behind the page is one nobody reads. */
+     rail's right edge, and the column is later in the tree, so it covers
+     whatever it ties with. A tooltip behind the page is one nobody reads.
+     Two is only above the column's own box; what puts it above everything the
+     column CONTAINS is `.main`'s `isolation: isolate`, which keeps a screen's
+     sticky layers from ever reaching this context. The pair is one invariant
+     and is held from both ends by app/chrome-layering.test.ts. */
   position: relative;
   z-index: 2;
 }

--- a/frontend/src/design-system/corners.test.ts
+++ b/frontend/src/design-system/corners.test.ts
@@ -40,6 +40,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { withoutComments } from "../testing/css";
 
 const frontendRoot = resolve(__dirname, "..", "..");
 const tokensFile = join(frontendRoot, "src", "design-system", "tokens.css");
@@ -211,17 +212,6 @@ function namedRungs(text: string, rungs: Set<string>): string[] {
     }
   }
   return out;
-}
-
-/**
- * The same text with every comment blanked to spaces of its own length. A
- * commented-out declaration declares nothing, and offsets are worth keeping:
- * the in-line waiver lives in a comment of its own, read from the original.
- */
-function withoutComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, (comment) =>
-    " ".repeat(comment.length),
-  );
 }
 
 /**

--- a/frontend/src/design-system/onecard.test.ts
+++ b/frontend/src/design-system/onecard.test.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { withoutComments } from "../testing/css";
 
 // `Card` is the one card surface, and a hand-rolled one is a second card the
 // moment any of its chrome moves — which is not a warning, it is a description
@@ -48,12 +49,6 @@ function stylesheets(dir: string): string[] {
 
 /** One `selector { … }` rule, as written. */
 type Rule = Readonly<{ selector: string; body: string }>;
-
-/** CSS comments are not rules, and one sitting above a rule was being read as
- * its selector. */
-function withoutComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
 
 function rules(css: string): Rule[] {
   const found: Rule[] = [];

--- a/frontend/src/testing/css.ts
+++ b/frontend/src/testing/css.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/**
+ * What a stylesheet DECLARES, for the gates that read one.
+ *
+ * Every CSS gate in this tree opens with the same problem: the property it
+ * hunts for appears in the paragraph explaining the rule at least as often as
+ * in the rule, and a commented-out declaration declares nothing. Three of them
+ * were each carrying their own copy of the answer.
+ */
+
+/**
+ * The same text with every comment blanked to spaces of its own length.
+ *
+ * Blanked rather than deleted, so every offset into the result still points at
+ * the same character of the original: a gate that reads an in-line waiver finds
+ * it in the comment beside the declaration, which it can only do while the two
+ * texts still line up.
+ */
+export function withoutComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, (comment) =>
+    " ".repeat(comment.length),
+  );
+}


### PR DESCRIPTION
## What

A collapsed sidebar's tooltip no longer disappears behind the table beside it. `.main` now forms its own stacking context, so the layers a screen raises inside the work column stay inside it.

## Why

The sidebar and the work column are siblings, and the collapsed rail's tooltips are the one piece of chrome that overlaps the page — they hang past the rail's 56px box, over the column.

The column formed no stacking context, so nothing inside it was internal: the list table's sticky header (1), frozen identity column (2), that column's shade (3) and its menus (20) all competed in the ROOT context against `.rail.collapsed`'s 2, and the column — later in the tree — won every tie. A tooltip was cut off at exactly the table's left edge, behind the frozen column, on every list screen.

The invariant: **nothing rendered inside the work column paints over the chrome.** It has two ends — the column isolates, and the sidebar takes a layer above it — and either end alone is green while the defect is on screen, which is why the gate holds both.

`isolation: isolate` rather than a z-index of the column's own: it makes the stacking context without making the element a containing block, so the fixed-position descendants that `.main`'s existing "no `contain: layout` here" note protects are laid out against the viewport exactly as before.

Two latent siblings of the same defect go with it: the capture chip (55) and a screen's popovers (30) could reach over the phone layout's bottom navigation bar (30) for the same reason.

## How verified

- Paint order in real Chromium, over the actual stylesheets, using the shell's own markup — `document.elementFromPoint` at the tooltip's right edge returns `lt-identity` before the change and `navtip` after. That is the reported symptom and its absence.
- `frontend/src/app/chrome-layering.test.ts` (new): reads `shell.css` and holds both ends — the column isolates, the sidebar's layers are above the column's, and each of those layers sits on a positioned element (a `z-index` on a static box is inert in the quietest way). The numbers are read from the sheet rather than repeated in the test. Confirmed to fail with either end removed, one at a time. It carries its own note on what it cannot see: paint, anything portalled to the body, and a new sibling of `.main`.
- `withoutComments` was already written twice in this tree (`onecard.test.ts`, `corners.test.ts`) and this gate needs it a third time, so it moves to `src/testing/css.ts` and both callers now import it.
- `make fe-ds-gates`, `pnpm lint`, `tsc --noEmit` green locally; `fe-unit`, `fe-quality`, `fe-bundle` and `live-boot` green in CI.

Noted in passing, not fixed here: on a newer ICU than CI's runner (Node 22 / ICU 78) two tests in `screens/home.readings.test.tsx` fail, because `formatMoneyCompact` sets `maximumFractionDigits` without `minimumFractionDigits` — the currency's default minimum of 2 survives and is clamped to one digit, so €420,000 reads `€420.0k` there and `€420k` on CI. Same code either way; it is not this diff, and a money-format change belongs in its own PR with its own gates.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers (no Go in this diff)
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code: the diagnosis, the CSS change, the gate, and the helper extraction. The Chromium paint-order probe was written and run to confirm the diagnosis rather than to assume it.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYLYYxpFAzNk7AL1An28GE