### PR TITLE
test(analytics): the screen answers in a browser, and says what it cannot

### DIFF
--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -1,0 +1,232 @@
+import { expect, type Page, test } from "@playwright/test";
+import { de } from "../src/i18n/de";
+import type { MessageKey } from "../src/i18n/en";
+import { mockApi } from "./seed";
+
+/**
+ * The Analytics screen, section by section.
+ *
+ * The behavioural tests (vitest) already prove which rows a card maps and which
+ * absence draws which plate. What none of them can see is whether a reader
+ * opening #/analytics reaches those sections at all, whether a section that has
+ * nothing to say SAYS so, and whether the answer survives a reload and a copied
+ * link.
+ *
+ * THE ONE ASSERTION THAT MATTERS MOST is that nothing renders as zero when it
+ * means something else. "Too few to say", "no project has gone quiet", "not
+ * checked yet" and "0" are four different facts, and an analytics screen that
+ * collapses them is worse than one that shows nothing: a manager acts on a
+ * number that was never measured. The fixtures are built to put an honest
+ * absence on screen BESIDE a real figure, so a screen that drew zeroes would
+ * fail here rather than look tidy.
+ *
+ * German, because the app renders German — asserting the English strings would
+ * pass against a build no user sees. Section names come from the translation
+ * table itself rather than being retyped, so a copy change moves both.
+ */
+
+const t = (key: MessageKey) => de[key];
+
+/**
+ * Open Analytics with the API mocked.
+ *
+ * mockApi alone, and NOT signIn: the mock answers /me with a seated reader, so
+ * the app is already authenticated when the first navigation lands. Signing in
+ * on top of that walked the app through the login flow and left every
+ * subsequent hash navigation on the not-found card — which every assertion here
+ * then passed against, because a page that renders nothing overflows nothing
+ * and contains none of the strings a negative check looks for.
+ *
+ * The other specs that reach this screen (history.spec.ts) do the same.
+ */
+async function openAnalytics(page: Page, section?: string) {
+  await mockApi(page);
+  await page.goto(`/#/analytics${section ? `/${section}` : ""}`, {
+    waitUntil: "networkidle",
+  });
+}
+
+test.describe("Analytics sections", () => {
+  test("every declared section draws its own answer", async ({ page }) => {
+    await openAnalytics(page);
+    // The strip is the screen's own contract: a section it declares and does
+    // not draw is a control that goes nowhere, which is how a reader learns to
+    // distrust the whole screen.
+    //
+    // A GROUP of pressable buttons, not a tablist, and the design system says
+    // why where it builds them: a tablist promises arrow-key movement between
+    // panels wired by id, and these route to a page. Asserting the role the
+    // component actually renders is the difference between testing the screen
+    // and testing a guess about it.
+    const strip = page.getByRole("group", { name: t("analytics.sections") });
+    await expect(strip).toBeVisible();
+    for (const key of [
+      "analytics.sectionForecast",
+      "analytics.sectionPipeline",
+      "analytics.sectionPerformance",
+      "analytics.sectionDelivery",
+    ] as const) {
+      await expect(
+        strip.getByRole("button", { name: t(key) }),
+        `the ${t(key)} section has no control`,
+      ).toBeVisible();
+    }
+
+    // And each one DRAWS something when pressed. A strip of controls that all
+    // route to the same body — or to none — passes a visibility check and fails
+    // every reader, so the tabs are pressed rather than counted.
+    for (const [key, expected] of [
+      ["analytics.sectionPerformance", "analytics.reportStageAge"],
+      ["analytics.sectionDelivery", "analytics.reportProjectsByPhase"],
+    ] as const) {
+      await strip.getByRole("button", { name: t(key) }).click();
+      await expect(
+        page.getByText(t(expected)).first(),
+        `pressing ${t(key)} drew no ${t(expected)} — the control routes nowhere`,
+      ).toBeVisible();
+    }
+    // Two sections are CONDITIONAL and their absence here is the screen being
+    // careful rather than incomplete:
+    //
+    //   - My outcomes appears only for a reader whose own lens is the default,
+    //     because it is that reader's own week and nobody else's;
+    //   - Data coverage appears only with the ops grant AND after the server
+    //     has answered, because a tab that opens onto a refusal is worse than
+    //     no tab.
+    //
+    // This fixture's reader measures the workspace and the mock serves no
+    // coverage probe, so neither is drawn. Asserting their ABSENCE keeps the
+    // rule visible: a build that showed an ops tab to everyone would fail
+    // here rather than look complete.
+    //
+    // The four assertions above are what makes this safe to assert. A count of
+    // zero passes on a page that rendered nothing at all, so an absence is only
+    // evidence once something PRESENT has been seen on the same strip — which
+    // is why these come after the loop rather than standing alone.
+    for (const key of [
+      "analytics.sectionOutcomes",
+      "analytics.sectionCoverage",
+    ] as const) {
+      await expect(
+        strip.getByRole("button", { name: t(key) }),
+        `${t(key)} is drawn for a reader who cannot use it`,
+      ).toHaveCount(0);
+    }
+  });
+
+  test("a section's answer survives a reload and a copied link", async ({
+    page,
+  }) => {
+    await openAnalytics(page, "delivery");
+    const delivery = page.getByRole("button", {
+      name: t("analytics.sectionDelivery"),
+    });
+    await expect(delivery).toHaveAttribute("aria-pressed", "true");
+
+    // A reader who reloads, or pastes the link to a colleague, must land on the
+    // same answer. A section held only in memory sends them back to the default
+    // and quietly answers a different question than the one they shared.
+    await page.reload({ waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("button", { name: t("analytics.sectionDelivery") }),
+      "the section was lost on reload — a copied link answers a different question",
+    ).toHaveAttribute("aria-pressed", "true");
+    // And the BODY came back with it. aria-pressed is computed from the route
+    // alone, so it stays true over a section that rendered nothing — which is
+    // the state a reader following a shared link would actually be in.
+    await expect(
+      page.getByText(t("analytics.reportProjectsByPhase")).first(),
+      "the pressed section drew no report after reload — the link restores a " +
+        "tab and not an answer",
+    ).toBeVisible();
+  });
+
+  test("a figure too small to report says so rather than showing zero", async ({
+    page,
+  }) => {
+    await openAnalytics(page, "performance");
+    // The stage-age fixture holds one stage with a real median (12 days) and one
+    // with too few deals to have one. BOTH are asserted: the number proves the
+    // card rendered and read its rows, and the words prove it does not fill an
+    // absence with a zero.
+    //
+    // The number first, because without it the words below could come from a
+    // card that failed to render anything at all.
+    // Scoped to the ROW, not to a container: DataTable's scroll region is
+    // labelled only when its content overflows, so there is no stable wrapper to
+    // find the card by. The row names its own stage, which is what makes these
+    // two assertions about the same table.
+    //
+    // Both, and in this order. The measured stage's median proves the card read
+    // its rows at all; without it the words below could come from a card that
+    // rendered nothing, or from win-loss, which draws the same DaysCell.
+    const measured = page.getByRole("row", { name: /Qualify/ });
+    await expect(
+      measured.getByText(t("analytics.days").replace("{days}", "12")),
+      "the measured stage drew no median — the card did not read its rows",
+    ).toBeVisible();
+
+    const unmeasured = page.getByRole("row", { name: /Proposal/ });
+    await expect(
+      unmeasured.getByText(t("analytics.tooFewForMedian")).first(),
+      "a stage under the sample floor drew no words — a reader cannot tell an " +
+        "unmeasured stage from a fast one",
+    ).toBeVisible();
+  });
+
+  test("a section with nothing to report says so in words", async ({ page }) => {
+    await openAnalytics(page, "delivery");
+    // projects-gone-quiet answers no rows, which is a real answer — "nothing
+    // has gone quiet" — and an empty table would leave a reader wondering
+    // whether the check ran.
+    await expect(
+      page.getByText(t("analytics.nothingQuiet")).first(),
+      "an empty result drew an empty table; a reader cannot tell that from a " +
+        "check that never ran",
+    ).toBeVisible();
+  });
+
+  test("the page does not scroll sideways at a phone width", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAnalytics(page, "performance");
+    // The content has to BE there before its width means anything: a blank body
+    // overflows nothing and would pass this by rendering less than the screen
+    // promises.
+    await expect(
+      page.getByText(t("analytics.reportStageAge")).first(),
+      "the performance section drew nothing, so measuring its width proves nothing",
+    ).toBeVisible();
+
+    // BOTH scrollers, not the document alone. The shell pins `.main` to
+    // overflow:hidden and scrolls content through `.scroll`, so wide content
+    // rides inside the page's own scroller while the document reports zero —
+    // ac.spec.ts records measuring 273px of overflow there against a body that
+    // never grew a pixel. A document-only check is structurally incapable of
+    // failing.
+    //
+    // A component's OWN scroll region is deliberately not measured: a table too
+    // wide for a phone scrolling inside its card is the sanctioned answer to
+    // wide content, and the page around it never moves.
+    const overflowing = await page.evaluate(() =>
+      [
+        { name: "the document", element: document.documentElement },
+        ...Array.from(document.querySelectorAll(".scroll")).map((element) => ({
+          name: "the shell content scroller (.scroll)",
+          element,
+        })),
+      ]
+        .map(({ name, element }) => ({
+          name,
+          overflow: element.scrollWidth - element.clientWidth,
+        }))
+        .filter(({ overflow }) => overflow > 1)
+        .map(({ name, overflow }) => `${name}: ${overflow}px past the viewport`),
+    );
+    expect(
+      overflowing,
+      "the page scrolls sideways at 390px — a column is out of reach",
+    ).toEqual([]);
+  });
+});

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -326,6 +326,135 @@ export const automationCatalog = [
 
 // Pre-seeded instance — the wire carries no origin, so this stands in for
 // the agent-authored case and must render like any other row.
+// The report answers the Analytics sections read, keyed by the report the
+// screen asks for.
+//
+// Each carries the ALIASES its card reads, because a card looking for
+// `median_days` on a row that carries `raw_minor` renders its empty state and a
+// sweep over that tab then measures this file rather than the screen.
+//
+// The values are chosen so an honest ABSENCE is on screen beside a real number:
+// stage-age's second row has too few deals for a median, and projects-gone-quiet
+// answers nothing at all. A fixture where every cell holds a figure cannot show
+// that the screen says "Too few to say" rather than "0".
+//
+// And every OTHER card carries its figures, which matters as much: win-loss
+// draws the same DaysCell, so a fixture omitting its medians puts "Too few to
+// say" on screen for a reason the test is not about — and an assertion looking
+// for those words then passes whatever stage-age does.
+export const reportFixtures: Record<string, unknown> = {
+  // Stage ids are the SHARED pipeline's, not invented ones: StageAgeTable joins
+  // them to `stages` for the name, and an id matching nothing renders every row
+  // as "unknown stage" — a table that looks populated and names no stage.
+  "stage-age": {
+    report: "stage-age",
+    plan: { group_by: ["stage_id"] },
+    columns: ["stage_id", "deal_count", "median_days", "p75_days"],
+    rows: [
+      {
+        stage_id: "s1",
+        deal_count: 6,
+        median_days: 12,
+        p75_days: 21,
+      },
+      // Under the sample floor: the server answers null and the card must say
+      // so in words rather than drawing a zero.
+      {
+        stage_id: "s2",
+        deal_count: 2,
+        median_days: null,
+        p75_days: null,
+      },
+    ],
+    total_rows: 2,
+    as_of: "2026-03-04T09:00:00Z",
+    timezone: "Europe/Berlin",
+    base_currency: "EUR",
+  },
+  "win-loss": {
+    report: "win-loss",
+    plan: { group_by: ["status"] },
+    columns: ["status", "deal_count", "raw_minor", "median_days", "p75_days"],
+    rows: [
+      {
+        status: "won",
+        deal_count: 7,
+        raw_minor: 4_200_000,
+        median_days: 34,
+        p75_days: 61,
+      },
+      {
+        status: "lost",
+        deal_count: 4,
+        raw_minor: 9_100_000,
+        median_days: 22,
+        p75_days: 40,
+      },
+    ],
+    total_rows: 2,
+    as_of: "2026-03-04T09:00:00Z",
+    timezone: "Europe/Berlin",
+    base_currency: "EUR",
+  },
+  "projects-by-phase": {
+    report: "projects-by-phase",
+    plan: { group_by: ["phase"] },
+    columns: ["phase", "projects", "open_deal_value_minor", "won_deal_value_minor"],
+    rows: [
+      {
+        phase: "delivering",
+        projects: 3,
+        open_deal_value_minor: 1_500_000,
+        won_deal_value_minor: 8_000_000,
+      },
+    ],
+    total_rows: 1,
+    as_of: "2026-03-04T09:00:00Z",
+    timezone: "Europe/Berlin",
+    base_currency: "EUR",
+  },
+  "project-commitments": {
+    report: "project-commitments",
+    plan: { group_by: ["project_id"] },
+    // name and phase travel with the id, because the card draws the project as
+    // a LINK with its phase beside it: a row carrying the id alone renders an
+    // empty link and a blank phase, which reads as a broken row rather than as
+    // the fixture being short.
+    columns: [
+      "project_id",
+      "name",
+      "phase",
+      "open_commitments",
+      "overdue_commitments",
+    ],
+    rows: [
+      {
+        project_id: "p1",
+        name: "Rollout",
+        phase: "delivering",
+        open_commitments: 4,
+        overdue_commitments: 1,
+      },
+    ],
+    total_rows: 1,
+    as_of: "2026-03-04T09:00:00Z",
+    timezone: "Europe/Berlin",
+    base_currency: "EUR",
+  },
+  // Deliberately empty: "nothing has gone quiet" is a real answer and the
+  // screen owes words for it rather than an empty table.
+  "projects-gone-quiet": {
+    report: "projects-gone-quiet",
+    plan: { group_by: ["project_id"] },
+    columns: ["project_id", "quiet_since"],
+    rows: [],
+    total_rows: 0,
+    as_of: "2026-03-04T09:00:00Z",
+    timezone: "Europe/Berlin",
+    base_currency: "EUR",
+  },
+};
+
 export const seededAutomation = {
   id: "au-1",
   key: "task_on_stage_entry",
@@ -2279,7 +2408,19 @@ export async function mockApi(
         base_currency: "EUR",
       });
     }
-    if (path.startsWith("/reports/")) {
+    // The report a caller ASKED for, not one shape for all of them.
+    //
+    // Every report answered `deals-by-stage`'s columns before this, so the
+    // Performance and Delivery sections received rows whose fields they do not
+    // read: a stage-age card looking for `median_days` on a row carrying
+    // `raw_minor` renders its empty state, and a sweep over those tabs proves
+    // the fixture rather than the screen.
+    if (path.startsWith("/reports/") && !path.includes("/derivation")) {
+      const key = path.slice("/reports/".length);
+      const shaped = reportFixtures[key];
+      if (shaped) {
+        return json(shaped);
+      }
       return json({
         report: "deals-by-stage",
         // The plan echoes what the CLIENT asked for, and the client groups money


### PR DESCRIPTION
Part of plan PR 13 — the browser half of the integrated acceptance pass.

## What it adds

The Analytics screen had no Playwright spec. The vitest suite (45 tests) proves
which rows a card maps and which absence draws which plate; it cannot see
whether a reader opening `#/analytics` reaches those sections at all, whether a
section with nothing to say **says so**, or whether the answer survives a reload.

Five cases. The one that matters most: **nothing renders as zero when it means
something else.** "Too few to say", "nothing has gone quiet", "not checked yet"
and "0" are four different facts, and a screen that collapses them lets a
manager act on a number nobody measured.

## The mock answers per report

Every key returned one `deals-by-stage` shape before this, so Performance and
Delivery received rows whose fields their cards do not read — a stage-age card
looking for `median_days` on a row carrying `raw_minor` draws its empty state,
and a sweep over those tabs then proves the fixture rather than the screen.

Stage ids are the shared pipeline's, because an id matching nothing renders
every row as "unknown stage": a table that looks populated and names nothing.

## The first version of this spec tested nothing

It called `signIn()` on top of a mock that already seats a reader, which left
every navigation on the **not-found card** — and all five cases passed against
it. A page that renders nothing overflows nothing and contains none of the
strings a negative check looks for, so four of the five were structurally
incapable of failing.

What caught it was adding ONE positive assertion beside a negative one: the
measured stage's median, which a blank page cannot produce.

So the rule the spec now follows, written into its comments: **a negative
assertion needs a positive one beside it, scoped to the same row.**

## Mutation-checked, both directions

| mutation | result |
|---|---|
| change the median to another value | the positive assertion fails |
| make the withheld median a `0` | the negative assertion fails |

## Overflow reads both scrollers

The shell pins `.main` to `overflow: hidden` and scrolls content through
`.scroll`, so wide content rides inside the page's own scroller while the
document reports zero. `ac.spec.ts` records measuring **273px** of overflow
there against a body that never grew a pixel — a document-only check is
structurally incapable of failing.

## Verified

- `make check-fe`: exit 0
- full Playwright suite at 4 workers: **281 passed, 0 failed**

## Not here

The journeys needing a live backend, several seeded personas, or the SDR
foundations — those wait on their own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first Playwright spec for the Analytics screen, covering five cases the vitest suite cannot see: every section draws its own answer, the answer survives a reload, "too few to say" renders as words rather than zero, and the page does not scroll sideways at phone width. The mock change fixes the seed so each report answers with its own shape — previously every report returned `deals-by-stage` columns, which made the Performance and Delivery cards render their empty states.

- Report fixtures now carry the columns each card reads, shared-pipeline stage ids, a deliberately empty `projects-gone-quiet`, and one stage under the sample floor so an honest absence sits beside a real median.
- Every negative assertion in the spec has a positive assertion beside it, scoped to the same row; the first version without this rule passed against a blank page.

<sup>Written for commit 18666b063c7cc220872c6898845596b44a81a9b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for the Analytics screen, including section controls, report rendering, expanded states, and shared links.
  - Added validation for accurate median messaging, empty results, conditional sections, and responsive behavior on mobile-width screens.
  - Expanded test data coverage for multiple Analytics reports, including empty and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->