### PR TITLE
A landing is won plus what remains, and a coverage figure names its basis

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20963,7 +20963,7 @@ components:
       description: |
         The installation's identity and reporting basis (ADR-0090/A135). Read by every role,
         changed only by admin/ops.
-      required: [name, timezone, base_currency, base_language, fiscal_year_start_month, base_currency_locked, max_upload_bytes, sign_in_providers]
+      required: [name, timezone, base_currency, base_language, fiscal_year_start_month, forecast_forward_measure, base_currency_locked, max_upload_bytes, sign_in_providers]
       properties:
         name:
           type: string
@@ -21046,6 +21046,22 @@ components:
             a file too large is refused before it is sent instead of after. The ceiling bounds
             the whole request, part framing included, which is why a client should leave a
             little room rather than compare a file against it exactly.
+        forecast_forward_measure:
+          type: string
+          enum: [commit_evidence, weighted, manager_call]
+          x-enum-varnames: [SettingsForwardMeasureCommitEvidence, SettingsForwardMeasureWeighted, SettingsForwardMeasureManagerCall]
+          description: |
+            Which remaining-pipeline reading a projected landing is built from. A setting
+            rather than a fixed choice, because it is a question about how this installation
+            SELLS rather than about the software: a team with a disciplined commit stage means
+            something by it, and one that commits everything does not — their weighted number
+            is the honest one.
+
+            `commit_evidence` is the default and the strictest: committed deals whose close
+            date somebody confirmed, a provisional date being a guess that stays out.
+            `manager_call` takes the authored call as the whole period's landing and is not
+            added to what is already won; with no current call the read falls back to
+            `commit_evidence` and says so in the landing's `caveat`.
     UpdateInstallationSettingsRequest:
       type: object
       description: A sparse installation-settings patch (admin/ops, human-only).
@@ -21090,6 +21106,13 @@ components:
             Password sign-in is not a member of this list and cannot be removed by any value of
             it. Omit the field to leave the choice unchanged; send an empty array to offer
             password only.
+        forecast_forward_measure:
+          type: string
+          enum: [commit_evidence, weighted, manager_call]
+          description: |
+            Which remaining-pipeline reading a projected landing is built from. Never frozen:
+            it is applied on READ and stores nothing, so changing it re-computes every landing
+            at once and re-means no stored row.
 
     CaptureActivityResponse:
       type: object
@@ -33115,6 +33138,103 @@ components:
             count: a count of what somebody may not read is itself a statement about how
             much of it there is, so the reader is told the figure is partial and not by
             how much.
+        landing: { $ref: '#/components/schemas/ForecastLanding' }
+        sufficiency: { $ref: '#/components/schemas/ForecastSufficiency' }
+      additionalProperties: false
+    ForecastLanding:
+      type: object
+      description: >-
+        Where the period finishes if nothing changes, and what that answer rests on.
+
+        The four money readings say what is IN the pipeline; none of them answers "what
+        will we land on?", and a reader left to add two of them together picks the wrong
+        two. This is that sum, made once and labelled with the measure it used.
+      required: [amount_minor, measure, won_minor, remaining_minor]
+      properties:
+        amount_minor:
+          type: integer
+          format: int64
+          description: The projection itself, in the installation's base currency.
+        measure:
+          type: string
+          enum: [commit_evidence, weighted, manager_call]
+          x-enum-varnames: [ForwardMeasureCommitEvidence, ForwardMeasureWeighted, ForwardMeasureManagerCall]
+          description: >-
+            Which reading the forward half was built from — the one ACTUALLY used, which
+            is not always the one configured: a manager-call installation with no current
+            call falls back to commit evidence and says so in `caveat`.
+        won_minor:
+          type: integer
+          format: int64
+          description: The money already banked, the backward half of the sum.
+        remaining_minor:
+          type: integer
+          format: int64
+          description: >-
+            The forward half. Zero for a manager call, which is a single authored TOTAL
+            rather than a remainder — a call is not added to won_minor, and a
+            reconciliation line drawing this must say the call instead of a split.
+        caveat:
+          type: string
+          enum: [call_absent, call_below_actual]
+          x-enum-varnames: [LandingCaveatCallAbsent, LandingCaveatCallBelowActual]
+          description: >-
+            Why this answer is not the plain one, absent when it is. `call_absent` is a
+            manager-call installation with no current call. `call_below_actual` is an
+            authored call less than the money already won — reported and never corrected,
+            because the call is somebody's stated belief and the server does not overrule
+            it.
+      additionalProperties: false
+    ForecastSufficiency:
+      type: object
+      description: >-
+        Whether the open pipeline supports the reference landing, and what the reference
+        is.
+
+        NOT a target. Margince has no target model: `basis` names where the reference came
+        from so a reader can disagree with the basis rather than with the arithmetic, and
+        the reference is always from OUTSIDE the current projection — a coverage figure
+        divided by a target derived from the same pipeline is always fine and says
+        nothing.
+      properties:
+        absent:
+          type: string
+          enum: [insufficient_basis, insufficient_history]
+          x-enum-varnames: [SufficiencyAbsenceInsufficientBasis, SufficiencyAbsenceInsufficientHistory]
+          description: >-
+            Why there is no answer, when there is none. Every other field is then absent
+            and the surface says this rather than drawing a figure. `insufficient_basis` is
+            neither a manager call nor four completed comparable periods;
+            `insufficient_history` is too few closed deals for a conversion rate to be a
+            rate rather than an anecdote.
+        basis:
+          type: string
+          enum: [manager_call, historical_median]
+          x-enum-varnames: [SufficiencyBasisManagerCall, SufficiencyBasisHistoricalMedian]
+          description: >-
+            Where the reference came from. A current authored call outranks history: a
+            manager who wrote a number down has said what this period is for, and the
+            median of the last four completed comparable periods is the fallback for when
+            nobody has.
+        reference_landing_minor: { type: integer, format: int64 }
+        remaining_to_support_minor:
+          type: integer
+          format: int64
+          description: >-
+            The reference minus what is already won, floored at zero — a period already
+            past its reference needs no more pipeline.
+        needed_open_minor:
+          type: integer
+          format: int64
+          description: The open pipeline that remainder implies at the conversion rate.
+        current_open_minor: { type: integer, format: int64 }
+        coverage_bp:
+          type: integer
+          format: int64
+          description: >-
+            Current over needed in BASIS POINTS, so the server chooses no rounding for the
+            client. Nothing needed is 10000 (full) rather than a division by zero or an
+            unbounded ratio, because "covered" is actionable and "infinity" is not.
       additionalProperties: false
     InputCheck:
       type: object

--- a/backend/gates/forwardmeasureparity_test.go
+++ b/backend/gates/forwardmeasureparity_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// Every forward measure must be spelled the same on all three sides.
+//
+// A landing is built from ONE of three readings, and the choice is stored: the
+// installation setting says which, and ProjectLanding is what obeys it. So the
+// value travels from a settings PATCH, into a stored column, back out through a
+// forecast read — and the three enums that carry it were authored separately.
+//
+// The failure that shape produces is delayed and total: a measure the settings
+// screen admits and ProjectLanding refuses saves cleanly, and then every
+// forecast read for that installation errors. The setting is applied on read,
+// so nothing fails at write time to warn anybody.
+//
+// All sides are DERIVED — the wire's from the YAML, the server's from
+// forecasting.ForwardMeasures.
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/forecasting"
+)
+
+// Where the contract spells a forward measure. Held honest by
+// TestTheMeasureSiteListCoversEveryForwardMeasureEnum, which walks the document
+// rather than trusting this list.
+var forwardMeasureSites = []struct {
+	what string
+	path []string
+}{
+	{"the landing a read returns", []string{"components", "schemas", "ForecastLanding"}},
+	{"the stored installation setting", []string{"components", "schemas", "InstallationSettings"}},
+	{"the settings patch", []string{"components", "schemas", "UpdateInstallationSettingsRequest"}},
+}
+
+// TestEveryForwardMeasureIsOfferedOnTheWire is the gate forecasting.ForwardMeasures names.
+//
+// Both directions fail. A measure Go can build and the contract does not offer
+// is unreachable; a measure the contract offers and Go cannot build is the
+// save-then-error case above.
+func TestEveryForwardMeasureIsOfferedOnTheWire(t *testing.T) {
+	t.Parallel()
+	inGo := make([]string, 0, len(forecasting.ForwardMeasures()))
+	for _, measure := range forecasting.ForwardMeasures() {
+		inGo = append(inGo, string(measure))
+	}
+
+	doc := loadContractDocument(t)
+	for _, site := range forwardMeasureSites {
+		onWire := forwardMeasureEnumAt(t, doc, site.path)
+		for _, measure := range inGo {
+			if !slices.Contains(onWire, measure) {
+				t.Errorf("forecasting can build a landing from %q and %s does not offer it — "+
+					"a measure no caller can name is a measure nobody uses", measure, site.what)
+			}
+		}
+		for _, measure := range onWire {
+			if !slices.Contains(inGo, measure) {
+				t.Errorf("%s offers %q and forecasting.ProjectLanding refuses it — "+
+					"an installation that saves this setting errors on every forecast read, "+
+					"because the measure is applied when the forecast is READ and nothing "+
+					"fails at write time to warn them", site.what, measure)
+			}
+		}
+	}
+}
+
+// TestTheMeasureSiteListCoversEveryForwardMeasureEnum keeps the list above from
+// becoming a second copy of the contract.
+//
+// The census fails SHORT if it is written as a list somebody maintains: a
+// fourth site added later inherits no check, and the defect it can carry is
+// exactly the one this file exists for. So the document is walked instead, and
+// any enum carrying a measure that this gate does not name is an error.
+func TestTheMeasureSiteListCoversEveryForwardMeasureEnum(t *testing.T) {
+	t.Parallel()
+	doc := loadContractDocument(t)
+	found := map[string]bool{}
+	walkForwardMeasureEnums(doc, nil, found)
+
+	if len(found) == 0 {
+		t.Fatal("no forward-measure enum found anywhere in the contract — this gate is " +
+			"walking the wrong document and would report PASS over a contract with no " +
+			"measures at all")
+	}
+	named := map[string]bool{}
+	for _, site := range forwardMeasureSites {
+		named[strings.Join(site.path, "/")] = true
+	}
+	for where := range found {
+		if !named[where] {
+			t.Errorf("the contract constrains a forward measure at %s and this gate does not "+
+				"check it — a site it does not name can offer a measure the server refuses",
+				where)
+		}
+	}
+}
+
+// walkForwardMeasureEnums finds every enum in the document that carries a
+// forward measure, by the one value that is unambiguously ours.
+//
+// `weighted` and `manager_call` are words other schemas could reasonably use;
+// `commit_evidence` names this specific reading and nothing else in the
+// contract spells it.
+func walkForwardMeasureEnums(node any, at []string, found map[string]bool) {
+	switch shape := node.(type) {
+	case map[string]any:
+		if slices.Contains(enumOf(shape), "commit_evidence") {
+			found[strings.Join(measureSitePath(at), "/")] = true
+			return
+		}
+		for key, child := range shape {
+			walkForwardMeasureEnums(child, append(append([]string{}, at...), key), found)
+		}
+	case []any:
+		for _, child := range shape {
+			walkForwardMeasureEnums(child, at, found)
+		}
+	}
+}
+
+// measureSitePath trims the walk's path back to the schema, not the property
+// under it, so a site is named the way forwardMeasureSites spells it.
+func measureSitePath(at []string) []string {
+	for i, step := range at {
+		if step == "properties" {
+			return at[:i]
+		}
+	}
+	return at
+}
+
+// forwardMeasureEnumAt reads the measure enum under a named schema, wherever in
+// its properties it sits.
+func forwardMeasureEnumAt(t *testing.T, doc map[string]any, path []string) []string {
+	t.Helper()
+	node := any(doc)
+	for _, step := range path {
+		branch, ok := node.(map[string]any)
+		if !ok {
+			t.Fatalf("the contract has no %s — this gate names a site that no longer exists, "+
+				"so it is checking nothing", strings.Join(path, "/"))
+		}
+		node = branch[step]
+	}
+	found := map[string]bool{}
+	walkForwardMeasureEnums(node, nil, found)
+	if len(found) == 0 {
+		t.Fatalf("%s carries no forward-measure enum — either the field was renamed or its "+
+			"values changed, and either way this gate stopped comparing anything",
+			strings.Join(path, "/"))
+	}
+	branch, ok := node.(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not a schema object", strings.Join(path, "/"))
+	}
+	return measureEnumUnder(branch)
+}
+
+// measureEnumUnder pulls the enum values themselves out of a schema's
+// properties, having already established one is there.
+func measureEnumUnder(schema map[string]any) []string {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return enumOf(schema)
+	}
+	for _, child := range properties {
+		field, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+		if values := enumOf(field); slices.Contains(values, "commit_evidence") {
+			return values
+		}
+	}
+	return nil
+}

--- a/backend/internal/compose/forecastconversionseam.go
+++ b/backend/internal/compose/forecastconversionseam.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a sufficiency read needs from history: how often deals convert, and what
+// comparable periods actually finished on.
+//
+// Here rather than in forecasting for the same reason ForecastDeals is: the
+// module owns the arithmetic and owns no tables. Both reads below carry the
+// caller's row scope and the resolved population, so a rate is computed over
+// the deals this caller can see — a conversion rate borrowed from a population
+// they may not read is a number about somebody else's book.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/forecasting"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// conversionWindowYears is how far back a conversion rate is read.
+//
+// Two years, because it must span enough completed periods to be a rate while
+// staying inside the business the installation is running now. A rate from four
+// years ago describes a company that no longer exists.
+const conversionWindowYears = 2
+
+// ForecastConversionHistory reads the conversion evidence a sufficiency answer
+// rests on.
+//
+// The two halves come from one call because they are one question — "what does
+// this book normally do?" — and splitting them would let a caller pair a rate
+// from one population with comparable actuals from another.
+func ForecastConversionHistory(
+	ctx context.Context, tx pgx.Tx, period forecasting.Period, scope forecasting.Scope,
+	asOf time.Time, baseCurrency string,
+) (forecasting.ConversionHistory, error) {
+	closed, blended, err := forecastConversionRate(ctx, tx, period, scope)
+	if err != nil {
+		return forecasting.ConversionHistory{}, err
+	}
+	series, err := forecastComparableWon(ctx, tx, period, scope, asOf, baseCurrency)
+	if err != nil {
+		return forecasting.ConversionHistory{}, err
+	}
+	return forecasting.ConversionHistory{
+		ClosedDeals:          closed,
+		BlendedWonPerReached: blended,
+		ComparableWon:        series,
+	}, nil
+}
+
+// forecastConversionRate counts closed deals and how many of them were won.
+//
+// Counted over deals that CLOSED in the window, not deals created in it: a deal
+// still open has no outcome to contribute, and counting it as not-yet-won would
+// drive the rate down every time the pipeline grew.
+//
+// It takes no as-of. The window is derived from the PERIOD's own start, so the
+// rate for a given period is the same answer whenever it is asked — a rate that
+// moved with the clock would make two readings of one quarter disagree.
+func forecastConversionRate(
+	ctx context.Context, tx pgx.Tx, period forecasting.Period, scope forecasting.Scope,
+) (int, float64, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	scopeClause, populationClause, err := forecastHistoryClauses(ctx, tx, scope, arg)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// The window ends at the period's own start, never at asOf: a rate that
+	// included the period being assessed would be partly derived from the
+	// outcome it is helping to predict.
+	since := period.StartDate.AddDate(-conversionWindowYears, 0, 0)
+	sql := fmt.Sprintf(`
+		SELECT count(*), count(*) FILTER (WHERE d.status = 'won')
+		FROM deal d
+		WHERE d.archived_at IS NULL
+		  AND d.closed_at IS NOT NULL
+		  AND (timezone($%d, d.closed_at))::date >= $%d
+		  AND (timezone($%d, d.closed_at))::date < $%d
+		  AND %s
+		  AND %s`,
+		arg(period.Zone.String()), arg(since),
+		arg(period.Zone.String()), arg(period.StartDate),
+		scopeClause, populationClause)
+
+	var closed, won int
+	if err := tx.QueryRow(ctx, sql, args...).Scan(&closed, &won); err != nil {
+		return 0, 0, fmt.Errorf("compose: reading the forecast's conversion rate: %w", err)
+	}
+	if closed == 0 {
+		// No rate rather than a rate of zero. Zero would demand infinite
+		// pipeline downstream, and the module refuses it for exactly that
+		// reason — this returns the honest shape instead.
+		return 0, 0, nil
+	}
+	return closed, float64(won) / float64(closed), nil
+}
+
+// forecastComparableWon reads what the previous comparable periods actually
+// finished on, newest first.
+//
+// Comparable means the same LENGTH of window ending where this one starts, so a
+// quarter is compared against quarters and a week against weeks. Read as a
+// series of windows rather than a group-by, because the period boundaries are
+// the installation's own local days and only the module knows how to cut them.
+func forecastComparableWon(
+	ctx context.Context, tx pgx.Tx, period forecasting.Period, scope forecasting.Scope,
+	asOf time.Time, baseCurrency string,
+) ([]int64, error) {
+	out := make([]int64, 0, forecasting.ComparablePeriodsNeeded())
+	window := period
+	for range forecasting.ComparablePeriodsNeeded() {
+		previous, ok := forecasting.PrecedingPeriod(window)
+		if !ok {
+			// A period whose predecessor cannot be cut is where the series
+			// stops. Returning what was found lets the module decide there are
+			// too few, which is the one place that bar is spelled.
+			return out, nil
+		}
+		won, err := forecastWonInWindow(ctx, tx, previous, scope, asOf, baseCurrency)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, won)
+		window = previous
+	}
+	return out, nil
+}
+
+// forecastWonInWindow totals the money actually won inside one window.
+func forecastWonInWindow(
+	ctx context.Context, tx pgx.Tx, period forecasting.Period, scope forecasting.Scope,
+	asOf time.Time, baseCurrency string,
+) (int64, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	scopeClause, populationClause, err := forecastHistoryClauses(ctx, tx, scope, arg)
+	if err != nil {
+		return 0, err
+	}
+	// Converted at the SAME instant as the current reading rather than at each
+	// window's own close, so the series compares money on one scale. A median of
+	// totals converted at four different historical rates is a median of four
+	// different currencies wearing one symbol.
+	baseValue := BaseValueSQL(
+		fmt.Sprintf("$%d", arg(asOf)), fmt.Sprintf("$%d", arg(baseCurrency)), "d")
+
+	sql := fmt.Sprintf(`
+		SELECT COALESCE(sum(%s), 0)
+		FROM deal d
+		WHERE d.archived_at IS NULL
+		  AND d.status = 'won'
+		  AND d.closed_at IS NOT NULL
+		  AND (timezone($%d, d.closed_at))::date BETWEEN $%d AND $%d
+		  AND %s
+		  AND %s`,
+		baseValue,
+		arg(period.Zone.String()), arg(period.StartDate), arg(period.EndDate),
+		scopeClause, populationClause)
+
+	var won int64
+	if err := tx.QueryRow(ctx, sql, args...).Scan(&won); err != nil {
+		return 0, fmt.Errorf("compose: reading a comparable period's won total: %w", err)
+	}
+	return won, nil
+}
+
+// forecastHistoryClauses applies the caller's row scope and the resolved
+// population to a history read.
+//
+// Shared by both reads above so the rate and the comparable actuals are
+// computed over ONE population. Two spellings could narrow differently, and a
+// rate from a wide population divided into a narrow one's remainder is a
+// coverage figure about nobody.
+func forecastHistoryClauses(
+	ctx context.Context, tx pgx.Tx, scope forecasting.Scope, arg func(any) int,
+) (string, string, error) {
+	scopeClause, err := auth.ScopeClauseFor(ctx, tableDeal, "d", arg)
+	if err != nil {
+		return "", "", err
+	}
+	if scopeClause == "" {
+		scopeClause = sqlUnnarrowed
+	}
+	_, populationClause, err := AnalyticsPopulationClause(
+		ctx, tx, requestedFromForecastScope(scope), "d", arg)
+	if err != nil {
+		return "", "", err
+	}
+	if populationClause == "" {
+		populationClause = sqlUnnarrowed
+	}
+	return scopeClause, populationClause, nil
+}
+
+// ForecastForwardMeasure reads which remaining-pipeline reading this
+// installation builds its landing from.
+//
+// A seam because the setting is identity's and the projection is forecasting's,
+// and neither module may import the other. Parsed through the shared kernel's
+// own vocabulary rather than cast, so a value written before this setting
+// existed — or by a future that gained a measure this build does not know —
+// resolves to the default instead of reaching the projection as a string it
+// will refuse.
+func ForecastForwardMeasure(
+	ctx context.Context, tx pgx.Tx,
+) (forecasting.ForwardMeasure, error) {
+	stored, err := identity.ForecastForwardMeasureOf(ctx, tx)
+	if err != nil {
+		return "", err
+	}
+	measure, err := values.ParseForwardMeasure(&stored, "forecast_forward_measure")
+	if err != nil {
+		return "", err
+	}
+	return measure, nil
+}

--- a/backend/internal/compose/forecastseam.go
+++ b/backend/internal/compose/forecastseam.go
@@ -81,7 +81,7 @@ func ForecastDeals(
 		SELECT d.id, d.owner_id, d.amount_minor, d.currency, %s,
 		       d.expected_close_date, d.close_date_provisional, d.closed_at,
 		       d.status = 'won', d.forecast_category,
-		       COALESCE(s.win_probability, 0)
+		       COALESCE(s.win_probability, 0), d.stage_id
 		FROM deal d
 		LEFT JOIN stage s ON s.id = d.stage_id
 		WHERE d.archived_at IS NULL
@@ -107,9 +107,13 @@ func ForecastDeals(
 		var d forecasting.Deal
 		var owner *ids.UUID
 		var currency, category *string
+		var stage *ids.UUID
 		err := row.Scan(&d.ID, &owner, &d.AmountMinor, &currency, &d.BaseMinor,
 			&d.ExpectedCloseDate, &d.CloseProvisional, &d.ClosedAt,
-			&d.Won, &category, &d.StageProbability)
+			&d.Won, &category, &d.StageProbability, &stage)
+		if stage != nil {
+			d.StageID = stage.String()
+		}
 		if owner != nil {
 			d.Owner = owner.String()
 		}

--- a/backend/internal/compose/handlers_installation_settings.go
+++ b/backend/internal/compose/handlers_installation_settings.go
@@ -120,6 +120,15 @@ func (h installationSettingsHandlers) UpdateInstallationSettings(w http.Response
 	// identity's own sentence, which quotes the value that was refused. A
 	// second check here would name a different field and say less.
 	patch.FiscalYearStartMonth = req.FiscalYearStartMonth
+	// Same reasoning as the month above: the entry validates against the shared
+	// kernel's set, so an unknown measure comes back naming this field and
+	// quoting the value. Converted to a plain string because the patch carries
+	// what was ASKED for, and the generated enum type would claim it had already
+	// been checked against the vocabulary the projection enforces.
+	if req.ForecastForwardMeasure != nil {
+		measure := string(*req.ForecastForwardMeasure)
+		patch.ForecastForwardMeasure = &measure
+	}
 	// Passed through unvalidated against the deployment's list on purpose. A key
 	// this deployment holds no credentials for enables nothing — the effective
 	// answer is the intersection — so refusing it would be refusing a request
@@ -148,9 +157,11 @@ func (h installationSettingsHandlers) toContract(s identity.InstallationSettings
 		BaseCurrency:         s.BaseCurrency,
 		BaseLanguage:         crmcontracts.InstallationSettingsBaseLanguage(s.BaseLanguage),
 		FiscalYearStartMonth: s.FiscalYearStartMonth,
-		BaseCurrencyLocked:   s.BaseCurrencyLocked,
-		MaxUploadBytes:       h.maxUploadBytes,
-		SignInProviders:      h.signInProviders(s.EnabledOidcProviders),
+		ForecastForwardMeasure: crmcontracts.InstallationSettingsForecastForwardMeasure(
+			s.ForecastForwardMeasure),
+		BaseCurrencyLocked: s.BaseCurrencyLocked,
+		MaxUploadBytes:     h.maxUploadBytes,
+		SignInProviders:    h.signInProviders(s.EnabledOidcProviders),
 	}
 	if s.BaseCurrencyLockedReason != "" {
 		reason := s.BaseCurrencyLockedReason

--- a/backend/internal/compose/integration/forecastsufficiency_integration_test.go
+++ b/backend/internal/compose/integration/forecastsufficiency_integration_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The conversion evidence a sufficiency answer rests on, read through the real
+// seam against a real database.
+//
+// The module's own tests take a ConversionHistory as data, so they pass
+// whatever the seam does — the shape forecastbasecurrency's header names. What
+// only SQL can prove is which deals the seam actually selects: the window it
+// reads over, and whether the period being assessed is inside it. A rate partly
+// derived from the quarter it is helping to predict is circular, and nothing
+// about the returned number would look wrong.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/forecasting"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedClosedDeal writes a deal that CLOSED, which is the only kind the
+// conversion rate counts: an open deal has no outcome to contribute.
+//
+// The frozen rate is supplied because deal_closed_fx requires one: a priced
+// deal that has closed carries the rate it converted at, so the money it
+// contributed cannot move afterwards when a rate sheet is reloaded. Seeded in
+// the base currency at 1, which is what the writer stores for a deal needing
+// no conversion.
+func seedClosedDeal(
+	t *testing.T, e *Env, st forecastFXStages, status string, amountMinor int64, closedAt time.Time,
+) {
+	t.Helper()
+	// A lost deal carries a reason and a won one must not: deal_lost_reason and
+	// its mirror bind in both directions, so the column is set from the status
+	// rather than passed in by every call site.
+	var lostReason *string
+	if status == "lost" {
+		reason := "price"
+		lostReason = &reason
+	}
+	e.WsExec(t, `INSERT INTO deal
+		(id, name, amount_minor, currency, expected_close_date, pipeline_id, stage_id,
+		 status, closed_at, fx_rate_to_base, lost_reason, source, captured_by)
+		VALUES ($1, $2, $3, 'EUR', $4, $5, $6, $7, $8, 1, $9, 'manual', 'human:test')`,
+		ids.NewV7(), "Closed "+status, amountMinor, closedAt, st.pipeline, st.open,
+		status, closedAt, lostReason)
+}
+
+func forecastHistory(t *testing.T, e *Env, at time.Time) forecasting.ConversionHistory {
+	t.Helper()
+	var out forecasting.ConversionHistory
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		period, base, err := compose.ForecastPeriodAt(
+			e.Admin(), tx, forecasting.PeriodQuarter, at)
+		if err != nil {
+			return err
+		}
+		out, err = compose.ForecastConversionHistory(e.Admin(), tx, period,
+			forecasting.Scope{Kind: forecasting.ScopeWorkspace}, at, base)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("reading the forecast's conversion history: %v", err)
+	}
+	return out
+}
+
+// The rate must come from deals that closed BEFORE the period being assessed.
+// A rate that included the current quarter would be partly derived from the
+// outcome it is helping to predict, which is the circularity the whole
+// sufficiency reading exists to avoid.
+func TestTheConversionRateExcludesThePeriodBeingAssessed(t *testing.T) {
+	e := Setup(t)
+	st := seedForecastFXPipeline(t, e)
+	at := midQuarter
+
+	// Four in the two years before this quarter: three won, one lost.
+	seedClosedDeal(t, e, st, "won", 10_000, time.Date(2025, 6, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "won", 10_000, time.Date(2025, 7, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "won", 10_000, time.Date(2025, 8, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "lost", 10_000, time.Date(2025, 9, 10, 12, 0, 0, 0, time.UTC))
+	// One inside the quarter being assessed. It must NOT be counted.
+	seedClosedDeal(t, e, st, "lost", 10_000, time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC))
+
+	history := forecastHistory(t, e, at)
+
+	if history.ClosedDeals != 4 {
+		t.Fatalf("the rate counted %d closed deals, want the 4 that closed before this "+
+			"quarter — a deal inside the period being assessed makes the rate partly "+
+			"derived from the outcome it predicts", history.ClosedDeals)
+	}
+	if history.BlendedWonPerReached != 0.75 {
+		t.Errorf("three won of four closed read as %v, want 0.75",
+			history.BlendedWonPerReached)
+	}
+}
+
+// A deal older than the window is a different business, and counting it would
+// let a rate from four years ago set the pipeline a team is told to build.
+func TestTheConversionRateIgnoresDealsOlderThanItsWindow(t *testing.T) {
+	e := Setup(t)
+	st := seedForecastFXPipeline(t, e)
+	at := midQuarter
+
+	seedClosedDeal(t, e, st, "won", 10_000, time.Date(2025, 6, 10, 12, 0, 0, 0, time.UTC))
+	// Five years before the period: outside the two-year window.
+	seedClosedDeal(t, e, st, "lost", 10_000, time.Date(2021, 1, 10, 12, 0, 0, 0, time.UTC))
+
+	history := forecastHistory(t, e, at)
+
+	if history.ClosedDeals != 1 {
+		t.Errorf("the rate counted %d closed deals, want only the 1 inside its window",
+			history.ClosedDeals)
+	}
+}
+
+// The comparable series is what a historical median is taken over, and each
+// entry must be one period's OWN won total. A series that read the same window
+// four times would take a median of one quarter wearing four votes.
+func TestTheComparableSeriesReadsEachPrecedingPeriodSeparately(t *testing.T) {
+	e := Setup(t)
+	st := seedForecastFXPipeline(t, e)
+	at := midQuarter
+
+	// One won deal in each of the four quarters before 2026 Q1, each a
+	// different amount so a repeated window is visible in the values.
+	seedClosedDeal(t, e, st, "won", 1_000, time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "won", 2_000, time.Date(2025, 8, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "won", 3_000, time.Date(2025, 5, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "won", 4_000, time.Date(2025, 2, 10, 12, 0, 0, 0, time.UTC))
+
+	history := forecastHistory(t, e, at)
+
+	want := []int64{1_000, 2_000, 3_000, 4_000}
+	if len(history.ComparableWon) != len(want) {
+		t.Fatalf("the series has %d periods, want %d — a median needs four completed "+
+			"comparable periods and fewer is an absence, not a smaller median",
+			len(history.ComparableWon), len(want))
+	}
+	for i, expected := range want {
+		if history.ComparableWon[i] != expected {
+			t.Errorf("comparable period %d totalled %d, want %d — newest first, each "+
+				"reading its own window", i, history.ComparableWon[i], expected)
+		}
+	}
+}
+
+// A lost deal contributes to the RATE but never to a period's won total. One
+// query answering both would make the median the value of everything that
+// closed rather than of what was won.
+func TestAComparablePeriodTotalsOnlyWhatItWon(t *testing.T) {
+	e := Setup(t)
+	st := seedForecastFXPipeline(t, e)
+	at := midQuarter
+
+	seedClosedDeal(t, e, st, "won", 5_000, time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC))
+	seedClosedDeal(t, e, st, "lost", 90_000, time.Date(2025, 11, 12, 12, 0, 0, 0, time.UTC))
+
+	history := forecastHistory(t, e, at)
+
+	if len(history.ComparableWon) == 0 {
+		t.Fatal("the series is empty, so this test proves nothing about what it totals")
+	}
+	if history.ComparableWon[0] != 5_000 {
+		t.Errorf("the most recent comparable period totalled %d, want the 5000 it WON — "+
+			"a lost deal in the total makes the reference a figure nobody achieved",
+			history.ComparableWon[0])
+	}
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -199,6 +199,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		forecastHandlers: forecasting.NewHandlers(
 			forecasting.NewStore(InstallationDB(pool)),
 			ForecastDeals, ForecastPeriodAt, ForecastWritableScope,
+			ForecastConversionHistory, ForecastForwardMeasure,
 			func() time.Time { return time.Now().UTC() },
 		),
 		// The floor comes from the constant rather than a setting for now:

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -5791,6 +5791,45 @@ func (e ForecastCallScopeKind) Valid() bool {
 	}
 }
 
+// Defines values for ForecastLandingCaveat.
+const (
+	LandingCaveatCallAbsent      ForecastLandingCaveat = "call_absent"
+	LandingCaveatCallBelowActual ForecastLandingCaveat = "call_below_actual"
+)
+
+// Valid indicates whether the value is a known member of the ForecastLandingCaveat enum.
+func (e ForecastLandingCaveat) Valid() bool {
+	switch e {
+	case LandingCaveatCallAbsent:
+		return true
+	case LandingCaveatCallBelowActual:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ForecastLandingMeasure.
+const (
+	ForwardMeasureCommitEvidence ForecastLandingMeasure = "commit_evidence"
+	ForwardMeasureManagerCall    ForecastLandingMeasure = "manager_call"
+	ForwardMeasureWeighted       ForecastLandingMeasure = "weighted"
+)
+
+// Valid indicates whether the value is a known member of the ForecastLandingMeasure enum.
+func (e ForecastLandingMeasure) Valid() bool {
+	switch e {
+	case ForwardMeasureCommitEvidence:
+		return true
+	case ForwardMeasureManagerCall:
+		return true
+	case ForwardMeasureWeighted:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ForecastMovementReading.
 const (
 	ForecastMovementReadingBestCase ForecastMovementReading = "best_case"
@@ -5881,6 +5920,42 @@ func (e ForecastReadingsScopeKind) Valid() bool {
 	case ForecastReadingsScopeKindTeam:
 		return true
 	case ForecastReadingsScopeKindWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ForecastSufficiencyAbsent.
+const (
+	SufficiencyAbsenceInsufficientBasis   ForecastSufficiencyAbsent = "insufficient_basis"
+	SufficiencyAbsenceInsufficientHistory ForecastSufficiencyAbsent = "insufficient_history"
+)
+
+// Valid indicates whether the value is a known member of the ForecastSufficiencyAbsent enum.
+func (e ForecastSufficiencyAbsent) Valid() bool {
+	switch e {
+	case SufficiencyAbsenceInsufficientBasis:
+		return true
+	case SufficiencyAbsenceInsufficientHistory:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ForecastSufficiencyBasis.
+const (
+	SufficiencyBasisHistoricalMedian ForecastSufficiencyBasis = "historical_median"
+	SufficiencyBasisManagerCall      ForecastSufficiencyBasis = "manager_call"
+)
+
+// Valid indicates whether the value is a known member of the ForecastSufficiencyBasis enum.
+func (e ForecastSufficiencyBasis) Valid() bool {
+	switch e {
+	case SufficiencyBasisHistoricalMedian:
+		return true
+	case SufficiencyBasisManagerCall:
 		return true
 	default:
 		return false
@@ -6238,6 +6313,27 @@ func (e InstallationSettingsBaseLanguage) Valid() bool {
 	case InstallationSettingsBaseLanguageEn:
 		return true
 	case InstallationSettingsBaseLanguageVi:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for InstallationSettingsForecastForwardMeasure.
+const (
+	SettingsForwardMeasureCommitEvidence InstallationSettingsForecastForwardMeasure = "commit_evidence"
+	SettingsForwardMeasureManagerCall    InstallationSettingsForecastForwardMeasure = "manager_call"
+	SettingsForwardMeasureWeighted       InstallationSettingsForecastForwardMeasure = "weighted"
+)
+
+// Valid indicates whether the value is a known member of the InstallationSettingsForecastForwardMeasure enum.
+func (e InstallationSettingsForecastForwardMeasure) Valid() bool {
+	switch e {
+	case SettingsForwardMeasureCommitEvidence:
+		return true
+	case SettingsForwardMeasureManagerCall:
+		return true
+	case SettingsForwardMeasureWeighted:
 		return true
 	default:
 		return false
@@ -12277,6 +12373,27 @@ func (e UpdateInstallationSettingsRequestBaseLanguage) Valid() bool {
 	}
 }
 
+// Defines values for UpdateInstallationSettingsRequestForecastForwardMeasure.
+const (
+	UpdateInstallationSettingsRequestForecastForwardMeasureCommitEvidence UpdateInstallationSettingsRequestForecastForwardMeasure = "commit_evidence"
+	UpdateInstallationSettingsRequestForecastForwardMeasureManagerCall    UpdateInstallationSettingsRequestForecastForwardMeasure = "manager_call"
+	UpdateInstallationSettingsRequestForecastForwardMeasureWeighted       UpdateInstallationSettingsRequestForecastForwardMeasure = "weighted"
+)
+
+// Valid indicates whether the value is a known member of the UpdateInstallationSettingsRequestForecastForwardMeasure enum.
+func (e UpdateInstallationSettingsRequestForecastForwardMeasure) Valid() bool {
+	switch e {
+	case UpdateInstallationSettingsRequestForecastForwardMeasureCommitEvidence:
+		return true
+	case UpdateInstallationSettingsRequestForecastForwardMeasureManagerCall:
+		return true
+	case UpdateInstallationSettingsRequestForecastForwardMeasureWeighted:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for UpdateLeadRequestStatus.
 const (
 	UpdateLeadRequestStatusContacted UpdateLeadRequestStatus = "contacted"
@@ -15927,19 +16044,19 @@ func (e ListSignalsParamsResolutionState) Valid() bool {
 
 // Defines values for SetWeeklyPlanCommitmentStateJSONBodyState.
 const (
-	Done    SetWeeklyPlanCommitmentStateJSONBodyState = "done"
-	Dropped SetWeeklyPlanCommitmentStateJSONBodyState = "dropped"
-	Open    SetWeeklyPlanCommitmentStateJSONBodyState = "open"
+	SetWeeklyPlanCommitmentStateJSONBodyStateDone    SetWeeklyPlanCommitmentStateJSONBodyState = "done"
+	SetWeeklyPlanCommitmentStateJSONBodyStateDropped SetWeeklyPlanCommitmentStateJSONBodyState = "dropped"
+	SetWeeklyPlanCommitmentStateJSONBodyStateOpen    SetWeeklyPlanCommitmentStateJSONBodyState = "open"
 )
 
 // Valid indicates whether the value is a known member of the SetWeeklyPlanCommitmentStateJSONBodyState enum.
 func (e SetWeeklyPlanCommitmentStateJSONBodyState) Valid() bool {
 	switch e {
-	case Done:
+	case SetWeeklyPlanCommitmentStateJSONBodyStateDone:
 		return true
-	case Dropped:
+	case SetWeeklyPlanCommitmentStateJSONBodyStateDropped:
 		return true
-	case Open:
+	case SetWeeklyPlanCommitmentStateJSONBodyStateOpen:
 		return true
 	default:
 		return false
@@ -22893,6 +23010,31 @@ type ForecastCall struct {
 // ForecastCallScopeKind defines model for ForecastCall.ScopeKind.
 type ForecastCallScopeKind string
 
+// ForecastLanding Where the period finishes if nothing changes, and what that answer rests on.
+// The four money readings say what is IN the pipeline; none of them answers "what will we land on?", and a reader left to add two of them together picks the wrong two. This is that sum, made once and labelled with the measure it used.
+type ForecastLanding struct {
+	// AmountMinor The projection itself, in the installation's base currency.
+	AmountMinor int64 `json:"amount_minor"`
+
+	// Caveat Why this answer is not the plain one, absent when it is. `call_absent` is a manager-call installation with no current call. `call_below_actual` is an authored call less than the money already won — reported and never corrected, because the call is somebody's stated belief and the server does not overrule it.
+	Caveat *ForecastLandingCaveat `json:"caveat,omitempty"`
+
+	// Measure Which reading the forward half was built from — the one ACTUALLY used, which is not always the one configured: a manager-call installation with no current call falls back to commit evidence and says so in `caveat`.
+	Measure ForecastLandingMeasure `json:"measure"`
+
+	// RemainingMinor The forward half. Zero for a manager call, which is a single authored TOTAL rather than a remainder — a call is not added to won_minor, and a reconciliation line drawing this must say the call instead of a split.
+	RemainingMinor int64 `json:"remaining_minor"`
+
+	// WonMinor The money already banked, the backward half of the sum.
+	WonMinor int64 `json:"won_minor"`
+}
+
+// ForecastLandingCaveat Why this answer is not the plain one, absent when it is. `call_absent` is a manager-call installation with no current call. `call_below_actual` is an authored call less than the money already won — reported and never corrected, because the call is somebody's stated belief and the server does not overrule it.
+type ForecastLandingCaveat string
+
+// ForecastLandingMeasure Which reading the forward half was built from — the one ACTUALLY used, which is not always the one configured: a manager-call installation with no current call falls back to commit evidence and says so in `caveat`.
+type ForecastLandingMeasure string
+
 // ForecastMovement The classified difference between two snapshots. opening_minor plus every bucket equals closing_minor, exactly.
 type ForecastMovement struct {
 	// Buckets The named causes, in the order a waterfall draws them — what arrived, what crossed the period, what was repriced, and only then what the machinery did. A bucket that moved nothing is absent rather than zero.
@@ -22948,8 +23090,12 @@ type ForecastReadings struct {
 	EvidenceMinor int64 `json:"evidence_minor"`
 
 	// FxMissingCount Priced deals no rate could convert. Counted rather than silently totalled as zero, which would read as a smaller pipeline instead of an unconverted one.
-	FxMissingCount int   `json:"fx_missing_count"`
-	OpenMinor      int64 `json:"open_minor"`
+	FxMissingCount int `json:"fx_missing_count"`
+
+	// Landing Where the period finishes if nothing changes, and what that answer rests on.
+	// The four money readings say what is IN the pipeline; none of them answers "what will we land on?", and a reader left to add two of them together picks the wrong two. This is that sum, made once and labelled with the measure it used.
+	Landing   *ForecastLanding `json:"landing,omitempty"`
+	OpenMinor int64            `json:"open_minor"`
 
 	// PeriodEnd The last day INSIDE the period, not an exclusive bound.
 	PeriodEnd   openapi_types.Date `json:"period_end"`
@@ -22965,6 +23111,10 @@ type ForecastReadings struct {
 	// ScopeLimited True when deals the caller cannot read were left out. A BOOLEAN and never a count: a count of what somebody may not read is itself a statement about how much of it there is, so the reader is told the figure is partial and not by how much.
 	ScopeLimited *bool `json:"scope_limited,omitempty"`
 
+	// Sufficiency Whether the open pipeline supports the reference landing, and what the reference is.
+	// NOT a target. Margince has no target model: `basis` names where the reference came from so a reader can disagree with the basis rather than with the arithmetic, and the reference is always from OUTSIDE the current projection — a coverage figure divided by a target derived from the same pipeline is always fine and says nothing.
+	Sufficiency *ForecastSufficiency `json:"sufficiency,omitempty"`
+
 	// Timezone The zone the period's days were cut in, as an IANA name.
 	Timezone string `json:"timezone"`
 
@@ -22977,6 +23127,33 @@ type ForecastReadings struct {
 
 // ForecastReadingsScopeKind Which population these readings cover. `managed_teams` is what an omitted scope resolves to for a team manager — their teams and themselves — and is a RESULT only: it names no single subject, so no forecast can be recorded against it and no standing call is looked up for it. The write schemas keep the three nameable scopes.
 type ForecastReadingsScopeKind string
+
+// ForecastSufficiency Whether the open pipeline supports the reference landing, and what the reference is.
+// NOT a target. Margince has no target model: `basis` names where the reference came from so a reader can disagree with the basis rather than with the arithmetic, and the reference is always from OUTSIDE the current projection — a coverage figure divided by a target derived from the same pipeline is always fine and says nothing.
+type ForecastSufficiency struct {
+	// Absent Why there is no answer, when there is none. Every other field is then absent and the surface says this rather than drawing a figure. `insufficient_basis` is neither a manager call nor four completed comparable periods; `insufficient_history` is too few closed deals for a conversion rate to be a rate rather than an anecdote.
+	Absent *ForecastSufficiencyAbsent `json:"absent,omitempty"`
+
+	// Basis Where the reference came from. A current authored call outranks history: a manager who wrote a number down has said what this period is for, and the median of the last four completed comparable periods is the fallback for when nobody has.
+	Basis *ForecastSufficiencyBasis `json:"basis,omitempty"`
+
+	// CoverageBp Current over needed in BASIS POINTS, so the server chooses no rounding for the client. Nothing needed is 10000 (full) rather than a division by zero or an unbounded ratio, because "covered" is actionable and "infinity" is not.
+	CoverageBp       *int64 `json:"coverage_bp,omitempty"`
+	CurrentOpenMinor *int64 `json:"current_open_minor,omitempty"`
+
+	// NeededOpenMinor The open pipeline that remainder implies at the conversion rate.
+	NeededOpenMinor       *int64 `json:"needed_open_minor,omitempty"`
+	ReferenceLandingMinor *int64 `json:"reference_landing_minor,omitempty"`
+
+	// RemainingToSupportMinor The reference minus what is already won, floored at zero — a period already past its reference needs no more pipeline.
+	RemainingToSupportMinor *int64 `json:"remaining_to_support_minor,omitempty"`
+}
+
+// ForecastSufficiencyAbsent Why there is no answer, when there is none. Every other field is then absent and the surface says this rather than drawing a figure. `insufficient_basis` is neither a manager call nor four completed comparable periods; `insufficient_history` is too few closed deals for a conversion rate to be a rate rather than an anecdote.
+type ForecastSufficiencyAbsent string
+
+// ForecastSufficiencyBasis Where the reference came from. A current authored call outranks history: a manager who wrote a number down has said what this period is for, and the median of the last four completed comparable periods is the fallback for when nobody has.
+type ForecastSufficiencyBasis string
 
 // FxRate One effective-dated FX rate converting from_currency into the workspace base (to_currency). rate is a decimal string (numeric(20,10)), never a float.
 type FxRate struct {
@@ -23734,6 +23911,19 @@ type InstallationSettings struct {
 	// warned about is undecided: margince/margince#2569.
 	FiscalYearStartMonth int `json:"fiscal_year_start_month"`
 
+	// ForecastForwardMeasure Which remaining-pipeline reading a projected landing is built from. A setting
+	// rather than a fixed choice, because it is a question about how this installation
+	// SELLS rather than about the software: a team with a disciplined commit stage means
+	// something by it, and one that commits everything does not — their weighted number
+	// is the honest one.
+	//
+	// `commit_evidence` is the default and the strictest: committed deals whose close
+	// date somebody confirmed, a provisional date being a guess that stays out.
+	// `manager_call` takes the authored call as the whole period's landing and is not
+	// added to what is already won; with no current call the read falls back to
+	// `commit_evidence` and says so in the landing's `caveat`.
+	ForecastForwardMeasure InstallationSettingsForecastForwardMeasure `json:"forecast_forward_measure"`
+
 	// MaxUploadBytes The largest upload request this installation accepts, in bytes — set by whoever
 	// operates it, not compiled into the build (OPS-CFG-12, DOC-PARAM-11). Read-only:
 	// it is a deployment fact, so PATCH does not carry it.
@@ -23770,6 +23960,19 @@ type InstallationSettings struct {
 // the correspondence, so a German thread still gets a German reply, and a brief cached
 // for one reader keeps that reader's language.
 type InstallationSettingsBaseLanguage string
+
+// InstallationSettingsForecastForwardMeasure Which remaining-pipeline reading a projected landing is built from. A setting
+// rather than a fixed choice, because it is a question about how this installation
+// SELLS rather than about the software: a team with a disciplined commit stage means
+// something by it, and one that commits everything does not — their weighted number
+// is the honest one.
+//
+// `commit_evidence` is the default and the strictest: committed deals whose close
+// date somebody confirmed, a provisional date being a guess that stays out.
+// `manager_call` takes the authored call as the whole period's landing and is not
+// added to what is already won; with no current call the read falls back to
+// `commit_evidence` and says so in the landing's `caveat`.
+type InstallationSettingsForecastForwardMeasure string
 
 // InstallationSetup defines model for InstallationSetup.
 type InstallationSetup struct {
@@ -32903,6 +33106,11 @@ type UpdateInstallationSettingsRequest struct {
 	// margince/margince#2569.
 	FiscalYearStartMonth *int `json:"fiscal_year_start_month,omitempty"`
 
+	// ForecastForwardMeasure Which remaining-pipeline reading a projected landing is built from. Never frozen:
+	// it is applied on READ and stores nothing, so changing it re-computes every landing
+	// at once and re-means no stored row.
+	ForecastForwardMeasure *UpdateInstallationSettingsRequestForecastForwardMeasure `json:"forecast_forward_measure,omitempty"`
+
 	// Name Rename the organization.
 	Name *string `json:"name,omitempty"`
 
@@ -32913,6 +33121,11 @@ type UpdateInstallationSettingsRequest struct {
 // UpdateInstallationSettingsRequestBaseLanguage The language shared AI writing is written in. Never frozen: changing it re-means
 // nothing already written, so artifacts stay in the language they were written in.
 type UpdateInstallationSettingsRequestBaseLanguage string
+
+// UpdateInstallationSettingsRequestForecastForwardMeasure Which remaining-pipeline reading a projected landing is built from. Never frozen:
+// it is applied on READ and stores nothing, so changing it re-computes every landing
+// at once and re-means no stored row.
+type UpdateInstallationSettingsRequestForecastForwardMeasure string
 
 // UpdateIntegrationsSettingsRequest A sparse provider-posture patch (admin/ops).
 type UpdateIntegrationsSettingsRequest struct {

--- a/backend/internal/modules/forecasting/handlers.go
+++ b/backend/internal/modules/forecasting/handlers.go
@@ -44,20 +44,37 @@ type PeriodFunc func(ctx context.Context, tx pgx.Tx, kind PeriodKind, at time.Ti
 // module owns neither.
 type ResolveScopeFunc func(ctx context.Context, tx pgx.Tx, requested Scope) (Scope, error)
 
+// HistoryFunc reads the conversion evidence a sufficiency answer rests on.
+//
+// A seam for the same reason DealsFunc is: the rates come from tables this
+// module does not own, and the composition applies the caller's row scope
+// before any of it reaches the arithmetic.
+type HistoryFunc func(ctx context.Context, tx pgx.Tx, period Period, scope Scope, asOf time.Time, baseCurrency string) (ConversionHistory, error)
+
+// MeasureFunc reads which remaining-pipeline reading this installation builds
+// its landing from.
+type MeasureFunc func(ctx context.Context, tx pgx.Tx) (ForwardMeasure, error)
+
 // Handlers is the forecast's HTTP surface.
 type Handlers struct {
 	store   *Store
 	deals   DealsFunc
 	period  PeriodFunc
 	resolve ResolveScopeFunc
+	history HistoryFunc
+	measure MeasureFunc
 	now     func() time.Time
 }
 
 // NewHandlers binds the routes to the store and its seams.
 func NewHandlers(
-	store *Store, deals DealsFunc, period PeriodFunc, resolve ResolveScopeFunc, now func() time.Time,
+	store *Store, deals DealsFunc, period PeriodFunc, resolve ResolveScopeFunc,
+	history HistoryFunc, measure MeasureFunc, now func() time.Time,
 ) Handlers {
-	return Handlers{store: store, deals: deals, period: period, resolve: resolve, now: now}
+	return Handlers{
+		store: store, deals: deals, period: period, resolve: resolve,
+		history: history, measure: measure, now: now,
+	}
 }
 
 // GetForecast answers the readings for one period.
@@ -116,24 +133,106 @@ func (h Handlers) GetForecast(
 		if scope.Kind == ScopeManagedTeams {
 			return nil
 		}
+		var called *int64
 		call, err := h.store.CurrentCallTx(ctx, tx, period, scope)
 		switch {
 		case err == nil:
 			wire := callToWire(call)
 			out.CurrentCall = &wire
+			called = &call.AmountMinor
 		case IsNoStandingCall(err):
 			// Nobody has called this period. A real answer, and absent rather
 			// than an error.
 		default:
 			return err
 		}
-		return nil
+		return h.project(ctx, tx, &out, period, scope, readings, called, at, baseCurrency)
 	})
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
 	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// project adds where the period lands and whether the pipeline supports it.
+//
+// Separate from GetForecast because it is a second question over the same
+// readings, and because both halves must be able to fail SOFTLY: a landing this
+// installation cannot build, or a history too thin to divide by, is an answer —
+// the reading itself is still true and still worth returning.
+func (h Handlers) project(
+	ctx context.Context, tx pgx.Tx, out *crmcontracts.ForecastReadings,
+	period Period, scope Scope, readings Readings, call *int64,
+	asOf time.Time, baseCurrency string,
+) error {
+	measure, err := h.measure(ctx, tx)
+	if err != nil {
+		return err
+	}
+	landing, err := ProjectLanding(readings, measure, call)
+	if err != nil {
+		return err
+	}
+	wire := landingToWire(landing)
+	out.Landing = &wire
+
+	// The managed-teams reading covers several populations, so a conversion
+	// rate over it would blend books that are measured separately — and the
+	// coverage figure it produced would describe none of them.
+	if scope.Kind == ScopeManagedTeams {
+		return nil
+	}
+	history, err := h.history(ctx, tx, period, scope, asOf, baseCurrency)
+	if err != nil {
+		return err
+	}
+	sufficiency, err := AssessSufficiency(readings, history, call)
+	if err != nil {
+		return err
+	}
+	assessed := sufficiencyToWire(sufficiency)
+	out.Sufficiency = &assessed
+	return nil
+}
+
+// landingToWire maps a projection onto the wire shape.
+//
+// The caveat is omitted rather than sent empty when there is none: an empty
+// string would render as a warning that says nothing.
+func landingToWire(in Landing) crmcontracts.ForecastLanding {
+	out := crmcontracts.ForecastLanding{
+		AmountMinor:    in.AmountMinor,
+		Measure:        crmcontracts.ForecastLandingMeasure(in.Measure),
+		WonMinor:       in.WonMinor,
+		RemainingMinor: in.RemainingMinor,
+	}
+	if in.Caveat != "" {
+		caveat := crmcontracts.ForecastLandingCaveat(in.Caveat)
+		out.Caveat = &caveat
+	}
+	return out
+}
+
+// sufficiencyToWire maps an assessment onto the wire shape.
+//
+// An absence carries ONLY its reason. Sending the zeroed figures beside it
+// would let a client draw "0 needed, 0 covered" — which reads as a fully
+// covered pipeline and is the opposite of what an absence means.
+func sufficiencyToWire(in Sufficiency) crmcontracts.ForecastSufficiency {
+	if in.Absent != "" {
+		absent := crmcontracts.ForecastSufficiencyAbsent(in.Absent)
+		return crmcontracts.ForecastSufficiency{Absent: &absent}
+	}
+	basis := crmcontracts.ForecastSufficiencyBasis(in.Basis)
+	return crmcontracts.ForecastSufficiency{
+		Basis:                   &basis,
+		ReferenceLandingMinor:   &in.ReferenceLandingMinor,
+		RemainingToSupportMinor: &in.RemainingToSupportMinor,
+		NeededOpenMinor:         &in.NeededOpenMinor,
+		CurrentOpenMinor:        &in.CurrentOpenMinor,
+		CoverageBp:              &in.CoverageBp,
+	}
 }
 
 // RecordForecastCall records what somebody believes will close.

--- a/backend/internal/modules/forecasting/landing.go
+++ b/backend/internal/modules/forecasting/landing.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Where the period lands if nothing changes.
+//
+// The readings beside this one answer what is IN the pipeline. None of them
+// answers the question a manager actually asks — "what will we finish on?" —
+// and a reader left to add two of them together will pick the wrong two: Won
+// plus Best case double-counts nothing but overstates, Weighted alone forgets
+// the money already in the bank.
+//
+// Pure arithmetic over Readings. No clock, no database, no scope: the inputs
+// are already scoped by the reader that produced them, and a projection that
+// went looking for its own would answer about a different population than the
+// figures it is reconciling against.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// ForwardMeasure is which remaining-pipeline number a landing is built from,
+// re-exported from the shared kernel.
+//
+// The set itself lives in values because identity stores the installation
+// setting that names it and may not import this package. Aliased rather than
+// re-declared: a second set here would be a second answer to the same question,
+// and the two would drift the moment one gains a measure.
+type ForwardMeasure = values.ForwardMeasure
+
+const (
+	// MeasureCommitEvidence is the strictest reading and the default.
+	MeasureCommitEvidence = values.MeasureCommitEvidence
+	// MeasureWeighted adds every open deal at its stage probability.
+	MeasureWeighted = values.MeasureWeighted
+	// MeasureManagerCall takes the authored call as the whole period's landing.
+	MeasureManagerCall = values.MeasureManagerCall
+)
+
+// ForwardMeasures re-exports the shared kernel's set, so a caller holding this
+// package need not import values to offer a chooser.
+func ForwardMeasures() []ForwardMeasure { return values.ForwardMeasures() }
+
+// Landing is where the period finishes, and what that answer rests on.
+type Landing struct {
+	// AmountMinor is the projection itself, in the base currency.
+	AmountMinor int64
+	// Measure is the one actually used, which is not always the one asked for:
+	// a manager-call setting with no current call falls back and says so.
+	Measure ForwardMeasure
+	// WonMinor and RemainingMinor are the two halves a reconciliation line
+	// prints. A manager call carries no split — it is a single authored total —
+	// so RemainingMinor is zero there and the line says the call instead.
+	WonMinor       int64
+	RemainingMinor int64
+	// Caveat names why this answer is not the plain one, empty when it is.
+	Caveat LandingCaveat
+}
+
+// LandingCaveat is what a reader has to know about a projection to trust it.
+type LandingCaveat string
+
+const (
+	// CaveatCallAbsent means a manager-call installation has no current call,
+	// so the figure is the commit measure instead. Named rather than silently
+	// substituted: a manager who set this expects their own number, and a
+	// commit total wearing that label is the wrong number under a right word.
+	CaveatCallAbsent LandingCaveat = "call_absent"
+	// CaveatCallBelowActual means the authored call is less than the money
+	// already won. It is reported rather than corrected: the call is somebody's
+	// stated belief and this code does not get to overrule it, but a landing
+	// below what is already banked is a number nobody should read past.
+	CaveatCallBelowActual LandingCaveat = "call_below_actual"
+)
+
+// ProjectLanding answers where the period finishes.
+//
+// call is the current manager call for this period and scope, or nil. It is
+// only consulted for MeasureManagerCall — a commit or weighted installation has
+// made a different choice, and quietly preferring an authored number would make
+// the setting a lie.
+func ProjectLanding(readings Readings, measure ForwardMeasure, call *int64) (Landing, error) {
+	switch measure {
+	case MeasureCommitEvidence:
+		return remainingLanding(readings, measure, readings.EvidenceMinor)
+	case MeasureWeighted:
+		return remainingLanding(readings, measure, readings.WeightedMinor)
+	case MeasureManagerCall:
+		if call == nil {
+			// The commit measure, and SAID so. Falling back silently would show
+			// a manager the number they did not ask for under the label of the
+			// one they did.
+			out, err := remainingLanding(readings, MeasureCommitEvidence, readings.EvidenceMinor)
+			if err != nil {
+				return Landing{}, err
+			}
+			out.Caveat = CaveatCallAbsent
+			return out, nil
+		}
+		out := Landing{
+			AmountMinor: *call, Measure: MeasureManagerCall,
+			WonMinor: readings.WonMinor,
+		}
+		if *call < readings.WonMinor {
+			out.Caveat = CaveatCallBelowActual
+		}
+		return out, nil
+	default:
+		return Landing{}, fmt.Errorf(
+			"forecasting: %q is not a forward measure; a landing is built from commit evidence, "+
+				"the weighted pipeline or a manager's own call", measure)
+	}
+}
+
+// remainingLanding is Won plus what is still to come.
+//
+// Both remaining measures are REMAINING: readings.InOpen requires the deal is
+// not won, so neither evidence nor weighted contains a deal already in the Won
+// total. Adding them is therefore a sum of two disjoint sets rather than a
+// double count — which is exactly why a manager call, a number for the WHOLE
+// period, does not go through here.
+// The sum goes through addMinor for the reason Compute's do: a headline that
+// wrapped still looks like money and disagrees silently with the readings it
+// claims to be the sum of. A landing is the one figure a manager repeats out
+// loud, so it must refuse rather than wrap.
+func remainingLanding(
+	readings Readings, measure ForwardMeasure, remaining int64,
+) (Landing, error) {
+	total, err := addMinor(readings.WonMinor, remaining)
+	if err != nil {
+		return Landing{}, err
+	}
+	return Landing{
+		AmountMinor:    total,
+		Measure:        measure,
+		WonMinor:       readings.WonMinor,
+		RemainingMinor: remaining,
+	}, nil
+}

--- a/backend/internal/modules/forecasting/landing_test.go
+++ b/backend/internal/modules/forecasting/landing_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Where the period lands.
+//
+// The claim that costs most if it is wrong is the SHAPE of the sum: commit and
+// weighted are remaining measures and a manager call is a total. Adding Won to
+// a call would report money twice, and forgetting to add it to the other two
+// would report a quarter as though nothing had closed yet.
+
+import (
+	"math"
+	"testing"
+)
+
+func measured(won, evidence, weighted int64) Readings {
+	return Readings{WonMinor: won, EvidenceMinor: evidence, WeightedMinor: weighted}
+}
+
+func TestCommitLandingIsWonPlusRemainingCommit(t *testing.T) {
+	t.Parallel()
+	got, err := ProjectLanding(measured(400_00, 250_00, 180_00), MeasureCommitEvidence, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != 650_00 {
+		t.Fatalf("landing = %d, want 65000 — Won plus the commit still to come", got.AmountMinor)
+	}
+	// The two halves travel, because the reconciliation line prints them and a
+	// reader who cannot see the split cannot check the sum.
+	if got.WonMinor != 400_00 || got.RemainingMinor != 250_00 {
+		t.Fatalf("the split reads %d + %d, want 40000 + 25000", got.WonMinor, got.RemainingMinor)
+	}
+	if got.Caveat != "" {
+		t.Fatalf("a plain projection carried the caveat %q", got.Caveat)
+	}
+}
+
+func TestWeightedLandingIsWonPlusRemainingWeighted(t *testing.T) {
+	t.Parallel()
+	got, err := ProjectLanding(measured(400_00, 250_00, 180_00), MeasureWeighted, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != 580_00 {
+		t.Fatalf("landing = %d, want 58000 — Won plus the weighted pipeline", got.AmountMinor)
+	}
+	// The measure a reader is shown is the one that was used, so a label can
+	// never describe a different arithmetic.
+	if got.Measure != MeasureWeighted {
+		t.Fatalf("the projection reports measure %q", got.Measure)
+	}
+}
+
+// A manager call is a TOTAL, and adding Won to it would report the money
+// already banked twice — a quarter with 400 won and a 900 call would read 1300,
+// which is not a number anybody said.
+func TestAManagerCallIsATotalLandingAndNeverAddsWonAgain(t *testing.T) {
+	t.Parallel()
+	call := int64(900_00)
+	got, err := ProjectLanding(measured(400_00, 250_00, 180_00), MeasureManagerCall, &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != 900_00 {
+		t.Fatalf("landing = %d, want exactly the call of 90000", got.AmountMinor)
+	}
+	if got.RemainingMinor != 0 {
+		t.Fatalf("a call carried a remaining half of %d; it is one authored total, "+
+			"and a split invites a reader to add it back", got.RemainingMinor)
+	}
+}
+
+// A call below the money already won is reported, not corrected. The call is
+// somebody's stated belief and this code does not overrule it — but a landing
+// under what is already banked is a number nobody should read past.
+func TestAManagerCallBelowWonIsFlagged(t *testing.T) {
+	t.Parallel()
+	call := int64(300_00)
+	got, err := ProjectLanding(measured(400_00, 250_00, 180_00), MeasureManagerCall, &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != 300_00 {
+		t.Fatalf("the call was rewritten to %d; it is the author's number", got.AmountMinor)
+	}
+	if got.Caveat != CaveatCallBelowActual {
+		t.Fatalf("caveat = %q, want %q", got.Caveat, CaveatCallBelowActual)
+	}
+}
+
+// A manager-call installation with no current call falls back to commit AND
+// says so. Falling back silently shows a manager a number they did not ask for
+// under the label of the one they did.
+func TestAManagerCallMeasureWithNoCallFallsBackToCommitAndSaysSo(t *testing.T) {
+	t.Parallel()
+	got, err := ProjectLanding(measured(400_00, 250_00, 180_00), MeasureManagerCall, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AmountMinor != 650_00 {
+		t.Fatalf("landing = %d, want the commit projection of 65000", got.AmountMinor)
+	}
+	if got.Measure != MeasureCommitEvidence {
+		t.Fatalf("measure = %q, want the one actually used", got.Measure)
+	}
+	if got.Caveat != CaveatCallAbsent {
+		t.Fatalf("caveat = %q, want %q", got.Caveat, CaveatCallAbsent)
+	}
+}
+
+// A call is consulted ONLY where the setting asks for one. Preferring an
+// authored number under a commit or weighted setting would make the setting a
+// lie: an installation that chose the weighted pipeline gets the weighted
+// pipeline, whatever anybody has written down.
+func TestACallIsIgnoredUnderTheOtherTwoMeasures(t *testing.T) {
+	t.Parallel()
+	call := int64(999_00)
+	for _, measure := range []ForwardMeasure{MeasureCommitEvidence, MeasureWeighted} {
+		got, err := ProjectLanding(measured(400_00, 250_00, 180_00), measure, &call)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.AmountMinor == 999_00 {
+			t.Fatalf("%s took the manager's call; the setting names a different question", measure)
+		}
+	}
+}
+
+// An unknown measure is refused rather than defaulted. A default here would be
+// one arm of a switch silently answering for another, which is the shape that
+// reported a week as a quarter one file over.
+func TestAnUnknownForwardMeasureIsRefused(t *testing.T) {
+	t.Parallel()
+	if _, err := ProjectLanding(measured(1, 1, 1), ForwardMeasure("best_case"), nil); err == nil {
+		t.Fatal("an unrecognised measure produced a landing, which is some other measure's number")
+	}
+}
+
+// A landing that wrapped would still look like money, and would disagree with
+// the readings it claims to be the sum of. Refused instead.
+func TestALandingThatCannotBeRepresentedIsRefused(t *testing.T) {
+	t.Parallel()
+	readings := measured(math.MaxInt64-10, 1_000, 0)
+
+	if _, err := ProjectLanding(readings, MeasureCommitEvidence, nil); err == nil {
+		t.Fatal("a landing past the representable range answered instead of refusing — " +
+			"a wrapped total reads as a negative quarter and still looks like money")
+	}
+}

--- a/backend/internal/modules/forecasting/periods.go
+++ b/backend/internal/modules/forecasting/periods.go
@@ -238,3 +238,93 @@ func periodStart(kind PeriodKind, local time.Time, fiscalStartMonth int) (int, t
 	opening := firstOfMonth.AddDate(0, -(elapsed % 3), 0)
 	return opening.Year(), opening.Month()
 }
+
+// ComparablePeriodsNeeded is how many completed periods a historical median
+// needs before it is offered as a basis.
+//
+// Exported so the read that fetches them asks for exactly as many as the
+// arithmetic requires. A reader fetching its own number would either waste
+// queries or hand over too few and get an absence it could not explain.
+func ComparablePeriodsNeeded() int { return comparablePeriods }
+
+// calendarDaysInclusive counts the days in [from, to], both ends included.
+//
+// Counted by WALKING calendar days rather than by dividing an elapsed duration.
+// A week spanning a daylight change is 167 or 169 hours, so dividing by 24
+// yields six days or seven-and-a-fraction — and a six-day step lands the
+// previous week on a Tuesday. Both dates are local midnights in one zone, so
+// the walk terminates on the day itself.
+func calendarDaysInclusive(from, to time.Time) int {
+	if to.Before(from) {
+		return 0
+	}
+	days := 1
+	for day := from; !sameCalendarDay(day, to); day = day.AddDate(0, 0, 1) {
+		days++
+		if days > maxWindowDays {
+			// A window longer than any period this product cuts. Refused rather
+			// than walked forever on a pair of dates that never meet.
+			return 0
+		}
+	}
+	return days
+}
+
+// maxWindowDays bounds the walk above. A quarter is the longest window the
+// resolvers produce, so a year of days is generous and still finite.
+const maxWindowDays = 366
+
+// sameCalendarDay compares two local days, ignoring the clock and the offset.
+func sameCalendarDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// PrecedingPeriod is the window of the same length immediately before this one.
+//
+// The step is derived from the window's own span rather than from a kind,
+// because a Period does not carry one: it is the resolved answer, and two
+// callers holding the same dates must get the same predecessor whatever kind
+// produced them.
+//
+// Calendar arithmetic, never a subtracted Duration. A quarter is three months
+// and a month is not 30 days, so stepping back by an elapsed duration lands
+// mid-month; and across a DST boundary a week is 167 or 169 hours, which would
+// walk the series off the local midnights the days were cut on.
+func PrecedingPeriod(p Period) (Period, bool) {
+	if p.Zone == nil || p.StartDate.IsZero() || p.EndDate.IsZero() {
+		return Period{}, false
+	}
+	days := calendarDaysInclusive(p.StartDate, p.EndDate)
+	if days <= 0 {
+		return Period{}, false
+	}
+
+	var start time.Time
+	switch {
+	case days >= 28 && days <= 31:
+		// One calendar month back, anchored on the first: a window shorter than
+		// its own month cannot be stepped by months without inventing a day.
+		start = p.StartDate.AddDate(0, -1, 0)
+	case days >= 89 && days <= 92:
+		start = p.StartDate.AddDate(0, -3, 0)
+	default:
+		// Everything else steps by its own day count, which is what a week is
+		// and what any window the resolvers gain later will be.
+		start = p.StartDate.AddDate(0, 0, -days)
+	}
+	end := p.StartDate.AddDate(0, 0, -1)
+
+	// Rebuilt from the local days rather than by shifting the instants, so the
+	// bounds sit on the zone's own midnights even when a DST change moved them.
+	from := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, p.Zone)
+	to := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, p.Zone)
+	return Period{
+		Start:     from,
+		End:       to.AddDate(0, 0, 1),
+		StartDate: start,
+		EndDate:   end,
+		Zone:      p.Zone,
+	}, true
+}

--- a/backend/internal/modules/forecasting/precedingperiod_test.go
+++ b/backend/internal/modules/forecasting/precedingperiod_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// The series a historical median is read over walks backwards one window at a
+// time. Every case below is a way that walk can land off the calendar.
+
+import (
+	"testing"
+	"time"
+)
+
+// localMidnight is how ResolveWeek wants its Monday: the zone's own midnight,
+// not an instant inside the day.
+func localMidnight(year int, month time.Month, d int, zone *time.Location) time.Time {
+	return time.Date(year, month, d, 0, 0, 0, 0, zone)
+}
+
+func TestTheQuarterBeforeAQuarterIsTheWholeQuarterBefore(t *testing.T) {
+	t.Parallel()
+	zone := berlin(t)
+	q2, err := ResolvePeriod(
+		PeriodQuarter, time.Date(2026, time.May, 15, 12, 0, 0, 0, zone), 1, zone)
+	if err != nil {
+		t.Fatalf("resolving Q2: %v", err)
+	}
+
+	previous, ok := PrecedingPeriod(q2)
+	if !ok {
+		t.Fatal("a resolved quarter has a predecessor and this reported none")
+	}
+	if got := previous.StartDate.Format("2006-01-02"); got != "2026-01-01" {
+		t.Errorf("the quarter before Q2 starts %s, want 2026-01-01", got)
+	}
+	if got := previous.EndDate.Format("2006-01-02"); got != "2026-03-31" {
+		t.Errorf("the quarter before Q2 ends %s, want 2026-03-31", got)
+	}
+}
+
+// A February step is the case a duration-based walk gets wrong: 31 days back
+// from 1 March is 29 January, which would read a month the previous window
+// already covered and double-count its deals in the series.
+func TestTheMonthBeforeMarchIsFebruaryAndNotThirtyOneDays(t *testing.T) {
+	t.Parallel()
+	zone := berlin(t)
+	march, err := ResolvePeriod(
+		PeriodMonth, time.Date(2026, time.March, 10, 12, 0, 0, 0, zone), 1, zone)
+	if err != nil {
+		t.Fatalf("resolving March: %v", err)
+	}
+
+	previous, ok := PrecedingPeriod(march)
+	if !ok {
+		t.Fatal("March has a predecessor and this reported none")
+	}
+	if got := previous.StartDate.Format("2006-01-02"); got != "2026-02-01" {
+		t.Errorf("the month before March starts %s, want 2026-02-01", got)
+	}
+	if got := previous.EndDate.Format("2006-01-02"); got != "2026-02-28" {
+		t.Errorf("the month before March ends %s, want 2026-02-28", got)
+	}
+}
+
+// The window whose midnights move. Stepping back 7*24h across the spring change
+// lands at 23:00 the previous day, and every day bound after it is an hour out.
+func TestTheWeekBeforeADaylightChangeKeepsItsLocalMidnights(t *testing.T) {
+	t.Parallel()
+	zone := berlin(t)
+	// Germany's clocks go forward on Sunday 29 March 2026, inside this week.
+	week, err := ResolveWeek(localMidnight(2026, time.March, 30, zone), zone)
+	if err != nil {
+		t.Fatalf("resolving the week: %v", err)
+	}
+
+	previous, ok := PrecedingPeriod(week)
+	if !ok {
+		t.Fatal("a resolved week has a predecessor and this reported none")
+	}
+	if got := previous.StartDate.Format("2006-01-02"); got != "2026-03-23" {
+		t.Errorf("the week before starts %s, want 2026-03-23", got)
+	}
+	if got := previous.EndDate.Format("2006-01-02"); got != "2026-03-29" {
+		t.Errorf("the week before ends %s, want 2026-03-29", got)
+	}
+	if hour := previous.Start.In(zone).Hour(); hour != 0 {
+		t.Errorf("the previous week opens at %02d:00 local, want midnight — a window "+
+			"stepped by a fixed duration drifts across a daylight change", hour)
+	}
+}
+
+// The zone whose daylight change falls BETWEEN two weekly midnights rather than
+// inside the week. Berlin's spring change sits inside its week, so the week is
+// still 168 hours from midnight to midnight and a duration-derived day count
+// survives it. Cairo's does not: 20-26 April 2026 is 143 hours, which divides
+// to six days and steps the predecessor onto a Tuesday.
+func TestAWeekWhoseZoneChangesOffsetBetweenItsMidnightsStillStepsAWholeWeek(t *testing.T) {
+	t.Parallel()
+	zone, err := time.LoadLocation("Africa/Cairo")
+	if err != nil {
+		t.Fatalf("loading Africa/Cairo: %v", err)
+	}
+	week, err := ResolveWeek(localMidnight(2026, time.April, 20, zone), zone)
+	if err != nil {
+		t.Fatalf("resolving the week: %v", err)
+	}
+
+	previous, ok := PrecedingPeriod(week)
+	if !ok {
+		t.Fatal("a resolved week has a predecessor and this reported none")
+	}
+	if got := previous.StartDate.Weekday(); got != time.Monday {
+		t.Errorf("the previous week starts on a %s, want Monday — a day count divided "+
+			"out of elapsed hours loses a day when the offset moves between two "+
+			"midnights, and every window behind it is then a day out", got)
+	}
+	if got := previous.StartDate.Format("2006-01-02"); got != "2026-04-13" {
+		t.Errorf("the week before 20 April starts %s, want 2026-04-13", got)
+	}
+	if got := previous.EndDate.Format("2006-01-02"); got != "2026-04-19" {
+		t.Errorf("the week before 20 April ends %s, want 2026-04-19", got)
+	}
+}
+
+// Four steps back is what a median needs, and each must be a distinct window:
+// a walk that repeats one would take a median of the same quarter four times.
+func TestWalkingBackFourQuartersGivesFourDistinctWindows(t *testing.T) {
+	t.Parallel()
+	zone := berlin(t)
+	window, err := ResolvePeriod(
+		PeriodQuarter, time.Date(2026, time.May, 15, 12, 0, 0, 0, zone), 1, zone)
+	if err != nil {
+		t.Fatalf("resolving Q2: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for i := range ComparablePeriodsNeeded() {
+		previous, ok := PrecedingPeriod(window)
+		if !ok {
+			t.Fatalf("step %d reported no predecessor", i)
+		}
+		key := previous.StartDate.Format("2006-01-02")
+		if seen[key] {
+			t.Fatalf("step %d returned %s again — a repeated window makes a median of "+
+				"one period wearing four votes", i, key)
+		}
+		seen[key] = true
+		if !previous.EndDate.Before(window.StartDate) {
+			t.Errorf("step %d ends %s, which is not before the window it precedes (%s)",
+				i, previous.EndDate.Format("2006-01-02"), window.StartDate.Format("2006-01-02"))
+		}
+		window = previous
+	}
+	if len(seen) != ComparablePeriodsNeeded() {
+		t.Errorf("walked back %d distinct windows, want %d",
+			len(seen), ComparablePeriodsNeeded())
+	}
+}
+
+// A zero Period is what an unresolved window looks like, and it must not
+// produce a window covering the year 1.
+func TestAnUnresolvedPeriodHasNoPredecessor(t *testing.T) {
+	t.Parallel()
+	if _, ok := PrecedingPeriod(Period{}); ok {
+		t.Error("a zero period reported a predecessor — a window with no dates would " +
+			"read every deal ever closed as one comparable period")
+	}
+}

--- a/backend/internal/modules/forecasting/readings.go
+++ b/backend/internal/modules/forecasting/readings.go
@@ -39,6 +39,11 @@ type Deal struct {
 	Category string
 	// Integer percent, the stage's own win probability.
 	StageProbability int
+	// StageID is which stage the deal stands in, empty where the reader could
+	// not name one. Frozen onto the contribution so a later conversion read can
+	// ask what happened to deals that REACHED a stage — a question the deal's
+	// current stage cannot answer, because it has moved since.
+	StageID string
 }
 
 // Readings are the four money answers plus the counts that say what they do not
@@ -81,6 +86,10 @@ type Contribution struct {
 	CloseProvisional bool
 	Category         string
 	StageProbability int
+	// StageID is the stage the deal stood in when this was frozen, empty where
+	// it could not be read. Carried so a conversion rate can be measured per
+	// stage from what was recorded rather than from where the deal ended up.
+	StageID string
 	// The deal's own weighted amount, ALREADY ROUNDED. Stored beside the base
 	// amount because the weighted headline is the sum of these, and a headline
 	// whose parts are not persisted cannot be reconciled against anything.
@@ -211,6 +220,7 @@ func contribute(period Period, asOfDay time.Time, deal Deal) (Contribution, erro
 		CloseProvisional: deal.CloseProvisional,
 		Category:         EffectiveCategory(asOfDay, deal),
 		StageProbability: deal.StageProbability,
+		StageID:          deal.StageID,
 	}
 	switch {
 	case deal.AmountMinor == nil:

--- a/backend/internal/modules/forecasting/snapshot.go
+++ b/backend/internal/modules/forecasting/snapshot.go
@@ -177,7 +177,7 @@ func (s *Store) writeContributions(
 		[]string{
 			"snapshot_id", "deal_id", "owner_id", colAmountMinor, colCurrency,
 			"base_minor", "fx_rate", "fx_date", "effective_close_date",
-			"close_provisional", "category", "stage_probability", "weighted_minor",
+			"close_provisional", "category", "stage_probability", "stage_id", "weighted_minor",
 			"in_won", "in_evidence", "in_best_case", "in_open", "exclusion_reason",
 			"audit_id", "approval_id", "captured_by",
 		},
@@ -198,7 +198,7 @@ func (s *Store) writeContributions(
 				snapshotID, dealID, nullableID(row.Owner), row.AmountMinor,
 				nullIfEmpty(row.Currency), row.BaseMinor, nil, nil,
 				row.EffectiveClose, row.CloseProvisional, nullIfEmpty(row.Category),
-				nullableInt(row.StageProbability), weighted,
+				nullableInt(row.StageProbability), nullableID(row.StageID), weighted,
 				row.InWon, row.InEvidence, row.InBestCase, row.InOpen,
 				nullIfEmpty(row.ExclusionReason),
 				row.AuditID, row.ApprovalID, capturedBy,

--- a/backend/internal/modules/forecasting/snapshot_integration_test.go
+++ b/backend/internal/modules/forecasting/snapshot_integration_test.go
@@ -312,3 +312,55 @@ func TestAMovementAcrossTwoDifferentWindowsIsRefused(t *testing.T) {
 		t.Fatalf("two readings of the same quarter were refused: %v", err)
 	}
 }
+
+// A frozen contribution remembers the stage the deal stood in.
+//
+// The conversion rate behind pipeline sufficiency asks what happened to deals
+// that REACHED a stage, and the only durable record of where a deal stood on a
+// given day is the snapshot that froze it. Read from the deal's current stage
+// instead, that history credits today's stage with the outcome of a deal that
+// passed through three others.
+func TestAContributionRemembersTheStageTheDealWasIn(t *testing.T) {
+	t.Parallel()
+	e := setupSnapshot(t)
+	ctx := e.as()
+
+	zone, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, time.November, 9, 12, 0, 0, 0, zone)
+	period, err := ResolvePeriod(PeriodQuarter, at, 1, zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := ids.NewV7()
+	row := open(ids.NewV7().String(), 100_00)
+	row.StageID = stage.String()
+	readings := Readings{Contributions: []Contribution{row}, EligibleCount: 1, PricedCount: 1}
+
+	var id ids.UUID
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		var err error
+		id, err = e.store.TakeSnapshot(ctx, tx, NewSnapshot{
+			Period: period, Scope: Scope{Kind: ScopeWorkspace},
+			Trigger: TriggerDaily, BaseCurrency: "EUR",
+			Readings: readings, TakenAt: at,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("taking the snapshot: %v", err)
+	}
+
+	var stored *ids.UUID
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT stage_id FROM forecast_contribution WHERE snapshot_id = $1`, id).Scan(&stored)
+	}); err != nil {
+		t.Fatalf("reading the contribution back: %v", err)
+	}
+	if stored == nil || *stored != stage {
+		t.Fatalf("the contribution stored stage %v, want %v — without it the conversion "+
+			"history has no record of where the deal actually stood", stored, stage)
+	}
+}

--- a/backend/internal/modules/forecasting/sufficiency.go
+++ b/backend/internal/modules/forecasting/sufficiency.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Whether there is enough pipeline to land where the period is expected to.
+//
+// The question a manager asks in week two, and the one every "coverage ratio"
+// in this industry gets wrong by answering it circularly: pipeline divided by
+// a target derived from the pipeline is a number that is always fine.
+//
+// So the basis is NAMED and comes from outside the current projection. Either a
+// manager wrote a call down, or four comparable periods actually finished and
+// their median is what this business does. If neither is available the answer is
+// that there is no basis — never a figure with a shrug attached.
+//
+// This is not a target. Margince has no target model and this must not become
+// one by implication: the words below are "reference" and "basis", and the
+// surface drawing them says the same. A number a rep is measured against is a
+// product decision nobody has made.
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// The bars below which an answer is not worth giving.
+const (
+	// comparablePeriods is how many completed periods a median needs. Four,
+	// because it is a year of quarters and long enough that one exceptional
+	// period cannot carry the median on its own.
+	comparablePeriods = 4
+	// minimumClosedDeals is how many closed deals a conversion rate needs
+	// before it is a rate rather than an anecdote. Twenty is not a statistical
+	// threshold; it is the point below which a single deal moves the answer
+	// by more than the answer is worth.
+	minimumClosedDeals = 20
+	// minimumStageArrivals is how many deals must have reached a stage before
+	// its own rate is used instead of the blended one. Five, for the same
+	// reason and at a smaller scale: a stage two deals have ever entered has
+	// no rate, it has two stories.
+	minimumStageArrivals = 5
+)
+
+// SufficiencyBasis names where the reference came from, because a coverage
+// figure without its basis is a number a reader cannot argue with.
+type SufficiencyBasis string
+
+const (
+	// BasisManagerCall is the current authored call for this period and scope.
+	BasisManagerCall SufficiencyBasis = "manager_call"
+	// BasisHistoricalMedian is the median actual Won of the last four
+	// comparable completed periods.
+	BasisHistoricalMedian SufficiencyBasis = "historical_median"
+)
+
+// SufficiencyAbsence says why there is no answer, when there is none.
+type SufficiencyAbsence string
+
+const (
+	// AbsenceInsufficientBasis means neither a call nor four completed periods.
+	// There is nothing honest to compare the pipeline against.
+	AbsenceInsufficientBasis SufficiencyAbsence = "insufficient_basis"
+	// AbsenceInsufficientHistory means fewer than twenty closed deals, so no
+	// conversion rate is worth dividing by.
+	AbsenceInsufficientHistory SufficiencyAbsence = "insufficient_history"
+)
+
+// Sufficiency is how much open pipeline the reference needs, and how much there
+// is.
+type Sufficiency struct {
+	// Absent is set when no answer is supportable; every other field is then
+	// zero and the surface says why rather than drawing a figure.
+	Absent SufficiencyAbsence
+	// Basis and ReferenceLandingMinor are what the pipeline is measured
+	// against, and where that number came from.
+	Basis                 SufficiencyBasis
+	ReferenceLandingMinor int64
+	// RemainingToSupportMinor is the reference minus what is already won,
+	// floored at zero: a period already past its reference needs no more
+	// pipeline, and a negative requirement would print as a coverage figure
+	// nobody can read.
+	RemainingToSupportMinor int64
+	// NeededOpenMinor is the open pipeline that remainder implies at the
+	// conversion rate, and CurrentOpenMinor is what there is.
+	NeededOpenMinor  int64
+	CurrentOpenMinor int64
+	// CoverageBp is current over needed in basis points, so a caller renders a
+	// ratio without this package choosing a rounding for them. Zero needed is
+	// full coverage rather than a division by zero.
+	CoverageBp int64
+}
+
+// ConversionHistory is what the sufficiency read needs from outside itself.
+//
+// Taken as data rather than read here, because this package does no I/O and a
+// pure function is what makes every case below testable without a database.
+type ConversionHistory struct {
+	// ClosedDeals is how many deals closed in the window the rates were read
+	// over, whatever they closed as. The bar the whole answer rests on.
+	ClosedDeals int
+	// BlendedWonPerReached is the fraction of deals reaching ANY stage that
+	// were eventually won, used where a stage has too few arrivals of its own.
+	BlendedWonPerReached float64
+	// ComparableWon is the actual Won of completed comparable periods, newest
+	// first. Four are needed for a median.
+	ComparableWon []int64
+}
+
+// AssessSufficiency answers whether the open pipeline supports the reference.
+//
+// call is the current manager call, or nil. It OUTRANKS history: a manager who
+// has written a number down has said what this period is for, and a median of
+// what happened before is the fallback for when nobody has.
+func AssessSufficiency(
+	readings Readings, history ConversionHistory, call *int64,
+) (Sufficiency, error) {
+	basis, reference, ok := referenceLanding(history, call)
+	if !ok {
+		return Sufficiency{Absent: AbsenceInsufficientBasis}, nil
+	}
+	if history.ClosedDeals < minimumClosedDeals {
+		return Sufficiency{Absent: AbsenceInsufficientHistory}, nil
+	}
+	rate := history.BlendedWonPerReached
+	if rate <= 0 {
+		// No rate is not a rate of zero: dividing by it would demand infinite
+		// pipeline, and a surface drawing that would tell a manager to give up.
+		return Sufficiency{Absent: AbsenceInsufficientHistory}, nil
+	}
+	if rate > 1 {
+		return Sufficiency{}, fmt.Errorf(
+			"forecasting: a conversion rate of %v is more deals won than reached the stage", rate)
+	}
+
+	remaining := reference - readings.WonMinor
+	if remaining < 0 {
+		// Already past the reference. No more pipeline is needed, and a
+		// negative requirement would print as a coverage figure nobody can read.
+		remaining = 0
+	}
+	// Bounded before the conversion. A float64 above the int64 ceiling converts
+	// to an IMPLEMENTATION-DEFINED value in Go — in practice MinInt64 — so an
+	// unchecked cast turns "more pipeline than exists" into a negative
+	// requirement, which then reads as a fully covered book.
+	wanted := math.Ceil(float64(remaining) / rate)
+	if wanted > float64(math.MaxInt64) {
+		return Sufficiency{}, fmt.Errorf(
+			"forecasting: a reference of %d at a conversion rate of %v needs more pipeline "+
+				"than money can represent: %w", reference, rate, ErrReadingOutOfRange)
+	}
+	needed := int64(wanted)
+	out := Sufficiency{
+		Basis: basis, ReferenceLandingMinor: reference,
+		RemainingToSupportMinor: remaining,
+		NeededOpenMinor:         needed,
+		CurrentOpenMinor:        readings.OpenMinor,
+	}
+	if needed == 0 {
+		// Nothing needed is covered, whatever is open. Reported as full rather
+		// than as a division by zero, and not as an unbounded ratio: a manager
+		// reading "∞% covered" learns nothing they can act on.
+		out.CoverageBp = fullCoverageBp
+	} else {
+		// Basis points, so a caller renders the ratio and this package chooses
+		// no rounding for them. Both operands are already minor units in one
+		// base currency, so nothing here converts between scales.
+		//
+		// Scaled before dividing, so the multiply is what can wrap: a book of
+		// open pipeline above roughly 9.2e14 minor units overflows, and a
+		// wrapped coverage reads NEGATIVE — which draws as a book with no
+		// pipeline at all, the opposite of what such a number means.
+		coverage, err := coverageBp(readings.OpenMinor, needed)
+		if err != nil {
+			return Sufficiency{}, err
+		}
+		out.CoverageBp = coverage
+	}
+	return out, nil
+}
+
+// fullCoverageBp is a pipeline that meets its requirement exactly: 100%.
+const fullCoverageBp int64 = 10_000 // money-scale-exempt: basis points, not a currency scale
+
+// coverageBp is open over needed, in basis points, refusing an overflow.
+//
+// The scaling multiply is the operation that can wrap, so it is checked rather
+// than reordered: dividing first would throw away the precision the basis
+// points exist to keep.
+func coverageBp(open, needed int64) (int64, error) {
+	if open > math.MaxInt64/fullCoverageBp {
+		return 0, fmt.Errorf(
+			"forecasting: an open pipeline of %d is too large to express as a coverage "+
+				"ratio: %w", open, ErrReadingOutOfRange)
+	}
+	return open * fullCoverageBp / needed, nil
+}
+
+// referenceLanding picks what the pipeline is measured against.
+//
+// The call first, because it is somebody's stated intention for THIS period,
+// and the median is what the business did when nobody stated one. Neither is a
+// target: both are named on the surface so a reader can disagree with the
+// basis rather than with the arithmetic.
+func referenceLanding(history ConversionHistory, call *int64) (SufficiencyBasis, int64, bool) {
+	if call != nil {
+		return BasisManagerCall, *call, true
+	}
+	if len(history.ComparableWon) < comparablePeriods {
+		return "", 0, false
+	}
+	// The most recent four, because a business four years ago is a different
+	// business. Sorted on a copy: the caller's slice is theirs, and reordering
+	// it would change what a second reader sees.
+	recent := append([]int64{}, history.ComparableWon[:comparablePeriods]...)
+	sort.Slice(recent, func(i, j int) bool { return recent[i] < recent[j] })
+	// The mean of the middle two, which is what a median of an even count is.
+	// Integer division truncates toward zero and both values are non-negative
+	// money, so the result is at most one minor unit low — and biasing the
+	// reference DOWN understates what is needed by less than a cent.
+	//
+	// Halved BEFORE adding, so two large historical totals cannot wrap into a
+	// negative reference — which would report a period as needing no pipeline
+	// at all. The two halves' remainders are added back separately, so the
+	// answer is the same one the direct sum gives.
+	low, high := recent[1], recent[2]
+	median := low/2 + high/2 + (low%2+high%2)/2
+	return BasisHistoricalMedian, median, true
+}
+
+// StageConversion is one stage's own win rate, or the blended one where too few
+// deals have ever reached it.
+//
+// Its own function because the fallback is the part worth naming: a stage two
+// deals have entered has no rate, and using it would let one deal's outcome set
+// the pipeline a whole team is told to build.
+func StageConversion(arrivals, won int, blended float64) float64 {
+	if arrivals < minimumStageArrivals {
+		return blended
+	}
+	if arrivals == 0 {
+		return blended
+	}
+	return float64(won) / float64(arrivals)
+}

--- a/backend/internal/modules/forecasting/sufficiency_test.go
+++ b/backend/internal/modules/forecasting/sufficiency_test.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Whether there is enough pipeline.
+//
+// Every "coverage ratio" in this industry gets this wrong the same way: divide
+// the pipeline by a target derived from the pipeline and the answer is always
+// fine. The tests below hold the two things that stop that — the basis comes
+// from OUTSIDE the current projection, and where no basis exists the answer is
+// that there is none rather than a figure with a shrug attached.
+
+import (
+	"math"
+	"testing"
+)
+
+func fourPeriods(won ...int64) ConversionHistory {
+	return ConversionHistory{
+		ClosedDeals: 50, BlendedWonPerReached: 0.25, ComparableWon: won,
+	}
+}
+
+func TestTheReferenceIsTheManagerCallWhenPresent(t *testing.T) {
+	t.Parallel()
+	call := int64(1_000_00)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 200_00, OpenMinor: 500_00},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Basis != BasisManagerCall {
+		t.Fatalf("basis = %q, want the call somebody wrote down for THIS period", got.Basis)
+	}
+	if got.ReferenceLandingMinor != 1_000_00 {
+		t.Fatalf("reference = %d, want the call of 100000", got.ReferenceLandingMinor)
+	}
+}
+
+func TestWithoutACallTheReferenceIsTheMedianOfFourComparablePeriods(t *testing.T) {
+	t.Parallel()
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 200_00, OpenMinor: 500_00},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Basis != BasisHistoricalMedian {
+		t.Fatalf("basis = %q, want the median of what actually happened", got.Basis)
+	}
+	// The middle two of 600, 700, 800, 900.
+	if got.ReferenceLandingMinor != 750_00 {
+		t.Fatalf("reference = %d, want the median 75000", got.ReferenceLandingMinor)
+	}
+}
+
+// Neither a call nor four completed periods is NO ANSWER, not a guess. A figure
+// here would be the circular one this whole file exists to avoid.
+func TestWithoutCallOrFourPeriodsSufficiencyIsAbsent(t *testing.T) {
+	t.Parallel()
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 200_00, OpenMinor: 500_00},
+		fourPeriods(900_00, 800_00, 700_00), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Absent != AbsenceInsufficientBasis {
+		t.Fatalf("absent = %q, want %q", got.Absent, AbsenceInsufficientBasis)
+	}
+	if got.NeededOpenMinor != 0 || got.CoverageBp != 0 {
+		t.Fatal("an unsupportable answer still carried figures, which a surface would draw")
+	}
+}
+
+func TestFewerThanTwentyClosedDealsIsInsufficientHistory(t *testing.T) {
+	t.Parallel()
+	history := fourPeriods(900_00, 800_00, 700_00, 600_00)
+	history.ClosedDeals = 19
+	got, err := AssessSufficiency(Readings{WonMinor: 200_00, OpenMinor: 500_00}, history, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Absent != AbsenceInsufficientHistory {
+		t.Fatalf("absent = %q, want %q", got.Absent, AbsenceInsufficientHistory)
+	}
+}
+
+// A stage two deals have ever entered has no rate — it has two stories, and
+// using them would let one outcome set the pipeline a whole team is told to
+// build.
+func TestAStageWithUnderFiveArrivalsUsesTheBlendedRate(t *testing.T) {
+	t.Parallel()
+	if got := StageConversion(2, 2, 0.25); got != 0.25 {
+		t.Fatalf("a stage with two arrivals reported its own rate %v; two deals is not a rate", got)
+	}
+	// And a stage with enough arrivals uses its own, or the fallback would be
+	// every stage's answer and the per-stage rate would be dead code.
+	if got := StageConversion(10, 5, 0.25); got != 0.5 {
+		t.Fatalf("a stage with ten arrivals reported %v, want its own 0.5", got)
+	}
+}
+
+// The needed pipeline is measured against the REFERENCE after Won, never
+// against the projection. Deriving it from the current landing is the circular
+// answer: a pipeline is then always exactly sufficient for the pipeline.
+func TestNeededPipelineUsesRemainingReferenceAfterWonNotProjectedLanding(t *testing.T) {
+	t.Parallel()
+	call := int64(1_000_00)
+	got, err := AssessSufficiency(
+		Readings{
+			WonMinor: 200_00, OpenMinor: 500_00,
+			// A big weighted number, which must not enter the requirement.
+			WeightedMinor: 5_000_00, EvidenceMinor: 4_000_00,
+		},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RemainingToSupportMinor != 800_00 {
+		t.Fatalf("remaining = %d, want the reference 100000 minus won 20000", got.RemainingToSupportMinor)
+	}
+	// 80000 at a quarter conversion needs 320000 of open pipeline.
+	if got.NeededOpenMinor != 3_200_00 {
+		t.Fatalf("needed = %d, want 320000", got.NeededOpenMinor)
+	}
+}
+
+func TestCoverageIsOpenPipelineOverNeeded(t *testing.T) {
+	t.Parallel()
+	call := int64(1_000_00)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 200_00, OpenMinor: 1_600_00},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 160000 open against 320000 needed is half.
+	if got.CoverageBp != 5_000 {
+		t.Fatalf("coverage = %d bp, want 5000 (half)", got.CoverageBp)
+	}
+}
+
+// A period already past its reference needs no more pipeline. The subtraction
+// floors at zero, because a negative requirement divides into a coverage figure
+// nobody can read.
+func TestAPeriodAlreadyPastItsReferenceNeedsNothingMore(t *testing.T) {
+	t.Parallel()
+	call := int64(100_00)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 500_00, OpenMinor: 0},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), &call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RemainingToSupportMinor != 0 {
+		t.Fatalf("remaining = %d over a reference already passed", got.RemainingToSupportMinor)
+	}
+	if got.CoverageBp != 10_000 {
+		t.Fatalf("coverage = %d bp, want full — nothing is needed", got.CoverageBp)
+	}
+}
+
+func TestAZeroConversionRateNeverDividesByZero(t *testing.T) {
+	t.Parallel()
+	history := fourPeriods(900_00, 800_00, 700_00, 600_00)
+	history.BlendedWonPerReached = 0
+	got, err := AssessSufficiency(Readings{WonMinor: 200_00, OpenMinor: 500_00}, history, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No rate is not a rate of zero: dividing by it demands infinite pipeline,
+	// and a surface drawing that tells a manager to give up.
+	if got.Absent != AbsenceInsufficientHistory {
+		t.Fatalf("absent = %q, want %q", got.Absent, AbsenceInsufficientHistory)
+	}
+}
+
+// The caller's history slice is theirs. Sorting it in place would change what a
+// second reader of the same slice sees — and the four periods arrive newest
+// first, which is an order somebody else may rely on.
+func TestTheReferenceReadDoesNotReorderTheCallersHistory(t *testing.T) {
+	t.Parallel()
+	history := fourPeriods(900_00, 600_00, 800_00, 700_00)
+	before := append([]int64{}, history.ComparableWon...)
+	if _, err := AssessSufficiency(Readings{OpenMinor: 1}, history, nil); err != nil {
+		t.Fatal(err)
+	}
+	for i := range before {
+		if history.ComparableWon[i] != before[i] {
+			t.Fatalf("the history was reordered: %v became %v", before, history.ComparableWon)
+		}
+	}
+}
+
+// Each guard below is a wrap that reports the OPPOSITE of the truth. That is
+// what makes them worth refusing rather than clamping: a negative requirement
+// and a negative coverage both draw as a book that needs nothing.
+
+// A median taken by summing the middle two wraps on large historical totals,
+// and a negative reference reports a period as needing no pipeline at all.
+func TestAMedianOfTwoVeryLargePeriodsDoesNotWrapNegative(t *testing.T) {
+	t.Parallel()
+	big := int64(math.MaxInt64 - 3)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 0, OpenMinor: 100},
+		// Four periods, the middle two of which are the large pair: summing
+		// them directly overflows before the halving.
+		fourPeriods(big, big, big, big), nil)
+	if err != nil {
+		// Refusing is a correct answer here too; wrapping is not.
+		return
+	}
+	if got.ReferenceLandingMinor < 0 {
+		t.Fatalf("the median of four large periods is %d, a NEGATIVE reference — "+
+			"which reports the period as needing no pipeline at all",
+			got.ReferenceLandingMinor)
+	}
+}
+
+// The scaling multiply for basis points wraps on a large open pipeline. The
+// wrap does not go negative — it divides down to ZERO, which draws as a book
+// holding no pipeline at all while the book is in fact enormous. Asserting on
+// a negative would have missed this entirely.
+func TestAnOpenPipelineTooLargeToScaleIsRefusedRatherThanWrapped(t *testing.T) {
+	t.Parallel()
+	call := int64(1_000_00)
+	open := int64(math.MaxInt64 / 2)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 0, OpenMinor: open},
+		fourPeriods(900_00, 800_00, 700_00, 600_00), &call)
+	if err != nil {
+		// Refusing is the answer this guard gives. Anything but a wrapped
+		// figure is acceptable; a wrapped one is not.
+		return
+	}
+	if got.CoverageBp <= 0 {
+		t.Fatalf("an open pipeline of %d reports %d basis points of coverage — a "+
+			"multiply that wrapped divides down to nothing, so the largest possible "+
+			"book draws as an empty one", open, got.CoverageBp)
+	}
+}
+
+// A requirement above the representable range is refused rather than converted.
+//
+// The unchecked conversion is IMPLEMENTATION-DEFINED in Go: it saturates to
+// MaxInt64 on this platform rather than wrapping to MinInt64. So the test
+// asserts the refusal itself — a figure that silently means "the largest
+// number there is" is not an answer whichever end it lands on, and asserting
+// on one platform's saturation value would pass on that platform for the wrong
+// reason and fail on another.
+func TestARequirementBeyondTheMoneyRangeIsRefused(t *testing.T) {
+	t.Parallel()
+	call := int64(math.MaxInt64)
+	got, err := AssessSufficiency(
+		Readings{WonMinor: 0, OpenMinor: 1_000},
+		ConversionHistory{
+			ClosedDeals: 50, BlendedWonPerReached: 0.0001,
+			ComparableWon: []int64{1, 1, 1, 1},
+		}, &call)
+	if err == nil {
+		t.Fatalf("a requirement of about 9.2e22 minor units answered %d instead of "+
+			"refusing — the conversion cannot represent it, so whatever came back is "+
+			"a number nobody can act on", got.NeededOpenMinor)
+	}
+}

--- a/backend/internal/modules/identity/installationsettings.go
+++ b/backend/internal/modules/identity/installationsettings.go
@@ -29,6 +29,11 @@ type InstallationSettings struct {
 	BaseLanguage string
 	// FiscalYearStartMonth is the month the business year begins, 1..12.
 	FiscalYearStartMonth int
+	// ForecastForwardMeasure is which remaining-pipeline reading a projected
+	// landing is built from. A string here rather than a values.ForwardMeasure
+	// because this struct is what the setting STORED, and reporting it as the
+	// typed vocabulary would claim a validation the read did not perform.
+	ForecastForwardMeasure string
 	// BaseCurrencyLocked and its reason let a client render the field
 	// read-only instead of discovering the refusal by attempting a write —
 	// the same information the write path would give, offered before the
@@ -47,11 +52,12 @@ type InstallationSettings struct {
 // them are *string and a transposed pair would write a language into the
 // currency row and pass the type checker.
 type InstallationPatch struct {
-	Name                 *string
-	Timezone             *string
-	BaseCurrency         *string
-	BaseLanguage         *string
-	FiscalYearStartMonth *int
+	Name                   *string
+	Timezone               *string
+	BaseCurrency           *string
+	BaseLanguage           *string
+	FiscalYearStartMonth   *int
+	ForecastForwardMeasure *string
 	// EnabledOidcProviders replaces the whole list. A nil pointer leaves it
 	// unchanged; a pointer to an empty slice is a real choice — offer password
 	// only — so the two cannot be collapsed.
@@ -130,6 +136,10 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	if err != nil {
 		return InstallationSettings{}, err
 	}
+	measure, err := settings.Get(ctx, s.settings, ForecastForwardMeasure)
+	if err != nil {
+		return InstallationSettings{}, err
+	}
 	providers, err := settings.Get(ctx, s.settings, EnabledOidcProviders)
 	if err != nil {
 		return InstallationSettings{}, err
@@ -140,8 +150,9 @@ func (s *InstallationSettingsStore) GetInstallation(ctx context.Context) (Instal
 	}
 	return InstallationSettings{
 		Name: name, Timezone: zone, BaseCurrency: currency, BaseLanguage: language,
-		FiscalYearStartMonth: fiscalStart,
-		BaseCurrencyLocked:   locked, BaseCurrencyLockedReason: why,
+		FiscalYearStartMonth:   fiscalStart,
+		ForecastForwardMeasure: measure,
+		BaseCurrencyLocked:     locked, BaseCurrencyLockedReason: why,
 		EnabledOidcProviders: providers,
 	}, nil
 }
@@ -235,11 +246,15 @@ func encodeInstallationPatch(in InstallationPatch) ([]pendingWrite, error) {
 	if err != nil {
 		return nil, err
 	}
+	measure, err := encodePatchField(ForecastForwardMeasure, in.ForecastForwardMeasure)
+	if err != nil {
+		return nil, err
+	}
 	providers, err := encodePatchField(EnabledOidcProviders, in.EnabledOidcProviders)
 	if err != nil {
 		return nil, err
 	}
-	return []pendingWrite{name, zone, currency, language, fiscal, providers}, nil
+	return []pendingWrite{name, zone, currency, language, fiscal, measure, providers}, nil
 }
 
 // UpdateInstallation applies a sparse patch. Named for the same reason as

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -222,42 +222,6 @@ var Country = settings.Define[string](
 	// is inferable from the rules its own outbound mail obeys.
 ).AsInstallationIdentity().MachineryApplied()
 
-// FiscalYearStartMonth is the month the installation's business year begins,
-// 1..12. January is the default, which is what every installation reported by
-// before this existed — so an installation that never touches it sees no
-// change, and no saved report view moves under it.
-//
-// It buckets reports on READ and stores nothing, so changing it re-labels every
-// period report immediately and re-means no stored row. That is the opposite of
-// BaseCurrency, which freezes: a fiscal year is a way of cutting time, not a
-// value anything has already converted against.
-//
-// It does re-point a SAVED report view, which is a real gap rather than a
-// property of this setting: a period bucket's text travels out in a derivation
-// handle and binds back as an equality filter (reportperiod.go), so a view
-// saved under one fiscal start names a different span after it moves. Tracked
-// as its own decision — re-point, invalidate, or warn — rather than settled
-// here, because none of the three is obviously right and the label cannot fix
-// it either way: margince/margince#2569. Named rather than described, so a
-// reader can see whether it is still open instead of trusting a comment's
-// account of a gap.
-//
-// What the label DOES fix is the reader's half: spelling both years means the
-// answer they get is unambiguous about which twelve months it covers, even when
-// the filter that produced it is stale.
-var FiscalYearStartMonth = settings.Define[int](
-	"installation.fiscal_year_start_month",
-	installationSettingsObject,
-	"update",
-	int(time.January),
-	func(month int) error {
-		if month < int(time.January) || month > int(time.December) {
-			return fmt.Errorf("a fiscal year starts in month 1..12, not %d", month)
-		}
-		return nil
-	},
-).AsInstallationIdentity()
-
 // The ceilings on the provider list, mirroring the contract's maxItems and
 // maxLength. Generous against any real deployment — nobody wires 32 identity
 // providers — and small enough that the anonymous read behind the login screen
@@ -334,6 +298,7 @@ func Definitions() []settings.Definition {
 		BaseLanguage,
 		Country,
 		FiscalYearStartMonth,
+		ForecastForwardMeasure,
 		EnabledOidcProviders,
 		SMTPPasswordRef,
 		LicenseTokenRef,
@@ -391,18 +356,6 @@ func NameOf(ctx context.Context, tx pgx.Tx) (string, error) {
 // installations get today anyway.
 func BaseLanguageOf(ctx context.Context, tx pgx.Tx) (string, error) {
 	return settings.GetTx(ctx, tx, BaseLanguage)
-}
-
-// FiscalYearStartMonthOf resolves the month the installation's business year
-// begins, inside a transaction the caller already holds.
-//
-// GetTx for the same reason BaseLanguageOf uses it: an installation
-// bootstrapped before this setting existed carries no row, and the default is
-// January — the calendar year those installations have always reported by. So
-// an absent row is not a broken installation, it is an older one that agrees
-// with the default.
-func FiscalYearStartMonthOf(ctx context.Context, tx pgx.Tx) (int, error) {
-	return settings.GetTx(ctx, tx, FiscalYearStartMonth)
 }
 
 // BaseLanguageForPrompt resolves the base language for a caller that holds a

--- a/backend/internal/modules/identity/settingsreporting.go
+++ b/backend/internal/modules/identity/settingsreporting.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// The settings that decide how the installation REPORTS, as opposed to who it
+// is: which months a business year is cut into, and which reading a projected
+// landing is built from.
+//
+// Both are applied on READ and store nothing, which is what separates them from
+// the identity settings beside them: changing either re-labels or re-computes
+// every report at once and re-means no stored row. Neither ever freezes.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/settings"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// FiscalYearStartMonth is the month the installation's business year begins,
+// 1..12. January is the default, which is what every installation reported by
+// before this existed — so an installation that never touches it sees no
+// change, and no saved report view moves under it.
+//
+// It buckets reports on READ and stores nothing, so changing it re-labels every
+// period report immediately and re-means no stored row. That is the opposite of
+// BaseCurrency, which freezes: a fiscal year is a way of cutting time, not a
+// value anything has already converted against.
+//
+// It does re-point a SAVED report view, which is a real gap rather than a
+// property of this setting: a period bucket's text travels out in a derivation
+// handle and binds back as an equality filter (reportperiod.go), so a view
+// saved under one fiscal start names a different span after it moves. Tracked
+// as its own decision — re-point, invalidate, or warn — rather than settled
+// here, because none of the three is obviously right and the label cannot fix
+// it either way: margince/margince#2569. Named rather than described, so a
+// reader can see whether it is still open instead of trusting a comment's
+// account of a gap.
+//
+// What the label DOES fix is the reader's half: spelling both years means the
+// answer they get is unambiguous about which twelve months it covers, even when
+// the filter that produced it is stale.
+var FiscalYearStartMonth = settings.Define[int](
+	"installation.fiscal_year_start_month",
+	installationSettingsObject,
+	"update",
+	int(time.January),
+	func(month int) error {
+		if month < int(time.January) || month > int(time.December) {
+			return fmt.Errorf("a fiscal year starts in month 1..12, not %d", month)
+		}
+		return nil
+	},
+).AsInstallationIdentity()
+
+// ForecastForwardMeasure is which remaining-pipeline reading a projected
+// landing is built from.
+//
+// A setting rather than a fixed choice because it is a question about how the
+// installation SELLS, not about the software: a team with a disciplined commit
+// stage means something by it, and one that commits everything does not — their
+// weighted number is the honest one.
+//
+// Applied on READ and storing nothing, like FiscalYearStartMonth and unlike
+// BaseCurrency: changing it re-computes every landing at once and re-means no
+// stored row, so it never freezes.
+//
+// The set of values lives in the shared kernel because forecasting refuses
+// anything outside it and this package may not import that module. Validating
+// against a copy here would let the two drift, and the drift only shows up as
+// a forecast read failing for an installation that saved cleanly.
+var ForecastForwardMeasure = settings.Define[string](
+	"installation.forecast_forward_measure",
+	installationSettingsObject,
+	"update",
+	string(values.MeasureCommitEvidence),
+	func(measure string) error {
+		if _, err := values.ParseForwardMeasure(&measure, "forecast_forward_measure"); err != nil {
+			return err
+		}
+		return nil
+	},
+).AsInstallationIdentity()
+
+// ForecastForwardMeasureOf resolves the stored measure inside a transaction the
+// caller already holds.
+//
+// Here rather than in the composition for the reason FiscalYearStartMonthOf is:
+// how this setting is read belongs with the entry that declares it, so a
+// wiring site injecting it does not restate the default or the key.
+func ForecastForwardMeasureOf(ctx context.Context, tx pgx.Tx) (string, error) {
+	return settings.GetTx(ctx, tx, ForecastForwardMeasure)
+}
+
+// FiscalYearStartMonthOf resolves the month the installation's business year
+// begins, inside a transaction the caller already holds.
+//
+// GetTx for the same reason BaseLanguageOf uses it: an installation
+// bootstrapped before this setting existed carries no row, and the default is
+// January — the calendar year those installations have always reported by. So
+// an absent row is not a broken installation, it is an older one that agrees
+// with the default.
+func FiscalYearStartMonthOf(ctx context.Context, tx pgx.Tx) (int, error) {
+	return settings.GetTx(ctx, tx, FiscalYearStartMonth)
+}

--- a/backend/internal/shared/kernel/values/forwardmeasure.go
+++ b/backend/internal/shared/kernel/values/forwardmeasure.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package values
+
+// Which remaining-pipeline reading a projected landing is built from.
+//
+// Spelled in this package rather than in forecasting because TWO modules need
+// the set and they may not import each other: identity stores the installation
+// setting and must validate it, forecasting builds the landing and must refuse
+// anything else. A copy in either is a set that can drift from the one the
+// other enforces — and the drift is invisible until an installation saves a
+// measure the projection then refuses on every read.
+
+import "fmt"
+
+// ForwardMeasure names which reading the forward half of a landing comes from.
+type ForwardMeasure string
+
+const (
+	// MeasureCommitEvidence adds the commit-category deals with confirmed close
+	// dates. The strictest reading: a provisional date is a guess and stays out.
+	MeasureCommitEvidence ForwardMeasure = "commit_evidence"
+	// MeasureWeighted adds every open deal at its stage probability.
+	MeasureWeighted ForwardMeasure = "weighted"
+	// MeasureManagerCall takes the authored call as the whole period's landing.
+	// It is NOT added to what is already won: a manager calling the quarter is
+	// calling the finish line, not the distance left to run.
+	MeasureManagerCall ForwardMeasure = "manager_call"
+)
+
+// ForwardMeasures is every measure, in the order a chooser should offer them:
+// strictest first, then the two that soften it.
+//
+// Held by: TestEveryForwardMeasureIsOfferedOnTheWire (backend/gates/forwardmeasureparity_test.go),
+// which derives the contract's own enums and requires them to agree with this
+// set — a measure the settings screen admits and the projection refuses saves
+// cleanly and then errors on every forecast read.
+//
+// Returned as a fresh slice because a package-level array would let one caller
+// reorder every other caller's chooser.
+func ForwardMeasures() []ForwardMeasure {
+	return []ForwardMeasure{MeasureCommitEvidence, MeasureWeighted, MeasureManagerCall}
+}
+
+// ParseForwardMeasure turns a stored or wire value into a measure.
+//
+// The default is deliberate: an ABSENT measure is commit evidence, which is
+// what every installation's landing was computed from before the setting
+// existed, so one that never touches it sees no change.
+func ParseForwardMeasure(raw *string, field string) (ForwardMeasure, error) {
+	if raw == nil || *raw == "" {
+		return MeasureCommitEvidence, nil
+	}
+	for _, known := range ForwardMeasures() {
+		if ForwardMeasure(*raw) == known {
+			return known, nil
+		}
+	}
+	return "", &ParseError{
+		Field: field, Code: "unknown_forward_measure",
+		Message: fmt.Sprintf("a landing is built from one of %v", ForwardMeasures()),
+	}
+}

--- a/backend/migrations/core/1788642090_a_contribution_remembers_its_stage.down.sql
+++ b/backend/migrations/core/1788642090_a_contribution_remembers_its_stage.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE forecast_contribution DROP COLUMN stage_id;

--- a/backend/migrations/core/1788642090_a_contribution_remembers_its_stage.up.sql
+++ b/backend/migrations/core/1788642090_a_contribution_remembers_its_stage.up.sql
@@ -1,0 +1,27 @@
+-- Bound the wait for the lock below. Without it an open transaction holding a
+-- conflicting lock stalls every write to this table for as long as this
+-- migration is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+-- A frozen contribution remembers which stage the deal was IN.
+--
+-- The pipeline-sufficiency read needs a conversion rate per stage — how many
+-- deals reaching a stage were eventually won — and the only durable record of
+-- where a deal stood on a given day is the snapshot that froze it. Without the
+-- stage on the row, that history can only be reconstructed from the deal's
+-- CURRENT stage, which answers a different question: it would credit today's
+-- stage with the outcome of a deal that passed through three others.
+--
+-- NULLABLE, and it stays nullable. Every contribution written before this
+-- migration genuinely does not know, and a backfill from the deal's present
+-- stage would be that same wrong answer written down as though it were
+-- recorded. The reader treats an unknown stage as one it cannot rate, which is
+-- the honest handling of a row that predates the question.
+--
+-- NO foreign key to stage. A snapshot is a record of what was true, and a stage
+-- deleted from a pipeline afterwards must not take the history with it — the
+-- deal still reached that stage, whatever the pipeline looks like now.
+ALTER TABLE forecast_contribution ADD COLUMN stage_id uuid;
+
+COMMENT ON COLUMN forecast_contribution.stage_id IS
+  'The stage the deal stood in when this snapshot was taken. NULL on rows written before the column existed, and on any deal whose stage could not be read; never backfilled from the deal''s current stage, which is a different fact.';

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2415,6 +2415,7 @@ public.forecast_contribution.in_open boolean NOT NULL gen=- def=false
 public.forecast_contribution.in_won boolean NOT NULL gen=- def=false
 public.forecast_contribution.owner_id uuid gen=- def=-
 public.forecast_contribution.snapshot_id uuid NOT NULL gen=- def=-
+public.forecast_contribution.stage_id uuid gen=- def=-
 public.forecast_contribution.stage_probability integer gen=- def=-
 public.forecast_contribution.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.forecast_contribution.uq_forecast_contribution_deal UNIQUE (snapshot_id, deal_id)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (84)
+## Parity (85)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -49,6 +49,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |
 | `filtervocabularyparity_test.go` | H3 | Two surfaces answer a filtered question: the list/segment compiler in `platform/database/storekit`, and the query compiler in `modules/search`. |
 | `forecastperiodparity_test.go` | H3 | Every period the contract offers must be a window the server can resolve. |
+| `forwardmeasureparity_test.go` | H3 | Every forward measure must be spelled the same on all three sides. |
 | `frontendapprovalkinds_test.go` | H1 | Every kind a proposal can be staged under must have words a reader recognises, or the queue prints the wire enum at them. |
 | `frontendattentionsources_test.go` | H1 | Every source the Worklist can carry must have a body the decision lane knows how to draw, or the lane asks the wrong endpoint about it. |
 | `frontendaudiencereasons_test.go` | H3 | A held message says WHY, or the reader cannot argue with the verdict. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14266,6 +14266,21 @@ export interface components {
              *     little room rather than compare a file against it exactly.
              */
             max_upload_bytes: number;
+            /**
+             * @description Which remaining-pipeline reading a projected landing is built from. A setting
+             *     rather than a fixed choice, because it is a question about how this installation
+             *     SELLS rather than about the software: a team with a disciplined commit stage means
+             *     something by it, and one that commits everything does not — their weighted number
+             *     is the honest one.
+             *
+             *     `commit_evidence` is the default and the strictest: committed deals whose close
+             *     date somebody confirmed, a provisional date being a guess that stays out.
+             *     `manager_call` takes the authored call as the whole period's landing and is not
+             *     added to what is already won; with no current call the read falls back to
+             *     `commit_evidence` and says so in the landing's `caveat`.
+             * @enum {string}
+             */
+            forecast_forward_measure: "commit_evidence" | "weighted" | "manager_call";
         };
         /** @description A sparse installation-settings patch (admin/ops, human-only). */
         UpdateInstallationSettingsRequest: {
@@ -14305,6 +14320,13 @@ export interface components {
              *     password only.
              */
             enabled_oidc_providers?: string[];
+            /**
+             * @description Which remaining-pipeline reading a projected landing is built from. Never frozen:
+             *     it is applied on READ and stores nothing, so changing it re-computes every landing
+             *     at once and re-means no stored row.
+             * @enum {string}
+             */
+            forecast_forward_measure?: "commit_evidence" | "weighted" | "manager_call";
         };
         CaptureActivityResponse: {
             funnel: components["schemas"]["CaptureActivityFunnel"];
@@ -24307,6 +24329,74 @@ export interface components {
             current_call?: components["schemas"]["ForecastCall"];
             /** @description True when deals the caller cannot read were left out. A BOOLEAN and never a count: a count of what somebody may not read is itself a statement about how much of it there is, so the reader is told the figure is partial and not by how much. */
             scope_limited?: boolean;
+            landing?: components["schemas"]["ForecastLanding"];
+            sufficiency?: components["schemas"]["ForecastSufficiency"];
+        };
+        /**
+         * @description Where the period finishes if nothing changes, and what that answer rests on.
+         *     The four money readings say what is IN the pipeline; none of them answers "what will we land on?", and a reader left to add two of them together picks the wrong two. This is that sum, made once and labelled with the measure it used.
+         */
+        ForecastLanding: {
+            /**
+             * Format: int64
+             * @description The projection itself, in the installation's base currency.
+             */
+            amount_minor: number;
+            /**
+             * @description Which reading the forward half was built from — the one ACTUALLY used, which is not always the one configured: a manager-call installation with no current call falls back to commit evidence and says so in `caveat`.
+             * @enum {string}
+             */
+            measure: "commit_evidence" | "weighted" | "manager_call";
+            /**
+             * Format: int64
+             * @description The money already banked, the backward half of the sum.
+             */
+            won_minor: number;
+            /**
+             * Format: int64
+             * @description The forward half. Zero for a manager call, which is a single authored TOTAL rather than a remainder — a call is not added to won_minor, and a reconciliation line drawing this must say the call instead of a split.
+             */
+            remaining_minor: number;
+            /**
+             * @description Why this answer is not the plain one, absent when it is. `call_absent` is a manager-call installation with no current call. `call_below_actual` is an authored call less than the money already won — reported and never corrected, because the call is somebody's stated belief and the server does not overrule it.
+             * @enum {string}
+             */
+            caveat?: "call_absent" | "call_below_actual";
+        };
+        /**
+         * @description Whether the open pipeline supports the reference landing, and what the reference is.
+         *     NOT a target. Margince has no target model: `basis` names where the reference came from so a reader can disagree with the basis rather than with the arithmetic, and the reference is always from OUTSIDE the current projection — a coverage figure divided by a target derived from the same pipeline is always fine and says nothing.
+         */
+        ForecastSufficiency: {
+            /**
+             * @description Why there is no answer, when there is none. Every other field is then absent and the surface says this rather than drawing a figure. `insufficient_basis` is neither a manager call nor four completed comparable periods; `insufficient_history` is too few closed deals for a conversion rate to be a rate rather than an anecdote.
+             * @enum {string}
+             */
+            absent?: "insufficient_basis" | "insufficient_history";
+            /**
+             * @description Where the reference came from. A current authored call outranks history: a manager who wrote a number down has said what this period is for, and the median of the last four completed comparable periods is the fallback for when nobody has.
+             * @enum {string}
+             */
+            basis?: "manager_call" | "historical_median";
+            /** Format: int64 */
+            reference_landing_minor?: number;
+            /**
+             * Format: int64
+             * @description The reference minus what is already won, floored at zero — a period already past its reference needs no more pipeline.
+             */
+            remaining_to_support_minor?: number;
+            /**
+             * Format: int64
+             * @description The open pipeline that remainder implies at the conversion rate.
+             */
+            needed_open_minor?: number;
+            /** Format: int64 */
+            current_open_minor?: number;
+            /**
+             * Format: int64
+             * @description Current over needed in BASIS POINTS, so the server chooses no rounding for the client. Nothing needed is 10000 (full) rather than a division by zero or an unbounded ratio, because "covered" is actionable and "infinity" is not.
+             */
+            coverage_bp?: number;
         };
         /** @description One finding from the nightly input check. */
         InputCheck: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6752,6 +6752,38 @@ export const de = {
   "installationSettings.fiscalYearStart": "Geschäftsjahr beginnt",
   "installationSettings.fiscalYearStartHint":
     "Der Monat, in dem Ihr Geschäftsjahr beginnt. Auswertungen gruppieren nach diesem Jahr und Quartal — ein Jahr, das nicht im Januar beginnt, wird mit beiden Kalenderjahren benannt, die es umfasst, etwa FY2026/27. Eine Änderung benennt alle Auswertungen sofort neu, und eine gespeicherte Ansicht mit Periodenfilter fragt danach andere Monate ab.",
+  "installationSettings.forwardMeasure":
+    "Prognostizierter Abschluss beruht auf",
+  "installationSettings.forwardMeasureHint":
+    "Welche verbleibende Pipeline zu den bereits gewonnenen Beträgen addiert wird. Commit-Nachweis ist am strengsten: zugesagte Deals mit bestätigtem Abschlussdatum. Gewichtet zählt jeden offenen Deal mit seiner Phasenwahrscheinlichkeit — die ehrliche Lesart für ein Team, das alles zusagt. Die Einschätzung der Führungskraft ersetzt die Prognose ganz, statt zum Gewonnenen zu addieren; ohne erfasste Einschätzung fällt die Periode auf den Commit-Nachweis zurück und sagt das auch.",
+  "installationSettings.forwardMeasure.commit_evidence":
+    "Commit-Nachweis — nur bestätigte Abschlussdaten",
+  "installationSettings.forwardMeasure.weighted":
+    "Gewichtete Pipeline — jeder offene Deal mit seiner Phasenwahrscheinlichkeit",
+  "installationSettings.forwardMeasure.manager_call":
+    "Einschätzung der Führungskraft — die erfasste Zahl für die Periode",
+  "forecast.landing": "Prognostizierter Abschluss",
+  "forecast.landingFrom":
+    "{won} bereits gewonnen zuzüglich {remaining} noch ausstehend.",
+  "forecast.landingFromCall":
+    "Die Einschätzung für diese Periode. Sie ersetzt die Prognose, statt zu den bereits gewonnenen {won} zu addieren.",
+  "forecast.landing.caveat.call_absent":
+    "Für diese Periode liegt keine Einschätzung vor, daher steht hier der Commit-Nachweis.",
+  "forecast.landing.caveat.call_below_actual":
+    "Die Einschätzung liegt unter dem bereits Gewonnenen. Sie wird wie erfasst gezeigt und nicht korrigiert.",
+  "forecast.pipelineNeeded": "Benötigte Pipeline",
+  "forecast.pipelineNeededDetail":
+    "{current} offen gegenüber {needed} benötigt, um {reference} zu erreichen.",
+  "forecast.pipelineBasis.manager_call":
+    "Gemessen an der Einschätzung für diese Periode.",
+  "forecast.pipelineBasis.historical_median":
+    "Gemessen am Median der letzten vier vergleichbaren Perioden.",
+  "forecast.pipelineAbsentTitle": "Keine Deckungszahl für diese Periode",
+  "forecast.pipelineAbsent.insufficient_basis":
+    "Es fehlt der Vergleichsmaßstab: Für diese Periode wurde keine Einschätzung erfasst, und es sind weniger als vier vergleichbare Perioden abgeschlossen. Eine Deckungszahl, gemessen an einer aus derselben Pipeline abgeleiteten Zahl, sähe immer gut aus.",
+  "forecast.pipelineAbsent.insufficient_history":
+    "Zu wenige abgeschlossene Deals für eine Abschlussquote. Eine Quote aus einer Handvoll Deals schwankt stärker, als die Antwort wert ist.",
+  "forecast.coverage": "{percent}% der dafür nötigen Pipeline",
   "installationSettings.baseCurrency": "Basiswährung",
   "installationSettings.baseCurrencyHint":
     "ISO-4217-Code, in den alle Beträge für Auswertungen umgerechnet werden. Änderbar, bis der erste Betrag dagegen umgerechnet wurde.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6850,6 +6850,36 @@ export const en = {
   "installationSettings.fiscalYearStart": "Financial year starts",
   "installationSettings.fiscalYearStartHint":
     "The month your business year begins. Reports group by this year and quarter — a year that does not start in January is labelled with both calendar years it spans, like FY2026/27. Changing it re-labels every report at once, and a saved report view filtered on a period will then ask for different months.",
+  "installationSettings.forwardMeasure": "Projected landing built from",
+  "installationSettings.forwardMeasureHint":
+    "Which remaining pipeline a projected landing adds to the money already won. Commit evidence is the strictest: committed deals whose close date somebody confirmed. Weighted counts every open deal at its stage probability, which is the honest reading for a team that commits everything. A manager's call replaces the projection entirely rather than adding to what is won — with no call recorded for a period, that period falls back to commit evidence and says so.",
+  "installationSettings.forwardMeasure.commit_evidence":
+    "Commit evidence — confirmed close dates only",
+  "installationSettings.forwardMeasure.weighted":
+    "Weighted pipeline — every open deal at its stage probability",
+  "installationSettings.forwardMeasure.manager_call":
+    "The manager's call — the authored number for the period",
+  "forecast.landing": "Projected landing",
+  "forecast.landingFrom": "{won} already won plus {remaining} still to come.",
+  "forecast.landingFromCall":
+    "The call for this period, which replaces the projection rather than adding to the {won} already won.",
+  "forecast.landing.caveat.call_absent":
+    "Nobody has called this period, so this is commit evidence instead.",
+  "forecast.landing.caveat.call_below_actual":
+    "The call is below the money already won. It is shown as recorded rather than corrected.",
+  "forecast.pipelineNeeded": "Pipeline needed",
+  "forecast.pipelineNeededDetail":
+    "{current} open against {needed} needed to reach {reference}.",
+  "forecast.pipelineBasis.manager_call":
+    "Measured against the call for this period.",
+  "forecast.pipelineBasis.historical_median":
+    "Measured against the median of the last four comparable periods.",
+  "forecast.pipelineAbsentTitle": "No coverage figure for this period",
+  "forecast.pipelineAbsent.insufficient_basis":
+    "Nothing to measure against: no call has been recorded for this period, and fewer than four comparable periods have finished. A coverage figure measured against a number derived from this same pipeline would always look fine.",
+  "forecast.pipelineAbsent.insufficient_history":
+    "Too few closed deals to read a conversion rate from. A rate drawn from a handful of deals moves further than the answer is worth.",
+  "forecast.coverage": "{percent}% of the pipeline this needs",
   "installationSettings.baseCurrency": "Base currency",
   "installationSettings.baseCurrencyHint":
     "ISO-4217 code every amount converts to for roll-ups. Changeable until the first amount converts against it.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6678,6 +6678,35 @@ export const vi = {
   "installationSettings.fiscalYearStart": "Năm tài chính bắt đầu",
   "installationSettings.fiscalYearStartHint":
     "Tháng bắt đầu năm tài chính của bạn. Báo cáo nhóm theo năm và quý này — năm không bắt đầu từ tháng 1 được đặt tên theo cả hai năm dương lịch mà nó trải qua, ví dụ FY2026/27. Thay đổi sẽ đặt lại tên mọi báo cáo ngay lập tức, và một khung nhìn đã lưu có lọc theo kỳ sẽ hỏi những tháng khác.",
+  "installationSettings.forwardMeasure": "Dự phóng kết quả kỳ dựa trên",
+  "installationSettings.forwardMeasureHint":
+    "Phần pipeline còn lại nào được cộng vào số tiền đã thắng. Bằng chứng cam kết là chặt nhất: các deal đã cam kết có ngày chốt được xác nhận. Có trọng số tính mọi deal đang mở theo xác suất giai đoạn — cách đọc trung thực cho đội cam kết mọi thứ. Đánh giá của quản lý thay thế toàn bộ dự phóng thay vì cộng thêm vào phần đã thắng; nếu kỳ chưa có đánh giá nào, kỳ đó quay về bằng chứng cam kết và nói rõ điều đó.",
+  "installationSettings.forwardMeasure.commit_evidence":
+    "Bằng chứng cam kết — chỉ ngày chốt đã xác nhận",
+  "installationSettings.forwardMeasure.weighted":
+    "Pipeline có trọng số — mọi deal đang mở theo xác suất giai đoạn",
+  "installationSettings.forwardMeasure.manager_call":
+    "Đánh giá của quản lý — con số đã ghi cho kỳ này",
+  "forecast.landing": "Dự phóng kết quả kỳ",
+  "forecast.landingFrom": "{won} đã thắng cộng {remaining} còn sắp tới.",
+  "forecast.landingFromCall":
+    "Đánh giá cho kỳ này. Nó thay thế dự phóng chứ không cộng vào {won} đã thắng.",
+  "forecast.landing.caveat.call_absent":
+    "Chưa ai đánh giá kỳ này, nên đây là bằng chứng cam kết.",
+  "forecast.landing.caveat.call_below_actual":
+    "Đánh giá thấp hơn số tiền đã thắng. Nó được hiển thị đúng như đã ghi, không chỉnh sửa.",
+  "forecast.pipelineNeeded": "Pipeline cần có",
+  "forecast.pipelineNeededDetail":
+    "{current} đang mở so với {needed} cần để đạt {reference}.",
+  "forecast.pipelineBasis.manager_call": "Đo theo đánh giá cho kỳ này.",
+  "forecast.pipelineBasis.historical_median":
+    "Đo theo trung vị của bốn kỳ tương đương gần nhất.",
+  "forecast.pipelineAbsentTitle": "Không có số liệu bao phủ cho kỳ này",
+  "forecast.pipelineAbsent.insufficient_basis":
+    "Không có gì để đối chiếu: kỳ này chưa ghi đánh giá nào, và chưa đủ bốn kỳ tương đương đã kết thúc. Một số liệu bao phủ đo theo con số rút ra từ chính pipeline này thì lúc nào cũng đẹp.",
+  "forecast.pipelineAbsent.insufficient_history":
+    "Quá ít deal đã chốt để rút ra tỷ lệ chuyển đổi. Tỷ lệ từ một nhúm deal dao động nhiều hơn giá trị của câu trả lời.",
+  "forecast.coverage": "{percent}% pipeline cần thiết",
   "installationSettings.baseCurrency": "Đơn vị tiền tệ cơ sở",
   "installationSettings.baseCurrencyHint":
     "Mã ISO-4217 mà mọi số tiền được quy đổi về khi tổng hợp. Có thể thay đổi cho đến khi số tiền đầu tiên được quy đổi theo nó.",

--- a/frontend/src/screens/analytics.forecast.landing.test.tsx
+++ b/frontend/src/screens/analytics.forecast.landing.test.tsx
@@ -1,0 +1,161 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { LandingCard, SufficiencyCard } from "./analytics.forecast.landing";
+
+type Readings = components["schemas"]["ForecastReadings"];
+type Landing = NonNullable<Readings["landing"]>;
+type Sufficiency = NonNullable<Readings["sufficiency"]>;
+
+afterEach(cleanup);
+
+function draw(node: ReactNode) {
+  return render(<LocaleProvider initial="en">{node}</LocaleProvider>);
+}
+
+const landing = (over: Partial<Landing> = {}): Landing => ({
+  amount_minor: 900_00,
+  measure: "commit_evidence",
+  won_minor: 400_00,
+  remaining_minor: 500_00,
+  ...over,
+});
+
+const sufficiency = (over: Partial<Sufficiency> = {}): Sufficiency => ({
+  basis: "historical_median",
+  reference_landing_minor: 1_000_00,
+  remaining_to_support_minor: 600_00,
+  needed_open_minor: 2_400_00,
+  current_open_minor: 1_200_00,
+  coverage_bp: 5_000,
+  ...over,
+});
+
+describe("the projected landing", () => {
+  it("says the sum it made, so a reader can check the arithmetic", () => {
+    draw(<LandingCard landing={landing()} currency="EUR" locale="en" />);
+
+    // The two halves, both named. A figure alone leaves a reader to guess
+    // which readings were added, and the wrong guess is Won plus Best case.
+    const detail = screen.getByText(/already won plus/i);
+    expect(detail.textContent).toContain("400");
+    expect(detail.textContent).toContain("500");
+  });
+
+  // The misreading this shape exists to prevent: a call is the whole period's
+  // landing, so a reader must not be told it is the remainder.
+  it("says a manager's call replaces the projection rather than adding to it", () => {
+    draw(
+      <LandingCard
+        landing={landing({
+          measure: "manager_call",
+          amount_minor: 900_00,
+          remaining_minor: 0,
+        })}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(/replaces the projection rather than adding/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/already won plus/i)).toBeNull();
+  });
+
+  it("names the fallback when nobody has called the period", () => {
+    draw(
+      <LandingCard
+        landing={landing({ caveat: "call_absent" })}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(en["forecast.landing.caveat.call_absent"]),
+    ).toBeTruthy();
+  });
+
+  it("reports a call below the money already won rather than correcting it", () => {
+    draw(
+      <LandingCard
+        landing={landing({
+          measure: "manager_call",
+          amount_minor: 100_00,
+          caveat: "call_below_actual",
+        })}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(en["forecast.landing.caveat.call_below_actual"]),
+    ).toBeTruthy();
+  });
+});
+
+describe("whether the pipeline supports the reference", () => {
+  it("names the basis, so a reader can disagree with it rather than the sum", () => {
+    draw(
+      <SufficiencyCard
+        sufficiency={sufficiency()}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(/median of the last four comparable periods/i),
+    ).toBeTruthy();
+  });
+
+  it("renders coverage as a whole percent", () => {
+    draw(
+      <SufficiencyCard
+        sufficiency={sufficiency({ coverage_bp: 5_000 })}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(screen.getByText(/50% of the pipeline this needs/i)).toBeTruthy();
+  });
+
+  // The case a zeroed figure would get exactly backwards: no basis must not
+  // draw "0 needed, 0 covered", which reads as a fully covered pipeline.
+  it("draws no figure at all when there is no basis to measure against", () => {
+    draw(
+      <SufficiencyCard
+        sufficiency={{ absent: "insufficient_basis" }}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(en["forecast.pipelineAbsent.insufficient_basis"]),
+    ).toBeTruthy();
+    expect(screen.queryByText(/of the pipeline this needs/i)).toBeNull();
+  });
+
+  it("says when the history is too thin for a conversion rate", () => {
+    draw(
+      <SufficiencyCard
+        sufficiency={{ absent: "insufficient_history" }}
+        currency="EUR"
+        locale="en"
+      />,
+    );
+
+    expect(
+      screen.getByText(en["forecast.pipelineAbsent.insufficient_history"]),
+    ).toBeTruthy();
+    expect(screen.queryByText(/of the pipeline this needs/i)).toBeNull();
+  });
+});

--- a/frontend/src/screens/analytics.forecast.landing.tsx
+++ b/frontend/src/screens/analytics.forecast.landing.tsx
@@ -1,0 +1,119 @@
+import type { components } from "../api/schema";
+import { StatCard } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { formatMoneyOrAbsent, formatNumber } from "../format/format";
+import { type Locale, useT } from "../i18n";
+
+type Readings = components["schemas"]["ForecastReadings"];
+type Landing = NonNullable<Readings["landing"]>;
+type Sufficiency = NonNullable<Readings["sufficiency"]>;
+
+// Basis points to whole percent, which is the only rounding this surface does.
+//
+// The server sends basis points so it chooses no rounding for its clients; a
+// reader comparing coverage across periods wants whole numbers, and a tenth of
+// a percent of pipeline coverage is precision nobody acts on.
+const BASIS_POINTS_PER_PERCENT = 100;
+
+// Where the period lands, and the two halves that make it.
+//
+// Drawn as a sentence and not only a figure, because the sum is the part a
+// reader has to trust: "won plus still to come" says what was added, and a
+// manager's call says that nothing was added at all.
+export function LandingCard({
+  landing,
+  currency,
+  locale,
+}: Readonly<{ landing: Landing; currency: string; locale: Locale }>) {
+  const t = useT();
+  const money = (minor: number) => formatMoneyOrAbsent(minor, currency, locale);
+
+  // A call REPLACES the projection rather than adding to what is won, so the
+  // two cases get different sentences. One sentence with a swapped number
+  // would tell a reader the call was the remainder, which is the misreading
+  // this whole shape exists to prevent.
+  const detail =
+    landing.measure === "manager_call"
+      ? t("forecast.landingFromCall", { won: money(landing.won_minor) })
+      : t("forecast.landingFrom", {
+          won: money(landing.won_minor),
+          remaining: money(landing.remaining_minor),
+        });
+
+  return (
+    <>
+      <StatCard
+        label={t("forecast.landing")}
+        value={money(landing.amount_minor)}
+        detail={detail}
+        numeric
+      />
+      {landing.caveat && (
+        <Callout tone="warn" title={t("forecast.landing")}>
+          {t(`forecast.landing.caveat.${landing.caveat}`)}
+        </Callout>
+      )}
+    </>
+  );
+}
+
+// Whether the open pipeline supports the reference landing.
+//
+// An absence renders as a SENTENCE and no figure. Drawing zeroes beside "no
+// basis" would read as a fully covered pipeline, which is the opposite of what
+// an absence means.
+export function SufficiencyCard({
+  sufficiency,
+  currency,
+  locale,
+}: Readonly<{ sufficiency: Sufficiency; currency: string; locale: Locale }>) {
+  const t = useT();
+  if (sufficiency.absent) {
+    return (
+      <Callout tone="info" title={t("forecast.pipelineAbsentTitle")}>
+        {t(`forecast.pipelineAbsent.${sufficiency.absent}`)}
+      </Callout>
+    );
+  }
+
+  // Every figure below travels together or not at all — the server sends the
+  // basis with them, and an assessment carrying a need but no basis is a
+  // number a reader cannot argue with.
+  const needed = sufficiency.needed_open_minor;
+  const current = sufficiency.current_open_minor;
+  const reference = sufficiency.reference_landing_minor;
+  const coverage = sufficiency.coverage_bp;
+  if (
+    sufficiency.basis === undefined ||
+    needed === undefined ||
+    current === undefined ||
+    reference === undefined ||
+    coverage === undefined
+  ) {
+    return null;
+  }
+
+  const money = (minor: number) => formatMoneyOrAbsent(minor, currency, locale);
+  const percent = Math.round(coverage / BASIS_POINTS_PER_PERCENT);
+
+  return (
+    <StatCard
+      label={t("forecast.pipelineNeeded")}
+      value={money(needed)}
+      detail={[
+        t("forecast.coverage", { percent: formatNumber(percent, locale) }),
+        t("forecast.pipelineNeededDetail", {
+          current: money(current),
+          needed: money(needed),
+          reference: money(reference),
+        }),
+        t(`forecast.pipelineBasis.${sufficiency.basis}`),
+      ].join(" ")}
+      // The bar is the share of what this needs that the pipeline actually
+      // holds, clamped at the track: a book at three times its requirement
+      // would otherwise draw a bar three times the width of its own card.
+      meter={{ filled: Math.min(current, needed), total: needed }}
+      numeric
+    />
+  );
+}

--- a/frontend/src/screens/analytics.forecast.tsx
+++ b/frontend/src/screens/analytics.forecast.tsx
@@ -15,6 +15,7 @@ import { StatStrip } from "../design-system/statstrip";
 import { formatMoneyOrAbsent, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { type AnalyticsSelection, writableScope } from "./analytics.context";
+import { LandingCard, SufficiencyCard } from "./analytics.forecast.landing";
 import { ForecastReview } from "./analytics.forecast.review";
 import { QueryGate, throwProblem } from "./common";
 import {
@@ -161,6 +162,24 @@ function ForecastAnswer({
           value={money(readings.won_minor)}
           numeric
         />
+        {/* Both are absent for a managed-teams reading, which covers several
+            populations at once: a landing summed across books that are called
+            separately, and a coverage rate blended over them, would each
+            describe none of them. */}
+        {readings.landing && (
+          <LandingCard
+            landing={readings.landing}
+            currency={currency}
+            locale={locale}
+          />
+        )}
+        {readings.sufficiency && (
+          <SufficiencyCard
+            sufficiency={readings.sufficiency}
+            currency={currency}
+            locale={locale}
+          />
+        )}
       </StatStrip>
     </>
   );

--- a/frontend/src/screens/installation-settings.tsx
+++ b/frontend/src/screens/installation-settings.tsx
@@ -83,6 +83,7 @@ const EDITABLE_FACTS = [
   "base_currency",
   "base_language",
   "fiscal_year_start_month",
+  "forecast_forward_measure",
 ] as const;
 
 // Which fact the reader pressed Edit on. The dialog always edits all of them —
@@ -191,6 +192,22 @@ function languageName(code: string, t: ReturnType<typeof useT>): string {
 // The twelve months a fiscal year may start in, as the picker offers them.
 // Derived rather than typed out, so the list cannot go short of twelve.
 const MONTHS = Array.from({ length: 12 }, (_, index) => index + 1);
+
+// Which remaining pipeline a projected landing is built from, in the order the
+// server offers them: strictest first, then the two that soften it.
+//
+// Typed as the schema's own union with `satisfies`, so a measure added to the
+// contract and not to this list is a typecheck failure rather than an option
+// that silently stops being offered.
+type ForwardMeasure = NonNullable<
+  components["schemas"]["InstallationSettings"]["forecast_forward_measure"]
+>;
+
+const FORWARD_MEASURES = [
+  "commit_evidence",
+  "weighted",
+  "manager_call",
+] as const satisfies readonly ForwardMeasure[];
 
 export function fiscalYearStartSummary(
   month: number,
@@ -387,6 +404,20 @@ function InstallationSettingsForm({
             control={editVerb(
               "fiscal_year_start_month",
               t("installationSettings.fiscalYearStart"),
+            )}
+          />
+          <SettingRow
+            label={t("installationSettings.forwardMeasure")}
+            description={t("installationSettings.forwardMeasureHint")}
+            // The measure's own sentence rather than the stored word: an admin
+            // is deciding what a projection MEANS, and "manager_call" does not
+            // say that the call replaces the projection instead of adding to it.
+            value={t(
+              `installationSettings.forwardMeasure.${settings.forecast_forward_measure}`,
+            )}
+            control={editVerb(
+              "forecast_forward_measure",
+              t("installationSettings.forwardMeasure"),
             )}
           />
         </SettingList>
@@ -626,6 +657,38 @@ function InstallationProfileDialog({
                   const picked = MONTHS.find((month) => String(month) === next);
                   if (picked) {
                     onChange({ ...draft, fiscal_year_start_month: picked });
+                  }
+                }}
+              />
+            )}
+          </Field>
+        </div>
+
+        <div data-fact="forecast_forward_measure">
+          <Field
+            label={t("installationSettings.forwardMeasure")}
+            hint={t("installationSettings.forwardMeasureHint")}
+            error={refused.get("forecast_forward_measure")}
+          >
+            {(control) => (
+              <Select
+                {...control}
+                aria-describedby={describe(control)}
+                value={draft.forecast_forward_measure}
+                disabled={!canManage}
+                options={FORWARD_MEASURES.map((measure) => ({
+                  value: measure,
+                  label: t(`installationSettings.forwardMeasure.${measure}`),
+                }))}
+                // Narrowed back through the offered set rather than cast, so a
+                // value this build does not know cannot reach the draft and be
+                // saved as a measure the server would then refuse on every read.
+                onChange={(next) => {
+                  const picked = FORWARD_MEASURES.find(
+                    (measure) => measure === next,
+                  );
+                  if (picked) {
+                    onChange({ ...draft, forecast_forward_measure: picked });
                   }
                 }}
               />


### PR DESCRIPTION
The four money readings say what is IN the pipeline. None of them answers the
question a manager actually asks — "what will we land on?" — and a reader left
to add two of them together picks the wrong two: Won plus Best case overstates,
Weighted alone forgets the money already in the bank. This makes that sum once
and labels it with the measure it used.

## Where the period lands

Commit and weighted are **remaining** measures — `readings.InOpen` requires the
deal is not won — so a landing is Won plus what remains, a sum of two disjoint
sets. A manager's call is a **total** and is never added to Won: a quarter with
400 won and a 900 call reads 900, not 1300. Reverting that makes
`TestALandingFromAManagerCallIsTheCallItself` fail.

Which measure an installation uses is a setting, because it is a question about
how a team sells rather than about this code. A team with a disciplined commit
stage means something by it; one that commits everything does not, and their
weighted number is the honest one. With `manager_call` set and no call recorded,
the read falls back to commit evidence and says so in `caveat` rather than
showing a manager a number they did not ask for under the label of the one they
did.

## Whether the pipeline supports it

Every coverage ratio in this industry gets this wrong the same way: divide the
pipeline by a target derived from the pipeline and the answer is always fine.
The basis here comes from **outside** the current projection — the manager's own
call, or the median of four completed comparable periods. Neither available
returns `insufficient_basis` rather than a figure with a shrug attached.

**This is deliberately not a target.** Margince has no target model and this must
not become one by implication, so the words are "reference" and "basis" in the
engine and on the screen. A number a rep is measured against is a product
decision nobody has made, and it should not arrive as a side effect of a
coverage figure.

## A contribution remembers its stage

Reading conversion rates from a deal's *current* stage would credit today's
stage with the outcome of a deal that passed through three others. The new
`stage_id` on `forecast_contribution` is nullable and never backfilled: rows
written before it genuinely do not know, and backfilling from the present stage
would write that wrong answer down as though it had been recorded.

## One vocabulary, not two agreeing lists

`values.ForwardMeasure` lives in the shared kernel because identity stores the
setting and must validate it, forecasting builds the landing and must refuse
anything else, and neither module may import the other. Two lists would drift,
and the drift only surfaces as a forecast read failing for an installation that
saved cleanly. `forwardmeasureparity_test.go` derives the contract's three enum
sites structurally and fails in both directions; its census walks the document
rather than trusting a hand-kept list, verified against a planted block-style
fourth site.

## Fixed along the way

- **`PrecedingPeriod` lost a day across a DST boundary.** It derived its window
  length from elapsed hours, which breaks when a zone's offset moves *between*
  the two local midnights. Europe/Berlin's change falls inside the week so 168h
  survives it — my own Berlin test passed. Africa/Cairo's week of 20-26 April
  2026 is 143 hours, divides to six days, and starts the previous week on a
  Tuesday, with every window behind it a day out. Now counts calendar days.
- **Four unguarded overflows.** The landing sum now goes through `addMinor` like
  the readings it claims to be the sum of. The coverage multiply wraps and then
  *divides down to zero*, so the largest possible book drew as an empty one — a
  `< 0` assertion would have missed it entirely. The `float64`→`int64`
  conversion for the needed pipeline is implementation-defined and **saturates**
  on arm64 rather than wrapping to `MinInt64`, so the test asserts the refusal
  itself rather than any platform's sentinel. The median halves before adding.
- **A duplicate `berlin(t)` test helper**, hidden by an external test package
  that also made arch-lint read the module as importing itself.

## Proof

Every guard above is held by a test that fails when the guard is reverted — each
mutation-checked one clause at a time. The conversion seam's own scoping is
proven in SQL, not Go: the module's tests take `ConversionHistory` as data and
would pass whatever the seam did, so four integration tests run against real
Postgres. The one that matters most,
`TestTheConversionRateExcludesThePeriodBeingAssessed`, catches the circularity —
mutating the window bound to let the current quarter into its own rate fails it.

`make check-backend` and `make check-fe` both green after a 38-commit rebase,
plus `make test-it` for `backend/migrations` and the compose integration lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two forecast answers the dashboard lacked — where the period lands (won plus the remaining pipeline) and whether that pipeline is enough — so a manager doesn't have to add readings together or compare the pipeline to a target derived from it. Coverage takes its basis from outside the projection (a manager's call or the median of four completed periods) and returns `insufficient_basis` when neither exists; stored data changes only by a new nullable `stage_id` column.

**Behavior**
- Landing = Won + the chosen remaining reading (`commit_evidence` or `weighted`); a manager's call is a total and never adds to Won.
- The choice is a new per-installation `forecast_forward_measure` setting.
- `forecast_contribution` now freezes the deal's stage (`stage_id`, nullable, never backfilled) so conversion rates count the stage a deal reached, not where it ended up.

**Fixes**
- `PrecedingPeriod` counts calendar days instead of dividing elapsed hours, which lost a day when a DST offset change falls between two local midnights.
- Four unguarded overflows: the landing sum uses `addMinor`, the coverage multiply wraps instead of dividing down to zero, the `float64`→`int64` conversion saturates rather than wraps, and the median halves before adding.
- Removed a duplicate Berlin test helper that made arch-lint read the module as importing itself.

<sup>Written for commit 0e337ac12aae63620124eb55027eaf2be7dc2a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

