### PR TITLE
A channel transport says whose credential it spends

### DIFF
--- a/backend/internal/compose/channelprovider.go
+++ b/backend/internal/compose/channelprovider.go
@@ -251,8 +251,16 @@ func upsertChannelProvider(ctx context.Context, tx pgx.Tx, facts channelProvider
 // door this package does not need to open for a value fixed at boot.
 var composedChannelProviders struct {
 	mu sync.RWMutex
-	// registered is every transport in the registry — what a message MAY name.
-	registered []string
+	// registered is every transport in the registry — what a message MAY name —
+	// carrying the row's OWN display facts rather than only its id.
+	//
+	// It used to be names alone, and the shaping then re-derived the rest from
+	// "this is a core connector", which published credential_model=workspace_bot
+	// for every unit transport however the unit had declared itself. The column
+	// exists to say whose credential a transport spends; an endpoint that
+	// answers it from a constant is telling an operator a member's own account
+	// is one the whole installation shares.
+	registered []channelProviderFacts
 	// sending maps the subset this binary composed a sender for — what a reply
 	// CAN leave on — to what that sender can carry alongside the message. Held
 	// separately from registered because the two differ (whatsapp is registered
@@ -298,20 +306,22 @@ var composedChannelProviders struct {
 // capability are separate axes, which is the same separation this whole arc is
 // about.
 func LoadChannelProviderDirectory(ctx context.Context, pool *pgxpool.Pool) error {
-	var registered []string
+	var registered []channelProviderFacts
 	err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,
-			`SELECT provider FROM channel_provider ORDER BY provider`)
+			`SELECT provider, transport, label, credential_model, supplies_transport
+			   FROM channel_provider ORDER BY provider`)
 		if err != nil {
 			return err
 		}
 		defer rows.Close()
 		for rows.Next() {
-			var p string
-			if err := rows.Scan(&p); err != nil {
+			var f channelProviderFacts
+			if err := rows.Scan(&f.provider, &f.transport, &f.label,
+				&f.credentialModel, &f.suppliesTransport); err != nil {
 				return err
 			}
-			registered = append(registered, p)
+			registered = append(registered, f)
 		}
 		return rows.Err()
 	})
@@ -322,7 +332,7 @@ func LoadChannelProviderDirectory(ctx context.Context, pool *pgxpool.Pool) error
 	return nil
 }
 
-func setComposedChannelProviders(registered []string, sending map[string]connector.Carriage) {
+func setComposedChannelProviders(registered []channelProviderFacts, sending map[string]connector.Carriage) {
 	composedChannelProviders.mu.Lock()
 	defer composedChannelProviders.mu.Unlock()
 	composedChannelProviders.registered = slices.Clone(registered)
@@ -331,7 +341,7 @@ func setComposedChannelProviders(registered []string, sending map[string]connect
 
 // ComposedChannelProviders returns this boot's registered transports and, for
 // the subset that can carry an outbound message, what each one can carry.
-func ComposedChannelProviders() (registered []string, sending map[string]connector.Carriage) {
+func ComposedChannelProviders() (registered []channelProviderFacts, sending map[string]connector.Carriage) {
 	composedChannelProviders.mu.RLock()
 	defer composedChannelProviders.mu.RUnlock()
 	return slices.Clone(composedChannelProviders.registered), maps.Clone(composedChannelProviders.sending)

--- a/backend/internal/compose/channelprovider_integration_test.go
+++ b/backend/internal/compose/channelprovider_integration_test.go
@@ -153,7 +153,7 @@ func TestReconcileChannelProvidersRegistersAUnitsDeclaredTransport(t *testing.T)
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
 	declaresTransport(t, "mine", extension.Channel{
-		Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 	t.Cleanup(func() {
 		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'mine_chat'`); err != nil {
@@ -199,6 +199,51 @@ func TestReconcileChannelProvidersRegistersAUnitsDeclaredTransport(t *testing.T)
 	}
 }
 
+// A unit supplying a COMPANY-WIDE account registers as workspace_bot, because
+// it declared so — not per_member, which is what "it is a unit" alone would say.
+//
+// This is the case the derivation got wrong. A Zalo Official Account, a shared
+// support inbox, any account an administrator binds once for everybody: it ships
+// as a unit and it is not one member's correspondence. Inferring per_member for
+// it puts a company's customer messages on the mailbox path with the connecting
+// admin as their "owner", and nothing downstream can tell — the row has exactly
+// one reader, so every audience invariant reads green while the whole company
+// has lost its own inbox.
+func TestReconcileChannelProvidersHonoursAUnitsDeclaredWorkspaceBotCredential(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := context.Background()
+	owner := integration.OwnerConn(t)
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "official", extension.Channel{
+		Provider: "official_account", CredentialModel: extension.CredentialWorkspaceBot,
+		Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'official_account'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram}); err != nil {
+		t.Fatalf("reconcileChannelProviders: %v", err)
+	}
+
+	var transport, credentialModel string
+	if err := owner.QueryRow(ctx,
+		`SELECT transport, credential_model FROM channel_provider WHERE provider = 'official_account'`).
+		Scan(&transport, &credentialModel); err != nil {
+		t.Fatalf("querying the unit's row: %v", err)
+	}
+	if transport != "unit" {
+		t.Errorf("transport = %q, want unit — who SUPPLIES it is still the unit", transport)
+	}
+	if credentialModel != "workspace_bot" {
+		t.Errorf("credential_model = %q, want workspace_bot — the unit declared it, and a declaration "+
+			"the registry overrides is a declaration that does nothing", credentialModel)
+	}
+}
+
 // A capture-only unit registers its provider and is NOT sendable. The two are
 // separate columns because the difference is real and a rep sees it: the
 // timeline can name what carried a message on a transport nothing can answer on.
@@ -208,7 +253,7 @@ func TestReconcileChannelProvidersRegistersACaptureOnlyUnitTransportAsUnsendable
 	owner := integration.OwnerConn(t)
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
-	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember})
 	t.Cleanup(func() {
 		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'mine_chat'`); err != nil {
 			t.Errorf("cleaning up channel_provider: %v", err)
@@ -248,7 +293,7 @@ func TestReconcileChannelProvidersRefusesAUnitThatShadowsACoreConnector(t *testi
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
 	declaresTransport(t, "impostor", extension.Channel{
-		Provider: capture.ProviderTelegram, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: capture.ProviderTelegram, CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 
 	err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram})
@@ -290,7 +335,7 @@ func TestReconcileChannelProvidersRefusesAUnitThatSeizesARegisteredCoreTransport
 	// whatsapp is deliberately NOT in the composed set below, which is the
 	// truth about this binary: nothing composes a WhatsApp connector.
 	declaresTransport(t, "impostor", extension.Channel{
-		Provider: "whatsapp", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: "whatsapp", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 
 	err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram})
@@ -337,7 +382,7 @@ func TestTheBootStepRegistersAComposedUnitTransportWithNoCaptureRegistry(t *test
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
 	declaresTransport(t, "boot", extension.Channel{
-		Provider: "boot_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: "boot_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 	t.Cleanup(func() {
 		if _, err := owner.Exec(context.Background(),
@@ -392,7 +437,7 @@ func TestTheBootStepReconcilesBeforeTheInstallationIsBootstrapped(t *testing.T) 
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
 	declaresTransport(t, "prebootstrap", extension.Channel{
-		Provider: "prebootstrap_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: "prebootstrap_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 	t.Cleanup(func() {
 		if _, err := owner.Exec(context.Background(),
@@ -430,7 +475,7 @@ func TestRecordingTheCompositionFailsTheBootWhenAUnitShadowsACoreTransport(t *te
 	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
 	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
 	declaresTransport(t, "impostor", extension.Channel{
-		Provider: capture.ProviderTelegram, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: capture.ProviderTelegram, CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 
 	err := RecordComposition(ctx, e.Pool, discardLog(), ComposedExtensions())

--- a/backend/internal/compose/channelproviderdirectory_integration_test.go
+++ b/backend/internal/compose/channelproviderdirectory_integration_test.go
@@ -17,6 +17,10 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/pkg/extension"
 )
 
 func TestTheDirectoryAndTheRegistryDescribeTheSameTransports(t *testing.T) {
@@ -24,17 +28,24 @@ func TestTheDirectoryAndTheRegistryDescribeTheSameTransports(t *testing.T) {
 	owner := integration.OwnerConn(t)
 	ctx := context.Background()
 
-	rows, err := owner.Query(ctx, `SELECT provider FROM channel_provider ORDER BY provider`)
+	rows, err := owner.Query(ctx, `SELECT provider, credential_model FROM channel_provider ORDER BY provider`)
 	if err != nil {
 		t.Fatalf("reading the registry: %v", err)
 	}
 	inRegistry := map[string]bool{}
+	// The registry's OWN answer per provider, not just which providers exist.
+	// Checking only that the published value is inside the enum passes while
+	// the endpoint publishes a constant — which it did, for every unit
+	// transport, because the directory carried provider names alone and the
+	// shaping re-derived the rest from "this is a core connector".
+	modelInRegistry := map[string]string{}
 	for rows.Next() {
-		var p string
-		if err := rows.Scan(&p); err != nil {
+		var p, model string
+		if err := rows.Scan(&p, &model); err != nil {
 			t.Fatalf("scanning a provider: %v", err)
 		}
 		inRegistry[p] = true
+		modelInRegistry[p] = model
 	}
 	rows.Close()
 	if len(inRegistry) == 0 {
@@ -67,6 +78,14 @@ func TestTheDirectoryAndTheRegistryDescribeTheSameTransports(t *testing.T) {
 		}
 		if !entry.CredentialModel.Valid() {
 			t.Errorf("%q publishes credential_model %q, which is outside the contract's enum", entry.Provider, entry.CredentialModel)
+		}
+		// Whose credential a transport spends is what every privacy rule about
+		// a channel message keys on, and this endpoint is where an operator
+		// reads it. Publishing a value the registry does not hold tells them
+		// one member's personal account is a company one, or the reverse.
+		if got, want := string(entry.CredentialModel), modelInRegistry[entry.Provider]; got != want {
+			t.Errorf("%q publishes credential_model %q; the registry holds %q — the directory is answering from somewhere other than the row it describes",
+				entry.Provider, got, want)
 		}
 	}
 	for p := range inRegistry {
@@ -155,5 +174,57 @@ func TestTheDirectoryLoadsFromTheRegistryAndNotFromTheCaptureBoot(t *testing.T) 
 	registered, _ := ComposedChannelProviders()
 	if len(registered) == 0 {
 		t.Fatal("the directory is empty after loading from the registry; a vault-less install would publish no labels at all and report 200 while doing it")
+	}
+}
+
+// The directory publishes the credential model a UNIT declared, not the one a
+// core connector would have.
+//
+// The sibling test above cannot see this on its own: the harness registers core
+// transports only, so every row it compares is workspace_bot either way and it
+// agrees with a directory that publishes that constant unconditionally. Which is
+// what the directory did — LoadChannelProviderDirectory carried provider NAMES
+// out of the registry and the shaping re-derived everything else as core. The
+// case has to be planted, because it is the shape the census cannot reach.
+//
+// It matters where an operator reads it: credential_model is what says whether a
+// transport's messages are the company's correspondence or one person's, and a
+// per-member account published as a workspace bot invites exactly the wrong
+// answer to that question.
+func TestTheDirectoryPublishesAUnitsOwnCredentialModel(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+	ctx := context.Background()
+	defer activities.SetChannelProviders([]string{capture.ProviderTelegram})
+	defer comms.SetChannelProviders([]string{capture.ProviderTelegram})
+	declaresTransport(t, "mine", extension.Channel{
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember,
+		Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+	})
+	t.Cleanup(func() {
+		if _, err := owner.Exec(context.Background(), `DELETE FROM channel_provider WHERE provider = 'mine_chat'`); err != nil {
+			t.Errorf("cleaning up channel_provider: %v", err)
+		}
+	})
+	if err := reconcileChannelProviders(ctx, e.Pool, []string{capture.ProviderTelegram}); err != nil {
+		t.Fatalf("reconcileChannelProviders: %v", err)
+	}
+	if err := LoadChannelProviderDirectory(ctx, e.Pool); err != nil {
+		t.Fatalf("loading the directory: %v", err)
+	}
+
+	registered, sending := ComposedChannelProviders()
+	var found bool
+	for _, entry := range publishedChannelProviders(registered, sending) {
+		if entry.Provider != "mine_chat" {
+			continue
+		}
+		found = true
+		if got := string(entry.CredentialModel); got != "per_member" {
+			t.Errorf("the directory publishes credential_model %q for a unit that declared per_member — an operator reading this endpoint is told a member's own account is one the installation shares", got)
+		}
+	}
+	if !found {
+		t.Fatal("the directory does not publish the unit transport at all, so the assertion above never ran")
 	}
 }

--- a/backend/internal/compose/channelproviderfacts.go
+++ b/backend/internal/compose/channelproviderfacts.go
@@ -20,14 +20,12 @@ import (
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
-// credentialWorkspaceBot and credentialPerMember are the two shapes a channel
-// credential takes. Closed on purpose, unlike the provider vocabulary: this
-// describes the SHAPE of a credential, which is installation-independent, not
-// which providers exist, which is not.
-const (
-	credentialWorkspaceBot = "workspace_bot" //nolint:gosec // G101 false positive: the SHAPE a credential takes, published in the contract's enum — not a credential
-	credentialPerMember    = "per_member"
-)
+// credentialWorkspaceBot is the shape a CORE connector's credential takes: one
+// bot for the installation. It is the published vocabulary's own value rather
+// than a second spelling of it — a unit declares from the same two constants,
+// and a registry that agreed with the enum only by coincidence would drift the
+// first time either moved.
+const credentialWorkspaceBot = string(extension.CredentialWorkspaceBot)
 
 // transportCore and transportUnit are who SUPPLIES a transport: a connector
 // compiled into the core, or an extension unit under extensions/. Closed for
@@ -127,7 +125,7 @@ func titleCasedID(id string) string {
 // in one and missing from the other.
 //
 // credential_model is workspace_bot for every core connector, because a core
-// channel connector binds ONE bot for the installation. A unit's is per_member —
+// channel connector binds ONE bot for the installation. A unit declares its own;
 // see unitChannelFacts.
 func channelProviderFactsFor(registered []string, sending map[string]connector.Carriage) []channelProviderFacts {
 	out := make([]channelProviderFacts, 0, len(registered))
@@ -174,10 +172,19 @@ func channelProviderFactsFor(registered []string, sending map[string]connector.C
 // and every previously-unrepliable WhatsApp conversation in the installation
 // became one the unit transmits.
 //
-// credential_model is per_member for every unit transport, because that is what
-// the tier makes available: a unit holds one sealed secret per member (the
-// user-scoped SecretsRequest) and has no installation credential to send under.
-// A unit that grows a workspace-wide one declares it, and this derives it.
+// credential_model is the unit's OWN declaration, carried through unchanged.
+//
+// It used to be derived — per_member for everything under extensions/, on the
+// reasoning that a unit holds one sealed secret per member. That is true of a
+// personal-account transport and false of a company one, and the tier permits
+// both: an Official Account is a shared business account that happens to ship as
+// a unit. Deriving it answered wrongly for that whole class, and wrongly in the
+// direction nothing detects — a message narrowed onto the mailbox path keeps
+// exactly one reader, the connecting admin, so no orphan invariant fires while a
+// company's customer correspondence has become one person's private mail.
+//
+// Channel.Validate refuses a unit that declares neither, so there is no default
+// to be wrong about here.
 //
 // The label is DERIVED from the id rather than declared, which is the same
 // decision providerLabel documents: this endpoint is readable by every
@@ -186,6 +193,15 @@ func unitChannelFacts(reserved map[string]bool) ([]channelProviderFacts, error) 
 	var out []channelProviderFacts
 	for _, ext := range ComposedExtensions() {
 		for _, ch := range ext.Channels {
+			if !ch.CredentialModel.Valid() {
+				// The registry column has its own CHECK, so an undeclared model
+				// is refused either way — but by name, three layers down, at the
+				// upsert. Refusing here names the unit, the transport and the
+				// two answers, which is what a unit author needs and what a
+				// constraint name cannot give them.
+				return nil, fmt.Errorf("compose: extension %q declares the transport %q without a credential model — say %q if one credential serves the whole installation, %q if each member deposits their own; it decides whether this transport's messages are the company's correspondence or one person's",
+					ext.Name, ch.Provider, extension.CredentialWorkspaceBot, extension.CredentialPerMember)
+			}
 			if reserved[ch.Provider] {
 				return nil, fmt.Errorf("compose: extension %q declares the transport %q, which this installation reserves for the core — a message on it would leave on the unit's credential instead of the workspace's, so rename the unit's channel", ext.Name, ch.Provider)
 			}
@@ -193,7 +209,7 @@ func unitChannelFacts(reserved map[string]bool) ([]channelProviderFacts, error) 
 				provider:          ch.Provider,
 				transport:         transportUnit,
 				label:             providerLabel(ch.Provider),
-				credentialModel:   credentialPerMember,
+				credentialModel:   string(ch.CredentialModel),
 				suppliesTransport: ch.SuppliesTransport(),
 				// The zero descriptor: extension.Channel has no field for a
 				// unit to declare carriage on yet. sendableCarriage states why

--- a/backend/internal/compose/channelproviderfacts_test.go
+++ b/backend/internal/compose/channelproviderfacts_test.go
@@ -123,7 +123,11 @@ func TestASendingProviderThatDeclaredNoCarriageCarriesNothing(t *testing.T) {
 // The wire entry carries every bound, not just the bool. An entry that published
 // carries=true with zero limits would tell a composer it may attach anything.
 func TestThePublishedEntryCarriesEveryBound(t *testing.T) {
-	published := publishedChannelProviders([]string{"telegram"},
+	published := publishedChannelProviders(
+		[]channelProviderFacts{{
+			provider: "telegram", transport: transportCore, label: "Telegram",
+			credentialModel: credentialWorkspaceBot, suppliesTransport: true,
+		}},
 		map[string]connector.Carriage{"telegram": {
 			Carries: true, MaxBytesPerFile: 20 << 20, MaxFiles: 10, MaxBodyWithFiles: 1024,
 		}})
@@ -160,5 +164,44 @@ func TestSendableCarriageGivesAnUndeclaredTransportNothing(t *testing.T) {
 	}
 	if carriage.Carries {
 		t.Errorf("a transport whose connector declared no carriage was published as able to carry files: %+v", carriage)
+	}
+}
+
+// The directory reads its two halves from two places, and a registry row cannot
+// make a reply leave an installation that composed no sender.
+//
+// This is the regression the credential_model fix nearly shipped. Once the
+// snapshot started carrying the registry's own columns it was tempting to take
+// `supplies_transport` from the row as well — every other display fact comes
+// from there. But the row says what the transport is REGISTERED as supplying,
+// and the question this field answers is whether THIS binary can send on it. A
+// worker-less role, or an installation whose connector was compiled out, would
+// then publish `supplies_transport: true` and offer a rep a reply box that parks
+// every message it accepts — the one failure a rep cannot tell from a broken
+// provider.
+func TestSuppliesTransportComesFromTheComposedSenderAndNotFromTheRegistryRow(t *testing.T) {
+	registered := []channelProviderFacts{{
+		provider: "mine_chat", transport: transportUnit, label: "Mine Chat",
+		credentialModel: string(extension.CredentialPerMember),
+		// The registry's answer, and deliberately the OPPOSITE of this
+		// binary's: nothing composed a sender for it below.
+		suppliesTransport: true,
+	}}
+
+	published := publishedChannelProviders(registered, map[string]connector.Carriage{})
+	if len(published) != 1 {
+		t.Fatalf("published %d entries for one provider", len(published))
+	}
+	if published[0].SuppliesTransport {
+		t.Error("the directory published supplies_transport=true from the registry row while this binary composed no sender for it — " +
+			"every reply a rep wrote on it would be staged and then parked")
+	}
+	// And the row's own facts still come from the row, or the fix this test
+	// guards would have thrown out what it was for.
+	if got := string(published[0].CredentialModel); got != string(extension.CredentialPerMember) {
+		t.Errorf("credential_model = %q, want %q — the display facts come from the registry row", got, extension.CredentialPerMember)
+	}
+	if published[0].Label != "Mine Chat" {
+		t.Errorf("label = %q, want the row's own", published[0].Label)
 	}
 }

--- a/backend/internal/compose/extchannelsend_test.go
+++ b/backend/internal/compose/extchannelsend_test.go
@@ -67,7 +67,7 @@ func TestThePreflightHoldsChannelDeclarationsToTheComposedSet(t *testing.T) {
 	sender := &capturedSend{}
 	mine := extension.Extension{
 		Name: "mine", Version: "1.0.0",
-		Channels: []extension.Channel{{Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil)}},
+		Channels: []extension.Channel{{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: sender.send, Live: answersLive(true, nil)}},
 	}
 
 	claimed := map[string]extension.Name{}
@@ -82,7 +82,7 @@ func TestThePreflightHoldsChannelDeclarationsToTheComposedSet(t *testing.T) {
 	// that arrived outside the generator path is held to the same rule the
 	// manifest generator applies.
 	ungrammatical := mine
-	ungrammatical.Channels = []extension.Channel{{Provider: "mine-chat"}}
+	ungrammatical.Channels = []extension.Channel{{Provider: "mine-chat", CredentialModel: extension.CredentialPerMember}}
 	if err := preflightChannels(ungrammatical, map[string]extension.Name{}); err == nil {
 		t.Error("a provider the registry grammar refuses was accepted; it would fail on the column instead, under a constraint name")
 	}
@@ -98,7 +98,7 @@ func TestThePreflightHoldsChannelDeclarationsToTheComposedSet(t *testing.T) {
 	// message travelled on.
 	theirs := extension.Extension{
 		Name: "theirs", Version: "1.0.0",
-		Channels: []extension.Channel{{Provider: "mine_chat"}},
+		Channels: []extension.Channel{{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember}},
 	}
 	err := preflightChannels(theirs, claimed)
 	if err == nil {
@@ -118,7 +118,7 @@ func TestThePreflightHoldsChannelDeclarationsToTheComposedSet(t *testing.T) {
 func TestResolveChannelPrefersTheUnitThatSuppliesTheTransport(t *testing.T) {
 	sender := &capturedSend{}
 	declaresTransport(t, "mine", extension.Channel{
-		Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: sender.send, Live: answersLive(true, nil),
 	})
 	r := commsResolver{channels: stubChannelSenders{err: errors.New("the capture registry was asked and should not have been")}}
 
@@ -150,20 +150,20 @@ func TestResolveUnitChannelTranslatesOnlyTheDeploymentFacts(t *testing.T) {
 	}{
 		{
 			name:    "a capture-only transport parks",
-			channel: extension.Channel{Provider: "mine_chat"},
+			channel: extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember},
 			want:    comms.ErrCannotSend,
 		},
 		{
 			name: "a member who disconnected parks",
 			channel: extension.Channel{
-				Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, nil),
+				Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(false, nil),
 			},
 			want: comms.ErrNoMailbox,
 		},
 		{
 			name: "a provider that could not answer is retried",
 			channel: extension.Channel{
-				Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, provider),
+				Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(false, provider),
 			},
 			want: provider,
 		},
@@ -191,7 +191,7 @@ func TestTheUnitSenderHandsOverTheDeliveryTheDispatcherBuilt(t *testing.T) {
 	sender := &capturedSend{receipt: extension.Receipt{ProviderMessageID: "provider-42"}}
 	member := ids.New[ids.UserKind]()
 	declaresTransport(t, "mine", extension.Channel{
-		Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: sender.send, Live: answersLive(true, nil),
 	})
 	r := commsResolver{}
 	resolved, _, err := r.ResolveChannel(context.Background(), member, "mine_chat")
@@ -262,7 +262,7 @@ func TestOnlyAnUnknownOutcomeStopsTheDeliveryRatherThanRetryingIt(t *testing.T) 
 		t.Run(name, func(t *testing.T) {
 			sender := &capturedSend{err: tc.from}
 			declaresTransport(t, "mine", extension.Channel{
-				Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+				Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: sender.send, Live: answersLive(true, nil),
 			})
 			r := commsResolver{}
 			resolved, _, err := r.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "mine_chat")
@@ -292,7 +292,7 @@ func TestOnlyAnUnknownOutcomeStopsTheDeliveryRatherThanRetryingIt(t *testing.T) 
 // declared any channel.
 func TestResolveChannelStillReachesTheCoreRegistryForACoreTransport(t *testing.T) {
 	declaresTransport(t, "mine", extension.Channel{
-		Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil),
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil),
 	})
 	r := commsResolver{channels: stubChannelSenders{sender: stubChannelSender{}}}
 
@@ -315,7 +315,7 @@ func TestResolveChannelStillReachesTheCoreRegistryForACoreTransport(t *testing.T
 func TestAUnitIsRefusedAMessageCarryingFilesItCannotPutAnywhere(t *testing.T) {
 	sender := &capturedSend{receipt: extension.Receipt{ProviderMessageID: "provider-42"}}
 	declaresTransport(t, "mine", extension.Channel{
-		Provider: "mine_chat", Send: sender.send, Live: answersLive(true, nil),
+		Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: sender.send, Live: answersLive(true, nil),
 	})
 	resolved, _, err := commsResolver{}.ResolveChannel(context.Background(), ids.New[ids.UserKind](), "mine_chat")
 	if err != nil {

--- a/backend/internal/compose/extingress_integration_test.go
+++ b/backend/internal/compose/extingress_integration_test.go
@@ -67,7 +67,7 @@ func setupIngress(t *testing.T) *ingressEnv {
 		// is the shape a channel unit actually has — and what a unit may name on a
 		// message is bounded by this declaration, so a set without it would leave
 		// the message tests refused for a reason the test never chose.
-		[]extension.Channel{{Provider: ingressProbeProvider}},
+		[]extension.Channel{{Provider: ingressProbeProvider, CredentialModel: extension.CredentialPerMember}},
 		extension.IngressSource{
 			System: ingressProbeSystem, Lands: []extension.RecordKind{extension.KindActivity},
 		})

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -244,7 +244,7 @@ func fieldsOf(t reflect.Type) map[string]bool {
 // both doors actually call it — which is the half that regresses, since a door
 // can be added or rewritten without anyone noticing the gate went missing.
 func TestAUnitMayNameOnlyItsOwnTransportThroughEitherDoor(t *testing.T) {
-	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember})
 
 	if err := refuseUndeclaredTransport("mine", activities.KindMessage, "mine_chat"); err != nil {
 		t.Errorf("a unit filing a message on the transport it declared was refused (%v); the declaration is what the permission is bounded by, so this is the case that must pass", err)
@@ -301,7 +301,7 @@ func TestAUnitMayNameOnlyItsOwnTransportThroughEitherDoor(t *testing.T) {
 // account under a core connector's provider could attach an account it controls
 // to somebody else's person record and inherit the replies meant for them.
 func TestAUnitMayBindAnAccountOnlyOnItsOwnTransport(t *testing.T) {
-	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat"})
+	declaresTransport(t, "mine", extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember})
 
 	if err := refuseUnitIdentity("mine", "mine_chat"); err != nil {
 		t.Errorf("binding an account on the unit's own transport was refused (%v)", err)

--- a/backend/internal/compose/extingressmergekey_integration_test.go
+++ b/backend/internal/compose/extingressmergekey_integration_test.go
@@ -26,7 +26,7 @@ func setupVouchingIngress(t *testing.T) *ingressEnv {
 	t.Helper()
 	e := setupExtRuntime(t)
 	composeCapturingUnit(t, ingressUnit,
-		[]extension.Channel{{Provider: ingressProbeProvider}},
+		[]extension.Channel{{Provider: ingressProbeProvider, CredentialModel: extension.CredentialPerMember}},
 		extension.IngressSource{
 			System: ingressProbeSystem,
 			Lands:  []extension.RecordKind{extension.KindActivity},

--- a/backend/internal/compose/handlers_channelproviders.go
+++ b/backend/internal/compose/handlers_channelproviders.go
@@ -104,22 +104,35 @@ func publishedCaptureSources(exts []extension.Extension) *[]crmcontracts.Capture
 // handler so the shaping is testable without a request, and sorted so the page
 // is stable — a directory that reorders between calls makes a diff of two
 // deployments unreadable.
-func publishedChannelProviders(registered []string, sending map[string]connector.Carriage) []crmcontracts.ChannelProviderEntry {
-	facts := channelProviderFactsFor(registered, sending)
-	out := make([]crmcontracts.ChannelProviderEntry, 0, len(facts))
-	for _, f := range facts {
+// Two sources, and the split is the point.
+//
+// WHAT A TRANSPORT IS comes from the registry row, carried through the boot
+// snapshot: its label, and whose credential it spends. Those are facts about the
+// registration and the same on every role.
+//
+// WHETHER A REPLY CAN LEAVE comes from the COMPOSED set, and never from the row.
+// `supplies_transport` answers "can this installation send on it", which is a
+// question about what this binary compiled in — a role that composed no sender
+// must publish false however the registry is stamped, or a rep is offered a
+// reply box that parks every message it takes. Carriage rides along for the same
+// reason: what a transport can carry alongside a message is a property of the
+// sender, not of the registration.
+func publishedChannelProviders(registered []channelProviderFacts, sending map[string]connector.Carriage) []crmcontracts.ChannelProviderEntry {
+	out := make([]crmcontracts.ChannelProviderEntry, 0, len(registered))
+	for _, f := range registered {
+		carriage, sends := sending[f.provider]
 		entry := crmcontracts.ChannelProviderEntry{
 			Provider:          f.provider,
 			Label:             f.label,
 			CredentialModel:   crmcontracts.ChannelProviderEntryCredentialModel(f.credentialModel),
-			SuppliesTransport: f.suppliesTransport,
+			SuppliesTransport: sends,
 		}
 		// Field by field rather than a shared struct: the contract's entry
 		// declares the object inline, so there is no named type to convert to.
-		entry.Attachments.Carries = f.carriage.Carries
-		entry.Attachments.MaxFiles = f.carriage.MaxFiles
-		entry.Attachments.MaxBytesPerFile = f.carriage.MaxBytesPerFile
-		entry.Attachments.MaxBodyWithFiles = f.carriage.MaxBodyWithFiles
+		entry.Attachments.Carries = carriage.Carries
+		entry.Attachments.MaxFiles = carriage.MaxFiles
+		entry.Attachments.MaxBytesPerFile = carriage.MaxBytesPerFile
+		entry.Attachments.MaxBodyWithFiles = carriage.MaxBodyWithFiles
 		out = append(out, entry)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Provider < out[j].Provider })

--- a/backend/internal/compose/integration/audienceorphanarms_integration_test.go
+++ b/backend/internal/compose/integration/audienceorphanarms_integration_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The audience gate is spelled twice, and this is what holds the two spellings
+// together.
+//
+// `activityAudienceArm` asks whether ONE named caller may read a message.
+// `ActivityHasAReaderTx` asks whether ANYBODY may — the question an audience
+// write owes, because a write that leaves the answer false has not narrowed the
+// message, it has deleted it from view with no way back. The two bind the user
+// differently, so they are different SQL rather than one clause with a
+// different operand (audienceorphan.go says why), and nothing in the compiler
+// notices when one grows an arm the other lacks.
+//
+// Each case below builds a row whose ONLY admitting arm is the named one, then
+// asks both functions about it. They must agree, and the agreement has to fail
+// in both directions:
+//
+//   - an arm the read clause has and the refusal lacks → a legal write refused,
+//     which is loud;
+//   - an arm the refusal keeps after the read clause dropped it → an orphan
+//     admitted, which is silent, and is the half no ordinary assertion notices.
+//
+// THE ARM SOURCES ARE SEEDED DIRECTLY, which AGENTS.md otherwise warns against.
+// It is right here because the SUBJECT is the predicate, not the writer: what is
+// under test is what the gate makes of a row in a given shape, and reaching each
+// shape through the producer that happens to write it today would test the
+// producers instead — and could not reach `no arm at all`, which is the case the
+// whole invariant exists for.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// armCase is one way a human is admitted to an activity's content: the row
+// shape that admits through that arm alone, and the seat it admits.
+type armCase struct {
+	name string
+	// audience the row carries. `participants` is the value that turns the
+	// workspace arm off without naming anybody, which is what makes every
+	// other arm the sole one under test.
+	audience string
+	// arrange puts the row into the shape this arm is about. It returns the
+	// user the arm should admit, or ids.Nil when the arm admits nobody.
+	arrange func(t *testing.T, e *Env, tx pgx.Tx, activityID ids.UUID) ids.UUID
+	// teams is what identity's loadGrants would hand that user's principal.
+	//
+	// It is stated per case rather than derived, because the harness's As binds
+	// TeamIDs DIRECTLY and never runs loadGrants — so a case that simply passed
+	// every team the user belongs to would model a principal the product never
+	// builds, and would quietly assert that an ARCHIVED team still admits its
+	// members. loadGrants joins `team ... archived_at IS NULL`, so a live team
+	// the user is in appears here and an archived one does not. That difference
+	// is the whole subject of two cases below.
+	teams []ids.UUID
+}
+
+// seedBareActivity writes an activity carrying none of the arms: captured by a
+// connector that names no human, imported by no mailbox, with no participant
+// and no audience member. Every case below starts here and adds exactly one.
+func seedBareActivity(t *testing.T, tx pgx.Tx, audience string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := tx.Exec(context.Background(), `
+		INSERT INTO activity (id, kind, channel_provider, direction, occurred_at, source, captured_by, audience, body)
+		VALUES ($1, 'message', 'telegram', 'inbound', now(), 'telegram', 'connector:telegram', $2, 'hello')`,
+		id, audience); err != nil {
+		t.Fatalf("seeding the bare activity: %v", err)
+	}
+	return id
+}
+
+func audienceArmCases(teamOne ids.UUID) []armCase {
+	return []armCase{
+		{
+			name:     "the workspace audience admits everyone",
+			audience: "workspace",
+			arrange:  func(_ *testing.T, e *Env, _ pgx.Tx, _ ids.UUID) ids.UUID { return e.Rep3 },
+		},
+		{
+			name:     "captured_by ending in a live user id admits that user",
+			audience: "participants",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(),
+					`UPDATE activity SET captured_by = 'connector:gmail:' || $2 WHERE id = $1`,
+					id, e.Rep1); err != nil {
+					t.Fatalf("stamping the provenance: %v", err)
+				}
+				return e.Rep1
+			},
+		},
+		{
+			name:     "an import row admits the mailbox that brought it in",
+			audience: "participants",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(),
+					`INSERT INTO capture_import (activity_id, user_id) VALUES ($1, $2)`,
+					id, e.Rep1); err != nil {
+					t.Fatalf("seeding the import row: %v", err)
+				}
+				return e.Rep1
+			},
+		},
+		{
+			name:     "a participant row admits the person on the conversation",
+			audience: "participants",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(),
+					`INSERT INTO activity_participant (activity_id, role, user_id) VALUES ($1, 'to', $2)`,
+					id, e.Rep1); err != nil {
+					t.Fatalf("seeding the participant row: %v", err)
+				}
+				return e.Rep1
+			},
+		},
+		{
+			name:     "a selected membership admits the named user",
+			audience: "selected",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(), `
+					INSERT INTO activity_audience_member (activity_id, subject_type, subject_id, created_by)
+					VALUES ($1, 'user', $2, $3)`, id, e.Rep1, e.AdminUser); err != nil {
+					t.Fatalf("seeding the audience member: %v", err)
+				}
+				return e.Rep1
+			},
+		},
+		{
+			name:     "a selected team with a member admits that member",
+			audience: "selected",
+			// Live, and Rep1 is in it, so loadGrants would carry it.
+			teams: []ids.UUID{teamOne},
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(), `
+					INSERT INTO activity_audience_member (activity_id, subject_type, subject_id, created_by)
+					VALUES ($1, 'team', $2, $3)`, id, e.Team1, e.AdminUser); err != nil {
+					t.Fatalf("seeding the team audience member: %v", err)
+				}
+				return e.Rep1
+			},
+		},
+		{
+			// An ARCHIVED team resolves no share. Its membership rows survive so
+			// a restore brings them back, but identity's loadGrants joins
+			// `team ... archived_at IS NULL` before a team id reaches a
+			// principal, so the read arm can never match one. Counting the
+			// membership rows alone would answer "somebody can read it" about a
+			// team nobody is in — an orphan admitted rather than refused, which
+			// is the direction nothing downstream notices.
+			name:     "a selected team that has been archived admits nobody",
+			audience: "selected",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(), `
+					INSERT INTO activity_audience_member (activity_id, subject_type, subject_id, created_by)
+					VALUES ($1, 'team', $2, $3)`, id, e.Team1, e.AdminUser); err != nil {
+					t.Fatalf("seeding the team audience member: %v", err)
+				}
+				if _, err := tx.Exec(context.Background(),
+					`UPDATE team SET archived_at = now() WHERE id = $1`, e.Team1); err != nil {
+					t.Fatalf("archiving the team: %v", err)
+				}
+				return ids.Nil
+			},
+		},
+		{
+			name:     "an empty selected team admits nobody",
+			audience: "selected",
+			arrange: func(t *testing.T, e *Env, tx pgx.Tx, id ids.UUID) ids.UUID {
+				t.Helper()
+				if _, err := tx.Exec(context.Background(), `
+					INSERT INTO activity_audience_member (activity_id, subject_type, subject_id, created_by)
+					VALUES ($1, 'team', $2, $3)`, id, e.Team2, e.AdminUser); err != nil {
+					t.Fatalf("seeding the team audience member: %v", err)
+				}
+				if _, err := tx.Exec(context.Background(),
+					`DELETE FROM team_membership WHERE team_id = $1`, e.Team2); err != nil {
+					t.Fatalf("emptying the team: %v", err)
+				}
+				return ids.Nil
+			},
+		},
+		{
+			name:     "no arm at all admits nobody",
+			audience: "participants",
+			arrange:  func(_ *testing.T, _ *Env, _ pgx.Tx, _ ids.UUID) ids.UUID { return ids.Nil },
+		},
+		{
+			name:     "a selected audience naming nobody admits nobody",
+			audience: "selected",
+			arrange:  func(_ *testing.T, _ *Env, _ pgx.Tx, _ ids.UUID) ids.UUID { return ids.Nil },
+		},
+	}
+}
+
+// readsContent answers whether this caller may read the row's CONTENT, through
+// the real read path rather than by re-composing the clause here — a test that
+// spelled the arm again would be a third writer of the thing under test.
+func readsContent(ctx context.Context, t *testing.T, e *Env, id ids.UUID) bool {
+	t.Helper()
+	got, err := e.Activities.GetActivity(ctx, ids.From[ids.ActivityKind](id), storekit.LiveOnly)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		// Not discoverable at all is not readable either, which is the answer
+		// this function is about.
+		return false
+	}
+	if err != nil {
+		// Anything else is the read path being broken, and swallowing it would
+		// let a wrong DSN or a dropped table read as "nobody can see this row" —
+		// which is what half these cases EXPECT, so the suite would go green on
+		// a harness that is not exercising the gate at all.
+		t.Fatalf("reading the activity back: %v", err)
+	}
+	return got.ContentState != nil && *got.ContentState == crmcontracts.ActivityContentStateAvailable
+}
+
+// TestTheOrphanRefusalAgreesWithTheAudienceGateArmForArm is the parity claim.
+func TestTheOrphanRefusalAgreesWithTheAudienceGateArmForArm(t *testing.T) {
+	e := Setup(t)
+	for _, tc := range audienceArmCases(e.Team1) {
+		t.Run(tc.name, func(t *testing.T) {
+			var admits ids.UUID
+			var id ids.UUID
+			if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+				id = seedBareActivity(t, tx, tc.audience)
+				admits = tc.arrange(t, e, tx, id)
+				return nil
+			}); err != nil {
+				t.Fatalf("arranging the row: %v", err)
+			}
+
+			// What the REFUSAL believes.
+			var hasReader bool
+			if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+				var err error
+				hasReader, err = auth.ActivityHasAReaderTx(context.Background(), tx, id)
+				return err
+			}); err != nil {
+				t.Fatalf("asking whether the row has a reader: %v", err)
+			}
+
+			wantReader := admits != ids.Nil
+			if hasReader != wantReader {
+				t.Fatalf("ActivityHasAReaderTx = %v, want %v — the refusal and the audience gate "+
+					"disagree about this arm, so one of them has an arm the other does not", hasReader, wantReader)
+			}
+
+			// And what the READ CLAUSE believes, over the same row: the parity
+			// is only worth something if the human the arm names really does
+			// get in, and if nobody at all gets into the arm-less row.
+			if wantReader && !readsContent(e.As(admits, tc.teams, activityLifecyclePerms), t, e, id) {
+				t.Fatal("the arm's own user cannot read the row it admits them to — " +
+					"ActivityHasAReaderTx said somebody could, and the read clause disagrees")
+			}
+			// Rep3 carries the case's own teams too: a row that admits NOBODY
+			// must admit nobody even to a reader holding every grant the
+			// admitted case would have had.
+			if !wantReader && readsContent(e.As(e.Rep3, tc.teams, activityLifecyclePerms), t, e, id) {
+				t.Fatal("a row with no arm was readable anyway — the read clause is not filtering, " +
+					"so every agreement above is vacuous")
+			}
+		})
+	}
+}

--- a/backend/internal/compose/integration/channels/telegram_audienceorphan_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_audienceorphan_integration_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package channels
+
+// Narrowing a captured channel message must not leave it readable by nobody.
+//
+// A Telegram message satisfies exactly ONE arm of the activity audience gate:
+// `audience = 'workspace'`. Its captured_by is a bare `connector:telegram` with
+// no trailing uuid, no mailbox imported it, and the sink stamps no our-side
+// participant because a bot binding has no owner. So a write that turns the
+// first arm off turns every arm off — and the row cannot be widened back,
+// because widening needs the content visibility the write just destroyed.
+//
+// The whole leg runs: the real poll, the real sink, the real audience writer.
+// A test that inserted an activity row by hand would prove nothing about the
+// arms, because the arms are about what capture actually wrote.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// audienceWriterCtx binds the seat that reaches PATCH /activities/{id}/audience
+// on the shipped path: a human on a full seat holding activity.update, on the
+// widest row scope, so nothing about ROW authority is what the assertions
+// below are measuring.
+//
+// It is the SEEDED admin rather than a minted id, because `selected` names a
+// real app_user row — and because the connecting admin holding no reader arm on
+// a message their own bot captured is the sharper version of the claim: a
+// channel connection's connected_by is audit-only and confers nothing.
+func (c *telegramEnv) audienceWriterCtx(t *testing.T) context.Context {
+	t.Helper()
+	user, err := ids.Parse(c.admin)
+	if err != nil {
+		t.Fatalf("parsing the admin id: %v", err)
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), c.workspaceID(t))
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + c.admin, UserID: user,
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"activity": {Read: true, Update: true},
+				"person":   {Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
+
+// captureOneChannelMessage runs the whole ingress leg and answers the activity
+// it produced, as the typed id the audience writer takes.
+func captureOneChannelMessage(t *testing.T, c *telegramEnv, u telegramUpdate) ids.ActivityID {
+	t.Helper()
+	c.ingestOne(t, u, compose.JobRunnerConfig{})
+	activityID, _ := c.capturedMessage(t, u)
+	id, err := ids.ParseAs[ids.ActivityKind](activityID)
+	if err != nil {
+		t.Fatalf("parsing the captured activity id: %v", err)
+	}
+	return id
+}
+
+// TestNarrowingAChannelMessageToParticipantsIsRefused is the invariant: an
+// audience write may not leave a message with no human reader.
+//
+// `participants` is the case that does it. The refusal is the fix rather than
+// hiding the control in the browser, because the browser hiding a button stops
+// no API client.
+func TestNarrowingAChannelMessageToParticipantsIsRefused(t *testing.T) {
+	c := setupTelegramConnected(t)
+	id := captureOneChannelMessage(t, c,
+		telegramUpdate{updateID: 7301, messageID: 41, senderID: 770301, username: "orphan", firstName: "Ann", text: "Do you still ship to Vienna?"})
+
+	store := activities.NewStore(c.DB())
+	writer := c.audienceWriterCtx(t)
+
+	if _, err := store.SetAudience(writer, id,
+		activities.SetAudienceInput{Audience: "participants"}); err == nil {
+		t.Fatal("narrowing a captured channel message to participants was accepted — " +
+			"the row now satisfies no arm of the audience gate and no human can read it or widen it back")
+	}
+
+	// The refusal has to be the WHOLE story: a partial write that narrowed the
+	// row and then failed would orphan it exactly as the accepted write did.
+	if _, err := store.GetActivityContent(writer, id, storekit.LiveOnly); err != nil {
+		t.Fatalf("the message is unreadable after the refused write: %v — "+
+			"the refusal committed part of the narrowing it exists to prevent", err)
+	}
+}
+
+// TestNarrowingAChannelMessageToSelectedStillWorks holds the refusal to its
+// reason rather than to the kind.
+//
+// `selected` naming somebody is survivable: the membership row IS an arm, so
+// the message keeps a reader and can be widened back by them. A refusal that
+// blocked this too would be a ban on narrowing channel messages, which is a
+// different rule with a different justification — and one nobody has asked for.
+func TestNarrowingAChannelMessageToSelectedStillWorks(t *testing.T) {
+	c := setupTelegramConnected(t)
+	id := captureOneChannelMessage(t, c,
+		telegramUpdate{updateID: 7302, messageID: 42, senderID: 770302, username: "selected", firstName: "Bo", text: "Sending the PO now."})
+
+	store := activities.NewStore(c.DB())
+	writer := c.audienceWriterCtx(t)
+	me, ok := principal.Actor(writer)
+	if !ok {
+		t.Fatal("the writer context carries no actor")
+	}
+
+	if _, err := store.SetAudience(writer, id, activities.SetAudienceInput{
+		Audience: "selected",
+		Members:  []activities.AudienceMember{{SubjectType: "user", SubjectID: me.UserID}},
+	}); err != nil {
+		t.Fatalf("narrowing a captured channel message to a named reader was refused: %v — "+
+			"the rule is about leaving no reader, not about the kind", err)
+	}
+
+	if _, err := store.GetActivityContent(writer, id, storekit.LiveOnly); err != nil {
+		t.Fatalf("the named reader cannot read the message they were named on: %v", err)
+	}
+}

--- a/backend/internal/compose/integration/channels/telegram_audienceorphan_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_audienceorphan_integration_test.go
@@ -20,6 +20,7 @@ package channels
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose"
@@ -87,10 +88,13 @@ func TestNarrowingAChannelMessageToParticipantsIsRefused(t *testing.T) {
 	store := activities.NewStore(c.DB())
 	writer := c.audienceWriterCtx(t)
 
-	if _, err := store.SetAudience(writer, id,
-		activities.SetAudienceInput{Audience: "participants"}); err == nil {
-		t.Fatal("narrowing a captured channel message to participants was accepted — " +
-			"the row now satisfies no arm of the audience gate and no human can read it or widen it back")
+	_, err := store.SetAudience(writer, id,
+		activities.SetAudienceInput{Audience: "participants"})
+	var orphaned *activities.OrphanedAudienceError
+	if !errors.As(err, &orphaned) {
+		t.Fatalf("narrowing a captured channel message to participants answered %v — "+
+			"the refusal has to be the orphan refusal itself, because any other error "+
+			"leaves the row satisfying no arm of the audience gate whenever that other cause goes away", err)
 	}
 
 	// The refusal has to be the WHOLE story: a partial write that narrowed the

--- a/backend/internal/compose/sendpreflight_test.go
+++ b/backend/internal/compose/sendpreflight_test.go
@@ -209,20 +209,20 @@ func TestSendCapableAsksTheUnitRatherThanTheWorkspaceBotTable(t *testing.T) {
 		wantErr error
 	}{
 		"a live connection can send": {
-			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(true, nil)},
+			channel: extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(true, nil)},
 			want:    true,
 		},
 		"a member who disconnected cannot": {
-			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, nil)},
+			channel: extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(false, nil)},
 		},
 		"a capture-only transport cannot": {
-			channel: extension.Channel{Provider: "mine_chat"},
+			channel: extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember},
 		},
 		// A pre-flight that cannot ask must not answer — the mail arm's own
 		// rule, applied here so a rep is never told at the composer something
 		// the transmission will contradict.
 		"a unit that could not answer reports the fault": {
-			channel: extension.Channel{Provider: "mine_chat", Send: (&capturedSend{}).send, Live: answersLive(false, unreachable)},
+			channel: extension.Channel{Provider: "mine_chat", CredentialModel: extension.CredentialPerMember, Send: (&capturedSend{}).send, Live: answersLive(false, unreachable)},
 			wantErr: unreachable,
 		},
 	} {

--- a/backend/internal/modules/activities/audience.go
+++ b/backend/internal/modules/activities/audience.go
@@ -122,6 +122,22 @@ func (s *Store) SetAudience(ctx context.Context, id ids.ActivityID, in SetAudien
 		if err := replaceAudienceMembers(ctx, tx, id, members); err != nil {
 			return err
 		}
+		// The state this write actually produced, asked of the audience gate
+		// itself: is there still a human who can read the message?
+		//
+		// AFTER the column and the member rows, not before them. A `selected`
+		// audience's readers are the rows replaceAudienceMembers just wrote, so
+		// a check that ran earlier would be answering about a state the write
+		// then changed — and the member set is exactly where the two ways to
+		// orphan a row by hand live: naming nobody, and naming only a team that
+		// has no members.
+		reachable, err := auth.ActivityHasAReaderTx(ctx, tx, id.UUID)
+		if err != nil {
+			return err
+		}
+		if !reachable {
+			return &OrphanedAudienceError{Audience: in.Audience}
+		}
 		stored, err := readAudienceImage(ctx, tx, id)
 		if err != nil {
 			return err
@@ -383,4 +399,32 @@ func (e *CapturedAudienceError) FieldFault() (field, code, message string) {
 	return "audience", "audience_is_derived",
 		"This message came from a mailbox, so who can read it follows from what each " +
 			"importing mailbox asks for. Share or keep the thread private instead."
+}
+
+// OrphanedAudienceError refuses an audience write that would leave the message
+// readable by nobody.
+//
+// The reachable case is a captured CHANNEL message narrowed to `participants`:
+// a bot binding has no seat, so the row's captured_by carries no user id, no
+// mailbox imported it and the sink stamped no our-side participant — and
+// `audience = 'workspace'` was the only arm holding it visible. Turning that
+// arm off leaves a row the system principal alone can read, which nothing can
+// undo: widening it back needs the content visibility the write just destroyed.
+//
+// The same refusal covers the two hand-made spellings of it — `selected`
+// naming nobody, and `selected` naming only an empty team — because the rule is
+// about the state produced, not about how a caller reached it.
+type OrphanedAudienceError struct {
+	Audience string
+}
+
+func (e *OrphanedAudienceError) Error() string {
+	return "activities: audience " + e.Audience + " would leave this message readable by nobody"
+}
+
+// FieldFault answers the orphaning write as a 422 on the audience field.
+func (e *OrphanedAudienceError) FieldFault() (field, code, message string) {
+	return "audience", "audience_leaves_no_reader",
+		"Nobody would be able to read this message afterwards, including you, and it " +
+			"could not be re-opened. Choose people to share it with instead."
 }

--- a/backend/internal/platform/auth/audienceorphan.go
+++ b/backend/internal/platform/auth/audienceorphan.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// The audience gate asked the other way round: not "may this caller read the
+// row" but "may anybody". An audience write owes that question, because a write
+// that leaves the answer no has not narrowed the message — it has deleted it
+// from view, and irreversibly.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ActivityHasAReaderTx answers whether ANY human is admitted to this
+// activity's content as the row now stands.
+//
+// It is activityAudienceArm's existential twin: that one asks whether ONE named
+// caller matches an arm, this one asks whether anybody does. An audience write
+// that leaves the answer false has not narrowed the message, it has deleted it
+// from view — and irreversibly, because widening it back needs the content
+// visibility the write destroyed.
+//
+// WHY IT IS A SECOND SPELLING RATHER THAN A SHARED CLAUSE. The two questions
+// bind the user differently, and that changes each arm's SQL shape rather than
+// only its operand: `captured_by LIKE '%:<me>'` becomes a join against every
+// live user, `ci.user_id = $me` becomes a bare EXISTS, and a `selected`
+// membership stops being "is it me" and becomes "does this subject name anybody
+// at all" — a team names its members, and an empty team names none.
+// A parameterised single spelling would have to carry all three shapes and
+// would read as neither. What holds the pair together instead is a test that
+// builds a row admitted by each arm alone and asserts the two functions agree
+// about it. It has to fail in BOTH directions: a refusal that missed an arm
+// refuses a legal write, and one that kept an arm the read clause has dropped
+// admits the orphan silently, which is the half no assertion would notice.
+//
+// Held by: TestTheOrphanRefusalAgreesWithTheAudienceGateArmForArm
+// (backend/internal/compose/integration/audienceorphanarms_integration_test.go)
+//
+// WHERE THE MIRROR STOPS, stated once so the two halves below are one rule and
+// not two exceptions.
+//
+// What is mirrored is the ARM — including any input the read side computes
+// OUTSIDE the SQL. Team ids are the case: identity's loadGrants joins
+// `team ... archived_at IS NULL` before a team id ever reaches a principal, so
+// the read arm's `am.subject_id = ANY($teams)` can never match an archived team
+// however many membership rows it keeps. Counting those rows here would answer
+// "somebody can read it" about a team nobody is currently in — the orphan
+// admitted rather than refused, which is the one direction of drift no
+// assertion downstream would catch. So the join carries that filter too.
+//
+// What is NOT mirrored is anything that gates every read alike rather than this
+// arm. Authentication is the one that matters: an archived account's uuid still
+// sitting in captured_by counts as a reader here, exactly as it does in the read
+// clause, and that seat cannot sign in to use it. Filtering it only here would
+// make the refusal stricter than the gate it mirrors, with no fitness function
+// behind the difference — and `status = 'active' AND archived_at IS NULL` has an
+// owner already (identity.LiveMemberSQL, which this package may not import), so
+// a third spelling would be the duplication this file exists to argue against.
+// Whether a departed seat's provenance should keep admitting a row at all is one
+// question about the READ clause, and it is not this one.
+//
+// It answers the AUDIENCE question alone. Reading content is
+// `discover AND audience`, and row scope is the other half: a named reader whose
+// scope reaches none of the activity's links still cannot open it. That is a
+// separate axis which a later scope change can flip either way, so the refusal
+// does not pretend to it — "nobody can read this" is proven here only in the
+// sense the audience column decides.
+func ActivityHasAReaderTx(ctx context.Context, tx pgx.Tx, id ids.UUID) (bool, error) {
+	var reachable bool
+	if err := tx.QueryRow(ctx, `
+		SELECT a.audience = 'workspace'
+		    OR EXISTS (SELECT 1 FROM app_user u WHERE a.captured_by LIKE '%:' || u.id)
+		    OR EXISTS (SELECT 1 FROM capture_import ci WHERE ci.activity_id = a.id)
+		    OR EXISTS (SELECT 1 FROM activity_participant ap
+		                WHERE ap.activity_id = a.id AND ap.user_id IS NOT NULL)
+		    OR (a.audience = 'selected' AND EXISTS (
+		          SELECT 1 FROM activity_audience_member am
+		           WHERE am.activity_id = a.id
+		             AND (am.subject_type = 'user'
+		               OR (am.subject_type = 'team' AND EXISTS (
+		                     SELECT 1 FROM team_membership tm
+		                       JOIN team t ON t.id = tm.team_id AND t.archived_at IS NULL
+		                      WHERE tm.team_id = am.subject_id)))))
+		  FROM activity a WHERE a.id = $1`, id).Scan(&reachable); err != nil {
+		return false, fmt.Errorf("auth: reading whether an activity still has a reader: %w", err)
+	}
+	return reachable, nil
+}

--- a/backend/internal/platform/auth/audienceorphanparity_test.go
+++ b/backend/internal/platform/auth/audienceorphanparity_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// The audience gate is spelled twice, and the integration suite holds the pair
+// arm by arm — for the arms somebody thought to list.
+//
+// That is the hole this file closes. A NEW arm added to one spelling has no case
+// over there, so a hand-enumerated parity suite passes while the two disagree
+// about a shape nobody wrote down. This asks the question the enumeration
+// cannot: do both SQL texts draw on the same set of relations?
+//
+// It reads the rendered SQL rather than a list kept beside it, because a list is
+// the second copy of the subject that AGENTS.md warns a gate not to become. Add
+// a table to one side and this fails naming it, whichever side grew it.
+//
+// The two are not identical queries and are not meant to be — the existential
+// resolves subjects the read clause receives ready-made — so what the existential
+// may hold BEYOND the shared arms is named here, each with the reason it is
+// resolution rather than an arm of its own. That list is the honest cost of the
+// second spelling and it is meant to stay short.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// resolutionOnlyRelations are the relations the existential twin reads that are
+// not arms — they resolve, per row, a value the read clause is simply HANDED by
+// the principal. Each is a claim, not an exemption: if one of these ever starts
+// deciding who may read, it belongs in the read clause too and this list is
+// where the next author is told to look.
+var resolutionOnlyRelations = gatekit.Waive(map[string]string{
+	// The read clause is given the caller's own uuid; the existential has to
+	// ask which uuids exist at all to match the captured_by suffix arm.
+	"app_user": "resolves the captured_by suffix arm against every user, where the read clause is handed one",
+	// The read clause is given p.TeamIDs, already filtered to live teams by
+	// identity's loadGrants; the existential has to do that filtering itself.
+	"team_membership": "resolves a selected team to its members, which the read clause receives as p.TeamIDs",
+	"team":            "carries loadGrants' own archived_at filter into the team resolution above",
+	// The existential is a standalone query and names its own subject; the read
+	// clause is a fragment composed into somebody else's FROM.
+	"activity": "the existential is a whole query and names the row it is about",
+})
+
+// sqlOf reads a function's query out of its own source.
+//
+// The query stays INLINE in the function it runs in, where the restricted-reader
+// census can see it: that gate attributes a reader by walking function bodies for
+// the activity table, and hoisting the text to a package-level constant took the
+// reader out of its view entirely — it reported PASS with no waiver and no
+// finding, which is the shape AGENTS.md calls a census that has already failed.
+// So the text is not moved to suit this test; this test goes and reads it, which
+// is also what keeps there being exactly one copy of it.
+func sqlOf(t *testing.T, file, fn string) string {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	var sql strings.Builder
+	for _, decl := range parsed.Decls {
+		d, ok := decl.(*ast.FuncDecl)
+		if !ok || d.Name.Name != fn {
+			continue
+		}
+		ast.Inspect(d, func(n ast.Node) bool {
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				sql.WriteString(lit.Value)
+				sql.WriteString("\n")
+			}
+			return true
+		})
+	}
+	if sql.Len() == 0 {
+		t.Fatalf("found no query in %s:%s — the extraction is broken, so every comparison is vacuous", file, fn)
+	}
+	return sql.String()
+}
+
+// relationsIn collects the relations a SQL text reads, from its own FROM and
+// JOIN clauses. Derived from the text so neither spelling can grow a source this
+// test does not see.
+func relationsIn(sql string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range regexp.MustCompile(`(?i)\b(?:FROM|JOIN)\s+([a-z_][a-z0-9_]*)`).FindAllStringSubmatch(sql, -1) {
+		out[strings.ToLower(m[1])] = true
+	}
+	return out
+}
+
+// TestBothSpellingsOfTheAudienceGateDrawOnTheSameArms is the fitness function
+// behind the hand-enumerated parity cases: it fails when either spelling grows a
+// relation the other lacks, without anybody having to think of the case.
+func TestBothSpellingsOfTheAudienceGateDrawOnTheSameArms(t *testing.T) {
+	// A fixture principal, only so the clause renders: what is under test is
+	// which relations the SQL names, which no principal changes.
+	n := 0
+	arg := func(any) int { n++; return n }
+	readSide := relationsIn(activityAudienceArm(principal.Principal{
+		Type: principal.PrincipalHuman, UserID: ids.NewV7(),
+	}, "a", arg))
+	if len(readSide) == 0 {
+		t.Fatal("the read clause names no relation at all — the extraction is broken, so every comparison below is vacuous")
+	}
+	existential := relationsIn(sqlOf(t, "audienceorphan.go", "ActivityHasAReaderTx"))
+
+	var missing, extra []string
+	for rel := range readSide {
+		if !existential[rel] {
+			missing = append(missing, rel)
+		}
+	}
+	for rel := range existential {
+		if readSide[rel] {
+			continue
+		}
+		if !resolutionOnlyRelations.Waived(t, rel) {
+			extra = append(extra, rel)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+
+	if len(missing) > 0 {
+		t.Errorf("the read clause admits readers through %v and the orphan refusal does not look there — "+
+			"a legal audience write will be refused as leaving nobody", missing)
+	}
+	// A named relation that no longer appears is ratification of SQL that is
+	// gone, which is how a waiver list turns into a list of stale claims.
+	resolutionOnlyRelations.AssertAllMatched(t)
+
+	if len(extra) > 0 {
+		t.Errorf("the orphan refusal reads %v, which no longer admits anybody through the read clause — "+
+			"it will report a reader for a row nobody can open, which is the orphan admitted silently. "+
+			"If one of these resolves a value rather than deciding a reader, name it in resolutionOnlyRelations with that reason", extra)
+	}
+}

--- a/backend/internal/platform/auth/inheritedscope.go
+++ b/backend/internal/platform/auth/inheritedscope.go
@@ -135,6 +135,11 @@ func ActivityAudienceArm(ctx context.Context, alias string, arg func(any) int) (
 // activityAudienceArm renders the audience membership test for one human (or
 // the human behind an agent). The participant arms hold for every audience:
 // a person on a conversation always reads it, limited or not.
+//
+// Its existential twin — does ANYBODY match, which is the question an audience
+// write owes before it narrows a row — is ActivityHasAReaderTx in
+// audienceorphan.go. Change an arm here and change it there; the pair is held by
+// a test named in that file's doc comment.
 func activityAudienceArm(p principal.Principal, alias string, arg func(any) int) string {
 	me := arg(p.UserID)
 	// captured_by is `human:<uuid>` for a hand-logged row and

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5162,6 +5162,31 @@ public.team_weekly_review.team_weekly_review_name_present CHECK ((btrim(team_nam
 public.team_weekly_review.team_weekly_review_pkey PRIMARY KEY (id)
 public.team_weekly_review.team_weekly_review_subsets CHECK (((meetings_with_next_step <= meetings_held) AND (commitments_kept <= commitments_due) AND ((leads_answered_in_target + leads_breached) <= leads_routed)))
 public.team_weekly_review.uq_team_weekly_review_team_week UNIQUE (team_id, local_week_start)
+public.team_weekly_review_outlook acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.team_weekly_review_outlook.base_currency text NOT NULL gen=- def=-
+public.team_weekly_review_outlook.best_case_minor bigint gen=- def=-
+public.team_weekly_review_outlook.closing_landing_minor bigint gen=- def=-
+public.team_weekly_review_outlook.closing_snapshot_id uuid gen=- def=-
+public.team_weekly_review_outlook.commit_minor bigint gen=- def=-
+public.team_weekly_review_outlook.forward_measure text gen=- def=-
+public.team_weekly_review_outlook.id uuid NOT NULL gen=- def=uuidv7()
+public.team_weekly_review_outlook.opening_landing_minor bigint gen=- def=-
+public.team_weekly_review_outlook.opening_snapshot_id uuid gen=- def=-
+public.team_weekly_review_outlook.period_end date NOT NULL gen=- def=-
+public.team_weekly_review_outlook.period_kind text NOT NULL gen=- def=-
+public.team_weekly_review_outlook.period_start date NOT NULL gen=- def=-
+public.team_weekly_review_outlook.team_weekly_review_id uuid NOT NULL gen=- def=-
+public.team_weekly_review_outlook.team_weekly_review_outlook_currency_present CHECK ((btrim(base_currency) <> ''::text))
+public.team_weekly_review_outlook.team_weekly_review_outlook_measure_known CHECK (((forward_measure IS NULL) OR (forward_measure = ANY (ARRAY['commit_evidence'::text, 'weighted'::text, 'manager_call'::text]))))
+public.team_weekly_review_outlook.team_weekly_review_outlook_measure_with_landing CHECK ((NOT ((forward_measure IS NULL) IS DISTINCT FROM (closing_landing_minor IS NULL))))
+public.team_weekly_review_outlook.team_weekly_review_outlook_opening_whole CHECK ((NOT ((opening_snapshot_id IS NULL) IS DISTINCT FROM (opening_landing_minor IS NULL))))
+public.team_weekly_review_outlook.team_weekly_review_outlook_period_kind_check CHECK ((period_kind = ANY (ARRAY['week'::text, 'month'::text, 'quarter'::text])))
+public.team_weekly_review_outlook.team_weekly_review_outlook_pkey PRIMARY KEY (id)
+public.team_weekly_review_outlook.team_weekly_review_outlook_review_fkey FOREIGN KEY (team_weekly_review_id) REFERENCES team_weekly_review(id) ON DELETE CASCADE
+public.team_weekly_review_outlook.team_weekly_review_outlook_window_ordered CHECK ((period_end >= period_start))
+public.team_weekly_review_outlook.weighted_minor bigint gen=- def=-
+public.team_weekly_review_outlook.won_minor bigint gen=- def=-
+public.team_weekly_review_outlook_pkey CREATE UNIQUE INDEX team_weekly_review_outlook_pkey ON public.team_weekly_review_outlook USING btree (id)
 public.team_weekly_review_pkey CREATE UNIQUE INDEX team_weekly_review_pkey ON public.team_weekly_review USING btree (id)
 public.team_weekly_review_rep acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.team_weekly_review_rep.commitments_due integer NOT NULL gen=- def=0
@@ -5353,6 +5378,7 @@ public.uq_site_read_triage_inflight CREATE UNIQUE INDEX uq_site_read_triage_infl
 public.uq_site_read_ws_id CREATE UNIQUE INDEX uq_site_read_ws_id ON public.site_read USING btree (id)
 public.uq_stage_position CREATE UNIQUE INDEX uq_stage_position ON public.stage USING btree (pipeline_id, "position") WHERE (archived_at IS NULL)
 public.uq_tag_name CREATE UNIQUE INDEX uq_tag_name ON public.tag USING btree (lower(name)) WHERE (archived_at IS NULL)
+public.uq_team_weekly_review_outlook_period CREATE UNIQUE INDEX uq_team_weekly_review_outlook_period ON public.team_weekly_review_outlook USING btree (team_weekly_review_id, period_kind)
 public.uq_team_weekly_review_rep CREATE UNIQUE INDEX uq_team_weekly_review_rep ON public.team_weekly_review_rep USING btree (team_weekly_review_id, user_id)
 public.uq_team_weekly_review_team_week CREATE UNIQUE INDEX uq_team_weekly_review_team_week ON public.team_weekly_review USING btree (team_id, local_week_start)
 public.uq_transcript_read_inflight CREATE UNIQUE INDEX uq_transcript_read_inflight ON public.transcript_read USING btree (activity_id) WHERE (status = ANY (ARRAY['queued'::text, 'running'::text]))

--- a/backend/pkg/extension/channel.go
+++ b/backend/pkg/extension/channel.go
@@ -31,6 +31,53 @@ var providerGrammar = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 const maxProviderLength = 32
 
+// CredentialModel says WHOSE credential a transport spends: one the whole
+// installation shares, or one each member deposits over their own account.
+//
+// It is not a detail of the connection. It is the axis that decides whether a
+// captured message is the company's correspondence or one human's — a workspace
+// bot serves everybody, so its traffic is workspace business; a per-member
+// credential is one person's own account, so their chats are theirs, which is
+// the mailbox model with the same floor, holds and postures.
+//
+// IT DECIDES NOTHING YET, and saying otherwise here would be the false comment
+// that stops the next author looking. decideBirthTx returns early for every kind
+// that is not `email`, so a channel message is born `audience = 'workspace'`
+// whichever model its transport declared. What the declaration does today is
+// reach `channel_provider.credential_model` and the discovery endpoint, so an
+// operator can read whose credential a transport spends. The floor and the holds
+// key on it when they reach channel traffic; the value has to be right BEFORE
+// that, because at that point a wrong one is wrong silently.
+//
+// DECLARED, NEVER DERIVED, and the difference is the reason this type exists.
+// It used to be inferred from whether the transport was a unit or a core
+// connector, which is a proxy that answers wrongly the moment a unit ships a
+// company-wide account: an Official Account is a shared business channel that
+// happens to be packaged as a unit, and inferring `per_member` for it would put
+// a company's customer correspondence on the mailbox path with whichever admin
+// pasted the token as its "owner". No invariant catches that — the row has
+// exactly one reader and every gate reads green — so the declaration has to
+// carry it.
+type CredentialModel string
+
+const (
+	// CredentialWorkspaceBot is ONE credential for the whole installation: a
+	// bot, an Official Account, anything an administrator binds once on behalf
+	// of everybody.
+	CredentialWorkspaceBot CredentialModel = "workspace_bot" //nolint:gosec // G101 false positive: the SHAPE a credential takes, published in the contract's enum — not a credential
+	// CredentialPerMember is one sealed credential per member, deposited by
+	// that member over their own account.
+	CredentialPerMember CredentialModel = "per_member"
+)
+
+// Valid reports whether this is one of the two shapes a credential takes.
+// The zero value is not one: a unit that has not said gets refused rather than
+// defaulted, because either default is wrong for half the transports and wrong
+// silently.
+func (m CredentialModel) Valid() bool {
+	return m == CredentialWorkspaceBot || m == CredentialPerMember
+}
+
 // Channel is one messaging provider a unit supplies transport for.
 //
 // Inert declaration plus function fields, matching Job and Subscription: the
@@ -47,6 +94,11 @@ type Channel struct {
 	// column rather than a sibling declaration that happens to look similar —
 	// `deal-room` is a legal ingress system and an illegal provider.
 	Provider string
+
+	// CredentialModel says whose credential this transport spends. REQUIRED:
+	// there is no default, because both defaults are wrong for half the
+	// transports and wrong without saying so. See CredentialModel.
+	CredentialModel CredentialModel
 
 	// Send transmits one message.
 	//
@@ -140,6 +192,16 @@ func (c Channel) Validate() error {
 	if len([]rune(c.Provider)) > maxProviderLength {
 		return fmt.Errorf("%w: channel provider %q is longer than %d characters",
 			ErrInvalid, c.Provider, maxProviderLength)
+	}
+	// REFUSED rather than defaulted. Whose credential a transport spends is
+	// what decides whether its messages are the company's correspondence or one
+	// human's, and both defaults are wrong for half the transports — silently,
+	// because the wrong answer still produces a readable row. A unit that has
+	// not answered has not been asked yet, and costing them one line at boot is
+	// cheaper than either default costs the installation that gets it.
+	if !c.CredentialModel.Valid() {
+		return fmt.Errorf("%w: channel %q must declare CredentialModel — %s for one credential the whole installation shares (a bot, an official account), %s for one sealed credential per member. There is no default: it decides whether this transport's messages are the company's correspondence or one person's",
+			ErrInvalid, c.Provider, CredentialWorkspaceBot, CredentialPerMember)
 	}
 	// The pairing, refused HERE rather than at the send: a transport that can
 	// transmit and cannot report its own liveness would force the core to

--- a/backend/pkg/extension/channel_test.go
+++ b/backend/pkg/extension/channel_test.go
@@ -10,6 +10,7 @@ package extension_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -31,9 +32,10 @@ func aLiveCheck() extension.ConnectionLiveChecker {
 // documented capture-only case, not an incomplete declaration.
 func TestAWellFormedChannelIsAcceptedSendingOrNot(t *testing.T) {
 	for name, ch := range map[string]extension.Channel{
-		"a transport that sends": {Provider: "dispact", Send: aSender(), Live: aLiveCheck()},
-		"a capture-only channel": {Provider: "dispact"},
-		"digits and underscores": {Provider: "deal_room2"},
+		"a transport that sends": {Provider: "dispact", CredentialModel: extension.CredentialPerMember, Send: aSender(), Live: aLiveCheck()},
+		"a capture-only channel": {Provider: "dispact", CredentialModel: extension.CredentialPerMember},
+		"digits and underscores": {Provider: "deal_room2", CredentialModel: extension.CredentialPerMember},
+		"a company-wide account": {Provider: "official_account", CredentialModel: extension.CredentialWorkspaceBot},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := ch.Validate(); err != nil {
@@ -64,7 +66,7 @@ func TestTheProviderGrammarIsTheRegistryColumnsAndNotTheIngressDeclarations(t *t
 		"over the length cap":       strings.Repeat("c", 33),
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := (extension.Channel{Provider: provider}).Validate(); err == nil {
+			if err := (extension.Channel{Provider: provider, CredentialModel: extension.CredentialPerMember}).Validate(); err == nil {
 				t.Fatalf("the grammar accepted %q, which channel_provider's own CHECK would refuse", provider)
 			}
 		})
@@ -77,7 +79,7 @@ func TestTheProviderGrammarIsTheRegistryColumnsAndNotTheIngressDeclarations(t *t
 // have sent and retrying one it already did, at the one moment that choice is
 // unrecoverable.
 func TestATransportThatCanSendMustBeAbleToSayWhetherItStillMay(t *testing.T) {
-	err := extension.Channel{Provider: "dispact", Send: aSender()}.Validate()
+	err := extension.Channel{Provider: "dispact", CredentialModel: extension.CredentialPerMember, Send: aSender()}.Validate()
 	if err == nil {
 		t.Fatal("a channel declaring Send without Live was accepted")
 	}
@@ -87,7 +89,7 @@ func TestATransportThatCanSendMustBeAbleToSayWhetherItStillMay(t *testing.T) {
 	// The other way round is legal: a capture-only channel may still answer
 	// whether the member's connection exists, and there is nothing unsafe about
 	// knowing it.
-	if err := (extension.Channel{Provider: "dispact", Live: aLiveCheck()}).Validate(); err != nil {
+	if err := (extension.Channel{Provider: "dispact", CredentialModel: extension.CredentialPerMember, Live: aLiveCheck()}).Validate(); err != nil {
 		t.Fatalf("a capture-only channel that can report liveness was refused: %v", err)
 	}
 }
@@ -96,10 +98,47 @@ func TestATransportThatCanSendMustBeAbleToSayWhetherItStillMay(t *testing.T) {
 // transport directory publishes, so the endpoint and the boot cannot disagree
 // about which registered transports a reply can actually leave on.
 func TestSuppliesTransportIsTheDeclarationsOwnAnswer(t *testing.T) {
-	if (extension.Channel{Provider: "dispact"}).SuppliesTransport() {
+	if (extension.Channel{Provider: "dispact", CredentialModel: extension.CredentialPerMember}).SuppliesTransport() {
 		t.Error("a channel with no Send reported that it supplies transport; every reply staged against it would park")
 	}
-	if !(extension.Channel{Provider: "dispact", Send: aSender(), Live: aLiveCheck()}).SuppliesTransport() {
+	if !(extension.Channel{Provider: "dispact", CredentialModel: extension.CredentialPerMember, Send: aSender(), Live: aLiveCheck()}).SuppliesTransport() {
 		t.Error("a channel with a Send reported that it supplies none")
+	}
+}
+
+// Whose credential a transport spends has NO default, and a unit that has not
+// said so is refused.
+//
+// The temptation is a default, and both candidates are wrong in the same way.
+// Defaulting to per_member puts a company's shared account on the mailbox path
+// with whichever admin bound it as the owner of everybody's customer
+// correspondence; defaulting to workspace_bot publishes one member's personal
+// chats to every colleague. Neither shows up as an error — both produce a row
+// that reads perfectly well to whoever it wrongly belongs to — so the only
+// place the mistake can be caught is here, before it is made.
+func TestAChannelMustSayWhoseCredentialItSpends(t *testing.T) {
+	for name, ch := range map[string]extension.Channel{
+		"declares nothing":     {Provider: "dispact"},
+		"declares a non-model": {Provider: "dispact", CredentialModel: "oauth"},
+		"declares empty":       {Provider: "dispact", CredentialModel: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ch.Validate()
+			if err == nil {
+				t.Fatal("a channel that did not say whose credential it spends was accepted — " +
+					"the registry would then answer for it, which is the derivation this declaration replaced")
+			}
+			if !errors.Is(err, extension.ErrInvalid) {
+				t.Fatalf("refusal = %v, want ErrInvalid", err)
+			}
+			// The message has to name both models: a unit author reading it is
+			// deciding, not correcting a typo, and a refusal that says only
+			// "invalid" sends them to the source of a package they do not own.
+			for _, want := range []string{"workspace_bot", "per_member"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("refusal %q does not name %q — it has to say what the two choices mean", err, want)
+				}
+			}
+		})
 	}
 }

--- a/backend/tools/gen-composition/astreader_channel.go
+++ b/backend/tools/gen-composition/astreader_channel.go
@@ -7,7 +7,8 @@ package main
 //
 // A channel is a governed capability in the sense that matters to an operator:
 // it says this unit can transmit messages out of the installation, on a
-// transport it names, under a member's own credential. That belongs in the
+// transport it names, under whichever credential it declares — one the whole
+// installation shares, or each member's own. That belongs in the
 // manifest for the same reason a tool's requested tier does — an operator has to
 // be able to see it before the unit ever runs.
 //
@@ -73,6 +74,15 @@ func (r *unitReader) readChannel(elt ast.Expr, ext string) (declaredChannel, err
 		switch k.Name {
 		case "Provider":
 			ch.Provider, err = r.stringLit(kv.Value, "Channel.Provider")
+		case "CredentialModel":
+			// constValue, not a reader of its own: it already resolves a
+			// published extension constant through the vocabulary derived from
+			// pkg/extension's own source — which carries the two credential
+			// models — and it already refuses a constant from another package.
+			// Validate below refuses a value outside the two, naming both.
+			var model string
+			model, err = r.constValue(kv.Value, ext)
+			ch.CredentialModel = extension.CredentialModel(model)
 		case "Send":
 			ch.SuppliesTransport = !isNilIdent(kv.Value)
 		case "Live":
@@ -91,8 +101,11 @@ func (r *unitReader) readChannel(elt ast.Expr, ext string) (declaredChannel, err
 			"channel %q declares Send without Live — a transport that can send must be able to say whether it still may", ch.Provider)
 	}
 	// Validated through the PUBLISHED rule, exactly as an ingress source is, so
-	// generation-time acceptance cannot diverge from boot-time.
-	if err := (extension.Channel{Provider: ch.Provider}).Validate(); err != nil {
+	// generation-time acceptance cannot diverge from boot-time. The read values
+	// are carried in rather than a bare Provider: Validate now asks about the
+	// credential model too, and a probe that left it zero would refuse every
+	// unit here for a field the unit actually declared.
+	if err := (extension.Channel{Provider: ch.Provider, CredentialModel: ch.CredentialModel}).Validate(); err != nil {
 		return declaredChannel{}, r.errPos(lit, "%v", err)
 	}
 	return ch, nil

--- a/backend/tools/gen-composition/unitmanifest.go
+++ b/backend/tools/gen-composition/unitmanifest.go
@@ -167,6 +167,11 @@ type ingressSource struct {
 // it has one, which is what an operator needs before the unit ever runs.
 type declaredChannel struct {
 	Provider string `json:"provider"`
+	// CredentialModel mirrors extension.Channel.CredentialModel. It is in the
+	// manifest because it is what the registry publishes and what every privacy
+	// rule about a channel message keys on — a generated composition that
+	// dropped it would put the decision back where it was derived.
+	CredentialModel extension.CredentialModel `json:"credential_model"`
 	// SuppliesTransport mirrors extension.Channel.SuppliesTransport: false is
 	// the documented capture-only case, not an omission.
 	SuppliesTransport bool `json:"supplies_transport"`

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -176,7 +176,7 @@ blast radius before enabling it:
 | `secrets` | `Secrets` | Which keys the unit expects, and at which scope |
 | `subscriptions` | `Subscriptions` | Which of the installation's facts it consumes |
 | `ingress` | `Ingress` | Which providers it lands records from, which kinds, and which identity keys the source **vouches for** (`merges`) |
-| `channels` | `Channels` | Which providers it supplies, and whether it supplies a **transport** (`supplies_transport`) or captures only |
+| `channels` | `Channels` | Which providers it supplies, whose credential each one spends (`credential_model` — required, no default), and whether it supplies a **transport** (`supplies_transport`) or captures only |
 
 The returned `extension.Extension` literal and every field the manifest derives must be literal
 values; an unrecognized field fails generation with its position rather than producing a manifest

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -563,8 +563,32 @@ A `Channel` declares a messaging provider your unit can carry messages on, so a 
 conversation you captured leaves through your unit rather than a surface of your own:
 
 ```go
-Channels: []extension.Channel{{Provider: "relay", Send: send, Live: live}},
+Channels: []extension.Channel{{
+	Provider: "relay", CredentialModel: extension.CredentialPerMember,
+	Send: send, Live: live,
+}},
 ```
+
+`CredentialModel` is **required and has no default**. Say `extension.CredentialPerMember` when each
+member deposits their own credential over their own account; say `extension.CredentialWorkspaceBot`
+when one credential serves the whole installation — a bot, an official account, anything an
+administrator binds once for everybody. Omit it and generation refuses the unit, naming both
+choices.
+
+**It is recorded and published, and it does not yet decide anything.** Declaring
+`CredentialPerMember` today does NOT make a captured message private to that member: `decideBirthTx`
+returns early for every kind that is not `email`, so a message on your transport is born
+`audience = 'workspace'` — readable by every colleague — whichever model you declare. What the
+declaration currently does is land the right value in `channel_provider.credential_model` and
+publish it on `GET /v1/channel-providers`, so an operator can see whose credential a transport
+spends.
+
+Declare it correctly anyway, and declare it now. It is the axis the workspace mail-sharing floor and
+the per-seat holds will key on when they reach channel traffic, and a wrong value becomes wrong
+silently at that point: a per-member account read as the company's publishes one person's private
+chats to their colleagues, and a company account read as per-member hands a shared inbox to whoever
+connected it. Neither shows up as an error, because both produce a row that reads perfectly well to
+whoever it wrongly belongs to.
 
 ```go
 func send(ctx context.Context, rt extension.Runtime, msg extension.OutboundMessage) (extension.Receipt, error)

--- a/extensions/openchannel/manifest.generated.json
+++ b/extensions/openchannel/manifest.generated.json
@@ -160,6 +160,7 @@
   "channels": [
     {
       "provider": "openchannel",
+      "credential_model": "per_member",
       "supplies_transport": true
     }
   ],

--- a/extensions/openchannel/openchannel.go
+++ b/extensions/openchannel/openchannel.go
@@ -74,7 +74,10 @@ func New() extension.Extension {
 		// generator cannot resolve. The two are the same string on purpose and a
 		// test holds them equal.
 		Channels: []extension.Channel{
-			{Provider: "openchannel", Send: send, Live: live},
+			// per_member because the inbound credential above is user-scoped:
+			// each member holds their own, so a conversation on it is that
+			// member's correspondence rather than the company's.
+			{Provider: "openchannel", CredentialModel: extension.CredentialPerMember, Send: send, Live: live},
 		},
 		Jobs: []extension.Job{
 			{Name: "drain", Handle: drain},


### PR DESCRIPTION
Two changes about one subject: what a captured channel message's audience may be,
and who the transport that captured it acts for. Neither changes runtime behaviour
for any transport shipping today — `decideBirthTx` still returns early on
`kind != "email"`, so every channel row is still born workspace-readable. This
lands the truthful declaration while it is still inert, before the workspace
mail-sharing floor makes it load-bearing.

## An audience write may not orphan a message

`activityAudienceArm` admits a reader through five arms. A captured Telegram
message satisfies exactly one — `audience = 'workspace'`:

| arm | telegram message |
| --- | --- |
| `audience = 'workspace'` | ✅ at birth, and only this |
| `captured_by LIKE '%:<uuid>'` | ❌ it is a bare `connector:telegram`, no uuid |
| a `capture_import` row | ❌ no mailbox imports a bot's traffic |
| an `activity_participant` row | ❌ owner is nil, and there is no address |
| `selected` + a membership row | — |

So `PATCH /activities/{id}/audience` with `participants` — offered by the timeline
to any full seat holding `activity.update` — turned the only arm off and left a row
the system principal alone could read. With no way back: widening it needs
`EnsureActivityWritableIn`, which first requires the content visibility the write
had just destroyed.

`SetAudience` now asks the audience gate about the state it actually produced,
**after** the column and the member rows, and refuses 422 when nobody is left. The
same refusal covers the two hand-made spellings of the same mistake: `selected`
naming nobody, and `selected` naming only a team that has no members.

The predicate is the audience arm asked existentially. It is a second spelling
rather than a shared clause because the two questions bind the user differently —
that changes each arm's SQL shape, not just its operand — and the pair is held two
ways: an integration suite that builds a row admitted by each arm alone, and a
fitness test in `platform/auth` that compares the relation sets of both SQL texts
so a NEW arm on either side fails without anybody writing a case for it. Both were
verified to fail in both directions.

## A channel transport says whose credential it spends

`channel_provider.credential_model` decides whether a captured message is the
company's correspondence or one human's. It was DERIVED from nothing more than
"is this a unit" → `per_member`.

That answers wrongly for a class the tier already permits: a company-wide account
packaged as a unit — an Official Account, a shared support inbox — is a
`workspace_bot` the derivation calls `per_member`. **Nothing downstream can
notice.** A row narrowed onto the mailbox path keeps exactly one reader, the
connecting admin, so every audience invariant reads green while a company has lost
its own inbox. The no-orphan invariant above does not catch it either — which is
why the declaration has to carry the weight.

`extension.Channel` now carries it, `Validate` refuses a unit that omits it (no
default: both defaults are wrong for half the transports, and wrong silently), the
AST reader carries it into the generated manifest, and `unitChannelFacts` publishes
what the unit said. `unitChannelFacts` also refuses an undeclared model with a
legible boot error rather than letting the registry CHECK answer by constraint name.

## Fixed along the way

**The directory endpoint published a constant.** `GET /v1/channel-providers`
reported `credential_model: workspace_bot` for every transport, including a unit
declaring `per_member` — `LoadChannelProviderDirectory` selected only `provider`
and the shaping re-derived the rest as core. Pre-existing, and it would have made
this PR cosmetic: the declaration truthful in the table and still a lie on the
surface an operator reads. Found by the UAT, not by a test — the existing directory
test compared core rows only and passed vacuously, so a unit transport is now
planted in a test of its own.

Also: the extension how-to's canonical `Channel` example (it omitted a now-required
field), two comments that still asserted the derivation this PR removes, an AST
reader that duplicated the existing `constValue` helper, and a test helper that
swallowed every error as "not readable".

## Deliberately NOT done

**No `SeatType.CanMutate()` in `SetAudience`.** `ThreadAudienceSetter.Decide`
checks it because it is reachable from `compose`; `SetAudience` has exactly one
caller, the HTTP handler, behind `identity/admission.go:69`, which refuses a read
seat's mutating REST method before RBAC. A store-level copy would be a second
writer of that invariant and would break every harness that binds a principal
without a seat, for a path nothing can reach.

**No repair for rows already orphaned before this ships.** An installation where
somebody already pressed `Participants only` on a Telegram message has rows no
human can open, and this does not touch them. The census that would size it must
run as the system principal against a real installation — by the defect, the rows
are invisible to everyone else. Filed.

## Filed rather than fixed

- **Archiving a team, or emptying it, can still orphan a `selected` audience.**
  The fix is in `identity` and needs a product answer (refuse the archive? rewrite
  the audiences that name it?).
- **The restricted-readers census can be discharged by an `archived_at IS NULL` on
  any table.** `heldLiteralMarkers` matches the predicate as text, so a reader that
  joins some unrelated table filtered that way counts as excluding held ACTIVITY
  rows. The new predicate discharges exactly this way, via its `team` join. The
  marker is shared by ~30 readers, so tightening it is its own change.

## Verification

- `make check` green (both halves).
- Reviewed by Fable and by Codex. Both independently found that the existential
  predicate counted an ARCHIVED team as a reader where the read side never puts one
  into a principal — the silent direction. Fixed, with three team cases added.
- UAT recorded against a live dev stack through the real browser path: the
  Visibility dialog on a captured Telegram message, `Participants only` refused
  inline with the row left untouched, then `Named people` saved and still readable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two attribution gaps for captured channel messages: an audience write can no longer leave a message unreadable, and a transport now declares whose credential it spends instead of having it inferred from whether it is a unit. Neither changes runtime behavior for any transport shipping today, and the migration head catalog is refreshed to match.

**Bug Fixes**
- `SetAudience` returns 422 when a write would leave the message with no human reader; previously narrowing a captured Telegram message to `participants` orphaned it with no way to widen it back.
- `GET /v1/channel-providers` publishes each transport's own `credential_model` from the registry; it previously reported `workspace_bot` for every transport.

**Migration**
- Unit extensions must add `CredentialModel` to each `Channel` declaration — `workspace_bot` for one installation-wide credential, `per_member` for one per member. A missing value fails `Validate`, and the generated manifest carries the declaration through.

<sup>Written for commit 2e242b43d746b5c66bef7a4333bb7339d273e568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel integrations now declare whether credentials are shared across a workspace or assigned per member.
  * Channel provider listings and manifests accurately report each integration’s credential model.
  * Audience changes that would make content unreadable to everyone are now rejected.

* **Bug Fixes**
  * Corrected credential information shown for unit-provided transports.
  * Prevented audience settings from creating inaccessible messages.

* **Documentation**
  * Added guidance for configuring credential models and understanding manifest reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->