### PR TITLE
Three daily passes collapse, and the sweep tag moves to the pass

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -368,43 +368,25 @@ kinds:
 
 
   capture_digest:
-    role: dispatcher
+    role: worker
     go_type: CaptureDigestArgs
     queue: default
-    timeout: 2m
+    timeout: 5m
     opts_owner: caller
     cadence: 24h
     registration: {when: [GmailRegistry], absent: registers_nothing}
-    fans_out_to: capture_digest_workspace
-    fan_out_unit: workspace
     reason: >-
       Daily, after the overnight passes it summarizes. The boot pass backfills
       a missed night, so a morning is never silently empty.
 
-  capture_digest_workspace:
-    role: worker
-    go_type: CaptureDigestWorkspaceArgs
-    queue: default
-    timeout: 5m
-    max_attempts: 3
-    opts_owner: fan_out
-    registration: {when: [GmailRegistry], absent: registers_nothing}
-    args:
-      Workspace: id
-    reason: >-
-      A database-only assembly, one digest per connected user — this worker
-      holds no model lane at all, which is also why it fans out onto default
-      rather than ai_capture.
 
   brief_generate:
-    role: dispatcher
+    role: worker
     go_type: BriefGenerateArgs
     queue: default
-    timeout: 2m
+    timeout: 10m
     opts_owner: caller
     cadence: 1h
-    fans_out_to: brief_generate_workspace
-    fan_out_unit: workspace
     reason: >-
       Hourly, not daily, because the morning it aims at is the installation's
       local one — an hourly tick crosses the briefing hour in every zone the
@@ -413,14 +395,12 @@ kinds:
       backfills a night the worker was down for.
 
   weekly_review_generate:
-    role: dispatcher
+    role: worker
     go_type: WeeklyReviewGenerateArgs
     queue: default
-    timeout: 2m
+    timeout: 10m
     opts_owner: caller
     cadence: 6h
-    fans_out_to: weekly_review_generate_workspace
-    fan_out_unit: workspace
     reason: >-
       Every six hours rather than weekly, for the same reason the brief ticks
       hourly: the Monday it aims at is the installation's local one, and a tick
@@ -429,36 +409,7 @@ kinds:
       uniqueness collapses the extra ticks into one review, and the same
       property backfills a Monday the worker was down for.
 
-  weekly_review_generate_workspace:
-    role: worker
-    go_type: WeeklyReviewGenerateWorkspaceArgs
-    queue: default
-    timeout: 10m
-    max_attempts: 3
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
-      One deterministic measuring pass per full-seat rep whose local Monday has
-      arrived — database-only counting, so it fans out onto default rather than
-      a model lane. Ten minutes covers a large team's serial passes; a rep whose
-      pass failed is retried with the rest, and the week uniqueness makes that
-      safe.
 
-  brief_generate_workspace:
-    role: worker
-    go_type: BriefGenerateWorkspaceArgs
-    queue: default
-    timeout: 10m
-    max_attempts: 3
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
-      One deterministic ranking pass per full-seat rep whose local morning has
-      arrived — database-only, so it fans out onto default rather than a model
-      lane. Ten minutes covers a large team's serial passes; a rep whose pass
-      failed is retried with the rest, and the day uniqueness makes that safe.
 
   capture_enrich:
     role: worker

--- a/backend/internal/compose/briefjobs.go
+++ b/backend/internal/compose/briefjobs.go
@@ -49,36 +49,16 @@ func (BriefGenerateArgs) Kind() string { return "brief_generate" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (BriefGenerateArgs) FleetWide() {}
 
-// briefGenerateWorker is the dispatcher for the overnight assembly.
-type briefGenerateWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *briefGenerateWorker) Work(ctx context.Context, _ *river.Job[BriefGenerateArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(BriefGenerateWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return BriefGenerateWorkspaceArgs{Workspace: ws} }))
-}
-
-// BriefGenerateWorkspaceArgs assembles one workspace's morning briefs.
-type BriefGenerateWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (BriefGenerateWorkspaceArgs) Kind() string { return "brief_generate_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a BriefGenerateWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// briefGenerateWorkspaceWorker assembles one workspace's briefs.
+// briefGenerateWorker assembles every live workspace's briefs.
+//
+// One worker where there were two (ADR-0103).
 //
 // The engine here carries no L2 ranker: the worker role holds no brief_ranking
 // model lane, so the overnight run is the deterministic §10.1 composite order.
 // That is the floor the whole feature is built on rather than a degradation —
 // the model re-order stays what the api role adds when a rep refreshes — and a
 // run assembled without it is still a complete, ranked, cited brief.
-type briefGenerateWorkspaceWorker struct {
+type briefGenerateWorker struct {
 	engine *briefs.BriefEngine
 	pool   *pgxpool.Pool
 	users  *identity.Service
@@ -93,16 +73,16 @@ type briefGenerateWorkspaceWorker struct {
 	now func() time.Time
 }
 
-func (w *briefGenerateWorkspaceWorker) Work(ctx context.Context, job *river.Job[BriefGenerateWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *briefGenerateWorker) Work(ctx context.Context, _ *river.Job[BriefGenerateArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.assembleOneWorkspace))
+}
+
+func (w *briefGenerateWorker) assembleOneWorkspace(ctx context.Context, workspace ids.UUID) error {
 	clock := w.now
 	if clock == nil {
 		clock = time.Now
 	}
-	return jobs.FaultContext(ctx, w.assembleWorkspace(wsCtx, job.Args.Workspace, clock().UTC()))
+	return w.assembleWorkspace(principal.WithWorkspaceID(ctx, workspace), workspace, clock().UTC())
 }
 
 // assembleWorkspace snapshots a run for every rep in this workspace whose
@@ -113,7 +93,7 @@ func (w *briefGenerateWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 // that stopped at the first failure would leave a whole team without briefs
 // because one seat had a broken authority row, and River's retry would keep
 // hitting the same seat first.
-func (w *briefGenerateWorkspaceWorker) assembleWorkspace(ctx context.Context, wsID ids.UUID, now time.Time) error {
+func (w *briefGenerateWorker) assembleWorkspace(ctx context.Context, wsID ids.UUID, now time.Time) error {
 	// The enumeration runs as the system: it reads the workspace's mode, the
 	// installation timezone and the seat roster — installation-level facts about
 	// WHO is due a brief, which belong to no rep. Every read of a rep's own data
@@ -176,7 +156,7 @@ type morningPass struct {
 // Read AFTER the assembly above so the runs it just wrote are included, and in
 // its own transaction for the same reason: the candidate read happened before
 // those runs existed.
-func (w *briefGenerateWorkspaceWorker) mailTheMorning(
+func (w *briefGenerateWorker) mailTheMorning(
 	ctx context.Context, wsID ids.UUID, pass morningPass, now time.Time,
 ) error {
 	var awaiting []briefs.BriefRun
@@ -208,7 +188,7 @@ func (w *briefGenerateWorkspaceWorker) mailTheMorning(
 // A fresh correlation id per rep, so one morning's work for one person is one
 // recoverable trace in the audit spine rather than a fleet pass nobody can take
 // apart.
-func (w *briefGenerateWorkspaceWorker) repContext(
+func (w *briefGenerateWorker) repContext(
 	ctx context.Context, wsID, userID ids.UUID,
 ) (context.Context, error) {
 	rbac, seat, err := w.users.EffectiveAuthority(ctx, wsID, userID)
@@ -239,7 +219,7 @@ func (w *briefGenerateWorkspaceWorker) repContext(
 // The MAIL is not here. It is a pass of its own over whatever is still unmailed
 // once the whole workspace is assembled — mailTheMorning says why, and the short
 // version is that a run may be mailed hours after it is written.
-func (w *briefGenerateWorkspaceWorker) assembleFor(ctx context.Context, wsID, userID ids.UUID, now time.Time) error {
+func (w *briefGenerateWorker) assembleFor(ctx context.Context, wsID, userID ids.UUID, now time.Time) error {
 	repCtx, err := w.repContext(ctx, wsID, userID)
 	if err != nil {
 		return err
@@ -278,7 +258,7 @@ func (w *briefGenerateWorkspaceWorker) assembleFor(ctx context.Context, wsID, us
 // Agents are excluded: a brief is a person's morning, and an agent seat has no
 // morning to prepare. Read seats are excluded because the brief's whole content
 // is deals to act on.
-func (w *briefGenerateWorkspaceWorker) morningPassFor(ctx context.Context, wsID ids.UUID, now time.Time) (morningPass, error) {
+func (w *briefGenerateWorker) morningPassFor(ctx context.Context, wsID ids.UUID, now time.Time) (morningPass, error) {
 	var pass morningPass
 	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
 		overlay, err := overlayModeOf(ctx, tx)

--- a/backend/internal/compose/briefjobs_integration_test.go
+++ b/backend/internal/compose/briefjobs_integration_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/riverqueue/river"
-
 	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/modules/identity"
@@ -32,7 +30,7 @@ import (
 // compose wires it, plus a clock the test moves.
 type briefJobEnv struct {
 	*integration.Env
-	worker *briefGenerateWorkspaceWorker
+	worker *briefGenerateWorker
 	now    time.Time
 }
 
@@ -46,7 +44,7 @@ func setupBriefJob(t *testing.T) *briefJobEnv {
 	// would prove nothing about it. Deal read is what the ranking needs;
 	// installation-settings read is what the base-currency and timezone lookups need.
 	b.grantEveryRepTheBriefsReads(t)
-	b.worker = &briefGenerateWorkspaceWorker{
+	b.worker = &briefGenerateWorker{
 		engine: briefs.NewBriefEngine(e.Pool, people.NewStore(InstallationDB(e.Pool))),
 		pool:   e.Pool,
 		users:  identity.NewService(e.Pool),
@@ -82,12 +80,14 @@ func (b *briefJobEnv) grantEveryRepTheBriefsReads(t *testing.T) {
 	}
 }
 
-// run drives the worker the way River does, through its Work method, so the
-// workspace binding and the clock read are the production ones.
+// run drives the worker's per-workspace turn, which is what River's row now
+// walks rather than what it carries: the pass takes no workspace in its args
+// (ADR-0103), so Work would enumerate the fleet and lose the one this suite is
+// about. The workspace binding and the clock read are the production ones
+// either way — assembleOneWorkspace is what Work calls per tenant.
 func (b *briefJobEnv) run(t *testing.T) error {
 	t.Helper()
-	return b.worker.Work(context.Background(),
-		&river.Job[BriefGenerateWorkspaceArgs]{Args: BriefGenerateWorkspaceArgs{Workspace: b.WS}})
+	return b.worker.assembleOneWorkspace(context.Background(), b.WS)
 }
 
 // runsFor counts the brief runs stored for one rep on one local day.

--- a/backend/internal/compose/briefmailjobs.go
+++ b/backend/internal/compose/briefmailjobs.go
@@ -52,7 +52,7 @@ type BriefMailConfig struct {
 // the mail still has the whole brief on Home, so a relay outage must not fail a
 // job that assembled a team's morning. What it must not do is send twice, and
 // that is the claim's job rather than this function's.
-func (w *briefGenerateWorkspaceWorker) mailMorning(
+func (w *briefGenerateWorker) mailMorning(
 	ctx context.Context, run briefs.BriefRun, now time.Time, localHour int,
 ) {
 	if w.mail.Mailer == nil {
@@ -114,7 +114,7 @@ func (w *briefGenerateWorkspaceWorker) mailMorning(
 // Separate so the failure path has one spelling: the two callers above differ
 // only in what went wrong, and a second copy of the log-and-store pair is how
 // one of them comes to store nothing.
-func (w *briefGenerateWorkspaceWorker) recordMailFailure(
+func (w *briefGenerateWorker) recordMailFailure(
 	ctx context.Context, runID ids.UUID, cause string,
 ) {
 	if err := w.engine.MailFailed(ctx, runID, cause); err != nil {
@@ -151,7 +151,7 @@ const briefMailBudget = 45 * time.Second
 // everyone who never chose would mail the whole company "nothing is waiting on
 // you" every quiet morning, and that message teaches its own readers to filter
 // the ones that matter.
-func (w *briefGenerateWorkspaceWorker) wantsMorningMail(
+func (w *briefGenerateWorker) wantsMorningMail(
 	ctx context.Context, run briefs.BriefRun, localHour int,
 ) bool {
 	settings, err := w.users.MyDelivery(ctx)

--- a/backend/internal/compose/capturedigest_integration_test.go
+++ b/backend/internal/compose/capturedigest_integration_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
-	"github.com/riverqueue/river"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
@@ -80,15 +79,15 @@ func TestMorningDigestBuildAndRead(t *testing.T) {
 		t.Fatalf("digest for an unbuilt day → %d, want 404", status)
 	}
 
-	// Idempotent per (user, day): the nightly worker's own re-run for this
+	// Idempotent per (user, day): the nightly pass's own re-run for this
 	// workspace replaces rather than stacks, and the latest read still answers
-	// exactly one row. The WORKSPACE worker is what rebuilds — the dispatcher
-	// beside it only enqueues.
-	dispatcher := &captureDigestWorker{registry: b.registry, pool: b.env.Pool, log: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return today }}
-	worker := &captureDigestWorkspaceWorker{digests: dispatcher}
-	if err := worker.Work(context.Background(), &river.Job[CaptureDigestWorkspaceArgs]{
-		Args: CaptureDigestWorkspaceArgs{Workspace: b.env.WS},
-	}); err != nil {
+	// exactly one row.
+	//
+	// digestWorkspace, not Work: the pass carries no workspace in its args
+	// (ADR-0103), so Work enumerates the fleet and this suite is about one
+	// tenant. It is the same code Work calls per tenant.
+	worker := &captureDigestWorker{registry: b.registry, pool: b.env.Pool, log: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return today }}
+	if err := worker.digestWorkspace(context.Background(), b.env.WS); err != nil {
 		t.Fatalf("digest worker: %v", err)
 	}
 	if status, _ := b.readDigest(t, nil); status != http.StatusOK {

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -198,42 +198,22 @@ type captureDigestWorker struct {
 // worker holds no model lane at all — and ai_capture exists to keep long,
 // model-bound work from evicting short jobs. Queueing the morning digest
 // behind two model workers would delay it for no reason.
+// The GRANULARITY returns to one row for the fleet (ADR-0103). A per-workspace
+// child gave a retry that re-ran only the workspace that failed; the pass joins
+// its failures again, as it did before that split, and a retry re-runs the
+// walk. Assembling a digest for a workspace that already has today's is a
+// re-build of the same day, which the payload's as-of-now truths make
+// idempotent — that is why the split was affordable to undo.
 func (w *captureDigestWorker) Work(ctx context.Context, _ *river.Job[CaptureDigestArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(CaptureDigestWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return CaptureDigestWorkspaceArgs{Workspace: ws} }))
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.digestWorkspace))
 }
 
-// CaptureDigestWorkspaceArgs builds one workspace's morning digests.
-type CaptureDigestWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (CaptureDigestWorkspaceArgs) Kind() string { return "capture_digest_workspace" }
-
-// WorkspaceID binds this build to its tenant (jobs.WorkspaceScoped).
-func (a CaptureDigestWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// captureDigestWorkspaceWorker assembles one workspace's digests. A failed
-// workspace already failed the job before this split — the pass joined its
-// failures rather than swallowing them — so what changes here is the
-// GRANULARITY: one row per workspace instead of one joined error for the
-// fleet, and a retry that re-runs only the workspace that failed.
-type captureDigestWorkspaceWorker struct {
-	digests *captureDigestWorker
-}
-
-func (w *captureDigestWorkspaceWorker) Work(ctx context.Context, job *river.Job[CaptureDigestWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	clock := w.digests.now
+func (w *captureDigestWorker) digestWorkspace(ctx context.Context, workspace ids.UUID) error {
+	clock := w.now
 	if clock == nil {
 		clock = time.Now
 	}
-	return jobs.FaultContext(ctx, w.digests.registry.BuildDigests(wsCtx, clock().UTC()))
+	return w.registry.BuildDigests(principal.WithWorkspaceID(ctx, workspace), clock().UTC())
 }
 
 // CaptureBackfillArgs pages ONE bounded backfill run (ADR-0063). Unique by
@@ -341,8 +321,13 @@ func (w *captureBackfillWorker) enqueueDigest(ctx context.Context, args CaptureB
 			"backfill", args.BackfillID, "err", err)
 		return
 	}
-	child := CaptureDigestWorkspaceArgs{Workspace: args.Workspace}
-	if _, err := client.Insert(ctx, child, oneOffChildOpts(child.Kind())); err != nil {
+	// The PASS, not a per-workspace child: the child kind went with the fan-out
+	// (ADR-0103). A backfill's same-day digest is wanted for the workspace it
+	// imported into, and the pass covers that workspace along with the rest —
+	// on the single-workspace installations this product supports, the same
+	// work.
+	child := CaptureDigestArgs{}
+	if _, err := client.Insert(ctx, child, oneOffPassOpts(child.Kind())); err != nil {
 		w.log.WarnContext(ctx, "capture backfill: digest enqueue failed",
 			"backfill", args.BackfillID, "err", err)
 	}

--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -71,7 +71,7 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	}()
 
 	// Drain the boot digest so the next one cannot be it — nor deduped by it.
-	awaitKindCompleted(t, sub, CaptureDigestWorkspaceArgs{}.Kind())
+	awaitKindCompleted(t, sub, CaptureDigestArgs{}.Kind())
 
 	// The boot pass placed its own dispatcher row, so "no dispatcher exists" is
 	// not the claim to make — "the completion added none" is. Read the count
@@ -87,30 +87,26 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	}
 	awaitKindCompleted(t, sub, "capture_backfill")
 	// The digest that follows the completed backfill is the payoff wiring.
-	awaitKindCompleted(t, sub, CaptureDigestWorkspaceArgs{}.Kind())
+	awaitKindCompleted(t, sub, CaptureDigestArgs{}.Kind())
 
 	// The waits above are satisfied by a digest of the right KIND, which the
-	// boot pass also produces — they prove the wiring fires, not WHAT it
-	// fires. The two assertions below tell a one-off workspace child from a
-	// fleet dispatcher, which on a single-workspace fixture produce the same
-	// visible outcome and are otherwise indistinguishable.
-
-	// A dispatcher row added here would be one workspace's backfill running
-	// the digest for every workspace in the installation.
-	if after := countJobsOfKind(ctx, t, b.env.Pool, CaptureDigestArgs{}.Kind()); after != dispatchersBefore {
-		t.Errorf("capture_digest rows went %d -> %d across the backfill; a completion must enqueue the "+
-			"CHILD kind for its own workspace, never the dispatcher that fans out over the whole fleet",
-			dispatchersBefore, after)
-	}
-
-	// An UNTAGGED child for this workspace is what a one-off enqueue looks
-	// like, and it is the row the boot fan-out cannot have written: every
-	// child of a fleet pass is tagged at the dispatch chokepoint. So finding
-	// one is proof the completion enqueued it, and proof it will not be
-	// counted as a fleet pass by the sweep gauges.
+	// scheduled pass also produces — they prove the wiring fires, not WHAT it
+	// fires. The assertion below tells a one-off enqueue from a scheduled tick,
+	// which produce the same visible outcome and are otherwise
+	// indistinguishable.
+	//
+	// It no longer tells a CHILD from a DISPATCHER, because there is no longer
+	// a pair to tell apart (ADR-0103): the digest is one kind, and a completion
+	// and a tick enqueue the same one. What survives that collapse is the TAG.
+	// A scheduled pass is stamped with jobs.SweepTag at the dispatch
+	// chokepoint; a one-off is deliberately not, so the sweep gauges do not
+	// count a backfill's digest as a day's coverage. So an untagged row is
+	// still proof the completion enqueued it, and still proof it will not be
+	// miscounted.
+	_ = dispatchersBefore
 	rows, err := b.env.Pool.Query(ctx,
 		`SELECT coalesce(args->>'workspace_id', ''), tags FROM river_job WHERE kind = $1 ORDER BY id`,
-		CaptureDigestWorkspaceArgs{}.Kind())
+		CaptureDigestArgs{}.Kind())
 	if err != nil {
 		t.Fatalf("reading digest rows: %v", err)
 	}
@@ -124,19 +120,22 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 			t.Fatalf("scanning a digest row: %v", err)
 		}
 		if slices.Contains(tags, jobs.SweepTag) {
-			continue // the boot fan-out's own child
+			continue // a scheduled tick's own row
 		}
 		oneOffs++
-		if workspace != b.env.WS.String() {
-			t.Errorf("the one-off digest names workspace %q, want the finishing tenant's %q", workspace, b.env.WS)
+		// The pass names NO tenant, and that is the collapse rather than a
+		// dropped field: it walks the workspaces itself, so a workspace in
+		// these args would be a claim the row is about one of them.
+		if workspace != "" {
+			t.Errorf("the one-off digest names workspace %q; a pass over the installation addresses no tenant", workspace)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf("reading digest rows: %v", err)
 	}
 	if oneOffs != 1 {
-		t.Errorf("%d untagged capture_digest_workspace row(s), want exactly 1 — the completion's own digest, "+
-			"tagged as a fleet pass or never enqueued at all", oneOffs)
+		t.Errorf("%d untagged capture_digest row(s), want exactly 1 — the completion's own digest, "+
+			"tagged as a scheduled pass or never enqueued at all", oneOffs)
 	}
 }
 

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -233,7 +233,7 @@ func TestFanOutChildOptsRefusesACallerOwnedKindWithNoOpts(t *testing.T) {
 // a value that merely happened not to carry them is one field away from doing
 // so, and neither failure is visible at the call site.
 func TestOneOffChildOptsTakeTheDeclaredQueueButNotTheFleetPassMarkings(t *testing.T) {
-	kind := CaptureDigestWorkspaceArgs{}.Kind()
+	kind := CaptureSyncArgs{}.Kind()
 	spec := specFor(t, kind)
 	opts := oneOffChildOpts(kind)
 

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "d1b084a36d62cbd9b19a925414211f4b0f997e678f267f223289da645b5bd8e4"
+const jobContractHash = "96a8c061619ec1c669ba4111f95293a2a35b2e37df06ba294adefef02266593f"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -35,14 +35,12 @@ type declaredJobArgs interface {
 		AssuranceSweepArgs |
 		AssuranceWorkspaceArgs |
 		BriefGenerateArgs |
-		BriefGenerateWorkspaceArgs |
 		CaptureAutoEnrichSweepArgs |
 		CaptureBackfillArgs |
 		CaptureClassifyArgs |
 		ConfidentialityVerdictArgs |
 		CounterpartyVerdictArgs |
 		CaptureDigestArgs |
-		CaptureDigestWorkspaceArgs |
 		CaptureEnrichArgs |
 		CaptureSyncArgs |
 		CaptureTraceSweepArgs |
@@ -108,8 +106,7 @@ type declaredJobArgs interface {
 		VoiceBuildArgs |
 		VoiceBuildRetryArgs |
 		WebhookRetryArgs |
-		WeeklyReviewGenerateArgs |
-		WeeklyReviewGenerateWorkspaceArgs
+		WeeklyReviewGenerateArgs
 }
 
 // addDeclaredWorker is the sanctioned registration path. Its type parameter
@@ -143,8 +140,6 @@ func addDeclaredWorkerWithTimeout[T declaredJobArgs](reg *jobRegistry, w jobs.Wo
 // no tenant work of its own.
 var (
 	_ jobs.FleetWide = AssuranceSweepArgs{}
-	_ jobs.FleetWide = BriefGenerateArgs{}
-	_ jobs.FleetWide = CaptureDigestArgs{}
 	_ jobs.FleetWide = CloseDateSweepArgs{}
 	_ jobs.FleetWide = FollowUpReconcileArgs{}
 	_ jobs.FleetWide = ForecastSnapshotSweepArgs{}
@@ -164,7 +159,6 @@ var (
 	_ jobs.FleetWide = TelegramPollSweepArgs{}
 	_ jobs.FleetWide = TimeScanArgs{}
 	_ jobs.FleetWide = VoiceBuildRetryArgs{}
-	_ jobs.FleetWide = WeeklyReviewGenerateArgs{}
 )
 
 // The declared tenant-scoped kinds: each says which workspace it is for
@@ -172,9 +166,7 @@ var (
 var (
 	_ jobs.WorkspaceScoped = AiModelRateRefreshArgs{}
 	_ jobs.WorkspaceScoped = AssuranceWorkspaceArgs{}
-	_ jobs.WorkspaceScoped = BriefGenerateWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureBackfillArgs{}
-	_ jobs.WorkspaceScoped = CaptureDigestWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureSyncArgs{}
 	_ jobs.WorkspaceScoped = CheckOrganizationVatArgs{}
 	_ jobs.WorkspaceScoped = CloseDateWorkspaceArgs{}
@@ -208,5 +200,4 @@ var (
 	_ jobs.WorkspaceScoped = TranscriptProposeArgs{}
 	_ jobs.WorkspaceScoped = VCardIngestArgs{}
 	_ jobs.WorkspaceScoped = VoiceBuildArgs{}
-	_ jobs.WorkspaceScoped = WeeklyReviewGenerateWorkspaceArgs{}
 )

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -42,7 +42,6 @@ func addGmailCaptureJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConf
 	}
 	digests := &captureDigestWorker{registry: cfg.GmailRegistry, pool: pool, log: log}
 	addDeclaredWorker[CaptureDigestArgs](reg, digests)
-	addDeclaredWorker[CaptureDigestWorkspaceArgs](reg, &captureDigestWorkspaceWorker{digests: digests})
 	addDeclaredWorker[GmailSyncArgs](reg, &gmailSyncWorker{registry: cfg.GmailRegistry, log: log})
 	// The sync dispatcher scans every registered connector, so a Google
 	// Calendar connection (the same Google OAuth app) syncs on the identical

--- a/backend/internal/compose/jobs_domaingroups.go
+++ b/backend/internal/compose/jobs_domaingroups.go
@@ -34,8 +34,7 @@ import (
 // overnight run is the deterministic composite order. The model re-order stays
 // what the api role adds on a rep's explicit refresh.
 func addBriefGenerateJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger, mail BriefMailConfig) {
-	addDeclaredWorker[BriefGenerateArgs](reg, &briefGenerateWorker{pool: pool})
-	addDeclaredWorker[BriefGenerateWorkspaceArgs](reg, &briefGenerateWorkspaceWorker{
+	addDeclaredWorker[BriefGenerateArgs](reg, &briefGenerateWorker{
 		engine: briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool))),
 		pool:   pool,
 		users:  identity.NewService(pool),

--- a/backend/internal/compose/jobs_weekly.go
+++ b/backend/internal/compose/jobs_weekly.go
@@ -25,8 +25,7 @@ import (
 // weekly engine and the identity service, neither of which the group's other
 // members carry.
 func addWeeklyReviewJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger, narrator completer, mail WeeklyMailConfig) {
-	addDeclaredWorker[WeeklyReviewGenerateArgs](reg, &weeklyGenerateWorker{pool: pool})
-	addDeclaredWorker[WeeklyReviewGenerateWorkspaceArgs](reg, &weeklyGenerateWorkspaceWorker{
+	addDeclaredWorker[WeeklyReviewGenerateArgs](reg, &weeklyGenerateWorker{
 		// The job re-reads a snapshot it has just written when a later tick
 		// finds one already there, and that read takes the same team gate a
 		// lead's does — it runs under a MEMBER's own authority, not the system

--- a/backend/internal/compose/jobschedule.go
+++ b/backend/internal/compose/jobschedule.go
@@ -12,6 +12,7 @@ package compose
 // declaration's.
 
 import (
+	"slices"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -62,6 +63,21 @@ func periodicInsertOpts(args river.JobArgs) *river.InsertOpts {
 	opts := sweepInsertOpts()
 	if _, owned := args.(river.JobArgsWithInsertOpts); !owned {
 		opts.MaxAttempts = periodicPassMaxAttempts
+	}
+	// A FLEET-WIDE tick carries the sweep tag, because since ADR-0103 this row
+	// IS the fleet pass. The tag used to go on the CHILDREN a dispatcher
+	// enqueued — one workspace's share each — and the sweep gauges count tagged
+	// rows; collapsing the pair left the gauges with nothing tagged to count,
+	// and left a one-off enqueue of the same kind indistinguishable from a
+	// scheduled pass. Tagging here restores both: what the gauges read is a
+	// pass that ran, and an untagged row of a fleet-wide kind is somebody's
+	// one-off, which is exactly what it meant before.
+	//
+	// Only FLEET-WIDE. A periodic kind that owns a tenant, or answers for the
+	// installation without walking it, is not a fleet pass and tagging it would
+	// put a row in the gauges that covers no workspaces.
+	if _, fleet := args.(jobs.FleetWide); fleet {
+		opts.Tags = append(slices.Clone(opts.Tags), jobs.SweepTag)
 	}
 	return opts
 }

--- a/backend/internal/compose/weeklyjobs.go
+++ b/backend/internal/compose/weeklyjobs.go
@@ -65,28 +65,10 @@ func (WeeklyReviewGenerateArgs) Kind() string { return "weekly_review_generate" 
 // FleetWide marks this as an enumerator that does no tenant work itself.
 func (WeeklyReviewGenerateArgs) FleetWide() {}
 
-type weeklyGenerateWorker struct{ pool *pgxpool.Pool }
-
-func (w *weeklyGenerateWorker) Work(ctx context.Context, _ *river.Job[WeeklyReviewGenerateArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(WeeklyReviewGenerateWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs {
-			return WeeklyReviewGenerateWorkspaceArgs{Workspace: ws}
-		}))
-}
-
-// WeeklyReviewGenerateWorkspaceArgs measures one workspace's reps.
-type WeeklyReviewGenerateWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind names the job in the contract.
-func (WeeklyReviewGenerateWorkspaceArgs) Kind() string { return "weekly_review_generate_workspace" }
-
-// WorkspaceID binds the pass to its tenant.
-func (a WeeklyReviewGenerateWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-type weeklyGenerateWorkspaceWorker struct {
+// weeklyGenerateWorker measures every live workspace's reps.
+//
+// One worker where there were two (ADR-0103).
+type weeklyGenerateWorker struct {
 	engine *weekly.Engine
 	pool   *pgxpool.Pool
 	users  *identity.Service
@@ -102,18 +84,16 @@ type weeklyGenerateWorkspaceWorker struct {
 	mail WeeklyMailConfig
 }
 
-func (w *weeklyGenerateWorkspaceWorker) Work(
-	ctx context.Context, job *river.Job[WeeklyReviewGenerateWorkspaceArgs],
-) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *weeklyGenerateWorker) Work(ctx context.Context, _ *river.Job[WeeklyReviewGenerateArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.measureOneWorkspace))
+}
+
+func (w *weeklyGenerateWorker) measureOneWorkspace(ctx context.Context, workspace ids.UUID) error {
 	clock := w.now
 	if clock == nil {
 		clock = time.Now
 	}
-	return jobs.FaultContext(ctx, w.measureWorkspace(wsCtx, job.Args.Workspace, clock().UTC()))
+	return w.measureWorkspace(principal.WithWorkspaceID(ctx, workspace), workspace, clock().UTC())
 }
 
 // measureWorkspace writes a review for every rep whose local Monday has
@@ -124,7 +104,7 @@ func (w *weeklyGenerateWorkspaceWorker) Work(
 // stopped at the first would leave a whole team without a retrospective because
 // one seat had a broken row, and River's retry would keep hitting that seat
 // first.
-func (w *weeklyGenerateWorkspaceWorker) measureWorkspace(
+func (w *weeklyGenerateWorker) measureWorkspace(
 	ctx context.Context, wsID ids.UUID, now time.Time,
 ) error {
 	// The enumeration runs as the system: it reads the installation timezone
@@ -196,7 +176,7 @@ func (w *weeklyGenerateWorkspaceWorker) measureWorkspace(
 // could see, so every read inside AssembleFor resolves through her grants, her
 // teams and her seat. EffectiveAuthority reads them as one snapshot — composed
 // from separate reads they can describe an authority she never held.
-func (w *weeklyGenerateWorkspaceWorker) measureFor(
+func (w *weeklyGenerateWorker) measureFor(
 	ctx context.Context, wsID, userID ids.UUID, now time.Time,
 ) (mailableReview, error) {
 	rbac, seat, err := w.users.EffectiveAuthority(ctx, wsID, userID)
@@ -273,7 +253,7 @@ type mailableReview struct {
 // It returns nothing. Every failure here is a week that reads without its
 // remark, which is a complete review — so the failure is loud in the log and
 // silent to the reader, and never the job's.
-func (w *weeklyGenerateWorkspaceWorker) narrate(ctx context.Context, review weekly.Review, now time.Time) {
+func (w *weeklyGenerateWorker) narrate(ctx context.Context, review weekly.Review, now time.Time) {
 	if w.narrator == nil {
 		// No lane in this role. Not an error and not worth a line every
 		// Monday: the deterministic review is the product either way.
@@ -338,7 +318,7 @@ func (w *weeklyGenerateWorkspaceWorker) narrate(ctx context.Context, review week
 // which an overlay workspace keeps in the incumbent, so a pass there would
 // measure a week of zeroes — and "a quiet week" and "this cannot be answered
 // here" read identically while only one is true.
-func (w *weeklyGenerateWorkspaceWorker) repsDueTheirReview(
+func (w *weeklyGenerateWorker) repsDueTheirReview(
 	ctx context.Context, wsID ids.UUID, now time.Time,
 ) ([]ids.UUID, error) {
 	var due []ids.UUID

--- a/backend/internal/compose/weeklymail_integration_test.go
+++ b/backend/internal/compose/weeklymail_integration_test.go
@@ -68,7 +68,7 @@ var weeklyMailClock = time.Date(2026, 7, 6, 6, 30, 0, 0, time.UTC)
 // with the relay swapped for one that counts.
 type mailEnv struct {
 	*integration.Env
-	worker *weeklyGenerateWorkspaceWorker
+	worker *weeklyGenerateWorker
 	relay  *countingMailer
 	repCtx context.Context
 }
@@ -80,7 +80,7 @@ func setupWeeklyMail(t *testing.T) *mailEnv {
 	return &mailEnv{
 		Env:   e,
 		relay: relay,
-		worker: &weeklyGenerateWorkspaceWorker{
+		worker: &weeklyGenerateWorker{
 			engine: weekly.NewEngine(e.Pool, newTeammatesSeam(e.Pool)),
 			pool:   e.Pool,
 			users:  identity.NewService(e.Pool),

--- a/backend/internal/compose/weeklymailjobs.go
+++ b/backend/internal/compose/weeklymailjobs.go
@@ -44,7 +44,7 @@ type WeeklyMailConfig struct {
 // the mail still has the whole review on Home, so a relay outage must not fail
 // a job that measured a team's week. What it must not do is send twice, and
 // that is the claim's job rather than this function's.
-func (w *weeklyGenerateWorkspaceWorker) mailWeekly(
+func (w *weeklyGenerateWorker) mailWeekly(
 	ctx context.Context, reviewID ids.UUID, now time.Time,
 ) {
 	if w.mail.Mailer == nil {
@@ -113,7 +113,7 @@ func (w *weeklyGenerateWorkspaceWorker) mailWeekly(
 // Separate so the failure path has one spelling: the two callers above differ
 // only in what went wrong, and a second copy of the log-and-store pair is how
 // one of them comes to store nothing.
-func (w *weeklyGenerateWorkspaceWorker) recordMailFailure(ctx context.Context, reviewID ids.UUID, cause string) {
+func (w *weeklyGenerateWorker) recordMailFailure(ctx context.Context, reviewID ids.UUID, cause string) {
 	if err := w.engine.MailFailed(ctx, reviewID, cause); err != nil {
 		w.log.WarnContext(ctx, "the weekly mail's failure could not be recorded",
 			"review", reviewID, "cause", err)
@@ -135,7 +135,7 @@ const mailBudget = 45 * time.Second
 // rep who wanted their weekly and did not get it is worse served than one who
 // gets a message they meant to switch off. The second is an annoyance they can
 // fix from the same page; the first is silence they have no way to notice.
-func (w *weeklyGenerateWorkspaceWorker) optedOutOfWeekly(ctx context.Context) bool {
+func (w *weeklyGenerateWorker) optedOutOfWeekly(ctx context.Context) bool {
 	settings, err := w.users.MyDelivery(ctx)
 	if err != nil {
 		w.log.WarnContext(ctx, "the weekly delivery preference could not be read; sending anyway",

--- a/backend/internal/compose/weeklymailoptout_test.go
+++ b/backend/internal/compose/weeklymailoptout_test.go
@@ -59,7 +59,7 @@ func TestAnUnreadablePreferenceStillSends(t *testing.T) {
 	}
 	body := string(source)
 
-	start := strings.Index(body, "func (w *weeklyGenerateWorkspaceWorker) optedOutOfWeekly")
+	start := strings.Index(body, "func (w *weeklyGenerateWorker) optedOutOfWeekly")
 	if start < 0 {
 		t.Fatal("no preference read found, so this test judged nothing")
 	}

--- a/backend/internal/compose/weeklyteamjobs.go
+++ b/backend/internal/compose/weeklyteamjobs.go
@@ -32,7 +32,7 @@ import (
 // One snapshot per team, assembled under the authority of a member who leads
 // it: the read is of frozen rows the team's own people wrote, and the tier gate
 // on TeamReview is what stops an own-scoped seat asking for one.
-func (w *weeklyGenerateWorkspaceWorker) snapshotTeams(
+func (w *weeklyGenerateWorker) snapshotTeams(
 	ctx context.Context, wsID ids.UUID, now time.Time,
 ) []error {
 	teams, err := w.liveTeams(ctx)
@@ -64,7 +64,7 @@ type liveTeam struct {
 // A team with no live members is skipped rather than snapshotted empty: an
 // empty week for a team that has nobody on it is a row saying the team did
 // nothing, which is not what happened.
-func (w *weeklyGenerateWorkspaceWorker) liveTeams(ctx context.Context) ([]liveTeam, error) {
+func (w *weeklyGenerateWorker) liveTeams(ctx context.Context) ([]liveTeam, error) {
 	var teams []liveTeam
 	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
@@ -102,7 +102,7 @@ func (w *weeklyGenerateWorkspaceWorker) liveTeams(ctx context.Context) ([]liveTe
 }
 
 // snapshotTeam freezes one team's week under a member's own authority.
-func (w *weeklyGenerateWorkspaceWorker) snapshotTeam(
+func (w *weeklyGenerateWorker) snapshotTeam(
 	ctx context.Context, wsID ids.UUID, team liveTeam, now time.Time,
 ) error {
 	rbac, seat, err := w.users.EffectiveAuthority(ctx, wsID, team.lead)
@@ -145,7 +145,7 @@ func (w *weeklyGenerateWorkspaceWorker) snapshotTeam(
 // answers "who shares a team with the caller" — the union across every team
 // they are on. A snapshot is about ONE team, and a lead on two would otherwise
 // freeze both teams' people into each.
-func (w *weeklyGenerateWorkspaceWorker) teamMembers(
+func (w *weeklyGenerateWorker) teamMembers(
 	ctx context.Context, teamID ids.UUID,
 ) ([]weekly.TeamMember, error) {
 	var members []weekly.TeamMember

--- a/backend/internal/compose/weeklyteamjobs_integration_test.go
+++ b/backend/internal/compose/weeklyteamjobs_integration_test.go
@@ -32,8 +32,8 @@ var teamJobClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
 // wiring mistake there is a wiring mistake here. The narrator and the mail
 // relay are omitted on purpose: both are absent by design in an installation
 // without them, and neither is what this test is about.
-func teamSnapshotWorker(e *integration.Env) *weeklyGenerateWorkspaceWorker {
-	return &weeklyGenerateWorkspaceWorker{
+func teamSnapshotWorker(e *integration.Env) *weeklyGenerateWorker {
+	return &weeklyGenerateWorker{
 		engine: weekly.NewEngine(e.Pool, newTeammatesSeam(e.Pool)),
 		pool:   e.Pool,
 		users:  identity.NewService(e.Pool),

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -177,15 +177,6 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		OrgNamePromotionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&orgNamePromotionWorkspaceWorker{}).Work(ctx, &river.Job[OrgNamePromotionWorkspaceArgs]{})
 		},
-		CaptureDigestWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&captureDigestWorkspaceWorker{}).Work(ctx, &river.Job[CaptureDigestWorkspaceArgs]{})
-		},
-		BriefGenerateWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&briefGenerateWorkspaceWorker{}).Work(ctx, &river.Job[BriefGenerateWorkspaceArgs]{})
-		},
-		WeeklyReviewGenerateWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&weeklyGenerateWorkspaceWorker{}).Work(ctx, &river.Job[WeeklyReviewGenerateWorkspaceArgs]{})
-		},
 		OverlayReconcileWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&overlayReconcileWorkspaceWorker{}).Work(ctx, &river.Job[OverlayReconcileWorkspaceArgs]{})
 		},

--- a/backend/internal/platform/jobs/role.go
+++ b/backend/internal/platform/jobs/role.go
@@ -30,10 +30,15 @@ type WorkspaceScoped interface {
 	WorkspaceID() ids.UUID
 }
 
-// FleetWide is implemented by DISPATCHER args: a job that enumerates the
-// fleet and enqueues one WorkspaceScoped job per workspace. A dispatcher
-// may read to discover work; it does no tenant WRITE, because the write is
-// the workspace job's to make and to be judged on.
+// FleetWide is implemented by the args of a job that answers for the WHOLE
+// installation rather than for one tenant: it reaches every workspace, either
+// by enqueuing one WorkspaceScoped job per workspace or — since ADR-0103
+// collapsed the workspace dispatchers — by walking them itself.
+//
+// It no longer implies "does no tenant write". A collapsed pass writes for
+// every workspace it walks, which is the point of it; what the marker still
+// says is that the row owns no single tenant, so nothing may read a workspace
+// off its args.
 //
 // The marker method is empty on purpose — it is a declaration, not
 // behaviour, and it is what the G1 gate reads.

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "d1b084a36d62cbd9b19a925414211f4b0f997e678f267f223289da645b5bd8e4"
+const JobContractHash = "96a8c061619ec1c669ba4111f95293a2a35b2e37df06ba294adefef02266593f"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -110,25 +110,13 @@ var specs = map[string]Spec{
 		Args:        []ArgField{{Name: "Workspace"}},
 	},
 	"brief_generate": {
-		Kind:       "brief_generate",
-		GoType:     "BriefGenerateArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "brief_generate_workspace",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{Fixed: 1 * time.Hour},
-	},
-	"brief_generate_workspace": {
-		Kind:        "brief_generate_workspace",
-		GoType:      "BriefGenerateWorkspaceArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
-		MaxAttempts: 3,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
+		Kind:      "brief_generate",
+		GoType:    "BriefGenerateArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 10 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{Fixed: 1 * time.Hour},
 	},
 	"capture_auto_enrich_sweep": {
 		Kind:      "capture_auto_enrich_sweep",
@@ -181,25 +169,12 @@ var specs = map[string]Spec{
 	"capture_digest": {
 		Kind:         "capture_digest",
 		GoType:       "CaptureDigestArgs",
-		Role:         Dispatcher,
-		Queue:        "default",
-		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit:   FanOutWorkspace,
-		FanOutTo:     "capture_digest_workspace",
-		OptsOwner:    OptsCaller,
-		Cadence:      Cadence{Fixed: 24 * time.Hour},
-		Registration: Registration{When: []string{"GmailRegistry"}},
-	},
-	"capture_digest_workspace": {
-		Kind:         "capture_digest_workspace",
-		GoType:       "CaptureDigestWorkspaceArgs",
 		Role:         Worker,
 		Queue:        "default",
 		Timeout:      TimeoutPolicy{Fixed: 5 * time.Minute},
-		MaxAttempts:  3,
-		OptsOwner:    OptsFanOut,
+		OptsOwner:    OptsCaller,
+		Cadence:      Cadence{Fixed: 24 * time.Hour},
 		Registration: Registration{When: []string{"GmailRegistry"}},
-		Args:         []ArgField{{Name: "Workspace"}},
 	},
 	"capture_enrich": {
 		Kind:         "capture_enrich",
@@ -889,25 +864,13 @@ var specs = map[string]Spec{
 		Registration: Registration{When: []string{"WebhookRetry.Deliverer"}},
 	},
 	"weekly_review_generate": {
-		Kind:       "weekly_review_generate",
-		GoType:     "WeeklyReviewGenerateArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "weekly_review_generate_workspace",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{Fixed: 6 * time.Hour},
-	},
-	"weekly_review_generate_workspace": {
-		Kind:        "weekly_review_generate_workspace",
-		GoType:      "WeeklyReviewGenerateWorkspaceArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
-		MaxAttempts: 3,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
+		Kind:      "weekly_review_generate",
+		GoType:    "WeeklyReviewGenerateArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 10 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{Fixed: 6 * time.Hour},
 	},
 }
 

--- a/backend/migrations/core/1788640001_three_daily_passes_leave_no_orphans.down.sql
+++ b/backend/migrations/core/1788640001_three_daily_passes_leave_no_orphans.down.sql
@@ -1,0 +1,8 @@
+-- Nothing to restore, for the reason its predecessors give.
+--
+-- The up migration deleted queue rows for work that had not run. A rollback
+-- re-registers those workers and the passes re-enqueue on their next tick, so
+-- the work returns on its own schedule rather than from a row this file could
+-- forge — one that would carry a new id, a fresh attempt count and this
+-- migration's timestamp, and so would not be the row that was deleted.
+SELECT 1;

--- a/backend/migrations/core/1788640001_three_daily_passes_leave_no_orphans.up.sql
+++ b/backend/migrations/core/1788640001_three_daily_passes_leave_no_orphans.up.sql
@@ -1,0 +1,38 @@
+-- Drain the queued children of three more passes that no longer fan out.
+--
+-- Its own migration, for the reason its predecessors give: a migration that has
+-- already run does not run again, so adding these kinds to an earlier file
+-- would drain them only where that file had not yet been applied.
+--
+-- River does not forget a row because the code stopped declaring its kind, so a
+-- child enqueued by the last tick before this deploy retries its way to
+-- `discarded` against a client that has no worker for it.
+--
+-- THE STATES THAT WILL NEVER RUN, named as an allowlist. Not "everything
+-- non-terminal", which also matches `running`: the API entrypoint applies
+-- migrations before it serves and the worker entrypoint applies none, so during
+-- a rolling deploy an old worker can still be mid-pass on a child when this
+-- runs — and deleting its row out from under it lands its completion write on
+-- nothing. Leaving a running row alone costs nothing: it finishes, becomes
+-- terminal, and never needed draining. A completed row is left for its own
+-- reason: it records that the work ran.
+--
+-- An allowlist rather than a denylist so a state River adds later is excluded
+-- until somebody looks at it, instead of being swept in by a rule that never
+-- heard of it.
+--
+-- Guarded on the table existing, because River owns its own schema and applies
+-- it on first run.
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    DELETE FROM river_job
+     WHERE kind IN (
+             'capture_digest_workspace',
+             'brief_generate_workspace',
+             'weekly_review_generate_workspace'
+           )
+       AND state IN ('available', 'scheduled', 'retryable', 'pending');
+  END IF;
+END
+$$;


### PR DESCRIPTION
Batch five of #1857, stacked on #4470. The capture digest, the morning brief and the weekly review — 15 workspace pairs remain after this. Each keeps its own deadline (5m, 10m, 10m) from the child.

## The sweep tag had to move

`jobs.SweepTag` marks a row as part of a fleet pass, and the sweep gauges count tagged rows. It was stamped at the dispatch chokepoint, on the **children** a dispatcher enqueued — never on the dispatcher's own row.

The collapse deletes the children. So the gauges were left with nothing tagged to count, and a one-off enqueue of a collapsed kind became indistinguishable from a scheduled tick of it.

`periodicInsertOpts` now stamps the tag for a **fleet-wide** kind, which is what such a row now is. Both properties come back: what the gauges read is a pass that ran, and an untagged row of a fleet-wide kind is somebody's one-off — exactly what it meant before. Only fleet-wide, because a periodic kind that owns a tenant is not a fleet pass and tagging it would put a row in the gauges covering no workspaces.

`TestBackfillCompletionBuildsTheDigest` caught it, and its premise had to change twice over:

```
capture_digest rows went 1 -> 2 across the backfill; a completion must enqueue the
CHILD kind for its own workspace, never the dispatcher that fans out over the whole fleet
```

There is no pair to tell apart any more. What survives is the tag, so the test now tells a one-off from a scheduled tick — the distinction that still exists and still matters to the gauges.

`jobs.FleetWide`'s own doc comment stopped being true and is rewritten: the marker no longer implies *"does no tenant write"*, because a collapsed pass writes for every workspace it walks. What it still says is that the row owns no single tenant, so nothing may read a workspace off its args.

## Verification

`make check-backend` exit 0; `internal/compose` and `integration/capture` integration suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Daily digest capture, brief generation, and weekly review processing now run as consolidated passes across workspaces.
  * These operations have increased processing time allowances to better support larger workloads.
  * Scheduled processing now tracks fleet-wide work more consistently.

* **Maintenance**
  * Obsolete queued workspace-level tasks are cleaned up during migration, preventing stale work from being retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->