### PR TITLE
fix(forecasting): the tests sharing a pool stop running in parallel

### DIFF
--- a/backend/internal/modules/forecasting/callhistory_integration_test.go
+++ b/backend/internal/modules/forecasting/callhistory_integration_test.go
@@ -8,10 +8,13 @@ package forecasting
 // The chain a call leaves behind, read back.
 //
 // Each case works in its OWN period, and the distinct years are load-bearing.
-// An installation holds exactly one workspace, so these tests share a database
-// even under t.Parallel(): two cases calling the same (period, scope) would see
-// each other's rows, and the count assertions would fail on a collision rather
-// than on a defect.
+// An installation holds exactly one workspace, so these tests share a database:
+// two cases calling the same (period, scope) would see each other's rows, and
+// the count assertions would fail on a collision rather than on a defect. That
+// stays true now they run in sequence — the periods keep them independent of
+// each other's ORDER, not only of each other's timing.
+//
+// They no longer call t.Parallel(); setupSnapshot says why.
 //
 // These need real Postgres for the reason the snapshot tests do: the ordering
 // is SQL's, the scope match is SQL's, and the NULL-versus-value distinction
@@ -80,7 +83,6 @@ func quarterOf(t *testing.T, day time.Time) Period {
 // from replacing nothing — a reader walking the chain needs the end of it to
 // be reachable.
 func TestTheCallHistoryIsTheChainNewestFirst(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 	period := quarterOf(t, time.Date(2031, time.August, 12, 12, 0, 0, 0, time.UTC))
@@ -123,7 +125,6 @@ func TestTheCallHistoryIsTheChainNewestFirst(t *testing.T) {
 // answer about a period the caller may read, and the endpoint serves `[]`
 // rather than `null` so a reader cannot tell one from the other by accident.
 func TestAPeriodNobodyCalledHasAnEmptyHistory(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	period := quarterOf(t, time.Date(2033, time.November, 12, 12, 0, 0, 0, time.UTC))
 
@@ -145,7 +146,6 @@ func TestAPeriodNobodyCalledHasAnEmptyHistory(t *testing.T) {
 // the workspace, and a query written with `=` instead of IS NOT DISTINCT FROM
 // finds nothing for the one scope every installation has.
 func TestACallHistoryHoldsOnlyItsOwnPeriodAndScope(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 	q3 := quarterOf(t, time.Date(2032, time.September, 12, 12, 0, 0, 0, time.UTC))
@@ -182,7 +182,6 @@ func TestACallHistoryHoldsOnlyItsOwnPeriodAndScope(t *testing.T) {
 // handler that resolves the caller's scope before calling it, and a second
 // object check here would refuse a manager who may call but not read.
 func TestACallHistoryNeedsTheForecastReadGrant(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	period := quarterOf(t, time.Date(2034, time.August, 12, 12, 0, 0, 0, time.UTC))
 
@@ -216,7 +215,6 @@ func (e *snapshotEnv) asUngranted() context.Context {
 // A period is called past the cap here rather than at it, so the assertion is
 // about the cut and not about an off-by-one at the boundary.
 func TestACappedHistoryKeepsTheNewestCalls(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 	period := quarterOf(t, time.Date(2035, time.May, 12, 12, 0, 0, 0, time.UTC))

--- a/backend/internal/modules/forecasting/snapshot_integration_test.go
+++ b/backend/internal/modules/forecasting/snapshot_integration_test.go
@@ -41,6 +41,22 @@ type snapshotEnv struct {
 	rep     ids.UUID
 }
 
+// setupSnapshot hands out the package's SHARED pool, and a test that takes it
+// must not call t.Parallel().
+//
+// testdb.AssertPoolsQuiesced is registered below as this test's own cleanup, and
+// it asserts that the shared pool has nothing checked out. For a parallel test
+// that cleanup runs while its siblings are still running and legitimately
+// holding connections from the same pool — so the first one to finish reports
+// the others as a leak, naming whichever test happened to end first. It fails
+// only on a loaded runner, which is what makes it read as infrastructure noise
+// rather than as the misattribution it is.
+//
+// The pure-unit files beside this one keep their parallelism: they touch no
+// database, so the gate has nothing to misread about them.
+//
+// #4496 tracks teaching the gate about parallel siblings, which would let these
+// be parallel again without weakening what it catches.
 func setupSnapshot(t *testing.T) *snapshotEnv {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
@@ -127,7 +143,6 @@ func mixedPopulation(t *testing.T) Readings {
 }
 
 func TestASnapshotWritesEveryContributionShapeTheTableAccepts(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 
@@ -193,7 +208,6 @@ func TestASnapshotWritesEveryContributionShapeTheTableAccepts(t *testing.T) {
 // repeatedly so a worker that was down still backfills, and without the
 // constraint that produces two snapshots and no error.
 func TestASecondDailySnapshotForTheSameDayIsRefused(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 
@@ -245,7 +259,6 @@ func TestASecondDailySnapshotForTheSameDayIsRefused(t *testing.T) {
 // waterfall is then a number describing no decision anybody made, and the
 // figures are large enough to look real.
 func TestAMovementAcrossTwoDifferentWindowsIsRefused(t *testing.T) {
-	t.Parallel()
 	e := setupSnapshot(t)
 	ctx := e.as()
 


### PR DESCRIPTION
**main is red, and deterministically so** — it took every PR whose merge commit reaches this package, survived a full rerun, and named the same test each time on three different shards.

```
snapshot_integration_test.go:79: the shared pool for …/margince_it_p5_24507 still had
1 connection(s) checked out 2s after this test ended. A goroutine this test started is
still running, and the next test resets the database under it
```

**No goroutine that test started is running**, and nothing is resetting the database under it. `testdb.AssertPoolsQuiesced` is registered as a **per-test** cleanup and asserts the **shared** pool is empty. For a `t.Parallel()` test that cleanup runs while its siblings are still running and legitimately holding connections from the same pool — so the first one to finish reports the others as a leak.

`TestTheCallHistoryIsTheChainNewestFirst` is simply whichever case finished first while a sibling was mid-query. It passes in isolation and passes for the whole package locally; it needs a loaded runner, which is why it reads as infrastructure noise and is not.

## The change

**Eight** `t.Parallel()` calls — five in `callhistory_integration_test.go`, three in `snapshot_integration_test.go` — the two files that take the shared pool. The **thirty** in the pure-unit files beside them stay: they touch no database, so the gate has nothing to misread about them.

*(Corrected from "nine" and "thirty-two" after review. My count matched the string `t.Parallel()` and picked up one occurrence inside a comment; the commit message still carries the wrong figures, and I have not amended it because force-pushing a pushed branch is not something I do.)*

Serialising costs this package nothing it was relying on. Each case already works in its own period precisely because they share one database, so what kept them independent was the periods rather than the timing. The package runs in 1.5s.

## Why not the general fix

#4496 carries it: teach the gate about parallel siblings. The obvious shape is a reference count — `testdb.Pool` increments, `AssertPoolsQuiesced` asserts only at zero — and it has a real cost: a leak is then attributed to the **last test out** rather than the one that leaked, which is most of the gate's diagnostic value. It can also drift silently upward if a file calls `Pool` more often than it registers the gate, and `modulepoolsharing_test.go` enforces that pairing per FILE, not per call.

That is shared infrastructure under ~30 packages where getting it wrong disables a real leak gate **silently** — the one direction it must not fail in. The gate's own doc already reasons carefully about exactly that (it waits rather than samples, for this reason), so the parallel case deserves the same care rather than a quick patch while main is red.

## Verification

`make test-it DIR=backend/internal/modules/forecasting` green. `make check-backend` and `make craft-static` green.
