### PR TITLE
test(e2e): the settings sweep names the pages that exist

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -101,47 +101,54 @@ const CORE_SCREENS = [
   "partners",
   "analytics",
   "settings",
-  // The automations editor is configuration on the AI settings page now, not a
-  // destination of its own. Sweeping `#/automations` after the route retired
-  // would measure the fallback screen and report it as coverage, so the sweeps
-  // follow the surface to where it actually lives.
-  "settings/ai",
-  // Settings is FIFTEEN pages behind one route (SETTINGS_TABS in
-  // screens/settings.tsx), and a bare `settings` resolves to Account — the
-  // shortest of them. Sweeping that alone and calling settings covered is how
-  // the widest page in the product went unmeasured: `data-model` carries two
+  // Settings is many pages behind one route (SETTINGS_PAGES in
+  // screens/settingscatalog.ts), and a bare `settings` resolves to Account —
+  // the shortest of them. Sweeping that alone and calling settings covered is
+  // how the widest page in the product went unmeasured: `fields` carries two
   // full list surfaces with their own toolbars, `integrations` four
-  // installation-wide cards, `people` a roster of rows that each end in two
+  // installation-wide cards, `members` a roster of rows that each end in two
   // buttons. These are where a narrow viewport actually breaks.
   //
-  // ALL fifteen. The list below is written out rather than derived, and that is
-  // the weakness to know about: it went stale once already, claiming twelve
-  // while three pages — capture-activity, knowledge, license — were in neither
-  // sweep and nothing failed to say so. A census that can fall short reports
-  // PASS on the smaller tree.
+  // Every id below is a CANONICAL page id. A renamed spelling still resolves —
+  // `settingsrouting.ts` keeps the old addresses working — but it resolves by
+  // redirecting, so sweeping one measures the page it lands on while reporting
+  // the name it was asked for. expectSettingsViewLanded below is what makes
+  // that visible rather than silently counting the same page twice.
+  //
+  // The list is written out rather than derived, and that is the weakness to
+  // know about: it went stale twice — once claiming twelve while three pages
+  // were in neither sweep, and again when the catalog was split into its
+  // current shape and six of these ids were renamed under it. A census that can
+  // fall short reports PASS on the smaller tree.
   //
   // The blocker named here — that reading the ids would pull the screen's whole
   // module graph through Playwright's transform — is GONE: `settingscatalog.ts`
   // is pure data and imports like `../src/i18n/de` above it already does. What
   // still blocks deriving it is the mock's grants: E2E_ADMIN_GRANTS in seed.ts
-  // predates the thirteen settings objects, so a derived sweep would name pages
-  // this principal cannot open, each of them landing on the fallback and
-  // reporting a page the run never read — the same short census in a new shape.
-  // Extend the grants first, then derive; doing it in that order is the whole
-  // point.
-  "settings/data-model",
+  // predates the settings objects, so a derived sweep would name pages this
+  // principal cannot open, each of them landing on the fallback and reporting a
+  // page the run never read — the same short census in a new shape. Extend the
+  // grants first, then derive; doing it in that order is the whole point.
+  "settings/models",
+  // Automations and the audit trail each used to be one body of a page already
+  // in this list. They are pages of their own now, so they are named here — a
+  // split surface that keeps only its old address is a surface that quietly
+  // left the sweep.
+  "settings/automations",
+  "settings/audit",
+  "settings/fields",
   "settings/integrations",
-  "settings/users",
+  "settings/members",
   "settings/voice",
   "settings/agents",
   "settings/connections",
-  "settings/general",
+  "settings/company",
   "settings/capture",
   "settings/privacy",
-  "settings/maintenance",
+  "settings/system-health",
   "settings/capture-activity",
   "settings/knowledge",
-  "settings/license",
+  "settings/seats",
 ];
 
 /**
@@ -602,12 +609,9 @@ test("AC-book: the booking page renders rail-less with live slots", async ({
 test("AC-automations-1 (B-EP09.15): create from the catalog arrives paused; enable is the deliberate second step", async ({
   page,
 }) => {
-  // Automations are configuration, not a destination: the editor is one BODY of
-  // the AI settings page, reached by its tab, so every assertion below is scoped
-  // to that section rather than to a page that also carries routing, provider
-  // credentials, spend and the call trace.
-  await page.goto("/#/settings/ai");
-  await page.getByRole("button", { name: "Automatisierungen" }).click();
+  // Scoped to the editor's own region rather than to the page, so the criterion
+  // still reads what it names if the page ever carries a second card.
+  await page.goto("/#/settings/automations");
   const automations = page.locator("[data-automations-admin]");
   await expect(automations.getByText("Stillstands-Erinnerung")).toBeVisible();
   await automations
@@ -640,12 +644,11 @@ test("AC-automations-1 (B-EP09.15): create from the catalog arrives paused; enab
 test("AC-automations-2 (features/10 §1): anti-DSL — no free-form rule body, no user-defined trigger", async ({
   page,
 }) => {
-  // The anti-DSL claim is about the automations surface, so it is asserted over
-  // that surface: the editor is one tab of a settings page whose other bodies
-  // carry inputs with nothing to do with rule authoring, and counting those in
-  // would say something else entirely.
-  await page.goto("/#/settings/ai");
-  await page.getByRole("button", { name: "Automatisierungen" }).click();
+  // The anti-DSL claim is about the automations surface, so it is counted over
+  // that surface's region rather than over the page: an input elsewhere on the
+  // page has nothing to do with rule authoring, and counting it in would say
+  // something else entirely.
+  await page.goto("/#/settings/automations");
   const automations = page.locator("[data-automations-admin]");
   await expect(automations.getByText("Stillstands-Erinnerung")).toBeVisible();
   await automations
@@ -667,14 +670,15 @@ test("AC-automations-2 (features/10 §1): anti-DSL — no free-form rule body, n
 test("AC-settings-16: the audit log renders attributed entries, filters live, and loads more", async ({
   page,
 }) => {
-  // The audit log is the last card on the Privacy & audit entry — the trail
-  // that proves the consent, retention and DSR surfaces above it were honoured
-  // — and it names the PERSON behind each entry (AuditEntryLine, PD-002): the
+  // The audit log is the trail that proves the consent, retention and DSR
+  // surfaces were honoured, on its own page because it answers to `audit_log`
+  // where those answer to the consent registry and the retention policy. It
+  // names the PERSON behind each entry (AuditEntryLine, PD-002): the
   // signed-in human reads "Du", and a machine acting under someone's authority
   // reads as THAT PERSON with the tool as a qualifier. An agent's own id is
   // never the label — attribution exists so somebody can be asked about a
   // change, and an identifier cannot be asked anything.
-  await page.goto("/#/settings/privacy");
+  await page.goto("/#/settings/audit");
   await expect(page.getByText("Du", { exact: true })).toBeVisible();
   await expect(page.getByText("Marcus Brandt", { exact: true })).toBeVisible();
   await expect(page.getByText("über einen Agenten")).toBeVisible();

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -58,6 +58,16 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // reporting two more pages covered.
   knowledge_corpus: ["create", "read", "update", "delete"],
   license: ["read"],
+  // Model routing, which the AI settings page gates its whole entry on. Read
+  // alone: the routing writes the sweep passes over are not what it measures,
+  // and a grant this fixture does not need is a grant it should not claim.
+  ai_routing: ["read"],
+  // The audit page asks for BOTH — the trail's own read, and the reset grant
+  // AuditLogCard still stands in for the admin role it checks. Either one alone
+  // leaves the entry invisible and the address falling back to Account, which
+  // is the failure this pair exists to keep out of the sweep.
+  audit_log: ["read"],
+  system_reset: ["delete"],
 };
 
 // The coherent seed (mirrors design/seed-fixtures.md entities: Anna Weber,
@@ -560,6 +570,29 @@ export const aiProviderKeys = {
     { provider: "gemini", configured: true, env_var: "GEMINI_API_KEY" },
     { provider: "anthropic", configured: false, env_var: "ANTHROPIC_API_KEY" },
   ],
+};
+
+// The lane bindings the routing card draws, and the fifth read behind the AI
+// page that the catch-all cannot answer: `tiers` and `embeddings` are required
+// by AiRouting, so `{data,page}` hands the form neither and it renders the
+// unbound callout — the one state that says nothing about the rows the sweeps
+// exist to measure.
+//
+// Two chat tiers and the embedding lane, because the lane row is the widest
+// thing on the page and the embedding binding is the one a reader can miss: a
+// fixture binding only chat would leave the retrieval row unvisited at 390px.
+export const aiRouting = {
+  profile: "eu_hosted",
+  tiers: {
+    cheap_cloud: { provider: "gemini", model: "gemini-2.5-flash" },
+    premium: { provider: "anthropic", model: "claude-sonnet-4-5" },
+  },
+  embeddings: {
+    provider: "ollama",
+    model: "nomic-embed-text",
+    base_url: "http://localhost:11434",
+    dimensions: 768,
+  },
 };
 
 // Whether the model lanes are answering (the AI settings health card). Two
@@ -2591,6 +2624,9 @@ export async function mockApi(
     }
     if (path === "/installation/license") {
       return json(installationLicense);
+    }
+    if (path === "/ai/routing" && method === "GET") {
+      return json(aiRouting);
     }
     if (path === "/ai/health") {
       return json(aiHealth);

--- a/frontend/e2e/unsaved.spec.ts
+++ b/frontend/e2e/unsaved.spec.ts
@@ -36,13 +36,12 @@ const editOrgName = (page: Page) =>
 
 // Types into the dialog and closes it again, leaving the draft behind on a page
 // with nothing open over it — which is what makes the navigation below possible.
-// The address the product MINTS for this page today. `settingsrouting.ts`
-// resolves the catalog's flat `#/settings/company`, but the screen is still
-// driven by the register in `settingsnav.tsx`, which knows the page as the
-// admin entry `general` — so the flat spelling falls through to the reader's
-// first visible entry and this dialog is on a page nobody navigated to.
+// The address the product MINTS for this page. The old `#/settings/admin/general`
+// still resolves, but it resolves by REDIRECTING to this one, so a test that
+// navigated by the old spelling would be asserting the guard against an address
+// the app rewrites out from under it.
 const typeAndCloseDialog = async (page: Page, name: string) => {
-  await page.goto("/#/settings/admin/general");
+  await page.goto("/#/settings/company");
   await editOrgName(page).click();
   await orgName(page).fill(name);
   await page.keyboard.press("Escape");
@@ -71,7 +70,7 @@ test("a settings draft holds the page when the reader leaves for another screen"
   // address back, so the reader is where their work is.
   await page.keyboard.press("Escape");
   await expect(asking).toBeHidden();
-  await expect(page).toHaveURL(/#\/settings\/admin\/general$/);
+  await expect(page).toHaveURL(/#\/settings\/company$/);
   // The draft survived the question: reopening the dialog shows what was typed
   // rather than the value the server still holds.
   await editOrgName(page).click();


### PR DESCRIPTION
## What

The `uat` lane goes green again. Twenty-eight e2e cases were failing on every branch: the settings census still named ids the catalog renamed, two pages the fixture principal could not see, and one page that threw on arrival.

## Why

The settings catalog is flat and per-capability now, and six ids were renamed under it — `general` → `company`, `users` → `members`, `data-model` → `fields`, `ai` → `models`, `maintenance` → `system-health`, `license` → `seats`. The old addresses still resolve, so nothing 404'd: they **redirect**, and each sweep measured a page it had not asked for while reporting the name it had. `expectSettingsViewLanded` is the assertion that exists to catch exactly that, and it did.

The invariant is the one the census comment already states and rule 8 of the rulebook restates: a census that can fall short reports PASS on the smaller tree. Three ways it was falling short here, and each is closed:

- **A renamed id is not a page.** The list now names canonical ids only. Automations and the audit trail were each one body of a page already in the list and are pages of their own now, so both are named — a split surface that keeps only its old address is a surface that quietly left the sweep.
- **A page the principal cannot see falls back to Account**, so the sweep measures the shortest page in settings twice while reporting two. `ai_routing:read` opens the models page; `audit_log:read` and `system_reset:delete` together open the audit page, because `AuditLogCard` still stands the reset grant in for the admin role it checks.
- **A page that throws renders almost nothing**, and an axe pass over nothing is clean. `/ai/routing` had no fixture, and the catch-all's `{data,page}` carries neither `tiers` nor `embeddings`, so opening the models page took the whole entry down. It joins the four reads already held here for that same reason, binding two chat tiers and the embedding lane so the widest rows on the page are the ones the 390px and axe passes actually read.

`unsaved.spec.ts` navigated by the legacy `#/settings/admin/general` and then asserted the address had not changed — an address the app rewrites out from under it. It drives the minted spelling now.

## How verified

- `make check-fe` green (8m42s).
- Full Playwright suite on this branch: **289 passed, 55 skipped, 0 failed**. On `main` at `8eeb2037` the same suite fails 28.
- Each of the three failure shapes was reproduced before it was fixed, and the models-page crash was watched turn into rendered lane rows (`ai-routing-tier-cheap_cloud`, `ai-routing-tier-premium`, `ai-routing-embeddings` all present in the axe pass).

- [x] `make check` is green (frontend half; this diff is `frontend/e2e/` only)
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — does not touch it
- [x] `make craft-static` reports no new blockers — no Go files in the diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Wholly AI-assisted: the diagnosis (reproducing the 28 failures with an unrelated branch's diff removed, then narrowing each shape), the census rewrite, the two grants, the routing fixture and this description were written by Claude Code under human review.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC


---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the e2e settings sweep so the `uat` lane goes green again: 28 cases were failing because the sweep named settings page IDs the catalog renamed, and old addresses resolve by redirecting, so each case measured a page it hadn't asked for.

- The sweep now lists canonical page IDs only; automations and the audit trail are named as pages of their own.
- Adds `ai_routing:read` for the models page, and `audit_log:read` with `system_reset:delete` for the audit page — without these grants both entries fall back to Account.
- Adds a `/ai/routing` fixture with two chat tiers and the embedding lane so the models page renders instead of crashing.
- `unsaved.spec.ts` now navigates by `#/settings/company` instead of the legacy `#/settings/admin/general` that the app rewrites.

<sup>Written for commit a2c7ad2371f69625cc37a027d7ce81d90fb393c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

