### PR TITLE
test(jobs): the sweep window is checked against River's own state vocabulary

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 39
+	wantFixtureAnnotations = 40
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -45,6 +45,11 @@ import (
 // scheduled for later. Naming a sixth would not compile, and a reader coming to
 // add one should know the case is already held rather than go looking for the
 // constant.
+//
+// That is a claim about a dependency's vocabulary, so it is checked against the
+// dependency: TestEveryRiverJobStateIsEitherInFlightOrFinished
+// (jobsweepstates_test.go) walks rivertype.JobStates() and fails on any state
+// this list and the finished set do not between them account for.
 var activeSweepStates = []rivertype.JobState{
 	rivertype.JobStateAvailable,
 	rivertype.JobStatePending,

--- a/backend/internal/compose/jobsweepstates_test.go
+++ b/backend/internal/compose/jobsweepstates_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every state River declares is on one side of the sweep window or the other.
+//
+// activeSweepStates is what suppresses a duplicate tick, and it is read by every
+// periodic pass in the product and by both push webhooks. Getting it wrong fails
+// in two opposite directions: a state left out lets a second pass run while the
+// first is still in flight, and a state wrongly included stops a sweep firing
+// because something the window did not expect holds it open.
+//
+// So the list is checked against RIVER'S OWN vocabulary rather than against a
+// copy of it. A ninth state — or a rename — fails here, where somebody decides
+// which side it belongs on, instead of being discovered as a sweep that stopped.
+//
+// It is also the answer to the question this test was written for: whether a
+// SNOOZED job is in flight. River has no snoozed state; JobSnooze puts the row
+// back as `scheduled`, which the window already holds. Nothing to add, and this
+// is what says so if that ever changes.
+
+import (
+	"testing"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+// gatekit:fixture the states a run can be in HAVING STOPPED, and why each one is
+// safe for the window to ignore. Not a waiver: nothing here excuses a finding —
+// the map is one half of the classification this test checks River's vocabulary
+// against, and an entry going stale means River dropped a state, which is the
+// failure the test reports rather than something to sweep up.
+//
+// The window must not hold any of them open.
+var finishedStates = map[rivertype.JobState]string{
+	rivertype.JobStateCompleted: "the pass ran; the next scheduled tick is exactly what should follow it, " +
+		"and River's default ByState would hold a 24h cadence shut until the row was cleaned out",
+	rivertype.JobStateDiscarded: "the pass exhausted its attempts. A window held open by it would silence " +
+		"the sweep for as long as the row survives, which is the failure that looks like nothing happening",
+	rivertype.JobStateCancelled: "somebody stopped this run. The next tick is a new decision, not a duplicate of it",
+}
+
+func TestEveryRiverJobStateIsEitherInFlightOrFinished(t *testing.T) {
+	t.Parallel()
+
+	inFlight := map[rivertype.JobState]bool{}
+	for _, state := range activeSweepStates {
+		inFlight[state] = true
+	}
+	declared := rivertype.JobStates()
+	if len(declared) == 0 {
+		t.Fatal("river declares no job states — this census is reading nothing, and a census that " +
+			"finds no subject cannot report a pass")
+	}
+	for _, state := range declared {
+		_, finished := finishedStates[state]
+		switch {
+		case inFlight[state] && finished:
+			t.Errorf("%q is listed as both in flight and finished: the window cannot both suppress "+
+				"a tick and let it through", state)
+		case !inFlight[state] && !finished:
+			t.Errorf("river declares %q and neither activeSweepStates nor finishedStates names it. "+
+				"Decide which it is: a state that means a pass is still coming belongs in the window, "+
+				"or a second tick can be enqueued alongside the first; a state that means the run has "+
+				"stopped must stay out, or the sweep goes quiet.", state)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3543.

## The question, answered

The ticket asks whether `activeSweepStates` should list `snoozed`, and says it could not be settled without first establishing whether any of our workers snooze.

**River has no `snoozed` state.** `rivertype.JobStates()` returns eight — available, cancelled, completed, discarded, pending, retryable, running, scheduled — and `JobSnooze` puts the row back as `scheduled`, which the window already holds. So a snoozed pass *is* recognised as in flight, and there is nothing to add. (For the record, no worker in this tree returns `river.JobSnooze` today either; the point stands regardless, because the state a snooze lands in is what the window reads.)

`jobs.go` already said this in a comment. A comment is the wrong place for a claim about a dependency's vocabulary.

## What this adds

`TestEveryRiverJobStateIsEitherInFlightOrFinished` walks `rivertype.JobStates()` and requires every state to be named by exactly one of:

- `activeSweepStates` — a pass is still coming, so a second tick is suppressed
- `finishedStates` (declared in the test) — the run has stopped, and each entry carries the reason the window must **not** hold it open: a completed pass is exactly what the next tick should follow; a discarded one would silence the sweep for as long as the row survives; a cancelled one is a decision, not a duplicate

A ninth state, or a rename, fails here — where somebody decides which side it belongs on — instead of being discovered as a sweep that quietly stopped firing. That is the test the ticket asked for: it tells the two failure directions apart, and it is derived from the vocabulary rather than being a third copy of it.

An empty `JobStates()` is a `Fatal`, not a pass: a census that finds no subject cannot report one.

The declaration in `jobs.go` now points at the test instead of asserting the fact alone. `finishedStates` is marked `gatekit:fixture` (it classifies, it does not excuse) and `wantFixtureAnnotations` moves 39 → 40 in the same change, as that census requires.

## Mutation check

Removing `retryable` from `activeSweepStates`:

```
river declares "retryable" and neither activeSweepStates nor finishedStates names it.
Decide which it is: a state that means a pass is still coming belongs in the window,
or a second tick can be enqueued alongside the first; a state that means the run has
stopped must stay out, or the sweep goes quiet.
```

`make check-go` green. No production behaviour changes: `activeSweepStates` is unchanged.