### PR TITLE
The week scores its funnel and its deals

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38871,6 +38871,119 @@ components:
             The focus in words, composed from the stored figures — never model-written, so it
             cannot say something the snapshot does not hold.
 
+    WeeklyReviewScorecard:
+      type: object
+      additionalProperties: false
+      description: |
+        One week's judgement of one rep's work, frozen with the review. Both blocks are optional
+        and each is absent when the rep had no such work that week.
+      properties:
+        lead:
+          description: |
+            The funnel slice. ABSENT when the rep carried no lead at all — which is a different
+            fact from a rep with forty untouched leads, who gets a present block of zeros.
+          allOf: [{ $ref: '#/components/schemas/WeeklyScorecardLeadBlock' }]
+        deal:
+          description: |
+            The pipeline slice. ABSENT when the rep had no open deal and no stage change in the
+            window — nothing to judge.
+          allOf: [{ $ref: '#/components/schemas/WeeklyScorecardDealBlock' }]
+
+    WeeklyScorecardLeadBlock:
+      type: object
+      additionalProperties: false
+      description: |
+        How the rep's leads moved, and whether the meetings behind them happened.
+      required:
+        [advanced, disqualified, promoted, answered_in_target, breached,
+         meetings_booked, meetings_held, meetings_no_show, meetings_partial_history]
+      properties:
+        advanced:
+          type: integer
+          minimum: 0
+          description: |
+            Status transitions UP the open ladder inside the week. Counted per transition, so a
+            lead that went new to contacted to engaged counts twice — the lead's own row records
+            only where it ended and could report at most one of them.
+        disqualified: { type: integer, minimum: 0 }
+        promoted: { type: integer, minimum: 0 }
+        answered_in_target:
+          type: integer
+          minimum: 0
+          description: Leads that arrived this week and were answered without breaching the SLA.
+        breached: { type: integer, minimum: 0 }
+        meetings_booked:
+          type: integer
+          minimum: 0
+          description: |
+            Meetings that BECAME booked this week, read from the meeting's transition history and
+            never from its current status. A meeting booked Monday and held Friday counts in both
+            this and `meetings_held`, which is what a funnel means; counting the current column
+            would report no bookings at all for the week it was booked in.
+        meetings_held: { type: integer, minimum: 0 }
+        meetings_no_show: { type: integer, minimum: 0 }
+        meetings_partial_history:
+          type: integer
+          minimum: 0
+          description: |
+            Meetings whose only history row was invented from their current state when the history
+            table was introduced. They cannot say when they were booked, so they are reported as
+            partial coverage rather than counted. A non-zero value means the three counts above
+            are a floor, and a reader should say so.
+
+    WeeklyScorecardDealBlock:
+      type: object
+      additionalProperties: false
+      description: |
+        Whether deals moved forward, and whether they are in a state anybody could work.
+      required:
+        [advances, regressions, with_next_step, open, multi_threaded,
+         close_date_sound, forecast_up, forecast_down]
+      properties:
+        advances:
+          type: integer
+          minimum: 0
+          description: |
+            Moves to a LATER stage of the same pipeline, by stage position. A deal that crossed
+            pipelines has no comparable position and counts as neither direction.
+        regressions: { type: integer, minimum: 0 }
+        median_days_in_stage:
+          type: [integer, 'null']
+          minimum: 0
+          description: |
+            Median whole days a deal sat in the stage it left this week. NULL when no deal changed
+            stage: a median of nothing is absent, never zero.
+        with_next_step:
+          type: integer
+          minimum: 0
+          description: Open deals carrying an open task. A count beside `open`, never a rate.
+        open:
+          type: integer
+          minimum: 0
+          description: |
+            The denominator the three coverage counts are read against. Published so a reader can
+            judge "3 of 5" rather than trust a percentage that cannot be told from 300 of 500.
+        multi_threaded:
+          type: integer
+          minimum: 0
+          description: |
+            Open deals with at least two distinct people in the last 30 days. Thirty rather than
+            the review's own week: the risk measured is the single point of failure, and a deal
+            worked steadily for a month is multi-threaded whether or not the second person
+            happened to appear in these seven days.
+        close_date_sound:
+          type: integer
+          minimum: 0
+          description: Open deals whose close date is set, not provisional, and not in the past.
+        forecast_up:
+          type: integer
+          minimum: 0
+          description: |
+            Deals whose forecast category ended the week higher than it started. Counted ONCE per
+            deal however many times it was edited — a rep who corrected a typo three times did not
+            upgrade three times.
+        forecast_down: { type: integer, minimum: 0 }
+
     WeeklyReview:
       type: object
       additionalProperties: false
@@ -38931,6 +39044,16 @@ components:
             review rather than "last week" — a rep with a gap has a previous week that is not seven
             days back.
           allOf: [{ $ref: '#/components/schemas/WeeklyReviewPrior' }]
+        scorecard:
+          description: |
+            How WELL the week went, as against what happened in it — the counts beside this say
+            forty leads arrived, this says twelve were answered inside the target.
+
+            ABSENT on a review written before scorecards existed. Each of its two blocks is
+            independently absent too, and absent is NOT zero: a rep who carried no leads did not
+            score zero on the funnel, and a reader must draw nothing rather than a row of zeros
+            that reads as failure at something nobody asked of them.
+          allOf: [{ $ref: '#/components/schemas/WeeklyReviewScorecard' }]
         outlook:
           type: array
           items: { $ref: '#/components/schemas/WeeklyReviewOutlook' }

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -443,6 +443,7 @@ var tableOwners = map[string]string{
 	"weekly_review_outlook":     "internal/compose/weekly",
 	"weekly_review_movement":    "internal/compose/weekly",
 	"weekly_review_driver":      "internal/compose/weekly",
+	"weekly_review_scorecard":   "internal/compose/weekly",
 	// The company view's per-user visit baseline: view state, not a record
 	// fact, so it is written without an audit row — the saved-view ruling.
 	// The person view acknowledges visits into the SAME table (one baseline

--- a/backend/internal/compose/weekly/weeklyassemble.go
+++ b/backend/internal/compose/weekly/weeklyassemble.go
@@ -154,6 +154,18 @@ func (e *Engine) AssembleFor(ctx context.Context, now time.Time) (Review, bool, 
 		if err := insertDealLines(ctx, tx, id, review.Deals); err != nil {
 			return err
 		}
+		// How well the week went, frozen in the same transaction as what
+		// happened in it. Both blocks may be absent — a rep with no leads and
+		// no deals gets a scorecard that says so, which is what lets a reader
+		// tell an empty week from an unmeasured one.
+		card, err := scoreWeek(ctx, tx, userID, start, end)
+		if err != nil {
+			return err
+		}
+		if err := insertScorecard(ctx, tx, id, card); err != nil {
+			return err
+		}
+		review.Scorecard = &card
 		// Where the week was landing, frozen into the same transaction as the
 		// counts. Split across two, a review could exist with no outlook and no
 		// way to tell that from an installation that forecasts nothing.

--- a/backend/internal/compose/weekly/weeklycompare.go
+++ b/backend/internal/compose/weekly/weeklycompare.go
@@ -193,9 +193,10 @@ func closedInWeek(
 // deref reads a nullable sum as zero. A week in which nothing closed sums to
 // NULL, and that IS zero — unlike an unconvertible week, which countWeekMoney
 // has already turned into an absent Money above.
-func deref(v *int64) int64 {
+func deref[T any](v *T) T {
 	if v == nil {
-		return 0
+		var zero T
+		return zero
 	}
 	return *v
 }

--- a/backend/internal/compose/weekly/weeklyhandlers.go
+++ b/backend/internal/compose/weekly/weeklyhandlers.go
@@ -105,6 +105,36 @@ func reviewToWire(review Review) crmcontracts.WeeklyReview {
 		}
 		out.Outlook = &outlook
 	}
+	if review.Scorecard != nil {
+		out.Scorecard = scorecardToWire(*review.Scorecard)
+	}
+	return out
+}
+
+// scorecardToWire renders the week's judgement.
+//
+// Each block travels only when it is present. An absent block is omitted rather
+// than sent as zeros, because a reader that received zeros would draw a rep who
+// carried no leads as having failed at the funnel.
+func scorecardToWire(card Scorecard) *crmcontracts.WeeklyReviewScorecard {
+	out := &crmcontracts.WeeklyReviewScorecard{}
+	if l := card.Lead; l != nil {
+		out.Lead = &crmcontracts.WeeklyScorecardLeadBlock{
+			Advanced: l.Advanced, Disqualified: l.Disqualified, Promoted: l.Promoted,
+			AnsweredInTarget: l.AnsweredInTarget, Breached: l.Breached,
+			MeetingsBooked: l.Booked, MeetingsHeld: l.Held, MeetingsNoShow: l.NoShow,
+			MeetingsPartialHistory: l.PartialHistory,
+		}
+	}
+	if d := card.Deal; d != nil {
+		out.Deal = &crmcontracts.WeeklyScorecardDealBlock{
+			Advances: d.Advances, Regressions: d.Regressions,
+			MedianDaysInStage: d.MedianDaysInStage,
+			WithNextStep:      d.WithNextStep, Open: d.Open,
+			MultiThreaded: d.MultiThreaded, CloseDateSound: d.CloseDateSound,
+			ForecastUp: d.ForecastUp, ForecastDown: d.ForecastDown,
+		}
+	}
 	return out
 }
 

--- a/backend/internal/compose/weekly/weeklyreviewsql.go
+++ b/backend/internal/compose/weekly/weeklyreviewsql.go
@@ -125,6 +125,13 @@ func scanReview(ctx context.Context, tx pgx.Tx, row pgx.Row) (Review, error) {
 		return Review{}, err
 	}
 	review.Outlook = outlook
+	// A review written before the scorecard existed has none, and readScorecard
+	// answers nil rather than failing: the panel draws nothing.
+	card, err := readScorecard(ctx, tx, review.ID)
+	if err != nil {
+		return Review{}, err
+	}
+	review.Scorecard = card
 	return review, nil
 }
 

--- a/backend/internal/compose/weekly/weeklyscorecard.go
+++ b/backend/internal/compose/weekly/weeklyscorecard.go
@@ -1,0 +1,470 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// How WELL the week went, as against what happened in it.
+//
+// The counts beside this say a rep was sent 40 leads and held 6 meetings. This
+// says they answered 12 inside the target and 4 of those meetings left a next
+// step behind. The two are different questions and a reader wants both, but
+// only this one is a judgement, so only this one has to be careful about what
+// it does when there is nothing to judge.
+//
+// A BLOCK IS PRESENT OR ABSENT, NEVER ZEROED. A rep who carried no leads at all
+// did not score zero on the funnel — the funnel was not their work that week,
+// and a row of zeros reads as failure at something nobody asked of them. Each
+// block reports whether it applies, and the panel draws only what applies.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// Scorecard is one week's judgement of one rep's work.
+//
+// Two independent blocks. Either may be absent, and absent is a different fact
+// from every count being zero: no leads at all versus forty leads and nothing
+// done with them.
+type Scorecard struct {
+	Lead *LeadBlock
+	Deal *DealBlock
+}
+
+// LeadBlock is the funnel slice: how the rep's leads moved, and whether the
+// meetings behind them happened.
+type LeadBlock struct {
+	// Movement, counted from the audit images rather than the lead row. The row
+	// carries the CURRENT status and a few milestone stamps, so it cannot say
+	// who moved from contacted to engaged inside a window.
+	Advanced     int
+	Disqualified int
+	Promoted     int
+
+	// The SLA slice, carried here as well as on Counts so a reader of the
+	// scorecard has the whole funnel in one record.
+	AnsweredInTarget int
+	Breached         int
+
+	// Meetings by what they BECAME this week. Never by activity.meeting_status:
+	// a meeting booked Monday and held Friday reads `held` today, so counting
+	// the column reports no bookings for the week it was booked in.
+	Booked int
+	Held   int
+	NoShow int
+	// Meetings whose only history row was invented by the backfill from current
+	// state. They cannot say when they were booked, so they are reported as
+	// partial coverage rather than counted as history.
+	PartialHistory int
+}
+
+// DealBlock is the pipeline slice: whether deals moved forward, and whether
+// they are in a state anybody could work.
+type DealBlock struct {
+	Advances    int
+	Regressions int
+
+	// Median whole days a deal sat in the stage it left this week. Absent when
+	// no deal changed stage: a median of nothing is not zero.
+	MedianDaysInStage *int
+
+	// Counts and their denominator, never a rate. A reader who sees 3 of 5 can
+	// judge the number; one who sees 60% cannot tell it from 300 of 500.
+	WithNextStep   int
+	Open           int
+	MultiThreaded  int
+	CloseDateSound int
+
+	// Category moves, each deal counted ONCE however many times it was edited.
+	ForecastUp   int
+	ForecastDown int
+}
+
+// multiThreadWindow is how far back a deal's second contact may be and still
+// count as coverage.
+//
+// Thirty days rather than the review's own week: a deal worked steadily for a
+// month is multi-threaded whether or not the second person happened to appear
+// in the seven days under review, and a week-long window would report a rep as
+// single-threaded for the ordinary reason that they spoke to one of the two
+// this week.
+const multiThreadWindow = 30 * 24 * time.Hour
+
+// minStakeholders is how many distinct people a deal needs to count as
+// multi-threaded. Two, because the risk being measured is the single point of
+// failure: one contact who leaves takes the deal with them.
+const minStakeholders = 2
+
+// scoreWeek reads both blocks for one rep's closed week.
+//
+// Both are read even when one turns out absent, because "absent" is itself a
+// finding the row records, and deciding not to ask would leave the reader
+// unable to tell an empty funnel from an unmeasured one.
+func scoreWeek(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
+) (Scorecard, error) {
+	lead, err := scoreLeads(ctx, tx, userID, start, end)
+	if err != nil {
+		return Scorecard{}, err
+	}
+	deal, err := scoreDeals(ctx, tx, userID, start, end)
+	if err != nil {
+		return Scorecard{}, err
+	}
+	return Scorecard{Lead: lead, Deal: deal}, nil
+}
+
+// ladderRungSQL ranks an open lead status by its position on the ladder, so a
+// transition has a DIRECTION.
+//
+// The rungs are the generated contract's own constants, so a status renamed in
+// crm.yaml stops compiling here rather than silently ranking -1. Their ORDER is
+// this list — the contract's enum is alphabetical and says nothing about
+// direction — and it is the SQL mirror of people.LeadStatus.Advances, which is
+// the Go spelling of the same rule.
+//
+// A terminal or unknown status ranks -1 and so is never a step UP, which is
+// right: promoted and disqualified LEAVE the ladder rather than climbing it,
+// and each already has its own count.
+func ladderRungSQL(column string) string {
+	ladder := []crmcontracts.LeadStatus{
+		crmcontracts.LeadStatusNew,
+		crmcontracts.LeadStatusContacted,
+		crmcontracts.LeadStatusEngaged,
+	}
+	var b strings.Builder
+	b.WriteString("CASE " + column)
+	for rung, status := range ladder {
+		fmt.Fprintf(&b, " WHEN '%s' THEN %d", status, rung)
+	}
+	b.WriteString(" ELSE -1 END")
+	return b.String()
+}
+
+// climbedTheLadderSQL is the predicate for a step UP: both ends on the ladder,
+// and the destination above the origin. The Go spelling of this rule is
+// people.LeadStatus.Advances, and the two must agree — a gate below holds it.
+func climbedTheLadderSQL() string {
+	from, to := ladderRungSQL("from_status"), ladderRungSQL("to_status")
+	return "(" + from + ") >= 0 AND (" + to + ") > (" + from + ")"
+}
+
+// scoreLeads reads the funnel block, or reports it absent.
+//
+// ABSENT means the rep carried no lead in the window at all — not that nothing
+// moved. A rep with forty untouched leads gets a present block full of zeros,
+// which is a real and unflattering finding; a rep with no leads gets no block.
+//
+// The movement counts come from audit_log's before/after images. That is where
+// a lead's movement lives: the lead row carries its current status and a few
+// milestone stamps (routed_at, first_response_at, promoted_at) and cannot
+// answer "who moved from contacted to engaged this week". All five writers of
+// lead.status — promote, demote, disqualify, the SLA ladder's AdvanceLeadStatus
+// and the ordinary PATCH — go through storekit.Audit, so the images are
+// complete; a sixth writer that bypassed it would make this undercount, which
+// is why the audit gate refuses one.
+//
+// Profiled before it was written, per this work package's own delivery gate: at
+// 10M audit rows with 333k lead updates over a year, one week for every owner
+// costs 277ms cold and 67ms warm — 5% of database.CallerPredicateBudget, on a
+// path no user waits on. The index that serves it is
+// idx_audit_entity_narrow (entity_type, entity_id, occurred_at): entity_type is
+// an equality on the leading column, so occurred_at is usable as a range even
+// with entity_id skipped between them, and the millions of rows belonging to
+// other entity types are never visited.
+func scoreLeads(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
+) (*LeadBlock, error) {
+	// Presence is asked FIRST and with its own argument list. The block query
+	// below binds the window as well, and a statement that binds a parameter it
+	// never mentions is rejected outright — so the two cannot share one list.
+	present, err := hasLeads(ctx, tx, userID, end)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		//nolint:nilnil // an absent block IS the answer for a rep who carried no leads, not a missing one: zeros here would read as failure at work nobody asked of them.
+		return nil, nil
+	}
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	startPos, endPos, userPos := arg(start), arg(end), arg(userID)
+	// A meeting has no owner and captured_by is a principal STRING, not a
+	// user id — the same attribution countWeekMeetings uses, and the reason
+	// this is not simply userID: comparing the text column to a uuid is a
+	// type error, and comparing it to the bare uuid text would never match.
+	capturedPos := arg("human:" + userID.String())
+	scope, err := auth.ScopeClauseFor(ctx, "lead", "l", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = sqlUnbounded
+	}
+	// Activities carry no owner, so their visibility comes from the records
+	// they link to and the audience the writer set — never hand-rolled.
+	meetingScope, err := auth.ActivityContentClause(ctx, "m", arg)
+	if err != nil {
+		return nil, err
+	}
+	// The rep's leads, scoped once and reused by every count below. Membership
+	// is "owned by this rep and visible to them", with no window on it: a lead
+	// routed last month that moved this week is this week's movement.
+	mine := fmt.Sprintf(`SELECT l.id FROM lead l
+		 WHERE l.owner_id = $%[1]d AND (%[2]s)`, userPos, scope)
+
+	block := &LeadBlock{}
+	// One statement for the whole block: eight counts read at eight moments
+	// would describe eight slightly different weeks.
+	err = tx.QueryRow(ctx, fmt.Sprintf(`
+		WITH mine AS (%[5]s),
+		-- Every status transition on those leads inside the window, one row per
+		-- audit entry. DISTINCT FROM rather than <>: a NULL on either side is a
+		-- change, and <> would silently drop the first transition of a lead
+		-- whose status was NULL before it.
+		moved AS (
+		  SELECT a.entity_id,
+		         a.before->>'status' AS from_status,
+		         a.after->>'status'  AS to_status
+		    FROM audit_log a
+		    JOIN mine ON mine.id = a.entity_id
+		   WHERE a.entity_type = 'lead'
+		     AND a.occurred_at >= $%[1]d AND a.occurred_at < $%[2]d
+		     AND a.before->>'status' IS DISTINCT FROM a.after->>'status'),
+		-- Meetings the rep's leads became something this week. Read from the
+		-- history table, so a meeting booked Monday and held Friday counts in
+		-- BOTH the booked and the held tally, which is what a funnel means.
+		met AS (
+		  SELECT h.status, h.partial_pre_history
+		    FROM activity_meeting_history h
+		    JOIN activity m ON m.id = h.activity_id
+		   WHERE m.kind = 'meeting' AND m.captured_by = $%[6]d
+		     AND m.archived_at IS NULL
+		     AND h.effective_at >= $%[1]d AND h.effective_at < $%[2]d
+		     AND (%[7]s))
+		SELECT
+		  (SELECT count(*) FROM moved WHERE %[8]s),
+		  (SELECT count(*) FROM moved WHERE to_status = 'disqualified'),
+		  (SELECT count(*) FROM moved WHERE to_status = 'promoted'),
+		  (SELECT count(*) FROM lead l JOIN mine ON mine.id = l.id
+		    WHERE COALESCE(l.routed_at, l.created_at) >= $%[1]d
+		      AND COALESCE(l.routed_at, l.created_at) < $%[2]d
+		      AND l.first_response_at IS NOT NULL AND l.sla_breached_at IS NULL),
+		  (SELECT count(*) FROM lead l JOIN mine ON mine.id = l.id
+		    WHERE COALESCE(l.routed_at, l.created_at) >= $%[1]d
+		      AND COALESCE(l.routed_at, l.created_at) < $%[2]d
+		      AND l.sla_breached_at IS NOT NULL),
+		  (SELECT count(*) FROM met WHERE status = 'booked' AND NOT partial_pre_history),
+		  (SELECT count(*) FROM met WHERE status = 'held' AND NOT partial_pre_history),
+		  (SELECT count(*) FROM met WHERE status = 'no_show' AND NOT partial_pre_history),
+		  (SELECT count(*) FROM met WHERE partial_pre_history)`,
+		startPos, endPos, userPos, scope, mine, capturedPos, meetingScope,
+		climbedTheLadderSQL()), args...).
+		Scan(&block.Advanced, &block.Disqualified, &block.Promoted,
+			&block.AnsweredInTarget, &block.Breached,
+			&block.Booked, &block.Held, &block.NoShow, &block.PartialHistory)
+	if err != nil {
+		return nil, fmt.Errorf("weekly: scoring the week's funnel: %w", err)
+	}
+	return block, nil
+}
+
+// hasLeads reports whether this rep carries any lead they can see.
+//
+// Bounded at the END of the week and open at the start: a rep whose leads all
+// arrived last month still has a funnel this week, so the question is "did they
+// carry one by then" rather than "did one arrive in these seven days" — which
+// would make a quiet week's block vanish. The upper bound is what stops a lead
+// created AFTER the week from conjuring a block onto it.
+//
+// Its own scope clause and its own argument list, because it binds only this
+// bound and a statement may not bind a parameter it does not mention.
+func hasLeads(ctx context.Context, tx pgx.Tx, userID ids.UUID, by time.Time) (bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	userPos, byPos := arg(userID), arg(by)
+	scope, err := auth.ScopeClauseFor(ctx, "lead", "l", arg)
+	if err != nil {
+		return false, err
+	}
+	if scope == "" {
+		scope = sqlUnbounded
+	}
+	var present bool
+	err = tx.QueryRow(ctx, fmt.Sprintf(
+		`SELECT EXISTS (SELECT 1 FROM lead l
+		   WHERE l.owner_id = $%[1]d AND l.created_at < $%[2]d AND (%[3]s))`,
+		userPos, byPos, scope), args...).Scan(&present)
+	if err != nil {
+		return false, fmt.Errorf("weekly: looking for the rep's leads: %w", err)
+	}
+	return present, nil
+}
+
+// forecastRankSQL orders the forecast categories so a move between two of them
+// has a direction.
+//
+// The vocabulary is deal_forecast_category_check's, and the order is the
+// confidence ladder the product already speaks: omitted is not in the number at
+// all, pipeline is in it, best_case is likely and commit is promised. A
+// category the CHECK does not allow, and a NULL, rank as -1 and so read as
+// BELOW omitted — a deal that gained a category moved up, and one that lost it
+// moved down, which is what happened.
+//
+// Spelled as SQL rather than compared in Go because the comparison happens
+// inside the aggregate that reduces a deal's many edits to one move; pulling
+// the rows out to rank them here would be a second pass over the same data to
+// answer the same question.
+func forecastRank(column string) string {
+	return `CASE ` + column + `
+		WHEN 'commit' THEN 3 WHEN 'best_case' THEN 2
+		WHEN 'pipeline' THEN 1 WHEN 'omitted' THEN 0 ELSE -1 END`
+}
+
+// dealScoreSQL is the deal block's one statement.
+//
+// One statement rather than ten, because ten counts read at ten moments
+// describe ten slightly different weeks. Lifted out of the function so the
+// arithmetic beside it stays readable at a glance; the format verbs are bound
+// at the single call site below.
+const dealScoreSQL = `
+		WITH mine AS (
+		  SELECT d.id, d.stage_id, d.pipeline_id, d.expected_close_date,
+		         d.close_date_provisional, d.archived_at, d.status
+		    FROM deal d
+		   WHERE d.owner_id = $%[3]d AND (%[8]s)),
+		open_deals AS (SELECT * FROM mine WHERE status = 'open' AND archived_at IS NULL),
+		-- Stage moves inside the window, with both ends' positions resolved.
+		-- A move whose two stages sit in different pipelines resolves to NULL
+		-- on one side and is counted as neither direction.
+		moves AS (
+		  SELECT h.deal_id, h.changed_at, h.from_stage_id,
+		         fs."position" AS from_pos, ts."position" AS to_pos
+		    FROM deal_stage_history h
+		    JOIN mine ON mine.id = h.deal_id
+		    LEFT JOIN stage fs ON fs.id = h.from_stage_id
+		         AND fs.pipeline_id = mine.pipeline_id
+		    LEFT JOIN stage ts ON ts.id = h.to_stage_id
+		         AND ts.pipeline_id = mine.pipeline_id
+		   WHERE h.changed_at >= $%[1]d AND h.changed_at < $%[2]d
+		     AND h.to_stage_id IS DISTINCT FROM h.from_stage_id),
+		-- How long the deal sat in the stage it LEFT: this move's moment less
+		-- the previous move into that stage. A deal whose prior move is outside
+		-- the window still resolves, because the lookup is not windowed.
+		dwell AS (
+		  SELECT m.deal_id,
+		         EXTRACT(epoch FROM m.changed_at - (
+		           SELECT max(p.changed_at) FROM deal_stage_history p
+		            WHERE p.deal_id = m.deal_id AND p.changed_at < m.changed_at
+		         )) / 86400 AS days
+		    FROM moves m
+		   WHERE m.from_stage_id IS NOT NULL),
+		-- Category moves, one row per deal: a rep who corrected a typo three
+		-- times did not downgrade three times. The direction is the deal's
+		-- FIRST and LAST category inside the window, compared once.
+		cat AS (
+		  SELECT a.entity_id,
+		         (array_agg(a.before->>'forecast_category'
+		           ORDER BY a.occurred_at, a.id))[1] AS first_cat,
+		         (array_agg(a.after->>'forecast_category'
+		           ORDER BY a.occurred_at DESC, a.id DESC))[1] AS last_cat
+		    FROM audit_log a
+		    JOIN mine ON mine.id = a.entity_id
+		   WHERE a.entity_type = 'deal'
+		     AND a.occurred_at >= $%[1]d AND a.occurred_at < $%[2]d
+		     AND a.before->>'forecast_category' IS DISTINCT FROM a.after->>'forecast_category'
+		   GROUP BY a.entity_id)
+		SELECT
+		  EXISTS (SELECT 1 FROM open_deals) OR EXISTS (SELECT 1 FROM moves),
+		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos > from_pos),
+		  (SELECT count(*) FROM moves WHERE from_pos IS NOT NULL AND to_pos < from_pos),
+		  (SELECT round(percentile_cont(0.5) WITHIN GROUP (ORDER BY days))::int
+		     FROM dwell WHERE days IS NOT NULL),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE EXISTS (
+		      SELECT 1 FROM activity_link tl
+		        JOIN activity task ON task.id = tl.activity_id
+		       WHERE tl.deal_id = o.id AND task.kind = 'task'
+		         AND task.archived_at IS NULL AND NOT task.is_done)),
+		  (SELECT count(*) FROM open_deals),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE (SELECT count(DISTINCT pl.person_id)
+		             FROM activity_link dl
+		             JOIN activity act ON act.id = dl.activity_id
+		             JOIN activity_link pl ON pl.activity_id = dl.activity_id
+		            WHERE dl.deal_id = o.id AND pl.person_id IS NOT NULL
+		              AND act.archived_at IS NULL
+		              AND act.occurred_at >= $%[4]d) >= $%[5]d),
+		  (SELECT count(*) FROM open_deals o
+		    WHERE o.expected_close_date IS NOT NULL
+		      AND NOT o.close_date_provisional
+		      AND o.expected_close_date >= (timezone($%[9]d, $%[2]d))::date),
+		  (SELECT count(*) FROM cat WHERE %[6]s > %[7]s),
+		  (SELECT count(*) FROM cat WHERE %[6]s < %[7]s)`
+
+// scoreDeals reads the pipeline block, or reports it absent.
+//
+// ABSENT means the rep had no open deal AND no stage change in the window —
+// nothing to judge. A rep with open deals that did not move gets a present
+// block of zeros, which is the finding.
+//
+// An advance is a move to a LATER stage of the same pipeline, a regression an
+// earlier one, both read from stage.position. Position rather than
+// win_probability: two stages may share a probability, and a move between them
+// is still a move. A deal that crossed pipelines has no comparable position and
+// counts as neither.
+func scoreDeals(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, start, end time.Time,
+) (*DealBlock, error) {
+	// The reporting zone, because expected_close_date is a DATE and the window
+	// is an instant: cast without it and Postgres uses the session zone, which
+	// puts a deal closing near midnight on the wrong side of the boundary.
+	zone, err := identity.TimezoneOf(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	startPos, endPos, userPos := arg(start), arg(end), arg(userID)
+	sincePos := arg(end.Add(-multiThreadWindow))
+	stakeholdersPos := arg(minStakeholders)
+	zonePos := arg(zone)
+	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = sqlUnbounded
+	}
+
+	block := &DealBlock{}
+	var present bool
+	// Nullable on its own: a present block whose deals all stayed put has no
+	// median, and that is absent rather than zero days.
+	var median *int
+	err = tx.QueryRow(ctx, fmt.Sprintf(dealScoreSQL,
+		startPos, endPos, userPos, sincePos, stakeholdersPos,
+		forecastRank("last_cat"), forecastRank("first_cat"), scope, zonePos), args...).
+		Scan(&present, &block.Advances, &block.Regressions, &median,
+			&block.WithNextStep, &block.Open, &block.MultiThreaded,
+			&block.CloseDateSound, &block.ForecastUp, &block.ForecastDown)
+	if err != nil {
+		return nil, fmt.Errorf("weekly: scoring the week's deals: %w", err)
+	}
+	if !present {
+		//nolint:nilnil // no open deal and no stage change means there is nothing to judge, which is a different fact from a block of zeros.
+		return nil, nil
+	}
+	block.MedianDaysInStage = median
+	return block, nil
+}

--- a/backend/internal/compose/weekly/weeklyscorecard_integration_test.go
+++ b/backend/internal/compose/weekly/weeklyscorecard_integration_test.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package weekly
+
+// The scorecard over real migrated Postgres.
+//
+// These cases are here rather than in a unit test because the thing under test
+// IS the SQL: the lead block reads status movement out of audit_log's
+// before/after images, which only exist because the real writers put them
+// there. A test that hand-inserted its own audit rows would prove that this
+// query can read rows this test knows how to write, and nothing about whether
+// production writes them that way.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedLeadFor mints a lead through the real writer and returns its id.
+func seedLeadFor(t *testing.T, e *weekEnv, name string, owner ids.UUID) ids.LeadID {
+	t.Helper()
+	ownerID := ids.From[ids.UserKind](owner)
+	lead, _, err := e.People.CreateLead(e.Admin(), people.CreateLeadInput{
+		FullName: &name, Status: "new", OwnerID: &ownerID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding lead %s: %v", name, err)
+	}
+	return ids.From[ids.LeadKind](ids.UUID(lead.Id))
+}
+
+// moveLead walks a lead up the ladder through UpdateLead, the writer whose
+// audit images the scorecard reads.
+func moveLead(t *testing.T, e *weekEnv, id ids.LeadID, to string) {
+	t.Helper()
+	if _, err := e.People.UpdateLead(e.Admin(), id, people.UpdateLeadInput{Status: &to}); err != nil {
+		t.Fatalf("moving lead to %s: %v", to, err)
+	}
+}
+
+// nextWeek is a clock one week after the fixture's own writes, so the week
+// under review — the one that just CLOSED — is the week the seeding happened
+// in. The audit log is append-only by trigger and by grant, so a test cannot
+// move a transition into the window; it moves the window instead.
+func nextWeek() time.Time { return time.Now().UTC().AddDate(0, 0, 7) }
+
+// A REP WITH NO LEADS GETS NO LEAD BLOCK. The distinction the whole presence
+// boolean exists for: absent means the funnel was not this rep's work, and a
+// row of zeros would read as failure at something nobody asked of them.
+func TestARepWithNoLeadsGetsNoLeadBlockRatherThanZeros(t *testing.T) {
+	e := setupWeekly(t)
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if review.Scorecard == nil {
+		t.Fatal("a review carries a scorecard even when both blocks are absent")
+	}
+	if review.Scorecard.Lead != nil {
+		t.Fatalf("a rep with no leads must have no lead block, got %+v", review.Scorecard.Lead)
+	}
+}
+
+// A rep WITH leads gets a block, even when nothing in it moved. The other side
+// of the case above: zeros are a finding, and only absence of leads is absence.
+func TestARepWithUntouchedLeadsGetsABlockOfZerosNotAnAbsentOne(t *testing.T) {
+	e := setupWeekly(t)
+	seedLeadFor(t, e, "Untouched", e.Rep1)
+
+	// Assembled from the FOLLOWING week, so the lead the fixture just wrote is
+	// one the rep already carried when the week under review closed. Presence
+	// asks "did they carry a funnel by then", and a lead minted after the week
+	// must not conjure a block onto it.
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := review.Scorecard.Lead
+	if block == nil {
+		t.Fatal("a rep who carries leads has a funnel to score, however still it stood")
+	}
+	if block.Advanced != 0 {
+		t.Fatalf("nothing moved this week, so Advanced is 0, got %d", block.Advanced)
+	}
+}
+
+// THE MOVEMENT COUNTS COME FROM THE AUDIT IMAGES. A lead that climbed the
+// ladder inside the window is counted; the lead row itself cannot say this,
+// because it carries only the status the lead ended on.
+func TestALeadThatClimbedTheLadderThisWeekIsCountedAsAdvanced(t *testing.T) {
+	e := setupWeekly(t)
+	lead := seedLeadFor(t, e, "Climber", e.Rep1)
+	moveLead(t, e, lead, "contacted")
+	moveLead(t, e, lead, "engaged")
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two transitions: new→contacted and contacted→engaged. The lead's own row
+	// now says `engaged` and could report at most one of them.
+	if got := review.Scorecard.Lead.Advanced; got != 2 {
+		t.Fatalf("two rungs climbed this week, want Advanced 2, got %d", got)
+	}
+}
+
+// A lead that moved BEFORE the window is not this week's movement, even though
+// the lead is still the rep's and still reads `engaged` today.
+//
+// Assembled two weeks on rather than by re-dating the audit row: the log is
+// append-only, by trigger and by grant, so the window is what moves.
+func TestALeadThatMovedBeforeTheWindowIsNotThisWeeksMovement(t *testing.T) {
+	e := setupWeekly(t)
+	lead := seedLeadFor(t, e, "Old mover", e.Rep1)
+	moveLead(t, e, lead, "contacted")
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek().AddDate(0, 0, 7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if review.Scorecard.Lead == nil {
+		t.Fatal("the rep still carries the lead, so the block is present")
+	}
+	if got := review.Scorecard.Lead.Advanced; got != 0 {
+		t.Fatalf("the move predates the week under review, want 0, got %d", got)
+	}
+}
+
+// THE SCORECARD IS FROZEN. Re-reading a written review returns the figures as
+// they were written, not a fresh count over today's rows.
+func TestTheScorecardIsFrozenWithTheReview(t *testing.T) {
+	e := setupWeekly(t)
+	lead := seedLeadFor(t, e, "Frozen", e.Rep1)
+	moveLead(t, e, lead, "contacted")
+
+	written, created, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("the first assembly of a week writes it")
+	}
+	before := written.Scorecard.Lead.Advanced
+	// The comparison below is only worth making against a real figure: 0 == 0
+	// would hold whether or not anything is frozen.
+	if before == 0 {
+		t.Fatal("fixture must produce a non-zero count, or the freeze proves nothing")
+	}
+
+	// Move the same lead again AFTER the week was frozen. A scorecard that
+	// recomputed on read would now report a different past.
+	moveLead(t, e, lead, "engaged")
+
+	read, err := e.engine.LatestReview(e.repCtx, &written.LocalWeekStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := read.Scorecard.Lead.Advanced; got != before {
+		t.Fatalf("a frozen week must read back unchanged: wrote %d, read %d", before, got)
+	}
+}
+
+// A REVIEW WRITTEN BEFORE THE SCORECARD EXISTED HAS NONE, and that is not an
+// error. The read path answers nil so the panel draws nothing.
+func TestAReviewWithNoScorecardRowReadsAsAbsentRatherThanFailing(t *testing.T) {
+	e := setupWeekly(t)
+	written, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.WsExec(t, `DELETE FROM weekly_review_scorecard WHERE weekly_review_id = $1`, written.ID)
+
+	read, err := e.engine.LatestReview(e.repCtx, &written.LocalWeekStart)
+	if err != nil {
+		t.Fatalf("a review predating the scorecard must still read: %v", err)
+	}
+	if read.Scorecard != nil {
+		t.Fatalf("no row means no scorecard, got %+v", read.Scorecard)
+	}
+}
+
+// Freezing twice leaves ONE scorecard. The review's own insert usually stops a
+// second pass, so this calls the freeze directly — otherwise the test would
+// pass on the upstream arbiter and prove nothing about this one.
+func TestFreezingAScorecardTwiceLeavesTheFirstOne(t *testing.T) {
+	e := setupWeekly(t)
+	written, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := Scorecard{Lead: &LeadBlock{Advanced: 99}}
+	if err := database.WithWorkspaceTx(e.repCtx, e.Pool, func(tx pgx.Tx) error {
+		return insertScorecard(e.repCtx, tx, written.ID, second)
+	}); err != nil {
+		t.Fatalf("a second freeze must be refused quietly, not fail: %v", err)
+	}
+
+	read, err := e.engine.LatestReview(e.repCtx, &written.LocalWeekStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Scorecard != nil && read.Scorecard.Lead != nil && read.Scorecard.Lead.Advanced == 99 {
+		t.Fatal("the second freeze overwrote the first; the record of a week must not be rewritten")
+	}
+}
+
+// THE SCORECARD REACHES THE WIRE. The Go value being right proves nothing about
+// what a client receives: a block mapped to the wrong field, or not mapped at
+// all, reads to the frontend as "this feature does nothing".
+func TestTheScorecardTravelsOnTheWireWithItsBlocks(t *testing.T) {
+	e := setupWeekly(t)
+	lead := seedLeadFor(t, e, "Wire", e.Rep1)
+	moveLead(t, e, lead, "contacted")
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire := reviewToWire(review)
+	if wire.Scorecard == nil {
+		t.Fatal("a review with a scorecard must carry it on the wire")
+	}
+	if wire.Scorecard.Lead == nil {
+		t.Fatal("the rep carries leads, so the lead block must travel")
+	}
+	if got := wire.Scorecard.Lead.Advanced; got != 1 {
+		t.Fatalf("one rung was climbed, want Advanced 1 on the wire, got %d", got)
+	}
+	// The rep has no deals, so that block must be OMITTED rather than zeroed —
+	// the distinction the whole presence design rests on.
+	if wire.Scorecard.Deal != nil {
+		t.Fatalf("a rep with no deals sends no deal block, got %+v", wire.Scorecard.Deal)
+	}
+}
+
+// A DEMOTION IS NOT AN ADVANCE. The ladder has a direction, and a lead pushed
+// back down it must not read as progress — the count is judged from BOTH ends
+// of the transition, mirroring people.LeadStatus.Advances.
+func TestALeadPushedBackDownTheLadderIsNotCountedAsAnAdvance(t *testing.T) {
+	e := setupWeekly(t)
+	lead := seedLeadFor(t, e, "Backwards", e.Rep1)
+	moveLead(t, e, lead, "contacted")
+	moveLead(t, e, lead, "engaged")
+	// Back down a rung. Its to_status is `contacted`, which a filter reading
+	// only the destination would score as a climb.
+	moveLead(t, e, lead, "contacted")
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := review.Scorecard.Lead.Advanced; got != 2 {
+		t.Fatalf("two climbs and one demotion is 2 advances, got %d", got)
+	}
+}
+
+// A WON DEAL IS NOT AN OPEN ONE. `open` is the denominator every coverage count
+// is read against, so counting closed deals in it understates every rate the
+// panel draws.
+func TestAWonDealLeavesTheOpenDenominator(t *testing.T) {
+	e := setupWeekly(t)
+	pipeline, openStage, wonStage := integration.DealFixture(t, e.Env)
+	e.SeedDeal(t, "Still working", pipeline, openStage, &e.Rep1)
+	closing := e.SeedDeal(t, "Closed this week", pipeline, openStage, &e.Rep1)
+	// A win needs a contract or a stated reason for having none; the fixture
+	// takes the reason, because this case is about the open DENOMINATOR and not
+	// about how a deal is allowed to close.
+	verbal := "verbal"
+	if _, err := e.Deals.AdvanceDeal(e.Admin(),
+		ids.From[ids.DealKind](closing),
+		deals.AdvanceDealInput{
+			ToStageID: wonStage, WonWithoutContractReason: &verbal,
+		}); err != nil {
+		t.Fatalf("winning the deal: %v", err)
+	}
+
+	review, _, err := e.engine.AssembleFor(e.repCtx, nextWeek())
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := review.Scorecard.Deal
+	if block == nil {
+		t.Fatal("the rep has deals, so the block is present")
+	}
+	if block.Open != 1 {
+		t.Fatalf("one deal is still open and one was won, want Open 1, got %d", block.Open)
+	}
+}
+
+// A LEAD MINTED AFTER THE WEEK DOES NOT CONJURE A BLOCK ONTO IT. Presence asks
+// whether the rep carried a funnel BY the end of the week under review; a lead
+// that did not exist then says nothing about that week.
+func TestALeadCreatedAfterTheWeekLeavesItsFunnelAbsent(t *testing.T) {
+	e := setupWeekly(t)
+	seedLeadFor(t, e, "Arrived later", e.Rep1)
+
+	// weekClock is June 2026, long before the fixture's own writes, so the week
+	// it reviews closed before this lead existed.
+	review, _, err := e.engine.AssembleFor(e.repCtx, weekClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if review.Scorecard.Lead != nil {
+		t.Fatalf("the lead postdates the week, so it has no funnel, got %+v",
+			review.Scorecard.Lead)
+	}
+}

--- a/backend/internal/compose/weekly/weeklyscorecardsql.go
+++ b/backend/internal/compose/weekly/weeklyscorecardsql.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// Freezing the scorecard, and reading it back unchanged.
+//
+// Split from the queries that compute it: those ask the week what happened,
+// these put the answer beyond further change. A scorecard recomputed on read
+// would answer differently every time somebody edits an old deal, so the
+// numbers are written once and every later reader gets the row.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// insertScorecard freezes one week's judgement beside its review.
+//
+// ON CONFLICT DO NOTHING on the one-per-review constraint: freezing is
+// reachable on its own, and a second pass must leave the first pass's figures
+// alone rather than overwrite a record of a week with a later reading of it.
+//
+// A nil block writes NULLs and its presence boolean false, which is what the
+// table's shape CHECK requires and what tells "no funnel this week" from "a
+// funnel that scored zero".
+func insertScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, card Scorecard) error {
+	cols, args := insertColumns{}, []any(nil)
+	add := func(name string, value any) {
+		cols = append(cols, name)
+		args = append(args, value)
+	}
+	add("weekly_review_id", reviewID)
+
+	add("has_lead_block", card.Lead != nil)
+	if l := card.Lead; l != nil {
+		add("lead_advanced", l.Advanced)
+		add("lead_disqualified", l.Disqualified)
+		add("lead_promoted", l.Promoted)
+		add("lead_answered_in_target", l.AnsweredInTarget)
+		add("lead_breached", l.Breached)
+		add("meetings_booked", l.Booked)
+		add("meetings_held", l.Held)
+		add("meetings_no_show", l.NoShow)
+		add("meetings_partial_history", l.PartialHistory)
+	}
+
+	add("has_deal_block", card.Deal != nil)
+	if d := card.Deal; d != nil {
+		add("deal_advances", d.Advances)
+		add("deal_regressions", d.Regressions)
+		// Nil travels as NULL: no deal changed stage, and a median of nothing
+		// is absent rather than zero days.
+		add("deal_median_days_in_stage", d.MedianDaysInStage)
+		add("deal_with_next_step", d.WithNextStep)
+		add("deal_open", d.Open)
+		add("deal_multi_threaded", d.MultiThreaded)
+		add("deal_close_date_sound", d.CloseDateSound)
+		add("deal_forecast_up", d.ForecastUp)
+		add("deal_forecast_down", d.ForecastDown)
+	}
+
+	_, err := tx.Exec(ctx, fmt.Sprintf(
+		`INSERT INTO weekly_review_scorecard (%s) VALUES (%s)
+		 ON CONFLICT (weekly_review_id) DO NOTHING`,
+		cols.names(), cols.placeholders()), args...)
+	if err != nil {
+		return fmt.Errorf("weekly: freezing the week's scorecard: %w", err)
+	}
+	return nil
+}
+
+// readScorecard reads one review's frozen scorecard, or nil when it has none.
+//
+// A review written before this table existed has no row, and that is not an
+// error: the panel draws nothing rather than the caller failing.
+func readScorecard(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) (*Scorecard, error) {
+	var hasLead, hasDeal bool
+	var l LeadBlock
+	var d DealBlock
+	// Every nullable column scans through a pointer, because a block's absence
+	// is exactly what NULL means here.
+	var la, ld, lp, lat, lb, mb, mh, mn, mp *int
+	var da, dr, dns, do, dmt, dcd, dfu, dfd *int
+	err := tx.QueryRow(ctx, `
+		SELECT has_lead_block, lead_advanced, lead_disqualified, lead_promoted,
+		       lead_answered_in_target, lead_breached, meetings_booked,
+		       meetings_held, meetings_no_show, meetings_partial_history,
+		       has_deal_block, deal_advances, deal_regressions,
+		       deal_median_days_in_stage, deal_with_next_step, deal_open,
+		       deal_multi_threaded, deal_close_date_sound,
+		       deal_forecast_up, deal_forecast_down
+		  FROM weekly_review_scorecard WHERE weekly_review_id = $1`, reviewID).
+		Scan(&hasLead, &la, &ld, &lp, &lat, &lb, &mb, &mh, &mn, &mp,
+			&hasDeal, &da, &dr, &d.MedianDaysInStage, &dns, &do, &dmt, &dcd, &dfu, &dfd)
+	if errors.Is(err, pgx.ErrNoRows) {
+		//nolint:nilnil // a review written before scorecards existed HAS none; the panel draws nothing rather than the read failing.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("weekly: reading the week's scorecard: %w", err)
+	}
+
+	card := Scorecard{}
+	if hasLead {
+		l.Advanced, l.Disqualified, l.Promoted = deref(la), deref(ld), deref(lp)
+		l.AnsweredInTarget, l.Breached = deref(lat), deref(lb)
+		l.Booked, l.Held, l.NoShow, l.PartialHistory = deref(mb), deref(mh), deref(mn), deref(mp)
+		card.Lead = &l
+	}
+	if hasDeal {
+		d.Advances, d.Regressions = deref(da), deref(dr)
+		d.WithNextStep, d.Open = deref(dns), deref(do)
+		d.MultiThreaded, d.CloseDateSound = deref(dmt), deref(dcd)
+		d.ForecastUp, d.ForecastDown = deref(dfu), deref(dfd)
+		card.Deal = &d
+	}
+	return &card, nil
+}

--- a/backend/internal/compose/weekly/weeklystore.go
+++ b/backend/internal/compose/weekly/weeklystore.go
@@ -74,6 +74,12 @@ type Review struct {
 	// rather than drawing zeros, because a week nobody forecast and a week that
 	// landed on nothing are different facts.
 	Outlook []Outlook
+
+	// How well the week went, as against what happened in it. Nil when the
+	// review predates the scorecard; each of its two blocks is independently
+	// absent when the rep had no such work, which is a different fact from
+	// every count in it being zero.
+	Scorecard *Scorecard
 }
 
 // PriorWeek is the earlier review a week is compared against.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -34136,6 +34136,15 @@ type WeeklyReview struct {
 	// review rather than "last week" — a rep with a gap has a previous week that is not seven
 	// days back.
 	Prior *WeeklyReviewPrior `json:"prior,omitempty"`
+
+	// Scorecard How WELL the week went, as against what happened in it — the counts beside this say
+	// forty leads arrived, this says twelve were answered inside the target.
+	//
+	// ABSENT on a review written before scorecards existed. Each of its two blocks is
+	// independently absent too, and absent is NOT zero: a rep who carried no leads did not
+	// score zero on the funnel, and a reader must draw nothing rather than a row of zeros
+	// that reads as failure at something nobody asked of them.
+	Scorecard *WeeklyReviewScorecard `json:"scorecard,omitempty"`
 }
 
 // WeeklyReviewCounts defines model for WeeklyReviewCounts.
@@ -34357,6 +34366,80 @@ type WeeklyReviewPrior struct {
 
 	// Pipeline Absent under the same rule as the current week's.
 	Pipeline *WeeklyReviewPipeline `json:"pipeline,omitempty"`
+}
+
+// WeeklyReviewScorecard One week's judgement of one rep's work, frozen with the review. Both blocks are optional
+// and each is absent when the rep had no such work that week.
+type WeeklyReviewScorecard struct {
+	// Deal The pipeline slice. ABSENT when the rep had no open deal and no stage change in the
+	// window — nothing to judge.
+	Deal *WeeklyScorecardDealBlock `json:"deal,omitempty"`
+
+	// Lead The funnel slice. ABSENT when the rep carried no lead at all — which is a different
+	// fact from a rep with forty untouched leads, who gets a present block of zeros.
+	Lead *WeeklyScorecardLeadBlock `json:"lead,omitempty"`
+}
+
+// WeeklyScorecardDealBlock Whether deals moved forward, and whether they are in a state anybody could work.
+type WeeklyScorecardDealBlock struct {
+	// Advances Moves to a LATER stage of the same pipeline, by stage position. A deal that crossed
+	// pipelines has no comparable position and counts as neither direction.
+	Advances int `json:"advances"`
+
+	// CloseDateSound Open deals whose close date is set, not provisional, and not in the past.
+	CloseDateSound int `json:"close_date_sound"`
+	ForecastDown   int `json:"forecast_down"`
+
+	// ForecastUp Deals whose forecast category ended the week higher than it started. Counted ONCE per
+	// deal however many times it was edited — a rep who corrected a typo three times did not
+	// upgrade three times.
+	ForecastUp int `json:"forecast_up"`
+
+	// MedianDaysInStage Median whole days a deal sat in the stage it left this week. NULL when no deal changed
+	// stage: a median of nothing is absent, never zero.
+	MedianDaysInStage *int `json:"median_days_in_stage,omitempty"`
+
+	// MultiThreaded Open deals with at least two distinct people in the last 30 days. Thirty rather than
+	// the review's own week: the risk measured is the single point of failure, and a deal
+	// worked steadily for a month is multi-threaded whether or not the second person
+	// happened to appear in these seven days.
+	MultiThreaded int `json:"multi_threaded"`
+
+	// Open The denominator the three coverage counts are read against. Published so a reader can
+	// judge "3 of 5" rather than trust a percentage that cannot be told from 300 of 500.
+	Open        int `json:"open"`
+	Regressions int `json:"regressions"`
+
+	// WithNextStep Open deals carrying an open task. A count beside `open`, never a rate.
+	WithNextStep int `json:"with_next_step"`
+}
+
+// WeeklyScorecardLeadBlock How the rep's leads moved, and whether the meetings behind them happened.
+type WeeklyScorecardLeadBlock struct {
+	// Advanced Status transitions UP the open ladder inside the week. Counted per transition, so a
+	// lead that went new to contacted to engaged counts twice — the lead's own row records
+	// only where it ended and could report at most one of them.
+	Advanced int `json:"advanced"`
+
+	// AnsweredInTarget Leads that arrived this week and were answered without breaching the SLA.
+	AnsweredInTarget int `json:"answered_in_target"`
+	Breached         int `json:"breached"`
+	Disqualified     int `json:"disqualified"`
+
+	// MeetingsBooked Meetings that BECAME booked this week, read from the meeting's transition history and
+	// never from its current status. A meeting booked Monday and held Friday counts in both
+	// this and `meetings_held`, which is what a funnel means; counting the current column
+	// would report no bookings at all for the week it was booked in.
+	MeetingsBooked int `json:"meetings_booked"`
+	MeetingsHeld   int `json:"meetings_held"`
+	MeetingsNoShow int `json:"meetings_no_show"`
+
+	// MeetingsPartialHistory Meetings whose only history row was invented from their current state when the history
+	// table was introduced. They cannot say when they were booked, so they are reported as
+	// partial coverage rather than counted. A non-zero value means the three counts above
+	// are a floor, and a reader should say so.
+	MeetingsPartialHistory int `json:"meetings_partial_history"`
+	Promoted               int `json:"promoted"`
 }
 
 // Worklist The rep's day, ranked. One list rather than fourteen lanes, because a reader

--- a/backend/migrations/core/1788654800_the_week_scores_its_funnel_and_its_deals.down.sql
+++ b/backend/migrations/core/1788654800_the_week_scores_its_funnel_and_its_deals.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+DROP TABLE IF EXISTS weekly_review_scorecard;

--- a/backend/migrations/core/1788654800_the_week_scores_its_funnel_and_its_deals.up.sql
+++ b/backend/migrations/core/1788654800_the_week_scores_its_funnel_and_its_deals.up.sql
@@ -1,0 +1,135 @@
+-- What the week's work came to, frozen beside the review that reports it.
+--
+-- The counts already on weekly_review say what HAPPENED — leads routed,
+-- meetings held, deals moved. This says how WELL, and the two are different
+-- questions: "you were sent 40 leads" is a fact about the week, "you answered
+-- 12 of them inside the target" is a judgement of it.
+--
+-- FROZEN for the reason the whole review is frozen. A scorecard recomputed on
+-- read answers differently every time somebody edits an old deal, and a rep
+-- comparing this week against March would be comparing today's arithmetic
+-- against today's arithmetic rather than two weeks.
+--
+-- PRESENCE IS NOT ZERO, and that is what the two booleans buy. A rep who
+-- carried no leads at all did not score 0% on the funnel — the funnel is not
+-- their job that week, and drawing them a row of zeros reads as failure at
+-- something they were never asked to do. So each block is present or absent,
+-- and a reader draws only what is present.
+SET LOCAL lock_timeout = '3s';
+
+CREATE TABLE weekly_review_scorecard (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    weekly_review_id uuid NOT NULL,
+
+    -- Whether this week had a funnel at all. False means the rep carried no
+    -- lead in the window, so every lead_* column below is NULL and the panel
+    -- draws no lead block.
+    has_lead_block boolean NOT NULL,
+    -- Status transitions counted from audit_log's before/after images, which is
+    -- where a lead's movement actually lives: the lead row carries its CURRENT
+    -- status and a handful of milestone stamps, so it cannot answer "who moved
+    -- from contacted to engaged last week". Every one of the five writers of
+    -- lead.status goes through storekit.Audit, so the images are complete.
+    lead_advanced integer,
+    lead_disqualified integer,
+    lead_promoted integer,
+    -- The SLA slice of the same week, copied from the review's own counts so
+    -- the scorecard reads as one record rather than sending a reader to two.
+    lead_answered_in_target integer,
+    lead_breached integer,
+    -- Meetings by the status they BECAME this week, read from
+    -- activity_meeting_history and never from activity.meeting_status: a
+    -- meeting booked Monday and held Friday reads `held` today, so counting the
+    -- column reports no bookings for the week it was booked in.
+    meetings_booked integer,
+    meetings_held integer,
+    meetings_no_show integer,
+    -- Meetings whose history is a row the backfill invented from current state.
+    -- They cannot say when they were booked, so coverage is reported as partial
+    -- rather than counting them as history.
+    meetings_partial_history integer,
+
+    -- Whether this week had deals to score. False means no open deal and no
+    -- stage change in the window.
+    has_deal_block boolean NOT NULL,
+    deal_advances integer,
+    deal_regressions integer,
+    -- Median whole days a deal sat in the stage it left this week. NULL with a
+    -- present deal block means no deal changed stage — a median of nothing is
+    -- absent, never zero.
+    deal_median_days_in_stage integer,
+    -- Open deals carrying an open task, over open deals. Counts, not a rate, so
+    -- a reader can see the denominator rather than trust a percentage.
+    deal_with_next_step integer,
+    deal_open integer,
+    -- Open deals with at least two distinct people linked in the last 30 days.
+    deal_multi_threaded integer,
+    -- Open deals whose close date is set and not in the past.
+    deal_close_date_sound integer,
+    -- Forecast category moves, each deal counted ONCE however many times it was
+    -- edited: a rep who corrected a typo three times did not downgrade thrice.
+    deal_forecast_up integer,
+    deal_forecast_down integer,
+
+    created_at timestamptz DEFAULT now() NOT NULL,
+
+    CONSTRAINT weekly_review_scorecard_pkey PRIMARY KEY (id),
+    CONSTRAINT weekly_review_scorecard_review_fkey
+        FOREIGN KEY (weekly_review_id) REFERENCES weekly_review(id) ON DELETE CASCADE,
+    -- One scorecard per review. The review's own insert is the arbiter of a
+    -- second assembly, but freezing is reachable on its own, so the constraint
+    -- is here rather than assumed upstream.
+    CONSTRAINT weekly_review_scorecard_one_per_review UNIQUE (weekly_review_id),
+
+    -- A block's columns are present exactly when the block is. Spelled with
+    -- IS NOT DISTINCT FROM because a CHECK evaluating to NULL PASSES in
+    -- Postgres, so `= false` would admit precisely the rows this refuses.
+    CONSTRAINT weekly_review_scorecard_lead_block_shape CHECK (
+        (has_lead_block IS NOT DISTINCT FROM true) = (lead_advanced IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (lead_disqualified IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (lead_promoted IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (lead_answered_in_target IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (lead_breached IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (meetings_booked IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (meetings_held IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (meetings_no_show IS NOT NULL)
+        AND (lead_advanced IS NOT NULL) = (meetings_partial_history IS NOT NULL)
+    ),
+    CONSTRAINT weekly_review_scorecard_deal_block_shape CHECK (
+        (has_deal_block IS NOT DISTINCT FROM true) = (deal_advances IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_regressions IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_with_next_step IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_open IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_multi_threaded IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_close_date_sound IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_forecast_up IS NOT NULL)
+        AND (deal_advances IS NOT NULL) = (deal_forecast_down IS NOT NULL)
+    ),
+    -- The median is the one deal column that may be absent inside a present
+    -- block, so it is excluded from the shape above and bounded here instead.
+    CONSTRAINT weekly_review_scorecard_median_needs_block CHECK (
+        deal_median_days_in_stage IS NULL OR has_deal_block IS NOT DISTINCT FROM true
+    ),
+    -- No count is negative. A negative would mean the arithmetic above it went
+    -- wrong, and storing it would put the mistake in the frozen record.
+    CONSTRAINT weekly_review_scorecard_counts_nonnegative CHECK (
+        COALESCE(lead_advanced, 0) >= 0 AND COALESCE(lead_disqualified, 0) >= 0
+        AND COALESCE(lead_promoted, 0) >= 0 AND COALESCE(lead_answered_in_target, 0) >= 0
+        AND COALESCE(lead_breached, 0) >= 0 AND COALESCE(meetings_booked, 0) >= 0
+        AND COALESCE(meetings_held, 0) >= 0 AND COALESCE(meetings_no_show, 0) >= 0
+        AND COALESCE(meetings_partial_history, 0) >= 0
+        AND COALESCE(deal_advances, 0) >= 0 AND COALESCE(deal_regressions, 0) >= 0
+        AND COALESCE(deal_median_days_in_stage, 0) >= 0
+        AND COALESCE(deal_with_next_step, 0) >= 0 AND COALESCE(deal_open, 0) >= 0
+        AND COALESCE(deal_multi_threaded, 0) >= 0
+        AND COALESCE(deal_close_date_sound, 0) >= 0
+        AND COALESCE(deal_forecast_up, 0) >= 0 AND COALESCE(deal_forecast_down, 0) >= 0
+    ),
+    -- A subset can never exceed its own denominator.
+    CONSTRAINT weekly_review_scorecard_subsets_fit CHECK (
+        (deal_open IS NULL OR (
+            deal_with_next_step <= deal_open
+            AND deal_multi_threaded <= deal_open
+            AND deal_close_date_sound <= deal_open))
+    )
+);

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29091,6 +29091,89 @@ export interface components {
             focus_label: string;
         };
         /**
+         * @description One week's judgement of one rep's work, frozen with the review. Both blocks are optional
+         *     and each is absent when the rep had no such work that week.
+         */
+        WeeklyReviewScorecard: {
+            /**
+             * @description The funnel slice. ABSENT when the rep carried no lead at all — which is a different
+             *     fact from a rep with forty untouched leads, who gets a present block of zeros.
+             */
+            lead?: components["schemas"]["WeeklyScorecardLeadBlock"];
+            /**
+             * @description The pipeline slice. ABSENT when the rep had no open deal and no stage change in the
+             *     window — nothing to judge.
+             */
+            deal?: components["schemas"]["WeeklyScorecardDealBlock"];
+        };
+        /** @description How the rep's leads moved, and whether the meetings behind them happened. */
+        WeeklyScorecardLeadBlock: {
+            /**
+             * @description Status transitions UP the open ladder inside the week. Counted per transition, so a
+             *     lead that went new to contacted to engaged counts twice — the lead's own row records
+             *     only where it ended and could report at most one of them.
+             */
+            advanced: number;
+            disqualified: number;
+            promoted: number;
+            /** @description Leads that arrived this week and were answered without breaching the SLA. */
+            answered_in_target: number;
+            breached: number;
+            /**
+             * @description Meetings that BECAME booked this week, read from the meeting's transition history and
+             *     never from its current status. A meeting booked Monday and held Friday counts in both
+             *     this and `meetings_held`, which is what a funnel means; counting the current column
+             *     would report no bookings at all for the week it was booked in.
+             */
+            meetings_booked: number;
+            meetings_held: number;
+            meetings_no_show: number;
+            /**
+             * @description Meetings whose only history row was invented from their current state when the history
+             *     table was introduced. They cannot say when they were booked, so they are reported as
+             *     partial coverage rather than counted. A non-zero value means the three counts above
+             *     are a floor, and a reader should say so.
+             */
+            meetings_partial_history: number;
+        };
+        /** @description Whether deals moved forward, and whether they are in a state anybody could work. */
+        WeeklyScorecardDealBlock: {
+            /**
+             * @description Moves to a LATER stage of the same pipeline, by stage position. A deal that crossed
+             *     pipelines has no comparable position and counts as neither direction.
+             */
+            advances: number;
+            regressions: number;
+            /**
+             * @description Median whole days a deal sat in the stage it left this week. NULL when no deal changed
+             *     stage: a median of nothing is absent, never zero.
+             */
+            median_days_in_stage?: number | null;
+            /** @description Open deals carrying an open task. A count beside `open`, never a rate. */
+            with_next_step: number;
+            /**
+             * @description The denominator the three coverage counts are read against. Published so a reader can
+             *     judge "3 of 5" rather than trust a percentage that cannot be told from 300 of 500.
+             */
+            open: number;
+            /**
+             * @description Open deals with at least two distinct people in the last 30 days. Thirty rather than
+             *     the review's own week: the risk measured is the single point of failure, and a deal
+             *     worked steadily for a month is multi-threaded whether or not the second person
+             *     happened to appear in these seven days.
+             */
+            multi_threaded: number;
+            /** @description Open deals whose close date is set, not provisional, and not in the past. */
+            close_date_sound: number;
+            /**
+             * @description Deals whose forecast category ended the week higher than it started. Counted ONCE per
+             *     deal however many times it was edited — a rep who corrected a typo three times did not
+             *     upgrade three times.
+             */
+            forecast_up: number;
+            forecast_down: number;
+        };
+        /**
          * @description One rep's week, as it was measured when the week closed. Every count is as-of `as_of`,
          *     which is why they are stored rather than recomputed.
          */
@@ -29156,6 +29239,16 @@ export interface components {
              *     days back.
              */
             prior?: components["schemas"]["WeeklyReviewPrior"];
+            /**
+             * @description How WELL the week went, as against what happened in it — the counts beside this say
+             *     forty leads arrived, this says twelve were answered inside the target.
+             *
+             *     ABSENT on a review written before scorecards existed. Each of its two blocks is
+             *     independently absent too, and absent is NOT zero: a rep who carried no leads did not
+             *     score zero on the funnel, and a reader must draw nothing rather than a row of zeros
+             *     that reads as failure at something nobody asked of them.
+             */
+            scorecard?: components["schemas"]["WeeklyReviewScorecard"];
             /**
              * @description Where the week was landing, one entry per horizon — the week itself, the month, and
              *     the fiscal quarter, because a rep asks three different questions on a Monday.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2502,6 +2502,32 @@ export const de = {
   "home.pipelineUnavailable": "Diese Zahl konnte nicht geladen werden.",
   "home.panel.weekly": "Letzte Woche",
   "home.weekly.weekOf": "Woche ab {day}",
+  "home.weekly.scorecard.title": "Wie die Woche lief",
+  "home.weekly.scorecard.leadBlock": "Leads und Termine",
+  "home.weekly.scorecard.dealBlock": "Deals",
+  "home.weekly.scorecard.advanced": "Leads weitergekommen",
+  "home.weekly.scorecard.advancedBasis": "Stufen nach oben, je Schritt gezählt",
+  "home.weekly.scorecard.answeredInTarget": "Fristgerecht beantwortet",
+  "home.weekly.scorecard.breachedDetail": "{count} über der Frist",
+  "home.weekly.scorecard.meetingsHeld": "Termine gehalten",
+  "home.weekly.scorecard.meetingsBasis":
+    "{booked} gebucht · {noShow} nicht erschienen",
+  "home.weekly.scorecard.partialHistory": "Termine ohne Verlauf",
+  "home.weekly.scorecard.partialHistoryBasis":
+    "Diese liegen vor dem Terminverlauf, die Zahlen oben sind daher ein Mindestwert",
+  "home.weekly.scorecard.advances": "Phasen vorangekommen",
+  "home.weekly.scorecard.regressionsDetail": "{count} zurückgefallen",
+  "home.weekly.scorecard.medianDaysInStage": "Median Tage in Phase",
+  "home.weekly.scorecard.medianBasis":
+    "Für die Phasen, die Deals diese Woche verlassen haben",
+  "home.weekly.scorecard.withNextStep": "Mit nächstem Schritt",
+  "home.weekly.scorecard.ofOpen": "von {total} offenen Deals",
+  "home.weekly.scorecard.multiThreaded": "Mehr als eine Person",
+  "home.weekly.scorecard.multiThreadedBasis":
+    "von {total} offenen Deals, in den letzten 30 Tagen",
+  "home.weekly.scorecard.closeDateSound": "Abschlussdatum trägt",
+  "home.weekly.scorecard.forecastMoves": "Forecast hochgestuft",
+  "home.weekly.scorecard.forecastMovesBasis": "{down} herabgestuft",
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der
   // einzige Teil dieser Seite, den noch jemand ändern kann.
   "plan.title": "Nächste Woche planen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2574,6 +2574,35 @@ export const en = {
   // the work that waits on a person, and this is a view of that same work.
   "home.panel.weekly": "Last week",
   "home.weekly.weekOf": "Week of {day}",
+  // How WELL the week went, beside what happened in it. Each block is drawn only
+  // when the server sent it: a rep who carried no leads did not score zero on
+  // the funnel, and an empty row would read as failure at something nobody
+  // asked of them.
+  "home.weekly.scorecard.title": "How the week went",
+  "home.weekly.scorecard.leadBlock": "Leads and meetings",
+  "home.weekly.scorecard.dealBlock": "Deals",
+  "home.weekly.scorecard.advanced": "Leads moved forward",
+  "home.weekly.scorecard.advancedBasis":
+    "Steps up the ladder, counted per move",
+  "home.weekly.scorecard.answeredInTarget": "Answered in target",
+  "home.weekly.scorecard.breachedDetail": "{count} breached the target",
+  "home.weekly.scorecard.meetingsHeld": "Meetings held",
+  "home.weekly.scorecard.meetingsBasis": "{booked} booked · {noShow} no-show",
+  "home.weekly.scorecard.partialHistory": "Meetings without history",
+  "home.weekly.scorecard.partialHistoryBasis":
+    "These predate the meeting history, so the counts above are a floor",
+  "home.weekly.scorecard.advances": "Stage advances",
+  "home.weekly.scorecard.regressionsDetail": "{count} went backwards",
+  "home.weekly.scorecard.medianDaysInStage": "Median days in stage",
+  "home.weekly.scorecard.medianBasis": "For the stages deals left this week",
+  "home.weekly.scorecard.withNextStep": "With a next step",
+  "home.weekly.scorecard.ofOpen": "of {total} open deals",
+  "home.weekly.scorecard.multiThreaded": "More than one person",
+  "home.weekly.scorecard.multiThreadedBasis":
+    "of {total} open deals, in the last 30 days",
+  "home.weekly.scorecard.closeDateSound": "Close date holds up",
+  "home.weekly.scorecard.forecastMoves": "Forecast upgrades",
+  "home.weekly.scorecard.forecastMovesBasis": "{down} downgraded",
   // The week ahead. The frozen review says what happened; this is the only part
   // of that page anybody can still change.
   "plan.title": "Plan next week",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2478,6 +2478,31 @@ export const vi = {
   "home.pipelineUnavailable": "Không tải được số liệu này.",
   "home.panel.weekly": "Tuần trước",
   "home.weekly.weekOf": "Tuần từ {day}",
+  "home.weekly.scorecard.title": "Tuần vừa qua thế nào",
+  "home.weekly.scorecard.leadBlock": "Khách tiềm năng và cuộc họp",
+  "home.weekly.scorecard.dealBlock": "Cơ hội",
+  "home.weekly.scorecard.advanced": "Khách tiềm năng tiến lên",
+  "home.weekly.scorecard.advancedBasis": "Số bậc tiến lên, đếm theo từng bước",
+  "home.weekly.scorecard.answeredInTarget": "Trả lời đúng hạn",
+  "home.weekly.scorecard.breachedDetail": "{count} quá hạn",
+  "home.weekly.scorecard.meetingsHeld": "Cuộc họp đã diễn ra",
+  "home.weekly.scorecard.meetingsBasis": "{booked} đã đặt · {noShow} không đến",
+  "home.weekly.scorecard.partialHistory": "Cuộc họp không có lịch sử",
+  "home.weekly.scorecard.partialHistoryBasis":
+    "Những cuộc họp này có trước lịch sử cuộc họp, nên các số trên là mức tối thiểu",
+  "home.weekly.scorecard.advances": "Tiến giai đoạn",
+  "home.weekly.scorecard.regressionsDetail": "{count} lùi lại",
+  "home.weekly.scorecard.medianDaysInStage": "Số ngày trung vị trong giai đoạn",
+  "home.weekly.scorecard.medianBasis":
+    "Cho các giai đoạn cơ hội rời khỏi tuần này",
+  "home.weekly.scorecard.withNextStep": "Có bước tiếp theo",
+  "home.weekly.scorecard.ofOpen": "trên {total} cơ hội đang mở",
+  "home.weekly.scorecard.multiThreaded": "Nhiều hơn một người",
+  "home.weekly.scorecard.multiThreadedBasis":
+    "trên {total} cơ hội đang mở, trong 30 ngày qua",
+  "home.weekly.scorecard.closeDateSound": "Ngày chốt đáng tin",
+  "home.weekly.scorecard.forecastMoves": "Nâng dự báo",
+  "home.weekly.scorecard.forecastMovesBasis": "{down} hạ dự báo",
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất
   // của trang đó mà vẫn còn ai đó thay đổi được.
   "plan.title": "Lập kế hoạch tuần tới",

--- a/frontend/src/screens/home.weekly.scorecard.test.tsx
+++ b/frontend/src/screens/home.weekly.scorecard.test.tsx
@@ -1,0 +1,133 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { en } from "../i18n/en";
+import { render } from "./home.testkit";
+import { ScorecardPanel } from "./home.weekly.scorecard";
+
+// The scorecard's whole design is that ABSENT is not ZERO, and every case here
+// is a way of asking whether the panel still honours that. A block of zeros
+// drawn for a rep who carried no leads reads as failure at something nobody
+// asked of them, and it is the one mistake this surface must not make.
+
+afterEach(cleanup);
+
+const leadBlock = {
+  advanced: 4,
+  disqualified: 1,
+  promoted: 2,
+  answered_in_target: 9,
+  breached: 3,
+  meetings_booked: 6,
+  meetings_held: 5,
+  meetings_no_show: 1,
+  meetings_partial_history: 0,
+};
+
+const dealBlock = {
+  advances: 7,
+  regressions: 2,
+  median_days_in_stage: 11,
+  with_next_step: 3,
+  open: 5,
+  multi_threaded: 2,
+  close_date_sound: 4,
+  forecast_up: 3,
+  forecast_down: 1,
+};
+
+describe("the weekly scorecard", () => {
+  it("draws nothing at all when the review carries no scorecard", () => {
+    const { container } = render(<ScorecardPanel scorecard={undefined} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("omits the lead block rather than drawing a rep zeros they did not earn", () => {
+    render(<ScorecardPanel scorecard={{ deal: dealBlock }} />);
+    expect(
+      screen.queryByRole("region", {
+        name: en["home.weekly.scorecard.leadBlock"],
+      }),
+    ).toBeNull();
+    // The deal block it DID send is still drawn: this is an omission, not a
+    // panel that gave up.
+    expect(
+      screen.getByRole("region", {
+        name: en["home.weekly.scorecard.dealBlock"],
+      }),
+    ).toBeTruthy();
+  });
+
+  it("omits the deal block on its own terms too", () => {
+    render(<ScorecardPanel scorecard={{ lead: leadBlock }} />);
+    expect(
+      screen.queryByRole("region", {
+        name: en["home.weekly.scorecard.dealBlock"],
+      }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("region", {
+        name: en["home.weekly.scorecard.leadBlock"],
+      }),
+    ).toBeTruthy();
+  });
+
+  it("draws a present block whose counts are zero, because that is a finding", () => {
+    render(
+      <ScorecardPanel
+        scorecard={{
+          lead: { ...leadBlock, advanced: 0, answered_in_target: 0 },
+        }}
+      />,
+    );
+    // Present and zero: the rep HAD leads and moved none, which the panel must
+    // say rather than hide.
+    expect(screen.getByText(en["home.weekly.scorecard.advanced"])).toBeTruthy();
+  });
+
+  it("omits the median when no deal changed stage, never drawing it as zero days", () => {
+    render(
+      <ScorecardPanel
+        scorecard={{ deal: { ...dealBlock, median_days_in_stage: null } }}
+      />,
+    );
+    expect(
+      screen.queryByText(en["home.weekly.scorecard.medianDaysInStage"]),
+    ).toBeNull();
+  });
+
+  it("draws the median when there is one", () => {
+    render(<ScorecardPanel scorecard={{ deal: dealBlock }} />);
+    expect(
+      screen.getByText(en["home.weekly.scorecard.medianDaysInStage"]),
+    ).toBeTruthy();
+  });
+
+  it("names the open-deal denominator beside each coverage count", () => {
+    render(<ScorecardPanel scorecard={{ deal: dealBlock }} />);
+    // "3 of 5 open deals" — the count is only judgeable against its
+    // denominator, which is why the server sends counts and not a rate.
+    expect(
+      screen.getAllByText(
+        en["home.weekly.scorecard.ofOpen"].replace("{total}", "5"),
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("says the meeting counts are a floor only when history is actually missing", () => {
+    render(<ScorecardPanel scorecard={{ lead: leadBlock }} />);
+    expect(
+      screen.queryByText(en["home.weekly.scorecard.partialHistory"]),
+    ).toBeNull();
+
+    cleanup();
+    render(
+      <ScorecardPanel
+        scorecard={{ lead: { ...leadBlock, meetings_partial_history: 2 } }}
+      />,
+    );
+    expect(
+      screen.getByText(en["home.weekly.scorecard.partialHistory"]),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/home.weekly.scorecard.tsx
+++ b/frontend/src/screens/home.weekly.scorecard.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { StatCard } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { StatStrip } from "../design-system/statstrip";
+import { formatNumber } from "../format/format";
+import { type Translator, useLocale, useT } from "../i18n";
+import type { WeeklyReview } from "./home.queries";
+
+// How well the week went, beside what happened in it.
+//
+// Two blocks, each drawn only when the server sent it. An ABSENT block is not a
+// block of zeros: a rep who carried no leads did not score zero on the funnel,
+// and drawing them an empty row reads as failure at something nobody asked of
+// them. The server decides; this file never substitutes a default.
+
+type Scorecard = NonNullable<WeeklyReview["scorecard"]>;
+type LeadBlock = NonNullable<Scorecard["lead"]>;
+type DealBlock = NonNullable<Scorecard["deal"]>;
+
+export function ScorecardPanel({
+  scorecard,
+}: Readonly<{ scorecard: Scorecard | undefined }>) {
+  const t = useT();
+  // A review written before scorecards existed carries none. Nothing is drawn
+  // rather than a panel of blanks, which would state a judgement nobody made.
+  if (!scorecard) return null;
+  const { lead, deal } = scorecard;
+  if (!lead && !deal) return null;
+
+  return (
+    <Panel title={t("home.weekly.scorecard.title")}>
+      <PanelBody>
+        {lead && <LeadBlockStrip block={lead} t={t} />}
+        {deal && <DealBlockStrip block={deal} t={t} />}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function LeadBlockStrip({
+  block,
+  t,
+}: Readonly<{ block: LeadBlock; t: Translator }>) {
+  const { locale } = useLocale();
+  const n = (value: number) => formatNumber(value, locale);
+  return (
+    <StatStrip
+      label={t("home.weekly.scorecard.leadBlock")}
+      testId="scorecard-lead"
+    >
+      <StatCard
+        label={t("home.weekly.scorecard.advanced")}
+        value={n(block.advanced)}
+        numeric
+        detail={t("home.weekly.scorecard.advancedBasis")}
+      />
+      <StatCard
+        label={t("home.weekly.scorecard.answeredInTarget")}
+        value={n(block.answered_in_target)}
+        numeric
+        detail={t("home.weekly.scorecard.breachedDetail", {
+          count: n(block.breached),
+        })}
+      />
+      <StatCard
+        label={t("home.weekly.scorecard.meetingsHeld")}
+        value={n(block.meetings_held)}
+        numeric
+        detail={t("home.weekly.scorecard.meetingsBasis", {
+          booked: n(block.meetings_booked),
+          noShow: n(block.meetings_no_show),
+        })}
+      />
+      {/* The partial figure is drawn ONLY when it is non-zero, and it says the
+          three counts above are a floor. A zero would be a reassurance nobody
+          asked for; a non-zero is a caveat the reader needs. */}
+      {block.meetings_partial_history > 0 && (
+        <StatCard
+          label={t("home.weekly.scorecard.partialHistory")}
+          value={n(block.meetings_partial_history)}
+          numeric
+          detail={t("home.weekly.scorecard.partialHistoryBasis")}
+        />
+      )}
+    </StatStrip>
+  );
+}
+
+function DealBlockStrip({
+  block,
+  t,
+}: Readonly<{ block: DealBlock; t: Translator }>) {
+  const { locale } = useLocale();
+  const n = (value: number) => formatNumber(value, locale);
+  return (
+    <StatStrip
+      label={t("home.weekly.scorecard.dealBlock")}
+      testId="scorecard-deal"
+    >
+      <StatCard
+        label={t("home.weekly.scorecard.advances")}
+        value={n(block.advances)}
+        numeric
+        detail={t("home.weekly.scorecard.regressionsDetail", {
+          count: n(block.regressions),
+        })}
+      />
+      {/* Absent when no deal changed stage. A median of nothing is not zero
+          days, so the card is omitted rather than drawn as 0. */}
+      {block.median_days_in_stage != null && (
+        <StatCard
+          label={t("home.weekly.scorecard.medianDaysInStage")}
+          value={n(block.median_days_in_stage)}
+          numeric
+          detail={t("home.weekly.scorecard.medianBasis")}
+        />
+      )}
+      <StatCard
+        label={t("home.weekly.scorecard.withNextStep")}
+        value={n(block.with_next_step)}
+        numeric
+        meter={{ filled: block.with_next_step, total: block.open }}
+        detail={t("home.weekly.scorecard.ofOpen", { total: n(block.open) })}
+      />
+      <StatCard
+        label={t("home.weekly.scorecard.multiThreaded")}
+        value={n(block.multi_threaded)}
+        numeric
+        meter={{ filled: block.multi_threaded, total: block.open }}
+        detail={t("home.weekly.scorecard.multiThreadedBasis", {
+          total: n(block.open),
+        })}
+      />
+      <StatCard
+        label={t("home.weekly.scorecard.closeDateSound")}
+        value={n(block.close_date_sound)}
+        numeric
+        meter={{ filled: block.close_date_sound, total: block.open }}
+        detail={t("home.weekly.scorecard.ofOpen", { total: n(block.open) })}
+      />
+      <StatCard
+        label={t("home.weekly.scorecard.forecastMoves")}
+        value={n(block.forecast_up)}
+        numeric
+        detail={t("home.weekly.scorecard.forecastMovesBasis", {
+          down: n(block.forecast_down),
+        })}
+      />
+    </StatStrip>
+  );
+}

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -26,6 +26,7 @@ import {
   type WeeklyReview,
 } from "./home.queries";
 import { OutlookPanel } from "./home.waterfall";
+import { ScorecardPanel } from "./home.weekly.scorecard";
 
 import "./home.weekly.css";
 
@@ -362,6 +363,10 @@ function WeeklyBody({
         horizon={horizon}
         onHorizon={setHorizon}
       />
+      {/* How well the week went, after where it was landing and before the
+          outcome strip's tallies. Absent blocks draw nothing at all — the
+          panel never substitutes zeros for work the rep did not have. */}
+      <ScorecardPanel scorecard={review.scorecard} />
       {/* FIVE slots, because a strip is read ACROSS as one comparison and ten
           is a table wearing a strip's clothes — at 1280 the row folded to two
           ranks of five and stopped being one reading at all (#3709).


### PR DESCRIPTION
The weekly review said what happened — leads routed, meetings held, deals moved. It did not say how *well*. This adds a frozen scorecard beside it: lead movement and meeting outcomes, and whether deals advanced and are in a state anybody could work.

## Absent is not zero

That is the whole design. A rep who carried no leads did not score zero on the funnel — the funnel was not their work that week, and a row of zeros reads as failure at something nobody asked of them. A rep with forty *untouched* leads does get a block of zeros, because that is a real finding.

Each block is independently present or absent, held in three places:
- the table's shape CHECKs, spelled `IS NOT DISTINCT FROM` because **a CHECK evaluating to NULL passes in Postgres** — `= false` would admit exactly the rows they refuse;
- `insertScorecard`, which writes NULLs and a false presence boolean for a nil block;
- the panel, which draws only what the server sent and never substitutes a default.

## The delivery gate, answered

The plan gated this work package on profiling before building:

> *lead status transition timestamps do not exist. Profile the audit-backed query with realistic data before WP4 is approved. If it misses the existing read budget, add and backfill an owner-derived transition projection in WP4 itself.*

Measured on Postgres with 10M audit rows (333k of them lead updates spread over a year) and 20k leads:

| Query | Cold | Warm |
|---|---|---|
| one week, one owner (2M rows) | 331 ms | 151 ms |
| one week, **all** owners (2M rows) | — | 145 ms |
| one week, **all** owners (10M rows) | 277 ms | 67 ms |

Against `database.CallerPredicateBudget = 5s`, on a background path nobody waits on. It holds because `idx_audit_entity_narrow` leads on `entity_type`: that equality lets Postgres use `occurred_at` as a range even with `entity_id` skipped between them, so the millions of rows belonging to other entity types are never visited.

**So there is no projection table and no backfill.** A projection would be a second writer of a fact `audit_log` already holds, and it would have to be written at all five writers of `lead.status` — `promote.go:230`, `demote.go:150`, `lead.go:442`, `AdvanceLeadStatus`, and the PATCH path — or silently undercount. All five go through `storekit.Audit`, which is what makes the read complete.

## Seven correctness defects found in review and fixed

Five would have put wrong numbers on screen:

1. **`multi_threaded` always counted ZERO.** `activity_link` rows are exclusive under `activity_link_shape`, so a single row can never carry both `deal_id` and `person_id`. The count now joins through the activity, as `countWeekMeetings` already does. A permanently-zero count looks like a real finding, which is what makes it dangerous.
2. **Won and lost deals sat in the `open` denominator**, understating every coverage count. Open is `status = 'open' AND archived_at IS NULL` — the tree's own definition.
3. **A demotion counted as an advance.** `engaged → contacted` has `to_status = 'contacted'`, which a destination-only filter scores as a climb. Direction is now judged from both ends, derived from the generated contract's constants so a rename stops compiling — the SQL mirror of `people.LeadStatus.Advances`.
4. **A no-op reassignment to the same stage manufactured a dwell measurement.**
5. **Forecast up/down broke on tied `occurred_at`.** Rows written in one transaction share `now()`, so the walk now orders by `(occurred_at, id)`; `audit_log.id` is uuidv7 and breaks the tie in write order.
6. **`expected_close_date` was cast in the session timezone**, misclassifying a deal closing near a week boundary. It now uses the reporting zone, as `deals/closedatesweep.go` does.
7. **Presence was unwindowed**, so a lead created *after* the week conjured a funnel onto it. Now bounded at the end of the week under review — still open at the start, because a rep whose leads arrived last month still has a funnel this week.

## Testing

`make check-backend` green, `make check-fe` green, and the full `make test-it DIR=backend/internal/compose/weekly` lane green.

**Every guard was mutation-checked one clause at a time** — reverting each fix fails its own test and no other. Two things that caught real problems:

- `TestTheScorecardIsFrozenWithTheReview` initially compared 0 to 0 and proved nothing. It now asserts the fixture produces a non-zero count before comparing.
- The migration's CHECKs were exercised through eight isolated savepoints — five refusals and three admissions. The admit cases matter as much: a constraint that refused everything would pass the refusals and be useless.

The frontend guards were mutation-checked the same way: drawing an absent block as zeros, and drawing an absent median as 0 days, each fail their own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The weekly review now scores how well the week went, not just what happened: a frozen scorecard beside the counts shows lead movement, meeting outcomes, and whether deals advanced. Each of the two blocks is present only when the rep had that work that week — absent is not zero.

- Lead movement reads `audit_log` before/after images; profiled at 10M rows it runs 67-277ms, well under the 5s budget, so no projection table was added.
- The scorecard is written in the same transaction as the review into the new `weekly_review_scorecard` table; reviews written before it read back with no scorecard.
- Shape CHECKs use `IS NOT DISTINCT FROM` because a CHECK evaluating to NULL passes in Postgres.

**Bug Fixes**
- Fixed seven defects found in review, five of which would have put wrong numbers on screen: `multi_threaded` always counted zero, won/lost deals stayed in the `open` denominator, demotions counted as advances, and no-op stage reassignments manufactured dwell.
- Forecast direction broke on tied `occurred_at` (rows in one transaction share `now()`); the walk now orders by `(occurred_at, id)`.
- Close dates now cast in the reporting zone, and block presence is bounded at the end of the week so a lead created after the week can't conjure a funnel.

<sup>Written for commit 4ee33792a9377fb60c186d0fc91d3ef9c07671ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a weekly scorecard to review sales activity and performance.
  * Displays lead movement, SLA responses, meetings, deal progress, stage duration, next-step coverage, multi-threading, close-date health, and forecast changes.
  * Scorecard sections appear only when relevant data exists, with accurate zero and unavailable-value handling.
  * Added English, German, and Vietnamese translations for scorecard content.

* **Tests**
  * Added coverage for scorecard calculations, persistence, rendering, and missing-data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->