### PR TITLE
fix(privacy): the satellite sweep declares its error instead of testing nil

### DIFF
--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -377,13 +377,10 @@ func anonymizePersonRecord(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
 // reads this FILE's SQL literals to prove every satellite is handled, so a
 // helper elsewhere or a loop over identifiers is invisible to it.
 func deleteIdentifyingSatellites(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
-	var err error
 	// The anonymize UPDATES the person row rather than deleting it, so none of
 	// these cascades — one skipped leaves the subject readable beside an
 	// "Erased Subject" record.
-	if err == nil {
-		_, err = tx.Exec(ctx, `DELETE FROM person_social WHERE person_id = $1`, id)
-	}
+	_, err := tx.Exec(ctx, `DELETE FROM person_social WHERE person_id = $1`, id)
 	if err == nil {
 		_, err = tx.Exec(ctx, `DELETE FROM person_email WHERE person_id = $1`, id)
 	}


### PR DESCRIPTION
## What

`deleteIdentifyingSatellites` opened with a `var err error` and then guarded its
first statement on a nil it had just declared. The chain reads the same without
it, and one fewer line stands between the reader and the comment that says why
every satellite has to be handled in this file.

One file, +2/−5. Nothing else.

### What this PR no longer carries

It opened as the craft-gate fix: `make craft-static` was red on `main` with two
`long-func` findings, `craftsmanship` sits in the `ci` rollup's `needs`, and so
every open pull request was red with it. That is no longer true — `main` at
`0a83bf599` reports `PASS — 0 blocker, 0 major, 0 minor`, and it got there by its
own route rather than this one. Rebased onto that `main`, each of this branch's
remaining pieces resolved to the answer already standing:

- **`AssembleFor` / `measureWeek`** — `main` landed its own `measureWeek`, with a
  wider signature that also folds in the deals read, the prior-review lookup and
  `LearningsState`. Keeping this branch's narrower spelling would define the
  function twice.
- **`newServer`** — `main` moved the forecast and analytics-share wiring out to
  `serverassembly.go`, which is a different answer to the same ceiling and is
  already merged. `newServer` is under 80 lines without this branch's helpers, so
  extracting a lone `newAssuranceHandlers` would add an abstraction with one
  caller and a second spelling of a seam that already exists.
- **`listActivitiesFilter`, `anonymizePersonRecord`, the migration-citation
  register, the send-surface census, `unsaved.spec.ts`** — dropped earlier for
  the same reason, each in a merge rather than as a competing spelling.

What survives is the cleanup above, which stands on its own.

## Why

The recurring defect behind the original findings is worth naming even though
this PR no longer fixes any of them: the pre-push hook runs `craft static`
**diff-scoped**, while CI runs it **whole-tree**. A change that is clean in its
own diff can push a function that was already at the ceiling over it, and the
author cannot see that locally. `AssembleFor` crossed the ceiling twice in one
night that way, at 84 lines and again at 92, from two separate PRs each adding a
few lines. Closing that gap is its own change.

## How verified

On this branch at `3c924ff7e`, rebased onto `main` at `0a83bf599`:

- `go run -C cli/craft . static --strict --root ../../backend`: `PASS — 0 blocker,
  0 major, 0 minor`. The same command on a clean `main` worktree also passes,
  which is what retired this PR's original purpose.
- `go test ./internal/modules/privacy/... ./gates/`: both packages `ok`.
- `go build ./...`, `go vet ./internal/modules/privacy/...`, `gofmt -l`: clean.

The `DELETE` statements themselves are untouched, so the gate that reads this
file's SQL literals to prove every satellite is handled sees the same corpus.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — no statement, argument or order changes; only the declaration of `err`
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

AI-generated in full: the cleanup, the rebase and the conflict resolutions, and
this description. Each conflict was resolved toward the implementation already
on `main` rather than toward this branch's, so the tree keeps one spelling of
each capability.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaNzMSm8r95MiJ5KZfVwcv