### PR TITLE
The timeline filter drops back under the length cap

### DIFF
--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -389,6 +389,29 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	if where, err = appendWaitingReplyClause(ctx, in, arg, where); err != nil {
 		return "", nil, "", nil, err
 	}
+	where = append(where, activityRowClauses(in, arg)...)
+	if in.Cursor != nil && *in.Cursor != "" {
+		if in.OpenAndDueBy != nil {
+			return "", nil, "", nil, errOpenAndDueByWithCursor
+		}
+		c, decodeErr := storekit.DecodeCursor(*in.Cursor)
+		if decodeErr != nil {
+			return "", nil, "", nil, decodeErr
+		}
+		where = append(where, sprintf("(a.occurred_at, a.id) < ($%d, $%d)", arg(c.CreatedAt), arg(c.ID)))
+	}
+	return join, where, content, args, nil
+}
+
+// activityRowClauses narrows on columns of the activity row itself: the
+// thread it belongs to, the words in it, when it happened, whether its
+// outcome is still open.
+//
+// None of them consults the caller's scope, so none can fail — which row is
+// in reach was already decided by the gate its caller picked, and these only
+// shrink that set further.
+func activityRowClauses(in ListActivitiesInput, arg func(any) int) []string {
+	var where []string
 	if in.ThreadKey != nil && *in.ThreadKey != "" {
 		where = append(where, sprintf("a.thread_key = $%d", arg(*in.ThreadKey)))
 	}
@@ -410,17 +433,7 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 		// and excluding it would empty this question on a connected calendar.
 		where = append(where, "(a.meeting_status IS NULL OR a.meeting_status = 'booked')")
 	}
-	if in.Cursor != nil && *in.Cursor != "" {
-		if in.OpenAndDueBy != nil {
-			return "", nil, "", nil, errOpenAndDueByWithCursor
-		}
-		c, decodeErr := storekit.DecodeCursor(*in.Cursor)
-		if decodeErr != nil {
-			return "", nil, "", nil, decodeErr
-		}
-		where = append(where, sprintf("(a.occurred_at, a.id) < ($%d, $%d)", arg(c.CreatedAt), arg(c.ID)))
-	}
-	return join, where, content, args, nil
+	return where
 }
 
 // filtersOnContent reports whether the list narrows on fields a withheld row


### PR DESCRIPTION
`craft-static` blocks main:

```
backend/internal/modules/activities/orgscope.go
  322: [MAJOR] long-func — listActivitiesFilter is 83 code lines (> 80) — extract helpers
BLOCK — 0 blocker, 1 major, 0 minor
```

The meeting-outcome narrowing (#4536) was the three lines that crossed it — it is not the offender, it is just what arrived last. Every PR opened since is red on it.

## The cut

The five narrowings pulled into `activityRowClauses` are the ones that read a column on the activity row and nothing else: which thread, which words, when it happened, whether the outcome is still open. **None of them can fail** — which rows are in reach was already decided by the gate its caller picked, and these only shrink that set further.

What stays in `listActivitiesFilter` is the part that carries a judgement: the DISCOVER/CONTENT gate choice, the audience arm, the entity walk, waiting-reply, and the cursor.

## The bind indexes travel with the clauses

`arg` numbers each placeholder at the moment it appends, so a clause's `$n` moves with it. The block is contiguous and stays in the same position in the sequence, so the generated SQL is byte-identical.

83 → 68 code lines. `make craft-static` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reorganized activity list filtering logic without changing user-visible behavior.
  - Existing filtering and cursor handling continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->