### PR TITLE
fix(main): two registers still name the composer that was consolidated away

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -246,7 +246,6 @@ frontend/src/screens/companyraildetails.tsx core 0203
 frontend/src/screens/embedreindex.stories.tsx migration 0115
 frontend/src/screens/embedreindex.test.tsx migration 0115
 frontend/src/screens/embedreindex.tsx migration 0115
-frontend/src/screens/persondrawers.tsx migration 0188
 frontend/src/screens/relationships.test.tsx migration 0007
 frontend/src/screens/relationships.tsx migration 0007
 frontend/src/screens/settings-nav.test.tsx migration 0261

--- a/backend/gates/frontendsendpermission_test.go
+++ b/backend/gates/frontendsendpermission_test.go
@@ -52,12 +52,12 @@ const (
 
 // silentSendSurfaces ratifies each surface that posts to a send door without
 // asking the engine first, with what the omission costs.
-var silentSendSurfaces = gatekit.Waive(map[string]string{
-	"screens/persondrawers.tsx": "the person page's composer leads with the person's purpose-keyed " +
-		"consent guard, read off the 360; drawing the engine's answer beside it would put two " +
-		"verdicts about one message on one drawer, so adopting the component there means " +
-		"retiring that guard first, which is its own change",
-})
+//
+// Empty today. It held screens/persondrawers.tsx until the person page's
+// composer was consolidated into the one mail drawer every record now shares:
+// that file posts to no send door any more, so there is nothing left to ratify.
+// The remaining composer asks the engine, which is why nothing takes its place.
+var silentSendSurfaces = gatekit.Waive(map[string]string{})
 
 // contractPathLine matches a path entry under `paths:`.
 var contractPathLine = regexp.MustCompile(`^  (/[^\s:]+):\s*$`)
@@ -225,10 +225,13 @@ func TestEverySurfaceThatSendsAsksTheEngineFirst(t *testing.T) {
 	if walkErr != nil {
 		t.Fatalf("walking the frontend: %v", walkErr)
 	}
-	// The composer and the person page's composer both post to a door today.
-	// Fewer means the walk has stopped seeing the surfaces it exists to hold.
-	if surfaces < 2 {
-		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the two composers: "+
+	// ONE composer posts to a door today: the single mail drawer every record
+	// shares. It was two until the person page's own composer was consolidated
+	// into it, and the floor moved down with the consolidation rather than being
+	// deleted — a census that cannot fail short reports PASS over a tree it has
+	// stopped reading, and there is no failing assertion to notice.
+	if surfaces < 1 {
+		t.Fatalf("found %d frontend file(s) posting to a send door, want at least the mail drawer: "+
 			"the census has stopped seeing its subject", surfaces)
 	}
 }

--- a/frontend/src/screens/compose.head.test.tsx
+++ b/frontend/src/screens/compose.head.test.tsx
@@ -25,10 +25,10 @@ import {
 // The head of the message: who it is to, and the two things a rep could not
 // reach from here before — a blind copy, and the paper the mail is about.
 //
-// Both were on the wire already. The backend has carried `bcc` since migration
-// 0188 and `attachment_ids` since ADR-0086/A131, and no surface in the product
-// named either: a rep who wanted to send the offer they were writing about had
-// to leave the drawer, file it on the record, and start the mail again.
+// Both were on the wire already. The backend has long carried `bcc` and
+// `attachment_ids` (ADR-0086/A131), and no surface in the product named
+// either: a rep who wanted to send the offer they were writing about had to
+// leave the drawer, file it on the record, and start the mail again.
 
 type Sent = { key: string; body: unknown };
 


### PR DESCRIPTION
Main is red on `TestEverySurfaceThatSendsAsksTheEngineFirst`. This fixes it, plus a citation register that had drifted alongside.

Consolidating the person page's composer into the one mail drawer every record shares (#4553) left three registers describing a tree that no longer exists.

- **`silentSendSurfaces`** ratified `screens/persondrawers.tsx` for posting to a send door without asking the engine. That file posts to no send door any more, so the waiver matched no subject and the gate failed on it. The map is empty now, with a comment saying why nothing replaced the entry.
- **The send census demanded at least TWO composers.** There is one. The floor moves down with the consolidation rather than being deleted — a census that cannot fail short reports PASS over a tree it has stopped reading, and there is no failing assertion to notice.
- **`danglingcitations.txt`** still recorded a `persondrawers.tsx` citation that is no longer dangling (pruned with `-update-citations`), and `compose.head.test.tsx` cited migration `0188`, which is not a version in this tree. That comment now states the invariant instead of a number a reader cannot look up.

`go test ./gates` green, `make check-fe` green.

Supersedes #4585, which was closed unmerged while main stayed red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `TestEverySurfaceThatSendsAsksTheEngineFirst` gate and citation registers that still referenced the person page's composer after it was consolidated into the shared mail drawer.

- Empties `silentSendSurfaces`; `screens/persondrawers.tsx` no longer posts to a send door.
- Lowers the send census minimum from two composers to one.
- Prunes the stale `persondrawers.tsx` citation from `danglingcitations.txt` and replaces the migration `0188` reference in `compose.head.test.tsx` with the invariant it described.

<sup>Written for commit 46aca439cf139d3650e2799cbaaf6a79027dd7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

