### PR TITLE
Two more passes collapse, and the actor gate stops going blind

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -711,29 +711,13 @@ kinds:
       writes nothing rather than a duplicate.
 
   follow_up_reconcile:
-    role: dispatcher
+    role: worker
     go_type: FollowUpReconcileArgs
     queue: default
-    timeout: 2m
+    timeout: 5m
     opts_owner: caller
     cadence: {operator: ReconcileInterval}
-    fans_out_to: follow_up_workspace
-    fan_out_unit: workspace
 
-  follow_up_workspace:
-    role: worker
-    go_type: FollowUpWorkspaceArgs
-    queue: default
-    timeout: 5m
-    max_attempts: 5
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
-      A database-only overnight pass over one tenant's open follow-ups, staging
-      what it proposes rather than acting. Five attempts for the reason
-      close_date_workspace takes five: both deals passes tick DAILY, so three
-      would cost a workspace a full day over a transient blip.
 
   fx_rate_refresh:
     role: worker
@@ -1612,29 +1596,13 @@ kinds:
       Telegram.
 
   time_scan:
-    role: dispatcher
+    role: worker
     go_type: TimeScanArgs
     queue: default
-    timeout: 2m
+    timeout: 10m
     opts_owner: caller
     cadence: {operator: TimeScanInterval}
-    fans_out_to: time_scan_workspace
-    fan_out_unit: workspace
 
-  time_scan_workspace:
-    role: worker
-    go_type: TimeScanWorkspaceArgs
-    queue: default
-    timeout: 10m
-    max_attempts: 3
-    opts_owner: fan_out
-    args:
-      Workspace: id
-    reason: >-
-      A coarse activity pre-filter, then one automation dispatch per matched
-      clock-triggered instance. Database-only — the actions in the closed
-      catalog write rows and stage approvals, they do not transmit — but the
-      matched set is a tenant's standing automations rather than a batch bound.
 
   voice_build:
     role: worker

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -36,7 +36,7 @@ func TestDispatchWithEnqueuesTheWholeFleetInOneInsert(t *testing.T) {
 		return nil
 	}
 
-	if err := dispatchWith(context.Background(), fleet, insert, workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()), timeScanWorkspaceArgsFor); err != nil {
+	if err := dispatchWith(context.Background(), fleet, insert, workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind()), signalScanWorkspaceArgsFor); err != nil {
 		t.Fatalf("dispatching a healthy fleet: %v", err)
 	}
 	if calls != 1 {
@@ -60,7 +60,7 @@ func TestDispatchWithFailsTheDispatcherWhenTheInsertIsRefused(t *testing.T) {
 	refused := errors.New("insert refused")
 	insert := func(context.Context, []river.InsertManyParams) error { return refused }
 
-	err := dispatchWith(context.Background(), fleet, insert, workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()), timeScanWorkspaceArgsFor)
+	err := dispatchWith(context.Background(), fleet, insert, workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind()), signalScanWorkspaceArgsFor)
 	if err == nil {
 		t.Fatal("a refused fan-out must surface, so the dispatcher row fails and the tick retries")
 	}
@@ -77,7 +77,7 @@ func TestDispatchWithEnqueuesNothingForAnEmptyFleet(t *testing.T) {
 		called = true
 		return nil
 	}
-	if err := dispatchWith(context.Background(), nil, insert, workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()), timeScanWorkspaceArgsFor); err != nil {
+	if err := dispatchWith(context.Background(), nil, insert, workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind()), signalScanWorkspaceArgsFor); err != nil {
 		t.Fatalf("an empty fleet is not a failure: %v", err)
 	}
 	if called {
@@ -267,8 +267,8 @@ func TestOneOffChildOptsRefusesAKindWhoseOptsItDoesNotOwn(t *testing.T) {
 	oneOffChildOpts(TelegramPollArgs{}.Kind()) // opts_owner: args
 }
 
-func timeScanWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
-	return TimeScanWorkspaceArgs{Workspace: ws}
+func signalScanWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
+	return SignalScanWorkspaceArgs{Workspace: ws}
 }
 
 // TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass — the
@@ -288,7 +288,7 @@ func TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass(t *testing.
 	fleet := []ids.UUID{ids.NewV7(), ids.NewV7()}
 
 	if err := dispatchWith(context.Background(), fleet, insert,
-		workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()), timeScanWorkspaceArgsFor); err != nil {
+		workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind()), signalScanWorkspaceArgsFor); err != nil {
 		t.Fatalf("dispatchWith: %v", err)
 	}
 
@@ -311,7 +311,7 @@ func TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass(t *testing.
 // it in place would accumulate one tag per workspace on a struct the caller
 // still owns.
 func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
-	opts := workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind())
+	opts := workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind())
 	// Spare CAPACITY is the case a length check cannot see: append would
 	// write into the caller's own backing array and leave len unchanged, so
 	// the aliasing this test exists to catch would go unnoticed.
@@ -322,7 +322,7 @@ func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
 
 	for range 3 {
 		if err := dispatchWith(context.Background(), []ids.UUID{ids.NewV7()}, insert, opts,
-			timeScanWorkspaceArgsFor); err != nil {
+			signalScanWorkspaceArgsFor); err != nil {
 			t.Fatalf("dispatchWith: %v", err)
 		}
 	}

--- a/backend/internal/compose/fanouttag_integration_test.go
+++ b/backend/internal/compose/fanouttag_integration_test.go
@@ -51,7 +51,7 @@ type fanOutProbeWorker struct {
 
 func (w *fanOutProbeWorker) Work(ctx context.Context, _ *river.Job[fanOutProbeArgs]) error {
 	err := dispatchWith(ctx, w.fleet, clientInsertMany(ctx),
-		workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()), timeScanWorkspaceArgsFor)
+		workspaceSweepOpts(SignalScanWorkspaceArgs{}.Kind()), signalScanWorkspaceArgsFor)
 	if err == nil {
 		err = dispatchOne(ctx, w.child, nil)
 	}
@@ -86,7 +86,7 @@ func TestARealFanOutInsertCarriesTheSweepTagIntoRiversTagsColumn(t *testing.T) {
 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, probe)
-	river.AddWorker(workers, &inertWorker[TimeScanWorkspaceArgs]{})
+	river.AddWorker(workers, &inertWorker[SignalScanWorkspaceArgs]{})
 	river.AddWorker(workers, &inertWorker[CaptureSyncArgs]{})
 
 	runner, err := jobs.New(e.Pool, jobs.Config{
@@ -121,7 +121,7 @@ func TestARealFanOutInsertCarriesTheSweepTagIntoRiversTagsColumn(t *testing.T) {
 		t.Fatal("the probe dispatcher never ran; nothing was fanned out")
 	}
 
-	assertRowIsTagged(ctx, t, e.Pool, TimeScanWorkspaceArgs{}.Kind(), fleetChild,
+	assertRowIsTagged(ctx, t, e.Pool, SignalScanWorkspaceArgs{}.Kind(), fleetChild,
 		"dispatchWith's fleet insert")
 	assertRowIsTagged(ctx, t, e.Pool, loopChild.Kind(), loopChild.Workspace,
 		"dispatchOne's single insert")

--- a/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
@@ -130,7 +130,11 @@ func TestNoActivityReminderReachesTheOwnersTasksScreenThroughTheRealRiverJob(t *
 
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	AwaitKindCompleted(waitCtx, t, sub, compose.TimeScanWorkspaceArgs{}.Kind())
+	// THE PASS, which is the only kind there is (ADR-0103). This waited on the
+	// workspace child, because a dispatcher completed as soon as its fan-out
+	// was enqueued and waiting on it raced the work; a collapsed pass completes
+	// when the work is done.
+	AwaitKindCompleted(waitCtx, t, sub, compose.TimeScanArgs{}.Kind())
 
 	// The firing must have cleared Sam's own gate as 'applied', not
 	// 'blocked' — if the seeded role above did not actually grant

--- a/backend/internal/compose/jobactor_test.go
+++ b/backend/internal/compose/jobactor_test.go
@@ -41,9 +41,9 @@ import (
 // jobActorUnbound: workers that predate this gate and bind no actor. Each
 // needs its own subsystem checked before it is changed — see #1127.
 var jobActorUnbound = gatekit.Waive(map[string]string{
-	"privacyRetentionWorker":  "retention sweep; whether its writes are gated is #1127's question",
-	"timeScanWorkspaceWorker": "automation time-scan; same audit",
-	"webhookRetryWorker":      "webhook delivery retry; same audit",
+	"privacyRetentionWorker": "retention sweep; whether its writes are gated is #1127's question",
+	"timeScanWorker":         "automation time-scan; same audit",
+	"webhookRetryWorker":     "webhook delivery retry; same audit",
 })
 
 // storeBuilders are the handle constructors a store is built on. A Work method
@@ -54,10 +54,21 @@ var jobActorUnbound = gatekit.Waive(map[string]string{
 // per-tenant fan-out (ADR-0103 §1) stops calling workspaceJobDB and starts
 // calling this one, so a regex naming only the old constructor would let every
 // collapsed worker slip out of this gate's sight while reading as green.
-var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB|InstallationDB)\(`)
+// database.BindTo joined the list with ADR-0103. workspaceJobDB reads the
+// workspace off a job's ARGS, and a collapsed pass has none — it takes the
+// workspace from the fleet walk instead and binds the handle directly, so a
+// pass that reaches a store now does it through BindTo. Leaving it out would
+// have let every collapsed pass build a store unwatched.
+var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB|InstallationDB|database\.BindTo)\(`)
 
-// actorBinders are the ways a worker legitimately names its principal: the
-// helper in this package, or principal.WithActor directly.
+// actorBinders are the ways a worker legitimately names its principal: one of
+// this package's context helpers, or principal.WithActor directly.
+//
+// reconcileWorkerCtx is one of those helpers — it binds the workspace, the
+// actor and a correlation id together and returns the context. It is listed for
+// the same reason providerJobActor is, and it was found the way a missing entry
+// here always will be: as a false positive, on a worker whose actor is bound
+// one call away.
 //
 // The ASSIGNMENT is part of the pattern, not decoration. Both calls return a
 // new context and mutate nothing, so `providerJobActor(wsCtx)` on its own line
@@ -65,11 +76,20 @@ var storeBuilders = regexp.MustCompile(`(providerRunStore|workspaceJobDB|Install
 // no actor in it — the precise bug this gate exists to catch, sailing past a
 // check that only asked whether the name appeared.
 var actorBinders = regexp.MustCompile(
-	`\w+\s*(=|:=)\s*(providerJobActor|principal\.WithActor)\(`)
+	`\w+\s*(=|:=)\s*(providerJobActor|reconcileWorkerCtx|principal\.WithActor)\(`)
 
 // workMethod matches a River worker's entry point and captures its receiver,
 // which is the worker's name in the failure message.
-var workMethod = regexp.MustCompile(`func \(\w+ \*(\w+)\) Work\(`)
+// A worker's ENTRY POINTS, which is Work and — since ADR-0103 collapsed the
+// workspace dispatchers — the per-workspace turn Work walks the fleet with.
+//
+// Both, because the collapse MOVED the store build out of Work. A collapsed
+// pass's Work is one line handing runPerWorkspace a method, and the store is
+// built inside that method, per tenant. Reading Work alone would have quietly
+// emptied this gate of subjects exactly as the passes were rewritten — every
+// one of them would have stopped being checked, and the gate would have gone
+// green by having nothing left to look at.
+var workMethod = regexp.MustCompile(`func \(\w+ \*(\w+)\) (?:Work|\w*[Ww]orkspace)\(`)
 
 func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
 	defer jobActorUnbound.AssertAllMatched(t)
@@ -117,7 +137,7 @@ func TestEveryJobWorkerThatReachesAStoreBindsAnActor(t *testing.T) {
 	}
 	sort.Strings(names)
 	for _, w := range names {
-		t.Errorf("%s.Work (%s) builds a store but binds no actor — its first RBAC-gated write will be refused with \"no actor bound to context\", and a queue carries no principal to inherit. Bind one the way providerJobActor does",
+		t.Errorf("%s (%s) builds a store but binds no actor — its first RBAC-gated write will be refused with \"no actor bound to context\", and a queue carries no principal to inherit. Bind one the way providerJobActor does",
 			w, offenders[w])
 	}
 }

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "569aec9506ef694ca57b45d169809e60e130bcc1355c28f450d796a6bc69bf13"
+const jobContractHash = "7c3099f32286f91dbc06fc1965860f757f1623cab6b516512b417ccabfe9ca9a"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -54,7 +54,6 @@ type declaredJobArgs interface {
 		EmbedReindexArgs |
 		FinanceSyncSweepArgs |
 		FollowUpReconcileArgs |
-		FollowUpWorkspaceArgs |
 		ForecastSnapshotSweepArgs |
 		ForecastSnapshotWorkspaceArgs |
 		FxRateRefreshArgs |
@@ -97,7 +96,6 @@ type declaredJobArgs interface {
 		TelegramPollArgs |
 		TelegramPollSweepArgs |
 		TimeScanArgs |
-		TimeScanWorkspaceArgs |
 		TranscriptProposeArgs |
 		VCardIngestArgs |
 		VoiceBuildArgs |
@@ -136,7 +134,6 @@ func addDeclaredWorkerWithTimeout[T declaredJobArgs](reg *jobRegistry, w jobs.Wo
 // The declared dispatchers: each enumerates the fleet and enqueues, and does
 // no tenant work of its own.
 var (
-	_ jobs.FleetWide = FollowUpReconcileArgs{}
 	_ jobs.FleetWide = ForecastSnapshotSweepArgs{}
 	_ jobs.FleetWide = GmailSyncArgs{}
 	_ jobs.FleetWide = GmailWatchArgs{}
@@ -151,7 +148,6 @@ var (
 	_ jobs.FleetWide = ProviderRunPollSweepArgs{}
 	_ jobs.FleetWide = SignalScanArgs{}
 	_ jobs.FleetWide = TelegramPollSweepArgs{}
-	_ jobs.FleetWide = TimeScanArgs{}
 	_ jobs.FleetWide = VoiceBuildRetryArgs{}
 )
 
@@ -165,7 +161,6 @@ var (
 	_ jobs.WorkspaceScoped = ScheduledSendArgs{}
 	_ jobs.WorkspaceScoped = SendEmailArgs{}
 	_ jobs.WorkspaceScoped = DocumentExtractArgs{}
-	_ jobs.WorkspaceScoped = FollowUpWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = ForecastSnapshotWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = FxRateRefreshArgs{}
 	_ jobs.WorkspaceScoped = GeocodeOrganizationArgs{}
@@ -187,7 +182,6 @@ var (
 	_ jobs.WorkspaceScoped = TechnicalEnrichOrganizationArgs{}
 	_ jobs.WorkspaceScoped = TelegramIngestArgs{}
 	_ jobs.WorkspaceScoped = TelegramPollArgs{}
-	_ jobs.WorkspaceScoped = TimeScanWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = TranscriptProposeArgs{}
 	_ jobs.WorkspaceScoped = VCardIngestArgs{}
 	_ jobs.WorkspaceScoped = VoiceBuildArgs{}

--- a/backend/internal/compose/jobregistry_test.go
+++ b/backend/internal/compose/jobregistry_test.go
@@ -80,9 +80,9 @@ func TestDeepReadTimeoutHoldsItsFloor(t *testing.T) {
 func TestAddGovernedWorkerRecordsTheKindItRegistered(t *testing.T) {
 	reg := newJobRegistry()
 	addGovernedWorker[CloseDateSweepArgs](reg, &closeDateSweepWorker{}, 0)
-	addGovernedWorker[TimeScanWorkspaceArgs](reg, &timeScanWorkspaceWorker{}, 0)
+	addGovernedWorker[SignalScanWorkspaceArgs](reg, &signalScanWorkspaceWorker{}, 0)
 
-	want := []string{"close_date_sweep", "time_scan_workspace"}
+	want := []string{"close_date_sweep", "signal_scan_workspace"}
 	if len(reg.kinds) != len(want) {
 		t.Fatalf("recorded %v, want %v", reg.kinds, want)
 	}

--- a/backend/internal/compose/jobs_automation.go
+++ b/backend/internal/compose/jobs_automation.go
@@ -16,8 +16,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // TimeScanArgs schedules one clock-trigger scan pass (Task 14a): the
@@ -33,54 +35,29 @@ func (TimeScanArgs) Kind() string { return "time_scan" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (TimeScanArgs) FleetWide() {}
 
-// timeScanWorker is the dispatcher: it enumerates the fleet and enqueues one
-// scan per workspace, and touches no tenant data itself.
+// timeScanWorker scans every live workspace.
+//
+// One worker where there were two (ADR-0103).
 type timeScanWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *timeScanWorker) Work(ctx context.Context, _ *river.Job[TimeScanArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(TimeScanWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return TimeScanWorkspaceArgs{Workspace: ws} }))
-}
-
-// TimeScanWorkspaceArgs is one workspace's clock-trigger scan pass.
-type TimeScanWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (TimeScanWorkspaceArgs) Kind() string { return "time_scan_workspace" }
-
-// WorkspaceID binds this scan to its tenant (jobs.WorkspaceScoped).
-func (a TimeScanWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
-// timeScanWorkspaceWorker delegates one workspace's pass to the automation
-// module's TimeScanner — River-agnostic by construction (this file's own doc:
-// the adapters are the only code that knows about River).
-type timeScanWorkspaceWorker struct {
 	pool *pgxpool.Pool
 	log  *slog.Logger
 }
 
-func (w *timeScanWorkspaceWorker) Work(ctx context.Context, job *river.Job[TimeScanWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
-	// Built per job: this is a fleet pass, so the scanner's engine binds the
-	// workspace THIS job names rather than whatever an installation resolver
-	// would answer (ADR-0091 §9 step 3).
-	db, err := workspaceJobDB(w.pool, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *timeScanWorker) Work(ctx context.Context, _ *river.Job[TimeScanArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.scanWorkspace))
+}
+
+func (w *timeScanWorker) scanWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
+	// Built per WORKSPACE: this is a fleet pass, so the scanner's engine binds
+	// the workspace this turn is for rather than whatever an installation
+	// resolver would answer (ADR-0091 §9 step 3).
+	db := database.BindTo(w.pool, ids.From[ids.WorkspaceKind](workspace))
 	scanner := NewTimeScanner(db, w.log)
-	if err := scanner.ScanWorkspace(wsCtx, job.Args.Workspace); err != nil {
-		return jobs.FaultContext(ctx, err)
+	if err := scanner.ScanWorkspace(wsCtx, workspace); err != nil {
+		return err
 	}
 	// The lead first-response SLA is clock-triggered too (formulas §18.2)
 	// and rides this pass rather than a job of its own.
-	return jobs.FaultContext(ctx, scanLeadSLA(wsCtx, db, time.Now, w.log))
+	return scanLeadSLA(wsCtx, db, time.Now, w.log)
 }

--- a/backend/internal/compose/jobs_databasesweeps.go
+++ b/backend/internal/compose/jobs_databasesweeps.go
@@ -36,8 +36,7 @@ import (
 // that is why they belong here rather than behind a condition of their own.
 func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger, briefMail BriefMailConfig) {
 	addDeclaredWorker[CloseDateSweepArgs](reg, &closeDateSweepWorker{pool: pool, corrector: NewCloseDateCorrector(pool, log)})
-	addDeclaredWorker[FollowUpReconcileArgs](reg, &followUpReconcileWorker{pool: pool})
-	addDeclaredWorker[FollowUpWorkspaceArgs](reg, &followUpWorkspaceWorker{reconciler: NewFollowUpReconciler(pool, log)})
+	addDeclaredWorker[FollowUpReconcileArgs](reg, &followUpReconcileWorker{pool: pool, reconciler: NewFollowUpReconciler(pool, log)})
 	addDeclaredWorker[AssuranceSweepArgs](reg, &assuranceSweepWorker{
 		pool: pool, now: func() time.Time { return time.Now().UTC() }, log: log,
 	})
@@ -45,8 +44,7 @@ func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Lo
 	addDeclaredWorker[ForecastSnapshotWorkspaceArgs](reg, &forecastSnapshotWorkspaceWorker{
 		pool: pool, now: func() time.Time { return time.Now().UTC() }, log: log,
 	})
-	addDeclaredWorker[TimeScanArgs](reg, &timeScanWorker{pool: pool})
-	addDeclaredWorker[TimeScanWorkspaceArgs](reg, &timeScanWorkspaceWorker{pool: pool, log: log})
+	addDeclaredWorker[TimeScanArgs](reg, &timeScanWorker{pool: pool, log: log})
 	addDeclaredWorker[IdempotencyRetentionArgs](reg, &idempotencyRetentionWorker{pool: pool})
 	addDeclaredWorker[IdempotencyRetentionWorkspaceArgs](reg, &idempotencyRetentionWorkspaceWorker{sweeper: NewIdempotencyRetentionSweeper(pool, log)})
 	addDeclaredWorker[AgentTaskRetentionArgs](reg, &agentTaskRetentionWorker{

--- a/backend/internal/compose/jobs_deals.go
+++ b/backend/internal/compose/jobs_deals.go
@@ -47,17 +47,6 @@ func (FollowUpReconcileArgs) Kind() string { return "follow_up_reconcile" }
 // and does no tenant work of its own (jobs.FleetWide).
 func (FollowUpReconcileArgs) FleetWide() {}
 
-// FollowUpWorkspaceArgs is one workspace's follow-up reconciliation pass.
-type FollowUpWorkspaceArgs struct {
-	Workspace ids.UUID `json:"workspace_id"`
-}
-
-// Kind is the stable job identifier River persists in river_job.
-func (FollowUpWorkspaceArgs) Kind() string { return "follow_up_workspace" }
-
-// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
-func (a FollowUpWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
-
 // closeDateSweepWorker is the dispatcher: it enumerates and enqueues, and
 // touches no tenant data itself.
 // closeDateSweepWorker corrects close dates for every live workspace.
@@ -90,25 +79,16 @@ func (w *closeDateSweepWorker) correctWorkspace(ctx context.Context, workspace i
 
 // followUpReconcileWorker is the dispatcher for the overnight pass.
 type followUpReconcileWorker struct {
-	pool *pgxpool.Pool
-}
-
-func (w *followUpReconcileWorker) Work(ctx context.Context, _ *river.Job[FollowUpReconcileArgs]) error {
-	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
-		workspaceSweepOpts(FollowUpWorkspaceArgs{}.Kind()),
-		func(ws ids.UUID) river.JobArgs { return FollowUpWorkspaceArgs{Workspace: ws} }))
-}
-
-// followUpWorkspaceWorker runs one workspace's overnight pass.
-type followUpWorkspaceWorker struct {
+	pool       *pgxpool.Pool
 	reconciler *deals.FollowUpReconciler
 }
 
-func (w *followUpWorkspaceWorker) Work(ctx context.Context, job *river.Job[FollowUpWorkspaceArgs]) error {
-	wsCtx, err := workspaceJobCtx(ctx, job.Args)
-	if err != nil {
-		return jobs.FaultContext(ctx, err)
-	}
+func (w *followUpReconcileWorker) Work(ctx context.Context, _ *river.Job[FollowUpReconcileArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.reconcileWorkspace))
+}
+
+func (w *followUpReconcileWorker) reconcileWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
 	// The overnight agent is the acting principal — its writes and stagings
 	// carry agent:overnight provenance (features/07 §8a), and every read the
 	// reconciler makes is scoped by its own query predicate against the

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -83,7 +83,7 @@ func TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace(t *testing.T) {
 func TestTheWorkspaceGuardBindsTheWorkspaceTheArgsDeclare(t *testing.T) {
 	want := ids.NewV7()
 
-	ctx, err := workspaceJobCtx(context.Background(), TimeScanWorkspaceArgs{Workspace: want})
+	ctx, err := workspaceJobCtx(context.Background(), SignalScanWorkspaceArgs{Workspace: want})
 	if err != nil {
 		t.Fatalf("the guard refused a workspace it was given: %v", err)
 	}
@@ -147,11 +147,8 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		ForecastSnapshotWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&forecastSnapshotWorkspaceWorker{}).Work(ctx, &river.Job[ForecastSnapshotWorkspaceArgs]{})
 		},
-		FollowUpWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&followUpWorkspaceWorker{}).Work(ctx, &river.Job[FollowUpWorkspaceArgs]{})
-		},
-		TimeScanWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
-			return (&timeScanWorkspaceWorker{}).Work(ctx, &river.Job[TimeScanWorkspaceArgs]{})
+		SignalScanWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
+			return (&signalScanWorkspaceWorker{}).Work(ctx, &river.Job[SignalScanWorkspaceArgs]{})
 		},
 		IdempotencyRetentionWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&idempotencyRetentionWorkspaceWorker{}).Work(ctx, &river.Job[IdempotencyRetentionWorkspaceArgs]{})

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "569aec9506ef694ca57b45d169809e60e130bcc1355c28f450d796a6bc69bf13"
+const JobContractHash = "7c3099f32286f91dbc06fc1965860f757f1623cab6b516512b417ccabfe9ca9a"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -295,25 +295,13 @@ var specs = map[string]Spec{
 		Cadence:   Cadence{Fixed: 6 * time.Hour},
 	},
 	"follow_up_reconcile": {
-		Kind:       "follow_up_reconcile",
-		GoType:     "FollowUpReconcileArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "follow_up_workspace",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{OperatorField: "ReconcileInterval"},
-	},
-	"follow_up_workspace": {
-		Kind:        "follow_up_workspace",
-		GoType:      "FollowUpWorkspaceArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
-		MaxAttempts: 5,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
+		Kind:      "follow_up_reconcile",
+		GoType:    "FollowUpReconcileArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 5 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{OperatorField: "ReconcileInterval"},
 	},
 	"forecast_snapshot_sweep": {
 		Kind:       "forecast_snapshot_sweep",
@@ -754,25 +742,13 @@ var specs = map[string]Spec{
 		Registration: Registration{When: []string{"ChannelVault"}},
 	},
 	"time_scan": {
-		Kind:       "time_scan",
-		GoType:     "TimeScanArgs",
-		Role:       Dispatcher,
-		Queue:      "default",
-		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
-		FanOutUnit: FanOutWorkspace,
-		FanOutTo:   "time_scan_workspace",
-		OptsOwner:  OptsCaller,
-		Cadence:    Cadence{OperatorField: "TimeScanInterval"},
-	},
-	"time_scan_workspace": {
-		Kind:        "time_scan_workspace",
-		GoType:      "TimeScanWorkspaceArgs",
-		Role:        Worker,
-		Queue:       "default",
-		Timeout:     TimeoutPolicy{Fixed: 10 * time.Minute},
-		MaxAttempts: 3,
-		OptsOwner:   OptsFanOut,
-		Args:        []ArgField{{Name: "Workspace"}},
+		Kind:      "time_scan",
+		GoType:    "TimeScanArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 10 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{OperatorField: "TimeScanInterval"},
 	},
 	"transcript_propose": {
 		Kind:         "transcript_propose",

--- a/backend/migrations/core/1788640003_two_more_passes_leave_no_orphans.down.sql
+++ b/backend/migrations/core/1788640003_two_more_passes_leave_no_orphans.down.sql
@@ -1,0 +1,8 @@
+-- Nothing to restore, for the reason its predecessors give.
+--
+-- The up migration deleted queue rows for work that had not run. A rollback
+-- re-registers those workers and the passes re-enqueue on their next tick, so
+-- the work returns on its own schedule rather than from a row this file could
+-- forge — one that would carry a new id, a fresh attempt count and this
+-- migration's timestamp, and so would not be the row that was deleted.
+SELECT 1;

--- a/backend/migrations/core/1788640003_two_more_passes_leave_no_orphans.up.sql
+++ b/backend/migrations/core/1788640003_two_more_passes_leave_no_orphans.up.sql
@@ -1,0 +1,34 @@
+-- Drain the queued children of two more passes that no longer fan out.
+--
+-- Its own migration, for the reason its predecessors give: a migration that has
+-- already run does not run again, so adding these kinds to an earlier file
+-- would drain them only where that file had not yet been applied.
+--
+-- River does not forget a row because the code stopped declaring its kind, so a
+-- child enqueued by the last tick before this deploy retries its way to
+-- `discarded` against a client that has no worker for it.
+--
+-- THE STATES THAT WILL NEVER RUN, named as an allowlist. Not "everything
+-- non-terminal", which also matches `running`: the API entrypoint applies
+-- migrations before it serves and the worker entrypoint applies none, so during
+-- a rolling deploy an old worker can still be mid-pass on a child when this
+-- runs — and deleting its row out from under it lands its completion write on
+-- nothing. Leaving a running row alone costs nothing: it finishes, becomes
+-- terminal, and never needed draining. A completed row is left for its own
+-- reason: it records that the work ran.
+--
+-- An allowlist rather than a denylist so a state River adds later is excluded
+-- until somebody looks at it, instead of being swept in by a rule that never
+-- heard of it.
+--
+-- Guarded on the table existing, because River owns its own schema and applies
+-- it on first run.
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    DELETE FROM river_job
+     WHERE kind IN ('follow_up_workspace', 'time_scan_workspace')
+       AND state IN ('available', 'scheduled', 'retryable', 'pending');
+  END IF;
+END
+$$;


### PR DESCRIPTION
Batch seven of #1857, stacked on #4482. The follow-up reconcile and the time scan — 10 workspace pairs remain after this.

## The actor gate would have emptied itself

This is the batch's finding, and it would have applied to every pass this ticket rewrites.

`TestEveryJobWorkerThatReachesAStoreBindsAnActor` reads **Work method bodies** and asks whether a body that builds a store also binds a principal. A collapsed pass's `Work` is one line handing `runPerWorkspace` a method — the store is built inside that method, per tenant. So the gate would have gone green on all 27 passes by having nothing left to look at.

It caught itself. A waiver that stops matching is what a gate losing its subjects looks like from the outside:

```
waiver timeScanWorkspaceWorker matched no subject: delete it, or correct the key
if the subject was renamed
```

Deleting that waiver would have been the easy read, and wrong.

Two changes keep it seeing:
- it reads the **per-workspace turn** beside `Work`;
- it counts `database.BindTo` as a store builder — `workspaceJobDB` reads the workspace off a job's args, which a collapsed pass does not have.

## Widening it found a third thing

`overlayReconcileWorkspaceWorker` came up as a worker that builds a store and binds no actor. **False positive**: `reconcileWorkerCtx` binds the workspace, the actor and a correlation id together one call away, and the binder pattern did not know that helper. It is listed now for the same reason `providerJobActor` is — and it was found the way a missing entry there always will be.

## Verification

`make check-backend` exit 0; `internal/compose` and `internal/compose/integration` integration suites green.