### PR TITLE
feat(automation): a failed firing can be re-driven, and says when it cannot

### DIFF
--- a/backend/internal/compose/redrivecensus_test.go
+++ b/backend/internal/compose/redrivecensus_test.go
@@ -59,15 +59,17 @@ var judged = map[string]struct {
 	"recompute_lead_score":           {true, "recomputes a score FROM the records it reads; a second pass over unchanged records lands on the same number"},
 	"recompute_lead_score_on_update": {true, "the same recompute on a different trigger"},
 
-	// Not yet audited. FALSE here is a decision to refuse until somebody looks,
-	// which is a different thing from the zero value meaning nobody has.
-	"assign_lead_owner":                      {false, "RouteLead assigns with no IfVersion, so a delayed repeat can overwrite a reassignment a human made in between"},
-	"lead_first_response":                    {false, "writes an SLA stamp through its own store; not audited for a repeat"},
-	"lead_status_ladder":                     {false, "writes a status transition through its own store; not audited for a repeat"},
-	"follow_up_auto_resolve":                 {false, "closes tasks through its own store; not audited for a repeat"},
-	"follow_up_auto_resolve_on_promoted":     {false, "the same resolve on a different trigger"},
-	"follow_up_auto_resolve_on_disqualified": {false, "the same resolve on a different trigger"},
-	"follow_up_owner_reconcile":              {false, "reassigns follow-ups through its own store; not audited for a repeat"},
+	// These write through their own stores, and each was read to the statement
+	// that makes a repeat a no-op. The guard is structural in every case — a
+	// row lock plus a condition that a completed first pass has already made
+	// false — rather than a claim the store happens to hold today.
+	"assign_lead_owner":                      {true, "RouteLead returns already_owned and writes nothing once the lead has an owner, under a row lock inside the workspace routing lock"},
+	"lead_first_response":                    {true, "stamps only an EARLIER first response; a later-or-equal stamp on an answered lead returns without writing"},
+	"lead_status_ladder":                     {true, "the ladder only climbs: AdvanceLeadStatus returns unless the current status Advances to the target"},
+	"follow_up_auto_resolve":                 {true, "completes only tasks still is_done=false, so a second pass finds none open"},
+	"follow_up_auto_resolve_on_promoted":     {true, "the same resolve on a different trigger"},
+	"follow_up_auto_resolve_on_disqualified": {true, "the same resolve on a different trigger"},
+	"follow_up_owner_reconcile":              {true, "reconciles to the owner NOW, selecting on assignee_id IS DISTINCT FROM it, so an aligned task is not selected twice"},
 }
 
 // TestEveryAutomationAnswersWhetherItMayRunTwice derives its corpus from the

--- a/backend/internal/modules/activities/followupownership.go
+++ b/backend/internal/modules/activities/followupownership.go
@@ -48,6 +48,10 @@ func (followUpOwnerReconcile) Spec() workflow.Spec {
 		Name:    "follow_up_owner_reconcile",
 		Trigger: workflow.Trigger{EventType: "lead.updated"},
 		Tier:    mcp.TierAutoExecute,
+		// Reconciliation converges by construction: it selects the tasks whose
+		// assignee_id IS DISTINCT FROM the lead's current owner, and a first
+		// pass leaves none of those behind.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -105,6 +105,9 @@ func (w followUpAutoResolve) Spec() workflow.Spec {
 		Name:    w.name,
 		Trigger: workflow.Trigger{EventType: w.trigger},
 		Tier:    mcp.TierAutoExecute,
+		// Completion is one-way and the query only sees open tasks: after a
+		// first pass there is nothing left is_done=false to close.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/modules/automation/autofixture_integration_test.go
+++ b/backend/internal/modules/automation/autofixture_integration_test.go
@@ -175,12 +175,22 @@ type scriptedWorkflow struct {
 	match func(ev workflow.Event) (bool, error)
 	plan  func(ev workflow.Event) (workflow.Effect, error)
 	apply func(ev workflow.Event) (workflow.RunResult, error)
+	// redrivable is what the retry gate reads off the spec. The zero value is
+	// the real default — a handler nobody audited refuses to be re-driven — so
+	// a case that wants a retry to proceed has to say so, exactly as a real
+	// handler does.
+	redrivable bool
 }
 
 const scriptedTrigger = "history.test_event"
 
 func (s scriptedWorkflow) Spec() workflow.Spec {
-	return workflow.Spec{Name: s.name, Trigger: workflow.Trigger{EventType: scriptedTrigger}, Tier: mcp.TierAutoExecute}
+	return workflow.Spec{
+		Name:                         s.name,
+		Trigger:                      workflow.Trigger{EventType: scriptedTrigger},
+		Tier:                         mcp.TierAutoExecute,
+		RedrivableWithoutDuplicating: s.redrivable,
+	}
 }
 
 func (s scriptedWorkflow) Match(_ context.Context, ev workflow.Event) (bool, error) {

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 
 	"github.com/jackc/pgx/v5"
 
@@ -41,7 +42,23 @@ import (
 // (troubledruns.go) for the cross-instance health read — a change to the
 // "@<automation id>" suffix lands on both.
 func runKey(h workflow.Handler, ev workflow.Event) string {
-	return h.IdempotencyKey(ev) + "@" + ev.AutomationID.String()
+	return retryPrefix(ev) + h.IdempotencyKey(ev) + "@" + ev.AutomationID.String()
+}
+
+// retryPrefix marks a re-driven firing so its run claims its own row instead
+// of colliding with the failed run it retries.
+//
+// It PREFIXES for a reason that is easy to get backwards: both readers of this
+// shape match "@<automation id>" anchored at the END of the key — ListRuns
+// (automations_runs.go) and troubledRunsSQL (troubledruns.go). A marker
+// appended after the automation id would break both, and it would break them
+// silently: retried runs would simply stop appearing in the health lane that
+// offered the retry, with nothing failing anywhere.
+func retryPrefix(ev workflow.Event) string {
+	if ev.RetryAttempt == 0 {
+		return ""
+	}
+	return "retry" + strconv.Itoa(ev.RetryAttempt) + ":"
 }
 
 // isClockTrigger distinguishes the two trigger shapes runOne must treat

--- a/backend/internal/modules/automation/retryrun.go
+++ b/backend/internal/modules/automation/retryrun.go
@@ -86,16 +86,27 @@ type RetryOutcome struct {
 // LEFT, because a missing envelope is an ANSWER here (refusal 3) rather than a
 // reason to report the run as absent.
 const retryCandidateSQL = `
-SELECT r.status, r.handler, a.id, a.params, a.owner_id, o.envelope,
+WITH target AS (
+  SELECT id, status, handler, trigger_event, idempotency_key,
+         -- The BASE key: this run's own attempt marker stripped. Retrying a
+         -- RETRY must count the attempts the original firing has already had,
+         -- so both cases ask the same question. Counting against the unstripped
+         -- key restarts at zero on a second retry, which re-mints the first
+         -- retry's key, loses the run claim, and returns having applied nothing
+         -- while reporting success.
+         regexp_replace(idempotency_key, '^retry[0-9]+:', '') AS base_key
+    FROM workflow_run WHERE id = $1
+)
+SELECT t.status, t.handler, a.id, a.params, a.owner_id, o.envelope,
        (SELECT count(*) FROM workflow_run prior
-         WHERE prior.handler = r.handler
-           AND prior.idempotency_key LIKE 'retry%:' || r.idempotency_key)
-  FROM workflow_run r
+         WHERE prior.handler = t.handler
+           AND prior.idempotency_key <> t.base_key
+           AND regexp_replace(prior.idempotency_key, '^retry[0-9]+:', '') = t.base_key)
+  FROM target t
   JOIN automation a ON a.archived_at IS NULL AND a.enabled
-   AND r.handler = a.key
-   AND r.idempotency_key LIKE '%@' || a.id
-  LEFT JOIN event_outbox o ON o.id = r.trigger_event
- WHERE r.id = $1`
+   AND t.handler = a.key
+   AND t.idempotency_key LIKE '%@' || a.id
+  LEFT JOIN event_outbox o ON o.id = t.trigger_event`
 
 // retryCandidate is one recovered firing, ready to re-dispatch.
 type retryCandidate struct {
@@ -140,6 +151,19 @@ func (e *WorkflowEngine) retryCandidateFor(ctx context.Context, runID ids.UUID) 
 	var found retryCandidate
 	var outcome RetryOutcome
 	err = e.db.Tx(ctx, func(tx pgx.Tx) error {
+		// One retry decision at a time per run. The attempt count and the run
+		// claim it feeds are two transactions — this one reads the count, and
+		// runOne's claimRun writes the row — so without serializing them two
+		// concurrent retries of one failed run can read different counts,
+		// compute different keys, and BOTH dispatch: one failed firing becomes
+		// two live ones, and the unique key each claims does not collide, so
+		// nothing refuses either. The lock is transaction-scoped and released
+		// when this read commits; the loser then reads the winner's count.
+		if _, lockErr := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock(hashtextextended('workflow_run_retry:' || $1::text, 0))`,
+			runID); lockErr != nil {
+			return lockErr
+		}
 		var status, handlerName string
 		var automationID ids.UUID
 		var params json.RawMessage

--- a/backend/internal/modules/automation/retryrun.go
+++ b/backend/internal/modules/automation/retryrun.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+// Retrying one failed firing.
+//
+// A retry re-dispatches the ORIGINAL event down the ordinary runOne path, so
+// every gate a first firing passes it passes again: the owner's live RBAC, the
+// audience check, the run claim, the effect claim. Nothing here re-applies the
+// stored `planned` effect — that was a plan made against a database which has
+// since moved, and replaying it would write yesterday's answer over today's
+// records.
+//
+// Three facts must ALL hold, each refusing for its own reason:
+//
+//  1. The run FAILED. A `blocked` run is the permission gate having refused it
+//     on purpose (engine_blocked.go); retrying a refusal asks the same question
+//     expecting a different answer, and reads to an operator as though the
+//     refusal had been a glitch.
+//  2. The handler declares RedrivableWithoutDuplicating (workflow.Spec). Every
+//     handler registered today does, each for a reason stated at its own Spec,
+//     so this arm refuses nothing now — it is here for the NEXT handler, whose
+//     zero value is false until somebody audits it.
+//  3. The trigger event is still recoverable. workflow_run keeps the event's id
+//     and nothing else about it — no Entity, no Payload — so the envelope has to
+//     come back from event_outbox. A CLOCK-triggered run synthesizes a fresh id
+//     per evaluation pass (timescan.go) that was never an outbox row, so those
+//     are unreplayable by construction rather than by policy: the clock will
+//     re-evaluate the same anchor on its own next pass anyway.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// runStatusFailed is the workflow_run.status a retry acts on. The other four
+// statuses in the CHECK constraint are each a reason to refuse: applied and
+// skipped have nothing to retry, requires_approval is waiting on a human, and
+// blocked is the permission gate having already said no.
+const runStatusFailed = "failed"
+
+// RetryRefusal names why a failed run may not be re-driven, in the vocabulary
+// an operator reads rather than the one the tables use.
+type RetryRefusal string
+
+const (
+	// RetryRefusedNotFailed covers a run that did not fail: an applied or
+	// skipped run has nothing to retry, and a blocked one was refused on
+	// purpose.
+	RetryRefusedNotFailed RetryRefusal = "not_failed"
+	// RetryRefusedRepeats is a handler a second pass would duplicate — the
+	// answer Spec.RedrivableWithoutDuplicating carries.
+	RetryRefusedRepeats RetryRefusal = "repeats_its_effect"
+	// RetryRefusedEventGone is a run whose trigger event cannot be rebuilt: a
+	// clock firing, or an outbox row aged out from under it.
+	RetryRefusedEventGone RetryRefusal = "trigger_event_unavailable"
+)
+
+// RetryOutcome answers what a retry did, or why it did nothing. Refusal is
+// empty exactly when Retried is true.
+type RetryOutcome struct {
+	Retried bool
+	Refusal RetryRefusal
+}
+
+// retryCandidateSQL recovers everything one re-dispatch needs. The run row
+// names the handler, the trigger event and the key; the key's "@<automation
+// id>" suffix names the instance, whose own row carries the params and the
+// owner this firing acts for. The outbox envelope carries the event itself.
+//
+// The join to automation is INNER on the live, enabled row for the reason
+// troubledRunsSQL's is: a rule its owner turned off must not be re-driven by a
+// card left over from before they turned it off. The join to event_outbox is
+// LEFT, because a missing envelope is an ANSWER here (refusal 3) rather than a
+// reason to report the run as absent.
+const retryCandidateSQL = `
+SELECT r.status, r.handler, a.id, a.params, a.owner_id, o.envelope,
+       (SELECT count(*) FROM workflow_run prior
+         WHERE prior.handler = r.handler
+           AND prior.idempotency_key LIKE 'retry%:' || r.idempotency_key)
+  FROM workflow_run r
+  JOIN automation a ON a.archived_at IS NULL AND a.enabled
+   AND r.handler = a.key
+   AND r.idempotency_key LIKE '%@' || a.id
+  LEFT JOIN event_outbox o ON o.id = r.trigger_event
+ WHERE r.id = $1`
+
+// retryCandidate is one recovered firing, ready to re-dispatch.
+type retryCandidate struct {
+	handler workflow.Handler
+	event   workflow.Event
+}
+
+// RetryRun re-dispatches one failed firing and answers what happened. A
+// refusal is a value, not an error: "this run may not be retried" is an answer
+// about the row, and the caller renders it rather than failing on it.
+//
+// The caller gates it. This is the engine, which acts as the system principal
+// by construction (HandleEvent stamps PrincipalSystem before any handler runs)
+// — a system principal bypasses object RBAC entirely, so an authorization
+// check placed HERE would be checking the system's authority and would pass for
+// everyone. The reader's authority is asked at the HTTP boundary, where a real
+// principal still exists.
+func (e *WorkflowEngine) RetryRun(ctx context.Context, runID ids.UUID) (RetryOutcome, error) {
+	candidate, outcome, err := e.retryCandidateFor(ctx, runID)
+	if err != nil || !outcome.Retried {
+		return outcome, err
+	}
+	// The same context shape HandleEvent builds: a retry is the firing
+	// happening again, not a new kind of caller.
+	runCtx := principal.WithWorkspaceID(ctx, candidate.event.WorkspaceID)
+	runCtx = principal.WithActor(runCtx,
+		principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
+	runCtx = principal.WithCorrelationID(runCtx, ids.NewV7())
+	runCtx = principal.WithCausationEvent(runCtx, candidate.event.ID)
+	if err := e.runOne(runCtx, candidate.handler, candidate.event); err != nil {
+		return RetryOutcome{}, fmt.Errorf("retrying %s: %w", candidate.handler.Spec().Name, err)
+	}
+	return outcome, nil
+}
+
+// retryCandidateFor reads the run and answers all three questions at once.
+func (e *WorkflowEngine) retryCandidateFor(ctx context.Context, runID ids.UUID) (retryCandidate, RetryOutcome, error) {
+	ws, err := e.db.Workspace(ctx)
+	if err != nil {
+		return retryCandidate{}, RetryOutcome{}, err
+	}
+	var found retryCandidate
+	var outcome RetryOutcome
+	err = e.db.Tx(ctx, func(tx pgx.Tx) error {
+		var status, handlerName string
+		var automationID ids.UUID
+		var params json.RawMessage
+		var owner *ids.UUID
+		var envelope []byte
+		var priorAttempts int
+		scanErr := tx.QueryRow(ctx, retryCandidateSQL, runID).Scan(
+			&status, &handlerName, &automationID, &params, &owner, &envelope, &priorAttempts)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return apperrors.ErrNotFound
+		}
+		if scanErr != nil {
+			return scanErr
+		}
+		if status != runStatusFailed {
+			outcome = RetryOutcome{Refusal: RetryRefusedNotFailed}
+			return nil
+		}
+		handler := e.handlerNamed(handlerName)
+		if handler == nil || !handler.Spec().RedrivableWithoutDuplicating {
+			// An unregistered handler answers the same way an unaudited one
+			// does: nobody can say a second pass is safe, so nobody may.
+			outcome = RetryOutcome{Refusal: RetryRefusedRepeats}
+			return nil
+		}
+		if len(envelope) == 0 {
+			outcome = RetryOutcome{Refusal: RetryRefusedEventGone}
+			return nil
+		}
+		event, decodeErr := eventFromEnvelope(envelope, ws.UUID)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		event.AutomationID = automationID
+		event.Params = params
+		// The attempt AFTER the ones already recorded, so a second retry of the
+		// same firing claims its own run row rather than folding into the first
+		// retry's. Counting rows rather than tracking a counter keeps the two
+		// from drifting: the run rows ARE the record of what has been tried.
+		event.RetryAttempt = priorAttempts + 1
+		if owner != nil {
+			event.OwnerID = *owner
+		}
+		found = retryCandidate{handler: handler, event: event}
+		outcome = RetryOutcome{Retried: true}
+		return nil
+	})
+	if err != nil {
+		return retryCandidate{}, RetryOutcome{}, fmt.Errorf("reading the run to retry: %w", err)
+	}
+	return found, outcome, nil
+}
+
+// handlerNamed finds one registered handler by its spec name, under the same
+// lock discipline dispatch reads the registry with, and returns nil for a name
+// nothing registers. Both registries are searched: a system handler fails and
+// is retried exactly like an instance one.
+//
+//nolint:ireturn // the registry holds workflow.Handler and the engine deliberately does not know the implementations; a concrete return type would name one.
+func (e *WorkflowEngine) handlerNamed(name string) workflow.Handler {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for _, h := range append(append([]workflow.Handler(nil), e.handlers...), e.system...) {
+		if h.Spec().Name == name {
+			return h
+		}
+	}
+	return nil
+}
+
+// eventFromEnvelope rebuilds the event a stored outbox row carried, in the same
+// shape HandleEvent builds one from a live delivery — including the workspace,
+// which the envelope does not carry (the bus is untenanted, ADR-0091 §6) and
+// which is this engine's own.
+func eventFromEnvelope(raw []byte, workspace ids.UUID) (workflow.Event, error) {
+	var env kevents.Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return workflow.Event{}, fmt.Errorf("decoding the stored trigger event: %w", err)
+	}
+	return workflow.Event{
+		ID:          env.EventID,
+		Type:        env.Type,
+		WorkspaceID: workspace,
+		OccurredAt:  env.OccurredAt,
+		Entity: datasource.EntityRef{
+			Type: datasource.EntityType(env.Entity.Type),
+			ID:   env.Entity.ID,
+		},
+		Payload: env.Payload,
+	}, nil
+}

--- a/backend/internal/modules/automation/retryrun_integration_test.go
+++ b/backend/internal/modules/automation/retryrun_integration_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package automation
+
+// Retrying a failed firing, against real Postgres.
+//
+// Each case drives a REAL failure through the engine — a scripted Apply that
+// returns an error on its first pass — rather than hand-inserting a 'failed'
+// row. A seeded row would prove the SQL reads what the test wrote and nothing
+// about whether the engine's own failure path leaves a run a retry can find.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// retryInstant is this file's frozen clock: every envelope it stages occurred
+// at the same moment, so nothing here depends on when the suite runs.
+var retryInstant = time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+
+// stagedEvent puts one envelope in event_outbox and returns it, so a run
+// triggered by it has a trigger event a retry can recover. The relay publishes
+// from this table and never deletes the row, which is what makes a retry
+// possible at all.
+func (fx *autoFixture) stagedEvent(t *testing.T, entity ids.UUID) kevents.Envelope {
+	t.Helper()
+	env := kevents.Envelope{
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		Version:    1,
+		OccurredAt: retryInstant,
+		Entity:     kevents.EntityRef{Type: "lead", ID: entity},
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshalling the envelope: %v", err)
+	}
+	fx.exec(t, `
+		INSERT INTO event_outbox (id, stream, envelope, published_at)
+		VALUES ($1, $2, $3::jsonb, now())`,
+		env.EventID, "crm.lead", raw)
+	return env
+}
+
+// failingOnce is an Apply that fails its first call and succeeds after — the
+// transient failure a retry exists for. It counts calls so a test can prove
+// the retry actually re-entered Apply rather than reporting success from the
+// stored run.
+type failingOnce struct{ calls int }
+
+func (f *failingOnce) apply() func(workflow.Event) (workflow.RunResult, error) {
+	return func(workflow.Event) (workflow.RunResult, error) {
+		f.calls++
+		if f.calls == 1 {
+			return workflow.RunResult{}, errors.New("the downstream service was unreachable")
+		}
+		return workflow.RunResult{}, nil
+	}
+}
+
+// engineOverScripted registers one scripted handler on a real engine.
+func engineOverScripted(fx *autoFixture, h scriptedWorkflow) *WorkflowEngine {
+	db := database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws))
+	engine := NewWorkflowEngine(db, fixtureResolver{})
+	engine.RegisterWorkflow(h)
+	return engine
+}
+
+// failedRunID is the id of the single run the fixture's handler recorded.
+func (fx *autoFixture) failedRunID(t *testing.T, handler string) (ids.UUID, string) {
+	t.Helper()
+	var id ids.UUID
+	var status string
+	if err := fx.owner.QueryRow(context.Background(),
+		`SELECT id, status FROM workflow_run WHERE handler = $1`, handler).Scan(&id, &status); err != nil {
+		t.Fatalf("reading the recorded run: %v", err)
+	}
+	return id, status
+}
+
+func TestARetriedRunAppliesOnTheSecondPass(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "retry_me"
+	fx.seedAutomation(t, handler)
+
+	script := &failingOnce{}
+	engine := engineOverScripted(fx, scriptedWorkflow{
+		name: handler, apply: script.apply(), redrivable: true,
+	})
+	env := fx.stagedEvent(t, ids.NewV7())
+	if err := engine.HandleEvent(context.Background(), env); err == nil {
+		t.Fatal("the scripted Apply failed, so HandleEvent must surface it")
+	}
+	runID, status := fx.failedRunID(t, handler)
+	if status != "failed" {
+		t.Fatalf("the first pass recorded status %q, want failed", status)
+	}
+
+	outcome, err := engine.RetryRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("RetryRun: %v", err)
+	}
+	if !outcome.Retried {
+		t.Fatalf("a failed run of a re-drivable handler refused the retry: %q", outcome.Refusal)
+	}
+	// The proof the retry re-DISPATCHED rather than reporting the stored run:
+	// Apply ran a second time.
+	if script.calls != 2 {
+		t.Fatalf("Apply ran %d times, want 2 — the retry did not re-enter the handler", script.calls)
+	}
+}
+
+func TestARetryRefusesARunThatDidNotFail(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "applied_cleanly"
+	fx.seedAutomation(t, handler)
+
+	engine := engineOverScripted(fx, scriptedWorkflow{name: handler, redrivable: true})
+	if err := engine.HandleEvent(context.Background(), fx.stagedEvent(t, ids.NewV7())); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	runID, status := fx.failedRunID(t, handler)
+	if status != "applied" {
+		t.Fatalf("the run recorded status %q, want applied", status)
+	}
+
+	outcome, err := engine.RetryRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("RetryRun: %v", err)
+	}
+	if outcome.Retried || outcome.Refusal != RetryRefusedNotFailed {
+		t.Fatalf("retrying an applied run answered (%v, %q), want a not_failed refusal",
+			outcome.Retried, outcome.Refusal)
+	}
+}
+
+func TestARetryRefusesAHandlerThatWouldRepeatItsEffect(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "unaudited"
+	fx.seedAutomation(t, handler)
+
+	script := &failingOnce{}
+	// redrivable stays false: the default a handler nobody has audited carries.
+	engine := engineOverScripted(fx, scriptedWorkflow{name: handler, apply: script.apply()})
+	if err := engine.HandleEvent(context.Background(), fx.stagedEvent(t, ids.NewV7())); err == nil {
+		t.Fatal("the scripted Apply failed, so HandleEvent must surface it")
+	}
+	runID, _ := fx.failedRunID(t, handler)
+
+	outcome, err := engine.RetryRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("RetryRun: %v", err)
+	}
+	if outcome.Retried || outcome.Refusal != RetryRefusedRepeats {
+		t.Fatalf("retrying an unaudited handler answered (%v, %q), want a repeats_its_effect refusal",
+			outcome.Retried, outcome.Refusal)
+	}
+	if script.calls != 1 {
+		t.Fatalf("Apply ran %d times, want 1 — the refusal must not have re-entered the handler", script.calls)
+	}
+}
+
+func TestARetryRefusesARunWhoseTriggerEventIsGone(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "clock_shaped"
+	fx.seedAutomation(t, handler)
+
+	script := &failingOnce{}
+	engine := engineOverScripted(fx, scriptedWorkflow{
+		name: handler, apply: script.apply(), redrivable: true,
+	})
+	// An envelope the engine never staged: this is the shape of a CLOCK firing,
+	// whose trigger_event is synthesized per evaluation pass (timescan.go) and
+	// was never an outbox row. Nothing can rebuild the event, so nothing may
+	// claim to re-drive it.
+	unstaged := kevents.Envelope{
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		Version:    1,
+		OccurredAt: retryInstant,
+		Entity:     kevents.EntityRef{Type: "lead", ID: ids.NewV7()},
+	}
+	if err := engine.HandleEvent(context.Background(), unstaged); err == nil {
+		t.Fatal("the scripted Apply failed, so HandleEvent must surface it")
+	}
+	runID, _ := fx.failedRunID(t, handler)
+
+	outcome, err := engine.RetryRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("RetryRun: %v", err)
+	}
+	if outcome.Retried || outcome.Refusal != RetryRefusedEventGone {
+		t.Fatalf("retrying a run with no recoverable event answered (%v, %q), "+
+			"want a trigger_event_unavailable refusal", outcome.Retried, outcome.Refusal)
+	}
+	if script.calls != 1 {
+		t.Fatalf("Apply ran %d times, want 1 — the refusal must not have re-entered the handler", script.calls)
+	}
+}
+
+func TestARetriedRunStaysVisibleToTheHealthLane(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "still_broken"
+	fx.seedAutomation(t, handler)
+
+	// An Apply that fails every time, so the retry's own run is failed too and
+	// the health lane has something to find.
+	engine := engineOverScripted(fx, scriptedWorkflow{
+		name:       handler,
+		redrivable: true,
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			return workflow.RunResult{}, errors.New("the downstream service was unreachable")
+		},
+	})
+	if err := engine.HandleEvent(context.Background(), fx.stagedEvent(t, ids.NewV7())); err == nil {
+		t.Fatal("the scripted Apply failed, so HandleEvent must surface it")
+	}
+	runID, _ := fx.failedRunID(t, handler)
+	// The retry re-runs an Apply that fails again, so RetryRun surfaces that
+	// failure exactly as the first dispatch did. The run row lands either way,
+	// which is what this test is about.
+	if _, err := engine.RetryRun(context.Background(), runID); err == nil {
+		t.Fatal("the scripted Apply fails every time, so the retry must surface it too")
+	}
+
+	// THE POINT OF THE PREFIX. troubledRunsSQL correlates a run to its
+	// automation with `idempotency_key LIKE '%@' || a.id`, anchored at the END.
+	// An attempt marker appended after the automation id would leave the
+	// retry's run row matching nothing — the failure would vanish from the
+	// very lane that offered the retry, and no test anywhere would fail.
+	both := fx.count(t, `
+		SELECT count(*) FROM workflow_run r
+		  JOIN automation a ON a.archived_at IS NULL AND a.enabled
+		   AND r.handler = a.key
+		   AND r.idempotency_key LIKE '%@' || a.id
+		 WHERE r.status = 'failed' AND r.handler = $1`, handler)
+	if both != 2 {
+		t.Fatalf("the health lane's join found %d failed runs, want 2 — the original and its "+
+			"retry. A retried run that stops matching this join disappears from the lane "+
+			"that offered the retry, silently", both)
+	}
+}

--- a/backend/internal/modules/automation/retryrun_integration_test.go
+++ b/backend/internal/modules/automation/retryrun_integration_test.go
@@ -251,3 +251,48 @@ func TestARetriedRunStaysVisibleToTheHealthLane(t *testing.T) {
 			"that offered the retry, silently", both)
 	}
 }
+
+func TestRetryingARetryIsItsOwnAttempt(t *testing.T) {
+	fx := setupAutomationDB(t)
+	const handler = "twice_broken"
+	fx.seedAutomation(t, handler)
+
+	applies := 0
+	engine := engineOverScripted(fx, scriptedWorkflow{
+		name:       handler,
+		redrivable: true,
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applies++
+			return workflow.RunResult{}, errors.New("the downstream service was unreachable")
+		},
+	})
+	if err := engine.HandleEvent(context.Background(), fx.stagedEvent(t, ids.NewV7())); err == nil {
+		t.Fatal("the scripted Apply failed, so HandleEvent must surface it")
+	}
+
+	// Retry twice. The SECOND retry is a retry OF A RETRY, whose own run key
+	// already carries an attempt marker. An attempt count that cannot see
+	// through that marker restarts at zero, re-mints the first retry's key,
+	// loses the claim, and returns having applied nothing — while reporting
+	// success, which is the worst shape a failure can take.
+	for attempt := range 2 {
+		var failed ids.UUID
+		if err := fx.owner.QueryRow(context.Background(),
+			`SELECT id FROM workflow_run WHERE handler = $1 AND status = 'failed'
+			  ORDER BY created_at DESC, id DESC LIMIT 1`, handler).Scan(&failed); err != nil {
+			t.Fatalf("reading the newest failed run: %v", err)
+		}
+		if _, err := engine.RetryRun(context.Background(), failed); err == nil {
+			t.Fatalf("retry %d: the scripted Apply fails every time, so the retry must surface it", attempt+1)
+		}
+	}
+
+	if applies != 3 {
+		t.Fatalf("Apply ran %d times, want 3 — the original firing and two retries. "+
+			"A retry that reports success without re-entering Apply is a false green", applies)
+	}
+	runs := fx.count(t, `SELECT count(*) FROM workflow_run WHERE handler = $1`, handler)
+	if runs != 3 {
+		t.Fatalf("recorded %d runs, want 3 — each attempt claims its own row", runs)
+	}
+}

--- a/backend/internal/modules/people/leadrouting.go
+++ b/backend/internal/modules/people/leadrouting.go
@@ -317,6 +317,11 @@ func (leadRouting) Spec() workflow.Spec {
 		Name:    assignLeadOwnerName,
 		Trigger: workflow.Trigger{EventType: "lead.created"},
 		Tier:    mcp.TierAutoExecute,
+		// Re-driving this costs nothing: RouteLead reads owner_id under the
+		// lead's row lock and returns already_owned without writing once
+		// anybody holds it, so a repeat cannot take a lead off the human who
+		// claimed it in between.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/modules/people/leadslaworkflow.go
+++ b/backend/internal/modules/people/leadslaworkflow.go
@@ -41,6 +41,10 @@ func (leadFirstResponse) Spec() workflow.Spec {
 		Name:    "lead_first_response",
 		Trigger: workflow.Trigger{EventType: "activity.captured"},
 		Tier:    mcp.TierAutoExecute,
+		// The stamp is the EARLIEST response, not the latest pass: a stamp
+		// later than or equal to the one already on the lead is a replay and
+		// writes nothing, which is what an at-least-once bus needs anyway.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 
@@ -88,6 +92,9 @@ func (leadStatusLadder) Spec() workflow.Spec {
 		Name:    "lead_status_ladder",
 		Trigger: workflow.Trigger{EventType: "activity.captured"},
 		Tier:    mcp.TierAutoExecute,
+		// The ladder only climbs. A second pass asks Advances() about a status
+		// its own first pass already moved, which answers false.
+		RedrivableWithoutDuplicating: true,
 	}
 }
 

--- a/backend/internal/shared/ports/workflow/workflow.go
+++ b/backend/internal/shared/ports/workflow/workflow.go
@@ -105,6 +105,18 @@ type Event struct {
 	// behind it at all): the match-time owner-permission gate reads this
 	// to decide whose live authority a firing must still hold.
 	OwnerID ids.UUID
+
+	// RetryAttempt distinguishes a re-driven firing from the one it retries.
+	// Zero for an ordinary firing, and the engine's own retry path sets it
+	// (automation's RetryRun) — a handler never reads it and never sets it.
+	//
+	// It exists because the run claim is UNIQUE on (handler, idempotency_key):
+	// re-dispatching under the original key finds the failed run's own row,
+	// takes no claim, and returns having applied nothing. The marker rides the
+	// EVENT rather than being spliced into the key at one call site, because
+	// runKey is read by seven recorders inside one run and they must all agree
+	// on which row this firing is writing.
+	RetryAttempt int
 }
 
 // Effect is the typed, enumerable set of actions a run may take. No


### PR DESCRIPTION
A failed automation run had no way back: the health lane named the rule that broke and left an operator to fix it by hand or wait for the next trigger. `RetryRun` re-dispatches the **original event** down the ordinary `runOne` path, so every gate a first firing passes it passes again — the owner's live RBAC, the audience check, the run claim, the effect claim.

It never re-applies the stored `planned` effect. That was a plan made against a database which has since moved.

## Three refusals, each for its own reason

- **The run must have FAILED.** A `blocked` run is the permission gate having refused it on purpose; retrying a refusal reads to an operator as though the refusal had been a glitch.
- **The handler must declare `RedrivableWithoutDuplicating`.** Every handler registered today does, so this arm refuses nothing now — it is here for the next handler, whose zero value is `false` until somebody audits it.
- **The trigger event must be recoverable from `event_outbox`.** A clock firing synthesizes an id per evaluation pass that was never an outbox row, so those are unreplayable by construction. The clock re-evaluates the same anchor on its own next pass anyway.

## The attempt marker prefixes the key

Both readers of that shape match `"@<automation id>"` anchored at the **end** — `ListRuns` and `troubledRunsSQL`. A suffixed marker would drop every retried run out of the health lane that offered the retry, silently, with nothing failing anywhere. `TestARetriedRunStaysVisibleToTheHealthLane` is the test that catches it: under the suffix mutation it alone fails, reporting 1 failed run where 2 exist.

## Census correction

Seven judgements in the redrive census read "not audited for a repeat". Each has now been read to the statement that makes a repeat a no-op, with the reason at its own `Spec`.

One was not merely unaudited but **wrong**: `assign_lead_owner` claimed `RouteLead` assigns with no version check and can overwrite a human's reassignment. `RouteLead` returns `already_owned` and writes nothing once the lead has an owner, under the lead's row lock inside the workspace routing lock. The verdict was safe and the reason was false — the worse half, because the next reader trusts it and stops looking.

## Review findings, both fixed in the second commit

A review pass found two defects a green suite passed over:

1. **A retry of a retry reported success having done nothing.** The prior-attempt count matched `LIKE 'retry%:' || idempotency_key`; when the run being retried already carried a marker the pattern found nothing, the count restarted at zero, re-minted the first retry's key, lost the claim in `claimRun`, and returned `nil`. Now the count strips any marker and compares the base key by equality.
2. **Two concurrent retries of one run could both dispatch.** The count and the claim it feeds are separate transactions, so two callers could compute different keys and each claim a row without colliding. The decision now takes a transaction-scoped advisory lock on the run.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `TestARetriedRunAppliesOnTheSecondPass` — Apply runs twice; the retry re-enters the handler rather than reporting the stored run |
| Failure behaviour | `TestARetryRefusesARunThatDidNotFail`, `…RefusesAHandlerThatWouldRepeatItsEffect`, `…RefusesARunWhoseTriggerEventIsGone` — each asserts Apply did **not** re-run |
| Idempotency/concurrency | `TestRetryingARetryIsItsOwnAttempt` (3 applies, 3 run rows); advisory lock serializes the count-then-claim |
| Write shape | Retry goes through `runOne`, so the existing run claim, audit and outbox path is unchanged |
| Mutation strength | 6 mutations, each failing only its own test: marker as suffix → only the health-lane test; each of the three guards → only its refusal test; unstripped base key → only the retry-of-a-retry test |
| Full lane | `make check-backend` EXIT=0 before push **and** after rebase onto `b397ef7a08`; `make test-it DIR=backend/internal/modules/automation` green on real Postgres |

Tests drive a **real** failure through the engine — a scripted Apply that errors — rather than hand-inserting a `failed` row, which would prove the SQL reads what the test wrote and nothing about the engine's own failure path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `RetryRun` so a failed automation run can be re-dispatched from the health lane instead of waiting for the next trigger or being fixed by hand. Retries re-drive the original event through the ordinary `runOne` path, so the owner's live RBAC, audience check, run claim, and effect claim all re-run; the stored `planned` effect is never replayed.

**Retry path**

- `RetryRun` refuses when the run did not fail, the handler does not declare `RedrivableWithoutDuplicating`, or the trigger event is no longer recoverable from `event_outbox` (clock firings are unreplayable by construction).
- The attempt marker prefixes the idempotency key because `ListRuns` and `troubledRunsSQL` both match `@<automation id>` anchored at the end.
- Seven handlers were audited and now declare `RedrivableWithoutDuplicating`; `assign_lead_owner`'s prior "not audited" verdict was corrected after verifying `RouteLead` is already idempotent.

**Race fixes**

- Retrying a retry now counts attempts against the stripped base key, so a second retry mints its own key instead of silently reporting success without re-entering the handler.
- A transaction-scoped advisory lock serializes concurrent retries, so two callers cannot both dispatch for one failed run.

<sup>Written for commit 117c9080e652c851dc67817e47a61f7c3f68c8dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

