### PR TITLE
feat(worklist): a bounced send names the address that refused it

### DIFF
--- a/backend/internal/compose/attention/bouncedetail_test.go
+++ b/backend/internal/compose/attention/bouncedetail_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Which address is dead, on the row that reports the failure.
+//
+// The card names a person and a subject. A rep opening a contact who carries
+// three addresses cannot tell from that which mailbox refused, so the row
+// reports a failure and leaves the fix to guesswork — the defect this lane was
+// built to remove, one step further along.
+
+import "testing"
+
+func TestABouncedSendNamesTheAddressThatRefusedIt(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		send BouncedSend
+		want string
+	}{
+		"both": {
+			BouncedSend{Recipient: "dana@turbinenbau.de", Reason: "550 no such user"},
+			"dana@turbinenbau.de — 550 no such user",
+		},
+		// The provider said nothing usable. The address alone still tells the
+		// reader which mailbox to fix, which is the move.
+		"address only": {
+			BouncedSend{Recipient: "dana@turbinenbau.de"},
+			"dana@turbinenbau.de",
+		},
+		// A send carrying no recipient — an older row, or one stored without
+		// one. The reason stands alone rather than the card claiming to know
+		// where it was aimed.
+		"reason only": {
+			BouncedSend{Reason: "550 no such user"},
+			"550 no such user",
+		},
+		// Neither: no line at all, so the card draws nothing rather than an
+		// empty supporting row under the subject.
+		"neither": {BouncedSend{}, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := bounceDetail(tc.send); got != tc.want {
+				t.Errorf("the card's line reads %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// And it reaches the row, not just the helper.
+//
+// bounceItem sets Detail only when the line is non-empty, so a helper returning
+// the right string proves nothing about what a reader sees.
+func TestTheBounceRowCarriesTheAddress(t *testing.T) {
+	t.Parallel()
+	item := bounceItem(BouncedSend{
+		Subject: "Retrofit quote", Recipient: "dana@turbinenbau.de",
+		Reason: "550 no such user",
+	})
+	if item.Detail == nil {
+		t.Fatal("the row carries no supporting line at all")
+	}
+	if *item.Detail != "dana@turbinenbau.de — 550 no such user" {
+		t.Errorf("the row's line reads %q, and a reader cannot see which address is dead", *item.Detail)
+	}
+	// And a send with nothing to say still draws no line.
+	bare := bounceItem(BouncedSend{Subject: "Retrofit quote"})
+	if bare.Detail != nil {
+		t.Errorf("a send with no address and no reason draws %q under its subject", *bare.Detail)
+	}
+}

--- a/backend/internal/compose/attention/bouncedetail_test.go
+++ b/backend/internal/compose/attention/bouncedetail_test.go
@@ -28,9 +28,12 @@ func TestABouncedSendNamesTheAddressThatRefusedIt(t *testing.T) {
 			BouncedSend{Recipient: "dana@turbinenbau.de"},
 			"dana@turbinenbau.de",
 		},
-		// A send carrying no recipient — an older row, or one stored without
-		// one. The reason stands alone rather than the card claiming to know
-		// where it was aimed.
+		// No address to name, which happens two ways: a row bounced before the
+		// column existed, and one whose address an erasure restriction NULLed
+		// (privacy/erasure_restrict.go). The second is the one worth knowing —
+		// a reader told only "an older row" would be surprised that a restricted
+		// send loses its address. The reason stands alone either way, rather
+		// than the card claiming to know where it was aimed.
 		"reason only": {
 			BouncedSend{Reason: "550 no such user"},
 			"550 no such user",

--- a/backend/internal/compose/attention/healthlanes.go
+++ b/backend/internal/compose/attention/healthlanes.go
@@ -119,6 +119,14 @@ type ParkedSend struct {
 	// PersonID is the person the send's activity is filed under, zero when it
 	// is filed under none — the card then offers no open.
 	PersonID ids.UUID
+	// Recipient is the address that refused the send.
+	//
+	// Without it the card names a person and a subject, and a rep opening a
+	// contact who carries three addresses cannot tell which one is dead — the
+	// row reports a failure and leaves the reader to guess at the fix. Empty
+	// when the send carries no recipient, and the card then says nothing about
+	// where it was aimed rather than guessing.
+	Recipient string
 }
 
 // Bounces is the reader's own sends whose delivery reports came back hard —
@@ -142,6 +150,14 @@ type BouncedSend struct {
 	// PersonID is the person the send's activity is filed under, zero when it
 	// is filed under none — the card then offers no open.
 	PersonID ids.UUID
+	// Recipient is the address that refused the send.
+	//
+	// Without it the card names a person and a subject, and a rep opening a
+	// contact who carries three addresses cannot tell which one is dead — the
+	// row reports a failure and leaves the reader to guess at the fix. Empty
+	// when the send carries none, and the card then says nothing about where it
+	// was aimed rather than guessing.
+	Recipient string
 }
 
 // AutomationHealth is the automations whose recent firings failed or were

--- a/backend/internal/compose/attention/healthlanes.go
+++ b/backend/internal/compose/attention/healthlanes.go
@@ -119,14 +119,6 @@ type ParkedSend struct {
 	// PersonID is the person the send's activity is filed under, zero when it
 	// is filed under none — the card then offers no open.
 	PersonID ids.UUID
-	// Recipient is the address that refused the send.
-	//
-	// Without it the card names a person and a subject, and a rep opening a
-	// contact who carries three addresses cannot tell which one is dead — the
-	// row reports a failure and leaves the reader to guess at the fix. Empty
-	// when the send carries no recipient, and the card then says nothing about
-	// where it was aimed rather than guessing.
-	Recipient string
 }
 
 // Bounces is the reader's own sends whose delivery reports came back hard —

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -147,15 +147,32 @@ func bounceItem(send BouncedSend) crmcontracts.AttentionItem {
 		subject := send.Subject
 		item.Title = &subject
 	}
-	if send.Reason != "" {
-		reason := send.Reason
-		item.Detail = &reason
+	// The address AND the refusal, because neither answers the reader alone.
+	// The reason says why it failed; the address says which mailbox to fix, and
+	// a contact carrying three of them leaves a rep guessing without it.
+	if detail := bounceDetail(send); detail != "" {
+		item.Detail = &detail
 	}
 	if !send.PersonID.IsZero() {
 		item.Subject = subjectOf("person", send.PersonID)
 		item.Actions = append(item.Actions, actionOpen)
 	}
 	return item
+}
+
+// bounceDetail is the supporting line: the address that refused, the receiving
+// side's own words, or both. The address leads because it is what the reader
+// acts on. Empty when the send carries neither, so the card draws no line
+// rather than an empty one.
+func bounceDetail(send BouncedSend) string {
+	switch {
+	case send.Recipient != "" && send.Reason != "":
+		return send.Recipient + " — " + send.Reason
+	case send.Recipient != "":
+		return send.Recipient
+	default:
+		return send.Reason
+	}
 }
 
 // parkedItem draws one send that was given up on. The subject line is the

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -147,9 +147,6 @@ func bounceItem(send BouncedSend) crmcontracts.AttentionItem {
 		subject := send.Subject
 		item.Title = &subject
 	}
-	// The address AND the refusal, because neither answers the reader alone.
-	// The reason says why it failed; the address says which mailbox to fix, and
-	// a contact carrying three of them leaves a rep guessing without it.
 	if detail := bounceDetail(send); detail != "" {
 		item.Detail = &detail
 	}

--- a/backend/internal/compose/attentionopsseam.go
+++ b/backend/internal/compose/attentionopsseam.go
@@ -127,6 +127,7 @@ func (b attentionBounces) HardBounces(ctx context.Context, since time.Time, limi
 			Reason:    send.Reason,
 			BouncedAt: send.BouncedAt,
 			PersonID:  send.PersonID,
+			Recipient: send.Recipient,
 		})
 	}
 	return out, nil

--- a/backend/internal/modules/comms/bouncelane.go
+++ b/backend/internal/modules/comms/bouncelane.go
@@ -27,14 +27,18 @@ type HardBounce struct {
 	Reason    string
 	BouncedAt time.Time
 	PersonID  ids.UUID
+	// Recipient is the address that refused it, so a reader knows WHICH of a
+	// person's addresses is dead. Empty when the send carries none.
+	Recipient string
 }
 
 // bounceLane is the lane's three words: the receiving side's own refusal, the
 // moment the report landed, and hard reports only.
 var bounceLane = sendLane{
-	reasonColumn: "bounce_reason",
-	atColumn:     "bounced_at",
-	only:         "o.bounce_kind = 'hard'",
+	reasonColumn:    "bounce_reason",
+	atColumn:        "bounced_at",
+	only:            "o.bounce_kind = 'hard'",
+	recipientColumn: "bounce_recipient",
 }
 
 // HardBouncesFor answers the calling person's own hard-bounced sends since
@@ -48,7 +52,7 @@ func (s *Store) HardBouncesFor(ctx context.Context, since time.Time, limit int) 
 	for _, send := range sends {
 		bounced = append(bounced, HardBounce{
 			ID: send.ID, Subject: send.Subject, Reason: send.Reason,
-			BouncedAt: send.At, PersonID: send.PersonID,
+			BouncedAt: send.At, PersonID: send.PersonID, Recipient: send.Recipient,
 		})
 	}
 	return bounced, nil

--- a/backend/internal/modules/comms/bouncelane_integration_test.go
+++ b/backend/internal/modules/comms/bouncelane_integration_test.go
@@ -144,3 +144,71 @@ func TestHardBouncesForRefusesAReaderWithoutTheActivityGrant(t *testing.T) {
 		t.Fatalf("HardBouncesFor without the activity grant = %v, want the permission sentinel", err)
 	}
 }
+
+// WHICH address refused, carried from the row the send was written to.
+//
+// A database test rather than a unit one because the address is read from
+// `comms_outbound.recipients`, a jsonb column, through a scan whose column
+// count has to agree with the statement's. Nothing in Go checks that agreement:
+// add a column to the SELECT and forget the scan target and the read fails at
+// runtime, on a lane whose whole job is to report other failures.
+//
+// Seeded through sentDelivery — the same writer the lane reads behind — so the
+// recipients column holds what a real send puts there rather than what this
+// test thinks it should.
+func TestHardBouncesForNamesTheAddressThatRefused(t *testing.T) {
+	e := setupStore(t)
+	person := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Anna Weber', 'test', 'human:x')`, person); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO activity_link (id, activity_id, entity_type, person_id) VALUES ($1, $2, 'person', $3)`,
+		ids.NewV7(), e.activity, person); err != nil {
+		t.Fatal(err)
+	}
+	// Staged with an EXPLICIT recipient rather than through sentDelivery, whose
+	// shared fixture hardcodes buyer@example.com. A test seeded from that would
+	// pass against a read that returned the constant, and prove nothing about
+	// the address travelling. The message id is what the bounce is matched on;
+	// the recipient is the separate fact under test.
+	// TWO recipients, and the one that bounced is NOT the first. A read taking
+	// `recipients->>0` would name the bystander — the exact defect the
+	// bounce_recipient column was added for, whose migration says a send with a
+	// CC would otherwise mark every address on it as the one that refused.
+	staged := e.stage(t, func() StageInput {
+		in := e.baseInput(e.activity, "dana-msg")
+		in.Recipients = []string{"colleague@turbinenbau.de", "dana@turbinenbau.de"}
+		return in
+	}())
+	if err := e.store.RecordSent(e.ctx, staged,
+		connector.SendReceipt{ProviderMessageID: "prov-dana-msg"}); err != nil {
+		t.Fatalf("recording the send: %v", err)
+	}
+	// The report names the same address the send was aimed at. bounceFor's
+	// shared fixture hardcodes buyer@example.com, and RecordBounce matches on
+	// the pair, so borrowing it here would leave the bounce unmatched.
+	report := connector.BounceReport{
+		MessageID: "dana-msg", Recipient: "dana@turbinenbau.de",
+		Kind: connector.BounceHard, Reason: "550 5.1.1 user unknown",
+	}
+	if marked, err := e.store.RecordBounce(
+		e.asCapturingConnector(e.user.UUID), report); err != nil || !marked {
+		t.Fatalf("recording the hard bounce: marked=%v err=%v", marked, err)
+	}
+
+	bounced, err := e.store.HardBouncesFor(
+		readerCtx(e.ws, e.user), e.clockValue.Add(-7*24*time.Hour), 8)
+	if err != nil {
+		t.Fatalf("reading the bounce lane: %v", err)
+	}
+	if len(bounced) != 1 {
+		t.Fatalf("the lane carries %d bounces, want the one just recorded", len(bounced))
+	}
+	if bounced[0].Recipient != "dana@turbinenbau.de" {
+		t.Errorf("the bounce names %q as the address that refused, want dana@turbinenbau.de — "+
+			"without it a reader opening a contact with three addresses cannot tell which is dead",
+			bounced[0].Recipient)
+	}
+}

--- a/backend/internal/modules/comms/bouncelane_integration_test.go
+++ b/backend/internal/modules/comms/bouncelane_integration_test.go
@@ -173,10 +173,9 @@ func TestHardBouncesForNamesTheAddressThatRefused(t *testing.T) {
 	// pass against a read that returned the constant, and prove nothing about
 	// the address travelling. The message id is what the bounce is matched on;
 	// the recipient is the separate fact under test.
-	// TWO recipients, and the one that bounced is NOT the first. A read taking
-	// `recipients->>0` would name the bystander — the exact defect the
-	// bounce_recipient column was added for, whose migration says a send with a
-	// CC would otherwise mark every address on it as the one that refused.
+	// TWO recipients, and the one that bounced is NOT the first: a read keyed on
+	// the send'"'"'s recipient list rather than the report'"'"'s own address names the
+	// bystander.
 	staged := e.stage(t, func() StageInput {
 		in := e.baseInput(e.activity, "dana-msg")
 		in.Recipients = []string{"colleague@turbinenbau.de", "dana@turbinenbau.de"}

--- a/backend/internal/modules/comms/sendlane.go
+++ b/backend/internal/modules/comms/sendlane.go
@@ -51,6 +51,22 @@ type sendLane struct {
 	atColumn string
 	// only is what makes a row this lane's business rather than the other's.
 	only string
+	// recipientColumn names the address the card reports, or is empty where the
+	// lane has none to name. A bounce report names ONE failed address and the
+	// row records it; a park is about the send as a whole and has no such
+	// column, so that lane says nothing about where it was aimed rather than
+	// naming a recipient the failure was not about.
+	recipientColumn string
+}
+
+// recipientExpr is the column the lane reads its address from, or a literal
+// empty string where it has none. A literal rather than a NULL so the scan
+// target stays a plain string on both lanes.
+func (l sendLane) recipientExpr() string {
+	if l.recipientColumn == "" {
+		return "''"
+	}
+	return "COALESCE(o." + l.recipientColumn + ", '')"
 }
 
 // laneSend is one send on a lane: the five facts a card is drawn from.
@@ -60,6 +76,11 @@ type laneSend struct {
 	Reason   string
 	At       time.Time
 	PersonID ids.UUID
+	// Recipient is the address the lane's failure was about, or empty where the
+	// lane names none. Never derived from the send's recipient list: a report
+	// names ONE address, and a send carrying a CC would otherwise blame the
+	// first name on it for a refusal that came from another.
+	Recipient string
 }
 
 // statement joins each send to the person its activity is filed under.
@@ -86,7 +107,8 @@ func (l sendLane) statement(ctx context.Context, userID ids.UUID, since time.Tim
 		visible = alwaysVisible
 	}
 	return fmt.Sprintf(`
-SELECT o.id, left(COALESCE(o.subject, ''), %d), COALESCE(o.%s, ''), o.%s, l.person_id
+SELECT o.id, left(COALESCE(o.subject, ''), %d), COALESCE(o.%s, ''), o.%s, l.person_id,
+       %s
   FROM comms_outbound o
   LEFT JOIN LATERAL (
     SELECT al.person_id FROM activity_link al
@@ -98,7 +120,7 @@ SELECT o.id, left(COALESCE(o.subject, ''), %d), COALESCE(o.%s, ''), o.%s, l.pers
    AND o.%s >= $%d
  ORDER BY o.%s DESC, o.id DESC
  LIMIT $%d`,
-		subjectLineBound, l.reasonColumn, l.atColumn,
+		subjectLineBound, l.reasonColumn, l.atColumn, l.recipientExpr(),
 		arg(userID), l.only, l.atColumn, arg(since), l.atColumn, arg(limit)), nil
 }
 
@@ -138,7 +160,7 @@ func (s *Store) readSendLane(ctx context.Context, lane sendLane, what string, si
 		for rows.Next() {
 			var send laneSend
 			var person *ids.UUID
-			if scanErr := rows.Scan(&send.ID, &send.Subject, &send.Reason, &send.At, &person); scanErr != nil {
+			if scanErr := rows.Scan(&send.ID, &send.Subject, &send.Reason, &send.At, &person, &send.Recipient); scanErr != nil {
 				return scanErr
 			}
 			if person != nil {


### PR DESCRIPTION
Lars decided **3B** on the fix-address item: name the address, no resend from
the queue.

The card said a message failed, named the person and the subject, and never
said **which** address bounced. Open a contact with three addresses and a rep is
guessing — the row reported a failure and left the fix to guesswork.

**The address comes from `bounce_recipient`**, the column `RecordBounce` writes
with the address the delivery report actually named. Not from the send's
recipient list, and that distinction is the whole PR:

> *"A delivery report names ONE failed recipient, but the bounce stamp landed on
> the whole row: a send with a CC would mark every address on it as the one that
> refused."* — the migration that added the column

**My first version had exactly that bug.** I read `recipients->>0` — the first
address on the send. Against a two-recipient send whose second address bounced,
it named `colleague@turbinenbau.de` as dead while `dana@` was the one that
refused. A rep would have "fixed" a working address and left the broken one
alone. The integration test now seeds the bounced address **second**, so
reverting to that spelling fails by name.

The column is per-lane: a park is about the send as a whole and has no address
to name, so the undelivered lane reads a literal `''` rather than borrowing a
recipient the failure was not about.

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestTheBounceRowCarriesTheAddress` — the card's line reads `dana@turbinenbau.de — 550 no such user`. |
| Permission/row scope | Unchanged, and no new disclosure: the lane is `o.user_id = $N`, the reader's own outbox, so the address was already theirs. When the person is withheld, `PersonID` is zero and the card draws no subject and no link — the address still shows, correctly, because it is the reader's own send. |
| Failure behavior | `TestABouncedSendNamesTheAddressThatRefusedIt` covers all four states: both, address only, reason only, neither. Neither draws no line rather than an empty one. |
| Idempotency/concurrency | Read path only. |
| Mobile | One existing line gains text; no layout change. |
| Storybook | No new component. |
| Accessibility | No new control. |
| Contract | None. `detail` already exists and its description already names "a bounce reason". |
| Write shape | n/a — read path. No migration: `bounce_recipient` shipped in `1788011515` and nothing read it. |
| Mutation strength | Reverting to `recipients->>0` names the bystander, by name. Dropping the read entirely reports `""`, by name. Both against real Postgres. |
| Full lane | `make check-backend` EXIT=0. All **151** comms integration tests pass — the statement is shared with the undelivered lane, so a column change could have broken it silently. |

**Codex did not review this.** Two runs backgrounded past their window and
returned no output. The recipient-index defect above is the finding I had asked
it to check for and found myself; the shared-statement and disclosure questions
I verified by execution. Flagging it rather than implying a review happened.

The test failed twice before it was right, both usefully: the shared fixture
hardcodes `buyer@example.com` in **two** places (the send's recipient and the
bounce report), so a test built on those would have passed against a read that
returned a constant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The worklist bounce card now names the address that refused the send, so a rep no longer has to guess which of a contact's addresses is dead after a delivery fails.

- Reads the address from `bounce_recipient`, the column `RecordBounce` writes with the address the delivery report actually named — not from the send's recipient list, which would name the first address on a multi-recipient send.
- The integration test seeds the bounced address second, so any read that takes the first recipient fails by name.
- The undelivered lane reads a literal empty string: a park is about the send as a whole and has no address to name.
- The card's supporting line pairs the address with the provider's reason, address first; a send carrying neither draws no line rather than an empty one.
- No resend from the queue; this only names the failed address.

No migration needed: `bounce_recipient` shipped in an earlier migration and nothing read it until now.

<sup>Written for commit c15a57c62ccc533b199d53d9edb74ac4057da150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bounce notifications now identify the specific recipient address that rejected a message.
  * Bounce details display the recipient, rejection reason, or both when available.
  * Bounce entries without recipient or reason details no longer show empty supporting text.

* **Tests**
  * Added coverage confirming recipient-specific bounce reporting and detail rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->