### PR TITLE
The craftsmanship gate is green on main again: four bare any signatures

### DIFF
--- a/backend/gates/forwardmeasureparity_test.go
+++ b/backend/gates/forwardmeasureparity_test.go
@@ -109,6 +109,8 @@ func TestTheMeasureSiteListCoversEveryForwardMeasureEnum(t *testing.T) {
 // `weighted` and `manager_call` are words other schemas could reasonably use;
 // `commit_evidence` names this specific reading and nothing else in the
 // contract spells it.
+//
+//craft:ignore naked-any a decoded YAML document is untyped by nature — mappings, sequences and scalars arrive as any, and the switch below is the narrowing
 func walkForwardMeasureEnums(node any, at []string, found map[string]bool) {
 	switch shape := node.(type) {
 	case map[string]any:

--- a/backend/internal/modules/consent/lift_integration_test.go
+++ b/backend/internal/modules/consent/lift_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -427,7 +428,7 @@ func TestALiftOfTheLastStopSaysSo(t *testing.T) {
 	payload := lastLiftPayload(t, e)
 	if payload.RemainingSuppressions == nil || *payload.RemainingSuppressions != 0 ||
 		payload.StillSuppressed == nil || *payload.StillSuppressed {
-		t.Errorf("remaining = %d, still_suppressed = %v; want 0 and false with no stop left",
+		t.Errorf("remaining = %s, still_suppressed = %s; want 0 and false with no stop left",
 			derefInt(payload.RemainingSuppressions), derefBool(payload.StillSuppressed))
 	}
 }
@@ -470,7 +471,7 @@ func TestALiftReportsAnAddressPinnedStopAsStanding(t *testing.T) {
 	payload := lastLiftPayload(t, e)
 	if payload.StillSuppressed == nil || !*payload.StillSuppressed ||
 		payload.RemainingSuppressions == nil || *payload.RemainingSuppressions != 1 {
-		t.Errorf("remaining = %d, still_suppressed = %v; want 1 and true — the bounce on "+
+		t.Errorf("remaining = %s, still_suppressed = %s; want 1 and true — the bounce on "+
 			"%s is still live and the engine will still refuse this mail",
 			derefInt(payload.RemainingSuppressions), derefBool(payload.StillSuppressed), address)
 	}
@@ -479,23 +480,23 @@ func TestALiftReportsAnAddressPinnedStopAsStanding(t *testing.T) {
 // The three fields are optional on the wire so an older consumer keeps
 // validating, but this writer always sets them — so a nil in a failure message
 // is itself the news, and these print it rather than an address.
-func derefInt(v *int) any {
+func derefInt(v *int) string {
 	if v == nil {
 		return "absent"
 	}
-	return *v
+	return strconv.Itoa(*v)
 }
 
-func derefBool(v *bool) any {
+func derefBool(v *bool) string {
 	if v == nil {
 		return "absent"
 	}
-	return *v
+	return strconv.FormatBool(*v)
 }
 
-func derefUUID(v *openapi_types.UUID) any {
+func derefUUID(v *openapi_types.UUID) string {
 	if v == nil {
 		return "absent"
 	}
-	return *v
+	return v.String()
 }


### PR DESCRIPTION
## What

`make craft-static` is red on `main` with four `naked-any` MAJOR findings, and since `craftsmanship` is in the `ci` rollup's `needs`, every open pull request's required check is red with it. This PR clears the four:

- `backend/gates/forwardmeasureparity_test.go`: `walkForwardMeasureEnums(node any, …)` walks a decoded YAML document, which is untyped by nature. It now carries the same `//craft:ignore naked-any` waiver its sibling `walkPeriodEnums` in `forecastperiodparity_test.go` already carries, with the same reason.
- `backend/internal/modules/consent/lift_integration_test.go`: `derefInt`, `derefBool` and `derefUUID` exist to print a value or the word "absent" in a failure message, so they return the `string` they print (`strconv.Itoa`, `strconv.FormatBool`, `UUID.String()`), and the two `%d` verbs that consumed them become `%s`.

No behaviour changes; test code only.

## Why

The findings arrived with #4520 and #4522 today. The pre-push hook runs the gate diff-scoped, but CI runs the whole-tree sweep, and the invariant the rulebook states is that touched code is clean and there is no backlog to exempt. Until `main` is clean again no PR can go green on its own.

## How verified

- `go run -C cli/craft . static --strict --root ../../backend` on this head: `PASS — 0 blocker, 0 major, 0 minor` (it reports the four findings on `main`).
- `go vet` over `./gates/` and `./internal/modules/consent/`: clean; `gofmt` applied.
- `go test ./gates/ -run ForwardMeasure`: green.
- `make test-it DIR=backend/internal/modules/consent RUN=Lift` on a local Postgres 16: green, so the reworded failure messages compile and the lift cases still pass.

- [x] `make check` is green (the backend gates this touches; nothing else in the diff)
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape)
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

AI-generated in full, from the failing gate's own output, including this description.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167QGEr6WrGR7sWXd9VmMZU

---
_Generated by [Claude Code](https://claude.ai/code/session_0167QGEr6WrGR7sWXd9VmMZU)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four `naked-any` findings so the craftsmanship gate is green on main again and PRs can pass CI. Test-only change; no behavior changes.

- Adds a `//craft:ignore naked-any` waiver to `walkForwardMeasureEnums`, matching the sibling `walkPeriodEnums` waiver, because decoded YAML is untyped by nature.
- Changes `derefInt`, `derefBool`, and `derefUUID` in the consent lift integration test to return `string` (via `strconv.Itoa`, `strconv.FormatBool`, and `UUID.String()`) instead of `any`, since they only print values in failure messages; the two `%d` verbs that consumed them are now `%s`.

<sup>Written for commit c6afbd058248f748504c1d4abb2ba8828fad9de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

