### PR TITLE
fix(ai): a routing read that answers off-contract costs a reading, not the page

### DIFF
--- a/frontend/src/screens/ai-settings.test.tsx
+++ b/frontend/src/screens/ai-settings.test.tsx
@@ -89,6 +89,7 @@ const KEYS = {
 function backendFor(
   allow: GrantSpec,
   fail: { usage?: boolean; keys?: boolean } = {},
+  routing: unknown = ROUTING,
 ) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const req =
@@ -107,7 +108,7 @@ function backendFor(
         : jsonResponse(KEYS);
     }
     if (req.url.includes("/ai/routing")) {
-      return jsonResponse(ROUTING);
+      return jsonResponse(routing);
     }
     if (req.url.includes("/ai/health")) {
       // Its own shape: the card reads `rungs`, and a catch-all that answered
@@ -161,6 +162,26 @@ const BothStats = () => (
 );
 
 describe("the AI readings", () => {
+  // A 200 that is not the routing document is an ABSENT read, not a crash.
+  //
+  // `tiers` and `embeddings` are both required of `AiRouting`, so the generated
+  // type says they are there — but nothing validates a response, and the type is
+  // a promise only the server keeps. Reading `Object.values(undefined)` threw
+  // inside render, and a throw here does not cost the reading: the error
+  // boundary sits above the shell, so the WHOLE settings page became "this view
+  // no longer works". A server too old, a projection that lost a field and a
+  // proxy answering something else all produce this body.
+  //
+  // The keyed count still answers, because it comes from a different read that
+  // was fine — the page degrades to what it actually knows.
+  it("says nothing about vendors when the routing read answers off-contract", async () => {
+    vi.stubGlobal("fetch", backendFor(OPERATOR, {}, { profile: "eu_hosted" }));
+    render(<BothStats />);
+
+    expect(await screen.findByText("1 keyed")).toBeTruthy();
+    expect(screen.queryByText(/bound with no key/)).toBeNull();
+  });
+
   it("answers both readings", async () => {
     vi.stubGlobal("fetch", backendFor(OPERATOR));
     render(<BothStats />);

--- a/frontend/src/screens/ai-settings.tsx
+++ b/frontend/src/screens/ai-settings.tsx
@@ -188,9 +188,21 @@ export function ProvidersStat() {
 // alike. The embedding lane is in here on purpose: retrieval binds separately
 // and can be the only thing pointing at an unkeyed vendor, which is exactly the
 // case a reader would otherwise find out about from a failed reindex.
+//
+// `null` for a body that is not the routing document. `tiers` and `embeddings`
+// are both REQUIRED of the response, so the type above says they are there —
+// but the type is a promise the WIRE does not keep: nothing validates a 200,
+// and reading `Object.values(undefined)` threw, which the error boundary turned
+// into the whole settings page saying "this view no longer works". A server too
+// old, a projection that lost a field or a proxy answering something else are
+// all real ways to get such a body, and none of them should cost a reader the
+// page. The caller already draws an unanswered read; this is one.
 function boundProviders(
   routing: NonNullable<ReturnType<typeof useRouting>["data"]>,
-): Set<string> {
+): Set<string> | null {
+  if (routing.tiers === undefined || routing.embeddings === undefined) {
+    return null;
+  }
   const named = new Set<string>();
   for (const binding of Object.values(routing.tiers)) {
     named.add(binding.provider);


### PR DESCRIPTION
Opening `#/settings/models` throws, and the error boundary turns that into the whole settings page saying "this view no longer works".

```
TypeError: Cannot convert undefined or null to object
  at Object.values → boundProviders (ai-settings.tsx)
```

## Why it is a product bug and not a fixture one

`tiers` and `embeddings` are both **required** of `AiRouting`, so the generated type says they are there. Nothing validates a 200, though, and that type is a promise only the server keeps — a server too old, a projection that lost a field, and a proxy answering something else all produce a body without them.

What the fault costs is out of proportion to the fault. The boundary is mounted above the shell (`main.tsx`), so a throw inside one stat card takes the **rail, the nav and every other card** with it — there is nothing left to navigate away with. It also scores a clean axe pass and zero horizontal overflow while doing it, because there is almost nothing on screen left to measure. That is the "dead page passing every check" `expectShellRendered` exists to catch.

`boundProviders` now answers `null` for a body that is not the routing document, which is a case **the caller already draws**:

```ts
const bound = routing.data ? boundProviders(routing.data) : null;
```

An absent read and a malformed one are the same fact to a reader — nothing is known about which vendors are bound — and the keyed count beside it still answers, because it comes from a read that was fine. The page degrades to what it actually knows instead of disappearing.

## How it was found, and why this PR is only half of it

The `uat` lane is red on `main` with 27 failures. I reproduced them on a clean `origin/main` checkout and they are one cause: the settings restructure gave the seven groups real pages, six of the addresses the AC sweep names became redirects to pages under other names, and the sweep compared the trail crumb against the *group's* label.

This crash was hiding inside that. `#/settings/ai` used to fall back to Account, so the sweep measured the shortest page in settings and **reported the AI page covered** — the page had never actually been rendered by any sweep.

https://github.com/margince/margince/pull/4596 fixes the e2e half, and fixes it more completely than my own branch did: it also repairs `e2e/unsaved.spec.ts`, which I had not run and which fails too. I have dropped my duplicate of that work rather than compete with it — this PR is the part https://github.com/margince/margince/pull/4596 does not carry, and the two are independent.

Worth being explicit about the difference: https://github.com/margince/margince/pull/4596 makes the mock serve `/ai/routing`, which is right and is what turns the lane green. It does not stop the component throwing if a **real** server ever answers that shape. Both halves are wrong; this is the other one.

## Verification

- `pnpm exec vitest run src/screens/ai-settings.test.tsx` — 4 passed.
- **Mutation-checked.** Reverting `ai-settings.tsx` and keeping the test:

  ```
  × says nothing about vendors when the routing read answers off-contract
  TypeError: Cannot convert undefined or null to object
   Test Files  1 failed (1)
  ```

  The test drives the real component against a 200 carrying only `profile`, so it fails on exactly the defect and not on a stand-in.
- `make check-fe` green on Node 24.

Related: https://github.com/margince/margince/issues/4594 — the settings sweep is a hand-written address list that has now gone stale twice; deriving it from `SETTINGS_PAGES` is tracked there, with the remaining fixture grants enumerated.