### PR TITLE
fix(capture): the import is visible during setup, and a stopped one can start again

### DIFF
--- a/frontend/src/app/capture-chip.css
+++ b/frontend/src/app/capture-chip.css
@@ -49,6 +49,13 @@
   font-size: var(--fs-sm);
   line-height: 1.25;
 }
+/* The rail-less variant is a status and not a target. It keeps the wrapper's
+   own pointer transparency, so onboarding's composer and buttons under it keep
+   every click that lands on them. */
+.capturechip-static {
+  pointer-events: none;
+}
+
 .capturechip-link:hover .capturechip-line {
   text-decoration: underline;
 }

--- a/frontend/src/app/capture-chip.stories.tsx
+++ b/frontend/src/app/capture-chip.stories.tsx
@@ -37,7 +37,7 @@ function importing(scanned: number, estimated: number | null) {
     });
 }
 
-function story(connectors: () => Response) {
+function story(connectors: () => Response, linked = true) {
   return () => {
     installFetchStub({
       "GET /me": meRoute({}),
@@ -49,7 +49,7 @@ function story(connectors: () => Response) {
           className="main"
           style={{ position: "relative", minHeight: "40vh" }}
         >
-          <CaptureChip route={{ screen: "deals" }} />
+          <CaptureChip linked={linked} />
         </div>
       </StoryProviders>
     );
@@ -74,3 +74,12 @@ export const Unpreviewed: Story = { render: story(importing(37, null)) };
 
 /** Nearly done: a full ring is the last thing drawn before the chip leaves. */
 export const AlmostDone: Story = { render: story(importing(2_880, 2_900)) };
+
+/**
+ * On a rail-less route — onboarding, where the import usually starts. The same
+ * gauge with nothing to press: a link out of a flow the reader is midway
+ * through would lose their place in it.
+ */
+export const Unlinked: Story = {
+  render: story(importing(1_204, 2_900), false),
+};

--- a/frontend/src/app/capture-chip.test.tsx
+++ b/frontend/src/app/capture-chip.test.tsx
@@ -9,11 +9,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { CaptureChip } from "./capture-chip";
-import type { Route } from "./router";
+import { useDrawsImportRun } from "./import-onscreen";
 
-// The chip is the import's gauge, top-centre of the content: present for
+// The chip is the import's gauge, bottom-centre of the content: present for
 // exactly as long as mail is arriving, carrying the server's own counts, and
-// leading to the card that holds the run in full.
+// leading to the card that holds the run in full — except where a surface on
+// screen already draws that run, and except where there is nowhere to lead.
 
 type Connector = components["schemas"]["CaptureConnection"];
 type BackfillStatus = components["schemas"]["BackfillStatus"];
@@ -42,7 +43,17 @@ function stubConnectors(connectors: readonly Connector[]) {
   );
 }
 
-function mount(route: Route, connectors: readonly Connector[]) {
+// A stand-in for the connections card and onboarding's backread step: any
+// surface that declares it is drawing the run in full.
+function RunPanel() {
+  useDrawsImportRun(true);
+  return <p>the run, in full</p>;
+}
+
+function mount(
+  connectors: readonly Connector[],
+  options?: Readonly<{ linked?: boolean; drawnOnScreen?: boolean }>,
+) {
   stubConnectors(connectors);
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -50,13 +61,12 @@ function mount(route: Route, connectors: readonly Connector[]) {
   return render(
     <QueryClientProvider client={client}>
       <LocaleProvider initial="en">
-        <CaptureChip route={route} />
+        {options?.drawnOnScreen === true && <RunPanel />}
+        <CaptureChip linked={options?.linked ?? true} />
       </LocaleProvider>
     </QueryClientProvider>,
   );
 }
-
-const DEALS: Route = { screen: "deals" };
 
 afterEach(() => {
   cleanup();
@@ -65,7 +75,7 @@ afterEach(() => {
 
 describe("CaptureChip", () => {
   it("draws the import with its share, the counts and a way to the run", async () => {
-    mount(DEALS, [
+    mount([
       mailbox({
         state: "running",
         estimated_messages: 2_900,
@@ -91,7 +101,7 @@ describe("CaptureChip", () => {
   });
 
   it("counts rather than guesses when the run has no estimate", async () => {
-    mount(DEALS, [
+    mount([
       mailbox({
         state: "running",
         estimated_messages: null,
@@ -104,7 +114,7 @@ describe("CaptureChip", () => {
   });
 
   it("is absent while nothing is importing", async () => {
-    const { container } = mount(DEALS, [
+    const { container } = mount([
       mailbox({ state: "done", estimated_messages: 10 }),
     ]);
     // Wait for the read to answer, then assert on the settled nothing.
@@ -112,15 +122,37 @@ describe("CaptureChip", () => {
     await waitFor(() => expect(container.innerHTML).toBe(""));
   });
 
-  it("stands down on the connections card, which already draws the run", async () => {
-    const { container } = mount({ screen: "settings", id: "connections" }, [
-      mailbox({
-        state: "running",
-        estimated_messages: 100,
-        counts: { messages_scanned: 1 },
-      }),
-    ]);
+  it("stands down where a surface already draws the run", async () => {
+    const { container } = mount(
+      [
+        mailbox({
+          state: "running",
+          estimated_messages: 100,
+          counts: { messages_scanned: 1 },
+        }),
+      ],
+      { drawnOnScreen: true },
+    );
     await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
-    await waitFor(() => expect(container.innerHTML).toBe(""));
+    expect(screen.getByText("the run, in full")).toBeTruthy();
+    await waitFor(() =>
+      expect(container.querySelector(".capturechip")).toBeNull(),
+    );
+  });
+
+  it("gauges without leading anywhere where the route carries no navigation", async () => {
+    mount(
+      [
+        mailbox({
+          state: "running",
+          estimated_messages: 2_900,
+          counts: { messages_scanned: 1_218 },
+        }),
+      ],
+      { linked: false },
+    );
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toContain("42% · 1,218 of 2,900 messages");
+    expect(status.querySelector("a")).toBeNull();
   });
 });

--- a/frontend/src/app/capture-chip.tsx
+++ b/frontend/src/app/capture-chip.tsx
@@ -6,7 +6,7 @@ import { formatNumber, formatPercent } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { useConnectors } from "../screens/connectors";
 import { liveCapture } from "./capture-progress";
-import type { Route } from "./router";
+import { useImportRunOnScreen } from "./import-onscreen";
 import "./capture-chip.css";
 
 /** Where the chip leads: the connections card, which holds the run in full. */
@@ -31,19 +31,26 @@ const CONNECTIONS_HREF = "#/settings/connections";
  * the work. Both read the same connections body, so they cannot disagree
  * about the share.
  *
- * It is a link and not a button: pressing it goes to the connections card,
- * where the import can be watched in full or stopped. On that card it is
- * absent, because a link to the page under it is a link to nowhere and the
- * card already draws the run.
+ * It stands down wherever the run is already drawn in full — the connections
+ * card, onboarding's backread step — and those surfaces say so themselves
+ * (app/import-onscreen.ts) rather than being listed here as routes.
  */
-export function CaptureChip({ route }: Readonly<{ route: Route }>) {
+export function CaptureChip({
+  linked,
+}: Readonly<{
+  /**
+   * Whether pressing the chip may take the reader to the connections card.
+   * False on the rail-less routes, which carry no navigation at all: onboarding
+   * is a flow with a place in it, and a link out of it loses that place.
+   */
+  linked: boolean;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const connectors = useConnectors();
   const capture = liveCapture(connectors.data?.data ?? []);
-  const onConnections =
-    route.screen === "settings" && route.id === "connections";
-  if (capture === null || onConnections) {
+  const drawnOnScreen = useImportRunOnScreen();
+  if (capture === null || drawnOnScreen) {
     return null;
   }
   const detail =
@@ -56,34 +63,45 @@ export function CaptureChip({ route }: Readonly<{ route: Route }>) {
           scanned: formatNumber(capture.scanned, locale),
           total: formatNumber(capture.estimated, locale),
         });
+  const gauge = (
+    <>
+      {/* Always `ingest`: this chip exists only while mail is arriving, so
+          the one state it can honestly wear is the one named for that. The
+          rail's orb may be showing a fault or a named run at the same moment;
+          that is the agent's standing, and this is the import's. Dark
+          surface, because the chip's own ground is the rail's. */}
+      <MarginceCoreScene
+        state="ingest"
+        size="md"
+        surface="dark"
+        progress={capture.fraction ?? undefined}
+        className="capturechip-core"
+      />
+      <span className="capturechip-words">
+        <span className="capturechip-line">{t("shell.capture.importing")}</span>
+        <span className="capturechip-detail">{detail}</span>
+      </span>
+    </>
+  );
   return (
     // The live region is the wrapper and the link is inside it: a link that was
     // itself a status would announce every poll's new share as a navigation.
     <div className="capturechip" role="status">
-      <a
-        className="capturechip-link"
-        href={CONNECTIONS_HREF}
-        aria-label={`${t("shell.capture.importing")}. ${detail}. ${t("shell.capture.open")}`}
-      >
-        {/* Always `ingest`: this chip exists only while mail is arriving, so
-            the one state it can honestly wear is the one named for that. The
-            rail's orb may be showing a fault or a named run at the same moment;
-            that is the agent's standing, and this is the import's. Dark
-            surface, because the chip's own ground is the rail's. */}
-        <MarginceCoreScene
-          state="ingest"
-          size="md"
-          surface="dark"
-          progress={capture.fraction ?? undefined}
-          className="capturechip-core"
-        />
-        <span className="capturechip-words">
-          <span className="capturechip-line">
-            {t("shell.capture.importing")}
-          </span>
-          <span className="capturechip-detail">{detail}</span>
-        </span>
-      </a>
+      {linked ? (
+        <a
+          className="capturechip-link"
+          href={CONNECTIONS_HREF}
+          aria-label={`${t("shell.capture.importing")}. ${detail}. ${t("shell.capture.open")}`}
+        >
+          {gauge}
+        </a>
+      ) : (
+        // The same chip with nowhere to go: still a status, never a control, so
+        // it takes no focus, promises no destination, and — floating over a
+        // surface whose own composer and buttons sit where it lands — never
+        // takes a click back from what is under it.
+        <div className="capturechip-link capturechip-static">{gauge}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/import-onscreen.ts
+++ b/frontend/src/app/import-onscreen.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useEffect, useSyncExternalStore } from "react";
+
+/**
+ * Whether a surface on screen right now already draws the mail import in full.
+ *
+ * The capture chip (app/capture-chip.tsx) is the import's gauge for a reader who
+ * is doing something else, so it stands down wherever the run is already on the
+ * page: the connections card in Settings, and the backread step of onboarding.
+ * The chip used to know that as a route — `#/settings/connections` spelled
+ * inside it — which is the chip holding a second copy of where those panels
+ * live, and it could only ever name the one place it knew about. The panels say
+ * it themselves instead, so a third one is covered by mounting.
+ *
+ * A module-level count published on every change, the shape
+ * `api/model-inflight.ts` already uses: the chip is the page's SIBLING in the
+ * shell's tree rather than its ancestor, so a context provided by a panel could
+ * not reach it, and there is exactly one chip in one app.
+ */
+let surfaces = 0;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+function importRunOnScreen(): boolean {
+  return surfaces > 0;
+}
+
+/**
+ * Declare that this surface draws the import run in full while `drawing` holds.
+ *
+ * A boolean rather than a bare mount, because both panels stay mounted for a
+ * mailbox with no run at all — a window picker is not a gauge, and a chip that
+ * stood down behind one would stand down behind every connected mailbox on the
+ * card.
+ */
+export function useDrawsImportRun(drawing: boolean): void {
+  useEffect(() => {
+    if (!drawing) {
+      return;
+    }
+    surfaces += 1;
+    notify();
+    return () => {
+      surfaces -= 1;
+      notify();
+    };
+  }, [drawing]);
+}
+
+/** Whether a surface on screen already draws the run, as a component sees it. */
+export function useImportRunOnScreen(): boolean {
+  return useSyncExternalStore(subscribe, importRunOnScreen, importRunOnScreen);
+}

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -868,6 +868,15 @@ export function Shell({
             navigation, so there is no repeated block ahead of the content for a
             reader to skip past (WCAG 2.4.1). */}
         <main className="main">
+          {/* The import a reader started during setup keeps running while they
+              answer the rest of it, and the step that drew the run is behind
+              them by then — so the gauge belongs here too. Onboarding only:
+              the other rail-less routes are the anonymous surfaces, which have
+              no connections to read, and the consent screen, which is one
+              request in flight and nothing else. Unlinked, because these
+              routes carry no navigation and a reader mid-flow has a place to
+              lose. */}
+          {route.screen === "onboarding" && <CaptureChip linked={false} />}
           <div className="scroll" ref={scroller}>
             {children}
           </div>
@@ -924,7 +933,7 @@ export function Shell({
             long as mail is arriving. Inside `.main` rather than beside the
             edge below, because it is positioned against the content column
             and not the window. */}
-          <CaptureChip route={route} />
+          <CaptureChip linked />
           {/* Focusable only as the skip link's destination — never a tab stop of
             its own, which is what tabIndex -1 buys. A reader who takes the skip
             lands here, PAST the strip, and the next Tab continues into the page's

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4451,6 +4451,7 @@ export const de = {
     "Er versucht es selbstständig erneut; alles bisher Erfasste bleibt erhalten.",
   "backfill.cancel": "Import stoppen",
   "backfill.cancelledNote": "Gestoppt. Alles bisher Erfasste bleibt erhalten.",
+  "backfill.restart": "Weiteren Import starten",
   "backfill.unsupportedNote":
     "Dieser Postfachtyp kann nicht rückwirkend importiert werden — ab jetzt werden nur neue E-Mails erfasst.",
   "backfill.narrowingNote":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4532,6 +4532,9 @@ export const en = {
     "It will retry on its own; everything captured so far is kept.",
   "backfill.cancel": "Stop the import",
   "backfill.cancelledNote": "Stopped. Everything captured so far is kept.",
+  // On a run that has stopped — cancelled, failed or finished. The window it
+  // opens on is the one that ran, because the server only ever widens.
+  "backfill.restart": "Start another import",
   "backfill.unsupportedNote":
     "This mailbox type can't be backfilled — only new mail is captured from now on.",
   "backfill.narrowingNote":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4398,6 +4398,7 @@ export const vi = {
     "Hệ thống sẽ tự thử lại; mọi thứ đã thu thập vẫn được giữ.",
   "backfill.cancel": "Dừng lượt nhập",
   "backfill.cancelledNote": "Đã dừng. Mọi thứ đã thu thập vẫn được giữ.",
+  "backfill.restart": "Bắt đầu lượt nhập khác",
   "backfill.unsupportedNote":
     "Loại hộp thư này không nhập lịch sử được — chỉ thư mới được thu thập từ giờ trở đi.",
   "backfill.narrowingNote":

--- a/frontend/src/screens/backfill-run.ts
+++ b/frontend/src/screens/backfill-run.ts
@@ -7,23 +7,8 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { throwProblem } from "./common";
 
-/**
- * The run row and the four operations on it, in one spelling.
- *
- * Two surfaces draw a connect-time import: the Settings connections card
- * (backfill.tsx) and the last step of onboarding (onboarding-backread.tsx).
- * They ask the reader different questions and say different things about the
- * answer — that is theirs — but the read, the estimate, the start, the stop and
- * the pick that ties them together are ONE behaviour, and they held two copies
- * of it. The copies had already begun to disagree in the way copies do: each
- * carried its own spelling of the cache key under a comment claiming the key was
- * shared, so an invalidation from one surface reached the other only because the
- * two strings happened to still match.
- *
- * What stays with each caller is what genuinely differs: which refusals it can
- * name, whether an estimate it has not seen may be acted on, and every word on
- * screen.
- */
+// The connect-time import, as both of its surfaces need it: the run row, the
+// four operations on it, and the window pick that ties them together.
 
 type BackfillStatus = components["schemas"]["BackfillStatus"];
 type BackfillPreview = components["schemas"]["BackfillPreview"];
@@ -102,6 +87,23 @@ async function cancelRun(provider: Provider): Promise<BackfillStatus> {
   return data;
 }
 
+/**
+ * The run row and the four operations on it, in one spelling.
+ *
+ * Two surfaces draw a connect-time import: the Settings connections card
+ * (backfill.tsx) and the last step of onboarding (onboarding-backread.tsx).
+ * They ask the reader different questions and say different things about the
+ * answer — that is theirs — but the read, the estimate, the start, the stop and
+ * the pick that ties them together are ONE behaviour, and they held two copies
+ * of it. The copies had already begun to disagree in the way copies do: each
+ * carried its own spelling of the cache key under a comment claiming the key
+ * was shared, so an invalidation from one surface reached the other only
+ * because the two strings happened to still match.
+ *
+ * What stays with each caller is what genuinely differs: which refusals it can
+ * name, whether an estimate it has not seen may be acted on, and every word on
+ * screen.
+ */
 export function useBackfillRun({
   provider,
   initial,

--- a/frontend/src/screens/backfill-run.ts
+++ b/frontend/src/screens/backfill-run.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+
+/**
+ * The run row and the four operations on it, in one spelling.
+ *
+ * Two surfaces draw a connect-time import: the Settings connections card
+ * (backfill.tsx) and the last step of onboarding (onboarding-backread.tsx).
+ * They ask the reader different questions and say different things about the
+ * answer — that is theirs — but the read, the estimate, the start, the stop and
+ * the pick that ties them together are ONE behaviour, and they held two copies
+ * of it. The copies had already begun to disagree in the way copies do: each
+ * carried its own spelling of the cache key under a comment claiming the key was
+ * shared, so an invalidation from one surface reached the other only because the
+ * two strings happened to still match.
+ *
+ * What stays with each caller is what genuinely differs: which refusals it can
+ * name, whether an estimate it has not seen may be acted on, and every word on
+ * screen.
+ */
+
+type BackfillStatus = components["schemas"]["BackfillStatus"];
+type BackfillPreview = components["schemas"]["BackfillPreview"];
+type Provider = components["schemas"]["CaptureConnection"]["provider"];
+
+/** The startable windows. `none` is expressed by never starting a run at all. */
+export type ImportWindow =
+  components["schemas"]["StartBackfillRequest"]["window"];
+
+/**
+ * The window a picker opens on. A multi-year import is worth offering and wrong
+ * to default into: it spends the customer's own inference budget on the day they
+ * have least reason to trust the estimate.
+ */
+export const DEFAULT_IMPORT_WINDOW: ImportWindow = "6m";
+
+/** A run that can still move. Every other state is terminal. */
+export function isLiveRun(state: BackfillStatus["state"] | undefined): boolean {
+  return state === "queued" || state === "running";
+}
+
+// The status read is a single indexed row (CAP-PARAM-2), so polling it is
+// indistinguishable from a push — and one cadence, so one mailbox is never
+// watched at two rates by the two surfaces that watch it.
+const POLL_MS = 2500;
+
+/** The one spelling of the run-row cache key: a start or a stop on either
+ *  surface invalidates the read on both. */
+const statusQueryKey = (provider: Provider) => ["backfill-status", provider];
+
+async function readRun(provider: Provider): Promise<BackfillStatus> {
+  const { data, error } = await api.GET("/connectors/{provider}/backfill", {
+    params: { path: { provider } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+async function previewRun(
+  provider: Provider,
+  window: ImportWindow,
+): Promise<BackfillPreview> {
+  const { data, error } = await api.POST(
+    "/connectors/{provider}/backfill/preview",
+    { params: { path: { provider } }, body: { window } },
+  );
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+async function startRun(
+  provider: Provider,
+  window: ImportWindow,
+): Promise<BackfillStatus> {
+  const { data, error } = await api.POST("/connectors/{provider}/backfill", {
+    params: { path: { provider } },
+    body: { window },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+async function cancelRun(provider: Provider): Promise<BackfillStatus> {
+  const { data, error } = await api.DELETE("/connectors/{provider}/backfill", {
+    params: { path: { provider } },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+export function useBackfillRun({
+  provider,
+  initial,
+  previewHeld = false,
+}: Readonly<{
+  provider: Provider;
+  /** The run row already embedded in the `GET /connectors` roster row — seeds
+   *  the first render, so a live run shows immediately and never offers to
+   *  start a second one. */
+  initial?: BackfillStatus;
+  /** The caller has taken the setup view off screen for a reason of its own
+   *  (Settings' "skip the history import"), so the scope must not be counted
+   *  for a form nobody is looking at. */
+  previewHeld?: boolean;
+}>) {
+  const qc = useQueryClient();
+  const [window, setWindow] = useState<ImportWindow>(DEFAULT_IMPORT_WINDOW);
+  // A run that has stopped — cancelled, failed or finished — is history, not a
+  // reason the mailbox can never be imported again. This puts the window pick
+  // back in front of the reader; the server still decides whether the pick is
+  // allowed (widen-only), exactly as it does the first time.
+  const [restarting, setRestarting] = useState(false);
+  const [previewedWindow, setPreviewedWindow] = useState<ImportWindow | null>(
+    null,
+  );
+
+  const status = useQuery({
+    queryKey: statusQueryKey(provider),
+    queryFn: () => readRun(provider),
+    initialData: initial,
+    // The embedded snapshot already answered this read once; skip the
+    // mount-time revalidation react-query would otherwise run (it treats
+    // fresh-but-present data as needing it) and rely on the live poll below, or
+    // an explicit invalidate, for a fresher row. Without a seed, fetch on mount.
+    staleTime: initial !== undefined ? Number.POSITIVE_INFINITY : 0,
+    refetchInterval: (query) =>
+      isLiveRun(query.state.data?.state) ? POLL_MS : false,
+  });
+
+  const preview = useMutation({
+    mutationFn: (pick: ImportWindow) => previewRun(provider, pick),
+  });
+
+  const start = useMutation({
+    mutationFn: (pick: ImportWindow) => startRun(provider, pick),
+    onSuccess: () => {
+      // The new run is what the reader watches now, so the pick they started it
+      // from stands down with it.
+      setRestarting(false);
+      return qc.invalidateQueries({ queryKey: statusQueryKey(provider) });
+    },
+  });
+
+  const cancel = useMutation({
+    mutationFn: () => cancelRun(provider),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
+  });
+
+  // The scope loads itself for whichever window is selected: the first thing a
+  // newly-connected reader sees is honest scope, not an empty form. A preview is
+  // a read and spends nothing; the spend still waits for the explicit start.
+  // Single-flight per window — `previewedWindow` stops it re-firing on unrelated
+  // re-renders while still re-counting on a window change.
+  const isSetup = !previewHeld && (status.data?.state === "none" || restarting);
+  useEffect(() => {
+    if (!isSetup || previewedWindow === window || preview.isPending) {
+      return;
+    }
+    setPreviewedWindow(window);
+    preview.mutate(window);
+  }, [isSetup, window, previewedWindow, preview]);
+
+  return {
+    status,
+    preview,
+    start,
+    cancel,
+    /** The window the picker is on. */
+    window,
+    setWindow,
+    /** The pick is on screen: no run has ever started, or a stopped one is
+     *  being started again. */
+    isSetup,
+    /**
+     * Reopen the pick on a stopped run.
+     *
+     * It opens on the window that run used, because the server refuses a
+     * narrower one (widen-only) and a picker that opens on a refusal wastes the
+     * reader's first press. The scope is re-counted rather than re-shown: the
+     * estimate that consented to the run which just ended was measured before
+     * that run captured anything.
+     */
+    restart: (run: BackfillStatus) => {
+      setWindow(run.window ?? DEFAULT_IMPORT_WINDOW);
+      setPreviewedWindow(null);
+      setRestarting(true);
+    },
+  };
+}

--- a/frontend/src/screens/backfill.stories.tsx
+++ b/frontend/src/screens/backfill.stories.tsx
@@ -135,6 +135,36 @@ export const Cancelled: Story = {
   }),
 };
 
+// The stopped run, and the way back out of it: pressing "Start another import"
+// puts the window picker in front of the reader again, opened on the window
+// that ran. Without it, stopping once left the mailbox with no path to a
+// second import at all.
+export const RestartAfterCancel: Story = {
+  render: panelStory(
+    "gmail",
+    {
+      state: "cancelled",
+      window: "12m",
+      counts: { captured: 20, messages_scanned: 40 },
+    },
+    {
+      "POST /connectors/gmail/backfill/preview": () =>
+        jsonResponse({
+          window: "12m",
+          estimated_messages: 890,
+          computed_at: "2026-07-23T10:00:00Z",
+        }),
+    },
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /Start another import/ }),
+    );
+    await canvas.findByText(/~890/);
+  },
+};
+
 // A running run whose updated_at hasn't moved in 20 minutes: the progress
 // bar stops claiming motion and the panel says when it last actually moved.
 export const Stale: Story = {

--- a/frontend/src/screens/backfill.test.tsx
+++ b/frontend/src/screens/backfill.test.tsx
@@ -284,6 +284,48 @@ describe("the connect-time backfill payoff", () => {
     expect(await screen.findByText(/Stopped\./)).toBeTruthy();
   });
 
+  // Stopping an import is a decision about the run, not about the mailbox: the
+  // panel used to draw the stopped run forever, so a reader who pressed stop
+  // could never import again — disconnecting and reconnecting did not help,
+  // because the run rows belong to the connection that survives both.
+  it("offers another import once a run has stopped, opening on the window that ran", async () => {
+    const calls = stubApi({
+      statuses: [
+        {
+          state: "cancelled",
+          backfill_id: "018f3a1b-0000-7000-8000-0000000000b1",
+          window: "12m",
+          estimated_messages: 400,
+          counts: { captured: 20, messages_scanned: 40 },
+        },
+      ],
+      preview: previewOf(1234),
+    });
+    render(<BackfillPanel provider="gmail" />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Start another import/ }),
+    );
+    // Opened on the window this mailbox already ran, because the server only
+    // ever widens — a picker that opens on a refusal wastes the first press.
+    expect(
+      (
+        (await screen.findByRole("radio", {
+          name: "12 months",
+        })) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Start the import/ }),
+    );
+    await waitFor(async () => {
+      const starts = requestsTo(calls, "/backfill", "POST");
+      expect(starts.length).toBe(1);
+      expect(await starts[0]?.clone().json()).toMatchObject({ window: "12m" });
+    });
+  });
+
   it("surfaces an honest error class without hiding the counts captured so far", async () => {
     stubApi({
       statuses: [countsStatus("error", { captured: 40, people_created: 9 })],

--- a/frontend/src/screens/backfill.tsx
+++ b/frontend/src/screens/backfill.tsx
@@ -3,6 +3,7 @@ import { Building2, CheckCircle2, History, Mail, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useDrawsImportRun } from "../app/import-onscreen";
 import { Badge, Button } from "../design-system/atoms";
 import { ChoiceList } from "../design-system/choicelist";
 import { CountUp } from "../design-system/countup";
@@ -138,6 +139,11 @@ export function BackfillPanel({
   const qc = useQueryClient();
   const [window, setWindow] = useState<BackfillWindow>("6m");
   const [skipped, setSkipped] = useState(false);
+  // A run that has stopped — cancelled, failed, or finished — is history, not a
+  // reason the mailbox can never be imported again. Pressing "start another"
+  // puts the window picker back in front of the reader; the server decides
+  // whether the pick is allowed (widen-only), exactly as it does the first time.
+  const [restarting, setRestarting] = useState(false);
 
   const status = useQuery({
     queryKey: statusQueryKey(provider),
@@ -189,8 +195,12 @@ export function BackfillPanel({
       }
       return data;
     },
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
+    onSuccess: () => {
+      // The new run is what the reader watches now, so the picker they started
+      // it from stands down with it.
+      setRestarting(false);
+      return qc.invalidateQueries({ queryKey: statusQueryKey(provider) });
+    },
   });
 
   const cancel = useMutation({
@@ -213,13 +223,17 @@ export function BackfillPanel({
     start.error,
   );
 
+  // This card draws the run in full, so the shell's capture chip stands down
+  // while it is on screen rather than gauging the same import twice.
+  useDrawsImportRun(isLiveState(status.data?.state));
+
   // Auto-load the scope for the selected window the moment the setup view is
   // live (no run yet, not skipped) — the user sees honest scope immediately.
   // The mutation is single-flight per window; previewedWindow guards against
   // re-firing on unrelated re-renders while still refreshing on a window
   // change. This never spends: the estimate is a read; the import waits for
   // the explicit start.
-  const isSetup = !skipped && status.data?.state === "none";
+  const isSetup = !skipped && (status.data?.state === "none" || restarting);
   const [previewedWindow, setPreviewedWindow] = useState<BackfillWindow | null>(
     null,
   );
@@ -246,7 +260,7 @@ export function BackfillPanel({
   }
 
   const run = status.data;
-  if (run.state === "none") {
+  if (run.state === "none" || restarting) {
     return (
       <BackfillSetup
         window={window}
@@ -274,6 +288,19 @@ export function BackfillPanel({
       cancelling={cancel.isPending}
       cancelError={cancel.isError ? problemMessageOf(cancel.error, t) : null}
       onCancel={() => cancel.mutate()}
+      onRestart={() => {
+        // Open on the window this mailbox already ran, because the server
+        // refuses a narrower one (widen-only) and a picker that opens on a
+        // refusal is a picker that wastes the reader's first press.
+        if (run.window) {
+          setWindow(run.window);
+        }
+        // Re-count the mailbox for the pick rather than re-showing the
+        // estimate that consented to the run which just ended: it was
+        // measured before that run captured anything.
+        setPreviewedWindow(null);
+        setRestarting(true);
+      }}
     />
   );
 }
@@ -473,11 +500,16 @@ function RunView({
   cancelling,
   cancelError,
   onCancel,
+  onRestart,
 }: {
   run: BackfillStatus;
   cancelling: boolean;
   cancelError: string | null;
   onCancel: () => void;
+  // Put the window picker back in front of the reader. Offered on every run
+  // that has stopped, which is every state this view draws that is not live:
+  // stopping an import is a decision about this run, never about the mailbox.
+  onRestart: () => void;
 }) {
   const t = useT();
   const { locale } = useLocale();
@@ -533,13 +565,17 @@ function RunView({
           {run.last_error_class ? ` (${run.last_error_class})` : ""}
         </p>
       )}
-      {live && (
-        <div className="backfill-foot">
+      <div className="backfill-foot">
+        {live ? (
           <Button small disabled={cancelling} onClick={onCancel}>
             {t("backfill.cancel")}
           </Button>
-        </div>
-      )}
+        ) : (
+          <Button small onClick={onRestart}>
+            {t("backfill.restart")}
+          </Button>
+        )}
+      </div>
       {live && cancelError && (
         <p className="t-caption backfill-error">{cancelError}</p>
       )}

--- a/frontend/src/screens/backfill.tsx
+++ b/frontend/src/screens/backfill.tsx
@@ -1,7 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Building2, CheckCircle2, History, Mail, Users } from "lucide-react";
-import { useEffect, useState } from "react";
-import { api } from "../api/client";
+import { useState } from "react";
 import type { components } from "../api/schema";
 import { useDrawsImportRun } from "../app/import-onscreen";
 import { Badge, Button } from "../design-system/atoms";
@@ -15,12 +13,8 @@ import {
 } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import {
-  ProblemError,
-  problemCode,
-  problemMessageOf,
-  throwProblem,
-} from "./common";
+import { type ImportWindow, isLiveRun, useBackfillRun } from "./backfill-run";
+import { ProblemError, problemCode, problemMessageOf } from "./common";
 import "./backfill.css";
 
 // The bounded connect-time backfill (ADR-0063): pick a window, see the scope
@@ -44,13 +38,11 @@ import "./backfill.css";
 
 type BackfillStatus = components["schemas"]["BackfillStatus"];
 type Provider = components["schemas"]["CaptureConnection"]["provider"];
-type BackfillWindow = "3m" | "6m" | "12m" | "24m" | "60m";
 
 // The CAP-PARAM-4 set, in reach order (ADR-0063, widened to 24/60 by
-// ADR-0106). The default selection stays 6m: a multi-year import is worth
-// offering and wrong to default into, since it spends the customer's own
-// inference budget on the day they have least reason to trust the estimate.
-const WINDOWS: { value: BackfillWindow; label: MessageKey }[] = [
+// ADR-0106). Which one the picker OPENS on is `DEFAULT_IMPORT_WINDOW`, beside
+// the operations both surfaces share.
+const WINDOWS: { value: ImportWindow; label: MessageKey }[] = [
   { value: "3m", label: "backfill.window3m" },
   { value: "6m", label: "backfill.window6m" },
   { value: "12m", label: "backfill.window12m" },
@@ -73,9 +65,6 @@ const STALE_AFTER_MS = 3 * 60_000;
 // them is lying to the reader about what they are about to spend. The symbol
 // itself is never spelled here — Intl derives it from the code and the locale.
 const FALLBACK_CURRENCY = "USD";
-
-const isLiveState = (state: BackfillStatus["state"] | undefined) =>
-  state === "running" || state === "queued";
 
 // Both preview and start can answer connector_unsupported (a provider with no
 // Backfiller — IMAP today) or window_narrowing (start only, a widen-only
@@ -122,10 +111,6 @@ function staleness(
   };
 }
 
-// statusQueryKey is shared by every reader of the run row so a start or
-// cancel invalidates them all.
-const statusQueryKey = (provider: string) => ["backfill-status", provider];
-
 export function BackfillPanel({
   provider,
   initial,
@@ -136,87 +121,9 @@ export function BackfillPanel({
   initial?: BackfillStatus;
 }) {
   const t = useT();
-  const qc = useQueryClient();
-  const [window, setWindow] = useState<BackfillWindow>("6m");
   const [skipped, setSkipped] = useState(false);
-  // A run that has stopped — cancelled, failed, or finished — is history, not a
-  // reason the mailbox can never be imported again. Pressing "start another"
-  // puts the window picker back in front of the reader; the server decides
-  // whether the pick is allowed (widen-only), exactly as it does the first time.
-  const [restarting, setRestarting] = useState(false);
-
-  const status = useQuery({
-    queryKey: statusQueryKey(provider),
-    queryFn: async () => {
-      const { data, error } = await api.GET("/connectors/{provider}/backfill", {
-        params: { path: { provider } },
-      });
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    initialData: initial,
-    // The embedded snapshot already answered this read once; skip the
-    // mount-time re-fetch it would otherwise trigger (react-query treats
-    // fresh-but-present data as needing revalidation by default) and rely on
-    // the live poll below, or an explicit invalidate (start/cancel), for a
-    // fresher row. Without a seed, behave exactly as before: fetch on mount.
-    staleTime: initial !== undefined ? Number.POSITIVE_INFINITY : 0,
-    // Poll while a run is live: the status read is a single indexed row
-    // (CAP-PARAM-2), so polling is indistinguishable from push here.
-    refetchInterval: (q) => (isLiveState(q.state.data?.state) ? 2500 : false),
-  });
-
-  const preview = useMutation({
-    mutationFn: async (w: BackfillWindow) => {
-      const { data, error } = await api.POST(
-        "/connectors/{provider}/backfill/preview",
-        { params: { path: { provider } }, body: { window: w } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
-
-  const start = useMutation({
-    mutationFn: async (w: BackfillWindow) => {
-      const { data, error } = await api.POST(
-        "/connectors/{provider}/backfill",
-        {
-          params: { path: { provider } },
-          body: { window: w },
-        },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    onSuccess: () => {
-      // The new run is what the reader watches now, so the picker they started
-      // it from stands down with it.
-      setRestarting(false);
-      return qc.invalidateQueries({ queryKey: statusQueryKey(provider) });
-    },
-  });
-
-  const cancel = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await api.DELETE(
-        "/connectors/{provider}/backfill",
-        { params: { path: { provider } } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
-  });
+  const importRun = useBackfillRun({ provider, initial, previewHeld: skipped });
+  const { status, preview, start, cancel, window, setWindow } = importRun;
 
   const { unsupported, narrowing } = classifyBackfillErrors(
     preview.error,
@@ -225,25 +132,7 @@ export function BackfillPanel({
 
   // This card draws the run in full, so the shell's capture chip stands down
   // while it is on screen rather than gauging the same import twice.
-  useDrawsImportRun(isLiveState(status.data?.state));
-
-  // Auto-load the scope for the selected window the moment the setup view is
-  // live (no run yet, not skipped) — the user sees honest scope immediately.
-  // The mutation is single-flight per window; previewedWindow guards against
-  // re-firing on unrelated re-renders while still refreshing on a window
-  // change. This never spends: the estimate is a read; the import waits for
-  // the explicit start.
-  const isSetup = !skipped && (status.data?.state === "none" || restarting);
-  const [previewedWindow, setPreviewedWindow] = useState<BackfillWindow | null>(
-    null,
-  );
-  useEffect(() => {
-    if (!isSetup || previewedWindow === window || preview.isPending) {
-      return;
-    }
-    setPreviewedWindow(window);
-    preview.mutate(window);
-  }, [isSetup, window, previewedWindow, preview]);
+  useDrawsImportRun(isLiveRun(status.data?.state));
 
   if (skipped) {
     return (
@@ -260,7 +149,7 @@ export function BackfillPanel({
   }
 
   const run = status.data;
-  if (run.state === "none" || restarting) {
+  if (importRun.isSetup) {
     return (
       <BackfillSetup
         window={window}
@@ -288,19 +177,7 @@ export function BackfillPanel({
       cancelling={cancel.isPending}
       cancelError={cancel.isError ? problemMessageOf(cancel.error, t) : null}
       onCancel={() => cancel.mutate()}
-      onRestart={() => {
-        // Open on the window this mailbox already ran, because the server
-        // refuses a narrower one (widen-only) and a picker that opens on a
-        // refusal is a picker that wastes the reader's first press.
-        if (run.window) {
-          setWindow(run.window);
-        }
-        // Re-count the mailbox for the pick rather than re-showing the
-        // estimate that consented to the run which just ended: it was
-        // measured before that run captured anything.
-        setPreviewedWindow(null);
-        setRestarting(true);
-      }}
+      onRestart={() => importRun.restart(run)}
     />
   );
 }
@@ -323,8 +200,8 @@ function BackfillSetup({
   onStart,
   onSkip,
 }: {
-  window: BackfillWindow;
-  onWindowChange: (w: BackfillWindow) => void;
+  window: ImportWindow;
+  onWindowChange: (w: ImportWindow) => void;
   unsupported: boolean;
   narrowing: boolean;
   previewPending: boolean;
@@ -515,7 +392,7 @@ function RunView({
   const { locale } = useLocale();
   const counts = run.counts;
   const scanned = counts?.messages_scanned ?? 0;
-  const live = isLiveState(run.state);
+  const live = isLiveRun(run.state);
   const done = run.state === "done";
   const { stale, agoMs } = staleness(run, live);
   // The card wears the AI family only while the machine is actually reading:

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -133,6 +133,11 @@ export type ConnectorsResult = {
   // webhooks_not_configured treatment).
   notConfigured: boolean;
   data: CaptureConnection[];
+  // Which providers this installation could connect at all, and why not where
+  // it could not. The connect surfaces draw their blockers from it; a body that
+  // carried none reads as an empty roster, which is what a deployment with no
+  // capture wired actually has.
+  providers: ProviderReadiness[];
   // The address this installation puts in outgoing links, and whether it
   // answered when last asked. Absent when none is configured — which is
   // itself the answer, not a failure.
@@ -141,6 +146,10 @@ export type ConnectorsResult = {
 
 type PublicOriginStatus =
   components["schemas"]["CaptureConnectionListResponse"]["public_origin"];
+
+type ProviderReadiness = NonNullable<
+  components["schemas"]["CaptureConnectionListResponse"]["providers"]
+>[number];
 
 // The OAuth return outcome (Task 2): the callback lands back on
 // #/settings/connections/{outcome} — id2 on that route only, never parsed
@@ -938,17 +947,28 @@ function useSetSignatureEnrichment(provider: CaptureConnection["provider"]) {
 /**
  * The installation's capture connections, in one spelling.
  *
- * Exported because the card is no longer the only reader: chrome that reports
- * whether the agent can reach its sources needs the same list, and two queries
- * against one path are two answers that can disagree on screen.
+ * Exported because the card is no longer the only reader: the chrome that
+ * reports whether the agent can reach its sources needs the same list, and so
+ * do onboarding's connect surfaces. Two queries against one path are two
+ * answers that can disagree on screen — and two SHAPES under the one
+ * `["connectors"]` cache entry are worse than that, because react-query keeps
+ * one entry per key and whichever reader fetched last decides what the others
+ * read. So every reader comes through here.
  */
-export function useConnectors() {
+export function useConnectors(
+  options?: Readonly<{
+    /** False holds the request without leaving the key: a reader that only
+     *  wants the answer when it already exists still shares the one entry. */
+    enabled?: boolean;
+  }>,
+) {
   return useQuery({
     queryKey: ["connectors"],
+    enabled: options?.enabled ?? true,
     queryFn: async (): Promise<ConnectorsResult> => {
       const { data, error, response } = await api.GET("/connectors");
       if (response.status === 501 && problemCode(error) === "not_implemented") {
-        return { notConfigured: true, data: [] };
+        return { notConfigured: true, data: [], providers: [] };
       }
       if (error) {
         throwProblem(error);
@@ -956,6 +976,7 @@ export function useConnectors() {
       return {
         notConfigured: false,
         data: data.data,
+        providers: data.providers ?? [],
         publicOrigin: data.public_origin,
       };
     },

--- a/frontend/src/screens/onboarding-backread.stories.tsx
+++ b/frontend/src/screens/onboarding-backread.stories.tsx
@@ -165,6 +165,29 @@ export const Cancelled: Story = {
   }),
 };
 
+// The way back out of a stopped read: the pick returns, opened on the window
+// that already ran. Without it the step ended on the stopped run with only the
+// exit, and a reader who pressed stop had no second chance at their history.
+export const RestartAfterCancel: Story = {
+  render: backreadStory(
+    {
+      state: "cancelled",
+      window: "12m",
+      counts: { messages_scanned: 300, captured: 96 },
+    },
+    {
+      "POST /connectors/gmail/backfill/preview": preview({ window: "12m" }),
+    },
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /Start another import/ }),
+    );
+    await canvas.findByText(/About 4,820 messages/);
+  },
+};
+
 // Stopping a live read: the status row answers cancelled and the outcome says
 // plainly that nothing was written.
 export const Stopping: Story = {

--- a/frontend/src/screens/onboarding-backread.test.tsx
+++ b/frontend/src/screens/onboarding-backread.test.tsx
@@ -253,6 +253,36 @@ describe("starting the read", () => {
     ).toBeInTheDocument();
   });
 
+  // A read that stopped is history, not a mailbox that can never be read: the
+  // step used to end on the stopped run with only the exit, so a reader who
+  // pressed stop had no way back to the pick.
+  it("offers a stopped read again, on the window it already ran", async () => {
+    const starts: unknown[] = [];
+    installFetchStub({
+      [PREVIEW_ROUTE]: () =>
+        previewOf({ window: "12m", estimated_messages: 90 }),
+      [START_ROUTE]: (body) => {
+        starts.push(body);
+        return jsonResponse({ state: "queued" }, 202);
+      },
+    });
+    render({ state: "cancelled", window: "12m", counts: { captured: 4 } });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Start another import" }),
+    );
+    expect(
+      (screen.getByRole("radio", { name: /12 months/ }) as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+
+    await screen.findByText("About 90 messages in that window.");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Connect and read" }),
+    );
+    await waitFor(() => expect(starts).toEqual([{ window: "12m" }]));
+  });
+
   it("says a start failed and never claims a running read", async () => {
     installFetchStub({
       [PREVIEW_ROUTE]: () => previewOf({}),

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useDrawsImportRun } from "../app/import-onscreen";
 import { Button, Radio, Skeleton } from "../design-system/atoms";
 import { formatMoney, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
@@ -127,6 +128,11 @@ export function OnboardingBackread({
   const t = useT();
   const qc = useQueryClient();
   const [selected, setSelected] = useState<BackreadWindow>(DEFAULT_WINDOW);
+  // A read that has stopped — cancelled, failed or finished — is history, not a
+  // mailbox that can never be read again. This puts the window pick back in
+  // front of the reader; the server still decides whether the pick is allowed
+  // (widen-only), exactly as it does the first time.
+  const [restarting, setRestarting] = useState(false);
 
   const status = useQuery({
     queryKey: statusQueryKey(provider),
@@ -176,8 +182,12 @@ export function OnboardingBackread({
       }
       return data;
     },
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
+    onSuccess: () => {
+      // The new read is what the reader watches now, so the picker they started
+      // it from stands down with it.
+      setRestarting(false);
+      return qc.invalidateQueries({ queryKey: statusQueryKey(provider) });
+    },
   });
 
   const cancel = useMutation({
@@ -195,10 +205,14 @@ export function OnboardingBackread({
       qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
   });
 
+  // This step draws the run in full, so the shell's capture chip stands down
+  // for as long as it is on screen rather than gauging the same import twice.
+  useDrawsImportRun(isLive(status.data?.state));
+
   // The scope loads itself for whichever window is selected: the first thing a
   // newly-connected user sees is honest scope, not an empty form. A preview is
   // a read and spends nothing; the spend still waits for the explicit start.
-  const isSetup = status.data?.state === "none";
+  const isSetup = status.data?.state === "none" || restarting;
   const [previewedWindow, setPreviewedWindow] = useState<BackreadWindow | null>(
     null,
   );
@@ -268,12 +282,23 @@ export function OnboardingBackread({
     );
   }
 
+  const run = status.data;
   return (
     <BackreadRun
-      run={status.data}
+      run={run}
       cancelling={cancel.isPending}
       cancelProblem={safeDetail(cancel.isError, cancel.error, t)}
       onCancel={() => cancel.mutate()}
+      onRestart={() => {
+        // Opened on the window this mailbox already read, because the server
+        // refuses a narrower one — a picker that opens on a refusal wastes the
+        // reader's first press.
+        setSelected(run.window ?? DEFAULT_WINDOW);
+        // Re-count the mailbox for the pick rather than re-showing the estimate
+        // that consented to the read which just ended.
+        setPreviewedWindow(null);
+        setRestarting(true);
+      }}
       onFinish={onFinish}
     />
   );
@@ -412,12 +437,17 @@ function BackreadRun({
   cancelling,
   cancelProblem,
   onCancel,
+  onRestart,
   onFinish,
 }: Readonly<{
   run: BackfillStatus;
   cancelling: boolean;
   cancelProblem: string | null;
   onCancel: () => void;
+  /** Put the window pick back in front of the reader. Offered on every read
+   *  this view draws that is not live: stopping one is a decision about that
+   *  read, never about the mailbox. */
+  onRestart: () => void;
   onFinish: (skipped: boolean) => void;
 }>) {
   const t = useT();
@@ -439,10 +469,12 @@ function BackreadRun({
         <Button variant="primary" onClick={() => onFinish(false)}>
           {live ? t("ob.backread.explore") : t("ob.s4.enterCrm")}
         </Button>
-        {live && (
+        {live ? (
           <Button disabled={cancelling} onClick={onCancel}>
             {t("ob.backread.cancel")}
           </Button>
+        ) : (
+          <Button onClick={onRestart}>{t("backfill.restart")}</Button>
         )}
       </div>
     </section>

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useId, useState } from "react";
-import { api } from "../api/client";
+import { useId } from "react";
 import type { components } from "../api/schema";
 import { useDrawsImportRun } from "../app/import-onscreen";
 import { Button, Radio, Skeleton } from "../design-system/atoms";
 import { formatMoney, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { problemMessageOf, throwProblem } from "./common";
+import { type ImportWindow, isLiveRun, useBackfillRun } from "./backfill-run";
+import { problemMessageOf } from "./common";
 import { errorClassKey } from "./connector-status";
 import "./onboarding-backread.css";
 
@@ -40,12 +39,11 @@ type BackfillPreview = components["schemas"]["BackfillPreview"];
 type BackfillCounts = NonNullable<BackfillStatus["counts"]>;
 type Provider = components["schemas"]["CaptureConnection"]["provider"];
 
-/** The startable windows. `none` is expressed by never starting a run at all —
- *  which is what the leave-without-reading control does. */
-export type BackreadWindow =
-  components["schemas"]["StartBackfillRequest"]["window"];
-
-const WINDOWS: readonly { value: BackreadWindow; label: MessageKey }[] = [
+// The startable windows, in reach order. `none` is expressed by never starting
+// a run at all — which is what the leave-without-reading control does, and
+// which windows are startable is `ImportWindow`, beside the operations this
+// step and the Settings card share.
+const WINDOWS: readonly { value: ImportWindow; label: MessageKey }[] = [
   { value: "3m", label: "ob.backread.window3m" },
   { value: "6m", label: "ob.backread.window6m" },
   { value: "12m", label: "ob.backread.window12m" },
@@ -53,17 +51,10 @@ const WINDOWS: readonly { value: BackreadWindow; label: MessageKey }[] = [
   { value: "60m", label: "ob.backread.window60m" },
 ];
 
-const DEFAULT_WINDOW: BackreadWindow = "6m";
-
 // The contract pins v1 estimates to USD minor units and leaves `currency`
 // optional, so USD is the documented fallback rather than a guess. The symbol
 // itself is never spelled here — Intl derives it from the code and the locale.
 const FALLBACK_CURRENCY = "USD";
-
-// The status read is a single indexed row, so polling it is indistinguishable
-// from a push — the same 2.5s cadence the Settings panel (screens/backfill.tsx)
-// already runs, kept identical so one mailbox is never watched at two rates.
-const POLL_MS = 2500;
 
 // Declaration order is render order. Every entry names a persisted count on the
 // wire and the copy for it; `dedupe_candidates` is deliberately absent — it is
@@ -75,16 +66,6 @@ const TALLIES: readonly { key: keyof BackfillCounts; label: MessageKey }[] = [
   { key: "people_created", label: "ob.backread.tallyPeople" },
   { key: "organizations_created", label: "ob.backread.tallyCompanies" },
 ];
-
-// A run is live while the job can still move; every other state is terminal and
-// polling stops there — a poll that outlives the run only costs battery.
-function isLive(state: BackfillStatus["state"] | undefined): boolean {
-  return state === "queued" || state === "running";
-}
-
-// The one spelling of the run-row cache key, shared with the Settings panel so
-// a read started here lands there too rather than on a second cache entry.
-const statusQueryKey = (provider: Provider) => ["backfill-status", provider];
 
 // The template-ready `{detail}` value for a mutation that may or may not
 // have failed — `null` while it hasn't, the failure's reader-safe text once it
@@ -126,103 +107,13 @@ export function OnboardingBackread({
   onFinish,
 }: OnboardingBackreadProps) {
   const t = useT();
-  const qc = useQueryClient();
-  const [selected, setSelected] = useState<BackreadWindow>(DEFAULT_WINDOW);
-  // A read that has stopped — cancelled, failed or finished — is history, not a
-  // mailbox that can never be read again. This puts the window pick back in
-  // front of the reader; the server still decides whether the pick is allowed
-  // (widen-only), exactly as it does the first time.
-  const [restarting, setRestarting] = useState(false);
-
-  const status = useQuery({
-    queryKey: statusQueryKey(provider),
-    queryFn: async () => {
-      const { data, error } = await api.GET("/connectors/{provider}/backfill", {
-        params: { path: { provider } },
-      });
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    initialData: initial,
-    // The roster row already answered this read once; skip the mount-time
-    // revalidation react-query would otherwise run and rely on the live poll
-    // below (or an explicit invalidate) for a fresher row. Without a seed,
-    // fetch on mount as usual.
-    staleTime: initial !== undefined ? Number.POSITIVE_INFINITY : 0,
-    refetchInterval: (query) =>
-      isLive(query.state.data?.state) ? POLL_MS : false,
-  });
-
-  const preview = useMutation({
-    mutationFn: async (pick: BackreadWindow) => {
-      const { data, error } = await api.POST(
-        "/connectors/{provider}/backfill/preview",
-        { params: { path: { provider } }, body: { window: pick } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
-
-  const start = useMutation({
-    mutationFn: async (pick: BackreadWindow) => {
-      const { data, error } = await api.POST(
-        "/connectors/{provider}/backfill",
-        {
-          params: { path: { provider } },
-          body: { window: pick },
-        },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    onSuccess: () => {
-      // The new read is what the reader watches now, so the picker they started
-      // it from stands down with it.
-      setRestarting(false);
-      return qc.invalidateQueries({ queryKey: statusQueryKey(provider) });
-    },
-  });
-
-  const cancel = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await api.DELETE(
-        "/connectors/{provider}/backfill",
-        { params: { path: { provider } } },
-      );
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: statusQueryKey(provider) }),
-  });
+  const importRun = useBackfillRun({ provider, initial });
+  const { status, preview, start, cancel } = importRun;
+  const selected = importRun.window;
 
   // This step draws the run in full, so the shell's capture chip stands down
   // for as long as it is on screen rather than gauging the same import twice.
-  useDrawsImportRun(isLive(status.data?.state));
-
-  // The scope loads itself for whichever window is selected: the first thing a
-  // newly-connected user sees is honest scope, not an empty form. A preview is
-  // a read and spends nothing; the spend still waits for the explicit start.
-  const isSetup = status.data?.state === "none" || restarting;
-  const [previewedWindow, setPreviewedWindow] = useState<BackreadWindow | null>(
-    null,
-  );
-  useEffect(() => {
-    if (!isSetup || previewedWindow === selected || preview.isPending) {
-      return;
-    }
-    setPreviewedWindow(selected);
-    preview.mutate(selected);
-  }, [isSetup, selected, previewedWindow, preview]);
+  useDrawsImportRun(isLiveRun(status.data?.state));
 
   // `preview.data`/`preview.error` are the mutation's LAST result, which
   // survives past the render where `selected` changes to a window nobody has
@@ -257,11 +148,11 @@ export function OnboardingBackread({
     );
   }
 
-  if (isSetup) {
+  if (importRun.isSetup) {
     return (
       <BackreadSetup
         selected={selected}
-        onSelect={setSelected}
+        onSelect={importRun.setWindow}
         // Gated on settled, not just on-selection: react-query already clears
         // `data` while a mutation is pending, but this does not depend on
         // that — the old window's estimate stays withheld on our own terms
@@ -289,16 +180,7 @@ export function OnboardingBackread({
       cancelling={cancel.isPending}
       cancelProblem={safeDetail(cancel.isError, cancel.error, t)}
       onCancel={() => cancel.mutate()}
-      onRestart={() => {
-        // Opened on the window this mailbox already read, because the server
-        // refuses a narrower one — a picker that opens on a refusal wastes the
-        // reader's first press.
-        setSelected(run.window ?? DEFAULT_WINDOW);
-        // Re-count the mailbox for the pick rather than re-showing the estimate
-        // that consented to the read which just ended.
-        setPreviewedWindow(null);
-        setRestarting(true);
-      }}
+      onRestart={() => importRun.restart(run)}
       onFinish={onFinish}
     />
   );
@@ -319,8 +201,8 @@ function BackreadSetup({
   onStart,
   onFinish,
 }: Readonly<{
-  selected: BackreadWindow;
-  onSelect: (pick: BackreadWindow) => void;
+  selected: ImportWindow;
+  onSelect: (pick: ImportWindow) => void;
   preview: BackfillPreview | undefined;
   previewProblem: string | null;
   /** A decision about this mailbox is still being written; the read must not
@@ -428,7 +310,7 @@ function BackreadScope({
 // failed or cancelled read leads with its sentence — "The backread stopped" is
 // prose, and setting it as a heading would shout the failure.
 function headingKey(state: BackfillStatus["state"]): MessageKey | null {
-  if (isLive(state)) return "ob.backread.running";
+  if (isLiveRun(state)) return "ob.backread.running";
   return state === "done" ? "ob.backread.doneHeading" : null;
 }
 
@@ -452,7 +334,7 @@ function BackreadRun({
 }>) {
   const t = useT();
   const heading = headingKey(run.state);
-  const live = isLive(run.state);
+  const live = isLiveRun(run.state);
 
   return (
     <section className="ob-backread">

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRight,
   CheckCircle2,
@@ -14,6 +14,7 @@ import type { MessageKey } from "../i18n/en";
 import { CaptureNotice } from "./capture-notice";
 import { problemMessageOf, throwProblem } from "./common";
 import { ConnectPostureStep } from "./connect-posture";
+import { useConnectors } from "./connectors";
 import { imapErrorMessage } from "./imap-connect-form";
 import { OnboardingBackread } from "./onboarding-backread";
 
@@ -258,17 +259,11 @@ export function OAuthReturnPanel({
   onComplete: (skipped: boolean) => Promise<void>;
 }>) {
   const t = useT();
-  const connections = useQuery({
-    queryKey: ["connectors"],
-    enabled: outcome === "ok",
-    queryFn: async () => {
-      const { data, error } = await api.GET("/connectors");
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
+  // The shared read, held until the return actually says "ok": one cache entry
+  // for every reader of this path (screens/connectors.tsx), so the roster this
+  // panel confirms a mailbox from is the same one the connect scene draws its
+  // cards from and the shell's chip gauges the import from.
+  const connections = useConnectors({ enabled: outcome === "ok" });
   const returning = asOAuthProvider(provider);
   // Raised while the posture write is in flight. The backread is what reads a
   // year of mail, so starting one before the answer commits imports under

--- a/frontend/src/screens/onboarding-conversation/connect-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-scene.tsx
@@ -1,14 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { Check, Circle } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { api } from "../../api/client";
 import type { components } from "../../api/schema";
 import { Button, Disclosure } from "../../design-system/atoms";
 import { ProviderMark } from "../../design-system/provider-mark";
 import { useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
-import { throwProblem } from "../common";
+import { useConnectors } from "../connectors";
 import { OvernightGrantChoice } from "../overnight-grant";
 import { ConnectDialog } from "./connect-dialog";
 import { WayOnward } from "./way-onward";
@@ -148,16 +146,7 @@ const BLOCKER_COPY: Readonly<
  * request, so this costs nothing extra on the common path.
  */
 function useConnectedMailProviders(): ConnectedMailRoster {
-  const roster = useQuery({
-    queryKey: ["connectors"],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/connectors");
-      if (error) {
-        throwProblem(error);
-      }
-      return data;
-    },
-  });
+  const roster = useConnectors();
   const connected = roster.data?.data.filter((c) => c.status === "connected");
   const blockers = new Map<string, ConnectBlocker>();
   for (const entry of roster.data?.providers ?? []) {
@@ -165,11 +154,16 @@ function useConnectedMailProviders(): ConnectedMailRoster {
       blockers.set(entry.provider, entry.reason);
     }
   }
+  // A deployment that never wired mail capture answers 501, which the shared
+  // read reports as `notConfigured` rather than as a failure. There is no
+  // roster to draw a card from either way, so this scene says the same thing
+  // for both: it could not read what this installation can connect.
+  const unreadable = roster.isError || roster.data?.notConfigured === true;
   return {
     providers: new Set((connected ?? []).map((c) => c.provider)),
     blockers,
-    verified: roster.isSuccess && !roster.isFetching,
-    failed: roster.isError,
+    verified: roster.isSuccess && !roster.isFetching && !unreadable,
+    failed: unreadable,
     retry: () => void roster.refetch(),
   };
 }


### PR DESCRIPTION
## What

Two dead ends around the connect-time mail import.

1. **The import started during onboarding now reports itself.** The capture chip — the gauge that says mail is arriving — lived only in the shell's railed branch, so an import started during cold start / onboarding, which is where most imports start, had nothing reporting it for the rest of the flow. It now draws on the onboarding route too, as an unlinked status.
2. **A stopped import can be started again.** Pressing "Stop the import" left the mailbox with no way back: the panel drew the stopped run forever, and disconnecting and reconnecting did not help because the run rows belong to the connection that survives both. A stopped run — cancelled, failed or finished — now offers "Start another import", opening on the window that already ran.

## Why

An import runs for minutes to hours, and setup is exactly when the reader is doing something else in the same window; a gauge that only exists on the routes they reach afterwards reports the one run nobody was watching.

The invariant behind the second half: **stopping a run is a decision about that run, never about the mailbox.** The server has always allowed a new run after a terminal one (widen-only versus any prior); only the surfaces refused to ask.

Two supporting changes the first half required:

- **Where the chip stands down is no longer a route the chip spells itself.** The surfaces that draw the run in full — the connections card and onboarding's backread step — declare it (`app/import-onscreen.ts`), and the chip reads that. A third such surface is covered by mounting rather than by a list.
- **One shape under the `["connectors"]` cache key.** Three readers of `GET /connectors` shared that key with two different result shapes, and react-query keeps one entry per key — whichever reader fetched last decided what the others read. Mounting the chip on the onboarding route would have made that collision live rather than latent, so every reader now comes through `useConnectors`, which carries the provider-readiness roster the connect scene needs.

## How verified

- `make check-fe` green (ds-gates, drift, lint, unit, build, composed typecheck, unit-screens lane), re-run after rebasing onto current `main`: 591 files / 7376 tests.
- `make fe-ds-gates` green.
- Backend is untouched by this diff, so `check-backend` and `make craft-static` (which sweep the Go trees) have nothing new to read.
- New tests, each failing before the change: the chip stands down where a surface already draws the run, and gauges without leading anywhere where the route carries no navigation; both backread surfaces offer a stopped run again and post the window that ran.
- New stories for the states introduced: `Shell/Capture chip → Unlinked`, `Settings/You/Connections/Backfill → RestartAfterCancel`, `Onboarding/Backread → RestartAfterCancel` (the last two drive the restart with a `play`).

- [x] `make check` is green — the frontend half in full (`make check-fe`); the backend half has no diff to read
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend only, no store, migration or handler touched
- [x] `make craft-static` reports no new blockers — no Go files in this diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-assisted throughout, under human accountability: the two defects were reported by a human from the running product, and the diagnosis, the design (a declared "the run is already drawn here" signal instead of a hard-coded route; unifying the three `/connectors` readers), the code, the tests and the stories were written by Claude Code and reviewed against the repository's rulebook before pushing.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGAsXAW5mGEkcVPAusuLAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAsXAW5mGEkcVPAusuLAS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two dead ends in the connect-time mail import: the capture chip now reports an import started during setup, and a stopped import can be started again.

- The capture chip previously only drew in the shell's railed branch, so an import started during onboarding had no gauge for the rest of the flow. It now draws on the onboarding route as an unlinked status.
- Pressing "Stop the import" left the mailbox with no way back — the panel drew the stopped run forever, and reconnecting did not help. A stopped run (cancelled, failed, or finished) now offers "Start another import", opened on the window that already ran.

**Refactors**
- Surfaces that draw the run in full now declare it via `useDrawsImportRun`, so the chip stands down by mounting rather than by a hard-coded route list.
- All readers of `GET /connectors` now go through `useConnectors`, which fixes a cache collision where three readers shared one key with two result shapes.
- The run's read, estimate, start, stop, and window pick now live in one spelling (`backfill-run.ts`), shared by the Settings card and onboarding's backread step, which each held a copy.

<sup>Written for commit 389946527f0ffd37fec63945f04773fadf39744e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to restart mailbox imports after cancellation, failure, or completion.
  - Restarting an import reopens the window selector with the previously used period selected.
  - Added localized “Start another import” labels in English, German, and Vietnamese.
- **Bug Fixes**
  - Import progress indicators now remain visible during onboarding without blocking nearby controls.
  - Progress indicators are hidden when the active import is already displayed elsewhere, avoiding duplicate status displays.
- **Tests**
  - Added coverage for restarting imports and updated progress indicator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->