### PR TITLE
fix(seed-demo,gates): the nightly-passes test builds the River schema it reads, and the send census gets a second matcher

### DIFF
--- a/backend/gates/frontendsendpermission_test.go
+++ b/backend/gates/frontendsendpermission_test.go
@@ -48,15 +48,21 @@ const (
 	sendPermissionContract  = "api/crm.yaml"
 	sendPermissionFrontend  = "../frontend/src"
 	sendPermissionComponent = "../frontend/src/screens/sendpermission.tsx"
+	// composerSurface is the file this walk must always see. It stands where a
+	// COUNT floor stood, deliberately: a number tracks how many composers the
+	// app happens to have and gets edited down each time they consolidate, while
+	// a name fails when the walk goes blind — the one way a census breaks
+	// silently — and says which file to go looking for.
+	composerSurface = "screens/compose.tsx"
 )
 
 // silentSendSurfaces ratifies each surface that posts to a send door without
 // asking the engine first, with what the omission costs.
 //
-// Empty today. It held screens/persondrawers.tsx until the person page's
-// composer was consolidated into the one mail drawer every record now shares:
-// that file posts to no send door any more, so there is nothing left to ratify.
-// The remaining composer asks the engine, which is why nothing takes its place.
+// Empty, and that is the answer rather than an absence: every surface that posts
+// to a door renders the component, so there is nothing left to ratify.
+// AssertAllMatched below is what keeps it that way — a key whose subject is gone
+// fails here rather than standing as a permission for a file nobody can find.
 var silentSendSurfaces = gatekit.Waive(map[string]string{})
 
 // contractPathLine matches a path entry under `paths:`.
@@ -139,6 +145,33 @@ func namesADoor(source string, doors []string) bool {
 	return false
 }
 
+// clientPostPath captures the path a typed-client POST names. The generated
+// client takes its path as a LITERAL — an interpolated one does not typecheck —
+// so a surface cannot reach a door without spelling it here.
+//
+// This is the census's SECOND opinion, computed from the call rather than from a
+// bare mention anywhere in the file, and the two are compared below. namesADoor
+// asks "does this file contain the door as a whole quoted string"; a file that
+// posts to `/emails/draft` names no door by that test while posting through one,
+// and a door list that went stale against the contract makes every surface
+// invisible at once. Either failure is silent in a single matcher and loud when
+// two disagree.
+var clientPostPath = regexp.MustCompile("api\\.POST\\(\\s*[\"'`]([^\"'`]+)")
+
+// postsThroughADoor reports whether source POSTs to a path that IS a door or
+// sits under one. The prefix half is what catches the surface namesADoor cannot
+// see: a longer path through the same door.
+func postsThroughADoor(source string, doors []string) bool {
+	for _, m := range clientPostPath.FindAllStringSubmatch(source, -1) {
+		for _, door := range doors {
+			if m[1] == door || strings.HasPrefix(m[1], door+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // rendersSendPermission matches the component's JSX tag and nothing that merely
 // starts with its name: a `<SendPermissionBanner` of a surface's own would be
 // the second spelling this gate exists to refuse.
@@ -189,7 +222,7 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 			"this gate by naming it now renders something else, or nothing")
 	}
 
-	surfaces := 0
+	var seen, posting []string
 	walkErr := filepath.WalkDir(sendPermissionFrontend, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -210,10 +243,13 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 			return readErr
 		}
 		source := string(raw)
+		if postsThroughADoor(source, doors) {
+			posting = append(posting, rel)
+		}
 		if !namesADoor(source, doors) {
 			return nil
 		}
-		surfaces++
+		seen = append(seen, rel)
 		if asksTheEngine(source) || silentSendSurfaces.Waived(t, rel) {
 			return nil
 		}
@@ -225,13 +261,22 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 	if walkErr != nil {
 		t.Fatalf("walking the frontend: %v", walkErr)
 	}
-	// ONE composer posts to a door today: the single mail drawer every record
-	// shares. It was two until the person page's own composer was consolidated
-	// into it, and the floor moved down with the consolidation rather than being
-	// deleted — a census that cannot fail short reports PASS over a tree it has
-	// stopped reading, and there is no failing assertion to notice.
-	if surfaces < 1 {
-		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the mail drawer: "+
-			"the census has stopped seeing its subject", surfaces)
+	// A surface the CALL sees and the mention does not is one this gate stopped
+	// asking about, which is the failure that reports PASS. The reverse is fine
+	// and expected: sendpermission.tsx names the preview door to ask about it and
+	// posts to nothing.
+	for _, rel := range posting {
+		if !slices.Contains(seen, rel) {
+			t.Errorf("%s posts through a send door that namesADoor cannot see, so the gate never "+
+				"asked whether it renders SendPermission: widen the match or name the door as a "+
+				"whole string literal", rel)
+		}
+	}
+	// Both matchers going blind at once — a door list that stopped resolving
+	// against the contract does exactly that — leaves the two agreeing on
+	// nothing at all, which the comparison above reads as success.
+	if !slices.Contains(seen, composerSurface) {
+		t.Fatalf("the walk saw %v and not %s: the census has stopped seeing its subject",
+			seen, composerSurface)
 	}
 }

--- a/backend/tools/seed-demo/nightlypasses_integration_test.go
+++ b/backend/tools/seed-demo/nightlypasses_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 )
@@ -31,6 +32,21 @@ func TestSeedPassesQueueRegisteredJobsAfterTheRecordsExist(t *testing.T) {
 		}
 	})
 	if err := testdb.EnsureSchema(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	// River's tables are NOT core migrations, so EnsureSchema does not build
+	// them and the insert below has nothing to land in. Every other suite that
+	// reads river_job says so at its own setup; this one relied on finding the
+	// tables already standing, which holds only in a database some other
+	// package migrated first — so under the parallel lane's private clone per
+	// package it fails, and under the serial lane it passed on a neighbour's
+	// work.
+	ownerPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(ownerPool.Close)
+	if err := testdb.EnsureRiverSchema(ctx, ownerPool, jobs.Migrate); err != nil {
 		t.Fatal(err)
 	}
 	tx, err := conn.Begin(ctx)


### PR DESCRIPTION
## What

Two files, on current `main`.

This branch carried ten commits. `main` has since landed its own version of **every one but these two** — the handoff's FK probes and register entries, the assurance and notice-case decisions, the compose grants' wording, and the head catalog. Keeping a second spelling of work already upstream is what the one-source-of-truth rule exists to stop, so the branch was rebuilt on `main` carrying only what `main` does not have.

## Why

**`./tools/seed-demo` reads a schema it never builds.** `TestSeedPassesQueueRegisteredJobsAfterTheRecordsExist` inserts into `river_job` and reads it back having built only the **core** schema. River's tables are not core migrations, so there is nothing for the insert to land in:

```
nightlypasses_integration_test.go:46: ERROR: relation "river_job" does not exist
```

It passed for as long as it ran against a database some *other* package had migrated first. The parallel lane gives each package a private clone, so the borrowed schema is gone and the hidden dependency is visible. The fix is the one line of setup all six other suites reading `river_job` already carry: `testdb.EnsureRiverSchema` with `jobs.Migrate`. It no-ops where the tables stand.

**The send census has one eye.** `main`'s floor asks whether the walk found at least *one* surface. That is a number tracking how many composers the product happens to have — it says nothing about *which* surface was seen, so a sending UI the matcher stopped recognising still reports PASS, and the floor moves again on the next consolidation.

The population is now counted twice from independent evidence:

| matcher | question |
|---|---|
| `namesADoor` | does the file contain a door as a whole quoted string? |
| `postsThroughADoor` *(new)* | what paths do the file's `api.POST(...)` calls name? |

The generated client takes its path as a **literal** — an interpolated one does not typecheck — so a surface cannot reach a door without spelling it there. A file the *call* sees and the *mention* does not is one this gate stopped asking about, and it fails naming that file. The prefix half covers a path going *through* a door rather than being one (`/emails/draft`), which the whole-string test structurally cannot see. A named anchor stays for the failure the comparison cannot see: a stale door list blinds *both* matchers, and two censuses seeing nothing agree perfectly.

## How verified

Against a real Postgres 16 and Redis, on this branch at current `main`:

- `go test -tags integration ./tools/seed-demo/` — green; fails identically on clean `main`.
- `go test ./gates/` — green, full package.
- `go test -tags integration ./migrations/` — green.
- `go test ./...` (unit lane), `gofmt` — clean.
- **Mutation-checked**: forcing `namesADoor` to return false now fails naming `screens/compose.tsx`, where `main`'s count floor passes.

## What this branch dropped, and why it is worth recording

Eight commits were removed because `main` landed equivalent work while they were open. One of them deserves a note: I had gated `assurance_task_item.task_activity_id` with `auth.EnsureActivityVisibleLive`. Review found two real defects in that — it sat before the `ON CONFLICT DO NOTHING`, so a replay whose task had since been archived would return `ErrNotFound` instead of the documented `applied=false`; and the probe takes no row lock, unlike `auth.EnsureLinkTarget`, leaving a window for a concurrent archive.

`main`'s answer avoids both by adding no probe: it classifies the column server-derived and records the obligation on the caller that does not exist yet. That is the better call, and this PR does not relitigate it.

The recurring shape behind all of this: a change correct in itself crossing a **whole-tree** obligation the author's own **diff-scoped** pre-push hook cannot see. Over one session that produced eight separate red-`main` events, several fixed twice in parallel by different people, with two competing PRs closed unmerged ([#4569](https://github.com/margince/margince/pull/4569), [#4573](https://github.com/margince/margince/pull/4573)). The hook seeing what CI sees would end that class; it is worth its own change and is not attempted here.

- [x] `make check` is green (backend lanes run individually — `lint` needs the pinned gate binary, which this environment cannot build against the 1.26 toolchain)
- [x] `make test-integration` is green for every package this touches
- [x] `make craft-static` reports no findings
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

AI-generated in full. One design call was argued rather than copied: the census was given a second independent matcher rather than the enumerated surface list review suggested, because an inventory duplicates the subject it guards and goes stale on every legitimate new composer. Every claim above was measured, including the clean-`main` attributions and the mutation check.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaNzMSm8r95MiJ5KZfVwcv