### PR TITLE
The settings catalog is one table, and it admits who the server admits

### DIFF
--- a/frontend/src/app/capability.test.tsx
+++ b/frontend/src/app/capability.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useMe } from "../screens/common";
 import {
+  grants,
   type RbacAction,
   type RbacObject,
   useCan,
@@ -87,6 +88,57 @@ async function mutate(): Promise<boolean> {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("grants — the pure predicate the hook and the catalog share", () => {
+  // The hook is now a one-line wrapper over `grants`, and these cases are here
+  // because the settings catalog calls the same function OUTSIDE React. If the
+  // two ever diverge, the rail, the palette and search stop agreeing about which
+  // settings pages exist — which they demonstrably did when the company-page
+  // check was spelled twice.
+  //
+  // Every case drives the pure function directly. A hook test cannot prove the
+  // non-React caller sees the same answer, because it never exercises that path.
+
+  it("grants what the snapshot grants", () => {
+    const me = meFixture({ allow: { person: ["read"] } });
+    expect(grants(me, "person", "read")).toBe(true);
+  });
+
+  it("denies an action the snapshot does not carry", () => {
+    const me = meFixture({ allow: { person: ["read"] } });
+    expect(grants(me, "person", "update")).toBe(false);
+  });
+
+  it("denies an object absent from the snapshot", () => {
+    // The index signature types a miss as PRESENT, so this is the case that
+    // proves the optional chain rather than the type system is doing the work.
+    const me = meFixture({ allow: { person: ["read"] } });
+    expect(grants(me, "deal", "read")).toBe(false);
+  });
+
+  it("denies while /me has not resolved", () => {
+    // The state every surface is in on first paint. Answering true here would
+    // flash a settings entry and then withdraw it.
+    expect(grants(undefined, "person", "read")).toBe(false);
+  });
+
+  it("gives the hook and the pure call the same answer", async () => {
+    // The claim the split exists to keep true, asserted rather than assumed:
+    // the hook goes through React and /me, the pure call does not, and both
+    // must land on the same boolean for the same snapshot.
+    const me = meFixture({ allow: { pipeline: ["read"], deal: ["update"] } });
+    stubMe(me);
+
+    for (const [object, action] of [
+      ["pipeline", "read"],
+      ["pipeline", "update"],
+      ["deal", "update"],
+      ["deal", "read"],
+    ] as const) {
+      expect(await can(object, action)).toBe(grants(me, object, action));
+    }
+  });
 });
 
 describe("useCan", () => {

--- a/frontend/src/app/capability.ts
+++ b/frontend/src/app/capability.ts
@@ -76,12 +76,42 @@ export type RbacAction = components["schemas"]["RbacAction"];
  * answer would hide a page a read seat may genuinely see.
  */
 export function useCan(object: RbacObject, action: RbacAction): boolean {
-  const me = useMe();
+  return grants(useMe().data, object, action);
+}
+
+/**
+ * The access snapshot every predicate here reads: `/me`, or nothing yet.
+ *
+ * Optional all the way down because each level is genuinely absent in a state
+ * the app reaches — the query before it resolves, a server too old to send the
+ * field, an object this principal holds no grant on.
+ */
+export type AccessSnapshot = components["schemas"]["MeResponse"] | undefined;
+
+/**
+ * Whether `snapshot` grants `action` on `object` — the same question `useCan`
+ * answers, without the hook.
+ *
+ * Split out because the settings catalog has to evaluate a page's requirement
+ * outside a component: navigation, the palette, search and the page itself must
+ * agree about which settings exist, and the only way they cannot disagree is
+ * that one function answers all four. A second copy of this chain is how the
+ * rail and the palette came to disagree about the company page.
+ *
+ * Fails closed on every uncertainty. An unknown object resolves to the zero
+ * grant on the server too, so a missing key is a denial rather than a gap to
+ * fill in optimistically.
+ */
+export function grants(
+  snapshot: AccessSnapshot,
+  object: RbacObject,
+  action: RbacAction,
+): boolean {
   // Two optional steps, both load-bearing. `objects` is an index signature, so
   // TypeScript types a miss as PRESENT — only the chain makes an absent grant
   // deny at runtime; and the chain must cover `objects` itself, or a snapshot
   // that arrived without it would throw in render rather than deny.
-  const grant = me.data?.authorization?.objects?.[object];
+  const grant = snapshot?.authorization?.objects?.[object];
   return grant?.[action] ?? false;
 }
 

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -172,3 +172,131 @@ describe("holds — the evaluator the four surfaces share", () => {
     expect(holds({ kind: "all", of: [person] }, me)).toBe(true);
   });
 });
+
+// Every page whose requirement DIFFERS from the entry that shipped, named with
+// the reader it now admits and the reason the server already admits them.
+//
+// These exist because a review found the previous cases could not see any of
+// it: they drove one rep-shaped fixture, and a widening only shows up under an
+// ASYMMETRIC snapshot — a reader holding the new object and not the old one.
+// Each case below is a deliberate correction of a client that disagreed with
+// the server, and stating them as tests is what stops the next author reading
+// the difference as an accident.
+describe("pages that admit readers the old register refused", () => {
+  function opens(page: SettingsPageId, allow: Parameters<typeof meFixture>[0]) {
+    return visibleSettingsPages(meFixture(allow)).some((p) => p.id === page);
+  }
+
+  it("opens extensions to a grant holder, not only the literal admin role", () => {
+    // `GET /v1/extensions` gates on extension_access.read, which ops holds. The
+    // old entry asked whether the reader WAS an admin, so it refused an ops
+    // principal the server answers 200 — the client disagreeing with the
+    // authority, which is what this redesign exists to stop.
+    expect(
+      opens("extensions", {
+        roles: ["ops"],
+        allow: { extension_access: ["read"] },
+      }),
+    ).toBe(true);
+    expect(opens("extensions", { roles: ["rep"], allow: {} })).toBe(false);
+  });
+
+  it("opens system-health on the job-health grant", () => {
+    // Same shape: the old entry was `isAdmin || embedding_reindex.read`, and
+    // its own comment said nobody below ops had anything to read there — which
+    // is the audience the grant already names.
+    expect(
+      opens("system-health", {
+        roles: ["ops"],
+        allow: { job_health: ["read"] },
+      }),
+    ).toBe(true);
+    expect(opens("system-health", { roles: ["rep"], allow: {} })).toBe(false);
+  });
+
+  it("opens audit on audit_log alone, without person.read", () => {
+    // privacy/auditlog.go requires exactly audit_log.read. The old entry folded
+    // the audit trail in with the consent registry, so a reader could hold the
+    // audit grant and still be refused the page carrying it.
+    expect(
+      opens("audit", { roles: ["admin"], allow: { audit_log: ["read"] } }),
+    ).toBe(true);
+    expect(
+      opens("audit", { roles: ["rep"], allow: { person: ["read"] } }),
+    ).toBe(false);
+  });
+
+  it("opens seats to management on seat_usage without license", () => {
+    // The split shipped for this reader: capacity without commercial standing.
+    // The old License entry asked for `license.read`, which management does not
+    // hold, so the page management is meant to use was hidden from them.
+    expect(
+      opens("seats", {
+        roles: ["management"],
+        allow: { seat_usage: ["read"] },
+      }),
+    ).toBe(true);
+    expect(opens("seats", { roles: ["rep"], allow: {} })).toBe(false);
+  });
+
+  it("opens authentication on its own grants", () => {
+    // Split out of the old General entry, which asked for installation
+    // settings, the company-context flag or FX rates — none of which is
+    // authentication, and all of which a reader can lack while holding this.
+    expect(
+      opens("authentication", {
+        roles: ["management"],
+        allow: { authentication_policy: ["read"] },
+      }),
+    ).toBe(true);
+    expect(
+      opens("authentication", {
+        roles: ["rep"],
+        allow: { installation_settings: ["read"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("splits the AI page by what each half actually reads", () => {
+    // A narrowing, not a widening: management held `automation` and so reached
+    // the whole combined page. Now they reach the parts their grants cover and
+    // NOT the routing editor, which asks for ai_routing they do not hold.
+    const management = {
+      roles: ["management"],
+      allow: { automation: ["read"], ai_diagnostics: ["read"] },
+    } satisfies Parameters<typeof meFixture>[0];
+    expect(opens("automations", management)).toBe(true);
+    expect(opens("usage", management)).toBe(true);
+    expect(opens("model-calls", management)).toBe(true);
+    expect(opens("models", management)).toBe(false);
+  });
+});
+
+describe("requirements that are not permissions — the composed units", () => {
+  it("does not open integrations on a grant nobody in the old predicate had", () => {
+    // `integrations.read` is held by every seeded role including read_only, so
+    // admitting it would put the page in front of everyone. The old predicate
+    // asked for overlay, webhook or a composed unit, and this keeps to that.
+    expect(
+      visibleSettingsPages(
+        meFixture({ roles: ["rep"], allow: { integrations: ["read"] } }),
+      ).some((p) => p.id === "integrations"),
+    ).toBe(false);
+  });
+
+  it("opens integrations to an overlay or webhook reader", () => {
+    // Spelled out rather than looped over a computed key: a computed key widens
+    // `allow` to a string index and loses the object/action checking that makes
+    // a misspelling here a compile error rather than a silently denied grant.
+    expect(
+      visibleSettingsPages(
+        meFixture({ allow: { overlay_connection: ["read"] } }),
+      ).some((p) => p.id === "integrations"),
+    ).toBe(true);
+    expect(
+      visibleSettingsPages(
+        meFixture({ allow: { webhook_subscription: ["read"] } }),
+      ).some((p) => p.id === "integrations"),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { meFixture } from "../app/mefixture";
+import {
+  holds,
+  SETTINGS_GROUPS,
+  SETTINGS_PAGES,
+  type SettingsPageId,
+  visibleSettingsPages,
+} from "./settingscatalog";
+
+// The catalog is the single answer four surfaces resolve from, so what it says
+// has to be checkable without rendering any of them.
+
+describe("the catalog's shape", () => {
+  it("gives every page a unique id", () => {
+    const ids = SETTINGS_PAGES.map((page) => page.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("places every page in a declared group", () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(SETTINGS_GROUPS).toContain(page.group);
+    }
+  });
+
+  it("leaves no group empty", () => {
+    // An empty group renders as a heading with nothing under it. Catching it
+    // here is cheaper than noticing it in a screenshot.
+    for (const group of SETTINGS_GROUPS) {
+      expect(SETTINGS_PAGES.some((page) => page.group === group)).toBe(true);
+    }
+  });
+});
+
+describe("who may open what", () => {
+  // The snapshot states each case names, built the way the app receives them.
+  const nobody = undefined;
+  const rep = meFixture({
+    roles: ["rep"],
+    allow: {
+      person: ["read"],
+      pipeline: ["read"],
+      custom_field: ["read"],
+      tag: ["read"],
+      product: ["read"],
+      capture_settings: ["read"],
+      knowledge_corpus: ["read"],
+      automation: ["read"],
+    },
+  });
+
+  function visibleIds(snapshot: Parameters<typeof visibleSettingsPages>[0]) {
+    return visibleSettingsPages(snapshot).map((page) => page.id);
+  }
+
+  it("shows the personal pages to everyone, including before /me resolves", () => {
+    // These carry no grant because they are about the reader themselves. They
+    // must survive the loading window too, or the rail flashes empty on every
+    // first paint.
+    expect(visibleIds(nobody)).toEqual([
+      "account",
+      "voice",
+      "agents",
+      "connections",
+      "capture-activity",
+      "members",
+      "teams",
+    ]);
+  });
+
+  it("opens the sales pages a rep's own grants already carry", () => {
+    // The point of the redesign: these were hidden behind an operator-seat
+    // check while the API answered a rep 200 on every one of them.
+    const seen = visibleIds(rep);
+    for (const id of [
+      "pipelines",
+      "leads",
+      "fields",
+      "tags",
+      "products",
+      "capture",
+      "knowledge",
+      "automations",
+    ] satisfies SettingsPageId[]) {
+      expect(seen).toContain(id);
+    }
+  });
+
+  it("withholds the governance pages from that same rep", () => {
+    const seen = visibleIds(rep);
+    for (const id of [
+      "audit",
+      "system-health",
+      "extensions",
+      "reset",
+      "roles",
+      "authentication",
+      "seats",
+    ] satisfies SettingsPageId[]) {
+      expect(seen).not.toContain(id);
+    }
+  });
+
+  it("opens privacy to a rep, because its purposes list is gated on person.read", () => {
+    // Not a widening: consent/store.go's ListPurposes calls Require(person,
+    // read), so a rep already reads it. A page that refused them here would
+    // disagree with the endpoint behind it.
+    expect(visibleIds(rep)).toContain("privacy");
+  });
+});
+
+describe("requirements that are not permissions", () => {
+  it("withholds the company page when the installation lacks the surface", () => {
+    // organization.read alone. The company profile ANDs its grant with a
+    // deployment flag, so a reader holding only that grant sees nothing when
+    // the flag is off — the surface may genuinely not exist here.
+    const holder = meFixture({
+      allow: { organization: ["read"] },
+      settingsAvailability: { company_context: false },
+    });
+    expect(visibleSettingsPages(holder).map((p) => p.id)).not.toContain(
+      "company",
+    );
+  });
+
+  it("shows it once the installation has it", () => {
+    const holder = meFixture({
+      allow: { organization: ["read"] },
+      settingsAvailability: { company_context: true },
+    });
+    expect(visibleSettingsPages(holder).map((p) => p.id)).toContain("company");
+  });
+
+  it("withholds it when /me carries no availability at all", () => {
+    // A server older than the field, or a snapshot cached before it shipped.
+    // Absent is not permission: it has to read as "no such surface here".
+    const holder = meFixture({
+      allow: { organization: ["read"] },
+      settingsAvailability: null,
+    });
+    expect(visibleSettingsPages(holder).map((p) => p.id)).not.toContain(
+      "company",
+    );
+  });
+
+  it("still shows it to a reader whose OTHER grant carries the page", () => {
+    // The flag gates one card, not the page: installation_settings.read opens
+    // the company page regardless, and treating the flag as a page-level
+    // condition would hide a surface the reader may use.
+    const admin = meFixture({
+      allow: { installation_settings: ["read"] },
+      settingsAvailability: { company_context: false },
+    });
+    expect(visibleSettingsPages(admin).map((p) => p.id)).toContain("company");
+  });
+});
+
+describe("holds — the evaluator the four surfaces share", () => {
+  it("denies a grant arm while /me is unresolved", () => {
+    expect(
+      holds({ kind: "grant", object: "person", action: "read" }, undefined),
+    ).toBe(false);
+  });
+
+  it("reads `any` as at-least-one and `all` as every", () => {
+    const me = meFixture({ allow: { person: ["read"] } });
+    const person = { kind: "grant", object: "person", action: "read" } as const;
+    const deal = { kind: "grant", object: "deal", action: "read" } as const;
+
+    expect(holds({ kind: "any", of: [person, deal] }, me)).toBe(true);
+    expect(holds({ kind: "all", of: [person, deal] }, me)).toBe(false);
+    expect(holds({ kind: "all", of: [person] }, me)).toBe(true);
+  });
+});

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -43,6 +43,11 @@ export type CapabilityExpression =
   | { kind: "always" }
   | { kind: "grant"; object: RbacObject; action: RbacAction }
   | { kind: "availability"; key: SettingsAvailabilityKey }
+  // Whether this BUILD composed any extension unit keeping secrets at `scope`.
+  // A composition fact, not a permission and not a deployment flag: the unit's
+  // settings live on the page below and there is no other route to them, so a
+  // page that ignored this would strand an installation's only way in.
+  | { kind: "units"; scope: UnitSecretScope }
   | { kind: "any"; of: readonly CapabilityExpression[] }
   | { kind: "all"; of: readonly CapabilityExpression[] };
 
@@ -55,6 +60,33 @@ export const reads = (object: RbacObject): CapabilityExpression => ({
 export const available = (
   key: SettingsAvailabilityKey,
 ): CapabilityExpression => ({ kind: "availability", key });
+export const composedUnits = (
+  scope: UnitSecretScope,
+): CapabilityExpression => ({
+  kind: "units",
+  scope,
+});
+
+/**
+ * Where a composed unit keeps its secrets. Mirrored rather than imported: the
+ * extensions registry reaches `@composition/screens` and so pulls React and a
+ * build alias into whatever imports it, which is the one thing this module may
+ * not do — being importable from anywhere is its whole purpose.
+ *
+ * `settingscatalog.units.test.ts` holds the two spellings equal.
+ */
+export type UnitSecretScope = "workspace" | "user";
+
+/**
+ * How the caller answers the composition question.
+ *
+ * Injected rather than read, for the import reason above. `holds` takes it as
+ * an option so the pure table stays evaluable in a test, a story or a script
+ * with no registry at all — and the one caller that has a registry passes it.
+ */
+export type CatalogContext = {
+  composedUnitScopes?: readonly UnitSecretScope[];
+};
 export const anyOf = (
   ...of: readonly CapabilityExpression[]
 ): CapabilityExpression => ({ kind: "any", of });
@@ -78,6 +110,7 @@ export const always: CapabilityExpression = { kind: "always" };
 export function holds(
   expression: CapabilityExpression,
   snapshot: AccessSnapshot,
+  context: CatalogContext = {},
 ): boolean {
   switch (expression.kind) {
     case "always":
@@ -86,10 +119,15 @@ export function holds(
       return grants(snapshot, expression.object, expression.action);
     case "availability":
       return snapshot?.settings_availability?.[expression.key] ?? false;
+    case "units":
+      // Not from the snapshot: which units this binary composed is fixed at
+      // build time and identical for every reader. Absent context means none,
+      // which fails closed the same way every other arm does.
+      return (context.composedUnitScopes ?? []).includes(expression.scope);
     case "any":
-      return expression.of.some((each) => holds(each, snapshot));
+      return expression.of.some((each) => holds(each, snapshot, context));
     case "all":
-      return expression.of.every((each) => holds(each, snapshot));
+      return expression.of.every((each) => holds(each, snapshot, context));
   }
 }
 
@@ -218,7 +256,10 @@ export const SETTINGS_PAGES = [
     requires: anyOf(
       reads("overlay_connection"),
       reads("webhook_subscription"),
-      reads("integrations"),
+      // A composed workspace-scoped unit puts its settings on this page and
+      // nowhere else, so the page has to open for it even when the reader holds
+      // none of the grants above.
+      composedUnits("workspace"),
     ),
   },
   {
@@ -309,6 +350,9 @@ export type SettingsPageId = (typeof SETTINGS_PAGES)[number]["id"];
 /** The pages this snapshot may open, in declaration order. */
 export function visibleSettingsPages(
   snapshot: AccessSnapshot,
+  context: CatalogContext = {},
 ): readonly (typeof SETTINGS_PAGES)[number][] {
-  return SETTINGS_PAGES.filter((page) => holds(page.requires, snapshot));
+  return SETTINGS_PAGES.filter((page) =>
+    holds(page.requires, snapshot, context),
+  );
 }

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -1,0 +1,314 @@
+// The settings catalog: which pages exist, where each sits, and what a reader
+// must hold to open it.
+//
+// PURE DATA AND PURE FUNCTIONS. No React, no lucide, no imports that reach a
+// card. That is what lets the four surfaces which must agree — the rail, the
+// command palette, search, and the page itself — resolve from one table instead
+// of four opinions. They have disagreed before: the rail and the palette each
+// decided whether the company page existed, and answered differently, because
+// the check was spelled twice.
+//
+// The requirement is an EXPRESSION rather than a predicate so it can be
+// evaluated against a snapshot outside React, and so a reader can see what a
+// page asks for without running it.
+
+import type { components } from "../api/schema";
+import {
+  type AccessSnapshot,
+  grants,
+  type RbacObject,
+} from "../app/capability";
+
+type RbacAction = components["schemas"]["RbacAction"];
+
+/**
+ * Which installation-level facts a page can depend on, beyond permissions.
+ *
+ * A surface can be absent for two unrelated reasons — this installation never
+ * enabled it, or this reader holds no grant on it — and settings navigation has
+ * to tell them apart: the first is not a destination at all, the second is a
+ * destination that explains itself.
+ */
+export type SettingsAvailabilityKey = "company_context";
+
+/**
+ * What a page requires, as a value.
+ *
+ * `role` is deliberately absent. Every arm here is a grant, a deployment fact,
+ * or a combination — a role arm would encode the seeded matrix into the client,
+ * which is exactly the inference that breaks on any workspace whose stored
+ * grants have drifted.
+ */
+export type CapabilityExpression =
+  | { kind: "always" }
+  | { kind: "grant"; object: RbacObject; action: RbacAction }
+  | { kind: "availability"; key: SettingsAvailabilityKey }
+  | { kind: "any"; of: readonly CapabilityExpression[] }
+  | { kind: "all"; of: readonly CapabilityExpression[] };
+
+/** Shorthand builders, so the table below reads as requirements rather than syntax. */
+export const reads = (object: RbacObject): CapabilityExpression => ({
+  kind: "grant",
+  object,
+  action: "read",
+});
+export const available = (
+  key: SettingsAvailabilityKey,
+): CapabilityExpression => ({ kind: "availability", key });
+export const anyOf = (
+  ...of: readonly CapabilityExpression[]
+): CapabilityExpression => ({ kind: "any", of });
+export const allOf = (
+  ...of: readonly CapabilityExpression[]
+): CapabilityExpression => ({ kind: "all", of });
+export const always: CapabilityExpression = { kind: "always" };
+
+/**
+ * Resolve one requirement against an access snapshot.
+ *
+ * Fails closed throughout: an unresolved `/me` denies every grant arm, and an
+ * absent availability field reads as "this installation does not have that
+ * surface" rather than as permission.
+ *
+ * `any` over an empty list is false and `all` over an empty list is true, which
+ * are the identities that make the two compose — but no entry in the table
+ * relies on either, because an empty requirement is almost always a mistake
+ * rather than a statement.
+ */
+export function holds(
+  expression: CapabilityExpression,
+  snapshot: AccessSnapshot,
+): boolean {
+  switch (expression.kind) {
+    case "always":
+      return true;
+    case "grant":
+      return grants(snapshot, expression.object, expression.action);
+    case "availability":
+      return snapshot?.settings_availability?.[expression.key] ?? false;
+    case "any":
+      return expression.of.some((each) => holds(each, snapshot));
+    case "all":
+      return expression.of.every((each) => holds(each, snapshot));
+  }
+}
+
+/**
+ * The seven groups, in the order they are shown.
+ *
+ * They replace the two-audience split ("you" and "admin"), which encoded who a
+ * page was FOR rather than what it was ABOUT — and so hid every installation
+ * page behind an operator-seat check, whatever grants the reader actually held.
+ */
+export const SETTINGS_GROUPS = [
+  "me",
+  "company",
+  "people",
+  "sales",
+  "data",
+  "ai",
+  "governance",
+] as const;
+export type SettingsGroupId = (typeof SETTINGS_GROUPS)[number];
+
+/**
+ * Whose state a setting changes, in the reader's words.
+ *
+ * `workspace` is the internal enum's name for it and is deliberately not shown:
+ * a person reading a settings page knows "Company", not the tenancy model.
+ */
+export type SettingsScope = "self" | "team" | "workspace" | "installation";
+
+/**
+ * Every settings page, its group, its scope and what it takes to open it.
+ *
+ * `requires` is a READ requirement — it says who may see the page, never who
+ * may change what is on it. Each card asks its own write question, because a
+ * page is routinely readable and only partly writable, and a page-level write
+ * flag would either hide a page somebody may read or promise controls they
+ * cannot use.
+ */
+export const SETTINGS_PAGES = [
+  { id: "account", group: "me", scope: "self", requires: always },
+  { id: "voice", group: "me", scope: "self", requires: always },
+  { id: "agents", group: "me", scope: "self", requires: always },
+  { id: "connections", group: "me", scope: "self", requires: always },
+  { id: "capture-activity", group: "me", scope: "self", requires: always },
+
+  {
+    id: "company",
+    group: "company",
+    scope: "installation",
+    // The union of what the three cards on it ask for. The company profile
+    // carries a second condition that is a deployment FLAG rather than a
+    // permission, so its grant ANDs with it: the surface may simply not exist
+    // on this installation.
+    requires: anyOf(
+      reads("installation_settings"),
+      allOf(reads("organization"), available("company_context")),
+      reads("fx_rate"),
+    ),
+  },
+  {
+    id: "authentication",
+    group: "company",
+    scope: "installation",
+    // The narrow sign-in projection, split out of the installation aggregate so
+    // it stops riding a grant every seeded role holds.
+    requires: anyOf(reads("authentication_policy"), reads("oauth_application")),
+  },
+
+  // `GET /users` answers 200 to any authenticated principal and the roster is
+  // not an admin's private question — the handler decides what the answer
+  // CONTAINS, and role keys are the privileged part. So the page opens for
+  // everyone and its controls withhold themselves.
+  { id: "members", group: "people", scope: "workspace", requires: always },
+  { id: "teams", group: "people", scope: "workspace", requires: always },
+  {
+    id: "roles",
+    group: "people",
+    scope: "workspace",
+    requires: reads("role_admin"),
+  },
+  {
+    id: "seats",
+    group: "people",
+    scope: "installation",
+    // Either grant opens it and they show different things: seat_usage is the
+    // capacity half, license the commercial one.
+    requires: anyOf(reads("seat_usage"), reads("license")),
+  },
+
+  {
+    id: "pipelines",
+    group: "sales",
+    scope: "workspace",
+    requires: reads("pipeline"),
+  },
+  {
+    id: "leads",
+    group: "sales",
+    scope: "workspace",
+    requires: reads("pipeline"),
+  },
+  {
+    id: "fields",
+    group: "sales",
+    scope: "workspace",
+    requires: reads("custom_field"),
+  },
+  { id: "tags", group: "sales", scope: "workspace", requires: reads("tag") },
+  {
+    id: "products",
+    group: "sales",
+    scope: "workspace",
+    requires: anyOf(reads("product"), reads("offer_template")),
+  },
+
+  {
+    id: "capture",
+    group: "data",
+    scope: "workspace",
+    requires: reads("capture_settings"),
+  },
+  {
+    id: "integrations",
+    group: "data",
+    scope: "workspace",
+    requires: anyOf(
+      reads("overlay_connection"),
+      reads("webhook_subscription"),
+      reads("integrations"),
+    ),
+  },
+  {
+    id: "knowledge",
+    group: "data",
+    scope: "workspace",
+    requires: reads("knowledge_corpus"),
+  },
+  {
+    id: "import",
+    group: "data",
+    scope: "workspace",
+    requires: reads("import_run"),
+  },
+
+  {
+    id: "models",
+    group: "ai",
+    scope: "workspace",
+    requires: reads("ai_routing"),
+  },
+  {
+    id: "automations",
+    group: "ai",
+    scope: "workspace",
+    requires: reads("automation"),
+  },
+  {
+    id: "usage",
+    group: "ai",
+    scope: "workspace",
+    requires: anyOf(reads("ai_diagnostics"), reads("ai_model_rate")),
+  },
+  {
+    id: "model-calls",
+    group: "ai",
+    scope: "workspace",
+    requires: reads("ai_diagnostics"),
+  },
+
+  {
+    id: "privacy",
+    group: "governance",
+    scope: "workspace",
+    requires: anyOf(
+      reads("consent_config"),
+      reads("retention_policy"),
+      reads("privacy_request"),
+      // The purposes list is gated on person.read server-side, which is not a
+      // role and not "any member" — moving it would 403 the Person 360 for
+      // every rep, so the page follows the gate the endpoint actually applies.
+      reads("person"),
+    ),
+  },
+  {
+    id: "audit",
+    group: "governance",
+    scope: "workspace",
+    requires: reads("audit_log"),
+  },
+  {
+    id: "system-health",
+    group: "governance",
+    scope: "installation",
+    requires: anyOf(reads("job_health"), reads("embedding_reindex")),
+  },
+  {
+    id: "extensions",
+    group: "governance",
+    scope: "installation",
+    requires: reads("extension_access"),
+  },
+  {
+    id: "reset",
+    group: "governance",
+    scope: "installation",
+    requires: { kind: "grant", object: "system_reset", action: "delete" },
+  },
+] as const satisfies readonly {
+  id: string;
+  group: SettingsGroupId;
+  scope: SettingsScope;
+  requires: CapabilityExpression;
+}[];
+
+export type SettingsPageId = (typeof SETTINGS_PAGES)[number]["id"];
+
+/** The pages this snapshot may open, in declaration order. */
+export function visibleSettingsPages(
+  snapshot: AccessSnapshot,
+): readonly (typeof SETTINGS_PAGES)[number][] {
+  return SETTINGS_PAGES.filter((page) => holds(page.requires, snapshot));
+}

--- a/frontend/src/screens/settingscatalog.units.test.ts
+++ b/frontend/src/screens/settingscatalog.units.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// `settingscatalog.ts` spells `UnitSecretScope` a second time rather than
+// importing it, because the extensions registry reaches `@composition/screens`
+// and would drag React and a build alias into a module whose whole purpose is
+// being importable from anywhere — including a plain node script and a test with
+// no alias configured.
+//
+// A mirrored type needs a gate that fails in BOTH directions, or the copy drifts
+// silently: a scope added to the registry and not here makes a page's units arm
+// unreachable, and one added here and not there makes it unsatisfiable. Neither
+// shows up as a type error, because the two are separate declarations.
+//
+// Compared as source text rather than as types: a type identity cannot be
+// asserted at runtime, and the point is precisely that these are two
+// declarations rather than one.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function scopesDeclaredIn(file: string, name: string): string[] {
+  const source = readFileSync(file, "utf8");
+  const match = source.match(new RegExp(`export type ${name} =([^;]+);`));
+  if (match === null) {
+    throw new Error(`no \`export type ${name}\` in ${file}`);
+  }
+  return [...match[1].matchAll(/"([a-z_]+)"/g)].map((m) => m[1]).sort();
+}
+
+describe("the mirrored UnitSecretScope", () => {
+  it("names exactly the scopes the registry names", () => {
+    const registry = scopesDeclaredIn(
+      join(here, "..", "app", "extensions.ts"),
+      "UnitSecretScope",
+    );
+    const catalog = scopesDeclaredIn(
+      join(here, "settingscatalog.ts"),
+      "UnitSecretScope",
+    );
+    expect(catalog).toEqual(registry);
+  });
+
+  it("finds a non-empty set in each, so the comparison cannot pass vacuously", () => {
+    // Two empty arrays are equal. Without this, a regex that stopped matching
+    // would report agreement between nothing and nothing.
+    expect(
+      scopesDeclaredIn(
+        join(here, "..", "app", "extensions.ts"),
+        "UnitSecretScope",
+      ),
+    ).toContain("workspace");
+    expect(
+      scopesDeclaredIn(join(here, "settingscatalog.ts"), "UnitSecretScope"),
+    ).toContain("workspace");
+  });
+});


### PR DESCRIPTION
The settings register held sixteen entries in two groups, "you" and "admin". That split said who a page was **for** rather than what it was **about**, which is why every installation page sat behind an operator-seat check — a rep holding `pipeline:read` was shown nothing while the API answered them 200.

This lands the replacement as pure data, plus the shared evaluator it needs. It does not route to it yet; the register still drives the screen.

## One evaluator, not two

`useCan` held the grant lookup inside a hook, so anything asking the same question outside a component had to spell the chain again — and the tree already had that bug, with the settings rail and the command palette each deciding whether the company page exists and disagreeing.

`grants(snapshot, object, action)` is that lookup as a plain function; `useCan` is now a one-line wrapper. A test drives both over the same snapshot and asserts they agree, so a future divergence fails rather than reaching a screen.

## The catalog

`settingscatalog.ts` — 29 pages across seven groups, each carrying its group, whose state it changes, and what a reader must hold to open it. The requirement is an **expression** (`reads("pipeline")`, `anyOf(...)`, `allOf(reads("organization"), available("company_context"))`) evaluated by `holds`, so the rail, the palette, search and the page resolve one table through one function.

Every object name is checked against the generated RBAC enum, so a misspelling is a compile error rather than a check that quietly denies forever.

## What the review caught

The first round of tests **could not see a widening**. They drove one rep-shaped fixture, and a page opening too far only appears under an *asymmetric* snapshot — a reader holding the new object and not the old one. Two real defects:

- **`integrations` asked for `integrations:read`**, which every seeded role holds including `read_only`. The page would have opened for everyone.
- **It dropped the composed-unit arm** the shipped predicate had. An installation whose only workspace-scoped extension unit keeps its settings on that page would have lost the one route to them.

Both fixed. The remaining differences are real and are now **stated as tests**, because a difference nobody writes down reads as an accident to the next author. Each is the client catching up with the server:

| Page | Old | Server actually gates on |
|---|---|---|
| extensions | literal `admin` role | `extension_access.read` — ops holds it |
| system-health | `isAdmin \|\| embedding_reindex` | `job_health.read` |
| audit | the consent registry's grant | `audit_log.read` |
| seats | `license.read` | `seat_usage.read` — which is what the split shipped for |

Splitting the AI page **narrows** management: they reach the parts their grants cover and not the routing editor, which asks for `ai_routing` they do not hold.

## One mirrored type, with a gate

`UnitSecretScope` is spelled twice rather than imported — the extensions registry reaches `@composition/screens` and would drag React and a build alias into a module whose whole purpose is being importable from anywhere. The composition fact is injected into `holds` instead, and `settingscatalog.units.test.ts` holds the two spellings equal, failing in **both** directions since a scope added on either side alone is invisible to the type checker.

## Verification

- `make check-fe` **green, exit 0**
- 23 catalog tests, 31 capability tests
- mutations checked one clause at a time: availability failing open, `any`/`all` swapped, the hook diverging from `grants`, and the mirror in both directions

One caveat worth stating: an earlier gate run failed on `leads.test.tsx` and `worklist.today.test.tsx`. Neither references this change; both pass alone (76 tests), pass alongside all six settings suites (170 tests), and the gate is green on rerun. That is the load-timing family `frontend/AGENTS.md` documents, and the same two files behaved identically on #4419.

Reviewed by Codex on `gpt-5.6-sol`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The settings register split sixteen entries by who a page was for, hiding installation pages behind operator-seat checks the server never enforced. This replaces it with a pure-data catalog of 29 pages across 7 groups gated by capability expressions the new `holds` function evaluates — pages now admit exactly who the server admits, but the register still drives the screen until the catalog is routed.

**Refactors**
- `grants(snapshot, object, action)` extracts the grant lookup from `useCan`, which is now a one-line wrapper, so the catalog and any non-React caller resolve the same access question.
- The catalog is pure data with no React imports; `UnitSecretScope` is mirrored rather than imported, and a test holds the two spellings equal in both directions.
- Page requirements are expressions over the generated RBAC enum, so a misspelled object name is a compile error.

**Bug fixes**
- Pages gate on the grants the server actually enforces: extensions, system-health, audit, and seats admit readers the old literal-role or wrong-object checks refused.
- The AI page narrows so management reaches the parts their grants cover but not the routing editor.
- `integrations` no longer asks for a grant every seeded role holds, and the composed-unit arm keeping workspace-scoped extension settings reachable is restored.

<sup>Written for commit 657d161fd6463b38d4a53ba3ac3beca6bfc2728c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a centralized settings catalog that controls page groups, visibility, scopes, and access requirements across settings navigation and discovery surfaces.
  - Settings pages now appear based on the viewer’s permissions, deployment availability, and configured units.
  - Added support for combined permission requirements and fail-closed handling when access information is unavailable.

- **Bug Fixes**
  - Unified permission checks so settings visibility and capability checks use consistent access decisions.

- **Tests**
  - Added coverage for permission evaluation, settings visibility, catalog structure, and unit scope consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->