### PR TITLE
The workspace label says what an empty value now means

### DIFF
--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -169,10 +169,26 @@ func workspaceLabelFor(r jobs.StateRow) string {
 // exposition text is provable without a database.
 //
 // workspace_id is admitted on these gauges by ADR-0080/A125 — the id, never
-// a name, because the exposition endpoint has no redaction path. An empty
-// value is a dispatcher, exactly and only: a job that does tenant work
-// declares its workspace, and a null in that column means a dispatcher and
-// nothing else.
+// a name, because the exposition endpoint has no redaction path.
+//
+// AN EMPTY VALUE IS A FLEET-WIDE PASS, and that used to read "is a
+// dispatcher". The two were the same thing until ADR-0103 collapsed the
+// workspace dispatchers: a dispatcher did no tenant work, and a null in this
+// column meant a row that only enumerated and enqueued. A collapsed pass owns
+// no workspace either — it walks them — but it does the tenant work itself, so
+// the old sentence describes the opposite of what an empty value means, on the
+// gauges an operator reads during an incident.
+//
+// The label still EARNS its exception, for a reason that also changed. It was
+// licensed while the fan-out existed, to tell one workspace's share of a pass
+// from another's; there are no such shares now. What it still separates is the
+// kinds whose args NAME a workspace — a queued send, an import, an ingest —
+// from the ones that answer for the installation. An operator reading queue
+// depth wants that split: a backlog on somebody's import is a different fact
+// from a backlog on the nightly passes.
+//
+// TestTheWorkspaceLabelStillSeparatesTwoPopulations holds that justification,
+// so it is a check rather than a paragraph.
 //
 // It returns an error because an io.Writer can fail. A scrape that
 // swallowed a refused write would serve a truncated exposition, which
@@ -189,7 +205,7 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 		return err
 	}
 	if err := writeQueueGauge(w, "margince_job_queue_depth",
-		"Jobs waiting to run (available + scheduled + retryable + pending) per queue and workspace. An empty workspace_id is a dispatcher, which does no tenant work.",
+		"Jobs waiting to run (available + scheduled + retryable + pending) per queue and workspace. An empty workspace_id is a fleet-wide pass, which answers for the installation rather than for one tenant.",
 		depth); err != nil {
 		return err
 	}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -480,3 +480,43 @@ func TestALiteralEscapeSequenceDoesNotCollideWithTheCharacterItEncodes(t *testin
 			"set makes Prometheus reject the entire scrape\ngot:\n%s", got)
 	}
 }
+
+// The workspace_id label discriminates, which is what earns it its ADR-0080
+// exception — and what earns it CHANGED when ADR-0103 collapsed the workspace
+// dispatchers.
+//
+// It was licensed to tell one workspace's share of a fleet pass from another's.
+// There are no such shares now: a collapsed pass walks the tenants inside one
+// row, so every scheduled pass reports an empty workspace_id. What the label
+// still separates is the kinds whose args NAME a workspace — a queued send, an
+// import, an ingest — from the ones that answer for the installation.
+//
+// So the exception rests on both populations existing. If the last
+// workspace-scoped kind were ever collapsed too, every row on these gauges
+// would carry the same empty label, and a label with one value is not a
+// dimension: it would be publishing a tenant id column that never varies, which
+// is exactly the trade ADR-0080 weighs. This says so out loud rather than
+// leaving the justification in a comment nobody re-reads.
+func TestTheWorkspaceLabelStillSeparatesTwoPopulations(t *testing.T) {
+	t.Parallel()
+
+	var tenanted, fleet int
+	for _, spec := range jobs.Declared() {
+		if spec.Fleet {
+			fleet++
+			continue
+		}
+		for _, arg := range spec.Args {
+			if arg.Name == "Workspace" {
+				tenanted++
+				break
+			}
+		}
+	}
+	if tenanted == 0 {
+		t.Error("no kind names a workspace in its args any more, so workspace_id is empty on every row — the label has stopped being a dimension and its ADR-0080 exception has stopped being earned")
+	}
+	if fleet == 0 {
+		t.Error("no kind is fleet-wide any more, so the empty workspace_id the gauges document never appears — the HELP text describes a value nothing produces")
+	}
+}


### PR DESCRIPTION
#1857's third item: `jobmetrics.go`'s `workspace_id` label carries an ADR-0080/A125 exception written against the fan-out existing, and the ticket asks whether it still earns it now the fan-out is gone.

## It does, for a different reason — and the comment was wrong

The comment read:

> An empty value is a dispatcher, **exactly and only**: a job that does tenant work declares its workspace, and a null in that column means a dispatcher and nothing else.

That was true while a dispatcher only enumerated and enqueued. A collapsed pass owns no workspace either — it walks them — but it **does the tenant work itself**. So the sentence now describes the opposite of what an empty label means, on the gauges an operator reads during an incident.

The label was licensed to tell one workspace's share of a pass from another's. There are no such shares now. What it still separates is the kinds whose args **name** a workspace — a queued send, an import, an ingest — from the ones that answer for the installation. That split is worth a dimension: a backlog on somebody's import is a different fact from a backlog on the nightly passes.

## The justification is a test now, not a paragraph

The exception rests on **both populations existing**. If the last workspace-scoped kind were ever collapsed too, every row would carry the same empty label — and a label with one value is not a dimension, it is a tenant id column that never varies, which is exactly the trade ADR-0080 weighs.

`TestTheWorkspaceLabelStillSeparatesTwoPopulations` says so when that happens, instead of leaving it in a comment nobody re-reads.

Mutation: stop counting fleet-wide kinds and it reports

```
no kind is fleet-wide any more, so the empty workspace_id the gauges document
never appears — the HELP text describes a value nothing produces
```

## Verification

`make check-backend` exit 0.

**Remaining for #1857:** ADR-0063's nightly mailbox-backfill dispatcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified job queue metrics help text to explain that an empty workspace identifier represents a fleet-wide pass answering for the installation, rather than a dispatcher.

- **Tests**
  - Added coverage to verify that metrics continue to distinguish fleet-wide operations from workspace-specific operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->