### PR TITLE
feat(pipeline): rebuild the board's card around what a rep asks of it

### DIFF
--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -9,10 +9,10 @@
  * the track gave them. */
 .board {
   display: flex;
-  gap: 12px;
+  gap: var(--space-4);
   align-items: flex-start;
   overflow-x: auto;
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
 }
 .board-col {
   /* The containing block for anything absolutely positioned inside a column.
@@ -27,10 +27,10 @@
   min-width: 220px;
   background: var(--bgCard);
   border-radius: var(--r-md);
-  padding: 10px;
+  padding: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 120px;
 }
 .board-col.droptarget {
@@ -137,21 +137,38 @@
   /* An anchor now rather than a button (composed.tsx says why), so it takes the
      two things the platform gives a link and this card must not have: the UA's
      own ink and an underline. `a:not([class])` in base.css does not reach a
-     classed anchor, so they are stated here. */
+     classed anchor, so they are stated here — and neither does its focus ring,
+     which is why this card states its own below. */
   color: inherit;
   text-decoration: none;
-  background: var(--bgElevated);
-  border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
-  box-shadow: var(--shadow-card);
-  padding: 10px 12px;
+  /* The pane over the column's ground, not the elevated surface: a card lifts
+     off the stage it sits in by being translucent white over it, which is the
+     same separation every other pane in the product is drawn with. No
+     --shadow-card on top — that token is a hairline ring, and a ring behind a
+     1px border is the same edge drawn twice. */
+  background: var(--pane);
+  border: 1px solid var(--paneEdge);
+  border-radius: var(--r-control);
+  padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--space-1);
   cursor: pointer;
   text-align: left;
   width: 100%;
   font-family: var(--f-body);
+}
+/* The edge firms up under the pointer. A background step would fight the
+   staged card's own tint, and this card's whole job is to keep those two
+   readings apart. It is stated ABOVE the staged and archived rules on purpose:
+   both restate the whole border, so a card whose edge carries provenance keeps
+   that edge under the pointer rather than trading it for a hover colour. */
+.deal-card:hover {
+  border-color: var(--borderStrong);
+}
+.deal-card:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
 }
 .deal-card.staged {
   background: var(--aiLight);
@@ -166,6 +183,9 @@
   font-weight: 600;
   color: var(--textPrimary);
 }
+/* ABOVE the deal's own name, and quiet: a rep reads this board by account
+   first and by deal second, so the company is what the eye lands on, while the
+   name of the record the card opens stays the line with the weight. */
 .deal-card .deal-org {
   display: flex;
   align-items: center;
@@ -202,6 +222,21 @@
   font-family: var(--f-mono);
   font-size: var(--fs-sm);
   color: var(--textPrimary);
+}
+/* How long it has sat there goes to the far edge, away from the figure: the
+   two are read as separate facts, and side by side they read as one. It is the
+   last item on the line so that the edge it is pushed to is the card's, not
+   whatever badge the deal happens to carry. */
+.deal-card .deal-age {
+  margin-left: auto;
+}
+/* THE CARD IS NOT A TABLE ROW. rowtags.css keeps the strip on one line because
+   a taller cell shifts every row under it; a card owns its own height, and a
+   stage column is narrow enough that a strip which cannot wrap runs past the
+   card's right edge instead. */
+.deal-card .rowtags {
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .record-head {

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -254,6 +254,22 @@
   font-size: var(--fs-sm);
   color: var(--textContent);
 }
+/* The company and, at the far edge of its line, who carries the deal: a mark
+   only, because a rep on a team board scans for their own initials and the
+   name is one hover or one screen reader away. It never gives way — the
+   company's name elides before the mark does, so the mark stays in the same
+   place on every card in the column. */
+.deal-card .deal-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.deal-card .deal-owner {
+  margin-left: auto;
+  flex: none;
+  display: flex;
+}
 
 .record-head {
   display: flex;

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -25,7 +25,12 @@
   position: relative;
   flex: 1 1 220px;
   min-width: 220px;
-  background: var(--bgCard);
+  /* A RECESS in the surface, not a card on it: the page's own ground showing
+     through, which is one hair off the surface in light and one hair under it
+     in dark. --bgCard is a card's ground and read as one — five of them in a
+     row made the board a grid of grey slabs with the deals inside them, and
+     the cards had to fight their own containers to look like the subject. */
+  background: var(--bgPage);
   border-radius: var(--r-md);
   padding: var(--space-3);
   display: flex;
@@ -76,7 +81,9 @@
   align-items: baseline;
   gap: 6px;
   padding: 2px 4px 4px;
-  background: var(--bgCard);
+  /* The column's own ground, or the cards slide visibly behind a transparent
+     strip. It follows --bgPage for the same reason it followed --bgCard. */
+  background: var(--bgPage);
 }
 .board-col-head .stage {
   font-size: var(--fs-sm);
@@ -229,14 +236,6 @@
    whatever badge the deal happens to carry. */
 .deal-card .deal-age {
   margin-left: auto;
-}
-/* THE CARD IS NOT A TABLE ROW. rowtags.css keeps the strip on one line because
-   a taller cell shifts every row under it; a card owns its own height, and a
-   stage column is narrow enough that a strip which cannot wrap runs past the
-   card's right edge instead. */
-.deal-card .rowtags {
-  flex-wrap: wrap;
-  min-width: 0;
 }
 
 .record-head {

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -25,12 +25,11 @@
   position: relative;
   flex: 1 1 220px;
   min-width: 220px;
-  /* A RECESS in the surface, not a card on it: the page's own ground showing
-     through, which is one hair off the surface in light and one hair under it
-     in dark. --bgCard is a card's ground and read as one — five of them in a
-     row made the board a grid of grey slabs with the deals inside them, and
-     the cards had to fight their own containers to look like the subject. */
-  background: var(--bgPage);
+  /* A RECESS in the surface, not a card on it. --bgCard is a card's ground and
+     read as one — five of them in a row made the board a grid of grey slabs
+     with the deals inside them, and the cards had to fight their own
+     containers to look like the subject. */
+  background: var(--bgWell);
   border-radius: var(--r-md);
   padding: var(--space-3);
   display: flex;
@@ -82,8 +81,8 @@
   gap: 6px;
   padding: 2px 4px 4px;
   /* The column's own ground, or the cards slide visibly behind a transparent
-     strip. It follows --bgPage for the same reason it followed --bgCard. */
-  background: var(--bgPage);
+     strip. */
+  background: var(--bgWell);
 }
 .board-col-head .stage {
   font-size: var(--fs-sm);
@@ -185,21 +184,25 @@
   opacity: 0.6;
   border-style: dashed;
 }
-.deal-card .deal-name {
-  font-size: var(--fs-body);
-  font-weight: 600;
-  color: var(--textPrimary);
+/* The card reads top to bottom as a triage: WHO it is with and how long it has
+   sat; WHAT it is; what it is WORTH and when it closes; and, only when there is
+   something to say, what is wrong with it. One fact per line, each in the
+   weight its importance earns — the figure is the loudest thing after the name,
+   because the figure is what a pipeline is a board OF. */
+.deal-card .deal-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  font-size: var(--fs-meta);
+  color: var(--textMeta);
 }
-/* ABOVE the deal's own name, and quiet: a rep reads this board by account
-   first and by deal second, so the company is what the eye lands on, while the
-   name of the record the card opens stays the line with the weight. */
 .deal-card .deal-org {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  font-size: var(--fs-meta);
-  color: var(--textMeta);
   min-width: 0;
+  flex: 1 1 auto;
 }
 /* The card is one line of company in a narrow column, so a long name elides
  * rather than wrapping under its own mark. */
@@ -212,30 +215,60 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-/* A stage column is narrow, so the meta line wraps as whole items: a value or a
- * badge broken across two lines is harder to read than one that moved down. */
-.deal-card .deal-meta {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-1) 7px;
-  font-size: var(--fs-meta);
-  color: var(--textMeta);
-}
-.deal-card .deal-meta > * {
-  white-space: nowrap;
-}
-.deal-card .deal-value {
-  font-family: var(--f-mono);
-  font-size: var(--fs-sm);
-  color: var(--textPrimary);
-}
-/* How long it has sat there goes to the far edge, away from the figure: the
-   two are read as separate facts, and side by side they read as one. It is the
-   last item on the line so that the edge it is pushed to is the card's, not
-   whatever badge the deal happens to carry. */
+/* How long it has sat in the stage, at the far edge of the head line — a
+   timestamp's place, and away from the name it would otherwise read as part
+   of. It never truncates: the company gives way, the figure does not. */
 .deal-card .deal-age {
   margin-left: auto;
+  flex: none;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.deal-card .deal-name {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--textPrimary);
+}
+.deal-card .deal-figure {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
+  margin-top: var(--space-1);
+}
+/* The one figure a reader compares across the board. Tabular so a column of
+   them lines up digit for digit; a hair tighter because a lead-size number in
+   the body face otherwise spreads wider than the name above it. */
+.deal-card .deal-value {
+  font-size: var(--fs-lead);
+  font-weight: var(--fw-semibold);
+  color: var(--textPrimary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.deal-card .deal-closes {
+  font-size: var(--fs-meta);
+  color: var(--textMeta);
+  white-space: nowrap;
+}
+/* A warning about the DATE, not about the deal: one nobody has confirmed, or
+   one already behind us. The tone marks the figure and leaves the card alone,
+   which is the deal strip's rule for the same fact. */
+.deal-card .deal-closes-warn {
+  color: var(--warn);
+}
+/* What is wrong with it, and only then: a card with nothing to flag has no
+   fourth line. Quiet badges — a dot and a word — because a stack of filled
+   pills at the foot of every third card is the field of colour this card was
+   just cleared of. The one filled badge left is the staged one, and it stays
+   filled because it is the agent's provenance and has to be seen. */
+.deal-card .deal-flags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1) var(--space-3);
+  margin-top: var(--space-1);
 }
 
 .record-head {

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -184,25 +184,35 @@
   opacity: 0.6;
   border-style: dashed;
 }
-/* The card reads top to bottom as a triage: WHO it is with and how long it has
-   sat; WHAT it is; what it is WORTH and when it closes; and, only when there is
-   something to say, what is wrong with it. One fact per line, each in the
-   weight its importance earns — the figure is the loudest thing after the name,
-   because the figure is what a pipeline is a board OF. */
-.deal-card .deal-head {
+/* The card answers a rep's questions in the order they ask them, from across
+   the board: does this one need me — a line that exists only when it does;
+   whose deal is it — the company, the line with the weight, because an account
+   is what a rep recognises in a column of forty; what is it worth and when does
+   it close — the figure at lead size, the one thing compared card to card; and
+   last, what it is called, the line that disambiguates two deals on one
+   account and is needed for nothing else. */
+.deal-card .deal-flags {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
-  min-width: 0;
-  font-size: var(--fs-meta);
-  color: var(--textMeta);
+  gap: var(--space-1) var(--space-3);
+  margin-bottom: var(--space-1);
+}
+/* The size of the stall, in the stall's own tone: it sits beside the word, and
+   only ever beside it. */
+.deal-card .deal-age {
+  font-size: var(--fs-sm);
+  color: var(--warn);
+  font-variant-numeric: tabular-nums;
 }
 .deal-card .deal-org {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
-  flex: 1 1 auto;
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--textPrimary);
 }
 /* The card is one line of company in a narrow column, so a long name elides
  * rather than wrapping under its own mark. */
@@ -215,37 +225,19 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-/* How long it has sat in the stage, at the far edge of the head line — a
-   timestamp's place, and away from the name it would otherwise read as part
-   of. It never truncates: the company gives way, the figure does not. */
-.deal-card .deal-age {
-  margin-left: auto;
-  flex: none;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-.deal-card .deal-name {
-  font-size: var(--fs-body);
-  font-weight: var(--fw-semibold);
-  color: var(--textPrimary);
-}
 .deal-card .deal-figure {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--space-1) var(--space-2);
-  margin-top: var(--space-1);
 }
-/* The one figure a reader compares across the board. Tabular so a column of
-   them lines up digit for digit; a hair tighter because a lead-size number in
-   the body face otherwise spreads wider than the name above it. */
+/* Tabular so a column of figures lines up digit for digit. */
 .deal-card .deal-value {
   font-size: var(--fs-lead);
   font-weight: var(--fw-semibold);
   color: var(--textPrimary);
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
 }
 .deal-card .deal-closes {
   font-size: var(--fs-meta);
@@ -258,17 +250,9 @@
 .deal-card .deal-closes-warn {
   color: var(--warn);
 }
-/* What is wrong with it, and only then: a card with nothing to flag has no
-   fourth line. Quiet badges — a dot and a word — because a stack of filled
-   pills at the foot of every third card is the field of colour this card was
-   just cleared of. The one filled badge left is the staged one, and it stays
-   filled because it is the agent's provenance and has to be seen. */
-.deal-card .deal-flags {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-1) var(--space-3);
-  margin-top: var(--space-1);
+.deal-card .deal-name {
+  font-size: var(--fs-sm);
+  color: var(--textContent);
 }
 
 .record-head {

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -181,16 +181,7 @@ const boardColumns: BoardMoneyColumn[] = [
     weightedMinor: 4_500,
     currency: "EUR",
     deals: [
-      // How a deal is FILED, on the card: the same chip strip a list row draws,
-      // so a reader moving between the board and the table reads one thing one
-      // way rather than learning two.
-      boardDeal("d1", "Contoso renewal", 12_000, 3, {
-        tags: [
-          { tag_id: "t-1", name: "Key Account", color: "amber" },
-          { tag_id: "t-2", name: "Churn Risk", color: "rose" },
-          { tag_id: "t-3", name: "DACH", color: "teal" },
-        ],
-      }),
+      boardDeal("d1", "Contoso renewal", 12_000, 3, { singleThreaded: true }),
       boardDeal("d2", "Fabrikam expansion", 33_000, 9, { stalled: true }),
     ],
   },

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -184,6 +184,7 @@ const boardColumns: BoardMoneyColumn[] = [
       boardDeal("d1", "Contoso renewal", 12_000, 3, {
         singleThreaded: true,
         closeDate: "2026-10-14",
+        owner: "Ada Lindqvist",
       }),
       // A close date the nightly run set and nobody confirmed: marked, not hidden.
       boardDeal("d2", "Fabrikam expansion", 33_000, 9, {
@@ -200,7 +201,9 @@ const boardColumns: BoardMoneyColumn[] = [
     rawMinor: 28_000,
     weightedMinor: 8_400,
     currency: "EUR",
-    deals: [boardDeal("d3", "Globex onboarding", 28_000, 14)],
+    deals: [
+      boardDeal("d3", "Globex onboarding", 28_000, 14, { owner: "Tim Rasche" }),
+    ],
   },
   {
     stage: "proposal",

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -181,8 +181,16 @@ const boardColumns: BoardMoneyColumn[] = [
     weightedMinor: 4_500,
     currency: "EUR",
     deals: [
-      boardDeal("d1", "Contoso renewal", 12_000, 3, { singleThreaded: true }),
-      boardDeal("d2", "Fabrikam expansion", 33_000, 9, { stalled: true }),
+      boardDeal("d1", "Contoso renewal", 12_000, 3, {
+        singleThreaded: true,
+        closeDate: "2026-10-14",
+      }),
+      // A close date the nightly run set and nobody confirmed: marked, not hidden.
+      boardDeal("d2", "Fabrikam expansion", 33_000, 9, {
+        stalled: true,
+        closeDate: "2026-09-30",
+        closeDateProvisional: true,
+      }),
     ],
   },
   {
@@ -278,6 +286,7 @@ export const BoardInSurface: StoryObj = {
       <PipelineBoard
         columns={boardColumns}
         cardHref={(d) => `#/deals/${d.id}`}
+        zone="Europe/Berlin"
       />
     </ListSurface>
   ),
@@ -363,6 +372,7 @@ export const BoardWithAbsentMoney: StoryObj = {
     <PipelineBoard
       columns={absentMoneyColumns}
       cardHref={(d) => `#/deals/${d.id}`}
+      zone="Europe/Berlin"
     />
   ),
 };
@@ -397,6 +407,7 @@ export const BoardWithWithheldCompany: StoryObj = {
     <PipelineBoard
       columns={withheldCompanyColumns}
       cardHref={(d) => `#/deals/${d.id}`}
+      zone="Europe/Berlin"
     />
   ),
 };
@@ -437,6 +448,7 @@ export const BoardWithALongStageName: StoryObj = {
     <PipelineBoard
       columns={longStageColumns}
       cardHref={(d) => `#/deals/${d.id}`}
+      zone="Europe/Berlin"
     />
   ),
 };

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -71,6 +71,29 @@ describe("DealCard + PipelineBoard", () => {
     expect(container.querySelector(".avatar")).toBeNull();
   });
 
+  // The owner is a mark at the head line's edge, and the mark carries the NAME:
+  // a monogram a teammate has to decode is not an answer, so the full name is
+  // its label. A deal nobody owns — or whose owner the caller could not name —
+  // draws no slot rather than a blank one.
+  it("marks the owner it was given, labelled by name, and no slot for a deal without one", () => {
+    const { container, rerender } = render(
+      <DealCard
+        deal={{ ...deal, owner: "Ada Lindqvist" }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
+    );
+    expect(screen.getByLabelText("Ada Lindqvist")).toBeTruthy();
+    rerender(
+      <DealCard
+        deal={{ ...deal, owner: null }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
+    );
+    expect(container.querySelector(".deal-owner")).toBeNull();
+  });
+
   it("draws no company slot at all for a deal that names none", () => {
     const { container } = render(
       <DealCard

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -39,7 +39,7 @@ describe("DealCard + PipelineBoard", () => {
   // carried an edge stripe said one thing twice, and the half of it that a
   // reader who cannot see colour gets is the badge.
   it("renders value/age and the stalled aging flag (AC-pipeline-5)", () => {
-    render(<DealCard deal={deal} href="#/deals/d1" />);
+    render(<DealCard deal={deal} href="#/deals/d1" zone="Europe/Berlin" />);
     expect(screen.getByText("€48,000.00")).toBeTruthy();
     expect(screen.getByText("stalled")).toBeTruthy();
     expect(screen.getByRole("link").className).not.toContain("stalled");
@@ -50,7 +50,7 @@ describe("DealCard + PipelineBoard", () => {
   // other surface draws over a withheld value, and a deal that names no company
   // draws nothing — the one case where an empty slot states the truth.
   it("names a company it was given, with the monogram beside it", () => {
-    render(<DealCard deal={deal} href="#/deals/d1" />);
+    render(<DealCard deal={deal} href="#/deals/d1" zone="Europe/Berlin" />);
     expect(screen.getByText("Brandt Automotive")).toBeTruthy();
     expect(screen.getByText("BA")).toBeTruthy();
     expect(screen.queryByLabelText(MASK)).toBeNull();
@@ -61,6 +61,7 @@ describe("DealCard + PipelineBoard", () => {
       <DealCard
         deal={{ ...deal, org: "", orgWithheld: true }}
         href="#/deals/d1"
+        zone="Europe/Berlin"
       />,
     );
     expect(screen.getByLabelText(MASK)).toBeTruthy();
@@ -72,7 +73,11 @@ describe("DealCard + PipelineBoard", () => {
 
   it("draws no company slot at all for a deal that names none", () => {
     const { container } = render(
-      <DealCard deal={{ ...deal, org: "" }} href="#/deals/d1" />,
+      <DealCard
+        deal={{ ...deal, org: "" }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
     );
     expect(screen.queryByLabelText(MASK)).toBeNull();
     expect(container.querySelector(".deal-org")).toBeNull();
@@ -84,10 +89,12 @@ describe("DealCard + PipelineBoard", () => {
         <DealCard
           deal={{ ...deal, id: "real", stalled: false }}
           href="#/deals/real"
+          zone="Europe/Berlin"
         />
         <DealCard
           deal={{ ...deal, id: "staged", stalled: false, staged: true }}
           href="#/deals/staged"
+          zone="Europe/Berlin"
         />
       </>,
     );
@@ -107,7 +114,11 @@ describe("DealCard + PipelineBoard", () => {
       deals: [deal],
     };
     render(
-      <PipelineBoard columns={[column]} cardHref={(d) => `#/deals/${d.id}`} />,
+      <PipelineBoard
+        columns={[column]}
+        cardHref={(d) => `#/deals/${d.id}`}
+        zone="Europe/Berlin"
+      />,
     );
     expect(screen.getByText("40%")).toBeTruthy();
     expect(screen.getByText("1 deals")).toBeTruthy();
@@ -130,7 +141,11 @@ describe("DealCard + PipelineBoard", () => {
       count: 137,
     };
     render(
-      <PipelineBoard columns={[column]} cardHref={(d) => `#/deals/${d.id}`} />,
+      <PipelineBoard
+        columns={[column]}
+        cardHref={(d) => `#/deals/${d.id}`}
+        zone="Europe/Berlin"
+      />,
     );
     expect(screen.getByText("137 deals")).toBeTruthy();
     expect(screen.queryByText("1 deals")).toBeNull();
@@ -154,7 +169,11 @@ describe("DealCard + PipelineBoard", () => {
       sumHidden: true,
     };
     render(
-      <PipelineBoard columns={[column]} cardHref={(d) => `#/deals/${d.id}`} />,
+      <PipelineBoard
+        columns={[column]}
+        cardHref={(d) => `#/deals/${d.id}`}
+        zone="Europe/Berlin"
+      />,
     );
     expect(
       screen.getByText("several currencies — no single total"),
@@ -169,13 +188,25 @@ describe("DealCard + PipelineBoard", () => {
   // amount the server never sent, and a currency sign the card chose cannot be
   // told apart from one the deal actually carries.
   it("a deal with an amount but no currency states no figure, never a currency the card chose", () => {
-    render(<DealCard deal={{ ...deal, currency: null }} href="#/deals/d1" />);
+    render(
+      <DealCard
+        deal={{ ...deal, currency: null }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
+    );
     expect(screen.getByText(MONEY_ABSENT)).toBeTruthy();
     expect(screen.queryByText(/48,000/)).toBeNull();
   });
 
   it("a deal with a currency but no amount states no figure, never a zero", () => {
-    render(<DealCard deal={{ ...deal, valueMinor: null }} href="#/deals/d1" />);
+    render(
+      <DealCard
+        deal={{ ...deal, valueMinor: null }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
+    );
     expect(screen.getByText(MONEY_ABSENT)).toBeTruthy();
     expect(screen.queryByText("€0.00")).toBeNull();
   });
@@ -195,7 +226,11 @@ describe("DealCard + PipelineBoard", () => {
       count: 4,
     };
     render(
-      <PipelineBoard columns={[column]} cardHref={(d) => `#/deals/${d.id}`} />,
+      <PipelineBoard
+        columns={[column]}
+        cardHref={(d) => `#/deals/${d.id}`}
+        zone="Europe/Berlin"
+      />,
     );
     expect(screen.getByText("4 deals")).toBeTruthy();
     expect(screen.getByText(`weighted ${MONEY_ABSENT}`)).toBeTruthy();

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -316,45 +316,51 @@ export function DealCard({
       onClick={(event) => onOpen?.(deal, event)}
       {...dragHandlers}
     >
-      {/* Four lines, read as a triage (composed.css says why in this order):
-          who it is with and how long it has sat; what it is; what it is worth
-          and when it closes; and what is wrong with it, only when something is. */}
-      <span className="deal-head">
-        <DealCardCompany deal={deal} />
-        <span className="deal-age">{formatDuration(deal.ageMs, locale)}</span>
-      </span>
-      <span className="deal-name">{deal.name}</span>
-      <span className="deal-figure">
-        <span className="deal-value">
-          {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}
-        </span>
-        {deal.closeDate && (
-          <DealCloses
-            day={deal.closeDate}
-            provisional={deal.closeDateProvisional ?? false}
-            zone={zone}
-          />
-        )}
-      </span>
-      {(deal.archived ||
+      {/* Read in the order a rep asks (composed.css says why): what needs
+          them, on this card, if anything; whose deal it is; what it is worth
+          and when it closes; and what it is called. */}
+      {(deal.staged ||
         deal.stalled ||
         deal.singleThreaded ||
-        deal.staged) && (
+        deal.archived) && (
         <span className="deal-flags">
-          {deal.archived && <Badge quiet>{t("deal.archived")}</Badge>}
-          {deal.stalled && (
-            <Badge quiet tone="warn">
-              {t("deal.stalled")}
-            </Badge>
-          )}
+          {deal.staged && <Badge tone="ai">{t("deal.staged")}</Badge>}
           {deal.singleThreaded && (
             <Badge quiet tone="danger">
               {t("deal.singleThreaded")}
             </Badge>
           )}
-          {deal.staged && <Badge tone="ai">{t("deal.staged")}</Badge>}
+          {deal.stalled && (
+            <Badge quiet tone="warn">
+              {t("deal.stalled")}
+            </Badge>
+          )}
+          {/* How long it has sat is the size of the stall, and only then: on a
+              healthy card the number is a fact nobody acts on. */}
+          {deal.stalled && (
+            <span className="deal-age">
+              {formatDuration(deal.ageMs, locale)}
+            </span>
+          )}
+          {deal.archived && <Badge quiet>{t("deal.archived")}</Badge>}
         </span>
       )}
+      <DealCardCompany deal={deal} />
+      <span className="deal-figure">
+        <span className="deal-value">
+          {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}
+        </span>
+        {deal.closeDate ? (
+          <DealCloses
+            day={deal.closeDate}
+            provisional={deal.closeDateProvisional ?? false}
+            zone={zone}
+          />
+        ) : (
+          <span className="deal-closes">{t("deal.undated")}</span>
+        )}
+      </span>
+      <span className="deal-name">{deal.name}</span>
     </a>
   );
 }

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -261,20 +261,27 @@ export function DealCard({
       onClick={(event) => onOpen?.(deal, event)}
       {...dragHandlers}
     >
-      <span className="deal-name">{deal.name}</span>
+      {/* The company leads and the deal's own name follows it: a board is read
+          by account first — which pile of cards is this customer's — and the
+          card is scanned rather than read, so the line the eye reaches first is
+          the one it groups by. Weight still says which record the card opens. */}
       <DealCardCompany deal={deal} />
+      <span className="deal-name">{deal.name}</span>
       <RowTags tags={deal.tags} />
       <span className="deal-meta">
         <span className="deal-value">
           {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}
         </span>
-        <span>{formatDuration(deal.ageMs, locale)}</span>
         {deal.archived && <Badge>{t("deal.archived")}</Badge>}
         {deal.stalled && <Badge tone="warn">{t("deal.stalled")}</Badge>}
         {deal.singleThreaded && (
           <Badge tone="danger">{t("deal.singleThreaded")}</Badge>
         )}
         {deal.staged && <Badge tone="ai">{t("deal.staged")}</Badge>}
+        {/* LAST, because the meta line pushes it to the far edge: what it is
+            pushed away from has to be every other item on that line, or a card
+            that carries a badge puts the badge at the edge instead. */}
+        <span className="deal-age">{formatDuration(deal.ageMs, locale)}</span>
       </span>
     </a>
   );

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -22,13 +22,10 @@ import { type Locale, translatePlural, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { EmailEntry } from "./emailentry";
 
-type RowTag = components["schemas"]["RowTag"];
-
 import type { components } from "../api/schema";
 import { Avatar, Badge, Button } from "./atoms";
 import { PageZones, type PageZonesShape } from "./pagezones";
 import { FieldGuard } from "./rbac";
-import { RowTags } from "./rowtags";
 import { useTruncationTooltip } from "./tooltip";
 import { type Provenance, ProvenanceTag } from "./trust";
 import "./composed.css";
@@ -91,9 +88,6 @@ export type BoardDeal = BoardRecord & {
   valueMinor: number | null;
   currency: string | null;
   ageMs: number;
-  /** How this deal is filed. The board draws the same chip strip a list row
-   *  does, so a reader moving between the two reads one thing one way. */
-  tags?: readonly RowTag[];
   stalled?: boolean;
   singleThreaded?: boolean;
   staged?: boolean;
@@ -208,6 +202,17 @@ function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
   );
 }
 
+/**
+ * One deal, as a card on the board.
+ *
+ * NO TAG STRIP. How a deal is filed is a fact about the record, not about the
+ * work in front of the reader, and a board is scanned: three coloured chips per
+ * card turned five columns into a field of colour with the deal names competing
+ * against it. The words are a column in the deals table and a panel on the
+ * record, which are the two places a reader goes to ask how something is filed.
+ * What stays here is what a reader triages by — who it is with, what it is,
+ * what it is worth, how long it has sat, and what is wrong with it.
+ */
 export function DealCard({
   deal,
   href,
@@ -267,7 +272,6 @@ export function DealCard({
           the one it groups by. Weight still says which record the card opens. */}
       <DealCardCompany deal={deal} />
       <span className="deal-name">{deal.name}</span>
-      <RowTags tags={deal.tags} />
       <span className="deal-meta">
         <span className="deal-value">
           {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -11,9 +11,11 @@ import {
 import type { ReactNode } from "react";
 import { Fragment, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { components } from "../api/schema";
+import { calendarDay, middayInstant } from "../format/calendarday";
 import { splitEmailBody } from "../format/emailtext";
 import {
   formatDate,
+  formatDayMonth,
   formatDuration,
   formatMoneyOrAbsent,
   formatNumber,
@@ -87,6 +89,16 @@ export type BoardDeal = BoardRecord & {
   valueMinor: number | null;
   currency: string | null;
   ageMs: number;
+  /**
+   * When the deal is expected to close, as the calendar day the record holds.
+   * Null on a deal nobody has dated, and the card then states no date rather
+   * than a guess. `closeDateProvisional` says the day is the nightly run's
+   * replacement for one that aged into the past and no human has confirmed —
+   * a date that reads as agreed with the buyer when it was not is the quiet
+   * kind of wrong, so the card marks it.
+   */
+  closeDate?: string | null;
+  closeDateProvisional?: boolean;
   stalled?: boolean;
   singleThreaded?: boolean;
   staged?: boolean;
@@ -202,6 +214,37 @@ function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
 }
 
 /**
+ * When the deal closes, on the card's figure line.
+ *
+ * Read as a calendar day in the record's zone, never as the instant midnight
+ * UTC — that instant is the previous date for half the world. The tone marks
+ * the DATE when it is one nobody confirmed or one already behind us, and says
+ * so in words for a reader who does not get the colour; the deal strip states
+ * the same fact the same two ways.
+ */
+function DealCloses({
+  day,
+  provisional,
+  zone,
+}: Readonly<{ day: string; provisional: boolean; zone: string }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const overdue = day < calendarDay(new Date(), zone);
+  const classes =
+    provisional || overdue ? "deal-closes deal-closes-warn" : "deal-closes";
+  return (
+    <span className={classes}>
+      {t("deal.closes", {
+        date: formatDayMonth(middayInstant(day, zone), locale, zone),
+      })}
+      {provisional && (
+        <span className="sr-only"> · {t("deal.closesProvisional")}</span>
+      )}
+    </span>
+  );
+}
+
+/**
  * One deal, as a card on the board.
  *
  * NO TAG STRIP. How a deal is filed is a fact about the record, not about the
@@ -215,10 +258,18 @@ function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
 export function DealCard({
   deal,
   href,
+  zone,
   onOpen,
   dragHandlers,
 }: Readonly<{
   deal: BoardDeal;
+  /**
+   * The IANA zone the close date is read in. A close date is a calendar day,
+   * and a day formatted as if it were an instant lands on the previous date
+   * for every reader west of Greenwich — so the card takes the zone the record
+   * lives in, the same way the timeline does, rather than the browser's.
+   */
+  zone: string;
   /**
    * The deal's own address.
    *
@@ -265,27 +316,45 @@ export function DealCard({
       onClick={(event) => onOpen?.(deal, event)}
       {...dragHandlers}
     >
-      {/* The company leads and the deal's own name follows it: a board is read
-          by account first — which pile of cards is this customer's — and the
-          card is scanned rather than read, so the line the eye reaches first is
-          the one it groups by. Weight still says which record the card opens. */}
-      <DealCardCompany deal={deal} />
+      {/* Four lines, read as a triage (composed.css says why in this order):
+          who it is with and how long it has sat; what it is; what it is worth
+          and when it closes; and what is wrong with it, only when something is. */}
+      <span className="deal-head">
+        <DealCardCompany deal={deal} />
+        <span className="deal-age">{formatDuration(deal.ageMs, locale)}</span>
+      </span>
       <span className="deal-name">{deal.name}</span>
-      <span className="deal-meta">
+      <span className="deal-figure">
         <span className="deal-value">
           {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}
         </span>
-        {deal.archived && <Badge>{t("deal.archived")}</Badge>}
-        {deal.stalled && <Badge tone="warn">{t("deal.stalled")}</Badge>}
-        {deal.singleThreaded && (
-          <Badge tone="danger">{t("deal.singleThreaded")}</Badge>
+        {deal.closeDate && (
+          <DealCloses
+            day={deal.closeDate}
+            provisional={deal.closeDateProvisional ?? false}
+            zone={zone}
+          />
         )}
-        {deal.staged && <Badge tone="ai">{t("deal.staged")}</Badge>}
-        {/* LAST, because the meta line pushes it to the far edge: what it is
-            pushed away from has to be every other item on that line, or a card
-            that carries a badge puts the badge at the edge instead. */}
-        <span className="deal-age">{formatDuration(deal.ageMs, locale)}</span>
       </span>
+      {(deal.archived ||
+        deal.stalled ||
+        deal.singleThreaded ||
+        deal.staged) && (
+        <span className="deal-flags">
+          {deal.archived && <Badge quiet>{t("deal.archived")}</Badge>}
+          {deal.stalled && (
+            <Badge quiet tone="warn">
+              {t("deal.stalled")}
+            </Badge>
+          )}
+          {deal.singleThreaded && (
+            <Badge quiet tone="danger">
+              {t("deal.singleThreaded")}
+            </Badge>
+          )}
+          {deal.staged && <Badge tone="ai">{t("deal.staged")}</Badge>}
+        </span>
+      )}
     </a>
   );
 }
@@ -330,6 +399,8 @@ type DealBoardProps = BoardHandlers<BoardDeal> & {
    */
   cardHref: (deal: BoardDeal) => string;
   onOpen?: (deal: BoardDeal, event: React.MouseEvent) => void;
+  /** The zone a close date is read in — see `DealCard`'s `zone`. */
+  zone: string;
 };
 
 type BoardLayoutProps<Record extends BoardRecord> = BoardHandlers<Record> & {
@@ -515,6 +586,7 @@ export function PipelineBoard<Record extends BoardRecord>(
         <DealCard
           deal={deal}
           href={props.cardHref(deal)}
+          zone={props.zone}
           onOpen={props.onOpen}
           dragHandlers={props.cardDragHandlers?.(deal, column)}
         />

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { Fragment, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { components } from "../api/schema";
 import { splitEmailBody } from "../format/emailtext";
 import {
   formatDate,
@@ -20,10 +21,8 @@ import {
 } from "../format/format";
 import { type Locale, translatePlural, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { EmailEntry } from "./emailentry";
-
-import type { components } from "../api/schema";
 import { Avatar, Badge, Button } from "./atoms";
+import { EmailEntry } from "./emailentry";
 import { PageZones, type PageZonesShape } from "./pagezones";
 import { FieldGuard } from "./rbac";
 import { useTruncationTooltip } from "./tooltip";

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -27,7 +27,7 @@ import { Avatar, Badge, Button } from "./atoms";
 import { EmailEntry } from "./emailentry";
 import { PageZones, type PageZonesShape } from "./pagezones";
 import { FieldGuard } from "./rbac";
-import { useTruncationTooltip } from "./tooltip";
+import { useTooltip, useTruncationTooltip } from "./tooltip";
 import { type Provenance, ProvenanceTag } from "./trust";
 import "./composed.css";
 
@@ -99,6 +99,13 @@ export type BoardDeal = BoardRecord & {
    */
   closeDate?: string | null;
   closeDateProvisional?: boolean;
+  /**
+   * Who carries the deal, as a display name. Null for a deal nobody owns and
+   * for one whose owner the caller could not name — the card draws nothing for
+   * either, small as it is; the table's owner column is where the two are
+   * told apart.
+   */
+  owner?: string | null;
   stalled?: boolean;
   singleThreaded?: boolean;
   staged?: boolean;
@@ -209,6 +216,31 @@ function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
           has nothing for the ellipsis to apply to, and wraps under its own
           mark instead. */}
       <span className="deal-org-name">{deal.org}</span>
+    </span>
+  );
+}
+
+/**
+ * Who carries the deal, as a mark at the edge of the company line.
+ *
+ * A monogram is not an answer on its own — a teammate has to decode it — so the
+ * mark carries the full name as its label, which a screen reader gets as part
+ * of the card's own name and a pointer gets as a tip. The tip grants no tab
+ * stop of its own: the card is a link and already has one, and a second stop
+ * inside it would be a control that does nothing.
+ */
+function DealOwner({ name }: Readonly<{ name: string }>) {
+  const tip = useTooltip<HTMLSpanElement>(name);
+  return (
+    <span
+      className="deal-owner"
+      role="img"
+      aria-label={name}
+      ref={tip.ref}
+      {...tip.trigger}
+    >
+      <Avatar name={name} size="xs" />
+      {tip.tip}
     </span>
   );
 }
@@ -345,7 +377,10 @@ export function DealCard({
           {deal.archived && <Badge quiet>{t("deal.archived")}</Badge>}
         </span>
       )}
-      <DealCardCompany deal={deal} />
+      <span className="deal-head">
+        <DealCardCompany deal={deal} />
+        {deal.owner && <DealOwner name={deal.owner} />}
+      </span>
       <span className="deal-figure">
         <span className="deal-value">
           {formatMoneyOrAbsent(deal.valueMinor, deal.currency, locale)}

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -45,6 +45,11 @@
    * only, which is invisible once the page stops being white. */
   --bgCard: #eaedeb;
   --bgHover: #edf0ee;
+  /* A RECESS in an elevated surface — the well a board's stage is drawn as.
+   * One hair under --bgElevated (1.03:1), which is what lets the panes inside
+   * it be the lifted thing: --bgCard is a card's own ground, and five of them
+   * side by side read as five cards with cards inside them. */
+  --bgWell: #f6f8f7;
   /* The sidebar's own ground, DARKER than the page rather than lighter: the
    * application's left edge is visible without a second border, and chrome that
    * recedes is chrome that stops competing with what it frames. A token rather
@@ -572,6 +577,9 @@
   --bgElevated: #161d1a;
   --bgCard: #1a211e;
   --bgHover: #1f2623;
+  /* Under --bgElevated, the way the light well sits under its surface: a
+     recess goes away from the lifted ground in both themes. */
+  --bgWell: #111815;
   /* The same RELATION the light theme states, mirrored rather than copied: the
      sidebar is one step off the page in the direction away from the elevated
      surface, so the chrome recedes in both themes. Dark is where that means
@@ -720,6 +728,9 @@
     --bgElevated: #161d1a;
     --bgCard: #1a211e;
     --bgHover: #1f2623;
+    /* Under --bgElevated, the way the light well sits under its surface: a
+       recess goes away from the lifted ground in both themes. */
+    --bgWell: #111815;
     --bgSidebar: #030504;
     --bgSidebarHover: #0a100e;
     --bgTopbar: rgba(14, 27, 22, 0.9);

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -288,6 +288,9 @@ export const de = {
   "deal.archived": "archiviert",
   "deal.singleThreaded": "nur eine Person",
   "deal.staged": "vorgemerkt",
+  "deal.closes": "Abschluss {date}",
+  "deal.closesProvisional":
+    "vorläufiger Abschlusstermin, von niemandem bestätigt",
   "record.notShown": "Nicht angezeigt",
   "record.timelineLoading": "Verlauf dieses Datensatzes wird geladen…",
   "record.chronologyLoading": "Änderungsverlauf wird gelesen…",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -289,6 +289,7 @@ export const de = {
   "deal.singleThreaded": "nur eine Person",
   "deal.staged": "vorgemerkt",
   "deal.closes": "Abschluss {date}",
+  "deal.undated": "kein Abschlusstermin",
   "deal.closesProvisional":
     "vorläufiger Abschlusstermin, von niemandem bestätigt",
   "record.notShown": "Nicht angezeigt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -309,6 +309,8 @@ export const en = {
   "deal.singleThreaded": "single-threaded",
   "deal.staged": "staged",
   "deal.archived": "archived",
+  "deal.closes": "closes {date}",
+  "deal.closesProvisional": "provisional close date, not confirmed by a human",
   "record.notShown": "Not shown",
   "record.timelineLoading": "Loading this record’s history…",
   "record.chronologyLoading": "Reading the change history…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -310,6 +310,7 @@ export const en = {
   "deal.staged": "staged",
   "deal.archived": "archived",
   "deal.closes": "closes {date}",
+  "deal.undated": "no close date",
   "deal.closesProvisional": "provisional close date, not confirmed by a human",
   "record.notShown": "Not shown",
   "record.timelineLoading": "Loading this record’s history…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -294,6 +294,8 @@ export const vi = {
   "deal.singleThreaded": "chỉ một đầu mối",
   "deal.staged": "chờ duyệt",
   "deal.archived": "đã lưu trữ",
+  "deal.closes": "chốt {date}",
+  "deal.closesProvisional": "ngày chốt tạm tính, chưa được ai xác nhận",
   "record.notShown": "Không hiển thị",
   "record.timelineLoading": "Đang tải lịch sử của bản ghi này…",
   "record.chronologyLoading": "Đang đọc lịch sử thay đổi…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -295,6 +295,7 @@ export const vi = {
   "deal.staged": "chờ duyệt",
   "deal.archived": "đã lưu trữ",
   "deal.closes": "chốt {date}",
+  "deal.undated": "chưa có ngày chốt",
   "deal.closesProvisional": "ngày chốt tạm tính, chưa được ai xác nhận",
   "record.notShown": "Không hiển thị",
   "record.timelineLoading": "Đang tải lịch sử của bản ghi này…",

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -730,21 +730,17 @@ describe("mapDealCreate", () => {
 });
 
 describe("DealsScreen", () => {
-  // The board card draws the same chip strip a list row does, so a reader
-  // moving between the two reads one thing one way. The card takes a view
-  // model rather than the wire row, so the tags have to be copied across in
-  // toBoardDeal — a field left out there is silently absent on every card.
-  it("draws a deal's tags on its board card", async () => {
+  // The card takes a view model rather than the wire row, so every fact it
+  // states has to be copied across in toBoardDeal — a field left out there is
+  // silently absent on every card. The close date is the one a rep sorts a
+  // quarter by, and the one a card without it would most quietly miss.
+  it("draws a deal's close date on its board card", async () => {
     vi.stubGlobal(
       "fetch",
-      stubBackend([
-        deal({
-          tags: [{ tag_id: "t-1", name: "Renewal", color: "teal" }],
-        }),
-      ]),
+      stubBackend([deal({ expected_close_date: "2099-10-14" })]),
     );
     render(<DealsScreen />);
-    expect(await screen.findByText("Renewal")).toBeTruthy();
+    expect(await screen.findByText("closes 14 Oct")).toBeTruthy();
   });
 
   it("board↔table swaps views over the same fetched set without a reload", async () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -124,7 +124,9 @@ import { DealStatusCardPanel, useDealStatusCard } from "./dealstatus";
 import { EditAction } from "./edit";
 import {
   EntityRef,
+  type OwnerNaming,
   rosterOwnerName,
+  rosterOwnerNaming,
   useEntityName,
   useRoster,
   useRosterPartial,
@@ -591,7 +593,11 @@ function dealCompany(
   return { org: mark?.name ?? "", orgLogoUrl: mark?.logoUrl };
 }
 
-export function toBoardDeal(deal: Deal, naming: CompanyNaming): BoardDeal {
+export function toBoardDeal(
+  deal: Deal,
+  naming: CompanyNaming,
+  owners?: OwnerNaming,
+): BoardDeal {
   const since = idleSince(deal);
   return {
     id: deal.id,
@@ -607,6 +613,7 @@ export function toBoardDeal(deal: Deal, naming: CompanyNaming): BoardDeal {
     archived: deal.archived_at != null,
     closeDate: deal.expected_close_date ?? null,
     closeDateProvisional: deal.close_date_provisional ?? false,
+    owner: owners?.(deal.owner_id) ?? null,
   };
 }
 
@@ -1349,6 +1356,7 @@ export function buildColumns(
   // asked at all — see measuresTheSamePopulation. Undefined when totals are in
   // play, which is the ordinary case.
   totalsWithheld?: string,
+  owners?: OwnerNaming,
 ): BoardMoneyColumn[] {
   return [...stages]
     .sort((a, b) => a.position - b.position)
@@ -1365,7 +1373,7 @@ export function buildColumns(
         rawMinor: stageTotals?.rawMinor ?? null,
         weightedMinor: stageTotals?.weightedMinor ?? null,
         currency: stageTotals?.currency ?? null,
-        deals: stageDeals.map((deal) => toBoardDeal(deal, naming)),
+        deals: stageDeals.map((deal) => toBoardDeal(deal, naming, owners)),
         // The true count, not the loaded page's — falls back to the page
         // count while totals are still loading, so the column shows SOME
         // number rather than a misleading 0.
@@ -1912,6 +1920,12 @@ function DealBoardBody({
 }>) {
   const t = useT();
   const recordZone = useRecordZone();
+  // Only walked when a card has an owner to name: a board of unowned deals
+  // needs no roster read to say so.
+  const roster = useRoster(
+    "user",
+    loadedDeals.some((deal) => Boolean(deal.owner_id)),
+  );
   // Every company the CARDS name. The picker's capped page answers most of them
   // for free; the rest are resolved by id (useOrgMarks), so no card is left
   // standing over a company the board simply failed to look up.
@@ -1946,6 +1960,7 @@ function DealBoardBody({
                   stageTotalsQuery.data ?? new Map(),
                   orgMarks,
                   totalsWithheld ? t(totalsWithheld) : undefined,
+                  rosterOwnerNaming(roster),
                 )}
                 onOpen={openDeal}
                 cardDragHandlers={cardDragHandlers}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -605,6 +605,8 @@ export function toBoardDeal(deal: Deal, naming: CompanyNaming): BoardDeal {
     ageMs: Math.max(0, Date.now() - new Date(since).getTime()),
     stalled: deal.stalled ?? false,
     archived: deal.archived_at != null,
+    closeDate: deal.expected_close_date ?? null,
+    closeDateProvisional: deal.close_date_provisional ?? false,
   };
 }
 
@@ -1909,6 +1911,7 @@ function DealBoardBody({
   >["columnDropHandlers"];
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   // Every company the CARDS name. The picker's capped page answers most of them
   // for free; the rest are resolved by id (useOrgMarks), so no card is left
   // standing over a company the board simply failed to look up.
@@ -1936,6 +1939,7 @@ function DealBoardBody({
             <>
               <PipelineBoard
                 cardHref={(deal) => routeHash({ screen: "deals", id: deal.id })}
+                zone={recordZone}
                 columns={buildColumns(
                   effectivePipeline.stages ?? [],
                   loadedDeals,

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -605,7 +605,6 @@ export function toBoardDeal(deal: Deal, naming: CompanyNaming): BoardDeal {
     ageMs: Math.max(0, Date.now() - new Date(since).getTime()),
     stalled: deal.stalled ?? false,
     archived: deal.archived_at != null,
-    tags: deal.tags,
   };
 }
 

--- a/frontend/src/screens/entityref.tsx
+++ b/frontend/src/screens/entityref.tsx
@@ -568,6 +568,30 @@ export function rosterOwnerName(
 }
 
 /**
+ * How a caller that maps records onto cards names their owners.
+ *
+ * A function rather than the roster itself, for the same reason the company
+ * mapping takes `CompanyNaming`: the mapper is pure and the roster is a query,
+ * and a mapper that reads a query's `.data` is one that every story and test
+ * of it has to assemble a query for. Null is BOTH "unowned" and "the roster
+ * cannot name this id" — on a card the two draw the same nothing, and the
+ * table's owner column is where they are told apart.
+ */
+export type OwnerNaming = (ownerId: string | null | undefined) => string | null;
+
+export function rosterOwnerNaming(
+  roster: ReturnType<typeof useRoster>,
+): OwnerNaming {
+  return (ownerId) => {
+    if (!ownerId) {
+      return null;
+    }
+    const found = (roster.data ?? []).find((entry) => entry.id === ownerId);
+    return found && "display_name" in found ? found.display_name : null;
+  };
+}
+
+/**
  * The owner of a record, by name, for a list column.
  *
  * Reads the shared roster cache (the same walked entry EntityRef and the Share

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -19,7 +19,7 @@ import type { MessageKey } from "../i18n/en";
 import { QueryGate } from "./common";
 import { errorClassKey, isUnhealthy } from "./connector-status";
 import { toBoardDeal, useOrgMarks } from "./deals";
-import { EntityRef } from "./entityref";
+import { EntityRef, rosterOwnerNaming, useRoster } from "./entityref";
 import {
   type Deal,
   type MorningDigest,
@@ -376,6 +376,10 @@ export function WatchPanel({
   // No page of organizations to draw on here — this is a short list, and every
   // company it names is resolved by id and cached.
   const naming = useOrgMarks([...deals], [], true);
+  const roster = useRoster(
+    "user",
+    deals.some((deal) => Boolean(deal.owner_id)),
+  );
   if (state === "loading") {
     return null;
   }
@@ -405,7 +409,7 @@ export function WatchPanel({
           {deals.map((deal) => (
             <DealCard
               key={deal.id}
-              deal={toBoardDeal(deal, naming)}
+              deal={toBoardDeal(deal, naming, rosterOwnerNaming(roster))}
               // A link, so no press handler: nothing here drags, and the
               // address is the whole behaviour.
               href={routeHash({ screen: "deals", id: deal.id })}

--- a/frontend/src/screens/home.rail.tsx
+++ b/frontend/src/screens/home.rail.tsx
@@ -372,6 +372,7 @@ export function WatchPanel({
   state: SectionState;
 }>) {
   const t = useT();
+  const recordZone = useRecordZone();
   // No page of organizations to draw on here — this is a short list, and every
   // company it names is resolved by id and cached.
   const naming = useOrgMarks([...deals], [], true);
@@ -408,6 +409,7 @@ export function WatchPanel({
               // A link, so no press handler: nothing here drags, and the
               // address is the whole behaviour.
               href={routeHash({ screen: "deals", id: deal.id })}
+              zone={recordZone}
             />
           ))}
         </SurfaceState>


### PR DESCRIPTION
## What

The pipeline board's deal card is rebuilt. It reads top to bottom in the order
a rep asks of a card from across the board: **does this need me** (a line that
exists only when something does); **whose deal is it** (the company, with its
mark, and the owner as a small labelled mark at the line's edge); **what is it
worth and when does it close** (the figure at lead size, tabular, with the
close date beside it — or "no close date"); and **what is it called**, last.
The tag strip comes off the card. The columns get a ground of their own, a new
`--bgWell` token one hair under the elevated surface, and the card is drawn as
the product's pane over it.

## Why

The card was one bold line with a small mono figure under it and three
coloured tag chips in between, on a column drawn on a card's own ground. Five
of those columns read as grey slabs with cards inside them, and the figure —
the thing a pipeline is a board of — was the quietest fact on the card.

- **Tags off the card.** How a deal is filed is a fact about the record, not
  the work in front of the reader; on a scanned board three chips per card
  were a field of colour the names had to compete with. The words keep their
  two homes: the deals table's column and the record's panel.
- **Close date on the card.** The record has carried `expected_close_date`
  all along and the board never stated it — the one field a rep sorts a
  quarter by. Read as a calendar day in the record's zone via
  `middayInstant`, never as midnight UTC (the previous date west of
  Greenwich); the zone arrives as a prop the way the timeline takes it. A date
  the nightly run set and no human confirmed, or one already behind us, is in
  the warn tone with the reason in words for a screen reader — the deal
  strip's rule for the same fact. A deal nobody dated says so.
- **Owner on the card.** The deal carries only `owner_id`; the name comes
  from the shared user roster (the same walked cache entry the table's owner
  column and `EntityRef` read), walked only when a card has an owner to name.
  The mapper takes the naming as a function, like `CompanyNaming`, so it stays
  pure. Drawn as a mark with the full name as its label: a name would not
  share a 220px line with anything.
- **Flags as quiet badges, first, and only when present.** Beside "stalled",
  how long — the one time age-in-stage is a fact anyone acts on. The `staged`
  badge stays filled: it is the agent's provenance and has to be seen.
- **`--bgWell`.** Every existing ground was a card's or the page's, both a
  full step under the surface the board sits on. The new rung is declared in
  all three token blocks; `tokens.test.ts`'s mirror check holds it.
- **Card surface.** `--pane` over the well, `--paneEdge`, the control rung;
  no `--shadow-card` (a hairline ring behind a 1px border is the same edge
  twice). Hover firms the edge; a focus ring is stated, since `a:not([class])`
  in base.css never reached this classed anchor.

## How verified

- `make check-fe` green on the pushed head, run alone (ds-gates incl.
  `type.test.ts` and `tokens.test.ts`, drift, biome, unit, build, composed
  typecheck, composed workspace screens).
- New/updated specs: the card marks an owner it is given and draws no slot
  without one; the deals screen copies the close date onto the card
  (replacing the tags-on-card spec); i18n keys in all three locales.
- Rendered the board at 1280px in both themes at each step and measured: the
  tag strip's overflow past the card edge went from +20px to inside the card
  before the strip was removed; the owner mark stays at the head line's edge
  at the 220px column floor.
- `make check`'s backend half cannot run in this environment (`golangci-lint`
  built against go1.25, modules target 1.26 — the tool refusing to load its
  config, not a finding). The diff is frontend-only.

- [ ] `make check` is green — frontend half green; backend half did not run, see above
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers — no Go in this diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Written by Claude Code under Jo's direction. The brief (style the pipeline to
the design prototype), each steer — a light ground behind the columns, then
lighter; the tags read as noise; "forget how it looks, ask what a salesperson
needs"; show the owner, small — and the acceptance of each render are Jo's.
The card order, the CSS, the token, the close-date and owner plumbing, the
tests and the verification are AI-authored.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC
