### PR TITLE
fix(frontend): a case's rendered tree is unmounted when the case ends

### DIFF
--- a/frontend/src/testing/autocleanup.test.tsx
+++ b/frontend/src/testing/autocleanup.test.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// The suite unmounts a case's tree without the case asking.
+//
+// React Testing Library's own auto-cleanup does not arm here — it registers on
+// a global `afterEach`, and this suite runs on vitest's `globals: false` — so
+// the hook is `vitest.setup.ts`'s to register. Nothing else would notice if it
+// stopped: 119 of the suites that render never call `cleanup` themselves, and
+// what a live tree costs is not a failing assertion but React's scheduler
+// waking after jsdom is gone, in whichever file happens to run last.
+//
+// So the claim is checked the only way it can be — across two cases, the second
+// asserting on what the first left behind. The order dependence IS the subject.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+const TREE_TEXT = "a tree this case never unmounts";
+
+describe("a rendered tree does not outlive its case", () => {
+  it("renders one and leaves it mounted", () => {
+    render(<p>{TREE_TEXT}</p>);
+    expect(screen.getByText(TREE_TEXT)).toBeTruthy();
+  });
+
+  it("finds the previous case's tree already gone", () => {
+    expect(document.body.innerHTML).toBe("");
+  });
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
 // Node ≥23 ships its own global Web Storage: a `localStorage` getter that
 // yields undefined unless the process was started with --localstorage-file.
@@ -101,6 +101,28 @@ if (typeof window !== "undefined") {
   beforeEach(() => {
     window.location.hash = "";
   });
+
+  // Unmount what a case rendered, because nothing else does.
+  //
+  // React Testing Library registers this hook itself — but only
+  // `if (typeof afterEach === 'function')`, and this suite runs on vitest's
+  // default `globals: false`, where that global does not exist. So the library's
+  // own cleanup never arms, and a file's renders are still mounted when the
+  // jsdom environment is torn down. React's scheduler then wakes on a
+  // `setImmediate` into a world with no `window` and throws there, which vitest
+  // reports as an uncaught exception and fails the lane on — a red run whose
+  // every test passed, and which clears on a re-run of the same commit.
+  //
+  // Registered here rather than asked of each file: 119 of the 418 suites that
+  // render never call `cleanup` themselves, and the next one written will not
+  // either. A suite that DOES call it is unaffected — vitest runs a file's own
+  // `afterEach` before this one, and unmounting an unmounted tree is a no-op.
+  //
+  // Imported here rather than at the top of the file so the node-environment
+  // suites, which are most of them, do not load react-dom for a hook that can
+  // only mean something where there is a DOM.
+  const { cleanup } = await import("@testing-library/react");
+  afterEach(cleanup);
 }
 
 // The calendar-drift lane: run the whole suite as if it were N days from now.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -217,6 +217,17 @@ sonar.cpd.exclusions=\
 # `webgl-program.ts` is the shader compile and link both renderers share, which
 # is context calls end to end. Same rationale as *_windows.go: an honest
 # exclusion beats a gap no work would close.
+# frontend/vitest.setup.ts is the vitest suite's own setup file, and it belongs
+# with vite.config.ts and playwright.config.ts below rather than with the code
+# they configure. It is not test code by the `sonar.test.inclusions` patterns
+# above — those reach `frontend/src/**` and `frontend/e2e/**`, and this file sits
+# at `frontend/` — so it was indexed as product source and measured for coverage.
+# It can never report any: it runs to ESTABLISH the environment each suite is
+# instrumented inside, so v8 never attributes a line to it and it appears nowhere
+# in frontend/coverage/lcov.info. Any new line here therefore reads as 0% however
+# thoroughly it is exercised, which is precisely what it means for the whole
+# suite to fail without it. Same honest-exclusion rationale as *_windows.go and
+# desktop/launcher: a gap no work could close is worse than saying so.
 # e2e/llm/check.py is the e2e-llm lane's own judge script — CI-only dev tooling
 # on the same footing as backend/tools and cli/craft above, not shippable
 # product code. No python coverage report is wired into this scan (no
@@ -240,6 +251,7 @@ sonar.coverage.exclusions=\
   e2e/llm/check.py,\
   frontend/src/main.tsx,\
   frontend/vite.config.ts,\
+  frontend/vitest.setup.ts,\
   frontend/playwright.config.ts,\
   frontend/src/**/*.stories.tsx
 


### PR DESCRIPTION
Closes https://github.com/margince/margince/issues/4435.

`fe-unit` fails with **every test passing**. Vitest reports one uncaught exception and the job exits non-zero on it alone:

```
Test Files  578 passed (578)
     Errors  1 error

ReferenceError: window is not defined
 ❯ react-dom/cjs/react-dom-client.development.js:17920:15
 ❯ Immediate.performWorkUntilDeadline scheduler/cjs/scheduler.development.js:45:48

This error originated in "src/screens/worklist.email.test.tsx"
```

## What is actually wrong

**Nothing unmounts a test file's renders.** React Testing Library registers that hook itself — but only under a guard this suite does not satisfy:

```js
if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
  if (typeof afterEach === 'function') {
    afterEach(() => { cleanup() })
  }
```

`frontend/vite.config.ts` sets no `globals`, so vitest's default `globals: false` applies and `afterEach` is not a global. The library's auto-cleanup therefore never arms — silently, since the guard is a `typeof` check with no else. A file's trees are still mounted when the jsdom environment is torn down, and React's scheduler wakes on a `setImmediate` into a world with no `window`.

## Measured, not inferred

An `afterAll` probe on the named file, reading `document.body` at the moment its last case ends:

| | `bytes` | `children` |
|---|---|---|
| `origin/main` @ `85e324eb5` | 15412 | 5 |
| this branch | 0 | 0 |

Five live React roots — one per render — still holding state and still able to schedule work, in an environment about to stop existing. That is the "component that starts a transition, a timer or a subscription and is not unmounted before the environment goes" the issue predicted, and it is not one component: it is every render in the file.

It reads as a flake because **which** file pays is whichever happens to run last, so a re-run of the same commit clears it and the attribution lands on an unrelated diff — including, as the issue notes, on whichever commits the two-hourly health check happened to find in its window.

## Why the setup file rather than the one test

`grep -rl "@testing-library/react" src/` finds 418 suites that render; `grep -rl "cleanup()"` finds 299. **119 never clean up**, and the next one written will not either — there is nothing to remind an author of a library default that is off. Fixing `worklist.email.test.tsx` alone would move the failure to one of the other 118.

A suite that *does* call `cleanup` is unaffected: vitest runs a file's own `afterEach` before this one, and unmounting an already-unmounted tree is a no-op.

The import is dynamic so the node-environment suites — most of them — do not load react-dom for a hook that can only mean something where there is a DOM.

## The guard

`src/testing/autocleanup.test.tsx` holds it, across two cases because that is the only shape this claim has: the second asserts on what the first left behind, and the order dependence *is* the subject. Without it, nothing would notice the hook being removed — a live tree costs a failing assertion nowhere, only an uncaught exception somewhere else.

Mutation-checked. On `origin/main`:

```
× finds the previous case's tree already gone
AssertionError: expected '<div><p>a tree this case never unmoun…' to be ''
 Test Files  1 failed (1)
```

On this branch it passes.

## Verification

`make check-fe` green on Node 24:

```
Test Files  584 passed (584)
     Tests  7247 passed (7247)
EXIT=0
```

Against **583 / 7245** on `origin/main` — the difference is exactly this test file's two cases. So no suite among the 119 depended on its tree outliving its case, which was the real risk in changing a default that has been off for the life of the suite.