### PR TITLE
feat(automation): every automation says whether running it twice repeats anything

### DIFF
--- a/backend/internal/compose/redrivecensus_test.go
+++ b/backend/internal/compose/redrivecensus_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every automation says whether running it twice repeats something.
+//
+// `workflow.Handler.Apply` is documented "idempotent on IdempotencyKey(ev)",
+// and nothing enforces it: no Apply in the tree reads that key. The promise
+// costs nothing while every run happens once, and becomes load-bearing the
+// moment anything re-drives one — a retry then means "the row lands where it
+// already was" for one handler and "the customer is told a second time" for
+// another, and the caller cannot tell which.
+//
+// The answer lives on the handler because the handler owns Apply. Keying it on
+// the ACTION KIND instead reads as tidier and is wrong: leadRouting plans
+// assign_owner and applies it through RouteLead, while the engine's own
+// handlers plan the same kind and apply it through applyAssignOwner. One
+// vocabulary, two writes.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// judged names every handler whose re-drive question has been ANSWERED on
+// purpose, with the reason, and says what the answer is.
+//
+// A handler absent from here fails the census below rather than defaulting
+// quietly: the zero value of Spec.RedrivableWithoutDuplicating is false, which
+// is the safe answer, and a safe answer nobody chose is still nobody's answer.
+// The map is what turns "false because unconsidered" into "false because of
+// this".
+var judged = map[string]struct {
+	redrivable bool
+	because    string
+}{
+	// The three clock reminders and the two stage-change starters mint ONE
+	// create_task and nothing else (taskeffect.go), applied through
+	// ApplyActions, whose create arm claims (handler, occurrence_key,
+	// fingerprint) before writing. A second pass loses the claim and folds.
+	"no_activity_reminder":     {true, "one claimed create_task; a repeat folds on the effect claim"},
+	"check_in_cadence":         {true, "one claimed create_task"},
+	"renewal_reminder":         {true, "one claimed create_task"},
+	"stage_change_create_task": {true, "one claimed create_task"},
+	"route_lead":               {true, "one claimed create_task"},
+
+	// These two plan a side effect nothing folds.
+	"stage_change_notify": {false, "plans notify; applyNotify calls the transport unconditionally, so a repeat tells somebody twice"},
+	"post_meeting_recap":  {false, "plans draft_email; a repeat composes a second draft and stages a second send behind it"},
+
+	// The people and activities handlers bypass ApplyActions entirely and write
+	// through their own stores, so the engine's effect claim does not reach
+	// them. Each needs its own answer, and only one has been established.
+	"recompute_lead_score":           {true, "recomputes a score FROM the records it reads; a second pass over unchanged records lands on the same number"},
+	"recompute_lead_score_on_update": {true, "the same recompute on a different trigger"},
+
+	// Not yet audited. FALSE here is a decision to refuse until somebody looks,
+	// which is a different thing from the zero value meaning nobody has.
+	"assign_lead_owner":                      {false, "RouteLead assigns with no IfVersion, so a delayed repeat can overwrite a reassignment a human made in between"},
+	"lead_first_response":                    {false, "writes an SLA stamp through its own store; not audited for a repeat"},
+	"lead_status_ladder":                     {false, "writes a status transition through its own store; not audited for a repeat"},
+	"follow_up_auto_resolve":                 {false, "closes tasks through its own store; not audited for a repeat"},
+	"follow_up_auto_resolve_on_promoted":     {false, "the same resolve on a different trigger"},
+	"follow_up_auto_resolve_on_disqualified": {false, "the same resolve on a different trigger"},
+	"follow_up_owner_reconcile":              {false, "reassigns follow-ups through its own store; not audited for a repeat"},
+}
+
+// TestEveryAutomationAnswersWhetherItMayRunTwice derives its corpus from the
+// constructors compose actually registers, so a handler added to the wiring and
+// not here fails on arrival.
+func TestEveryAutomationAnswersWhetherItMayRunTwice(t *testing.T) {
+	t.Parallel()
+	handlers := everyRegisteredHandler()
+	if len(handlers) == 0 {
+		t.Fatal("no handlers were built, so this census would pass over nothing")
+	}
+	seen := map[string]bool{}
+	for _, h := range handlers {
+		spec := h.Spec()
+		seen[spec.Name] = true
+		answer, ok := judged[spec.Name]
+		if !ok {
+			t.Errorf("%q has not been judged: decide whether applying its effect a second "+
+				"time repeats anything, and say so in `judged` with the reason", spec.Name)
+			continue
+		}
+		if spec.RedrivableWithoutDuplicating != answer.redrivable {
+			t.Errorf("%q declares redrivable=%v and the census says %v (%s) — the two have "+
+				"to agree, or a caller reads one and a reviewer reads the other",
+				spec.Name, spec.RedrivableWithoutDuplicating, answer.redrivable, answer.because)
+		}
+	}
+	// And nothing lingers: a handler removed from the wiring must not keep a
+	// judgement here, which would read as coverage of something that is gone.
+	for name := range judged {
+		if !seen[name] {
+			t.Errorf("the census judges %q, which compose no longer registers", name)
+		}
+	}
+}
+
+// A judgement carries a reason, because "false" alone cannot be told from
+// "nobody looked" — which is the exact confusion this whole file removes.
+func TestEveryJudgementSaysWhy(t *testing.T) {
+	t.Parallel()
+	for name, answer := range judged {
+		if answer.because == "" {
+			t.Errorf("%q is judged with no reason, so the next reader cannot tell a decision "+
+				"from a default", name)
+		}
+	}
+}
+
+// everyRegisteredHandler builds the handlers compose wires, from the same
+// constructors. Nil stores are safe: Spec() reads none of them, and this census
+// asks only what each handler DECLARES.
+func everyRegisteredHandler() []workflow.Handler {
+	handlers := automation.StarterWorkflows(automation.Executors{})
+	handlers = append(handlers, people.LeadRoutingWorkflow(nil))
+	handlers = append(handlers, people.LeadScoreWorkflows(nil)...)
+	handlers = append(handlers, people.LeadSLAWorkflows(nil)...)
+	handlers = append(handlers, activities.FollowUpWorkflows(nil)...)
+	return append(handlers, activities.OwnershipWorkflows(nil)...)
+}

--- a/backend/internal/modules/automation/handlers_clock.go
+++ b/backend/internal/modules/automation/handlers_clock.go
@@ -192,6 +192,10 @@ func (noActivityReminder) Spec() workflow.Spec {
 		Name:    noActivityReminderName,
 		Trigger: workflow.Trigger{Schedule: noActivityScheduleMarker},
 		Tier:    mcp.TierAutoExecute,
+		// One claimed create_task and nothing else: applyCreate takes the effect
+		// claim before writing, so a second pass folds instead of minting a
+		// duplicate reminder.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 
@@ -281,6 +285,10 @@ func (checkInCadence) Spec() workflow.Spec {
 		Name:    checkInCadenceName,
 		Trigger: workflow.Trigger{Schedule: checkInCadenceScheduleMarker},
 		Tier:    mcp.TierAutoExecute,
+		// One claimed create_task and nothing else: applyCreate takes the effect
+		// claim before writing, so a second pass folds instead of minting a
+		// duplicate reminder.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 
@@ -397,6 +405,10 @@ func (renewalReminder) Spec() workflow.Spec {
 		Name:    renewalReminderName,
 		Trigger: workflow.Trigger{Schedule: renewalScheduleMarker},
 		Tier:    mcp.TierAutoExecute,
+		// One claimed create_task and nothing else: applyCreate takes the effect
+		// claim before writing, so a second pass folds instead of minting a
+		// duplicate reminder.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/modules/automation/handlers_event.go
+++ b/backend/internal/modules/automation/handlers_event.go
@@ -71,6 +71,10 @@ func (stageChangeCreateTask) Spec() workflow.Spec {
 		Name:    stageChangeCreateTaskName,
 		Trigger: workflow.Trigger{EventType: eventDealStageChanged},
 		Tier:    mcp.TierAutoExecute,
+		// One claimed create_task and nothing else: applyCreate takes the effect
+		// claim before writing, so a second pass folds instead of minting a
+		// duplicate reminder.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 
@@ -142,6 +146,10 @@ func (routeLeadCreateTask) Spec() workflow.Spec {
 		Name:    routeLeadName,
 		Trigger: workflow.Trigger{EventType: eventLeadCreated},
 		Tier:    mcp.TierAutoExecute,
+		// One claimed create_task and nothing else: applyCreate takes the effect
+		// claim before writing, so a second pass folds instead of minting a
+		// duplicate reminder.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/modules/people/leadrecompute.go
+++ b/backend/internal/modules/people/leadrecompute.go
@@ -253,6 +253,11 @@ func (w leadScoreRecompute) Spec() workflow.Spec {
 		Name:    w.name,
 		Trigger: workflow.Trigger{EventType: w.trigger},
 		Tier:    mcp.TierAutoExecute,
+		// The score is recomputed FROM the records this reads, not adjusted by
+		// a delta, so a second pass over unchanged records lands on the same
+		// number. It writes no audit line of its own — RecomputeLeadScore is
+		// the whole effect.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/shared/ports/workflow/workflow.go
+++ b/backend/internal/shared/ports/workflow/workflow.go
@@ -48,6 +48,24 @@ type Spec struct {
 	Name    string // stable id: "flag_idle_deals", "route_lead", …
 	Trigger Trigger
 	Tier    mcp.RiskTier
+	// RedrivableWithoutDuplicating says whether applying this handler's effect a
+	// SECOND time repeats a side effect nobody asked for.
+	//
+	// Apply is documented idempotent on IdempotencyKey(ev), and nothing enforces
+	// that: no Apply in the tree reads the key. The promise costs nothing while
+	// every run happens once, and becomes load-bearing the moment anything
+	// re-drives one — a retry then means "the row lands where it already was"
+	// for one handler and "the customer is told a second time" for another.
+	//
+	// The answer belongs HERE rather than on the action kind, because the kind
+	// does not decide what runs: leadRouting plans assign_owner and applies it
+	// through RouteLead, while the engine's own handlers plan the same kind and
+	// apply it through applyAssignOwner. One vocabulary, two writes.
+	//
+	// FALSE IS THE ZERO VALUE, so a handler that has not considered the question
+	// answers no. A caller re-driving reads this; a false answer means the run
+	// needs a human rather than a button.
+	RedrivableWithoutDuplicating bool
 }
 
 // Trigger binds to the event bus or a schedule: EventType for bus events,


### PR DESCRIPTION
Groundwork for automation retry (#4442), after Lars chose **B** — one central
answer rather than each handler promising privately.

`workflow.Handler.Apply` is documented *"idempotent on IdempotencyKey(ev)"* and
**nothing enforces it**: no `Apply` in the tree reads that key. The promise costs
nothing while every run happens once. It becomes load-bearing the moment
anything re-drives one — a retry then means "the row lands where it already was"
for one handler and "the customer is told a second time" for another, and the
caller cannot tell which.

`Spec.RedrivableWithoutDuplicating` is that answer.

**It lives on the handler because the handler owns `Apply`.** An earlier draft
of this change keyed it on the action KIND, which reads tidier and is wrong:
`leadRouting` plans `assign_owner` and applies it through `RouteLead`, while the
engine's own handlers plan the same kind and apply it through
`applyAssignOwner`. One vocabulary, two writes. That draft was unwound.

**False is the zero value**, so a handler nobody has considered refuses rather
than permits. The census turns that into a decision: every handler `compose`
registers must appear in `judged` with a REASON, and its declaration must agree.
*"False because unconsidered"* and *"false because RouteLead assigns with no
IfVersion, so a delayed repeat can overwrite a human's reassignment"* are
different facts, and only the second helps the next reader.

**Nine of sixteen are re-drivable.** Five mint one claimed `create_task` and fold
on the effect claim `applyCreate` already takes; two recompute a score *from* the
records they read, so a second pass over unchanged records lands on the same
number — and `RecomputeLeadScore` writes no audit line of its own, which I
checked rather than assumed.

| Obligation | Evidence |
|---|---|
| User-visible outcome | None yet, by design. Nothing reads the flag; it is what a retry must ask first. |
| Permission/row scope | Unchanged — no read or write added. |
| Failure behavior | The zero value refuses. A handler added to the wiring and not judged fails the census on arrival. |
| Idempotency/concurrency | This IS the idempotency work. |
| Mobile / Storybook / Accessibility | n/a — no UI. |
| Contract | None. |
| Write shape | n/a — no writes added. |
| Mutation strength | A handler declaring `true` while the census says `false` fails, naming both. A judgement losing its reason fails, naming the handler. |
| Full lane | `make check-backend` EXIT=0. |

**The corpus is built from the constructors `compose` actually registers, not a
list.** Writing the list by hand produced ten names, then fourteen; the real
answer is **sixteen**. Three undercounts is why the census derives rather than
enumerates — and the first run of it named eight handlers I had invented.

Reviewed by Codex (`gpt-5.6-sol`), which found the action-kind keying was wrong
and that I had misclassified `recompute_score` as unreachable when
`leadScoreRecompute` emits it and applies it directly. Both corrected by the
rebuild. It also confirmed a point I want on the record for whoever does the
retry itself: an "unchanged" update is **not** harmless — this repo's write
shape commits domain row + audit + outbox together, so a repeat writes a second
audit line, and without an `IfVersion` guard a delayed retry can clobber a
human's intervening edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Spec.RedrivableWithoutDuplicating` so every automation says whether running it twice repeats anything. This is groundwork for retry (#4442) and changes no behavior yet.

- Previously `workflow.Handler.Apply` promised idempotency on `IdempotencyKey(ev)` but nothing enforced it; now each handler's answer is recorded on its spec.
- The flag lives on the handler rather than the action kind, because the same action kind can be written through different handlers.
- False is the zero value, so a handler that hasn't been considered refuses a retry instead of allowing it.
- A new census test builds every handler `compose` registers and fails if a handler is missing a judgement or its declaration disagrees.
- Task-creating and score-recompute handlers are marked re-drivable; notification and store-writing handlers are not.

<sup>Written for commit 2a769e8359c4129c9738a2dd5ac494d3fa5f8fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reprocessing reliability for clock-triggered tasks, lead routing, stage changes, and lead-score updates.
  * Re-running supported automations now avoids creating duplicate reminders or other repeated effects.

* **Reliability**
  * Added safeguards requiring every automation workflow to explicitly declare whether it can be safely re-run without duplicating outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->