### PR TITLE
fix(rail): a run a rep starts reaches the AI activity feed while it is still running

### DIFF
--- a/frontend/src/app/ai-activity.test.tsx
+++ b/frontend/src/app/ai-activity.test.tsx
@@ -9,7 +9,7 @@ import {
   modelCallsInFlight,
 } from "../api/model-inflight";
 import type { components } from "../api/schema";
-import { useAiActivity } from "./ai-activity";
+import { useAiActivity, watchStartedAiRun } from "./ai-activity";
 import { displayedKinds, lineFor } from "./ai-activity-lines";
 
 // What the rail asks the runner, and how often. Three things here can only be
@@ -25,6 +25,11 @@ type AiActivity = components["schemas"]["AiActivity"];
 // cached body for this long, so a mount-time refetch alone cannot explain a
 // read that lands the moment the tab returns.
 const STALE_TIME_MS = 30_000;
+
+// The hook's own two periods, mirrored so a case says which one it is proving
+// rather than repeating a bare number that could mean either.
+const POLL_LIVE_MS = 3_000;
+const START_WATCH_MS = 30_000;
 
 const A_RUN: AiActivityItem = {
   id: "3f1c0a2e-0000-4000-8000-000000000001",
@@ -47,10 +52,17 @@ function jsonResponse(body: unknown, status = 200): Response {
 /** Whether the tab is hidden, read by the hook through `document.hidden`. */
 let hidden = false;
 
+/**
+ * The client the mounted hook reads through, rebuilt per case.
+ *
+ * Module-scoped rather than minted inside `wrapper`, because `watchStartedAiRun`
+ * is given a client by its caller and a case has to hand it the SAME one the
+ * hook is reading through — a start reported against some other client would
+ * refetch nothing and prove nothing.
+ */
+let client: QueryClient;
+
 function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, staleTime: STALE_TIME_MS } },
-  });
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
@@ -91,6 +103,9 @@ async function setTabHidden(value: boolean): Promise<void> {
 }
 
 beforeEach(() => {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: STALE_TIME_MS } },
+  });
   hidden = false;
   Object.defineProperty(document, "hidden", {
     configurable: true,
@@ -140,6 +155,86 @@ describe("the cadence", () => {
 
     await advance(1_000);
     expect(reads).toHaveLength(2);
+  });
+});
+
+// A durable run answers 202 and reaches the feed through the outbox, so it is
+// never in the read fired on that 202. These cases are the difference between
+// looking for it and waiting for it.
+describe("a run this tab started", () => {
+  it("polls fast while the feed does not carry it yet", async () => {
+    const { reads } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+
+    await act(async () => {
+      watchStartedAiRun(client);
+    });
+    // The read on the press itself, which the projection cannot have answered.
+    await advance(0);
+    const onThePress = reads.length;
+
+    await advance(POLL_LIVE_MS);
+    expect(reads.length).toBe(onThePress + 1);
+  });
+
+  it("reports the run inside the watch rather than at the idle poll", async () => {
+    let projected = false;
+    const { result } = mount(() =>
+      jsonResponse(activity(projected ? [A_RUN] : [])),
+    );
+    await advance(0);
+
+    await act(async () => {
+      watchStartedAiRun(client);
+    });
+    // The read on the press, which the outbox cannot have beaten.
+    await advance(0);
+    expect(result.current.working).toBe(false);
+
+    // The relay, the bus and the projection's upsert have all happened by the
+    // time the watch's own reads come round — which is the whole point of it,
+    // and the difference this case measures is against the idle period below.
+    projected = true;
+    await advance(POLL_LIVE_MS * 2);
+    expect(result.current.working).toBe(true);
+  });
+
+  it("gives up on a start the feed never carried", async () => {
+    const { reads } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    await act(async () => {
+      watchStartedAiRun(client);
+    });
+    await advance(0);
+
+    await advance(START_WATCH_MS);
+    const watched = reads.length;
+
+    // Back to the idle cadence: one live period buys no read at all.
+    await advance(POLL_LIVE_MS);
+    expect(reads).toHaveLength(watched);
+  });
+
+  it("re-arms on a second start rather than expiring on the first's clock", async () => {
+    const { reads } = mount(() => jsonResponse(activity([])));
+    await advance(0);
+    await act(async () => {
+      watchStartedAiRun(client);
+    });
+    await advance(0);
+
+    // Late in the first watch, a second run is started.
+    await advance(START_WATCH_MS - POLL_LIVE_MS);
+    await act(async () => {
+      watchStartedAiRun(client);
+    });
+    await advance(0);
+    // Past where the first watch would have ended.
+    await advance(POLL_LIVE_MS * 2);
+    const watched = reads.length;
+
+    await advance(POLL_LIVE_MS);
+    expect(reads.length).toBeGreaterThan(watched);
   });
 });
 

--- a/frontend/src/app/ai-activity.ts
+++ b/frontend/src/app/ai-activity.ts
@@ -3,7 +3,7 @@
 
 import type { QueryClient } from "@tanstack/react-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { api } from "../api/client";
 import { useModelCallsInFlight } from "../api/model-inflight";
 import type { components } from "../api/schema";
@@ -31,19 +31,64 @@ const POLL_IDLE_MS = 30_000;
  */
 const ASK_LINGER_MS = 900;
 
+/**
+ * How long the feed is watched at the live cadence for a run this tab started.
+ *
+ * A durable run is not in the feed when its own request answers, and cannot be:
+ * the 202 means the row is committed, and the occurrence reaches the projection
+ * through the outbox — the relay's own poll, then the bus, then the consumer's
+ * upsert. So the read fired on the 202 asks at the one instant the answer is
+ * guaranteed to be no, and with nothing running the cadence then drops to
+ * POLL_IDLE_MS. That is how a website read a rep pressed and then watched
+ * announced itself on the rail up to half a minute later, or — for a reading
+ * that settled inside the window — never.
+ *
+ * The ceiling is the idle period itself, because past it the ordinary cadence
+ * has asked anyway: watching longer would not be watching, it would be polling
+ * fast for a run that is not coming. It ends on the clock rather than on the
+ * feed carrying the run, because from that moment the live rule below is what
+ * holds the cadence — the watch only has to cover the gap before it.
+ */
+const START_WATCH_MS = POLL_IDLE_MS;
+
 const ACTIVITY_KEY = ["me", "ai-activity"] as const;
 
 /**
- * Ask the feed again now, because this tab just did something the feed will
- * carry.
- *
- * For the surfaces that START a durable run and answer 202 — a website read
- * from a company page — rather than hold a model call open: those never count
- * as an ask in flight, so without this the orb would light on the next idle
- * poll, up to half a minute after the button, and the reader who pressed it
- * would see nothing move. Same shape as the refetch on an ask's edges below.
+ * How many durable runs this tab has started. A counter and not a flag: two
+ * presses are two waits, and the second must re-arm the first's rather than
+ * expire on its clock.
  */
-export function refetchAiActivity(client: QueryClient): void {
+let starts = 0;
+const startListeners = new Set<() => void>();
+
+function startCount(): number {
+  return starts;
+}
+
+function subscribeToStarts(onChange: () => void): () => void {
+  startListeners.add(onChange);
+  return () => {
+    startListeners.delete(onChange);
+  };
+}
+
+/**
+ * Report that this tab just started a durable run, so the feed goes looking for
+ * it instead of waiting for it.
+ *
+ * For the surfaces that START a run and answer 202 — a website read from a
+ * company page, a document reading from an attachment — rather than hold a
+ * model call open: those never count as an ask in flight, so nothing else here
+ * knows the agent has been given work. The immediate read is kept for the case
+ * it can actually answer — a request that JOINED a crawl already in flight,
+ * whose occurrence has been in the feed for minutes — and the watch covers the
+ * one it cannot.
+ */
+export function watchStartedAiRun(client: QueryClient): void {
+  starts += 1;
+  for (const listener of startListeners) {
+    listener();
+  }
   void client.refetchQueries({ queryKey: ACTIVITY_KEY });
 }
 
@@ -85,6 +130,7 @@ export function useAiActivity(): AiActivity {
   const client = useQueryClient();
   const [visible, setVisible] = useState(() => !document.hidden);
   const open = useModelCallsInFlight();
+  const watching = useStartedRunWatch();
 
   useEffect(() => {
     const onVisibilityChange = () => {
@@ -134,8 +180,12 @@ export function useAiActivity(): AiActivity {
     // a run that lasted five seconds was read at thirty-second resolution.
     // The raw count and not the lingering flag: the linger is presentation,
     // and the cadence follows the fact.
+    //
+    // A run this tab started is the third thing that makes the cadence live,
+    // and the only one neither of the other two can see: the feed does not
+    // carry it yet and no model call is open for it.
     refetchInterval: (q) =>
-      open > 0 || (q.state.data?.running ?? NOTHING).length > 0
+      watching || open > 0 || (q.state.data?.running ?? NOTHING).length > 0
         ? POLL_LIVE_MS
         : POLL_IDLE_MS,
   });
@@ -194,6 +244,43 @@ export function useAiActivity(): AiActivity {
     working: running.some((item) => item.state !== "stalled"),
     asking,
   };
+}
+
+/**
+ * Whether this tab is still looking for a run it started.
+ *
+ * The start is module state rather than a prop for the same reason the
+ * in-flight count is (`api/model-inflight.ts`): the surface that presses the
+ * button and the rail that reports the work are on opposite sides of the app,
+ * and threading a callback between them would put the rail's cadence in the
+ * hands of every screen that starts anything.
+ *
+ * The count seen at mount is not a start this tab is waiting on — it happened
+ * before this rail existed — so the ref opens on it rather than on zero, and a
+ * remounted rail does not arm a watch nobody asked for.
+ */
+function useStartedRunWatch(): boolean {
+  const started = useSyncExternalStore(
+    subscribeToStarts,
+    startCount,
+    startCount,
+  );
+  const [watching, setWatching] = useState(false);
+  const seen = useRef(started);
+  useEffect(() => {
+    if (started === seen.current) {
+      return undefined;
+    }
+    seen.current = started;
+    setWatching(true);
+    const timer = setTimeout(() => {
+      setWatching(false);
+    }, START_WATCH_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [started]);
+  return watching;
 }
 
 /**

--- a/frontend/src/screens/documentextraction.tsx
+++ b/frontend/src/screens/documentextraction.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { watchStartedAiRun } from "../app/ai-activity";
 import { Button, TextInput } from "../design-system/atoms";
 import { EvidenceMark } from "../design-system/evidencemark";
 import type { ConfidenceLevel } from "../design-system/trust";
@@ -168,6 +169,12 @@ export function DocumentExtractionPanel({
       // one: it would pre-fill the new field, differ from the new value, and be
       // sent as a deliberate human edit of a reading nobody typed it against.
       setEdits({});
+      // The reading is queued, not held open: this route answers at once and
+      // the occurrence reaches the rail's feed through the outbox afterwards.
+      // Without this the reading is the agent's own work with nothing on the
+      // chrome saying so until an idle poll happens to catch it — and a short
+      // one settles inside that window and is never announced at all.
+      watchStartedAiRun(queryClient);
       await queryClient.invalidateQueries({
         queryKey: ["attachment-extraction", attachmentId],
       });

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { refetchAiActivity } from "../app/ai-activity";
+import { watchStartedAiRun } from "../app/ai-activity";
 import { PageAsideToggle, usePageAside } from "../app/pageaside";
 import { usePageName } from "../app/pagemeta";
 import { useRecordZone } from "../app/recordzone";
@@ -1051,9 +1051,10 @@ function DeepReadCard({ orgId }: Readonly<{ orgId: string }>) {
         queryKey: ["site-read-latest", orgId],
       });
       // The read is queued the moment the 202 lands, and the rail's feed is
-      // what draws the crawl on the Core — so ask it now rather than on its
-      // next idle poll.
-      refetchAiActivity(queryClient);
+      // what draws the crawl on the Core — but the occurrence reaches that feed
+      // through the outbox, so it is not there yet. This is what makes the rail
+      // watch for it rather than meet it on its next idle poll.
+      watchStartedAiRun(queryClient);
     },
   });
 


### PR DESCRIPTION
## What

A durable AI run a rep starts from a record page — a website read from a
company's profile tab, a document reading from an attachment — now reaches the
Core rail's AI-activity feed while it is still running, instead of up to half a
minute later or not at all.

## Why

Both surfaces answer 202: the row is committed and the occurrence reaches the
projection through the outbox — the relay's own poll, then the bus, then the
consumer's upsert. The single read fired on that 202 therefore asks at the one
instant the answer is guaranteed to be no. With nothing running, the feed's
cadence then drops to its idle period, so the crawl announced itself on the rail
up to 30 seconds after the button — and a reading that settled inside that
window was never announced at all. The document reading did not ask the feed at
all, so it was invisible on the rail for the whole idle period every time.

The invariant, stated where the feed lives rather than at each caller: a run
this tab started is live work the feed does not carry yet, and it is the only
one of the three live facts that neither of the other two can see — the feed has
no row for it, and no model call is held open for it (`MODEL_ROUTE_SUFFIXES`
deliberately excludes both routes, because neither waits on a model).

A start therefore arms a watch that holds the feed at the live cadence until the
occurrence arrives. The ceiling is the idle period itself: past it the ordinary
cadence has already asked, so watching longer would be polling fast for a run
that is not coming. The immediate read is kept for the case it can actually
answer — a request that JOINED a crawl already in flight, whose occurrence has
been in the feed for minutes.

Nothing about what the rail SAYS changed: the orb still lights only when the
feed names the occurrence, so no line is drawn from a client-side assumption
about work the server has not confirmed.

## How verified

`make check-fe` in its parts, all green: `fe-lint`, `fe-typecheck`,
`fe-ds-gates`, `fe-drift`, `fe-unit` (587 files, 7298 tests), `fe-build`. The
suite was run in legs rather than as one target only because the whole target
runs past this environment's command timeout.

Four new cases in `frontend/src/app/ai-activity.test.tsx`, each checked to fail
without the change it holds:

- polls fast while the feed does not carry the started run yet
- reports the run inside the watch rather than at the idle poll
- gives up on a start the feed never carried (fails if the ceiling is removed)
- re-arms on a second start rather than expiring on the first's clock

- [x] `make check` is green — the frontend half in the legs listed above; no Go, no contract and no migration in this diff, so `check-backend` has nothing here to run against
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend only, no store, no query, no write
- [x] `make craft-static` reports no new blockers — no Go files changed, so the diff-scoped gate has nothing to read
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

Not driven manually: this environment has no dev stack (no Postgres, no worker),
so the timing was proved with fake timers against the real hook rather than by
watching a crawl. The two call sites are one line each and are not themselves
covered by a test — asserting "this module function was called" would be the
over-mocking the rubric refuses, and the mechanism they call is what the four
cases above hold.

## AI involvement

Written by Claude Code: the investigation, the change, the tests and this
description. The defect was diagnosed by reading the path from the button
through the outbox to the rail rather than by reproducing it against a running
stack.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGw2APhLQ9WU8gfcb64jnA

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGw2APhLQ9WU8gfcb64jnA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AI-activity rail so a durable run a rep starts — a website read from a company's profile tab, a document reading from an attachment — appears on it while it is still running, instead of up to half a minute later or not at all.

- The read fired on the 202 asked at the only instant the occurrence cannot be in the feed, dropping the cadence to the idle 30s poll while the run traveled through the outbox.
- A start now arms a watch that holds the feed at the live cadence until the occurrence arrives, capped at the idle period itself.
- The immediate read is kept for requests that joined a crawl already in flight, whose occurrence is already in the feed.
- Document readings now report their starts; previously they never asked the feed at all.

<sup>Written for commit 224a6446cc024d7a67273a3232b3d7a07e1b3464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

