### PR TITLE
fix(record): a header carrying a sentence stops widening the page

### DIFF
--- a/frontend/e2e/meeting-brief.spec.ts
+++ b/frontend/e2e/meeting-brief.spec.ts
@@ -75,18 +75,27 @@ async function settleAnimations(page: Page) {
   ).toEqual([]);
 }
 
-// The no-sideways-scroll check, over what THIS surface owns: the document and
-// the drawer's own scroll lane.
+// The no-sideways-scroll check, over every scroller this page has: the
+// document, the shell's content column, and the drawer's own lane.
 //
-// The shell's content scroller is deliberately not measured here. It carries a
-// 16px overflow on the person record's meetings tab with no drawer open at all
-// — a pre-existing fault of that page, filed rather than fixed in this change,
-// and one that would make this spec fail for a reason the meeting brief cannot
-// cause and cannot fix.
+// THE SHELL SCROLLER USED TO BE EXCLUDED, and the exclusion said why: the
+// meetings tab carried an overflow with no drawer open at all, so measuring it
+// here would have failed this spec for a fault the meeting brief could neither
+// cause nor fix. That fault is fixed, so the exclusion goes with it — leaving
+// it would be a hole in the one check that would notice the fault coming back.
+//
+// The shell pins `.main` to `overflow: hidden` and gives `.scroll` the page's
+// own scrolling, so a header or a card that spills spills into that element
+// and the document never grows a pixel. Measuring the document alone is a
+// check that cannot fail on the shape this page actually has.
 async function pageOverflow(page: Page): Promise<string[]> {
   return page.evaluate(() => {
     const scrollers: { name: string; element: Element }[] = [
       { name: "the document", element: document.documentElement },
+      ...Array.from(document.querySelectorAll(".scroll")).map((element) => ({
+        name: "the shell content scroller (.scroll)",
+        element,
+      })),
       ...Array.from(document.querySelectorAll(".drawer-body")).map(
         (element) => ({ name: "the drawer's scroll lane", element }),
       ),

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -433,6 +433,19 @@
   justify-content: flex-end;
 }
 
+/* A GROUP HOLDING PROSE IS BOUNDED BY THE HEADER, not by the prose.
+   `flex-basis: 100%` gives the caption its own line INSIDE the group, and the
+   group's own width is what 100% resolves against — which the sentence set,
+   because an action row does not shrink. So a long caption widened the group
+   past the page and the record scrolled sideways by the difference.
+   `flex-shrink: 0` still holds for a row of plain verbs, which is what it was
+   written for: buttons that shrink read as a broken control. A sentence wraps
+   instead, which is what a sentence is for. */
+.record-actions-inline:has(> .t-caption) {
+  flex-shrink: 1;
+  min-inline-size: 0;
+}
+
 /* On a phone the record's verbs stick to the bottom of the viewport (plan
  * §10.3). A rep scrolling an account's story is several screens from the
  * header by the time they decide to write; an action row that scrolled away


### PR DESCRIPTION
Closes #3577.

## What it is

The person record's meetings tab scrolls sideways with nothing open over it — **16px when this was filed, 29px by the time I measured it**, so it has been growing.

Found by walking every element inside `.scroll` and comparing right edges against the scroller's, which named the culprit directly rather than by guesswork:

```
div.record-actions record-actions-inline  right=1309  w=1065   (scroller ends at 1280)
p.t-caption                               right=1309  w=1065
```

## Why it happens

Two rules that are each right, meeting:

- `.record-actions-inline { flex-shrink: 0 }` — deliberate, and its comment says so: buttons that shrink read as broken controls.
- `.record-actions > .t-caption { flex-basis: 100% }` — so a caption the caller puts in the group takes its own line rather than sitting between the verbs. Its own comment records that at its natural width the sentence *"set the group's width"*.

`flex-basis: 100%` resolves against the group's own width — and that width is content-driven, because the group does not shrink. So the caption's natural measure still set it, one level further in than the rule that was written to stop exactly this.

## The fix

A group **holding prose** is bounded by the header rather than by the prose. `flex-shrink: 0` still holds for a row of plain verbs, which is what it was written for; a sentence wraps, which is what a sentence is for.

## And the exclusion goes with the fault

`meeting-brief.spec.ts` deliberately did not measure the shell scroller, and said why:

> It carries a 16px overflow on the person record's meetings tab with no drawer open at all — a pre-existing fault of that page, filed rather than fixed in this change

So the fault was, in the issue's own words, *"currently unmeasured by any test"*. With it fixed, leaving the exclusion would be a hole in the one check that would notice it coming back. The spec now measures `.scroll` alongside the document and the drawer's lane — and the document alone could never have caught this, since the shell pins `.main` to `overflow: hidden` and gives `.scroll` the page's scrolling.

Mutation-checked: reverting the CSS to `flex-shrink: 0` fails the spec (2 of 18).

## Verification

- `pnpm exec playwright test e2e/meeting-brief.spec.ts` — 18 passed.
- `pnpm exec playwright test e2e/ac.spec.ts` — 195 passed, 1 skipped, so the change does not move any other record header.
- `make check-fe` green.
