### PR TITLE
fix(authz): the link-target probe holds the row it answers about

### DIFF
--- a/backend/internal/modules/people/linktargetlock_integration_test.go
+++ b/backend/internal/modules/people/linktargetlock_integration_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// auth.EnsureLinkTarget's lock, driven against a real target row.
+//
+// The probe answers "may this caller reference this record, and is it still
+// live", and every caller writes the reference afterwards in the same
+// transaction. What makes the answer still true at the write is a two-
+// transaction claim about a row lock, so it is held here rather than beside the
+// primitive: locking needs a real row, and the auth package's own tests take no
+// database. Its sibling for the exclusive subject lock is
+// subjectlock_integration_test.go.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+)
+
+func TestAProbedLinkTargetMakesTheArchiveWait(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Marit Fossum", "marit@held.test", "Fossum AS", "held.test")
+
+	held, release := make(chan struct{}), make(chan struct{})
+	holding := make(chan error, 1)
+	// once, because WithWorkspaceTx may run the closure again and a second
+	// close would panic in a goroutine the test cannot recover.
+	var announce sync.Once
+	go func() {
+		holding <- e.store.tx(ctx, func(tx pgx.Tx) error {
+			if err := auth.EnsureLinkTarget(ctx, tx, entityPerson, personID.UUID); err != nil {
+				return err
+			}
+			announce.Do(func() { close(held) })
+			<-release
+			return nil
+		})
+	}()
+	// Either outcome, never just the good one: a probe that FAILED sends on
+	// holding and closes nothing, so waiting on held alone would hang to the
+	// package timeout and report a deadline where the real answer is one line
+	// of error text.
+	select {
+	case <-held:
+	case err := <-holding:
+		t.Fatalf("the probe failed, so this proves nothing about the archive: %v", err)
+	}
+
+	// No sleep and no clock: the archive's own lock_timeout reports the
+	// blocking, and it can only fire while something holds the row.
+	archive := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '2s'`); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `UPDATE person SET archived_at = now() WHERE id = $1`, personID)
+		return err
+	})
+	close(release)
+	if err := <-holding; err != nil {
+		t.Fatalf("the probe itself failed, so this proves nothing about the archive: %v", err)
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(archive, &pgErr) || pgErr.Code != "55P03" {
+		t.Fatalf("the archive got %v, want a lock timeout (55P03) — FOR SHARE must conflict with it, "+
+			"or every reference written after this probe can still land on a record archived in between",
+			archive)
+	}
+}
+
+// The other half of the pairing, and the reason the lock is SHARE rather than
+// exclusive: a person mid-ingest is referenced by every message captured for
+// them, and two references onto one record are not in conflict. An exclusive
+// lock here would be correct and would serialize the whole of capture behind
+// one contact.
+func TestTwoReferencesOntoOneRecordDoNotWaitForEachOther(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Sindre Vang", "sindre@shared.test", "Vang AS", "shared.test")
+
+	held, release := make(chan struct{}), make(chan struct{})
+	holding := make(chan error, 1)
+	var announce sync.Once
+	go func() {
+		holding <- e.store.tx(ctx, func(tx pgx.Tx) error {
+			if err := auth.EnsureLinkTarget(ctx, tx, entityPerson, personID.UUID); err != nil {
+				return err
+			}
+			announce.Do(func() { close(held) })
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-held:
+	case err := <-holding:
+		t.Fatalf("the first probe failed, so this proves nothing about the second: %v", err)
+	}
+
+	// The same lock_timeout the archive above trips on. Here it must NOT fire.
+	second := e.store.tx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '2s'`); err != nil {
+			return err
+		}
+		return auth.EnsureLinkTarget(ctx, tx, entityPerson, personID.UUID)
+	})
+	close(release)
+	if err := <-holding; err != nil {
+		t.Fatalf("the first probe failed: %v", err)
+	}
+	if second != nil {
+		t.Fatalf("the second probe got %v, want it to pass while the first still holds the row: "+
+			"a shared lock is what keeps concurrent references off each other's queue", second)
+	}
+}

--- a/backend/internal/platform/auth/linkscope.go
+++ b/backend/internal/platform/auth/linkscope.go
@@ -14,12 +14,20 @@ package auth
 //     READ IT when its audience is limited (ActivityContentClause).
 //   - MAY I BE TOLD WHAT IT IS ABOUT: per link, because the any-link answer
 //     above does not license disclosing the other records it touches.
+//   - MAY I POINT A LINK AT THIS RECORD: EnsureLinkTarget, the write-side
+//     question, which the FK cannot answer because it is checked as the table
+//     owner and carries no row scope at all.
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -101,4 +109,64 @@ func linkTargetArm(alias, column, table, probe, predicate string) string {
 	}
 	return fmt.Sprintf(`(%[1]s.%[2]s IS NOT NULL AND EXISTS (SELECT 1 FROM %[3]s %[4]s WHERE %[4]s.id = %[1]s.%[2]s AND %[5]s))`,
 		alias, column, table, probe, predicate)
+}
+
+// EnsureLinkTarget verifies an activity link's target row exists AND is
+// visible to the caller — an explicit row-scope probe, because the FK that
+// would otherwise catch a bad id is checked as the table owner and carries
+// no row scope at all: it accepts any id that exists, so without this a
+// guessed foreign UUID would persist a link to a record the caller may not
+// read. A link to an archived record is equally refused: the link would
+// outlive the row it names.
+//
+// It HOLDS the row it answers about, and that is what separates it from
+// EnsureVisibleLive. Every caller writes the reference afterwards, in the same
+// transaction: probe, then insert. Read unlocked, an archive committing in
+// between makes the answer stale before it is used, and the reference lands on
+// a record that is no longer live — the TOCTOU storekit.LockRow's own doc warns
+// against, on the target side. Under READ COMMITTED the lock is also the
+// re-check: a waiter wakes on the archived row and the liveness filter refuses
+// it, rather than acting on what it read before waiting.
+//
+// FOR SHARE, and the pairing is the point. It conflicts with the archive, which
+// UPDATEs the row, while two references onto one record do not conflict and have
+// no reason to queue behind each other — a person mid-ingest is referenced by
+// every message captured for them. The same pairing the activity_link trigger
+// takes on the activity it is about (migration 1788000100).
+//
+// Taken in the probe rather than at each write, unlike LockSubjectLive next door
+// in writescope.go. That lock is exclusive and would add an edge to two dozen
+// documented lock orders at once; this one is shared, so it orders nothing
+// against another reference and only ever waits for a writer of the very row
+// being referenced. Against that, forty call sites would each have to remember,
+// and the one that forgot would look exactly like the thirty-nine that did not.
+//
+// The few read paths that call this for its existence half — a contract listing
+// under an organization, a relationship read under its anchor — pay for it too:
+// they hold that one anchor for the length of a short read, which delays an
+// archive of it and blocks nothing else. That is the price of the probe having
+// one meaning.
+func EnsureLinkTarget(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+
+	clause, err := ScopeClauseFor(ctx, table, "", arg)
+	if err != nil {
+		return err
+	}
+	q := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $%d AND archived_at IS NULL`, table, idPos)
+	if clause != "" {
+		q += " AND " + clause
+	}
+	q += " FOR SHARE"
+
+	var held int
+	if err := tx.QueryRow(ctx, q, args...).Scan(&held); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		return err
+	}
+	return nil
 }

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -365,8 +365,57 @@ func EnsureVisibleForSubjectRights(ctx context.Context, tx pgx.Tx, table string,
 // guessed foreign UUID would persist a link to a record the caller may not
 // read. A link to an archived record is equally refused: the link would
 // outlive the row it names.
+//
+// It HOLDS the row it answers about, and that is what separates it from
+// EnsureVisibleLive. Every caller writes the reference afterwards, in the same
+// transaction: probe, then insert. Read unlocked, an archive committing in
+// between makes the answer stale before it is used, and the reference lands on
+// a record that is no longer live — the TOCTOU storekit.LockRow's own doc warns
+// against, on the target side. Under READ COMMITTED the lock is also the
+// re-check: a waiter wakes on the archived row and the liveness filter refuses
+// it, rather than acting on what it read before waiting.
+//
+// FOR SHARE, and the pairing is the point. It conflicts with the archive, which
+// UPDATEs the row, while two references onto one record do not conflict and have
+// no reason to queue behind each other — a person mid-ingest is referenced by
+// every message captured for them. The same pairing the activity_link trigger
+// takes on the activity it is about (migration 1788000100).
+//
+// Taken in the probe rather than at each write, unlike LockSubjectLive next door
+// in writescope.go. That lock is exclusive and would add an edge to two dozen
+// documented lock orders at once; this one is shared, so it orders nothing
+// against another reference and only ever waits for a writer of the very row
+// being referenced. Against that, forty call sites would each have to remember,
+// and the one that forgot would look exactly like the thirty-nine that did not.
+//
+// The few read paths that call this for its existence half — a contract listing
+// under an organization, a relationship read under its anchor — pay for it too:
+// they hold that one anchor for the length of a short read, which delays an
+// archive of it and blocks nothing else. That is the price of the probe having
+// one meaning.
 func EnsureLinkTarget(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
-	return EnsureVisibleLive(ctx, tx, table, id)
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+
+	clause, err := ScopeClauseFor(ctx, table, "", arg)
+	if err != nil {
+		return err
+	}
+	q := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $%d AND archived_at IS NULL`, table, idPos)
+	if clause != "" {
+		q += " AND " + clause
+	}
+	q += " FOR SHARE"
+
+	var held int
+	if err := tx.QueryRow(ctx, q, args...).Scan(&held); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 // VisibleTo probes whether one row passes the caller's row scope WITHOUT

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -358,66 +358,6 @@ func EnsureVisibleForSubjectRights(ctx context.Context, tx pgx.Tx, table string,
 	return nil
 }
 
-// EnsureLinkTarget verifies an activity link's target row exists AND is
-// visible to the caller — an explicit row-scope probe, because the FK that
-// would otherwise catch a bad id is checked as the table owner and carries
-// no row scope at all: it accepts any id that exists, so without this a
-// guessed foreign UUID would persist a link to a record the caller may not
-// read. A link to an archived record is equally refused: the link would
-// outlive the row it names.
-//
-// It HOLDS the row it answers about, and that is what separates it from
-// EnsureVisibleLive. Every caller writes the reference afterwards, in the same
-// transaction: probe, then insert. Read unlocked, an archive committing in
-// between makes the answer stale before it is used, and the reference lands on
-// a record that is no longer live — the TOCTOU storekit.LockRow's own doc warns
-// against, on the target side. Under READ COMMITTED the lock is also the
-// re-check: a waiter wakes on the archived row and the liveness filter refuses
-// it, rather than acting on what it read before waiting.
-//
-// FOR SHARE, and the pairing is the point. It conflicts with the archive, which
-// UPDATEs the row, while two references onto one record do not conflict and have
-// no reason to queue behind each other — a person mid-ingest is referenced by
-// every message captured for them. The same pairing the activity_link trigger
-// takes on the activity it is about (migration 1788000100).
-//
-// Taken in the probe rather than at each write, unlike LockSubjectLive next door
-// in writescope.go. That lock is exclusive and would add an edge to two dozen
-// documented lock orders at once; this one is shared, so it orders nothing
-// against another reference and only ever waits for a writer of the very row
-// being referenced. Against that, forty call sites would each have to remember,
-// and the one that forgot would look exactly like the thirty-nine that did not.
-//
-// The few read paths that call this for its existence half — a contract listing
-// under an organization, a relationship read under its anchor — pay for it too:
-// they hold that one anchor for the length of a short read, which delays an
-// archive of it and blocks nothing else. That is the price of the probe having
-// one meaning.
-func EnsureLinkTarget(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) error {
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	idPos := arg(id)
-
-	clause, err := ScopeClauseFor(ctx, table, "", arg)
-	if err != nil {
-		return err
-	}
-	q := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $%d AND archived_at IS NULL`, table, idPos)
-	if clause != "" {
-		q += " AND " + clause
-	}
-	q += " FOR SHARE"
-
-	var held int
-	if err := tx.QueryRow(ctx, q, args...).Scan(&held); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return apperrors.ErrNotFound
-		}
-		return err
-	}
-	return nil
-}
-
 // VisibleTo probes whether one row passes the caller's row scope WITHOUT
 // erroring — for the dedupe pre-checks, which must answer 409 either way
 // but may only disclose the existing row's id when the caller could read


### PR DESCRIPTION
Closes #3561.

## The defect

`EnsureLinkTarget` is every reference gate's target check: it answers that the row exists, is live, and is visible to the caller. It read that row **unlocked**, and every caller writes the reference afterwards in the same transaction — probe, then insert.

Under READ COMMITTED an archive committing in between makes the answer stale before it is used, and the reference lands on a record that is no longer live. That is the TOCTOU `storekit.LockRow`'s own doc warns against, on the target side of a relink rather than the activity side.

## The fix

The probe now takes `FOR SHARE` on the row it validates, in the same statement as the liveness filter and the row scope. The lock is also the re-check: a waiter wakes on the archived row and the filter refuses it, rather than acting on what it read before waiting.

**SHARE, not exclusive.** It conflicts with the archive, which UPDATEs the row, while two references onto one record do not conflict and have no reason to queue behind each other — a person mid-ingest is referenced by every message captured for them. That is the same pairing the `activity_link` trigger already takes on the activity it is about (migration `1788000100`).

**In the probe rather than at each write**, unlike `LockSubjectLive` next door in `writescope.go`. That lock is exclusive, and its own comment explains why it is taken at the write: it would add an edge to two dozen documented lock orders at once. A shared lock orders nothing against another reference and only ever waits for a writer of the very row being referenced. Against that, forty call sites would each have to remember, and the one that forgot would look exactly like the thirty-nine that did not — so this fixes every reference gate in the tree rather than the relink doors alone, and there is no census to keep.

The few read paths that call this for its existence half (a contract listing under an organization, a relationship read under its anchor) hold that one anchor for the length of a short read. That is stated in the comment rather than left for the next reader to find.

## Tests

`backend/internal/modules/people/linktargetlock_integration_test.go`, beside `subjectlock_integration_test.go` for the same reason it gives — locking needs a real row, and the auth package's own tests take no database:

- **`TestAProbedLinkTargetMakesTheArchiveWait`** — the probe is held open in one transaction; a concurrent `UPDATE person SET archived_at` under `lock_timeout = '2s'` must fail 55P03. No sleep and no clock: the timeout can only fire while something holds the row.
- **`TestTwoReferencesOntoOneRecordDoNotWaitForEachOther`** — the same timeout must *not* fire for a second probe of the same row, which is what makes SHARE the right mode rather than a correct-but-serializing exclusive one.

Mutation-checked both ways: removing the locking clause fails the first (`the archive got <nil>`); changing it to `FOR UPDATE` fails the second (`canceling statement due to lock timeout`).

`make check-go` green. `make test-integration` has three failures on this branch — `compose/integration/e2e/usecases` (`the complaint is dated September and the record says October`), `modules/approvals` (`marked 2 approval(s)`) and `modules/integrations` (`an employer linked after the no-identifiers skip was NOT re-selected`). All three reproduce on `origin/main` with none of this change applied, so they are not from the lock; a lock defect would surface as a timeout or a deadlock rather than a wrong month or a wrong count.