### PR TITLE
test(analytics): four more canonical questions, and two the engine cannot answer

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 38
+	wantFixtureAnnotations = 39
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/analyticsmcpquestions_integration_test.go
+++ b/backend/internal/compose/analyticsmcpquestions_integration_test.go
@@ -48,6 +48,32 @@ func loadCanonicalQuestions(t *testing.T) []canonicalQuestion {
 	return doc.Questions
 }
 
+// questionSurfaces are the tools this suite can drive.
+//
+// run_analytics_query is the agent's typed grammar; run_report is the HTTP
+// report path. They are different reaches, not two names for one.
+var questionSurfaces = map[string]bool{"run_analytics_query": true, "run_report": true}
+
+// caseSurfaces names which surface each proof ACTUALLY drives, so the corpus
+// cannot claim one and prove another.
+//
+// Kept beside the case map rather than derived from it: a proof's body is what
+// decides its surface, and reading that from the source would be a census over
+// a thing this file already knows by hand.
+//
+// gatekit:fixture the surface each canonical proof actually drives
+var caseSurfaces = map[string]string{
+	"G01": "run_analytics_query",
+	"G02": "run_analytics_query",
+	"G03": "run_analytics_query",
+	"M04": "run_analytics_query",
+	"M05": "run_analytics_query",
+	"M06": "run_analytics_query",
+	"M07": "run_report",
+	"M08": "run_analytics_query",
+	"M12": "run_analytics_query",
+}
+
 // canonicalCases maps each corpus id to its executable proof.
 func canonicalCases() map[string]func(t *testing.T) {
 	return map[string]func(t *testing.T){
@@ -55,7 +81,11 @@ func canonicalCases() map[string]func(t *testing.T) {
 		"G02": proveG02WorkspaceRefused,
 		"G03": proveG03OneBaseCurrencyNumber,
 		"M04": proveM04OneRowPerStage,
+		"M05": proveM05ConcentrationNeedsCountAndValue,
 		"M06": proveM06MedianUnderTheFloor,
+		"M07": proveM07StuckDealsUseTheSharedRule,
+		"M08": proveM08WinRateByCountAndValue,
+		"M12": proveM12WonRevenueByLeadSource,
 	}
 }
 
@@ -63,9 +93,24 @@ func TestEveryCanonicalQuestionHasExecutableProof(t *testing.T) {
 	cases := canonicalCases()
 	seen := map[string]bool{}
 	for _, q := range loadCanonicalQuestions(t) {
-		if q.Tool != "run_analytics_query" {
+		// Two tools, because two surfaces answer these questions and one cannot
+		// answer all of them: the analytics schema publishes a spec's dimensions
+		// and measures, so a question turning on a report FILTER (M07's
+		// `stalled`) is reachable over HTTP and not through the typed grammar.
+		//
+		// The tool a question NAMES has to be the surface its proof drives, and
+		// that is checked below rather than assumed. Accepting the value alone
+		// would let a question declare one surface while its case exercised
+		// another — which is how a corpus comes to claim the agent can answer
+		// something only the web app can.
+		if _, known := questionSurfaces[q.Tool]; !known {
 			t.Errorf("%s names tool %q, which this suite does not drive — either the corpus "+
 				"or the case map is ahead of the other", q.ID, q.Tool)
+		}
+		if surface := caseSurfaces[q.ID]; surface != "" && surface != q.Tool {
+			t.Errorf("%s says it is answered by %q and its proof drives %q — a corpus that "+
+				"names the wrong surface claims a reach the product does not have",
+				q.ID, q.Tool, surface)
 		}
 		if _, proved := cases[q.ID]; !proved {
 			t.Errorf("%s (%q) has no executable case — a question without proof is prose", q.ID, q.Question)

--- a/backend/internal/compose/analyticsmcpquestions_manager_integration_test.go
+++ b/backend/internal/compose/analyticsmcpquestions_manager_integration_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The manager half of the canonical corpus, answered through the MCP tool
+// runner against a real database.
+//
+// Each case seeds a fixture that can DISCRIMINATE: a wrong engine returns a
+// different number rather than the same one, and the failure message says which
+// wrong answer it got. A proof whose fixture cannot tell right from wrong is
+// prose with a test around it.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedClosedOwnedDeal writes one won or lost deal OWNED by somebody.
+//
+// seedPricedDeal leaves owner_id NULL, which is right for the currency cases it
+// serves and wrong here: every report in this file measures the caller's own
+// population by default, so an unowned deal is invisible to the manager asking
+// about their team and the fixture would prove nothing.
+func seedClosedOwnedDeal(
+	t *testing.T, e *forecastEnv, name string, amountMinor int64, status, source string, owner ids.UUID,
+) {
+	t.Helper()
+	e.seedID(t, `INSERT INTO deal
+		(id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, status, closed_at,
+		 fx_rate_to_base, fx_rate_date, lost_reason, expected_close_date, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, $6, 'EUR', $7::text, now(), 1, current_date,
+		        CASE WHEN $7::text = 'lost' THEN 'went elsewhere' END,
+		        (now() + interval '30 days')::date, $8, 'human:x')`,
+		name, e.pipeline, e.stages[pipelineTestStage], owner, amountMinor, status, source)
+}
+
+// M08 — win rate by deal COUNT and by VALUE, this quarter.
+//
+// The two rates are different questions and a manager acts differently on each:
+// winning most of the small ones and losing the large one is a good count rate
+// and a bad value rate. An engine that reported one number for both would hide
+// exactly the quarter worth knowing about.
+func proveM08WinRateByCountAndValue(t *testing.T) {
+	e := setupForecast(t)
+	// Six won at 10k and five lost at 60k: 6 of 11 deals won (55%) against
+	// 60k of 360k in value (17%). Most deals won, most of the money lost —
+	// deliberately opposite, so one number cannot land on both.
+	//
+	// Both groups clear the privacy floor. A cohort under it is WITHHELD, which
+	// is the right answer to a question about few people and the wrong fixture
+	// for a question about arithmetic: every assertion below would read null.
+	for range 6 {
+		seedClosedOwnedDeal(t, e, "Small win", 10_000, "won", "manual", e.Rep1)
+	}
+	for range 5 {
+		seedClosedOwnedDeal(t, e, "Large loss", 60_000, "lost", "manual", e.Rep1)
+	}
+
+	got, err := askTool(e.wideLensCtx(e.Rep1), t, e,
+		`{"entity":"win-loss","group_by":["status"],"measures":[`+
+			`{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_base_minor","as":"value"}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byStatus := map[string]map[string]any{}
+	for _, raw := range got.Rows {
+		row := toolRow(t, raw)
+		status, ok := row["status"].(string)
+		if !ok {
+			t.Fatalf("a row carries status %v (%T), want a string", row["status"], row["status"])
+		}
+		byStatus[status] = row
+	}
+	if len(byStatus) != 2 {
+		t.Fatalf("the answer holds %d statuses, want won and lost", len(byStatus))
+	}
+	if n := byStatus["won"]["deals"]; n != float64(6) {
+		t.Errorf("won deals = %v, want 6", n)
+	}
+	if n := byStatus["lost"]["deals"]; n != float64(5) {
+		t.Errorf("lost deals = %v, want 5", n)
+	}
+	// The value side, where the count answer would be wrong. 300k lost against
+	// 30k won: a manager reading only the count rate would call this a good
+	// quarter.
+	if v := byStatus["won"]["value"]; v != float64(60_000) {
+		t.Errorf("won value = %v, want 60000 — the count rate and the value rate must be "+
+			"separately readable, or lost money hides behind a majority of small wins", v)
+	}
+	if v := byStatus["lost"]["value"]; v != float64(300_000) {
+		t.Errorf("lost value = %v, want 300000 — more deals won, more money lost", v)
+	}
+}
+
+// M12 — which lead sources created the most won revenue.
+//
+// Grouped by the source the deal actually carries, and over WON deals only:
+// counting open pipeline here would credit a source for revenue nobody has.
+func proveM12WonRevenueByLeadSource(t *testing.T) {
+	e := setupForecast(t)
+	// Two sources, unequal, plus five LOST outbound deals worth far more than
+	// either won total.
+	//
+	// The lost cohort is the discriminator and an open deal would not be: this
+	// report's base predicate already excludes open deals before any caller
+	// filter runs, so seeding one proves nothing about the status filter. An
+	// engine that ignored the filter would count the losses and report outbound
+	// as the best source in the business.
+	for range 5 {
+		seedClosedOwnedDeal(t, e, "Referral win", 16_000, "won", "referral", e.Rep1)
+		seedClosedOwnedDeal(t, e, "Outbound win", 4_000, "won", "outbound", e.Rep1)
+		seedClosedOwnedDeal(t, e, "Outbound loss", 200_000, "lost", "outbound", e.Rep1)
+	}
+
+	got, err := askTool(e.wideLensCtx(e.Rep1), t, e,
+		`{"entity":"win-loss","group_by":["source"],"measures":[`+
+			`{"fn":"sum","field":"amount_base_minor","as":"value"}],`+
+			`"filters":[{"field":"status","op":"eq","value":"won"}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bySource := map[string]any{}
+	for _, raw := range got.Rows {
+		row := toolRow(t, raw)
+		source, ok := row["source"].(string)
+		if !ok {
+			t.Fatalf("a row carries source %v (%T), want a string", row["source"], row["source"])
+		}
+		bySource[source] = row["value"]
+	}
+	if v := bySource["referral"]; v != float64(80_000) {
+		t.Errorf("referral won revenue = %v, want 80000", v)
+	}
+	// An engine ignoring the status filter answers 1020000 here and reports
+	// outbound as the best source in the business, on a million of losses.
+	if v := bySource["outbound"]; v != float64(20_000) {
+		t.Errorf("outbound won revenue = %v, want 20000 — a lost deal is not won revenue", v)
+	}
+	if len(bySource) != 2 {
+		t.Errorf("the answer holds %d sources, want exactly referral and outbound — a third "+
+			"row means the cohort reached deals this fixture did not seed", len(bySource))
+	}
+}
+
+// M05 — is our pipeline too concentrated in a few large deals?
+//
+// Count and value together, because concentration IS the gap between them: ten
+// deals worth a million where one is 900k is a different book from ten worth
+// a hundred thousand each, and the count alone cannot tell them apart.
+func proveM05ConcentrationNeedsCountAndValue(t *testing.T) {
+	e := setupForecast(t)
+	small := int64(10_000)
+	for range 9 {
+		e.seedOpenDeal(t, "Ordinary", pipelineTestStage, &e.Rep1, &small, nil)
+	}
+	whale := int64(900_000)
+	e.seedOpenDeal(t, "The whale", pipelineTestStage, &e.Rep1, &whale, nil)
+
+	got, err := askTool(e.wideLensCtx(e.Rep1), t, e,
+		`{"entity":"pipeline-current","measures":[`+
+			`{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_base_minor","as":"value"},`+
+			`{"fn":"max","field":"amount_base_minor","as":"largest"}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rows) != 1 {
+		t.Fatalf("an ungrouped question answered %d rows, want 1", len(got.Rows))
+	}
+	row := toolRow(t, got.Rows[0])
+	if n := row["deals"]; n != float64(10) {
+		t.Errorf("deals = %v, want 10", n)
+	}
+	if v := row["value"]; v != float64(990_000) {
+		t.Errorf("value = %v, want 990000", v)
+	}
+	// The largest beside the total is what makes concentration sayable: 900k of
+	// 990k rests on one deal, and no count could reveal that.
+	if v := row["largest"]; v != float64(900_000) {
+		t.Errorf("largest = %v, want 900000 — without it a reader cannot tell a concentrated "+
+			"book from an even one", v)
+	}
+}
+
+// M07 — which open deals are stuck with no agreed next step.
+//
+// Answered through the REPORT path rather than the typed grammar, and that is
+// the finding rather than a workaround: `stalled` is a report FILTER, and the
+// analytics schema publishes dimensions and measures only
+// (analyticsqueryseam.go). So an agent asking this question through
+// run_analytics_query is told the field does not exist, while the same question
+// answers fine over HTTP.
+//
+// Stalled is a shared rule (deals.StalledSQL) rather than a threshold this
+// report invents: a deal flagged here and unflagged on the board would make one
+// of the two screens wrong.
+func proveM07StuckDealsUseTheSharedRule(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(50_000)
+	// One deal untouched for 90 days, one created just now.
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor,
+		currency, status, expected_close_date, source, captured_by, created_at, updated_at)
+		VALUES ($1, 'Idle for months', $2, $3, $4, 50000, 'EUR', 'open',
+		        (now() + interval '30 days')::date, 'manual', 'human:x',
+		        now() - interval '90 days', now() - interval '90 days')`,
+		e.pipeline, e.stages[pipelineTestStage], e.Rep1)
+	e.seedOpenDeal(t, "Fresh", pipelineTestStage, &e.Rep1, &amount, nil)
+
+	result := e.runReport(e.wideLensCtx(e.Rep1), t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"}],`+
+			`"filters":{"stalled":true}}`)
+	row := dealsByStageRow(t, result, e.stages[pipelineTestStage].String())
+	if got := wireInt(t, row, "deals"); got != 1 {
+		t.Errorf("stalled deals = %d, want 1 — the fresh deal is not stuck, and a rule that "+
+			"counted it would flag every deal a rep opened this morning", got)
+	}
+}

--- a/backend/internal/compose/testdata/analytics_mcp_questions.json
+++ b/backend/internal/compose/testdata/analytics_mcp_questions.json
@@ -1,5 +1,5 @@
 {
-  "comment": "The canonical persona questions the analytics MCP surface answers deterministically. The exact question string here is THE question — no test may refer to an older draft. Every entry has an executable case in analyticsmcpquestions_integration_test.go, held in both directions by TestEveryCanonicalQuestionHasExecutableProof.",
+  "comment": "The canonical persona questions the analytics MCP surface answers deterministically. The exact question string here is THE question \u2014 no test may refer to an older draft. Every entry has an executable case in analyticsmcpquestions_integration_test.go, held in both directions by TestEveryCanonicalQuestionHasExecutableProof.",
   "questions": [
     {
       "id": "G01",
@@ -13,7 +13,7 @@
       "persona": "rep",
       "question": "Show me the whole company's pipeline by owner.",
       "tool": "run_analytics_query",
-      "expects": "Refused outright — never quietly narrowed to a population the answer does not name."
+      "expects": "Refused outright \u2014 never quietly narrowed to a population the answer does not name."
     },
     {
       "id": "G03",
@@ -27,7 +27,7 @@
       "persona": "team manager",
       "question": "How much open pipeline does my team have in each stage right now?",
       "tool": "run_analytics_query",
-      "expects": "One row per stage, open deals only, the caller's own population — a colleague's deals and closed deals both stay out."
+      "expects": "One row per stage, open deals only, the caller's own population \u2014 a colleague's deals and closed deals both stay out."
     },
     {
       "id": "M06",
@@ -35,6 +35,34 @@
       "question": "Which stages are taking longer than normal for my team?",
       "tool": "run_analytics_query",
       "expects": "Asked under the caller's own lens; a median below the five-value sample floor is null beside an honest count, never one deal's value wearing a statistic's name."
+    },
+    {
+      "id": "M05",
+      "persona": "team manager",
+      "question": "Is our pipeline too concentrated in a few large deals?",
+      "tool": "run_analytics_query",
+      "expects": "Count and value together, plus the largest deal \u2014 concentration is the gap between them, and a count alone cannot show it."
+    },
+    {
+      "id": "M07",
+      "persona": "team manager",
+      "question": "Which open deals are stuck and have no agreed next step?",
+      "tool": "run_report",
+      "expects": "The shared stalled rule over the report path. `stalled` is a report FILTER and the analytics schema publishes dimensions and measures only, so an agent asking this through run_analytics_query is told the field does not exist."
+    },
+    {
+      "id": "M08",
+      "persona": "team manager",
+      "question": "What is my team's win rate by deal count and by value this quarter?",
+      "tool": "run_analytics_query",
+      "expects": "Count and value are separate readings: six wins at 10k beside five losses at 60k is a majority of deals won and a majority of the money lost, and one number cannot say both."
+    },
+    {
+      "id": "M12",
+      "persona": "team manager",
+      "question": "Which lead sources created the most won revenue?",
+      "tool": "run_analytics_query",
+      "expects": "Won revenue by the source the deal carries, in base currency. The lost cohort is the discriminator: win-loss already excludes open deals, so an engine ignoring the status filter would count losses as revenue."
     }
   ]
 }


### PR DESCRIPTION
Part of #4337. The corpus goes from five Core questions to nine, each with an
executable proof against a real database.

## Why not more

The census here is two-way and strict: a question with no case fails, and a case
proving a question the corpus dropped fails. **A question cannot be added as
prose.** So the count is bounded by what the engine can actually answer, and
finding that boundary was most of the work.

New: pipeline concentration (M05), stuck deals (M07), win rate by count AND
value (M08), won revenue by lead source (M12).

## Two questions were written, passed, and removed

Both proved a **different, weaker question** than the plan asks, and keeping
either would make the corpus assert a reach this product does not have.

- **M11** — "why are we losing, by recorded reason". `win-loss` publishes no
  `lost_reason` dimension, so the proof counted lost deals by status and called
  that reasons.
- **G04** — "prove why this account is included". `AnalyticsQueryResult` carries
  no derivation handle and no records, so the proof exercised the HTTP report
  path while the corpus claimed the agent could do it.

Filed as #4476 with the shape each needs.

## An agent cannot ask which deals are stuck

`run_analytics_query` answers *no field named "stalled"*; the web screen answers
fine. The analytics schema publishes a spec's dimensions and measures, and
`stalled` lives in a third vocabulary — the filters holding rules a caller
cannot express as a column comparison. Filed as #4475.

M07 is proved on the report path, and **the census now binds the tool a question
declares to the surface its proof drives**. Accepting the value alone let a
corpus name one surface and prove another, which is exactly how it comes to
claim the agent can do what only the web app can.

## Three fixtures were silently withheld

Seeded at one to three deals, every group fell under the privacy floor and every
value came back `null` — so the assertions compared nothing and passed. A cohort
under the floor is the right ANSWER to a question about few records and the
wrong FIXTURE for a question about arithmetic.

## M12's discriminator proved nothing

It seeded an open deal to show "won revenue excludes pipeline", but `win-loss`
excludes open deals in its base predicate before any caller filter runs. It now
seeds a million in **lost** deals.

## Mutation-checked

- dropping every caller filter → M12 fails
- breaking the base-value measure → M08 fails with the count in its place, the
  "one number for both rates" defect it exists to catch
- mislabelling M07's surface → the census fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the canonical analytics question corpus from five to nine Core questions, each with an executable proof against a real database. Part of #4337.

Four new questions join: pipeline concentration (M05), stuck deals (M07), win rate by count and value (M08), and won revenue by lead source (M12).

- Two written questions (M11, G04) were removed because their proofs answered a weaker question than the plan asks; filed as #4476.
- M07 runs over the report path: `stalled` is a report filter, so `run_analytics_query` cannot reach it; filed as #4475.
- The census now fails when a question declares one tool but its proof drives another.
- Fixtures now clear the privacy floor; previously every group returned `null` and assertions compared nothing.
- M12 now seeds a million in lost deals, so an engine ignoring the status filter fails the proof.

<sup>Written for commit e18824a748f59a414deae38db13d9c6f1840d9f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded analytics integration coverage for manager-focused scenarios, including pipeline concentration, stalled deals, win rates, and won revenue by lead source.
  * Added validation across both typed analytics queries and report-based analytics results.
  * Updated test fixtures to cover an additional annotated package declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->