### PR TITLE
craft-static is green on main again: two long functions

### DIFF
--- a/backend/internal/compose/weekly/weeklyassemble.go
+++ b/backend/internal/compose/weekly/weeklyassemble.go
@@ -94,49 +94,7 @@ func (e *Engine) AssembleFor(ctx context.Context, now time.Time) (Review, bool, 
 		}
 
 		review = Review{UserID: userID, LocalWeekStart: weekStart, AsOf: now.UTC()}
-		if review.Counts, err = countWeek(ctx, tx, userID, start, end); err != nil {
-			return err
-		}
-		// Leads and meetings read separately from the tallies above: different
-		// tables, different scope clauses, and each dated by a rule that takes
-		// a paragraph to justify. They fold onto the same Counts because a
-		// reader of a week wants one set of figures.
-		c := &review.Counts
-		if c.LeadsRouted, c.LeadsAnsweredInTarget, c.LeadsBreached, err =
-			countWeekLeads(ctx, tx, userID, start, end); err != nil {
-			return err
-		}
-		if c.MeetingsHeld, c.MeetingsWithNextStep, err =
-			countWeekMeetings(ctx, tx, userID, start, end); err != nil {
-			return err
-		}
-		if review.Money, err = countWeekMoney(ctx, tx, userID, start, end); err != nil {
-			return err
-		}
-		// The plan's outcome, settled once and then frozen alongside the rest.
-		//
-		// Settled BEFORE the counts are written, so the review records what the
-		// week actually came to rather than what was still open when the job
-		// happened to run. CloseWeek is idempotent, so the dispatcher's extra
-		// ticks inside a week do not re-settle a commitment the rep completed
-		// after the first pass.
-		if e.plan != nil {
-			c := &review.Counts
-			if c.CommitmentsDue, c.CommitmentsKept, err = e.plan.CloseWeek(ctx, now); err != nil {
-				return err
-			}
-		}
-		if review.Deals, err = readWeekDeals(ctx, tx, userID, start, end); err != nil {
-			return err
-		}
-		// The week this one is measured against: the rep's most recent EARLIER
-		// review, whenever it was.
-		//
-		// Their previous review rather than "last week" by arithmetic. A rep
-		// with a gap — a leave, a worker outage — has a prior week that is not
-		// seven days back, and looking for one would find nothing and report
-		// every count as new.
-		if review.PriorReviewID, err = priorReview(ctx, tx, userID, weekStart); err != nil {
+		if err := e.measureWeek(ctx, tx, &review, now, start, end); err != nil {
 			return err
 		}
 
@@ -187,6 +145,60 @@ func (e *Engine) AssembleFor(ctx context.Context, now time.Time) (Review, bool, 
 		return existing, false, err
 	}
 	return review, true, nil
+}
+
+// measureWeek fills in everything the review REPORTS: the tallies, the money,
+// the plan's outcome, the deals and the week it is compared against. Every one
+// is a read — nothing here writes the review, which is why it can run before the
+// insert decides whether this rep's week is already taken.
+func (e *Engine) measureWeek(
+	ctx context.Context, tx pgx.Tx, review *Review, now, start, end time.Time,
+) error {
+	userID := review.UserID
+	var err error
+	if review.Counts, err = countWeek(ctx, tx, userID, start, end); err != nil {
+		return err
+	}
+	// Leads and meetings read separately from the tallies above: different
+	// tables, different scope clauses, and each dated by a rule that takes
+	// a paragraph to justify. They fold onto the same Counts because a
+	// reader of a week wants one set of figures.
+	c := &review.Counts
+	c.LeadsRouted, c.LeadsAnsweredInTarget, c.LeadsBreached, err = countWeekLeads(ctx, tx, userID, start, end)
+	if err != nil {
+		return err
+	}
+	c.MeetingsHeld, c.MeetingsWithNextStep, err = countWeekMeetings(ctx, tx, userID, start, end)
+	if err != nil {
+		return err
+	}
+	if review.Money, err = countWeekMoney(ctx, tx, userID, start, end); err != nil {
+		return err
+	}
+	// The plan's outcome, settled once and then frozen alongside the rest.
+	//
+	// Settled BEFORE the counts are written, so the review records what the
+	// week actually came to rather than what was still open when the job
+	// happened to run. CloseWeek is idempotent, so the dispatcher's extra
+	// ticks inside a week do not re-settle a commitment the rep completed
+	// after the first pass.
+	if e.plan != nil {
+		if c.CommitmentsDue, c.CommitmentsKept, err = e.plan.CloseWeek(ctx, now); err != nil {
+			return err
+		}
+	}
+	if review.Deals, err = readWeekDeals(ctx, tx, userID, start, end); err != nil {
+		return err
+	}
+	// The week this one is measured against: the rep's most recent EARLIER
+	// review, whenever it was.
+	//
+	// Their previous review rather than "last week" by arithmetic. A rep
+	// with a gap — a leave, a worker outage — has a prior week that is not
+	// seven days back, and looking for one would find nothing and report
+	// every count as new.
+	review.PriorReviewID, err = priorReview(ctx, tx, userID, review.LocalWeekStart)
+	return err
 }
 
 // localWeekWindow turns a local week's calendar start into the two instants

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -236,6 +236,8 @@ func (s *RetentionService) eraseActivityContent(ctx context.Context, tx pgx.Tx, 
 // deliberately rather than left for it to notice.
 //
 // Held by: TestErasingAndAnonymizingClearTheSameTables (backend/gates/personscrub_test.go)
+//
+//craft:ignore long-func the length IS the register — one statement per table with the judgement that put it there — and three fitness gates bind these writes to THIS file and THIS function name: TestEveryPackageOnlyWritesTablesItOwns ratifies each cross-module write under a key naming both, TestEveryPersonSatelliteJoinsEveryLifecyclePathThatApplies reads the anonymize path out of this file, and TestErasureAndSARReachEveryPIITable derives the purge set from these statements. Extracting a helper moves writes out from under all three at once, which is a decomposition that costs more coverage than the cap buys
 func anonymizePersonRecord(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
 	// The subject's addresses, read BEFORE person_email is deleted
 	// below. The graph structures name them by raw address as well as


### PR DESCRIPTION
```
backend/internal/compose/weekly/weeklyassemble.go
  63: [MAJOR] long-func — AssembleFor is 84 code lines (> 80)
backend/internal/modules/privacy/retentionactions.go
  239: [MAJOR] long-func — anonymizePersonRecord is 86 code lines (> 80)
BLOCK — 0 blocker, 2 major, 0 minor
```

Both are recent arrivals crossing the cap, and every PR opened since is red on them. **They want opposite treatments, which is the point.**

## `AssembleFor` splits

Everything it does before the insert is a *read*: the tallies, the money, the plan's outcome, the deals, the week this one is compared against. `measureWeek` is exactly that set — which is why it can run before the insert has decided whether this rep's week is already taken.

What stays behind is the transaction's judgement: which week closed, which instants bound it, who won the insert, and what may only be frozen onto the row that won.

## `anonymizePersonRecord` does not — and the waiver says why

I tried the extraction first. Three fitness gates bind these writes to *this file* and *this function name*:

| gate | keys on |
|---|---|
| `TestEveryPackageOnlyWritesTablesItOwns` | `package:table:file:function` — each cross-module write ratified under a key naming both |
| `TestEveryPersonSatelliteJoinsEveryLifecyclePathThatApplies` | reads the anonymize path out of this file |
| `TestErasureAndSARReachEveryPIITable` | derives the declared purge set from these statements |

A four-line helper moved writes out from under all three at once and turned one craft finding into **seventeen gate failures**. The length there is not incidental — it *is* the register, one statement per table with the judgement that put it there. The waiver records the experiment rather than leaving the next person to repeat it.

## Verification

`make check-backend` exit 0 — craft `PASS — 0 blocker, 0 major, 0 minor`, lint 0 issues, gates green. `internal/compose/weekly` and `internal/modules/privacy` integration suites pass.

Supersedes #4564, whose FK half landed on main independently.