### PR TITLE
The decision census proves where deliveries are staged

### DIFF
--- a/backend/gates/decisioncoverage_test.go
+++ b/backend/gates/decisioncoverage_test.go
@@ -29,11 +29,12 @@ package gates
 // says so in its own comment and defends with an explicit error. Asserting the
 // guard here is what keeps that defence from being deleted as belt-and-braces.
 //
-// NOT in the corpus: comms.Store.StageControllerTx. It has no production caller
-// on main — the controller mail lane it belongs to was never wired — so it
-// stages nothing today and an obligation on it would be an assertion about code
-// that does not run. It joins the corpus the moment a caller appears, because
-// the corpus is derived from who calls the stagers rather than listed here.
+// The corpus is proven, not asserted: gatekit.Scope sweeps the code this gate
+// does NOT read and fails on any staging site outside its roots. A module never
+// writes a sibling's table, so a delivery is staged only by a compose
+// implementation of the module-facing stager interface — and if that stops
+// being true, the sweep names the file rather than a comment claiming it cannot
+// happen.
 
 import (
 	"go/ast"
@@ -41,6 +42,8 @@ import (
 	"go/token"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 // stagingObligations are the calls a staging method must pair. Each is the
@@ -60,32 +63,39 @@ var stagerCalls = []string{"StageTx", "StageChannelTx", "StageControllerTx"}
 func TestEveryStagedDeliveryCarriesItsAuthorization(t *testing.T) {
 	t.Parallel()
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset,
-		"internal/compose/commsstager.go", nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("parsing the staging seam: %v", err)
+	scope := gatekit.Scope{
+		Roots:   []string{"internal/compose"},
+		Subject: stagesADeliveryFile,
+		Exempt:  stagerCallers,
 	}
 
 	subjects := map[string]map[string]bool{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
+	for _, file := range scope.Files(t) {
+		for _, decl := range file.File.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			called := callsIn(fn)
+			if !stagesADelivery(called) {
+				continue
+			}
+			subjects[fn.Name.Name] = called
 		}
-		called := callsIn(fn)
-		if !stagesADelivery(called) {
-			continue
-		}
-		subjects[fn.Name.Name] = called
 	}
 
-	// Under-recognition is the one way this must not fail. A gate that parsed
-	// the wrong file, or a rename that made every method stop matching, would
-	// find no subjects and report PASS.
-	if len(subjects) < 2 {
-		t.Fatalf("found %d staging methods, want at least the mail and channel pair: "+
-			"the gate is looking in the wrong place or the stagers were renamed", len(subjects))
+	// An exemption that matched nothing is ratification of code that is gone: if
+	// activities ever stops reaching the seam, the entry saying why that was
+	// fine must fail rather than sit there looking deliberate.
+	stagerCallers.AssertAllMatched(t)
+
+	// Derived from the writers themselves, not counted by hand: one subject per
+	// delivery writer, so renaming a stager fails here rather than leaving a
+	// smaller number for somebody to edit the floor down to.
+	if len(subjects) < len(stagerCalls) {
+		t.Fatalf("found %d staging methods, want one per delivery writer (%d): "+
+			"a writer whose callers vanished is a lane staging nothing, or a "+
+			"rename this gate stopped matching", len(subjects), len(stagerCalls))
 	}
 
 	names := map[string]bool{}
@@ -149,6 +159,45 @@ func TestAStagingPathWithNoAuthorityFailsRatherThanStages(t *testing.T) {
 }
 
 // stagesADelivery reports whether a method writes a delivery row.
+// stagerCallers ratifies the module-tier files that CALL a delivery writer
+// without being one.
+//
+// Modules never write a sibling's table, so activities reaches the delivery row
+// through an interface it declares and compose implements. The call reads like
+// a staging site to a selector-matching gate and is not one: the obligations
+// live in the implementation, which is inside the roots. Widening the roots to
+// cover these would put the obligation on the caller, where AuthorizeStagingTx
+// is not reachable and could not be satisfied.
+var stagerCallers = gatekit.Waive(map[string]string{
+	"internal/modules/activities/sendcore.go": "calls StageTx on the DeliveryStager " +
+		"INTERFACE (email.go:122), which compose implements: the mail send path hands the " +
+		"delivery to the seam and the seam carries the authorization, so the obligation " +
+		"belongs to commsStager.StageTx and is asserted there",
+
+	"internal/modules/activities/channelsend.go": "the channel twin of sendcore, calling " +
+		"StageChannelTx on the same injected seam for the same reason — a module may not " +
+		"reach the delivery table itself, so what it calls is an interface and what carries " +
+		"the obligation is the compose method behind it",
+})
+
+// stagesADeliveryFile reports whether a file holds any staging site at all.
+//
+// The same predicate Scope applies inside the roots and outside them: a file
+// anywhere in the module that calls a delivery writer is this gate's business,
+// and one outside internal/compose means the roots below are wrong.
+func stagesADeliveryFile(_ string, file *ast.File) bool {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if stagesADelivery(callsIn(fn)) {
+			return true
+		}
+	}
+	return false
+}
+
 func stagesADelivery(called map[string]bool) bool {
 	for _, stager := range stagerCalls {
 		if called[stager] {

--- a/backend/gates/directmailbypass_test.go
+++ b/backend/gates/directmailbypass_test.go
@@ -27,13 +27,6 @@ package gates
 // never when it is correspondence with a data subject about the relationship,
 // which is what the consent engine exists to authorize.
 //
-// KNOWN GAP, ratified below rather than hidden: consent's confirm-details link
-// is mailed directly. The eight-PR consent plan's PR 3 was to move it onto the
-// durable lane and never landed, so the message that asks somebody to check
-// what is held about them is itself unrecorded. It is waived because refusing
-// it would delete a working feature, and the waiver names the cost so the debt
-// is legible instead of forgotten.
-
 import (
 	"go/ast"
 	"go/parser"


### PR DESCRIPTION
Round-7 item K. Two gate files, no production code — but the gate in question was passing over a lane it could not see.

## The gate was reading one file

`TestEveryStagedDeliveryCarriesItsAuthorization` asserts that every method staging a delivery pairs it with an authorization decision. It parsed one hard-coded filename, `internal/compose/commsstager.go`, while its own comment claimed *"the corpus is derived from who calls the stagers rather than listed here."*

Neither half was true. When the controller mail lane landed and `QueueConfirmationTx` became a real caller of `StageControllerTx`, the gate carried on reading a file that never mentions it — and reported PASS over a lane staging real deliveries. The stale comment even named this as a future event ("it joins the corpus the moment a caller appears"), which is precisely what did not happen.

This is the failure mode AGENTS.md rule 8 names: under-recognition reads a smaller tree and leaves no assertion to notice.

## The fix uses the tool the tree already owns

`gatekit.Scope` exists for exactly this defect, and its doc comment states the problem in the same words. **The sibling gate edited in this same change was already using it** — I did not notice until review.

Scope sweeps the code the gate does *not* read and fails on any subject outside its roots, so the roots become a proven claim rather than an assumption.

It immediately named two files: `activities/sendcore.go` and `activities/channelsend.go`, both calling delivery writers by name. Both reach them through the `DeliveryStager` interface that compose implements — a module may not write a sibling's table — so the obligation belongs to the implementation and could not be satisfied at the caller. They are ratified with that reason, and `AssertAllMatched` fails the ratification if activities ever stops reaching the seam.

Worth being plain about: before review I had this as a *comment* asserting those files were fine. Scope turned the argument into an assertion that fails.

## Two magic numbers went with it

I had shipped a source-count floor of `50` and a subject floor of `3`. The first measured a population the gate never used — the glob returns 1195 files, only 619 non-test, and the check ran before the filter, so it would have passed with 1145 files missing. The second hard-coded the very thing this change is about.

The floor is now `len(stagerCalls)`: one subject per delivery writer, so renaming a stager fails here rather than leaving a smaller number for somebody to quietly edit down to.

## Mutation check

Narrowing the roots back to the single file fires **both** guards: Scope names `controllermail.go` as a site outside the roots, and the derived floor fails at 2 of 3. Re-verified after the final rebase, not just on the base I developed against.

## Also here

`directmailbypass_test.go` documented consent's confirm-details link as a known gap because "the consent plan's PR 3 never landed." It landed. `consent` holds no mailer — `confirmmail.go` reports whether sending is possible and routes through the durable lane — and the waiver list's only consent-adjacent entry is the transport *under* that lane. I verified this against the tree rather than assuming, since the whole point of the change is that stale claims mislead.

`make check-backend` green on the rebased tree. Reviewed by `craft-reviewer`, which is what caught the magic numbers and pointed at `gatekit.Scope`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delivery staging coverage gate to prove its corpus via `gatekit.Scope` instead of a hard-coded file, so new staging sites like the controller mail lane are caught instead of silently passing. Also removes a stale "known gap" comment for consent whose referenced PR has landed.

- The gate now sweeps the whole module and fails on any staging site outside its roots, and the floor is derived from the writers.
- Two activity files that call delivery writers via the `DeliveryStager` interface are explicitly waived with reasons.
- The `directmailbypass_test.go` waiver comment describing a debt already paid is removed.

<sup>Written for commit 4e3e34ef82e5ce3c232e5136d63cbeb955424322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded delivery authorization coverage to sweep the relevant module scope.
  - Added validation that all staged-delivery callers are accounted for.
  - Updated coverage thresholds to reflect the discovered call sites.
  - Added documented waivers for approved exceptions.
- **Documentation**
  - Removed outdated explanatory comments regarding a direct-mail consent flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->