### PR TITLE
fix(voice): adding several sources at once adds all of them

### DIFF
--- a/backend/internal/modules/ai/voice_concurrent_ingest_integration_test.go
+++ b/backend/internal/modules/ai/voice_concurrent_ingest_integration_test.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package ai
+
+// Concurrency is the subject here, so this runs against a real Postgres: a
+// deadlock is something only the lock manager can produce, and no fake
+// transaction has one. Onboarding drops several files at once and every ingest
+// lands on the SAME voice_profile row, which is the contention this proves the
+// store survives.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// concurrentIngestClock is the store's injected now, so nothing here reads the
+// wall clock.
+var concurrentIngestClock = time.Date(2026, 9, 6, 8, 0, 0, 0, time.UTC)
+
+// concurrentIngestCount is how many sources are added at once. Onboarding's
+// file drop is the shape being modelled; more than a couple of writers is what
+// makes a lock cycle reachable at all.
+const concurrentIngestCount = 8
+
+// pgSerializationDeadlock is PostgreSQL's deadlock_detected. Named here so the
+// failure message can say what actually happened rather than printing a code.
+const pgSerializationDeadlock = "40P01"
+
+type concurrentIngestEnv struct {
+	owner *pgx.Conn
+	pool  *pgxpool.Pool
+}
+
+func setupConcurrentIngest(t *testing.T) *concurrentIngestEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
+	return &concurrentIngestEnv{owner: owner, pool: pool}
+}
+
+// seedBuiltProfile mints a workspace holding one human's ALREADY BUILT voice
+// profile. Built is the load-bearing part: markProfileStale returns early on a
+// profile_version of 0, so a never-built profile would leave the shared row
+// untouched and the test would pass without exercising the contention it
+// exists to prove.
+func (e *concurrentIngestEnv) seedBuiltProfile(t *testing.T) (context.Context, ids.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	workspace := ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, workspace); err != nil {
+		t.Fatal(err)
+	}
+	var owner ids.UUID
+	if err := e.owner.QueryRow(ctx, `
+		INSERT INTO app_user (email, display_name)
+		VALUES ($1, 'Corpus Owner') RETURNING id`,
+		"owner-"+ids.NewV7().String()+"@example.test").Scan(&owner); err != nil {
+		t.Fatal(err)
+	}
+	var profile ids.UUID
+	if err := e.owner.QueryRow(ctx, `
+		INSERT INTO voice_profile (owner_id, scope, status, profile_version, source, captured_by)
+		VALUES ($1, 'user', 'ready', 3, 'ui', $2) RETURNING id`,
+		owner, "human:"+owner.String()).Scan(&profile); err != nil {
+		t.Fatal(err)
+	}
+	actor := principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + owner.String(), UserID: owner,
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"}, RowScope: principal.RowScopeTeam,
+			Objects: map[string]principal.ObjectGrant{
+				"voice_profile": {Read: true, Update: true},
+			},
+		},
+	}
+	callCtx := principal.WithCorrelationID(
+		principal.WithActor(principal.WithWorkspaceID(ctx, workspace), actor),
+		ids.NewV7())
+	return callCtx, profile
+}
+
+func (e *concurrentIngestEnv) storeIn(ws ids.UUID) *VoiceStore {
+	s := NewVoiceStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](ws)))
+	s.now = func() time.Time { return concurrentIngestClock }
+	return s
+}
+
+// Adding several sources at once must add all of them. Each writer owns a
+// DISTINCT source_ref, so the per-source advisory lock never serializes them,
+// and the profile row is the only thing they all touch.
+//
+// This is the onboarding file drop as a test, and it fails without the
+// profile-first lock: removing that one call from ingestPreparedSource aborts
+// five to seven of the eight with SQLSTATE 40P01 and leaves one or two sources
+// in the manifest — measured over eight runs of the mutation, every one of
+// which failed here.
+func TestConcurrentIngestOfDistinctSourcesAllSucceed(t *testing.T) {
+	e := setupConcurrentIngest(t)
+	ctx, profile := e.seedBuiltProfile(t)
+	store := e.storeIn(workspaceOf(ctx, t))
+
+	errs := make([]error, concurrentIngestCount)
+	// The barrier releases the writers together. It synchronizes their START,
+	// not their arrival at any particular lock — nothing here can force that,
+	// since each transaction opens inside IngestSource. Overlap is what the
+	// cycle needs and what releasing them together buys; the deadlock is
+	// structural rather than a narrow window, which is why the mutation above
+	// fails every time rather than occasionally.
+	var ready, done sync.WaitGroup
+	start := make(chan struct{})
+	ready.Add(concurrentIngestCount)
+	done.Add(concurrentIngestCount)
+	for i := range concurrentIngestCount {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			_, _, _, err := store.IngestSource(ctx, profile, IngestSourceInput{
+				Kind:        voiceSourceKindDocument,
+				SourceLabel: fmt.Sprintf("sample-%d.txt", i),
+				SourceRef:   fmt.Sprintf("voice:upload:concurrent-%d", i),
+				Format:      corpusWireFormatText,
+				Content:     fmt.Sprintf("Sample %d. I write plainly and I keep my sentences short.", i),
+			})
+			errs[i] = err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+
+	for i, err := range errs {
+		if err == nil {
+			continue
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgSerializationDeadlock {
+			t.Errorf("ingest %d deadlocked (%s): concurrent ingests of distinct sources must not contend on the profile row", i, pgErr.Code)
+			continue
+		}
+		t.Errorf("ingest %d: %v", i, err)
+	}
+
+	var stored int
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM voice_corpus_source
+			WHERE voice_profile_id = $1 AND archived_at IS NULL`, profile).Scan(&stored)
+	}); err != nil {
+		t.Fatalf("counting the manifest: %v", err)
+	}
+	if stored != concurrentIngestCount {
+		t.Errorf("manifest holds %d sources, want %d", stored, concurrentIngestCount)
+	}
+}
+
+// The staleness mark still fires, and exactly once per ingest that changes
+// anything: a corpus that moved under a built profile must invalidate it, or
+// the reader is served a voice that no longer describes its sources. Guarding
+// this is what stops the deadlock fix from being "stop writing the row".
+func TestConcurrentIngestMarksTheBuiltProfileStale(t *testing.T) {
+	e := setupConcurrentIngest(t)
+	ctx, profile := e.seedBuiltProfile(t)
+	store := e.storeIn(workspaceOf(ctx, t))
+
+	if _, _, _, err := store.IngestSource(ctx, profile, IngestSourceInput{
+		Kind:        voiceSourceKindDocument,
+		SourceLabel: "first.txt",
+		SourceRef:   "voice:upload:stale-1",
+		Format:      corpusWireFormatText,
+		Content:     "I write plainly and I keep my sentences short.",
+	}); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+
+	status, version := e.readProfile(ctx, t, profile)
+	if status != voiceProfileStatusStale {
+		t.Errorf("profile status is %q, want %q — a corpus change must invalidate the built voice", status, voiceProfileStatusStale)
+	}
+
+	// A second ingest onto an already-stale profile must not bump the version
+	// again: the row says "stale" once, and a second bump would present version
+	// skew to a reader holding the first.
+	if _, _, _, err := store.IngestSource(ctx, profile, IngestSourceInput{
+		Kind:        voiceSourceKindDocument,
+		SourceLabel: "second.txt",
+		SourceRef:   "voice:upload:stale-2",
+		Format:      corpusWireFormatText,
+		Content:     "A second sample, in the same voice as the first.",
+	}); err != nil {
+		t.Fatalf("second ingest: %v", err)
+	}
+	_, after := e.readProfile(ctx, t, profile)
+	if after != version {
+		t.Errorf("profile version moved from %d to %d on an already-stale profile; the mark must be idempotent", version, after)
+	}
+}
+
+func (e *concurrentIngestEnv) readProfile(ctx context.Context, t *testing.T, profile ids.UUID) (status string, version int64) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status, version FROM voice_profile WHERE id = $1`, profile).Scan(&status, &version)
+	}); err != nil {
+		t.Fatalf("reading the profile: %v", err)
+	}
+	return status, version
+}

--- a/backend/internal/modules/ai/voice_corpus_summary.go
+++ b/backend/internal/modules/ai/voice_corpus_summary.go
@@ -120,6 +120,39 @@ func (s *VoiceStore) ProfilePresentation(ctx context.Context, profileID ids.UUID
 	return summary, candidateVersion, err
 }
 
+// lockProfileForCorpusWrite takes the voice_profile row a corpus mutation holds
+// for the rest of its transaction, and it is the FIRST lock such a writer takes
+// — before the voice_corpus_source row it is about to write.
+//
+// The order is the whole contract. RunBuild and CompleteBuild lock
+// profile-then-build; a corpus writer locks profile-then-source. One order
+// across all of them means no pair can wait on each other in opposite
+// directions.
+//
+// Reaching the profile LAST is what deadlocked. Each ingest first took the
+// advisory lock naming its own source (keyed on source_ref, so ingests of
+// different files never met there) and inserted its row, and only then queued
+// for this shared profile row. Onboarding drops several files at once, so
+// several writers each held a different source and reached for this one in
+// whatever order they arrived. Postgres broke the resulting cycles by aborting
+// all but one with SQLSTATE 40P01, which reaches the reader as a 500 they can
+// do nothing about: the corpus kept whichever ingest won and the rest were
+// lost, with nothing on screen saying which.
+//
+// Taking it here rather than dropping it keeps what the lock is FOR. RunBuild
+// and CompleteBuild each read corpusSourceHash while holding this row and
+// refuse a build whose corpus moved underneath it. A corpus writer that did not
+// hold it could commit a source after a build had read that hash, and the build
+// would then publish a profile built from a corpus that no longer exists.
+func lockProfileForCorpusWrite(ctx context.Context, tx pgx.Tx, profileID ids.UUID) error {
+	_, err := storekit.LockRow(ctx, tx, "voice_profile", profileID, storekit.LiveOnly)
+	return err
+}
+
+// markProfileStale records that the corpus moved under a built profile, so the
+// next read knows the built voice no longer describes its sources. Every caller
+// already holds this row through lockProfileForCorpusWrite; re-taking it is
+// idempotent, and leaving it spelled out keeps the function readable alone.
 func markProfileStale(ctx context.Context, tx pgx.Tx, profile VoiceProfile, now time.Time) error {
 	if _, err := storekit.LockRow(ctx, tx, "voice_profile", profile.ID, storekit.LiveOnly); err != nil {
 		return err

--- a/backend/internal/modules/ai/voice_source_mutations.go
+++ b/backend/internal/modules/ai/voice_source_mutations.go
@@ -81,6 +81,11 @@ func validateSourceUpdate(in UpdateSourceInput) (*bool, error) {
 }
 
 func (s *VoiceStore) updateVoiceSource(ctx context.Context, tx pgx.Tx, profileID, sourceID ids.UUID, in UpdateSourceInput, excluded *bool) (VoiceCorpusSource, CorpusSummary, error) {
+	// Before the source row this is about to write, so every corpus writer
+	// queues here in one order — see lockProfileForCorpusWrite.
+	if err := lockProfileForCorpusWrite(ctx, tx, profileID); err != nil {
+		return VoiceCorpusSource{}, CorpusSummary{}, err
+	}
 	profile, err := s.visibleProfile(ctx, tx, profileID)
 	if err != nil {
 		return VoiceCorpusSource{}, CorpusSummary{}, err
@@ -179,6 +184,11 @@ func (s *VoiceStore) DeleteSource(ctx context.Context, profileID, sourceID ids.U
 	}
 	var removed VoiceCorpusSource
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// Before the source row this is about to archive, so every corpus writer
+		// queues here in one order — see lockProfileForCorpusWrite.
+		if err := lockProfileForCorpusWrite(ctx, tx, profileID); err != nil {
+			return err
+		}
 		profile, err := s.visibleProfile(ctx, tx, profileID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/ai/voice_source_store.go
+++ b/backend/internal/modules/ai/voice_source_store.go
@@ -59,6 +59,11 @@ func (s *VoiceStore) PreviewSource(ctx context.Context, profileID ids.UUID, form
 }
 
 func (s *VoiceStore) ingestPreparedSource(ctx context.Context, tx pgx.Tx, profileID ids.UUID, prepared preparedSource) (VoiceCorpusSource, CorpusSummary, error) {
+	// Before the source row this is about to write, so every corpus writer
+	// queues here in one order — see lockProfileForCorpusWrite.
+	if err := lockProfileForCorpusWrite(ctx, tx, profileID); err != nil {
+		return VoiceCorpusSource{}, CorpusSummary{}, err
+	}
 	profile, err := s.visibleProfile(ctx, tx, profileID)
 	if err != nil {
 		return VoiceCorpusSource{}, CorpusSummary{}, err


### PR DESCRIPTION
## What was wrong

Dropping a folder of writing samples into onboarding sends one ingest per file, and all but one came back as a 500. The corpus kept whichever ingest won the race; the rest were lost, with nothing on screen saying which.

## Why

Every corpus writer ends by marking the profile's built voice stale, and it reached that shared `voice_profile` row LAST — after taking the advisory lock naming its own source and inserting the row. That advisory lock is keyed on `source_ref`, so ingests of different files never met there. Each writer therefore held a different source row and only then queued for the one profile row, in whatever order it arrived.

Postgres named both sides of the cycle:

```
Process 72484: SELECT id FROM voice_profile WHERE id = $1 AND archived_at IS NULL FOR UPDATE
Process 72470: SELECT id FROM voice_profile WHERE id = $1 AND archived_at IS NULL FOR UPDATE
while locking tuple (0,1) in relation "voice_profile"
```

It broke the cycles by aborting all but one with `SQLSTATE 40P01`, which reaches the reader as a 500 they can do nothing about.

## The change

The three corpus writers now take the profile row FIRST, through `lockProfileForCorpusWrite`, before the source row they are about to write. `RunBuild` and `CompleteBuild` already lock profile-then-build; a corpus writer now locks profile-then-source, so one order covers all of them. `ClearCorpus` already did this, which is why it was never part of the cycle.

**The lock is moved, not removed.** An earlier draft of this PR collapsed `markProfileStale` into a single conditional UPDATE and dropped the lock. That was wrong: `RunBuild` and `CompleteBuild` each read `corpusSourceHash` while holding this row and refuse a build whose corpus moved underneath it. A writer that did not hold it could commit a source after a build had read that hash, and the build would publish a profile built from a corpus that no longer exists. `markProfileStale` is now byte-for-byte unchanged from main.

## Proof

`TestConcurrentIngestOfDistinctSourcesAllSucceed` fires eight concurrent ingests of distinct sources and asserts all eight land.

Mutation-checked: removing only the ingest's `lockProfileForCorpusWrite` line aborts five to seven of the eight with 40P01 and leaves one or two sources in the manifest. That was measured over eight separate runs, every one of which failed — the deadlock is structural rather than a narrow timing window, so the test does not depend on winning a race.

Also verified end-to-end against a running stack: eight concurrent `POST /voice-profiles/{id}/sources` with real VTT transcripts returned **8× 201**, the manifest held all eight sources, and the API log recorded zero deadlocks. The same shape against main gave one 201 and seven 500s.

`TestConcurrentIngestMarksTheBuiltProfileStale` holds the behaviour the fix must not trade away: the mark still fires on a built profile, and stays idempotent on an already-stale one.

The profile is seeded already built (`profile_version = 3`) on purpose — `markProfileStale` returns early on version 0, so a never-built profile would leave the shared row untouched and the test would pass without exercising the contention.

## Review

Codex reviewed twice. Its first pass raised a BLOCKER against the original lock-removal design — that a concurrent build could publish an artifact from a corpus snapshot missing the pending source — plus a MAJOR that a source mutation could commit under a profile archived out from under it. Both were correct and drove the redesign above. Its second pass confirms all three substantive findings resolved, and found no new inverse lock ordering against archive, rebuild, build claim/complete, version apply/reject/rollback, or the retention sweep.

One test was cut in response: a held-row test I wrote proved the FK's own `KEY SHARE` lock rather than this change, so it could not fail for the reason it claimed and was removed rather than kept as false coverage.

## Gates

`make check-backend` green in full. `craft static --strict` clean on every file in this diff. `make rls-store-path` and `make no-jurisdiction` green. The `ai` integration lane green.

Note for the team, unrelated to this diff: `make craft-static` over the whole tree currently reports 4 MAJOR `naked-any` findings in `backend/gates/forwardmeasureparity_test.go` and `backend/internal/modules/consent/lift_integration_test.go`. Neither file is touched here; they arrived on main.