### PR TITLE
The rest of the UI calls a person record a person, in all three locales

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -804,7 +804,7 @@ test("AC-create-1: a contact is created from the list and lands on its 360", asy
   page,
 }) => {
   await page.goto("/#/contacts");
-  await page.getByRole("button", { name: "Neuer Kontakt" }).click();
+  await page.getByRole("button", { name: "Neue Person" }).click();
   await page.getByLabel("Vollständiger Name").fill("Peter Neu");
   // Email is now a repeatable row group (P-15): add a row, then fill it.
   await page.getByRole("button", { name: "E-Mail hinzufügen" }).click();
@@ -1847,7 +1847,7 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
     // runs in it.
     await page.getByRole("button", { name: "Weitere Aktionen" }).click();
     await expect(
-      page.getByRole("button", { name: "Neuer Kontakt" }),
+      page.getByRole("button", { name: "Neue Person" }),
     ).toBeVisible();
     await expectNoAaViolations(page, "contacts (folded header)");
   });

--- a/frontend/e2e/leads.spec.ts
+++ b/frontend/e2e/leads.spec.ts
@@ -59,7 +59,7 @@ test("AC-leaddetail-qualify: the dialog says what qualifying will do and why, th
     .getByRole("button", { name: "Qualifizieren", exact: true })
     .click();
   await expect(
-    page.getByText("Die Übernahme legt einen neuen Kontakt an."),
+    page.getByText("Die Übernahme legt eine neue Person an."),
   ).toBeVisible();
   // The reason is derived, not asked for: the seeded lead has no captured
   // engagement, so it is the rep's own call.

--- a/frontend/e2e/leads.spec.ts
+++ b/frontend/e2e/leads.spec.ts
@@ -51,7 +51,7 @@ test("AC-leaddetail-work: a note is logged against the lead itself", async ({
   expect(body.links).toEqual([{ entity_type: "lead", entity_id: "l-1" }]);
 });
 
-test("AC-leaddetail-qualify: the dialog says what qualifying will do and why, then the page stays and names the contact", async ({
+test("AC-leaddetail-qualify: the dialog says what qualifying will do and why, then the page stays and names the person", async ({
   page,
 }) => {
   await page.goto("/#/leads/l-1");
@@ -69,5 +69,5 @@ test("AC-leaddetail-qualify: the dialog says what qualifying will do and why, th
     .getByRole("button", { name: /^Qualifizieren/ })
     .click();
   await expect(page).toHaveURL(/#\/leads\/l-1$/);
-  await expect(page.getByText(/ist jetzt ein Kontakt:/)).toBeVisible();
+  await expect(page.getByText(/ist jetzt eine Person:/)).toBeVisible();
 });

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -286,7 +286,7 @@ export const de = {
   "dealfiles.unhidden": "Wieder an diesem Deal sichtbar",
   "deal.stalled": "stockt",
   "deal.archived": "archiviert",
-  "deal.singleThreaded": "nur ein Kontakt",
+  "deal.singleThreaded": "nur eine Person",
   "deal.staged": "vorgemerkt",
   "record.notShown": "Nicht angezeigt",
   "record.timelineLoading": "Verlauf dieses Datensatzes wird geladen…",
@@ -374,7 +374,7 @@ export const de = {
   "edit.versionSkew":
     "Dieser Datensatz hat sich geändert, seit du ihn geöffnet hast — neu laden und erneut versuchen.",
 
-  "merge.person": "Kontakt zusammenführen",
+  "merge.person": "Person zusammenführen",
   "merge.org": "Firma zusammenführen",
   "merge.searchPlaceholder": "Suchen…",
   "merge.pickTarget": "Überlebenden Datensatz auswählen",
@@ -776,10 +776,10 @@ export const de = {
   "consent.grant": "Erteilen",
   "consent.withdraw": "Widerrufen",
   "consent.doiBySubject":
-    "Diesen Zweck best\u00e4tigt der Kontakt selbst \u2013 \u00fcber einen Link an seine eigene Adresse. Nutzen Sie unten \u201eUm Best\u00e4tigung der Daten bitten\u201c.",
+    "Diesen Zweck best\u00e4tigt die Person selbst \u2013 \u00fcber einen Link an ihre eigene Adresse. Nutzen Sie unten \u201eUm Best\u00e4tigung der Daten bitten\u201c.",
   "consent.askToConfirm": "Um Bestätigung der Daten bitten",
   "consent.askToConfirmWhat":
-    "Schickt diesem Kontakt einen persönlichen Link: Er sieht, was ihr über ihn gespeichert habt, kann es korrigieren und sagen, ob er von euch hören möchte. Der Link geht an seine hinterlegte Adresse — woandershin könnt ihr ihn nicht schicken.",
+    "Schickt dieser Person einen persönlichen Link: Sie sieht, was ihr über sie gespeichert habt, kann es korrigieren und sagen, ob sie von euch hören möchte. Der Link geht an ihre hinterlegte Adresse — woandershin könnt ihr ihn nicht schicken.",
   "consent.askQueued": "Unterwegs an {address}.",
   "consent.askNotDelivered":
     "Der Link wurde für {address} erstellt, aber diese Installation verschickt keine Mails — es hat ihn also niemand bekommen.",
@@ -1077,12 +1077,12 @@ export const de = {
     "Die Sitzung endet sofort und der Link funktioniert nicht mehr. Kommentare bleiben sichtbar und zugeordnet. Der Zugang lässt sich nicht durch eine Link-Anfrage wiederherstellen.",
   "access.changeCapabilityTitle": "Was darf {name} tun?",
   "persondealrooms.title": "Deal Rooms",
-  "persondealrooms.sub": "Räume, die dieser Kontakt noch betreten kann.",
+  "persondealrooms.sub": "Räume, die diese Person noch betreten kann.",
   "persondealrooms.open": "Öffnen",
   "persondealrooms.seatGone":
     "Diese Adresse hat in dem Raum keinen Platz mehr.",
   "persondealrooms.cut":
-    "Nur die ersten Räume werden gezeigt; dieser Kontakt sitzt in weiteren.",
+    "Nur die ersten Räume werden gezeigt; diese Person sitzt in weiteren.",
   "persondealrooms.revokeTitle": "Zugang zu {room} entziehen?",
   "room.state.draft": "Entwurf",
   "room.state.building": "Wird erstellt",
@@ -1097,8 +1097,8 @@ export const de = {
   "co.pulse.owner": "Betreut von",
   "co.pulse.sizeBand": "{band} Mitarbeitende",
   "co.pulse.strongestLead": "Zugang \u00fcber",
-  "co.pulse.strengthTail_one": "\u2014 der einzige Kontakt hier",
-  "co.pulse.strengthTail_other": "\u2014 von {count} Kontakten hier",
+  "co.pulse.strengthTail_one": "\u2014 die einzige Person hier",
+  "co.pulse.strengthTail_other": "\u2014 von {count} Personen hier",
   "co.pulse.unowned": "Nicht zugewiesen",
   "co.since.first": "Du öffnest diesen Account zum ersten Mal.",
   "co.partial":
@@ -1337,13 +1337,13 @@ export const de = {
   "co.evidence.kind.rule": "Abgeleitet",
   "co.brief.cite.deal": "Deal",
   "co.brief.cite.activity": "Aktivität",
-  "co.brief.cite.person": "Kontakt",
+  "co.brief.cite.person": "Person",
   "co.brief.cite.organization": "Account",
   "co.brief.cite.fact": "Fakt",
   "co.brief.cite.profile_field": "Profilfeld",
   "co.brief.cite.deal.many": "{count} Deals",
   "co.brief.cite.activity.many": "{count} Aktivitäten",
-  "co.brief.cite.person.many": "{count} Kontakte",
+  "co.brief.cite.person.many": "{count} Personen",
   "co.brief.cite.organization.many": "{count} Accounts",
   "co.brief.cite.fact.many": "{count} Fakten",
   "co.brief.cite.profile_field.many": "{count} Profilfelder",
@@ -1367,7 +1367,7 @@ export const de = {
   "approval.kind.site_lead": "Person von der Website aufnehmen",
   "approval.kind.capture_counterparty": "Person aus deiner Mail aufnehmen",
   "approval.kind.org_name_promotion": "Account umbenennen",
-  "approval.kind.vcard_create": "Kontakt aus einer Visitenkarte anlegen",
+  "approval.kind.vcard_create": "Person aus einer Visitenkarte anlegen",
   "approval.kind.lifecycle_change": "Account-Phase",
   "approval.kind.transcript_proposal":
     "Nächsten Schritt aus einem Transkript übernehmen",
@@ -1412,7 +1412,7 @@ export const de = {
   "approval.field.published_email": "E-Mail auf der Seite",
   "approval.field.connection_name": "Auf LinkedIn",
   "approval.field.connection_company": "Arbeitet bei",
-  "approval.field.person_name": "Kontakt hier",
+  "approval.field.person_name": "Person hier",
   "approval.field.owner": "Zuständig",
   "approval.field.to": "An",
   "approval.field.currency": "Währung",
@@ -1473,8 +1473,8 @@ export const de = {
   "co.rail.deals.attentionCommitment": "Sie schulden uns",
   "co.rail.people.title": "Ihre Ansprechpartner",
   "co.rail.people.empty":
-    "Noch keine Kontakte. Niemand, dem man schreiben kann.",
-  "co.rail.people.add": "Kontakt hinzufügen",
+    "Noch keine Personen. Niemand, dem man schreiben kann.",
+  "co.rail.people.add": "Person hinzufügen",
   "co.rail.people.inTouch": "Bereits mit ihnen in Kontakt",
   "co.rail.details.all": "Alle Felder",
   "co.commercial.title": "Kommerziell",
@@ -1496,7 +1496,7 @@ export const de = {
   "linkedinImport.notConnectedNote":
     "Mit deiner hinterlegten Profil-URL werden importierte Kontakte dir namentlich zugeordnet.",
   "linkedinImport.whichFile":
-    "LinkedIn stellt dir Connections.csv unter Einstellungen \u2192 Datenschutz \u2192 Kopie deiner Daten bereit; das Archiv enth\u00e4lt ein Dutzend weitere, gesucht ist diese eine. Was du hochl\u00e4dst, wird niemals zu Kontakten: die Verbindungen erscheinen weder in der Suche noch in Listen oder auf Kontaktseiten, und niemand kann ihnen schreiben oder mailen.",
+    "LinkedIn stellt dir Connections.csv unter Einstellungen \u2192 Datenschutz \u2192 Kopie deiner Daten bereit; das Archiv enth\u00e4lt ein Dutzend weitere, gesucht ist diese eine. Was du hochl\u00e4dst, wird niemals zu Personen: die Verbindungen erscheinen weder in der Suche noch in Listen oder auf Personenseiten, und niemand kann ihnen schreiben oder mailen.",
   "linkedinImport.choose": "Connections.csv ausw\u00e4hlen",
   "linkedinImport.importLabel": "Kontakt-Export",
   "linkedinImport.noMatchesYet":
@@ -1613,7 +1613,7 @@ export const de = {
     "Einige Empfänger stehen im Blindkopie-Feld und werden Ihnen nicht angezeigt",
   "compose.audienceWorkspace": "Alle in der Organisation",
   "compose.audienceWorkspaceHint":
-    "Jeder, der den Kontakt sehen darf, liest auch diese Nachricht.",
+    "Jeder, der die Person sehen darf, liest auch diese Nachricht.",
   "compose.audienceParticipants": "Nur Beteiligte",
   "compose.audienceParticipantsHint":
     "Nur die Personen auf dieser Nachricht lesen Betreff und Inhalt. Andere sehen nur, dass an diesem Tag eine Nachricht gewechselt wurde.",
@@ -1624,7 +1624,7 @@ export const de = {
   "compose.audienceMembersLoading": "Personenliste wird gelesen…",
   "compose.audienceConfirm": "Sichtbarkeit speichern",
   "compose.audienceNote":
-    "Gilt nur f\u00fcr diese Nachricht \u2014 nicht f\u00fcr den Thread und nicht f\u00fcr den Kontakt.",
+    "Gilt nur f\u00fcr diese Nachricht \u2014 nicht f\u00fcr den Thread und nicht f\u00fcr die Person.",
   "timeline.textMore": "Lesen",
   "timeline.textLess": "Weniger",
   "timeline.tailMore": "Signatur und Zitat anzeigen",
@@ -1947,7 +1947,7 @@ export const de = {
   "tagResult.viewAll": "Alle {count} {kind} anzeigen",
   "tagResult.resultsTitle": "Datensätze mit diesem Tag",
   "tagResult.nothingCarries":
-    "Noch kein Datensatz trägt dieses Tag. Vergeben Sie es auf einem Kontakt, einem Unternehmen oder einem Deal.",
+    "Noch kein Datensatz trägt dieses Tag. Vergeben Sie es auf einer Person, einem Unternehmen oder einem Deal.",
   "tagResult.loadingRows": "{kind} werden geladen…",
   "tagResult.noneLeft": "Trägt niemand mehr",
   "tagResult.unnamed": "Ohne Namen",
@@ -2087,23 +2087,23 @@ export const de = {
   "lead.boardTerminalOnly":
     "Keiner dieser Leads ist noch offen \u2014 sie z\u00e4hlen unter Qualifiziert und Disqualifiziert.",
   "person.fromLead": "Aus Lead übernommen",
-  "lead.promotedTitle": "Als Kontakt übernommen",
+  "lead.promotedTitle": "Als Person übernommen",
   "lead.promotedMerged":
-    "Dieser Lead wurde mit einem bereits bekannten Kontakt zusammengeführt — es entstand kein Duplikat.",
-  "lead.promotedCreated": "Aus diesem Lead wurde ein neuer Kontakt.",
+    "Dieser Lead wurde mit einer bereits bekannten Person zusammengeführt — es entstand kein Duplikat.",
+  "lead.promotedCreated": "Aus diesem Lead wurde eine neue Person.",
   "lead.promotedAt": "Übernommen am",
   "lead.promotedTrigger": "Auslöser:",
   "lead.promotedEvidence": "Beleg:",
   "lead.previewPending": "Prüfe, ob wir diese Person schon kennen …",
-  "lead.previewCreate": "Die Übernahme legt einen neuen Kontakt an.",
+  "lead.previewCreate": "Die Übernahme legt eine neue Person an.",
   "lead.previewMerge":
-    "Die Übernahme führt mit dem bestehenden Kontakt zusammen:",
+    "Die Übernahme führt mit der bestehenden Person zusammen:",
   "lead.previewMergeWithheld":
-    "Die Übernahme führt mit einem bestehenden Kontakt zusammen, den Sie nicht sehen können.",
+    "Die Übernahme führt mit einer bestehenden Person zusammen, die Sie nicht sehen können.",
   "lead.demote": "Übernahme rückgängig machen",
   "lead.demoteDialog": "Übernahme rückgängig machen?",
   "lead.demoteExplain":
-    "Der Lead kehrt als „In Bearbeitung“ in die Liste zurück. Ein Kontakt, den die Übernahme angelegt hat, wird archiviert; ein Kontakt, mit dem zusammengeführt wurde, bleibt unverändert. Bei einem Kontakt an einem laufenden Deal ist die Rücknahme nicht möglich.",
+    "Der Lead kehrt als „In Bearbeitung“ in die Liste zurück. Eine Person, die die Übernahme angelegt hat, wird archiviert; eine Person, mit der zusammengeführt wurde, bleibt unverändert. Bei einer Person an einem laufenden Deal ist die Rücknahme nicht möglich.",
   "lead.demoteReason": "Grund (wird im Protokoll festgehalten)",
   "lead.demoteReasonRequired": "Bitte zuerst begr\u00fcnden.",
   "lead.demoteConfirm": "Rückgängig machen",
@@ -2220,7 +2220,7 @@ export const de = {
   "lead.trigger.humanQualify": "Manuell qualifiziert",
   "lead.evidenceNote": "Beleg-Notiz (optional)",
   "lead.segregation":
-    "Leads bleiben von Kontakten getrennt. Ein Lead wird erst zum Kontakt, wenn du ihn qualifizierst.",
+    "Leads bleiben von Personen getrennt. Ein Lead wird erst zur Person, wenn du ihn qualifizierst.",
   "lead.segregationDismiss": "Verstanden",
   "list.emptyMine": "Dir sind keine {unit} zugewiesen.",
   "list.showAll": "Alle anzeigen",
@@ -2240,13 +2240,13 @@ export const de = {
   "lead.ladder.theyReplied": "Antwort erhalten",
   "lead.ladder.meetingBooked": "Termin gebucht",
   "lead.ladder.meetingHeld": "Termin stattgefunden",
-  "lead.ladder.qualified": "Qualifiziert — dieser Lead ist jetzt ein Kontakt.",
+  "lead.ladder.qualified": "Qualifiziert — dieser Lead ist jetzt eine Person.",
   "lead.ladder.qualifiedOn":
-    "Qualifiziert am {at} — dieser Lead ist jetzt ein Kontakt.",
+    "Qualifiziert am {at} — dieser Lead ist jetzt eine Person.",
   "lead.ladder.disqualified": "Disqualifiziert.",
   "lead.ladder.disqualifiedWithReason": "Disqualifiziert: {reason}",
   "lead.qualify.title": "{name} qualifizieren",
-  "lead.qualify.contact": "Kontakt",
+  "lead.qualify.contact": "Person",
   "lead.qualify.alsoDeal": "Auch einen Deal anlegen",
   "lead.qualify.pipeline": "Pipeline",
   "lead.qualify.stage": "Phase",
@@ -2264,7 +2264,7 @@ export const de = {
   "lead.qualify.reasonHuman": "Grund: von dir qualifiziert.",
   "lead.qualify.confirm": "Qualifizieren",
   "lead.qualify.confirmWithDeal": "Qualifizieren und Deal anlegen",
-  "lead.qualify.done": "{name} ist jetzt ein Kontakt:",
+  "lead.qualify.done": "{name} ist jetzt eine Person:",
   "lead.disqualify.title": "{name} disqualifizieren",
   "lead.disqualify.reason": "Grund",
   "lead.disqualify.pickReason": "Grund wählen",
@@ -2803,7 +2803,7 @@ export const de = {
   "deepread.kindTeam": "Team",
   "deepread.kindServices": "Leistungen",
   "deepread.kindProducts": "Produkte",
-  "deepread.kindContact": "Kontakt",
+  "deepread.kindContact": "Person",
   "deepread.kindOther": "Sonstiges",
 
   "transcriptread.title": "Dieses Transkript lesen",
@@ -2833,7 +2833,7 @@ export const de = {
     "Erforderlich – mindestens eine Option wählen.",
   "create.save": "Anlegen",
   "create.saving": "Wird angelegt…",
-  "create.contact": "Neuer Kontakt",
+  "create.contact": "Neue Person",
   "vcardImport.action": "Karten importieren",
   "vcardImport.title": "Visitenkarten importieren",
   "vcardImport.fileLabel": "Visitenkarten-Datei",
@@ -2937,7 +2937,7 @@ export const de = {
   "co.spine.days_other": "{count} Tage",
   "co.spine.quietSince": "Seitdem Funkstille",
   "co.spine.neverReplied": "Sie haben nie geantwortet",
-  "co.spine.singleThreaded": "Ein Kontakt, und keine Antwort von ihm",
+  "co.spine.singleThreaded": "Eine Person, und keine Antwort von ihr",
   "co.spine.overdue": "\u00dcberf\u00e4llig",
   "co.spine.expectedClose": "Erwarteter Abschluss",
   "co.360.subject": "{name} · 360",
@@ -2956,7 +2956,7 @@ export const de = {
   "today.source.nextMeeting": "der Kalender",
   "today.source.deals": "Deals",
   "today.meeting.prepare": "Meeting vorbereiten",
-  "today.source.people": "die Kontakte",
+  "today.source.people": "die Personen",
   "today.source.standing": "wer am Zug ist und die Signale",
   "today.source.activities": "was gesprochen wurde",
   "today.silence.days": "seit {count} Tagen keine Antwort",
@@ -2974,10 +2974,10 @@ export const de = {
   "evidence.humanSet": "Von einer Person gesetzt",
   "acctCoverage.open": "Abdeckung vergleichen",
   "acctCoverage.title": "Wer diesen Account abdeckt",
-  "acctCoverage.contact": "Kontakt",
-  "acctCoverage.findContact": "Kontakt suchen",
+  "acctCoverage.contact": "Person",
+  "acctCoverage.findContact": "Person suchen",
   "acctCoverage.untried": "Nicht versucht",
-  "acctCoverage.noMatch": "Kein Kontakt passt dazu.",
+  "acctCoverage.noMatch": "Niemand passt dazu.",
   "acctCoverage.columnCap":
     "{cap} Kolleginnen und Kollegen angezeigt — einen abwählen, um einen weiteren hinzuzufügen.",
   "acctCoverage.partial":
@@ -3139,12 +3139,12 @@ export const de = {
   "log.save": "Erfassen",
   "log.saving": "Wird erfasst…",
 
-  "personAccess.title": "Wer diesen Kontakt sieht",
+  "personAccess.title": "Wer diese Person sieht",
   "personAccess.privateToYou":
-    "Nur für Sie. Ihr Postfach hat diesen Kontakt angelegt, und niemand sonst im Unternehmen sieht ihn — auch nicht Ihr Team und keine Administration.",
-  "personAccess.organization": "Alle im Unternehmen sehen diesen Kontakt.",
+    "Nur für Sie. Ihr Postfach hat diese Person angelegt, und niemand sonst im Unternehmen sieht sie — auch nicht Ihr Team und keine Administration.",
+  "personAccess.organization": "Alle im Unternehmen sehen diese Person.",
   "personAccess.share": "Mit dem Unternehmen teilen",
-  "personAccess.published": "Das Unternehmen sieht diesen Kontakt jetzt.",
+  "personAccess.published": "Das Unternehmen sieht diese Person jetzt.",
   "compose.reply": "Antworten",
   "compose.writeEmail": "E-Mail schreiben",
   "compose.relink": "Neu verknüpfen",
@@ -3172,9 +3172,9 @@ export const de = {
   "compose.cc": "Cc",
   "compose.subject": "Betreff",
   "compose.noGroundableRecipient":
-    "Noch kein Kontakt zu diesem Account — schreibe die Nachricht selbst oder lege zuerst einen Kontakt an",
+    "Noch niemand an diesem Account — schreibe die Nachricht selbst oder lege zuerst eine Person an",
   "compose.draftTo": "Entwurf an",
-  "compose.draftToUnset": "Kontakt wählen",
+  "compose.draftToUnset": "Person wählen",
   "compose.relatedTo": "Bezug",
   "compose.relatedToNone": "Der Account allgemein",
   "compose.project": "Projekt",
@@ -3720,7 +3720,7 @@ export const de = {
   "settings.tierRead":
     "Lesen, Zusammenfassen, Entwerfen — läuft sofort, voll protokolliert.",
   "settings.tierSend":
-    "E-Mail senden, Termine buchen, einen Kontakt oder Deal ändern — läuft ebenfalls sofort, wenn du dem Agenten diesen Bereich gegeben hast. Deine Erlaubnis ist die Freigabe, einmal erteilt.",
+    "E-Mail senden, Termine buchen, eine Person oder einen Deal ändern — läuft ebenfalls sofort, wenn du dem Agenten diesen Bereich gegeben hast. Deine Erlaubnis ist die Freigabe, einmal erteilt.",
   "settings.tierWait":
     "Anreicherung, eigene Felder, Webhooks, Tags zusammenführen — das wartet in deinem Eingang.",
   "settings.tierAdvance":
@@ -3747,7 +3747,7 @@ export const de = {
   "import.object.organization": "Firmen",
   "import.object.person": "Personen",
   "import.objectHint.lead":
-    "Eine unbearbeitete Liste landet als Leads zur Qualifizierung, bevor sie jemand als Kontakte behandelt.",
+    "Eine unbearbeitete Liste landet als Leads zur Qualifizierung, bevor sie jemand als Personen behandelt.",
   "import.objectHint.organization":
     "Firmen werden über den zugeordneten Namen erkannt, ein erneuter Upload korrigiert also statt zu duplizieren.",
   "import.objectHint.person":
@@ -4515,7 +4515,7 @@ export const de = {
     "Sobald Ihr Postfach E-Mails eingebracht hat, steht hier jeder Absender mit dem, was aus ihm wurde.",
   "senders.colSender": "Absender",
   "senders.colDecision": "Entschieden",
-  "senders.colRecord": "Kontakt",
+  "senders.colRecord": "Person",
   "senders.colActions": "Aktionen",
   "senders.recordYes": "Ja",
   "senders.recordNo": "Nein",
@@ -4526,7 +4526,7 @@ export const de = {
   "senders.withdraw": "Zurücknehmen",
   "senders.keepOutTitle": "Diesen Absender dauerhaft aussperren?",
   "senders.keepOutBody":
-    "Es wird kein Kontakt angelegt, und die E-Mails, die dieser Absender bereits in Ihr Postfach eingebracht hat, werden vernichtet. E-Mails, die auch eine Kollegin importiert hat, bleiben ihr erhalten.",
+    "Es wird keine Person angelegt, und die E-Mails, die dieser Absender bereits in Ihr Postfach eingebracht hat, werden vernichtet. E-Mails, die auch eine Kollegin importiert hat, bleiben ihr erhalten.",
   "senders.keepOutConfirm": "Aussperren und vernichten",
   "senders.kind.person": "Eine Person",
   "senders.kind.roleMailbox": "Ein Funktionspostfach",
@@ -4541,7 +4541,7 @@ export const de = {
   "senders.kind.undecided": "Noch nicht entschieden",
   "mailSharing.title": "E-Mail-Freigabe",
   "mailSharing.sub":
-    "Erfasste E-Mails sind für alle Kolleginnen und Kollegen lesbar, die den Kontakt sehen können. Standardmäßig eingeschaltet — das macht die Pipeline gemeinsam.",
+    "Erfasste E-Mails sind für alle Kolleginnen und Kollegen lesbar, die die Person sehen können. Standardmäßig eingeschaltet — das macht die Pipeline gemeinsam.",
   "mailSharing.label": "Erfasste E-Mails im Team teilen",
   "mailSharing.help":
     "Einzelne Nachrichten lassen sich nachträglich einschränken, Adressen und Domains vorab ausschließen.",
@@ -4589,7 +4589,7 @@ export const de = {
     "Was dieser Connector einbringt, ablegen unter",
   "connectors.contextTag.none": "Kein Tag",
   "connectors.contextTag.hint":
-    "Ein vorhandenes Tag. Jeder Kontakt, den dieser Connector ab jetzt anlegt, wird darunter abgelegt — so kannst du fragen, was aus dieser Quelle kam. Kontakte, die schon da sind, behalten ihre Tags.",
+    "Ein vorhandenes Tag. Jede Person, die dieser Connector ab jetzt anlegt, wird darunter abgelegt — so kannst du fragen, was aus dieser Quelle kam. Personen, die schon da sind, behalten ihre Tags.",
   "connectors.contextTag.archived":
     "{name} ist archiviert, also wird nichts mehr darunter abgelegt. Wähl ein anderes Tag oder keins.",
   "connectors.signatureEnrich.followingDefault":
@@ -4598,7 +4598,7 @@ export const de = {
     "Eigene Antwort dieses Postfachs — bleibt bestehen, was auch immer Ihre Organisation einstellt.",
   "hold.sectionTitle": "Private Korrespondenz",
   "hold.notHeld":
-    "E-Mails mit diesem Kontakt folgen der Einstellung Ihres Postfachs.",
+    "E-Mails mit dieser Person folgen der Einstellung Ihres Postfachs.",
   "hold.heldByAddress":
     "Sie behalten E-Mails mit dieser Adresse bei den Beteiligten.",
   "hold.heldByDomain": "Sie behalten E-Mails mit {domain} bei den Beteiligten.",
@@ -4616,7 +4616,7 @@ export const de = {
   "hold.confirmHistoryNote":
     "Das gilt ab jetzt. Bereits erfasste E-Mails behalten ihre bisherige Sichtbarkeit.",
   "captureNotice.whatHappens":
-    "Margince liest dieses Postfach und legt ab, was es findet: die Nachrichten, wer daran beteiligt war, sowie die Kontakte und Firmen hinter den Adressen. Anhänge werden mit ihrer Nachricht gespeichert.",
+    "Margince liest dieses Postfach und legt ab, was es findet: die Nachrichten, wer daran beteiligt war, sowie die Personen und Firmen hinter den Adressen. Anhänge werden mit ihrer Nachricht gespeichert.",
   "captureNotice.whoReads":
     "Ein neues Postfach ist standardmäßig zurückgehalten. Eine Nachricht bleibt bei den Beteiligten, bis eine Einstufung den Verlauf als gewöhnliche geschäftliche Korrespondenz beurteilt — erst dann können Kolleginnen und Kollegen sie lesen. Sie können das Postfach jederzeit so einstellen, dass alles zurückgehalten bleibt.",
   "captureNotice.yourControl":
@@ -4824,7 +4824,7 @@ export const de = {
   "ob.s4.accessToggle": "Welchen Zugriff das gibt",
   "ob.s4.scope1Lead": "Wir lesen — wir müllen nichts voll.",
   "ob.s4.scope1Rest":
-    "Deine Post wird automatisch zu Kontakten, Firmen und Aktivitäten.",
+    "Deine Post wird automatisch zu Personen, Firmen und Aktivitäten.",
   "ob.s4.scope2Lead": "Senden gehört zu dieser Erlaubnis.",
   "ob.s4.scope2Rest":
     "Margince kann aus diesem Postfach senden — wenn du sendest, und wenn du einem Agenten einen Passport mit Senderecht gibst. Diese Erlaubnis ist deine Freigabe, einmal erteilt. Du kannst sie jederzeit zurücknehmen.",
@@ -4996,10 +4996,10 @@ export const de = {
   "ob.conv.scene.continue": "Weiter",
   "ob.conv.connect.sceneTitle": "Verbinde deine Konten.",
   "ob.conv.connect.sceneSub":
-    "Ich baue Kontakte, Firmen und Historie aus dem, was schon im Postfach liegt.",
+    "Ich baue Personen, Firmen und Historie aus dem, was schon im Postfach liegt.",
   "ob.conv.connect.mailboxTitle": "Dein Postfach",
   "ob.conv.connect.mailboxHint":
-    "Wähle eins. Von hier kommen deine Kontakte, Firmen und Historie.",
+    "Wähle eins. Von hier kommen deine Personen, Firmen und Historie.",
   "ob.conv.connect.networkTitle": "Dein Netzwerk",
   "ob.conv.connect.networkHint":
     "Optional, aber lohnend. Macht aus Bekannten Accounts und beobachtet sie auf Trigger.",
@@ -5028,7 +5028,7 @@ export const de = {
     "Diese Installation bietet {name} nicht an.",
   "ob.conv.connect.appSetupLink": "In den Einstellungen einrichten",
   "ob.conv.connect.dialogIntro":
-    "{brings}. Ich lese es einmal, um deine Kontakte und Historie aufzubauen, und halte es danach synchron.",
+    "{brings}. Ich lese es einmal, um deine Personen und Historie aufzubauen, und halte es danach synchron.",
   "ob.conv.connect.dialogClose": "Schließen",
   "ob.conv.connect.linkedinName": "LinkedIn",
   "ob.conv.connect.linkedinConnected": "Verbunden",
@@ -5125,7 +5125,7 @@ export const de = {
   "ob.conv.recap.readDeferred":
     "Willkommen zurück. Mein Lesevorgang von {host} pausiert gerade. Nenn mir wieder eine Website oder erzähl es mir direkt.",
   "ob.conv.linkedin.cardBody":
-    "Macht aus deinem Netzwerk Firmen und Kontakte, und meldet, wenn jemand aus deinem Netzwerk den Job wechselt.",
+    "Macht aus deinem Netzwerk Firmen und Personen, und meldet, wenn jemand aus deinem Netzwerk den Job wechselt.",
   "ob.conv.linkedin.limitsToggle": "Was Margince sehen kann und was nicht",
   "ob.conv.linkedin.scope1Lead": "Deine Kontaktliste \u2014",
   "ob.conv.linkedin.scope1Rest":
@@ -5140,7 +5140,7 @@ export const de = {
   "ob.conv.linkedin.scope4Rest":
     "Das Verbinden verschickt keine Einladungen und keine Nachrichten \u2014 nie.",
   "ob.conv.linkedin.neverContacts":
-    "Deine Kontakte werden nie zu CRM-Kontakten. Sie beantworten nur: Wer hier kennt sie schon?",
+    "Deine Kontakte werden nie zu Personen im CRM. Sie beantworten nur: Wer hier kennt sie schon?",
   "ob.conv.linkedin.profileLabel": "Deine LinkedIn-Profil-URL",
   "ob.conv.linkedin.profilePlaceholder": "https://www.linkedin.com/in/…",
   "ob.conv.linkedin.profileWhy":
@@ -5526,7 +5526,7 @@ export const de = {
   "client.open360": "360 öffnen",
   "client.unknown": "Noch nicht in deiner Organisation.",
   "client.unknownDetail":
-    "Dieser Absender passt zu keinem Kontakt, den du sehen kannst. Von woanders wurde nichts geholt.",
+    "Dieser Absender passt zu keiner Person, die du sehen kannst. Von woanders wurde nichts geholt.",
   "client.createLead": "Als Lead erfassen",
   "client.isolation": "spricht nur mit DEINER Organisation",
   "client.attribution": "Jede Erfassung ist zugeordnet und prüfbar.",
@@ -5837,9 +5837,9 @@ export const de = {
   "network.bucket.strong": "Stark",
   "coverage.engaged": "Im Austausch",
   "coverage.quiet": "Kein beidseitiger Kontakt",
-  "coverage.seatWithheld": "Ein Kontakt, den Sie nicht lesen dürfen",
+  "coverage.seatWithheld": "Eine Person, die Sie nicht lesen dürfen",
   "coverage.daysSinceTouch": "{days} Tage",
-  "coverage.risk.single_threaded_theirs": "Nur ein Kontakt",
+  "coverage.risk.single_threaded_theirs": "Nur eine Person",
   "coverage.risk.single_threaded_ours": "Von einer Person getragen",
   "coverage.risk.coverage_gap": "Kein engagierter Fürsprecher",
   "coverage.risk.champion_left": "Fürsprecher hat gekündigt",
@@ -5853,7 +5853,7 @@ export const de = {
   "cf.object": "Objekt",
   "cf.obj.deal": "Deal",
   "cf.obj.organization": "Firma",
-  "cf.obj.person": "Kontakt",
+  "cf.obj.person": "Person",
   "cf.obj.lead": "Lead",
   "cf.listLabel": "Felder auf {object}",
   "cf.col.field": "Feld",
@@ -5866,9 +5866,9 @@ export const de = {
   "cf.empty.organization":
     "Noch keine benutzerdefinierten Felder auf Firma. Füge eines hinzu, wenn du etwas erfasst, das wir nicht mitgeliefert haben.",
   "cf.empty.person":
-    "Noch keine benutzerdefinierten Felder auf Kontakt. Die Kernfelder decken den Kontaktdatensatz ab; füge eines hinzu, wenn du mehr erfasst.",
+    "Noch keine benutzerdefinierten Felder auf Person. Die Kernfelder decken den Personendatensatz ab; füge eines hinzu, wenn du mehr erfasst.",
   "cf.empty.lead":
-    "Noch keine benutzerdefinierten Felder auf Lead. Ein Feld, das du hier hinzufügst, erscheint auch, sobald ein Lead zu einem Kontakt befördert wird.",
+    "Noch keine benutzerdefinierten Felder auf Lead. Ein Feld, das du hier hinzufügst, erscheint auch, sobald ein Lead zu einer Person befördert wird.",
   "cf.type.text": "Text",
   "cf.type.number": "Zahl",
   "cf.type.date": "Datum",
@@ -6016,7 +6016,7 @@ export const de = {
   "captureActivity.contentNone": "kein Absender erfasst",
   "captureActivity.outcome.captured": "Erfasst",
   "captureActivity.outcome.internal": "Als intern verworfen",
-  "captureActivity.outcome.suppressed": "Kein Kontakt angelegt",
+  "captureActivity.outcome.suppressed": "Keine Person angelegt",
   "captureActivity.outcome.deferred": "Wartet auf Beurteilung",
   "captureActivity.outcome.fault": "Ableitung fehlgeschlagen",
   "captureActivity.reason.internal_only":
@@ -6026,19 +6026,19 @@ export const de = {
   "captureActivity.reason.noise_prior":
     "eine frühere Beurteilung stufte diesen Absender als Rauschen ein, die Nachricht wird archiviert",
   "captureActivity.reason.decided_prior":
-    "über diesen Absender wurde bereits entschieden, es wird kein Kontakt angelegt",
+    "über diesen Absender wurde bereits entschieden, es wird keine Person angelegt",
   "captureActivity.reason.no_granting_human":
     "die Verbindung nannte kein Mitglied, für das gehandelt werden kann",
   "captureActivity.reason.invisible_incumbent":
     "sie traf auf einen Datensatz außerhalb Ihrer Sicht",
   "captureActivity.reason.derivation_failed":
-    "der Kontaktschritt schlug fehl; die Nachricht selbst ist unberührt",
+    "der Schritt zur Person schlug fehl; die Nachricht selbst ist unberührt",
   "captureActivity.reason.no_counterparty":
     "kein Absender, den dieses CRM erfassen konnte",
   "captureActivity.reason.role_mailbox":
-    "ein Sammelpostfach, keine Person — gespeichert, aber kein Kontakt angelegt",
+    "ein Sammelpostfach, keine Person — gespeichert, aber keine Person angelegt",
   "captureActivity.reason.private_thread":
-    "ein privater Austausch — für Sie gespeichert, aber kein Kontakt angelegt",
+    "ein privater Austausch — für Sie gespeichert, aber keine Person angelegt",
   "captureActivity.reason.transactional_infra":
     "der Absender ist Mail-Infrastruktur, kein Unternehmen, mit dem Sie arbeiten",
   "captureActivity.reason.transactional_prefix":
@@ -6047,7 +6047,7 @@ export const de = {
   "captureActivity.outcome.deferred_sent": "Zur Entscheidung vorgelegt",
   "captureActivity.resolution.pending": "wartet noch",
   "captureActivity.resolution.unsure": "an die Prüfliste gesendet",
-  "captureActivity.resolution.real": "als echter Kontakt beurteilt",
+  "captureActivity.resolution.real": "als echte Person beurteilt",
   "captureActivity.resolution.noise": "als Rauschen beurteilt",
   "captureActivity.resolution.rejected": "von einer Person abgelehnt",
   "captureActivity.resolution.suppressed": "unterdrückt",
@@ -6077,8 +6077,8 @@ export const de = {
   "pipeline.stage.erasure_check": "Löschprüfung",
   "pipeline.stage.internal_drop": "Prüfung auf rein interne Nachricht",
   "pipeline.stage.activity_write": "In der Chronik gespeichert",
-  "pipeline.stage.tier_ladder": "Kontaktentscheidung",
-  "pipeline.stage.person_create": "Kontakt angelegt",
+  "pipeline.stage.tier_ladder": "Personenentscheidung",
+  "pipeline.stage.person_create": "Person angelegt",
   "pipeline.stage.verdict": "Absenderurteil",
   "pipeline.stage.company_triage": "Firmenprüfung",
   "pipeline.stage.attention_label": "Aufmerksamkeits-Label",
@@ -6101,17 +6101,17 @@ export const de = {
   "pipeline.reason.no_counterparty":
     "kein Absender, den dieses CRM erfassen konnte",
   "pipeline.reason.role_mailbox":
-    "ein Sammelpostfach, keine Person — gespeichert, aber kein Kontakt angelegt",
+    "ein Sammelpostfach, keine Person — gespeichert, aber keine Person angelegt",
   "pipeline.reason.private_thread":
-    "ein privater Austausch — für Sie gespeichert, aber kein Kontakt angelegt",
+    "ein privater Austausch — für Sie gespeichert, aber keine Person angelegt",
   "pipeline.reason.no_granting_human":
     "die Verbindung nennt kein Mitglied, in dessen Namen gehandelt wird",
   "pipeline.reason.derivation_failed":
-    "der Kontaktschritt ist fehlgeschlagen; die Nachricht selbst ist unberührt",
+    "der Schritt zur Person ist fehlgeschlagen; die Nachricht selbst ist unberührt",
   "pipeline.reason.not_linked_yet":
-    "mit dieser Nachricht ist noch kein Kontakt verknüpft",
+    "mit dieser Nachricht ist noch keine Person verknüpft",
   "pipeline.reason.no_contact_intended":
-    "die Kontaktentscheidung ergab, dass keiner anzulegen war",
+    "die Personenentscheidung ergab, dass keine anzulegen war",
   "pipeline.reason.awaiting_verdict": "der Absender wartet noch auf ein Urteil",
   "pipeline.reason.verdict_reached": "für diesen Absender liegt ein Urteil vor",
   "pipeline.reason.no_open_question":
@@ -6929,14 +6929,14 @@ export const de = {
     "Ein Unternehmen wechselt die Phase aufgrund dessen, was mit ihm geschehen ist. Das kann auch ändern, wer das Konto sieht und welche Automationen laufen.",
   "captureSettings.title": "Anreicherung",
   "captureSettings.sub":
-    "Wie erfasste Unternehmen und Kontakte nach ihrer Erstellung angereichert werden.",
+    "Wie erfasste Unternehmen und Personen nach ihrer Erstellung angereichert werden.",
   "captureSettings.autoEnrich.label":
     "Erfasste Unternehmen automatisch anreichern",
   "captureSettings.autoEnrich.help":
     "Wenn aktiviert, erhält jedes aus erfassten E-Mails erstellte Unternehmen automatisch ein Web-Dossier — seine Website wird gelesen und sein Profil ausgefüllt. Läuft unter einem Tageslimit.",
   "captureSettings.signatureEnrich.label": "Kontaktdaten aus E-Mails auswerten",
   "captureSettings.signatureEnrich.help":
-    "Wenn aktiv, übernimmt Margince, was ein Kontakt in E-Mails an Sie unter seinem eigenen Namen angibt — in der Signatur und auf einer angehängten Visitenkarte. Position, Telefonnummer, Adresse, Firma. Das geschieht innerhalb von Minuten nach Eingang der E-Mail. Nichts wird erschlossen: Was die E-Mail nicht nennt, wird nicht geschrieben. Das ist die Voreinstellung der Organisation; ein Postfach mit eigener Einstellung behält sie.",
+    "Wenn aktiv, übernimmt Margince, was eine Person in E-Mails an Sie unter ihrem eigenen Namen angibt — in der Signatur und auf einer angehängten Visitenkarte. Position, Telefonnummer, Adresse, Firma. Das geschieht innerhalb von Minuten nach Eingang der E-Mail. Nichts wird erschlossen: Was die E-Mail nicht nennt, wird nicht geschrieben. Das ist die Voreinstellung der Organisation; ein Postfach mit eigener Einstellung behält sie.",
   "captureSettings.adminOnly":
     "Nur ein Administrator oder Ops kann dies ändern.",
 
@@ -6950,14 +6950,14 @@ export const de = {
   "captureExclusions.empty": "Keine Ausschlüsse.",
   "ownerIdentities.title": "Ihre weiteren Adressen",
   "ownerIdentities.sub":
-    "Adressen, die auch Sie sind: ein Alias zum Senden, eine private Domain, die Sie lesen, eine Adresse, von der Sie weiterleiten. Post zwischen Ihren eigenen Adressen ist keine Korrespondenz mit jemandem — sie wird nicht erfasst und wird nie ein Kontakt.",
+    "Adressen, die auch Sie sind: ein Alias zum Senden, eine private Domain, die Sie lesen, eine Adresse, von der Sie weiterleiten. Post zwischen Ihren eigenen Adressen ist keine Korrespondenz mit jemandem — sie wird nicht erfasst und wird nie eine Person.",
   "ownerIdentities.add": "Adresse hinzufügen",
   "ownerIdentities.addLabel": "Eine weitere Adresse als Ihre eigene angeben",
   "ownerIdentities.addDescription":
     "Nur Ihre. Kolleginnen und Kollegen sehen nie, was Sie hier eintragen.",
   "ownerIdentities.current": "Angegeben",
   "ownerIdentities.notRetroactive":
-    "Gilt ab der nächsten Nachricht. Bereits erfasste Post bleibt, und ein aus einem Alias entstandener Kontakt bleibt, bis Sie ihn zusammenführen oder entfernen.",
+    "Gilt ab der nächsten Nachricht. Bereits erfasste Post bleibt, und eine aus einem Alias entstandene Person bleibt, bis Sie sie zusammenführen oder entfernen.",
   "ownerIdentities.empty": "Sie haben keine weiteren Adressen angegeben.",
   "ownerIdentities.remove": "Diese Adresse zurückziehen",
   "ownerIdentities.added": "Adresse hinzugefügt.",
@@ -7157,7 +7157,7 @@ export const de = {
   "person.enriched.confirm": "Das stimmt",
   "person.enriched.save": "Korrektur speichern",
   "person.enriched.cancel": "Abbrechen",
-  "person.graph.loading": "Das Netzwerk um diesen Kontakt wird gelesen \u2026",
+  "person.graph.loading": "Das Netzwerk um diese Person wird gelesen \u2026",
   "person.graph.routeDirect": "{name} steht bereits im Austausch mit ihnen.",
   "person.graph.routeVia":
     "{name} steht im Austausch mit {through} im selben Unternehmen.",
@@ -7168,7 +7168,7 @@ export const de = {
   "person.graph.recordWorksWith": "Festhalten: arbeitet mit {name} zusammen",
   "person.graph.noEdge": "Keine erfasste Korrespondenz mit {name}.",
   "person.graph.withColleague": "mit {name}",
-  "person.graph.withContact": "mit diesem Kontakt",
+  "person.graph.withContact": "mit dieser Person",
   "person.graph.counts":
     "{total} Interaktionen in 90 Tagen \u00b7 {inbound} eingehend, {outbound} ausgehend",
   "person.graph.untitledMessage": "Ohne Titel",
@@ -7179,7 +7179,7 @@ export const de = {
   "person.graph.withheldDirect":
     "Einige Kolleginnen und Kollegen werden nicht angezeigt.",
   "person.graph.withheldAccount":
-    "Einige Kontakte dieses Unternehmens werden nicht angezeigt.",
+    "Einige Personen dieses Unternehmens werden nicht angezeigt.",
   "person.intro.askFirstName": "{name} um eine Vorstellung bitten",
   "person.intro.leadEyebrow": "Empfohlener Weg",
   "person.intro.leadRouteBadge": "Starker Weg",
@@ -7250,7 +7250,7 @@ export const de = {
   "person.intro.lanePeers": "Mit wem sie sprechen",
   "person.intro.laneTarget": "Zielperson",
   "person.intro.useThisRoute": "Diesen Weg nutzen",
-  "person.intro.mapRegion": "Wer diesen Kontakt erreicht, und über wen",
+  "person.intro.mapRegion": "Wer diese Person erreicht, und über wen",
   "person.intro.edgeDirect": "{name} korrespondiert direkt mit ihr",
   "person.intro.edgeAccount": "arbeitet mit {name}",
   "person.intro.routesSub":
@@ -7274,13 +7274,13 @@ export const de = {
   "person.intro.askFailed": "Die Anfrage konnte nicht gespeichert werden.",
   "person.intro.reasonLabel": "Warum Sie fragen",
   "person.intro.reasonHint":
-    "Das liest Ihre Kollegin, nicht der Kontakt. Sagen Sie, warum sich die Vorstellung lohnt.",
-  "person.intro.valueLabel": "Was der Kontakt davon hat",
+    "Das liest Ihre Kollegin, nicht die Person. Sagen Sie, warum sich die Vorstellung lohnt.",
+  "person.intro.valueLabel": "Was die Person davon hat",
   "person.intro.valueHint":
-    "Der Grund, warum der Kontakt dieses Gespräch wollen würde.",
+    "Der Grund, warum die Person dieses Gespräch wollen würde.",
   "person.intro.noteLabel": "Notiz zum Weiterleiten",
   "person.intro.noteHint":
-    "Nur dieser Teil erreicht den Kontakt. Schreiben Sie ihn so, dass er unverändert weitergegeben werden kann.",
+    "Nur dieser Teil erreicht die Person. Schreiben Sie ihn so, dass er unverändert weitergegeben werden kann.",
   "person.intro.nameDropAsk": "Um Erlaubnis bitten, den Namen zu nennen",
   "person.intro.fallbackLegend": "Falls abgelehnt wird",
   "person.intro.fallbackNone": "Nichts weiter",
@@ -7380,7 +7380,7 @@ export const de = {
   "person.network.replied": "antwortete {when}",
 
   "person.page.loading": "Wird geladen…",
-  "person.page.notOpened": "Dieser Kontakt konnte nicht geöffnet werden.",
+  "person.page.notOpened": "Diese Person konnte nicht geöffnet werden.",
   "person.page.buyingRole": "Rolle im Kauf",
   "person.page.owner": "Zuständig",
   "person.page.ownerUnassigned": "Nicht zugewiesen",
@@ -7388,7 +7388,7 @@ export const de = {
   "person.page.openProfile": "Profil öffnen",
   "person.rail.detailsTitle": "Details",
   "person.rail.archivedReadOnly":
-    "Dieser Kontakt ist archiviert. Stelle ihn wieder her, um hier etwas zu ändern.",
+    "Diese Person ist archiviert. Stelle sie wieder her, um hier etwas zu ändern.",
   "person.rail.employmentVersionUnresolved":
     "Die aktuelle Version dieser Zeile konnte nicht zum Speichern zurückgelesen werden. Lade neu und versuche es erneut.",
   "person.rail.employmentTitle": "Unternehmen",
@@ -7413,7 +7413,7 @@ export const de = {
   "person.meetings.noneLogged": "Es ist kein Termin mit ihnen erfasst.",
   "person.meetings.untitled": "Termin ohne Betreff",
   "person.meetings.participants": "Im Raum",
-  "person.documents.empty": "Zu diesem Kontakt liegt keine Datei.",
+  "person.documents.empty": "Zu dieser Person liegt keine Datei.",
   "person.research.empty": "Zu ihnen wurde noch nichts recherchiert.",
   "person.research.fields": "Belege der Anreicherung",
   "person.research.fieldsEmpty":
@@ -7548,7 +7548,7 @@ export const de = {
   "person.rail.noReplyDays": "Seit {count} Tagen keine Antwort",
   "person.rail.repliedDaysAgo_one": "Antwort vor {count} Tag",
   "person.rail.repliedDaysAgo_other": "Antwort vor {count} Tagen",
-  "person.rail.singleThreaded": "Nur ein Kontakt in diesem Deal",
+  "person.rail.singleThreaded": "Nur eine Person in diesem Deal",
   "person.rail.noMeetingBooked": "Kein nächster Termin vereinbart",
   "person.rail.consentTitle": "Einwilligung & Kanäle",
   "person.rail.email": "E-Mail",
@@ -7589,7 +7589,7 @@ export const de = {
   "person.composer.blockedRewrite":
     "Eine Nachricht unter einem anderen Zweck muss auch diese Art von Nachricht SEIN — sie umzuetikettieren macht sie nicht dazu.",
   "person.composer.blockedRecordConsent":
-    "Wenn Sie eine Rechtsgrundlage haben, erfassen Sie die Einwilligungsentscheidung am Kontakt.",
+    "Wenn Sie eine Rechtsgrundlage haben, erfassen Sie die Einwilligungsentscheidung am Datensatz der Person.",
   "person.composer.consentPickPurpose":
     "Wählen Sie, wofür diese Nachricht ist — die Einwilligung gilt je Zweck.",
   "person.composer.intent": "Worum soll es gehen?",
@@ -7707,26 +7707,26 @@ export const de = {
   "provider.deleteDataConfirm.title":
     "Alles löschen, was von diesem Anbieter stammt?",
   "provider.deleteDataConfirm.body":
-    "Jeder Wert dieses Anbieters verschwindet von jedem Kontakt. Was du ausgegeben hast, bleibt in den Aufzeichnungen; die Daten nicht. Das lässt sich nicht rückgängig machen.",
+    "Jeder Wert dieses Anbieters verschwindet von jeder Person. Was du ausgegeben hast, bleibt in den Aufzeichnungen; die Daten nicht. Das lässt sich nicht rückgängig machen.",
   "provider.deleteDataConfirm.typed":
     "Zum Bestätigen den Namen des Anbieters eingeben",
-  "provider.automaticLookup": "Kontakte automatisch nachschlagen",
+  "provider.automaticLookup": "Personen automatisch nachschlagen",
   "provider.automaticLookupHint":
-    "Jeder Kontakt wird einmal nachgeschlagen — für das, was die Verbindung auswählt und der Anbieter nicht berechnet, in der Regel den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber und den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft: die kosten Guthaben und bleiben eine Entscheidung pro Kontakt.",
+    "Jede Person wird einmal nachgeschlagen — für das, was die Verbindung auswählt und der Anbieter nicht berechnet, in der Regel den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber und den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft: die kosten Guthaben und bleiben eine Entscheidung pro Person.",
   "provider.automaticLookupJurisdiction":
-    "Schalt das aus, wenn deine Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
+    "Schalt das aus, wenn die Personen in deinem CRM einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf der einzelnen Person funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
   "provider.buyable": "Kauf von {category} erlauben",
   "provider.buyableHint_one":
-    "Dieser Schalter kauft nichts. Er stellt bei jedem Kontakt eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
+    "Dieser Schalter kauft nichts. Er stellt bei jeder Person eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
   "provider.buyableHint_other":
-    "Dieser Schalter kauft nichts. Er stellt bei jedem Kontakt eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
+    "Dieser Schalter kauft nichts. Er stellt bei jeder Person eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
   "provider.buyableNeeds":
     "Der Anbieter sucht danach nur zusammen mit {prerequisite}. Einzeln lässt es sich nicht kaufen — erlauben Sie zuerst diese Angabe.",
   "provider.backlog": "Noch nachzuschlagen",
-  "provider.backlogRemaining_one": "{count} Kontakt",
-  "provider.backlogRemaining_other": "{count} Kontakte",
+  "provider.backlogRemaining_one": "{count} Person",
+  "provider.backlogRemaining_other": "{count} Personen",
   "provider.backlogWorking":
-    "Kontakte, die es beim Verbinden schon gab, werden nach und nach nachgeschlagen.",
+    "Personen, die es beim Verbinden schon gab, werden nach und nach nachgeschlagen.",
   "provider.backlogPaused":
     "Zurzeit wird nichts nachgeschlagen: automatische Abfragen sind aus, das Tageslimit ist aufgebraucht, oder der Anbieter ist nicht nutzbar.",
   "provider.credits": "Restguthaben beim Anbieter",
@@ -7752,11 +7752,10 @@ export const de = {
   "provider.profile.notConnected":
     "Es ist kein Datenanbieter verbunden, also wurde nichts gekauft.",
   "provider.profile.notEligible":
-    "Für diesen Kontakt nicht zulässig — er hat widersprochen, oder der Datensatz ist archiviert.",
+    "Für diese Person nicht zulässig — sie hat widersprochen, oder der Datensatz ist archiviert.",
   "provider.profile.nothingToLookUp":
-    "Es gibt nichts, womit sich dieser Kontakt nachschlagen ließe. Tragen Sie die LinkedIn-URL oder das Unternehmen ein, dann kann die Suche laufen.",
-  "provider.profile.neverRun":
-    "Diesen Kontakt hat noch niemand nachgeschlagen.",
+    "Es gibt nichts, womit sich diese Person nachschlagen ließe. Tragen Sie die LinkedIn-URL oder das Unternehmen ein, dann kann die Suche laufen.",
+  "provider.profile.neverRun": "Diese Person hat noch niemand nachgeschlagen.",
   "provider.profile.queued": "In der Warteschlange",
   "provider.profile.inProgress": "Wird nachgeschlagen …",
   "provider.profile.working":
@@ -7764,7 +7763,7 @@ export const de = {
   "provider.profile.landing":
     "Antwort da. Sie wird in den Datensatz übernommen.",
   "provider.profile.completed": "Gefunden",
-  "provider.profile.noMatch": "Der Anbieter hatte nichts zu diesem Kontakt.",
+  "provider.profile.noMatch": "Der Anbieter hatte nichts zu dieser Person.",
   "provider.profile.stale":
     "Früher gekauft. Der Anbieter ist nicht mehr verbunden, eine Auffrischung ist deshalb nicht möglich.",
   "provider.profile.invalidCredentials":
@@ -7779,12 +7778,12 @@ export const de = {
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":
     "Bezahlt, aber die Daten sind nie an diesem Datensatz angekommen. Niemand muss danach suchen — das hier ist die Lücke.",
-  "provider.profile.enrichNow": "Kontakt nachschlagen · kostenlos",
+  "provider.profile.enrichNow": "Person nachschlagen · kostenlos",
   "provider.profile.recheck": "Erneut prüfen · kostenlos",
   "provider.profile.lookingUp": "Wir fragen den Anbieter. Das dauert kurz.",
-  "provider.profile.emptyTitle": "Für diesen Kontakt wurde noch nichts gekauft",
+  "provider.profile.emptyTitle": "Für diese Person wurde noch nichts gekauft",
   "provider.profile.emptyBody":
-    "Eine Abfrage holt bei {provider} Angaben zu diesem Kontakt — je nachdem, was für diese Verbindung eingekauft werden soll. Sie kostet {provider}-Credits, und was zurückkommt steht hier neben dem Datensatz; überschrieben wird nichts, was jemand aus dem Team eingetragen hat.",
+    "Eine Abfrage holt bei {provider} Angaben zu dieser Person — je nachdem, was für diese Verbindung eingekauft werden soll. Sie kostet {provider}-Credits, und was zurückkommt steht hier neben dem Datensatz; überschrieben wird nichts, was jemand aus dem Team eingetragen hat.",
   "provider.profile.emails": "E-Mail-Adressen",
   "provider.profile.emailType.provider": "{type}, so vom Anbieter bezeichnet",
   "provider.profile.emailType.requested":
@@ -7803,9 +7802,9 @@ export const de = {
   "provider.profile.buyRebuys":
     "Im Preis ist {categories} erneut enthalten: Der Anbieter sucht ohne diese Angabe nicht danach und berechnet alles, was er zurückliefert.",
   "provider.freeTier.hint":
-    "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
+    "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jede neue Person bekommt sie, ohne dass jemand entscheiden muss.",
   "provider.pricedTier.hint":
-    "Werden nie automatisch gekauft. Jemand drückt bei einem einzelnen Kontakt auf den Knopf, und der Preis steht darauf.",
+    "Werden nie automatisch gekauft. Jemand drückt bei einer einzelnen Person auf den Knopf, und der Preis steht darauf.",
   "provider.profile.receiptAt": "Abgefragt am {at}.",
   "provider.profile.receipt":
     "Abgefragt am {at} · {asked} Angaben angefragt, {answered} zurückbekommen.",
@@ -7863,7 +7862,7 @@ export const de = {
   "filters.tab.deals": "Gesch\u00e4fte",
   "filters.builderTitle": "Filter",
   "filters.dynamic": "Dynamisch \u2014 bei jedem Ereignis neu berechnet",
-  "filters.matchContacts": "{count} Kontakte treffen zu",
+  "filters.matchContacts": "{count} Personen treffen zu",
   "filters.matchCompanies": "{count} Firmen treffen zu",
   "filters.matchDeals": "{count} Gesch\u00e4fte treffen zu",
   "filters.noFilterYet": "Bedingung hinzuf\u00fcgen, um die Treffer zu sehen",
@@ -7947,7 +7946,7 @@ export const de = {
   "projectCompanies.searchLabel": "Unternehmen nach Name suchen",
   "personProjects.title": "Projekte",
   "personProjects.empty":
-    "Dieser Kontakt erscheint hier, sobald er an einer Lieferung beteiligt ist — als Sponsor, Ansprechpartner oder wer sonst daran arbeitet.",
+    "Diese Person erscheint hier, sobald sie an einer Lieferung beteiligt ist — als Sponsor, Ansprechpartner oder wer sonst daran arbeitet.",
   "projectRole.customer": "Kunde",
   "projectRole.partner": "Partner",
   "projectRole.subcontractor": "Subunternehmer",
@@ -8380,7 +8379,7 @@ export const de = {
   "worklist.untitled.dsr": "Eine offene Datenschutzanfrage",
   "worklist.untitled.sync_health":
     "Die CRM-Synchronisierung braucht Aufmerksamkeit",
-  "worklist.sync.class.contacts": "Kontakte",
+  "worklist.sync.class.contacts": "Personen",
   "worklist.sync.class.companies": "Firmen",
   "worklist.sync.class.deals": "Deals",
   "worklist.sync.class.leads": "Interessenten",
@@ -8438,9 +8437,9 @@ export const de = {
   "worklist.verb.dismissed": "Für einen Monat zurückgestellt.",
   "worklist.verb.dismissUndo": "Rückgängig",
   "worklist.verb.dismissFailed":
-    "Dieser Kontakt konnte nicht zurückgestellt werden.",
+    "Diese Person konnte nicht zurückgestellt werden.",
   "worklist.verb.dismissUndoFailed":
-    "Dieser Kontakt konnte nicht zurückgeholt werden.",
+    "Diese Person konnte nicht zurückgeholt werden.",
   "worklist.verb.completeUndo": "Rückgängig",
   "worklist.verb.completeUndoFailed":
     "Diese Aufgabe konnte nicht wieder geöffnet werden.",
@@ -8519,7 +8518,7 @@ export const de = {
   "ob.digest.pageKind.team": "Team-Seite",
   "ob.digest.pageKind.services": "Leistungsseite",
   "ob.digest.pageKind.products": "Produktseite",
-  "ob.digest.pageKind.contact": "Kontaktseite",
+  "ob.digest.pageKind.contact": "Personenseite",
   "ob.digest.pageKind.other": "Seite",
   "ob.deck.counter": "{n} von {m}",
   "ob.deck.left": "Noch {n} von {m}",
@@ -8617,10 +8616,10 @@ export const de = {
   "aiRates.proposedDetail":
     "Gerade beim Anbieter gelesen, nicht aus deiner Preisliste. Beim Binden landet er in deinem Freigabe-Eingang, damit Verbrauch und Kosten ihn nach deiner Bestätigung bepreisen können.",
   "firstRun.ai.foot": "Vor dem Klick auf Weiter geht nichts an Ihren Anbieter.",
-  "person.readings.title": "Wo dieser Kontakt steht",
+  "person.readings.title": "Wo diese Person steht",
   "person.readings.move": "Wer ist am Zug",
   "person.readings.yourMove": "Du",
-  "person.readings.theirMove": "Der Kontakt",
+  "person.readings.theirMove": "Die Person",
   "person.readings.quiet": "Verstummt",
   "person.readings.neverSpoke": "Noch nie gesprochen",
   "person.readings.lastFromThem": "zuletzt von ihnen: {when}",
@@ -8636,8 +8635,8 @@ export const de = {
   "deal.strip.lastTouch": "Letzter Kontakt",
   "lead.standing.qualified": "Qualifiziert",
   "lead.standing.qualifiedOn":
-    "Qualifiziert am {at}. Dieser Lead ist jetzt ein Kontakt.",
-  "lead.standing.qualifiedUndated": "Dieser Lead ist jetzt ein Kontakt.",
+    "Qualifiziert am {at}. Dieser Lead ist jetzt eine Person.",
+  "lead.standing.qualifiedUndated": "Dieser Lead ist jetzt eine Person.",
   "lead.standing.closed": "Geschlossen",
   "lead.standing.closedFor":
     "Geschlossen: {reason}. Der Datensatz bleibt als Spur.",
@@ -8651,7 +8650,7 @@ export const de = {
   "lead.standing.inMotion": "In Bewegung",
   "lead.standing.engagedBecause":
     "Der Lead hat geantwortet, oder ein Termin steht im Kalender.",
-  "lead.standing.rests.promoted": "Zu einem Kontakt befördert.",
+  "lead.standing.rests.promoted": "Zu einer Person befördert.",
   "lead.standing.rests.closed": "Disqualifiziert, kein Grund erfasst.",
   "lead.standing.rests.ladder": "Lead-Leiter",
   "lead.standing.rests.record": "Lead-Datensatz",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2803,7 +2803,7 @@ export const de = {
   "deepread.kindTeam": "Team",
   "deepread.kindServices": "Leistungen",
   "deepread.kindProducts": "Produkte",
-  "deepread.kindContact": "Person",
+  "deepread.kindContact": "Kontakt",
   "deepread.kindOther": "Sonstiges",
 
   "transcriptread.title": "Dieses Transkript lesen",
@@ -8518,7 +8518,7 @@ export const de = {
   "ob.digest.pageKind.team": "Team-Seite",
   "ob.digest.pageKind.services": "Leistungsseite",
   "ob.digest.pageKind.products": "Produktseite",
-  "ob.digest.pageKind.contact": "Personenseite",
+  "ob.digest.pageKind.contact": "Kontaktseite",
   "ob.digest.pageKind.other": "Seite",
   "ob.deck.counter": "{n} von {m}",
   "ob.deck.left": "Noch {n} von {m}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -398,7 +398,7 @@ export const en = {
   "edit.versionSkew":
     "This record changed since you opened it — reload and try again.",
 
-  "merge.person": "Merge contact",
+  "merge.person": "Merge person",
   "merge.org": "Merge company",
   "merge.searchPlaceholder": "Search…",
   "merge.pickTarget": "Select the surviving record",
@@ -826,10 +826,10 @@ export const en = {
   "consent.grant": "Grant",
   "consent.withdraw": "Withdraw",
   "consent.doiBySubject":
-    "This purpose is confirmed by the contact themselves, through a link mailed to their own address. Use \u201cAsk them to confirm their details\u201d below.",
+    "This purpose is confirmed by the person themselves, through a link mailed to their own address. Use \u201cAsk them to confirm their details\u201d below.",
   "consent.askToConfirm": "Ask them to confirm their details",
   "consent.askToConfirmWhat":
-    "Mails this contact a private link to see what you hold about them, correct it, and say whether they want to hear from you. It goes to their own recorded address; you cannot send it anywhere else.",
+    "Mails this person a private link to see what you hold about them, correct it, and say whether they want to hear from you. It goes to their own recorded address; you cannot send it anywhere else.",
   "consent.askQueued": "On its way to {address}.",
   "consent.askNotDelivered":
     "The link was created for {address} but this installation sends no mail, so nobody was sent it.",
@@ -1143,12 +1143,12 @@ export const en = {
     "Their session ends now and their link stops working. Their comments stay visible and attributed. Access cannot be restored by them asking for a link.",
   "access.changeCapabilityTitle": "What may {name} do?",
   "persondealrooms.title": "Deal Rooms",
-  "persondealrooms.sub": "Rooms this contact can still enter.",
+  "persondealrooms.sub": "Rooms this person can still enter.",
   "persondealrooms.open": "Open",
   "persondealrooms.seatGone":
     "This address no longer holds a seat in that room.",
   "persondealrooms.cut":
-    "Only the first rooms are shown; this contact sits in more.",
+    "Only the first rooms are shown; this person sits in more.",
   "persondealrooms.revokeTitle": "Revoke access to {room}?",
   "room.state.draft": "Draft",
   "room.state.building": "Building",
@@ -1166,8 +1166,8 @@ export const en = {
   "co.pulse.owner": "Owner",
   "co.pulse.sizeBand": "{band} employees",
   "co.pulse.strongestLead": "Way in",
-  "co.pulse.strengthTail_one": "\u2014 the only contact here",
-  "co.pulse.strengthTail_other": "\u2014 of {count} contacts here",
+  "co.pulse.strengthTail_one": "\u2014 the only person here",
+  "co.pulse.strengthTail_other": "\u2014 of {count} people here",
   "co.pulse.unowned": "Unassigned",
   "co.since.first": "You are opening this account for the first time.",
   "co.partial":
@@ -1404,7 +1404,7 @@ export const en = {
   "co.evidence.kind.rule": "Derived",
   "co.brief.cite.deal": "deal",
   "co.brief.cite.activity": "activity",
-  "co.brief.cite.person": "contact",
+  "co.brief.cite.person": "person",
   "co.brief.cite.organization": "account",
   "co.brief.cite.fact": "fact",
   "co.brief.cite.profile_field": "profile field",
@@ -1412,7 +1412,7 @@ export const en = {
   // counted chip, rather than a run of identical labels.
   "co.brief.cite.deal.many": "{count} deals",
   "co.brief.cite.activity.many": "{count} activities",
-  "co.brief.cite.person.many": "{count} contacts",
+  "co.brief.cite.person.many": "{count} people",
   "co.brief.cite.organization.many": "{count} accounts",
   "co.brief.cite.fact.many": "{count} facts",
   "co.brief.cite.profile_field.many": "{count} profile fields",
@@ -1436,7 +1436,7 @@ export const en = {
   "approval.kind.site_lead": "Add a person found on the site",
   "approval.kind.capture_counterparty": "Add someone from your mail",
   "approval.kind.org_name_promotion": "Rename an account",
-  "approval.kind.vcard_create": "Create a contact from a card",
+  "approval.kind.vcard_create": "Create a person from a card",
   "approval.kind.lifecycle_change": "Account stage",
   "approval.kind.transcript_proposal": "Add a next step from a transcript",
   "approval.kind.fx_rate_proposal": "Refresh exchange rates",
@@ -1481,7 +1481,7 @@ export const en = {
   "approval.field.published_email": "Email on the page",
   "approval.field.connection_name": "On LinkedIn",
   "approval.field.connection_company": "Works at",
-  "approval.field.person_name": "Contact here",
+  "approval.field.person_name": "Person here",
   "approval.field.owner": "Owner",
   "approval.field.to": "To",
   "approval.field.currency": "Currency",
@@ -1539,8 +1539,8 @@ export const en = {
   "co.rail.deals.attentionOverdue": "Overdue",
   "co.rail.deals.attentionCommitment": "They owe us",
   "co.rail.people.title": "Their key people",
-  "co.rail.people.empty": "No contacts yet. Nobody to write to.",
-  "co.rail.people.add": "Add a contact",
+  "co.rail.people.empty": "No people yet. Nobody to write to.",
+  "co.rail.people.add": "Add a person",
   "co.rail.people.inTouch": "Already in touch with them",
   "co.rail.details.all": "All fields",
   "co.commercial.title": "Commercial",
@@ -1562,14 +1562,14 @@ export const en = {
   "linkedinImport.notConnectedNote":
     "Recording your profile URL attributes any connections you import to you by name.",
   "linkedinImport.whichFile":
-    "LinkedIn gives you Connections.csv under Settings \u2192 Data privacy \u2192 Get a copy of your data; the archive holds a dozen others, and this is the one. What you upload never becomes contacts: the connections stay out of search, lists and contact pages, and nobody can write to or email them.",
+    "LinkedIn gives you Connections.csv under Settings \u2192 Data privacy \u2192 Get a copy of your data; the archive holds a dozen others, and this is the one. What you upload never becomes people here: the connections stay out of search, lists and person pages, and nobody can write to or email them.",
   "linkedinImport.choose": "Choose Connections.csv",
   "linkedinImport.importLabel": "Connections export",
   "linkedinImport.noMatchesYet":
-    "No matches yet, which is normal in a new organization: your connections are matched against contacts the CRM knows, and those arrive as your mail is read. This runs again every hour, so matches appear as the CRM fills up.",
+    "No matches yet, which is normal in a new organization: your connections are matched against people the CRM knows, and those arrive as your mail is read. This runs again every hour, so matches appear as the CRM fills up.",
   "linkedinImport.working": "Reading your export…",
   "linkedinImport.imported": "Connections imported",
-  "linkedinImport.confirmed": "Matched to a contact",
+  "linkedinImport.confirmed": "Matched to a person",
   "linkedinImport.suggested": "Awaiting your confirmation",
 
   // The review queue and the reach table (ADR-0078 §2.1b).
@@ -1583,7 +1583,7 @@ export const en = {
   "linkedinReach.accountsLabel": "Accounts you reach",
   "linkedinReach.account": "Account",
   "linkedinReach.connections": "You know",
-  "linkedinReach.onFile": "Already contacts",
+  "linkedinReach.onFile": "Already on file",
   "linkedinReach.onFileOf": "{onFile} of {total}",
   "linkedinReach.footnote":
     "Showing {shown} of {total} accounts. {unresolved} connections work somewhere that is not an account on file yet.",
@@ -1680,7 +1680,7 @@ export const en = {
     "Some recipients were blind-copied and are not shown to you",
   "compose.audienceWorkspace": "Everyone in the organization",
   "compose.audienceWorkspaceHint":
-    "Anyone who may see the contact reads this message too.",
+    "Anyone who may see the person reads this message too.",
   "compose.audienceParticipants": "Participants only",
   "compose.audienceParticipantsHint":
     "Only the people on this message read its subject and body. Others see that a message was exchanged that day, nothing more.",
@@ -1691,7 +1691,7 @@ export const en = {
   "compose.audienceMembersLoading": "Reading the list of people…",
   "compose.audienceConfirm": "Save visibility",
   "compose.audienceNote":
-    "Applies to this message only \u2014 not to the thread and not to the contact.",
+    "Applies to this message only \u2014 not to the thread and not to the person.",
   "timeline.textMore": "Read it",
   "timeline.textLess": "Show less",
   "timeline.tailMore": "Show signature and quoted text",
@@ -2011,7 +2011,7 @@ export const en = {
   "tagResult.viewAll": "View all {count} {kind}",
   "tagResult.resultsTitle": "Records with this tag",
   "tagResult.nothingCarries":
-    "Nothing carries this tag yet. Apply it from any contact, company or deal.",
+    "Nothing carries this tag yet. Apply it from any person, company or deal.",
   "tagResult.loadingRows": "Loading {kind}…",
   "tagResult.noneLeft": "Nothing carries it any more",
   "tagResult.unnamed": "Unnamed",
@@ -2148,28 +2148,28 @@ export const en = {
   "lead.boardTerminalOnly":
     "None of these leads are still open \u2014 they are counted under Qualified and Disqualified.",
   "person.fromLead": "From lead",
-  "lead.promotedTitle": "Promoted to a contact",
+  "lead.promotedTitle": "Promoted to a person",
   "lead.promotedMerged":
-    "This lead merged into a contact we already knew — no duplicate was created.",
-  "lead.promotedCreated": "This lead became a new contact.",
+    "This lead merged into a person we already knew — no duplicate was created.",
+  "lead.promotedCreated": "This lead became a new person.",
   "lead.promotedAt": "Promoted",
   "lead.promotedTrigger": "Trigger:",
   "lead.promotedEvidence": "Evidence:",
   "lead.previewPending": "Checking whether we already know this person…",
-  "lead.previewCreate": "Promoting will create a new contact.",
-  "lead.previewMerge": "Promoting will merge into the existing contact",
+  "lead.previewCreate": "Promoting will create a new person.",
+  "lead.previewMerge": "Promoting will merge into the existing person",
   "lead.previewMergeWithheld":
-    "Promoting will merge into an existing contact you cannot see.",
+    "Promoting will merge into an existing person you cannot see.",
   "lead.demote": "Reverse promotion",
   "lead.demoteDialog": "Reverse this promotion?",
   "lead.demoteExplain":
-    "The lead returns to the queue as “Working”. A contact the promotion created is archived; a contact it merged into stays as it is. A contact on a live deal cannot be reversed.",
+    "The lead returns to the queue as “Working”. A person the promotion created is archived; a person it merged into stays as they are. A person on a live deal cannot be reversed.",
   "lead.demoteReason": "Reason (recorded in the audit trail)",
   "lead.demoteReasonRequired": "Say why first.",
   "lead.demoteConfirm": "Reverse",
   "lead.promotedOutcomePending": "Reading what this promotion did…",
   "lead.promotedOutcomeUnavailable":
-    "We cannot show whether this merged or created a contact.",
+    "We cannot show whether this merged or created a person.",
   "lead.terminalPromoted": "Promoted — this lead is now read-only.",
   "lead.statusNew": "New",
   "lead.statusContacted": "Contacted",
@@ -2275,7 +2275,7 @@ export const en = {
   "lead.trigger.humanQualify": "Human qualified",
   "lead.evidenceNote": "Evidence note (optional)",
   "lead.segregation":
-    "Leads are kept apart from Contacts. A lead becomes a contact only when you qualify it.",
+    "Leads are kept apart from People. A lead becomes a person only when you qualify it.",
   "lead.segregationDismiss": "Got it",
   "list.emptyMine": "You own no {unit}.",
   "list.showAll": "Show all",
@@ -2293,12 +2293,12 @@ export const en = {
   "lead.ladder.theyReplied": "they replied",
   "lead.ladder.meetingBooked": "a meeting was booked",
   "lead.ladder.meetingHeld": "a meeting was held",
-  "lead.ladder.qualified": "Qualified — this lead is a contact now.",
-  "lead.ladder.qualifiedOn": "Qualified on {at} — this lead is a contact now.",
+  "lead.ladder.qualified": "Qualified — this lead is a person now.",
+  "lead.ladder.qualifiedOn": "Qualified on {at} — this lead is a person now.",
   "lead.ladder.disqualified": "Disqualified.",
   "lead.ladder.disqualifiedWithReason": "Disqualified: {reason}",
   "lead.qualify.title": "Qualify {name}",
-  "lead.qualify.contact": "Contact",
+  "lead.qualify.contact": "Person",
   "lead.qualify.alsoDeal": "Also open a deal",
   "lead.qualify.pipeline": "Pipeline",
   "lead.qualify.stage": "Stage",
@@ -2316,7 +2316,7 @@ export const en = {
   "lead.qualify.reasonHuman": "Reason: qualified by you.",
   "lead.qualify.confirm": "Qualify",
   "lead.qualify.confirmWithDeal": "Qualify and open deal",
-  "lead.qualify.done": "{name} is now a contact:",
+  "lead.qualify.done": "{name} is now a person:",
   "lead.disqualify.title": "Disqualify {name}",
   "lead.disqualify.reason": "Reason",
   "lead.disqualify.pickReason": "Pick a reason",
@@ -2870,7 +2870,7 @@ export const en = {
   "deepread.kindTeam": "Team",
   "deepread.kindServices": "Services",
   "deepread.kindProducts": "Products",
-  "deepread.kindContact": "Contact",
+  "deepread.kindContact": "Person",
   "deepread.kindOther": "Other",
 
   "transcriptread.title": "Read this transcript",
@@ -2898,7 +2898,7 @@ export const en = {
   "create.multiselect.required": "Required — select at least one.",
   "create.save": "Create",
   "create.saving": "Creating…",
-  "create.contact": "New contact",
+  "create.contact": "New person",
   // The fast path beside it: reading a profile in another window and typing
   // what it says. The label names the ACT, not the source, because the same
   // form takes a conference badge and a business card.
@@ -3005,7 +3005,7 @@ export const en = {
   "co.spine.days_other": "{count} days",
   "co.spine.quietSince": "Silence since then",
   "co.spine.neverReplied": "They have never written back",
-  "co.spine.singleThreaded": "One contact, and no reply from them",
+  "co.spine.singleThreaded": "One person, and no reply from them",
   "co.spine.overdue": "Past its date",
   "co.spine.expectedClose": "Expected close",
   "co.360.subject": "{name} · 360",
@@ -3024,7 +3024,7 @@ export const en = {
   "today.source.nextMeeting": "the calendar",
   "today.source.deals": "deals",
   "today.meeting.prepare": "Prepare meeting",
-  "today.source.people": "the contacts",
+  "today.source.people": "the people",
   "today.source.standing": "whose move it is and the signals",
   "today.source.activities": "what was said",
   "today.silence.days": "no answer in {count} days",
@@ -3042,10 +3042,10 @@ export const en = {
   "evidence.humanSet": "Set by a person",
   "acctCoverage.open": "Compare coverage",
   "acctCoverage.title": "Who covers this account",
-  "acctCoverage.contact": "Contact",
-  "acctCoverage.findContact": "Find a contact",
+  "acctCoverage.contact": "Person",
+  "acctCoverage.findContact": "Find a person",
   "acctCoverage.untried": "Untried",
-  "acctCoverage.noMatch": "No contact matches that.",
+  "acctCoverage.noMatch": "Nobody matches that.",
   "acctCoverage.columnCap":
     "Showing {cap} colleagues — deselect one to add another.",
   "acctCoverage.partial":
@@ -3200,13 +3200,13 @@ export const en = {
   "log.save": "Log",
   "log.saving": "Logging…",
 
-  "personAccess.title": "Who can see this contact",
+  "personAccess.title": "Who can see this person",
   "personAccess.privateToYou":
-    "Private to you. Your mailbox created this contact, and nobody else in the organization can see it — not your team, and not an admin.",
+    "Private to you. Your mailbox created this person, and nobody else in the organization can see them — not your team, and not an admin.",
   "personAccess.organization":
-    "Everyone in the organization can see this contact.",
+    "Everyone in the organization can see this person.",
   "personAccess.share": "Share with the organization",
-  "personAccess.published": "The organization can see this contact now.",
+  "personAccess.published": "The organization can see this person now.",
   "compose.reply": "Reply",
   "compose.writeEmail": "Write email",
   "compose.relink": "Relink",
@@ -3234,9 +3234,9 @@ export const en = {
   "compose.cc": "Cc",
   "compose.subject": "Subject",
   "compose.noGroundableRecipient":
-    "No contact on this account yet — write the message yourself, or add a contact first",
+    "Nobody on this account yet — write the message yourself, or add a person first",
   "compose.draftTo": "Draft to",
-  "compose.draftToUnset": "Choose a contact",
+  "compose.draftToUnset": "Choose a person",
   "compose.relatedTo": "Related to",
   "compose.relatedToNone": "The account in general",
   "compose.project": "Project",
@@ -3797,7 +3797,7 @@ export const en = {
   "settings.autonomySub": "what runs instantly vs. what waits in the inbox",
   "settings.tierRead": "Read, summarize, draft — runs instantly, fully logged.",
   "settings.tierSend":
-    "Send email, book meetings, update a contact or a deal — runs instantly too, if you gave the agent that scope. Your grant is the approval, given once.",
+    "Send email, book meetings, update a person or a deal — runs instantly too, if you gave the agent that scope. Your grant is the approval, given once.",
   "settings.tierWait":
     "Enrichment, custom fields, webhooks, merging tags — these wait in your inbox.",
   "settings.tierAdvance":
@@ -3824,7 +3824,7 @@ export const en = {
   "import.object.organization": "Companies",
   "import.object.person": "People",
   "import.objectHint.lead":
-    "An unworked list lands as leads for a human to qualify before anyone treats them as contacts.",
+    "An unworked list lands as leads for a human to qualify before anyone treats them as people.",
   "import.objectHint.organization":
     "Companies are matched by the name you map, so a re-upload corrects rather than duplicates.",
   "import.objectHint.person":
@@ -4590,7 +4590,7 @@ export const en = {
     "Once your mailbox has brought in mail, every sender it saw is listed here with what became of them.",
   "senders.colSender": "Sender",
   "senders.colDecision": "Decided",
-  "senders.colRecord": "Contact",
+  "senders.colRecord": "Person",
   "senders.colActions": "What you can do",
   "senders.recordYes": "Yes",
   "senders.recordNo": "No",
@@ -4601,7 +4601,7 @@ export const en = {
   "senders.withdraw": "Undo",
   "senders.keepOutTitle": "Keep this sender out for good?",
   "senders.keepOutBody":
-    "No contact is created, and the mail this sender already brought into your mailbox is destroyed. Mail a colleague also imported stays theirs.",
+    "No person is created, and the mail this sender already brought into your mailbox is destroyed. Mail a colleague also imported stays theirs.",
   "senders.keepOutConfirm": "Keep out and destroy",
   "senders.kind.person": "A person",
   "senders.kind.roleMailbox": "A role mailbox",
@@ -4616,7 +4616,7 @@ export const en = {
   "senders.kind.undecided": "Not yet decided",
   "mailSharing.title": "Email sharing",
   "mailSharing.sub":
-    "Captured mail is readable by every colleague who can see the contact. On by default — it is what makes the pipeline shared.",
+    "Captured mail is readable by every colleague who can see the person. On by default — it is what makes the pipeline shared.",
   "mailSharing.label": "Share captured mail with the team",
   "mailSharing.help":
     "Individual messages can be limited afterwards, and addresses or domains excluded up front.",
@@ -4663,7 +4663,7 @@ export const en = {
   "connectors.contextTag.label": "File what this connector brings in under",
   "connectors.contextTag.none": "No tag",
   "connectors.contextTag.hint":
-    "An existing tag. Every contact this connector creates from now on is filed under it, so you can ask what came in from this source. Contacts already here keep the tags they have.",
+    "An existing tag. Every person this connector creates from now on is filed under it, so you can ask what came in from this source. People already here keep the tags they have.",
   "connectors.contextTag.archived":
     "{name} has been archived, so nothing is being filed under it. Choose another tag, or none.",
   "connectors.signatureEnrich.followingDefault":
@@ -4671,7 +4671,7 @@ export const en = {
   "connectors.signatureEnrich.ownAnswer":
     "This mailbox's own answer, kept whatever your organization's setting becomes.",
   "hold.sectionTitle": "Private correspondence",
-  "hold.notHeld": "Mail with this contact follows your mailbox setting.",
+  "hold.notHeld": "Mail with this person follows your mailbox setting.",
   "hold.heldByAddress": "You keep mail with this address to the people on it.",
   "hold.heldByDomain": "You keep mail with {domain} to the people on it.",
   "hold.holdAddress": "Keep private",
@@ -4688,7 +4688,7 @@ export const en = {
   "hold.confirmHistoryNote":
     "This covers mail from here on. Mail already captured keeps the visibility it has.",
   "captureNotice.whatHappens":
-    "Margince reads this mailbox and files what it finds: the messages, who was on them, and the contacts and companies behind the addresses. Attachments are stored with their message.",
+    "Margince reads this mailbox and files what it finds: the messages, who was on them, and the people and companies behind the addresses. Attachments are stored with their message.",
   "captureNotice.whoReads":
     "A new mailbox is held by default. A message stays with the people who were on it until a classifier judges the thread to be ordinary business — only then can colleagues read it. You can set the mailbox to hold everything instead, at any time.",
   "captureNotice.yourControl":
@@ -4900,7 +4900,7 @@ export const en = {
   "ob.s4.accessToggle": "What access this gives",
   "ob.s4.scope1Lead": "We read — we don't clutter.",
   "ob.s4.scope1Rest":
-    "Your mail becomes contacts, companies and activities, captured automatically.",
+    "Your mail becomes people, companies and activities, captured automatically.",
   "ob.s4.scope2Lead": "Sending is part of this permission.",
   "ob.s4.scope2Rest":
     "Margince can send from this mailbox — when you send, and when you give an agent a passport that allows sending. That grant is your approval, given once. You can withdraw it at any time.",
@@ -5080,10 +5080,10 @@ export const en = {
   "ob.conv.scene.continue": "Continue",
   "ob.conv.connect.sceneTitle": "Connect your accounts.",
   "ob.conv.connect.sceneSub":
-    "I build your contacts, companies and history from what is already in your inbox.",
+    "I build your people, companies and history from what is already in your inbox.",
   "ob.conv.connect.mailboxTitle": "Your mailbox",
   "ob.conv.connect.mailboxHint":
-    "Pick one. This is where your contacts, companies and history come from.",
+    "Pick one. This is where your people, companies and history come from.",
   "ob.conv.connect.networkTitle": "Your network",
   "ob.conv.connect.networkHint":
     "Optional but worth it. Turns who you know into accounts and watches them for triggers.",
@@ -5116,7 +5116,7 @@ export const en = {
   "ob.conv.connect.unsupportedCard": "This installation does not serve {name}.",
   "ob.conv.connect.appSetupLink": "Set it up in Settings",
   "ob.conv.connect.dialogIntro":
-    "{brings}. I read it once to build your contacts and history, then keep it in sync.",
+    "{brings}. I read it once to build your people and history, then keep it in sync.",
   "ob.conv.connect.dialogClose": "Close",
   "ob.conv.connect.linkedinName": "LinkedIn",
   "ob.conv.connect.linkedinConnected": "Connected",
@@ -5216,7 +5216,7 @@ export const en = {
   "ob.conv.connect.mailboxNeeded":
     "A mailbox is still needed: mail is what gets read and drafted. Connect one above, or continue without one for now.",
   "ob.conv.linkedin.cardBody":
-    "Turns your network into accounts and contacts, and flags it when a connection changes jobs.",
+    "Turns your network into accounts and people, and flags it when a connection changes jobs.",
   "ob.conv.linkedin.limitsToggle": "What Margince can and cannot see",
   "ob.conv.linkedin.scope1Lead": "Your connection list \u2014",
   "ob.conv.linkedin.scope1Rest":
@@ -5231,7 +5231,7 @@ export const en = {
   "ob.conv.linkedin.scope4Rest":
     "Connecting sends no invitations and no messages, ever.",
   "ob.conv.linkedin.neverContacts":
-    "Your connections never become contacts. They answer one question: who here already knows them?",
+    "Your connections never become people here. They answer one question: who here already knows them?",
   "ob.conv.linkedin.profileLabel": "Your LinkedIn profile URL",
   "ob.conv.linkedin.profilePlaceholder": "https://www.linkedin.com/in/…",
   "ob.conv.linkedin.profileWhy":
@@ -5636,7 +5636,7 @@ export const en = {
   "client.open360": "Open the 360",
   "client.unknown": "Not in your organization yet.",
   "client.unknownDetail":
-    "This sender matches no contact you can see. Nothing was fetched from anywhere else.",
+    "This sender matches no person you can see. Nothing was fetched from anywhere else.",
   "client.createLead": "Capture as lead",
   "client.isolation": "talks only to YOUR organization",
   "client.attribution": "Every capture is attributed and auditable.",
@@ -5943,7 +5943,7 @@ export const en = {
   "network.bucket.strong": "Strong",
   "coverage.engaged": "Engaged",
   "coverage.quiet": "No two-way contact",
-  "coverage.seatWithheld": "A contact you cannot read",
+  "coverage.seatWithheld": "A person you cannot read",
   "coverage.daysSinceTouch": "{days} days",
   "coverage.risk.single_threaded_theirs": "Single-threaded",
   "coverage.risk.single_threaded_ours": "Carried by one colleague",
@@ -5959,7 +5959,7 @@ export const en = {
   "cf.object": "Object",
   "cf.obj.deal": "Deal",
   "cf.obj.organization": "Company",
-  "cf.obj.person": "Contact",
+  "cf.obj.person": "Person",
   "cf.obj.lead": "Lead",
   "cf.listLabel": "Fields on {object}",
   "cf.col.field": "Field",
@@ -5972,9 +5972,9 @@ export const en = {
   "cf.empty.organization":
     "No custom fields on Company yet. Add one if you track something we didn't ship.",
   "cf.empty.person":
-    "No custom fields on Contact yet. Core fields cover the contact record; add one if you track more.",
+    "No custom fields on Person yet. Core fields cover the person record; add one if you track more.",
   "cf.empty.lead":
-    "No custom fields on Lead yet. A field you add here also appears once a lead is promoted to a contact.",
+    "No custom fields on Lead yet. A field you add here also appears once a lead is promoted to a person.",
   "cf.type.text": "Text",
   "cf.type.number": "Number",
   "cf.type.date": "Date",
@@ -6124,7 +6124,7 @@ export const en = {
   "captureActivity.contentNone": "no sender recorded",
   "captureActivity.outcome.captured": "Captured",
   "captureActivity.outcome.internal": "Dropped as internal",
-  "captureActivity.outcome.suppressed": "No contact created",
+  "captureActivity.outcome.suppressed": "No person created",
   "captureActivity.outcome.deferred": "Waiting on a verdict",
   "captureActivity.outcome.fault": "Derivation failed",
   "captureActivity.reason.internal_only": "every party was on your own domains",
@@ -6133,18 +6133,18 @@ export const en = {
   "captureActivity.reason.noise_prior":
     "a previous verdict judged this sender noise, so it will be archived",
   "captureActivity.reason.decided_prior":
-    "this sender was already decided, so no contact will be created",
+    "this sender was already decided, so no person will be created",
   "captureActivity.reason.no_granting_human":
     "the connection named no member to act for",
   "captureActivity.reason.invisible_incumbent":
     "it matched a record outside what you can see",
   "captureActivity.reason.derivation_failed":
-    "the contact step failed; the message itself is unaffected",
+    "the person step failed; the message itself is unaffected",
   "captureActivity.reason.no_counterparty": "no sender this CRM could record",
   "captureActivity.reason.role_mailbox":
-    "a shared mailbox, not a person — kept, but no contact created",
+    "a shared mailbox, not a person — kept, but no person created",
   "captureActivity.reason.private_thread":
-    "a private conversation — kept for you, but no contact created",
+    "a private conversation — kept for you, but no person created",
   "captureActivity.reason.transactional_infra":
     "the sender is mail infrastructure, not a company you work with",
   "captureActivity.reason.transactional_prefix":
@@ -6153,7 +6153,7 @@ export const en = {
   "captureActivity.outcome.deferred_sent": "Sent for a verdict",
   "captureActivity.resolution.pending": "still waiting",
   "captureActivity.resolution.unsure": "sent to the review queue",
-  "captureActivity.resolution.real": "judged a real contact",
+  "captureActivity.resolution.real": "judged a real person",
   "captureActivity.resolution.noise": "judged noise",
   "captureActivity.resolution.rejected": "declined by a human",
   "captureActivity.resolution.suppressed": "suppressed",
@@ -6182,8 +6182,8 @@ export const en = {
   "pipeline.stage.erasure_check": "Erasure check",
   "pipeline.stage.internal_drop": "Internal-only check",
   "pipeline.stage.activity_write": "Saved to the timeline",
-  "pipeline.stage.tier_ladder": "Contact decision",
-  "pipeline.stage.person_create": "Contact created",
+  "pipeline.stage.tier_ladder": "Person decision",
+  "pipeline.stage.person_create": "Person created",
   "pipeline.stage.verdict": "Sender verdict",
   "pipeline.stage.company_triage": "Company check",
   "pipeline.stage.attention_label": "Attention label",
@@ -6202,16 +6202,16 @@ export const en = {
   "pipeline.reason.decided_prior": "this sender was already decided",
   "pipeline.reason.no_counterparty": "no sender this CRM could record",
   "pipeline.reason.role_mailbox":
-    "a shared mailbox, not a person — kept, but no contact created",
+    "a shared mailbox, not a person — kept, but no person created",
   "pipeline.reason.private_thread":
-    "a private conversation — kept for you, but no contact created",
+    "a private conversation — kept for you, but no person created",
   "pipeline.reason.no_granting_human":
     "the connection named no member to act for",
   "pipeline.reason.derivation_failed":
-    "the contact step failed; the message itself is unaffected",
-  "pipeline.reason.not_linked_yet": "no contact is linked to this message yet",
+    "the person step failed; the message itself is unaffected",
+  "pipeline.reason.not_linked_yet": "no person is linked to this message yet",
   "pipeline.reason.no_contact_intended":
-    "the contact decision concluded that none was to be made",
+    "the person decision concluded that none was to be made",
   "pipeline.reason.awaiting_verdict":
     "the sender is still waiting on a verdict",
   "pipeline.reason.verdict_reached":
@@ -7014,13 +7014,13 @@ export const en = {
     "A company moves stage on what has happened with it. This one can also change who sees the account and which automations run.",
   "captureSettings.title": "Enrichment",
   "captureSettings.sub":
-    "How captured companies and contacts are enriched after they are created.",
+    "How captured companies and people are enriched after they are created.",
   "captureSettings.autoEnrich.label": "Auto-enrich captured companies",
   "captureSettings.autoEnrich.help":
     "When on, each new company created from captured mail gets an automatic web dossier — its site is read and its profile filled in. Runs under a daily limit.",
   "captureSettings.signatureEnrich.label": "Read contact details from mail",
   "captureSettings.signatureEnrich.help":
-    "When on, Margince reads what a contact states under their own name in mail they sent you — in a signature, and on a business card attached to it. A title, a phone number, an address, a company. It happens within minutes of the mail arriving. Nothing is inferred: a detail the mail does not state is not written. This is the organization's default; a mailbox that set its own switch keeps it.",
+    "When on, Margince reads what a person states under their own name in mail they sent you — in a signature, and on a business card attached to it. A title, a phone number, an address, a company. It happens within minutes of the mail arriving. Nothing is inferred: a detail the mail does not state is not written. This is the organization's default; a mailbox that set its own switch keeps it.",
   "captureSettings.adminOnly": "Only an admin or ops can change this.",
 
   "ownDomains.companyTitle": "Company domains",
@@ -7033,14 +7033,14 @@ export const en = {
   "captureExclusions.empty": "No exclusions.",
   "ownerIdentities.title": "Your other addresses",
   "ownerIdentities.sub":
-    "Addresses that are also you: a send-as alias, a private domain you read, an address you forward from. Mail between your own addresses is not correspondence with anybody, so it is not captured and never becomes a contact.",
+    "Addresses that are also you: a send-as alias, a private domain you read, an address you forward from. Mail between your own addresses is not correspondence with anybody, so it is not captured and never becomes a person.",
   "ownerIdentities.add": "Add address",
   "ownerIdentities.addLabel": "Declare another address as your own",
   "ownerIdentities.addDescription":
     "Yours alone. A colleague never sees what you list here.",
   "ownerIdentities.current": "Declared",
   "ownerIdentities.notRetroactive":
-    "Applies from the next message on. Mail already captured stays, and a contact already made from an alias stays until you merge or remove it.",
+    "Applies from the next message on. Mail already captured stays, and a person already made from an alias stays until you merge or remove it.",
   "ownerIdentities.empty": "You have declared no other addresses.",
   "ownerIdentities.remove": "Withdraw this address",
   "ownerIdentities.added": "Address added.",
@@ -7237,7 +7237,7 @@ export const en = {
   "person.enriched.confirm": "That is right",
   "person.enriched.save": "Save the correction",
   "person.enriched.cancel": "Cancel",
-  "person.graph.loading": "Reading the network around this contact…",
+  "person.graph.loading": "Reading the network around this person…",
   "person.graph.routeDirect": "{name} already corresponds with them.",
   "person.graph.routeVia":
     "{name} corresponds with {through} at the same company.",
@@ -7250,7 +7250,7 @@ export const en = {
   "person.graph.recordWorksWith": "Record: works with {name}",
   "person.graph.noEdge": "No recorded correspondence with {name}.",
   "person.graph.withColleague": "with {name}",
-  "person.graph.withContact": "with this contact",
+  "person.graph.withContact": "with this person",
   "person.graph.counts":
     "{total} interactions in 90 days · {inbound} in, {outbound} out",
   "person.graph.untitledMessage": "Untitled",
@@ -7259,8 +7259,7 @@ export const en = {
   "person.intro.routesTitle": "Ways in",
   "person.graph.droppedNote": "{count} more not shown.",
   "person.graph.withheldDirect": "Some colleagues are not shown.",
-  "person.graph.withheldAccount":
-    "Some contacts at this company are not shown.",
+  "person.graph.withheldAccount": "Some people at this company are not shown.",
   "person.intro.askFirstName": "Ask {name} for an intro",
   "person.intro.leadEyebrow": "Recommended route",
   "person.intro.leadRouteBadge": "Strong route",
@@ -7328,7 +7327,7 @@ export const en = {
   "person.intro.lanePeers": "Who they talk to",
   "person.intro.laneTarget": "Target",
   "person.intro.useThisRoute": "Use this route",
-  "person.intro.mapRegion": "Who can reach this contact, and through whom",
+  "person.intro.mapRegion": "Who can reach this person, and through whom",
   "person.intro.edgeDirect": "{name} corresponds with them directly",
   "person.intro.edgeAccount": "works with {name}",
   "person.intro.routesSub":
@@ -7352,13 +7351,13 @@ export const en = {
   "person.intro.askFailed": "The ask could not be recorded.",
   "person.intro.reasonLabel": "Why you are asking",
   "person.intro.reasonHint":
-    "Your colleague reads this, not the contact. Say what makes the introduction worth making.",
+    "Your colleague reads this, not the person. Say what makes the introduction worth making.",
   "person.intro.valueLabel": "What is in it for them",
   "person.intro.valueHint":
-    "The reason the contact would want this conversation.",
+    "The reason the person would want this conversation.",
   "person.intro.noteLabel": "Note your colleague can forward",
   "person.intro.noteHint":
-    "The only part the contact reads. Write it so it can be pasted as it stands.",
+    "The only part the person reads. Write it so it can be pasted as it stands.",
   "person.intro.nameDropAsk": "Ask permission to mention their name",
   "person.intro.fallbackLegend": "If they say no",
   "person.intro.fallbackNone": "Nothing further",
@@ -7455,7 +7454,7 @@ export const en = {
   // absence of correspondence, "None" under a meeting is an absence of a
   // booking, and German renders them differently.
   "person.page.loading": "Loading…",
-  "person.page.notOpened": "This contact could not be opened.",
+  "person.page.notOpened": "This person could not be opened.",
   "person.page.buyingRole": "Buying role",
   "person.page.owner": "Owner",
   "person.page.ownerUnassigned": "Unassigned",
@@ -7464,11 +7463,11 @@ export const en = {
   // correct AND a place to go, and the verb names the second so neither reads
   // as the other.
   "person.page.openProfile": "Open profile",
-  // The rail's own details grid: the contact's own fields, at a glance above
+  // The rail's own details grid: the person's own fields, at a glance above
   // the six relationship sections below it.
   "person.rail.detailsTitle": "Details",
   "person.rail.archivedReadOnly":
-    "This contact is archived. Restore them to change anything here.",
+    "This person is archived. Restore them to change anything here.",
   // Fired when an employment row's version could not be read back before a
   // write — the row is not saved unpinned, so the reader is told to reload
   // rather than left to think the edit landed.
@@ -7497,7 +7496,7 @@ export const en = {
   "person.meetings.noneLogged": "No meeting with them has been logged.",
   "person.meetings.untitled": "Untitled meeting",
   "person.meetings.participants": "In the room",
-  "person.documents.empty": "No file has been filed against this contact.",
+  "person.documents.empty": "No file has been filed against this person.",
   "person.research.empty": "Nothing has been researched about them yet.",
   "person.research.fields": "Enrichment evidence",
   "person.research.fieldsEmpty": "No enriched field carries evidence yet.",
@@ -7676,7 +7675,7 @@ export const en = {
   "person.composer.blockedRewrite":
     "A message sent under another purpose has to BE that kind of message — relabelling this one does not make it so.",
   "person.composer.blockedRecordConsent":
-    "If you have a basis for writing, record the consent decision on their contact record.",
+    "If you have a basis for writing, record the consent decision on their record.",
   "person.composer.consentPickPurpose":
     "Choose what this message is for — consent is decided per purpose.",
   "person.composer.intent": "What should it be about?",
@@ -7783,7 +7782,7 @@ export const en = {
     "Paste a new key to replace the stored one",
   "provider.connectConfirm.title": "Connect this data provider?",
   "provider.connectConfirm.body":
-    "The key is checked against the provider before anything is saved. Once connected, enriching a contact spends your credits.",
+    "The key is checked against the provider before anything is saved. Once connected, enriching a person spends your credits.",
   "provider.disconnect": "Disconnect",
   "provider.disconnectConfirm.title": "Disconnect the provider?",
   "provider.disconnectConfirm.body":
@@ -7792,25 +7791,25 @@ export const en = {
   "provider.deleteDataConfirm.title":
     "Delete everything bought from this provider?",
   "provider.deleteDataConfirm.body":
-    "Every value this provider supplied is removed from every contact. What you spent stays in your records; the data does not. This cannot be undone.",
+    "Every value this provider supplied is removed from every person. What you spent stays in your records; the data does not. This cannot be undone.",
   "provider.deleteDataConfirm.typed": "Type the provider's name to confirm",
-  "provider.automaticLookup": "Look up contacts automatically",
+  "provider.automaticLookup": "Look up people automatically",
   "provider.automaticLookupHint":
-    "Every contact is looked up once for whatever the connection selects that the provider charges nothing for — typically the professional profile link, the current role and employer, and the work history. Email addresses and mobile numbers are never bought this way: those cost credits and stay a decision you make per contact.",
+    "Every person is looked up once for whatever the connection selects that the provider charges nothing for — typically the professional profile link, the current role and employer, and the work history. Email addresses and mobile numbers are never bought this way: those cost credits and stay a decision you make per person.",
   "provider.automaticLookupJurisdiction":
-    "Switch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
+    "Switch this off if the people in your CRM fall under a law that forbids trading personal data, Vietnam's among them. The button on each person still works, which keeps the decision with the person making it.",
   "provider.buyable": "Allow buying {category}",
   "provider.buyableHint_one":
-    "Switching this on buys nothing. It puts a button on each contact, priced at {credits} credit, so somebody can buy this detail for one person at a time.",
+    "Switching this on buys nothing. It puts a button on each person, priced at {credits} credit, so somebody can buy this detail for one person at a time.",
   "provider.buyableHint_other":
-    "Switching this on buys nothing. It puts a button on each contact, priced at {credits} credits, so somebody can buy this detail for one person at a time.",
+    "Switching this on buys nothing. It puts a button on each person, priced at {credits} credits, so somebody can buy this detail for one person at a time.",
   "provider.buyableNeeds":
     "The provider looks for this only alongside the {prerequisite}, so it cannot be bought on its own. Allow that one first.",
   "provider.backlog": "Still to look up",
-  "provider.backlogRemaining_one": "{count} contact",
-  "provider.backlogRemaining_other": "{count} contacts",
+  "provider.backlogRemaining_one": "{count} person",
+  "provider.backlogRemaining_other": "{count} people",
   "provider.backlogWorking":
-    "Contacts that were already here when the provider was connected are being looked up a few at a time.",
+    "People who were already here when the provider was connected are being looked up a few at a time.",
   "provider.backlogPaused":
     "Nothing is being looked up right now: automatic lookups are off, the day's limit is spent, or the provider is not usable.",
   "provider.credits": "Credits left with the provider",
@@ -7839,16 +7838,16 @@ export const en = {
   "provider.profile.notConnected":
     "No data provider is connected, so nothing has been bought.",
   "provider.profile.notEligible":
-    "This contact is not eligible — they have objected, or the record is archived.",
+    "This person is not eligible — they have objected, or the record is archived.",
   "provider.profile.nothingToLookUp":
-    "There is nothing to look this contact up by. Add their LinkedIn URL, or the company they work for, and the lookup can run.",
-  "provider.profile.neverRun": "Nobody has looked this contact up yet.",
+    "There is nothing to look this person up by. Add their LinkedIn URL, or the company they work for, and the lookup can run.",
+  "provider.profile.neverRun": "Nobody has looked this person up yet.",
   "provider.profile.queued": "Queued",
   "provider.profile.inProgress": "Looking them up…",
   "provider.profile.working": "Asking {provider}. This takes up to a minute.",
   "provider.profile.landing": "Answer received. Putting it on the record.",
   "provider.profile.completed": "Found",
-  "provider.profile.noMatch": "The provider had nothing for this contact.",
+  "provider.profile.noMatch": "The provider had nothing for this person.",
   "provider.profile.stale":
     "Bought earlier. The provider is no longer connected, so this cannot be refreshed.",
   "provider.profile.invalidCredentials":
@@ -7863,12 +7862,12 @@ export const en = {
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":
     "Paid for, but the details never reached this record. Nobody has to hunt for them — this is the gap.",
-  "provider.profile.enrichNow": "Look this contact up · free",
+  "provider.profile.enrichNow": "Look this person up · free",
   "provider.profile.recheck": "Check again · free",
   "provider.profile.lookingUp": "Asking the provider. This takes a moment.",
-  "provider.profile.emptyTitle": "Nothing bought for this contact yet",
+  "provider.profile.emptyTitle": "Nothing bought for this person yet",
   "provider.profile.emptyBody":
-    "A lookup asks {provider} about this contact, for whichever details this connection is set to buy. It spends {provider} credits, and what comes back sits here beside the record rather than overwriting anything a colleague typed.",
+    "A lookup asks {provider} about this person, for whichever details this connection is set to buy. It spends {provider} credits, and what comes back sits here beside the record rather than overwriting anything a colleague typed.",
   "provider.profile.emails": "Email addresses",
   "provider.profile.emailType.provider": "{type}, as the provider labelled it",
   "provider.profile.emailType.requested":
@@ -7891,9 +7890,9 @@ export const en = {
   "provider.profile.buyRebuys":
     "The price includes the {categories} again: the provider will not look for this without it, and it charges for whatever it sends back.",
   "provider.freeTier.hint":
-    "LinkedIn profile, current role and work history cost no credits. Leave this on: every new contact gets them without anybody deciding.",
+    "LinkedIn profile, current role and work history cost no credits. Leave this on: every new person gets them without anybody deciding.",
   "provider.pricedTier.hint":
-    "Never bought automatically. Somebody presses a button on one contact, and the price is on the button.",
+    "Never bought automatically. Somebody presses a button on one person, and the price is on the button.",
   "provider.profile.receiptAt": "Looked up {at}.",
   "provider.profile.receipt":
     "Looked up {at} · asked for {asked} details, got {answered} back.",
@@ -7947,7 +7946,7 @@ export const en = {
   "filters.op.atMost": "is at most",
 
   // The Filters & views screen's own chrome. The match line is keyed per object
-  // because "3 contacts match" and "3 companies match" are different sentences in
+  // because "3 people match" and "3 companies match" are different sentences in
   // every language, and a shared "{count} match" would make the object a
   // placeholder that some grammars cannot place.
   "filters.title": "Filters & views",
@@ -7959,7 +7958,7 @@ export const en = {
   "filters.tab.deals": "Deals",
   "filters.builderTitle": "Filter",
   "filters.dynamic": "Dynamic \u2014 recomputes on every event",
-  "filters.matchContacts": "{count} contacts match",
+  "filters.matchContacts": "{count} people match",
   "filters.matchCompanies": "{count} companies match",
   "filters.matchDeals": "{count} deals match",
   "filters.noFilterYet": "Add a clause to see what it selects",
@@ -8059,7 +8058,7 @@ export const en = {
   "projectCompanies.searchLabel": "Search companies by name",
   "personProjects.title": "Projects",
   "personProjects.empty":
-    "This contact appears here once they are on a delivery — as a sponsor, a contact, or whoever else is working it.",
+    "This person appears here once they are on a delivery — as a sponsor, a contact, or whoever else is working it.",
   "projectRole.customer": "Customer",
   "projectRole.partner": "Partner",
   "projectRole.subcontractor": "Subcontractor",
@@ -8485,7 +8484,7 @@ export const en = {
   "worklist.untitled.failed_approval": "Something you approved did not run",
   "worklist.untitled.dsr": "An open privacy request",
   "worklist.untitled.sync_health": "The CRM sync needs attention",
-  "worklist.sync.class.contacts": "contacts",
+  "worklist.sync.class.contacts": "people",
   "worklist.sync.class.companies": "companies",
   "worklist.sync.class.deals": "deals",
   "worklist.sync.class.leads": "prospects",
@@ -8540,8 +8539,8 @@ export const en = {
   "worklist.verb.dismiss": "Not now",
   "worklist.verb.dismissed": "Set aside for a month.",
   "worklist.verb.dismissUndo": "Undo",
-  "worklist.verb.dismissFailed": "That contact could not be set aside.",
-  "worklist.verb.dismissUndoFailed": "That contact could not be put back.",
+  "worklist.verb.dismissFailed": "That person could not be set aside.",
+  "worklist.verb.dismissUndoFailed": "That person could not be put back.",
   "worklist.verb.completeUndo": "Undo",
   "worklist.verb.completeUndoFailed": "That task could not be reopened.",
   // The frame states the fact and the source follows it, rather than the
@@ -8629,7 +8628,7 @@ export const en = {
   "ob.digest.pageKind.team": "Team page",
   "ob.digest.pageKind.services": "Services page",
   "ob.digest.pageKind.products": "Products page",
-  "ob.digest.pageKind.contact": "Contact page",
+  "ob.digest.pageKind.contact": "Person page",
   "ob.digest.pageKind.other": "Page",
   "ob.deck.counter": "{n} of {m}",
   "ob.deck.left": "{n} of {m} left",
@@ -8725,7 +8724,7 @@ export const en = {
   "firstRun.ignite.carryOn": "Carry on",
   "firstRun.ai.foot":
     "Nothing is sent to your vendor until you press Continue.",
-  "person.readings.title": "Where this contact stands",
+  "person.readings.title": "Where this person stands",
   "person.readings.move": "Whose move",
   "person.readings.yourMove": "Yours",
   "person.readings.theirMove": "Theirs",
@@ -8743,8 +8742,8 @@ export const en = {
   "deal.strip.openHistory": "See the ledger",
   "deal.strip.lastTouch": "Last touch",
   "lead.standing.qualified": "Qualified",
-  "lead.standing.qualifiedOn": "Qualified on {at}. This lead is a contact now.",
-  "lead.standing.qualifiedUndated": "This lead is a contact now.",
+  "lead.standing.qualifiedOn": "Qualified on {at}. This lead is a person now.",
+  "lead.standing.qualifiedUndated": "This lead is a person now.",
   "lead.standing.closed": "Closed",
   "lead.standing.closedFor": "Closed: {reason}. The record stays as the trail.",
   "lead.standing.closedUnreasoned": "Closed. The record stays as the trail.",
@@ -8755,7 +8754,7 @@ export const en = {
   "lead.standing.inMotion": "In motion",
   "lead.standing.engagedBecause":
     "They answered, or a meeting is on the calendar.",
-  "lead.standing.rests.promoted": "Promoted to a contact.",
+  "lead.standing.rests.promoted": "Promoted to a person.",
   "lead.standing.rests.closed": "Disqualified, no reason recorded.",
   "lead.standing.rests.ladder": "Lead ladder",
   "lead.standing.rests.record": "Lead record",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2870,7 +2870,7 @@ export const en = {
   "deepread.kindTeam": "Team",
   "deepread.kindServices": "Services",
   "deepread.kindProducts": "Products",
-  "deepread.kindContact": "Person",
+  "deepread.kindContact": "Contact",
   "deepread.kindOther": "Other",
 
   "transcriptread.title": "Read this transcript",
@@ -8628,7 +8628,7 @@ export const en = {
   "ob.digest.pageKind.team": "Team page",
   "ob.digest.pageKind.services": "Services page",
   "ob.digest.pageKind.products": "Products page",
-  "ob.digest.pageKind.contact": "Person page",
+  "ob.digest.pageKind.contact": "Contact page",
   "ob.digest.pageKind.other": "Page",
   "ob.deck.counter": "{n} of {m}",
   "ob.deck.left": "{n} of {m} left",

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { de } from "./de";
+import { en } from "./en";
+import { vi } from "./vi";
+
+// The person record is called a person — "People" in the nav, "person" in a
+// sentence — and never a contact. The older word survives only where it names
+// the ACT of reaching someone ("never contacted", "last contact yesterday"),
+// the details one reaches them by ("contact data", "contact email"), or a
+// buyer's counterpart in a room ("your contact"). Those keys are waived here by
+// name, so a new value that says "contact" for the record fails, and a waiver
+// whose value stops carrying the word fails too: a stale waiver would let the
+// next author reintroduce the record noun under a key nobody looks at.
+type Catalog = Record<string, string>;
+
+const RECORD_NOUN: Record<string, RegExp> = {
+  en: /\bcontacts?\b/i,
+  de: /kontakt/i,
+  vi: /liên hệ|\bcontacts?\b/i,
+};
+
+// Shared across the locales: the act of reaching someone, and the details one
+// reaches them by. A locale adds the keys where only its own wording says the
+// word — German says "Kontaktstand" where English says "Engagement".
+const ACT_OR_DETAIL_KEYS_SHARED = [
+  "co.routeIn.band.strong",
+  "co.routeIn.band.some",
+  "co.routeIn.band.faint",
+  "co.routeIn.band.unknown",
+  "co.factField.contact_email",
+  "deal.strip.momentum.detail",
+  "passport.scope.enrich",
+  "connectors.signatureEnrich.label",
+  "captureSettings.signatureEnrich.label",
+  "network.empty",
+  "network.neverSpoken",
+  "network.bucket.none",
+  "license.holder.contact",
+  "person.intro.evidenceLastContact",
+  "person.intro.stripWhoMix",
+  "person.intro.whenToday",
+  "person.intro.whenYesterday",
+  "person.intro.whenDays",
+  "person.intro.whenNever",
+  "person.band.none",
+  "person.research.notConnected",
+  "provider.title",
+  "provider.sub",
+  "provider.profile.title",
+];
+
+// The buyer room: "your contact" is the steward on the seller's side, a
+// counterpart rather than a record.
+const BUYER_COUNTERPART_KEYS = [
+  "buyer.deadAskContact",
+  "buyer.expiredBody",
+  "buyer.contact",
+  "buyer.stewardUnknown",
+  "buyer.docs.downloadFailed",
+];
+
+const ACT_OR_DETAIL_KEYS: Record<string, readonly string[]> = {
+  en: [
+    ...ACT_OR_DETAIL_KEYS_SHARED,
+    ...BUYER_COUNTERPART_KEYS,
+    // `{contact}` is the placeholder's name, not a word the reader sees.
+    "co.intro.who",
+    // What a phone exports is called contacts by the phone.
+    "vcardImport.whichFile",
+    "coverage.quiet",
+    // "as a sponsor, a contact, or whoever else": a role on the delivery.
+    "personProjects.empty",
+  ],
+  de: [
+    ...ACT_OR_DETAIL_KEYS_SHARED,
+    "partner.stage.contacted",
+    "co.strip.lastTouch",
+    "co.strip.engagement.never_contacted",
+    "co.health.means.relationship",
+    "co.rail.people.inTouch",
+    // LinkedIn calls a connection a Kontakt in German, and these describe
+    // the import of LinkedIn's own file.
+    "linkedinImport.title",
+    "linkedinImport.connectedNote",
+    "linkedinImport.notConnectedNote",
+    "linkedinImport.importLabel",
+    "linkedinImport.noMatchesYet",
+    "linkedinImport.imported",
+    "ob.conv.linkedin.scope1Lead",
+    "ob.conv.linkedin.scope4Lead",
+    "ob.conv.linkedin.neverContacts",
+    "ob.conv.linkedin.connected",
+    "co.people.engagement",
+    "co.people.filter.status",
+    "co.people.filter.statusAll",
+    "co.people.band.untried",
+    "co.people.band.showUntried",
+    "lead.statusContacted",
+    "lead.status.contacted",
+    "lead.ladder.new",
+    "home.readings.leads",
+    "vcardImport.whichFile",
+    "acctCoverage.noneButPartial",
+    "compose.why.requestedFollowup",
+    "confirm.marketing.title",
+    "coverage.quiet",
+    "person.thin.logFirst",
+    "person.intro.evidenceOneSided_one",
+    "person.intro.evidenceOneSided_other",
+    "person.network.twoWay",
+    "person.network.oneSided",
+    "person.rail.nobodyYet",
+    "person.rail.exchanges",
+    "person.meeting.what_changed",
+    "person.meeting.arc",
+    "deal.strip.lastTouch",
+  ],
+  vi: [
+    ...ACT_OR_DETAIL_KEYS_SHARED,
+    ...BUYER_COUNTERPART_KEYS,
+    "partner.stage.contacted",
+    "co.strip.noInboundEver",
+    "co.strip.engagement.never_contacted",
+    "signal.kind.reengagement",
+    "co.rail.people.inTouch",
+    "co.people.engagement",
+    "co.people.filter.status",
+    "co.intro.who",
+    "lead.source.inbound",
+    "lead.statusContacted",
+    "lead.status.contacted",
+    "lead.ladder.new",
+    "compose.why.requestedFollowup",
+    "ob.conv.linkedin.scope4Lead",
+    "person.intro.fallbackNameDropHelp",
+    "person.intro.answerNameDropHelp",
+  ],
+};
+
+const CATALOGS: Record<string, Catalog> = { en, de, vi };
+
+describe.each(Object.keys(CATALOGS))(
+  "%s names the record a person",
+  (locale) => {
+    const catalog = CATALOGS[locale];
+    const pattern = RECORD_NOUN[locale];
+    const waived = new Set(ACT_OR_DETAIL_KEYS[locale]);
+
+    it("says contact only where the key is waived as the act or the details", () => {
+      const offenders = Object.entries(catalog)
+        .filter(([key, value]) => !waived.has(key) && pattern.test(value))
+        .map(([key, value]) => `${key}: ${value}`);
+      expect(offenders).toEqual([]);
+    });
+
+    it("keeps every waiver pointing at a value that still says contact", () => {
+      const stale = [...waived].filter(
+        (key) => !(key in catalog) || !pattern.test(catalog[key]),
+      );
+      expect(stale).toEqual([]);
+    });
+  },
+);

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -19,6 +19,13 @@ const RECORD_NOUN: Record<string, RegExp> = {
   vi: /liên hệ|\bcontacts?\b/i,
 };
 
+// A company website's Contact page, as the deep read and the onboarding
+// digest classify what they cited: a kind of page, not a record.
+const WEBSITE_PAGE_KIND_KEYS = [
+  "deepread.kindContact",
+  "ob.digest.pageKind.contact",
+];
+
 // Shared across the locales: the act of reaching someone, and the details one
 // reaches them by. A locale adds the keys where only its own wording says the
 // word — German says "Kontaktstand" where English says "Engagement".
@@ -47,6 +54,7 @@ const ACT_OR_DETAIL_KEYS_SHARED = [
   "provider.title",
   "provider.sub",
   "provider.profile.title",
+  ...WEBSITE_PAGE_KIND_KEYS,
 ];
 
 // The buyer room: "your contact" is the steward on the seller's side, a
@@ -63,8 +71,6 @@ const ACT_OR_DETAIL_KEYS: Record<string, readonly string[]> = {
   en: [
     ...ACT_OR_DETAIL_KEYS_SHARED,
     ...BUYER_COUNTERPART_KEYS,
-    // `{contact}` is the placeholder's name, not a word the reader sees.
-    "co.intro.who",
     // What a phone exports is called contacts by the phone.
     "vcardImport.whichFile",
     "coverage.quiet",
@@ -125,7 +131,6 @@ const ACT_OR_DETAIL_KEYS: Record<string, readonly string[]> = {
     "co.rail.people.inTouch",
     "co.people.engagement",
     "co.people.filter.status",
-    "co.intro.who",
     "lead.source.inbound",
     "lead.statusContacted",
     "lead.status.contacted",
@@ -139,6 +144,12 @@ const ACT_OR_DETAIL_KEYS: Record<string, readonly string[]> = {
 
 const CATALOGS: Record<string, Catalog> = { en, de, vi };
 
+// `{contact}` in "introduce you to {contact}" is the placeholder's name, which
+// the reader never sees; only the visible words are judged.
+function visibleWords(value: string): string {
+  return value.replace(/\{[^}]*\}/g, "");
+}
+
 describe.each(Object.keys(CATALOGS))(
   "%s names the record a person",
   (locale) => {
@@ -148,14 +159,17 @@ describe.each(Object.keys(CATALOGS))(
 
     it("says contact only where the key is waived as the act or the details", () => {
       const offenders = Object.entries(catalog)
-        .filter(([key, value]) => !waived.has(key) && pattern.test(value))
+        .filter(
+          ([key, value]) =>
+            !waived.has(key) && pattern.test(visibleWords(value)),
+        )
         .map(([key, value]) => `${key}: ${value}`);
       expect(offenders).toEqual([]);
     });
 
     it("keeps every waiver pointing at a value that still says contact", () => {
       const stale = [...waived].filter(
-        (key) => !(key in catalog) || !pattern.test(catalog[key]),
+        (key) => !(key in catalog) || !pattern.test(visibleWords(catalog[key])),
       );
       expect(stale).toEqual([]);
     });

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -382,7 +382,7 @@ export const vi = {
   "edit.versionSkew":
     "Bản ghi đã thay đổi kể từ khi bạn mở — tải lại rồi thử lại.",
 
-  "merge.person": "Gộp contact",
+  "merge.person": "Gộp hồ sơ người",
   "merge.org": "Gộp công ty",
   "merge.searchPlaceholder": "Tìm kiếm…",
   "merge.pickTarget": "Chọn bản ghi được giữ lại",
@@ -766,10 +766,10 @@ export const vi = {
   "consent.grant": "Cấp chấp thuận",
   "consent.withdraw": "Rút lại",
   "consent.doiBySubject":
-    "M\u1ee5c \u0111\u00edch n\u00e0y do ch\u00ednh li\u00ean h\u1ec7 x\u00e1c nh\u1eadn, qua li\u00ean k\u1ebft g\u1eedi t\u1edbi \u0111\u1ecba ch\u1ec9 c\u1ee7a h\u1ecd. H\u00e3y d\u00f9ng \u201c\u0110\u1ec1 ngh\u1ecb h\u1ecd x\u00e1c nh\u1eadn th\u00f4ng tin\u201d b\u00ean d\u01b0\u1edbi.",
+    "M\u1ee5c \u0111\u00edch n\u00e0y do ch\u00ednh ng\u01b0\u1eddi \u0111\u00f3 x\u00e1c nh\u1eadn, qua li\u00ean k\u1ebft g\u1eedi t\u1edbi \u0111\u1ecba ch\u1ec9 c\u1ee7a h\u1ecd. H\u00e3y d\u00f9ng \u201c\u0110\u1ec1 ngh\u1ecb h\u1ecd x\u00e1c nh\u1eadn th\u00f4ng tin\u201d b\u00ean d\u01b0\u1edbi.",
   "consent.askToConfirm": "Đề nghị họ xác nhận thông tin",
   "consent.askToConfirmWhat":
-    "Gửi cho liên hệ này một liên kết riêng để họ xem bạn đang lưu gì về họ, sửa lại nếu sai, và cho biết họ có muốn nhận tin từ bạn không. Liên kết chỉ đến địa chỉ đã lưu của họ; bạn không thể gửi đi nơi khác.",
+    "Gửi cho người này một liên kết riêng để họ xem bạn đang lưu gì về họ, sửa lại nếu sai, và cho biết họ có muốn nhận tin từ bạn không. Liên kết chỉ đến địa chỉ đã lưu của họ; bạn không thể gửi đi nơi khác.",
   "consent.askQueued": "Đang trên đường tới {address}.",
   "consent.askNotDelivered":
     "Liên kết đã được tạo cho {address} nhưng bản cài đặt này không gửi thư, nên chưa ai nhận được.",
@@ -1065,11 +1065,11 @@ export const vi = {
     "Phiên của họ kết thúc ngay và liên kết ngừng hoạt động. Bình luận của họ vẫn hiển thị và ghi tên. Không thể khôi phục bằng cách xin liên kết.",
   "access.changeCapabilityTitle": "{name} được làm gì?",
   "persondealrooms.title": "Deal Room",
-  "persondealrooms.sub": "Các phòng liên hệ này vẫn có thể vào.",
+  "persondealrooms.sub": "Các phòng người này vẫn có thể vào.",
   "persondealrooms.open": "Mở",
   "persondealrooms.seatGone": "Địa chỉ này không còn chỗ trong phòng đó.",
   "persondealrooms.cut":
-    "Chỉ hiện các phòng đầu tiên; liên hệ này còn ở trong các phòng khác.",
+    "Chỉ hiện các phòng đầu tiên; người này còn ở trong các phòng khác.",
   "persondealrooms.revokeTitle": "Thu hồi quyền vào {room}?",
   "room.state.draft": "Bản nháp",
   "room.state.building": "Đang dựng",
@@ -1084,8 +1084,8 @@ export const vi = {
   "co.pulse.owner": "Người phụ trách",
   "co.pulse.sizeBand": "{band} nhân viên",
   "co.pulse.strongestLead": "Đường tiếp cận",
-  "co.pulse.strengthTail_one": "— contact duy nhất ở đây",
-  "co.pulse.strengthTail_other": "— trong {count} contact ở đây",
+  "co.pulse.strengthTail_one": "— người duy nhất ở đây",
+  "co.pulse.strengthTail_other": "— trong {count} người ở đây",
   "co.pulse.unowned": "Chưa giao",
   "co.since.first": "Bạn đang mở tài khoản này lần đầu.",
   "co.partial":
@@ -1335,7 +1335,7 @@ export const vi = {
   "co.evidence.kind.rule": "Được suy ra",
   "co.brief.cite.deal": "deal",
   "co.brief.cite.activity": "hoạt động",
-  "co.brief.cite.person": "contact",
+  "co.brief.cite.person": "người",
   "co.brief.cite.organization": "tài khoản",
   "co.brief.cite.fact": "dữ kiện",
   "co.brief.cite.profile_field": "trường hồ sơ",
@@ -1343,7 +1343,7 @@ export const vi = {
   // counted chip, rather than a run of identical labels.
   "co.brief.cite.deal.many": "{count} deal",
   "co.brief.cite.activity.many": "{count} hoạt động",
-  "co.brief.cite.person.many": "{count} contact",
+  "co.brief.cite.person.many": "{count} người",
   "co.brief.cite.organization.many": "{count} tài khoản",
   "co.brief.cite.fact.many": "{count} dữ kiện",
   "co.brief.cite.profile_field.many": "{count} trường hồ sơ",
@@ -1367,7 +1367,7 @@ export const vi = {
   "approval.kind.site_lead": "Thêm người tìm thấy trên website",
   "approval.kind.capture_counterparty": "Thêm người từ email của bạn",
   "approval.kind.org_name_promotion": "Đổi tên một công ty",
-  "approval.kind.vcard_create": "Tạo liên hệ từ danh thiếp",
+  "approval.kind.vcard_create": "Tạo hồ sơ người từ danh thiếp",
   "approval.kind.lifecycle_change": "Giai đoạn công ty",
   "approval.kind.transcript_proposal":
     "Thêm bước tiếp theo từ bản ghi cuộc trò chuyện",
@@ -1410,7 +1410,7 @@ export const vi = {
   "approval.field.published_email": "Email trên trang",
   "approval.field.connection_name": "Trên LinkedIn",
   "approval.field.connection_company": "Làm việc tại",
-  "approval.field.person_name": "Liên hệ ở đây",
+  "approval.field.person_name": "Người ở đây",
   "approval.field.owner": "Phụ trách",
   "approval.field.to": "Đến",
   "approval.field.currency": "Tiền tệ",
@@ -1468,9 +1468,9 @@ export const vi = {
   "co.rail.deals.noCloseDate": "chưa có ngày chốt",
   "co.rail.deals.attentionOverdue": "Quá hạn",
   "co.rail.deals.attentionCommitment": "Họ còn nợ chúng ta",
-  "co.rail.people.title": "Người liên hệ chính",
-  "co.rail.people.empty": "Chưa có liên hệ nào. Không có ai để viết thư.",
-  "co.rail.people.add": "Thêm liên hệ",
+  "co.rail.people.title": "Người chủ chốt của họ",
+  "co.rail.people.empty": "Chưa có người nào. Không có ai để viết thư.",
+  "co.rail.people.add": "Thêm người",
   "co.rail.people.inTouch": "Đã liên hệ với họ",
   "co.rail.details.all": "Tất cả trường",
   "co.commercial.title": "Thương mại",
@@ -1492,14 +1492,14 @@ export const vi = {
   "linkedinImport.notConnectedNote":
     "Ghi lại URL hồ sơ của bạn sẽ quy mọi kết nối bạn nhập vào về đúng tên bạn.",
   "linkedinImport.whichFile":
-    "LinkedIn cho bạn tệp Connections.csv trong Settings → Data privacy → Get a copy of your data; kho lưu trữ còn cả chục tệp khác, và đây là tệp cần dùng. Những gì bạn tải lên không bao giờ trở thành contact: các kết nối nằm ngoài tìm kiếm, danh sách và trang contact, và không ai viết thư hay gửi email cho họ được.",
+    "LinkedIn cho bạn tệp Connections.csv trong Settings → Data privacy → Get a copy of your data; kho lưu trữ còn cả chục tệp khác, và đây là tệp cần dùng. Những gì bạn tải lên không bao giờ trở thành người trong CRM: các kết nối nằm ngoài tìm kiếm, danh sách và trang của từng người, và không ai viết thư hay gửi email cho họ được.",
   "linkedinImport.choose": "Chọn tệp Connections.csv",
   "linkedinImport.importLabel": "Tệp xuất danh bạ",
   "linkedinImport.noMatchesYet":
-    "Chưa có kết quả khớp nào, điều này là bình thường với một tổ chức mới: các kết nối của bạn được đối chiếu với những contact mà CRM đã biết, và số đó tăng dần khi thư của bạn được đọc. Việc này chạy lại mỗi giờ, nên kết quả khớp sẽ xuất hiện khi CRM đầy dần lên.",
+    "Chưa có kết quả khớp nào, điều này là bình thường với một tổ chức mới: các kết nối của bạn được đối chiếu với những người mà CRM đã biết, và số đó tăng dần khi thư của bạn được đọc. Việc này chạy lại mỗi giờ, nên kết quả khớp sẽ xuất hiện khi CRM đầy dần lên.",
   "linkedinImport.working": "Đang đọc bản xuất của bạn…",
   "linkedinImport.imported": "Kết nối đã nhập",
-  "linkedinImport.confirmed": "Đã khớp với một contact",
+  "linkedinImport.confirmed": "Đã khớp với một người",
   "linkedinImport.suggested": "Đang chờ bạn xác nhận",
 
   // The review queue and the reach table (ADR-0078 §2.1b).
@@ -1513,7 +1513,7 @@ export const vi = {
   "linkedinReach.accountsLabel": "Tài khoản bạn vươn tới",
   "linkedinReach.account": "Tài khoản",
   "linkedinReach.connections": "Bạn quen",
-  "linkedinReach.onFile": "Đã là contact",
+  "linkedinReach.onFile": "Đã có hồ sơ",
   "linkedinReach.onFileOf": "{onFile} trên {total}",
   "linkedinReach.footnote":
     "Đang hiện {shown} trên {total} tài khoản. {unresolved} kết nối làm việc ở nơi chưa có trong hồ sơ tài khoản.",
@@ -1607,7 +1607,7 @@ export const vi = {
     "Một số người nhận ở dạng ẩn và không hiển thị với bạn",
   "compose.audienceWorkspace": "Mọi người trong tổ chức",
   "compose.audienceWorkspaceHint":
-    "Ai thấy được liên hệ này cũng đọc được tin nhắn này.",
+    "Ai thấy được người này cũng đọc được tin nhắn này.",
   "compose.audienceParticipants": "Chỉ người tham gia",
   "compose.audienceParticipantsHint":
     "Chỉ những người có trên tin nhắn này đọc được tiêu đề và nội dung. Người khác chỉ thấy rằng có một tin nhắn được trao đổi vào ngày đó.",
@@ -1618,7 +1618,7 @@ export const vi = {
   "compose.audienceMembersLoading": "Đang đọc danh sách người…",
   "compose.audienceConfirm": "Lưu hiển thị",
   "compose.audienceNote":
-    "Chỉ áp dụng cho tin nhắn này — không cho chuỗi hội thoại và không cho liên hệ.",
+    "Chỉ áp dụng cho tin nhắn này — không cho chuỗi hội thoại và không cho người này.",
   "timeline.textMore": "Đọc",
   "timeline.textLess": "Thu gọn",
   "timeline.tailMore": "Hiện chữ ký và phần trích dẫn",
@@ -1933,7 +1933,7 @@ export const vi = {
   "tagResult.viewAll": "Xem tất cả {count} {kind}",
   "tagResult.resultsTitle": "Bản ghi có thẻ này",
   "tagResult.nothingCarries":
-    "Chưa có bản ghi nào mang thẻ này. Hãy gán thẻ từ một liên hệ, công ty hoặc thương vụ.",
+    "Chưa có bản ghi nào mang thẻ này. Hãy gán thẻ từ một người, công ty hoặc thương vụ.",
   "tagResult.loadingRows": "Đang tải {kind}…",
   "tagResult.noneLeft": "Không còn bản ghi nào mang thẻ",
   "tagResult.unnamed": "Chưa có tên",
@@ -2075,29 +2075,29 @@ export const vi = {
   "lead.boardTerminalOnly":
     "Không còn mục nào đang mở — chúng được tính ở cột Đã chuyển đổi và Đã loại.",
   "person.fromLead": "Từ khách hàng tiềm năng",
-  "lead.promotedTitle": "Đã chuyển thành liên hệ",
+  "lead.promotedTitle": "Đã chuyển thành hồ sơ người",
   "lead.promotedMerged":
-    "Khách hàng tiềm năng này đã được gộp vào một liên hệ đã biết — không tạo bản trùng.",
+    "Khách hàng tiềm năng này đã được gộp vào một người đã biết — không tạo bản trùng.",
   "lead.promotedCreated":
-    "Khách hàng tiềm năng này đã trở thành một liên hệ mới.",
+    "Khách hàng tiềm năng này đã trở thành một hồ sơ người mới.",
   "lead.promotedAt": "Đã chuyển",
   "lead.promotedTrigger": "Tác nhân:",
   "lead.promotedEvidence": "Bằng chứng:",
   "lead.previewPending": "Đang kiểm tra xem chúng ta đã biết người này chưa…",
-  "lead.previewCreate": "Việc chuyển sẽ tạo một liên hệ mới.",
-  "lead.previewMerge": "Việc chuyển sẽ gộp vào liên hệ hiện có",
+  "lead.previewCreate": "Việc chuyển sẽ tạo một hồ sơ người mới.",
+  "lead.previewMerge": "Việc chuyển sẽ gộp vào người hiện có",
   "lead.previewMergeWithheld":
-    "Việc chuyển sẽ gộp vào một liên hệ hiện có mà bạn không xem được.",
+    "Việc chuyển sẽ gộp vào một người hiện có mà bạn không xem được.",
   "lead.demote": "Hoàn tác chuyển đổi",
   "lead.demoteDialog": "Hoàn tác việc chuyển đổi này?",
   "lead.demoteExplain":
-    "Lead quay lại hàng đợi ở trạng thái “Đang xử lý”. Liên hệ do việc chuyển tạo ra sẽ được lưu trữ; liên hệ đã được gộp vào giữ nguyên. Không thể hoàn tác với liên hệ đang gắn với một deal.",
+    "Lead quay lại hàng đợi ở trạng thái “Đang xử lý”. Hồ sơ người do việc chuyển tạo ra sẽ được lưu trữ; người đã được gộp vào giữ nguyên. Không thể hoàn tác với người đang gắn với một deal.",
   "lead.demoteReason": "Lý do (được ghi vào nhật ký)",
   "lead.demoteReasonRequired": "H\u00e3y n\u00eau l\u00fd do tr\u01b0\u1edbc.",
   "lead.demoteConfirm": "Hoàn tác",
   "lead.promotedOutcomePending": "Đang đọc kết quả của lần chuyển này…",
   "lead.promotedOutcomeUnavailable":
-    "Không thể hiển thị việc này đã gộp hay tạo liên hệ mới.",
+    "Không thể hiển thị việc này đã gộp hay tạo hồ sơ người mới.",
   "lead.terminalPromoted":
     "Đã chuyển — khách hàng tiềm năng này giờ ở chế độ chỉ đọc.",
   "lead.statusNew": "Mới",
@@ -2204,7 +2204,7 @@ export const vi = {
   "lead.trigger.humanQualify": "Người xác nhận đủ điều kiện",
   "lead.evidenceNote": "Ghi chú bằng chứng (không bắt buộc)",
   "lead.segregation":
-    "Khách hàng tiềm năng được giữ tách biệt với Liên hệ. Chỉ trở thành liên hệ khi bạn xác nhận đủ điều kiện.",
+    "Khách hàng tiềm năng được giữ tách biệt với Người. Chỉ trở thành người trong CRM khi bạn xác nhận đủ điều kiện.",
   "lead.segregationDismiss": "Đã hiểu",
   "list.emptyMine": "Bạn không có {unit} nào được giao.",
   "list.showAll": "Hiện tất cả",
@@ -2224,13 +2224,13 @@ export const vi = {
   "lead.ladder.meetingBooked": "đã đặt lịch họp",
   "lead.ladder.meetingHeld": "đã họp",
   "lead.ladder.qualified":
-    "Đủ điều kiện — khách hàng tiềm năng này giờ là liên hệ.",
+    "Đủ điều kiện — khách hàng tiềm năng này giờ là người trong CRM.",
   "lead.ladder.qualifiedOn":
-    "Đủ điều kiện vào {at} — khách hàng tiềm năng này giờ là liên hệ.",
+    "Đủ điều kiện vào {at} — khách hàng tiềm năng này giờ là người trong CRM.",
   "lead.ladder.disqualified": "Đã loại.",
   "lead.ladder.disqualifiedWithReason": "Đã loại: {reason}",
   "lead.qualify.title": "Xác nhận đủ điều kiện cho {name}",
-  "lead.qualify.contact": "Liên hệ",
+  "lead.qualify.contact": "Người",
   "lead.qualify.alsoDeal": "Đồng thời mở một thương vụ",
   "lead.qualify.pipeline": "Quy trình",
   "lead.qualify.stage": "Giai đoạn",
@@ -2248,7 +2248,7 @@ export const vi = {
   "lead.qualify.reasonHuman": "Lý do: do bạn xác nhận.",
   "lead.qualify.confirm": "Đủ điều kiện",
   "lead.qualify.confirmWithDeal": "Đủ điều kiện và mở thương vụ",
-  "lead.qualify.done": "{name} giờ là liên hệ:",
+  "lead.qualify.done": "{name} giờ là người trong CRM:",
   "lead.disqualify.title": "Loại {name}",
   "lead.disqualify.reason": "Lý do",
   "lead.disqualify.pickReason": "Chọn lý do",
@@ -2777,7 +2777,7 @@ export const vi = {
   "deepread.kindTeam": "Đội ngũ",
   "deepread.kindServices": "Dịch vụ",
   "deepread.kindProducts": "Sản phẩm",
-  "deepread.kindContact": "Liên hệ",
+  "deepread.kindContact": "Người",
   "deepread.kindOther": "Khác",
 
   "transcriptread.title": "Đọc bản chép lời này",
@@ -2805,7 +2805,7 @@ export const vi = {
   "create.multiselect.required": "Bắt buộc — chọn ít nhất một.",
   "create.save": "Tạo",
   "create.saving": "Đang tạo…",
-  "create.contact": "Contact mới",
+  "create.contact": "Người mới",
   "vcardImport.action": "Nhập danh thiếp",
   "vcardImport.title": "Nhập danh thiếp",
   "vcardImport.fileLabel": "Tệp danh thiếp",
@@ -2932,7 +2932,7 @@ export const vi = {
   "today.source.nextMeeting": "lịch",
   "today.source.deals": "deal",
   "today.meeting.prepare": "Chuẩn bị cuộc họp",
-  "today.source.people": "các liên hệ",
+  "today.source.people": "những người ở đây",
   "today.source.standing": "phía nào cần hành động và các tín hiệu",
   "today.source.activities": "những gì đã trao đổi",
   "today.silence.days": "không hồi âm trong {count} ngày",
@@ -2950,10 +2950,10 @@ export const vi = {
   "evidence.humanSet": "Do một người đặt",
   "acctCoverage.open": "So sánh mức phủ",
   "acctCoverage.title": "Ai đang phủ tài khoản này",
-  "acctCoverage.contact": "Liên hệ",
-  "acctCoverage.findContact": "Tìm liên hệ",
+  "acctCoverage.contact": "Người",
+  "acctCoverage.findContact": "Tìm người",
   "acctCoverage.untried": "Chưa thử",
-  "acctCoverage.noMatch": "Không có liên hệ nào khớp.",
+  "acctCoverage.noMatch": "Không có ai khớp.",
   "acctCoverage.columnCap":
     "Đang hiển thị {cap} đồng nghiệp — bỏ chọn một người để thêm người khác.",
   "acctCoverage.partial":
@@ -3108,13 +3108,13 @@ export const vi = {
   "log.save": "Ghi nhận",
   "log.saving": "Đang ghi nhận…",
 
-  "personAccess.title": "Ai xem được liên hệ này",
+  "personAccess.title": "Ai xem được người này",
   "personAccess.privateToYou":
-    "Riêng của bạn. Hộp thư của bạn đã tạo liên hệ này, và không ai khác trong tổ chức xem được — kể cả nhóm của bạn và quản trị viên.",
+    "Riêng của bạn. Hộp thư của bạn đã tạo người này, và không ai khác trong tổ chức xem được — kể cả nhóm của bạn và quản trị viên.",
   "personAccess.organization":
-    "Mọi người trong tổ chức đều xem được liên hệ này.",
+    "Mọi người trong tổ chức đều xem được người này.",
   "personAccess.share": "Chia sẻ với tổ chức",
-  "personAccess.published": "Tổ chức đã xem được liên hệ này.",
+  "personAccess.published": "Tổ chức đã xem được người này.",
   "compose.reply": "Trả lời",
   "compose.writeEmail": "Viết email",
   "compose.relink": "Liên kết lại",
@@ -3143,9 +3143,9 @@ export const vi = {
   "compose.cc": "Cc",
   "compose.subject": "Tiêu đề",
   "compose.noGroundableRecipient":
-    "Tài khoản này chưa có liên hệ nào — hãy tự viết thư, hoặc thêm liên hệ trước",
+    "Tài khoản này chưa có ai — hãy tự viết thư, hoặc thêm người trước",
   "compose.draftTo": "Soạn gửi",
-  "compose.draftToUnset": "Chọn liên hệ",
+  "compose.draftToUnset": "Chọn người",
   "compose.relatedTo": "Liên quan đến",
   "compose.relatedToNone": "Toàn bộ tài khoản",
   "compose.project": "Dự án",
@@ -3675,7 +3675,7 @@ export const vi = {
   "settings.tierRead":
     "Đọc, tóm tắt, soạn nháp — chạy ngay, ghi nhật ký đầy đủ.",
   "settings.tierSend":
-    "Gửi email, đặt lịch họp, sửa một liên hệ hay một deal — cũng chạy ngay, nếu bạn đã cấp phạm vi đó cho tác nhân. Việc bạn cấp quyền chính là phê duyệt, cấp một lần.",
+    "Gửi email, đặt lịch họp, sửa một người hay một deal — cũng chạy ngay, nếu bạn đã cấp phạm vi đó cho tác nhân. Việc bạn cấp quyền chính là phê duyệt, cấp một lần.",
   "settings.tierWait":
     "Làm giàu dữ liệu, trường tuỳ chỉnh, webhook, gộp thẻ — những việc này chờ trong hộp phê duyệt.",
   "settings.tierAdvance":
@@ -3702,7 +3702,7 @@ export const vi = {
   "import.object.organization": "Công ty",
   "import.object.person": "Người",
   "import.objectHint.lead":
-    "Danh sách chưa xử lý vào dạng lead để người thẩm định trước khi được xem là liên hệ.",
+    "Danh sách chưa xử lý vào dạng lead để người thẩm định trước khi được xem là người trong CRM.",
   "import.objectHint.organization":
     "Công ty được nhận diện theo tên bạn ánh xạ, nên tải lên lại sẽ sửa chứ không nhân đôi.",
   "import.objectHint.person":
@@ -4462,7 +4462,7 @@ export const vi = {
     "Khi hộp thư của bạn đã mang thư vào, mọi người gửi sẽ được liệt kê ở đây cùng kết quả xử lý.",
   "senders.colSender": "Người gửi",
   "senders.colDecision": "Đã quyết định",
-  "senders.colRecord": "Liên hệ",
+  "senders.colRecord": "Người",
   "senders.colActions": "Thao tác",
   "senders.recordYes": "Có",
   "senders.recordNo": "Không",
@@ -4473,7 +4473,7 @@ export const vi = {
   "senders.withdraw": "Hoàn tác",
   "senders.keepOutTitle": "Chặn vĩnh viễn người gửi này?",
   "senders.keepOutBody":
-    "Không tạo liên hệ, và thư mà người gửi này đã mang vào hộp thư của bạn sẽ bị hủy. Thư mà đồng nghiệp cũng đã nhập vẫn thuộc về họ.",
+    "Không tạo hồ sơ người, và thư mà người gửi này đã mang vào hộp thư của bạn sẽ bị hủy. Thư mà đồng nghiệp cũng đã nhập vẫn thuộc về họ.",
   "senders.keepOutConfirm": "Chặn và hủy",
   "senders.kind.person": "Một người",
   "senders.kind.roleMailbox": "Hộp thư chức năng",
@@ -4488,7 +4488,7 @@ export const vi = {
   "senders.kind.undecided": "Chưa quyết định",
   "mailSharing.title": "Chia sẻ email",
   "mailSharing.sub":
-    "Email được thu thập sẽ hiển thị với mọi đồng nghiệp có quyền xem liên hệ. Bật mặc định — đây là điều làm cho pipeline được chia sẻ.",
+    "Email được thu thập sẽ hiển thị với mọi đồng nghiệp có quyền xem người đó. Bật mặc định — đây là điều làm cho pipeline được chia sẻ.",
   "mailSharing.label": "Chia sẻ email đã thu thập với nhóm",
   "mailSharing.help":
     "Có thể giới hạn từng tin nhắn sau đó, và loại trừ địa chỉ hoặc tên miền ngay từ đầu.",
@@ -4536,7 +4536,7 @@ export const vi = {
   "connectors.contextTag.label": "Lưu những gì trình kết nối này mang về dưới",
   "connectors.contextTag.none": "Không có thẻ",
   "connectors.contextTag.hint":
-    "Một thẻ đã có sẵn. Mọi liên hệ trình kết nối này tạo ra từ giờ sẽ được lưu dưới thẻ đó, để bạn hỏi được những gì đã đến từ nguồn này. Các liên hệ đã có giữ nguyên thẻ của mình.",
+    "Một thẻ đã có sẵn. Người nào trình kết nối này tạo ra từ giờ đều được lưu dưới thẻ đó, để bạn hỏi được những gì đã đến từ nguồn này. Những người đã có giữ nguyên thẻ của mình.",
   "connectors.contextTag.archived":
     "{name} đã được lưu trữ nên không có gì được lưu dưới thẻ đó nữa. Hãy chọn thẻ khác, hoặc không chọn.",
   "connectors.signatureEnrich.followingDefault":
@@ -4544,7 +4544,7 @@ export const vi = {
   "connectors.signatureEnrich.ownAnswer":
     "Lựa chọn riêng của hộp thư này, giữ nguyên dù thiết lập của tổ chức thay đổi.",
   "hold.sectionTitle": "Trao đổi riêng tư",
-  "hold.notHeld": "Thư với liên hệ này theo thiết lập hộp thư của bạn.",
+  "hold.notHeld": "Thư với người này theo thiết lập hộp thư của bạn.",
   "hold.heldByAddress":
     "Bạn giữ thư với địa chỉ này chỉ cho những người có trong thư.",
   "hold.heldByDomain":
@@ -4563,11 +4563,11 @@ export const vi = {
   "hold.confirmHistoryNote":
     "Điều này áp dụng từ nay về sau. Thư đã thu thập giữ nguyên phạm vi hiển thị hiện tại.",
   "captureNotice.whatHappens":
-    "Margince đọc hộp thư này và lưu lại những gì tìm thấy: các thư, những ai có trong thư, cùng liên hệ và công ty đứng sau các địa chỉ. Tệp đính kèm được lưu cùng thư của nó.",
+    "Margince đọc hộp thư này và lưu lại những gì tìm thấy: các thư, những ai có trong thư, cùng những người và công ty đứng sau các địa chỉ. Tệp đính kèm được lưu cùng thư của nó.",
   "captureNotice.whoReads":
     "Hộp thư mới mặc định được giữ lại. Một thư chỉ dành cho những người có trong thư cho đến khi bộ phân loại đánh giá chuỗi thư là công việc thông thường — khi đó đồng nghiệp mới đọc được. Bạn có thể đặt hộp thư giữ lại mọi thứ bất cứ lúc nào.",
   "captureNotice.yourControl":
-    "Bạn quyết định theo từng người gửi và từng chuỗi thư, tại Cài đặt → Kết nối: chặn hẳn một người liên hệ, chia sẻ chuỗi thư với nhóm, hoặc xóa những gì một người gửi đã mang vào. Ở đây không yêu cầu bạn đồng ý — đây là điều sẽ xảy ra, để bạn biết trước khi kết nối.",
+    "Bạn quyết định theo từng người gửi và từng chuỗi thư, tại Cài đặt → Kết nối: chặn hẳn một người gửi, chia sẻ chuỗi thư với nhóm, hoặc xóa những gì một người gửi đã mang vào. Ở đây không yêu cầu bạn đồng ý — đây là điều sẽ xảy ra, để bạn biết trước khi kết nối.",
   "connectors.mailPosture.label": "Ai được đọc thư từ hộp thư này",
   "connectors.mailPosture.classified": "Giữ lại cho đến khi phân loại",
   "connectors.mailPosture.held": "Luôn giữ lại",
@@ -4770,7 +4770,7 @@ export const vi = {
   "ob.s4.accessToggle": "Quyền truy cập này cho phép gì",
   "ob.s4.scope1Lead": "Chúng tôi chỉ đọc — không làm rối hộp thư.",
   "ob.s4.scope1Rest":
-    "Email của bạn thành contact, công ty và hoạt động, được thu thập tự động.",
+    "Email của bạn thành người, công ty và hoạt động, được thu thập tự động.",
   "ob.s4.scope2Lead": "Quyền này bao gồm cả việc gửi.",
   "ob.s4.scope2Rest":
     "Margince có thể gửi từ hộp thư này — khi bạn gửi, và khi bạn cấp cho tác nhân một passport có quyền gửi. Việc cấp quyền đó chính là phê duyệt, cấp một lần. Bạn có thể thu hồi bất cứ lúc nào.",
@@ -4940,10 +4940,10 @@ export const vi = {
   "ob.conv.scene.continue": "Tiếp tục",
   "ob.conv.connect.sceneTitle": "Kết nối các tài khoản của bạn.",
   "ob.conv.connect.sceneSub":
-    "Tôi dựng contact, công ty và lịch sử từ những gì đã có trong hộp thư.",
+    "Tôi dựng hồ sơ người, công ty và lịch sử từ những gì đã có trong hộp thư.",
   "ob.conv.connect.mailboxTitle": "Hộp thư của bạn",
   "ob.conv.connect.mailboxHint":
-    "Hãy chọn một. Contact, công ty và lịch sử của bạn đều đến từ đây.",
+    "Hãy chọn một. Người, công ty và lịch sử của bạn đều đến từ đây.",
   "ob.conv.connect.networkTitle": "Mạng lưới quan hệ của bạn",
   "ob.conv.connect.networkHint":
     "Không bắt buộc nhưng đáng làm. Biến những người bạn quen thành tài khoản và theo dõi để bắt tín hiệu.",
@@ -4971,7 +4971,7 @@ export const vi = {
   "ob.conv.connect.unsupportedCard": "Bản cài đặt này không hỗ trợ {name}.",
   "ob.conv.connect.appSetupLink": "Thiết lập trong Cài đặt",
   "ob.conv.connect.dialogIntro":
-    "{brings}. Tôi đọc một lần để dựng contact và lịch sử của bạn, rồi giữ đồng bộ về sau.",
+    "{brings}. Tôi đọc một lần để dựng hồ sơ người và lịch sử của bạn, rồi giữ đồng bộ về sau.",
   "ob.conv.connect.dialogClose": "Đóng",
   "ob.conv.connect.linkedinName": "LinkedIn",
   "ob.conv.connect.linkedinConnected": "Đã kết nối",
@@ -5070,7 +5070,7 @@ export const vi = {
   "ob.conv.connect.mailboxNeeded":
     "Vẫn cần một hộp thư: thư là thứ được đọc và soạn nháp. Kết nối một hộp thư ở trên, hoặc tạm tiếp tục mà không có.",
   "ob.conv.linkedin.cardBody":
-    "Biến mạng lưới quan hệ của bạn thành tài khoản và contact, và báo khi một người quen đổi việc.",
+    "Biến mạng lưới quan hệ của bạn thành tài khoản và người, và báo khi một người quen đổi việc.",
   "ob.conv.linkedin.limitsToggle": "Margince thấy được gì và không thấy gì",
   "ob.conv.linkedin.scope1Lead": "Danh sách kết nối của bạn —",
   "ob.conv.linkedin.scope1Rest": "tên, chức danh, công ty và ngày bạn kết nối.",
@@ -5084,7 +5084,7 @@ export const vi = {
   "ob.conv.linkedin.scope4Rest":
     "Việc kết nối không gửi lời mời hay tin nhắn nào, không bao giờ.",
   "ob.conv.linkedin.neverContacts":
-    "Kết nối của bạn không thành contact. Chúng chỉ trả lời: ai ở đây đã quen họ?",
+    "Kết nối của bạn không thành người trong CRM. Chúng chỉ trả lời: ai ở đây đã quen họ?",
   "ob.conv.linkedin.profileLabel": "Đường dẫn hồ sơ LinkedIn của bạn",
   "ob.conv.linkedin.profilePlaceholder": "https://www.linkedin.com/in/…",
   "ob.conv.linkedin.profileWhy":
@@ -5470,7 +5470,7 @@ export const vi = {
   "client.open360": "Mở màn hình 360",
   "client.unknown": "Chưa có trong tổ chức của bạn.",
   "client.unknownDetail":
-    "Người gửi này không khớp contact nào bạn xem được. Không có gì được lấy từ nơi khác.",
+    "Người gửi này không khớp người nào bạn xem được. Không có gì được lấy từ nơi khác.",
   "client.createLead": "Ghi nhận thành lead",
   "client.isolation": "chỉ nói chuyện với tổ chức CỦA BẠN",
   "client.attribution":
@@ -5779,7 +5779,7 @@ export const vi = {
   "network.bucket.strong": "Mạnh",
   "coverage.engaged": "Đang trao đổi",
   "coverage.quiet": "Chưa có trao đổi hai chiều",
-  "coverage.seatWithheld": "Một liên hệ bạn không thể xem",
+  "coverage.seatWithheld": "Một người bạn không thể xem",
   "coverage.daysSinceTouch": "{days} ngày",
   "coverage.risk.single_threaded_theirs": "Chỉ một đầu mối",
   "coverage.risk.single_threaded_ours": "Chỉ một đồng nghiệp phụ trách",
@@ -5795,7 +5795,7 @@ export const vi = {
   "cf.object": "Đối tượng",
   "cf.obj.deal": "Deal",
   "cf.obj.organization": "Công ty",
-  "cf.obj.person": "Contact",
+  "cf.obj.person": "Người",
   "cf.obj.lead": "Lead",
   "cf.listLabel": "Các trường trên {object}",
   "cf.col.field": "Trường",
@@ -5808,9 +5808,9 @@ export const vi = {
   "cf.empty.organization":
     "Chưa có trường tuỳ chỉnh nào trên Công ty. Hãy thêm một trường nếu bạn theo dõi thứ mà bản gốc chưa có.",
   "cf.empty.person":
-    "Chưa có trường tuỳ chỉnh nào trên Contact. Các trường lõi đã bao quát bản ghi contact; hãy thêm một trường nếu bạn theo dõi thêm.",
+    "Chưa có trường tuỳ chỉnh nào trên Người. Các trường lõi đã bao quát bản ghi người; hãy thêm một trường nếu bạn theo dõi thêm.",
   "cf.empty.lead":
-    "Chưa có trường tuỳ chỉnh nào trên Lead. Trường bạn thêm ở đây cũng xuất hiện khi một lead được chuyển thành contact.",
+    "Chưa có trường tuỳ chỉnh nào trên Lead. Trường bạn thêm ở đây cũng xuất hiện khi một lead được chuyển thành người trong CRM.",
   "cf.type.text": "Văn bản",
   "cf.type.number": "Số",
   "cf.type.date": "Ngày",
@@ -5954,9 +5954,9 @@ export const vi = {
   "captureActivity.contentNone": "không ghi nhận người gửi",
   "captureActivity.outcome.captured": "Đã thu thập",
   "captureActivity.outcome.internal": "Bỏ qua vì nội bộ",
-  "captureActivity.outcome.suppressed": "Không tạo liên hệ",
+  "captureActivity.outcome.suppressed": "Không tạo hồ sơ người",
   "captureActivity.outcome.deferred": "Đang chờ phán quyết",
-  "captureActivity.outcome.fault": "Suy ra liên hệ thất bại",
+  "captureActivity.outcome.fault": "Suy luận thất bại",
   "captureActivity.reason.internal_only":
     "mọi bên đều thuộc tên miền của chính bạn",
   "captureActivity.reason.deferral_capped":
@@ -5964,19 +5964,19 @@ export const vi = {
   "captureActivity.reason.noise_prior":
     "một phán quyết trước đã xem người gửi này là nhiễu, tin nhắn sẽ được lưu trữ",
   "captureActivity.reason.decided_prior":
-    "người gửi này đã được quyết định, sẽ không tạo liên hệ",
+    "người gửi này đã được quyết định, sẽ không tạo hồ sơ người",
   "captureActivity.reason.no_granting_human":
     "kết nối không nêu thành viên nào để hành động thay",
   "captureActivity.reason.invisible_incumbent":
     "nó khớp với bản ghi ngoài phạm vi bạn thấy",
   "captureActivity.reason.derivation_failed":
-    "bước tạo liên hệ thất bại; bản thân tin nhắn không bị ảnh hưởng",
+    "bước tạo hồ sơ người thất bại; bản thân tin nhắn không bị ảnh hưởng",
   "captureActivity.reason.no_counterparty":
     "không có người gửi nào CRM có thể ghi nhận",
   "captureActivity.reason.role_mailbox":
-    "hộp thư dùng chung, không phải một người — vẫn lưu, nhưng không tạo liên hệ",
+    "hộp thư dùng chung, không phải một người — vẫn lưu, nhưng không tạo hồ sơ người",
   "captureActivity.reason.private_thread":
-    "một cuộc trao đổi riêng tư — vẫn lưu cho bạn, nhưng không tạo liên hệ",
+    "một cuộc trao đổi riêng tư — vẫn lưu cho bạn, nhưng không tạo hồ sơ người",
   "captureActivity.reason.transactional_infra":
     "người gửi là hạ tầng thư, không phải công ty bạn làm việc cùng",
   "captureActivity.reason.transactional_prefix":
@@ -5985,7 +5985,7 @@ export const vi = {
   "captureActivity.outcome.deferred_sent": "Đã gửi để phân định",
   "captureActivity.resolution.pending": "vẫn đang chờ",
   "captureActivity.resolution.unsure": "đã gửi vào hàng chờ duyệt",
-  "captureActivity.resolution.real": "được xem là liên hệ thật",
+  "captureActivity.resolution.real": "được xem là người thật",
   "captureActivity.resolution.noise": "được xem là nhiễu",
   "captureActivity.resolution.rejected": "bị người dùng từ chối",
   "captureActivity.resolution.suppressed": "bị chặn",
@@ -6014,8 +6014,8 @@ export const vi = {
   "pipeline.stage.erasure_check": "Kiểm tra yêu cầu xóa",
   "pipeline.stage.internal_drop": "Kiểm tra nội bộ",
   "pipeline.stage.activity_write": "Lưu vào dòng thời gian",
-  "pipeline.stage.tier_ladder": "Quyết định về liên hệ",
-  "pipeline.stage.person_create": "Đã tạo liên hệ",
+  "pipeline.stage.tier_ladder": "Quyết định về hồ sơ người",
+  "pipeline.stage.person_create": "Đã tạo hồ sơ người",
   "pipeline.stage.verdict": "Kết luận về người gửi",
   "pipeline.stage.company_triage": "Kiểm tra công ty",
   "pipeline.stage.attention_label": "Nhãn ưu tiên",
@@ -6037,17 +6037,17 @@ export const vi = {
   "pipeline.reason.no_counterparty":
     "không có người gửi nào CRM này ghi nhận được",
   "pipeline.reason.role_mailbox":
-    "hộp thư dùng chung, không phải một người — vẫn lưu, nhưng không tạo liên hệ",
+    "hộp thư dùng chung, không phải một người — vẫn lưu, nhưng không tạo hồ sơ người",
   "pipeline.reason.private_thread":
-    "một cuộc trao đổi riêng tư — vẫn lưu cho bạn, nhưng không tạo liên hệ",
+    "một cuộc trao đổi riêng tư — vẫn lưu cho bạn, nhưng không tạo hồ sơ người",
   "pipeline.reason.no_granting_human":
     "kết nối không chỉ định thành viên nào để thay mặt",
   "pipeline.reason.derivation_failed":
-    "bước tạo liên hệ thất bại; bản thân tin nhắn không bị ảnh hưởng",
+    "bước tạo hồ sơ người thất bại; bản thân tin nhắn không bị ảnh hưởng",
   "pipeline.reason.not_linked_yet":
-    "chưa có liên hệ nào được gắn với tin nhắn này",
+    "chưa có người nào được gắn với tin nhắn này",
   "pipeline.reason.no_contact_intended":
-    "quyết định về liên hệ kết luận rằng không cần tạo",
+    "quyết định về hồ sơ người kết luận rằng không cần tạo",
   "pipeline.reason.awaiting_verdict": "người gửi vẫn đang chờ kết luận",
   "pipeline.reason.verdict_reached": "đã có kết luận cho người gửi này",
   "pipeline.reason.no_open_question":
@@ -6852,14 +6852,14 @@ export const vi = {
     "Một công ty chuyển giai đoạn dựa trên những gì đã diễn ra. Điều này cũng có thể đổi ai nhìn thấy tài khoản và những automation nào chạy.",
   "captureSettings.title": "Bổ sung thông tin",
   "captureSettings.sub":
-    "Cách các công ty và contact đã thu thập được bổ sung thông tin sau khi tạo.",
+    "Cách các công ty và người đã thu thập được bổ sung thông tin sau khi tạo.",
   "captureSettings.autoEnrich.label":
     "Tự động bổ sung thông tin cho công ty đã thu thập",
   "captureSettings.autoEnrich.help":
     "Khi bật, mỗi công ty mới tạo từ thư đã thu thập sẽ được lập hồ sơ web tự động — website của công ty được đọc và hồ sơ được điền. Chạy trong một giới hạn theo ngày.",
   "captureSettings.signatureEnrich.label": "Đọc thông tin liên hệ từ thư",
   "captureSettings.signatureEnrich.help":
-    "Khi bật, Margince lấy những gì người liên hệ tự ghi dưới tên mình trong thư gửi cho bạn — trong chữ ký, và trên danh thiếp đính kèm. Chức danh, số điện thoại, địa chỉ, công ty. Việc này diễn ra trong vài phút sau khi thư đến. Không suy đoán: điều thư không nói thì không được ghi. Đây là mặc định của tổ chức; hộp thư đã tự chọn thì giữ lựa chọn đó.",
+    "Khi bật, Margince lấy những gì một người tự ghi dưới tên mình trong thư gửi cho bạn — trong chữ ký, và trên danh thiếp đính kèm. Chức danh, số điện thoại, địa chỉ, công ty. Việc này diễn ra trong vài phút sau khi thư đến. Không suy đoán: điều thư không nói thì không được ghi. Đây là mặc định của tổ chức; hộp thư đã tự chọn thì giữ lựa chọn đó.",
   "captureSettings.adminOnly":
     "Chỉ quản trị viên hoặc vận hành mới đổi được mục này.",
 
@@ -6873,14 +6873,14 @@ export const vi = {
   "captureExclusions.empty": "Không có loại trừ.",
   "ownerIdentities.title": "Các địa chỉ khác của bạn",
   "ownerIdentities.sub":
-    "Những địa chỉ cũng là bạn: một bí danh gửi thay, một tên miền riêng bạn đọc, một địa chỉ bạn chuyển tiếp. Thư giữa các địa chỉ của chính bạn không phải là trao đổi với ai cả, nên không được thu thập và không bao giờ thành liên hệ.",
+    "Những địa chỉ cũng là bạn: một bí danh gửi thay, một tên miền riêng bạn đọc, một địa chỉ bạn chuyển tiếp. Thư giữa các địa chỉ của chính bạn không phải là trao đổi với ai cả, nên không được thu thập và không bao giờ thành hồ sơ người.",
   "ownerIdentities.add": "Thêm địa chỉ",
   "ownerIdentities.addLabel": "Khai báo một địa chỉ khác là của bạn",
   "ownerIdentities.addDescription":
     "Chỉ của riêng bạn. Đồng nghiệp không bao giờ thấy những gì bạn liệt kê ở đây.",
   "ownerIdentities.current": "Đã khai báo",
   "ownerIdentities.notRetroactive":
-    "Áp dụng từ thư kế tiếp. Thư đã thu thập vẫn giữ nguyên, và liên hệ đã tạo từ một bí danh vẫn còn cho đến khi bạn gộp hoặc xoá.",
+    "Áp dụng từ thư kế tiếp. Thư đã thu thập vẫn giữ nguyên, và người đã tạo từ một bí danh vẫn còn cho đến khi bạn gộp hoặc xoá.",
   "ownerIdentities.empty": "Bạn chưa khai báo địa chỉ nào khác.",
   "ownerIdentities.remove": "Rút lại địa chỉ này",
   "ownerIdentities.added": "Đã thêm địa chỉ.",
@@ -7078,7 +7078,7 @@ export const vi = {
   "person.enriched.confirm": "Đúng rồi",
   "person.enriched.save": "Lưu bản sửa",
   "person.enriched.cancel": "Huỷ",
-  "person.graph.loading": "Đang đọc mạng lưới quanh contact này…",
+  "person.graph.loading": "Đang đọc mạng lưới quanh người này…",
   "person.graph.routeDirect": "{name} đã có trao đổi với họ.",
   "person.graph.routeVia": "{name} có trao đổi với {through} ở cùng công ty.",
   "person.graph.noRoute":
@@ -7088,7 +7088,7 @@ export const vi = {
   "person.graph.recordWorksWith": "Ghi nhận: làm việc cùng {name}",
   "person.graph.noEdge": "Chưa ghi nhận trao đổi nào với {name}.",
   "person.graph.withColleague": "với {name}",
-  "person.graph.withContact": "với contact này",
+  "person.graph.withContact": "với người này",
   "person.graph.counts":
     "{total} lượt tương tác trong 90 ngày · {inbound} đến, {outbound} đi",
   "person.graph.untitledMessage": "Không có tiêu đề",
@@ -7098,7 +7098,7 @@ export const vi = {
   "person.graph.droppedNote": "Còn {count} mục không hiển thị.",
   "person.graph.withheldDirect": "Một số đồng nghiệp không được hiển thị.",
   "person.graph.withheldAccount":
-    "Một số người liên hệ tại công ty này không được hiển thị.",
+    "Một số người tại công ty này không được hiển thị.",
   "person.intro.askFirstName": "Nhờ {name} giới thiệu",
   "person.intro.leadEyebrow": "Hướng được đề xuất",
   "person.intro.leadRouteBadge": "Hướng mạnh",
@@ -7191,12 +7191,12 @@ export const vi = {
   "person.intro.askFailed": "Không ghi nhận được lời nhờ.",
   "person.intro.reasonLabel": "Lý do bạn nhờ",
   "person.intro.reasonHint":
-    "Đồng nghiệp của bạn đọc phần này, không phải người liên hệ. Hãy nói vì sao lời giới thiệu đáng thực hiện.",
-  "person.intro.valueLabel": "Người liên hệ được gì",
-  "person.intro.valueHint": "Lý do người liên hệ muốn có cuộc trò chuyện này.",
+    "Đồng nghiệp của bạn đọc phần này, không phải người được giới thiệu. Hãy nói vì sao lời giới thiệu đáng thực hiện.",
+  "person.intro.valueLabel": "Người đó được gì",
+  "person.intro.valueHint": "Lý do người đó muốn có cuộc trò chuyện này.",
   "person.intro.noteLabel": "Ghi chú để đồng nghiệp chuyển tiếp",
   "person.intro.noteHint":
-    "Chỉ phần này đến tay người liên hệ. Hãy viết sao cho có thể chuyển đi nguyên văn.",
+    "Chỉ phần này đến tay người đó. Hãy viết sao cho có thể chuyển đi nguyên văn.",
   "person.intro.nameDropAsk": "Xin phép được nhắc tên họ",
   "person.intro.fallbackLegend": "Nếu họ từ chối",
   "person.intro.fallbackNone": "Không làm gì thêm",
@@ -7289,7 +7289,7 @@ export const vi = {
   "person.network.replied": "đã hồi đáp {when}",
 
   "person.page.loading": "Đang tải…",
-  "person.page.notOpened": "Không mở được liên hệ này.",
+  "person.page.notOpened": "Không mở được người này.",
   "person.page.buyingRole": "Vai trò mua hàng",
   "person.page.owner": "Người phụ trách",
   "person.page.ownerUnassigned": "Chưa giao",
@@ -7297,7 +7297,7 @@ export const vi = {
   "person.page.openProfile": "Mở hồ sơ",
   "person.rail.detailsTitle": "Chi tiết",
   "person.rail.archivedReadOnly":
-    "Liên hệ này đã lưu trữ. Khôi phục để thay đổi bất kỳ thông tin nào tại đây.",
+    "Người này đã lưu trữ. Khôi phục để thay đổi bất kỳ thông tin nào tại đây.",
   "person.rail.employmentVersionUnresolved":
     "Không đọc lại được phiên bản hiện tại của dòng này để lưu. Hãy tải lại và thử lại.",
   "person.rail.employmentTitle": "Công ty",
@@ -7321,7 +7321,7 @@ export const vi = {
   "person.meetings.noneLogged": "Chưa ghi nhận cuộc họp nào với họ.",
   "person.meetings.untitled": "Cuộc họp chưa có tiêu đề",
   "person.meetings.participants": "Có mặt",
-  "person.documents.empty": "Chưa có tệp nào lưu cho liên hệ này.",
+  "person.documents.empty": "Chưa có tệp nào lưu cho người này.",
   "person.research.empty": "Chưa nghiên cứu gì về họ.",
   "person.research.fields": "Bằng chứng làm giàu dữ liệu",
   "person.research.fieldsEmpty": "Chưa trường dữ liệu nào có bằng chứng.",
@@ -7494,7 +7494,7 @@ export const vi = {
   "person.composer.blockedRewrite":
     "Thư gửi với mục đích khác thì phải THỰC SỰ là loại thư đó — đổi nhãn không làm nó thành như vậy.",
   "person.composer.blockedRecordConsent":
-    "Nếu bạn có cơ sở để viết, hãy ghi nhận quyết định đồng ý trên hồ sơ liên hệ.",
+    "Nếu bạn có cơ sở để viết, hãy ghi nhận quyết định đồng ý trên hồ sơ của họ.",
   "person.composer.consentPickPurpose":
     "Hãy chọn mục đích của thư này — sự đồng ý được xét theo từng mục đích.",
   "person.composer.intent": "Nội dung nên nói về điều gì?",
@@ -7608,25 +7608,25 @@ export const vi = {
   "provider.deleteData": "Xoá dữ liệu đã mua",
   "provider.deleteDataConfirm.title": "Xoá mọi thứ đã mua từ nhà cung cấp này?",
   "provider.deleteDataConfirm.body":
-    "Mọi giá trị nhà cung cấp này đã cấp sẽ bị gỡ khỏi mọi liên hệ. Khoản bạn đã chi vẫn được ghi lại; dữ liệu thì không. Không thể hoàn tác.",
+    "Mọi giá trị nhà cung cấp này đã cấp sẽ bị gỡ khỏi mọi hồ sơ người. Khoản bạn đã chi vẫn được ghi lại; dữ liệu thì không. Không thể hoàn tác.",
   "provider.deleteDataConfirm.typed": "Nhập tên nhà cung cấp để xác nhận",
-  "provider.automaticLookup": "Tự động tra cứu liên hệ",
+  "provider.automaticLookup": "Tự động tra cứu người",
   "provider.automaticLookupHint":
-    "Mỗi liên hệ được tra cứu một lần — cho những mục mà kết nối chọn và nhà cung cấp không tính phí, thường là liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, cùng quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này: chúng tốn tín dụng và vẫn là quyết định cho từng liên hệ.",
+    "Mỗi người được tra cứu một lần — cho những mục mà kết nối chọn và nhà cung cấp không tính phí, thường là liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, cùng quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này: chúng tốn tín dụng và vẫn là quyết định cho từng người.",
   "provider.automaticLookupJurisdiction":
-    "Hãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
+    "Hãy tắt mục này nếu những người trong CRM của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng người vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
   "provider.buyable": "Cho phép mua {category}",
   "provider.buyableHint_one":
-    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi liên hệ, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
+    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi người, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
   "provider.buyableHint_other":
-    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi liên hệ, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
+    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi người, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
   "provider.buyableNeeds":
     "Nhà cung cấp chỉ tìm thông tin này cùng với {prerequisite}, nên không thể mua riêng. Hãy cho phép mục đó trước.",
   "provider.backlog": "Còn phải tra cứu",
-  "provider.backlogRemaining_one": "{count} liên hệ",
-  "provider.backlogRemaining_other": "{count} liên hệ",
+  "provider.backlogRemaining_one": "{count} người",
+  "provider.backlogRemaining_other": "{count} người",
   "provider.backlogWorking":
-    "Những liên hệ đã có sẵn khi kết nối nhà cung cấp đang được tra cứu dần.",
+    "Những người đã có sẵn khi kết nối nhà cung cấp đang được tra cứu dần.",
   "provider.backlogPaused":
     "Hiện không tra cứu gì: tra cứu tự động đang tắt, đã hết hạn mức trong ngày, hoặc nhà cung cấp không dùng được.",
   "provider.credits": "Tín dụng còn lại ở nhà cung cấp",
@@ -7651,16 +7651,16 @@ export const vi = {
   "provider.profile.notConnected":
     "Chưa kết nối nhà cung cấp dữ liệu nào, nên chưa mua gì cả.",
   "provider.profile.notEligible":
-    "Liên hệ này không đủ điều kiện — họ đã phản đối, hoặc hồ sơ đã được lưu trữ.",
+    "Người này không đủ điều kiện — họ đã phản đối, hoặc hồ sơ đã được lưu trữ.",
   "provider.profile.nothingToLookUp":
-    "Không có thông tin nào để tra cứu liên hệ này. Hãy thêm URL LinkedIn hoặc công ty của họ, rồi việc tra cứu mới chạy được.",
-  "provider.profile.neverRun": "Chưa ai tra cứu liên hệ này.",
+    "Không có thông tin nào để tra cứu người này. Hãy thêm URL LinkedIn hoặc công ty của họ, rồi việc tra cứu mới chạy được.",
+  "provider.profile.neverRun": "Chưa ai tra cứu người này.",
   "provider.profile.queued": "Trong hàng đợi",
   "provider.profile.inProgress": "Đang tra cứu…",
   "provider.profile.working": "Đang hỏi {provider}. Việc này mất tới một phút.",
   "provider.profile.landing": "Đã có câu trả lời. Đang ghi vào hồ sơ.",
   "provider.profile.completed": "Đã tìm thấy",
-  "provider.profile.noMatch": "Nhà cung cấp không có gì về liên hệ này.",
+  "provider.profile.noMatch": "Nhà cung cấp không có gì về người này.",
   "provider.profile.stale":
     "Đã mua trước đây. Nhà cung cấp không còn kết nối nên không thể làm mới.",
   "provider.profile.invalidCredentials":
@@ -7675,12 +7675,12 @@ export const vi = {
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":
     "Đã trả tiền, nhưng thông tin chưa bao giờ đến hồ sơ này. Không ai phải đi tìm — đây chính là chỗ thiếu.",
-  "provider.profile.enrichNow": "Tra cứu liên hệ này · miễn phí",
+  "provider.profile.enrichNow": "Tra cứu người này · miễn phí",
   "provider.profile.recheck": "Kiểm tra lại · miễn phí",
   "provider.profile.lookingUp": "Đang hỏi nhà cung cấp. Việc này mất một lát.",
-  "provider.profile.emptyTitle": "Chưa mua dữ liệu nào cho liên hệ này",
+  "provider.profile.emptyTitle": "Chưa mua dữ liệu nào cho người này",
   "provider.profile.emptyBody":
-    "Một lượt tra cứu sẽ hỏi {provider} về liên hệ này, lấy những thông tin mà kết nối này được đặt để mua. Việc đó tiêu tốn tín dụng {provider}, và những gì nhận được sẽ nằm cạnh hồ sơ chứ không ghi đè lên bất cứ điều gì đồng nghiệp đã nhập.",
+    "Một lượt tra cứu sẽ hỏi {provider} về người này, lấy những thông tin mà kết nối này được đặt để mua. Việc đó tiêu tốn tín dụng {provider}, và những gì nhận được sẽ nằm cạnh hồ sơ chứ không ghi đè lên bất cứ điều gì đồng nghiệp đã nhập.",
   "provider.profile.emails": "Địa chỉ email",
   "provider.profile.emailType.provider": "{type}, theo nhãn của nhà cung cấp",
   "provider.profile.emailType.requested":
@@ -7699,9 +7699,9 @@ export const vi = {
   "provider.profile.buyRebuys":
     "Giá này bao gồm việc mua lại {categories}: nhà cung cấp không tìm thông tin này nếu thiếu mục đó, và tính phí cho mọi thứ họ trả về.",
   "provider.freeTier.hint":
-    "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
+    "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: người mới nào cũng có chúng mà không ai phải quyết định.",
   "provider.pricedTier.hint":
-    "Không bao giờ mua tự động. Ai đó bấm nút trên một liên hệ cụ thể, và giá hiện ngay trên nút.",
+    "Không bao giờ mua tự động. Ai đó bấm nút trên một người cụ thể, và giá hiện ngay trên nút.",
   "provider.profile.receiptAt": "Tra cứu ngày {at}.",
   "provider.profile.receipt":
     "Tra cứu ngày {at} · đã hỏi {asked} thông tin, nhận về {answered}.",
@@ -7762,7 +7762,7 @@ export const vi = {
   "filters.builderTitle": "B\u1ed9 l\u1ecdc",
   "filters.dynamic":
     "\u0110\u1ed9ng \u2014 t\u00ednh l\u1ea1i sau m\u1ecdi s\u1ef1 ki\u1ec7n",
-  "filters.matchContacts": "{count} li\u00ean h\u1ec7 kh\u1edbp",
+  "filters.matchContacts": "{count} ng\u01b0\u1eddi kh\u1edbp",
   "filters.matchCompanies": "{count} c\u00f4ng ty kh\u1edbp",
   "filters.matchDeals": "{count} th\u01b0\u01a1ng v\u1ee5 kh\u1edbp",
   "filters.noFilterYet":
@@ -7853,7 +7853,7 @@ export const vi = {
   "projectCompanies.searchLabel": "Tìm công ty theo tên",
   "personProjects.title": "Dự án",
   "personProjects.empty":
-    "Liên hệ này xuất hiện ở đây khi tham gia một dự án — với vai trò người bảo trợ, đầu mối, hoặc bất kỳ ai đang thực hiện.",
+    "Người này xuất hiện ở đây khi tham gia một dự án — với vai trò người bảo trợ, đầu mối, hoặc bất kỳ ai đang thực hiện.",
   "projectRole.customer": "Khách hàng",
   "projectRole.partner": "Đối tác",
   "projectRole.subcontractor": "Nhà thầu phụ",
@@ -8277,7 +8277,7 @@ export const vi = {
   "worklist.untitled.failed_approval": "Điều bạn duyệt đã không chạy",
   "worklist.untitled.dsr": "Một yêu cầu quyền riêng tư",
   "worklist.untitled.sync_health": "Đồng bộ CRM cần chú ý",
-  "worklist.sync.class.contacts": "liên hệ",
+  "worklist.sync.class.contacts": "người",
   "worklist.sync.class.companies": "công ty",
   "worklist.sync.class.deals": "giao dịch",
   "worklist.sync.class.leads": "khách hàng tiềm năng",
@@ -8330,8 +8330,8 @@ export const vi = {
   "worklist.verb.dismiss": "Chưa phải lúc",
   "worklist.verb.dismissed": "Đã tạm gác lại một tháng.",
   "worklist.verb.dismissUndo": "Hoàn tác",
-  "worklist.verb.dismissFailed": "Không thể tạm gác liên hệ này.",
-  "worklist.verb.dismissUndoFailed": "Không thể đưa liên hệ này trở lại.",
+  "worklist.verb.dismissFailed": "Không thể tạm gác người này.",
+  "worklist.verb.dismissUndoFailed": "Không thể đưa người này trở lại.",
   "worklist.verb.completeUndo": "Hoàn tác",
   "worklist.verb.completeUndoFailed": "Không thể mở lại nhiệm vụ này.",
   "worklist.source.failed": "Không đọc được một nguồn: {source}",
@@ -8406,7 +8406,7 @@ export const vi = {
   "ob.digest.pageKind.team": "Trang đội ngũ",
   "ob.digest.pageKind.services": "Trang dịch vụ",
   "ob.digest.pageKind.products": "Trang sản phẩm",
-  "ob.digest.pageKind.contact": "Trang liên hệ",
+  "ob.digest.pageKind.contact": "Trang hồ sơ người",
   "ob.digest.pageKind.other": "Trang",
   "ob.deck.counter": "{n} / {m}",
   "ob.deck.left": "Còn {n} / {m}",
@@ -8504,7 +8504,7 @@ export const vi = {
     "Vừa đọc từ nhà cung cấp, không phải từ bảng giá của bạn. Khi bạn gán mô hình này, giá sẽ vào hộp phê duyệt để mức dùng và chi phí tính được sau khi bạn xác nhận.",
   "firstRun.ai.foot":
     "Chưa có gì gửi tới nhà cung cấp của bạn cho tới khi bạn bấm Tiếp tục.",
-  "person.readings.title": "Vị thế của liên hệ này",
+  "person.readings.title": "Vị thế của người này",
   "person.readings.move": "Lượt của ai",
   "person.readings.yourMove": "Bạn",
   "person.readings.theirMove": "Họ",
@@ -8523,8 +8523,9 @@ export const vi = {
   "deal.strip.lastTouch": "Lần chạm cuối",
   "lead.standing.qualified": "Đã đủ điều kiện",
   "lead.standing.qualifiedOn":
-    "Đủ điều kiện ngày {at}. Khách hàng tiềm năng này giờ là liên hệ.",
-  "lead.standing.qualifiedUndated": "Khách hàng tiềm năng này giờ là liên hệ.",
+    "Đủ điều kiện ngày {at}. Khách hàng tiềm năng này giờ là người trong CRM.",
+  "lead.standing.qualifiedUndated":
+    "Khách hàng tiềm năng này giờ là người trong CRM.",
   "lead.standing.closed": "Đã đóng",
   "lead.standing.closedFor":
     "Đã đóng: {reason}. Hồ sơ vẫn giữ lại làm dấu vết.",
@@ -8537,7 +8538,7 @@ export const vi = {
   "lead.standing.inMotion": "Đang tiến triển",
   "lead.standing.engagedBecause":
     "Họ đã trả lời, hoặc đã có cuộc họp trong lịch.",
-  "lead.standing.rests.promoted": "Đã chuyển thành liên hệ.",
+  "lead.standing.rests.promoted": "Đã chuyển thành hồ sơ người.",
   "lead.standing.rests.closed": "Đã loại, không ghi lý do.",
   "lead.standing.rests.ladder": "Bậc thang khách hàng tiềm năng",
   "lead.standing.rests.record": "Hồ sơ khách hàng tiềm năng",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2777,7 +2777,7 @@ export const vi = {
   "deepread.kindTeam": "Đội ngũ",
   "deepread.kindServices": "Dịch vụ",
   "deepread.kindProducts": "Sản phẩm",
-  "deepread.kindContact": "Người",
+  "deepread.kindContact": "Liên hệ",
   "deepread.kindOther": "Khác",
 
   "transcriptread.title": "Đọc bản chép lời này",
@@ -8406,7 +8406,7 @@ export const vi = {
   "ob.digest.pageKind.team": "Trang đội ngũ",
   "ob.digest.pageKind.services": "Trang dịch vụ",
   "ob.digest.pageKind.products": "Trang sản phẩm",
-  "ob.digest.pageKind.contact": "Trang hồ sơ người",
+  "ob.digest.pageKind.contact": "Trang liên hệ",
   "ob.digest.pageKind.other": "Trang",
   "ob.deck.counter": "{n} / {m}",
   "ob.deck.left": "Còn {n} / {m}",

--- a/frontend/src/screens/capture-activity.test.tsx
+++ b/frontend/src/screens/capture-activity.test.tsx
@@ -381,7 +381,7 @@ describe("capture activity", () => {
     );
     const row = within(await screen.findByRole("list"));
     expect(row.getByText(/sent for a verdict/i)).toBeInTheDocument();
-    expect(row.getByText(/judged a real contact/i)).toBeInTheDocument();
+    expect(row.getByText(/judged a real person/i)).toBeInTheDocument();
     expect(row.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/screens/companyrail.test.tsx
+++ b/frontend/src/screens/companyrail.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { CompanyRail } from "./companyrail";
 
 type Organization360 = components["schemas"]["Organization360"];
@@ -1011,11 +1012,9 @@ describe("CompanyRail", () => {
     const spy = vi.fn();
     stub();
     renderRail({ onTab: spy });
-    expect(
-      screen.getByText("No contacts yet. Nobody to write to."),
-    ).toBeInTheDocument();
+    expect(screen.getByText(en["co.rail.people.empty"])).toBeInTheDocument();
     await userEvent.click(
-      screen.getByRole("button", { name: "Add a contact" }),
+      screen.getByRole("button", { name: en["co.rail.people.add"] }),
     );
     expect(spy).toHaveBeenCalledWith("people");
     // That is the empty roster's one verb: no second "Add" under it.

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { TodayOnThisAccount } from "./companytoday";
 
 // The section earns its place by carrying what nothing else on the page says,
@@ -128,7 +129,7 @@ describe("what needs a person on this account today", () => {
     show({ ...BASE, sections_omitted: ["people"] });
 
     expect(screen.getByText(/Hidden from you/).textContent).toContain(
-      "the contacts",
+      en["today.source.people"],
     );
   });
 

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -2376,9 +2376,7 @@ describe("ComposeModal started from an account", () => {
       />,
     );
 
-    expect(
-      await screen.findByText(/No contact on this account yet/),
-    ).toBeTruthy();
+    expect(await screen.findByText(/Nobody on this account yet/)).toBeTruthy();
     // The dead end is about the DRAFT, not about which body of work the
     // message is for.
     expect(

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -303,7 +303,7 @@ describe("ConsentSection", () => {
     await screen.findByText("Marketing");
     // One row requires DOI in the fixture; the note belongs to it alone.
     expect(
-      screen.getAllByText(/confirmed by the contact themselves/i),
+      screen.getAllByText(/confirmed by the person themselves/i),
     ).toHaveLength(1);
   });
 

--- a/frontend/src/screens/coverageexplorer.test.tsx
+++ b/frontend/src/screens/coverageexplorer.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { CoverageExplorer } from "./coverageexplorer";
 
 // The grid exists to answer "where are we thin" without becoming a contact ×
@@ -134,7 +135,7 @@ describe("comparing the colleagues a reader chooses", () => {
     await screen.findByText("Dana Buyer");
 
     await user.type(
-      screen.getByRole("searchbox", { name: "Find a contact" }),
+      screen.getByRole("searchbox", { name: en["acctCoverage.findContact"] }),
       "Sam",
     );
     expect(screen.queryByText("Dana Buyer")).toBeNull();

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -12,6 +12,7 @@ import { type ReactNode, useLayoutEffect, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import {
   type CreateField,
   CreateRecordModal,
@@ -132,7 +133,7 @@ describe("contact create flow", () => {
       captured,
     );
     render(<ContactsScreen />);
-    await userEvent.click(screen.getByText("New contact"));
+    await userEvent.click(screen.getByText(en["create.contact"]));
     await userEvent.type(screen.getByLabelText("Full name *"), "Peter Neu");
     await userEvent.click(screen.getByText("Add email"));
     await userEvent.type(screen.getByLabelText("Email *"), "peter@neu.example");
@@ -158,7 +159,7 @@ describe("contact create flow", () => {
         ),
     });
     render(<ContactsScreen />);
-    await userEvent.click(screen.getByText("New contact"));
+    await userEvent.click(screen.getByText(en["create.contact"]));
     await userEvent.type(screen.getByLabelText("Full name *"), "x");
     await userEvent.click(screen.getByRole("button", { name: "Create" }));
     await waitFor(() =>

--- a/frontend/src/screens/customfields.test.tsx
+++ b/frontend/src/screens/customfields.test.tsx
@@ -217,7 +217,7 @@ describe("FieldTable", () => {
       />,
     );
     expect(
-      screen.getByText(/No custom fields on Contact yet/i),
+      screen.getByText(/No custom fields on Person yet/i),
     ).toBeInTheDocument();
   });
 
@@ -389,7 +389,7 @@ describe("CustomFieldsAdmin", () => {
     await waitFor(() =>
       expect(screen.getByText("Renewal date")).toBeInTheDocument(),
     );
-    for (const name of [/Deal/, /Company/, /Contact/, /Lead/]) {
+    for (const name of [/Deal/, /Company/, /Person/, /Lead/]) {
       expect(screen.getByRole("button", { name })).toBeInTheDocument();
     }
   });

--- a/frontend/src/screens/deal360/deal360.test.tsx
+++ b/frontend/src/screens/deal360/deal360.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
+import { en } from "../../i18n/en";
 import { DealIdentityLine } from "../deals";
 import { DealPulse } from "./dealpulse";
 import { DealSeats } from "./dealseats";
@@ -322,7 +323,7 @@ describe("the rail says who is on the deal", () => {
         }}
       />,
     );
-    expect(screen.getByText("A contact you cannot read")).toBeInTheDocument();
+    expect(screen.getByText(en["coverage.seatWithheld"])).toBeInTheDocument();
     expect(screen.getByText("No two-way contact")).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/filters.test.tsx
+++ b/frontend/src/screens/filters.test.tsx
@@ -230,7 +230,7 @@ it("says how many match once a clause is complete", async () => {
   // incomplete — typing a value is what makes it askable.
   await user.type(screen.getByLabelText("Value"), "ann");
 
-  expect(await screen.findByText("12 contacts match")).toBeTruthy();
+  expect(await screen.findByText("12 people match")).toBeTruthy();
 });
 
 it("names the count after the object, not after a placeholder", async () => {
@@ -242,7 +242,7 @@ it("names the count after the object, not after a placeholder", async () => {
   await user.click(screen.getByRole("button", { name: "Add clause" }));
   await user.type(screen.getByLabelText("Value"), "s1");
 
-  // "3 deals match", not "3 contacts match" and not "3 match" — the object is
+  // "3 deals match", not "3 people match" and not "3 match" — the object is
   // part of the sentence, which is why the copy is keyed per object.
   expect(await screen.findByText("3 deals match")).toBeTruthy();
 });
@@ -264,7 +264,7 @@ it("restores a saved filter, count and all, without a clause being retyped", asy
   // The stored clause is on screen AND askable: a view that restores a tree the
   // engine would refuse is a view that fails the moment it is opened.
   expect(await screen.findByDisplayValue("ann")).toBeTruthy();
-  expect(await screen.findByText("7 contacts match")).toBeTruthy();
+  expect(await screen.findByText("7 people match")).toBeTruthy();
 });
 
 it("does not offer a view whose stored filter it cannot read", async () => {
@@ -447,7 +447,7 @@ it("reads a refused preview as a failure, not as an unwritten filter", async () 
 
   await user.click(await screen.findByRole("button", { name: "Add clause" }));
   await user.type(screen.getByLabelText("Value"), "ann");
-  await screen.findByText("2 contacts match");
+  await screen.findByText("2 people match");
 
   // A bodiless 502 — a proxy between the client and the app — is the failure
   // with the least to say, so what the screen says instead is all its own.
@@ -482,7 +482,7 @@ it("names the seat when a read seat is refused a preview", async () => {
 
   await user.click(await screen.findByRole("button", { name: "Add clause" }));
   await user.type(screen.getByLabelText("Value"), "ann");
-  await screen.findByText("2 contacts match");
+  await screen.findByText("2 people match");
 
   vi.stubGlobal(
     "fetch",

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SLOWEST_MEASURED_TEST_MS } from "../../vitest.budget";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { ProviderCard } from "./integrations-provider";
 
 type Me = components["schemas"]["MeResponse"];
@@ -193,7 +194,7 @@ describe("ProviderCard write posture", () => {
   const DISCONNECT = "Disconnect";
   const DELETE_DATA = "Delete bought data";
   const KEY_FIELD = "Replace the API key";
-  const AUTOMATIC_LOOKUP = "Look up contacts automatically";
+  const AUTOMATIC_LOOKUP = en["provider.automaticLookup"];
   // Disconnect and delete-data live behind the overflow, because neither is the
   // same weight as Connect: one is recoverable and the other irreversibly
   // destroys purchased contact data. The trigger's presence is what the grant

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -284,7 +284,7 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     // The page stays (ADR-0119): the outcome is said here, with the contact.
     expect(window.location.hash).toBe("#/leads/l-1");
     expect(
-      await screen.findByText(/Jonas Petersen is now a contact:/),
+      await screen.findByText(/Jonas Petersen is now a person:/),
     ).toBeTruthy();
   });
 
@@ -580,23 +580,19 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     render(<LeadScreen id="l-1" />);
 
     // It stays on the lead's own page.
-    expect(await screen.findByText("Promoted to a contact")).toBeTruthy();
+    expect(await screen.findByText(en["lead.promotedTitle"])).toBeTruthy();
     expect(window.location.hash).not.toBe("#/contacts/p-42");
     // And it names WHICH outcome, which is the whole reason a rep opens it.
     // Awaited: the outcome comes from the audit read, a second request that
     // lands after the lead itself.
-    expect(
-      await screen.findByText(
-        "This lead merged into a contact we already knew — no duplicate was created.",
-      ),
-    ).toBeTruthy();
+    expect(await screen.findByText(en["lead.promotedMerged"])).toBeTruthy();
     expect(screen.getByText(/Inbound reply/)).toBeTruthy();
     expect(screen.getByText(/Replied asking for a quote\./)).toBeTruthy();
   });
 
   it("the promote dialog says what promotion will do before the rep commits", async () => {
     // ADR-0119/A170: merge-into-existing vs create is the difference between
-    // "my prospect is now a contact" and "my prospect was already someone we
+    // "my prospect is now a person" and "my prospect was already someone we
     // knew". The preview runs the same ladder the promotion runs.
     stubFetch(async (url) => {
       if (url.includes("/promote-preview")) {
@@ -610,7 +606,7 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     render(<LeadScreen id="l-1" />);
     await userEvent.click(await screen.findByTestId("lead-qualify"));
     expect(
-      await screen.findByText(/Promoting will merge into the existing contact/),
+      await screen.findByText(/Promoting will merge into the existing person/),
     ).toBeTruthy();
   });
 
@@ -629,13 +625,9 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     render(<LeadScreen id="l-1" />);
     await userEvent.click(await screen.findByTestId("lead-qualify"));
     expect(
-      await screen.findByText(
-        "Promoting will merge into an existing contact you cannot see.",
-      ),
+      await screen.findByText(en["lead.previewMergeWithheld"]),
     ).toBeTruthy();
-    expect(
-      screen.queryByText("Promoting will create a new contact."),
-    ).toBeNull();
+    expect(screen.queryByText(en["lead.previewCreate"])).toBeNull();
   });
 
   it("a promoted lead can be demoted from its own page, with a recorded reason", async () => {
@@ -749,11 +741,7 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     });
     render(<LeadScreen id="l-1" />);
 
-    expect(
-      await screen.findByText(
-        "This lead merged into a contact we already knew — no duplicate was created.",
-      ),
-    ).toBeTruthy();
+    expect(await screen.findByText(en["lead.promotedMerged"])).toBeTruthy();
     expect(historyURLs).toHaveLength(1);
     expect(historyURLs[0]).toContain("action=promote");
   });
@@ -782,11 +770,7 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
       await screen.findByText("Promoted — this lead is now read-only."),
     ).toBeTruthy();
     // The outcome line never claims a result it could not read.
-    expect(
-      screen.queryByText(
-        "This lead merged into a contact we already knew — no duplicate was created.",
-      ),
-    ).toBeNull();
+    expect(screen.queryByText(en["lead.promotedMerged"])).toBeNull();
   });
 
   it("re-reads the history after promoting, so the new audit row is not missed", async () => {
@@ -880,11 +864,9 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     render(<LeadScreen id="l-1" />);
 
     expect(
-      await screen.findByText(
-        "We cannot show whether this merged or created a contact.",
-      ),
+      await screen.findByText(en["lead.promotedOutcomeUnavailable"]),
     ).toBeTruthy();
-    expect(screen.queryByText("This lead became a new contact.")).toBeNull();
+    expect(screen.queryByText(en["lead.promotedCreated"])).toBeNull();
   });
 
   it("promote is disabled for an ineligible lead, and the button says why", async () => {

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1396,7 +1396,7 @@ describe("CompanyScreen — the account pulse line (P-4)", () => {
     // The way in. WHEN contact last happened is the readings row's (Last
     // touch), not the header's: one fact, one home.
     await waitFor(() => expect(screen.getByText(/Way in/)).toBeTruthy());
-    expect(screen.getByText(/of 3 contacts here/)).toBeTruthy();
+    expect(screen.getByText(/of 3 people here/)).toBeTruthy();
     expect(screen.queryByText(/Last contact/)).toBeNull();
     // The composite is gone: it was PO-F-3's MAX over contacts, so one
     // talkative contact spoke for the account and "41/100" read as a verdict.

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { activityTimeline } from "../design-system/activitytimeline";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { ContactsScreen, PersonScreen } from "./people";
 
 // B-EP09.10a acceptance: per-row provenance chips, row→360 navigation, and
@@ -924,7 +925,7 @@ describe("PersonScreen — archived is read-only (P-3)", () => {
       // sentence the control does not point at reaches no reader who needed it.
       const describedBy = control.getAttribute("aria-describedby");
       expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
-        "This contact is archived. Restore them to change anything here.",
+        en["person.rail.archivedReadOnly"],
       );
     }
   });

--- a/frontend/src/screens/personfiles.test.tsx
+++ b/frontend/src/screens/personfiles.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { PersonFilesTab } from "./personfiles";
 
 type Attachment = components["schemas"]["Attachment"];
@@ -264,9 +265,7 @@ describe("the person's files tab", () => {
     stub({ data: [], page: { has_more: false } });
     show(<PersonFilesTab personId="p-1" />);
 
-    expect(
-      await screen.findByText("No file has been filed against this contact."),
-    ).toBeTruthy();
+    expect(await screen.findByText(en["person.documents.empty"])).toBeTruthy();
   });
 
   it("says the read failed, with a way to retry, rather than reading as empty", async () => {
@@ -275,9 +274,7 @@ describe("the person's files tab", () => {
 
     expect(await screen.findByText("This section did not load.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
-    expect(
-      screen.queryByText("No file has been filed against this contact."),
-    ).toBeNull();
+    expect(screen.queryByText(en["person.documents.empty"])).toBeNull();
   });
 
   it("draws a cut page's rows and says the list was cut, not the whole of it", async () => {
@@ -417,7 +414,7 @@ describe("the person's files tab", () => {
     stub({ data: [], page: { has_more: false } });
     show(<PersonFilesTab personId="p-42" />);
 
-    await screen.findByText("No file has been filed against this contact.");
+    await screen.findByText(en["person.documents.empty"]);
     if (!lastRequest) {
       throw new Error("the tab asked for nothing at all");
     }

--- a/frontend/src/screens/personnetwork-panel.test.tsx
+++ b/frontend/src/screens/personnetwork-panel.test.tsx
@@ -62,9 +62,7 @@ describe("PersonNetworkTab", () => {
     // the crash happens on the render that receives the data, and asserting
     // before then would pass on the loading frame alone.
     await waitFor(() =>
-      expect(
-        screen.queryByText("Reading the network around this contact…"),
-      ).toBeNull(),
+      expect(screen.queryByText(en["person.graph.loading"])).toBeNull(),
     );
     // The sibling is the assertion. Reading `.find` off undefined unmounted
     // the whole tree, and the relationship list on the same tab vanished with
@@ -316,7 +314,7 @@ describe("PersonNetworkTab", () => {
     expect(screen.queryByText("with Bo")).toBeNull();
     // The anchor's own sentence belongs to an edge that reaches the anchor.
     // This one does not touch them at all.
-    expect(screen.queryByText("with this contact")).toBeNull();
+    expect(screen.queryByText(en["person.graph.withContact"])).toBeNull();
   });
 
   it("names the anchor as the page's subject when the edge reaches them", async () => {
@@ -344,7 +342,9 @@ describe("PersonNetworkTab", () => {
     // equal to it.
     await user.click(await screen.findByRole("button", { name: /Dana/ }));
 
-    expect(await screen.findByText("with this contact")).toBeTruthy();
+    expect(
+      await screen.findByText(en["person.graph.withContact"]),
+    ).toBeTruthy();
   });
 
   // The panel outlives the contact: moving between records on the Relationships
@@ -401,14 +401,16 @@ describe("PersonNetworkTab", () => {
     const { showContact } = renderPanel();
 
     await user.click(await screen.findByRole("button", { name: /Dana/ }));
-    expect(await screen.findByText("with this contact")).toBeTruthy();
+    expect(
+      await screen.findByText(en["person.graph.withContact"]),
+    ).toBeTruthy();
 
     showContact("p-2");
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Elif/ })).toBeTruthy(),
     );
-    expect(screen.queryByText("with this contact")).toBeNull();
+    expect(screen.queryByText(en["person.graph.withContact"])).toBeNull();
     expect(screen.queryByText("No recorded correspondence with .")).toBeNull();
   });
 

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
+import { en } from "../i18n/en";
 import {
   keepPolling,
   PersonProviderSection,
@@ -98,9 +99,7 @@ describe("a contact nobody has bought data for", () => {
 
     // The plate names what is missing AND what a lookup costs. Without it the
     // panel is a blank body whose only verb sits in the header corner.
-    const title = await screen.findByText(
-      "Nothing bought for this contact yet",
-    );
+    const title = await screen.findByText(en["provider.profile.emptyTitle"]);
     expect(await screen.findByText(/It spends Surfe credits/)).toBeDefined();
 
     // The verb lives INSIDE the plate, which is the whole point: a button that
@@ -116,7 +115,7 @@ describe("a contact nobody has bought data for", () => {
     const posted = mount(neverRun(), queuedRun);
 
     await user.click(
-      await screen.findByRole("button", { name: /Look this contact up/ }),
+      await screen.findByRole("button", { name: /Look this person up/ }),
     );
 
     // One request, naming a provider. A body without one is refused by the
@@ -146,7 +145,7 @@ describe("a contact nobody has bought data for", () => {
     );
 
     await user.click(
-      await screen.findByRole("button", { name: /Look this contact up/ }),
+      await screen.findByRole("button", { name: /Look this person up/ }),
     );
 
     // The server's own words, not a generic line: a refusal nobody can read is
@@ -171,9 +170,7 @@ describe("a contact whose data was already bought", () => {
     ).toBeDefined();
     // The plate belongs to the empty case only — a panel with values that also
     // said "nothing bought yet" would contradict what is under it.
-    expect(
-      screen.queryByText("Nothing bought for this contact yet"),
-    ).toBeNull();
+    expect(screen.queryByText(en["provider.profile.emptyTitle"])).toBeNull();
     // "Check again", not "look this contact up": this contact HAS been looked
     // up, and the button offers the same free details a second time in case a
     // job changed. The first-lookup wording on a record already showing a
@@ -183,7 +180,7 @@ describe("a contact whose data was already bought", () => {
       await screen.findByRole("button", { name: /Check again/ }),
     ).toBeDefined();
     expect(
-      screen.queryByRole("button", { name: /Look this contact up/ }),
+      screen.queryByRole("button", { name: /Look this person up/ }),
     ).toBeNull();
   });
 
@@ -197,9 +194,7 @@ describe("a contact whose data was already bought", () => {
     expect(
       await screen.findByText(providerCompletedProfile.emails[0].value),
     ).toBeDefined();
-    expect(
-      screen.queryByText("Nothing bought for this contact yet"),
-    ).toBeNull();
+    expect(screen.queryByText(en["provider.profile.emptyTitle"])).toBeNull();
   });
 });
 
@@ -261,7 +256,7 @@ describe("two providers connected", () => {
     // button, or a body that named the wrong provider, would buy from whoever
     // happened to be first.
     const buttons = await screen.findAllByRole("button", {
-      name: /Look this contact up/,
+      name: /Look this person up/,
     });
     expect(buttons.length).toBe(2);
     await user.click(buttons[1]);
@@ -300,7 +295,7 @@ describe("which contact a lookup is charged to", () => {
         <PersonProviderSection personId="p-1" profiles={[neverRun()]} />
       </StoryProviders>,
     );
-    await screen.findByRole("button", { name: /Look this contact up/ });
+    await screen.findByRole("button", { name: /Look this person up/ });
 
     // The panel stays mounted across the change of subject: the record page
     // keys its subtree by contact today, and this is the case that breaks the
@@ -311,7 +306,7 @@ describe("which contact a lookup is charged to", () => {
       </StoryProviders>,
     );
     await user.click(
-      await screen.findByRole("button", { name: /Look this contact up/ }),
+      await screen.findByRole("button", { name: /Look this person up/ }),
     );
 
     await expect.poll(() => paths).toEqual(["p-2"]);

--- a/frontend/src/screens/record360/spine.test.tsx
+++ b/frontend/src/screens/record360/spine.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { components } from "../../api/schema";
 import { LocaleProvider } from "../../i18n";
+import { en } from "../../i18n/en";
 import { RecordSpine } from "./spine";
 
 // The thread's one rule: it may only draw what the payload supports. Every
@@ -131,9 +132,7 @@ describe("the silence between the last word and today", () => {
 
     expect(screen.getByText("7 days")).toBeTruthy();
     expect(screen.getByText("They have never written back")).toBeTruthy();
-    expect(
-      screen.getByText("One contact, and no reply from them"),
-    ).toBeTruthy();
+    expect(screen.getByText(en["co.spine.singleThreaded"])).toBeTruthy();
   });
 
   it("draws no gap when they answered after we did", () => {

--- a/frontend/src/screens/worklist.detail.test.tsx
+++ b/frontend/src/screens/worklist.detail.test.tsx
@@ -220,7 +220,7 @@ describe("the supporting line each source sends", () => {
       what: "stale object classes",
       kind: "objects_stale",
       detail: "deals, contacts",
-      says: "Out of date here: deals, contacts.",
+      says: "Out of date here: deals, people.",
       never: "deals, contacts",
     },
   ])(


### PR DESCRIPTION
Closes #4112.

#4069 renamed the nav, the import objects and the access labels to **People**. The other 80-odd catalog values that named the record type still said *contact*, so a reader met both words in one session. This PR finishes the sweep across `en.ts`, `de.ts` and `vi.ts`.

## What changed

- **Every value that names the record** now says person / Person / người: merge, create, promote, capture pipeline, access, provider lookups, filters, worklist, digest, readings.
- **Values that name the act** ("never contacted", "last contact yesterday", "in regular contact"), **the details one reaches someone by** ("contact data", "contact email") and **a buyer's counterpart in a room** ("your contact") keep the word — there it is the right one.
- `linkedinReach.onFile` reads "Already on file" rather than "Already contacts"; `acctCoverage.noMatch` reads "Nobody matches that."

## Vietnamese and German

Per the ticket, Vietnamese was read rather than replaced. `mọi liên hệ` would become `mọi người` (*everyone*), so those sentences are reordered ("Người nào trình kết nối này tạo ra … đều"). A bare `tạo người` reads as creating a human, so creation and promotion phrasing says `hồ sơ người` (person record) while a reference stays `người này`. The untranslated `contact` that `vi.ts` still carried in a dozen values is gone with it.

German changes gender with the noun, so articles and pronouns follow: "dieser Kontakt … ihn" → "diese Person … sie". LinkedIn's own German word for a connection is *Kontakt*; the LinkedIn import strings keep it and are waived by key.

## Tests

Tests that asserted one of these labels as a literal now read the key from the English catalog (`en["create.contact"]` and so on), as `filters.test.tsx` already did after #4069, so the next rename does not recur in them. Only interpolated forms ("12 people match") are retyped. Two e2e assertions in German are updated.

## The gate the ticket asked about

`frontend/src/i18n/record-noun.test.ts` holds the outcome. Per locale, any catalog value carrying the record noun fails unless its key is in the waiver list (act, details, buyer counterpart, LinkedIn's own vocabulary), and a waiver whose value no longer carries the word fails too, so the list cannot go stale and cover a reintroduction. The act/record split turned out to be crisp enough to encode as an enumerated waiver: 33 keys in English, 63 in German, 43 in Vietnamese, each read.

## Verification

`make check` green locally (backend and frontend, 7251 frontend tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the UI-wide rename of the person record from "contact" to "person" across the English, German, and Vietnamese catalogs, so readers no longer see both words for the same thing in one session. Closes #4112.

- Renames every catalog value that names the record itself (merge, create, promote, filters, worklist, digest, provider lookups, access labels, and more) to person / Person / người.
- Keeps "contact" where it names the act of reaching someone, the details one reaches them by, a buyer's counterpart in a room, or a company website's Contact page kind.
- Vietnamese is reworded rather than substituted: "mọi liên hệ" would read as "everyone," and bare "tạo người" would read as creating a human, so creation and promotion use "hồ sơ người" (person record).
- German articles and pronouns follow the noun's gender ("dieser Kontakt … ihn" → "diese Person … sie"); LinkedIn import strings keep "Kontakt" since that is LinkedIn's own vocabulary.

**Tests**
- Adds `record-noun.test.ts`, which fails any catalog value using the record noun unless its key is waived as act, details, LinkedIn vocabulary, or website page kind, and fails waivers whose values no longer carry the word, so the waiver list cannot go stale.
- The gate strips `{placeholders}` before judging a value, so interpolated keys need no blanket waiver.
- Tests that asserted labels as literals now read the key from the English catalog, so the next rename will not recur in them.

<sup>Written for commit cc658bb97628267530204fabf6aefa2fb8b0a2ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User-Facing Changes**
  * Updated terminology across English, German, and Vietnamese interfaces to refer to contact records as “people” consistently.
  * Refined related labels, messages, empty states, and person-management workflows to match the updated terminology.
  * Updated contact creation and qualification wording to use “person” terminology.

* **Tests**
  * Updated automated checks to reflect the revised translations and terminology.
  * Added coverage ensuring person records are not labeled as contacts in localized interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->