### PR TITLE
feat(webread): a page that builds itself in the browser still says who it is

### DIFF
--- a/backend/internal/platform/webread/fingerprint.go
+++ b/backend/internal/platform/webread/fingerprint.go
@@ -160,7 +160,7 @@ func extractStackMarkers(rawHTML string, base *url.URL) (scriptSrcs []string, ge
 			continue
 		}
 		switch string(name) {
-		case "script":
+		case tagScript:
 			if src, ok := absoluteAttr(tagAttrs(tokenizer)["src"], base); ok && !seen[src] {
 				seen[src] = true
 				scriptSrcs = append(scriptSrcs, src)

--- a/backend/internal/platform/webread/headtext.go
+++ b/backend/internal/platform/webread/headtext.go
@@ -19,6 +19,12 @@ import (
 	"golang.org/x/net/html"
 )
 
+// tagScript is the element three harvests in this package read: the
+// fingerprint's asset scan, the module count, and the JSON-LD claims. Shared
+// rather than spelled at each, so a typo in any of them is a compile error
+// instead of a scan that quietly matches nothing.
+const tagScript = "script"
+
 // headTextRunes bounds one harvested head declaration. A description is a
 // sentence or two by convention; anything longer is a page stuffing the tag,
 // and it would be spent out of a prompt budget that belongs to the page's own
@@ -97,7 +103,7 @@ func countScripts(rawHTML string) (external, modules int) {
 			continue
 		}
 		name, hasAttr := tokenizer.TagName()
-		if string(name) != "script" || !hasAttr {
+		if string(name) != tagScript || !hasAttr {
 			continue
 		}
 		attrs := tagAttrs(tokenizer)

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -46,9 +46,16 @@ type Page struct {
 	// leaving the page's own registrable domain. A caller follows it only
 	// after finding nothing else to read — see MetaRefreshOnly.
 	Refresh string
-	// HeadText is what the <head> says this page is ABOUT, in document order:
-	// the meta description and the Open Graph title and description, each at
-	// most headTextRunes long.
+	// HeadText is what this page SAYS it is about, in document order: the meta
+	// description and the Open Graph title and description, then the names and
+	// descriptions its JSON-LD declares. Each is at most headTextRunes long.
+	//
+	// The JSON-LD half is here rather than in a field of its own because it
+	// answers the same question and every reader of this one already asks it:
+	// a schema.org block naming the organization is the page's claim about
+	// itself exactly as a meta description is, and a separate field would have
+	// to be threaded through the crawl's dedupe, its prose and its emptiness
+	// test one call site at a time.
 	//
 	// Kept apart from Text, and that separation is the point. Text is
 	// StripTags' output and evidence snippets are matched against it, so
@@ -153,7 +160,7 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 		OGImage:         head.ogImage,
 		Icons:           head.icons,
 		Refresh:         head.refresh,
-		HeadText:        head.text,
+		HeadText:        append(head.text, linkedDataClaims(body)...),
 		ExternalScripts: external,
 		ModuleScripts:   modules,
 		Fingerprint:     fingerprintOf(got.header, body, base),

--- a/backend/internal/platform/webread/schemaorg.go
+++ b/backend/internal/platform/webread/schemaorg.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// What a page declares about itself in JSON-LD.
+//
+// A client-rendered site sends a loader and a <head>; the words a reader wants
+// are assembled by a browser this fetcher does not run. The head's own prose
+// (headtext.go) recovers some of it, and this recovers the rest: a marketing
+// site built by any current framework ships a schema.org block naming the
+// organization behind it, served as text by the server, needing no browser at
+// all.
+//
+// Its own file rather than headtext.go's, because the shape is different in the
+// way that matters: a <meta> is one attribute to read, and this is a JSON
+// document of arbitrary depth that arrived from a stranger. Everything below is
+// bounded for that reason.
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// The bounds this reader answers within. All three exist because the input is
+// untrusted: a page chooses its own JSON, and an unbounded parse of it would
+// spend the crawl's memory and the prompt's budget on whatever a stranger sent.
+const (
+	// ldBlockBytes bounds ONE script block before it is parsed at all. Generous
+	// against real product catalogs, far below what a page could send.
+	ldBlockBytes = 256 * 1024
+	// ldMaxDepth bounds how deep the walk descends. schema.org nests a few
+	// levels; a document nesting hundreds is not describing a company.
+	ldMaxDepth = 12
+	// ldMaxClaims bounds what reaches a caller. The company's own name and
+	// description are the first thing a page declares; the twentieth product in
+	// a catalog is not what a reader asked.
+	ldMaxClaims = 4
+)
+
+// ldClaimKeys are the fields worth reading off a node, in the order a reader
+// wants them: what the thing is called, then what it says it does.
+var ldClaimKeys = []string{"name", "legalName", "description"}
+
+// linkedDataClaims reads the names and descriptions a page declares in JSON-LD.
+//
+// THE TYPE IS DELIBERATELY NOT FILTERED, and that is the decision worth reading.
+// schema.org's organization vocabulary is OPEN — Corporation, NGO, and every
+// LocalBusiness subtype down to Dentist are organizations — so a list of the
+// types to accept is a census that goes quietly short: a site declaring itself
+// a `SportsActivityLocation` would be read as declaring nothing, and the read
+// would report an empty page about a company that named itself in the markup.
+//
+// What bounds this instead is the CLAIM COUNT, which cannot fail that way. The
+// consumer is a model reading prose, for which a page's own declared names are
+// signal whatever node they hang off — and four of them is a sentence, not a
+// catalog.
+func linkedDataClaims(rawHTML string) []string {
+	var claims []string
+	seen := map[string]bool{}
+	for _, block := range linkedDataBlocks(rawHTML) {
+		var doc any
+		if err := json.Unmarshal([]byte(block), &doc); err != nil {
+			// A page's own malformed JSON is not this crawl's problem to report:
+			// the block is one source of prose among several, and a site that
+			// ships broken markup still has a <head> and a body to read.
+			continue
+		}
+		claims = collectLDClaims(doc, 0, seen, claims)
+		if len(claims) >= ldMaxClaims {
+			return claims
+		}
+	}
+	return claims
+}
+
+// linkedDataBlocks returns the raw text of each application/ld+json script.
+func linkedDataBlocks(rawHTML string) []string {
+	var blocks []string
+	tokenizer := html.NewTokenizer(strings.NewReader(rawHTML))
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return blocks
+		case html.StartTagToken:
+			name, hasAttr := tokenizer.TagName()
+			if string(name) != tagScript || !hasAttr {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(tagAttrs(tokenizer)["type"]), "application/ld+json") {
+				continue
+			}
+			// The tokenizer hands script contents back as one text token, so the
+			// block is whatever follows this tag.
+			if tokenizer.Next() != html.TextToken {
+				continue
+			}
+			block := string(tokenizer.Text())
+			if len(block) > ldBlockBytes {
+				continue
+			}
+			blocks = append(blocks, block)
+		}
+	}
+}
+
+// collectLDClaims walks one decoded document, gathering claims depth-first in
+// document order. seen drops a repeated value: a site declaring its name on
+// every node would otherwise spend the whole budget saying it again per node.
+//
+// nobody declares — schema.org is an open vocabulary and the page chooses which
+// of it to send, so a concrete type here would be this package inventing a
+// contract the input never agreed to. The walk answers only "is this a map, a
+// list, or a string", which is the whole of what json.Unmarshal into `any` can
+// be asked.
+//
+//craft:ignore naked-any the parameter IS a decoded JSON document of a shape
+func collectLDClaims(node any, depth int, seen map[string]bool, into []string) []string {
+	if depth > ldMaxDepth || len(into) >= ldMaxClaims {
+		return into
+	}
+	switch value := node.(type) {
+	case map[string]any:
+		for _, key := range ldClaimKeys {
+			claim, ok := value[key].(string)
+			if !ok {
+				continue
+			}
+			claim = strings.Join(strings.Fields(claim), " ")
+			if claim == "" || seen[claim] {
+				continue
+			}
+			seen[claim] = true
+			into = append(into, truncateRunes(claim, headTextRunes))
+			if len(into) >= ldMaxClaims {
+				return into
+			}
+		}
+		// Nested nodes in a stable order, so one page reads the same way twice.
+		// Map iteration is randomized in Go, and a crawl whose prose changed
+		// between two reads of one page would make every downstream dedupe and
+		// evidence match depend on which order this walk happened to take.
+		for _, key := range sortedKeys(value) {
+			into = collectLDClaims(value[key], depth+1, seen, into)
+		}
+	case []any:
+		for _, item := range value {
+			into = collectLDClaims(item, depth+1, seen, into)
+		}
+	}
+	return into
+}
+
+// sortedKeys is the walk's fixed order over a JSON object.
+func sortedKeys(node map[string]any) []string {
+	keys := make([]string, 0, len(node))
+	for key := range node {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/backend/internal/platform/webread/schemaorg_test.go
+++ b/backend/internal/platform/webread/schemaorg_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// What a client-rendered page still tells a reader that runs no JavaScript.
+//
+// The case behind these: a Next.js marketing site serves a shell with no body
+// text, so the read judged it "no readable text" and settled the domain as
+// parked — a real company on file as an empty address. The words were in the
+// markup the whole time, in the schema.org block the framework emitted.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func ldPage(block string) string {
+	return `<html><head><script type="application/ld+json">` + block +
+		`</script></head><body><div id="__next"></div></body></html>`
+}
+
+func TestAShellDeclaringAnOrganizationIsNotAnEmptyPage(t *testing.T) {
+	got := linkedDataClaims(ldPage(`{
+		"@context":"https://schema.org","@type":"Organization",
+		"name":"Intouch Sports","description":"Coaching for teams that travel."}`))
+
+	want := []string{"Intouch Sports", "Coaching for teams that travel."}
+	if !slices.Equal(got, want) {
+		t.Errorf("claims = %q, want %q", got, want)
+	}
+}
+
+// The type is deliberately unfiltered, and this is the case that decides it:
+// schema.org's organization vocabulary is open, so a list of accepted types
+// would read a site declaring itself a LocalBusiness subtype as declaring
+// nothing at all.
+func TestAnOrganizationSubtypeIsReadLikeAnyOther(t *testing.T) {
+	for _, kind := range []string{"Corporation", "NGO", "Dentist", "SportsActivityLocation"} {
+		got := linkedDataClaims(ldPage(fmt.Sprintf(
+			`{"@context":"https://schema.org","@type":%q,"name":"Nordic Works"}`, kind)))
+		if len(got) != 1 || got[0] != "Nordic Works" {
+			t.Errorf("@type %s: claims = %q, want the declared name", kind, got)
+		}
+	}
+}
+
+// A @graph, which is how most frameworks emit more than one node.
+func TestAGraphIsWalkedAndTheNamesDeduped(t *testing.T) {
+	got := linkedDataClaims(ldPage(`{"@context":"https://schema.org","@graph":[
+		{"@type":"WebSite","name":"Nordic Works"},
+		{"@type":"Organization","name":"Nordic Works","description":"We build boats."}]}`))
+
+	want := []string{"Nordic Works", "We build boats."}
+	if !slices.Equal(got, want) {
+		t.Errorf("claims = %q, want the name once and the description after it", got)
+	}
+}
+
+// The bound is the claim count, because that is the one that cannot fail short.
+func TestACatalogueIsCutToTheClaimBound(t *testing.T) {
+	var nodes []string
+	for i := range 20 {
+		nodes = append(nodes, fmt.Sprintf(`{"@type":"Product","name":"Product %02d"}`, i))
+	}
+	got := linkedDataClaims(ldPage(`[` + strings.Join(nodes, ",") + `]`))
+
+	if len(got) != ldMaxClaims {
+		t.Errorf("claims = %d, want the bound of %d", len(got), ldMaxClaims)
+	}
+	// In document order, so one page reads the same way twice.
+	if got[0] != "Product 00" {
+		t.Errorf("first claim = %q, want the first node's", got[0])
+	}
+}
+
+// A page's own broken JSON is not this crawl's problem to report: the block is
+// one source of prose among several, and the head and the body still read.
+func TestMalformedLinkedDataIsSkippedRatherThanFailing(t *testing.T) {
+	got := linkedDataClaims(ldPage(`{"@type":"Organization","name":`))
+	if len(got) != 0 {
+		t.Errorf("claims = %q, want none from an unparseable block", got)
+	}
+}
+
+// The whole page, through the fetch a caller actually makes.
+//
+// Driven end to end rather than by calling the reader directly: what the ticket
+// is about is a FETCHED page reading as empty, and a test that assembled the
+// claims itself would pass over a Page that never carried them.
+func TestAFetchedShellCarriesWhatItDeclared(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head>` +
+			`<meta name="description" content="Coaching for teams that travel.">` +
+			`<script type="application/ld+json">{"@type":"Organization","name":"Intouch Sports"}</script>` +
+			`<script type="module" src="/_next/main.js"></script>` +
+			`</head><body><div id="__next"></div></body></html>`))
+	}))
+	defer server.Close()
+
+	page, err := newFetcher(server.Client().Transport).FetchPage(context.Background(), server.URL+"/")
+	if err != nil {
+		t.Fatalf("FetchPage: %v", err)
+	}
+
+	// The shape the defect is about: a body with nothing in it.
+	if strings.TrimSpace(page.Text) != "" {
+		t.Fatalf("page text = %q, want the empty body this case is about", page.Text)
+	}
+	if !slices.Contains(page.HeadText, "Intouch Sports") {
+		t.Errorf("head text = %q, want it to carry the organization the markup declared — "+
+			"without it this page reads as having no readable text and settles as parked",
+			page.HeadText)
+	}
+	// And the head's own prose still leads: it is written for a stranger, which
+	// is the question both model lanes ask.
+	if len(page.HeadText) == 0 || page.HeadText[0] != "Coaching for teams that travel." {
+		t.Errorf("head text = %q, want the meta description first", page.HeadText)
+	}
+}


### PR DESCRIPTION
Closes #3645.

## What the issue names, and what was already done

A client-rendered site serves a shell with no readable text, so `classifySeed` answered `parked` with confidence 1 and no model call — no company created, and settled dispositions are final. The issue offers two routes: render pages in a headless browser, or recognise a JS shell and answer `unclear`.

**The second one already landed** — #3905 recognises a shell (`isJSShell`), answers `unclear`, and recovers the head's own prose (meta description, `og:title`, `og:description`). Measured that on `origin/main` before building anything.

**The first one is a product decision**, and the issue says so: a browser in the crawl path carries its own cost, security and pacing questions.

So this is a third route the issue does not consider, and it is the cheap one: **read what the server already sends**. A marketing site built by any current framework ships a schema.org block naming the organization behind it — as text, in the markup, needing no browser at all.

## The decision worth reading: the type is not filtered

schema.org's organization vocabulary is **open**. `Corporation`, `NGO`, and every `LocalBusiness` subtype down to `Dentist` are organizations. A list of types to accept is therefore a census that goes quietly short — a site declaring itself a `SportsActivityLocation` would read as declaring nothing, and the read would report an empty page about a company that named itself in the markup. That is the exact failure shape the rulebook's eighth review-loop rule forbids.

What bounds it instead is the **claim count**, which cannot fail that way. The consumer is a model reading prose, for which a page's own declared names are signal whatever node they hang off — and four of them is a sentence, not a catalog.

## Bounded because the input is untrusted

A page chooses its own JSON. A block over 256KB is not parsed at all; the walk stops at twelve levels; four claims reach a caller, each capped at the same rune count a head declaration is; repeated values are dropped so a site naming itself on every node does not spend the whole budget. Nested nodes are walked in sorted key order — Go randomizes map iteration, and a crawl whose prose changed between two reads of one page would make every downstream dedupe and evidence match depend on which order the walk happened to take.

A page's own malformed JSON is skipped rather than reported: the block is one source of prose among several, and a site that ships broken markup still has a head and a body to read.

## Why the claims ride `HeadText`

They answer the same question — what this page says it is about — and every reader of that field already asks it: the crawl's dedupe (`bodyIdentity`), both model lanes' `prose()`, and the emptiness test in `classifySeed` that decides `parked`. A field of its own would have to be threaded through each of those one call site at a time.

## Mutation checks

| Mutation | Caught by |
|---|---|
| the walk stops at the top level | `TestAGraphIsWalkedAndTheNamesDeduped` |
| repeated values are not deduped | same |
| the claim bound never fires | `TestACatalogueIsCutToTheClaimBound` |
| the claims never reach `HeadText` | `TestAFetchedShellCarriesWhatItDeclared` |

The last is driven end to end through `FetchPage` against an `httptest` server, not by calling the reader directly — what the issue is about is a *fetched* page reading as empty, and a test that assembled the claims itself would pass over a `Page` that never carried them. It asserts the premise first: the body really is empty, so the case is the one the issue describes.

`tagScript` is shared by the three harvests in this package that scan for `<script>`, which `goconst` asked for.

## Verification

`make check-backend` and `make craft-static` green.