### PR TITLE
feat(contracts): a renewal can name the deal that won it

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1193,7 +1193,12 @@ export const de = {
   "contracts.renew.title": "Diese Vereinbarung verlängern",
   "contracts.renew.hint":
     "Erstellt eine neue Vereinbarung und markiert diese als abgelöst. Eigene Bedingungen — nichts wird übernommen außer der Vertragspartei.",
+  "contracts.renew.deal": "Deal",
+  "contracts.renew.dealHint":
+    "Der Deal, der diese Laufzeit gewonnen hat, falls es einen gab — nie der des Vorgängers.",
+  "contracts.renew.dealNone": "Kein Deal",
   "contracts.renew.submit": "Verlängern",
+  "contracts.deal": "Deal",
   "contracts.statusChange.title": "Status ändern",
   "contracts.statusChange.label": "Neuer Status",
   "contracts.statusChange.submit": "Status ändern",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1258,7 +1258,12 @@ export const en = {
   "contracts.renew.title": "Renew this agreement",
   "contracts.renew.hint":
     "Creates a new agreement and marks this one superseded. Its own terms — nothing carries over but the counterparty.",
+  "contracts.renew.deal": "Deal",
+  "contracts.renew.dealHint":
+    "The opportunity that won this term, if there was one — never the predecessor's own.",
+  "contracts.renew.dealNone": "No deal",
   "contracts.renew.submit": "Renew",
+  "contracts.deal": "Deal",
   "contracts.statusChange.title": "Change status",
   "contracts.statusChange.label": "New status",
   "contracts.statusChange.submit": "Change status",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -156,6 +156,8 @@ const KEPT_IN_ENGLISH = new Set<string>([
   "co.brief.cite.deal",
   "co.brief.cite.person",
   "deals.unit",
+  "contracts.renew.deal",
+  "contracts.deal",
   "history.actorAgent",
 
   // Endonyms: a locale's own name for itself, identical in every catalog.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1184,7 +1184,12 @@ export const vi = {
   "contracts.renew.title": "Gia h\u1ea1n th\u1ecfa thu\u1eadn n\u00e0y",
   "contracts.renew.hint":
     "T\u1ea1o m\u1ed9t th\u1ecfa thu\u1eadn m\u1edbi v\u00e0 \u0111\u00e1nh d\u1ea5u th\u1ecfa thu\u1eadn n\u00e0y l\u00e0 \u0111\u00e3 thay th\u1ebf. \u0110i\u1ec1u kho\u1ea3n ri\u00eang \u2014 kh\u00f4ng g\u00ec \u0111\u01b0\u1ee3c gi\u1eef l\u1ea1i ngo\u00e0i b\u00ean \u0111\u1ed1i t\u00e1c.",
+  "contracts.renew.deal": "Deal",
+  "contracts.renew.dealHint":
+    "Deal \u0111\u00e3 gi\u00e0nh \u0111\u01b0\u1ee3c k\u1ef3 h\u1ea1n n\u00e0y, n\u1ebfu c\u00f3 \u2014 kh\u00f4ng bao gi\u1edd l\u00e0 deal c\u1ee7a h\u1ee3p \u0111\u1ed3ng tr\u01b0\u1edbc.",
+  "contracts.renew.dealNone": "Kh\u00f4ng c\u00f3 deal",
   "contracts.renew.submit": "Gia h\u1ea1n",
+  "contracts.deal": "Deal",
   "contracts.statusChange.title": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",
   "contracts.statusChange.label": "Tr\u1ea1ng th\u00e1i m\u1edbi",
   "contracts.statusChange.submit": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",

--- a/frontend/src/screens/companycontracts.menu.test.tsx
+++ b/frontend/src/screens/companycontracts.menu.test.tsx
@@ -38,6 +38,7 @@ const ACTIVE = {
 };
 
 const EXPIRED = { ...ACTIVE, id: "c-2", status: "expired" };
+const RENEWED_DEAL = { id: "d-1", name: "2025 renewal" };
 
 const GRANTED = meFixture({
   allow: { contract: ["read", "create", "update", "delete"] },
@@ -52,7 +53,9 @@ function stub(contracts: unknown[], me: unknown = GRANTED) {
         ? me
         : url.includes("/documents")
           ? { data: [] }
-          : { data: contracts };
+          : url.includes("/deals/")
+            ? RENEWED_DEAL
+            : { data: contracts };
       return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -154,5 +157,27 @@ describe("the contract row menu", () => {
     expect(
       screen.queryByRole("button", { name: "Contract actions" }),
     ).toBeNull();
+  });
+});
+
+// margince#3286 (re-measured): a renewal made through the screen could not
+// name the deal that won it, and no row said which deal a contract WAS
+// linked to even where one existed. These prove the row's own display half.
+describe("the contract row's linked deal", () => {
+  it("names the deal a contract carries", async () => {
+    stub([{ ...ACTIVE, deal_id: RENEWED_DEAL.id }]);
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await screen.findByText("Framework agreement 2024");
+    expect(await screen.findByText(RENEWED_DEAL.name)).toBeTruthy();
+  });
+
+  it("shows nothing where a contract carries no deal", async () => {
+    stub([ACTIVE]);
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await screen.findByText("Framework agreement 2024");
+    expect(screen.queryByText(RENEWED_DEAL.name)).toBeNull();
+    expect(screen.queryByText("Deal")).toBeNull();
   });
 });

--- a/frontend/src/screens/companycontracts.tsx
+++ b/frontend/src/screens/companycontracts.tsx
@@ -26,6 +26,7 @@ import {
   isTerminalContractStatus,
 } from "./contractlifecycle";
 import { useContractPaper } from "./contractpaper";
+import { EntityRef } from "./entityref";
 // The row and card shapes this file draws — co-rowlink, co-row-meta, co-card —
 // are defined in company360.css. Imported HERE rather than left to the caller:
 // it works today only because the company record page pulls that stylesheet in
@@ -308,6 +309,17 @@ function ContractRow({
           )}
           <ContractTerm contract={contract} />
           <ContractTermState contract={contract} />
+          {/* A bare EntityRef here would read as an org name or a person —
+              the other siblings on this line are all self-identifying by
+              format (a mono number, a date range, a state pill), and a deal's
+              name is not. Same {label}{" "}<EntityRef/> shape deals.tsx uses
+              for its own second, non-obvious reference (partner_org_id). */}
+          {contract.deal_id && (
+            <span className="t-caption">
+              {t("contracts.deal")}{" "}
+              <EntityRef kind="deal" id={contract.deal_id} />
+            </span>
+          )}
         </span>
         {/* The paper sits under the agreement's own line: a file is about the
             agreement, not about any one of the facts beside it. */}

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -53,30 +53,47 @@ function show(ui: ReactNode) {
   );
 }
 
+// A predecessor's own organization has exactly one deal on record for these
+// tests — enough to prove the picker lists it and sends its id, without a
+// second candidate to disambiguate against.
+const ORG_DEAL = { id: "d-1", name: "Renewal — 2025 term" };
+
+function stubRenewalFetch(onRenewal: (request: Request) => Promise<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname === "/v1/deals") {
+        return new Response(
+          JSON.stringify({ data: [ORG_DEAL], page: { has_more: false } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/renewal")) {
+        return onRenewal(request);
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+}
+
 describe("ContractRenewModal", () => {
-  it("posts the successor's own title, basis and the predecessor's version as If-Match", async () => {
+  it("posts the successor's own title, basis and the predecessor's version as If-Match, with no deal picked", async () => {
     let posted: { body: unknown; ifMatch: string | null; path: string } | null =
       null;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request =
-          input instanceof Request ? input : new Request(input, init);
-        const url = new URL(request.url);
-        if (request.method === "POST" && url.pathname.endsWith("/renewal")) {
-          posted = {
-            body: await request.json(),
-            ifMatch: request.headers.get("if-match"),
-            path: url.pathname,
-          };
-          return new Response(
-            JSON.stringify({ ...PREDECESSOR, id: "c-2", version: 1 }),
-            { status: 201, headers: { "Content-Type": "application/json" } },
-          );
-        }
-        return new Response("not found", { status: 404 });
-      }),
-    );
+    stubRenewalFetch(async (request) => {
+      posted = {
+        body: await request.json(),
+        ifMatch: request.headers.get("if-match"),
+        path: new URL(request.url).pathname,
+      };
+      return new Response(
+        JSON.stringify({ ...PREDECESSOR, id: "c-2", version: 1 }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
     const user = userEvent.setup();
     const onClose = vi.fn();
     show(<ContractRenewModal contract={PREDECESSOR} open onClose={onClose} />);
@@ -98,7 +115,7 @@ describe("ContractRenewModal", () => {
     // The FULL body, not two fields of it: RenewContractRequest inherits
     // nothing from the predecessor but the counterparty (which the server
     // derives from the path, not the body) — a regression that leaked
-    // value_minor or currency from the predecessor would pass a check that
+    // value_minor, currency, or an unpicked deal_id would pass a check that
     // only asserted title and value_basis.
     expect(sent.body).toEqual({
       title: "Framework agreement 2024",
@@ -108,19 +125,50 @@ describe("ContractRenewModal", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  // margince#3286 (re-measured): a renewal made through the API could always
+  // name the deal that won it; the screen path could not, so a renewal
+  // recorded here left deal_id null even where the API allowed it.
+  it("sends the picked deal's id", async () => {
+    let posted: { body: Record<string, unknown> } | null = null;
+    stubRenewalFetch(async (request) => {
+      posted = { body: await request.json() };
+      return new Response(
+        JSON.stringify({ ...PREDECESSOR, id: "c-2", version: 1 }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    show(<ContractRenewModal contract={PREDECESSOR} open onClose={onClose} />);
+
+    await user.click(await screen.findByRole("combobox", { name: "Deal" }));
+    await user.click(
+      await screen.findByRole("option", { name: ORG_DEAL.name }),
+    );
+    await user.click(screen.getByRole("button", { name: "Renew" }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    expect(
+      (posted as unknown as { body: Record<string, unknown> }).body,
+    ).toEqual({
+      title: "Framework agreement 2024",
+      value_basis: "annualized_12m",
+      auto_renew: false,
+      deal_id: ORG_DEAL.id,
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
   it("shows the server's refusal inline rather than closing silently", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              code: "validation_error",
-              detail: "a term cannot end before it starts",
-            }),
-            { status: 422, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+    stubRenewalFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "validation_error",
+            detail: "a term cannot end before it starts",
+          }),
+          { status: 422, headers: { "Content-Type": "application/json" } },
+        ),
     );
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -85,6 +85,7 @@ function renewDraftOf(predecessor: Contract): ContractDraft {
 
 function renewalBody(
   draft: ContractDraft,
+  dealId: string,
 ): components["schemas"]["RenewContractRequest"] {
   return {
     title: draft.title.trim(),
@@ -94,6 +95,13 @@ function renewalBody(
     // itself is a fact about the paper, and a field this form quietly omitted
     // would be a guess the record could not distinguish from an answer.
     auto_renew: false,
+    // Omitted rather than sent empty, same rule as every field in
+    // contractTermsBody: no deal picked is "not recorded", not a value the
+    // server has to reject. Never the PREDECESSOR's own deal_id — the server
+    // does not inherit it either (contract_write.go), because a renewal is
+    // usually won by its own opportunity and attributing it to the one that
+    // won the old term would name the wrong sale.
+    ...(dealId !== "" ? { deal_id: dealId } : {}),
     ...contractTermsBody(draft),
   };
 }
@@ -106,18 +114,38 @@ function renewalBody(
 async function renewContract(
   predecessor: Contract,
   draft: ContractDraft,
+  dealId: string,
 ): Promise<string> {
   const { data, error } = await api.POST("/contracts/{id}/renewal", {
     params: {
       path: { id: predecessor.id },
       ...ifMatch(requireVersion(predecessor.version)),
     },
-    body: renewalBody(draft),
+    body: renewalBody(draft, dealId),
   });
   if (error) {
     throwProblem(error);
   }
   return data?.id ?? "";
+}
+
+// The organization's own deals, for the picker below — every status, not only
+// `open`: a renewal is usually recorded after the opportunity that won it has
+// already closed, so filtering to `open` would hide the one deal a renewal is
+// most often actually tied to.
+function dealsForOrg(organizationId: string) {
+  return {
+    queryKey: ["orgDeals", organizationId],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/deals", {
+        params: { query: { organization_id: organizationId, limit: 100 } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data?.data ?? [];
+    },
+  };
 }
 
 export function ContractRenewModal({
@@ -133,8 +161,15 @@ export function ContractRenewModal({
   const titleId = useId();
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<ContractDraft>(renewDraftOf(contract));
+  // Never seeded from the predecessor — see renewalBody's comment: the
+  // successor's deal is a fresh answer, not a carried-over one.
+  const [dealId, setDealId] = useState("");
   const baseCurrency = useInstallationSettings().data?.base_currency;
   const contractCurrency = draft.currency || baseCurrency || "";
+  const deals = useQuery({
+    ...dealsForOrg(contract.organization_id),
+    enabled: open,
+  });
 
   // Re-seed on open, and when a different row's renewal is what just opened:
   // otherwise the form keeps the previous agreement's title and basis.
@@ -147,6 +182,7 @@ export function ContractRenewModal({
   useEffect(() => {
     if (open) {
       setDraft(renewDraftOf(contract));
+      setDealId("");
     }
   }, [open, contract.id]);
 
@@ -154,7 +190,9 @@ export function ContractRenewModal({
     mutationFn: async (submitted: {
       predecessor: Contract;
       draft: ContractDraft;
-    }) => renewContract(submitted.predecessor, submitted.draft),
+      dealId: string;
+    }) =>
+      renewContract(submitted.predecessor, submitted.draft, submitted.dealId),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["orgContracts", contract.organization_id],
@@ -179,6 +217,30 @@ export function ContractRenewModal({
         currency={contractCurrency}
       />
 
+      {/* Never required: the API path this mirrors has always accepted a
+          renewal with no deal, and a picker that refused to submit without
+          one would refuse an agreement the server has always allowed. */}
+      <Field
+        label={t("contracts.renew.deal")}
+        hint={t("contracts.renew.dealHint")}
+      >
+        {(props) => (
+          <Select
+            {...props}
+            value={dealId}
+            onChange={setDealId}
+            disabled={deals.isPending}
+            options={[
+              { value: "", label: t("contracts.renew.dealNone") },
+              ...(deals.data ?? []).map((deal) => ({
+                value: deal.id,
+                label: deal.name,
+              })),
+            ]}
+          />
+        )}
+      </Field>
+
       {renew.error && (
         <p className="t-caption" role="alert">
           {problemMessageOf(renew.error, t)}
@@ -195,6 +257,7 @@ export function ContractRenewModal({
             renew.mutate({
               predecessor: contract,
               draft: pricedIn(draft, baseCurrency),
+              dealId,
             })
           }
         >


### PR DESCRIPTION
## Summary
- Closes the remaining gap from margince#3286 (re-measured after #4002 shipped the Renew/status/cancel screens): the Renew modal had no field for `deal_id`, so a renewal made through the screen always left the successor's `deal_id` null even though `POST /contracts/{id}/renewal` has always accepted one (landed by #3137).
- Adds an organization-scoped deal picker to `ContractRenewModal` — `GET /deals` has no free-text search, so it lists every status for the contract's own organization rather than filtering to `open` (a renewal is usually recorded after the opportunity that won it has already closed, so `open`-only would hide the very deal a renewal is most often tied to).
- Shows a contract's linked deal on its row via the existing `EntityRef` component (`{t("contracts.deal")} <EntityRef kind="deal" .../>`, the same labeled-reference shape `deals.tsx` uses for its own second reference), closing the display half of the original finding alongside the write half.
- Never inherits the predecessor's own deal — matches the existing "nothing carries over but the counterparty" rule and the server's own refusal to inherit it (`contract_write.go`).

## Test plan
- [x] `make check-fe` — full frontend gate, green (composed typecheck, ds-gates/drift/lint/unit/build, unit-screens suite)
- [x] New tests: `contractlifecycle.test.tsx` ("sends the picked deal's id"), `companycontracts.menu.test.tsx` ("names the deal a contract carries" / "shows nothing where a contract carries no deal")
- [x] Live UAT on a fresh dev stack: created a contract with no deal, renewed it and picked a real deal from the org's own list, confirmed the successor's row shows "Deal 2025 renewal" as a working link to the deal, and the predecessor shows Superseded
- [x] i18n: en/de/vi translations added, `i18n.test.ts`'s untranslated-copy allowlist updated for "Deal" (kept in English per the existing CRM-noun convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a renewal name the deal that won it. Renewals made through the screen previously left the successor's deal unset because the Renew modal had no `deal_id` field, even though the API always accepted one. The modal now has an organization-scoped deal picker, and a contract's linked deal shows on its row via the existing `EntityRef` component.

**Notes**
- The picker lists deals in every status, not just `open`, since a renewal is usually recorded after the winning deal has already closed.
- Deal is optional; submitting without one still posts a valid renewal.
- The successor never inherits the predecessor's deal, matching the existing rule that nothing carries over but the counterparty.

<sup>Written for commit b4f98792195e1198eb63fbce943b06f9b494d016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

