### PR TITLE
feat(worklist): a rep can hand on their own task

### DIFF
--- a/frontend/src/screens/worklist.manager.test.tsx
+++ b/frontend/src/screens/worklist.manager.test.tsx
@@ -13,13 +13,14 @@
 
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import { CoachControl, ReassignControl } from "./worklist.manager";
+import { WorklistRow } from "./worklist.row";
 import { jsonResponse, row } from "./worklist.testkit";
 
 afterEach(() => {
@@ -34,7 +35,11 @@ afterEach(() => {
 const LENA = "u-lena";
 const MINH = "u-minh";
 
-function stubRosterAnd(write: (input: Request) => Response | undefined) {
+function stubRosterAnd(
+  write: (input: Request) => Response | undefined,
+  options: { answerMe?: boolean } = {},
+) {
+  const answerMe = options.answerMe ?? true;
   const fetched = vi.fn(async (input: RequestInfo | URL) => {
     const request = input instanceof Request ? input : undefined;
     const url = String(request ? request.url : input);
@@ -43,6 +48,16 @@ function stubRosterAnd(write: (input: Request) => Response | undefined) {
       if (answered) {
         return answered;
       }
+    }
+    // Who is reading. The reassign picker falls back to this when no rep is
+    // selected, so a stub without it leaves the exclusion comparing against
+    // undefined — and the reader is offered their own name.
+    if (url.includes("/me")) {
+      if (!answerMe) {
+        // Pending forever: the holder is never learned.
+        return new Promise<Response>(() => {});
+      }
+      return jsonResponse({ user: { id: LENA, display_name: "Lena Fischer" } });
     }
     if (url.includes("/users")) {
       // The list AND the end of it. `walkRoster` pages until a null cursor, so
@@ -236,5 +251,104 @@ describe("leaving a note on somebody's queue", () => {
       recipient_user_id: LENA,
       kind: "coach_general",
     });
+  });
+});
+
+// Handing work on is not a manager's verb.
+//
+// The control used to be gated on a rep being SELECTED, so a reader looking at
+// their own queue — where nobody is selected — had no way to pass a task along.
+// Dropping that gate is only safe if the picker still refuses the person who
+// already holds the task: with no selection the exclusion had nothing to
+// compare against, and the reader was offered their own name. A press on it
+// posts a reassignment from Lena to Lena, which is a write that changes
+// nothing and reads on screen exactly like one that did.
+describe("a rep hands on their own task", () => {
+  it("offers everyone but the reader, when no rep is selected", async () => {
+    stubRosterAnd(() => undefined);
+    renderUnderAToastRegion(
+      <ReassignControl item={row({ id: "a-1" })} owner="" />,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    );
+    // The listbox is PORTALLED, so its options are not inside the labelled
+    // trigger — reading them through `within(picker)` finds none and the
+    // not-offered assertion below passes over an empty list.
+    await userEvent.click(
+      await screen.findByLabelText(en["worklist.manager.reassignTo"]),
+    );
+    const offered = (await screen.findAllByRole("option")).map(
+      (option) => option.textContent,
+    );
+    expect(offered).toContain("Minh Tran");
+    expect(offered).not.toContain("Lena Fischer");
+  });
+
+  // The window between opening the picker and learning who is reading.
+  //
+  // Nothing on the server refuses a reassignment to the person who already
+  // holds the task, so the client filter is the only guard — and a filter with
+  // nothing to compare against is not one. A reader quick enough to open the
+  // picker before `/me` lands would be offered their own name.
+  it("offers nobody until it knows who is reading", async () => {
+    // `/me` never answers, which is what makes this the WINDOW rather than a
+    // restatement of the test above: with the stub resolving immediately the
+    // holder is known before the picker can open, and removing the guard under
+    // test changes nothing a click can see.
+    const fetched = stubRosterAnd(() => undefined, { answerMe: false });
+    const fetchedRoster = () =>
+      fetched.mock.calls.some(([input]) =>
+        String(input instanceof Request ? input.url : input).includes("/users"),
+      );
+    renderUnderAToastRegion(
+      <ReassignControl item={row({ id: "a-1" })} owner="" />,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    );
+    await userEvent.click(
+      await screen.findByLabelText(en["worklist.manager.reassignTo"]),
+    );
+    // The roster has to have LANDED first, or this passes because nothing has
+    // rendered yet rather than because the guard held. Minh is in the same
+    // answer as Lena, so his absence with the guard in place and his presence
+    // without it is what tells the two apart.
+    await waitFor(() => {
+      expect(fetchedRoster()).toBe(true);
+    });
+    expect(screen.queryByRole("option", { name: "Minh Tran" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "Lena Fischer" })).toBeNull();
+  });
+});
+
+// And the ROW offers it, which is the change this issue was about.
+//
+// The two tests above mount ReassignControl directly, so they hold what the
+// control does with an empty owner and prove nothing about whether the row
+// still hides it. The condition that hid it lived in worklist.row.tsx.
+describe("the row a rep is standing on", () => {
+  it("offers reassign on the reader's own task", async () => {
+    stubRosterAnd(() => undefined);
+    renderUnderAToastRegion(
+      <WorklistRow
+        item={row({ id: "a-1", source: "task" })}
+        position={1}
+        owner=""
+        selected={false}
+        onSelect={() => {}}
+        onReview={() => {}}
+        onOpenEmail={() => {}}
+      />,
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: en["worklist.manager.reassign"],
+      }),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/screens/worklist.manager.tsx
+++ b/frontend/src/screens/worklist.manager.tsx
@@ -18,6 +18,7 @@ import { Button, SegmentedControl } from "../design-system/atoms";
 import { Select } from "../design-system/select";
 import { useToast } from "../design-system/toast";
 import { useT } from "../i18n";
+import { useMe } from "./common";
 import { useRoster } from "./entityref";
 import {
   subjectAcceptsAnOwner,
@@ -107,7 +108,22 @@ export function ReassignControl({
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const [assignee, setAssignee] = useState("");
-  const options = useAssigneeOptions(owner);
+  // Whose queue is being read, which is the person a reassignment moves work
+  // AWAY from. On a rep's drill-down that is the selected rep; on the reader's
+  // own queue nobody is selected and it is the reader. Without the fallback the
+  // exclusion below compares against "" and matches nobody, so a rep was
+  // offered their own name and a press did nothing a reader could see.
+  const me = useMe();
+  const holder = owner !== "" ? owner : me.data?.user?.id;
+  // Nobody is offered until the holder is KNOWN. On the reader's own queue the
+  // holder is whoever `/me` names, and until that lands the exclusion below has
+  // nothing to compare against — so a picker opened in that window would list
+  // the reader's own name, and nothing on the server refuses a reassignment to
+  // the person already holding the task. An empty list is the honest state of a
+  // question not yet answered; a self-reassignment is a write that changes
+  // nothing and looks on screen exactly like one that did.
+  const options = useAssigneeOptions(holder);
+  const settled = holder !== undefined;
   const reassign = useReassignTask();
 
   if (!open) {
@@ -120,7 +136,7 @@ export function ReassignControl({
   return (
     <div className="worklist-manager-control">
       <Select
-        options={options}
+        options={settled ? options : []}
         value={assignee}
         onChange={setAssignee}
         placeholder={t("worklist.manager.reassignTo")}

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -75,8 +75,10 @@ export function WorklistRow({
 }: Readonly<{
   item: WorklistItem;
   position: number;
-  // Whose queue this row is on, empty for the reader's own. A row can only be
-  // handed to somebody else from a page that is already about somebody else.
+  // Whose queue this row is on, empty for the reader's own. It names the
+  // person a reassignment moves work AWAY from, which on the reader's own
+  // queue is the reader — ReassignControl resolves that rather than this
+  // prop carrying it, so an empty value is a real state and not a missing one.
   owner: string;
   // Whether the pane beside the queue is about this row.
   //
@@ -230,8 +232,15 @@ export function WorklistRow({
           drawn beside them rather than among them. */}
         <PinVerb item={item} />
         {/* Only a task carries an assignee, so only a task can be handed on. A
-          group row stands for a pile and names no single activity to move. */}
-        {owner !== "" && item.source === "task" && !item.batch && (
+          group row stands for a pile and names no single activity to move.
+
+          Offered on the reader's OWN queue too: handing work on is not a
+          manager's verb, and gating it on a selected rep left somebody
+          looking at their own list with no way to pass a task along. Who is
+          excluded from the destinations follows the queue rather than this
+          condition — ReassignControl falls back to the reader when no rep is
+          selected, so the current holder is never offered as the new one. */}
+        {item.source === "task" && !item.batch && (
           <ReassignControl item={item} owner={owner} />
         )}
         <RowAnswer item={item} />


### PR DESCRIPTION
Lars decided **5A** on #4441.

Reassign was drawn only when a rep was SELECTED (`owner !== ""` in
`worklist.row.tsx`), so a reader on their own queue had no way to pass a task
along. The verb existed; the viewing context withheld it, and nothing in the
tree said why.

**Dropping that condition alone would have shipped a worse bug.** The
destination picker excludes whoever currently holds the task, and with nobody
selected the exclusion compared against `""`, matched nobody, and offered the
reader their own name. Codex confirmed the server has no guard here: the write
path validates permission, writability and that the assignee exists, but never
compares the new `assignee_id` against the current one — the SQL is a plain
`coalesce` update. So a press would have written a no-op indistinguishable on
screen from a real hand-off.

`ReassignControl` now resolves the holder itself — the selected rep on a
drill-down, whoever `/me` names on the reader's own queue — and offers nobody
until that answer lands.

Closes #4441.

| Obligation | Evidence |
|---|---|
| User-visible outcome | `the row a rep is standing on > offers reassign on the reader's own task` — renders the real `WorklistRow` with `owner=""` and finds the verb. |
| Permission/row scope | Unchanged. The server already refuses a reassignment the caller may not make; this widens no authority, only which rows draw the control. |
| Failure behavior | `offers nobody until it knows who is reading` — `/me` held pending forever, and the picker lists nobody rather than the reader. |
| Idempotency/concurrency | n/a — no new write. The existing mutation is unchanged. |
| Mobile | No layout change; the control sits in the same band as before. |
| Storybook | No new component. |
| Accessibility | Options read through `getAllByRole("option")` on the portalled listbox, so the test asserts what a screen reader reaches. |
| Contract | No contract change. |
| Write shape | n/a — read-side gating only. |
| Mutation strength | Three mutations, three distinct failures: restoring `owner !== ""` fails the row test; dropping the `/me` fallback fails the exclusion test; removing the `settled` guard fails the loading-window test. That last one **passed** its first mutation — the stub resolved `/me` before the click, so the window never opened. It now holds `/me` pending and waits for the roster to land first, which is what makes its absence assertion mean something. |
| Full lane | `make check-fe` EXIT=0, zero failures. Backend untouched. |

Reviewed by Codex (`gpt-5.6-sol`), which found both weaknesses in my tests: the
loading-window test not waiting for the roster before asserting an absence, and
no test proving the row-level condition actually changed. Both fixed here.

Note on CI: `App.test.tsx` and `project360.test.tsx` flaked on one gate run
under load and pass alone. I re-ran the full gate on clean `origin/main`
(EXIT=0) and on this branch (EXIT=0) before believing that — neither file is in
this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows a rep to hand on a task from their own queue. Reassign previously only rendered when a rep was selected on a drill-down, so a reader on their own list had no way to pass a task along; the control now resolves the holder — the selected rep, or the reader via `/me` — and excludes that person from the destination picker. Closes #4441.

**Bug Fixes**
- Dropping the gate alone would have offered the reader their own name, since the picker's exclusion compared against an empty string; nothing on the server refuses a self-reassignment, so that press was an invisible no-op.
- The picker now lists nobody until the holder is known, so the unresolved `/me` window cannot list the reader.
- Only read-side gating changes; the write path is untouched.

<sup>Written for commit 631d4b892cfef605e0c0676291771b4c3ba6b053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reassignment is now available for tasks in the current reader’s own queue.
  * Destination options automatically exclude the current queue holder.

* **Bug Fixes**
  * Prevented users from assigning work back to themselves.
  * Reassignment options remain unavailable until the current queue holder is identified, avoiding incorrect choices while information is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->