### PR TITLE
Who may sign in is asked on its own grant

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10862,6 +10862,61 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /installation/authentication-policy:
+    get:
+      tags: [Identity]
+      operationId: getAuthenticationPolicy
+      security: [ { cookieAuth: [] } ]   # human session only (x-agent-access: human-only)
+      x-agent-access: human-only
+      summary: Which sign-in methods this installation offers.
+      description: |
+        The sign-in half of the installation's settings, read on its own.
+
+        It is a separate operation rather than a field on `GET /installation/settings`
+        because the two have different readers. Every role reads the installation's name,
+        timezone and base currency — a rep reading amounts benefits from knowing the
+        currency. Who may sign in and how is authentication administration, and showing it
+        to every seat that holds `installation_settings.read` would be handing out the shape
+        of the login surface to readers with no business in it.
+
+        The aggregate could not simply carry the narrower grant. Its fields are read through
+        one settings catalog whose entries each declare one object, so gating the sign-in
+        field there would make the WHOLE aggregate demand this grant and take the ordinary
+        installation read down with it. Hence a projection: same values, own gate.
+
+        `sign_in_providers` reports every provider this DEPLOYMENT mounted, each marked with
+        whether the installation has CHOSEN to offer it. Chosen is not the same as working:
+        a provider mounted without a stored OAuth app and without environment credentials
+        is still listed, and still reads as enabled, because this is the screen an operator
+        goes to in order to finish configuring it — the login page withholds it until they
+        do. A client rendering this as "what a visitor sees today" would be wrong. The
+        effective set is
+        the intersection — an admin can only ever narrow what the deployment configured,
+        never invent a client id — and a nil stored choice means every configured provider,
+        so an installation that upgrades into the setting keeps the login screen it had.
+
+        PASSWORD IS NOT LISTED and cannot be disabled. It is the method every installation
+        always has, and the one an admin must not be able to strand everybody by removing.
+
+        Governed by `authentication_policy` for this READ. Two things it does not yet
+        govern, both tracked and both visible from here rather than discovered later:
+        `GET /installation/settings` still returns the same `sign_in_providers` field to
+        any holder of `installation_settings.read`, and `PATCH /installation/settings`
+        still accepts `enabled_oidc_providers` on `installation_settings.update`. Closing
+        either means removing a published field or verb, which is a breaking change and a
+        deprecation cycle rather than an edit. Until then this endpoint is the narrower
+        surface, not a narrower authority.
+
+        Human-only: an agent never reads how humans sign in.
+      responses:
+        '200':
+          description: The sign-in policy.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AuthenticationPolicy' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /installation/settings:
     get:
       tags: [Identity]
@@ -21461,6 +21516,24 @@ components:
             answers sends them to debug a mismatch that was never the cause.
           items:
             $ref: '#/components/schemas/ConnectorAppRedirectUri'
+    AuthenticationPolicy:
+      type: object
+      description: |
+        Which sign-in methods this installation offers, apart from the rest of its settings.
+
+        Carries only what `authentication_policy` governs. The installation's name, timezone
+        and currency are NOT here — every role reads those, and repeating them in a document
+        governed by a narrower grant would make the same fact answer to two authorities.
+      required: [sign_in_providers]
+      properties:
+        sign_in_providers:
+          type: array
+          description: |
+            Every provider this deployment mounted, each marked with whether the
+            installation has chosen to offer it — which is a stored choice, not a
+            guarantee the provider has working credentials. Password is never listed: it
+            is the method every installation always has and cannot switch off.
+          items: { $ref: '#/components/schemas/SignInProvider' }
     SignInProvider:
       type: object
       additionalProperties: false

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -241,6 +241,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/forecast/shared/{token}/export.csv":                         {Op: "exportForecastShare", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/imports/{id}":                                               {Op: "getImportRun", Access: "tool", Tool: "read_import_run", RecordType: "import_run", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/imports/{id}/report":                                        {Op: "getImportRunReport", Access: "tool", Tool: "read_import_report", RecordType: "import_run", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/installation/authentication-policy":                         {Op: "getAuthenticationPolicy", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/installation/license":                                       {Op: "getLicenseEntitlement", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/installation/oauth-apps/{provider}":                         {Op: "getOauthApp", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/installation/seat-usage":                                    {Op: "getSeatUsage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -51,6 +51,35 @@ func (h installationSettingsHandlers) GetInstallationSettings(w http.ResponseWri
 	httperr.WriteJSON(w, http.StatusOK, h.toContract(s))
 }
 
+// GetAuthenticationPolicy answers the sign-in half on its own grant.
+//
+// The values are identical to the `sign_in_providers` field of the aggregate;
+// what differs is who may read them. Every role reads the installation's name,
+// timezone and currency, and who may sign in is not that — so it answers to
+// `authentication_policy`, which the store checks before it reads the entry.
+func (h installationSettingsHandlers) GetAuthenticationPolicy(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		httperr.NotImplemented(w, r, "GetAuthenticationPolicy")
+		return
+	}
+	// Human-only (x-agent-access): an agent never reads how humans sign in.
+	if err := auth.RequireHuman(r.Context()); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	chosen, err := h.store.SignInPolicy(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	// The SAME resolver the aggregate renders and the login screen is served
+	// from, so a reader cannot be told a different answer by asking a different
+	// surface.
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.AuthenticationPolicy{
+		SignInProviders: h.signInProviders(chosen),
+	})
+}
+
 func (h installationSettingsHandlers) UpdateInstallationSettings(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		httperr.NotImplemented(w, r, "UpdateInstallationSettings")

--- a/backend/internal/compose/integration/authentication_policy_integration_test.go
+++ b/backend/internal/compose/integration/authentication_policy_integration_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The sign-in policy read apart from the installation settings around it.
+//
+// `GET /installation/settings` carries the installation's name, timezone and
+// base currency, which every role reads — a rep reading amounts benefits from
+// knowing the currency. It also carried `sign_in_providers`, which is
+// authentication administration and has no business being handed to every seat
+// holding `installation_settings.read`.
+//
+// The obvious fix does not work and this file is built around why. The values
+// come from a settings ENTRY, and the settings catalog gates both verbs on an
+// entry's single object, so repointing EnabledOidcProviders at
+// authentication_policy would make every read of the aggregate demand the new
+// grant — the name, the timezone and the currency with it. So the projection
+// carries the gate and reads the entry as the installation afterwards.
+//
+// That shape puts the whole security of the read in one `auth.Require`: the
+// system principal underneath it bypasses object RBAC entirely. What follows
+// therefore proves three things, and the third is the one a unit test cannot
+// reach:
+//
+//   the grant admits, and its absence refuses
+//   the ordinary installation read still works WITHOUT the new grant
+//   installation_settings.read alone does NOT open the sign-in policy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// authPolicyCtx builds a caller holding exactly the grants named, so a case can
+// state which object it is testing and hold every other one absent. The
+// one-object helper beside it cannot express "installation_settings but not
+// authentication_policy", which is the pair this split turns on.
+func (e *SearchEnv) authPolicyCtx(grants map[string]principal.ObjectGrant) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{Objects: grants, RowScope: principal.RowScopeAll},
+	})
+}
+
+func TestSignInPolicyAnswersItsOwnGrantAndRefusesWithoutIt(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+
+	// Admitted on the new grant alone: the projection does not also require the
+	// aggregate's object, or a reader who may administer sign-in but not rename
+	// the company would be refused.
+	holder := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"authentication_policy": {Read: true},
+	})
+	if _, err := store.SignInPolicy(holder); err != nil {
+		t.Fatalf("an authentication_policy holder was refused the sign-in policy: %v", err)
+	}
+
+	// Refused without it. This is the assertion the system principal underneath
+	// makes load-bearing: with the Require gone, this caller reads the entry as
+	// the installation and the refusal disappears silently.
+	none := e.authPolicyCtx(map[string]principal.ObjectGrant{})
+	if _, err := store.SignInPolicy(none); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("read without a grant returned %v, want ErrPermissionDenied", err)
+	}
+}
+
+// The reason the projection exists rather than a moved entry: the ordinary
+// installation read must keep working for a reader who holds nothing else.
+//
+// If this ever fails, the sign-in split has taken the company name and the
+// reporting currency with it, and every role that reads amounts is looking at a
+// permission error instead.
+func TestTheInstallationReadSurvivesWithoutTheSignInGrant(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+
+	rep := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"installation_settings": {Read: true},
+	})
+	got, err := store.GetInstallation(rep)
+	if err != nil {
+		t.Fatalf("the installation read now demands the sign-in grant: %v", err)
+	}
+	if got.Timezone != "UTC" || got.BaseCurrency != "EUR" {
+		t.Errorf("unset settings read as timezone=%q currency=%q, want the registered defaults UTC/EUR",
+			got.Timezone, got.BaseCurrency)
+	}
+}
+
+// And the other direction, which is the whole point of splitting: holding the
+// aggregate's grant does not carry the sign-in policy with it.
+//
+// Without this case the split could be entirely undone — by gating the
+// projection on installation_settings — and every other test here would still
+// pass.
+func TestTheInstallationGrantDoesNotOpenTheSignInPolicy(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+
+	rep := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"installation_settings": {Read: true, Update: true},
+	})
+	if _, err := store.SignInPolicy(rep); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("installation_settings alone opened the sign-in policy: %v", err)
+	}
+}
+
+// The split is only HALF done, and this records which half.
+//
+// A narrow endpoint beside an aggregate that still hands the same field to every
+// role is a second door onto data nobody closed: `GET /installation/settings`
+// continues to return `sign_in_providers` on `installation_settings.read`, so
+// today the new grant buys a tidier surface and no confidentiality.
+//
+// Closing it means REMOVING a published response field, which
+// `contract-breaking-check` refuses — correctly, since a client reading that
+// field would break. The supported route is to deprecate it, ship a release
+// where both exist, and remove it once clients have moved. That is a product
+// decision about a published contract, not something to slip into this change.
+//
+// This test is written to FAIL when the leak is closed, so the day somebody
+// deprecates and removes the field, the suite says so rather than staying quiet.
+// Until then it asserts the leak is still exactly where it is: no narrower, so
+// nobody believes the split is finished, and no wider.
+func TestTheAggregateStillCarriesTheSignInProvidersUntilItIsDeprecated(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+
+	// A provider must actually be STORED first. With none stored the field is nil
+	// whatever the aggregate does, and this test would pass against a surface
+	// that discloses everything — the vacuous green a leak test must not have.
+	writer := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"installation_settings": {Read: true, Update: true},
+	})
+	chosen := []string{"google"}
+	if _, err := store.UpdateInstallation(writer, identity.InstallationPatch{
+		EnabledOidcProviders: &chosen,
+	}); err != nil {
+		t.Fatalf("storing a sign-in provider: %v", err)
+	}
+
+	rep := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"installation_settings": {Read: true},
+	})
+	got, err := store.GetInstallation(rep)
+	if err != nil {
+		t.Fatalf("the installation read failed: %v", err)
+	}
+	if len(got.EnabledOidcProviders) == 0 {
+		t.Fatal("the aggregate no longer carries the sign-in providers — if the field " +
+			"was deprecated and removed on purpose, delete this test and the comment " +
+			"above it; the split is then complete")
+	}
+}
+
+// The WRITE half is unsplit too, and for the same reason: `enabled_oidc_providers`
+// is a published field of `PATCH /installation/settings`, gated on
+// `installation_settings.update` through the settings entry.
+//
+// So an ops seat — or any custom role holding installation-settings update
+// without authentication-policy update — can still turn a sign-in provider on or
+// off. The read endpoint above narrows who SEES the policy; nothing yet narrows
+// who CHANGES it, and a reader of that endpoint's description should not have to
+// infer that.
+//
+// Like its read counterpart this is written to FAIL when the gap closes, so the
+// change that finally gates the write is told to come back and delete it.
+func TestTheSettingsPatchStillChangesSignInProvidersUntilItIsSplit(t *testing.T) {
+	e := SetupSearch(t)
+	store := identity.NewInstallationSettings(e.DB(), compose.NewSettingsStore(e.Pool))
+
+	// Deliberately WITHOUT authentication_policy: this is the caller the split is
+	// supposed to be keeping out of the sign-in policy.
+	opsish := e.authPolicyCtx(map[string]principal.ObjectGrant{
+		"installation_settings": {Read: true, Update: true},
+	})
+	chosen := []string{"google"}
+	if _, err := store.UpdateInstallation(opsish, identity.InstallationPatch{
+		EnabledOidcProviders: &chosen,
+	}); err != nil {
+		t.Fatalf("installation_settings.update can no longer change the sign-in providers "+
+			"(%v) — if the write was split onto authentication_policy on purpose, delete "+
+			"this test and the note in the endpoint description; the split is then complete", err)
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1019,6 +1019,10 @@ func (stubs) UndoImportRun(w nethttp.ResponseWriter, r *nethttp.Request, id open
 	httperr.NotImplemented(w, r, "UndoImportRun")
 }
 
+func (stubs) GetAuthenticationPolicy(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetAuthenticationPolicy")
+}
+
 func (stubs) GetLicenseEntitlement(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetLicenseEntitlement")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -18284,6 +18284,19 @@ type AuthCapabilities struct {
 	ReleaseVersion *string `json:"release_version,omitempty"`
 }
 
+// AuthenticationPolicy Which sign-in methods this installation offers, apart from the rest of its settings.
+//
+// Carries only what `authentication_policy` governs. The installation's name, timezone
+// and currency are NOT here — every role reads those, and repeating them in a document
+// governed by a narrower grant would make the same fact answer to two authorities.
+type AuthenticationPolicy struct {
+	// SignInProviders Every provider this deployment mounted, each marked with whether the
+	// installation has chosen to offer it — which is a stored choice, not a
+	// guarantee the provider has working credentials. Password is never listed: it
+	// is the method every installation always has and cannot switch off.
+	SignInProviders []SignInProvider `json:"sign_in_providers"`
+}
+
 // Authorization What this principal may do, as the server itself computed it — never a client-side re-derivation from role keys, which drifts the moment an installation's stored grants differ from the compiled-in defaults.
 // Two independent axes, both of which must permit an action: the licensing seat ceiling (A62/ADR-0047), checked BEFORE RBAC and clamped on HTTP method, and the object grants. A client that collapses them into one predicate will be wrong in both directions.
 // This is a snapshot, not an authority. A role change does not revoke live sessions, so a client refetches on window focus and after any 403, and treats the server's answer as the only one that counts. It does not express the human-principal gate, nor the few routes that still key on the literal admin role independently of any grant — a permitted grant here is necessary, never sufficient.
@@ -49140,6 +49153,9 @@ type ServerInterface interface {
 	// Reverse a completed CSV import run.
 	// (POST /imports/{id}/undo)
 	UndoImportRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Which sign-in methods this installation offers.
+	// (GET /installation/authentication-policy)
+	GetAuthenticationPolicy(w http.ResponseWriter, r *http.Request)
 	// The installation's entitlement and seat usage (admin/ops).
 	// (GET /installation/license)
 	GetLicenseEntitlement(w http.ResponseWriter, r *http.Request)
@@ -51681,6 +51697,12 @@ func (_ Unimplemented) GetImportRunReport(w http.ResponseWriter, r *http.Request
 // Reverse a completed CSV import run.
 // (POST /imports/{id}/undo)
 func (_ Unimplemented) UndoImportRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Which sign-in methods this installation offers.
+// (GET /installation/authentication-policy)
+func (_ Unimplemented) GetAuthenticationPolicy(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -63766,6 +63788,26 @@ func (siw *ServerInterfaceWrapper) UndoImportRun(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UndoImportRun(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAuthenticationPolicy operation middleware
+func (siw *ServerInterfaceWrapper) GetAuthenticationPolicy(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAuthenticationPolicy(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -80086,6 +80128,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/imports/{id}/undo", wrapper.UndoImportRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/installation/authentication-policy", wrapper.GetAuthenticationPolicy)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/installation/license", wrapper.GetLicenseEntitlement)

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -146,6 +146,40 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	}, nil
 }
 
+// signInPolicyReadActor names the entry read this projection performs after it
+// has already admitted the caller. A SYSTEM actor for the same reason the login
+// screen's read uses one: the question is what this INSTALLATION offers, not
+// what this reader may see, and the reader's own authority was settled one line
+// above.
+const signInPolicyReadActor = "system:sign_in_policy_read"
+
+// SignInPolicy answers which sign-in providers the installation offers, gated on
+// `authentication_policy` rather than on the settings aggregate around it.
+//
+// THE GATE HERE IS THE WHOLE SECURITY OF THIS READ. The entry itself is defined
+// on installation_settings — moving it would make every read of the aggregate
+// demand this grant and take the name, timezone and currency with it, which
+// every role is meant to read — so this checks the caller first and then reads
+// the entry as the installation. A system principal bypasses object RBAC
+// entirely, so removing or weakening the Require below does not merely widen
+// this endpoint, it removes its only gate.
+func (s *InstallationSettingsStore) SignInPolicy(ctx context.Context) ([]string, error) {
+	if err := auth.Require(ctx, authenticationPolicyObject, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	// Only after the caller is admitted. The workspace and correlation id ride
+	// from the request so the read stays attributable to the trace that asked.
+	readCtx := principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem,
+		ID:   signInPolicyReadActor,
+	})
+	chosen, err := settings.Get(readCtx, s.settings, EnabledOidcProviders)
+	if err != nil {
+		return nil, fmt.Errorf("identity: reading the sign-in policy: %w", err)
+	}
+	return chosen, nil
+}
+
 // baseCurrencyLock asks the entry's own probe, so the answer the read reports
 // and the answer the write enforces come from one place. A read with the probe
 // unwired reports "changeable", which is what the write would then do — the

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -35,6 +35,20 @@ import (
 // benefits from knowing which one it is — and write is admin/ops.
 const installationSettingsObject = "installation_settings"
 
+// authenticationPolicyObject gates the sign-in half of the installation's
+// settings, read apart from the rest.
+//
+// Not the entry's object, and it cannot be. EnabledOidcProviders is defined on
+// installationSettingsObject and the settings catalog gates BOTH verbs on an
+// entry's one object (settings.Raw, settings.SetRawTx), so moving the entry here
+// would make every read of the aggregate demand this grant — the name, the
+// timezone and the base currency with it, which every role is meant to read.
+//
+// So the projection carries the gate instead: SignInPolicy checks this before
+// reading the entry as the installation itself, which is the same shape the
+// login screen already uses to resolve providers for an anonymous visitor.
+const authenticationPolicyObject = "authentication_policy"
+
 // SettingsObject is the same object, for compose.
 //
 // Exported because the installation-setup surface takes this gate itself: its

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7366,6 +7366,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/installation/authentication-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Which sign-in methods this installation offers.
+         * @description The sign-in half of the installation's settings, read on its own.
+         *
+         *     It is a separate operation rather than a field on `GET /installation/settings`
+         *     because the two have different readers. Every role reads the installation's name,
+         *     timezone and base currency — a rep reading amounts benefits from knowing the
+         *     currency. Who may sign in and how is authentication administration, and showing it
+         *     to every seat that holds `installation_settings.read` would be handing out the shape
+         *     of the login surface to readers with no business in it.
+         *
+         *     The aggregate could not simply carry the narrower grant. Its fields are read through
+         *     one settings catalog whose entries each declare one object, so gating the sign-in
+         *     field there would make the WHOLE aggregate demand this grant and take the ordinary
+         *     installation read down with it. Hence a projection: same values, own gate.
+         *
+         *     `sign_in_providers` reports every provider this DEPLOYMENT mounted, each marked with
+         *     whether the installation has CHOSEN to offer it. Chosen is not the same as working:
+         *     a provider mounted without a stored OAuth app and without environment credentials
+         *     is still listed, and still reads as enabled, because this is the screen an operator
+         *     goes to in order to finish configuring it — the login page withholds it until they
+         *     do. A client rendering this as "what a visitor sees today" would be wrong. The
+         *     effective set is
+         *     the intersection — an admin can only ever narrow what the deployment configured,
+         *     never invent a client id — and a nil stored choice means every configured provider,
+         *     so an installation that upgrades into the setting keeps the login screen it had.
+         *
+         *     PASSWORD IS NOT LISTED and cannot be disabled. It is the method every installation
+         *     always has, and the one an admin must not be able to strand everybody by removing.
+         *
+         *     Governed by `authentication_policy` for this READ. Two things it does not yet
+         *     govern, both tracked and both visible from here rather than discovered later:
+         *     `GET /installation/settings` still returns the same `sign_in_providers` field to
+         *     any holder of `installation_settings.read`, and `PATCH /installation/settings`
+         *     still accepts `enabled_oidc_providers` on `installation_settings.update`. Closing
+         *     either means removing a published field or verb, which is a breaking change and a
+         *     deprecation cycle rather than an edit. Until then this endpoint is the narrower
+         *     surface, not a narrower authority.
+         *
+         *     Human-only: an agent never reads how humans sign in.
+         */
+        get: operations["getAuthenticationPolicy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/installation/settings": {
         parameters: {
             query?: never;
@@ -14538,6 +14595,22 @@ export interface components {
             source: "stored" | "environment" | "none";
             /** @description Every callback URL that must be registered as a redirect URI on the vendor's OAuth client, one per purpose this deployment actually serves. A purpose that is not composed is absent rather than listed, because telling an operator to register a URL nothing answers sends them to debug a mismatch that was never the cause. */
             redirect_uris: components["schemas"]["ConnectorAppRedirectUri"][];
+        };
+        /**
+         * @description Which sign-in methods this installation offers, apart from the rest of its settings.
+         *
+         *     Carries only what `authentication_policy` governs. The installation's name, timezone
+         *     and currency are NOT here — every role reads those, and repeating them in a document
+         *     governed by a narrower grant would make the same fact answer to two authorities.
+         */
+        AuthenticationPolicy: {
+            /**
+             * @description Every provider this deployment mounted, each marked with whether the
+             *     installation has chosen to offer it — which is a stored choice, not a
+             *     guarantee the provider has working credentials. Password is never listed: it
+             *     is the method every installation always has and cannot switch off.
+             */
+            sign_in_providers: components["schemas"]["SignInProvider"][];
         };
         /** @description One external sign-in provider this deployment holds credentials for, and whether the installation currently offers it. An admin can turn one off; they cannot add one, because a client id and secret cannot be invented from a settings screen. */
         SignInProvider: {
@@ -43138,6 +43211,28 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    getAuthenticationPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The sign-in policy. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthenticationPolicy"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
         };
     };
     getInstallationSettings: {


### PR DESCRIPTION
`GET /installation/settings` carries the installation's name, timezone and base currency — which every role reads, since a rep reading amounts benefits from knowing the currency. It also carries `sign_in_providers`, which is authentication administration and has no business being handed to every seat holding `installation_settings.read`.

`GET /installation/authentication-policy` answers that half on the `authentication_policy` grant.

## Why a projection and not a moved setting

Repointing the `EnabledOidcProviders` entry at the new object does not work. The settings catalog gates **both verbs on an entry's single object** (`settings.Raw` for reads, `SetRawTx` for writes), so moving the entry makes every read of the aggregate demand the new grant — taking the company name and the reporting currency with it. I measured that rather than predicting it: six connector tests fail the same way when the equivalent move is tried on the OAuth entries.

So the projection checks the caller and *then* reads the entry as the installation, which is the same shape the login screen already uses to resolve providers for an anonymous visitor.

That design puts the entire security of the read in one `auth.Require`. The system principal beneath it bypasses object RBAC entirely, so deleting that line does not widen the endpoint — it removes its only gate. Both refusal tests fail without it, and both fail again when the object is swapped for the aggregate's.

## Two halves are still open, and both are now tests

Codex found the second one, which I had missed.

- `GET /installation/settings` **still returns the same field** on `installation_settings.read`.
- `PATCH /installation/settings` **still accepts `enabled_oidc_providers`** on `installation_settings.update`, so an ops seat can still turn a provider on or off.

Closing either means removing a published response field or request field. `contract-breaking-check` refuses it, correctly — a client reading that field would break — and the supported route is deprecate, ship, then remove. That is a product decision about a published contract, not something to slip into this change.

So this narrows the **surface** and not yet the **authority**, and the endpoint's own description says so rather than leaving the next reader to discover it. Each gap is an integration test written to **fail when the gap closes**, telling whoever closes it to come back and delete the test.

One of those tests was vacuous on first writing — it passed because the fixture stored no providers, so the field was nil whether or not the aggregate leaked. It now stores one first, and fails against the leak as it should.

## Verification

- `make check-backend` **green, exit 0**
- 6 integration tests pass; frontend `tsc --noEmit` clean against the regenerated contract
- two mutations checked one at a time: removing the `auth.Require`, and swapping `authentication_policy` for `installation_settings` — each failed both refusal tests

Reviewed by Codex on `gpt-5.6-sol`. It raised three findings: the read leak (recorded as a test), the write leak I had missed (recorded as a test), and a contract description that claimed providers were "currently offered" when the value is a stored choice that may have no working credentials — the wording is now corrected on both the path and the schema.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /installation/authentication-policy` to return sign-in providers on the `authentication_policy` grant instead of handing them to every `installation_settings.read` holder via `GET /installation/settings`.

It's a projection, not a moved settings entry, because the settings catalog gates both verbs on each entry's single object — moving `EnabledOidcProviders` would make the whole aggregate read (name, timezone, currency) demand the new grant. The projection's single `auth.Require` is the entire security of the read, since the system principal beneath it bypasses object RBAC, and the endpoint is human-only.

**Remaining gaps**
- `GET /installation/settings` still returns `sign_in_providers` on `installation_settings.read`.
- `PATCH /installation/settings` still accepts `enabled_oidc_providers` on `installation_settings.update`.
- Both are tracked by integration tests that fail when the gap closes, since closing either requires a breaking-change deprecation cycle.

<sup>Written for commit b37619759eefc04b1526e371232a1663cad2c9d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authentication policy endpoint that shows which sign-in providers are available for an installation.
  - Authentication policy information is available through a dedicated, human-only access path.
  - Added permission controls specifically for viewing sign-in provider availability, separate from broader installation settings.
- **Bug Fixes**
  - Preserved existing installation settings and sign-in provider update behavior while introducing the dedicated authentication policy view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->