### PR TITLE
Three capture passes collapse: classify, owed verdict and enrich

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -294,66 +294,32 @@ kinds:
       "unreachable".
 
   capture_classify:
-    role: dispatcher
+    role: worker
     go_type: CaptureClassifyArgs
     queue: default
-    timeout: 2m
+    timeout: 15m
     opts_owner: caller
     cadence: 1h
     registration: {when: [ClassifyBrain], absent: registers_nothing}
-    fans_out_to: capture_classify_workspace
-    fan_out_unit: workspace
     reason: >-
       An hourly catch-up (ADR-0063). The nightly suite reruns the same engine,
       so this pass exists to shorten the wait rather than to be the only run;
       the backlog index makes a caught-up tenant one cheap probe.
 
-  capture_classify_workspace:
-    role: worker
-    go_type: CaptureClassifyWorkspaceArgs
-    queue: ai_capture
-    timeout: 15m
-    max_attempts: 3
-    opts_owner: fan_out
-    registration: {when: [ClassifyBrain], absent: registers_nothing}
-    args:
-      Workspace: id
-    reason: >-
-      Up to fifty serial model calls (classifyCatchUpCap 500 labels, ten
-      messages per prompt). The engine commits per batch, so the cap decides how
-      much one hourly tick drains rather than whether work is lost — and it is
-      what keeps a hung model lane from holding one of two ai_capture workers.
 
   owed_verdict:
-    role: dispatcher
+    role: worker
     go_type: OwedVerdictArgs
     queue: default
-    timeout: 2m
+    timeout: 15m
     opts_owner: caller
     cadence: 1h
     registration: {when: [OwedBrain], absent: registers_nothing}
-    fans_out_to: owed_verdict_workspace
-    fan_out_unit: workspace
     reason: >-
       Hourly, like the capture-label pass it is modelled on, and for the same
       reason: the backlog is a query, so a caught-up tenant costs one cheap
       probe and a busy one gets its answer inside the hour a rep is working.
 
-  owed_verdict_workspace:
-    role: worker
-    go_type: OwedVerdictWorkspaceArgs
-    queue: ai_capture
-    timeout: 15m
-    max_attempts: 3
-    opts_owner: fan_out
-    registration: {when: [OwedBrain], absent: registers_nothing}
-    args:
-      Workspace: id
-    reason: >-
-      Up to fifty serial model calls (owedCatchUpCap 500 verdicts, ten messages
-      per prompt) — the same shape and the same bound as the capture-label
-      worker beside it. The engine commits per batch, so the cap decides how
-      much one tick drains rather than whether work is lost.
 
   capture_counterparty_verdict:
     role: dispatcher
@@ -554,33 +520,17 @@ kinds:
       failed is retried with the rest, and the day uniqueness makes that safe.
 
   capture_enrich:
-    role: dispatcher
+    role: worker
     go_type: CaptureEnrichArgs
     queue: default
-    timeout: 2m
+    timeout: 20m
     opts_owner: caller
     cadence: 24h
     registration: {when: [EnrichBrain], absent: registers_nothing}
-    fans_out_to: capture_enrich_workspace
-    fan_out_unit: workspace
     reason: >-
       Daily — the ADR-0063 nightly cadence rides this job until the nightly
       dispatcher lands.
 
-  capture_enrich_workspace:
-    role: worker
-    go_type: CaptureEnrichWorkspaceArgs
-    queue: ai_capture
-    timeout: 20m
-    max_attempts: 3
-    opts_owner: fan_out
-    registration: {when: [EnrichBrain], absent: registers_nothing}
-    args:
-      Workspace: id
-    reason: >-
-      One model call per candidate signature, up to enrichPassLimit (100) in
-      series — more calls than the classify pass makes, though each is smaller.
-      The nightly cycle picks up whatever a stopped pass did not reach.
 
   capture_sync:
     role: worker

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -92,11 +92,6 @@ func (g *CaptureEnrichTrigger) HandleEvent(ctx context.Context, env events.Envel
 	if time.Since(env.OccurredAt) > captureEnrichFreshWindow {
 		return nil
 	}
-	// The envelope carries no tenant (ADR-0091 §6); the store's handle names it.
-	ws, err := InstallationDB(g.pool).Workspace(ctx)
-	if err != nil {
-		return err
-	}
 	// The uniqueness is the flood bound: a mailbox sync lands hundreds of
 	// messages in seconds, and without it each one would put its own row on
 	// the ai_capture queue. ByArgs over the active states collapses the burst
@@ -107,10 +102,17 @@ func (g *CaptureEnrichTrigger) HandleEvent(ctx context.Context, env events.Envel
 	// mid-pass can dedupe against a pass that already listed its candidates,
 	// and then waits for the nightly run. The alternative — no uniqueness —
 	// trades that bounded promptness miss for an unbounded queue, which is
-	// worse. Same args and states as the fleet dispatcher's insert, so the two
-	// doors dedupe against each other rather than stacking.
-	child := CaptureEnrichWorkspaceArgs{Workspace: ws.UUID}
-	opts := oneOffChildOpts(child.Kind())
+	// worse. Same states as the scheduled tick's own insert, so the two doors
+	// dedupe against each other rather than stacking.
+	//
+	// The PASS, not a per-workspace child: the child kind went with the
+	// fan-out (ADR-0103). Its args carried the workspace, so ByArgs collapsed a
+	// burst onto the pass queued for THAT workspace; the pass carries none, so
+	// the same dedupe now collapses onto the one pending pass — which is what a
+	// flood bound wanted, and what it already meant on an installation with a
+	// single workspace.
+	child := CaptureEnrichArgs{}
+	opts := oneOffPassOpts(child.Kind())
 	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
 	return g.enqueue.Enqueue(ctx, child, opts)
 }

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // CaptureClassifyArgs runs one catch-up classify pass (ADR-0063; §2.8).
@@ -35,41 +36,22 @@ func (CaptureClassifyArgs) Kind() string { return "capture_classify" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (CaptureClassifyArgs) FleetWide() {}
 
-// captureClassifyWorker is the dispatcher for the label pass.
-type captureClassifyWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *captureClassifyWorker) Work(ctx context.Context, _ *river.Job[CaptureClassifyArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(CaptureClassifyWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return CaptureClassifyWorkspaceArgs{Workspace: ws} }))
-}
-
-// CaptureClassifyWorkspaceArgs is one workspace's catch-up label pass.
-type CaptureClassifyWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (CaptureClassifyWorkspaceArgs) Kind() string { return "capture_classify_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a CaptureClassifyWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// captureClassifyWorkspaceWorker drives the batched label engine for one
+// captureClassifyWorker drives the batched label engine for every live
 // workspace; the engine commits per model call, so a mid-pass crash or budget
 // stop loses nothing and the next tick resumes from the shrunken backlog.
-type captureClassifyWorkspaceWorker struct {
+//
+// One worker where there were two (ADR-0103).
+type captureClassifyWorker struct {
+	pool       *pgxpool.Pool
 	classifier *CaptureClassifier
 }
 
-func (w *captureClassifyWorkspaceWorker) Work(ctx context.Context, job *river.Job[CaptureClassifyWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	return jobs.FaultContext(ctx, w.classifier.RunWorkspace(wsCtx, 0))
+func (w *captureClassifyWorker) Work(ctx context.Context, _ *river.Job[CaptureClassifyArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.classifyWorkspace))
+}
+
+func (w *captureClassifyWorker) classifyWorkspace(ctx context.Context, workspace ids.UUID) error {
+	return w.classifier.RunWorkspace(principal.WithWorkspaceID(ctx, workspace), 0)
 }
 
 // CaptureEnrichArgs runs one signature-enrich pass (ADR-0063; §2.9).
@@ -82,47 +64,29 @@ func (CaptureEnrichArgs) Kind() string { return "capture_enrich" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (CaptureEnrichArgs) FleetWide() {}
 
-// captureEnrichWorker is the dispatcher for the signature-enrich pass.
+// captureEnrichWorker drives the evidence-gated signature pass for every live
+// workspace; every accepted field is auditable back to its verbatim signature
+// line.
+//
+// One worker where there were two (ADR-0103).
 type captureEnrichWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *captureEnrichWorker) Work(ctx context.Context, _ *river.Job[CaptureEnrichArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(CaptureEnrichWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return CaptureEnrichWorkspaceArgs{Workspace: ws} }))
-}
-
-// CaptureEnrichWorkspaceArgs is one workspace's signature-enrich pass.
-type CaptureEnrichWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (CaptureEnrichWorkspaceArgs) Kind() string { return "capture_enrich_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a CaptureEnrichWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// captureEnrichWorkspaceWorker drives the evidence-gated signature pass for
-// one workspace; every accepted field is auditable back to its verbatim
-// signature line.
-type captureEnrichWorkspaceWorker struct {
+	pool     *pgxpool.Pool
 	enricher *CaptureEnricher
 	log      *slog.Logger
 }
 
-func (w *captureEnrichWorkspaceWorker) Work(ctx context.Context, job *river.Job[CaptureEnrichWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *captureEnrichWorker) Work(ctx context.Context, _ *river.Job[CaptureEnrichArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.enrichWorkspace))
+}
+
+func (w *captureEnrichWorker) enrichWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
 	filled, err := w.enricher.RunWorkspace(wsCtx)
 	if err != nil {
-		return jobs.FaultContext(ctx, err)
+		return err
 	}
 	if filled {
-		w.enqueueContinuation(wsCtx, job.Args)
+		w.enqueueContinuation(wsCtx, workspace)
 	}
 	return nil
 }
@@ -139,17 +103,23 @@ func (w *captureEnrichWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 // the ByArgs/active-state uniqueness the trigger uses would dedupe the
 // continuation against its own still-running parent and drop it silently —
 // which is precisely the case this exists to fix.
-func (w *captureEnrichWorkspaceWorker) enqueueContinuation(ctx context.Context, args CaptureEnrichWorkspaceArgs) {
+// It queues the PASS, which the collapse made the only kind there is: the
+// continuation used to name one workspace and now re-runs the walk. On an
+// installation with a single workspace — the only shape the product supports
+// (identity.InstallationWorkspace refuses more) — that is the same work. On a
+// fleet it would re-visit the workspaces that did not fill their limit, and
+// each of those is a cheap no-op read against a backlog it just emptied.
+func (w *captureEnrichWorker) enqueueContinuation(ctx context.Context, workspace ids.UUID) {
 	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
 	if err != nil {
 		w.log.WarnContext(ctx, "signature enrich: no River client in context, so the continuation was not enqueued",
-			"workspace", args.Workspace.String(), "err", err)
+			"workspace", workspace.String(), "err", err)
 		return
 	}
-	if _, err := client.Insert(ctx, CaptureEnrichWorkspaceArgs{Workspace: args.Workspace},
-		oneOffChildOpts(CaptureEnrichWorkspaceArgs{}.Kind())); err != nil {
+	if _, err := client.Insert(ctx, CaptureEnrichArgs{},
+		oneOffPassOpts(CaptureEnrichArgs{}.Kind())); err != nil {
 		w.log.WarnContext(ctx, "signature enrich: continuation enqueue failed",
-			"workspace", args.Workspace.String(), "err", err)
+			"workspace", workspace.String(), "err", err)
 	}
 }
 

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -112,7 +112,7 @@ func TestWorkspaceSweepOptsTagsEveryFanOutChild(t *testing.T) {
 // for every fan-out child, and by ARGS because one workspace's job is
 // otherwise indistinguishable from another's.
 func TestWorkspaceSweepOptsDedupesByArgsOnActiveStates(t *testing.T) {
-	opts := workspaceSweepOpts(CaptureClassifyWorkspaceArgs{}.Kind())
+	opts := workspaceSweepOpts(CaptureSyncArgs{}.Kind())
 
 	if !opts.UniqueOpts.ByArgs {
 		t.Fatal("uniqueness must be by args, or one workspace's job is indistinguishable from another's — the whole fleet would collapse to one queued child")
@@ -346,7 +346,7 @@ func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
 // uniqueness window would change how the fleet is enqueued in order to
 // describe it, which is the one thing an observability change may not do.
 func TestTheFanOutTagCarriesTheCallersEnqueuePolicyThrough(t *testing.T) {
-	opts := workspaceSweepOpts(CaptureClassifyWorkspaceArgs{}.Kind())
+	opts := workspaceSweepOpts(CaptureSyncArgs{}.Kind())
 	marked := markedAsFleetPass(opts)
 
 	if marked.Queue != opts.Queue {

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "2214e01dba3aab6b7b75e9c383c179f54d84e55cc2a0d1efdba99a1136ef4cfe"
+const jobContractHash = "3a3de981a308bca94bf2152717dd8481adf56a1153bb0135d79e3d0f185afcec"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -39,7 +39,6 @@ type declaredJobArgs interface {
 		CaptureAutoEnrichSweepArgs |
 		CaptureBackfillArgs |
 		CaptureClassifyArgs |
-		CaptureClassifyWorkspaceArgs |
 		ConfidentialityVerdictArgs |
 		ConfidentialityVerdictWorkspaceArgs |
 		CounterpartyVerdictArgs |
@@ -47,7 +46,6 @@ type declaredJobArgs interface {
 		CaptureDigestArgs |
 		CaptureDigestWorkspaceArgs |
 		CaptureEnrichArgs |
-		CaptureEnrichWorkspaceArgs |
 		CaptureSyncArgs |
 		CaptureTraceSweepArgs |
 		CaptureTraceSweepWorkspaceArgs |
@@ -90,7 +88,6 @@ type declaredJobArgs interface {
 		OverlayReconcileWorkspaceArgs |
 		OverlayRefetchArgs |
 		OwedVerdictArgs |
-		OwedVerdictWorkspaceArgs |
 		ParticipantBackfillArgs |
 		ParticipantBackfillWorkspaceArgs |
 		PrivacyRetentionArgs |
@@ -150,11 +147,9 @@ func addDeclaredWorkerWithTimeout[T declaredJobArgs](reg *jobRegistry, w jobs.Wo
 var (
 	_ jobs.FleetWide = AssuranceSweepArgs{}
 	_ jobs.FleetWide = BriefGenerateArgs{}
-	_ jobs.FleetWide = CaptureClassifyArgs{}
 	_ jobs.FleetWide = ConfidentialityVerdictArgs{}
 	_ jobs.FleetWide = CounterpartyVerdictArgs{}
 	_ jobs.FleetWide = CaptureDigestArgs{}
-	_ jobs.FleetWide = CaptureEnrichArgs{}
 	_ jobs.FleetWide = CaptureTraceSweepArgs{}
 	_ jobs.FleetWide = CloseDateSweepArgs{}
 	_ jobs.FleetWide = FollowUpReconcileArgs{}
@@ -168,7 +163,6 @@ var (
 	_ jobs.FleetWide = LinkedInRematchArgs{}
 	_ jobs.FleetWide = OrgNamePromotionArgs{}
 	_ jobs.FleetWide = OverlayReconcileArgs{}
-	_ jobs.FleetWide = OwedVerdictArgs{}
 	_ jobs.FleetWide = ParticipantBackfillArgs{}
 	_ jobs.FleetWide = ProviderLookupSweepArgs{}
 	_ jobs.FleetWide = ProviderRunPollSweepArgs{}
@@ -186,11 +180,9 @@ var (
 	_ jobs.WorkspaceScoped = AssuranceWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = BriefGenerateWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureBackfillArgs{}
-	_ jobs.WorkspaceScoped = CaptureClassifyWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ConfidentialityVerdictWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CounterpartyVerdictWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureDigestWorkspaceArgs{}
-	_ jobs.WorkspaceScoped = CaptureEnrichWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureSyncArgs{}
 	_ jobs.WorkspaceScoped = CaptureTraceSweepWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CheckOrganizationVatArgs{}
@@ -212,7 +204,6 @@ var (
 	_ jobs.WorkspaceScoped = OrgNamePromotionWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = OverlayReconcileWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = OverlayRefetchArgs{}
-	_ jobs.WorkspaceScoped = OwedVerdictWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ParticipantBackfillWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ProviderLookupArgs{}
 	_ jobs.WorkspaceScoped = ProviderRunPollArgs{}

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -102,22 +102,22 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 	}
 
 	if cfg.ClassifyBrain != nil {
-		addDeclaredWorker[CaptureClassifyArgs](reg, &captureClassifyWorker{pool: pool})
-		addDeclaredWorker[CaptureClassifyWorkspaceArgs](reg, &captureClassifyWorkspaceWorker{
+		addDeclaredWorker[CaptureClassifyArgs](reg, &captureClassifyWorker{
+			pool:       pool,
 			classifier: NewCaptureClassifier(pool, cfg.ClassifyBrain, log),
 		})
 	}
 
 	if cfg.OwedBrain != nil {
-		addDeclaredWorker[OwedVerdictArgs](reg, &owedVerdictWorker{pool: pool})
-		addDeclaredWorker[OwedVerdictWorkspaceArgs](reg, &owedVerdictWorkspaceWorker{
+		addDeclaredWorker[OwedVerdictArgs](reg, &owedVerdictWorker{
+			pool:       pool,
 			classifier: NewOwedClassifier(pool, cfg.OwedBrain, nil, log),
 		})
 	}
 
 	if cfg.EnrichBrain != nil {
-		addDeclaredWorker[CaptureEnrichArgs](reg, &captureEnrichWorker{pool: pool})
-		addDeclaredWorker[CaptureEnrichWorkspaceArgs](reg, &captureEnrichWorkspaceWorker{
+		addDeclaredWorker[CaptureEnrichArgs](reg, &captureEnrichWorker{
+			pool:     pool,
 			enricher: NewCaptureEnricher(pool, cfg.EnrichBrain, log),
 			log:      log,
 		})

--- a/backend/internal/compose/owedclassify_integration_test.go
+++ b/backend/internal/compose/owedclassify_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/modules/activities"
@@ -111,11 +110,15 @@ func verdictOf(t *testing.T, e *integration.Env, id ids.UUID) *string {
 // runOwedWorker drives the job River drives, with the context River gives it.
 func runOwedWorker(t *testing.T, e *integration.Env, brain completer) {
 	t.Helper()
-	worker := &owedVerdictWorkspaceWorker{
+	worker := &owedVerdictWorker{
+		pool:       e.Pool,
 		classifier: NewOwedClassifier(e.Pool, brain, nil, slog.New(slog.DiscardHandler)),
 	}
-	job := &river.Job[OwedVerdictWorkspaceArgs]{Args: OwedVerdictWorkspaceArgs{Workspace: e.WS}}
-	if err := worker.Work(context.Background(), job); err != nil {
+	// The per-workspace turn, which is what River's row now walks rather than
+	// what it carries: the pass takes no workspace in its args (ADR-0103), so
+	// driving Work here would enumerate the fleet and lose the one this test is
+	// about. judgeWorkspace is the same code either way.
+	if err := worker.judgeWorkspace(context.Background(), e.WS); err != nil {
 		t.Fatalf("the worker failed: %v", err)
 	}
 }

--- a/backend/internal/compose/owedjobs.go
+++ b/backend/internal/compose/owedjobs.go
@@ -31,42 +31,24 @@ func (OwedVerdictArgs) Kind() string { return "owed_verdict" }
 // tenant work of its own (jobs.FleetWide).
 func (OwedVerdictArgs) FleetWide() {}
 
-// owedVerdictWorker is the dispatcher for the verdict pass.
-type owedVerdictWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *owedVerdictWorker) Work(ctx context.Context, _ *river.Job[OwedVerdictArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(OwedVerdictWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return OwedVerdictWorkspaceArgs{Workspace: ws} }))
-}
-
-// OwedVerdictWorkspaceArgs is one workspace's catch-up verdict pass.
-type OwedVerdictWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (OwedVerdictWorkspaceArgs) Kind() string { return "owed_verdict_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a OwedVerdictWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// owedVerdictWorkspaceWorker drives the verdict engine for one workspace.
+// owedVerdictWorker drives the verdict engine for every live workspace.
 //
 // The engine commits per model call, so a mid-pass crash or a budget stop loses
 // nothing: what was judged stays judged, and the next tick reads a backlog that
 // has shrunk by exactly that much.
-type owedVerdictWorkspaceWorker struct {
+//
+// One worker where there were two (ADR-0103).
+type owedVerdictWorker struct {
+	pool       *pgxpool.Pool
 	classifier *OwedClassifier
 }
 
-func (w *owedVerdictWorkspaceWorker) Work(ctx context.Context, job *river.Job[OwedVerdictWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *owedVerdictWorker) Work(ctx context.Context, _ *river.Job[OwedVerdictArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.judgeWorkspace))
+}
+
+func (w *owedVerdictWorker) judgeWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
 	// The workspace binding alone is not enough here, and the difference is the
 	// whole reason this is spelled out: the backlog read and the verdict write
 	// are both RBAC-gated, so an unbound context fails them with "no actor bound
@@ -83,5 +65,5 @@ func (w *owedVerdictWorkspaceWorker) Work(ctx context.Context, job *river.Job[Ow
 		Type: principal.PrincipalSystem, ID: "system:owed_verdict",
 		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
 	})
-	return jobs.FaultContext(ctx, w.classifier.RunWorkspace(wsCtx, 0))
+	return w.classifier.RunWorkspace(wsCtx, 0)
 }

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -177,15 +177,6 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		OrgNamePromotionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&orgNamePromotionWorkspaceWorker{}).Work(ctx, &river.Job[OrgNamePromotionWorkspaceArgs]{})
 		},
-		CaptureClassifyWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&captureClassifyWorkspaceWorker{}).Work(ctx, &river.Job[CaptureClassifyWorkspaceArgs]{})
-		},
-		OwedVerdictWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&owedVerdictWorkspaceWorker{}).Work(ctx, &river.Job[OwedVerdictWorkspaceArgs]{})
-		},
-		CaptureEnrichWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&captureEnrichWorkspaceWorker{}).Work(ctx, &river.Job[CaptureEnrichWorkspaceArgs]{})
-		},
 		CaptureDigestWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&captureDigestWorkspaceWorker{}).Work(ctx, &river.Job[CaptureDigestWorkspaceArgs]{})
 		},

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "2214e01dba3aab6b7b75e9c383c179f54d84e55cc2a0d1efdba99a1136ef4cfe"
+const JobContractHash = "3a3de981a308bca94bf2152717dd8481adf56a1153bb0135d79e3d0f185afcec"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -153,25 +153,12 @@ var specs = map[string]Spec{
 	"capture_classify": {
 		Kind:         "capture_classify",
 		GoType:       "CaptureClassifyArgs",
-		Role:         Dispatcher,
+		Role:         Worker,
 		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "capture_classify_workspace",
+		Timeout:      TimeoutPolicy{Fixed: 15 * time.Minute},
 		OptsOwner:    OptsCaller,
 		Cadence:      Cadence{Fixed: 1 * time.Hour},
 		Registration: Registration{When: []string{"ClassifyBrain"}},
-	},
-	"capture_classify_workspace": {
-		Kind:         "capture_classify_workspace",
-		GoType:       "CaptureClassifyWorkspaceArgs",
-		Role:         Worker,
-		Queue:        "ai_capture",
-		Timeout:      TimeoutPolicy{Fixed: 15 * time.Minute},
-		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
-		Registration: Registration{When: []string{"ClassifyBrain"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 	"capture_confidentiality_verdict": {
 		Kind:       "capture_confidentiality_verdict",
@@ -241,25 +228,12 @@ var specs = map[string]Spec{
 	"capture_enrich": {
 		Kind:         "capture_enrich",
 		GoType:       "CaptureEnrichArgs",
-		Role:         Dispatcher,
+		Role:         Worker,
 		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "capture_enrich_workspace",
+		Timeout:      TimeoutPolicy{Fixed: 20 * time.Minute},
 		OptsOwner:    OptsCaller,
 		Cadence:      Cadence{Fixed: 24 * time.Hour},
 		Registration: Registration{When: []string{"EnrichBrain"}},
-	},
-	"capture_enrich_workspace": {
-		Kind:         "capture_enrich_workspace",
-		GoType:       "CaptureEnrichWorkspaceArgs",
-		Role:         Worker,
-		Queue:        "ai_capture",
-		Timeout:      TimeoutPolicy{Fixed: 20 * time.Minute},
-		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
-		Registration: Registration{When: []string{"EnrichBrain"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 	"capture_sync": {
 		Kind:         "capture_sync",
@@ -697,25 +671,12 @@ var specs = map[string]Spec{
 	"owed_verdict": {
 		Kind:         "owed_verdict",
 		GoType:       "OwedVerdictArgs",
-		Role:         Dispatcher,
+		Role:         Worker,
 		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "owed_verdict_workspace",
+		Timeout:      TimeoutPolicy{Fixed: 15 * time.Minute},
 		OptsOwner:    OptsCaller,
 		Cadence:      Cadence{Fixed: 1 * time.Hour},
 		Registration: Registration{When: []string{"OwedBrain"}},
-	},
-	"owed_verdict_workspace": {
-		Kind:         "owed_verdict_workspace",
-		GoType:       "OwedVerdictWorkspaceArgs",
-		Role:         Worker,
-		Queue:        "ai_capture",
-		Timeout:      TimeoutPolicy{Fixed: 15 * time.Minute},
-		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
-		Registration: Registration{When: []string{"OwedBrain"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 	"participant_backfill": {
 		Kind:       "participant_backfill",

--- a/backend/migrations/core/1788621568_three_capture_passes_leave_no_orphans.down.sql
+++ b/backend/migrations/core/1788621568_three_capture_passes_leave_no_orphans.down.sql
@@ -1,0 +1,8 @@
+-- Nothing to restore, for the reason its predecessors give.
+--
+-- The up migration deleted queue rows for work that had not run. A rollback
+-- re-registers those workers and the passes re-enqueue on their next tick, so
+-- the work returns on its own schedule rather than from a row this file could
+-- forge — one that would carry a new id, a fresh attempt count and this
+-- migration's timestamp, and so would not be the row that was deleted.
+SELECT 1;

--- a/backend/migrations/core/1788621568_three_capture_passes_leave_no_orphans.up.sql
+++ b/backend/migrations/core/1788621568_three_capture_passes_leave_no_orphans.up.sql
@@ -1,0 +1,24 @@
+-- Drain the queued children of three more passes that no longer fan out.
+--
+-- Its own migration, for the reason the previous two give: a migration that has
+-- already run does not run again, so adding these kinds to an earlier file
+-- would drain them only where that file had not yet been applied.
+--
+-- River does not forget a row because the code stopped declaring its kind, so a
+-- child enqueued by the last tick before this deploy retries its way to
+-- `discarded` against a client that has no worker for it. NON-TERMINAL states
+-- only — a completed row records that the work ran — and guarded on the table
+-- existing, because River owns its own schema and applies it on first run.
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    DELETE FROM river_job
+     WHERE kind IN (
+             'capture_classify_workspace',
+             'owed_verdict_workspace',
+             'capture_enrich_workspace'
+           )
+       AND state NOT IN ('completed', 'discarded', 'cancelled');
+  END IF;
+END
+$$;


### PR DESCRIPTION
Batch three of #1857, on main. Same shape as #4192 and #4193.

`capture_classify`, `owed_verdict` and `capture_enrich` — 24 workspace pairs remain after this.

## Each pass keeps its own deadline

15m, 15m and 20m, taken from the children. The pattern batch two found holds: the dispatcher's two minutes bounded an enumeration and an insert, and the number that has to survive is the one that bounds the work.

`owed_verdict` keeps the system principal it binds per workspace, and the comment saying why — its backlog read and verdict write are both RBAC-gated, so a workspace binding alone leaves the pass writing nothing on every tick. That binding moved from the child's `Work` into the per-workspace turn, which is the same place in the new shape.

## The attachment this batch turned up

`capture_enrich` has a **continuation**: a pass that filled its limit enqueued another child for the same workspace to carry on. There is no child now, so it enqueues the pass.

On the single-workspace installations this product supports that is the same work. On a fleet it would also re-visit the workspaces that did not fill their limit — each a cheap no-op read against a backlog it just emptied. Its deliberate absence of uniqueness is unchanged: the continuation runs *inside* the pass it continues, so a `ByArgs` window would dedupe it against its own still-running parent.

The enrich trigger follows the org trigger from batch one: it queued a child for one workspace and now queues the pass, so its flood bound collapses a burst onto the one pending pass rather than one per workspace.

## Two tests moved rather than went

- `TestWorkspaceSweepOptsDedupesByArgsOnActiveStates` asserted the helper's uniqueness through a kind that has stopped being a fan-out child. It asks through one that has not (`capture_sync`).
- The owed integration test drove the child's `Work` with a workspace in its args. It drives `judgeWorkspace` instead — `Work` now enumerates the fleet and would lose the workspace the test is about.

## Verification

`make check-backend` exit 0; `internal/compose` and `integration/capture` integration suites green.