### PR TITLE
A crawl that filled its page budget is not a fault

### DIFF
--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -133,7 +133,7 @@ func readWarnings(legalWarning string, extractErr error, jsShell bool) []string 
 		warnings = append(warnings, legalWarning)
 	}
 	if extractErr != nil {
-		warnings = append(warnings, "Some pages could not be extracted; the grounded findings that completed are still available.")
+		warnings = append(warnings, people.SiteReadPartialExtractionWarning)
 	}
 	if jsShell {
 		// Said out loud, because the dossier otherwise looks like a thin

--- a/backend/internal/compose/integration/aiactivity_siteread_integration_test.go
+++ b/backend/internal/compose/integration/aiactivity_siteread_integration_test.go
@@ -231,10 +231,13 @@ func TestAWebsiteReadRunsAndSettlesInTheProjection(t *testing.T) {
 	}
 }
 
-// The read's own vocabulary has words the projection's does not, and each maps
-// to the honest one: a truncated crawl is `degraded` with the reason it
-// stopped, never `done`.
-func TestATruncatedWebsiteReadSettlesDegradedWithItsStopReason(t *testing.T) {
+// The read's own vocabulary has words the projection's does not, and `partial`
+// is the one that maps to two: the projection's `degraded` is what the rail's
+// fault arm is bounded on, so it claims somebody must be TOLD, and a crawl that
+// filled the page budget it was given is not that. It settles `done` and still
+// says where it stopped — the reason is the record, the state is the
+// interruption.
+func TestAWebsiteReadThatFilledItsPageBudgetSettlesDoneWithItsStopReason(t *testing.T) {
 	f := newWebsiteReadFixture(t)
 	claim, err := f.env.People.BeginSiteRead(f.worker, f.readID, siteReadLease)
 	if err != nil {
@@ -249,11 +252,36 @@ func TestATruncatedWebsiteReadSettlesDegradedWithItsStopReason(t *testing.T) {
 	f.drain(t)
 
 	got := f.projection(t)
-	if got.State != "degraded" {
-		t.Fatalf("state = %s, want degraded — a partial read must never read as done", got.State)
+	if got.State != "done" {
+		t.Fatalf("state = %s, want done — a crawl that filled its page budget is not somebody's to act on", got.State)
 	}
 	if got.DegradeReason == nil || *got.DegradeReason != "The read stopped at its page limit." {
 		t.Fatalf("degrade_reason = %v, want the closed sentence for a page cap", got.DegradeReason)
+	}
+}
+
+// The other half of that split, driven end to end so the two cannot be proved
+// only where they are decided. A read short of what it was ASKED for still
+// settles `degraded` — here a crawl that filled its page budget AND lost an
+// extraction lane, which is the shape stopped_reason alone cannot see, since
+// the row spells it with the cap's own reason.
+func TestAWebsiteReadThatAlsoLostALaneStaysDegraded(t *testing.T) {
+	f := newWebsiteReadFixture(t)
+	claim, err := f.env.People.BeginSiteRead(f.worker, f.readID, siteReadLease)
+	if err != nil {
+		t.Fatalf("BeginSiteRead: %v", err)
+	}
+	stopped := "page_cap"
+	if err := f.env.People.FinishSiteRead(f.worker, f.readID, people.FinishSiteReadInput{
+		Status: "partial", ClaimedAt: &claim.ClaimedAt, StoppedReason: &stopped,
+		Warnings: []string{people.SiteReadPartialExtractionWarning},
+	}); err != nil {
+		t.Fatalf("FinishSiteRead: %v", err)
+	}
+	f.drain(t)
+
+	if got := f.projection(t); got.State != "degraded" {
+		t.Fatalf("state = %s, want degraded — a lost lane is a fault however full the page budget was", got.State)
 	}
 }
 

--- a/backend/internal/modules/people/sitereadactivity.go
+++ b/backend/internal/modules/people/sitereadactivity.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -71,7 +72,25 @@ func (sr SiteRead) claim() SiteReadClaim {
 	}
 }
 
+// activityStateDegraded is the projection's word for a settled occurrence that
+// kept partial state. It is the one answer below that no site_read status
+// spells, so it is named rather than repeated.
+const activityStateDegraded = "degraded"
+
 // The dossier's own statuses in the projection's vocabulary.
+//
+// `degraded` is not a synonym for "not done": the projection's fault arm is
+// bounded on it, and the rail holds the newest unacknowledged one on the orb
+// until a reader opens the panel. So the question each arm answers is whether
+// a person has to be TOLD, and `partial` splits on exactly that. A crawl that
+// ran into one of the ceilings this product sets for it — the page cap, the
+// byte cap, the wall clock — did what it was configured to do: it read the
+// site down to the budget it was given and staged everything it found, and the
+// dossier carries where it stopped. A crawl whose extraction lost a lane, or
+// whose workspace ran out of AI credit, is short of what it was ASKED for.
+// Only the second is somebody's to act on; the first is true of almost every
+// ordinary company site, whose pages outnumber the cap, and an orb amber on
+// every one of those is a signal nobody reads any more.
 //
 // deferred settles rather than staying live: the read is not being worked, the
 // budget it waits on may return hours later, and an orb lit that whole time
@@ -82,16 +101,46 @@ func (sr SiteRead) claim() SiteReadClaim {
 // cancelled is a read withdrawn by a decision rather than a fault, and it
 // reports `failed` because the vocabulary has no third settled word for "did
 // not happen" — the reason says which it was.
-func siteReadActivityState(status string) string {
-	switch status {
+func (sr SiteRead) activityState() string {
+	switch sr.Status {
 	case siteReadStatusQueued, siteReadStatusRunning, siteReadStatusDone, siteReadStatusFailed:
-		return status
-	case siteReadStatusDeferred, siteReadStatusPartial:
-		return "degraded"
+		return sr.Status
+	case siteReadStatusPartial:
+		if sr.stoppedAtOwnCeiling() {
+			return siteReadStatusDone
+		}
+		return activityStateDegraded
+	case siteReadStatusDeferred:
+		return activityStateDegraded
 	case siteReadStatusCancelled:
 		return siteReadStatusFailed
 	}
-	return status
+	return sr.Status
+}
+
+// stoppedAtOwnCeiling answers whether this partial is a crawl that filled its
+// budget and nothing else.
+//
+// Both halves are required, and the second is the one that is easy to forget:
+// a run can hit the page cap AND lose an extraction lane, and the row spells
+// that with the cap's own stop reason, indistinguishable from a clean one.
+// SiteReadPartialExtractionWarning is what the worker writes when a lane died,
+// so its presence is what keeps that read out of the healthy answer.
+func (sr SiteRead) stoppedAtOwnCeiling() bool {
+	if sr.StoppedReason == nil || !siteReadOwnCeiling[*sr.StoppedReason] {
+		return false
+	}
+	return !slices.Contains(sr.Warnings, SiteReadPartialExtractionWarning)
+}
+
+// siteReadOwnCeiling is the half of the stop vocabulary that names a bound
+// this product chose. `budget` is deliberately absent: the workspace running
+// out of AI credit is a condition an operator repairs, not a ceiling the crawl
+// was built to fill.
+var siteReadOwnCeiling = map[string]bool{
+	siteReadStopPageCap:  true,
+	siteReadStopByteCap:  true,
+	siteReadStopDeadline: true,
 }
 
 // The stop reasons as prose. Server-authored and closed — never a provider's
@@ -140,7 +189,7 @@ func (sr SiteRead) activitySettledAt() *time.Time {
 	if sr.FinishedAt != nil {
 		return sr.FinishedAt
 	}
-	if state := siteReadActivityState(sr.Status); state == siteReadStatusQueued || state == siteReadStatusRunning {
+	if state := sr.activityState(); state == siteReadStatusQueued || state == siteReadStatusRunning {
 		return nil
 	}
 	settled := sr.UpdatedAt
@@ -161,7 +210,7 @@ func emitSiteReadActivity(ctx context.Context, tx pgx.Tx, ledgerID ids.UUID, sr 
 		OccurrenceKey: sr.ID.String(),
 		Kind:          SiteReadActivityKind,
 		Attempt:       sr.Attempt,
-		State:         siteReadActivityState(sr.Status),
+		State:         sr.activityState(),
 		// The instant THIS attempt became current, not the read's creation: a
 		// live row ages from here, and a read claimed again hours later would
 		// otherwise be past its lease before the worker fetched a page.

--- a/backend/internal/modules/people/sitereadactivity_test.go
+++ b/backend/internal/modules/people/sitereadactivity_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// What a settled dossier tells the AI-activity projection about itself.
+//
+// The subject is SiteRead.activityState, and what it decides is whether the
+// agent rail's orb goes amber: the projection's fault arm is bounded on
+// `degraded` and `failed`, and the rail holds the newest unacknowledged one
+// until a reader opens the panel. So the question every case below asks is the
+// product question — is this an outcome a person has to be told about — and
+// not merely which word the row carries.
+
+import (
+	"testing"
+	"time"
+)
+
+// partialAt builds the settled row a crawl leaves behind when it stopped early
+// having read pages: `partial` is the only status stopped_reason may accompany.
+func partialAt(reason string, warnings ...string) SiteRead {
+	return SiteRead{Status: siteReadStatusPartial, StoppedReason: &reason, Warnings: warnings}
+}
+
+// A crawl fills the budget it was given. That is the design working, not a
+// fault, and it is the common case: an ordinary company site has more pages
+// than the cap buys, so reporting it as a fault put an amber orb in front of
+// every new reader on their first screen.
+func TestAPartialAtTheCrawlsOwnCeilingReportsDone(t *testing.T) {
+	for _, reason := range []string{siteReadStopPageCap, siteReadStopByteCap, siteReadStopDeadline} {
+		if got := partialAt(reason).activityState(); got != siteReadStatusDone {
+			t.Errorf("a crawl stopped at %s reports %q, want %q", reason, got, siteReadStatusDone)
+		}
+	}
+}
+
+// The workspace running out of AI credit is not a ceiling the crawl was built
+// to fill: it is a condition an operator repairs, and the reader is owed it.
+func TestAPartialAtTheAIBudgetStaysDegraded(t *testing.T) {
+	if got := partialAt(siteReadStopBudget).activityState(); got != activityStateDegraded {
+		t.Errorf("a crawl stopped at the AI budget reports %q, want %q", got, activityStateDegraded)
+	}
+}
+
+// No stop reason and still partial means the extraction fan-out died with
+// evidence already in hand. Nothing was capped; something broke.
+func TestAPartialWithNoCeilingStaysDegraded(t *testing.T) {
+	if got := (SiteRead{Status: siteReadStatusPartial}).activityState(); got != activityStateDegraded {
+		t.Errorf("a partial with no stop reason reports %q, want %q", got, activityStateDegraded)
+	}
+}
+
+// The case the stop reason alone cannot see: a run may fill its page budget AND
+// lose an extraction lane, and the row spells that with the cap's own reason,
+// indistinguishable from a clean stop. The worker's warning is what tells them
+// apart, and a fault must not be read as a full budget.
+func TestPartialAtACeilingWithALostLaneStaysDegraded(t *testing.T) {
+	capped := partialAt(siteReadStopPageCap, SiteReadPartialExtractionWarning)
+	if got := capped.activityState(); got != activityStateDegraded {
+		t.Errorf("a capped crawl that also lost a lane reports %q, want %q", got, activityStateDegraded)
+	}
+}
+
+// A caveat that is not the extraction one must not suppress the ceiling: the
+// legal-census and client-rendered-site notes are things the dossier says about
+// what it found, not reports that the read went wrong.
+func TestOtherCaveatsDoNotTurnACeilingIntoAFault(t *testing.T) {
+	capped := partialAt(siteReadStopPageCap, "This site builds its pages in the browser.")
+	if got := capped.activityState(); got != siteReadStatusDone {
+		t.Errorf("a capped crawl carrying an unrelated caveat reports %q, want %q", got, siteReadStatusDone)
+	}
+}
+
+// A deferral kept what it had read and is waiting on budget that may return
+// hours later; a cancellation did not happen at all. Neither word changes here,
+// and pinning them is what keeps the ceiling split above from widening into
+// outcomes it was never about.
+func TestTheOtherSettledStatusesKeepTheirWords(t *testing.T) {
+	for status, want := range map[string]string{
+		siteReadStatusDeferred:  activityStateDegraded,
+		siteReadStatusCancelled: siteReadStatusFailed,
+		siteReadStatusFailed:    siteReadStatusFailed,
+		siteReadStatusDone:      siteReadStatusDone,
+		siteReadStatusQueued:    siteReadStatusQueued,
+		siteReadStatusRunning:   siteReadStatusRunning,
+	} {
+		if got := (SiteRead{Status: status}).activityState(); got != want {
+			t.Errorf("%s reports %q, want %q", status, got, want)
+		}
+	}
+}
+
+// A ceiling stop reports `done` and still says why it ended where it did. The
+// state decides whether a reader is interrupted; the reason is the record, and
+// dropping it would buy the calm orb by making the occurrence say less than the
+// row knows.
+func TestACeilingStopStillCarriesItsReason(t *testing.T) {
+	capped := partialAt(siteReadStopPageCap)
+	if got := capped.activityDegradeReason(); got != siteReadStopSaid[siteReadStopPageCap] {
+		t.Errorf("a page-capped crawl explains itself with %q, want %q", got, siteReadStopSaid[siteReadStopPageCap])
+	}
+}
+
+// A settled attempt says WHEN it settled whatever word it settled under. The
+// ceiling split moved a partial from `degraded` to `done`, and a `done`
+// occurrence with no finished_at would read as still running.
+func TestACeilingStopIsStillSettled(t *testing.T) {
+	finished := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	capped := partialAt(siteReadStopPageCap)
+	capped.FinishedAt = &finished
+	if got := capped.activitySettledAt(); got == nil || !got.Equal(finished) {
+		t.Errorf("a page-capped crawl settled at %v, want %v", got, finished)
+	}
+}

--- a/backend/internal/modules/people/sitereadfinish.go
+++ b/backend/internal/modules/people/sitereadfinish.go
@@ -165,6 +165,17 @@ const (
 	siteReadStopDeadline = "deadline"
 )
 
+// SiteReadPartialExtractionWarning is the caveat a read carries when part of
+// its extraction fan-out died with evidence already in hand.
+//
+// Exported because it is written on one side of a seam and read on the other:
+// the deep-read worker puts it in FinishSiteReadInput.Warnings, and
+// stoppedAtOwnCeiling looks for it to tell a crawl that merely filled its page
+// budget from one that also lost a lane. It is one constant rather than the
+// same sentence twice, so a reworded caveat cannot quietly turn every such
+// read healthy — the failure a second copy would cause is silent.
+const SiteReadPartialExtractionWarning = "Some pages could not be extracted; the grounded findings that completed are still available."
+
 // FinishSiteRead records the crawl's outcome in one guarded UPDATE from
 // running to a terminal status. No auth.Require, same as BeginSiteRead:
 // the worker runs under the job's workspace context, not a human


### PR DESCRIPTION
## What

A site read that stopped at one of the crawl's own ceilings — the page cap, the byte cap, the wall clock — now reports `done` to the AI-activity projection instead of `degraded`, still carrying the reason it ended where it did. The AI-budget stop, the budget deferral and a read whose extraction lost a lane keep `degraded`.

Visible effect: the agent rail's orb no longer goes amber over a crawl that did exactly what it was configured to do. On a fresh install that is the first screen a new reader sees — onboarding reads their company website, an ordinary site has more pages than the 40-page cap buys, and the read settled `partial` → `degraded` → an unacknowledged fault held on the orb, captioned "I stopped before finishing the company website."

## Why

The projection's fault arm is bounded on `state IN ('degraded','failed')`, and the rail holds the newest unacknowledged one on the orb until a reader opens the panel. So `degraded` is not a synonym for "not done" — it is a claim that somebody has to be told. `partial` was carrying two outcomes that differ on exactly that question:

- a crawl that filled the budget it was given, staged everything it found, and recorded where it stopped — nobody's to act on, and true of almost every real company website;
- a crawl short of what it was *asked* for: an extraction lane that died, or a workspace out of AI credit — somebody's to act on.

Reporting the first as a fault is the failure `agentrail.tsx`'s own licence comment already names: an ambient warning that is always on stops being a warning. `budget` is deliberately not a ceiling here — running out of credit is a condition an operator repairs, not a bound the crawl was built to fill.

The two causes of `partial` are not separable from `stopped_reason` alone: a run can hit the page cap **and** lose a lane, and the row spells that with the cap's own reason. The worker's caveat is what separates them, so it is now one exported constant written by `compose` and read by `people` rather than the same sentence spelled in two places — a reworded copy would silently turn every such read healthy, which is the direction a census must not fail in.

Filed alongside, on the crawl budget itself rather than its reporting: margince#4525 asks whether a model should choose which pages the budget buys.

## How verified

- `make check-go` green — build, vet, every unit package, and the full `./gates` lane (the lane needs full history; this container's clone was shallow and was unshallowed first). The one red leg is environmental, not this diff: `golangci-lint` in this container refuses to start because the pinned binary was built with Go 1.25 against a Go 1.26.6 toolchain. `go vet` on both changed packages is clean; CI runs the real lint.
- `craft static --strict` on all four changed files: 0 blocker, 0 major, 0 minor.
- `scripts/check-rls-store-path.sh` and `scripts/check-no-jurisdiction.sh` green.
- `make check-fe` was run; no frontend file is touched by this diff.
- Eight new unit specs in `sitereadactivity_test.go` drive `SiteRead.activityState` over every settled shape: each of the three ceilings reports `done`; the AI-budget stop, a partial with no stop reason, and a ceiling stop that also carries the extraction caveat all stay `degraded`; an *unrelated* caveat does not suppress the ceiling; deferral, cancellation and the live states keep their words; and a ceiling stop still carries its reason and its settled instant.

- [x] `make check` is green (with the two environmental caveats named above)
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — this change touches none: no schema, no migration, no new query, no change to what `emitSiteReadActivity` writes beyond the state string it derives.
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by Claude Code end to end — the diagnosis (tracing the amber orb from the screenshot back through the rail, the feed's fault arm and the state mapping to the crawl's page cap), the design call on where to split `partial`, the code, the comments and the tests. Reviewed by Joschua, who reported the symptom and chose this fix over the two alternatives considered (grading `degraded` as non-faulting in the frontend, or excluding onboarding reads from the rail).

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198K5Z7dgkhkjwwyd6SZSfU

---
_Generated by [Claude Code](https://claude.ai/code/session_0198K5Z7dgkhkjwwyd6SZSfU)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Site reads that stop at a crawl-owned ceiling — the page cap, byte cap, or deadline — now report `done` to the AI-activity projection instead of `degraded`, so the agent rail's orb no longer goes amber on a read that did what it was configured to do. Stops at the AI budget, budget deferrals, and reads that also lost an extraction lane keep `degraded`.

**Notes**
- The worker's extraction-lane caveat is now one exported constant, `SiteReadPartialExtractionWarning`, shared by `compose` and `people`; `stopped_reason` alone can't tell a capped crawl from one that also lost a lane.
- Ceiling stops still carry their stop reason and settled instant.

<sup>Written for commit 40781e3d1dea55d4eaabedcc3486ea71c64f029f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Website reads that reach their page, byte, or time limits now settle as **Done** while retaining the applicable stop reason.
  * Reads affected by extraction failures, AI budget exhaustion, or other unresolved issues continue to settle as **Degraded**.
  * Partial extraction warnings are now reported consistently across website-read activity and completion results.
* **Tests**
  * Added coverage for read-status mapping, stop reasons, settlement timestamps, and degraded scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->