### PR TITLE
fix(ai): the Art. 50 disclosure has one spelling, in the draft's language

### DIFF
--- a/backend/gates/aidisclosure_test.go
+++ b/backend/gates/aidisclosure_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H1
+
+package gates
+
+// The Art. 50 disclosure has ONE spelling, and it is draftfloor.AIDisclosure.
+//
+// The sentence a model-written message carries to say a model wrote it is a
+// legal obligation, and the tree carried five copies of it that had drifted:
+// some named the article and some did not, two of the five were English
+// whatever language the draft was in, and which sentence a customer received
+// depended on which surface wrote their message. That is the shape of defect
+// nobody notices until two emails are compared side by side — and the one that
+// is hardest to argue was an accident afterwards.
+//
+// So the prohibition is on the SENTENCE, not on a symbol: a second copy arrives
+// as a string literal, which is exactly what a new drafting surface reaches for
+// when it does not know the helper exists. The check reads the shipped wording
+// from the helper itself rather than restating it, so the day the wording
+// changes this gate follows rather than failing.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// disclosureHome is the file this gate exempts: its literals are the subject
+// rather than a violation.
+//
+// Held by: TestTheAIDisclosureHasOneSpelling (backend/gates/aidisclosure_test.go)
+const disclosureHome = "backend/internal/shared/kernel/draftfloor/persontext.go"
+
+// disclosureStems are the parts of each sentence a copy would carry, short of
+// the citation clause: a drafter that wrote its own would spell the opening and
+// might well leave the article off, which is precisely the drift that happened.
+//
+// Matched anywhere in the file rather than only at the start of a literal. A
+// second copy does not have to be a whole string — the first one this gate was
+// tried against was appended to the real line — and a comment quoting the
+// sentence is a copy too: it is what the next reader edits when the wording
+// changes and the code does not.
+func disclosureStems(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, lang := range textlang.Shipped {
+		line := draftfloor.AIDisclosure(lang)
+		stem, _, found := strings.Cut(line, " (")
+		if !found {
+			t.Fatalf("the %s disclosure carries no citation clause to cut at: %q", lang, line)
+		}
+		out = append(out, stem)
+	}
+	if len(out) == 0 {
+		t.Fatal("no shipped language answered a disclosure — this gate is reading nothing")
+	}
+	return out
+}
+
+func TestTheAIDisclosureHasOneSpelling(t *testing.T) {
+	t.Parallel()
+
+	stems := disclosureStems(t)
+	root := filepath.Join(repoRoot, "backend")
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		if filepath.ToSlash(rel) == disclosureHome {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		source := string(raw)
+		for _, stem := range stems {
+			if !strings.Contains(source, stem) {
+				continue
+			}
+			t.Errorf("%s writes the Art. 50 disclosure itself:\n\n\t%s…\n\n"+
+				"It is a legal line with three translations, and a second copy is how the tree "+
+				"came to send one sentence from one surface and a different one from another. "+
+				"Call draftfloor.AIDisclosure(lang) with the draft's own language.", rel, stem)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -461,7 +461,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
 	"cannot-drift":   162,
-	"once":           176,
+	"once":           174,
 	"one-of-a-kind":  174,
 	"is-every-named": 88,
 	"only-noun":      12,

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -218,13 +218,9 @@ func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang strin
 		}
 		out.To = &to
 	}
-	if aiWritten {
-		// The DRAFT's language, not the server's: this line used to be an
-		// English constant, so a German draft carried an English legal
-		// sentence. draftfloor holds the one spelling, in all three.
-		disclosure := draftfloor.AIDisclosure(textlang.Lang(lang))
-		out.AiDisclosure = &disclosure
-	}
+	// The DRAFT's language, not the server's: a German draft owes a German
+	// disclosure.
+	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, textlang.Lang(lang))
 	return out
 }
 

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // Assembler is the caller's own composite read of the account — the same seam
@@ -183,7 +184,7 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	out := wire(draft, by, voice.Degraded)
+	out := wire(draft, by, voice.Degraded, req.Envelope.Language)
 	// The scoped read's own report of what the narrowing kept, so the
 	// composer's scope line counts what the draft was actually written from.
 	out.Scope = view.Scope
@@ -200,7 +201,7 @@ func (s *Service) Draft(
 // draft_ref is deliberately absent. The reply drafter returns one so the voice
 // model can learn from what the rep changed — and recording a served draft is
 // a WRITE, which this operation does not perform.
-func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontracts.AccountEmailDraft {
+func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang string) crmcontracts.AccountEmailDraft {
 	aiWritten := by == crmcontracts.Model
 	out := crmcontracts.AccountEmailDraft{
 		Subject:       draft.Subject,
@@ -218,16 +219,14 @@ func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontrac
 		out.To = &to
 	}
 	if aiWritten {
-		disclosure := aiDisclosure
+		// The DRAFT's language, not the server's: this line used to be an
+		// English constant, so a German draft carried an English legal
+		// sentence. draftfloor holds the one spelling, in all three.
+		disclosure := draftfloor.AIDisclosure(textlang.Lang(lang))
 		out.AiDisclosure = &disclosure
 	}
 	return out
 }
-
-// The machine-readable Art. 50 line, the same sentence the reply drafter
-// stamps. Written once here rather than assembled per call: a disclosure that
-// varies by call site is one a reader learns to skim.
-const aiDisclosure = "This message was drafted with AI assistance."
 
 func wireReasons(reasons []Reason) []crmcontracts.AccountDraftReason {
 	out := make([]crmcontracts.AccountDraftReason, 0, len(reasons))

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -218,8 +218,6 @@ func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang strin
 		}
 		out.To = &to
 	}
-	// The DRAFT's language, not the server's: a German draft owes a German
-	// disclosure.
 	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, textlang.Lang(lang))
 	return out
 }

--- a/backend/internal/compose/accountdraft/write_test.go
+++ b/backend/internal/compose/accountdraft/write_test.go
@@ -220,7 +220,7 @@ func TestTheCallersOwnIntentIsOutsideTheFence(t *testing.T) {
 func TestDraftingNeverReturnsADraftRef(t *testing.T) {
 	// draft_ref exists so a served draft can be scored later, which is a
 	// write. This operation performs none, so the field stays null.
-	out := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false)
+	out := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false, "en")
 	if out.DraftRef != nil {
 		t.Fatalf("draft_ref = %v, want null: recording a served draft is a write", out.DraftRef)
 	}
@@ -230,11 +230,11 @@ func TestDraftingNeverReturnsADraftRef(t *testing.T) {
 // so the degraded flag is pinned here too — in both states, because a client
 // reading an absent field as false must not see "fine" for a lost voice.
 func TestWireCarriesTheVoiceDegradedFlag(t *testing.T) {
-	degraded := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, true)
+	degraded := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, true, "en")
 	if degraded.VoiceDegraded == nil || !*degraded.VoiceDegraded {
 		t.Fatal("a degraded voice load must be stamped on the wire draft")
 	}
-	clean := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false)
+	clean := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false, "en")
 	if clean.VoiceDegraded == nil || *clean.VoiceDegraded {
 		t.Fatal("a clean load must stamp voice_degraded=false, not omit it")
 	}

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -25,9 +25,10 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/search"
-	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // setupWithOfferDraft boots the e2e harness with the offer-drafting brain
@@ -161,7 +162,7 @@ func TestOfferRegenerateHTTP_GroundedAIDraftStagesAndDisclosesWithoutMovingTotal
 	if regenerated.AiGenerated == nil || !*regenerated.AiGenerated {
 		t.Fatalf("ai_generated = %v, want true (the candidate grounds)", regenerated.AiGenerated)
 	}
-	if regenerated.AiDisclosure == nil || *regenerated.AiDisclosure != signals.Art50Disclosure {
+	if regenerated.AiDisclosure == nil || *regenerated.AiDisclosure != draftfloor.AIDisclosure(textlang.English) {
 		t.Fatalf("ai_disclosure = %v, want the Art.50 disclosure", regenerated.AiDisclosure)
 	}
 	if regenerated.DiffFromPrevious == nil || len(regenerated.DiffFromPrevious.Added) != 1 ||

--- a/backend/internal/compose/leaddraft/service.go
+++ b/backend/internal/compose/leaddraft/service.go
@@ -132,5 +132,5 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	return persondraft.Wire(draft, by, voice.Degraded), nil
+	return persondraft.Wire(draft, by, voice.Degraded, envelope.Language), nil
 }

--- a/backend/internal/compose/network/intronotewrite.go
+++ b/backend/internal/compose/network/intronotewrite.go
@@ -310,8 +310,6 @@ func wireIntroNote(
 		AiGenerated: &aiWritten,
 		Reasoning:   noteReasons(facts),
 	}
-	// The DRAFT's language, not the server's: a German draft owes a German
-	// disclosure.
 	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, noteLang(facts.lang))
 	return out
 }

--- a/backend/internal/compose/network/intronotewrite.go
+++ b/backend/internal/compose/network/intronotewrite.go
@@ -310,10 +310,9 @@ func wireIntroNote(
 		AiGenerated: &aiWritten,
 		Reasoning:   noteReasons(facts),
 	}
-	if aiWritten {
-		disclosure := draftfloor.AIDisclosure(noteLang(facts.lang))
-		out.AiDisclosure = &disclosure
-	}
+	// The DRAFT's language, not the server's: a German draft owes a German
+	// disclosure.
+	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, noteLang(facts.lang))
 	return out
 }
 

--- a/backend/internal/compose/offerdraft.go
+++ b/backend/internal/compose/offerdraft.go
@@ -52,11 +52,12 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
-	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 	"github.com/margince/margince/backend/internal/shared/ports/retrieval"
@@ -232,7 +233,7 @@ func (d offerDrafter) DraftOfferLines(ctx context.Context, offerID ids.OfferID) 
 	}
 
 	added, removed, changed := diffOfferLines(linesOf(before), linesOf(after))
-	disclosure := signals.Art50Disclosure
+	disclosure := draftfloor.AIDisclosure(textlang.Lang(identity.BaseLanguageForPrompt(ctx, d.pool)))
 	diff := buildOfferDiff(added, removed, changed)
 	after.AiGenerated = boolPtr(true)
 	after.AiDisclosure = &disclosure

--- a/backend/internal/compose/offerdraft_integration_test.go
+++ b/backend/internal/compose/offerdraft_integration_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/search"
-	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // offerDraftPerms is the deal-desk grant this suite drives the drafter
@@ -196,7 +197,7 @@ func TestDraftOfferLinesStagesGroundedLinesAndDiscloses(t *testing.T) {
 	if !result.AIGenerated {
 		t.Fatalf("AIGenerated = false, want true (two candidates ground)")
 	}
-	if result.AIDisclosure == nil || *result.AIDisclosure != signals.Art50Disclosure {
+	if result.AIDisclosure == nil || *result.AIDisclosure != draftfloor.AIDisclosure(textlang.English) {
 		t.Fatalf("AIDisclosure = %v, want the Art.50 disclosure", result.AIDisclosure)
 	}
 	if result.Diff == nil || result.Diff.Added == nil || len(*result.Diff.Added) != 2 {

--- a/backend/internal/compose/org360/introdraft.go
+++ b/backend/internal/compose/org360/introdraft.go
@@ -241,8 +241,6 @@ func wireIntroRequest(
 		AiGenerated: &aiWritten,
 		Reasoning:   introReasons(facts),
 	}
-	// The DRAFT's language, not the server's: a German draft owes a German
-	// disclosure.
 	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, facts.lang)
 	return out
 }

--- a/backend/internal/compose/org360/introdraft.go
+++ b/backend/internal/compose/org360/introdraft.go
@@ -241,10 +241,9 @@ func wireIntroRequest(
 		AiGenerated: &aiWritten,
 		Reasoning:   introReasons(facts),
 	}
-	if aiWritten {
-		disclosure := draftfloor.AIDisclosure(facts.lang)
-		out.AiDisclosure = &disclosure
-	}
+	// The DRAFT's language, not the server's: a German draft owes a German
+	// disclosure.
+	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, facts.lang)
 	return out
 }
 

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -185,13 +185,9 @@ func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang strin
 		}
 		out.To = &to
 	}
-	if aiWritten {
-		// The DRAFT's language, not the server's: this line used to be an
-		// English constant, so a German draft carried an English legal
-		// sentence. draftfloor holds the one spelling, in all three.
-		disclosure := draftfloor.AIDisclosure(textlang.Lang(lang))
-		out.AiDisclosure = &disclosure
-	}
+	// The DRAFT's language, not the server's: a German draft owes a German
+	// disclosure.
+	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, textlang.Lang(lang))
 	return out
 }
 

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -185,8 +185,6 @@ func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang strin
 		}
 		out.To = &to
 	}
-	// The DRAFT's language, not the server's: a German draft owes a German
-	// disclosure.
 	out.AiDisclosure = draftfloor.AIDisclosureFor(aiWritten, textlang.Lang(lang))
 	return out
 }

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // Assembler is the caller's own composite read of the person — the same seam
@@ -141,7 +142,7 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	out := Wire(draft, by, voice.Degraded)
+	out := Wire(draft, by, voice.Degraded, req.Envelope.Language)
 	// The scoped read's own report of what the narrowing kept, so the
 	// composer's scope line counts what the draft was actually written from.
 	out.Scope = view.Scope
@@ -163,7 +164,11 @@ func (s *Service) Draft(
 // same writer, and a second mapping of one Draft onto one AccountEmailDraft is
 // two answers to one question — including which of them stamps the Art. 50
 // disclosure, which is the half a reader would notice missing.
-func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontracts.AccountEmailDraft {
+//
+// lang is the DRAFT's language, from the envelope its caller resolved. Passed
+// rather than read here because the two callers resolve their own, and a wire
+// mapper that went looking for one would be a second resolver.
+func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool, lang string) crmcontracts.AccountEmailDraft {
 	aiWritten := by == crmcontracts.Model
 	out := crmcontracts.AccountEmailDraft{
 		Subject:       draft.Subject,
@@ -181,16 +186,14 @@ func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontrac
 		out.To = &to
 	}
 	if aiWritten {
-		disclosure := aiDisclosure
+		// The DRAFT's language, not the server's: this line used to be an
+		// English constant, so a German draft carried an English legal
+		// sentence. draftfloor holds the one spelling, in all three.
+		disclosure := draftfloor.AIDisclosure(textlang.Lang(lang))
 		out.AiDisclosure = &disclosure
 	}
 	return out
 }
-
-// The machine-readable Art. 50 line, the same sentence every drafter stamps.
-// Written once here rather than assembled per call: a disclosure that varies by
-// call site is one a reader learns to skim.
-const aiDisclosure = "This message was drafted with AI assistance."
 
 func wireReasons(reasons []Reason) []crmcontracts.AccountDraftReason {
 	out := make([]crmcontracts.AccountDraftReason, 0, len(reasons))

--- a/backend/internal/compose/persondraft/wire_test.go
+++ b/backend/internal/compose/persondraft/wire_test.go
@@ -16,12 +16,12 @@ func TestWireCarriesTheVoiceDegradedFlag(t *testing.T) {
 	t.Parallel()
 	draft := Draft{Subject: "s", Body: "b"}
 
-	degraded := Wire(draft, crmcontracts.Model, true)
+	degraded := Wire(draft, crmcontracts.Model, true, "en")
 	if degraded.VoiceDegraded == nil || !*degraded.VoiceDegraded {
 		t.Fatal("a degraded voice load must be stamped on the wire draft")
 	}
 
-	clean := Wire(draft, crmcontracts.Model, false)
+	clean := Wire(draft, crmcontracts.Model, false, "en")
 	if clean.VoiceDegraded == nil || *clean.VoiceDegraded {
 		t.Fatal("a clean load must stamp voice_degraded=false, not omit it")
 	}

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -20,11 +20,11 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/ai"
-	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 const replyActivityMaxRunes = 12_000
@@ -180,7 +180,10 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		d.logger().WarnContext(ctx, "model reply draft unavailable; using deterministic draft", "err", err)
 		return activities.DraftResult{Subject: fallbackSubject, Body: fallbackBody, VoiceDegraded: voice.Degraded}, nil
 	}
-	disclosure := signals.Art50Disclosure
+	// The draft's OWN language, from the envelope the drafter already resolved:
+	// a German reply used to carry an English legal line, which is the half of
+	// the drift a reader meets rather than a maintainer.
+	disclosure := draftfloor.AIDisclosure(textlang.Lang(envelope.Language))
 	return activities.DraftResult{
 		Subject:             draft.Subject,
 		Body:                draft.Body,

--- a/backend/internal/modules/signals/intropath.go
+++ b/backend/internal/modules/signals/intropath.go
@@ -28,14 +28,6 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
-// Art50Disclosure is the Art. 50 AI-assisted disclosure every proposed
-// draft renders (EU AI Act Art. 50; A33/ADR-0025) — one spelling, machine
-// readable in the payload AND human readable inside the draft body.
-// Exported so every AI-drafted-content surface reuses this one string
-// rather than drafting its own wording (compose/offerdraft.go's
-// ai_disclosure is the other consumer).
-const Art50Disclosure = "This message was drafted with AI assistance (EU AI Act Art. 50 disclosure)."
-
 // IntroPath proposes the warm-intro path for a warm signal: the strongest
 // visible contact at the resolved organization is the route in.
 func (s *Store) IntroPath(ctx context.Context, signalID ids.SignalID, now time.Time) (crmcontracts.SignalIntroPath, error) {
@@ -131,7 +123,7 @@ var introTable = map[textlang.Lang]introPhrases{
 		DirectSubject: "Getting in touch about %s",
 		DirectBody: "Hi %s,\n\nI am writing because of something we picked up about %s: %s. " +
 			"Given that we %s, this felt worth raising with you directly.\n\n%s",
-		Disclosure: Art50Disclosure,
+		Disclosure: draftfloor.AIDisclosure(textlang.English),
 		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
 			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "are working together on a deal",
 			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "know each other through your company",
@@ -144,7 +136,7 @@ var introTable = map[textlang.Lang]introPhrases{
 		DirectSubject: "Kurze Anfrage zu %s",
 		DirectBody: "Hallo %s,\n\nich melde mich, weil wir etwas zu %s aufgenommen haben: %s. " +
 			"Da wir %s, wollte ich das direkt mit Ihnen besprechen.\n\n%s",
-		Disclosure: "Diese Nachricht wurde mit KI-Unterstützung verfasst (Offenlegung nach Art. 50 EU-KI-Verordnung).",
+		Disclosure: draftfloor.AIDisclosure(textlang.German),
 		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
 			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "gemeinsam an einem Vorgang arbeiten",
 			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "über Ihr Unternehmen in Kontakt stehen",
@@ -157,7 +149,7 @@ var introTable = map[textlang.Lang]introPhrases{
 		DirectSubject: "Xin được liên hệ về %s",
 		DirectBody: "Chào %s,\n\ntôi liên hệ vì chúng tôi ghi nhận một việc liên quan đến %s: %s. " +
 			"Vì hai bên %s, tôi muốn trao đổi trực tiếp với anh/chị.\n\n%s",
-		Disclosure: "Thư này được soạn với sự hỗ trợ của AI (công bố theo Điều 50 Đạo luật AI của EU).",
+		Disclosure: draftfloor.AIDisclosure(textlang.Vietnamese),
 		Relationships: map[crmcontracts.SignalWarmContactRelationshipKind]string{
 			crmcontracts.SignalWarmContactRelationshipKindDealStakeholder: "đang cùng làm việc trong một cơ hội",
 			crmcontracts.SignalWarmContactRelationshipKindEmployment:      "có liên hệ qua công ty của anh/chị",

--- a/backend/internal/shared/kernel/draftfloor/persontext.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext.go
@@ -149,20 +149,28 @@ func wordRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
 }
 
-// AIDisclosure is the Art. 50 authorship line, in the draft's own language.
+// AIDisclosure is the Art. 50 authorship line, in the draft's own language, and
+// it is the ONLY spelling of it in the tree.
 //
-// Here rather than beside one drafting site because it is a LEGAL obligation
-// with three translations, and the tree already carries several spellings of it
-// that have drifted apart — some naming the article, some not. Every new
-// drafting surface should reach for this one; consolidating the older copies is
-// its own piece of work, filed as issue #3513.
+// Here rather than beside one drafting site because it is a LEGAL obligation:
+// the tree carried five copies that had drifted, some naming the article and
+// some not, so which sentence a customer received depended on which surface
+// wrote their message. That is the shape of defect nobody notices until two
+// emails are compared side by side.
+//
+// It NAMES THE ARTICLE, which is what three of the five did and what the German
+// copy did: consolidating had to pick one, and the citation is the half a reader
+// can act on — it says which obligation the line is discharging rather than
+// leaving them to guess. Nothing that carried it loses it.
+//
+// Held by: TestTheAIDisclosureHasOneSpelling (backend/gates/aidisclosure_test.go)
 func AIDisclosure(lang textlang.Lang) string {
 	switch lang {
 	case textlang.German:
-		return "Diese Nachricht wurde mit KI-Unterstützung verfasst."
+		return "Diese Nachricht wurde mit KI-Unterstützung verfasst (Offenlegung nach Art. 50 EU-KI-Verordnung)."
 	case textlang.Vietnamese:
-		return "Tin nhắn này được soạn với sự hỗ trợ của AI."
+		return "Tin nhắn này được soạn với sự hỗ trợ của AI (công bố theo Điều 50 Đạo luật AI của EU)."
 	default:
-		return "This message was drafted with AI assistance."
+		return "This message was drafted with AI assistance (EU AI Act Art. 50 disclosure)."
 	}
 }

--- a/backend/internal/shared/kernel/draftfloor/persontext.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext.go
@@ -176,8 +176,10 @@ func AIDisclosure(lang textlang.Lang) string {
 }
 
 // AIDisclosureFor answers the contract's optional disclosure field: the Art. 50
-// line in the draft's own language when a model wrote it, and nil when a person
-// did.
+// line when a model wrote the draft, and nil when a person did.
+//
+// The DRAFT's language, not the server's — a German draft owes a German
+// disclosure, and the caller passes the language the draft is written in.
 //
 // The pointer is why this exists beside AIDisclosure rather than at each
 // composer. Four of them stamp the field under the same condition, and the

--- a/backend/internal/shared/kernel/draftfloor/persontext.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext.go
@@ -174,3 +174,20 @@ func AIDisclosure(lang textlang.Lang) string {
 		return "This message was drafted with AI assistance (EU AI Act Art. 50 disclosure)."
 	}
 }
+
+// AIDisclosureFor answers the contract's optional disclosure field: the Art. 50
+// line in the draft's own language when a model wrote it, and nil when a person
+// did.
+//
+// The pointer is why this exists beside AIDisclosure rather than at each
+// composer. Four of them stamp the field under the same condition, and the
+// failure mode is not a wrong sentence but an ABSENT one — a nil field is a
+// draft that discloses nothing, which reads to every test around it exactly
+// like a draft a person wrote.
+func AIDisclosureFor(aiWritten bool, lang textlang.Lang) *string {
+	if !aiWritten {
+		return nil
+	}
+	line := AIDisclosure(lang)
+	return &line
+}

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -215,10 +215,10 @@ func TestTheArt50DisclosureIsWrittenInEachLanguageTheProductSpeaks(t *testing.T)
 	}
 	for _, lang := range []textlang.Lang{textlang.German, textlang.Vietnamese} {
 		got := AIDisclosure(lang)
-		switch {
-		case got == "":
+		switch got {
+		case "":
 			t.Errorf("%s has no disclosure", lang)
-		case got == english:
+		case english:
 			t.Errorf("%s falls through to the English disclosure — a reader owed this sentence "+
 				"under Art. 50 is handed one they may not read", lang)
 		}

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -235,3 +235,22 @@ func TestAnUnknownLanguageStillCarriesADisclosure(t *testing.T) {
 			"a disclosure may not be", got)
 	}
 }
+
+// The optional field the composers stamp, in both directions. An absent
+// disclosure on a model-written draft is the failure Art. 50 names, and a
+// disclosure on a draft a person wrote is a claim about them that is not true.
+func TestTheDisclosureFieldIsStampedOnlyForAModelWrittenDraft(t *testing.T) {
+	t.Parallel()
+
+	written := AIDisclosureFor(true, textlang.German)
+	if written == nil {
+		t.Fatal("a model-written draft carried no disclosure field at all — nil reads to every " +
+			"caller exactly like a draft a person wrote")
+	}
+	if *written != AIDisclosure(textlang.German) {
+		t.Errorf("the stamped line is %q, want the German disclosure", *written)
+	}
+	if AIDisclosureFor(false, textlang.German) != nil {
+		t.Error("a draft a person wrote was stamped as AI-assisted")
+	}
+}

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -12,6 +12,8 @@ package draftfloor
 import (
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // A line break is not only "\\n".
@@ -189,5 +191,47 @@ func TestACombiningMarkExtendsTheWord(t *testing.T) {
 	}
 	if !NamesPerson("Grüße Lena, kurz zum Angebot", "Lena") {
 		t.Error("a name beside ordinary punctuation was refused")
+	}
+}
+
+// The Art. 50 line is in the language of the draft it sits under.
+//
+// It used to be one English constant appended to every draft, so a German
+// reply carried an English legal sentence. That is the half of a language drift
+// a READER meets rather than a maintainer — and this particular sentence is the
+// one the regulation requires them to understand.
+//
+// The three languages are named rather than enumerated because textlang
+// declares no set to walk. What holds the completeness claim is
+// backend/gates/languageset_test.go, which fails when the languages the product
+// speaks stop agreeing across the places that declare them; a fourth arriving
+// without a disclosure is caught there and lands here next.
+func TestTheArt50DisclosureIsWrittenInEachLanguageTheProductSpeaks(t *testing.T) {
+	t.Parallel()
+
+	english := AIDisclosure(textlang.English)
+	if english == "" {
+		t.Fatal("English has no disclosure at all")
+	}
+	for _, lang := range []textlang.Lang{textlang.German, textlang.Vietnamese} {
+		got := AIDisclosure(lang)
+		switch {
+		case got == "":
+			t.Errorf("%s has no disclosure", lang)
+		case got == english:
+			t.Errorf("%s falls through to the English disclosure — a reader owed this sentence "+
+				"under Art. 50 is handed one they may not read", lang)
+		}
+	}
+}
+
+// An unknown language still carries a disclosure. Silence is the one answer
+// Art. 50 does not allow, so the fallback is English rather than nothing.
+func TestAnUnknownLanguageStillCarriesADisclosure(t *testing.T) {
+	t.Parallel()
+
+	if got := AIDisclosure(textlang.Lang("kl")); got != AIDisclosure(textlang.English) {
+		t.Errorf("an unknown language answered %q — silence or a guess is the one thing "+
+			"a disclosure may not be", got)
 	}
 }

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -63,7 +63,6 @@ gates/preferencecentrewriters_test.go#func TestThePreferenceCentreResolvesOnePri
 gates/replayscope_test.go#var replayScopeConsts
 gates/restrictedreaders_test.go#var activityReaderScope
 gates/tableownerregistry_test.go#var tableOwners
-internal/compose/accountdraft/service.go#const aiDisclosure
 internal/compose/agentcommand.go#const block at const opApproveApproval
 internal/compose/agentcommand_integration_test.go#func archivableRecordTypes
 internal/compose/agentgatecanon.go#const keyBindsTheRetry
@@ -221,7 +220,6 @@ internal/compose/person360/sectionstimeline.go#func projectScope
 internal/compose/personbrief/doc.go#package personbrief
 internal/compose/persondraft/deterministic.go#type Draft
 internal/compose/persondraft/fold.go#func ConversationState
-internal/compose/persondraft/service.go#const aiDisclosure
 internal/compose/pipelinetrace/rungs.go#func unavailable
 internal/compose/project360/sectionswork.go#var entityTypeProject
 internal/compose/queryseam.go#func queryRunner

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -299,10 +299,11 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (49)
+## Prohibition (50)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
+| `aidisclosure_test.go` | H1 | The Art. 50 disclosure has ONE spelling, and it is draftfloor.AIDisclosure. |
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |


### PR DESCRIPTION
Closes #3513.

## The drift

The EU AI Act Art. 50 line — the sentence a model-written message carries to say a model wrote it — existed in five places, and they disagreed in two visible ways: three named the article and two did not, and two of the five returned English whatever language the draft was in. Which sentence a customer received depended on which surface wrote to them. A legal line that differs by code path is the shape of defect nobody notices until two emails are compared side by side.

## One spelling

`draftfloor.AIDisclosure(lang)` is now the only one, and every drafting surface reaches for it with the language its own envelope already resolved:

| surface | before | now |
|---|---|---|
| `signals/intropath` | its own const + a German literal + a Vietnamese literal | the helper, per language |
| `compose/replydraft` | the English const | the helper, at the envelope's language |
| `compose/offerdraft` | the English const | the helper, at the installation's base language |
| `compose/accountdraft` | an English const, unlocalized | the helper, at the draft's language |
| `compose/persondraft` (and `leaddraft` through it) | an English const, unlocalized | the helper, at the draft's language |

`signals.Art50Disclosure` is gone.

**It names the article.** Consolidating had to pick one wording, and this is the one three of the five already used and the one the German copy used. The citation is the half a reader can act on — it says which obligation the line is discharging rather than leaving them to guess. Nothing that carried it loses it; the two that did not, gain it, along with the two translations they never had.

The Vietnamese now carries the citation clause the intro-path translator already wrote, rather than a new one of mine.

## The gate

`TestTheAIDisclosureHasOneSpelling` (`prohibition H1`) reads the shipped sentence **from the helper** — so the day the wording changes, the gate follows rather than failing — and refuses it anywhere else under `backend/`, in any of the three languages, matching the stem before the citation clause. A second copy arrives as a string literal, which is exactly what a new drafting surface reaches for when it does not know the helper exists.

Matched anywhere in a file rather than only at the start of a literal: the first mutation I tried against it appended the sentence to the real line and slipped through a stricter match. A comment quoting the sentence trips it too, deliberately — a quoted copy is what the next reader edits when the wording changes and the code does not.

Two entries leave `uniquenessclaims.txt` (both now-deleted consts), and the two shape rows move with them.

## Mutation check

Replacing one call site with the old English literal fails the gate by file and sentence; appending it to a real call fails the same way; both restored and re-run green.

`make check-go` green, and the compose integration package passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI disclosure text is now localized for English, German, and Vietnamese drafts.
  * Disclosures now include an EU AI Act Article 50 citation.
  * Unknown languages continue to receive an English disclosure.

* **Bug Fixes**
  * Standardized AI disclosure wording across generated drafts.

* **Documentation**
  * Updated the gate inventory to document the disclosure consistency check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->