### PR TITLE
lock_timeout bounds the wait, never the hold

### DIFF
--- a/docs/how-to/apply-migrations.md
+++ b/docs/how-to/apply-migrations.md
@@ -79,7 +79,25 @@ Follow this checklist — several obligations are enforced by fitness tests, so 
    const set, or `enumsync_test.go` fails.
 4. **Reach erasure + SAR** if the table holds PII (`piicoverage_test.go`), and record the table in the
    owning module's `doc.go` "Tables owned" list (`tableownership_test.go`).
-5. **Apply and verify** — `make migrate`, then `make check` / `make test-integration`.
+5. **`SET LOCAL lock_timeout` bounds the WAIT, never the HOLD.** It caps how long a statement
+   queues for a lock before giving up. Once the lock is granted it is held until the transaction
+   ends — and the runner wraps each migration in exactly one transaction, so an `ALTER TABLE ...
+   ADD COLUMN` followed by a full-table `UPDATE` and a `CHECK` keeps `ACCESS EXCLUSIVE` for the
+   whole backfill. Every reader of that table blocks for the duration.
+
+   `backend/migrations/core/1788572167_a_suppression_records_who_decided_it.up.sql` has this shape,
+   and its own comment claims the timeout makes it safe on a live table. It does not. The migration
+   is harmless in practice — `communication_suppression` was empty when it ran, and a fresh install
+   backfills nothing — but do not copy the pattern onto a table that holds rows and expect the
+   timeout to protect readers.
+
+   On a table with real rows, the backfill cannot be batched here: one transaction per migration is
+   the runner's contract. Land the column with a `DEFAULT` and no rewrite, then backfill from
+   application code or a job, then add the `CHECK` as `NOT VALID` and `VALIDATE` it separately —
+   `1787831200_a_company_event_is_a_signal.up.sql` is the worked example of that last step, and
+   explains why: `NOT VALID` takes the lock without scanning, and `VALIDATE` drops to
+   `SHARE UPDATE EXCLUSIVE` for the pass.
+6. **Apply and verify** — `make migrate`, then `make check` / `make test-integration`.
 
 Fork-local schema goes in `backend/migrations/custom/`, which has its own tracking table and applies
 after core (`YYYYMMDDHHMMSS`-named, `x_`-prefixed columns) and survives upstream merges untouched.


### PR DESCRIPTION
Closes the last open item from the round-6 review pass, as a doc note rather than a migration.

## The wrong lesson in the tree

`backend/migrations/core/1788572167_a_suppression_records_who_decided_it.up.sql` sets `SET LOCAL lock_timeout = '3s'` above an `ALTER TABLE ... ADD COLUMN`, a full-table `UPDATE` and a `CHECK`, with a comment presenting the timeout as what keeps it safe on a live table.

It is not. The timeout caps how long the statement queues **for** the lock. Once granted, `ACCESS EXCLUSIVE` is held until the transaction ends — and this repo's runner wraps each migration in exactly one transaction, as `docs/how-to/apply-migrations.md` already notes a few lines above. So every reader of that table blocks for the entire backfill.

I wrote that comment, in response to an earlier review that flagged the unbounded ALTER. The timeout was the wrong answer to a real question.

## Why this is a doc change and not a migration

The migration is harmless in practice:

- It has already applied wherever it will ever apply; an applied version never re-runs.
- `communication_suppression` was empty when it ran — `consent/suppress.go` is its only production writer and postdates it.
- A fresh install creates the table and adds the column with no rows to backfill.

Shipped migrations are additive-only, so the file cannot be edited. A corrective migration would change nothing that is currently wrong. What is actually costly is the pattern sitting in the directory people copy from: the next author reaching for a backfill on a table that holds rows would inherit a guarantee that is not there.

## What changed

One checklist step in `docs/how-to/apply-migrations.md`, where a migration author is already reading. It states what the timeout does, names that file as the shape not to copy and why it was harmless anyway, and points at `1787831200_a_company_event_is_a_signal.up.sql` for the `NOT VALID` + `VALIDATE` pattern that does shorten the hold — verified present, four occurrences, with its own comment explaining that `NOT VALID` takes the lock without scanning and `VALIDATE` drops to `SHARE UPDATE EXCLUSIVE`.

Docs gates pass; page is 131 lines and needs no length waiver.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies in the migration checklist that `lock_timeout` only bounds the wait for a lock, never the hold. The previous wording suggested the timeout made a full-table backfill safe on a live table; the doc now corrects that misconception and points to the `NOT VALID` + `VALIDATE` pattern instead.

<sup>Written for commit 226aaf84a3648b71a454a1b25db50dad8f467b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded migration-writing guidance to clarify how lock timeouts and transaction-scoped locks affect readers during backfills.
  - Added safer migration patterns for adding columns, backfilling data, and validating constraints separately.
  - Included examples illustrating both potentially blocking and safer approaches.
  - Renumbered the migration checklist’s “Apply and verify” step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->