### PR TITLE
fix(frontend): main is green on fe-lint again

### DIFF
--- a/frontend/e2e/person-record.spec.ts
+++ b/frontend/e2e/person-record.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { signIn } from "./waits";
 
 /**
@@ -45,11 +45,12 @@ live("the contact page on live data", () => {
     // Asserting the boundary is ABSENT is the whole test: it is what the
     // reader saw instead of the page.
     await expect(
-      page.getByText(
-        /stopped working|nicht mehr|ngừng hoạt động/i,
-      ),
+      page.getByText(/stopped working|nicht mehr|ngừng hoạt động/i),
     ).toHaveCount(0);
-    expect(crashes, `uncaught error on the contact page:\n${crashes[0]}`).toEqual([]);
+    expect(
+      crashes,
+      `uncaught error on the contact page:\n${crashes[0]}`,
+    ).toEqual([]);
 
     // And something of the contact is actually drawn, so the assertion above
     // cannot pass over a blank page that merely failed quietly.
@@ -107,7 +108,9 @@ live("the contact page on live data", () => {
     // them takes it down.
     await expect(page.locator(".emaildetail__parties")).toBeVisible();
     await expect(
-      page.getByText(/stopped working|funktioniert nicht mehr|ngừng hoạt động/i),
+      page.getByText(
+        /stopped working|funktioniert nicht mehr|ngừng hoạt động/i,
+      ),
     ).toHaveCount(0);
 
     // A drawer OVER the record, not a page instead of it: the address does not

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -912,8 +912,7 @@ describe("reports never sum money across currencies", () => {
       const aggregates = (body.aggregates ?? []) as { field?: string }[];
       const sumsNative = aggregates.some(
         (aggregate) =>
-          aggregate.field != null &&
-          aggregate.field.endsWith("_minor") &&
+          aggregate.field?.endsWith("_minor") &&
           !aggregate.field.endsWith("_base_minor"),
       );
       if (!sumsNative) {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1818,13 +1818,11 @@ function LeadRecord({
       // fold and memory of it as every other record page.
       aside={
         details.open ? (
-          <>
-            <LeadRail
-              lead={lead}
-              writer={writer}
-              terminalReasonId={terminalReasonId}
-            />
-          </>
+          <LeadRail
+            lead={lead}
+            writer={writer}
+            terminalReasonId={terminalReasonId}
+          />
         ) : undefined
       }
       name={leadIdentityName(lead) || t("lead.unnamed")}
@@ -1847,17 +1845,15 @@ function LeadRecord({
         ) : null
       }
       actions={
-        <>
-          <LeadActions
-            lead={lead}
-            id={id}
-            cf={cf}
-            overlay={overlay}
-            terminalReasonId={terminalReasonId}
-            onQualify={() => setDialog("qualify")}
-            onDisqualify={() => setDialog("disqualify")}
-          />
-        </>
+        <LeadActions
+          lead={lead}
+          id={id}
+          cf={cf}
+          overlay={overlay}
+          terminalReasonId={terminalReasonId}
+          onQualify={() => setDialog("qualify")}
+          onDisqualify={() => setDialog("disqualify")}
+        />
       }
       actionsInline
       // The shell stamps timeline rows in this zone. The viewer's own is the

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -409,20 +409,18 @@ export function PersonPageV2({
         subtitle={<PersonSubtitle view={view.data} />}
         pulse={<PersonIdentityLine view={view.data} />}
         actions={
-          <>
-            <PersonActions
-              view={view.data}
-              consentAllows={emailAllowed}
-              consentKnown={guard.data !== undefined}
-              personId={id}
-              overlay={overlay}
-              onWrite={() => openComposer("")}
-              onWriteMail={() => setDrawer("mail")}
-              onResearch={() => setDrawer("research")}
-              onLogActivity={() => setDrawer("activity_log")}
-              onAddTask={() => setDrawer("activity_task")}
-            />
-          </>
+          <PersonActions
+            view={view.data}
+            consentAllows={emailAllowed}
+            consentKnown={guard.data !== undefined}
+            personId={id}
+            overlay={overlay}
+            onWrite={() => openComposer("")}
+            onWriteMail={() => setDrawer("mail")}
+            onResearch={() => setDrawer("research")}
+            onLogActivity={() => setDrawer("activity_log")}
+            onAddTask={() => setDrawer("activity_task")}
+          />
         }
         actionsInline
         zone={recordZone}


### PR DESCRIPTION
**`fe-lint` is red on main.** Reproduced on a pristine `origin/main` checkout before changing anything:

```
src/screens/leads.tsx:1821:11        lint/complexity/noUselessFragments
src/screens/leads.tsx:1850:9         lint/complexity/noUselessFragments
src/screens/personpage.tsx:412:11    lint/complexity/noUselessFragments
src/screens/analytics.test.tsx:915   lint/complexity/useOptionalChain
e2e/person-record.spec.ts:1:18       lint/correctness/noUnusedImports
e2e/person-record.spec.ts            format
```

None introduced here. #4401 fixed the **uat** half of the same main-red episode and left this half, so every frontend PR still inherits a failing required lane through its merge commit.

Applied with biome's own fixer rather than by hand, so the diff is exactly what the lane asks for and nothing else.

`make check-fe` green.

This is the residue of my #4405, which I closed as superseded once #4401 landed — it covered the uat causes but not these.
