### PR TITLE
One component answers "may I send this?", on every surface that sends

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30799,6 +30799,24 @@ components:
           type: [string, 'null']
           format: uuid
           description: The conversation this reply will join; null for an account-started message.
+        links:
+          type: array
+          items: { $ref: '#/components/schemas/ActivityLinkInput' }
+          description: |
+            The records an account-started message files itself under, as the send named
+            them. Absent on a reply, which inherits its anchor's. Carried so a surface can
+            ask the engine the SAME question the fire will ask: the account-send preview
+            refuses a message that names no records, and a surface that could not name them
+            would fall silent on exactly the cold sends where consent matters most.
+        communication_context:
+          allOf: [{ $ref: '#/components/schemas/CommunicationContext' }]
+          description: |
+            What the sender claimed the message is, frozen with it. Absent when nothing was
+            claimed, which is the ordinary case for a reply — the engine derives it from the
+            anchor.
+        marketing_purpose:
+          type: string
+          description: For a marketing send, the consent purpose key it claimed, frozen with the message.
         activity_id:
           type: [string, 'null']
           format: uuid

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30804,10 +30804,12 @@ components:
           items: { $ref: '#/components/schemas/ActivityLinkInput' }
           description: |
             The records an account-started message files itself under, as the send named
-            them. Absent on a reply, which inherits its anchor's. Carried so a surface can
-            ask the engine the SAME question the fire will ask: the account-send preview
-            refuses a message that names no records, and a surface that could not name them
-            would fall silent on exactly the cold sends where consent matters most.
+            them. Absent on a reply: a reply's records come from its anchor, and the ones it
+            was told to file under beyond those (`also_links` on the send) are not carried
+            here, because the reply preview resolves from the anchor alone. Carried so a
+            surface can ask the engine the SAME question the fire will ask: the account-send
+            preview refuses a message that names no records, and a surface that could not
+            name them would fall silent on exactly the cold sends where consent matters most.
         communication_context:
           allOf: [{ $ref: '#/components/schemas/CommunicationContext' }]
           description: |
@@ -30817,6 +30819,18 @@ components:
         marketing_purpose:
           type: string
           description: For a marketing send, the consent purpose key it claimed, frozen with the message.
+        consent_purpose:
+          type: string
+          description: |
+            The deprecated purpose key the sender still supplied, frozen with the message. The
+            fire consults it where the record supports no category, so a preview that could
+            not pass it would answer a different question than the send.
+        evidence:
+          allOf: [{ $ref: '#/components/schemas/CommunicationEvidence' }]
+          description: |
+            The records the sender named in support of the message, frozen with it. Absent
+            when none were named. Evidence is what makes a claimed category supported, so a
+            preview asked without it would answer "unproven" about a message the fire allows.
         activity_id:
           type: [string, 'null']
           format: uuid

--- a/backend/gates/emailpresentation_test.go
+++ b/backend/gates/emailpresentation_test.go
@@ -260,14 +260,6 @@ func camelCase(field string) string {
 	return strings.Join(parts, "")
 }
 
-// describesRatherThanRenders is a file that talks ABOUT the components: a test,
-// a story, or the generated schema itself. None of them is a second rendering.
-func describesRatherThanRenders(path string) bool {
-	return strings.HasPrefix(path, "api/") ||
-		strings.Contains(path, ".test.") ||
-		strings.Contains(path, ".stories.")
-}
-
 // An `entry` schema reaches the canonical components and nothing else.
 func TestAnEmailIsDrawnOnlyByTheCanonicalComponents(t *testing.T) {
 	t.Parallel()

--- a/backend/gates/forecastperiodparity_test.go
+++ b/backend/gates/forecastperiodparity_test.go
@@ -80,6 +80,8 @@ func TestTheSiteListCoversEveryPeriodEnumInTheContract(t *testing.T) {
 //
 // The path recorded is the one this gate's own site list spells, so a site the
 // walk finds and the list omits names itself in the failure.
+//
+//craft:ignore naked-any a decoded YAML document is untyped by nature — mappings, sequences and scalars arrive as any, and the switch below is the narrowing
 func walkPeriodEnums(node any, at []string, found map[string]bool) {
 	switch shape := node.(type) {
 	case map[string]any:

--- a/backend/gates/frontendsendpermission_test.go
+++ b/backend/gates/frontendsendpermission_test.go
@@ -21,9 +21,10 @@ package gates
 //
 // The doors are DERIVED from the contract rather than listed: a send door is an
 // operation whose request body carries `operator_reason`, the field through
-// which a sender's own word about a send reaches the engine. A list here would
-// be a second copy of the contract, and the copy that stopped matching would
-// let a fourth door ship with no question asked.
+// which a sender's own word about a send reaches the engine — recorded beside
+// the decision, and granting nothing. A list here would be a second copy of the
+// contract, and the copy that stopped matching would let a fourth door ship
+// with no question asked.
 //
 // NOT asserted: a surface that stages a send without posting to a door — the
 // scheduled-send queue lists messages already staged, and the approval card
@@ -32,7 +33,6 @@ package gates
 // third such surface arriving without one.
 
 import (
-	"bufio"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -65,31 +65,33 @@ var contractPathLine = regexp.MustCompile(`^  (/[^\s:]+):\s*$`)
 // contractSchemaLine matches a schema entry under `components: schemas:`.
 var contractSchemaLine = regexp.MustCompile(`^    ([A-Za-z][A-Za-z0-9]*):\s*$`)
 
-// contractSchemaRef matches a request-body reference to a named schema.
+// contractSchemaRef matches a reference to a named schema anywhere under a
+// path: request body, response or parameter alike. Over-recognition is the safe
+// direction for a census — a response that carried the sender's reason would
+// surface as a door and be looked at, where a narrower match that missed a
+// request body would report PASS over an unasked send.
 var contractSchemaRef = regexp.MustCompile(`\$ref: '#/components/schemas/([A-Za-z][A-Za-z0-9]*)'`)
 
-// overrideProperty is the field that marks a schema as a send request body.
-var overrideProperty = regexp.MustCompile(`^        operator_reason:\s*$`)
+// senderReasonProperty is the field that marks a schema as a send request body:
+// the sender's own word about why they are writing, recorded and granting
+// nothing.
+var senderReasonProperty = regexp.MustCompile(`^        operator_reason:\s*$`)
 
-// sendDoors reads the contract for every path whose request body schema carries
-// operator_reason: the doors through which a sender's own word about a send
-// reaches the engine.
+// sendDoors reads the contract for every path whose schemas carry the sender's
+// reason: the doors through which a sender's own word about a send reaches the
+// engine.
 func sendDoors(t *testing.T) []string {
 	t.Helper()
-	file, err := os.Open(sendPermissionContract)
+	contract, err := os.ReadFile(sendPermissionContract)
 	if err != nil {
 		t.Fatalf("reading the contract: %v", err)
 	}
-	defer file.Close()
 
 	refsByPath := map[string][]string{}
-	carriesOverride := map[string]bool{}
+	carriesSenderReason := map[string]bool{}
 	var path, schema string
 	inSchemas := false
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range strings.Split(string(contract), "\n") {
 		switch {
 		case line == "components:":
 			inSchemas = true
@@ -102,18 +104,15 @@ func sendDoors(t *testing.T) []string {
 			}
 		case inSchemas && contractSchemaLine.MatchString(line):
 			schema = contractSchemaLine.FindStringSubmatch(line)[1]
-		case inSchemas && schema != "" && overrideProperty.MatchString(line):
-			carriesOverride[schema] = true
+		case inSchemas && schema != "" && senderReasonProperty.MatchString(line):
+			carriesSenderReason[schema] = true
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		t.Fatalf("scanning the contract: %v", err)
 	}
 
 	var doors []string
 	for p, refs := range refsByPath {
 		for _, ref := range refs {
-			if carriesOverride[ref] {
+			if carriesSenderReason[ref] {
 				doors = append(doors, p)
 				break
 			}
@@ -123,10 +122,17 @@ func sendDoors(t *testing.T) []string {
 	return doors
 }
 
-// namesADoor reports whether source posts to any of the doors.
+// namesADoor reports whether source names any of the doors as a whole string
+// literal, whichever quote the file uses.
+//
+// The closing delimiter is what keeps `/emails` from matching the preview door
+// `/emails:preview` that the hook itself names. The opening one is any of the
+// three JavaScript quotes rather than the double quote the formatter enforces,
+// because under-recognition is the one way a census must not fail: a surface
+// written with backticks would otherwise be invisible and report PASS.
 func namesADoor(source string, doors []string) bool {
 	for _, door := range doors {
-		if strings.Contains(source, `"`+door+`"`) {
+		if regexp.MustCompile("[\"'`]" + regexp.QuoteMeta(door) + "[\"'`]").MatchString(source) {
 			return true
 		}
 	}
@@ -138,23 +144,24 @@ func namesADoor(source string, doors []string) bool {
 // the second spelling this gate exists to refuse.
 var rendersSendPermission = regexp.MustCompile(`<SendPermission[\s/>]`)
 
+// importsSendPermission matches the component's module wherever the surface
+// sits: a screen beside it imports `./sendpermission`, a surface elsewhere
+// reaches it through a longer path, and both are the one component.
+var importsSendPermission = regexp.MustCompile(`from "[^"]*/sendpermission"`)
+
 // asksTheEngine reports whether source renders the shared component.
 func asksTheEngine(source string) bool {
-	return strings.Contains(source, `from "./sendpermission"`) &&
+	return importsSendPermission.MatchString(source) &&
 		rendersSendPermission.MatchString(source)
 }
 
 // isSendSurfaceSource is the frontend production source the census sweeps:
-// TypeScript, minus tests, stories and the generated contract.
-func isSendSurfaceSource(path string) bool {
-	if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".tsx") {
+// TypeScript that renders, rather than a file that describes what renders.
+func isSendSurfaceSource(rel string) bool {
+	if !strings.HasSuffix(rel, ".ts") && !strings.HasSuffix(rel, ".tsx") {
 		return false
 	}
-	base := filepath.Base(path)
-	return !strings.Contains(base, ".test.") &&
-		!strings.Contains(base, ".stories.") &&
-		!strings.Contains(base, ".testkit.") &&
-		!strings.HasSuffix(base, ".d.ts")
+	return !describesRatherThanRenders(rel)
 }
 
 func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
@@ -168,6 +175,10 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 		t.Fatalf("derived %d send door(s) from the contract, want at least the three that carry "+
 			"operator_reason: the census has stopped seeing its subject (%v)", len(doors), doors)
 	}
+
+	// Deferred here, once the subject is fixed, so a fatal on the walk cannot
+	// skip the stale-waiver report.
+	defer silentSendSurfaces.AssertAllMatched(t)
 
 	component, err := os.ReadFile(sendPermissionComponent)
 	if err != nil {
@@ -183,7 +194,15 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if entry.IsDir() || !isSendSurfaceSource(path) {
+		if entry.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(sendPermissionFrontend, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if !isSendSurfaceSource(rel) {
 			return nil
 		}
 		raw, readErr := os.ReadFile(path)
@@ -195,11 +214,6 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 			return nil
 		}
 		surfaces++
-		rel, relErr := filepath.Rel(sendPermissionFrontend, path)
-		if relErr != nil {
-			return relErr
-		}
-		rel = filepath.ToSlash(rel)
 		if asksTheEngine(source) || silentSendSurfaces.Waived(t, rel) {
 			return nil
 		}
@@ -217,5 +231,4 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the two composers: "+
 			"the census has stopped seeing its subject", surfaces)
 	}
-	silentSendSurfaces.AssertAllMatched(t)
 }

--- a/backend/gates/frontendsendpermission_test.go
+++ b/backend/gates/frontendsendpermission_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every surface that posts to a send door asks the engine first, through the
+// one component that says what it answered.
+//
+// The engine decides whether a message may go, and the preview doors have
+// answered that since it landed. A surface that sends without asking teaches a
+// rep the refusal by pressing Send and reading an error — and a surface that
+// asks through its OWN reading of the preview is a second spelling of a consent
+// surface, which is the worst place for one: two spellings that drift mean one
+// screen tells a rep they may send and another that they may not, about the
+// same message.
+//
+// So every frontend file that names a send door either renders SendPermission
+// or is ratified here with what its silence costs.
+//
+// The doors are DERIVED from the contract rather than listed: a send door is an
+// operation whose request body carries `operator_reason`, the field through
+// which a sender's own word about a send reaches the engine. A list here would
+// be a second copy of the contract, and the copy that stopped matching would
+// let a fourth door ship with no question asked.
+//
+// NOT asserted: a surface that stages a send without posting to a door — the
+// scheduled-send queue lists messages already staged, and the approval card
+// releases them through a generic decide route. Both adopt the component today,
+// and nothing derivable marks their routes as sends, so the census cannot see a
+// third such surface arriving without one.
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	sendPermissionContract  = "api/crm.yaml"
+	sendPermissionFrontend  = "../frontend/src"
+	sendPermissionComponent = "../frontend/src/screens/sendpermission.tsx"
+)
+
+// silentSendSurfaces ratifies each surface that posts to a send door without
+// asking the engine first, with what the omission costs.
+var silentSendSurfaces = gatekit.Waive(map[string]string{
+	"screens/persondrawers.tsx": "the person page's composer leads with the person's purpose-keyed " +
+		"consent guard, read off the 360; drawing the engine's answer beside it would put two " +
+		"verdicts about one message on one drawer, so adopting the component there means " +
+		"retiring that guard first, which is its own change",
+})
+
+// contractPathLine matches a path entry under `paths:`.
+var contractPathLine = regexp.MustCompile(`^  (/[^\s:]+):\s*$`)
+
+// contractSchemaLine matches a schema entry under `components: schemas:`.
+var contractSchemaLine = regexp.MustCompile(`^    ([A-Za-z][A-Za-z0-9]*):\s*$`)
+
+// contractSchemaRef matches a request-body reference to a named schema.
+var contractSchemaRef = regexp.MustCompile(`\$ref: '#/components/schemas/([A-Za-z][A-Za-z0-9]*)'`)
+
+// overrideProperty is the field that marks a schema as a send request body.
+var overrideProperty = regexp.MustCompile(`^        operator_reason:\s*$`)
+
+// sendDoors reads the contract for every path whose request body schema carries
+// operator_reason: the doors through which a sender's own word about a send
+// reaches the engine.
+func sendDoors(t *testing.T) []string {
+	t.Helper()
+	file, err := os.Open(sendPermissionContract)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	defer file.Close()
+
+	refsByPath := map[string][]string{}
+	carriesOverride := map[string]bool{}
+	var path, schema string
+	inSchemas := false
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "components:":
+			inSchemas = true
+			path = ""
+		case !inSchemas && contractPathLine.MatchString(line):
+			path = contractPathLine.FindStringSubmatch(line)[1]
+		case !inSchemas && path != "":
+			if m := contractSchemaRef.FindStringSubmatch(line); m != nil {
+				refsByPath[path] = append(refsByPath[path], m[1])
+			}
+		case inSchemas && contractSchemaLine.MatchString(line):
+			schema = contractSchemaLine.FindStringSubmatch(line)[1]
+		case inSchemas && schema != "" && overrideProperty.MatchString(line):
+			carriesOverride[schema] = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanning the contract: %v", err)
+	}
+
+	var doors []string
+	for p, refs := range refsByPath {
+		for _, ref := range refs {
+			if carriesOverride[ref] {
+				doors = append(doors, p)
+				break
+			}
+		}
+	}
+	slices.Sort(doors)
+	return doors
+}
+
+// namesADoor reports whether source posts to any of the doors.
+func namesADoor(source string, doors []string) bool {
+	for _, door := range doors {
+		if strings.Contains(source, `"`+door+`"`) {
+			return true
+		}
+	}
+	return false
+}
+
+// rendersSendPermission matches the component's JSX tag and nothing that merely
+// starts with its name: a `<SendPermissionBanner` of a surface's own would be
+// the second spelling this gate exists to refuse.
+var rendersSendPermission = regexp.MustCompile(`<SendPermission[\s/>]`)
+
+// asksTheEngine reports whether source renders the shared component.
+func asksTheEngine(source string) bool {
+	return strings.Contains(source, `from "./sendpermission"`) &&
+		rendersSendPermission.MatchString(source)
+}
+
+// isSendSurfaceSource is the frontend production source the census sweeps:
+// TypeScript, minus tests, stories and the generated contract.
+func isSendSurfaceSource(path string) bool {
+	if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".tsx") {
+		return false
+	}
+	base := filepath.Base(path)
+	return !strings.Contains(base, ".test.") &&
+		!strings.Contains(base, ".stories.") &&
+		!strings.Contains(base, ".testkit.") &&
+		!strings.HasSuffix(base, ".d.ts")
+}
+
+func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
+	t.Parallel()
+
+	doors := sendDoors(t)
+	// Under-recognition is the failure that reports PASS. The mail reply, the
+	// channel reply and the account-started mail all carry the field; fewer
+	// means the scanner has stopped seeing its subject.
+	if len(doors) < 3 {
+		t.Fatalf("derived %d send door(s) from the contract, want at least the three that carry "+
+			"operator_reason: the census has stopped seeing its subject (%v)", len(doors), doors)
+	}
+
+	component, err := os.ReadFile(sendPermissionComponent)
+	if err != nil {
+		t.Fatalf("reading the shared component: %v", err)
+	}
+	if !strings.Contains(string(component), "export function SendPermission(") {
+		t.Fatal("sendpermission.tsx no longer exports SendPermission: every surface that satisfies " +
+			"this gate by naming it now renders something else, or nothing")
+	}
+
+	surfaces := 0
+	walkErr := filepath.WalkDir(sendPermissionFrontend, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !isSendSurfaceSource(path) {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		source := string(raw)
+		if !namesADoor(source, doors) {
+			return nil
+		}
+		surfaces++
+		rel, relErr := filepath.Rel(sendPermissionFrontend, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if asksTheEngine(source) || silentSendSurfaces.Waived(t, rel) {
+			return nil
+		}
+		t.Errorf("%s posts to a send door and never asks the engine: a rep learns a refusal by "+
+			"pressing Send. Render SendPermission fed by useSendPermission, or ratify the surface in "+
+			"silentSendSurfaces with what its silence costs", rel)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking the frontend: %v", walkErr)
+	}
+	// The composer and the person page's composer both post to a door today.
+	// Fewer means the walk has stopped seeing the surfaces it exists to hold.
+	if surfaces < 2 {
+		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the two composers: "+
+			"the census has stopped seeing its subject", surfaces)
+	}
+	silentSendSurfaces.AssertAllMatched(t)
+}

--- a/backend/gates/gates_test.go
+++ b/backend/gates/gates_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -37,6 +38,19 @@ import (
 // compiled under `go test` and failed to compile under the linter, in a file
 // that never mentioned the tag.
 const repoRoot = ".."
+
+// describesRatherThanRenders is a frontend file, named relative to
+// frontend/src, that talks ABOUT what renders rather than rendering: a test, a
+// story, a test kit, or the generated contract. Shared by every gate that
+// sweeps the frontend for a second rendering of something, so two gates cannot
+// disagree about what counts as production source.
+func describesRatherThanRenders(rel string) bool {
+	return strings.HasPrefix(rel, "api/") ||
+		strings.Contains(rel, ".test.") ||
+		strings.Contains(rel, ".stories.") ||
+		strings.Contains(rel, ".testkit.") ||
+		strings.HasSuffix(rel, ".d.ts")
+}
 
 func TestMain(m *testing.M) {
 	if err := os.Chdir(".."); err != nil {

--- a/backend/gates/gates_test.go
+++ b/backend/gates/gates_test.go
@@ -41,9 +41,9 @@ const repoRoot = ".."
 
 // describesRatherThanRenders is a frontend file, named relative to
 // frontend/src, that talks ABOUT what renders rather than rendering: a test, a
-// story, a test kit, or the generated contract. Shared by every gate that
-// sweeps the frontend for a second rendering of something, so two gates cannot
-// disagree about what counts as production source.
+// story, a test kit, or the generated contract. Shared by the gates that sweep
+// the frontend for a second rendering of something, so they read the same
+// tree as production source.
 func describesRatherThanRenders(rel string) bool {
 	return strings.HasPrefix(rel, "api/") ||
 		strings.Contains(rel, ".test.") ||

--- a/backend/internal/compose/integration/scheduledsendpreview_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsendpreview_integration_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A scheduled message reads back what a surface needs to ask the engine the
+// same question the fire will ask: the records it names, and what its sender
+// claimed. Through the real writer and the real read, because the frozen
+// payload is one shape and the wire is another, and a field dropped between
+// them fails nowhere else — the queue would simply fall silent on the message.
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// scheduledOnTheWire is the slice of the wire a preview is asked with.
+type scheduledOnTheWire struct {
+	ID             string `json:"id"`
+	AnchorActivity string `json:"anchor_activity_id"`
+	Links          []struct {
+		EntityType string `json:"entity_type"`
+		EntityID   string `json:"entity_id"`
+	} `json:"links"`
+	CommunicationContext string `json:"communication_context"`
+	ConsentPurpose       string `json:"consent_purpose"`
+	Evidence             *struct {
+		ActivityID string `json:"activity_id"`
+	} `json:"evidence"`
+}
+
+func (p *preflightEnv) scheduledOnTheWire(t *testing.T, id ids.UUID) scheduledOnTheWire {
+	t.Helper()
+	var got scheduledOnTheWire
+	if status := p.Call(t, "GET", "/v1/scheduled-sends/"+id.String(), nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("reading the scheduled send → %d", status)
+	}
+	return got
+}
+
+func TestAScheduledAccountSendReadsBackWhatItWillAskTheEngine(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	var scheduled struct {
+		ID string `json:"id"`
+	}
+	status := p.Call(t, "POST", "/v1/emails", AnyMap{
+		"subject": "Your quote", "body": "As discussed.",
+		"to":              []string{"buyer@preflight.test"},
+		"consent_purpose": "transactional",
+		"links": []AnyMap{
+			{"entity_type": "person", "entity_id": p.personID},
+		},
+		"evidence":     AnyMap{"activity_id": p.activityID},
+		"scheduled_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		"scheduled_tz": "Europe/Berlin",
+	}, nil, &scheduled)
+	if status != http.StatusCreated {
+		t.Fatalf("scheduling an account send → %d, want 201", status)
+	}
+	id, err := ids.Parse(scheduled.ID)
+	if err != nil {
+		t.Fatalf("scheduling returned no id: %v", err)
+	}
+
+	got := p.scheduledOnTheWire(t, id)
+	if len(got.Links) != 1 || got.Links[0].EntityType != "person" || got.Links[0].EntityID != p.personID {
+		t.Errorf("the records the send named came back as %+v, want the one person it was filed under: "+
+			"the account-send preview refuses a message naming no records, so a row without them "+
+			"cannot be asked about", got.Links)
+	}
+	if got.ConsentPurpose != "transactional" {
+		t.Errorf("consent purpose came back %q, want transactional: the fire consults it where the record "+
+			"supports no category, so a preview without it asks a different question", got.ConsentPurpose)
+	}
+	if got.Evidence == nil || got.Evidence.ActivityID != p.activityID {
+		t.Errorf("evidence came back %+v, want the activity named: evidence is what makes a claimed "+
+			"category supported", got.Evidence)
+	}
+	if got.AnchorActivity != "" {
+		t.Errorf("an account-started send names anchor %q, want none", got.AnchorActivity)
+	}
+}
+
+// A reply's records come from its anchor and it freezes none of its own, so the
+// wire names the anchor and no records. The NULL origin_links column the
+// origin-shape CHECK requires of a reply row is the case this holds: read as
+// "none", never as a row the list cannot show.
+func TestAScheduledReplyNamesItsAnchorAndNoRecords(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	id := p.scheduleFor(t, time.Now().Add(2*time.Hour))
+	got := p.scheduledOnTheWire(t, id)
+	if got.AnchorActivity != p.activityID {
+		t.Errorf("a reply names anchor %q, want %q", got.AnchorActivity, p.activityID)
+	}
+	if len(got.Links) != 0 {
+		t.Errorf("a reply came back naming records of its own: %+v", got.Links)
+	}
+	if got.ConsentPurpose != "transactional" {
+		t.Errorf("consent purpose came back %q, want transactional", got.ConsentPurpose)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30968,7 +30968,17 @@ type ScheduledSend struct {
 	// claimed, which is the ordinary case for a reply — the engine derives it from the
 	// anchor.
 	CommunicationContext *CommunicationContext `json:"communication_context,omitempty"`
-	CreatedAt            time.Time             `json:"created_at"`
+
+	// ConsentPurpose The deprecated purpose key the sender still supplied, frozen with the message. The
+	// fire consults it where the record supports no category, so a preview that could
+	// not pass it would answer a different question than the send.
+	ConsentPurpose *string   `json:"consent_purpose,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+
+	// Evidence The records the sender named in support of the message, frozen with it. Absent
+	// when none were named. Evidence is what makes a claimed category supported, so a
+	// preview asked without it would answer "unproven" about a message the fire allows.
+	Evidence *CommunicationEvidence `json:"evidence,omitempty"`
 
 	// HeldReason Why a human has to look at it. `consent_withdrawn` — a recipient withdrew consent
 	// after it was scheduled. `sender_inactive` — the scheduler lost their seat or mailbox.
@@ -30979,10 +30989,12 @@ type ScheduledSend struct {
 	Id         openapi_types.UUID       `json:"id"`
 
 	// Links The records an account-started message files itself under, as the send named
-	// them. Absent on a reply, which inherits its anchor's. Carried so a surface can
-	// ask the engine the SAME question the fire will ask: the account-send preview
-	// refuses a message that names no records, and a surface that could not name them
-	// would fall silent on exactly the cold sends where consent matters most.
+	// them. Absent on a reply: a reply's records come from its anchor, and the ones it
+	// was told to file under beyond those (`also_links` on the send) are not carried
+	// here, because the reply preview resolves from the anchor alone. Carried so a
+	// surface can ask the engine the SAME question the fire will ask: the account-send
+	// preview refuses a message that names no records, and a surface that could not
+	// name them would fall silent on exactly the cold sends where consent matters most.
 	Links *[]ActivityLinkInput `json:"links,omitempty"`
 
 	// MarketingPurpose For a marketing send, the consent purpose key it claimed, frozen with the message.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30960,19 +30960,34 @@ type ScheduledSend struct {
 
 	// Bcc Visible to the SENDER, who is the only person this record is readable by. A scheduled
 	// message's blind-copy list is not workspace-readable the way a sent activity is.
-	Bcc       *[]openapi_types.Email `json:"bcc,omitempty"`
-	Body      *string                `json:"body,omitempty"`
-	Cc        *[]openapi_types.Email `json:"cc,omitempty"`
-	CreatedAt time.Time              `json:"created_at"`
+	Bcc  *[]openapi_types.Email `json:"bcc,omitempty"`
+	Body *string                `json:"body,omitempty"`
+	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
+
+	// CommunicationContext What the sender claimed the message is, frozen with it. Absent when nothing was
+	// claimed, which is the ordinary case for a reply — the engine derives it from the
+	// anchor.
+	CommunicationContext *CommunicationContext `json:"communication_context,omitempty"`
+	CreatedAt            time.Time             `json:"created_at"`
 
 	// HeldReason Why a human has to look at it. `consent_withdrawn` — a recipient withdrew consent
 	// after it was scheduled. `sender_inactive` — the scheduler lost their seat or mailbox.
 	// `missed_window` — it came due while nothing was running and is now too late to be the
 	// message that was written. `timer_exhausted` — the job that wakes it ran out of
 	// attempts. `send_refused` — a gate refused for another reason at fire.
-	HeldReason  *ScheduledSendHeldReason `json:"held_reason,omitempty"`
-	Id          openapi_types.UUID       `json:"id"`
-	ScheduledAt time.Time                `json:"scheduled_at"`
+	HeldReason *ScheduledSendHeldReason `json:"held_reason,omitempty"`
+	Id         openapi_types.UUID       `json:"id"`
+
+	// Links The records an account-started message files itself under, as the send named
+	// them. Absent on a reply, which inherits its anchor's. Carried so a surface can
+	// ask the engine the SAME question the fire will ask: the account-send preview
+	// refuses a message that names no records, and a surface that could not name them
+	// would fall silent on exactly the cold sends where consent matters most.
+	Links *[]ActivityLinkInput `json:"links,omitempty"`
+
+	// MarketingPurpose For a marketing send, the consent purpose key it claimed, frozen with the message.
+	MarketingPurpose *string   `json:"marketing_purpose,omitempty"`
+	ScheduledAt      time.Time `json:"scheduled_at"`
 
 	// ScheduledTz The IANA zone the human picked the moment in, kept so it re-renders as meant.
 	ScheduledTz string `json:"scheduled_tz"`

--- a/backend/internal/modules/activities/handlers_scheduledsend.go
+++ b/backend/internal/modules/activities/handlers_scheduledsend.go
@@ -12,6 +12,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // WithScheduleTimer returns handlers that can defer a send. Compose calls this;
@@ -125,17 +126,34 @@ func scheduledSendResponse(row ScheduledSend) crmcontracts.ScheduledSend {
 		anchor := openapi_types.UUID(row.Anchor.UUID)
 		out.AnchorActivityId = &anchor
 	}
+	// The caller's own frozen input, echoed to its author and nobody else: the
+	// read is scoped to scheduled_by, and every door that ACTS on these links —
+	// the preview, the fire — re-probes each one through the caller's row scope
+	// before the engine sees it. A record the scheduler can no longer read is
+	// refused there, not hidden here, because a list that silently dropped one
+	// would have the preview ask a narrower question than the fire.
 	if len(row.Links) > 0 {
 		links := linksOnWire(row.Links)
 		out.Links = &links
 	}
-	if row.Context != "" {
+	// Only a category the wire's enum publishes. The store type also names the
+	// five controller-only categories, which the door refuses and the fire
+	// refuses again; a row that carried one anyway must not reach a client as
+	// a value outside its own contract.
+	if row.Context.Valid() && !row.Context.ServesTheSubject() {
 		claimed := crmcontracts.CommunicationContext(row.Context)
 		out.CommunicationContext = &claimed
 	}
 	if row.MarketingPurpose != "" {
 		purpose := row.MarketingPurpose
 		out.MarketingPurpose = &purpose
+	}
+	if row.ConsentPurpose != "" {
+		purpose := row.ConsentPurpose
+		out.ConsentPurpose = &purpose
+	}
+	if evidence, named := evidenceOnWire(row.Evidence); named {
+		out.Evidence = &evidence
 	}
 	if row.ActivityID != (ids.UUID{}) {
 		activityID := openapi_types.UUID(row.ActivityID)
@@ -159,6 +177,29 @@ func linksOnWire(links []ActivityLinkInput) []crmcontracts.ActivityLinkInput {
 		})
 	}
 	return out
+}
+
+// evidenceOnWire is evidenceFrom read backwards. The second value says whether
+// anything was named, so a message with no evidence omits the block rather than
+// sending six nulls a client would have to read as "none".
+func evidenceOnWire(e commsauthz.Evidence) (crmcontracts.CommunicationEvidence, bool) {
+	var out crmcontracts.CommunicationEvidence
+	named := false
+	name := func(into **openapi_types.UUID, id ids.UUID) {
+		if id == (ids.UUID{}) {
+			return
+		}
+		wire := openapi_types.UUID(id)
+		*into = &wire
+		named = true
+	}
+	name(&out.ActivityId, e.ActivityID)
+	name(&out.DealId, e.DealID)
+	name(&out.InvoiceId, e.InvoiceID)
+	name(&out.ContractId, e.ContractID)
+	name(&out.ConsentEventId, e.ConsentEventID)
+	name(&out.BasisId, e.BasisID)
+	return out, named
 }
 
 // emailList renders stored addresses onto the wire's email type.

--- a/backend/internal/modules/activities/handlers_scheduledsend.go
+++ b/backend/internal/modules/activities/handlers_scheduledsend.go
@@ -125,6 +125,18 @@ func scheduledSendResponse(row ScheduledSend) crmcontracts.ScheduledSend {
 		anchor := openapi_types.UUID(row.Anchor.UUID)
 		out.AnchorActivityId = &anchor
 	}
+	if len(row.Links) > 0 {
+		links := linksOnWire(row.Links)
+		out.Links = &links
+	}
+	if row.Context != "" {
+		claimed := crmcontracts.CommunicationContext(row.Context)
+		out.CommunicationContext = &claimed
+	}
+	if row.MarketingPurpose != "" {
+		purpose := row.MarketingPurpose
+		out.MarketingPurpose = &purpose
+	}
 	if row.ActivityID != (ids.UUID{}) {
 		activityID := openapi_types.UUID(row.ActivityID)
 		out.ActivityId = &activityID
@@ -132,6 +144,19 @@ func scheduledSendResponse(row ScheduledSend) crmcontracts.ScheduledSend {
 	if row.HeldReason != "" {
 		reason := crmcontracts.ScheduledSendHeldReason(row.HeldReason)
 		out.HeldReason = &reason
+	}
+	return out
+}
+
+// linksOnWire is linkInputsOf read backwards: the frozen records a scheduled
+// message names, in the shape a caller supplied them.
+func linksOnWire(links []ActivityLinkInput) []crmcontracts.ActivityLinkInput {
+	out := make([]crmcontracts.ActivityLinkInput, 0, len(links))
+	for _, l := range links {
+		out = append(out, crmcontracts.ActivityLinkInput{
+			EntityType: crmcontracts.ActivityLinkInputEntityType(l.EntityType),
+			EntityId:   openapi_types.UUID(l.EntityID),
+		})
 	}
 	return out
 }

--- a/backend/internal/modules/activities/scheduledpayload.go
+++ b/backend/internal/modules/activities/scheduledpayload.go
@@ -14,6 +14,7 @@ package activities
 // reason, rather than asserting the handful somebody remembered.
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -91,6 +92,23 @@ func (f frozenEvidence) thaw() (commsauthz.Evidence, error) {
 		*field.into = id
 	}
 	return out, nil
+}
+
+// thawOriginLinks reads the records an account-started row froze. The ONE
+// reader for the list, the detail and the fire: the shape carries no JSON tags,
+// so it is held only by everybody decoding it the same way, and three decodings
+// of one column would be three places for that to stop being true. A NULL
+// column — a reply row, which the origin-shape CHECK requires it of — reads as
+// no records rather than as an error.
+func thawOriginLinks(raw []byte) ([]ActivityLinkInput, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var links []ActivityLinkInput
+	if err := json.Unmarshal(raw, &links); err != nil {
+		return nil, fmt.Errorf("scheduled send: reading the frozen record links: %w", err)
+	}
+	return links, nil
 }
 
 // idText renders an id for the row, and an unnamed record as the empty string.

--- a/backend/internal/modules/activities/scheduledpayload.go
+++ b/backend/internal/modules/activities/scheduledpayload.go
@@ -94,12 +94,12 @@ func (f frozenEvidence) thaw() (commsauthz.Evidence, error) {
 	return out, nil
 }
 
-// thawOriginLinks reads the records an account-started row froze. The ONE
-// reader for the list, the detail and the fire: the shape carries no JSON tags,
-// so it is held only by everybody decoding it the same way, and three decodings
-// of one column would be three places for that to stop being true. A NULL
-// column — a reply row, which the origin-shape CHECK requires it of — reads as
-// no records rather than as an error.
+// thawOriginLinks reads the records an account-started row froze, for the list,
+// the detail and the fire alike. The shape carries no JSON tags, so what holds
+// it is every reader decoding it the same way, and a decoding of its own in
+// each caller would be three places for that to stop being true. A NULL column
+// — a reply row, which the origin-shape CHECK requires it of — reads as no
+// records rather than as an error.
 func thawOriginLinks(raw []byte) ([]ActivityLinkInput, error) {
 	if len(raw) == 0 {
 		return nil, nil

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // scheduleCeiling bounds how far ahead a message may be scheduled. A year-out
@@ -114,9 +115,18 @@ type ScheduledSend struct {
 	ScheduledBy ids.UUID
 	ActivityID  ids.UUID
 	HeldReason  string
-	Version     int64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// Links are the records an account-started message files itself under,
+	// frozen at composition. Empty on a reply, which inherits its anchor's.
+	Links []ActivityLinkInput
+	// Context and MarketingPurpose are what the sender CLAIMED, frozen with the
+	// message so a surface previewing it asks the engine the same question the
+	// fire will. A preview that dropped the claim would answer about a different
+	// message and disagree with the send.
+	Context          commsauthz.Category
+	MarketingPurpose string
+	Version          int64
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 // Scheduled-send states.

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -116,14 +116,20 @@ type ScheduledSend struct {
 	ActivityID  ids.UUID
 	HeldReason  string
 	// Links are the records an account-started message files itself under,
-	// frozen at composition. Empty on a reply, which inherits its anchor's.
+	// frozen at composition. Empty on a reply, whose records come from its
+	// anchor; the ones a reply adds beyond those travel in also_links and are
+	// the fire's concern, not this read's.
 	Links []ActivityLinkInput
-	// Context and MarketingPurpose are what the sender CLAIMED, frozen with the
-	// message so a surface previewing it asks the engine the same question the
-	// fire will. A preview that dropped the claim would answer about a different
-	// message and disagree with the send.
+	// What the sender said about the message — the claimed category, the
+	// marketing purpose, the legacy purpose key, the evidence — frozen with it
+	// so a surface previewing the row asks the engine the SAME question the
+	// fire will. These are every input the frozen payload holds that the
+	// preview door accepts; a preview asked with fewer answers about a
+	// different message and disagrees with the send.
 	Context          commsauthz.Category
 	MarketingPurpose string
+	ConsentPurpose   string
+	Evidence         commsauthz.Evidence
 	Version          int64
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
@@ -268,21 +274,7 @@ func (s *Store) scheduleSend(
 		return ScheduledSend{}, err
 	}
 
-	row := ScheduledSend{
-		ID:          ids.NewV7(),
-		Status:      ScheduledStatusScheduled,
-		ScheduledAt: sched.At.UTC(),
-		ScheduledTZ: sched.TZ,
-		OriginKind:  originKind(origin),
-		Anchor:      origin.anchor,
-		Subject:     in.Subject,
-		Recipients:  in.Recipients,
-		Cc:          in.Cc,
-		Bcc:         in.Bcc,
-		Body:        in.Body,
-		ScheduledBy: actor.UserID,
-		Version:     1,
-	}
+	row := freshScheduledRow(origin, in, sched, actor.UserID)
 
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		prov := provenanceOf(actor)
@@ -378,6 +370,34 @@ func nullableAnchor(o SendOrigin) *ids.UUID {
 // Null when there are none, and null on an account origin, whose whole set is
 // origin_links. A reply that named nothing is every reply sent before the
 // column existed.
+// freshScheduledRow is the row a scheduling writes, as the list and the detail
+// will read it back. The 201 and the GET are one record: a create answer that
+// dropped the records or the claim would let a client ask the engine about a
+// different message than the one it just scheduled, and the account-send
+// preview refuses a message naming no records.
+func freshScheduledRow(origin SendOrigin, in SendEmailInput, sched SendSchedule, scheduledBy ids.UUID) ScheduledSend {
+	return ScheduledSend{
+		ID:               ids.NewV7(),
+		Status:           ScheduledStatusScheduled,
+		ScheduledAt:      sched.At.UTC(),
+		ScheduledTZ:      sched.TZ,
+		OriginKind:       originKind(origin),
+		Anchor:           origin.anchor,
+		Subject:          in.Subject,
+		Recipients:       in.Recipients,
+		Cc:               in.Cc,
+		Bcc:              in.Bcc,
+		Body:             in.Body,
+		ScheduledBy:      scheduledBy,
+		Links:            origin.links,
+		Context:          in.Context,
+		MarketingPurpose: in.MarketingPurpose,
+		ConsentPurpose:   in.ConsentPurpose,
+		Evidence:         in.Evidence,
+		Version:          1,
+	}
+}
+
 func marshalAlsoLinks(o SendOrigin) ([]byte, error) {
 	if !o.isReply() || len(o.also) == 0 {
 		return nil, nil

--- a/backend/internal/modules/activities/scheduledsendfire.go
+++ b/backend/internal/modules/activities/scheduledsendfire.go
@@ -249,9 +249,9 @@ func (c claimedSend) replay() (SendOrigin, SendEmailInput, error) {
 		// again for exactly that reason.
 		return origin.AlsoFiledUnder(also), in, nil
 	}
-	var links []ActivityLinkInput
-	if err := json.Unmarshal(c.OriginLinks, &links); err != nil {
-		return SendOrigin{}, SendEmailInput{}, fmt.Errorf("scheduled send: reading the frozen record links: %w", err)
+	links, err := thawOriginLinks(c.OriginLinks)
+	if err != nil {
+		return SendOrigin{}, SendEmailInput{}, err
 	}
 	return FromAccount(links), in, nil
 }

--- a/backend/internal/modules/activities/scheduledsendresponse_test.go
+++ b/backend/internal/modules/activities/scheduledsendresponse_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"reflect"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// What a scheduled row says about itself on the wire is what a surface asks the
+// engine with. Every input the frozen payload holds that the preview door
+// accepts has to survive the render, and nothing the wire cannot say may leak
+// through it.
+
+func scheduledRow() ScheduledSend {
+	return ScheduledSend{
+		ID:          ids.NewV7(),
+		Status:      ScheduledStatusScheduled,
+		Subject:     "Your quote",
+		Recipients:  []string{"buyer@example.test"},
+		ScheduledBy: ids.NewV7(),
+		Version:     1,
+	}
+}
+
+func TestTheWireCarriesEveryInputThePreviewAsksWith(t *testing.T) {
+	t.Parallel()
+	deal := ids.NewV7()
+	org := ids.NewV7()
+	row := scheduledRow()
+	row.Links = []ActivityLinkInput{{EntityType: "organization", EntityID: org}}
+	row.Context = commsauthz.CategoryMarketing
+	row.MarketingPurpose = "newsletter"
+	row.ConsentPurpose = "marketing_email"
+	row.Evidence = commsauthz.Evidence{DealID: deal}
+
+	out := scheduledSendResponse(row)
+
+	wantLinks := []crmcontracts.ActivityLinkInput{{
+		EntityType: crmcontracts.ActivityLinkInputEntityType("organization"),
+		EntityId:   openapi_types.UUID(org),
+	}}
+	if out.Links == nil || !reflect.DeepEqual(*out.Links, wantLinks) {
+		t.Errorf("links on the wire = %v, want %v", out.Links, wantLinks)
+	}
+	if out.CommunicationContext == nil || *out.CommunicationContext != crmcontracts.CommunicationContext("marketing") {
+		t.Errorf("claim on the wire = %v, want marketing", out.CommunicationContext)
+	}
+	if out.MarketingPurpose == nil || *out.MarketingPurpose != "newsletter" {
+		t.Errorf("marketing purpose on the wire = %v, want newsletter", out.MarketingPurpose)
+	}
+	if out.ConsentPurpose == nil || *out.ConsentPurpose != "marketing_email" {
+		t.Errorf("consent purpose on the wire = %v, want marketing_email", out.ConsentPurpose)
+	}
+	if out.Evidence == nil || out.Evidence.DealId == nil || ids.UUID(*out.Evidence.DealId) != deal {
+		t.Errorf("evidence on the wire = %+v, want the deal named", out.Evidence)
+	}
+	if out.Evidence != nil && out.Evidence.InvoiceId != nil {
+		t.Errorf("evidence names an invoice nobody named: %v", out.Evidence.InvoiceId)
+	}
+}
+
+// A message that claimed nothing says nothing, rather than sending empty
+// strings and a block of six nulls a client would have to read as "none".
+func TestAMessageThatClaimedNothingSaysNothing(t *testing.T) {
+	t.Parallel()
+	out := scheduledSendResponse(scheduledRow())
+	if out.Links != nil || out.CommunicationContext != nil || out.MarketingPurpose != nil ||
+		out.ConsentPurpose != nil || out.Evidence != nil {
+		t.Errorf("a row with no claim rendered one: %+v", out)
+	}
+}
+
+// The store type names the five controller-only categories; the wire's enum
+// does not. A row carrying one — a legacy row, or a writer the fire's own guard
+// exists to catch — must not reach a client as a value outside its contract.
+func TestAControllerOnlyCategoryNeverReachesTheWire(t *testing.T) {
+	t.Parallel()
+	row := scheduledRow()
+	row.Context = commsauthz.CategorySecurityNotice
+	if out := scheduledSendResponse(row); out.CommunicationContext != nil {
+		t.Errorf("a controller-only category reached the wire as %q", *out.CommunicationContext)
+	}
+	row.Context = commsauthz.Category("a_category_this_build_does_not_know")
+	if out := scheduledSendResponse(row); out.CommunicationContext != nil {
+		t.Errorf("an unknown category reached the wire as %q", *out.CommunicationContext)
+	}
+}
+
+// The records an account send freezes come back exactly as frozen, and a reply
+// — which freezes none — reads as none rather than as an error. One reader for
+// the list and the fire, so this holds both.
+func TestFrozenRecordLinksRoundTrip(t *testing.T) {
+	t.Parallel()
+	links := []ActivityLinkInput{
+		{EntityType: "organization", EntityID: ids.NewV7()},
+		{EntityType: "deal", EntityID: ids.NewV7()},
+	}
+	frozen, err := marshalOriginLinks(FromAccount(links))
+	if err != nil {
+		t.Fatalf("freezing: %v", err)
+	}
+	thawed, err := thawOriginLinks(frozen)
+	if err != nil {
+		t.Fatalf("thawing: %v", err)
+	}
+	if !reflect.DeepEqual(thawed, links) {
+		t.Errorf("records came back changed:\n frozen: %+v\n thawed: %+v", links, thawed)
+	}
+
+	replyFrozen, err := marshalOriginLinks(FromActivity(ids.ActivityID{UUID: ids.NewV7()}))
+	if err != nil {
+		t.Fatalf("freezing a reply: %v", err)
+	}
+	replyThawed, err := thawOriginLinks(replyFrozen)
+	if err != nil {
+		t.Fatalf("a reply's NULL records read as an error: %v", err)
+	}
+	if replyThawed != nil {
+		t.Errorf("a reply thawed records it never froze: %+v", replyThawed)
+	}
+}

--- a/backend/internal/modules/activities/scheduledsendstore.go
+++ b/backend/internal/modules/activities/scheduledsendstore.go
@@ -277,7 +277,8 @@ func scanScheduledSend(rows pgx.Rows) (ScheduledSend, error) {
 		activityID *ids.UUID
 		heldReason *string
 		// SQL NULL on a reply row, which the origin-shape CHECK requires: a
-		// reply inherits its anchor's records and freezes none of its own.
+		// reply's records come from its anchor, and the ones it adds beyond
+		// those travel in also_links, which the fire reads and this does not.
 		originLinks []byte
 	)
 	if err := rows.Scan(
@@ -287,15 +288,24 @@ func scanScheduledSend(rows pgx.Rows) (ScheduledSend, error) {
 	); err != nil {
 		return ScheduledSend{}, fmt.Errorf("scheduled send: reading a row: %w", err)
 	}
+	// payload_version is not checked on this read, and the fire's refusal of a
+	// payload this build did not write is what makes that safe: a stale row can
+	// never send, so the worst this read can do is describe a message that will
+	// be held — and a rep has to be able to see it to withdraw it.
 	var payload scheduledPayload
 	if err := json.Unmarshal(payloadRaw, &payload); err != nil {
 		return ScheduledSend{}, fmt.Errorf("scheduled send: reading the frozen message: %w", err)
 	}
-	if len(originLinks) > 0 {
-		if err := json.Unmarshal(originLinks, &row.Links); err != nil {
-			return ScheduledSend{}, fmt.Errorf("scheduled send: reading the frozen record links: %w", err)
-		}
+	links, err := thawOriginLinks(originLinks)
+	if err != nil {
+		return ScheduledSend{}, err
 	}
+	row.Links = links
+	evidence, err := payload.Evidence.thaw()
+	if err != nil {
+		return ScheduledSend{}, err
+	}
+	row.Evidence = evidence
 	if anchor != nil {
 		row.Anchor = ids.ActivityID{UUID: *anchor}
 	}
@@ -312,5 +322,6 @@ func scanScheduledSend(rows pgx.Rows) (ScheduledSend, error) {
 	row.Body = payload.Body
 	row.Context = commsauthz.Category(payload.Context)
 	row.MarketingPurpose = payload.MarketingPurpose
+	row.ConsentPurpose = payload.ConsentPurpose
 	return row, nil
 }

--- a/backend/internal/modules/activities/scheduledsendstore.go
+++ b/backend/internal/modules/activities/scheduledsendstore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // scheduledSendColumns is the read shape, spelled once so the list and the
@@ -49,7 +50,7 @@ const scheduledSendColumns = `
 	` + scheduledSendStatusExpr + ` AS status,
 	scheduled_at, scheduled_tz, origin_kind,
 	anchor_activity_id, payload, scheduled_by, activity_id,
-	held_reason, version, created_at, updated_at`
+	held_reason, version, created_at, updated_at, origin_links`
 
 // ListScheduledSends returns the caller's pending and held messages.
 func (s *Store) ListScheduledSends(ctx context.Context, status string) ([]ScheduledSend, error) {
@@ -275,17 +276,25 @@ func scanScheduledSend(rows pgx.Rows) (ScheduledSend, error) {
 		payloadRaw []byte
 		activityID *ids.UUID
 		heldReason *string
+		// SQL NULL on a reply row, which the origin-shape CHECK requires: a
+		// reply inherits its anchor's records and freezes none of its own.
+		originLinks []byte
 	)
 	if err := rows.Scan(
 		&row.ID, &row.Status, &row.ScheduledAt, &row.ScheduledTZ, &row.OriginKind,
 		&anchor, &payloadRaw, &row.ScheduledBy, &activityID,
-		&heldReason, &row.Version, &row.CreatedAt, &row.UpdatedAt,
+		&heldReason, &row.Version, &row.CreatedAt, &row.UpdatedAt, &originLinks,
 	); err != nil {
 		return ScheduledSend{}, fmt.Errorf("scheduled send: reading a row: %w", err)
 	}
 	var payload scheduledPayload
 	if err := json.Unmarshal(payloadRaw, &payload); err != nil {
 		return ScheduledSend{}, fmt.Errorf("scheduled send: reading the frozen message: %w", err)
+	}
+	if len(originLinks) > 0 {
+		if err := json.Unmarshal(originLinks, &row.Links); err != nil {
+			return ScheduledSend{}, fmt.Errorf("scheduled send: reading the frozen record links: %w", err)
+		}
 	}
 	if anchor != nil {
 		row.Anchor = ids.ActivityID{UUID: *anchor}
@@ -301,5 +310,7 @@ func scanScheduledSend(rows pgx.Rows) (ScheduledSend, error) {
 	row.Cc = payload.Cc
 	row.Bcc = payload.Bcc
 	row.Body = payload.Body
+	row.Context = commsauthz.Category(payload.Context)
+	row.MarketingPurpose = payload.MarketingPurpose
 	return row, nil
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (82)
+## Parity (83)
 
 | Gate | Hardness | What it holds |
 |---|---|---|

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -103,7 +103,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (111)
+## Census (112)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -151,6 +151,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensionsignored_test.go` | H3 | The enabled set must be a set git actually has. |
 | `fliponehandle_test.go` | H2 | The overlay flip runs on ONE workspace binding, and this is what keeps it so. |
 | `forecastscopeauthority_test.go` | H2 | Every forecasting store entry point that RECORDS against a scope asks whether its caller answers for that scope. |
+| `frontendsendpermission_test.go` | H2 | Every surface that posts to a send door asks the engine first, through the one component that says what it answered. |
 | `gatecensus_test.go` | H2 | The census over this repo's own gate machinery: a gate's exceptions are held to the standard the gate holds its subjects to. |
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
 | `insertattemptcaps_test.go` | H2 | An insert that names no MaxAttempts does not run without a retry ladder — it runs on River's default of 25, on attempt-to-the-fourth backoff, which reaches days. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22282,10 +22282,12 @@ export interface components {
             anchor_activity_id?: string | null;
             /**
              * @description The records an account-started message files itself under, as the send named
-             *     them. Absent on a reply, which inherits its anchor's. Carried so a surface can
-             *     ask the engine the SAME question the fire will ask: the account-send preview
-             *     refuses a message that names no records, and a surface that could not name them
-             *     would fall silent on exactly the cold sends where consent matters most.
+             *     them. Absent on a reply: a reply's records come from its anchor, and the ones it
+             *     was told to file under beyond those (`also_links` on the send) are not carried
+             *     here, because the reply preview resolves from the anchor alone. Carried so a
+             *     surface can ask the engine the SAME question the fire will ask: the account-send
+             *     preview refuses a message that names no records, and a surface that could not
+             *     name them would fall silent on exactly the cold sends where consent matters most.
              */
             links?: components["schemas"]["ActivityLinkInput"][];
             /**
@@ -22296,6 +22298,18 @@ export interface components {
             communication_context?: components["schemas"]["CommunicationContext"];
             /** @description For a marketing send, the consent purpose key it claimed, frozen with the message. */
             marketing_purpose?: string;
+            /**
+             * @description The deprecated purpose key the sender still supplied, frozen with the message. The
+             *     fire consults it where the record supports no category, so a preview that could
+             *     not pass it would answer a different question than the send.
+             */
+            consent_purpose?: string;
+            /**
+             * @description The records the sender named in support of the message, frozen with it. Absent
+             *     when none were named. Evidence is what makes a claimed category supported, so a
+             *     preview asked without it would answer "unproven" about a message the fire allows.
+             */
+            evidence?: components["schemas"]["CommunicationEvidence"];
             /**
              * Format: uuid
              * @description The timeline activity this produced, once released.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22281,6 +22281,22 @@ export interface components {
              */
             anchor_activity_id?: string | null;
             /**
+             * @description The records an account-started message files itself under, as the send named
+             *     them. Absent on a reply, which inherits its anchor's. Carried so a surface can
+             *     ask the engine the SAME question the fire will ask: the account-send preview
+             *     refuses a message that names no records, and a surface that could not name them
+             *     would fall silent on exactly the cold sends where consent matters most.
+             */
+            links?: components["schemas"]["ActivityLinkInput"][];
+            /**
+             * @description What the sender claimed the message is, frozen with it. Absent when nothing was
+             *     claimed, which is the ordinary case for a reply — the engine derives it from the
+             *     anchor.
+             */
+            communication_context?: components["schemas"]["CommunicationContext"];
+            /** @description For a marketing send, the consent purpose key it claimed, frozen with the message. */
+            marketing_purpose?: string;
+            /**
              * Format: uuid
              * @description The timeline activity this produced, once released.
              */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3228,6 +3228,10 @@ export const de = {
     "Margince hat keinen Nachweis, warum Sie schreiben dürfen.",
   "sendPermission.unprovenHint":
     "Wenn Sie den Grund kennen — man hat Sie darum gebeten, Sie hatten ein Treffen, es ist ein Kunde —, halten Sie ihn fest. Er wird unter Ihrem Namen gespeichert.",
+  "sendPermission.unprovenRefuses":
+    "Der Versand wird abgelehnt, bis Margince einen Nachweis hat.",
+  "sendPermission.unanswered":
+    "Margince konnte nicht prüfen, ob diese Nachricht gesendet werden darf. Beim Senden wird erneut geprüft.",
   "sendPermission.reason.objected":
     "Diese Person hat Werbung widersprochen. Das kann hier niemand aufheben, auch keine Administration.",
   "sendPermission.reason.withdrawn":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3292,6 +3292,10 @@ export const en = {
     "Margince has no record of why you may write to them.",
   "sendPermission.unprovenHint":
     "If you know why — they asked you to, you met, they are a customer — say so and it is recorded against your name.",
+  "sendPermission.unprovenRefuses":
+    "Sending it will be refused until Margince has a record.",
+  "sendPermission.unanswered":
+    "Margince could not check whether this message may be sent. Sending it asks again.",
   "sendPermission.reason.objected":
     "They asked not to receive marketing. Nobody here can lift that, including an administrator.",
   "sendPermission.reason.withdrawn":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3198,6 +3198,10 @@ export const vi = {
     "Margince không có ghi nhận nào về lý do bạn được phép viết cho họ.",
   "sendPermission.unprovenHint":
     "Nếu bạn biết lý do — họ đã đề nghị, bạn đã gặp họ, họ là khách hàng — hãy nêu ra và điều đó được ghi lại dưới tên bạn.",
+  "sendPermission.unprovenRefuses":
+    "Việc gửi sẽ bị từ chối cho đến khi Margince có ghi nhận.",
+  "sendPermission.unanswered":
+    "Margince không kiểm tra được tin nhắn này có được phép gửi hay không. Khi gửi sẽ kiểm tra lại.",
   "sendPermission.reason.objected":
     "Họ đã từ chối nhận quảng cáo. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
   "sendPermission.reason.withdrawn":

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 
+import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
@@ -14,6 +15,7 @@ import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
 import type { Approval } from "./approvals.queries";
+import { isPreviewDoor, refusedPreview } from "./sendpermission.testkit";
 
 // What a reader sees after approving, and where the button goes.
 //
@@ -158,5 +160,90 @@ describe("the offer to put an approved change back", () => {
     expect(
       screen.queryByRole("button", { name: "Undo on the record" }),
     ).toBeNull();
+  });
+});
+
+// The card says whether the engine would let the staged mail go, before the
+// approver releases it. An approver decides on somebody else's behalf, and
+// used to learn of a refusal the way the author would have: by pressing Accept
+// and reading the effect's failure.
+describe("whether the staged mail may go", () => {
+  function heldDraft(over: Partial<Approval> = {}): Approval {
+    return {
+      id: "ap2",
+      kind: "held_draft",
+      status: "pending",
+      summary: "Reply to Anna about the quote",
+      proposed_by: "system:automation",
+      proposed_change: {
+        anchor_activity_id: "act-1",
+        to: "anna@example.test",
+        subject: "Re: the quote",
+        body: "Attached, as promised.",
+      },
+      created_at: "2026-08-20T09:00:00Z",
+      target_entity_type: "activity",
+      target_entity_id: "act-1",
+      ...over,
+    };
+  }
+
+  // Routes the preview door and nothing else: the card's other reads answer
+  // empty, so what appears can only have come from the engine's answer.
+  function stubEngine(answer: () => Response) {
+    const fetched = vi.fn(async (input: RequestInfo | URL) => {
+      const path =
+        input instanceof Request
+          ? new URL(input.url).pathname
+          : new URL(String(input), "https://test").pathname;
+      return isPreviewDoor(path) ? answer() : jsonResponse({ data: [] });
+    });
+    vi.stubGlobal("fetch", fetched);
+    return fetched;
+  }
+
+  it("names who decided against the message, and that nobody may lift it", async () => {
+    const fetched = stubEngine(() =>
+      jsonResponse(
+        refusedPreview("anna@example.test", {
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+        }),
+      ),
+    );
+    render(<ApprovalRow approval={heldDraft()} />);
+
+    expect(
+      await screen.findByText(/asked not to receive marketing/i),
+    ).toBeInTheDocument();
+    // Asked the way the release will ask: against the thread the draft answers.
+    const asked = fetched.mock.calls.find(([input]) =>
+      isPreviewDoor(
+        input instanceof Request ? new URL(input.url).pathname : String(input),
+      ),
+    );
+    expect(
+      asked && asked[0] instanceof Request
+        ? new URL(asked[0].url).pathname
+        : "",
+    ).toBe("/v1/activities/act-1/send-email:preview");
+  });
+
+  // A decided row has nothing left to release, so there is nothing to ask.
+  it("asks nothing about a proposal already decided", async () => {
+    const fetched = stubEngine(() => jsonResponse({}));
+    render(
+      <ApprovalRow approval={heldDraft({ status: "approved" })} decided />,
+    );
+    await screen.findByText("Reply to Anna about the quote");
+    expect(
+      fetched.mock.calls.some(([input]) =>
+        isPreviewDoor(
+          input instanceof Request
+            ? new URL(input.url).pathname
+            : String(input),
+        ),
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -39,6 +39,7 @@ import {
   stagedDayFormatter,
 } from "./approvalkind";
 import type { Approval } from "./approvals.queries";
+import { stagedSendOf } from "./approvalsend";
 import {
   isAlreadyDecided,
   isVersionSkew,
@@ -47,6 +48,8 @@ import {
   throwProblem,
   useViewerId,
 } from "./common";
+import { SendPermission } from "./sendpermission";
+import { useSendPermission } from "./usesendpermission";
 import "./approvalrow.css";
 
 // One staged proposal as a decidable row, and the screen-level sink that
@@ -201,6 +204,20 @@ export function ApprovalRow({
   // Decided lists (interval 0 ⇒ useNow does not tick).
   const needsCountdown = !decided && approval.expires_at != null;
   const now = useNow(needsCountdown ? 1000 : 0);
+  // Whether the engine would let the staged mail go, asked before the approver
+  // releases it. An approver is deciding on somebody else's behalf, and until
+  // now learned of a refusal the way the author would have: by pressing Accept
+  // and reading the effect's failure. Only a live row asks — a decided one has
+  // nothing left to release — and only a kind whose payload describes a mail.
+  const staged = stagedSendOf(approval);
+  const permission = useSendPermission({
+    recipients: staged?.recipients ?? [],
+    anchorActivityId: staged?.anchorActivityId,
+    links: staged?.links,
+    context: staged?.context,
+    marketingPurpose: staged?.marketingPurpose,
+    enabled: !decided && staged !== undefined,
+  });
 
   // Where an approved change can be put back, and where it cannot.
   //
@@ -385,12 +402,23 @@ export function ApprovalRow({
       // extra. The contract's reason field stays for callers that have one.
       onReject={() => decide.mutate({ verdict: "reject" })}
       notice={
-        <DecideOutcome
-          decide={decide}
-          skew={skew}
-          alreadyDecided={alreadyDecided}
-          onReRead={reRead}
-        />
+        <>
+          {/* Read-only: the approver may release or refuse the message, and an
+              override of the engine belongs to whoever is writing to the
+              person, recorded against their own name. */}
+          {!decided && staged !== undefined && (
+            <SendPermission
+              preview={permission.preview}
+              unanswered={permission.unanswered}
+            />
+          )}
+          <DecideOutcome
+            decide={decide}
+            skew={skew}
+            alreadyDecided={alreadyDecided}
+            onReRead={reRead}
+          />
+        </>
       }
     >
       <ApprovalDetailModal

--- a/frontend/src/screens/approvalsend.test.ts
+++ b/frontend/src/screens/approvalsend.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import type { Approval } from "./approvals.queries";
+import { stagedSendOf } from "./approvalsend";
+
+// What the approval card asks the engine about, read off the proposal.
+//
+// Each staged send kind spells its payload its own way, and the card must ask
+// the question the release will ask — same addressees, same anchor or records,
+// same claim — or its answer is about a different message.
+
+function approval(over: Partial<Approval>): Approval {
+  return {
+    id: "ap-1",
+    kind: "send_email",
+    status: "pending",
+    proposed_by: "agent:runner",
+    created_at: "2026-08-01T09:00:00Z",
+    ...over,
+  };
+}
+
+describe("the automation's held draft", () => {
+  it("asks about its one addressee, against the thread it answers", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "held_draft",
+          proposed_change: {
+            anchor_activity_id: "act-1",
+            to: "anna@example.test",
+            subject: "Re: the quote",
+            body: "Attached.",
+            communication_context: "reply_to_inbound",
+          },
+        }),
+      ),
+    ).toEqual({
+      recipients: ["anna@example.test"],
+      anchorActivityId: "act-1",
+      context: "reply_to_inbound",
+      marketingPurpose: undefined,
+    });
+  });
+
+  // A draft with no thread is not a reply anybody can preview, and guessing an
+  // anchor would ask about a conversation the message will not join.
+  it("asks nothing when the draft names no thread", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "held_draft",
+          proposed_change: { to: "anna@example.test", body: "Hi" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("an agent's reply", () => {
+  it("asks about every addressee, against the approval's own target", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_email",
+          target_entity_type: "activity",
+          target_entity_id: "act-9",
+          proposed_change: {
+            to: ["anna@example.test"],
+            cc: ["ops@example.test"],
+            subject: "Follow-up",
+            body: "Hi",
+          },
+        }),
+      ),
+    ).toEqual({
+      recipients: ["anna@example.test", "ops@example.test"],
+      anchorActivityId: "act-9",
+      context: undefined,
+      marketingPurpose: undefined,
+    });
+  });
+
+  // The target is the anchor only when it IS an activity. A reply staged
+  // against anything else is a payload this build does not understand.
+  it("asks nothing when the target is not the thread", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_email",
+          target_entity_type: "deal",
+          target_entity_id: "d-1",
+          proposed_change: { to: ["anna@example.test"] },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("an agent's account-started mail", () => {
+  it("asks about the records it would be filed under, with its claim", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_account_email",
+          proposed_change: {
+            to: ["buyer@example.test"],
+            links: [
+              { entity_type: "organization", entity_id: "org-1" },
+              { entity_type: "deal", entity_id: "deal-1" },
+            ],
+            communication_context: "marketing",
+            marketing_purpose: "newsletter",
+          },
+        }),
+      ),
+    ).toEqual({
+      recipients: ["buyer@example.test"],
+      links: [
+        { entity_type: "organization", entity_id: "org-1" },
+        { entity_type: "deal", entity_id: "deal-1" },
+      ],
+      context: "marketing",
+      marketingPurpose: "newsletter",
+    });
+  });
+
+  // One malformed link is not a shorter list. Asking about the records that
+  // happened to parse would answer about a message filed differently from the
+  // one that will go.
+  it("asks nothing when a record link is not a link", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_account_email",
+          proposed_change: {
+            to: ["buyer@example.test"],
+            links: [
+              { entity_type: "organization", entity_id: "org-1" },
+              { entity_type: "spaceship", entity_id: "x" },
+            ],
+          },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  // A claim the preview door would refuse is dropped rather than sent: refused,
+  // the card would say "could not check" about a message that merely carried a
+  // word this build does not know.
+  it("drops a claim outside the contract's vocabulary", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_account_email",
+          proposed_change: {
+            to: ["buyer@example.test"],
+            links: [{ entity_type: "person", entity_id: "p-1" }],
+            communication_context: "security_notice",
+          },
+        }),
+      )?.context,
+    ).toBeUndefined();
+  });
+});
+
+describe("what is not a mail anybody can preview", () => {
+  it("asks nothing about a channel reply, which names no addressee", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_message",
+          target_entity_type: "activity",
+          target_entity_id: "act-1",
+          proposed_change: { body: "Hi" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("asks nothing about a proposal with nobody to write to", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "send_email",
+          target_entity_type: "activity",
+          target_entity_id: "act-1",
+          proposed_change: { to: [], subject: "Follow-up" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("asks nothing about a kind that changes a record rather than sending", () => {
+    expect(
+      stagedSendOf(
+        approval({
+          kind: "update_record",
+          proposed_change: { to: "somebody@example.test" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/screens/approvalsend.ts
+++ b/frontend/src/screens/approvalsend.ts
@@ -1,0 +1,157 @@
+import type { components } from "../api/schema";
+import type { Approval } from "./approvals.queries";
+import { RELINK_KINDS, type RelinkKind } from "./compose";
+
+// The message a staged proposal would send, read back out of the proposal.
+//
+// An approver releasing somebody else's mail deserves the same answer the
+// composer gives its author: whether the engine would refuse it, and whose
+// decision that is. The proposal carries what the engine needs — addressees,
+// the anchor or the records, the claim — but under the kind's own payload
+// shape, and `proposed_change` reaches the browser as an untyped document. So
+// this reads each shape as an ADMISSION: a field is used only when it has the
+// type the staging code writes, and a payload that does not describe a mail
+// yields no question rather than a guessed one.
+//
+// A kind absent here is not asked about, and each absence is a fact about the
+// message rather than an omission: a channel reply names no addressee anybody
+// can preview, and a held scheduled send is answered on the queue that holds
+// it, beside the controls that move it.
+
+type CommunicationContext = components["schemas"]["CommunicationContext"];
+type Link = components["schemas"]["ActivityLinkInput"];
+
+/** What the preview hook is asked, for one staged send. */
+export type StagedSend = Readonly<{
+  recipients: readonly string[];
+  anchorActivityId?: string;
+  links?: readonly Link[];
+  context?: CommunicationContext;
+  marketingPurpose?: string;
+}>;
+
+function stringOf(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+/**
+ * An address list, whichever way the kind spells it: the automation's held
+ * draft names ONE addressee as a string, the agent tools name a list.
+ */
+function addressesOf(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.trim() === "" ? [] : [value];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is string =>
+      typeof entry === "string" && entry.trim() !== "",
+  );
+}
+
+function isRelinkKind(value: unknown): value is RelinkKind {
+  return (
+    typeof value === "string" &&
+    (RELINK_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * The records an account-started send names. Every entry must be a whole link:
+ * a list with one malformed entry is not a shorter list, it is a payload this
+ * build does not understand, and the question is not asked.
+ */
+function linksOf(value: unknown): Link[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const links: Link[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) {
+      return undefined;
+    }
+    const type: unknown = Reflect.get(entry, "entity_type");
+    const id = stringOf(Reflect.get(entry, "entity_id"));
+    if (!isRelinkKind(type) || id === undefined) {
+      return undefined;
+    }
+    links.push({ entity_type: type, entity_id: id });
+  }
+  return links;
+}
+
+/**
+ * The claim, only when it is one this build can pass on.
+ *
+ * Spelled as the contract's enum rather than accepted as any string, because
+ * the preview door refuses a value outside it and a refused preview reads as
+ * "could not check" on a message that merely carried an unknown word. Dropped,
+ * the engine derives the category from the record, which is what an absent
+ * claim means on every other path.
+ */
+function contextOf(value: unknown): CommunicationContext | undefined {
+  switch (value) {
+    case "reply_to_inbound":
+    case "requested_followup":
+    case "precontract_quote":
+    case "active_deal_followup":
+    case "customer_service":
+    case "account_notice":
+    case "contract_notice":
+    case "invoice_or_payment":
+    case "marketing":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * What to ask the engine about this proposal, or undefined when it is not a
+ * mail anybody can preview.
+ */
+export function stagedSendOf(approval: Approval): StagedSend | undefined {
+  const change = approval.proposed_change ?? {};
+  const recipients = [...addressesOf(change.to), ...addressesOf(change.cc)];
+  if (recipients.length === 0) {
+    return undefined;
+  }
+  const context = contextOf(change.communication_context);
+  const marketingPurpose = stringOf(change.marketing_purpose);
+  switch (approval.kind) {
+    // The automation's reply, waiting for a human to read and release. It names
+    // the thread it answers in its own payload.
+    case "held_draft": {
+      const anchorActivityId = stringOf(change.anchor_activity_id);
+      if (anchorActivityId === undefined) {
+        return undefined;
+      }
+      return { recipients, anchorActivityId, context, marketingPurpose };
+    }
+    // An agent's reply. The anchor is the approval's own target: the row the
+    // effect hangs off, which for a reply is the activity being answered.
+    case "send_email": {
+      if (approval.target_entity_type !== "activity") {
+        return undefined;
+      }
+      const anchorActivityId = stringOf(approval.target_entity_id);
+      if (anchorActivityId === undefined) {
+        return undefined;
+      }
+      return { recipients, anchorActivityId, context, marketingPurpose };
+    }
+    // An agent's account-started mail: no anchor, so the records it would be
+    // filed under are the question's other half.
+    case "send_account_email": {
+      const links = linksOf(change.links);
+      if (links === undefined || links.length === 0) {
+        return undefined;
+      }
+      return { recipients, links, context, marketingPurpose };
+    }
+    default:
+      return undefined;
+  }
+}

--- a/frontend/src/screens/compose-dead-address.test.tsx
+++ b/frontend/src/screens/compose-dead-address.test.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
+import { allowedPreview, isPreviewDoor } from "./sendpermission.testkit";
 
 // The composer warns about an address that is known not to arrive.
 //
@@ -74,6 +75,7 @@ function stubRoutes(
       if (override) return override();
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (isPreviewDoor(url.pathname)) return jsonResponse(allowedPreview([]));
       return jsonResponse({});
     }),
   );

--- a/frontend/src/screens/compose-lead-draft.test.tsx
+++ b/frontend/src/screens/compose-lead-draft.test.tsx
@@ -11,6 +11,11 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
 
 // Drafting to a LEAD.
 //
@@ -81,6 +86,9 @@ function stubRoutes(
       if (override) return override();
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
       return jsonResponse({});
     }),
   );

--- a/frontend/src/screens/compose-links.test.tsx
+++ b/frontend/src/screens/compose-links.test.tsx
@@ -12,6 +12,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
 
 // What a sent message files under.
 //
@@ -116,6 +121,9 @@ function stubRoutes(
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
       if (key === "GET /organizations/org-1/360") return jsonResponse(ORG_VIEW);
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
       return jsonResponse({});
     }),
   );

--- a/frontend/src/screens/compose-permission.test.tsx
+++ b/frontend/src/screens/compose-permission.test.tsx
@@ -1,0 +1,202 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+  refusedPreview,
+} from "./sendpermission.testkit";
+
+// The composer asks the engine whether the message may go, and says so where
+// the rep is writing it.
+//
+// Until now a rep learned a send was refused by pressing Send and reading an
+// error. The preview endpoint has answered since the engine landed; these hold
+// that the composer asks it, asks the RIGHT question, and draws the answer in
+// the shared component's words rather than its own.
+
+type Activity = components["schemas"]["Activity"];
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const inbound: Activity = {
+  id: "act-1",
+  kind: "email",
+  direction: "inbound",
+  occurred_at: "2026-08-01T09:00:00Z",
+  source: "capture",
+  captured_by: "system:capture",
+  subject: "The quote",
+  from_address: "anna@example.test",
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+};
+
+type Ask = { path: string; body: unknown };
+
+/**
+ * Every route the composer reads answers empty; the anchor answers with the
+ * inbound message; the preview doors answer however the case says.
+ */
+function stubEngine(engine: (addresses: string[]) => Preview | Response) {
+  const asks: Ask[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const path = url.pathname.replace(/^\/v1/, "");
+      if (path === "/activities/act-1") return jsonResponse(inbound);
+      if (isPreviewDoor(path)) {
+        let body: unknown = null;
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+        asks.push({ path, body });
+        const answer = engine(previewedAddresses(body));
+        return answer instanceof Response ? answer : jsonResponse(answer);
+      }
+      return jsonResponse({ data: [] });
+    }),
+  );
+  return asks;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function openReplyAndAddress(address: string) {
+  render(
+    <ComposeModal
+      activityId="act-1"
+      entityType="person"
+      entityId="p-1"
+      open
+      onClose={vi.fn()}
+    />,
+  );
+  await screen.findByText(
+    "This continues their own message, so it needs no reason from you.",
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("To"), address);
+  await user.tab();
+}
+
+describe("the composer asks before anybody presses Send", () => {
+  it("says who decided against the message, and that nobody may lift it", async () => {
+    const asks = stubEngine((addresses) =>
+      addresses.length === 0
+        ? allowedPreview([])
+        : refusedPreview(addresses[0] ?? "", {
+            reason_code: "marketing_objection",
+            decided_by: "subject",
+          }),
+    );
+    await openReplyAndAddress("anna@example.test");
+
+    expect(
+      await screen.findByText(/asked not to receive marketing/i),
+    ).toBeInTheDocument();
+    // The question is about THIS message: the thread being answered and the
+    // addressee the rep named, through the reply door the send will use.
+    const asked = asks.find((ask) => previewedAddresses(ask.body).length > 0);
+    expect(asked?.path).toBe("/activities/act-1/send-email:preview");
+    expect(previewedAddresses(asked?.body)).toEqual(["anna@example.test"]);
+  });
+
+  // The overwhelming majority of sends. It has to cost no attention at all.
+  it("says nothing when the engine allows the message", async () => {
+    const asks = stubEngine(allowedPreview);
+    await openReplyAndAddress("anna@example.test");
+
+    // The absence means something only once the question about the addressee
+    // has gone out; before that, nothing is drawn for the uninteresting reason
+    // that nothing has been asked.
+    await waitFor(() =>
+      expect(asks.some((ask) => previewedAddresses(ask.body).length > 0)).toBe(
+        true,
+      ),
+    );
+    expect(screen.queryByText(/cannot send this message/i)).toBeNull();
+    expect(screen.queryByText(/no record of why/i)).toBeNull();
+    expect(screen.queryByText(/could not check/i)).toBeNull();
+  });
+
+  // No override exists yet on the server, so no control is drawn: a button here
+  // would promise a lift the staging gate refuses. The state still explains
+  // itself, and says what happens to the message as it stands.
+  it("explains an unproven send without offering a control", async () => {
+    stubEngine((addresses) =>
+      addresses.length === 0
+        ? allowedPreview([])
+        : refusedPreview(addresses[0] ?? "", {
+            reason_code: "no_compatible_evidence",
+            decided_by: "machine",
+            can_be_overruled: true,
+          }),
+    );
+    await openReplyAndAddress("stranger@example.test");
+
+    expect(
+      await screen.findByText(/no record of why you may write/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/will be refused/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /say why you may write/i }),
+    ).toBeNull();
+  });
+
+  // A failed check is not permission. An empty 502 from a gateway carries no
+  // body, and a composer that read "no error" as "allowed" would fall silent on
+  // exactly the message it could not check.
+  it("says the check did not happen on a bodiless failure", async () => {
+    stubEngine((addresses) =>
+      addresses.length === 0
+        ? allowedPreview([])
+        : new Response(null, { status: 502 }),
+    );
+    await openReplyAndAddress("anna@example.test");
+
+    expect(await screen.findByText(/could not check/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/compose-permission.test.tsx
+++ b/frontend/src/screens/compose-permission.test.tsx
@@ -43,10 +43,10 @@ const inbound: Activity = {
   kind: "email",
   direction: "inbound",
   occurred_at: "2026-08-01T09:00:00Z",
+  is_done: false,
   source: "capture",
   captured_by: "system:capture",
   subject: "The quote",
-  from_address: "anna@example.test",
   created_at: "2026-08-01T09:00:00Z",
   updated_at: "2026-08-01T09:00:00Z",
 };
@@ -184,6 +184,20 @@ describe("the composer asks before anybody presses Send", () => {
     expect(
       screen.queryByRole("button", { name: /say why you may write/i }),
     ).toBeNull();
+  });
+
+  // A 200 that is not a preview — a proxy's page, a server of another version
+  // — is not an answer either, and must not take the composer down with it:
+  // the message is still the rep's to send, and the door still refuses it if
+  // it must.
+  it("says the check did not happen on an answer it cannot read", async () => {
+    stubEngine((addresses) =>
+      addresses.length === 0 ? allowedPreview([]) : jsonResponse({}),
+    );
+    await openReplyAndAddress("anna@example.test");
+
+    expect(await screen.findByText(/could not check/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("To")).toBeInTheDocument();
   });
 
   // A failed check is not permission. An empty 502 from a gateway carries no

--- a/frontend/src/screens/compose-recipient.test.tsx
+++ b/frontend/src/screens/compose-recipient.test.tsx
@@ -12,6 +12,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { primaryEmail } from "../format/primaryemail";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
 
 // Who the composer says a reply goes to, before a draft is asked for.
 //
@@ -76,6 +81,9 @@ function stubRoutes(
       if (override) return override();
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
       return jsonResponse({});
     }),
   );

--- a/frontend/src/screens/compose.scheduled.test.tsx
+++ b/frontend/src/screens/compose.scheduled.test.tsx
@@ -17,6 +17,7 @@ import { pickOption } from "../design-system/select-testing";
 import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
+import { allowedPreview, isPreviewDoor } from "./sendpermission.testkit";
 
 // The door out of a scheduled send.
 //
@@ -70,6 +71,7 @@ function stubSend(status: number) {
       if (method === "POST" && url.pathname.endsWith("/send-email")) {
         return jsonResponse(ACTIVITY, status);
       }
+      if (isPreviewDoor(url.pathname)) return jsonResponse(allowedPreview([]));
       return jsonResponse({ data: [], page: { next_cursor: null } });
     }),
   );

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -14,6 +14,11 @@ import type { components } from "../api/schema";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ChannelReplyAction, ComposeModal, RelinkModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
 import { TimelineActions } from "./timelineactions";
 
 type Activity = components["schemas"]["Activity"];
@@ -169,6 +174,9 @@ function stubRoutes(
       if (override) return override();
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /voice-profiles") return jsonResponse(NO_VOICE_PROFILE);
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
       return jsonResponse({});
     }),
   );

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -78,6 +78,8 @@ import {
   withSubjectTag,
 } from "./projectrecord";
 import { SCHEDULED_SCREEN } from "./scheduledsends";
+import { SendPermission } from "./sendpermission";
+import { useSendPermission } from "./usesendpermission";
 import { useVoiceProfile } from "./voice-profile";
 import "./compose.css";
 
@@ -2822,6 +2824,28 @@ export function ComposeModal({
     context,
     asksContext: asksWhy(anchorActivity),
   });
+  // What the send will file under, spelled ONCE for the send and for the
+  // question asked ahead of it. Two spellings here would let the preview be
+  // asked about records the send then does not name, and the engine reads the
+  // records — so the answer on screen would be about a different message.
+  const chosenGrounding = groundable
+    ? { ...account.grounding, projectId: projectFiling.projectId }
+    : null;
+  // The engine's answer about the message as it stands, asked where the rep is
+  // writing it rather than learned from the Send button's error. Mail only: a
+  // channel reply names no addressee for anybody to ask about, and the preview
+  // doors are the two mail doors.
+  const permission = useSendPermission({
+    recipients: [...to, ...cc],
+    anchorActivityId: answering,
+    links: composedLinks(
+      { entityType, entityId },
+      chosenGrounding,
+      projectFiling.projectId,
+    ),
+    context: claimedContext,
+    enabled: open && !isChannelReply,
+  });
   // Whether the reader has ASKED to send yet. The fields say nothing until
   // then: a form that reports what is missing before anybody has tried is a
   // form scolding a reader for not having finished typing.
@@ -2974,11 +2998,7 @@ export function ComposeModal({
             globalThis.requestAnimationFrame(focusFirstMissing);
             return;
           }
-          send.mutate(
-            groundable
-              ? { ...account.grounding, projectId: projectFiling.projectId }
-              : null,
-          );
+          send.mutate(chosenGrounding);
         }}
         pending={send.isPending}
         error={sendError}
@@ -3143,7 +3163,18 @@ export function ComposeModal({
             )}
 
             {!isChannelReply && (
-              <MailSendNotices to={to} cc={cc} context={claimedContext} />
+              <>
+                <MailSendNotices to={to} cc={cc} context={claimedContext} />
+                {/* No override offered yet: the engine records what a sender
+                    types about their own send and grants nothing on it, so a
+                    button here would promise a lift the staging gate refuses.
+                    The component explains the state instead, and takes the
+                    control as a prop the day the override exists. */}
+                <SendPermission
+                  preview={permission.preview}
+                  unanswered={permission.unanswered}
+                />
+              </>
             )}
             {sendUnavailable && (
               <p className="t-caption">{t("compose.sendUnavailable")}</p>

--- a/frontend/src/screens/scheduledsends.test.tsx
+++ b/frontend/src/screens/scheduledsends.test.tsx
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
 import { ScheduledSendsScreen } from "./scheduledsends";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+  refusedPreview,
+} from "./sendpermission.testkit";
 
 type Send = {
   id: string;
@@ -20,6 +27,7 @@ type Send = {
   created_at: string;
   updated_at: string;
   held_reason?: string;
+  anchor_activity_id?: string;
 };
 
 // The reader's own zone, whatever machine this runs on. Every zone assertion
@@ -57,6 +65,11 @@ const SENT: Send = {
   subject: "Last week's summary",
 };
 
+/** How the engine answers a row's preview, given the addressees it named. */
+type PreviewFor = (
+  addresses: readonly string[],
+) => ReturnType<typeof allowedPreview>;
+
 /** Every request the screen made, so a test can assert on the write itself. */
 type Call = {
   method: string;
@@ -65,7 +78,7 @@ type Call = {
   ifMatch: string | null;
 };
 
-function mount(rows: Send[]) {
+function mount(rows: Send[], preview: PreviewFor = allowedPreview) {
   const calls: Call[] = [];
   vi.stubGlobal(
     "fetch",
@@ -85,14 +98,20 @@ function mount(rows: Send[]) {
         : request
           ? await request.clone().text()
           : "";
+      const body: unknown = raw === "" ? null : JSON.parse(raw);
       calls.push({
         method,
         path: url.pathname,
-        body: raw === "" ? null : JSON.parse(raw),
+        body,
         ifMatch: headers.get("If-Match"),
       });
       if (method === "PATCH" || url.pathname.endsWith("/cancel")) {
         return new Response(null, { status: 204 });
+      }
+      if (isPreviewDoor(url.pathname)) {
+        return new Response(JSON.stringify(preview(previewedAddresses(body))), {
+          headers: { "Content-Type": "application/json" },
+        });
       }
       return new Response(JSON.stringify(rows), {
         headers: { "Content-Type": "application/json" },
@@ -140,6 +159,11 @@ function mountRefusing(rows: Send[], refuse: "PATCH" | "POST") {
       }
       if (url.pathname.endsWith("/scheduled-sends")) {
         return new Response(JSON.stringify(rows), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (isPreviewDoor(url.pathname)) {
+        return new Response(JSON.stringify(allowedPreview([])), {
           headers: { "Content-Type": "application/json" },
         });
       }
@@ -305,4 +329,44 @@ it("says nothing is scheduled with one sentence, not three", async () => {
     await screen.findByText("You have not scheduled a message yet."),
   ).toBeTruthy();
   expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
+});
+
+// The queue says WHOSE decision stopped a message, in the composer's words.
+//
+// The held reason names a gate; this names the person. A rep reading "consent
+// withdrawn" has to decide whether to move the message or give up on it, and
+// only "she asked us to stop, and nobody here can lift that" answers that.
+it("names who decided against a held message, and that nobody may lift it", async () => {
+  const anchored = {
+    ...HELD,
+    to: ["anna@acme.test"],
+    anchor_activity_id: "019f7e65-fbf7-7114-b114-40af4af63af0",
+  };
+  const { calls } = mount([anchored], (addresses) =>
+    refusedPreview(addresses[0] ?? "", {
+      reason_code: "marketing_objection",
+      decided_by: "subject",
+    }),
+  );
+
+  expect(
+    await screen.findByText(/asked not to receive marketing/i),
+  ).toBeInTheDocument();
+  // Asked against the thread the message will join, about the addressee it
+  // names: the same question the fire will ask.
+  const asked = calls.find((call) => call.path.endsWith(":preview"));
+  expect(asked?.path).toBe(
+    "/v1/activities/019f7e65-fbf7-7114-b114-40af4af63af0/send-email:preview",
+  );
+  expect(previewedAddresses(asked?.body)).toEqual(["anna@acme.test"]);
+});
+
+// A message that already went, or was withdrawn, is not asked about: nothing
+// about it will change on its own, and a verdict on it is noise.
+it("asks nothing about a message that is no longer going to send", async () => {
+  const { calls } = mount([
+    { ...SENT, anchor_activity_id: "019f7e65-fbf7-7114-b114-40af4af63af0" },
+  ]);
+  await screen.findByText("Last week's summary");
+  expect(calls.some((call) => call.path.endsWith(":preview"))).toBe(false);
 });

--- a/frontend/src/screens/scheduledsends.tsx
+++ b/frontend/src/screens/scheduledsends.tsx
@@ -33,6 +33,8 @@ import {
   throwProblem,
 } from "./common";
 import { scheduleFields } from "./compose";
+import { SendPermission } from "./sendpermission";
+import { useSendPermission } from "./usesendpermission";
 
 // The queue behind "send later", and the reason it has to exist: a rep who can
 // schedule a message must be able to reach it again. Without this page the
@@ -294,6 +296,19 @@ function SendRow({
   const heldReasonKey = send.held_reason
     ? HELD_REASON_LABEL[send.held_reason]
     : undefined;
+  // What the engine says about this message NOW, for a message that will still
+  // go. Asked the way the fire will ask it — every addressee, the frozen claim,
+  // the frozen records — so the row cannot say "will send" about a message the
+  // fire then holds. A closed row is not asked: nothing about it will change on
+  // its own, and a verdict on a cancelled message is noise.
+  const permission = useSendPermission({
+    recipients: [...send.to, ...(send.cc ?? []), ...(send.bcc ?? [])],
+    anchorActivityId: send.anchor_activity_id ?? undefined,
+    links: send.links,
+    context: send.communication_context,
+    marketingPurpose: send.marketing_purpose,
+    enabled: actionable,
+  });
   return (
     <Card as="div" style={{ marginBottom: "var(--space-2)" }}>
       <div
@@ -333,6 +348,16 @@ function SendRow({
         <p className="t-caption" style={{ marginTop: "var(--space-1)" }}>
           {t(heldReasonKey)}
         </p>
+      )}
+      {/* The held reason above says a gate stopped it; this says WHOSE decision
+          that was and whether anybody may change it, in the same words the
+          composer uses. Read-only: the queue moves or withdraws a message, and
+          an override belongs where the message is written. */}
+      {actionable && (
+        <SendPermission
+          preview={permission.preview}
+          unanswered={permission.unanswered}
+        />
       )}
     </Card>
   );

--- a/frontend/src/screens/scheduledsends.tsx
+++ b/frontend/src/screens/scheduledsends.tsx
@@ -307,6 +307,8 @@ function SendRow({
     links: send.links,
     context: send.communication_context,
     marketingPurpose: send.marketing_purpose,
+    consentPurpose: send.consent_purpose,
+    evidence: send.evidence,
     enabled: actionable,
   });
   return (

--- a/frontend/src/screens/sendpermission.stories.tsx
+++ b/frontend/src/screens/sendpermission.stories.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { SendPermission } from "./sendpermission";
+
+// What the engine decided about a message, said where the rep is writing it.
+//
+// One component for every surface that stages a send: the composer, the
+// scheduled-send queue and the approval card. Three states and a rep sees
+// exactly one, chosen by the engine's answer. The allowed state renders
+// NOTHING, which is why it has no story: the overwhelming majority of sends
+// should cost no attention at all.
+const meta: Meta = {
+  title: "Patterns/Send permission",
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <LocaleProvider initial="en">
+        <Story />
+      </LocaleProvider>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj;
+
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+type Recipient = components["schemas"]["SendAuthorizationPreviewRecipient"];
+
+function refused(over: Partial<Recipient>): Preview {
+  return {
+    allowed: false,
+    recipients: [
+      {
+        address: "anna@example.test",
+        verdict: "deny",
+        reason_code: "no_compatible_evidence",
+        decided_by: "machine",
+        would_refuse: true,
+        can_be_overruled: false,
+        ...over,
+      },
+    ],
+  };
+}
+
+/** The subject's own act. No control, and the sentence says whose decision it is. */
+export const RefusedBySubject: Story = {
+  render: () => (
+    <SendPermission
+      preview={refused({
+        reason_code: "marketing_objection",
+        decided_by: "subject",
+      })}
+    />
+  ),
+};
+
+/** The engine's own reading, and still absolute: a dead mailbox is nobody's to lift. */
+export const RefusedByTheRecord: Story = {
+  render: () => (
+    <SendPermission
+      preview={refused({ reason_code: "hard_bounce", decided_by: "machine" })}
+    />
+  ),
+};
+
+/**
+ * The engine has no record, and this surface can take the rep's answer. The
+ * ONLY state that offers a control.
+ */
+export const UnprovenWithOverride: Story = {
+  render: () => (
+    <SendPermission
+      preview={refused({ can_be_overruled: true })}
+      onOverride={() => undefined}
+    />
+  ),
+};
+
+/**
+ * The same state on a surface that cannot take an answer — an approval card,
+ * or a composer before the override exists. It explains, and says what happens
+ * to the message as it stands, rather than drawing a button that does nothing.
+ */
+export const UnprovenReadOnly: Story = {
+  render: () => <SendPermission preview={refused({ can_be_overruled: true })} />,
+};
+
+/** The question did not arrive. Said out loud, because silence reads as yes. */
+export const Unanswered: Story = {
+  render: () => <SendPermission preview={undefined} unanswered />,
+};

--- a/frontend/src/screens/sendpermission.stories.tsx
+++ b/frontend/src/screens/sendpermission.stories.tsx
@@ -87,7 +87,9 @@ export const UnprovenWithOverride: Story = {
  * to the message as it stands, rather than drawing a button that does nothing.
  */
 export const UnprovenReadOnly: Story = {
-  render: () => <SendPermission preview={refused({ can_be_overruled: true })} />,
+  render: () => (
+    <SendPermission preview={refused({ can_be_overruled: true })} />
+  ),
 };
 
 /** The question did not arrive. Said out loud, because silence reads as yes. */

--- a/frontend/src/screens/sendpermission.test.tsx
+++ b/frontend/src/screens/sendpermission.test.tsx
@@ -35,10 +35,18 @@ function preview(...recipients: Recipient[]): Preview {
 
 afterEach(cleanup);
 
-function draw(ui: Preview | undefined, onOverride?: () => void) {
+function draw(
+  ui: Preview | undefined,
+  onOverride?: () => void,
+  unanswered = false,
+) {
   return render(
     <LocaleProvider initial="en">
-      <SendPermission preview={ui} onOverride={onOverride} />
+      <SendPermission
+        preview={ui}
+        onOverride={onOverride}
+        unanswered={unanswered}
+      />
     </LocaleProvider>,
   );
 }
@@ -240,5 +248,53 @@ describe("what a rep is shown", () => {
     );
     expect(screen.queryByText(/frequency_cap_reached/)).toBeNull();
     expect(screen.getByText(/clears on its own/i)).toBeInTheDocument();
+  });
+});
+
+describe("what the hint tells a rep to do", () => {
+  // With the control, the hint says how to answer. Without it, "say so" would
+  // be the dead button in prose: an instruction the surface cannot take.
+  it("tells a rep how to answer only where there is a way to", () => {
+    draw(
+      preview(answer({ would_refuse: true, can_be_overruled: true })),
+      () => {},
+    );
+    expect(screen.getByText(/say so/i)).toBeInTheDocument();
+    expect(screen.queryByText(/will be refused/i)).toBeNull();
+  });
+
+  it("says what happens to the message where nobody can answer here", () => {
+    draw(preview(answer({ would_refuse: true, can_be_overruled: true })));
+    expect(screen.getByText(/will be refused/i)).toBeInTheDocument();
+    expect(screen.queryByText(/say so/i)).toBeNull();
+  });
+});
+
+describe("when the question did not arrive", () => {
+  // Silence is what "allowed" looks like. A failed check has to say it failed,
+  // or the rep learns of the refusal from the Send button — the exact failure
+  // the component exists to end.
+  it("says the check did not happen rather than falling silent", () => {
+    draw(undefined, undefined, true);
+    expect(screen.getByRole("status")).toHaveTextContent(/could not check/i);
+  });
+
+  // A stale answer must not outrank the fact that the latest ask failed: the
+  // preview on hand describes a message that may since have changed.
+  it("outranks an earlier answer", () => {
+    draw(
+      preview(
+        answer({
+          reason_code: "marketing_objection",
+          decided_by: "subject",
+          would_refuse: true,
+          can_be_overruled: false,
+        }),
+      ),
+      undefined,
+      true,
+    );
+    expect(screen.getByText(/could not check/i)).toBeInTheDocument();
+    expect(screen.queryByText(/asked not to receive marketing/i)).toBeNull();
   });
 });

--- a/frontend/src/screens/sendpermission.testkit.ts
+++ b/frontend/src/screens/sendpermission.testkit.ts
@@ -1,0 +1,61 @@
+import type { components } from "../api/schema";
+
+// Answers for the two preview doors, in the shape the server sends.
+//
+// Every surface that stages a send now asks the engine before anybody presses
+// Send, so a harness that answers unknown routes with `{}` hands the component
+// a preview with no recipients and the surface under test crashes for a reason
+// that is not the test's. Each harness routes the preview doors here instead.
+
+type Preview = components["schemas"]["SendAuthorizationPreview"];
+type Recipient = components["schemas"]["SendAuthorizationPreviewRecipient"];
+
+/** Whether a request went to one of the two preview doors. */
+export function isPreviewDoor(pathname: string): boolean {
+  return pathname.endsWith(":preview");
+}
+
+/** The addressees a preview request named, read off its body. */
+export function previewedAddresses(body: unknown): string[] {
+  if (typeof body !== "object" || body === null) {
+    return [];
+  }
+  const to: unknown = Reflect.get(body, "to");
+  return Array.isArray(to)
+    ? to.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+/** The engine allowing every addressee: the answer most sends get. */
+export function allowedPreview(addresses: readonly string[]): Preview {
+  return {
+    allowed: true,
+    recipients: addresses.map((address) => ({
+      address,
+      verdict: "allow",
+      reason_code: "allowed",
+      decided_by: "machine",
+      would_refuse: false,
+      can_be_overruled: false,
+    })),
+  };
+}
+
+/** One refused addressee, with the rest of the answer spelled by the caller. */
+export function refusedPreview(
+  address: string,
+  over: Partial<Recipient> & Pick<Recipient, "reason_code" | "decided_by">,
+): Preview {
+  return {
+    allowed: false,
+    recipients: [
+      {
+        address,
+        verdict: "deny",
+        would_refuse: true,
+        can_be_overruled: false,
+        ...over,
+      },
+    ],
+  };
+}

--- a/frontend/src/screens/sendpermission.tsx
+++ b/frontend/src/screens/sendpermission.tsx
@@ -93,9 +93,17 @@ export function decidingRecipient(preview: Preview | undefined): {
  */
 export function SendPermission({
   preview,
+  unanswered = false,
   onOverride,
 }: Readonly<{
   preview: Preview | undefined;
+  /**
+   * The question did not arrive: the preview failed rather than answered. Said
+   * out loud, because a surface that fell silent here would look exactly like
+   * one that was told yes — and a rep would learn of the refusal by pressing
+   * Send, which is the failure this component exists to end.
+   */
+  unanswered?: boolean;
   /**
    * Offered only in the `unproven` state. Absent means the surface cannot take
    * an override — a read-only approval card, say — and the state renders as a
@@ -105,6 +113,14 @@ export function SendPermission({
 }>) {
   const t = useT();
   const { state, recipient } = decidingRecipient(preview);
+
+  if (unanswered) {
+    return (
+      <p className="t-caption" role="status">
+        {t("sendPermission.unanswered")}
+      </p>
+    );
+  }
 
   if (state === "allowed") return null;
 
@@ -129,7 +145,17 @@ export function SendPermission({
       }
     >
       <p>{t("sendPermission.unproven")}</p>
-      <p className="t-caption">{t("sendPermission.unprovenHint")}</p>
+      {/* The hint says what the rep can DO, so it changes with what is on
+          offer: with the control, how to answer; without it, what happens if
+          the message goes as it stands. Telling a reader to "say so" beside no
+          control would be the dead button in prose. */}
+      <p className="t-caption">
+        {t(
+          onOverride
+            ? "sendPermission.unprovenHint"
+            : "sendPermission.unprovenRefuses",
+        )}
+      </p>
     </Callout>
   );
 }

--- a/frontend/src/screens/usesendpermission.ts
+++ b/frontend/src/screens/usesendpermission.ts
@@ -41,6 +41,18 @@ export function useSendPermission(args: {
    * different message than the one that will go.
    */
   marketingPurpose?: string;
+  /**
+   * The deprecated purpose key, where the surface still holds one. The send
+   * consults it where the record supports no category, so a preview asked
+   * without it answers a different question than the send.
+   */
+  consentPurpose?: string;
+  /**
+   * The records named in support of the message. Evidence is what makes a
+   * claimed category supported: asked without it, the engine answers
+   * "unproven" about a message the send allows.
+   */
+  evidence?: components["schemas"]["CommunicationEvidence"];
   /** Off while the rep is still choosing a recipient — nothing to ask about yet. */
   enabled?: boolean;
 }): { preview: Preview | undefined; asking: boolean; unanswered: boolean } {
@@ -67,6 +79,8 @@ export function useSendPermission(args: {
       links,
       args.context ?? "",
       args.marketingPurpose ?? "",
+      args.consentPurpose ?? "",
+      args.evidence ?? {},
     ],
     enabled,
     // A refusal is live state — somebody may unsubscribe between the preview
@@ -78,6 +92,8 @@ export function useSendPermission(args: {
         to: [...recipients],
         communication_context: args.context,
         marketing_purpose: args.marketingPurpose,
+        consent_purpose: args.consentPurpose,
+        evidence: args.evidence,
       };
       const answered = args.anchorActivityId
         ? await api.POST("/activities/{id}/send-email:preview", {
@@ -98,7 +114,18 @@ export function useSendPermission(args: {
           },
         );
       }
-      return answered.data;
+      // An answer this build cannot read is not an answer. A 200 with no
+      // recipients — a proxy's page, a server of another version — must read
+      // as "could not check" on this one notice, never take down the composer
+      // around it: the message is still the rep's to send, and the server
+      // still refuses it at the door if it must.
+      const preview = answered.data;
+      if (!preview || !Array.isArray(preview.recipients)) {
+        throwProblem({
+          title: "send permission: the preview answered without recipients",
+        });
+      }
+      return preview;
     },
   });
 

--- a/frontend/src/screens/usesendpermission.ts
+++ b/frontend/src/screens/usesendpermission.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { throwProblem } from "./common";
 
 // Asking the engine whether a message would be allowed, before anybody presses
 // Send.
@@ -34,6 +35,12 @@ export function useSendPermission(args: {
    */
   links?: readonly components["schemas"]["ActivityLinkInput"][];
   context?: components["schemas"]["CommunicationContext"];
+  /**
+   * Which marketing purpose, when the claim is `marketing`. Part of the
+   * question: a marketing send previewed without it is asked about a
+   * different message than the one that will go.
+   */
+  marketingPurpose?: string;
   /** Off while the rep is still choosing a recipient — nothing to ask about yet. */
   enabled?: boolean;
 }): { preview: Preview | undefined; asking: boolean; unanswered: boolean } {
@@ -59,6 +66,7 @@ export function useSendPermission(args: {
       recipients,
       links,
       args.context ?? "",
+      args.marketingPurpose ?? "",
     ],
     enabled,
     // A refusal is live state — somebody may unsubscribe between the preview
@@ -66,23 +74,31 @@ export function useSendPermission(args: {
     // cached verdict that outlives what it described.
     staleTime: 0,
     queryFn: async () => {
-      const body = { to: [...recipients], communication_context: args.context };
-      if (args.anchorActivityId) {
-        const { data, error } = await api.POST(
-          "/activities/{id}/send-email:preview",
-          {
+      const body = {
+        to: [...recipients],
+        communication_context: args.context,
+        marketing_purpose: args.marketingPurpose,
+      };
+      const answered = args.anchorActivityId
+        ? await api.POST("/activities/{id}/send-email:preview", {
             params: { path: { id: args.anchorActivityId } },
             body,
+          })
+        : await api.POST("/emails:preview", {
+            body: { ...body, links: [...links] },
+          });
+      // Only a real 2xx is an answer. openapi-fetch reports a falsy `error` for
+      // a bodiless non-2xx — an empty 502 from a gateway — and taking that as
+      // success would resolve with no preview, which renders as ALLOWED: a
+      // permission check that failed, drawn as permission granted.
+      if (!answered.response.ok) {
+        throwProblem(
+          answered.error ?? {
+            title: `send permission: the preview answered ${answered.response.status}`,
           },
         );
-        if (error) throw error;
-        return data;
       }
-      const { data, error } = await api.POST("/emails:preview", {
-        body: { ...body, links: [...links] },
-      });
-      if (error) throw error;
-      return data;
+      return answered.data;
     },
   });
 


### PR DESCRIPTION
Closes #4277.

The engine has answered "may I send this?" since the authorization engine landed, and #4317 built the one component and the one hook that draw that answer. Neither had a caller: a rep still learned a refusal by pressing Send and reading an error. This change wires the three surfaces the issue names, and holds the seam with a gate.

## What a rep sees now

**The composer** asks the engine about the message as it stands: the addressees in To and Cc, the thread it answers or the records it files under, and the claim the rep made. It draws the answer in the shared component's words beside the other send notices. Allowed renders nothing. A refusal names whose decision it is and that nobody may lift it. An unproven send says the engine has no record and that sending will be refused.

**The scheduled-send queue** asks the same question about every message that will still go, and says so on the row under the held reason. "Consent withdrawn" says a gate stopped it; "she asked not to receive marketing, and nobody here can lift that" says who. Closed rows are not asked: nothing about them changes on its own.

**The approval card** asks about a staged mail before the approver releases it. The approver decides on somebody else's behalf and used to learn of a refusal by pressing Accept and reading the effect's failure. The card reads the proposal's own payload shape per kind (the automation's held draft, an agent's reply, an agent's account-started mail), as an admission: a field is used only when it has the type the staging code writes, and a payload that does not describe a mail yields no question rather than a guessed one. Read-only, because an override belongs to whoever is writing to the person.

## No override control yet, on purpose

#4275's step 3 is not built: `operator_reason` reaches the engine and is recorded, and grants nothing. A "say why you may write" button here would promise a lift the staging gate refuses, which is exactly the dead control the issue forbids. So no surface passes `onOverride`, and the unproven state's hint changes with what is on offer: with the control, how to answer; without it, what happens to the message as it stands. The prop is there for the day the override exists. Instrumenting presses waits for the button.

## What had to change underneath

**The hook gated on `error`, so an empty 502 resolved as allowed.** openapi-fetch reports a falsy `error` for a bodiless non-2xx. The hook now gates on `response.ok`, refuses a 200 whose body is not a preview, and the component has an `unanswered` state that says the check did not happen, because silence is what "allowed" looks like. A malformed answer reads as "could not check" on one notice and never takes the composer down with it.

**A scheduled account-started send could not be asked about.** The account-send preview refuses a request naming no records, and the wire carried none. `ScheduledSend` now carries every input the frozen payload holds that the preview door accepts: `links`, `communication_context`, `marketing_purpose`, `consent_purpose` and `evidence`, read off the row and returned identically by the 201 and the GET. The queue asks the same question the fire will ask rather than falling silent on exactly the cold sends where consent matters most. Additive contract change; the wire is the sender's own list, and a controller-only category never reaches it. The `origin_links` column now has one reader shared by the list, the detail and the fire. Unit tests hold the render; two integration tests schedule through the real doors and read back through the real endpoints.

## The gate

`backend/gates/frontendsendpermission_test.go`: every frontend file that posts to a send door renders `SendPermission` or is ratified with what its silence costs. The doors are derived from the contract rather than listed: a send door is an operation whose request body carries `operator_reason`. Mutation-verified in both directions: the composer renaming its tag to a spelling of its own fails it, and the walk floors both the door count and the surface count so an empty read cannot pass.

One waiver, and it is honest about what it costs: the person page's composer leads with the person's purpose-keyed consent guard read off the 360. Drawing the engine's answer beside it would put two verdicts about one message on one drawer, so adopting the component there means retiring that guard first. Filed as #4464.

What the gate cannot see: a surface that stages a send without posting to a door. The queue and the approval card both adopt the component today, and nothing derivable marks their routes as sends. The gate's own comment says so.

## Fixed along the way

Main's new `backend/gates/forecastperiodparity_test.go` (#4471) walks a decoded YAML document through an `any` parameter, and the craftsmanship sweep runs on every pull request's merge commit, so every PR blocked on it. The finding is waived in source with its reason: a decoded YAML node is untyped by nature, and the type switch is the narrowing.

## Verification

`make check` green (both halves), `craft static --strict` clean on the changed Go files. New tests: the composer asks the right door about the right addressee and draws each of the three visible states plus the bodiless failure; the queue names who decided and asks nothing about a closed row; the card names who decided and asks nothing about a decided row; the payload reader for every send kind and every malformed shape; the component's hint and unanswered state. Six existing composer harnesses now answer the preview doors, because the composer asks on every open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
