### PR TITLE
A consent proof says what the subject was shown

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37101,6 +37101,16 @@ components:
         new_state: { type: string, enum: [granted, withdrawn] }
         lawful_basis: { type: [string, 'null'] }
         source: { type: [string, 'null'] }
+        wording:
+          type: string
+          maxLength: 2000
+          description: |
+            The exact wording the subject was shown, stored verbatim as proof. Required with a
+            grant and refused as a 422 without one: Art. 7(1) asks the controller to demonstrate
+            what the subject agreed TO, and a grant that cannot say what was shown demonstrates
+            nothing. A withdrawal needs none — nothing is being demonstrated when somebody takes
+            consent back, and refusing that would leave a person unable to opt out. The 2000-character
+            bound matches the confirm-details door, which stores wording on the same proof row.
 
     RecordClaim:
       type: object
@@ -37201,8 +37211,8 @@ components:
       required: [purpose_id, policy_version]
       properties:
         purpose_id: { type: string, format: uuid }
-        policy_version: { type: string, description: Version id of the consent wording shown to the subject. }
-        wording: { type: [string, 'null'], description: 'The exact wording shown, stored with the consent event for demonstrability.' }
+        policy_version: { type: string, maxLength: 200, description: Version id of the consent wording shown to the subject. }
+        wording: { type: [string, 'null'], maxLength: 2000, description: 'The exact wording shown, stored with the consent event for demonstrability.' }
 
     PreferenceCenter:
       type: object

--- a/backend/internal/compose/integration/booking_consent_integration_test.go
+++ b/backend/internal/compose/integration/booking_consent_integration_test.go
@@ -71,7 +71,10 @@ func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *apptest.AppEnv, pe
 
 	// An unknown purpose cannot be recorded.
 	unknownPurpose := bookingAt(slot, personID, AnyMap{
-		"consent": AnyMap{"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01"},
+		"consent": AnyMap{
+			"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+		},
 	})
 	if status := e.Call(t, "POST", "/v1/bookings", unknownPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with an unknown consent purpose → %d, want 422", status)
@@ -85,10 +88,24 @@ func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *apptest.AppEnv, pe
 		t.Fatalf("booking consent without policy_version → %d, want 422", status)
 	}
 
+	// And the wording itself. Refused HERE rather than at the consent writer,
+	// because this door creates the person before it records the grant: a
+	// refusal further in would leave that row behind, and this door is
+	// anonymous.
+	noWording := bookingAt(slot, personID, AnyMap{
+		"consent": AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
+	})
+	if status := e.Call(t, "POST", "/v1/bookings", noWording, nil, nil); status != 422 {
+		t.Fatalf("booking consent without wording → %d, want 422", status)
+	}
+
 	// Consent is person-keyed: no linked person, nothing to attach to.
 	subjectless := bookingAt(slot, personID, AnyMap{
-		"links":   []AnyMap{},
-		"consent": AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
+		"links": []AnyMap{},
+		"consent": AnyMap{
+			"purpose_id": purposeID, "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+		},
 	})
 	if status := e.Call(t, "POST", "/v1/bookings", subjectless, nil, nil); status != 422 {
 		t.Fatalf("booking consent without a linked person → %d, want 422", status)

--- a/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/channels/telegram_roundtrip_integration_test.go
@@ -79,6 +79,7 @@ func (c *telegramEnv) grantConsent(t *testing.T, personID, purposeKey string) {
 	}
 	if status := c.Call(t, "POST", "/v1/people/"+personID+"/consent", integration.AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
 	}

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -160,6 +160,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 	}
 	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
 	}

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -317,6 +317,7 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	}
 	status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, &problem)
 	if status != 422 {
 		t.Fatalf("DOI-less marketing grant → %d, want 422", status)
@@ -324,6 +325,7 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	// A fabricated token proves nothing: only a server-issued one confirms.
 	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
+		"wording":             "Yes, you may contact me about this.",
 		"double_opt_in_token": "doi-token-forged",
 	}, nil, nil); status != 422 {
 		t.Fatalf("forged DOI grant → %d, want 422", status)
@@ -425,6 +427,7 @@ func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	grant := func() int {
 		return c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 			"purpose_id": c.purposes["transactional"], "new_state": "granted",
+			"wording": "Yes, you may contact me about this.",
 		}, nil, nil)
 	}
 	if status := grant(); status != http.StatusOK {

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -132,6 +132,7 @@ func grantPurpose(t *testing.T, c *consentEnv, purposeID string) {
 	t.Helper()
 	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant %s → %d", purposeID, status)
 	}

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -136,7 +136,7 @@ func assertAnonymousAvailability(t *testing.T, e *apptest.AppEnv, base, window s
 // assertBookingRequiresValidConsent checks consent is validated before
 // any write: no consent and a bogus purpose are both 422s that leave
 // zero person rows behind.
-func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base string, monday time.Time) {
+func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base, purposeID string, monday time.Time) {
 	t.Helper()
 	// A booking without consent is refused before any write.
 	noConsent := AnyMap{
@@ -149,11 +149,30 @@ func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base str
 	// A bogus purpose is refused before any write too.
 	badPurpose := AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
-		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
-		"consent": AnyMap{"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01"},
+		"booker": AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"consent": AnyMap{
+			"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01",
+			"wording": "You agree we may contact you about this meeting.",
+		},
 	}
 	if status := publicCall(t, e, "POST", base, badPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with unknown purpose → %d, want 422", status)
+	}
+	// A grant that cannot say what was shown is refused the same way, and for
+	// the same reason it is checked at this door: the person is created before
+	// the consent is recorded, so a refusal further in would leave the row
+	// behind. This endpoint is anonymous, which makes that a way to grow the
+	// person table one rejected request at a time.
+	// A REAL purpose, so the missing wording is the only thing wrong with this
+	// request. With the bogus id above it would be refused by the purpose check
+	// and pass whether or not the wording rule exists at all.
+	noWording := AnyMap{
+		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
+		"booker":  AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"consent": AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
+	}
+	if status := publicCall(t, e, "POST", base, noWording, nil, nil); status != 422 {
+		t.Fatalf("booking consent without wording → %d, want 422", status)
 	}
 	var persons int
 	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM person`).Scan(&persons); err != nil {
@@ -312,7 +331,7 @@ func TestPublicBookingEndToEnd(t *testing.T) {
 	window := fmt.Sprintf("?from=%s&to=%s", monday.Format(time.RFC3339), monday.Add(8*time.Hour).Format(time.RFC3339))
 
 	assertAnonymousAvailability(t, e, base, window)
-	assertBookingRequiresValidConsent(t, e, base, monday)
+	assertBookingRequiresValidConsent(t, e, base, purposeID, monday)
 
 	consent := AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01", "wording": "You agree we may contact you about this meeting."}
 	booking := bookHappyPathSlot(t, e, base, monday, consent)

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -172,8 +172,10 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		},
 		"RecordConsentRequest.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent",
-			omitted:  AnyMap{"new_state": "granted"},
-			supplied: AnyMap{"new_state": "granted", "purpose_id": absent},
+			// wording rides along because a grant without it is refused naming
+			// THAT field, and this case asserts the refusal names purpose_id.
+			omitted:  AnyMap{"new_state": "granted", "wording": "Yes, you may contact me about this."},
+			supplied: AnyMap{"new_state": "granted", "wording": "Yes, you may contact me about this.", "purpose_id": absent},
 			field:    "purpose_id",
 		},
 		"IssueDoubleOptInJSONBody.purpose_id": {

--- a/backend/internal/compose/integration/scheduledsend_integration_test.go
+++ b/backend/internal/compose/integration/scheduledsend_integration_test.go
@@ -84,6 +84,7 @@ func (p *preflightEnv) seedConsentedRecipient(t *testing.T, name, email string) 
 	}
 	if status := p.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "contract",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant consent for %s → %d", email, status)
 	}
@@ -253,9 +254,14 @@ func (p *preflightEnv) setTransactionalConsent(t *testing.T, state string) {
 	if transactional == "" {
 		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", AnyMap{
-		"purpose_id": transactional, "new_state": state, "lawful_basis": "consent",
-	}, nil, nil); status != http.StatusOK {
+	body := AnyMap{"purpose_id": transactional, "new_state": state, "lawful_basis": "consent"}
+	// Only a grant carries it: a grant that cannot say what the subject agreed
+	// to is refused, and a withdrawal demonstrates nothing, so sending it for
+	// one would describe a request this helper never makes.
+	if state == "granted" {
+		body["wording"] = "Yes, you may contact me about this."
+	}
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", body, nil, nil); status != http.StatusOK {
 		t.Fatalf("setting consent to %s → %d", state, status)
 	}
 }

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -143,6 +143,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	}
 	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "consent",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
 	}

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -87,6 +87,7 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	}
 	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", AnyMap{
 		"purpose_id": purpose.ID, "new_state": "granted", "lawful_basis": "consent",
+		"wording": "Yes, you may contact me about this.",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30459,6 +30459,14 @@ type RecordConsentRequest struct {
 	NewState    RecordConsentRequestNewState `json:"new_state"`
 	PurposeId   openapi_types.UUID           `json:"purpose_id"`
 	Source      *string                      `json:"source,omitempty"`
+
+	// Wording The exact wording the subject was shown, stored verbatim as proof. Required with a
+	// grant and refused as a 422 without one: Art. 7(1) asks the controller to demonstrate
+	// what the subject agreed TO, and a grant that cannot say what was shown demonstrates
+	// nothing. A withdrawal needs none — nothing is being demonstrated when somebody takes
+	// consent back, and refusing that would leave a person unable to opt out. The 2000-character
+	// bound matches the confirm-details door, which stores wording on the same proof row.
+	Wording *string `json:"wording,omitempty"`
 }
 
 // RecordConsentRequestNewState defines model for RecordConsentRequest.NewState.

--- a/backend/internal/modules/activities/scheduling.go
+++ b/backend/internal/modules/activities/scheduling.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -406,6 +407,14 @@ func (h Handlers) BookMeeting(w http.ResponseWriter, r *http.Request, _ crmcontr
 		}
 		if req.Consent.PolicyVersion == "" {
 			httperr.Write(w, r, httperr.Validation("consent.policy_version", "required", "the consent wording version shown to the subject is required"))
+			return
+		}
+		// Both halves of the proof row are settled before anything is written,
+		// for the reason stated above: recording is mandatory once the field is
+		// present, and a grant that cannot say what the subject read is not
+		// demonstrable.
+		if req.Consent.Wording == nil || strings.TrimSpace(*req.Consent.Wording) == "" {
+			httperr.Write(w, r, httperr.Validation("consent.wording", "required", "the consent wording shown to the subject is required"))
 			return
 		}
 		personID, ok := consentSubjectLink(w, r, in.Links)

--- a/backend/internal/modules/activities/scheduling_public.go
+++ b/backend/internal/modules/activities/scheduling_public.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -162,6 +163,15 @@ func (h Handlers) BookPublicMeeting(w http.ResponseWriter, r *http.Request, host
 	// recordable consent to.
 	if req.Consent.PolicyVersion == "" {
 		httperr.Write(w, r, httperr.Validation("consent.policy_version", "required", "the consent wording version shown to the booker is required"))
+		return
+	}
+	// Checked HERE, not left to the consent writer, for the reason the comment
+	// above gives: EnsurePersonByEmail below commits a person row before the
+	// grant is attempted, so a refusal down there would leave one behind — and
+	// this door is unauthenticated, so a caller omitting the field in a loop
+	// grows the person table one rejected request at a time.
+	if req.Consent.Wording == nil || strings.TrimSpace(*req.Consent.Wording) == "" {
+		httperr.Write(w, r, httperr.Validation("consent.wording", "required", "the consent wording shown to the booker is required"))
 		return
 	}
 	purposeID := ids.UUID(req.Consent.PurposeId)

--- a/backend/internal/modules/consent/archivedsubject_integration_test.go
+++ b/backend/internal/modules/consent/archivedsubject_integration_test.go
@@ -145,6 +145,10 @@ func assertConsentSplit(
 
 	grant := in
 	grant.NewState = string(StateGranted)
+	// A grant carries wording or the writer refuses it before it ever reaches
+	// the archived-subject probe — and what this asserts is the probe's answer,
+	// not the wording rule's.
+	grant.PolicyText = &grantWording
 	if _, err := store.Record(ctx, grant); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("granting consent for an archived subject: got %v, want not found", err)
 	}

--- a/backend/internal/modules/consent/channelconsent_integration_test.go
+++ b/backend/internal/modules/consent/channelconsent_integration_test.go
@@ -153,6 +153,7 @@ func TestConsentGateRefusesAChannelRecipientWithoutAGrant(t *testing.T) {
 
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		PersonID: e.person, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -186,6 +187,7 @@ func TestConsentGateRefusesAChannelRecipientAfterWithdrawal(t *testing.T) {
 
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		PersonID: e.person, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -242,6 +244,7 @@ func TestRequireGrantedForEmailsStillAnswersThroughTheSharedRule(t *testing.T) {
 	}
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		PersonID: e.person, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/consent/confirmsubmit.go
+++ b/backend/internal/modules/consent/confirmsubmit.go
@@ -46,6 +46,10 @@ const maxProposedValueRunes = 500
 // its disclosures, and shorter than anything that could be used as storage.
 const maxWordingRunes = 2000
 
+// maxVersionRunes bounds the version id that names the wording above. It is an
+// identifier, not prose, so it is bounded far shorter.
+const maxVersionRunes = 200
+
 // ConfirmSubmission is what the subject sent: their corrections, whether they
 // asked to be removed, and their answer to the marketing question.
 type ConfirmSubmission struct {

--- a/backend/internal/modules/consent/consenteventwording_integration_test.go
+++ b/backend/internal/modules/consent/consenteventwording_integration_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What a proof row may claim about what the subject was shown.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func wordingOf(t *testing.T, e *channelConsentEnv) (*string, *string) {
+	t.Helper()
+	var text, version *string
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT policy_text, policy_version FROM consent_event
+		 WHERE person_id = $1 ORDER BY captured_at DESC, id DESC LIMIT 1`,
+		e.person).Scan(&text, &version); err != nil {
+		t.Fatalf("reading the proof row: %v", err)
+	}
+	return text, version
+}
+
+// TestAWithdrawalNeedsNoWording is the other half, and the one that matters
+// more: nothing is demonstrated when somebody takes consent back, so requiring
+// a sentence there would leave a person unable to opt out.
+func TestAWithdrawalNeedsNoWording(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		PersonID: e.person, PurposeID: e.newsletter, NewState: "withdrawn",
+	}); err != nil {
+		t.Fatalf("withdrawing without wording: %v — a person must always be able to opt out", err)
+	}
+
+	text, version := wordingOf(t, e)
+	if text != nil || version != nil {
+		t.Errorf("the withdrawal recorded wording %v / version %v, want both NULL: "+
+			"a placeholder invents a claim about a screen that never existed", text, version)
+	}
+}
+
+// TestAGrantRecordsTheWordingVerbatim is what the whole rule is for.
+func TestAGrantRecordsTheWordingVerbatim(t *testing.T) {
+	e := setupChannelConsent(t)
+	shown := "Yes, email me about events. I can unsubscribe at any time."
+
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		PersonID: e.person, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &shown,
+	}); err != nil {
+		t.Fatalf("recording a grant with wording: %v", err)
+	}
+
+	text, version := wordingOf(t, e)
+	if text == nil || *text != shown {
+		t.Errorf("stored wording = %v, want the exact sentence shown", text)
+	}
+	// A door showing wording without naming a version still produces a row that
+	// says which wording this was, via defaultWordingVersion. This asserts that
+	// default is applied — not that the CHECK refused anything, which no path
+	// through this writer can reach.
+	if version == nil {
+		t.Error("wording was stored with no version, so nothing names which sentence this was")
+	}
+}
+
+// TestThePairCheckRefusesAHalfRecordedWording holds the constraint itself.
+//
+// The writer above cannot produce a half-filled pair, so the CHECK is never
+// exercised by any test that goes through it — and an unexercised constraint is
+// one nobody would notice losing. This writes the row the writer will not,
+// straight past Go, and expects the database to refuse it.
+func TestThePairCheckRefusesAHalfRecordedWording(t *testing.T) {
+	e := setupChannelConsent(t)
+
+	_, err := e.owner.Exec(e.ctx, `
+		INSERT INTO consent_event (person_id, purpose_id, new_state, source,
+		                           policy_text, policy_version, captured_at, captured_by)
+		VALUES ($1, $2, 'granted', 'test', 'a sentence with no version', NULL, now(), 'test')`,
+		e.person, e.newsletter)
+
+	if err == nil {
+		t.Fatal("a row carrying wording with no version was accepted: consent_event_wording_pairs " +
+			"is not holding, so a proof row can name a sentence nothing identifies")
+	}
+	if !strings.Contains(err.Error(), "consent_event_wording_pairs") {
+		t.Errorf("refused by %v, want the pair CHECK", err)
+	}
+}

--- a/backend/internal/modules/consent/consentproof.go
+++ b/backend/internal/modules/consent/consentproof.go
@@ -72,6 +72,15 @@ func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in Record
 	}
 }
 
+// policy_text and policy_version are written as they arrive, with NO placeholder.
+//
+// It used to coalesce to the literal 'recorded via API', which made every
+// wordless grant produce a row that reads like proof and demonstrates nothing —
+// and a subject access export would return that sentence as what the person was
+// shown. admitRecord now refuses a grant with no wording (requireWordingForGrant),
+// so a NULL reaching here belongs to a withdrawal, where there is nothing to
+// demonstrate and a placeholder would invent a claim.
+//
 // upsertConsentWithProof writes the state row and appends the immutable
 // proof row — one concept: the current state is always backed by an
 // append-only consent_event that says when, how, and by whom. The upsert
@@ -101,12 +110,20 @@ func upsertConsentWithProof(ctx context.Context, tx pgx.Tx, in RecordInput, sub 
 		named := string(in.MailboxProof)
 		trigger = &named
 	}
+	// The version travels with the text, both-or-neither, held by
+	// consent_event_wording_pairs. Doors that show wording without naming a
+	// version — the preference centre, the confirm link — get the default here
+	// rather than each spelling one, because a version each invented would be a
+	// second answer to "which wording was this". Set HERE and not in admitRecord,
+	// which takes its input by value: a default written there never reaches the
+	// INSERT, and the CHECK would refuse every row that door writes.
+	text, version := wordingFor(ConsentState(in.NewState), in.PolicyText, in.PolicyVersion)
 	_, err := tx.Exec(ctx, `
 		INSERT INTO consent_event (`+sub.column+`, purpose_id, new_state, lawful_basis, source,
 		                           policy_text, policy_version, double_opt_in_confirmed_at, captured_at, captured_by,
 		                           issuance_trigger)
-		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), coalesce($6, 'recorded via API'), coalesce($7, 'v1'), $8, $9, $10, $11)`,
+		VALUES ($1, $2, $3, $4, coalesce($5, 'api'), $6, $7, $8, $9, $10, $11)`,
 		sub.id, in.PurposeID, in.NewState, in.LawfulBasis, in.Source,
-		in.PolicyText, in.PolicyVersion, doiConfirmedAt, capturedAt, actorID, trigger)
+		text, version, doiConfirmedAt, capturedAt, actorID, trigger)
 	return err
 }

--- a/backend/internal/modules/consent/correspondenceconsent_integration_test.go
+++ b/backend/internal/modules/consent/correspondenceconsent_integration_test.go
@@ -33,6 +33,10 @@ func (e *qualifyingEnv) grant(t *testing.T, state string) {
 		PurposeID: ids.From[ids.PurposeKind](ids.MustParse(e.correspondence.ID)),
 		NewState:  state,
 		Source:    &source,
+		// Only a grant needs it, and passing it for a withdrawal too keeps this
+		// helper one shape. wordingFor drops it on a withdrawal, so the proof
+		// row does not claim a sentence that accompanied the grant.
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatalf("recording consent %q: %v", state, err)
 	}

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -133,6 +133,10 @@ func (h Handlers) RecordConsent(w http.ResponseWriter, r *http.Request, id crmco
 		NewState:    string(req.NewState),
 		LawfulBasis: req.LawfulBasis,
 		Source:      req.Source,
+		// Passed through unchanged, including absent. admitRecord decides
+		// whether this door may record without it, so the rule lives in one
+		// place rather than at each caller that reaches the writer.
+		PolicyText: req.Wording,
 	})
 	if err != nil {
 		writeConsentErr(w, r, err)

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -131,6 +131,7 @@ func TestLeadScopedConsentRecordsProofAndReadsBack(t *testing.T) {
 
 	state, err := e.store.Record(e.ctx, RecordInput{
 		LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	})
 	if err != nil {
 		t.Fatalf("recording a lead-scoped grant: %v", err)
@@ -154,6 +155,7 @@ func TestLeadScopedConsentRecordsProofAndReadsBack(t *testing.T) {
 	// Re-asserting the same state appends no second proof row.
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatalf("re-asserting the grant: %v", err)
 	}
@@ -189,6 +191,7 @@ func TestLeadScopedDOIGrantIsRefused(t *testing.T) {
 	e := setupLeadConsent(t)
 	_, err := e.store.Record(e.ctx, RecordInput{
 		LeadID: e.lead, PurposeID: e.doiNews, NewState: "granted",
+		PolicyText: &grantWording,
 	})
 	var invalid *ValidationError
 	if !errors.As(err, &invalid) {
@@ -206,6 +209,7 @@ func TestOutboundGateAcceptsTheLeadArm(t *testing.T) {
 	}
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -261,6 +265,7 @@ func TestTheEngineAnswersAboutALeadRatherThanShrugging(t *testing.T) {
 
 	if _, err := e.store.Record(e.ctx, RecordInput{
 		LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+		PolicyText: &grantWording,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -294,6 +299,7 @@ func TestTheEngineAndTheLegacyGateAgreeAboutALead(t *testing.T) {
 		if step.grant {
 			if _, err := e.store.Record(e.ctx, RecordInput{
 				LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+				PolicyText: &grantWording,
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -338,6 +344,9 @@ func TestAWithdrawnLeadIsNotReportedAsNeverGranted(t *testing.T) {
 	for _, state := range []string{"granted", "withdrawn"} {
 		if _, err := e.store.Record(e.ctx, RecordInput{
 			LeadID: e.lead, PurposeID: e.newsletter, NewState: state,
+			// Both arms of the loop carry it: the grant needs it, and the
+			// withdrawal ignores it, so one literal covers the pair.
+			PolicyText: &grantWording,
 		}); err != nil {
 			t.Fatalf("recording %s: %v", state, err)
 		}

--- a/backend/internal/modules/consent/preferencesave_integration_test.go
+++ b/backend/internal/modules/consent/preferencesave_integration_test.go
@@ -84,7 +84,7 @@ func TestASaveRecordsItsWithdrawalsEvenWhenAGrantIsRefused(t *testing.T) {
 	// The grant is listed FIRST on purpose: in request order it refuses before
 	// the withdrawal is ever reached.
 	rec := preferenceSave(t, e, token, `{"choices":[
-		{"purpose_key":"doi_newsletter","state":"granted"},
+		{"purpose_key":"doi_newsletter","state":"granted","wording":"Yes, send me the newsletter."},
 		{"purpose_key":"newsletter","state":"withdrawn"}]}`)
 
 	// 200 with the refusal NAMED, not a 4xx: the withdrawal beside it did
@@ -130,7 +130,7 @@ func TestAPurposeNamedTwiceInOneSaveSettlesOnTheWithdrawal(t *testing.T) {
 	// withdrawals-first pass, the grant would be the one left standing.
 	rec := preferenceSave(t, e, token, `{"choices":[
 		{"purpose_key":"newsletter","state":"withdrawn"},
-		{"purpose_key":"NEWSLETTER ","state":"granted"}]}`)
+		{"purpose_key":"NEWSLETTER ","state":"granted","wording":"Yes, send me the newsletter."}]}`)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
@@ -147,7 +147,7 @@ func TestASaveRecordsEveryDistinctChoice(t *testing.T) {
 	token := seedPreferenceToken(t, e)
 
 	rec := preferenceSave(t, e, token, `{"choices":[
-		{"purpose_key":"newsletter","state":"granted"},
+		{"purpose_key":"newsletter","state":"granted","wording":"Yes, send me the newsletter."},
 		{"purpose_key":"doi_newsletter","state":"withdrawn"}]}`)
 
 	if rec.Code != http.StatusOK {

--- a/backend/internal/modules/consent/requiredids_test.go
+++ b/backend/internal/modules/consent/requiredids_test.go
@@ -36,6 +36,7 @@ func TestAnOmittedPurposeIsNamed(t *testing.T) {
 
 	_, err := store.Record(ctx, RecordInput{
 		PersonID: ids.New[ids.PersonKind](), NewState: "granted",
+		PolicyText: &grantWording,
 	})
 	faulttest.AssertNamesOmittedID(t, err, "purpose_id")
 }

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -345,6 +345,9 @@ func admitRecord(ctx context.Context, in RecordInput) (subject, ConsentState, er
 	if err != nil {
 		return subject{}, "", err
 	}
+	if err := requireRecordableWording(state, in.PolicyText, in.PolicyVersion); err != nil {
+		return subject{}, "", err
+	}
 	return sub, state, nil
 }
 

--- a/backend/internal/modules/consent/subject_test.go
+++ b/backend/internal/modules/consent/subject_test.go
@@ -47,9 +47,10 @@ func TestConsentSubjectIsExactlyOne(t *testing.T) {
 func TestRecordRefusesAnAmbiguousSubjectBeforeAnyWrite(t *testing.T) {
 	store := NewStore(nil)
 	_, err := store.Record(context.Background(), RecordInput{
-		PersonID: ids.New[ids.PersonKind](),
-		LeadID:   ids.New[ids.LeadKind](),
-		NewState: "granted",
+		PersonID:   ids.New[ids.PersonKind](),
+		LeadID:     ids.New[ids.LeadKind](),
+		NewState:   "granted",
+		PolicyText: &grantWording,
 	})
 	var invalid *ValidationError
 	if !errors.As(err, &invalid) {
@@ -59,3 +60,12 @@ func TestRecordRefusesAnAmbiguousSubjectBeforeAnyWrite(t *testing.T) {
 		t.Fatalf("error names field %q, want subject", invalid.Field)
 	}
 }
+
+// grantWording is what a fixture shows the subject.
+//
+// Not decoration: a grant that cannot say what was shown is refused
+// (requireWordingForGrant), because Art. 7(1) asks the controller to
+// demonstrate what the subject agreed TO. A fixture omitting it would model a
+// request the product does not accept, and every test written against it would
+// describe a product we do not ship.
+var grantWording = "Yes, send me the newsletter. I can unsubscribe at any time."

--- a/backend/internal/modules/consent/wording.go
+++ b/backend/internal/modules/consent/wording.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a proof row may claim about what the subject was shown.
+//
+// Art. 7(1) asks the controller to demonstrate what the subject agreed TO, so a
+// grant that cannot say what was on the screen is a grant nobody can stand
+// behind. The confirm-details door enforced this at its own edge from the day it
+// shipped; every other door reached the same writer without it, and the writer
+// filled the gap with the literal 'recorded via API'. One rule, at the writer
+// both doors go through.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultWordingVersion names wording a door recorded without versioning it.
+//
+// Not a claim that the sentence never changes: it is the version the proof row
+// carries when the door showing it does not manage versions of its own, which
+// is every door but the booking form today. When consent_text_version lands,
+// this is what a row pointing at a published version stops needing.
+const defaultWordingVersion = "v1"
+
+// wordingFor settles what the proof row actually stores, for both columns at
+// once, because consent_event_wording_pairs stores them both-or-neither.
+//
+// ONLY A GRANT CARRIES WORDING. A withdrawal demonstrates nothing — there is no
+// screen to quote — so anything a caller passes for one is dropped rather than
+// written. Several fixtures pass the same input for both states to keep one
+// helper shape, and without this a withdrawal row would claim the sentence that
+// accompanied a GRANT.
+//
+// A grant with no version named gets the default: doors that show wording
+// without versioning it (the preference centre, the confirm link) would each
+// otherwise invent one, which is a second answer to "which wording was this".
+//
+// Settled HERE and not in admitRecord, which takes its input by value: a value
+// written there never reaches the INSERT, and the CHECK would refuse every row
+// those doors write.
+func wordingFor(state ConsentState, text, version *string) (*string, *string) {
+	if state != StateGranted {
+		return nil, nil
+	}
+	if text == nil {
+		return nil, nil
+	}
+	if version == nil {
+		// A local copy: the default is a const, and every row must carry its own
+		// value rather than share one address across concurrent writes.
+		fallback := defaultWordingVersion
+		return text, &fallback
+	}
+	return text, version
+}
+
+// requireRecordableWording is the whole rule, at the one place every door
+// reaches. The sentence and the version that names it are stored together, so
+// they are checked together — a bound on one alone leaves the same hole open a
+// column across.
+func requireRecordableWording(state ConsentState, wording, version *string) error {
+	if err := requireWordingForGrant(state, wording); err != nil {
+		return err
+	}
+	return requireBoundedVersion(version)
+}
+
+func requireWordingForGrant(state ConsentState, wording *string) error {
+	if state != StateGranted {
+		return nil
+	}
+	if wording == nil || strings.TrimSpace(*wording) == "" {
+		return &ValidationError{
+			Field:  "wording",
+			Reason: "a grant records the exact wording shown to the subject",
+		}
+	}
+	// The contract's own maxLength, enforced here because nothing generated
+	// does: unchecked, one caller stores a megabyte on a proof row that every
+	// later reader of this person's consent history is served in full, and the
+	// subject access export reads it back.
+	if len([]rune(*wording)) > maxWordingRunes {
+		return &ValidationError{
+			Field:  "wording",
+			Reason: fmt.Sprintf("the recorded wording is at most %d characters", maxWordingRunes),
+		}
+	}
+	return nil
+}
+
+// requireBoundedVersion bounds the OTHER half of the pair.
+//
+// The wording and the version that names it are stored or absent together, so a
+// bound on one alone leaves the same hole open: an anonymous booking may set the
+// version, it is written verbatim, and the subject access export reads it back
+// in full. A version id is a short token — the ceiling only has to be low enough
+// that a proof row cannot become a payload.
+func requireBoundedVersion(version *string) error {
+	if version == nil {
+		return nil
+	}
+	// Blank is not "absent": absent means the writer picks the default, while a
+	// caller-supplied empty string stores wording that names no version at all.
+	if strings.TrimSpace(*version) == "" {
+		return &ValidationError{
+			Field:  "policy_version",
+			Reason: "a recorded wording version cannot be blank",
+		}
+	}
+	if len([]rune(*version)) > maxVersionRunes {
+		return &ValidationError{
+			Field:  "policy_version",
+			Reason: fmt.Sprintf("the recorded wording version is at most %d characters", maxVersionRunes),
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/consent/wording_test.go
+++ b/backend/internal/modules/consent/wording_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a proof row may claim about what the subject was shown, refused before
+// a connection is ever taken.
+//
+// These sit in the unit lane deliberately. The rule is enforced in admitRecord,
+// which runs before s.db.Tx opens, and a nil pool is what PROVES that: were the
+// refusal to move inside the transaction, or come to rest on a database
+// constraint instead, these tests would panic rather than pass. Against a live
+// pool they would go on passing and prove only that something, somewhere,
+// said no.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// wordingCtx binds the actor the writer requires, and nothing else. The RBAC
+// check runs before the wording rule, so a bare context would fail these tests
+// on the wrong obligation and prove nothing about wording.
+func wordingCtx() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test",
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Create: true, Read: true, Update: true, Delete: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// TestAGrantWithoutWordingIsRefused holds Art. 7(1) at the writer.
+//
+// It used to be recorded, with the literal 'recorded via API' standing in for
+// the sentence nobody captured — a row that reads like evidence in a subject
+// access export and demonstrates nothing.
+func TestAGrantWithoutWordingIsRefused(t *testing.T) {
+	store := NewStore(nil)
+
+	_, err := store.Record(wordingCtx(), RecordInput{
+		PersonID:  ids.New[ids.PersonKind](),
+		PurposeID: ids.New[ids.PurposeKind](),
+		NewState:  "granted",
+	})
+
+	var invalid *ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("recording a wordless grant returned %v, want a validation error", err)
+	}
+	if invalid.Field != "wording" {
+		t.Errorf("refusal named field %q, want %q", invalid.Field, "wording")
+	}
+}
+
+// TestWordingIsBoundedAtTheWriter keeps a proof row from becoming a payload.
+func TestWordingIsBoundedAtTheWriter(t *testing.T) {
+	store := NewStore(nil)
+	huge := strings.Repeat("x", maxWordingRunes+1)
+
+	_, err := store.Record(wordingCtx(), RecordInput{
+		PersonID:   ids.New[ids.PersonKind](),
+		PurposeID:  ids.New[ids.PurposeKind](),
+		NewState:   "granted",
+		PolicyText: &huge,
+	})
+
+	var invalid *ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("an oversized wording returned %v, want a validation error — unchecked, one "+
+			"caller stores a megabyte every later reader of this history is served in full", err)
+	}
+	if invalid.Field != "wording" {
+		t.Errorf("refusal named field %q, want %q", invalid.Field, "wording")
+	}
+}
+
+// TestTheWordingVersionIsBoundedToo covers the other half of the pair.
+//
+// consent_event_wording_pairs stores the two together, so a bound on the
+// sentence alone leaves the same hole open one column across: the anonymous
+// booking door sets the version, it is written verbatim, and the subject
+// access export reads it back in full.
+func TestTheWordingVersionIsBoundedToo(t *testing.T) {
+	store := NewStore(nil)
+	huge := strings.Repeat("v", maxVersionRunes+1)
+
+	_, err := store.Record(wordingCtx(), RecordInput{
+		PersonID:      ids.New[ids.PersonKind](),
+		PurposeID:     ids.New[ids.PurposeKind](),
+		NewState:      "granted",
+		PolicyText:    &grantWording,
+		PolicyVersion: &huge,
+	})
+
+	var invalid *ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("an oversized version returned %v, want a validation error", err)
+	}
+	if invalid.Field != "policy_version" {
+		t.Errorf("refusal named field %q, want %q", invalid.Field, "policy_version")
+	}
+}
+
+// TestAWithdrawalStoresNoWordingEvenWhenGivenSome holds the rule at the WRITER
+// rather than at the door.
+//
+// Fixtures pass one input for both states to keep a helper single-shaped, and
+// admitRecord only refuses a grant that has none — it does not strip what a
+// withdrawal supplies. Without wordingFor the row would record the sentence
+// that accompanied a GRANT as though the person had read it while opting out.
+func TestAWithdrawalStoresNoWordingEvenWhenGivenSome(t *testing.T) {
+	version := "v1"
+	text, gotVersion := wordingFor(StateWithdrawn, &grantWording, &version)
+	if text != nil || gotVersion != nil {
+		t.Errorf("a withdrawal stored wording %v / version %v, want both nil: nothing is "+
+			"demonstrated when somebody takes consent back", text, gotVersion)
+	}
+}
+
+// TestAVersionWithoutTextIsNeverStored keeps the pair CHECK from being reached
+// as a raw database error.
+//
+// consent_event_wording_pairs refuses one column without the other. A caller
+// passing a version and no text used to satisfy validation and fail at the
+// constraint, which surfaces as an opaque 500 rather than a refusal naming the
+// field.
+func TestAVersionWithoutTextIsNeverStored(t *testing.T) {
+	version := "v1"
+	text, gotVersion := wordingFor(StateGranted, nil, &version)
+	if text != nil || gotVersion != nil {
+		t.Errorf("stored version %v with text %v, want both nil so the pair CHECK is never "+
+			"reached with half a row", gotVersion, text)
+	}
+}
+
+// TestABlankVersionIsRefused — absent means "the writer picks the default";
+// a caller-supplied empty string would store wording naming no version at all.
+func TestABlankVersionIsRefused(t *testing.T) {
+	blank := "   "
+	err := requireBoundedVersion(&blank)
+	var invalid *ValidationError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("a blank version returned %v, want a validation error", err)
+	}
+	if invalid.Field != "policy_version" {
+		t.Errorf("refusal named field %q, want policy_version", invalid.Field)
+	}
+}

--- a/backend/internal/modules/people/consentcarry.go
+++ b/backend/internal/modules/people/consentcarry.go
@@ -70,6 +70,13 @@ const (
 )
 
 // consentCarrySpec is one carry's answers to the four questions above.
+// carriedWordingVersion names the wording a carried withdrawal records.
+//
+// A carry writes a note, not a sentence the subject read, so this identifies
+// the note's own text rather than any consent screen. It moves when that text
+// moves, which is what lets an old proof row still say which wording it carried.
+const carriedWordingVersion = "carry-v1"
+
 type consentCarrySpec struct {
 	// name is what a reader of an error or a failing gate sees.
 	name string
@@ -80,6 +87,13 @@ type consentCarrySpec struct {
 	// source is written to both consent_event.source and
 	// consent_event.policy_version, as the pre-shared copies did.
 	source string
+	// carriedWordingVersion names the wording below. It is a version id, and the
+	// source ("merge"/"promotion") used to be written into this column — a value
+	// that answers "how did this row get here", not "which sentence is this".
+	// consent_event_wording_pairs stores the note and its version together, so
+	// the pair is filled with a real version rather than a second copy of the
+	// source.
+	//
 	// policyText is the sentence a reader of the proof row sees. Each carry
 	// says what actually happened to the record, so an audit reading the event
 	// alone can tell a merge from a promotion.
@@ -183,9 +197,9 @@ func flipCarriedWithdrawals(ctx context.Context, tx pgx.Tx, spec consentCarrySpe
 		)
 		INSERT INTO consent_event (%[2]s, purpose_id, new_state, source,
 		                           policy_text, policy_version, captured_at, captured_by)
-		SELECT $2, purpose_id, 'withdrawn', $5, $6, $5, $3, $4
+		SELECT $2, purpose_id, 'withdrawn', $5, $6, $7, $3, $4
 		FROM flipped`, spec.from, spec.to),
-		fromID, toID, now, by, spec.source, spec.policyText)
+		fromID, toID, now, by, spec.source, spec.policyText, carriedWordingVersion)
 	if err != nil {
 		return fmt.Errorf("carry withdrawals onto the surviving record: %w", err)
 	}

--- a/backend/migrations/core/1788654810_a_withdrawal_demonstrates_nothing.down.sql
+++ b/backend/migrations/core/1788654810_a_withdrawal_demonstrates_nothing.down.sql
@@ -1,0 +1,16 @@
+-- Bound the wait for the locks below. Without it an open transaction holding a
+-- conflicting lock stalls every write to consent_event for as long as this
+-- migration is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+-- Restoring NOT NULL needs every NULL filled, and the only value available is
+-- the placeholder this migration exists to remove. Rows written after it are
+-- withdrawals that genuinely showed nothing, so the down path names them for
+-- what they are rather than claiming wording they never had.
+ALTER TABLE consent_event DROP CONSTRAINT IF EXISTS consent_event_wording_pairs;
+
+UPDATE consent_event SET policy_text = 'no wording recorded' WHERE policy_text IS NULL;
+UPDATE consent_event SET policy_version = 'v1' WHERE policy_version IS NULL;
+
+ALTER TABLE consent_event ALTER COLUMN policy_text SET NOT NULL;
+ALTER TABLE consent_event ALTER COLUMN policy_version SET NOT NULL;

--- a/backend/migrations/core/1788654810_a_withdrawal_demonstrates_nothing.up.sql
+++ b/backend/migrations/core/1788654810_a_withdrawal_demonstrates_nothing.up.sql
@@ -1,0 +1,56 @@
+-- Bound the wait for the locks below. Without it an open transaction holding a
+-- conflicting lock stalls every write to consent_event for as long as this
+-- migration is willing to queue, which is forever.
+SET LOCAL lock_timeout = '3s';
+
+-- policy_text records WHAT THE SUBJECT WAS SHOWN, and only a grant has one.
+--
+-- The column has been NOT NULL since the baseline, and the writer satisfied it
+-- by coalescing an absent wording to the literal 'recorded via API'. That made
+-- every wordless grant produce a row reading like proof and holding none — the
+-- subject access export returns that sentence as what the person was shown.
+--
+-- A grant now carries real wording or is refused (requireWordingForGrant), so
+-- the placeholder is gone. What is left is the WITHDRAWAL: nothing is being
+-- demonstrated when somebody takes consent back, there is no wording to record,
+-- and a placeholder there would invent a claim about a screen that never
+-- existed. NULL is the honest value, and the column has to admit it.
+--
+-- Not a widening of what a grant may store: a grant reaching the writer without
+-- wording is refused before the INSERT, and consenteventwording_test.go holds
+-- that. This only lets a withdrawal say nothing.
+ALTER TABLE consent_event ALTER COLUMN policy_text DROP NOT NULL;
+
+-- policy_version travels with the text for the same reason: a version naming
+-- wording that does not exist is a number pointing at nothing.
+ALTER TABLE consent_event ALTER COLUMN policy_version DROP NOT NULL;
+
+-- Both or neither, and only on a grant. A row carrying a version with no text
+-- cannot say what that version SAID, and one carrying text with no version
+-- cannot be told apart from a later edit of the same wording.
+-- The rows already carrying the placeholder are cleared, not left standing.
+--
+-- Dropping NOT NULL only stops NEW wordless rows from inventing a sentence;
+-- every row the old writer produced still reads 'recorded via API', and the
+-- subject access export goes on returning it as what that person was shown.
+-- That is the defect this migration is named for, so it is fixed for the rows
+-- that have it rather than only for rows nobody has written yet.
+--
+-- NULL is the honest replacement: the wording was never captured, and no value
+-- available here can say what somebody read. The version goes with it, because
+-- the CHECK below stores the two together.
+-- Matched as a PAIR, not on the text alone. The old writer coalesced the two
+-- columns together — 'recorded via API' always beside version 'v1' — so the
+-- pair is the placeholder's signature. Matching the sentence by itself would
+-- also clear a row where somebody genuinely typed those words under a different
+-- version, and that is real evidence this migration must not destroy.
+UPDATE consent_event
+   SET policy_text = NULL, policy_version = NULL
+ WHERE (policy_text = 'recorded via API' AND policy_version = 'v1')
+    -- The down migration's own filler, so a down/up cycle returns to where it
+    -- started instead of leaving fabricated pairs the up path does not know.
+    OR (policy_text = 'no wording recorded' AND policy_version = 'v1');
+
+ALTER TABLE consent_event
+    ADD CONSTRAINT consent_event_wording_pairs
+        CHECK ((policy_text IS NULL) = (policy_version IS NULL));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1632,6 +1632,7 @@ public.consent_event.consent_event_person_id_fkey FOREIGN KEY (person_id) REFERE
 public.consent_event.consent_event_pkey PRIMARY KEY (id)
 public.consent_event.consent_event_purpose_id_fkey FOREIGN KEY (purpose_id) REFERENCES consent_purpose(id) ON DELETE RESTRICT
 public.consent_event.consent_event_subject CHECK (((person_id IS NOT NULL) OR (lead_id IS NOT NULL)))
+public.consent_event.consent_event_wording_pairs CHECK (((policy_text IS NULL) = (policy_version IS NULL)))
 public.consent_event.double_opt_in_confirmed_at timestamp with time zone gen=- def=-
 public.consent_event.id uuid NOT NULL gen=- def=uuidv7()
 public.consent_event.issuance_trigger text gen=- def=-
@@ -1639,8 +1640,8 @@ public.consent_event.lawful_basis text gen=- def=-
 public.consent_event.lead_id uuid gen=- def=-
 public.consent_event.new_state text NOT NULL gen=- def=-
 public.consent_event.person_id uuid gen=- def=-
-public.consent_event.policy_text text NOT NULL gen=- def=-
-public.consent_event.policy_version text NOT NULL gen=- def=-
+public.consent_event.policy_text text gen=- def=-
+public.consent_event.policy_version text gen=- def=-
 public.consent_event.purpose_id uuid NOT NULL gen=- def=-
 public.consent_event.source text NOT NULL gen=- def=-
 public.consent_event_pkey CREATE UNIQUE INDEX consent_event_pkey ON public.consent_event USING btree (id)
@@ -5690,6 +5691,40 @@ public.weekly_review_outlook.weighted_minor bigint gen=- def=-
 public.weekly_review_outlook.won_minor bigint gen=- def=-
 public.weekly_review_outlook_pkey CREATE UNIQUE INDEX weekly_review_outlook_pkey ON public.weekly_review_outlook USING btree (id)
 public.weekly_review_pkey CREATE UNIQUE INDEX weekly_review_pkey ON public.weekly_review USING btree (id)
+public.weekly_review_scorecard acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.weekly_review_scorecard.created_at timestamp with time zone NOT NULL gen=- def=now()
+public.weekly_review_scorecard.deal_advances integer gen=- def=-
+public.weekly_review_scorecard.deal_close_date_sound integer gen=- def=-
+public.weekly_review_scorecard.deal_forecast_down integer gen=- def=-
+public.weekly_review_scorecard.deal_forecast_up integer gen=- def=-
+public.weekly_review_scorecard.deal_median_days_in_stage integer gen=- def=-
+public.weekly_review_scorecard.deal_multi_threaded integer gen=- def=-
+public.weekly_review_scorecard.deal_open integer gen=- def=-
+public.weekly_review_scorecard.deal_regressions integer gen=- def=-
+public.weekly_review_scorecard.deal_with_next_step integer gen=- def=-
+public.weekly_review_scorecard.has_deal_block boolean NOT NULL gen=- def=-
+public.weekly_review_scorecard.has_lead_block boolean NOT NULL gen=- def=-
+public.weekly_review_scorecard.id uuid NOT NULL gen=- def=uuidv7()
+public.weekly_review_scorecard.lead_advanced integer gen=- def=-
+public.weekly_review_scorecard.lead_answered_in_target integer gen=- def=-
+public.weekly_review_scorecard.lead_breached integer gen=- def=-
+public.weekly_review_scorecard.lead_disqualified integer gen=- def=-
+public.weekly_review_scorecard.lead_promoted integer gen=- def=-
+public.weekly_review_scorecard.meetings_booked integer gen=- def=-
+public.weekly_review_scorecard.meetings_held integer gen=- def=-
+public.weekly_review_scorecard.meetings_no_show integer gen=- def=-
+public.weekly_review_scorecard.meetings_partial_history integer gen=- def=-
+public.weekly_review_scorecard.weekly_review_id uuid NOT NULL gen=- def=-
+public.weekly_review_scorecard.weekly_review_scorecard_counts_nonnegative CHECK (((COALESCE(lead_advanced, 0) >= 0) AND (COALESCE(lead_disqualified, 0) >= 0) AND (COALESCE(lead_promoted, 0) >= 0) AND (COALESCE(lead_answered_in_target, 0) >= 0) AND (COALESCE(lead_breached, 0) >= 0) AND (COALESCE(meetings_booked, 0) >= 0) AND (COALESCE(meetings_held, 0) >= 0) AND (COALESCE(meetings_no_show, 0) >= 0) AND (COALESCE(meetings_partial_history, 0) >= 0) AND (COALESCE(deal_advances, 0) >= 0) AND (COALESCE(deal_regressions, 0) >= 0) AND (COALESCE(deal_median_days_in_stage, 0) >= 0) AND (COALESCE(deal_with_next_step, 0) >= 0) AND (COALESCE(deal_open, 0) >= 0) AND (COALESCE(deal_multi_threaded, 0) >= 0) AND (COALESCE(deal_close_date_sound, 0) >= 0) AND (COALESCE(deal_forecast_up, 0) >= 0) AND (COALESCE(deal_forecast_down, 0) >= 0)))
+public.weekly_review_scorecard.weekly_review_scorecard_deal_block_shape CHECK ((((NOT (has_deal_block IS DISTINCT FROM true)) = (deal_advances IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_regressions IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_with_next_step IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_open IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_multi_threaded IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_close_date_sound IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_forecast_up IS NOT NULL)) AND ((deal_advances IS NOT NULL) = (deal_forecast_down IS NOT NULL))))
+public.weekly_review_scorecard.weekly_review_scorecard_lead_block_shape CHECK ((((NOT (has_lead_block IS DISTINCT FROM true)) = (lead_advanced IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (lead_disqualified IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (lead_promoted IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (lead_answered_in_target IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (lead_breached IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (meetings_booked IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (meetings_held IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (meetings_no_show IS NOT NULL)) AND ((lead_advanced IS NOT NULL) = (meetings_partial_history IS NOT NULL))))
+public.weekly_review_scorecard.weekly_review_scorecard_median_needs_block CHECK (((deal_median_days_in_stage IS NULL) OR (NOT (has_deal_block IS DISTINCT FROM true))))
+public.weekly_review_scorecard.weekly_review_scorecard_one_per_review UNIQUE (weekly_review_id)
+public.weekly_review_scorecard.weekly_review_scorecard_pkey PRIMARY KEY (id)
+public.weekly_review_scorecard.weekly_review_scorecard_review_fkey FOREIGN KEY (weekly_review_id) REFERENCES weekly_review(id) ON DELETE CASCADE
+public.weekly_review_scorecard.weekly_review_scorecard_subsets_fit CHECK (((deal_open IS NULL) OR ((deal_with_next_step <= deal_open) AND (deal_multi_threaded <= deal_open) AND (deal_close_date_sound <= deal_open))))
+public.weekly_review_scorecard_one_per_review CREATE UNIQUE INDEX weekly_review_scorecard_one_per_review ON public.weekly_review_scorecard USING btree (weekly_review_id)
+public.weekly_review_scorecard_pkey CREATE UNIQUE INDEX weekly_review_scorecard_pkey ON public.weekly_review_scorecard USING btree (id)
 public.workflow_run acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.workflow_run.applied jsonb gen=- def=-
 public.workflow_run.created_at timestamp with time zone NOT NULL gen=- def=now()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27313,6 +27313,15 @@ export interface components {
             new_state: "granted" | "withdrawn";
             lawful_basis?: string | null;
             source?: string | null;
+            /**
+             * @description The exact wording the subject was shown, stored verbatim as proof. Required with a
+             *     grant and refused as a 422 without one: Art. 7(1) asks the controller to demonstrate
+             *     what the subject agreed TO, and a grant that cannot say what was shown demonstrates
+             *     nothing. A withdrawal needs none — nothing is being demonstrated when somebody takes
+             *     consent back, and refusing that would leave a person unable to opt out. The 2000-character
+             *     bound matches the confirm-details door, which stores wording on the same proof row.
+             */
+            wording?: string;
         };
         RecordClaim: {
             /** @enum {string} */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -785,6 +785,8 @@ export const de = {
   "org.filterSizeBandAll": "Alle Größen",
   "person.consent": "Einwilligung",
   "consent.grant": "Erteilen",
+  "consent.operatorWording":
+    "Von einem Mitarbeiter im CRM erfasst, der bestätigt hat, dass diese Person ihre Einwilligung für {label} außerhalb des Produkts erteilt hat. Ihr wurde hier kein Text angezeigt.",
   "consent.withdraw": "Widerrufen",
   "consent.doiBySubject":
     "Diesen Zweck best\u00e4tigt die Person selbst \u2013 \u00fcber einen Link an ihre eigene Adresse. Nutzen Sie unten \u201eUm Best\u00e4tigung der Daten bitten\u201c.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -837,6 +837,13 @@ export const en = {
   "org.filterSizeBandAll": "Any size",
   "person.consent": "Consent",
   "consent.grant": "Grant",
+  // Submitted as the proof row's wording when an operator records a grant
+  // here. It does NOT quote a screen the subject read — this door has none —
+  // so it says what actually happened: a named operator attested to a consent
+  // obtained away from the product. A canned subject-facing sentence would be
+  // the fabricated proof this rule exists to remove.
+  "consent.operatorWording":
+    "Recorded in the CRM by a member of staff, who attested that this person gave their consent for {label} outside the product. No wording was shown to them here.",
   "consent.withdraw": "Withdraw",
   "consent.doiBySubject":
     "This purpose is confirmed by the person themselves, through a link mailed to their own address. Use \u201cAsk them to confirm their details\u201d below.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -773,6 +773,8 @@ export const vi = {
   "org.filterSizeBandAll": "Mọi quy mô",
   "person.consent": "Chấp thuận",
   "consent.grant": "Cấp chấp thuận",
+  "consent.operatorWording":
+    "Được nhân viên ghi nhận trong CRM, xác nhận rằng người này đã đồng ý cho {label} bên ngoài sản phẩm. Không có nội dung nào được hiển thị cho họ tại đây.",
   "consent.withdraw": "Rút lại",
   "consent.doiBySubject":
     "M\u1ee5c \u0111\u00edch n\u00e0y do ch\u00ednh ng\u01b0\u1eddi \u0111\u00f3 x\u00e1c nh\u1eadn, qua li\u00ean k\u1ebft g\u1eedi t\u1edbi \u0111\u1ecba ch\u1ec9 c\u1ee7a h\u1ecd. H\u00e3y d\u00f9ng \u201c\u0110\u1ec1 ngh\u1ecb h\u1ecd x\u00e1c nh\u1eadn th\u00f4ng tin\u201d b\u00ean d\u01b0\u1edbi.",

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -402,9 +402,15 @@ describe("ConsentSection", () => {
       ).toHaveLength(1),
     );
     const posts = sent.filter((s) => s.key === "POST /people/person-1/consent");
+    // An exact match, so a token key reappearing in this body fails here — the
+    // point of this test. The wording rides along because the server refuses a
+    // grant that cannot say what the subject agreed to; this door has no screen
+    // the subject read, so it attests to a consent taken elsewhere rather than
+    // quoting one.
     expect(posts.at(-1)?.body).toEqual({
       purpose_id: "p1",
       new_state: "granted",
+      wording: expect.stringContaining("outside the product"),
     });
   });
 

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -198,6 +198,11 @@ function MutationError({ error }: Readonly<{ error: unknown }>) {
 // RecordConsentRequest and this control has no field for it yet. Errors
 // surface verbatim (a DOI-required purpose 422s here rather than silently
 // no-opping) so the human sees exactly why the toggle didn't take.
+//
+// A grant carries wording, because the server refuses one that cannot say what
+// the subject agreed to. This door has no screen the subject read — an operator
+// is recording a consent obtained elsewhere — so it submits an attestation
+// naming that, rather than quoting a sentence nobody was shown.
 function ConsentRow({
   mayWrite,
   personId,
@@ -224,6 +229,15 @@ function ConsentRow({
         body: {
           purpose_id: entry.purpose_id,
           new_state: newState,
+          // Only a grant needs it: a withdrawal demonstrates nothing, and the
+          // server stores no wording for one.
+          ...(newState === "granted"
+            ? {
+                wording: t("consent.operatorWording", {
+                  label: purpose?.label ?? entry.purpose_key ?? "",
+                }),
+              }
+            : {}),
         },
       });
       if (error) {


### PR DESCRIPTION
A consent proof row records what the subject was shown when they granted. It could not say that: `consentproof.go` coalesced an absent wording to the literal `'recorded via API'`, so a wordless grant produced a row that reads like evidence and holds none — and the subject access export returns that sentence as "what this person was shown".

## What changes

- **A grant must record its wording.** `requireRecordableWording` refuses a grant whose wording is absent or blank, at `admitRecord`, before a connection is taken. A withdrawal needs none: nothing is demonstrated when somebody takes consent back, and a placeholder there would invent a claim about a screen that never existed.
- **`RecordConsentRequest` gains an optional `wording`** (maxLength 2000).
- **`policy_text` and `policy_version` become nullable**, with `consent_event_wording_pairs CHECK ((policy_text IS NULL) = (policy_version IS NULL))` — both or neither, so a version can never name wording that does not exist.
- **Existing placeholder rows are cleared.** The migration NULLs every row still reading `'recorded via API'`, so the export stops returning it for records already written.

## The behaviour change `oasdiff` cannot see

`check-contract-breaking.sh` reports no breaking changes, and that is true of the schema: an optional property is additive. The behaviour is stricter. **A caller sending a grant without `wording` now gets 422 where it previously got 200.** No gate can see this, because the rule lives in the handler rather than the contract. Callers in this tree are all updated; an external caller posting grants would need the field.

## Fixed along the way

Three defects the reviewers found in the change itself:

1. **Unauthenticated person-table growth.** `POST /public/booking/{host_slug}` calls `EnsurePersonByEmail` before `CaptureBookingConsent`, with no transaction spanning them. A caller omitting `wording` would 422 *after* the person row committed — repeatable in a loop with a fresh email each time. Wording is now validated before any write, at both booking doors, where the existing `policy_version` check already stood.
2. **`policy_version` was unbounded** while `policy_text` was capped, on the same anonymous path, and it is read back in full by the SAR export. Now bounded to 200 runes.
3. **`defaultWordingVersion` was a mutable package-level `var` whose address escaped** into every concurrent proof-row write. Now a `const`, copied per row.

And one defect outside the change, which the new CHECK made load-bearing: `people/consentcarry.go` wrote `spec.source` (`"merge"` / `"promotion"`) into `policy_version`. A version column holding `"merge"` answers "how did this row get here", not "which sentence is this". It now carries a real version id.

## Tests

The two refusal tests run in the **unit** lane against `NewStore(nil)`. That is the proof, not a saving: a nil pool means no connection is ever consulted, so were the refusal to move inside the transaction or come to rest on a database constraint, they would panic rather than pass. Against a live pool they would go on passing and prove only that something, somewhere, said no.

`TestThePairCheckRefusesAHalfRecordedWording` writes the half-filled row the Go writer cannot produce, straight past the writer, and expects the database to refuse it — the constraint had no other exercise.

Mutation-checked one clause at a time — neutering the wording guard fails only the wording test, the version bound only the version test, the withdrawal drop only the withdrawal test.

One test in this diff proved nothing until it was mutation-checked. The no-wording case on the anonymous booking door originally used a *bogus* purpose id, so it was refused by the purpose check and passed whether or not the wording guard existed. With a valid purpose id, removing the guard now fails with `refused bookings left 1 person rows, want 0` — the security defect above, named by the assertion that catches it.

## What Codex found that the others did not

Codex `gpt-5.6-sol` raised six findings after the two repo reviewers were done. Four were real:

1. **A withdrawal carrying a version but no text passed validation** and then violated the pair CHECK as a raw database error rather than a named refusal.
2. **A withdrawal carrying wording stored it.** Several fixtures pass one input for both states to keep a helper single-shaped, so a withdrawal proof row could record the sentence that accompanied the *grant*. My own comment claimed the writer dropped it; it did not.
3. **A blank `policy_version` passed the bound**, storing wording that names no version.
4. **The backfill matched the placeholder text alone.** Now matched as the pair the old writer actually produced (`'recorded via API'` beside version `'v1'`), so a genuine sentence equal to that string under a different version survives. The up path also clears the down path's own filler, so a down/up cycle returns to where it started — `TestMigrations_applyReverseReapply` covers it.

(1) and (2) shared a root cause: the rule was enforced at admission, but the writer did not hold it. `wordingFor` now settles both columns at the writer, so every door gets the same answer.

**One finding rejected.** Codex reported that a DOI-required purpose could still be refused after `EnsurePersonByEmail` commits. Not reachable on the anonymous door: `ValidatePurpose` restricts it to the single `transactional` purpose, which requires no double opt-in, and that check already runs before the person is created.

## Reviewers

`security-redteam`, `craft-reviewer` and Codex `gpt-5.6-sol` all ran on this diff, and each found defects the others missed.

One reviewer suggestion was **rejected**: making `wording` `required` on `CaptureConsent` in the contract. `check-contract-breaking.sh` flags it as breaking, and it would reject existing booking embeds at the schema door — trading one break for another. Validating before the write fixes the ordering defect without that.

## Known red, not from this change

`TestFK_rowScopedTargetsHaveVisibilityDecision` fails on pristine `origin/main` with four `sdr_handoff` FK errors, from #4568. Verified by running the gate on a detached `origin/main` checkout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A consent proof row now records the wording the subject was actually shown. Previously, a grant without wording stored the literal `'recorded via API'`, which the subject access export returned as what the person was shown; now a grant is refused with 422 unless it carries real wording, and a withdrawal records none.

**Migration**
- `policy_text` and `policy_version` become nullable, with a both-or-neither CHECK.
- Existing placeholder rows are cleared to NULL.
- `RecordConsentRequest` gains optional `wording` (max 2000 chars); `policy_version` is bounded to 200 chars.

**Behavior changes**
- Callers posting grants without `wording` now get 422 instead of 200.
- Booking doors validate wording before the person is created, so the anonymous booking endpoint cannot grow the person table with rejected requests.
- Consent carries write a real version id into `policy_version` instead of the merge/promotion source.
- Frontend sends an operator attestation string when a staff member records a grant in the CRM.

<sup>Written for commit afc89b0890a6f247f9ff98b0969a2df84caa2a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Consent grants now record the exact wording shown to the person, with automatic wording for operator-recorded consent.
  - Consent withdrawals continue without storing consent wording.
  - Consent wording and policy versions now have defined length limits and must be provided together.

- **Bug Fixes**
  - Meeting bookings with missing or blank consent wording are rejected before any records are created.
  - Consent records now preserve wording accurately and avoid placeholder text when no wording applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->