### PR TITLE
feat(worklist): the reply opens on the conversation the row is about

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7617,6 +7617,8 @@ export const de = {
   "person.composer.draftWithAi": "Mit KI entwerfen",
   "person.composer.intentAgenda":
     "eine Agenda für den anstehenden Termin vorschlagen",
+  "person.composer.threadGone":
+    "Das Gespräch, auf das dieser Link zeigt, kann nicht mehr beantwortet werden — der Kanal oder die Adresse dazu gibt es nicht mehr. Das hier ist eine neue Nachricht.",
   "person.composer.intentReply": "auf die letzte Nachricht antworten",
   "person.composer.intentCommitment": "einlösen, was wir zugesagt haben",
   "person.composer.intentFollowUp": "nachfassen — es ist still geworden",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7709,6 +7709,8 @@ export const en = {
     "Optional — e.g. ask for a date in the first week of September",
   "person.composer.draftWithAi": "Draft with AI",
   "person.composer.intentAgenda": "propose an agenda for the upcoming meeting",
+  "person.composer.threadGone":
+    "The conversation this link named can no longer be answered — the channel or address it was on is gone. This is a new message to them.",
   "person.composer.intentReply": "reply to their last message",
   "person.composer.intentCommitment": "deliver what we promised them",
   "person.composer.intentFollowUp": "follow up — it has gone quiet",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7522,6 +7522,8 @@ export const vi = {
     "Tùy chọn — ví dụ: xin một buổi hẹn trong tuần đầu tháng 9",
   "person.composer.draftWithAi": "Soạn bằng AI",
   "person.composer.intentAgenda": "đề xuất chương trình cho buổi hẹn sắp tới",
+  "person.composer.threadGone":
+    "Cuộc trò chuyện mà liên kết này trỏ tới không còn trả lời được nữa — kênh hoặc địa chỉ của nó đã không còn. Đây là một tin nhắn mới.",
   "person.composer.intentReply": "trả lời tin nhắn gần nhất của họ",
   "person.composer.intentCommitment": "thực hiện điều chúng ta đã hứa",
   "person.composer.intentFollowUp": "nhắc lại — đã lâu không có phản hồi",

--- a/frontend/src/screens/persondrawers.tsx
+++ b/frontend/src/screens/persondrawers.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Badge, Button, Modal, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import {
   liveProjects,
   ProjectPicker,
@@ -26,7 +27,7 @@ import { refusalOf, SendRefusal, scheduleFields } from "./compose";
 import { useConsentPurposes } from "./consent";
 import { PersonProviderSection } from "./personprovider";
 import type { Transport } from "./persontransports";
-import { useTransports } from "./persontransports";
+import { transportForActivity, useTransports } from "./persontransports";
 
 // The three surfaces the person page opens over itself: the composer, the
 // research drawer, and the meeting brief.
@@ -326,20 +327,34 @@ function ToLine({
 // A hook rather than three lines in the composer because the composer is at its
 // complexity ceiling and this is one idea — "which way is this going" — that a
 // reader should be able to take in on its own.
-function useTransportChoice(view: Person360) {
+function useTransportChoice(view: Person360, threadId?: string) {
   const transports = useTransports(view);
   // The composer opens on the first way this person can be reached. An empty
   // selection resolves to that rather than being seeded, so a contact whose
   // reachability arrives after the first render does not stay stuck on the
   // transport that existed before it.
   const [transportId, setTransportId] = useState("");
+  // UNLESS A CALLER NAMED A CONVERSATION. A worklist row is about one message,
+  // and the transport that message is on is the one to answer it from — the
+  // person's own lead transport is the right default for somebody who pressed
+  // Write on the record and the wrong one for a link that named a thread.
+  //
+  // The reader's own pick still wins: this decides what the composer OPENS on,
+  // and changing the dial afterwards is a choice they are entitled to make.
+  const anchored = transportForActivity(transports, view, threadId);
   const transport =
-    transports.find((option) => option.id === transportId) ?? transports[0];
+    transports.find((option) => option.id === transportId) ??
+    anchored.chosen ??
+    transports[0];
   return {
     transports,
     transport,
     isChannel: transport != null && transport.id !== "email",
     setTransportId,
+    // The named conversation cannot be answered any more — disconnected,
+    // removed, or off the end of the page's own window. The composer is open on
+    // something else, and the reader is told rather than left to notice.
+    staleThread: anchored.stale,
   };
 }
 
@@ -431,6 +446,26 @@ async function sendChannelReply(
 // One transport gets the composer this contact has always had: a picker with a
 // single option is a control that cannot be used, and it would appear on every
 // mail-only contact in the installation to say nothing.
+// THE CONVERSATION THAT WAS NAMED AND IS NOT THERE.
+//
+// A link from the day names the message it is about. If that thread can no
+// longer be answered — a channel disconnected, an address removed, the message
+// off the end of the page's own window — the composer still opens, on this
+// contact's own lead transport, and says which of the two it is doing.
+// Swapping one conversation for another without a word is the thing the whole
+// anchor exists to prevent.
+//
+// Its own component so the composer keeps one branch fewer: it is already at
+// the complexity ceiling, and a notice that renders nothing most of the time
+// should not cost the surface around it a decision.
+function ThreadGoneNotice({ stale }: Readonly<{ stale: boolean }>) {
+  const t = useT();
+  if (!stale) {
+    return null;
+  }
+  return <Callout tone="warn">{t("person.composer.threadGone")}</Callout>;
+}
+
 function TransportPicker({
   transports,
   selected,
@@ -559,12 +594,17 @@ export function PersonComposer({
   guard,
   open,
   intent: initialIntent,
+  threadId,
   onClose,
 }: Readonly<{
   personId: string;
   view: Person360;
   guard: PersonConsentGuard | undefined;
   open: boolean;
+  // The conversation this composer was opened to answer, when a caller named
+  // one. It decides which transport the composer OPENS on; the reader may
+  // still change it.
+  threadId?: string;
   // What the rep (or the moment action that opened this) wants the draft to be
   // about. A rung that fired knows WHY — "their reply is overdue", "the meeting
   // needs an agenda" — and that reason shaped nothing until it arrived here.
@@ -601,8 +641,8 @@ export function PersonComposer({
   const [projectId, setProjectId] = useState("");
   const projects = liveProjects(view.projects);
   useSoleProjectDefault(projects, projectId, setProjectId);
-  const { transports, transport, isChannel, setTransportId } =
-    useTransportChoice(view);
+  const { transports, transport, isChannel, setTransportId, staleThread } =
+    useTransportChoice(view, threadId);
 
   // One spelling of "this composer holds no message", for the two moments that
   // need it: the recipient changing, and a send succeeding.
@@ -738,6 +778,7 @@ export function PersonComposer({
       />
 
       <div className="drawer-body">
+        <ThreadGoneNotice stale={staleThread} />
         <TransportPicker
           transports={transports}
           selected={transport}

--- a/frontend/src/screens/personpage.address.ts
+++ b/frontend/src/screens/personpage.address.ts
@@ -17,9 +17,24 @@ export const BRIEF_PARAM = "prep";
  * `?compose=reply` — the same intent vocabulary a moment action's prefill uses,
  * so a link and a rung ask for the draft the same way.
  *
- * WHAT IT DOES NOT SAY IS WHICH MESSAGE. The composer drafts to the PERSON,
- * choosing its transport from their own reachability rather than from a thread
- * a caller names, so an address cannot open it on one message. A parameter
- * naming an activity would promise a precision the composer does not have.
+ * WHICH MESSAGE is the THREAD_PARAM below, and the two are separate keys
+ * because they answer separately: an address may ask for the composer without
+ * naming a conversation, and every caller that names one is also asking for it.
  */
 export const COMPOSE_PARAM = "compose";
+
+/**
+ * Which conversation the composer should open on.
+ *
+ * The activity id of the message being answered. Without it the composer drafts
+ * to the PERSON and picks its transport from their own reachability — which is
+ * right for a rep who pressed Write on the record, and wrong for a worklist row
+ * that is about ONE message: a contact reachable on two channels would have the
+ * reply drafted into whichever they lead with.
+ *
+ * A thread this contact can no longer be answered on is not silently swapped
+ * for another. The composer opens on the default and says the named
+ * conversation is gone — see transportForActivity, which returns that as its
+ * own answer rather than as an absent transport.
+ */
+export const THREAD_PARAM = "thread";

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -55,7 +55,7 @@ import { PersonComposer, PersonResearchDrawer } from "./persondrawers";
 import { PersonFilesTab } from "./personfiles";
 import { PersonMemory } from "./personmemory";
 import { PersonNetworkTab } from "./personnetwork";
-import { BRIEF_PARAM, COMPOSE_PARAM } from "./personpage.address";
+import { BRIEF_PARAM, COMPOSE_PARAM, THREAD_PARAM } from "./personpage.address";
 import { PersonRail } from "./personrail";
 import { PersonReadings } from "./personreadings";
 import { PersonResearchTab } from "./personresearch";
@@ -528,6 +528,7 @@ export function PersonPageV2({
           guard={guard.data}
           open={composer.open}
           intent={composer.intent}
+          threadId={composer.threadId}
           onClose={composer.close}
         />
         {/* One drawer over the record. The timeline's rows and the rail's
@@ -622,7 +623,12 @@ function useComposer(
   pressedOpen: boolean,
   pressedIntent: string,
   onPressedClose: () => void,
-): Readonly<{ open: boolean; intent: string; close: () => void }> {
+): Readonly<{
+  open: boolean;
+  intent: string;
+  threadId: string | undefined;
+  close: () => void;
+}> {
   const [params, setParams] = useUrlParams();
   const asked = params.get(COMPOSE_PARAM);
   const key = asked ? COMPOSER_INTENT_KEYS[asked] : undefined;
@@ -639,6 +645,14 @@ function useComposer(
   return {
     open: pressedOpen || key !== undefined,
     intent: key ? t(key) : pressedIntent,
+    // Which conversation, when the address named one. Read beside the intent
+    // rather than folded into it: the intent is words for the reader, and this
+    // decides which transport the composer opens on.
+    //
+    // Only for an address-opened composer. A rep who pressed Write is not
+    // answering anything in particular, and carrying a thread id from a link
+    // they already dismissed would anchor that press on it.
+    threadId: (key !== undefined && params.get(THREAD_PARAM)) || undefined,
     close,
   };
 }

--- a/frontend/src/screens/persontransports.test.ts
+++ b/frontend/src/screens/persontransports.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import type { Transport } from "./persontransports";
+import { transportForActivity } from "./persontransports";
+
+type Person360 = components["schemas"]["Person360"];
+
+// Two channels and an address, so "which one" is a real question rather than
+// one the fixture answers by having a single option.
+const TRANSPORTS: Transport[] = [
+  { id: "email", label: "Email" },
+  { id: "whatsapp", label: "WhatsApp", anchorId: "wa-newest" },
+  { id: "telegram", label: "Telegram", anchorId: "tg-newest" },
+];
+
+function pageWith(
+  activities: Array<{ id: string; kind: string; channel_provider?: string }>,
+): Person360 {
+  return {
+    activities: { data: activities, page: {} },
+  } as unknown as Person360;
+}
+
+const PAGE = pageWith([
+  { id: "wa-older", kind: "message", channel_provider: "whatsapp" },
+  { id: "wa-newest", kind: "message", channel_provider: "whatsapp" },
+  { id: "tg-newest", kind: "message", channel_provider: "telegram" },
+  { id: "mail-1", kind: "email" },
+]);
+
+describe("transportForActivity", () => {
+  // Nothing named is not the same as something named and missing, and the pair
+  // exists so a caller can tell them apart.
+  it("claims nothing when no conversation was named", () => {
+    expect(transportForActivity(TRANSPORTS, PAGE, undefined)).toEqual({
+      chosen: undefined,
+      stale: false,
+    });
+  });
+
+  it("answers a message on the channel it is on", () => {
+    const got = transportForActivity(TRANSPORTS, PAGE, "tg-newest");
+    expect(got.stale).toBe(false);
+    expect(got.chosen?.id).toBe("telegram");
+  });
+
+  // THE NAMED MESSAGE, not the provider's newest. The transport list offers the
+  // latest conversation per provider because that is what a rep means when they
+  // pick from the list; a caller who named one means that one.
+  it("anchors on the conversation named rather than the provider's newest", () => {
+    const got = transportForActivity(TRANSPORTS, PAGE, "wa-older");
+    expect(got.chosen?.id).toBe("whatsapp");
+    expect(got.chosen?.anchorId).toBe("wa-older");
+  });
+
+  // Anything that is not a channel message is answered by mail, which is the
+  // one transport that can open a conversation rather than continue one.
+  it("answers a mail with mail", () => {
+    const got = transportForActivity(TRANSPORTS, PAGE, "mail-1");
+    expect(got.chosen?.id).toBe("email");
+    expect(got.stale).toBe(false);
+  });
+
+  // The case the pair exists for: a channel disconnected since the row was
+  // ranked. Answering with the person's lead transport and saying nothing is
+  // the reader writing into a conversation they did not choose.
+  it("reports a named channel this contact no longer has as stale", () => {
+    const withoutTelegram = TRANSPORTS.filter((t) => t.id !== "telegram");
+    const got = transportForActivity(withoutTelegram, PAGE, "tg-newest");
+    expect(got.chosen).toBeUndefined();
+    expect(got.stale).toBe(true);
+  });
+
+  // And a message that has fallen off the page's own window entirely — the
+  // row named it, the record no longer carries it.
+  it("reports a message the record does not carry as stale", () => {
+    const got = transportForActivity(TRANSPORTS, PAGE, "gone-1");
+    expect(got.chosen).toBeUndefined();
+    expect(got.stale).toBe(true);
+  });
+});

--- a/frontend/src/screens/persontransports.ts
+++ b/frontend/src/screens/persontransports.ts
@@ -81,6 +81,61 @@ export function transportsFor(
   return out;
 }
 
+/**
+ * Which transport a NAMED message is on, and whether it can still be answered.
+ *
+ * A worklist row is about one message. Opening the composer on whichever
+ * transport the person happens to lead with would draft a reply to the wrong
+ * conversation — the same overstated promise that kept `moveHref` returning a
+ * bare record href until the composer could honour the link.
+ *
+ * `chosen` is the transport to open on, absent when the message names none this
+ * contact still has. `stale` says which of the two absences it is, and the
+ * distinction is the whole reason this returns a pair rather than a transport:
+ *
+ *   - no id asked         → nothing named, no claim to keep, `stale` is false
+ *   - named, resolved     → open on it
+ *   - named, unresolvable → open on the default AND say so
+ *
+ * The third is a real shape rather than a defensive one: a channel disconnected
+ * since the row was ranked, an address removed, a message archived out of the
+ * page's own window. Falling back silently there is the defect this pair
+ * exists to prevent — the reader asked to answer one conversation and would be
+ * writing into another without being told.
+ */
+export type AnchoredTransport = {
+  chosen: Transport | undefined;
+  stale: boolean;
+};
+
+export function transportForActivity(
+  transports: readonly Transport[],
+  view: Person360,
+  activityId: string | undefined,
+): AnchoredTransport {
+  if (!activityId) {
+    return { chosen: undefined, stale: false };
+  }
+  const named = (view.activities?.data ?? []).find(
+    (activity) => activity.id === activityId,
+  );
+  if (!named) {
+    return { chosen: undefined, stale: true };
+  }
+  // A message belongs to its channel; anything else on the timeline — a mail,
+  // a note, a call — is answered by mail, which is the one transport that can
+  // OPEN a conversation rather than continue one.
+  const wanted = named.kind === "message" ? named.channel_provider : "email";
+  const chosen = transports.find((transport) => transport.id === wanted);
+  return chosen
+    ? // ANCHORED ON THE MESSAGE THE CALLER NAMED, not on the provider's newest.
+      // transportsFor offers the latest conversation per provider because that
+      // is what a rep means when they pick a transport from the list; a caller
+      // who named one means that one.
+      { chosen: { ...chosen, anchorId: named.id }, stale: false }
+    : { chosen: undefined, stale: true };
+}
+
 // The same answer for a caller that holds only the record.
 //
 // Both readers need the transport directory and the reader's own language to

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -125,6 +125,26 @@ describe("moveHref — the draft_reply move", () => {
     }
   });
 
+  // WHICH message, not just which person. A contact reachable two ways would
+  // otherwise have the reply drafted into whichever they lead with — the reason
+  // this link returned a bare record href until the composer could honour it.
+  it("names the message the row is about", () => {
+    const href = moveHref(replyRow({ type: "person", id: "p-1" }));
+    expect(href).toContain("thread=a-1");
+  });
+
+  // A fresh message names no thread, and must not: draft_email OPENS a
+  // conversation rather than continuing one, so a thread id here would anchor
+  // it on something the reader is not answering.
+  it("names no thread for a move that opens a conversation", () => {
+    const fresh = {
+      ...replyRow({ type: "person", id: "p-1" }),
+      move: { action: "draft_email" },
+    } as unknown as WorklistItem;
+    expect(moveHref(fresh)).toContain("compose=reply");
+    expect(moveHref(fresh)).not.toContain("thread=");
+  });
+
   it("offers no move at all where the row names no record", () => {
     expect(moveHref(replyRow(undefined))).toBeUndefined();
   });

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -10,7 +10,7 @@ import {
 } from "../format/format";
 import type { Locale, useT } from "../i18n";
 import { translatePlural } from "../i18n";
-import { BRIEF_PARAM, COMPOSE_PARAM } from "./personpage.address";
+import { BRIEF_PARAM, COMPOSE_PARAM, THREAD_PARAM } from "./personpage.address";
 import { settingsAddress } from "./settingsnav";
 import type {
   Worklist,
@@ -508,17 +508,20 @@ function sameDayInZone(utcIso: string, now: Date, zone: string): boolean {
 // promise what the click cannot do — the defect this function's own comment
 // warned about before the route existed.
 //
-// AND IT NAMES NO MESSAGE. `?compose=reply` asks for a reply to the PERSON, not
-// to the thread this row is about, because the composer cannot be aimed at one.
-// The row keeps its link to the record beside this, where the message sits on
-// the timeline. A parameter naming an activity would promise a precision the
-// composer does not have.
+// AND IT NAMES THE MESSAGE. `?thread=<activity>` carries the conversation this
+// row is about, so the composer opens on the transport that message is on
+// rather than on whichever this contact leads with. Without it a contact
+// reachable two ways had the reply drafted into the wrong one — which is why
+// this function returned a bare record href until the composer could be aimed.
+//
+// `draft_email` carries none, and must not: it OPENS a conversation rather than
+// continuing one, so a thread id would anchor it on something the reader is not
+// answering.
 // The verbs this row can take a reader to.
 //
-// Both end at a person's composer. Which of the two the server chose still
-// matters to the LABEL — one answers a message, the other opens a fresh one —
-// but not to the address, because the composer picks its own transport and
-// threading from the person.
+// Both end at a person's composer, and which of the two the server chose
+// reaches the address as well as the label: `draft_reply` names the message it
+// answers, `draft_email` names none because it is opening a conversation.
 //
 // `open_meeting_brief` is the third, and it lands somewhere else entirely: the
 // brief is read as `?prep=<activity>` on the PERSON's record, so the address
@@ -590,7 +593,15 @@ export function moveHref(item: WorklistItem): string | undefined {
   if (!record || item.subject?.type !== "person") {
     return record;
   }
-  return `${record}?${COMPOSE_PARAM}=reply`;
+  // The message the row is about travels with the ask. Without it the composer
+  // would open on whichever transport this contact leads with, which for a
+  // contact reachable two ways is a reply drafted into the wrong conversation —
+  // the overstated promise this link was withheld for until it could be kept.
+  const thread = move.activity_id;
+  const anchored = thread
+    ? `&${THREAD_PARAM}=${encodeURIComponent(thread)}`
+    : "";
+  return `${record}?${COMPOSE_PARAM}=reply${anchored}`;
 }
 
 /**


### PR DESCRIPTION
Closes #3587.

## What was already there

`moveHref` sends a `draft_reply` row to `?compose=reply` on the contact's record — that half landed after this issue was filed. What it could not say was **which message**, and `personpage.address.ts` said why in as many words:

> WHAT IT DOES NOT SAY IS WHICH MESSAGE. The composer drafts to the PERSON, choosing its transport from their own reachability rather than from a thread a caller names, so an address cannot open it on one message.

For a contact reachable two ways, that is the reply drafted into whichever they lead with — the overstated promise this link was withheld for in the first place.

## The change

`?thread=<activity>` names the message. `transportForActivity` resolves which transport it is on and the composer opens there.

**Anchored on that message, not the provider's newest.** `transportsFor` offers a provider's latest conversation because that is what a rep means when they pick a transport from the list; a caller who named one means that one.

**`draft_email` carries no thread, and must not.** It opens a conversation rather than continuing one, so an anchor would aim it at something the reader is not answering. `moveIsComplete` already guarantees `activity_id` for `draft_reply` and not for `draft_email`, so the two fall out of the contract rather than out of a special case here.

## The decision this issue asked for

> A decision about what happens when the named thread's transport is not one the person currently has (a channel since disconnected, an address since removed).

**Say so.** The composer opens on the contact's own lead transport and tells the reader the conversation the link named is gone. Falling back silently is the same defect one step further in — the reader asked to answer one thing and would be writing into another with nothing on screen saying so.

That is why `transportForActivity` returns a pair rather than an optional transport: *nothing named* and *named but unresolvable* are different answers, and only the second is worth interrupting for. A message that has fallen off the page's own window reads the same way, which is right — the row named it and the record cannot show it.

The reader's own pick still wins throughout: this decides what the composer OPENS on.

## Mutation checks

| Mutation | Caught by |
|---|---|
| the anchor stays the provider's newest | `anchors on the conversation named rather than the provider's newest` |
| an unresolvable thread is not reported | `reports a named channel this contact no longer has as stale` |
| the link drops the thread | `names the message the row is about` |

Six cases cover the resolution rule, including the two absences separately and mail-versus-channel. The fixture carries **two** channels and an address on purpose — with one option, "which transport" is a question the fixture answers rather than the code.

## Housekeeping

`PersonComposer` was at the lint's cognitive-complexity ceiling, as the issue warned. The notice is its own component rather than a branch in the composer — a line that renders nothing most of the time should not cost the surface around it a decision.

The two comments that said this could not be done are updated rather than left: one in `personpage.address.ts`, one in `worklist.copy.ts`. Both existed to stop somebody promising precision the composer lacked, and the next reader should find the current rule rather than the reason it used to be impossible.

## Verification

`make check-fe` green, 38 tests over the two suites touched.
