### PR TITLE
fix(frontend): the re-buy note reads the record, not the provider's answer

### DIFF
--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -26,6 +26,7 @@ import {
 // verb they cannot find is a capability they do not have.
 
 type Profile = components["schemas"]["PersonProviderProfile"];
+type Person = components["schemas"]["Person"];
 
 afterEach(() => {
   cleanup();
@@ -417,6 +418,24 @@ describe("the details that cost credits", () => {
     },
   ];
 
+  /** The record the panel reads its own held addresses from. Stubbed in every
+   *  case rather than left to the fetch fallback: the fallback answers an
+   *  empty PAGE, which has no `person` at all, so a case that leaned on it
+   *  would be asserting against a payload this endpoint cannot return. */
+  function recordWith(person: Partial<Person> = {}): Response {
+    return jsonResponse({
+      as_of: "2026-08-20T09:00:00Z",
+      person: {
+        id: "p-1",
+        full_name: "Dana Ruiz",
+        emails: [],
+        phones: [],
+        ...person,
+      },
+      sections_omitted: [],
+    });
+  }
+
   function mountWithCatalog(
     profile: Profile,
     run: () => Response,
@@ -428,6 +447,11 @@ describe("the details that cost credits", () => {
       professional_email: true,
       mobile: true,
     },
+    // What the CRM record holds, which the provider's own answer does not say:
+    // an address somebody typed in or a mailbox captured is on the record and
+    // was never bought here. Empty is the default because most cases are about
+    // the provider's half.
+    record: Partial<Person> = {},
   ) {
     const posted: unknown[] = [];
     installFetchStub({
@@ -448,6 +472,7 @@ describe("the details that cost credits", () => {
             },
           ],
         }),
+      "GET /people/p-1/360": () => recordWith(record),
       "POST /people/p-1/enrichment-runs": (body) => {
         posted.push(body);
         return run();
@@ -694,6 +719,185 @@ describe("the details that cost credits", () => {
       name: /Buy work email and mobile number · 2 credits/,
     });
     expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
+  // The loading window, which on this row is a money question rather than a
+  // cosmetic one: a button pressed before the record answers cannot say which
+  // half of its price buys something already on file. So it waits.
+  //
+  // A route that never settles IS that window. Omitting it instead would fall
+  // through to the stub's empty page, the query would settle, and this case
+  // would pass while testing nothing.
+  it("offers no purchase until the record says what it already holds", async () => {
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /provider-connections": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "surfe",
+              status: "connected",
+              credential_present: true,
+              catalog,
+              configuration: {
+                categories: { professional_email: true, mobile: true },
+              },
+              credits: { pools: {} },
+              version: 1,
+              created_at: "2026-08-20T09:00:00Z",
+              updated_at: "2026-08-20T09:00:00Z",
+            },
+          ],
+        }),
+      "GET /people/p-1/360": () =>
+        new Response(new ReadableStream({ start() {} }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[{ ...neverRun(), state: "completed" }]}
+        />
+      </StoryProviders>,
+    );
+
+    // The free lookup is unaffected — it spends nothing, so it has nothing to
+    // disclose and no reason to wait. Its ENABLED state is also the proof that
+    // the catalog has landed: it stays disabled until the catalog says what
+    // free means, so every priced button that is ever going to be drawn has
+    // been drawn by the time it goes live. Asserting the absence any earlier
+    // would pass on a row that had not been rendered yet.
+    const free = await screen.findByRole("button", { name: /Check again/ });
+    await expect.poll(() => free).toHaveProperty("disabled", false);
+    expect(screen.queryByRole("button", { name: /^Buy / })).toBeNull();
+  });
+
+  // The address the provider never sold us. A rep typed the work email in from
+  // a business card, or a mailbox connector captured it off a signature — it is
+  // on the record, the provider's answer says nothing about it, and Surfe bills
+  // for the email pool all the same when the mobile press makes it look again.
+  it("names the re-buy for a work address that came from the record", async () => {
+    mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+      undefined,
+      {
+        emails: [
+          {
+            id: "e-1",
+            email: "dana@acme.example",
+            email_type: "work",
+            is_primary: true,
+            position: 0,
+            source: "manual",
+            captured_by: "u-1",
+          },
+        ],
+      },
+    );
+
+    // The press still costs two credits and still returns a number, so it is
+    // still offered — with the second charge named.
+    expect(
+      await screen.findByRole("button", {
+        name: /Buy mobile number · 2 credits/,
+      }),
+    ).toBeDefined();
+    expect(
+      await screen.findByText(/includes the work email again/),
+    ).toBeDefined();
+
+    // And nothing offers to buy an address the reader can already see on the
+    // record, whoever put it there.
+    expect(screen.queryByRole("button", { name: /Buy work email/ })).toBeNull();
+  });
+
+  it("still offers the work email when the record holds only a personal one", async () => {
+    mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+      undefined,
+      {
+        emails: [
+          {
+            id: "e-2",
+            email: "dana@privatemail.example",
+            email_type: "personal",
+            is_primary: true,
+            position: 0,
+            source: "manual",
+            captured_by: "u-1",
+          },
+        ],
+      },
+    );
+
+    // The record keeps the same type distinction the provider's answer does,
+    // and for the same reason: the two are separate purchases from separate
+    // pools, so a private address is no reason to withhold a work one.
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+    expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
+  // `other` is the record's third filing, and it is not a third purchase. It is
+  // one of the two and nobody said which, so it buys no offer and claims no
+  // re-buy — the same answer the provider's unclassified address gets.
+  it("treats an address the record files as other as neither purchase", async () => {
+    mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+      undefined,
+      {
+        emails: [
+          {
+            id: "e-3",
+            email: "dana@unknown.example",
+            email_type: "other",
+            is_primary: false,
+            position: 0,
+            source: "import",
+            captured_by: "u-1",
+          },
+        ],
+      },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+    expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
+  // The other half of the same press, and the same defect: a number already on
+  // the record is one the mobile press pays for again.
+  it("offers no mobile purchase for a number the record already holds", async () => {
+    mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+      undefined,
+      {
+        phones: [
+          {
+            id: "ph-1",
+            phone: "+491701234567",
+            phone_type: "mobile",
+            is_primary: true,
+            position: 0,
+            source: "manual",
+            captured_by: "u-1",
+          },
+        ],
+      },
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: /mobile number/ })).toBeNull();
   });
 
   it("offers nothing once both halves of a press are held", async () => {

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -19,6 +19,7 @@ import {
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { type Locale, useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
+import { usePerson360 } from "./person360";
 import { categoryNames, categoryNamesTogether } from "./provider-categories";
 import {
   canEnrichNow,
@@ -35,6 +36,7 @@ import {
 // alike invites a rep to treat a purchase as a confirmation.
 
 type Profile = components["schemas"]["PersonProviderProfile"];
+type Person = components["schemas"]["Person"];
 type Provider = components["schemas"]["Provider"];
 type ProviderConnection = components["schemas"]["ProviderConnection"];
 
@@ -293,6 +295,16 @@ function BuyPriced({
   const connection = connections.data?.connections.find(
     (c) => c.provider === profile.provider,
   );
+  // What the RECORD holds, which is not the same as what this provider
+  // returned: an address typed in by hand or captured from a mailbox is billed
+  // for again exactly as one Surfe sold us, and reading `profile.emails` alone
+  // is what left that second charge unsaid.
+  //
+  // Read here rather than handed down from the mount sites: there are two of
+  // them today and a third would have to remember. This is the query the page
+  // around it already made, under the same key, so it costs a cache read.
+  const record = usePerson360(personId);
+  const held = heldCategories(profile, record.data?.person);
   // Only what this connection actually carries, asked of EVERY category the
   // press would send — not just the one on the button.
   //
@@ -313,18 +325,24 @@ function BuyPriced({
     (entry) =>
       !entry.free &&
       boughtWith(entry).every(enabled) &&
-      !alreadyHeld(profile, entry.category),
+      !held.has(entry.category),
   );
-  if (buyable.length === 0 || !canEnrichNow(profile.state, running)) {
+  // Without the record there is nothing to check a re-buy against, and a
+  // spending button that cannot say what it pays for twice is the defect this
+  // row exists to prevent. Absent is a moment rather than a state — the page
+  // that mounts this has already asked — so nothing here waits on it for long.
+  if (
+    !record.data ||
+    buyable.length === 0 ||
+    !canEnrichNow(profile.state, running)
+  ) {
     return null;
   }
   return (
     <div className="pe-buy-row">
       {buyable.map((entry) => {
         const asks = boughtWith(entry);
-        const rebought = asks.filter((category) =>
-          alreadyHeld(profile, category),
-        );
+        const rebought = asks.filter((category) => held.has(category));
         return (
           <div className="pe-buy-offer" key={entry.category}>
             <Button
@@ -345,7 +363,7 @@ function BuyPriced({
                 // Naming a detail already on the record would read as an
                 // offer to buy what the reader can see they have.
                 category: categoryNamesTogether(
-                  asks.filter((category) => !alreadyHeld(profile, category)),
+                  asks.filter((category) => !held.has(category)),
                   t,
                   locale,
                 ),
@@ -408,40 +426,64 @@ function creditsOf(
   return Object.values(entry.cost).reduce((total, n) => total + n, 0);
 }
 
-/** Whether the section already shows what this category buys.
+/** The purchase categories this record already shows, whatever put them there.
  *
- *  Asked TWICE about one press, for two different questions. Whether to offer
- *  the button reads the category being sought — a mobile is worth offering
- *  when the work email it needs is already held. What the button says reads
- *  every category the press sends, because the provider bills for whatever it
- *  returns and cannot be told to skip an address we hold, so that press pays
- *  for the email a second time.
+ *  Consulted TWICE about one press, for two different questions. Whether to
+ *  offer the button reads the category being sought — a mobile is worth
+ *  offering when the work email it needs is already held. What the button says
+ *  reads every category the press sends, because the provider bills for
+ *  whatever it returns and cannot be told to skip an address we hold, so that
+ *  press pays for the email a second time.
  *
  *  Answering only the first question is what let the second charge go
- *  unmentioned. */
-function alreadyHeld(profile: Profile, category: string): boolean {
-  switch (category) {
-    // By TYPE, not by "any address at all". The two are separate purchases
-    // from separate pools, and collapsing them hid each behind the other: a
-    // contact whose personal address came back was never offered a work
-    // email, and the reverse.
-    //
-    // An address the provider could not classify counts for neither. It is
-    // one of the two, and guessing which would either hide an offer the
-    // reader can still use or claim a re-buy that does not happen — both
-    // worse than offering a purchase they may decline.
-    case "professional_email":
-      return profile.emails.some(
-        (email) => email.email_type === "professional",
-      );
-    case "personal_email":
-      return profile.emails.some((email) => email.email_type === "personal");
-    case "mobile":
-      return profile.mobile_phones.length > 0;
-    default:
-      return false;
+ *  unmentioned; asking only the provider's own answer is what let it go
+ *  unmentioned for an address the provider never returned.
+ */
+function heldCategories(
+  profile: Profile,
+  person: Person | undefined,
+): ReadonlySet<string> {
+  const held = new Set<string>();
+  for (const email of profile.emails) {
+    const bought = PROVIDER_EMAIL_CATEGORY[email.email_type ?? ""];
+    if (bought) {
+      held.add(bought);
+    }
   }
+  for (const email of person?.emails ?? []) {
+    const filed = RECORD_EMAIL_CATEGORY[email.email_type];
+    if (filed) {
+      held.add(filed);
+    }
+  }
+  if (
+    profile.mobile_phones.length > 0 ||
+    (person?.phones ?? []).some((phone) => phone.phone_type === "mobile")
+  ) {
+    held.add("mobile");
+  }
+  return held;
 }
+
+// By TYPE, not by "any address at all". The two are separate purchases from
+// separate pools, and collapsing them hid each behind the other: a contact
+// whose personal address came back was never offered a work email, and the
+// reverse.
+//
+// Both vocabularies stop short of the whole enum on purpose. An address the
+// provider could not classify counts for neither, and neither does one the
+// record files as `other`: it is one of the two, and guessing which would
+// either hide an offer the reader can still use or claim a re-buy that does
+// not happen — both worse than offering a purchase they may decline.
+const PROVIDER_EMAIL_CATEGORY: Readonly<Record<string, string>> = {
+  professional: "professional_email",
+  personal: "personal_email",
+};
+
+const RECORD_EMAIL_CATEGORY: Readonly<Record<string, string>> = {
+  work: "professional_email",
+  personal: "personal_email",
+};
 
 // A component rather than a hook call in the section, so the watch mounts
 // only where a profile exists — the section returns early without one, and a


### PR DESCRIPTION
Closes #3576.

## The defect

The buy panel decided what a press re-buys from `profile.emails` — the addresses *this provider* returned. A work email a rep typed in from a business card, or a mailbox connector captured off a signature, is on the record and absent from that list. So pressing the mobile button showed **"Buy work email and mobile number · 2 credits"** with no re-buy line, even though Surfe bills for the email pool whatever it already knows we hold.

The price was right. The disclosure was missing.

## The fix

`heldCategories(profile, person)` replaces `alreadyHeld(profile, category)`: one set of "what this record already shows", built from the provider's answer *and* the person's canonical emails and phones. Both questions the old predicate answered — whether to offer a button, and what the button's note says — read it, so they cannot disagree.

Read inside the panel via `usePerson360(personId)` rather than threaded through props: there are two mount sites today (`persondrawers.tsx`, `personresearch.tsx`) and a third would have to remember. Both already hold that query under the same key, so it is a cache read.

The type distinction is kept on both sides. The provider files addresses as `professional | personal | null`; the record files them as `work | personal | other`. A held **personal** address does not suppress a work-email offer, and an address nobody classified — `null` from the provider, `other` on the record — counts for neither purchase: it is one of the two, and guessing which would either hide an offer the reader can still use or claim a re-buy that does not happen.

The row now waits for the record before drawing a spending button. Without it there is nothing to check a re-buy against, and a button that cannot say what it pays for twice is the defect this row exists to prevent.

## Tests

Five cases in `personprovider.test.tsx`, plus a record stub in `mountWithCatalog` — every case now answers `GET /people/p-1/360` with a real payload instead of leaning on the fetch stub's empty page, which has no `person` at all.

- a work address that came from the record names the re-buy, and offers no second purchase of itself
- a personal address on the record does not suppress the work-email offer
- an address the record files as `other` is neither purchase
- a mobile already on the record is not offered again
- no priced button until the record answers (asserted after the free button goes live, which is what proves the catalog landed — asserting earlier would pass on a row that had not rendered)

Mutation-checked, three ways: ignoring the record's emails and phones fails two cases; collapsing the record's email types onto `professional_email` fails two others; dropping the loading gate fails the fifth.

`make check-fe` green.