### PR TITLE
fix(signals): technical-change summaries speak English

### DIFF
--- a/backend/internal/compose/signalscan.go
+++ b/backend/internal/compose/signalscan.go
@@ -158,13 +158,14 @@ func WriteGhostedSignals(ctx context.Context, tx pgx.Tx, now time.Time) (Ghosted
 	if err != nil {
 		return GhostedPass{}, err
 	}
+	said := signalSummaryCopyFor(baseLanguageForSummary(ctx, tx))
 	pass := GhostedPass{Considered: len(candidates)}
 	for _, found := range candidates {
 		days := int(now.Sub(found.At).Hours() / 24)
 		raised, err := signals.RecordDerived(ctx, tx, signals.DerivedSignal{
 			Kind:           kindGhostedThread,
 			OrganizationID: found.OrganizationID,
-			Summary:        fmt.Sprintf("We wrote %d days ago and nobody has answered.", days),
+			Summary:        fmt.Sprintf(said.ghostedThread, days),
 			Severity:       severityWarn,
 			Fingerprint:    signalFingerprint(kindGhostedThread, found.OrganizationID, found.ActivityID),
 			// The message is CITED, not quoted. This finding is shared with

--- a/backend/internal/compose/signalscan_project.go
+++ b/backend/internal/compose/signalscan_project.go
@@ -96,6 +96,7 @@ func WriteProjectQuietSignals(ctx context.Context, tx pgx.Tx, now time.Time) (Gh
 	if err != nil {
 		return GhostedPass{}, err
 	}
+	said := signalSummaryCopyFor(baseLanguageForSummary(ctx, tx))
 	pass := GhostedPass{Considered: len(found)}
 	for _, project := range found {
 		days := int(now.Sub(project.QuietSince).Hours() / 24)
@@ -103,7 +104,7 @@ func WriteProjectQuietSignals(ctx context.Context, tx pgx.Tx, now time.Time) (Gh
 			Kind:           kindProjectGoneQuiet,
 			OrganizationID: project.OrganizationID,
 			ProjectID:      project.ProjectID,
-			Summary:        fmt.Sprintf("Nothing has been filed on %s for %d days.", project.Name, days),
+			Summary:        fmt.Sprintf(said.projectQuiet, project.Name, days),
 			Severity:       severityWarn,
 			Fingerprint:    fingerprintOf(kindProjectGoneQuiet, project.ProjectID.String(), project.QuietSince.UTC().Format(time.RFC3339Nano)),
 			Audit: map[string]any{

--- a/backend/internal/compose/signalsummarycopy.go
+++ b/backend/internal/compose/signalsummarycopy.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The sentences the deterministic signal producers write onto an account.
+//
+// A signal summary is shared-record text: it is stored once and read by
+// everyone who can see the account, so it follows the installation's base
+// language rather than the language of whatever produced it. Hardcoding one
+// language reads correctly on exactly the installations that chose it and
+// wrongly on the rest, which is what a German summary on an English screen
+// already looked like in production.
+//
+// The model-written producers need none of this — they are instructed through
+// promptlang.Rule, which already answers for every shipped language. What lives
+// here is the copy this product writes itself, in the shape onboardingcopy.go
+// established: a table keyed by the language, with the shipped set as the
+// census, so a language the product gains fails a test rather than a reader.
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// signalSummaryCopy is one language's set. Every field is required — a partial
+// set is a silent English fallback in miniature, and the census refuses one.
+type signalSummaryCopy struct {
+	// ghostedThread says we wrote and nobody answered. %d is how many days ago.
+	ghostedThread string
+	// projectQuiet says a project has had nothing filed on it. %s is the
+	// project's name, %d how many days — in that order, and the census holds
+	// both holes present so a translation cannot drop the number it is about.
+	projectQuiet string
+}
+
+// signalSummaryByLang is the census, keyed by textlang.Lang so the test can
+// walk textlang.Shipped and ask this map directly.
+var signalSummaryByLang = map[textlang.Lang]signalSummaryCopy{
+	textlang.English: {
+		ghostedThread: "We wrote %d days ago and nobody has answered.",
+		projectQuiet:  "Nothing has been filed on %s for %d days.",
+	},
+	textlang.German: {
+		ghostedThread: "Wir haben vor %d Tagen geschrieben und niemand hat geantwortet.",
+		projectQuiet:  "Zu %s wurde seit %d Tagen nichts abgelegt.",
+	},
+	textlang.Vietnamese: {
+		ghostedThread: "Chúng ta đã viết cách đây %d ngày và chưa ai trả lời.",
+		projectQuiet:  "Không có gì được lưu cho %s trong %d ngày.",
+	},
+}
+
+// signalSummaryCopyFor answers the installation's language, and English for
+// anything else.
+//
+// The fallback is unreachable for a language the product ships — the census
+// holds that — and it is still here because the language comes off a settings
+// row a person can edit. Answering in a language beats answering in none.
+func signalSummaryCopyFor(lang textlang.Lang) signalSummaryCopy {
+	if said, ok := signalSummaryByLang[lang]; ok {
+		return said
+	}
+	return signalSummaryByLang[textlang.English]
+}
+
+// baseLanguageForSummary resolves the installation's base language inside the
+// transaction the producer already holds.
+//
+// It never fails the caller, for the reason identity.BaseLanguageForPrompt
+// documents: refusing to file a real observation about an account because a
+// settings read failed trades a fact for a formatting preference. The failure
+// IS logged, because this returns a language and nothing else, so the caller
+// has no way to notice a degraded resolve and say so itself.
+func baseLanguageForSummary(ctx context.Context, tx pgx.Tx) textlang.Lang {
+	lang, err := identity.BaseLanguageOf(ctx, tx)
+	if err != nil {
+		slog.WarnContext(ctx, "the installation's base language could not be read; this signal summary is English",
+			"reason", err)
+		return textlang.English
+	}
+	return textlang.Lang(lang)
+}

--- a/backend/internal/compose/signalsummarycopy_test.go
+++ b/backend/internal/compose/signalsummarycopy_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every shipped language reads a deterministic signal in ITS OWN words.
+//
+// A census that only checked for an entry would pass against a set copied from
+// English and never translated — the same reader in the same wrong language,
+// with a row in a table saying otherwise. So the sentences are asserted
+// different from English, and their formatting holes asserted present: a %d
+// dropped in translation prints a sentence without the number the sentence is
+// about, and a %s dropped from the project line stops naming the project.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+func TestEveryShippedLanguageWritesItsOwnSignalSummaries(t *testing.T) {
+	english, ok := signalSummaryByLang[textlang.English]
+	if !ok {
+		t.Fatal("English has no signal summary set, and it is the fallback for everything else")
+	}
+	for _, lang := range textlang.Shipped {
+		t.Run(string(lang), func(t *testing.T) {
+			said, ok := signalSummaryByLang[lang]
+			if !ok {
+				t.Fatalf("the product ships %s and this table has not learned it", lang)
+			}
+			for _, field := range []struct {
+				name, got, en string
+				holes         map[string]int
+			}{
+				{"ghostedThread", said.ghostedThread, english.ghostedThread, map[string]int{"%d": 1}},
+				{"projectQuiet", said.projectQuiet, english.projectQuiet, map[string]int{"%s": 1, "%d": 1}},
+			} {
+				if field.got == "" {
+					t.Errorf("%s is empty — a blank summary reaches the reader as nothing at all", field.name)
+					continue
+				}
+				for verb, want := range field.holes {
+					if got := strings.Count(field.got, verb); got != want {
+						t.Errorf("%s carries %d %s holes, want %d: %q", field.name, got, verb, want, field.got)
+					}
+				}
+				if lang != textlang.English && field.got == field.en {
+					t.Errorf("%s is the English sentence verbatim; the entry exists and the reader still gets English",
+						field.name)
+				}
+			}
+		})
+	}
+}
+
+// The project line names the project before it counts the days. Go's verbs are
+// positional, so a translation that reorders them silently prints the day count
+// as the project's name.
+func TestTheProjectSummaryNamesTheProjectBeforeTheDayCount(t *testing.T) {
+	for _, lang := range textlang.Shipped {
+		said := signalSummaryByLang[lang]
+		if strings.Index(said.projectQuiet, "%s") > strings.Index(said.projectQuiet, "%d") {
+			t.Errorf("%s's projectQuiet counts days before it names the project, so the two arguments swap: %q",
+				lang, said.projectQuiet)
+		}
+	}
+}
+
+// An unshipped language answers English rather than an empty set, because the
+// language comes off a settings row a person can edit by hand.
+func TestAnUnknownLanguageFallsBackToEnglish(t *testing.T) {
+	said := signalSummaryCopyFor(textlang.Lang("kl"))
+	if said.ghostedThread != signalSummaryByLang[textlang.English].ghostedThread {
+		t.Errorf("an unshipped language answered %q, want the English sentence", said.ghostedThread)
+	}
+}

--- a/backend/internal/compose/technicalsignals.go
+++ b/backend/internal/compose/technicalsignals.go
@@ -93,24 +93,24 @@ func technicalChangeSummary(change people.TechnicalChange) (string, bool) {
 	switch change.Field {
 	case people.FactMailProvider:
 		if change.Kind == people.TechnicalMoved {
-			return fmt.Sprintf("Mail läuft jetzt über %s (vorher %s)", change.Value, change.Previous), true
+			return fmt.Sprintf("Mail now runs on %s (was %s)", change.Value, change.Previous), true
 		}
-		return fmt.Sprintf("Mail läuft über %s", change.Value), true
+		return fmt.Sprintf("Mail runs on %s", change.Value), true
 	case people.FactOperatedService:
 		if change.Kind == people.TechnicalGone {
-			return fmt.Sprintf("%s ist offline gegangen", change.Value), true
+			return fmt.Sprintf("%s went offline", change.Value), true
 		}
-		return fmt.Sprintf("%s ist neu online", change.Value), true
+		return fmt.Sprintf("%s is newly online", change.Value), true
 	case people.FactHostingProvider:
 		if change.Kind == people.TechnicalMoved {
-			return fmt.Sprintf("Hosting jetzt bei %s (vorher %s)", change.Value, change.Previous), true
+			return fmt.Sprintf("Hosting moved to %s (was %s)", change.Value, change.Previous), true
 		}
-		return fmt.Sprintf("Hosting bei %s", change.Value), true
+		return fmt.Sprintf("Hosted at %s", change.Value), true
 	case people.FactTechnology:
 		if change.Kind == people.TechnicalGone {
-			return fmt.Sprintf("%s wird nicht mehr eingesetzt", change.Value), true
+			return fmt.Sprintf("No longer uses %s", change.Value), true
 		}
-		return fmt.Sprintf("Setzt jetzt %s ein", change.Value), true
+		return fmt.Sprintf("Now uses %s", change.Value), true
 	default:
 		// email_security lands here on purpose. A DMARC policy tightening is a
 		// real fact about the company and belongs on the record, but it is not

--- a/backend/internal/compose/technicalsignals.go
+++ b/backend/internal/compose/technicalsignals.go
@@ -18,12 +18,10 @@ package compose
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/techprofile"
@@ -47,7 +45,7 @@ const (
 // together or not at all.
 func technicalChangeRecorder() people.TechnicalChangeRecorder {
 	return func(ctx context.Context, tx pgx.Tx, change people.TechnicalChange, at time.Time) error {
-		summary, ok := technicalChangeSummary(technicalSummaryLanguage(ctx, tx), change)
+		summary, ok := technicalChangeSummary(baseLanguageForSummary(ctx, tx), change)
 		if !ok {
 			// A change in a field nobody would act on. The record still holds
 			// it; it just does not earn a line on the account's signal list.
@@ -85,26 +83,6 @@ func technicalChangeRecorder() people.TechnicalChangeRecorder {
 		}
 		return nil
 	}
-}
-
-// technicalSummaryLanguage resolves the installation's base language inside the
-// transaction the recorder already holds — the summary is shared-record text,
-// and shared-record text follows the base language, not the language of
-// whatever produced the change.
-//
-// It never fails the caller, for the reason identity.BaseLanguageForPrompt
-// documents: refusing to file a real change on the record because a settings
-// read failed trades a fact for a formatting preference. The failure is logged
-// because this returns a string and nothing else, so the caller cannot notice
-// a degraded resolve and say so itself.
-func technicalSummaryLanguage(ctx context.Context, tx pgx.Tx) textlang.Lang {
-	lang, err := identity.BaseLanguageOf(ctx, tx)
-	if err != nil {
-		slog.WarnContext(ctx, "the installation's base language could not be read; this technical-change summary is English",
-			"reason", err)
-		return textlang.English
-	}
-	return textlang.Lang(lang)
 }
 
 // technicalSummaryCopy is one language's set of summary sentences. Every field

--- a/backend/internal/compose/technicalsignals.go
+++ b/backend/internal/compose/technicalsignals.go
@@ -18,12 +18,16 @@ package compose
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/signals"
+	"github.com/margince/margince/backend/internal/platform/techprofile"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // The signal vocabulary for a technical change: one kind, because a rep filters
@@ -43,7 +47,7 @@ const (
 // together or not at all.
 func technicalChangeRecorder() people.TechnicalChangeRecorder {
 	return func(ctx context.Context, tx pgx.Tx, change people.TechnicalChange, at time.Time) error {
-		summary, ok := technicalChangeSummary(change)
+		summary, ok := technicalChangeSummary(technicalSummaryLanguage(ctx, tx), change)
 		if !ok {
 			// A change in a field nobody would act on. The record still holds
 			// it; it just does not earn a line on the account's signal list.
@@ -83,34 +87,177 @@ func technicalChangeRecorder() people.TechnicalChangeRecorder {
 	}
 }
 
+// technicalSummaryLanguage resolves the installation's base language inside the
+// transaction the recorder already holds — the summary is shared-record text,
+// and shared-record text follows the base language, not the language of
+// whatever produced the change.
+//
+// It never fails the caller, for the reason identity.BaseLanguageForPrompt
+// documents: refusing to file a real change on the record because a settings
+// read failed trades a fact for a formatting preference. The failure is logged
+// because this returns a string and nothing else, so the caller cannot notice
+// a degraded resolve and say so itself.
+func technicalSummaryLanguage(ctx context.Context, tx pgx.Tx) textlang.Lang {
+	lang, err := identity.BaseLanguageOf(ctx, tx)
+	if err != nil {
+		slog.WarnContext(ctx, "the installation's base language could not be read; this technical-change summary is English",
+			"reason", err)
+		return textlang.English
+	}
+	return textlang.Lang(lang)
+}
+
+// technicalSummaryCopy is one language's set of summary sentences. Every field
+// is required — a partial set is a silent English fallback in miniature, and
+// the census test refuses one. Each verb interpolates change.Value, and the
+// two "moved" forms interpolate change.Previous after it; product and provider
+// names are never translated, which is why the holes are all there is.
+type technicalSummaryCopy struct {
+	// mailMoved / mailSet: the mail system moved, or was seen for the first time.
+	mailMoved string
+	mailSet   string
+	// serviceGone / serviceNew: an operated service left the air, or arrived.
+	serviceGone string
+	serviceNew  string
+	// hostingMoved / hostingSet: the hosting provider changed, or was first seen.
+	hostingMoved string
+	hostingSet   string
+	// technologyGone / technologyNew: a product left the stack, or joined it.
+	technologyGone string
+	technologyNew  string
+	// serviceNames names every service key techprofile can classify, because
+	// techprofile's own labels are the record's, written in one language, and
+	// a sentence in the reader's language must not carry a name in another.
+	// The census test holds this map complete against techprofile.ServiceKeys.
+	serviceNames map[string]string
+	// mailNames covers the two mail fallback labels techprofile writes in
+	// prose ("own mail server", "another provider"); a real provider's key is
+	// absent here on purpose, so its vendor name passes through untranslated.
+	mailNames map[string]string
+}
+
+// technicalSummaryByLang is the census, keyed by textlang.Lang so the test can
+// walk textlang.Shipped and ask this map directly.
+var technicalSummaryByLang = map[textlang.Lang]technicalSummaryCopy{
+	textlang.English: {
+		mailMoved:      "Mail now runs on %s (was %s)",
+		mailSet:        "Mail runs on %s",
+		serviceGone:    "%s went offline",
+		serviceNew:     "%s is newly online",
+		hostingMoved:   "Hosting moved to %s (was %s)",
+		hostingSet:     "Hosted at %s",
+		technologyGone: "No longer uses %s",
+		technologyNew:  "Now uses %s",
+		serviceNames: map[string]string{
+			techprofile.ServiceWebshop:        "Webshop",
+			techprofile.ServiceCustomerPortal: "Customer portal",
+			techprofile.ServiceCareers:        "Careers page",
+			techprofile.ServiceAPI:            "Public API",
+			techprofile.ServiceVPN:            "VPN access",
+			techprofile.ServiceMail:           "Own mail infrastructure",
+			techprofile.ServiceFileCloud:      "File cloud",
+			techprofile.ServiceDevInfra:       "Development infrastructure",
+			techprofile.ServiceStatusPage:     "Status page",
+			techprofile.ServiceSupport:        "Support portal",
+		},
+		mailNames: map[string]string{
+			techprofile.MailSelfHosted: "their own mail server",
+			techprofile.MailOther:      "another provider",
+		},
+	},
+	textlang.German: {
+		mailMoved:      "Mail läuft jetzt über %s (vorher %s)",
+		mailSet:        "Mail läuft über %s",
+		serviceGone:    "%s ist offline gegangen",
+		serviceNew:     "%s ist neu online",
+		hostingMoved:   "Hosting jetzt bei %s (vorher %s)",
+		hostingSet:     "Hosting bei %s",
+		technologyGone: "%s wird nicht mehr eingesetzt",
+		technologyNew:  "Setzt jetzt %s ein",
+		serviceNames: map[string]string{
+			techprofile.ServiceWebshop:        "Webshop",
+			techprofile.ServiceCustomerPortal: "Kundenportal",
+			techprofile.ServiceCareers:        "Karriereseite",
+			techprofile.ServiceAPI:            "Öffentliche API",
+			techprofile.ServiceVPN:            "VPN-Zugang",
+			techprofile.ServiceMail:           "Eigene Mail-Infrastruktur",
+			techprofile.ServiceFileCloud:      "Datei-Cloud",
+			techprofile.ServiceDevInfra:       "Entwicklungs-Infrastruktur",
+			techprofile.ServiceStatusPage:     "Statusseite",
+			techprofile.ServiceSupport:        "Support-Portal",
+		},
+		mailNames: map[string]string{
+			techprofile.MailSelfHosted: "eigener Mailserver",
+			techprofile.MailOther:      "anderer Anbieter",
+		},
+	},
+	textlang.Vietnamese: {
+		mailMoved:      "Mail hiện chạy trên %s (trước đây là %s)",
+		mailSet:        "Mail chạy trên %s",
+		serviceGone:    "%s đã ngừng hoạt động",
+		serviceNew:     "%s vừa xuất hiện trực tuyến",
+		hostingMoved:   "Hosting đã chuyển sang %s (trước đây là %s)",
+		hostingSet:     "Hosting tại %s",
+		technologyGone: "Không còn dùng %s",
+		technologyNew:  "Hiện đang dùng %s",
+		serviceNames: map[string]string{
+			techprofile.ServiceWebshop:        "Cửa hàng trực tuyến",
+			techprofile.ServiceCustomerPortal: "Cổng khách hàng",
+			techprofile.ServiceCareers:        "Trang tuyển dụng",
+			techprofile.ServiceAPI:            "API công khai",
+			techprofile.ServiceVPN:            "Truy cập VPN",
+			techprofile.ServiceMail:           "Hạ tầng mail riêng",
+			techprofile.ServiceFileCloud:      "Đám mây lưu trữ tệp",
+			techprofile.ServiceDevInfra:       "Hạ tầng phát triển",
+			techprofile.ServiceStatusPage:     "Trang trạng thái",
+			techprofile.ServiceSupport:        "Cổng hỗ trợ",
+		},
+		mailNames: map[string]string{
+			techprofile.MailSelfHosted: "máy chủ mail riêng",
+			techprofile.MailOther:      "nhà cung cấp khác",
+		},
+	},
+}
+
 // technicalChangeSummary is the sentence a rep reads on the account.
 //
 // Written per field rather than from a template, because the four fields are
 // four different pieces of news: a mail system moving is an IT decision worth a
 // call, a careers page appearing is a hiring signal, and a shared phrasing
 // would flatten both into "a technical signal changed".
-func technicalChangeSummary(change people.TechnicalChange) (string, bool) {
+func technicalChangeSummary(lang textlang.Lang, change people.TechnicalChange) (string, bool) {
+	said, ok := technicalSummaryByLang[lang]
+	if !ok {
+		// Unreachable for a language the product ships — the census holds that
+		// — but the language comes off a settings row, and answering English
+		// beats answering nothing.
+		said = technicalSummaryByLang[textlang.English]
+	}
 	switch change.Field {
 	case people.FactMailProvider:
+		// The fallback mail labels are prose and follow the language; a real
+		// provider's key misses the map and its vendor name passes through.
+		value := nameOr(said.mailNames, change.ValueKey, change.Value)
 		if change.Kind == people.TechnicalMoved {
-			return fmt.Sprintf("Mail now runs on %s (was %s)", change.Value, change.Previous), true
+			return fmt.Sprintf(said.mailMoved, value, nameOr(said.mailNames, change.PreviousKey, change.Previous)), true
 		}
-		return fmt.Sprintf("Mail runs on %s", change.Value), true
+		return fmt.Sprintf(said.mailSet, value), true
 	case people.FactOperatedService:
+		value := nameOr(said.serviceNames, change.ValueKey, change.Value)
 		if change.Kind == people.TechnicalGone {
-			return fmt.Sprintf("%s went offline", change.Value), true
+			return fmt.Sprintf(said.serviceGone, value), true
 		}
-		return fmt.Sprintf("%s is newly online", change.Value), true
+		return fmt.Sprintf(said.serviceNew, value), true
 	case people.FactHostingProvider:
 		if change.Kind == people.TechnicalMoved {
-			return fmt.Sprintf("Hosting moved to %s (was %s)", change.Value, change.Previous), true
+			return fmt.Sprintf(said.hostingMoved, change.Value, change.Previous), true
 		}
-		return fmt.Sprintf("Hosted at %s", change.Value), true
+		return fmt.Sprintf(said.hostingSet, change.Value), true
 	case people.FactTechnology:
 		if change.Kind == people.TechnicalGone {
-			return fmt.Sprintf("No longer uses %s", change.Value), true
+			return fmt.Sprintf(said.technologyGone, change.Value), true
 		}
-		return fmt.Sprintf("Now uses %s", change.Value), true
+		return fmt.Sprintf(said.technologyNew, change.Value), true
 	default:
 		// email_security lands here on purpose. A DMARC policy tightening is a
 		// real fact about the company and belongs on the record, but it is not
@@ -118,4 +265,13 @@ func technicalChangeSummary(change people.TechnicalChange) (string, bool) {
 		// put a line on every signal list for nobody to act on.
 		return "", false
 	}
+}
+
+// nameOr is the display name a language keeps for a key, and the record's own
+// label when it keeps none — a vendor name, which no language translates.
+func nameOr(names map[string]string, key, recorded string) string {
+	if name, ok := names[key]; ok {
+		return name
+	}
+	return recorded
 }

--- a/backend/internal/compose/technicalsignals_test.go
+++ b/backend/internal/compose/technicalsignals_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every shipped language reads a technical change in ITS OWN words.
+//
+// The bug this censuses against was real: the summaries were written in one
+// language and stored, so every other installation read them in a language it
+// never chose. An entry alone is not enough — a set copied from English and
+// never translated is the same reader in the same wrong language — so the
+// sentence frames are asserted different, not just present. The service names
+// are not: a name can legitimately coincide across languages ("Webshop" is
+// both the German and the English word), so for names the census asks for
+// coverage of the owner's key set instead.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/techprofile"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// frames flattens one language's sentence frames beside how many value holes
+// each must keep: a %s dropped in translation prints a sentence without the
+// thing the sentence is about.
+func frames(said technicalSummaryCopy) []struct {
+	name, frame string
+	holes       int
+} {
+	return []struct {
+		name, frame string
+		holes       int
+	}{
+		{"mailMoved", said.mailMoved, 2},
+		{"mailSet", said.mailSet, 1},
+		{"serviceGone", said.serviceGone, 1},
+		{"serviceNew", said.serviceNew, 1},
+		{"hostingMoved", said.hostingMoved, 2},
+		{"hostingSet", said.hostingSet, 1},
+		{"technologyGone", said.technologyGone, 1},
+		{"technologyNew", said.technologyNew, 1},
+	}
+}
+
+func TestEveryShippedLanguageSummarisesTechnicalChanges(t *testing.T) {
+	english, ok := technicalSummaryByLang[textlang.English]
+	if !ok {
+		t.Fatal("English has no technical summary set, and it is the fallback for everything else")
+	}
+	for _, lang := range textlang.Shipped {
+		t.Run(string(lang), func(t *testing.T) {
+			said, ok := technicalSummaryByLang[lang]
+			if !ok {
+				t.Fatalf("the product ships %s and this table has not learned it", lang)
+			}
+			for _, field := range frames(said) {
+				if field.frame == "" {
+					t.Errorf("%s is empty — a blank frame reaches the reader as nothing at all", field.name)
+					continue
+				}
+				if got := strings.Count(field.frame, "%s"); got != field.holes {
+					t.Errorf("%s carries %d %%s holes, want %d: %q", field.name, got, field.holes, field.frame)
+				}
+				if lang != textlang.English && field.frame == englishFrame(english, field.name) {
+					t.Errorf("%s is the English frame verbatim; the entry exists and the reader still gets English", field.name)
+				}
+			}
+			for _, key := range techprofile.ServiceKeys() {
+				if said.serviceNames[key] == "" {
+					t.Errorf("service %q has no %s name — its sentence would carry the record's label in whatever language the record stored", key, lang)
+				}
+			}
+			for _, key := range []string{techprofile.MailSelfHosted, techprofile.MailOther} {
+				if said.mailNames[key] == "" {
+					t.Errorf("mail fallback %q has no %s name — the one mail label that is prose rather than a vendor name", key, lang)
+				}
+			}
+		})
+	}
+}
+
+func englishFrame(english technicalSummaryCopy, name string) string {
+	for _, field := range frames(english) {
+		if field.name == name {
+			return field.frame
+		}
+	}
+	return ""
+}
+
+// A vendor name must survive untouched: the mail map holds only the two prose
+// fallbacks, so a real provider's label passes through as recorded.
+func TestVendorNamesAreNeverTranslated(t *testing.T) {
+	for _, lang := range textlang.Shipped {
+		said := technicalSummaryByLang[lang]
+		if got := nameOr(said.mailNames, "microsoft365", "Microsoft 365"); got != "Microsoft 365" {
+			t.Errorf("%s renames Microsoft 365 to %q", lang, got)
+		}
+	}
+}

--- a/backend/internal/modules/people/organizationtechnical.go
+++ b/backend/internal/modules/people/organizationtechnical.go
@@ -122,8 +122,11 @@ type TechnicalChange struct {
 	ValueKey       string
 	Value          string
 	// Previous is what the record held before, empty when this is the first
-	// time the field was read.
-	Previous string
+	// time the field was read. PreviousKey is that value's stable key, for a
+	// consumer that renders the display label itself rather than repeating
+	// the one the record stored.
+	Previous    string
+	PreviousKey string
 	// Kind says which way it moved.
 	Kind TechnicalChangeKind
 	// Evidence is the record that proves the new state.

--- a/backend/internal/modules/people/organizationtechnical_write.go
+++ b/backend/internal/modules/people/organizationtechnical_write.go
@@ -224,7 +224,8 @@ func technicalChanges(in TechnicalEnrichment, held []heldFact, removed []map[str
 		// a rep acts on, and it needs the value that was replaced.
 		if previous, ok := replacedValue(heldByField[observation.Field], observation.Field); ok {
 			change.Kind = TechnicalMoved
-			change.Previous = previous
+			change.Previous = previous.Value
+			change.PreviousKey = previous.ValueKey
 		}
 		changes = append(changes, change)
 	}
@@ -261,7 +262,7 @@ func goneChanges(
 		changes = append(changes, TechnicalChange{
 			OrganizationID: in.OrganizationID,
 			Field:          field, ValueKey: valueKey, Value: value,
-			Previous: value, Kind: TechnicalGone,
+			Previous: value, PreviousKey: valueKey, Kind: TechnicalGone,
 			Evidence: heldByKey[field+technicalKeySeparator+valueKey].Value,
 		})
 	}
@@ -282,14 +283,14 @@ var singleValuedTechnicalFields = map[string]bool{
 
 // replacedValue reports the value a single-valued field held before, when the
 // row that held it was not a human's.
-func replacedValue(held []heldFact, field string) (string, bool) {
+func replacedValue(held []heldFact, field string) (heldFact, bool) {
 	if !singleValuedTechnicalFields[field] {
-		return "", false
+		return heldFact{}, false
 	}
 	for _, fact := range held {
 		if !fact.HumanHeld {
-			return fact.Value, true
+			return fact, true
 		}
 	}
-	return "", false
+	return heldFact{}, false
 }

--- a/backend/internal/platform/techprofile/services.go
+++ b/backend/internal/platform/techprofile/services.go
@@ -99,6 +99,18 @@ func ServiceLabel(key string) (string, bool) {
 	return label, known
 }
 
+// ServiceKeys lists the classifiable service keys, sorted, derived from the
+// same map ServiceLabel reads. Exported so a surface that renders its own
+// label per service can walk the owner's set rather than keep a copy of it.
+func ServiceKeys() []string {
+	keys := make([]string, 0, len(serviceLabels))
+	for key := range serviceLabels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // OperatedServices reads the services a domain's certificate hostnames reveal.
 //
 // Only the first label is consulted, and only against the allowlist above.


### PR DESCRIPTION
Signal summaries are stored shared-record text — written once, read by everyone on the account — so they must follow the installation's base language. Two producers got it wrong in opposite directions.

**The reported bug:** technical-change summaries were hardcoded German, so an English installation read "Setzt jetzt WordPress ein" under the English kind label "Technology changed".

**Found by sweeping for the same class:** the ghosted-thread (`signalscan.go:166`) and quiet-project (`signalscan_project.go:106`) summaries were hardcoded English on the same list, so a German installation read those two cards in English.

All three now resolve the language with `identity.BaseLanguageOf` inside the write transaction the producer already holds, English on a failed read (logged — the caller gets a language and nothing else, so it cannot notice a degraded resolve itself). Refusing to file a real observation because a settings read failed would trade a fact for a formatting preference.

The sentences live in per-language tables keyed by `textlang.Lang` — the shape `onboardingcopy.go` established — with census tests walking `textlang.Shipped`, so a language the product gains fails a test rather than a reader. The interpolated values come along too: `techprofile`'s service labels and the two prose mail fallbacks are stored in German, so the seam renders them per language by key (`people.TechnicalChange` gains `PreviousKey` for the replaced value). Vendor names pass through untranslated, held by `TestVendorNamesAreNeverTranslated`. The project line asserts `%s` before `%d`, because Go's verbs are positional and a reordered translation would print the day count as the project's name.

Both census clauses were mutation-checked: copying the English sentence into the German entry, and swapping the two verbs, each fail.

**Not in scope — filed rather than grown into this diff.** The sweep found six more instances of this bug class on other surfaces:
- #4530 company-record tech facts (the German labels this PR renders around, still stored German at write time — now also a four-way duplicate of the service names)
- #4537 brief and dossier deterministic floors write English while the model half beside them follows the base language
- #4538 deal-coverage risk summaries
- #4539 worklist notices and approval-queue summaries

Rows already stored keep their old text; fingerprint dedupe means an unchanged company will not re-raise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)