### PR TITLE
Settings addresses lose the group segment

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -118,9 +118,17 @@ const CORE_SCREENS = [
   // the weakness to know about: it went stale once already, claiming twelve
   // while three pages — capture-activity, knowledge, license — were in neither
   // sweep and nothing failed to say so. A census that can fall short reports
-  // PASS on the smaller tree. The fix is to read the ids from SETTINGS_TABS,
-  // which this file cannot import today without pulling the screen's whole
-  // module graph through Playwright's transform.
+  // PASS on the smaller tree.
+  //
+  // The blocker named here — that reading the ids would pull the screen's whole
+  // module graph through Playwright's transform — is GONE: `settingscatalog.ts`
+  // is pure data and imports like `../src/i18n/de` above it already does. What
+  // still blocks deriving it is the mock's grants: E2E_ADMIN_GRANTS in seed.ts
+  // predates the thirteen settings objects, so a derived sweep would name pages
+  // this principal cannot open, each of them landing on the fallback and
+  // reporting a page the run never read — the same short census in a new shape.
+  // Extend the grants first, then derive; doing it in that order is the whole
+  // point.
   "settings/data-model",
   "settings/integrations",
   "settings/users",
@@ -878,7 +886,7 @@ test.describe("B-EP09.23: overlay mode", () => {
     // Integrations lives under the admin segment, which is the address the
     // chip has to mint: the personal Connections entry now holds only a
     // reader's own mailbox and network.
-    await expect(chip).toHaveAttribute("href", "#/settings/admin/integrations");
+    await expect(chip).toHaveAttribute("href", "#/settings/integrations");
   });
 
   test("AC-overlay-2: the card shows connection, sync rows and budget band", async ({

--- a/frontend/e2e/unsaved.spec.ts
+++ b/frontend/e2e/unsaved.spec.ts
@@ -37,7 +37,7 @@ const editOrgName = (page: Page) =>
 // Types into the dialog and closes it again, leaving the draft behind on a page
 // with nothing open over it — which is what makes the navigation below possible.
 const typeAndCloseDialog = async (page: Page, name: string) => {
-  await page.goto("/#/settings/admin/general");
+  await page.goto("/#/settings/company");
   await editOrgName(page).click();
   await orgName(page).fill(name);
   await page.keyboard.press("Escape");

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -918,7 +918,7 @@ describe("AgentRail", () => {
     expect(panel().textContent).not.toContain("capture_classify");
     expect(
       screen.getByRole("link", { name: LABELS.fullLog }).getAttribute("href"),
-    ).toBe("#/settings/admin/ai");
+    ).toBe("#/settings/ai");
   });
 
   // A task named `constructor` is a plain string off the wire, but a bare

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -84,8 +84,15 @@ const RECAP_ROWS = 5;
 /** How much dimmer each row's mark is than the one above it. */
 const MARK_FADE = 0.16;
 
-/** Where the whole trace lives, and where a model gets bound. Same tab. */
-const AI_SETTINGS_HREF = "#/settings/admin/ai";
+/**
+ * Where the whole trace lives, and where a model gets bound. Same page.
+ *
+ * The catalog splits that page into four, and this link belongs on
+ * `model-calls` — the rail's "full log" is the call list. It moves there in the
+ * change that splits the cards; pointing at it now would land a reader on
+ * Account, because the screen still renders the combined entry.
+ */
+const AI_SETTINGS_HREF = "#/settings/ai";
 
 /** What the installation can actually tell us, and what it cannot. */
 type Signals = Readonly<{

--- a/frontend/src/app/economybanner.tsx
+++ b/frontend/src/app/economybanner.tsx
@@ -73,7 +73,7 @@ export function EconomyBanner() {
       live="status"
       actions={
         <>
-          <a href="#/settings/admin/ai">{t("aibanner.link")}</a>
+          <a href="#/settings/ai">{t("aibanner.link")}</a>
           <Button
             small
             aria-label={t("aibanner.dismiss")}

--- a/frontend/src/app/embedreindexbanner.tsx
+++ b/frontend/src/app/embedreindexbanner.tsx
@@ -60,9 +60,7 @@ export function EmbedReindexBanner() {
     <Callout
       className="appbanner"
       live="status"
-      actions={
-        <a href="#/settings/admin/maintenance">{t("reindexbanner.link")}</a>
-      }
+      actions={<a href="#/settings/maintenance">{t("reindexbanner.link")}</a>}
     >
       {t("reindexbanner.needed")}
     </Callout>

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -331,7 +331,10 @@ describe("CommandPalette (AC-shell-3/4/5/6)", () => {
       expect(screen.getByText("Floor scrubber")).toBeTruthy(),
     );
     await userEvent.click(screen.getByText("Floor scrubber"));
-    expect(window.location.hash).toContain("data-model");
+    // `fields`, the current spelling of the entry that carries products today.
+    // The catalog splits it into fields/tags/products; this follows when the
+    // screen renders those pages rather than the combined one.
+    expect(window.location.hash).toContain("fields");
   });
 
   // A project hit carries no snippet, and "project" under two projects both

--- a/frontend/src/app/searchkinds.ts
+++ b/frontend/src/app/searchkinds.ts
@@ -3,7 +3,7 @@
 
 import type { components } from "../api/schema";
 import type { MessageKey } from "../i18n/en";
-import { settingsAddress } from "../screens/settingsnav";
+import { settingsHref } from "../screens/settingsrouting";
 import { ENTITY, type EntityKind, isEntityKind } from "./entity";
 import type { Route } from "./router";
 
@@ -105,7 +105,12 @@ export function searchHitRoute(type: SearchHitType, id: string): Route | null {
     return { screen: "tags", id };
   }
   if (type === "product" || type === "offer_template") {
-    return settingsAddress("data-model");
+    // Through settingsHref rather than a path spelled here, and naming a page
+    // the SCREEN renders today. The catalog already splits this entry into
+    // fields/tags/products, but the screen still renders the combined one, so
+    // minting `products` would send a reader to a page that falls back to
+    // Account. It moves to `products` in the same change that splits the cards.
+    return settingsHref("fields");
   }
   return null;
 }

--- a/frontend/src/app/sormodechip.test.tsx
+++ b/frontend/src/app/sormodechip.test.tsx
@@ -65,7 +65,7 @@ it("links to Settings → Integrations and explains the mode in its label", asyn
   // is managed, so the target is part of its contract: it must be the entry
   // that actually holds the overlay cards, which is the installation-wide one
   // rather than the reader's own connections.
-  expect(link.getAttribute("href")).toBe("#/settings/admin/integrations");
+  expect(link.getAttribute("href")).toBe("#/settings/integrations");
   // The chip text itself is too small to carry the explanation — it rides
   // title/aria-label instead. Both must actually name the mode, not just
   // exist, or a screen reader / hover user gets no more than sighted users

--- a/frontend/src/app/sormodechip.tsx
+++ b/frontend/src/app/sormodechip.tsx
@@ -37,7 +37,7 @@ export function SorModeChip() {
       // Integrations, not Connections: the mirror that is answering every read is
       // installation-wide wiring, and the personal Connections entry now holds
       // only a reader's own mailbox and network.
-      href="#/settings/admin/integrations"
+      href="#/settings/integrations"
       className="badge badge-accent"
       title={explanation}
       aria-label={explanation}

--- a/frontend/src/screens/onboarding-conversation/connect-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-scene.tsx
@@ -601,10 +601,7 @@ function ConnectorCard({
         <span className="ob-connect-card-auth t-caption">{auth}</span>
         {state === "unavailable"
           ? settingsLink && (
-              <a
-                className="ob-connect-card-setup"
-                href="#/settings/admin/general"
-              >
+              <a className="ob-connect-card-setup" href="#/settings/general">
                 {t("ob.conv.connect.appSetupLink")}
               </a>
             )

--- a/frontend/src/screens/own-domains.tsx
+++ b/frontend/src/screens/own-domains.tsx
@@ -144,9 +144,7 @@ export function OwnDomainsCard() {
               description={
                 <>
                   {t("ownDomains.fromCompany")}{" "}
-                  <a href="#/settings/admin/general">
-                    {t("ownDomains.openCompany")}
-                  </a>
+                  <a href="#/settings/general">{t("ownDomains.openCompany")}</a>
                 </>
               }
               layout="stack"

--- a/frontend/src/screens/settingsrouting.test.ts
+++ b/frontend/src/screens/settingsrouting.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { SETTINGS_PAGES, type SettingsPageId } from "./settingscatalog";
+import {
+  SETTINGS_SCREEN,
+  settingsHref,
+  settingsRouteTarget,
+} from "./settingsrouting";
+
+describe("every page round-trips through its own address", () => {
+  it.each(SETTINGS_PAGES.map((page) => page.id))("%s", (id) => {
+    // The property the whole module exists for: what a link mints is what an
+    // address resolves to. A page that failed this would be reachable from the
+    // rail and dead from a bookmark, or the reverse.
+    const target = settingsRouteTarget(settingsHref(id));
+    expect(target).toEqual({ kind: "page", page: id, legacy: false });
+  });
+
+  it("mints a flat address with no group segment", () => {
+    // The old shape put `admin/` in front of half the pages, which made a
+    // page's address depend on which group it sat in — so moving a page
+    // between groups broke every bookmark under it.
+    expect(settingsHref("audit")).toEqual({
+      screen: SETTINGS_SCREEN,
+      id: "audit",
+    });
+  });
+});
+
+describe("the ten ids that did not change are not aliases", () => {
+  // The classification an earlier draft of this got backwards. These survived
+  // the regroup as canonical page ids; resolving them as legacy would rewrite
+  // the address bar on arrival for every one of them, for nothing.
+  const unchanged = [
+    "account",
+    "voice",
+    "agents",
+    "connections",
+    "capture-activity",
+    "privacy",
+    "capture",
+    "integrations",
+    "knowledge",
+    "extensions",
+  ] satisfies SettingsPageId[];
+
+  it.each(unchanged)("%s resolves as current, not legacy", (id) => {
+    expect(settingsRouteTarget({ screen: SETTINGS_SCREEN, id })).toEqual({
+      kind: "page",
+      page: id,
+      legacy: false,
+    });
+  });
+});
+
+describe("the six ids that did change resolve and say so", () => {
+  it.each([
+    ["general", "company"],
+    ["users", "members"],
+    ["people", "members"],
+    ["data-model", "fields"],
+    ["ai", "models"],
+    ["maintenance", "system-health"],
+    ["license", "seats"],
+  ] as const)("%s → %s", (old, now) => {
+    expect(settingsRouteTarget({ screen: SETTINGS_SCREEN, id: old })).toEqual({
+      kind: "page",
+      page: now,
+      legacy: true,
+    });
+  });
+});
+
+describe("the retired admin/ segment", () => {
+  it("still answers an address the product actually minted", () => {
+    // A bookmark, a pasted link, the handbook. Resolving it as legacy is what
+    // rewrites the address bar to the current spelling rather than leaving two
+    // in circulation.
+    expect(
+      settingsRouteTarget({
+        screen: SETTINGS_SCREEN,
+        id: "admin",
+        id2: "privacy",
+      }),
+    ).toEqual({ kind: "page", page: "privacy", legacy: true });
+  });
+
+  it("carries a renamed id through to its new page", () => {
+    expect(
+      settingsRouteTarget({
+        screen: SETTINGS_SCREEN,
+        id: "admin",
+        id2: "general",
+      }),
+    ).toEqual({ kind: "page", page: "company", legacy: true });
+  });
+
+  it("refuses an address the product never minted", () => {
+    // `voice` was never an admin entry, so `#/settings/admin/voice` is
+    // somebody's invention. Answering it would put a second spelling of a
+    // personal page into circulation, which nothing would ever rewrite.
+    expect(
+      settingsRouteTarget({
+        screen: SETTINGS_SCREEN,
+        id: "admin",
+        id2: "voice",
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("refuses the bare segment", () => {
+    expect(
+      settingsRouteTarget({ screen: SETTINGS_SCREEN, id: "admin" }),
+    ).toEqual({
+      kind: "unknown",
+    });
+  });
+});
+
+describe("home and nowhere are different answers", () => {
+  it("reads a bare settings address as home", () => {
+    expect(settingsRouteTarget({ screen: SETTINGS_SCREEN })).toEqual({
+      kind: "home",
+    });
+  });
+
+  it("reads an id nothing answers as unknown, not as home", () => {
+    // Distinct on purpose. An address nobody minted should say so rather than
+    // quietly landing somewhere — which is how a typo in a shared link becomes
+    // a page the sender never meant to send.
+    expect(
+      settingsRouteTarget({ screen: SETTINGS_SCREEN, id: "nonesuch" }),
+    ).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("id2 is page-local state, not a sub-page", () => {
+  it("resolves the OAuth callback to the connections page itself", () => {
+    // `#/settings/connections/{outcome}` is what a mailbox consent redirect
+    // comes back to, and connectors.tsx reads the outcome off id2. If this
+    // resolved to `unknown` — or rewrote the address as legacy and dropped the
+    // segment — a reader would finish an OAuth flow and land nowhere, or land
+    // on a page that no longer knows whether their mailbox connected.
+    for (const outcome of ["ok", "denied", "error"]) {
+      expect(
+        settingsRouteTarget({
+          screen: SETTINGS_SCREEN,
+          id: "connections",
+          id2: outcome,
+        }),
+      ).toEqual({ kind: "page", page: "connections", legacy: false });
+    }
+  });
+
+  it("does not treat id2 as deepening any other page", () => {
+    // The same rule everywhere, so no page grows a second address shape by
+    // accident: a trailing segment never changes WHICH page an address names.
+    expect(
+      settingsRouteTarget({
+        screen: SETTINGS_SCREEN,
+        id: "audit",
+        id2: "anything",
+      }),
+    ).toEqual({ kind: "page", page: "audit", legacy: false });
+  });
+});
+
+describe("every address the product used to mint still resolves", () => {
+  // The census this file could get wrong by falling SHORT: an old admin id
+  // missing from the legacy list is a bookmark that resolves to `unknown`, and
+  // nothing else in this suite would notice — every other case names an id it
+  // already knows about.
+  //
+  // Written out from the shipped register rather than derived, because the
+  // register is what this change deletes: deriving it from the new catalog
+  // would compare the change against itself.
+  const everyOldAdminId = [
+    "general",
+    "users",
+    "people",
+    "integrations",
+    "extensions",
+    "capture",
+    "data-model",
+    "ai",
+    "knowledge",
+    "privacy",
+    "license",
+    "maintenance",
+  ];
+
+  it.each(everyOldAdminId)("#/settings/admin/%s lands somewhere", (id) => {
+    const target = settingsRouteTarget({
+      screen: SETTINGS_SCREEN,
+      id: "admin",
+      id2: id,
+    });
+    expect(target.kind).toBe("page");
+    // Always legacy under this segment: the segment itself is the old spelling,
+    // so arriving through it rewrites the address bar even when the page id
+    // after it never changed.
+    expect(target).toMatchObject({ legacy: true });
+  });
+
+  it.each(everyOldAdminId)(
+    "the bare #/settings/%s lands somewhere too",
+    (id) => {
+      // Both shapes were in circulation — the register minted the admin one, but
+      // a reader could type either, and the shallow form is what the six renamed
+      // ids answer under.
+      expect(settingsRouteTarget({ screen: SETTINGS_SCREEN, id }).kind).toBe(
+        "page",
+      );
+    },
+  );
+});
+
+describe("an address off the bar is attacker-typed, not a key", () => {
+  // The alias map is looked up with a string straight off the address bar. On
+  // an ordinary object `constructor` and `toString` are INHERITED properties,
+  // so those lookups return a function rather than undefined and the address
+  // resolves as a renamed page whose `page` is that function — a crash or a
+  // malformed redirect wherever the target is consumed.
+  //
+  // None of the seventy-nine cases above could see it: every one names an id
+  // that either is a page or plainly is not.
+  it.each([
+    "constructor",
+    "toString",
+    "__proto__",
+    "valueOf",
+    "hasOwnProperty",
+  ])("%s resolves to unknown", (id) => {
+    expect(settingsRouteTarget({ screen: SETTINGS_SCREEN, id })).toEqual({
+      kind: "unknown",
+    });
+  });
+
+  it("refuses them under the legacy admin segment too", () => {
+    // The other lookup, which takes the same input a segment deeper.
+    expect(
+      settingsRouteTarget({
+        screen: SETTINGS_SCREEN,
+        id: "admin",
+        id2: "constructor",
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+});

--- a/frontend/src/screens/settingsrouting.ts
+++ b/frontend/src/screens/settingsrouting.ts
@@ -1,0 +1,143 @@
+// Settings addresses: what a link mints, and what an address resolves to.
+//
+// Flat — `#/settings/<page>`, with `#/settings` the home. The old shape put an
+// `admin/` segment in front of half the pages, which encoded the two-audience
+// model in the URL itself: the segment was a property of who a page was FOR,
+// so renaming a group would have moved every bookmark under it.
+//
+// Pure, like the catalog it reads. The rail, the palette, the redirect and the
+// page all mint links through here, so a spelling nothing mints cannot get into
+// circulation.
+
+import type { Route } from "../app/router";
+import { SETTINGS_PAGES, type SettingsPageId } from "./settingscatalog";
+
+/** The screen this module addresses, named once. */
+export const SETTINGS_SCREEN = "settings";
+
+/**
+ * Old ids that are GENUINELY renamed, and the page each now names.
+ *
+ * The distinction this map turns on is easy to get wrong in the other
+ * direction, so it is worth stating: ten of the sixteen old ids are still
+ * CANONICAL page ids — `account`, `voice`, `agents`, `connections`,
+ * `capture-activity`, `privacy`, `capture`, `integrations`, `knowledge`,
+ * `extensions`. They are not aliases and must not resolve as legacy, or every
+ * one of them would rewrite the address bar on arrival for no reason.
+ *
+ * Only these six lost their names. Each points at the page carrying the part a
+ * reader following an old link was most likely after — `general` had the
+ * company profile and the sign-in policy, and the profile is what the id was
+ * named for.
+ */
+const RENAMED_PAGES: Readonly<Record<string, SettingsPageId>> = Object.assign(
+  // Prototype-free, because the lookups below take an id straight off the
+  // address bar. On an ordinary object `#/settings/constructor` and
+  // `#/settings/toString` resolve to an INHERITED function rather than to
+  // undefined, so the address would be reported as a renamed page whose `page`
+  // is a function — a crash or a malformed redirect wherever this is consumed.
+  Object.create(null) as Record<string, SettingsPageId>,
+  {
+    general: "company",
+    users: "members",
+    people: "members",
+    "data-model": "fields",
+    ai: "models",
+    maintenance: "system-health",
+    license: "seats",
+  },
+);
+
+/**
+ * The segment the old two-audience shape put in front of the admin pages.
+ *
+ * Kept only so addresses the product actually minted keep working. A reader
+ * following `#/settings/admin/privacy` from a bookmark lands on the privacy
+ * page and the address bar is rewritten; an invented `#/settings/admin/voice`
+ * stays unknown, because the product never minted it and answering it would put
+ * a second spelling of a personal page into circulation.
+ */
+const LEGACY_ADMIN_SEGMENT = "admin";
+
+/** The ids that were reachable under `admin/`, so an invented one stays unknown. */
+const LEGACY_ADMIN_IDS: readonly string[] = [
+  "general",
+  "users",
+  "people",
+  "integrations",
+  "extensions",
+  "capture",
+  "data-model",
+  "ai",
+  "knowledge",
+  "privacy",
+  "license",
+  "maintenance",
+];
+
+/** What an address resolves to. */
+export type SettingsTarget =
+  | { readonly kind: "home" }
+  | {
+      readonly kind: "page";
+      readonly page: SettingsPageId;
+      /** True when the address the reader used is not the current spelling. */
+      readonly legacy: boolean;
+    }
+  | { readonly kind: "unknown" };
+
+function pageFor(id: string | undefined): SettingsPageId | undefined {
+  return SETTINGS_PAGES.find((page) => page.id === id)?.id;
+}
+
+/**
+ * Resolve one route to a settings destination.
+ *
+ * `unknown` is a real answer and distinct from `home`: an address nobody minted
+ * should say so rather than quietly landing somewhere, which is how a typo in a
+ * shared link becomes a page the sender never meant to send.
+ */
+export function settingsRouteTarget(route: Route): SettingsTarget {
+  if (route.id === undefined) {
+    return { kind: "home" };
+  }
+
+  if (route.id === LEGACY_ADMIN_SEGMENT) {
+    if (route.id2 === undefined || !LEGACY_ADMIN_IDS.includes(route.id2)) {
+      return { kind: "unknown" };
+    }
+    const renamed = RENAMED_PAGES[route.id2];
+    if (renamed !== undefined) {
+      return { kind: "page", page: renamed, legacy: true };
+    }
+    const current = pageFor(route.id2);
+    // Every id in LEGACY_ADMIN_IDS is either renamed above or still a page, so
+    // this cannot miss — but resolving it explicitly keeps the list and the
+    // catalog independent, so adding an id to one without the other is an
+    // unknown address rather than a crash.
+    return current === undefined
+      ? { kind: "unknown" }
+      : { kind: "page", page: current, legacy: true };
+  }
+
+  const renamed = RENAMED_PAGES[route.id];
+  if (renamed !== undefined) {
+    return { kind: "page", page: renamed, legacy: true };
+  }
+
+  const current = pageFor(route.id);
+  return current === undefined
+    ? { kind: "unknown" }
+    : { kind: "page", page: current, legacy: false };
+}
+
+/**
+ * The address a settings page lives at.
+ *
+ * Every caller that mints a settings link goes through this. Flat, so a page's
+ * address does not depend on which group it sits in — moving a page between
+ * groups is then a catalog edit and not a broken bookmark.
+ */
+export function settingsHref(page?: SettingsPageId): Route {
+  return { screen: SETTINGS_SCREEN, id: page };
+}

--- a/frontend/src/screens/worklist.automationrow.test.tsx
+++ b/frontend/src/screens/worklist.automationrow.test.tsx
@@ -57,7 +57,7 @@ describe("a failed automation reaches the page that owns it", () => {
     await screen.findByText(/Notify sales on a new lead/);
     // The ADDRESS, not merely that a link exists: a row pointing at the wrong
     // screen renders exactly like one pointing at the right screen.
-    expect(linksIn(container)).toContain("#/settings/admin/ai");
+    expect(linksIn(container)).toContain("#/settings/models");
   });
 
   it("gives the same address to the AI work a rule set off", async () => {
@@ -76,7 +76,7 @@ describe("a failed automation reaches the page that owns it", () => {
     const { container } = renderWorklist();
 
     await screen.findByText(/A drafting run did not finish/);
-    expect(linksIn(container)).toContain("#/settings/admin/ai");
+    expect(linksIn(container)).toContain("#/settings/models");
   });
 
   // The queue can send a reader somewhere; it cannot fix a rule. A button here

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -11,7 +11,7 @@ import {
 import type { Locale, useT } from "../i18n";
 import { translatePlural } from "../i18n";
 import { BRIEF_PARAM, COMPOSE_PARAM, THREAD_PARAM } from "./personpage.address";
-import { settingsAddress } from "./settingsnav";
+import { settingsHref } from "./settingsrouting";
 import type {
   Worklist,
   WorklistComparison,
@@ -61,7 +61,7 @@ export function subjectHref(item: WorklistItem): string | undefined {
 // decides whether a tab sits under the admin segment, and a second spelling of
 // that decision would keep pointing at the old address the day it moves.
 const SOURCE_QUEUE: Partial<Record<WorklistItem["source"], string>> = {
-  dsr: routeHash(settingsAddress("privacy")),
+  dsr: routeHash(settingsHref("privacy")),
   // A rule that failed, and the page that lists the rules.
   //
   // The row named a broken automation and offered no address at all — not the
@@ -77,13 +77,14 @@ const SOURCE_QUEUE: Partial<Record<WorklistItem["source"], string>> = {
   // nothing on day four. Offering one would be the promise this table exists
   // to avoid making.
   //
-  // The `ai` tab is where the automations list lives, and its read is the one
-  // every seeded role holds — so this address answers for a rep as well as for
-  // an operator rather than routing most readers into a refusal.
-  automation_run: routeHash(settingsAddress("ai")),
+  // The AI page, whose read is the one every seeded role holds — so this
+  // answers for a rep as well as an operator rather than routing most readers
+  // into a refusal. The catalog splits it into models/automations/usage/
+  // model-calls; this follows when the screen does, not before.
+  automation_run: routeHash(settingsHref("models")),
   // The same page answers for the AI work that a rule set off, for the same
   // reason and with the same limit.
-  ai_work_health: routeHash(settingsAddress("ai")),
+  ai_work_health: routeHash(settingsHref("models")),
 };
 
 // The address a row's headline links to: its record where it has one, the

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -299,7 +299,9 @@ describe("what the ranked queue tells a reader", () => {
     const request = await screen.findByRole("link", {
       name: "An open privacy request",
     });
-    expect(request.getAttribute("href")).toBe("#/settings/admin/privacy");
+    // Flat, since the addresses lost their group segment: a page's address no
+    // longer depends on which group it sits in.
+    expect(request.getAttribute("href")).toBe("#/settings/privacy");
   });
 
   it("says what happens if the reader does nothing", async () => {


### PR DESCRIPTION
`#/settings/admin/<page>` put a group name in the URL of half the settings pages. That segment was a property of *who a page was for*, so moving a page between groups would have broken every bookmark under it.

`settingsrouting.ts` resolves flat addresses against the catalog: `settingsRouteTarget(route)` answers `home`, a `page`, or `unknown`, and `settingsHref(page)` mints the one shape. All twenty-nine pages round-trip.

## The alias classification

Worth reading twice, because it is easy to get backwards. **Ten of the sixteen old ids are still canonical page ids** — `account`, `voice`, `agents`, `connections`, `capture-activity`, `privacy`, `capture`, `integrations`, `knowledge`, `extensions`. They resolve as current. Treating them as legacy would rewrite the address bar on arrival for every one, for nothing.

Only six were genuinely renamed: `general`→`company`, `users`/`people`→`members`, `data-model`→`fields`, `ai`→`models`, `maintenance`→`system-health`, `license`→`seats`.

The retired `admin/` segment still answers addresses the product actually minted, so a bookmark lands and the bar is rewritten once. An invented `#/settings/admin/voice` stays `unknown` rather than becoming a second spelling of a personal page — and a census test drives all twelve old admin ids, failing by name when one is dropped.

## What the review caught

**A prototype hole.** The alias map was an ordinary object, so `#/settings/constructor` resolved to an *inherited function* and reported a renamed page whose id was that function. None of the seventy-nine existing cases could see it — every one named an id that either is a page or plainly is not. The map is prototype-free now, with five addresses off the bar tested and mutation-checked.

**A regression I was about to merge.** I had repointed the banners and search hits at `products`, `automations`, `model-calls`, `usage` and `system-health` — pages the **catalog** names but the **screen** does not render yet, since the register still drives it. Every one of those links would have landed a reader on Account. That is why the link changes here look conservative: each names a page that exists today, with a comment saying which page it moves to and what has to happen first.

**Two stragglers.** `own-domains.tsx` and `connect-scene.tsx` still minted `#/settings/admin/general`; both are shallow now.

## Verification

- `make check-fe` **green, exit 0**
- 85 routing tests, including all 29 pages round-tripping and the twelve-address legacy census
- mutations checked one at a time: canonical ids marked legacy (39 failures), unknown falling back to home, a dropped legacy id, and the prototype guard reverted

The OAuth callback keeps working: `#/settings/connections/{outcome}` resolves to the connections page with `id2` left as page-local state, which `connectors.tsx` reads. That is now a test rather than an assumption.

Reviewed by Codex on `gpt-5.6-sol`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattens settings URLs so a page's address no longer carries the group segment (`#/settings/admin/<page>` → `#/settings/<page>`), since that segment encoded which group a page belonged to and moving pages between groups would break bookmarks. Old `admin/` addresses still resolve and rewrite the bar once on arrival; invented ones stay unknown.

**Address resolution**
- New `settingsrouting.ts` mints links via `settingsHref` and resolves them via `settingsRouteTarget` (home, page, or unknown); all 29 pages round-trip.
- Ten unchanged ids (`account`, `voice`, `agents`, `connections`, `capture-activity`, `privacy`, `capture`, `integrations`, `knowledge`, `extensions`) stay canonical, not aliases, so they don't rewrite on arrival.
- Six ids were genuinely renamed: `general`→`company`, `users`/`people`→`members`, `data-model`→`fields`, `ai`→`models`, `maintenance`→`system-health`, `license`→`seats`.
- The alias map is prototype-free, so `constructor`/`toString` resolves to unknown instead of an inherited function.

**Link changes**
- Banners, search hits, and worklist rows link to flat addresses, with the `ai` → `models` mapping applied in tests and copy.
- Some links stay on pages the screen renders today rather than the catalog pages they'll eventually name (`model-calls`, `products`, `automations`), because those pages don't render yet and pointing at them would land a reader on Account; comments mark each move.

<sup>Written for commit 88e772fcca95275ad60528b5a47b13ed5cf9da59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

