### PR TITLE
The collapse's own comments stop describing a dispatcher

### DIFF
--- a/backend/internal/compose/briefjobs.go
+++ b/backend/internal/compose/briefjobs.go
@@ -45,8 +45,8 @@ type BriefGenerateArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (BriefGenerateArgs) Kind() string { return "brief_generate" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (BriefGenerateArgs) FleetWide() {}
 
 // briefGenerateWorker assembles every live workspace's briefs.

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -70,8 +70,8 @@ type CaptureAutoEnrichSweepArgs struct{}
 // Kind is the River job kind for the auto-enrich sweep.
 func (CaptureAutoEnrichSweepArgs) Kind() string { return "capture_auto_enrich_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CaptureAutoEnrichSweepArgs) FleetWide() {}
 
 // captureAutoEnrichSweepWorker runs one sweep pass across every workspace.

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -32,8 +32,8 @@ type CaptureClassifyArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CaptureClassifyArgs) Kind() string { return "capture_classify" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CaptureClassifyArgs) FleetWide() {}
 
 // captureClassifyWorker drives the batched label engine for every live
@@ -81,8 +81,8 @@ type CaptureEnrichArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CaptureEnrichArgs) Kind() string { return "capture_enrich" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CaptureEnrichArgs) FleetWide() {}
 
 // captureEnrichWorker drives the evidence-gated signature pass for every live
@@ -150,11 +150,10 @@ type OrgNamePromotionArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (OrgNamePromotionArgs) Kind() string { return "org_name_promotion" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (OrgNamePromotionArgs) FleetWide() {}
 
-// orgNamePromotionWorker is the dispatcher for the corroborated-name sweep.
 // orgNamePromotionWorker promotes names for every live workspace.
 //
 // One worker where there were two (ADR-0103).
@@ -181,8 +180,8 @@ type CaptureDigestArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CaptureDigestArgs) Kind() string { return "capture_digest" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CaptureDigestArgs) FleetWide() {}
 
 // captureDigestWorker assembles one digest per connected user per
@@ -297,20 +296,26 @@ func (w *captureBackfillWorker) Work(ctx context.Context, job *river.Job[Capture
 // ambient River client; the digest worker rebuilds the day idempotently
 // (as-of-now truths).
 //
-// The child kind, never the dispatcher. The finishing tenant is known here, and
-// CaptureDigestArgs is a fleet fan-out: enqueueing it would run every workspace
-// in the installation because one of them imported its history, and N tenants
-// finishing together would run the fleet N times. The intent is local, so the
-// enqueue is too — which also leaves the fan-out path exclusively the
-// dispatcher's, so a digest pass in the sweep gauges is one a clock scheduled.
+// THE PASS, because there is no longer a child to prefer to it. This argued the
+// opposite until ADR-0103 collapsed the digest pair: the intent here is local —
+// one tenant just imported its history — and a fleet fan-out would have run
+// every workspace in the installation for it, N times over if N tenants
+// finished together. There is one kind now, so "local" is not something the
+// enqueue can express any more.
 //
-// oneOffChildOpts carries the queue and attempt cap the contract declares for
-// the kind, and states there why a one-off deliberately takes neither the sweep
-// tag nor the active-state uniqueness the fleet's children carry. The second of
-// those matters here in particular: a digest already RUNNING may have
-// snapshotted the workspace BEFORE this backfill's rows landed, and deduping
-// against it would drop the freshly-imported history off the morning screen
-// until the nightly pass.
+// What that costs is bounded by the same invariant the collapse rests on: an
+// installation holds one active workspace (identity.InstallationWorkspace
+// refuses more), so the pass covers exactly the tenant that finished. On a
+// fleet it would also re-walk the others, each a re-build of a day they already
+// have — the digest is idempotent over as-of-now truths, which is what made the
+// pair affordable to collapse in the first place.
+//
+// oneOffPassOpts carries the queue the contract declares for the kind, and
+// states there why a one-off deliberately takes neither the sweep tag nor the
+// active-state uniqueness a scheduled tick carries. The second matters here in
+// particular: a digest already RUNNING may have snapshotted the workspace
+// BEFORE this backfill's rows landed, and deduping against it would drop the
+// freshly-imported history off the morning screen until the nightly pass.
 //
 // The Safely variant is deliberate: the plain ClientFromContext PANICS when
 // there is no client, and a best-effort enqueue must degrade rather than crash
@@ -326,11 +331,6 @@ func (w *captureBackfillWorker) enqueueDigest(ctx context.Context, args CaptureB
 			"backfill", args.BackfillID, "err", err)
 		return
 	}
-	// The PASS, not a per-workspace child: the child kind went with the fan-out
-	// (ADR-0103). A backfill's same-day digest is wanted for the workspace it
-	// imported into, and the pass covers that workspace along with the rest —
-	// on the single-workspace installations this product supports, the same
-	// work.
 	child := CaptureDigestArgs{}
 	if _, err := client.Insert(ctx, child, oneOffPassOpts(child.Kind())); err != nil {
 		w.log.WarnContext(ctx, "capture backfill: digest enqueue failed",
@@ -344,8 +344,8 @@ type CounterpartyVerdictArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CounterpartyVerdictArgs) Kind() string { return "capture_counterparty_verdict" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CounterpartyVerdictArgs) FleetWide() {}
 
 // counterpartyVerdictWorker drives the disposition ledger's stages in the order

--- a/backend/internal/compose/capturetracejobs.go
+++ b/backend/internal/compose/capturetracejobs.go
@@ -35,11 +35,11 @@ type CaptureTraceSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CaptureTraceSweepArgs) Kind() string { return "capture_trace_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CaptureTraceSweepArgs) FleetWide() {
 	// Intentionally empty: jobs.FleetWide is a marker interface, and the method
-	// exists to be satisfied rather than called. The dispatcher's work is
+	// exists to be satisfied rather than called. The pass's work is
 	// Work(), which enumerates the fleet.
 }
 

--- a/backend/internal/compose/confidentialityjobs.go
+++ b/backend/internal/compose/confidentialityjobs.go
@@ -28,8 +28,8 @@ type ConfidentialityVerdictArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (ConfidentialityVerdictArgs) Kind() string { return "capture_confidentiality_verdict" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (ConfidentialityVerdictArgs) FleetWide() {}
 
 // confidentialityVerdictWorker drains every live workspace's thread backlog.

--- a/backend/internal/compose/embeddriftsweep.go
+++ b/backend/internal/compose/embeddriftsweep.go
@@ -35,8 +35,8 @@ type EmbedDriftSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (EmbedDriftSweepArgs) Kind() string { return "embed_drift_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (EmbedDriftSweepArgs) FleetWide() {}
 
 // embedDriftSweepWorker heals every live workspace's drift.

--- a/backend/internal/compose/graphedgereconcile.go
+++ b/backend/internal/compose/graphedgereconcile.go
@@ -39,8 +39,8 @@ type GraphEdgeReconcileArgs struct{}
 // Kind is the River job kind for the interaction-projection reconcile.
 func (GraphEdgeReconcileArgs) Kind() string { return "graph_edge_reconcile" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (GraphEdgeReconcileArgs) FleetWide() {}
 
 // graphEdgeReconcileWorker rebuilds the projection for every workspace.

--- a/backend/internal/compose/jobs_assurance.go
+++ b/backend/internal/compose/jobs_assurance.go
@@ -42,12 +42,10 @@ type AssuranceSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (AssuranceSweepArgs) Kind() string { return "assurance_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (AssuranceSweepArgs) FleetWide() {}
 
-// assuranceSweepWorker is the dispatcher: it enumerates and enqueues, and
-// touches no tenant data itself.
 // assuranceSweepWorker checks every live tenant's forecast inputs.
 //
 // One worker where there were two (ADR-0103).

--- a/backend/internal/compose/jobs_automation.go
+++ b/backend/internal/compose/jobs_automation.go
@@ -31,8 +31,8 @@ type TimeScanArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (TimeScanArgs) Kind() string { return "time_scan" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (TimeScanArgs) FleetWide() {}
 
 // timeScanWorker scans every live workspace.

--- a/backend/internal/compose/jobs_deals.go
+++ b/backend/internal/compose/jobs_deals.go
@@ -32,8 +32,8 @@ type CloseDateSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (CloseDateSweepArgs) Kind() string { return "close_date_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (CloseDateSweepArgs) FleetWide() {}
 
 // FollowUpReconcileArgs schedules one overnight follow-up reconciliation
@@ -43,12 +43,10 @@ type FollowUpReconcileArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (FollowUpReconcileArgs) Kind() string { return "follow_up_reconcile" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (FollowUpReconcileArgs) FleetWide() {}
 
-// closeDateSweepWorker is the dispatcher: it enumerates and enqueues, and
-// touches no tenant data itself.
 // closeDateSweepWorker corrects close dates for every live workspace.
 //
 // One worker where there were two (ADR-0103).
@@ -77,7 +75,9 @@ func (w *closeDateSweepWorker) correctWorkspace(ctx context.Context, workspace i
 	return jobs.FaultContext(ctx, w.corrector.SweepWorkspace(wsCtx))
 }
 
-// followUpReconcileWorker is the dispatcher for the overnight pass.
+// followUpReconcileWorker runs the overnight pass for every live workspace.
+//
+// One worker where there were two (ADR-0103).
 type followUpReconcileWorker struct {
 	pool       *pgxpool.Pool
 	reconciler *deals.FollowUpReconciler

--- a/backend/internal/compose/jobs_embedreindex.go
+++ b/backend/internal/compose/jobs_embedreindex.go
@@ -76,9 +76,8 @@ type EmbedReindexArgs struct {
 // Kind is the stable job identifier River persists in river_job.
 func (EmbedReindexArgs) Kind() string { return "embed_reindex" }
 
-// FleetWide marks this as owning no tenant of its own (jobs.FleetWide): since
-// ADR-0091 §8 phase D no embeddable entity carries a workspace, so the corpus
-// this rebuilds is the installation's.
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (EmbedReindexArgs) FleetWide() {}
 
 // embedReindexWorker rebuilds the installation's corpus under the run's target

--- a/backend/internal/compose/jobs_finance.go
+++ b/backend/internal/compose/jobs_finance.go
@@ -39,8 +39,8 @@ type FinanceSyncSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (FinanceSyncSweepArgs) Kind() string { return "finance_sync_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (FinanceSyncSweepArgs) FleetWide() {}
 
 // financeSyncSweepWorker mirrors every live workspace's accounting source.

--- a/backend/internal/compose/jobs_forecastsnapshot.go
+++ b/backend/internal/compose/jobs_forecastsnapshot.go
@@ -49,12 +49,13 @@ type ForecastSnapshotSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (ForecastSnapshotSweepArgs) Kind() string { return "forecast_snapshot_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (ForecastSnapshotSweepArgs) FleetWide() {}
 
-// forecastSnapshotSweepWorker is the dispatcher: it enumerates and enqueues, and
-// touches no tenant data itself.
+// forecastSnapshotSweepWorker freezes every live workspace's forecast.
+//
+// One worker where there were two (ADR-0103).
 type forecastSnapshotSweepWorker struct {
 	pool *pgxpool.Pool
 	now  func() time.Time

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -69,8 +69,8 @@ type OverlayReconcileArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (OverlayReconcileArgs) Kind() string { return "overlay_reconcile" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (OverlayReconcileArgs) FleetWide() {}
 
 // overlayReconcileWorker is the poller's DISPATCHER: it runs the due-scan

--- a/backend/internal/compose/jobs_providerlookup.go
+++ b/backend/internal/compose/jobs_providerlookup.go
@@ -32,8 +32,8 @@ type ProviderLookupSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (ProviderLookupSweepArgs) Kind() string { return "provider_lookup_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (ProviderLookupSweepArgs) FleetWide() {}
 
 // providerLookupSweepWorker fans the pass out per workspace.

--- a/backend/internal/compose/jobs_providerruns.go
+++ b/backend/internal/compose/jobs_providerruns.go
@@ -119,8 +119,8 @@ type ProviderRunPollSweepArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (ProviderRunPollSweepArgs) Kind() string { return "provider_run_poll_sweep" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (ProviderRunPollSweepArgs) FleetWide() {}
 
 // providerJobActor binds the principal a provider run STARTS as, plus the

--- a/backend/internal/compose/jobs_retention.go
+++ b/backend/internal/compose/jobs_retention.go
@@ -27,11 +27,11 @@ type IdempotencyRetentionArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (IdempotencyRetentionArgs) Kind() string { return "idempotency_retention" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (IdempotencyRetentionArgs) FleetWide() {}
 
-// idempotencyRetentionWorker is the dispatcher. It enumerates EVERY
+// idempotencyRetentionWorker sweeps EVERY
 // workspace, archived ones included: archiving does not un-store the claim
 // snapshots inside a workspace, and idempotency_key.workspace_id is
 // ON DELETE RESTRICT, so leftovers would also refuse the eventual hard delete.

--- a/backend/internal/compose/jobs_signals.go
+++ b/backend/internal/compose/jobs_signals.go
@@ -37,11 +37,13 @@ type SignalScanArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (SignalScanArgs) Kind() string { return "signal_scan" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (SignalScanArgs) FleetWide() {}
 
-// signalScanWorker is the dispatcher.
+// signalScanWorker scans every live workspace.
+//
+// One worker where there were two (ADR-0103).
 type signalScanWorker struct {
 	pool      *pgxpool.Pool
 	extractor *SignalExtractor

--- a/backend/internal/compose/linkedinrematch.go
+++ b/backend/internal/compose/linkedinrematch.go
@@ -50,8 +50,8 @@ type LinkedInRematchArgs struct{}
 // Kind is the River job kind for the LinkedIn re-match sweep.
 func (LinkedInRematchArgs) Kind() string { return "linkedin_rematch" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (LinkedInRematchArgs) FleetWide() {}
 
 type linkedInRematchWorker struct {

--- a/backend/internal/compose/linkreconcile.go
+++ b/backend/internal/compose/linkreconcile.go
@@ -60,8 +60,8 @@ type LinkReconcileArgs struct{}
 // Kind is the River job kind for the captured-mail link reconcile.
 func (LinkReconcileArgs) Kind() string { return "link_reconcile" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (LinkReconcileArgs) FleetWide() {}
 
 type linkReconcileWorker struct {

--- a/backend/internal/compose/owedjobs.go
+++ b/backend/internal/compose/owedjobs.go
@@ -27,8 +27,8 @@ type OwedVerdictArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (OwedVerdictArgs) Kind() string { return "owed_verdict" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
-// tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (OwedVerdictArgs) FleetWide() {}
 
 // owedVerdictWorker drives the verdict engine for every live workspace.

--- a/backend/internal/compose/participantbackfilljob.go
+++ b/backend/internal/compose/participantbackfilljob.go
@@ -35,8 +35,8 @@ type ParticipantBackfillArgs struct{}
 // Kind is the River job kind for the participant backfill.
 func (ParticipantBackfillArgs) Kind() string { return "participant_backfill" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (ParticipantBackfillArgs) FleetWide() {}
 
 // participantBackfillBatch is how many activities one statement attributes.

--- a/backend/internal/compose/weeklyjobs.go
+++ b/backend/internal/compose/weeklyjobs.go
@@ -62,7 +62,8 @@ type WeeklyReviewGenerateArgs struct{}
 // Kind names the job in the contract.
 func (WeeklyReviewGenerateArgs) Kind() string { return "weekly_review_generate" }
 
-// FleetWide marks this as an enumerator that does no tenant work itself.
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
 func (WeeklyReviewGenerateArgs) FleetWide() {}
 
 // weeklyGenerateWorker measures every live workspace's reps.


### PR DESCRIPTION
Cleanup of prose I left wrong across #1857's nine batches. The ticket is itself about *names describing a structure the code does not have*, so finishing it while leaving new instances of that would be a poor joke.

## The worst one argued against its own code

`captureBackfillWorker.enqueueDigest`'s doc comment still read:

> The child kind, **never the dispatcher**. The finishing tenant is known here, and `CaptureDigestArgs` is a fleet fan-out: enqueueing it would run every workspace in the installation because one of them imported its history…

The body below it enqueues exactly that — the collapse left one kind, and "local" is not something the enqueue can express any more. A reader following the comment would have concluded the code was a bug.

It now says what the code does and what that costs, bounded by the invariant the collapse rests on: one active workspace per installation, so the pass covers exactly the tenant that finished; on a fleet it re-walks days already built, which the digest's as-of-now idempotence is what made the pair affordable to collapse in the first place.

## Twenty-eight `FleetWide` markers

They said *"marks this a dispatcher: it enumerates and enqueues, and does no tenant work of its own"*. True of the five kinds that still fan out — over a connection or a build — and false of every pass that absorbed its child: a collapsed pass owns no workspace **and does the tenant work itself**.

They say that instead. The five real dispatchers keep the old wording, because for them it is still the truth.

## Seven doubled worker comments

The scripted conversion left the old `// X is the dispatcher…` line sitting above the new one, and four types had no replacement at all — so they still introduced themselves as dispatchers that enqueue.

`make check-backend` exit 0; `internal/compose` integration suite green.