### PR TITLE
fix(main): two registers still name the composer that was consolidated away

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -246,7 +246,6 @@ frontend/src/screens/companyraildetails.tsx core 0203
 frontend/src/screens/embedreindex.stories.tsx migration 0115
 frontend/src/screens/embedreindex.test.tsx migration 0115
 frontend/src/screens/embedreindex.tsx migration 0115
-frontend/src/screens/persondrawers.tsx migration 0188
 frontend/src/screens/relationships.test.tsx migration 0007
 frontend/src/screens/relationships.tsx migration 0007
 frontend/src/screens/settings-nav.test.tsx migration 0261

--- a/backend/gates/frontendsendpermission_test.go
+++ b/backend/gates/frontendsendpermission_test.go
@@ -52,12 +52,7 @@ const (
 
 // silentSendSurfaces ratifies each surface that posts to a send door without
 // asking the engine first, with what the omission costs.
-var silentSendSurfaces = gatekit.Waive(map[string]string{
-	"screens/persondrawers.tsx": "the person page's composer leads with the person's purpose-keyed " +
-		"consent guard, read off the 360; drawing the engine's answer beside it would put two " +
-		"verdicts about one message on one drawer, so adopting the component there means " +
-		"retiring that guard first, which is its own change",
-})
+var silentSendSurfaces = gatekit.Waive(map[string]string{})
 
 // contractPathLine matches a path entry under `paths:`.
 var contractPathLine = regexp.MustCompile(`^  (/[^\s:]+):\s*$`)
@@ -225,10 +220,16 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 	if walkErr != nil {
 		t.Fatalf("walking the frontend: %v", walkErr)
 	}
-	// The composer and the person page's composer both post to a door today.
-	// Fewer means the walk has stopped seeing the surfaces it exists to hold.
-	if surfaces < 2 {
-		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the two composers: "+
+	// ONE composer posts to a door today, and it is one on purpose: the person
+	// page's drawer used to carry a second — waived here, because it led with its
+	// own consent guard — and #4553 gave every record the same mail drawer, so
+	// the surface and its waiver went together.
+	//
+	// The floor stays because the failure it guards is the walk finding NOTHING:
+	// a census that stops seeing its subject reports a pass, and this one holds
+	// the surface where a rep learns a refusal by pressing Send.
+	if surfaces < 1 {
+		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the composer: "+
 			"the census has stopped seeing its subject", surfaces)
 	}
 }

--- a/frontend/src/screens/compose.head.test.tsx
+++ b/frontend/src/screens/compose.head.test.tsx
@@ -25,10 +25,11 @@ import {
 // The head of the message: who it is to, and the two things a rep could not
 // reach from here before — a blind copy, and the paper the mail is about.
 //
-// Both were on the wire already. The backend has carried `bcc` since migration
-// 0188 and `attachment_ids` since ADR-0086/A131, and no surface in the product
-// named either: a rep who wanted to send the offer they were writing about had
-// to leave the drawer, file it on the record, and start the mail again.
+// Both were on the wire already — the send door has taken `bcc` and
+// `attachment_ids` for as long as either has existed — and no surface in the
+// product named either: a rep who wanted to send the offer they were writing
+// about had to leave the drawer, file it on the record, and start the mail
+// again.
 
 type Sent = { key: string; body: unknown };
 


### PR DESCRIPTION
`deterministic-gates` and `extension-reference` fail on `origin/main`, and therefore on every open PR — mine and everyone else's. Both failures are registers left pointing at `screens/persondrawers.tsx`, the surface #4553 consolidated into the one mail drawer. I checked the open PRs first: none was in flight for either.

```
TestEverySurfaceThatSendsAsksTheEngineFirst
  found 1 frontend file(s) posting to a send door, want at least the two composers
  waiver screens/persondrawers.tsx matched no subject

TestEveryCitedMigrationExists
  frontend/src/screens/compose.head.test.tsx:28 cites migration 0188
  danglingcitations.txt records "frontend/src/screens/persondrawers.tsx migration 0188",
  which is no longer a dangling citation
```

## The send census

The waiver existed because the person drawer's composer led with the person's own purpose-keyed consent guard, so adopting the shared `SendPermission` there meant retiring that guard first. That drawer is gone; the composer every record now opens asks the engine like every other caller. The waiver goes with its subject.

The floor moves from two composers to one, and **stays** — the failure it guards is the walk finding *nothing*, which is a census reporting a pass while seeing no subject. The comment now names why the number moved rather than leaving a lowered number for the next reader to wonder about.

## The citation

The comment moved file with the test. Rather than re-pointing it at a version that is not in the tree — which the gate rightly refuses to launder — it states the invariant instead, which is what the gate's own message asks for: the send door has taken `bcc` and `attachment_ids` for as long as either has existed. The stale register line is pruned with `-update-citations`.

`make check-backend` green; `compose.head.test.tsx` passes (14).