### PR TITLE
test(usecases): case 6 reads both dates in one zone

### DIFF
--- a/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case6_ask_the_company_test.go
@@ -203,8 +203,13 @@ func TestCase6BothTheRecordAndTheProseReachTheCaller(t *testing.T) {
 		t.Fatalf("case 6 criterion 2: the complaint email carries no occurred_at; a model holding " +
 			"an undated record and a note that says 'im Oktober' will say October")
 	}
+	// Both sides read in ONE zone. daysAgo answers UTC and pgx hands the column
+	// back in the machine's, so east of UTC the two disagree for the hours that
+	// straddle a month end — 340 days before 2026-09-06 is 30 September in UTC
+	// and 1 October in UTC+7, and the fixture's whole point is which month the
+	// record says. CI runs UTC and never sees it; a contributor's laptop does.
 	wantMonth := daysAgo(complaintDaysAgo).Month()
-	if got := record.OccurredAt.Month(); got != wantMonth {
+	if got := record.OccurredAt.UTC().Month(); got != wantMonth {
 		t.Fatalf("case 6 criterion 2: the complaint is dated %s and the record says %s",
 			wantMonth, got)
 	}


### PR DESCRIPTION
Found while running `make test-integration` for #3561. Not from that change — it reproduces on `origin/main` untouched.

## The defect

`case6_ask_the_company_test.go` compares two times read in different zones:

```go
wantMonth := daysAgo(complaintDaysAgo).Month()   // daysAgo returns time.Now().UTC()
if got := record.OccurredAt.Month(); got != wantMonth {
```

`daysAgo` answers UTC; pgx hands the column back in the machine's zone. East of UTC the two disagree for the hours that straddle a month end — 340 days before 2026-09-06 is **30 September** in UTC and **1 October** in UTC+7 — and which month the record says is the entire fixture (the prose claims "Oktober" and the record is supposed to disagree).

CI runs UTC and structurally cannot see this. A contributor's laptop can:

```
case 6 criterion 2: the complaint is dated September and the record says October
```

on a tree with nothing wrong in it.

## The fix

Read both sides in one zone: `record.OccurredAt.UTC().Month()`.

Verified in both directions — the package passes under `TZ=UTC` and under `TZ=Asia/Bangkok`; before the change it passed under the first and failed under the second.

## Two more of the same class, not fixed here

The same lane has two other tests that pass under `TZ=UTC` and fail under the machine's zone, and I could not diagnose either in the time this fix took:

- `internal/modules/approvals` — `TestAnApprovalTheAgentNeverRedeemedIsMarkedRatherThanLeftSilent`: `marked 2 approval(s), want the one nobody redeemed`
- `internal/modules/integrations` — `TestAnEmployerLinkedAfterNoIdentifiersIsPickedUpAtOnce`: the contact was not re-selected

Filed as #4509 rather than guessed at, because a wrong fix to a clock-dependent test is indistinguishable from a right one on a UTC runner.