### PR TITLE
fix(integrations): the catalog names the trigger a fallback is bought with

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24048,6 +24048,16 @@ components:
             case: asked for on its own it makes the vendor hunt for an email nobody bought,
             fail, and skip the number — returning a run that COMPLETED with nothing in it.
             A buy button asks for both or neither; the server refuses the lone request.
+        follows:
+          type: [string, 'null']
+          description: >-
+            The category whose EMPTY answer triggers this one, for a category that is a
+            fallback rather than a purchase of its own. Surfe's personal email is the case:
+            the cascade fires only when the professional address comes back with nothing, so
+            a request naming the fallback alone never issues it and the server refuses it.
+            Sent beside `requires` because the two are different relations with the same
+            consequence for a button — ask for both or neither — and `cost` already prices
+            the pair.
 
     ProviderLookupBacklog:
       type: object

--- a/backend/internal/compose/integrationsmapping.go
+++ b/backend/internal/compose/integrationsmapping.go
@@ -286,6 +286,9 @@ func catalogWire(catalog []integrations.CategoryCost) *[]crmcontracts.ProviderCa
 		if entry.Requires != "" {
 			wire.Requires = &entry.Requires
 		}
+		if entry.Follows != "" {
+			wire.Follows = &entry.Follows
+		}
 		out = append(out, wire)
 	}
 	return &out

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29657,6 +29657,9 @@ type ProviderCategoryCost struct {
 	// Cost Credits charged per pool, worst case, the fallback included. Empty when free.
 	Cost map[string]int `json:"cost"`
 
+	// Follows The category whose EMPTY answer triggers this one, for a category that is a fallback rather than a purchase of its own. Surfe's personal email is the case: the cascade fires only when the professional address comes back with nothing, so a request naming the fallback alone never issues it and the server refuses it. Sent beside `requires` because the two are different relations with the same consequence for a button — ask for both or neither — and `cost` already prices the pair.
+	Follows *string `json:"follows,omitempty"`
+
 	// Free Automatic enrichment buys exactly these; everything else waits for a human to press a button.
 	Free bool `json:"free"`
 

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -11,6 +11,8 @@ package integrations
 
 import (
 	"maps"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -102,6 +104,54 @@ func TestAFallbackIsPricedWithTheCategoryThatTriggersIt(t *testing.T) {
 	if fallback.Cost["email"] != 3 {
 		t.Errorf("personal_email costs %v, want the trigger's 1 plus the fallback's 2", fallback.Cost)
 	}
+}
+
+// The catalog PRICES a category together with everything the provider will
+// issue alongside it, and it has to NAME that same set — the price is on a
+// button whose press sends what the names say. The two came apart once: the
+// wire carried the prerequisite and said nothing about a cascade trigger, so
+// the personal-email button quoted three credits and posted one category,
+// which the server refused every time.
+//
+// Derived from pricedWith rather than listed, so a third relation added there
+// fails here instead of shipping as another silent short request.
+func TestTheCatalogNamesEveryCategoryItPricesWith(t *testing.T) {
+	for _, adapter := range []provider.Adapter{NewOfflineProvider(0, time.Now)} {
+		desc := adapter.Descriptor()
+		t.Run(desc.Name, func(t *testing.T) {
+			named := map[string][]string{}
+			for _, entry := range catalogOf(desc) {
+				named[entry.Category] = namedWith(entry)
+			}
+			for _, category := range desc.Categories {
+				priced := make([]string, 0, 3)
+				for _, c := range pricedWith(desc, category) {
+					priced = append(priced, string(c))
+				}
+				sort.Strings(priced)
+				got := named[string(category)]
+				sort.Strings(got)
+				if !slices.Equal(got, priced) {
+					t.Errorf("catalog names %v for %q, and the price is the worst case of %v: "+
+						"a button quoting one set and sending the other spends what nobody agreed to",
+						got, category, priced)
+				}
+			}
+		})
+	}
+}
+
+// namedWith is what a buy button reads off one catalog entry — the same set
+// frontend/src/screens/personprovider.tsx builds from the wire.
+func namedWith(entry CategoryCost) []string {
+	out := []string{entry.Category}
+	if entry.Requires != "" {
+		out = append(out, entry.Requires)
+	}
+	if entry.Follows != "" {
+		out = append(out, entry.Follows)
+	}
+	return out
 }
 
 func TestAProviderThatGivesNothingAwayStillConnects(t *testing.T) {

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -75,6 +75,9 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 		if err := prerequisitesAreFlat(d); err != nil {
 			return nil, err
 		}
+		if err := oneCascadePerFallback(d); err != nil {
+			return nil, err
+		}
 		if d.EgressHost == "" {
 			return nil, fmt.Errorf("integrations: provider %q declared no egress host", d.Name)
 		}
@@ -179,6 +182,34 @@ func prerequisitesAreFlat(d provider.Descriptor) error {
 					"map walks one hop, so the chain would be priced and requested short and refused by the server",
 				d.Name, category, prerequisite, next)
 		}
+	}
+	return nil
+}
+
+// oneCascadePerFallback refuses a descriptor declaring two cascades for the
+// same fallback category.
+//
+// The catalog PRICES a fallback with every trigger that can fire it and NAMES
+// one — Follows is a single category, because a button asks for a pair. With two
+// declared, the price would cover both triggers while the press sent one, and
+// the server would refuse the press for the trigger left out: a button quoting a
+// number nobody can spend.
+//
+// Refused where the author can see it rather than carried on the wire as a list,
+// for the reason pricedWith gives about hops: the shape nobody has written is
+// not the shape to build for, and this is the error that says so when somebody
+// does. TestTheCatalogNamesEveryCategoryItPricesWith is the backstop underneath
+// it — it fails on any descriptor whose named set and priced set differ.
+func oneCascadePerFallback(d provider.Descriptor) error {
+	after := make(map[provider.Category]provider.Category, len(d.Cascades))
+	for _, cascade := range d.Cascades {
+		if first, seen := after[cascade.Category]; seen {
+			return fmt.Errorf(
+				"integrations: provider %q declares %q as a fallback after both %q and %q: the catalog prices "+
+					"a fallback with every trigger and names one, so the button would quote both and ask for one",
+				d.Name, cascade.Category, first, cascade.After)
+		}
+		after[cascade.Category] = cascade.After
 	}
 	return nil
 }

--- a/backend/internal/modules/integrations/registrymatch_test.go
+++ b/backend/internal/modules/integrations/registrymatch_test.go
@@ -171,3 +171,51 @@ func TestAPrerequisiteChainIsRefusedAtRegistration(t *testing.T) {
 		})
 	}
 }
+
+// cascadingTo replaces a descriptor's cascades, so a case can declare the graph
+// an author would write by hand.
+type cascadingTo struct {
+	provider.Adapter
+	cascades []provider.Cascade
+}
+
+func (c cascadingTo) Descriptor() provider.Descriptor {
+	d := c.Adapter.Descriptor()
+	d.Cascades = c.cascades
+	return d
+}
+
+// Two cascades for one fallback are refused where the author declares them.
+//
+// The catalog prices a fallback with EVERY trigger that can fire it and names
+// ONE, because a buy button asks for a pair. Declared twice, the button quotes
+// the price of both triggers and posts one, and the server refuses the press
+// for the trigger left out — a number on a button that nobody can spend.
+func TestTwoCascadesForOneFallbackAreRefusedAtRegistration(t *testing.T) {
+	t.Parallel()
+
+	// The shipped fake registers as it is, so the case below is not passing
+	// over a descriptor refused for some other reason.
+	shipped := NewOfflineProvider(0, time.Now).Descriptor()
+	if len(shipped.Cascades) == 0 {
+		t.Fatal("the shipped fake declares no cascade, so no dev stack or test exercises this rule")
+	}
+	if _, err := NewRegistry(NewOfflineProvider(0, time.Now)); err != nil {
+		t.Fatalf("the shipped adapter is refused by its own rule: %v", err)
+	}
+
+	_, err := NewRegistry(cascadingTo{
+		Adapter: NewOfflineProvider(0, time.Now),
+		cascades: []provider.Cascade{
+			{Category: "personal_email", After: "professional_email", Cost: map[provider.Pool]int{"email": 2}},
+			{Category: "personal_email", After: "linkedin_profile", Cost: map[provider.Pool]int{"email": 2}},
+		},
+	})
+	if err == nil {
+		t.Fatal("an adapter declaring one fallback after two triggers registered: the catalog would price " +
+			"both and name one, and every press of that button is refused")
+	}
+	if !strings.Contains(err.Error(), "linkedin_profile") {
+		t.Errorf("the refusal does not name the second trigger, so an author cannot act on it: %v", err)
+	}
+}

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -134,6 +134,14 @@ type CategoryCost struct {
 	// empty when there is none. A buy button asks for both or neither, and
 	// Cost above is already the price of the pair.
 	Requires string
+	// Follows names the category whose empty answer triggers this one, for a
+	// fallback rather than a purchase of its own — empty when there is none.
+	// The consequence for a button is the same as Requires, and so is the
+	// pricing: pricedWith walks both, so Cost is the price of the pair either
+	// way. Carried separately because the two are different relations, and a
+	// message telling somebody why their request was refused has to name the
+	// right one.
+	Follows string
 }
 
 // Connection is one provider's connection as the surfaces read it. It carries
@@ -376,6 +384,7 @@ func catalogOf(d provider.Descriptor) []CategoryCost {
 			Free:     free[category],
 			Cost:     priced,
 			Requires: string(d.RequiresAnswerTo[category]),
+			Follows:  string(triggerOf(d, category)),
 		})
 	}
 	return out
@@ -406,6 +415,21 @@ func pricedWith(d provider.Descriptor, category provider.Category) []provider.Ca
 		out = append(out, prerequisite)
 	}
 	return out
+}
+
+// triggerOf names the category whose empty answer fires this one as a
+// fallback, or "" where it is not a fallback at all.
+//
+// Read off the same Cascades that pricedWith walks: the catalog's price and
+// the catalog's pairing must come from one declaration, or a button prices a
+// pair and sends one half — which is precisely what shipped.
+func triggerOf(d provider.Descriptor, category provider.Category) provider.Category {
+	for _, cascade := range d.Cascades {
+		if cascade.Category == category {
+			return cascade.After
+		}
+	}
+	return ""
 }
 
 func categoriesFrom(raw []string) []provider.Category {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16782,6 +16782,8 @@ export interface components {
             };
             /** @description Another category this one is only looked up alongside, because the provider skips it entirely when that one comes back empty. Surfe's mobile lookup is the case: asked for on its own it makes the vendor hunt for an email nobody bought, fail, and skip the number — returning a run that COMPLETED with nothing in it. A buy button asks for both or neither; the server refuses the lone request. */
             requires?: string | null;
+            /** @description The category whose EMPTY answer triggers this one, for a category that is a fallback rather than a purchase of its own. Surfe's personal email is the case: the cascade fires only when the professional address comes back with nothing, so a request naming the fallback alone never issues it and the server refuses it. Sent beside `requires` because the two are different relations with the same consequence for a button — ask for both or neither — and `cost` already prices the pair. */
+            follows?: string | null;
         };
         /** @description How much of the installation is still waiting to be looked up once, and whether the sweep is moving. A count without the paused flag reads as progress that has stalled; the two together say whether waiting is the right thing to do. */
         ProviderLookupBacklog: {

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -415,6 +415,16 @@ describe("the details that cost credits", () => {
       cost: { mobile: 1, email: 1 },
       requires: "professional_email",
     },
+    // The OTHER pairing, and a different relation: the personal address is a
+    // fallback the vendor issues only when the professional pass comes back
+    // empty. Priced at the trigger's credit plus the fallback's two, which is
+    // what the server reserves for the pair.
+    {
+      category: "personal_email",
+      free: false,
+      cost: { email: 3 },
+      follows: "professional_email",
+    },
   ];
 
   function mountWithCatalog(
@@ -718,6 +728,39 @@ describe("the details that cost credits", () => {
     // Nothing left to look for, so no offer — and in particular not a
     // two-credit button that would buy both again.
     expect(screen.queryByRole("button", { name: /^Buy / })).toBeNull();
+  });
+
+  // A fallback is not a purchase of its own. Surfe issues the personal address
+  // only when the professional pass returns nothing, so a press naming it alone
+  // is refused every time — "personal_email is a fallback for professional_email
+  // and cannot be bought without it" — while the button beside it quoted the
+  // price of both. The catalog says which category triggers it, and the press
+  // names the pair the price is for.
+  it("sends the trigger alongside a fallback the provider only issues after it", async () => {
+    const user = userEvent.setup();
+    const posted = mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+      // The fallback switched on and the mobile off, so the row under test is
+      // the cascade rather than the prerequisite beside it.
+      {
+        linkedin_profile: true,
+        professional_email: true,
+        personal_email: true,
+      },
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Buy work email and personal email · 3 credits/,
+      }),
+    );
+
+    await expect.poll(() => posted.length).toBe(1);
+    expect(posted[0]).toEqual({
+      provider: "surfe",
+      categories: ["professional_email", "personal_email"],
+    });
   });
 
   it("names the free categories when the plain lookup button is pressed", async () => {

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -374,7 +374,7 @@ function BuyPriced({
 }
 
 /** What one press actually asks for: the category, and the one it can only be
- *  looked up alongside.
+ *  bought alongside.
  *
  *  Surfe's mobile lookup is the case. Asked for on its own, the provider hunts
  *  for an email nobody bought, fails, and skips the number — returning a run
@@ -396,7 +396,20 @@ function BuyPriced({
 function boughtWith(
   entry: components["schemas"]["ProviderCategoryCost"],
 ): string[] {
-  return entry.requires ? [entry.requires, entry.category] : [entry.category];
+  // The mirror of `pricedWith` (backend/internal/modules/integrations/store.go):
+  // the category itself, the trigger whose EMPTY answer fires it as a fallback,
+  // and the prerequisite it needs an answer from. Two different relations with
+  // one consequence — the server refuses a request missing either — and `cost`
+  // is already the price of the whole set, so a press naming less would quote a
+  // pair and buy one half of it.
+  //
+  // Both are walked, not the first that answers: nothing refuses a descriptor
+  // declaring a category with each, and the price would then name three
+  // categories while the press named two.
+  const alongside = [entry.follows, entry.requires].filter(
+    (category): category is string => Boolean(category),
+  );
+  return [...new Set([...alongside, entry.category])];
 }
 
 /** The credits one category costs, summed across pools. A category priced in


### PR DESCRIPTION
Closes #3575.

## The defect

`personal_email` is a **cascade**, not a category with a prerequisite: Surfe issues it only when the professional pass comes back empty. `requireCascadeTriggers` refuses a request naming it alone —

```
integrations: that is not a purchase this run can make: "personal_email" is a fallback
for "professional_email" and cannot be bought without it
```

— and the button posted exactly that. `boughtWith` followed `requires`, which names a prerequisite, and the wire carried nothing about a cascade trigger, so the frontend had no way to derive the pairing. Meanwhile the catalog already priced the pair (`email: 3` — one credit for the trigger plus two for the fallback), so the button quoted two categories and sent one. `full` is `DefaultPreset` and carries the category, so an installation on defaults renders that button.

## The fix

`ProviderCategoryCost` gains `follows` beside `requires`, populated in `catalogOf` from the same `Descriptor.Cascades` that `pricedWith` already walks for the price. `boughtWith` names both relations rather than the first that answers — nothing refuses a descriptor declaring a category with each, and picking one would reintroduce the same short request one hop over.

`requires` and `follows` stay separate fields because they are different relations: the server's two refusals name different ones, and a message telling somebody why their press was rejected has to be right about which.

Contract regenerated on both sides (`make gen`, `pnpm gen:api`) and committed.

## Tests

**`TestTheCatalogNamesEveryCategoryItPricesWith`** (`catalog_test.go`) derives the obligation instead of listing it: for every registered adapter and every category, the set the catalog *names* — the entry plus `requires` plus `follows` — must equal the set `pricedWith` computes the price from. That is the invariant that came apart, stated so a third relation added to the price fails here rather than shipping as another silent short request.

**`sends the trigger alongside a fallback the provider only issues after it`** (`personprovider.test.tsx`) presses the personal-email button on a catalog entry carrying `follows` and asserts the posted body is `["professional_email", "personal_email"]`.

Mutation-checked both ways: dropping `Follows` from `catalogOf` fails the backend test with `catalog names [personal_email] ... and the price is the worst case of [personal_email professional_email]`; dropping `entry.follows` from `boughtWith` fails the frontend one.

`make check-go` green. `make check-fe` green apart from `voice-corpus-file.test.ts` ("extracts the text of a PDF"), which timed out under a parallel suite on this machine and passes on its own — that file is untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fallback provider categories that are triggered when a primary category returns no result.
  - Catalog entries now identify their fallback relationships alongside existing requirements.
  - Purchasing a category automatically includes any required trigger and fallback categories in the request.
  - Requests for fallback categories without their triggering category are rejected by the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->