### PR TITLE
The voice build reads as one block, orb first

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5085,7 +5085,8 @@ export const de = {
   "ob.conv.voice.footFloor":
     "Mindestens {min} Wörter. Darunter kopiert das Modell nur Formulierungen.",
   "ob.conv.voice.buildingTitle": "Ich lerne deine Stimme",
-  "ob.conv.voice.buildingMeta": "{words} Wörter, {sources} Quellen",
+  "ob.conv.voice.buildingMeta_one": "{words} Wörter, {sources} Quelle",
+  "ob.conv.voice.buildingMeta_other": "{words} Wörter, {sources} Quellen",
   "ob.conv.voice.resultSub":
     "Lies zuerst das Beispiel. Passt es, bestätige. Passt es nicht, gib mir mehr Quellen und ich baue neu.",
   "ob.conv.voice.resultSubNoSample":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5180,7 +5180,8 @@ export const en = {
   "ob.conv.voice.footFloor":
     "{min} words minimum. Below that the model just copies phrasing.",
   "ob.conv.voice.buildingTitle": "Learning your voice",
-  "ob.conv.voice.buildingMeta": "{words} words, {sources} sources",
+  "ob.conv.voice.buildingMeta_one": "{words} words, {sources} source",
+  "ob.conv.voice.buildingMeta_other": "{words} words, {sources} sources",
   "ob.conv.voice.resultSub":
     "Read the sample first. If it lands, confirm. If it is off, add more sources and I rebuild.",
   "ob.conv.voice.resultSubNoSample":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5025,7 +5025,8 @@ export const vi = {
   "ob.conv.voice.footFloor":
     "Tối thiểu {min} từ. Dưới mức đó, mô hình chỉ chép lại cách dùng từ.",
   "ob.conv.voice.buildingTitle": "Đang học giọng văn của bạn",
-  "ob.conv.voice.buildingMeta": "{words} từ, {sources} nguồn",
+  "ob.conv.voice.buildingMeta_one": "{words} từ, {sources} nguồn",
+  "ob.conv.voice.buildingMeta_other": "{words} từ, {sources} nguồn",
   "ob.conv.voice.resultSub":
     "Hãy đọc mẫu trước. Thấy đúng thì xác nhận. Thấy lệch thì thêm nguồn và tôi dựng lại.",
   "ob.conv.voice.resultSubNoSample":

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -1480,17 +1480,54 @@
   color: var(--textPrimary);
 }
 
-/* The build scene: the Core carries the ring, the percentage sits in it. */
+/* The build scene: the Core carries the ring, the percentage sits in it.
+   Held to the pair's own measure rather than the board's — the account beside
+   the orb is a short line and a four-item checklist, and stretched to 74rem it
+   read as two things at opposite ends of the board rather than as one. */
 .ob-voice-building {
-  align-items: center;
+  max-width: 48rem;
   padding-top: var(--space-6);
-  text-align: center;
+}
+
+/* The orb is the subject and keeps its own column; the account reads down the
+   column beside it. Centred under the orb, each of those lines started from a
+   different place and the eye crossed the board to find it. */
+.ob-voice-building-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-6);
+  align-items: center;
+}
+
+.ob-voice-building-account {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+/* One column where the two cannot sit side by side. The orb is sized in px, so
+   the breakpoint is where the account's own lines start to break, not where
+   the orb stops fitting. */
+@container ob-scene (max-width: 32rem) {
+  .ob-voice-building-row {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
 }
 
 .ob-voice-orb {
   position: relative;
   display: grid;
   place-items: center;
+}
+
+/* The orb's column is `auto` — measured against the Core's own px size — so the
+   primitive's viewport cap has nothing left to protect and would only shrink
+   the sphere on a narrow window that still holds both columns. Set on the Core
+   itself, which is where the default it overrides is declared. */
+.ob-voice-orb .core {
+  --coreCap: 100%;
 }
 
 /* White, not --textPrimary: the ring behind it is the Core's own dark
@@ -1519,27 +1556,6 @@
   margin: 0;
   color: var(--textSecondary);
   font-size: var(--fs-body);
-}
-
-.ob-voice-building-model {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin: 0;
-  font-family: var(--f-mono);
-}
-
-.ob-voice-building-model i {
-  width: 6px;
-  height: 6px;
-  border-radius: var(--r-full);
-  corner-shape: round;
-  background: var(--aiText);
-}
-
-.ob-voice-building .ob-conv-stages {
-  margin-top: var(--space-4);
-  text-align: start;
 }
 
 /* ---- the connect scene ---- */

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -23,7 +23,7 @@ import {
   VoiceResultScene,
   VoiceSpeakerScene,
 } from "./voice-scenes";
-import { ConversationWorkbench, useConfiguredModel } from "./workbench";
+import { ConversationWorkbench } from "./workbench";
 
 // The voice act driver: intake and ingestion live in useVoiceCorpus, the
 // build lifecycle in useVoiceBuild. Every source — a browsed file, a window
@@ -81,7 +81,6 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   };
 
   const presence = presenceFor(state);
-  const configuredModel = useConfiguredModel();
 
   // Where the journey stands, in the rail's own counting.
   const stops = railStops(state.memberPath);
@@ -101,7 +100,6 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
       fileRef={fileRef}
       onFiles={onFiles}
       onAnswer={handleAnswer}
-      model={configuredModel}
     />
   );
 
@@ -238,7 +236,6 @@ function VoiceSurface({
   fileRef,
   onFiles,
   onAnswer,
-  model,
 }: Readonly<{
   state: ConversationState;
   dispatch: Dispatch<ConversationEvent>;
@@ -248,7 +245,6 @@ function VoiceSurface({
   fileRef: RefObject<HTMLInputElement | null>;
   onFiles: (event: ChangeEvent<HTMLInputElement>) => void;
   onAnswer: (questionId: string, value: string) => void;
-  model: string;
 }>) {
   const t = useT();
   if (state.phase === "vo.collecting") {
@@ -282,7 +278,6 @@ function VoiceSurface({
         stage={build.stage}
         summary={corpus.summary}
         sources={corpus.manifest.length}
-        model={model}
       />
     );
   }

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.stories.tsx
@@ -240,12 +240,7 @@ export const SpeakerAskGerman: Story = {
 export const BuildQueued: Story = {
   render: () => (
     <StoryProviders>
-      <VoiceBuildScene
-        stage={null}
-        summary={summary(4220, 2)}
-        sources={2}
-        model="deepseek-chat"
-      />
+      <VoiceBuildScene stage={null} summary={summary(4220, 2)} sources={2} />
     </StoryProviders>
   ),
 };
@@ -255,12 +250,7 @@ export const BuildQueued: Story = {
 export const BuildExtracting: Story = {
   render: () => (
     <StoryProviders>
-      <VoiceBuildScene
-        stage="extract"
-        summary={summary(4220, 2)}
-        sources={2}
-        model="deepseek-chat"
-      />
+      <VoiceBuildScene stage="extract" summary={summary(4220, 2)} sources={2} />
     </StoryProviders>
   ),
 };
@@ -274,7 +264,6 @@ export const BuildActivating: Story = {
         stage="activate"
         summary={summary(4220, 2)}
         sources={2}
-        model="deepseek-chat"
       />
     </StoryProviders>
   ),
@@ -285,12 +274,7 @@ export const BuildActivating: Story = {
 export const BuildExtractingGerman: Story = {
   render: () => (
     <StoryProviders locale="de">
-      <VoiceBuildScene
-        stage="extract"
-        summary={summary(4220, 2)}
-        sources={2}
-        model="deepseek-chat"
-      />
+      <VoiceBuildScene stage="extract" summary={summary(4220, 2)} sources={2} />
     </StoryProviders>
   ),
 };

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.test.tsx
@@ -324,12 +324,7 @@ describe("the collect scene's corpus floor meter", () => {
 describe("VoiceBuildScene", () => {
   function buildScene(stage: "snapshot" | "extract" | null) {
     return withLocale(
-      <VoiceBuildScene
-        stage={stage}
-        summary={null}
-        sources={1}
-        model="gemini-3.5-flash"
-      />,
+      <VoiceBuildScene stage={stage} summary={null} sources={1} />,
     );
   }
 
@@ -346,6 +341,14 @@ describe("VoiceBuildScene", () => {
     buildScene(null);
 
     expect(screen.queryByText("Why this step matters")).toBeNull();
+  });
+
+  it("counts a single source in the singular", () => {
+    withLocale(
+      <VoiceBuildScene stage="extract" summary={summaryOf(4216)} sources={1} />,
+    );
+
+    expect(screen.getByText("4,216 words, 1 source")).toBeTruthy();
   });
 
   it("creeps toward the reported stage's ceiling instead of jumping to it, and never passes it", () => {
@@ -378,12 +381,7 @@ describe("VoiceBuildScene", () => {
 
     rerender(
       <LocaleProvider initial="en">
-        <VoiceBuildScene
-          stage="extract"
-          summary={null}
-          sources={1}
-          model="gemini-3.5-flash"
-        />
+        <VoiceBuildScene stage="extract" summary={null} sources={1} />
       </LocaleProvider>,
     );
     // extract's ceiling is 2/5 = 40%; the very next frame must not already

--- a/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-scenes.tsx
@@ -6,7 +6,7 @@ import { Button, Disclosure } from "../../design-system/atoms";
 import { MarginceCoreScene } from "../../design-system/margince-core";
 import { usePrefersReducedMotion } from "../../design-system/motion";
 import { formatNumber } from "../../format/format";
-import { type Locale, useLocale, useT } from "../../i18n";
+import { type Locale, useLocale, usePlural, useT } from "../../i18n";
 import { ACCEPTED_CORPUS_ATTR } from "../voice-corpus-file";
 import type { VoiceInsightsData } from "../voice-insights";
 import { parseVoiceInsights } from "../voice-insights";
@@ -459,7 +459,8 @@ export function VoiceSpeakerScene({
 
 /**
  * The build scene: the Core carrying the progress ring with the percentage
- * inside it, and the four pipeline stages as a checklist. The ceiling is
+ * inside it, and beside it — never stacked under it — what the build is
+ * reading and the four pipeline stages as a checklist. The ceiling is
  * DERIVED from the stage the server reports; the displayed number crawls
  * toward it (useCrawlingProgress) so the ring keeps moving during a stage
  * instead of sitting still, but it can never pass the ceiling the server has
@@ -470,14 +471,13 @@ export function VoiceBuildScene({
   stage,
   summary,
   sources,
-  model,
 }: Readonly<{
   stage: BuildStage | null;
   summary: CorpusSummary | null;
   sources: number;
-  model: string;
 }>) {
   const t = useT();
+  const plural = usePlural();
   const { locale } = useLocale();
   const reached = stage === null ? -1 : BUILD_STAGES.indexOf(stage);
   // A queued build (no stage yet) shows nothing claimed; each reached stage
@@ -486,43 +486,56 @@ export function VoiceBuildScene({
   const progress = useCrawlingProgress(ceiling);
   return (
     <div className="ob-scene ob-voice-building">
-      <div className="ob-voice-orb">
-        <MarginceCoreScene
-          state={buildCore(stage)}
-          progress={progress}
-          feed={false}
-        />
-        {/* Decorative: the stage checklist below and the rail's own log
-            (role="log" in ConversationThread) already carry the build's
-            progress in words, so the crawling digits stay out of the a11y
-            tree instead of being announced on every tick. */}
-        <span className="ob-voice-orb-pct" aria-hidden>
-          {formatNumber(Math.round(progress * 100), locale)}
-          <small>%</small>
-        </span>
-      </div>
-      <p className="ob-voice-building-meta">
-        {t("ob.conv.voice.buildingMeta", {
-          words: formatNumber(summary?.total_words ?? 0, locale),
-          sources: formatNumber(sources, locale),
-        })}
-      </p>
-      <p className="ob-voice-building-model t-caption">
-        <i aria-hidden /> {model}
-      </p>
-      <ol className="ob-conv-stages" aria-label={t("ob.conv.voice.stageTitle")}>
-        {BUILD_STAGES.map((name, index) => (
-          <li
-            key={name}
-            data-state={
-              index < reached ? "done" : index === reached ? "current" : "todo"
-            }
+      {/* The orb is the subject and takes its own column; what the build is
+          reading and how far it has got reads down the column beside it.
+          Which model is answering is NOT repeated here — the band's runtime
+          chip above names it for every screen in the room, and the second
+          copy was a full-width line of identifiers under the orb. */}
+      <div className="ob-voice-building-row">
+        <div className="ob-voice-orb">
+          <MarginceCoreScene
+            state={buildCore(stage)}
+            progress={progress}
+            feed={false}
+          />
+          {/* Decorative: the stage checklist beside it and the rail's own log
+              (role="log" in ConversationThread) already carry the build's
+              progress in words, so the crawling digits stay out of the a11y
+              tree instead of being announced on every tick. */}
+          <span className="ob-voice-orb-pct" aria-hidden>
+            {formatNumber(Math.round(progress * 100), locale)}
+            <small>%</small>
+          </span>
+        </div>
+        <div className="ob-voice-building-account">
+          <p className="ob-voice-building-meta">
+            {plural("ob.conv.voice.buildingMeta", sources, {
+              words: formatNumber(summary?.total_words ?? 0, locale),
+              sources: formatNumber(sources, locale),
+            })}
+          </p>
+          <ol
+            className="ob-conv-stages"
+            aria-label={t("ob.conv.voice.stageTitle")}
           >
-            {index < reached && <Check aria-hidden />}
-            <span>{t(stageLabelKeys[name])}</span>
-          </li>
-        ))}
-      </ol>
+            {BUILD_STAGES.map((name, index) => (
+              <li
+                key={name}
+                data-state={
+                  index < reached
+                    ? "done"
+                    : index === reached
+                      ? "current"
+                      : "todo"
+                }
+              >
+                {index < reached && <Check aria-hidden />}
+                <span>{t(stageLabelKeys[name])}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

The voice act's build scene (`Learning your voice`) is laid out as two columns: the Core in its own column on the left, and the build's account — what it is reading, and the four-stage checklist — reading down the column beside it. It was a centred stack under the orb, and the whole thing is now held to the pair's own measure instead of stretching to the board's full 74rem.

The line naming every configured model identifier is gone, not moved. The source count is pluralised: it read "1 sources".

## Why

Three things were wrong with the stack, and all three came from the same choice to centre everything under the orb:

- The orb sat in the middle of a wide board with the reader's eye crossing empty space to reach each line under it, and each of those lines started from a different place.
- The model line was a **second copy** of what the band above already carries. `ConversationWorkbench` renders `AiRuntimeChip` with `configured={useConfiguredModel()}` on every screen in this room; the build scene called the same hook and printed the same string in monospace across the board's full width, which is what made it wrap to two lines. One claim about what is answering, one place that makes it — so the scene stands its copy down, and the `model` prop chain (act → surface → scene) goes with it.
- `ob.conv.voice.buildingMeta` interpolated a raw count into a fixed plural, so a one-source corpus read "4,216 words, 1 sources". It is a plural pair now and the count picks its own arm through the locale's own rule, in all three catalogues.

Two smaller corrections in the same area: the Core takes `--coreCap: 100%` (set on `.core`, where the default it overrides is declared) because its column is `auto` and measured against the sphere's own px size — the viewport cap would only shrink it on a narrow window that still holds both columns; and the row collapses to one centred column under a container query on the scene, which is where the collect scene's own stack already happens.

## How verified

- `make check` green end to end (both halves, tree clean afterwards). Getting there needed three fixes to the session container, none of them to this diff: `make tools` (its `golangci-lint` was built against an older Go than the repo targets), `git fetch --unshallow` (the RBAC baseline-era gate derives its pre-state from history and says so when the checkout is shallow), and installing `rsync` (the handbook-embed drift step needs it).
- `voice-scenes.test.tsx` gains a case pinning the singular: one source renders "4,216 words, 1 source". The existing crawl/ceiling cases still hold, so the ring's honesty is unchanged by the restructure.
- No Go in this diff, so `craft static` has nothing new in scope, and no tenant data, RLS or write-shape surface is touched.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Written by Claude Code end to end: the layout change, the CSS, the plural pair in the three catalogues, and the added test. A human raised the defect from a screenshot of the running build scene.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB5r9iyK6TMAzUCfiHuGdy