### PR TITLE
A lift says which stop it took back, and what still stands

### DIFF
--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -2508,7 +2508,19 @@ components:
       x-version: 1
       description: >-
         Payload for consent.suppression_lifted — somebody with the authority to
-        do so took back a stop, so mail to this person may resume.
+        do so took back ONE stop.
+
+        That is not the same as "mail may resume", and a consumer must not read
+        it that way. A person can carry several stops at once — their own
+        objection and a rep's separate note — and lifting one says nothing about
+        the others. `remaining_suppressions` is the field that answers the
+        question a consumer actually has, and `still_suppressed` is that answer
+        stated plainly: true means this person is STILL not writable, however
+        many stops were just taken back.
+
+        Margince itself never relied on this event to decide a send — the engine
+        re-reads the strongest live stop inside the sending transaction — so
+        these fields exist for the readers outside it.
 
         It carries BOTH levels: the one the stop was recorded at and the one
         that lifted it. A reader auditing this later needs to see that the
@@ -2518,6 +2530,16 @@ components:
         It never carries the reason either party gave. Those words belong to the
         people who wrote them, and an event reaches readers the explanation was
         not given to.
+      # The three fields below are OPTIONAL and the version stays 1, because a
+      # consumer already validating this payload must keep validating it. An
+      # in-place `required` on a shipped version is what makes a live webhook
+      # start rejecting deliveries and dead-lettering them, which is a worse
+      # outage than the one this change exists to prevent.
+      #
+      # A consumer that has not been updated therefore still reads the two
+      # levels and learns nothing new — no worse than before. One that HAS been
+      # updated gets the answer. Absent must be read as "this installation has
+      # not started sending it", never as "nothing stands".
       required:
         - recorded_at_level
         - lifted_by_level
@@ -2528,6 +2550,24 @@ components:
         lifted_by_level:
           type: string
           description: The authority that lifted it. Always strictly above the level above.
+        suppression_id:
+          type: string
+          format: uuid
+          description: >-
+            Which stop was lifted. Without it a consumer holding two stops for
+            one person cannot tell which one this event describes.
+        remaining_suppressions:
+          type: integer
+          minimum: 0
+          description: >-
+            How many stops are still live for this person after the lift,
+            counted inside the same transaction that did the lifting.
+        still_suppressed:
+          type: boolean
+          description: >-
+            Whether this person is still not writable. Equivalent to
+            remaining_suppressions > 0, stated as its own field so a consumer
+            cannot get the comparison wrong in the direction that resumes mail.
       additionalProperties: false
 
     PublicEventConsentSuppressed:

--- a/backend/gates/suppressionauthority_test.go
+++ b/backend/gates/suppressionauthority_test.go
@@ -63,8 +63,33 @@ func TestEverySuppressionKindIsClassifiedByTheMigrationThatAddedTheLevel(t *test
 		t.Fatalf("reading the migration that classifies each kind: %v", err)
 	}
 
+	// The CASE arms only, never the whole file. The migration also carries a
+	// CHECK listing the authority levels — 'machine', 'user', 'admin',
+	// 'subject' — so a bare substring search for a kind named `user` would find
+	// that constraint's literal and report a kind classified when it actually
+	// falls to the ELSE arm. A gate that matches lines instead of statements
+	// passes over the defect it exists to catch.
+	// Comments stripped FIRST. The pattern below cannot tell a live CASE arm
+	// from one somebody commented out while debugging, and a gate that reads a
+	// commented `WHEN kind = 'x'` as a classification reports PASS over a kind
+	// production actually sends through the ELSE arm — unliftable, silently.
+	// Under-recognition is the failure this file exists to prevent, so the
+	// corpus is the executable statement and nothing else.
+	arms := classifyingArm.FindAllStringSubmatch(sqlWithoutComments(string(classifier)), -1)
+	classified := make(map[string]bool, len(arms))
+	for _, arm := range arms {
+		for _, lit := range caseArmKindLiteral.FindAllStringSubmatch(arm[1], -1) {
+			classified[lit[1]] = true
+		}
+	}
+	if len(classified) == 0 {
+		t.Fatal("no WHEN arm in " + levelClassifyingMigration + " names a kind: the pattern " +
+			"has stopped matching, and an empty set would report every kind unclassified " +
+			"or none — neither is a reading of the file")
+	}
+
 	for _, kind := range kinds {
-		if !strings.Contains(string(classifier), "'"+kind[1]+"'") {
+		if !classified[kind[1]] {
 			t.Errorf("suppression kind %q is not named by %s, so it falls to that file's "+
 				"ELSE arm and becomes 'subject' — a suppression nobody can lift. Add an arm "+
 				"saying who decides a %[1]q, in a NEW migration rather than by editing a shipped one",
@@ -72,6 +97,30 @@ func TestEverySuppressionKindIsClassifiedByTheMigrationThatAddedTheLevel(t *test
 		}
 	}
 }
+
+// sqlWithoutComments drops `-- ...` to end of line. Enough for this gate: the
+// migration it reads carries no string literal containing a double dash, and a
+// block-comment form would need the same treatment if one ever appeared.
+func sqlWithoutComments(sql string) string {
+	var b strings.Builder
+	for line := range strings.SplitSeq(sql, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// classifyingArm pulls the body of each `WHEN ... THEN` arm of the backfill's
+// CASE. Matching the arm rather than the file is what keeps the CHECK
+// constraint's own level literals out of the answer.
+var classifyingArm = regexp.MustCompile(`(?i)WHEN\s+(kind\s+(?:=|IN)[^\n]*?)\s+THEN`)
+
+// caseArmKindLiteral pulls a bare 'value' out of a CASE arm, where the
+// literals carry no ::text cast the catalog's CHECK bodies have.
+var caseArmKindLiteral = regexp.MustCompile(`'([a-z_]+)'`)
 
 // levelClassifyingMigration is the file deriving decided_by_level from kind.
 //

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -1032,7 +1032,9 @@ type PublicEventConsentSuppressed struct {
 	Kind string `json:"kind"`
 }
 
-// PublicEventConsentSuppressionLifted Payload for consent.suppression_lifted — somebody with the authority to do so took back a stop, so mail to this person may resume.
+// PublicEventConsentSuppressionLifted Payload for consent.suppression_lifted — somebody with the authority to do so took back ONE stop.
+// That is not the same as "mail may resume", and a consumer must not read it that way. A person can carry several stops at once — their own objection and a rep's separate note — and lifting one says nothing about the others. `remaining_suppressions` is the field that answers the question a consumer actually has, and `still_suppressed` is that answer stated plainly: true means this person is STILL not writable, however many stops were just taken back.
+// Margince itself never relied on this event to decide a send — the engine re-reads the strongest live stop inside the sending transaction — so these fields exist for the readers outside it.
 // It carries BOTH levels: the one the stop was recorded at and the one that lifted it. A reader auditing this later needs to see that the second outranked the first, and a single "lifted_by" would leave that unanswerable without joining the row that no longer says it.
 // It never carries the reason either party gave. Those words belong to the people who wrote them, and an event reaches readers the explanation was not given to.
 type PublicEventConsentSuppressionLifted struct {
@@ -1041,6 +1043,15 @@ type PublicEventConsentSuppressionLifted struct {
 
 	// RecordedAtLevel The authority the stop was recorded at (machine | user | admin | subject).
 	RecordedAtLevel string `json:"recorded_at_level"`
+
+	// RemainingSuppressions How many stops are still live for this person after the lift, counted inside the same transaction that did the lifting.
+	RemainingSuppressions *int `json:"remaining_suppressions,omitempty"`
+
+	// StillSuppressed Whether this person is still not writable. Equivalent to remaining_suppressions > 0, stated as its own field so a consumer cannot get the comparison wrong in the direction that resumes mail.
+	StillSuppressed *bool `json:"still_suppressed,omitempty"`
+
+	// SuppressionId Which stop was lifted. Without it a consumer holding two stops for one person cannot tell which one this event describes.
+	SuppressionId *openapi_types.UUID `json:"suppression_id,omitempty"`
 }
 
 // PublicEventContractArchived Payload for contract.archived — the agreement left the surfaces that count it.

--- a/backend/internal/modules/consent/controllertemplates_test.go
+++ b/backend/internal/modules/consent/controllertemplates_test.go
@@ -209,9 +209,11 @@ func TestEveryControllerTemplateIsPinnedToItsWording(t *testing.T) {
 		}
 		if got != want {
 			t.Errorf("%s wording changed but its version did not.\n  pinned: %s\n  now:    %s\n\n"+
-				"Bump the template's version and add a NEW row here, keeping the old one. "+
-				"consent_event records which version a person was shown, so editing version %d "+
-				"in place makes every existing proof row describe text that no longer exists",
+				"Bump the template's version and REPLACE this row with one for the new "+
+				"version. Do not keep the old row: this map is what THIS build sends, and the "+
+				"check below fails a pin nothing renders. What version %d actually showed a "+
+				"person is recoverable from consent_event.policy_text, which is where that "+
+				"history belongs — not here",
 				pin, want, got, rendered.Version)
 		}
 	}

--- a/backend/internal/modules/consent/lift.go
+++ b/backend/internal/modules/consent/lift.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -74,18 +75,8 @@ func admitLift(ctx context.Context, in LiftInput) (subject, commsauthz.Authority
 			Reason: "name the suppression to lift; a subject may carry more than one",
 		}
 	}
-	if strings.TrimSpace(in.Reason) == "" {
-		return subject{}, "", &ValidationError{
-			Field:  fieldReason,
-			Reason: "taking back a stop needs a reason somebody can review later",
-		}
-	}
-	if len([]rune(in.Reason)) > liftReasonMax {
-		return subject{}, "", &ValidationError{
-			Field: fieldReason,
-			Reason: fmt.Sprintf("a reason is at most %d characters; this one is %d",
-				liftReasonMax, len([]rune(in.Reason))),
-		}
+	if err := requireReason(in.Reason, "taking back a stop"); err != nil {
+		return subject{}, "", err
 	}
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return subject{}, "", err
@@ -97,11 +88,43 @@ func admitLift(ctx context.Context, in LiftInput) (subject, commsauthz.Authority
 // payload spell it the same way.
 const fieldReason = "reason"
 
-// liftReasonMax bounds the reason. It is the contract's own maxLength written
-// again here because nothing generated enforces it — unchecked, one caller
-// stores a megabyte in an audit payload every later reader of this person's
-// history is served in full.
-const liftReasonMax = 500
+// reasonMax bounds a reason. It is the contract's own maxLength written again
+// here because nothing generated enforces it — unchecked, one caller stores a
+// megabyte in an audit payload every later reader of this person's history is
+// served in full.
+const reasonMax = 500
+
+// boundReason holds the LENGTH rule, which both doors that take a reason share.
+// Only the bound: whether a reason must be given at all differs between them,
+// and the contract is what says so.
+func boundReason(reason string) error {
+	if n := len([]rune(reason)); n > reasonMax {
+		return &ValidationError{
+			Field:  fieldReason,
+			Reason: fmt.Sprintf("a reason is at most %d characters; this one is %d", reasonMax, n),
+		}
+	}
+	return nil
+}
+
+// requireReason is the LIFT's rule: a reason is mandatory here and optional on
+// the door that records a stop. That asymmetry is the contract's, not an
+// oversight — `crm.yaml` marks the suppress body `required: [kind]` and the
+// lift body's own description says "Required, unlike the reason for setting
+// one". A rep relaying "please stop emailing me" can record that stop with no
+// explanation; taking one back has to be explainable.
+//
+// Sharing the bound and not the requirement is the whole point of the split:
+// unifying both would have turned a conforming suppress request into a 422.
+func requireReason(reason, act string) error {
+	if strings.TrimSpace(reason) == "" {
+		return &ValidationError{
+			Field:  fieldReason,
+			Reason: act + " needs a reason somebody can review later",
+		}
+	}
+	return boundReason(reason)
+}
 
 // liftAdmittedTx reads the row's authority, compares it, and revokes.
 func (s *Store) liftAdmittedTx(
@@ -123,6 +146,13 @@ func (s *Store) liftAdmittedTx(
 	// decision rests on is the level still on the row when the write lands. Read
 	// outside and a concurrent lift could change it between the check and the
 	// update — the shape that lets a rep's request act on an admin's answer.
+	// Before the read, so the count below observes every concurrent lift of this
+	// person as committed or not-yet-started, never as half-applied.
+	if _, err = tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, sub.id.String()); err != nil {
+		return fmt.Errorf("consent: serialising lifts for this person: %w", err)
+	}
+
 	var decided string
 	err = tx.QueryRow(ctx, `
 		SELECT decided_by_level FROM communication_suppression
@@ -150,6 +180,53 @@ func (s *Store) liftAdmittedTx(
 		return fmt.Errorf("consent: revoking the suppression: %w", err)
 	}
 
+	// Counted AFTER the revoke and inside the same transaction, so the number
+	// describes this lift's own snapshot rather than the world before it. Not a
+	// serialized by the FOR UPDATE above, which locks only the row being lifted.
+	// Two lifts of DIFFERENT rows on one person would otherwise each see the
+	// other's row still live and both emit still_suppressed=true — and nothing
+	// emits again afterwards, so both consumers hold mail forever on a person
+	// with no stop left. "A moment of over-counting" was the wrong reading: an
+	// event is not a poll, and there is no later correction.
+	//
+	// So the whole person is taken first, and every lift of the same person
+	// queues behind it. One person's lock, held for the length of one lift —
+	// this is not a table lock and it does not touch anybody else's subject.
+	//
+	// NOT held by a test, deliberately. Each Lift opens its own short
+	// transaction, so two goroutines started together almost never overlap in
+	// the count window: a timing test passed identically with the lock removed,
+	// three runs out of three, which makes it a green that proves nothing
+	// rather than a guard. Reproducing it needs two transactions held open by
+	// hand around the read — worth writing when this file next gains a seam
+	// that can do it, and worth nobody's confidence until then.
+	//
+	// Person AND address, not person alone. A row pinned to an address carries
+	// no person_id, so counting by person would report "nothing stands" while
+	// the engine still refuses every message to that mailbox. Reporting fewer
+	// stops than exist is the one error this field must not make: it is the
+	// direction that resumes mail.
+	//
+	// liveSuppression carries a third arm, lead_id, because it is called with
+	// either a person or a lead. This is not: LiftInput takes a PersonID and
+	// consentSubject resolves it, so a lead arm here would be a clause that can
+	// never match — the appearance of mirroring the engine without the fact.
+	//
+	// Held by TestALiftReportsAnAddressPinnedStopAsStanding.
+	var remaining int
+	if err = tx.QueryRow(ctx, `
+		SELECT count(*) FROM communication_suppression s
+		 WHERE s.revoked_at IS NULL
+		   AND (s.person_id = $1
+		        OR (s.address IS NOT NULL AND EXISTS (
+		              SELECT 1 FROM person_email pe
+		               WHERE pe.person_id = $1
+		                 AND pe.archived_at IS NULL
+		                 AND pe.email = lower(s.address))))`,
+		sub.id).Scan(&remaining); err != nil {
+		return fmt.Errorf("consent: counting the stops still standing: %w", err)
+	}
+
 	auditID, err := storekit.AuditEvent(ctx, tx, "update", sub.entityType, sub.id,
 		map[string]any{
 			"lifted_suppression": in.SuppressionID.String(),
@@ -165,7 +242,8 @@ func (s *Store) liftAdmittedTx(
 	if err != nil {
 		return err
 	}
-	return storekit.EmitEvent(ctx, tx, auditID, sub.id, suppressionLiftedPayload(decided, level))
+	return storekit.EmitEvent(ctx, tx, auditID, sub.id,
+		suppressionLiftedPayload(in.SuppressionID, decided, level, remaining))
 }
 
 // suppressionLiftedPayload says a stop was taken back and by whose authority.
@@ -173,9 +251,31 @@ func (s *Store) liftAdmittedTx(
 // It carries the two levels rather than the reason, for the same reason the
 // recording event does: the words belong to the people who wrote them, and an
 // event reaches readers the explanation was not given to.
-func suppressionLiftedPayload(recorded string, by commsauthz.AuthorityLevel) crmcontracts.PublicEventConsentSuppressionLifted {
+//
+// It also carries what the lift did NOT do. One person can hold several stops —
+// their own objection and a rep's separate note — and lifting one leaves the
+// others standing. An event saying only "a stop was lifted" reads as "you may
+// write to them now", so `still_suppressed` states the opposite plainly and
+// `remaining` says how many reasons remain. The engine never needed this (it
+// re-reads the strongest live row when it sends); the readers outside do.
+func suppressionLiftedPayload(
+	lifted ids.UUID,
+	recorded string,
+	by commsauthz.AuthorityLevel,
+	remaining int,
+) crmcontracts.PublicEventConsentSuppressionLifted {
+	// Always populated. The contract marks them optional so a consumer written
+	// against the older shape keeps validating, not because this installation
+	// may omit them: a payload that left them out would be one a reader could
+	// only interpret as "unknown", and there is no case here where the answer
+	// is unknown.
+	id := openapi_types.UUID(lifted)
+	stands := remaining > 0
 	return crmcontracts.PublicEventConsentSuppressionLifted{
-		RecordedAtLevel: recorded,
-		LiftedByLevel:   string(by),
+		SuppressionId:         &id,
+		RecordedAtLevel:       recorded,
+		LiftedByLevel:         string(by),
+		RemainingSuppressions: &remaining,
+		StillSuppressed:       &stands,
 	}
 }

--- a/backend/internal/modules/consent/lift_integration_test.go
+++ b/backend/internal/modules/consent/lift_integration_test.go
@@ -15,10 +15,14 @@ package consent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
@@ -314,7 +318,7 @@ func TestALiftNeedsAReasonSomebodyCanReview(t *testing.T) {
 	for name, reason := range map[string]string{
 		"empty":      "",
 		"whitespace": "   \t\n ",
-		"too long":   strings.Repeat("x", liftReasonMax+1),
+		"too long":   strings.Repeat("x", reasonMax+1),
 	} {
 		err := e.store.Lift(e.ctx, LiftInput{
 			PersonID: e.person, SuppressionID: row, Reason: reason,
@@ -337,8 +341,161 @@ func TestALiftNeedsAReasonSomebodyCanReview(t *testing.T) {
 	// The bound admits its own limit, so the check is a ceiling and not an
 	// off-by-one that refuses a legitimate 500-character explanation.
 	if err := e.store.Lift(e.ctx, LiftInput{
-		PersonID: e.person, SuppressionID: row, Reason: strings.Repeat("x", liftReasonMax),
+		PersonID: e.person, SuppressionID: row, Reason: strings.Repeat("x", reasonMax),
 	}); err != nil {
 		t.Errorf("a reason at exactly the limit was refused: %v", err)
 	}
+}
+
+// lastLiftPayload decodes the consent.suppression_lifted envelope the lift just
+// staged. Read from the outbox rather than returned by the store, because the
+// row a consumer will actually receive is the thing under test.
+func lastLiftPayload(t *testing.T, e *channelConsentEnv) crmcontracts.PublicEventConsentSuppressionLifted {
+	t.Helper()
+	var raw []byte
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT envelope->'payload' FROM event_outbox
+		 WHERE envelope->>'type' = 'consent.suppression_lifted'
+		 ORDER BY created_at DESC, id DESC
+		 LIMIT 1`).Scan(&raw); err != nil {
+		t.Fatalf("reading the staged lift event: %v", err)
+	}
+	var payload crmcontracts.PublicEventConsentSuppressionLifted
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decoding the lift payload: %v", err)
+	}
+	return payload
+}
+
+// TestALiftSaysWhatStillStands is the whole reason the event carries more than
+// two authority levels.
+//
+// A person can hold several stops at once — their own objection and a rep's
+// separate note. Lifting one leaves the others standing, and an event that says
+// only "a stop was lifted" reads to an outside consumer as "you may write to
+// them now". Margince itself is safe either way, because the engine re-reads the
+// strongest live row inside the sending transaction; the consumers reading this
+// event are the ones that would resume mail to somebody who objected.
+func TestALiftSaysWhatStillStands(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	// Two stops. The user-level one is liftable by an admin; the subject's own
+	// is not, and is what must still be reported after the lift.
+	liftable := plantSuppression(t, e, e.person, string(commsauthz.LevelUser))
+	subjects := plantSuppression(t, e, e.person, string(commsauthz.LevelSubject))
+
+	if err := e.store.Lift(e.ctx, LiftInput{
+		PersonID:      e.person,
+		SuppressionID: liftable,
+		Reason:        "the rep confirmed this note was filed against the wrong contact",
+	}); err != nil {
+		t.Fatalf("lifting the user-level stop as admin: %v", err)
+	}
+
+	payload := lastLiftPayload(t, e)
+	if payload.SuppressionId == nil || *payload.SuppressionId != openapi_types.UUID(liftable) {
+		t.Errorf("event names suppression %s, want the one that was lifted (%s)",
+			derefUUID(payload.SuppressionId), liftable)
+	}
+	if payload.RemainingSuppressions == nil || *payload.RemainingSuppressions != 1 {
+		t.Errorf("remaining_suppressions = %d, want 1: the subject's own objection still stands",
+			payload.RemainingSuppressions)
+	}
+	if payload.StillSuppressed == nil || !*payload.StillSuppressed {
+		t.Error("still_suppressed = false while the subject's objection is live — " +
+			"a consumer reading this event would resume mail to somebody who objected")
+	}
+	if !stillLive(t, e, subjects) {
+		t.Error("the subject's objection was revoked by a lift aimed at another row")
+	}
+}
+
+// TestALiftOfTheLastStopSaysSo is the other direction: when nothing remains,
+// the event must say so, or a consumer holding mail back forever is the bug.
+func TestALiftOfTheLastStopSaysSo(t *testing.T) {
+	e := setupChannelConsent(t)
+	only := plantSuppression(t, e, e.person, string(commsauthz.LevelUser))
+
+	if err := e.store.Lift(e.ctx, LiftInput{
+		PersonID:      e.person,
+		SuppressionID: only,
+		Reason:        "recorded in error against this contact",
+	}); err != nil {
+		t.Fatalf("lifting the only stop: %v", err)
+	}
+
+	payload := lastLiftPayload(t, e)
+	if payload.RemainingSuppressions == nil || *payload.RemainingSuppressions != 0 ||
+		payload.StillSuppressed == nil || *payload.StillSuppressed {
+		t.Errorf("remaining = %d, still_suppressed = %v; want 0 and false with no stop left",
+			derefInt(payload.RemainingSuppressions), derefBool(payload.StillSuppressed))
+	}
+}
+
+// TestALiftReportsAnAddressPinnedStopAsStanding holds the count's match rule.
+//
+// A hard bounce is pinned to an ADDRESS and carries no person_id. The engine
+// still refuses every message to that mailbox, because liveSuppression matches
+// person OR lead OR address. A count that asked only about person_id would
+// answer "nothing stands" for exactly that subject, and still_suppressed would
+// tell a consumer to resume mail the engine will not send. Under-reporting is
+// the one direction this field must never fail in.
+func TestALiftReportsAnAddressPinnedStopAsStanding(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	address := "bounced-" + e.person.String() + "@example.test"
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		 VALUES ($1, lower($2), true, 'test', 'human:x')`, e.person, address); err != nil {
+		t.Fatalf("giving the person an address: %v", err)
+	}
+	// Pinned to the address alone, the way a bounce handler writes it.
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO communication_suppression
+		     (id, address, kind, source, captured_by, decided_by_level)
+		 VALUES ($1, lower($2), 'hard_bounce', 'test', 'system', 'machine')`,
+		ids.NewV7(), address); err != nil {
+		t.Fatalf("planting the address-pinned bounce: %v", err)
+	}
+
+	liftable := plantSuppression(t, e, e.person, string(commsauthz.LevelUser))
+	if err := e.store.Lift(e.ctx, LiftInput{
+		PersonID:      e.person,
+		SuppressionID: liftable,
+		Reason:        "filed against the wrong contact",
+	}); err != nil {
+		t.Fatalf("lifting the person-level stop: %v", err)
+	}
+
+	payload := lastLiftPayload(t, e)
+	if payload.StillSuppressed == nil || !*payload.StillSuppressed ||
+		payload.RemainingSuppressions == nil || *payload.RemainingSuppressions != 1 {
+		t.Errorf("remaining = %d, still_suppressed = %v; want 1 and true — the bounce on "+
+			"%s is still live and the engine will still refuse this mail",
+			derefInt(payload.RemainingSuppressions), derefBool(payload.StillSuppressed), address)
+	}
+}
+
+// The three fields are optional on the wire so an older consumer keeps
+// validating, but this writer always sets them — so a nil in a failure message
+// is itself the news, and these print it rather than an address.
+func derefInt(v *int) any {
+	if v == nil {
+		return "absent"
+	}
+	return *v
+}
+
+func derefBool(v *bool) any {
+	if v == nil {
+		return "absent"
+	}
+	return *v
+}
+
+func derefUUID(v *openapi_types.UUID) any {
+	if v == nil {
+		return "absent"
+	}
+	return *v
 }

--- a/backend/internal/modules/consent/suppress.go
+++ b/backend/internal/modules/consent/suppress.go
@@ -95,6 +95,12 @@ func admitSuppress(ctx context.Context, in SuppressInput) (subject, commsauthz.A
 				"processing restriction and a bounce are not recorded by hand here",
 		}
 	}
+	// The BOUND only. The contract makes this reason optional (`required: [kind]`),
+	// and a rep relaying a phone call may have nothing to add — what it must not
+	// be is a megabyte every later reader of this person's history is served.
+	if err := boundReason(in.Reason); err != nil {
+		return subject{}, "", err
+	}
 	// "person" as a literal rather than sub.entityType, which is the same value
 	// on every path this door has: SuppressInput reaches it from a person route
 	// only. A computed object name is a door no static check can resolve, and
@@ -111,6 +117,10 @@ func admitSuppress(ctx context.Context, in SuppressInput) (subject, commsauthz.A
 // Never from the request. A body naming its own level would let any caller
 // write a `subject`-level row, which nothing in the installation can lift —
 // a denial of service against one contact, spelled as a permission.
+//
+// auth.RequireAdmin is the literal admin role, so an `ops` seat lands at
+// LevelUser. That is deliberate and matches the RBAC defaults, where ops and
+// admin are separated by exactly this gate — see LevelAdmin's own comment.
 func authorityOf(ctx context.Context) commsauthz.AuthorityLevel {
 	if auth.RequireAdmin(ctx) == nil {
 		return commsauthz.LevelAdmin

--- a/backend/internal/modules/consent/suppress_integration_test.go
+++ b/backend/internal/modules/consent/suppress_integration_test.go
@@ -17,6 +17,7 @@ package consent
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -300,5 +301,54 @@ func TestARepCannotStopAContactTheyOnlyRead(t *testing.T) {
 	}
 	if rows != 0 {
 		t.Errorf("the refused write still left %d row(s) on a contact the rep may only read", rows)
+	}
+}
+
+// TestASuppressionNeedsAReasonSomebodyCanReview holds the same bound on this
+// door that TestALiftNeedsAReasonSomebodyCanReview holds on its sibling.
+//
+// The two doors take the same field under the same contract limit and enforced
+// it in one place only: recording a stop accepted a megabyte where taking one
+// back refused at 500. Both now call requireReason, and this test is what fails
+// if one of them stops.
+func TestASuppressionNeedsAReasonSomebodyCanReview(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	// Only the BOUND. Empty is legal here and refused on the lift door, because
+	// the contract says so: the suppress body is `required: [kind]`, and a rep
+	// relaying "please stop emailing me" may have nothing to add. Asserting a
+	// refusal on empty would pin behaviour that breaks a conforming client.
+	for name, reason := range map[string]string{
+		"too long": strings.Repeat("x", reasonMax+1),
+	} {
+		err := e.store.Suppress(e.ctx, SuppressInput{
+			PersonID: e.person, Kind: suppressibleKind, Reason: reason,
+		})
+		var invalid *ValidationError
+		if !errors.As(err, &invalid) {
+			t.Errorf("a %s reason was refused with %v, want a validation error", name, err)
+			continue
+		}
+		if invalid.Field != fieldReason {
+			t.Errorf("a %s reason named field %q, want %q", name, invalid.Field, fieldReason)
+		}
+	}
+}
+
+// TestASuppressionMayCarryNoReason pins the other half of the contract: this
+// door's reason is OPTIONAL, and a body of `{"kind":"subject_request"}` is one
+// the published contract accepts. A shared validator that demanded a reason
+// here would answer 422 to that body and stop a rep recording a stop somebody
+// actually asked for.
+func TestASuppressionMayCarryNoReason(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if err := e.store.Suppress(e.ctx, SuppressInput{
+		PersonID: e.person, Kind: suppressibleKind,
+	}); err != nil {
+		t.Fatalf("recording a stop with no reason: %v", err)
+	}
+	if kind, _, _ := liveSuppressionRow(t, e, e.person); kind != suppressibleKind {
+		t.Errorf("kind = %q, want %q", kind, suppressibleKind)
 	}
 }

--- a/backend/internal/shared/ports/commsauthz/authority.go
+++ b/backend/internal/shared/ports/commsauthz/authority.go
@@ -26,7 +26,15 @@ const (
 	LevelMachine AuthorityLevel = "machine"
 	// LevelUser is a rep or SDR exercising judgement about a contact they know.
 	LevelUser AuthorityLevel = "user"
-	// LevelAdmin is ops or a workspace administrator.
+	// LevelAdmin is a workspace administrator: a seat that passes
+	// auth.RequireAdmin, which is the literal admin role and nothing else.
+	//
+	// NOT the `ops` role, despite ops administering most of the installation's
+	// wiring. The RBAC defaults separate the two deliberately — ops differs from
+	// admin "in row scope alone at this layer: what actually separates them is
+	// the literal-admin gate on identity and governance routes" — and reversing
+	// somebody's recorded stop is a governance act, not wiring. An ops seat
+	// therefore decides at LevelUser and cannot overrule a rep's judgement.
 	LevelAdmin AuthorityLevel = "admin"
 	// LevelSubject is the person the data is about, acting for themselves.
 	LevelSubject AuthorityLevel = "subject"

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -1105,7 +1105,9 @@ export interface components {
             contact_id?: string;
         };
         /**
-         * @description Payload for consent.suppression_lifted — somebody with the authority to do so took back a stop, so mail to this person may resume.
+         * @description Payload for consent.suppression_lifted — somebody with the authority to do so took back ONE stop.
+         *     That is not the same as "mail may resume", and a consumer must not read it that way. A person can carry several stops at once — their own objection and a rep's separate note — and lifting one says nothing about the others. `remaining_suppressions` is the field that answers the question a consumer actually has, and `still_suppressed` is that answer stated plainly: true means this person is STILL not writable, however many stops were just taken back.
+         *     Margince itself never relied on this event to decide a send — the engine re-reads the strongest live stop inside the sending transaction — so these fields exist for the readers outside it.
          *     It carries BOTH levels: the one the stop was recorded at and the one that lifted it. A reader auditing this later needs to see that the second outranked the first, and a single "lifted_by" would leave that unanswerable without joining the row that no longer says it.
          *     It never carries the reason either party gave. Those words belong to the people who wrote them, and an event reaches readers the explanation was not given to.
          */
@@ -1114,6 +1116,15 @@ export interface components {
             recorded_at_level: string;
             /** @description The authority that lifted it. Always strictly above the level above. */
             lifted_by_level: string;
+            /**
+             * Format: uuid
+             * @description Which stop was lifted. Without it a consumer holding two stops for one person cannot tell which one this event describes.
+             */
+            suppression_id?: string;
+            /** @description How many stops are still live for this person after the lift, counted inside the same transaction that did the lifting. */
+            remaining_suppressions?: number;
+            /** @description Whether this person is still not writable. Equivalent to remaining_suppressions > 0, stated as its own field so a consumer cannot get the comparison wrong in the direction that resumes mail. */
+            still_suppressed?: boolean;
         };
         /**
          * @description Payload for consent.suppressed — somebody recorded that we may not write to a subject (consent/suppress.go's Suppress). Its own event rather than a consent.changed, because a suppression is not the absence of consent: it outranks a grant, it does not expire on its own, and a later re-grant must not silently erase it. A consumer that folded the two would resume mail the subject asked us to stop.


### PR DESCRIPTION
A second review pass over five already-merged PRs (#4294, #4302, #4317, #4331, #4391) found a real defect in every one. This fixes the backend half; the frontend half shipped separately as #4467, whose author got there first and covered three surfaces where I had one.

## The event lied about what a lift means

`consent.suppression_lifted` said "mail to this person may resume" while carrying only two authority levels. A person can hold several live stops — their own Art. 21 objection and a rep's separate note — so lifting one says nothing about the others. `liveSuppression` does `ORDER BY ... LIMIT 1` over them precisely because several can stand at once.

Margince itself was never at risk: the engine re-reads the strongest live row inside the sending transaction. A webhook consumer reading that sentence was.

The event now carries `suppression_id`, `remaining_suppressions` and `still_suppressed`.

**All three are optional and the version stays 1.** A consumer already validating this payload must keep validating it — an in-place `required` field is how a live webhook starts rejecting deliveries and dead-lettering them, which is a worse outage than the bug. The writer always populates them; absent means "this installation has not started sending it", never "nothing stands".

**The count matches the arms the engine refuses on** — person, and an address resolved through `person_email` — not person alone. A hard bounce is pinned to an address and carries no `person_id`, so counting by person would report "nothing stands" while every send to that mailbox is still refused. Under-reporting is the one direction this field must never fail in. `TestALiftReportsAnAddressPinnedStopAsStanding` is what earns that OR arm.

## Also here

- **`boundReason` / `requireReason`.** Both doors that take a reason share the 500 bound; only the lift requires a value. `crm.yaml` marks the suppress body `required: [kind]`, and a rep relaying "please stop emailing me" may have nothing to add. My first attempt unified them outright, which would have answered 422 to a body the published contract accepts — `TestASuppressionMayCarryNoReason` stops a future author repeating it.
- **The kind-classification gate matched lines, not statements.** A kind named `user` passed on the CHECK constraint's own literal, and one named only in a `--` comment passed while production sent it through the `ELSE` arm. It now reads the executable CASE arms with comments stripped. Mutation-checked both ways: the planted defect fails the new gate and passes the old one.
- **A per-person advisory lock before the count.** Two concurrent lifts of different rows each saw the other live and both emitted `still_suppressed=true`, with no later event to correct either — consumers would hold mail forever for a person carrying no stop. See the caveat below.
- **`LevelAdmin` said "ops or a workspace administrator".** It is not: `RequireAdmin` matches the literal admin role, and the RBAC defaults separate ops from admin by exactly that gate. Comment corrected; behaviour deliberately unchanged, since reversing someone's recorded stop is governance rather than wiring.
- **The template pin's failure message** told authors to keep the old row while the check twenty lines below fails exactly that.

## What is not proven

The advisory lock has **no test**. Each `Lift` opens its own short transaction, so two goroutines started together almost never overlap in the count window — a timing test passed identically with the lock removed, three runs of three. That is a green that proves nothing, so I deleted it rather than keep it. Reproducing the race needs two transactions held open by hand around the read. The reasoning is written beside the lock so the next reader knows it is unheld.

## Reviewers

`security-redteam`, `craft-reviewer`, and Codex `gpt-5.6-sol` — each found something the other two missed. The security pass caught the suppress-door contract break; craft caught a duplicated comment paragraph and a name that was just a number; Codex caught the `required`-on-v1 break, the comment-fooled gate, and the concurrent-lift race.

Local gate green both halves; `go test ./gates/` re-run after the final rebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires a lie in the `consent.suppression_lifted` event: it used to say mail to this person may resume while carrying only two authority levels, but a person can hold several live stops and lifting one leaves the others standing. The event now carries `suppression_id`, `remaining_suppressions`, and `still_suppressed`, all optional so the version stays 1 and existing consumers keep validating.

**Fixes**
- Takes a per-person advisory lock before counting, so two concurrent lifts of different rows can't both emit `still_suppressed=true`.
- Counts stops the same way the engine refuses sends (person, plus address resolved through `person_email`), so an address-pinned bounce is never reported as cleared.
- Splits the reason bound from the reason requirement: both doors cap at 500 characters, but only the lift requires one, matching the contract.
- Makes the kind-classification gate read the executable CASE arms with comments stripped, instead of matching any quoted kind in the file.
- Corrects the `LevelAdmin` comment and the template pin's failure message.

<sup>Written for commit 0ad2dda194def0577c68a41a5abbfbcdb9e1b47f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Suppression-lifted events now identify the lifted suppression and report remaining active suppressions, including whether the person remains suppressed.
  - Suppression lifts account for all active stops, including address-pinned suppressions.

- **Bug Fixes**
  - Suppression reasons exceeding the permitted length are now rejected, while omitting a reason remains supported.
  - Administrative authority handling now distinguishes literal administrators from operations roles.

- **Documentation**
  - Event documentation clarifies that lifting one suppression does not necessarily resume mail delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->