### PR TITLE
fix(agents): a read-resolved tier carries its reading into the write

### DIFF
--- a/backend/gates/agentwritepin_test.go
+++ b/backend/gates/agentwritepin_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A tool whose tier is resolved by READING a record carries that reading's
+// version into its write.
+//
+// The dynamic tier is a verdict about a record as it was: the resolver reads it,
+// the gate admits or refuses on that reading, and the read commits before the
+// write opens. An agent controls both sides of that window — its own 🟢 tools can
+// commit inside it — so a write that names no version lands on a row the verdict
+// never described. `pinForWrite` is the one place that decides what a write is
+// conditioned on: the caller's own pin, the version a released approval was
+// granted against, or the version the gate read. Whichever it is, the store then
+// re-checks it under the row lock, which is where the window actually closes.
+//
+// The corpus is derived from the RESOLVER rather than listed: a tool declares
+// `ResolverInput` exactly when its tier comes from a read, so a fourth one added
+// later is subject by construction rather than by somebody remembering. The
+// three today — relink_activity, progress_deal, advance_deal — all pass, which is
+// why this is a fence around a property that holds rather than a report of a
+// break.
+//
+// What it cannot see: that the pin reaches the store unchanged, and that the
+// store compares it under a lock. Those are one type-checked argument and
+// relinkbatch.go's own tests, not something a source walk can add to.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	// The method a tool declares when its tier is decided from a record read.
+	tierResolver = "ResolverInput"
+	// The method that performs the call once a tier admits it.
+	toolHandle = "Handle"
+	// The one place a write's version condition is decided.
+	writePin = "pinForWrite"
+)
+
+func TestEveryReadResolvedToolPinsItsWrite(t *testing.T) {
+	t.Parallel()
+
+	resolvers, handlers := agentToolMethods(t)
+	if len(resolvers) == 0 {
+		t.Fatal("no tool declares " + tierResolver + " — either the resolver hook was renamed and " +
+			"this gate now reads nothing, or the scan is looking in the wrong tree. A census that " +
+			"finds no subject cannot report a pass.")
+	}
+	for _, tool := range sortedKeys(resolvers) {
+		body, handled := handlers[tool]
+		if !handled {
+			t.Errorf("%s resolves a tier from a record read and declares no %s: the reading is taken "+
+				"and nothing consumes it.", tool, toolHandle)
+			continue
+		}
+		if !strings.Contains(body, writePin+"(") {
+			t.Errorf("%s resolves its tier by reading the record and writes without %s, so its write "+
+				"names no version. The resolver's verdict describes the record as it was; a write with "+
+				"nothing to condition it on lands on whatever the row has become, and the agent controls "+
+				"both sides of that window.", tool, writePin)
+		}
+	}
+}
+
+// agentToolMethods answers the receiver types declaring a tier resolver, and
+// the body of every Handle keyed by the same receiver.
+//
+// Keyed by receiver rather than by file: a tool's two methods routinely sit
+// apart, and the pairing is what the rule is about.
+func agentToolMethods(t *testing.T) (resolvers map[string]bool, handlers map[string]string) {
+	t.Helper()
+	dir := filepath.Join(repoRoot, "backend", "internal", "modules", "agents")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	resolvers, handlers = map[string]bool{}, map[string]string{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		source := string(raw)
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, source, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Recv == nil || len(fn.Recv.List) != 1 {
+				continue
+			}
+			receiver := receiverType(fn.Recv.List[0].Type)
+			if receiver == "" {
+				continue
+			}
+			switch fn.Name.Name {
+			case tierResolver:
+				resolvers[receiver] = true
+			case toolHandle:
+				handlers[receiver] = source[fset.Position(fn.Body.Pos()).Offset:fset.Position(fn.Body.End()).Offset]
+			}
+		}
+	}
+	return resolvers, handlers
+}
+
+// receiverType names the type a method hangs on, through a pointer receiver and
+// through a generic one. An unrecognised shape answers "" rather than a guess:
+// a census that invented a name would pair two methods that are not siblings.
+func receiverType(expr ast.Expr) string {
+	switch node := expr.(type) {
+	case *ast.StarExpr:
+		return receiverType(node.X)
+	case *ast.IndexExpr:
+		return receiverType(node.X)
+	case *ast.IndexListExpr:
+		return receiverType(node.X)
+	case *ast.Ident:
+		return node.Name
+	default:
+		return ""
+	}
+}

--- a/backend/internal/modules/activities/relinkbatch.go
+++ b/backend/internal/modules/activities/relinkbatch.go
@@ -259,6 +259,16 @@ func relinkedChangedFields(entityType string, entityID ids.UUID) crmcontracts.Pu
 // No pin is the ordinary case and is not an error: a human's relink through the
 // app conditions on nothing, and a static-tier agent call has nothing to
 // condition on either.
+//
+// What makes that safe is that the callers who DO owe a version cannot arrive
+// without one. A tier resolved by reading the record is a verdict about the
+// record as it was, and every tool that resolves one takes its pin from
+// agents.pinForWrite — held by TestEveryReadResolvedToolPinsItsWrite
+// (backend/gates/agentwritepin_test.go), which derives its corpus from the
+// resolver hook so a fourth such tool is subject without anybody adding it. The
+// REST door carries the same version as If-Match (compose/agentgate.go). So an
+// absent pin here means nobody read anything to decide this call, not that a
+// reading was taken and dropped.
 func relinkMeetsItsPin(ctx context.Context, tx pgx.Tx, id ids.ActivityID, ifVersion *int64, held bool) error {
 	// held=true skips the compare: every write to a held row is refused by
 	// activity_refuse_restricted_mutation below regardless of version, so a

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -104,12 +104,13 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (112)
+## Census (113)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `activityprojectionfields_test.go` | H2 | Every writer of `Activity.AudienceReason` is named here with the test that proves it withholds the reason from a reader who may not see the content. |
 | `agentgrantscopes_test.go` | H2 | A credential that does not fund the tools its agent declares buys a run that starts, discovers it cannot do its job, and stops. |
+| `agentwritepin_test.go` | H2 | A tool whose tier is resolved by READING a record carries that reading's version into its write. |
 | `aggregateaudience_test.go` | H2 | A reader that COUNTS messages asks the audience, exactly as one that shows them does. |
 | `aggregategatereach_test.go` | H3 | Every job the `ci` aggregate depends on can actually RUN on the merge queue. |
 | `aitaskcensus_test.go` | H3 | The census as a fitness function: the contract says which AI tasks ship and what their invocation sites are called, and this build must register exactly those. |


### PR DESCRIPTION
Closes #3560.

## What the ticket found

`RelinkActivityInput.IfVersion` is optional at the single-relink door, and `relinkMeetsItsPin` returns immediately when it is nil — so a call without a pin runs with no snapshot fence.

## What is actually true

No pin is the ordinary case and is not the defect: a human's relink through the app conditions on nothing, and a static-tier agent call has nothing to condition on either. The case where a pin **is** owed is the dynamic tier — the resolver reads the activity to decide whether the destination may auto-execute, that read commits, and an agent controls both sides of the gap.

Every tool that resolves a tier from a read already takes its pin from `pinForWrite`, which returns the caller's own pin, the version a released approval was granted against, or the version the gate read. The three today (`relink_activity`, `progress_deal`, `advance_deal`) all do. The REST door carries the same version as `If-Match` (`compose/agentgate.go`). So the invariant holds — it was just unheld and unsaid.

The ticket's two options were "require a non-nil `IfVersion` at the door" or "confirm every caller supplies one and add an assertion that says so". The first refuses the ordinary human relink, so this is the second.

## The fix

**`backend/gates/agentwritepin_test.go`** — `TestEveryReadResolvedToolPinsItsWrite`. A tool declares `ResolverInput` exactly when its tier comes from a record read, so the corpus is derived from the resolver hook rather than listed: a fourth such tool is subject by construction rather than by somebody remembering to add it. Each subject's `Handle` must name `pinForWrite`. An empty corpus is a `Fatal`, not a pass — a census that finds no subject has failed short.

**`relinkMeetsItsPin`** now says where the invariant lives, so a reader of "no pin is the ordinary case" learns why that is safe rather than assuming it: an absent pin means nobody read anything to decide this call, not that a reading was taken and dropped.

The gate inventory is regenerated in the same commit.

## Mutation check

Replacing `relinkActivity.Handle`'s `pinForWrite` call with a nil pin fails the gate by name:

```
relinkActivity resolves its tier by reading the record and writes without pinForWrite,
so its write names no version.
```

What the gate cannot see, said in its own doc: that the pin reaches the store unchanged, and that the store compares it under a lock. Those are one type-checked argument and `relinkbatch.go`'s own tests.

`make check-go` green.