### PR TITLE
A backfill that lost its pager gets one back

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -272,6 +272,40 @@ kinds:
       linked one, and writes only what changed. The hash covers the source's own
       values, so a pass over an unchanged ledger writes nothing.
 
+  capture_backfill_reconcile:
+    role: worker
+    fleet: true
+    go_type: CaptureBackfillReconcileArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    registration: {when: [GmailRegistry], absent: registers_nothing}
+    reason: >-
+      The nightly pass ADR-0063 called for and nobody built: it puts a paging
+      job back behind every backfill run that is still live.
+
+      IT EXISTS BECAUSE TWO CORRECT DECISIONS MEET BADLY. capture_backfill is
+      inserted with one attempt, because the run ROW owns the outcome and a
+      River retry would re-page a run the engine already ended; and a run is
+      protected by a unique index over the connection while it is queued or
+      running, so one import cannot start on top of another. If that single
+      attempt is ever lost to something the engine never sees — a worker killed
+      mid-page, a rescue, a queue that dropped it — the row stays live with no
+      job behind it, and the index then refuses every future StartBackfill for
+      that connection. The import stops and the only symptom is a person who
+      cannot start one.
+
+      It re-enqueues rather than deciding anything: the insert carries the same
+      ByArgs uniqueness the start does, so a run whose job is alive dedupes onto
+      it and a run whose job is gone gets a new one. Nightly rather than
+      minutely because the failure it repairs is rare and its cost is a delay,
+      not a loss — and a pass that ran often enough to notice quickly would
+      spend its every tick confirming that nothing was wrong.
+
+      Two minutes bounds an enumeration and an insert per live run. It does no
+      paging itself: the job it queues does that, under its own eight.
+
   capture_backfill:
     role: worker
     go_type: CaptureBackfillArgs

--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -28,7 +28,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertest"
 	"github.com/riverqueue/river/rivertype"
 
 	"github.com/margince/margince/backend/internal/compose/costestimate"
@@ -705,4 +709,88 @@ func assertAStepOnAVanishedRunIsTerminal(t *testing.T, b *backfillWireEnv) {
 // authztest.AdmittedFromPair for why the body is not written out here.
 func (r backfillAuthority) AdmittedAuthority(ctx context.Context, ws, human, _ ids.UUID) (authz.RBAC, principal.SeatType, error) {
 	return authztest.AdmittedFromPair(ctx, ws, human, r.EffectiveRBAC, r.SeatType)
+}
+
+// The nightly reconcile puts a pager back behind a run that lost its own, and
+// leaves a healthy run alone (ADR-0063, #1857).
+//
+// THE TRAP IT REPAIRS is two correct decisions meeting badly. A pager is
+// inserted with ONE attempt, because the run row owns the outcome and a River
+// retry would re-page a run the engine already ended; and a run is protected by
+// a unique index over its connection while it is queued or running, so one
+// import cannot start on top of another. Lose that single attempt to something
+// the engine never sees — a worker killed mid-page, a rescue, a queue that
+// dropped it — and the row stays live with no job behind it. The index then
+// refuses every future StartBackfill for that connection, and the only symptom
+// is a person who cannot start one.
+//
+// The stranded state is built the way the strand happens rather than described:
+// StartBackfill is given an enqueue that does nothing, so the run is committed
+// live with no pager, which is exactly the row a lost attempt leaves.
+func TestTheNightlyReconcileRestoresAPagerAndDoesNotDoubleOne(t *testing.T) {
+	b := setupBackfillWire(t)
+	ctx := principal.WithWorkspaceID(context.Background(), b.env.WS)
+	// The client is built here rather than taken from platform/jobs, which holds
+	// its own unexported — an insert-only client, exactly the shape
+	// jobs.NewInserter builds, so what this drives is the real insert path.
+	client, err := river.NewClient(riverpgxv5.New(b.env.Pool), &river.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("river.NewClient: %v", err)
+	}
+	jobCtx := rivertest.WorkContext(ctx, client)
+
+	runID := strandedBackfill(t, b)
+	worker := &captureBackfillReconcileWorker{
+		pool: b.env.Pool, registry: b.registry,
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if n := pagersFor(t, b.env.Pool, runID); n != 0 {
+		t.Fatalf("the fixture starts with %d pager(s); it must strand the run, or this proves nothing", n)
+	}
+	if err := worker.reconcileWorkspace(jobCtx, b.env.WS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n := pagersFor(t, b.env.Pool, runID); n != 1 {
+		t.Fatalf("%d pager(s) after the reconcile, want 1 — a live run with no job blocks its connection permanently", n)
+	}
+
+	// AND AGAIN, because the pass runs nightly against runs that are usually
+	// healthy. The insert carries the start's own ByArgs uniqueness, so the
+	// second night dedupes onto the job the first one queued rather than
+	// stacking a second pager on the same run.
+	if err := worker.reconcileWorkspace(jobCtx, b.env.WS); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if n := pagersFor(t, b.env.Pool, runID); n != 1 {
+		t.Fatalf("%d pager(s) after a second reconcile, want 1 — the pass must dedupe onto a live job, not stack another", n)
+	}
+}
+
+// strandedBackfill opens a run with an enqueue that does nothing, leaving the
+// row live with no pager — the state a lost attempt produces.
+func strandedBackfill(t *testing.T, b *backfillWireEnv) ids.UUID {
+	t.Helper()
+	run, err := b.registry.StartBackfill(b.human, "gmail", ids.From[ids.UserKind](b.env.Rep1), 6, 25,
+		func(context.Context, pgx.Tx, ids.UUID) error { return nil })
+	if err != nil {
+		t.Fatalf("StartBackfill: %v", err)
+	}
+	return run.ID
+}
+
+// pagersFor counts the live pagers naming one run.
+func pagersFor(t *testing.T, pool *pgxpool.Pool, runID ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*) FROM river_job
+		 WHERE kind = $1 AND args->>'backfill_id' = $2
+		   AND state IN ('available', 'scheduled', 'retryable', 'pending', 'running')`,
+		CaptureBackfillArgs{}.Kind(), runID.String()).Scan(&n); err != nil {
+		t.Fatalf("counting pagers: %v", err)
+	}
+	return n
 }

--- a/backend/internal/compose/capturebackfillreconcile.go
+++ b/backend/internal/compose/capturebackfillreconcile.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The nightly repair behind mailbox backfill (ADR-0063). A paging job is
+// inserted with one attempt because the run row owns the outcome, and a run
+// is protected by a unique index over its connection while it is live. Lose
+// that one attempt to something River never sees and the run stays live with
+// no job — and the index then refuses every future start on that connection.
+// This pass re-enqueues, under the same uniqueness the start uses, so a live
+// job absorbs the insert and a lost one is replaced.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// CaptureBackfillReconcileArgs is the nightly pass that puts a paging job back
+// behind every backfill run that is still live (ADR-0063).
+type CaptureBackfillReconcileArgs struct{}
+
+// Kind is the stable job identifier River persists in river_job.
+func (CaptureBackfillReconcileArgs) Kind() string { return "capture_backfill_reconcile" }
+
+// FleetWide marks this as answering for the whole installation: it owns no
+// workspace, and walks them itself (jobs.FleetWide, ADR-0103).
+func (CaptureBackfillReconcileArgs) FleetWide() {}
+
+// captureBackfillReconcileWorker re-enqueues the runs nothing is paging.
+//
+// It DECIDES NOTHING, and that is the whole design. A run that is queued or
+// running is owed a job; the insert carries the same ByArgs uniqueness the
+// start does, so a run whose job is alive dedupes onto it and a run whose job
+// is gone gets a new one. There is no staleness threshold to tune and no
+// judgement about whether a run "looks stuck" — the uniqueness answers that
+// exactly, and a wrong answer from a heuristic would either re-page a healthy
+// import or leave a stranded one stranded.
+//
+// It does not fail runs either. A stranded run has recorded no failure —
+// nothing failed, something disappeared — so its give-up cap has nothing to say
+// about it. What decides whether it keeps going is the engine, on the next page
+// it actually runs.
+type captureBackfillReconcileWorker struct {
+	pool     *pgxpool.Pool
+	registry *capture.Registry
+	log      *slog.Logger
+}
+
+func (w *captureBackfillReconcileWorker) Work(ctx context.Context, _ *river.Job[CaptureBackfillReconcileArgs]) error {
+	return jobs.FaultContext(ctx, runPerWorkspace(ctx, w.pool, w.reconcileWorkspace))
+}
+
+func (w *captureBackfillReconcileWorker) reconcileWorkspace(ctx context.Context, workspace ids.UUID) error {
+	wsCtx := principal.WithWorkspaceID(ctx, workspace)
+	live, err := w.registry.LiveBackfills(wsCtx)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, id := range live {
+		// One insert per run, each in its own transaction: a run whose enqueue
+		// is refused must not take the others down with it, because they are
+		// unrelated imports that happen to be live at the same moment.
+		if err := w.enqueuePaging(wsCtx, workspace, id); err != nil {
+			failures = append(failures, fmt.Errorf("backfill %s: %w", id, err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// enqueuePaging offers ONE run a paging job, on the same terms the start does.
+//
+// The options are the start's, deliberately spelled the same way: one attempt,
+// because the run row owns the outcome, and ByArgs uniqueness over the active
+// states, which is what makes this whole pass idempotent. A different cap or a
+// different window here would make a re-enqueued run behave unlike a started
+// one, and the difference would only ever show up on the runs that had already
+// gone wrong once.
+// The AMBIENT client, the way this file's other one-off enqueues reach River:
+// this runs inside a job, so the client that is working it is the one to insert
+// through. The Safely variant is deliberate — the plain ClientFromContext
+// panics when there is none, and reaching this from outside a running job is a
+// wiring mistake worth an error rather than a crash.
+func (w *captureBackfillReconcileWorker) enqueuePaging(ctx context.Context, workspace, backfillID ids.UUID) error {
+	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
+	if err != nil {
+		return fmt.Errorf("no River client in context: %w", err)
+	}
+	_, err = client.Insert(ctx, CaptureBackfillArgs{
+		Workspace: workspace, BackfillID: backfillID.String(),
+	}, &river.InsertOpts{
+		MaxAttempts: rowOwnedMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	})
+	return err
+}

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "3c27788b9c8659aa51e648db4cce293fd8655ca7721c4b1faba697735c95abd3"
+const jobContractHash = "253c873e99809cdb538a3da45bfb8e43db5c16d5c16f72b20fcd05a5d8a56101"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -36,6 +36,7 @@ type declaredJobArgs interface {
 		BriefGenerateArgs |
 		CaptureAutoEnrichSweepArgs |
 		CaptureBackfillArgs |
+		CaptureBackfillReconcileArgs |
 		CaptureClassifyArgs |
 		ConfidentialityVerdictArgs |
 		CounterpartyVerdictArgs |
@@ -129,6 +130,7 @@ var (
 	_ jobs.FleetWide = AssuranceSweepArgs{}
 	_ jobs.FleetWide = BriefGenerateArgs{}
 	_ jobs.FleetWide = CaptureAutoEnrichSweepArgs{}
+	_ jobs.FleetWide = CaptureBackfillReconcileArgs{}
 	_ jobs.FleetWide = CaptureClassifyArgs{}
 	_ jobs.FleetWide = ConfidentialityVerdictArgs{}
 	_ jobs.FleetWide = CounterpartyVerdictArgs{}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -450,6 +450,7 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 		periodicFor(cfg, CaptureTraceSweepArgs{}),
 		periodicFor(cfg, OrgNamePromotionArgs{}),
 		periodicFor(cfg, CaptureDigestArgs{}),
+		periodicFor(cfg, CaptureBackfillReconcileArgs{}),
 		periodicFor(cfg, BriefGenerateArgs{}),
 		periodicFor(cfg, WeeklyReviewGenerateArgs{}),
 		periodicFor(cfg, GmailSyncArgs{}),

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -51,9 +51,13 @@ func addGmailCaptureJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConf
 	// dispatcher's own cadence can be frequent without meaning frequent
 	// provider calls.
 	addDeclaredWorker[CaptureSyncArgs](reg, &captureSyncWorker{registry: cfg.GmailRegistry, log: log})
-	// Backfill jobs are enqueued by the api (start op); the worker role only
-	// needs the pager registered.
+	// Backfill jobs are enqueued by the api (start op); the worker role needs
+	// the pager registered, and the nightly reconcile that puts a pager back
+	// behind a run whose own was lost (ADR-0063).
 	addDeclaredWorker[CaptureBackfillArgs](reg, &captureBackfillWorker{registry: cfg.GmailRegistry, log: log})
+	addDeclaredWorker[CaptureBackfillReconcileArgs](reg, &captureBackfillReconcileWorker{
+		pool: pool, registry: cfg.GmailRegistry, log: log,
+	})
 	if cfg.GmailWatch.Topic == "" {
 		return
 	}

--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -296,3 +296,38 @@ func (r *Registry) CancelBackfill(ctx context.Context, provider string, userID i
 	}
 	return r.BackfillStatus(ctx, provider, userID)
 }
+
+// LiveBackfills answers the runs this workspace still owes work on: every row
+// the live-run index counts, which is queued or running.
+//
+// It exists for the nightly reconcile (ADR-0063), and the shape of the problem
+// is why. A backfill's paging job is inserted with ONE attempt — the row owns
+// the outcome, so a River retry would re-page a run the engine already ended —
+// and the run is protected by a unique index over (connection_id) WHERE status
+// IN ('queued', 'running'). Those two together are the trap: if that single
+// attempt is lost to something the engine never sees — a worker killed
+// mid-page, a rescue, a queue that dropped it — the row stays live with no job
+// behind it, and the index then refuses every future StartBackfill for that
+// connection. The import stops, and the only symptom is a person who cannot
+// start one.
+//
+// A run's own give-up cap is NOT consulted here. A stranded run has recorded no
+// failure — nothing failed, something disappeared — so the cap has nothing to
+// say about it; what decides whether a re-enqueued run keeps going is the
+// engine, on the next page it actually runs.
+func (r *Registry) LiveBackfills(ctx context.Context) ([]ids.UUID, error) {
+	var ids0 []ids.UUID
+	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM capture_backfill
+			 WHERE status IN ('queued', 'running')
+			 ORDER BY created_at`)
+		if err != nil {
+			return fmt.Errorf("capture: reading the live backfills: %w", err)
+		}
+		defer rows.Close()
+		ids0, err = pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+		return err
+	})
+	return ids0, err
+}

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "3c27788b9c8659aa51e648db4cce293fd8655ca7721c4b1faba697735c95abd3"
+const JobContractHash = "253c873e99809cdb538a3da45bfb8e43db5c16d5c16f72b20fcd05a5d8a56101"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -128,6 +128,17 @@ var specs = map[string]Spec{
 		Registration: Registration{When: []string{"GmailRegistry"}},
 		Fault:        FaultPolicy{NilAfterLogging: "the backfill ROW owns the outcome: RunBackfillStep ends the run and records the fault class on the row against its own give-up cap, on a context detached from the job because the job context dying mid-page is the commonest fault. A River retry would re-page a run the engine already ended."},
 		Args:         []ArgField{{Name: "BackfillID"}, {Name: "Workspace"}},
+	},
+	"capture_backfill_reconcile": {
+		Kind:         "capture_backfill_reconcile",
+		GoType:       "CaptureBackfillReconcileArgs",
+		Role:         Worker,
+		Fleet:        true,
+		Queue:        "default",
+		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
+		OptsOwner:    OptsCaller,
+		Cadence:      Cadence{Fixed: 24 * time.Hour},
+		Registration: Registration{When: []string{"GmailRegistry"}},
 	},
 	"capture_classify": {
 		Kind:         "capture_classify",


### PR DESCRIPTION
The last of #1857. ADR-0063 called for a single nightly dispatcher over mailbox backfill and it was never built — bounded and previewed both shipped, this is the third thing that record asked for.

## What it repairs

Two correct decisions meeting badly.

A pager is inserted with **one attempt**, because the run row owns the outcome and a River retry would re-page a run the engine already ended. And a run is protected by a **unique index over its connection** while it is queued or running, so one import cannot start on top of another.

Lose that single attempt to something the engine never sees — a worker killed mid-page, a rescue, a queue that dropped it — and the row stays live with no job behind it. The index then refuses **every future `StartBackfill` for that connection**. The import stops, nothing reports it, and the only symptom is a person who cannot start one.

The code already knew the shape of this. Two comments in the pager warn about stranding a run *"queued/running, blocking every future StartBackfill for the connection"* — as a thing to avoid doing, with nothing to repair it if it happened anyway.

## It decides nothing

Every live run is owed a job, and the insert carries **the same `ByArgs` uniqueness the start does**. A run whose pager is alive dedupes onto it; a run whose pager is gone gets a new one.

There is no staleness threshold to tune and no judgement about whether a run "looks stuck" — the uniqueness answers that exactly, where a heuristic would either re-page a healthy import or leave a stranded one stranded.

It does not fail runs either. A stranded run has recorded **no failure** — nothing failed, something disappeared — so its give-up cap has nothing to say about it. What decides whether it continues is the engine, on the next page it actually runs.

Nightly rather than minutely because what it repairs is rare and costs a delay rather than a loss; a pass frequent enough to notice quickly would spend every tick confirming nothing was wrong.

## The fixture strands a run the way the strand happens

`StartBackfill` is given an enqueue that does nothing — exactly the row a lost attempt leaves — rather than a row hand-written to look like one.

| mutation | result |
|---|---|
| reconcile enqueues nothing | `0 pager(s) after the reconcile, want 1` |
| drop the `ByArgs` uniqueness | `2 pager(s) after a second reconcile, want 1` |

## Verification

`make check-backend` exit 0; `internal/compose` and `integration/capture` suites green. Kind count 68 → 69. The reconcile lives in its own file: `capturejobs.go` was already at the 500-LOC cap..

**This closes #1857's scope** alongside #4526 (the metric label) and #4534 (the collapse's stale comments).