### PR TITLE
A plan names its risks and its room

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -17832,6 +17832,44 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
+  /weekly-plans/current/contract:
+    put:
+      tags: [Brief]
+      operationId: setWeeklyPlanContract
+      summary: Say what could go wrong this week, and what room there is for it.
+      description: |
+        Both fields are written together and either may be omitted to leave that half alone.
+        Sending an explicit `null` CLEARS a field back to unwritten, which is a different
+        state from an empty string: cleared means nobody has said, empty means the rep says
+        there is nothing to name.
+
+        Opens the week if the rep has not started one — writing your risks is starting to
+        plan, and a rep whose first sentence could not be saved would have to invent a
+        commitment before they were allowed to record a worry.
+
+        A closed week is refused with `week_closed`: its counts are already frozen into the
+        review, and a plan that kept accepting prose would let a rep rewrite what their lead
+        has read.
+      x-agent-access: human-only
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                risks: { type: [string, 'null'], maxLength: 2000 }
+                capacity_note: { type: [string, 'null'], maxLength: 2000 }
+      responses:
+        '200':
+          description: The plan as it now stands.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/WeeklyPlan' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /weekly-plans/commitments/{id}/response:
     put:
       tags: [Brief]
@@ -34089,6 +34127,51 @@ components:
         commitments:
           type: array
           items: { $ref: '#/components/schemas/WeeklyPlanCommitment' }
+        risks:
+          type: [string, 'null']
+          maxLength: 2000
+          description: |
+            What the rep expects to get in the way this week, in their own words.
+
+            NULL and the empty string are different answers and a reader must draw them
+            differently: null is a rep who has written nothing, and "" is one who looked and
+            says there is nothing to name. Folding the two would report an unconsidered week
+            as a safe one.
+        capacity_note:
+          type: [string, 'null']
+          maxLength: 2000
+          description: |
+            What the rep says about the room they have — "two days at the conference" — which
+            is the half of capacity no query can know. It stands beside `capacity`, which is
+            counted, and never replaces it.
+
+            Null and empty carry the same distinction as `risks`.
+        capacity:
+          description: |
+            What next week's calendar already holds, counted rather than authored.
+
+            ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
+            week nobody has looked at is unknown, and drawing it as "nothing booked" would
+            tell a rep their week is free on the strength of a missing integration.
+          allOf: [{ $ref: '#/components/schemas/WeeklyPlanCapacity' }]
+    WeeklyPlanCapacity:
+      type: object
+      additionalProperties: false
+      description: |
+        How much of the coming week is already spoken for.
+      required: [meetings, tasks]
+      properties:
+        meetings:
+          type: integer
+          minimum: 0
+          description: |
+            Meetings BOOKED in next week's local window. Booked and not held: the week has not
+            happened, so a meeting there has no outcome yet, and counting `held` would only
+            find rows somebody backdated.
+        tasks:
+          type: integer
+          minimum: 0
+          description: Open tasks assigned to the rep and due inside next week's local window.
     WeeklyPlanCommitment:
       type: object
       additionalProperties: false

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 40
+	wantFixtureAnnotations = 41
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/planprosebounds_test.go
+++ b/backend/gates/planprosebounds_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// A plan's prose columns are bounded twice, and the two numbers must agree.
+//
+// The module refuses an over-long field at the seam (weeklyplan.bounded, which
+// answers a 422 naming the field) and the database refuses it again in a CHECK.
+// Neither is redundant: the seam gives the client a usable error instead of a
+// constraint violation, and the CHECK is what holds when a second writer
+// arrives that never passed through the seam.
+//
+// They drift silently. A CHECK raised to 4000 while Go still refuses at 2000
+// makes the database's extra room unreachable; lowered to 1000, the seam
+// cheerfully accepts text the INSERT then rejects as a 500. Both directions are
+// failures and neither shows up in a test of either side alone, so this
+// compares them.
+//
+// The corpus is DERIVED from the migrations rather than listed here: a gate
+// that hard-codes which columns it protects stops protecting the next one
+// somebody adds, and reports PASS while doing it.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A `length(<column>) <= <n>` clause in any CHECK on a weekly_plan table.
+var planBoundCheck = regexp.MustCompile(`(?i)\b(?:char_length|character_length|length)\((\w+)\)\s*<=\s*(\d+)`)
+
+// A dropped bound constraint, by its name.
+var planBoundDrop = regexp.MustCompile(`(?i)DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?(\w*_bound\w*)`)
+
+// The Go constants the weeklyplan module bounds its prose with.
+var planBoundConst = regexp.MustCompile(`(?m)^\s*(\w*[Bb]ound)\s*=\s*(\d+)`)
+
+// gatekit:fixture the column-to-constant pairing, which neither side declares
+//
+// Which Go constant each column is bounded by at the seam. This pairing is the
+// one thing a machine cannot read off either side — the call sites say
+// `bounded(fieldLabel, ..., labelBound)` and the column name is not in it — so
+// it is stated here and every column found in the schema must appear.
+var planColumnBound = map[string]string{
+	"label":            "labelBound",
+	"help_requested":   "proseBound",
+	"manager_response": "proseBound",
+	"risks":            "proseBound",
+	"capacity_note":    "proseBound",
+}
+
+func TestEveryPlanProseColumnMatchesItsGoBound(t *testing.T) {
+	t.Parallel()
+	consts := planGoBounds(t)
+	columns := planSchemaBounds(t)
+
+	if len(columns) == 0 {
+		t.Fatal("no bounded prose column found on a weekly_plan table: the scan " +
+			"has stopped reading its own subject, which reports PASS while holding nothing")
+	}
+	for column, sqlBound := range columns {
+		name, paired := planColumnBound[column]
+		if !paired {
+			t.Errorf("weekly_plan column %q carries a length CHECK but no entry in "+
+				"planColumnBound: name the Go constant that bounds it at the seam, "+
+				"or this gate silently stops covering it", column)
+			continue
+		}
+		goBound, known := consts[name]
+		if !known {
+			t.Errorf("column %q names Go constant %s, which weeklyplan does not define",
+				column, name)
+			continue
+		}
+		if goBound != sqlBound {
+			t.Errorf("column %q is bounded at %d in SQL and %d in Go (%s): "+
+				"the seam and the constraint must refuse the same text",
+				column, sqlBound, goBound, name)
+		}
+	}
+}
+
+// The other direction: a Go bound this gate claims to pair must actually reach
+// a column. A constant left in the map after its column is dropped makes the
+// pairing above look complete when it is not.
+func TestEveryPairedPlanBoundReachesAColumn(t *testing.T) {
+	t.Parallel()
+	columns := planSchemaBounds(t)
+	for column := range planColumnBound {
+		if _, found := columns[column]; !found {
+			t.Errorf("planColumnBound names column %q, which carries no length CHECK "+
+				"on any weekly_plan table: drop the entry or restore the constraint", column)
+		}
+	}
+}
+
+// planGoBounds reads the module's own bound constants.
+func planGoBounds(t *testing.T) map[string]int {
+	t.Helper()
+	out := map[string]int{}
+	for _, file := range planModuleFiles(t) {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		for _, m := range planBoundConst.FindAllStringSubmatch(string(body), -1) {
+			n, err := strconv.Atoi(m[2])
+			if err != nil {
+				t.Fatalf("%s: bound %q is not a number: %v", file, m[2], err)
+			}
+			out[m[1]] = n
+		}
+	}
+	return out
+}
+
+// planSchemaBounds reads every length CHECK on a weekly_plan table out of the
+// migrations, newest wins — a later migration may raise a ceiling, and the
+// current one is what the database actually enforces.
+func planSchemaBounds(t *testing.T) map[string]int {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join("migrations", "core", "*.up.sql"))
+	if err != nil {
+		t.Fatalf("listing migrations: %v", err)
+	}
+	sortStrings(files)
+	out := map[string]int{}
+	for _, file := range files {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "weekly_plan") {
+			continue
+		}
+		for _, m := range planBoundCheck.FindAllStringSubmatch(text, -1) {
+			n, err := strconv.Atoi(m[2])
+			if err != nil {
+				t.Fatalf("%s: bound %q is not a number: %v", file, m[2], err)
+			}
+			out[m[1]] = n
+		}
+		// A later migration that DROPS a bound retires it here too. Without
+		// this the map keeps the historical number and the gate goes on
+		// asserting a ceiling the database no longer enforces — a pass that
+		// describes a schema that no longer exists.
+		for _, m := range planBoundDrop.FindAllStringSubmatch(text, -1) {
+			delete(out, boundedColumnOf(m[1]))
+		}
+	}
+	return out
+}
+
+// boundedColumnOf reads the column out of a bound constraint's name.
+//
+// The tree names them `<table>_<column>_bound(ed)`, so the column is what is
+// left once the table prefix and the suffix are stripped. Derived rather than
+// mapped: a constraint this gate could not attribute would silently survive a
+// drop.
+func boundedColumnOf(constraint string) string {
+	name := strings.TrimPrefix(constraint, "weekly_plan_commitment_")
+	name = strings.TrimPrefix(name, "weekly_plan_")
+	name = strings.TrimSuffix(name, "_bounded")
+	return strings.TrimSuffix(name, "_bound")
+}
+
+func planModuleFiles(t *testing.T) []string {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join("internal", "modules", "weeklyplan", "*.go"))
+	if err != nil {
+		t.Fatalf("listing the weeklyplan module: %v", err)
+	}
+	return files
+}

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -636,5 +636,6 @@ var agentPolicies = map[string]agentPolicy{
 	"PUT /v1/weekly-plans/commitments/{id}/help":                         {Op: "askForWeeklyPlanHelp", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/weekly-plans/commitments/{id}/response":                     {Op: "answerWeeklyPlanCommitment", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/weekly-plans/commitments/{id}/state":                        {Op: "setWeeklyPlanCommitmentState", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"PUT /v1/weekly-plans/current/contract":                              {Op: "setWeeklyPlanContract", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PUT /v1/worklist/pins":                                              {Op: "pinWorklistRow", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 }

--- a/backend/internal/compose/integration/weeklyplancontract_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplancontract_integration_test.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration_test
+
+// What the rep says about the week ahead, over real migrated Postgres.
+//
+// The three things a unit test cannot see: the write leaves an audit row and an
+// event behind, a closed week refuses the write, and the capacity line counts
+// only the meetings that are actually next week's.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/weeklyplan"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+func ptr(s string) *string { return &s }
+
+// THE WRITE SHAPE. Domain row, audit row and event in ONE transaction — the
+// obligation every mutation in this tree carries, and a plan's prose is a
+// mutation like any other.
+func TestRisksAndCapacityNoteAreAuditedAndEmitted(t *testing.T) {
+	e := setupPlan(t)
+
+	plan, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: ptr("Two people out; the Nordwind renewal has no sponsor"),
+		SetCapacityNote: true, CapacityNote: ptr("Conference Thursday and Friday"),
+	})
+	if err != nil {
+		t.Fatalf("writing the contract: %v", err)
+	}
+	if plan.Risks == nil || plan.CapacityNote == nil {
+		t.Fatalf("the plan must carry what was just written, got %+v", plan)
+	}
+
+	var audits, events int
+	if err := database.WithWorkspaceTx(e.rep1Ctx, e.Pool, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(e.rep1Ctx, `
+			SELECT count(*) FROM audit_log
+			 WHERE entity_type = 'weekly_plan' AND entity_id = $1
+			   AND action = 'update'
+			   AND after->>'risks' IS NOT NULL`, plan.ID).Scan(&audits); err != nil {
+			return err
+		}
+		// The event's TYPE and its changed-field list, not merely that a row
+		// exists: a consumer filters on both, and an event naming the wrong
+		// field reaches nobody who is listening for this change.
+		return tx.QueryRow(e.rep1Ctx, `
+			SELECT count(*) FROM event_outbox
+			 WHERE envelope->>'type' = 'weekly_plan.updated'
+			   AND envelope->'payload'->>'plan_id' = $1::text
+			   AND envelope->'payload'->'changed_fields' ? 'contract'`,
+			plan.ID).Scan(&events)
+	}); err != nil {
+		t.Fatalf("reading the trail: %v", err)
+	}
+	if audits == 0 {
+		t.Error("the contract write left no audit row naming the risks it stored")
+	}
+	if events == 0 {
+		t.Error("the contract write left no event, so no consumer learns the plan changed")
+	}
+}
+
+// A CLOSED WEEK IS HISTORY. Its counts are frozen into a review that has been
+// read; a plan that kept accepting prose would let a rep rewrite what their
+// lead already saw.
+func TestAClosedWeeksContractCannotBeRewritten(t *testing.T) {
+	e := setupPlan(t)
+
+	if _, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{SetRisks: true, Risks: ptr("As planned"), SetCapacityNote: true, CapacityNote: nil}); err != nil {
+		t.Fatalf("writing the contract while the week is open: %v", err)
+	}
+	// Closing runs the week on, exactly as the weekly job does.
+	if _, err := e.store.CloseWeek(e.rep1Ctx, planClock.AddDate(0, 0, 7)); err != nil {
+		t.Fatalf("closing the week: %v", err)
+	}
+
+	_, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{SetRisks: true, Risks: ptr("Rewritten after the fact"), SetCapacityNote: true, CapacityNote: nil})
+	var parse *values.ParseError
+	if !errors.As(err, &parse) || parse.Code != "week_closed" {
+		t.Fatalf("rewriting a closed week got %v, wanted a week_closed refusal", err)
+	}
+}
+
+// AN ABSENT SEAM IS UNKNOWN, NEVER ZERO. An installation that composed no
+// calendar has not looked at next week; reporting "nothing booked" would tell a
+// rep their week is free on the strength of a missing integration.
+func TestAnAbsentCapacitySeamLeavesCapacityAbsentNotZero(t *testing.T) {
+	e := setupPlan(t)
+	// setupPlan builds the store WITHOUT WithCapacity, which is the state under
+	// test: no calendar reader composed.
+	if _, err := e.store.StartWeek(e.rep1Ctx, planClock); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := e.store.Current(e.rep1Ctx, planClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Capacity != nil {
+		t.Fatalf("no capacity seam composed must read as unknown, got %+v", plan.Capacity)
+	}
+}
+
+// stubCapacity answers a fixed load, so the test above and this one differ in
+// exactly one thing: whether a reader is composed at all.
+type stubCapacity struct{ committed weeklyplan.Committed }
+
+func (s stubCapacity) NextWeek(_ context.Context, _ ids.UUID, _ time.Time) (weeklyplan.Committed, error) {
+	return s.committed, nil
+}
+
+// A COMPOSED SEAM IS A FIGURE, including a real zero. The mirror of the case
+// above: a rep whose next week is genuinely empty gets 0, and that 0 is a fact
+// about their calendar rather than about the installation.
+func TestAComposedCapacitySeamReportsEvenAnEmptyWeek(t *testing.T) {
+	e := setupPlan(t)
+	e.store = e.store.WithCapacity(stubCapacity{})
+	if _, err := e.store.StartWeek(e.rep1Ctx, planClock); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := e.store.Current(e.rep1Ctx, planClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Capacity == nil {
+		t.Fatal("a composed seam answers a figure, even when the week is empty")
+	}
+	if plan.Capacity.Meetings != 0 || plan.Capacity.Tasks != 0 {
+		t.Fatalf("the stub reports an empty week, got %+v", plan.Capacity)
+	}
+}
+
+// AN OMITTED FIELD IS NOT A CLEARED ONE. A client sending only `risks` must not
+// silently erase a capacity note somebody wrote — the two halves travel
+// together and each keeps its own state.
+func TestWritingOneHalfOfTheContractLeavesTheOtherAlone(t *testing.T) {
+	e := setupPlan(t)
+	if _, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: ptr("Sponsor risk"),
+		SetCapacityNote: true, CapacityNote: ptr("Conference Thursday"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Only the risks half is SET. The capacity note is left unsent, and the
+	// store resolves it from the row under its own lock — which is the whole
+	// point: passing the value read a moment ago would race a concurrent save.
+	plan, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: ptr("Sponsor risk, now escalated"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.CapacityNote == nil || *plan.CapacityNote != "Conference Thursday" {
+		t.Fatalf("the untouched half must stand, got %v", plan.CapacityNote)
+	}
+}
+
+// CLEARED IS NOT UNWRITTEN. A rep who empties the field has said there is
+// nothing to name; one who never wrote has said nothing. Both reach the
+// surface, so both must survive a round trip.
+func TestAClearedRiskIsTellableFromOneNeverWritten(t *testing.T) {
+	e := setupPlan(t)
+	if _, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{SetRisks: true, Risks: ptr("Something"), SetCapacityNote: true, CapacityNote: nil}); err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{SetRisks: true, Risks: ptr(""), SetCapacityNote: true, CapacityNote: nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared.Risks == nil {
+		t.Fatal("an emptied field is present and empty, not absent")
+	}
+	if *cleared.Risks != "" {
+		t.Fatalf("wanted an empty string, got %q", *cleared.Risks)
+	}
+	unset, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{SetRisks: true, Risks: nil, SetCapacityNote: true, CapacityNote: nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unset.Risks != nil {
+		t.Fatalf("a nil clears the column back to unwritten, got %q", *unset.Risks)
+	}
+}
+
+// A SUCCESSFUL SAVE ANSWERS WITH THE CAPACITY A READ WOULD GIVE. The plan's own
+// tables do not carry it — the seam does — so a write that returned only what
+// readPlan knows would tell a client "no calendar composed" moments after a GET
+// told it otherwise.
+func TestASavedContractStillCarriesTheCountedCapacity(t *testing.T) {
+	e := setupPlan(t)
+	e.store = e.store.WithCapacity(stubCapacity{
+		committed: weeklyplan.Committed{Meetings: 3, Tasks: 2},
+	})
+
+	plan, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: ptr("Sponsor risk"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Capacity == nil {
+		t.Fatal("a save must answer with the capacity a read would give, not omit it")
+	}
+	if plan.Capacity.Meetings != 3 || plan.Capacity.Tasks != 2 {
+		t.Fatalf("wanted the composed figure back, got %+v", plan.Capacity)
+	}
+}
+
+// PROSE IS BOUNDED IN CHARACTERS, NOT BYTES. The refusal says "characters" and
+// the column's CHECK counts characters, so a note in German or Vietnamese must
+// not hit a ceiling the same length in English clears.
+func TestProseIsBoundedInCharactersSoAccentsDoNotCostDouble(t *testing.T) {
+	e := setupPlan(t)
+	// 1500 accented characters — well inside 2000 — but 3000 BYTES.
+	long := strings.Repeat("é", 1500)
+
+	plan, err := e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: &long,
+	})
+	if err != nil {
+		t.Fatalf("1500 characters is inside the 2000-character bound: %v", err)
+	}
+	if plan.Risks == nil || utf8.RuneCountInString(*plan.Risks) != 1500 {
+		t.Fatalf("the whole note must be stored, got %d characters",
+			utf8.RuneCountInString(deref(plan.Risks)))
+	}
+
+	// And the bound still bites: 2001 characters is refused.
+	tooLong := strings.Repeat("é", 2001)
+	_, err = e.store.SetContract(e.rep1Ctx, planClock, weeklyplan.ContractEdit{
+		SetRisks: true, Risks: &tooLong,
+	})
+	var parse *values.ParseError
+	if !errors.As(err, &parse) || parse.Code != "too_long" {
+		t.Fatalf("2001 characters must be refused as too_long, got %v", err)
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -2371,6 +2371,10 @@ func (stubs) StartWeeklyPlan(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "StartWeeklyPlan")
 }
 
+func (stubs) SetWeeklyPlanContract(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "SetWeeklyPlanContract")
+}
+
 func (stubs) GetTeammateWeeklyPlan(w nethttp.ResponseWriter, r *nethttp.Request, ownerId openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "GetTeammateWeeklyPlan")
 }

--- a/backend/internal/compose/weeklyplancapacity_integration_test.go
+++ b/backend/internal/compose/weeklyplancapacity_integration_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What next week already holds, over real migrated Postgres.
+//
+// The window is the whole subject. A capacity line that counted this week, or a
+// fixed 168 hours, or a meeting somebody has already held would each be a
+// plausible number that answers a different question than the one a rep is
+// asking on a Monday — and none of them is visible without a database that
+// knows the installation's reporting zone.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// capacityClock is a Wednesday, so "next week" is unambiguous and is not the
+// week the fixture's own writes land in.
+var capacityClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+
+// THE WINDOW IS NEXT WEEK'S, AND ONLY BOOKED COUNTS.
+//
+// Three meetings, one in each of the weeks either side and one inside. Plus a
+// held meeting inside the window, which must not count: the week has not
+// happened, so a meeting with an outcome there is one somebody backdated, and
+// counting it would inflate a figure a rep plans against.
+func TestCapacityCountsOnlyBookedMeetingsInNextWeeksLocalWindow(t *testing.T) {
+	e := integration.Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+
+	// capacityClock is Wednesday 10 June 2026; this week's Monday is the 8th,
+	// so next week runs Monday 15 June to Sunday 21 June inclusive.
+	// TWO in this week, so the count differs between the two windows. With one
+	// in each, a seam reading the wrong week answers 1 either way and the
+	// assertion cannot tell them apart — which is exactly how this test first
+	// passed with the window shifted a week off.
+	bookMeeting(t, e, "This week — too early", capacityClock.AddDate(0, 0, 1), "booked")
+	bookMeeting(t, e, "This week — also too early", capacityClock.AddDate(0, 0, 2), "booked")
+	bookMeeting(t, e, "Next week — counts", time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC), "booked")
+	bookMeeting(t, e, "Next week but held", time.Date(2026, 6, 17, 10, 0, 0, 0, time.UTC), "held")
+	bookMeeting(t, e, "The week after — too late", time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC), "booked")
+
+	// The shared bookMeeting helper logs as the ADMIN, so the meetings above are
+	// attributed to them; asking about Rep1 would count a week nobody booked
+	// and pass at zero whatever the window did.
+	seam := weeklyPlanCapacity{pool: e.Pool}
+	got, err := seam.NextWeek(rep, e.AdminUser, capacityClock)
+	if err != nil {
+		t.Fatalf("reading next week's capacity: %v", err)
+	}
+	if got.Meetings != 1 {
+		t.Fatalf("one booked meeting falls in next week, got %d", got.Meetings)
+	}
+}

--- a/backend/internal/compose/weeklyplanseam.go
+++ b/backend/internal/compose/weeklyplanseam.go
@@ -12,12 +12,17 @@ package compose
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgxpool"
+	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/weeklyplan"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 type weeklyPlanOutcome struct{ store *weeklyplan.Store }
@@ -38,5 +43,71 @@ func (o weeklyPlanOutcome) CloseWeek(ctx context.Context, now time.Time) (int, i
 // about the same seven days, and compose/weekly owns that answer. A module may
 // not import compose, so it takes the function.
 func weeklyPlanStore(pool *pgxpool.Pool) *weeklyplan.Store {
-	return weeklyplan.NewStore(InstallationDB(pool), weekly.WeekStartOf, newTeammatesSeam(pool))
+	return weeklyplan.NewStore(InstallationDB(pool), weekly.WeekStartOf, newTeammatesSeam(pool)).
+		WithCapacity(weeklyPlanCapacity{pool: pool})
+}
+
+// weeklyPlanCapacity counts what next week already holds for one rep.
+//
+// It lives here because the meetings and the tasks belong to other modules and
+// weeklyplan may not read their tables. Two counts across the seam, and the
+// plan's own rows stay the plan's business — the same trade weeklyPlanOutcome
+// above makes in the other direction.
+type weeklyPlanCapacity struct{ pool *pgxpool.Pool }
+
+var _ weeklyplan.Capacity = weeklyPlanCapacity{}
+
+// NextWeek counts booked meetings and open tasks due in NEXT week's local
+// window — the week the plan being written is about, not the one being lived.
+//
+// Booked only, never held: this is a question about a week that has not
+// happened, so a meeting's outcome cannot be known and `held` there would mean
+// somebody backdated it. Canceled and no_show are absent for the same reason.
+//
+// The window is the LOCAL week resolved to instants, through weekly's own
+// WeekStartOf, so the plan and the review beside it agree about which seven
+// days these are.
+func (c weeklyPlanCapacity) NextWeek(
+	ctx context.Context, owner ids.UUID, now time.Time,
+) (weeklyplan.Committed, error) {
+	var out weeklyplan.Committed
+	err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+		thisWeek, err := weekly.WeekStartOf(ctx, tx, now)
+		if err != nil {
+			return err
+		}
+		zone, err := identity.TimezoneOf(ctx, tx)
+		if err != nil {
+			return err
+		}
+		nextWeek := thisWeek.AddDate(0, 0, 7)
+		// A calendar date carried as midnight UTC is the wrong shape for a
+		// range: comparing timestamptz against it measures a week offset by the
+		// installation's UTC offset, and across a DST change a fixed 168 hours
+		// rather than the week people will live.
+		var start, end time.Time
+		if err := tx.QueryRow(ctx, `
+			SELECT ($1::date)::timestamp AT TIME ZONE $2,
+			       ($1::date + 7)::timestamp AT TIME ZONE $2`, nextWeek, zone).
+			Scan(&start, &end); err != nil {
+			return fmt.Errorf("compose: bounding next week: %w", err)
+		}
+		return tx.QueryRow(ctx, `
+			SELECT
+			  (SELECT count(*) FROM activity m
+			    WHERE m.kind = 'meeting' AND m.archived_at IS NULL
+			      AND m.meeting_status = 'booked'
+			      AND m.captured_by = $3
+			      AND m.occurred_at >= $1 AND m.occurred_at < $2),
+			  (SELECT count(*) FROM activity t
+			    WHERE t.kind = 'task' AND t.archived_at IS NULL
+			      AND NOT t.is_done AND t.assignee_id = $4
+			      AND t.due_at >= $1 AND t.due_at < $2)`,
+			start, end, "human:"+owner.String(), owner).
+			Scan(&out.Meetings, &out.Tasks)
+	})
+	if err != nil {
+		return weeklyplan.Committed{}, err
+	}
+	return out, nil
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -34058,11 +34058,32 @@ type WebhookSubscriptionListResponse struct {
 // WeeklyPlan One rep's week as they meant it to go — the forward counterpart to the frozen
 // WeeklyReview beside it.
 type WeeklyPlan struct {
-	Commitments []WeeklyPlanCommitment `json:"commitments"`
-	Id          openapi_types.UUID     `json:"id"`
+	// Capacity What next week's calendar already holds, counted rather than authored.
+	//
+	// ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
+	// week nobody has looked at is unknown, and drawing it as "nothing booked" would
+	// tell a rep their week is free on the strength of a missing integration.
+	Capacity *WeeklyPlanCapacity `json:"capacity,omitempty"`
+
+	// CapacityNote What the rep says about the room they have — "two days at the conference" — which
+	// is the half of capacity no query can know. It stands beside `capacity`, which is
+	// counted, and never replaces it.
+	//
+	// Null and empty carry the same distinction as `risks`.
+	CapacityNote *string                `json:"capacity_note,omitempty"`
+	Commitments  []WeeklyPlanCommitment `json:"commitments"`
+	Id           openapi_types.UUID     `json:"id"`
 
 	// LocalWeekStart The Monday of the week planned, in the installation reporting timezone.
 	LocalWeekStart openapi_types.Date `json:"local_week_start"`
+
+	// Risks What the rep expects to get in the way this week, in their own words.
+	//
+	// NULL and the empty string are different answers and a reader must draw them
+	// differently: null is a rep who has written nothing, and "" is one who looked and
+	// says there is nothing to name. Folding the two would report an unconsidered week
+	// as a safe one.
+	Risks *string `json:"risks,omitempty"`
 
 	// Status `closed` once the weekly job has settled the week and frozen its outcome into the
 	// review. A closed plan stops accepting edits, which is what keeps the review's
@@ -34074,6 +34095,17 @@ type WeeklyPlan struct {
 // review. A closed plan stops accepting edits, which is what keeps the review's
 // counts true.
 type WeeklyPlanStatus string
+
+// WeeklyPlanCapacity How much of the coming week is already spoken for.
+type WeeklyPlanCapacity struct {
+	// Meetings Meetings BOOKED in next week's local window. Booked and not held: the week has not
+	// happened, so a meeting there has no outcome yet, and counting `held` would only
+	// find rows somebody backdated.
+	Meetings int `json:"meetings"`
+
+	// Tasks Open tasks assigned to the rep and due inside next week's local window.
+	Tasks int `json:"tasks"`
+}
 
 // WeeklyPlanCommitment One thing a rep said they would do this week.
 type WeeklyPlanCommitment struct {
@@ -40296,6 +40328,12 @@ type SetWeeklyPlanCommitmentStateJSONBody struct {
 // SetWeeklyPlanCommitmentStateJSONBodyState defines parameters for SetWeeklyPlanCommitmentState.
 type SetWeeklyPlanCommitmentStateJSONBodyState string
 
+// SetWeeklyPlanContractJSONBody defines parameters for SetWeeklyPlanContract.
+type SetWeeklyPlanContractJSONBody struct {
+	CapacityNote *string `json:"capacity_note,omitempty"`
+	Risks        *string `json:"risks,omitempty"`
+}
+
 // GetLatestWeeklyReviewParams defines parameters for GetLatestWeeklyReview.
 type GetLatestWeeklyReviewParams struct {
 	// Week The Monday of the week to open, in the installation reporting timezone. Omitted serves the most recent.
@@ -41172,6 +41210,9 @@ type AnswerWeeklyPlanCommitmentJSONRequestBody AnswerWeeklyPlanCommitmentJSONBod
 
 // SetWeeklyPlanCommitmentStateJSONRequestBody defines body for SetWeeklyPlanCommitmentState for application/json ContentType.
 type SetWeeklyPlanCommitmentStateJSONRequestBody SetWeeklyPlanCommitmentStateJSONBody
+
+// SetWeeklyPlanContractJSONRequestBody defines body for SetWeeklyPlanContract for application/json ContentType.
+type SetWeeklyPlanContractJSONRequestBody SetWeeklyPlanContractJSONBody
 
 // PinWorklistRowJSONRequestBody defines body for PinWorklistRow for application/json ContentType.
 type PinWorklistRowJSONRequestBody = WorklistPinRequest
@@ -50742,6 +50783,9 @@ type ServerInterface interface {
 	// Open a plan for this week.
 	// (POST /weekly-plans/current)
 	StartWeeklyPlan(w http.ResponseWriter, r *http.Request)
+	// Say what could go wrong this week, and what room there is for it.
+	// (PUT /weekly-plans/current/contract)
+	SetWeeklyPlanContract(w http.ResponseWriter, r *http.Request)
 	// A teammate's plan for this week, for their lead.
 	// (GET /weekly-plans/{owner_id}/current)
 	GetTeammateWeeklyPlan(w http.ResponseWriter, r *http.Request, ownerId openapi_types.UUID)
@@ -54303,6 +54347,12 @@ func (_ Unimplemented) GetCurrentWeeklyPlan(w http.ResponseWriter, r *http.Reque
 // Open a plan for this week.
 // (POST /weekly-plans/current)
 func (_ Unimplemented) StartWeeklyPlan(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Say what could go wrong this week, and what room there is for it.
+// (PUT /weekly-plans/current/contract)
+func (_ Unimplemented) SetWeeklyPlanContract(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -79440,6 +79490,28 @@ func (siw *ServerInterfaceWrapper) StartWeeklyPlan(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// SetWeeklyPlanContract operation middleware
+func (siw *ServerInterfaceWrapper) SetWeeklyPlanContract(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetWeeklyPlanContract(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetTeammateWeeklyPlan operation middleware
 func (siw *ServerInterfaceWrapper) GetTeammateWeeklyPlan(w http.ResponseWriter, r *http.Request) {
 
@@ -81758,6 +81830,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/weekly-plans/current", wrapper.StartWeeklyPlan)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/weekly-plans/current/contract", wrapper.SetWeeklyPlanContract)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/weekly-plans/{owner_id}/current", wrapper.GetTeammateWeeklyPlan)

--- a/backend/internal/modules/weeklyplan/closeweek.go
+++ b/backend/internal/modules/weeklyplan/closeweek.go
@@ -73,7 +73,7 @@ func (s *Store) CloseWeek(ctx context.Context, now time.Time) (Outcome, error) {
 		if err != nil {
 			return err
 		}
-		if plan.Status != "open" {
+		if plan.Status != PlanOpen {
 			// The STAMPED answer, not a fresh count. A commitment that moved
 			// after the first close — a late-landing write, a repair — must not
 			// change what the review already froze.

--- a/backend/internal/modules/weeklyplan/contract.go
+++ b/backend/internal/modules/weeklyplan/contract.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weeklyplan
+
+// What the rep expects to get in the way, and what they say about their room.
+//
+// The commitments beside these say what the week is FOR. These say what it is
+// up against, and they are the half a lead actually reads: five commitments
+// with no room to do them is a plan that has already failed, and nobody has
+// said so out loud.
+//
+// Plan-level rather than per-commitment, which is why this is not AskForHelp.
+// That asks for help with ONE thing; this is the shape of the whole week, and a
+// risk that belongs to no single commitment has nowhere else to live.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// The two columns this write owns, and the field name its event reports.
+const (
+	fieldRisks        = "risks"
+	fieldCapacityNote = "capacity_note"
+
+	// changedContract is what a consumer filters on to see either half move.
+	// One name for both, because they are written together and a reader of the
+	// week wants to know the rep restated it, not which column moved.
+	changedContract = "contract"
+)
+
+// SetContract records what the rep says about the week ahead.
+//
+// Both fields travel together and either may be nil, which is what makes
+// "unset" reachable: a nil clears the column back to NULL, and NULL is the rep
+// having said nothing. An empty string is a different statement — they looked,
+// and there is nothing to name — so the two are not folded here.
+//
+// A CLOSED WEEK IS REFUSED, through the same door every other write uses. Its
+// counts are frozen into a review, and a plan that kept accepting prose after
+// the retrospective quoted it would let a rep rewrite what their lead already
+// read.
+func (s *Store) SetContract(ctx context.Context, now time.Time, in ContractEdit) (Plan, error) {
+	if err := auth.Require(ctx, "weekly_plan", principal.ActionUpdate); err != nil {
+		return Plan{}, err
+	}
+	// Bounded at the seam so the client gets a named field back rather than a
+	// constraint violation. The column carries the same ceiling, and
+	// TestEveryPlanProseColumnMatchesItsGoBound fails if the two drift.
+	risks, err := boundedOptional(fieldRisks, in.Risks)
+	if err != nil {
+		return Plan{}, err
+	}
+	capacityNote, err := boundedOptional(fieldCapacityNote, in.CapacityNote)
+	if err != nil {
+		return Plan{}, err
+	}
+	owner, err := planUser(ctx)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	var out Plan
+	err = database.WithWorkspaceTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
+		// Opens the week if the rep has not started one. Writing their risks IS
+		// starting to plan, and refusing until they have added a commitment
+		// would make the first thing they type the one thing they cannot save.
+		plan, err := s.openPlanTx(ctx, tx, owner, now)
+		if err != nil {
+			return err
+		}
+		lock, err := storekit.LockRow(ctx, tx, "weekly_plan", plan.ID, storekit.NoArchiveColumn)
+		if err != nil {
+			return err
+		}
+		storedRisks, storedNote, err := contractUnderLock(ctx, tx, plan.ID)
+		if err != nil {
+			return err
+		}
+		patch := storekit.NewPatch()
+		// An UNSENT half keeps what is stored, resolved from the row this
+		// transaction holds rather than from one read before the lock.
+		if in.SetRisks {
+			patch.Set(fieldRisks, storedRisks, risks)
+		}
+		if in.SetCapacityNote {
+			patch.Set(fieldCapacityNote, storedNote, capacityNote)
+		}
+		if err := patch.ApplyLocked(ctx, tx, lock); err != nil {
+			return err
+		}
+		auditID, err := storekit.Audit(ctx, tx, "update", "weekly_plan", plan.ID,
+			patch.Before(), patch.After())
+		if err != nil {
+			return err
+		}
+		if err := storekit.EmitEvent(ctx, tx, auditID, owner,
+			crmcontracts.PublicEventWeeklyPlanUpdated{
+				PlanId: openapi_types.UUID(plan.ID), OwnerUserId: openapi_types.UUID(owner),
+				ChangedFields: []string{changedContract},
+			}); err != nil {
+			return err
+		}
+		out, err = readPlan(ctx, tx, owner, plan.LocalWeekStart)
+		return err
+	})
+	if err != nil {
+		return Plan{}, err
+	}
+	// The counted capacity, which readPlan does not carry: it reads the plan's
+	// own tables and the seam reads other modules'. Without this a successful
+	// save answers with no capacity at all, which a client reads as "no
+	// calendar composed" moments after a GET told it otherwise.
+	out.Capacity, err = s.capacityFor(ctx, owner, now)
+	if err != nil {
+		return Plan{}, err
+	}
+	return out, nil
+}
+
+// contractUnderLock re-reads what the write depends on, holding the row lock.
+//
+// openPlanTx read the row BEFORE the lock, so both the status and the current
+// text were a snapshot somebody else could have moved. Two things go wrong if
+// the write trusts it:
+//
+//   - the week can close in between (a request spanning the Monday rollover),
+//     and a plan whose counts are frozen into a review must refuse the write
+//     rather than rewrite what a lead has already read;
+//   - two saves each touching one half would both read the old values, and the
+//     second would write back the first's field as it was before, silently
+//     undoing a save that reported success.
+func contractUnderLock(
+	ctx context.Context, tx pgx.Tx, planID ids.UUID,
+) (risks, capacityNote *string, err error) {
+	var status string
+	if err := tx.QueryRow(ctx, `
+		SELECT status, risks, capacity_note FROM weekly_plan WHERE id = $1`,
+		planID).Scan(&status, &risks, &capacityNote); err != nil {
+		return nil, nil, fmt.Errorf("weeklyplan: re-reading the plan under lock: %w", err)
+	}
+	if status != PlanOpen {
+		return nil, nil, &values.ParseError{
+			Field: fieldWeek, Code: codeWeekClosed,
+			Message: "that week is closed; plan the current one",
+		}
+	}
+	return risks, capacityNote, nil
+}
+
+// ContractEdit says which halves of the contract this write touches.
+//
+// A bare pair of pointers cannot: nil would have to mean both "clear this
+// field" and "leave it alone", and those are opposite instructions. The
+// Set… flags carry the distinction the wire already draws between an omitted
+// key and an explicit null.
+type ContractEdit struct {
+	SetRisks bool
+	Risks    *string
+
+	SetCapacityNote bool
+	CapacityNote    *string
+}
+
+// boundedOptional trims and bounds a field that may be absent.
+//
+// It keeps nil as nil rather than folding it to "", because the two are
+// different answers: nobody has written this, versus the rep says there is
+// nothing to write.
+func boundedOptional(field string, value *string) (*string, error) {
+	if value == nil {
+		return nil, nil //nolint:nilnil // an absent field IS the answer here: nil means the rep left it alone, which is not an empty string.
+	}
+	text, err := bounded(field, *value, proseBound)
+	if err != nil {
+		return nil, err
+	}
+	return &text, nil
+}
+
+// Capacity is what next week's calendar already holds.
+//
+// A SEAM rather than a query, because the meetings and tasks it counts belong
+// to other modules and this one may not read their tables. compose binds it.
+//
+// Absent — a nil Capacity on the plan — is not zero. An installation that
+// composed no calendar has an UNKNOWN week ahead, and drawing that as "no
+// meetings booked" would tell a rep their week is free when nothing has looked.
+type Capacity interface {
+	// NextWeek reports how much of the coming week is already committed, for
+	// the given rep, in the installation's reporting zone.
+	NextWeek(ctx context.Context, owner ids.UUID, now time.Time) (Committed, error)
+}
+
+// Committed is the count behind the capacity line.
+//
+// Two figures and not one: a week of six meetings reads differently from a week
+// of six overdue tasks, and a single "commitments" total would hide which.
+type Committed struct {
+	Meetings int
+	Tasks    int
+}
+
+// WithCapacity binds the reader behind the plan's capacity line.
+//
+// Called inside compose's weeklyPlanStore rather than at a call site, because
+// that constructor has more than one caller: an option applied at one of them
+// would give the handlers a capacity reader and leave the weekly job's store
+// without one, and the difference would show as a capacity line that is present
+// on the page and absent in the mail.
+func (s *Store) WithCapacity(c Capacity) *Store {
+	s.capacity = c
+	return s
+}
+
+// capacityFor reads next week's load, or reports it unknown.
+//
+// An unbound seam answers nil, and every caller must carry that through as
+// absent. This is the one place that decides it, so a surface cannot
+// accidentally substitute a zero.
+func (s *Store) capacityFor(ctx context.Context, owner ids.UUID, now time.Time) (*Committed, error) {
+	if s.capacity == nil {
+		//nolint:nilnil // no capacity seam composed means the week ahead is UNKNOWN, which a zero would misreport as free.
+		return nil, nil
+	}
+	committed, err := s.capacity.NextWeek(ctx, owner, now)
+	if err != nil {
+		return nil, fmt.Errorf("weeklyplan: reading next week's capacity: %w", err)
+	}
+	return &committed, nil
+}

--- a/backend/internal/modules/weeklyplan/handlers.go
+++ b/backend/internal/modules/weeklyplan/handlers.go
@@ -253,12 +253,22 @@ func planToWire(plan Plan) crmcontracts.WeeklyPlan {
 	for _, c := range plan.Commitments {
 		commitments = append(commitments, commitmentToWire(c))
 	}
-	return crmcontracts.WeeklyPlan{
+	out := crmcontracts.WeeklyPlan{
 		Id:             openapi_types.UUID(plan.ID),
 		LocalWeekStart: openapi_types.Date{Time: plan.LocalWeekStart},
 		Status:         crmcontracts.WeeklyPlanStatus(plan.Status),
 		Commitments:    commitments,
+		Risks:          plan.Risks,
+		CapacityNote:   plan.CapacityNote,
 	}
+	// Absent when no calendar reader is composed. Sending zeros instead would
+	// tell a rep their week is free on the strength of a missing integration.
+	if c := plan.Capacity; c != nil {
+		out.Capacity = &crmcontracts.WeeklyPlanCapacity{
+			Meetings: c.Meetings, Tasks: c.Tasks,
+		}
+	}
+	return out
 }
 
 // commitmentToWire puts one commitment on the contract's shape.
@@ -299,4 +309,58 @@ func nullableText(value string) *string {
 		return nil
 	}
 	return &value
+}
+
+// SetWeeklyPlanContract records what the rep says about the week ahead.
+//
+// The body distinguishes THREE states per field, which a *string cannot: absent
+// (leave it alone), explicit null (clear it back to unwritten), and a string
+// (set it). Decoded as RawMessage for exactly that reason — a plain pointer
+// reads an omitted field and a JSON null identically as nil, and the two mean
+// opposite things here.
+func (h Handlers) SetWeeklyPlanContract(w http.ResponseWriter, r *http.Request) {
+	var body map[string]json.RawMessage
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	edit := ContractEdit{}
+	var err error
+	if edit.SetRisks, edit.Risks, err = contractField(body, fieldRisks); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	if edit.SetCapacityNote, edit.CapacityNote, err = contractField(body, fieldCapacityNote); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	plan, err := h.store.SetContract(r.Context(), h.now(), edit)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, planToWire(plan))
+}
+
+// contractField reads one half of the contract body.
+//
+// It reports whether the key was SENT at all, separately from its value. An
+// absent key leaves that half alone — resolved by the store under its row lock,
+// never here, because a value read before the lock is one another request can
+// have moved. An explicit null clears; anything else must be a string.
+func contractField(body map[string]json.RawMessage, field string) (bool, *string, error) {
+	raw, sent := body[field]
+	if !sent {
+		return false, nil, nil
+	}
+	if string(raw) == "null" {
+		return true, nil, nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return false, nil, &values.ParseError{
+			Field: field, Code: "invalid_type",
+			Message: field + " is a string or null",
+		}
+	}
+	return true, &text, nil
 }

--- a/backend/internal/modules/weeklyplan/settle.go
+++ b/backend/internal/modules/weeklyplan/settle.go
@@ -231,7 +231,7 @@ func ownCommitmentTx(
 		return ids.Nil, Commitment{}, fmt.Errorf("weeklyplan: reading the commitment: %w", err)
 	}
 	// A closed week is frozen into a review that has already been counted.
-	if status != "open" {
+	if status != PlanOpen {
 		return ids.Nil, Commitment{}, &values.ParseError{
 			Field: fieldWeek, Code: codeWeekClosed,
 			Message: "that week is closed and its outcome is recorded",

--- a/backend/internal/modules/weeklyplan/store.go
+++ b/backend/internal/modules/weeklyplan/store.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -49,6 +50,15 @@ const (
 	planCap = 50
 )
 
+// The two states a PLAN moves through — distinct from the commitment states
+// below, which happen to share a spelling for "open" and mean something else:
+// this is whether the week still accepts edits, that is whether one thing on it
+// is still to do.
+const (
+	PlanOpen   = "open"
+	PlanClosed = "closed"
+)
+
 // The states a commitment moves through.
 const (
 	StateOpen    = "open"
@@ -78,6 +88,10 @@ type Store struct {
 	db        *database.DB
 	weekStart WeekStartFunc
 	teammates Teammates
+	// capacity reads what next week already holds. Nil is a real state — an
+	// installation that composed no calendar — and capacityFor is the one
+	// place that turns it into "unknown" rather than zero.
+	capacity Capacity
 }
 
 // NewStore binds the store to db.
@@ -96,6 +110,22 @@ type Plan struct {
 	// Outcome is what the week came to, stamped at close. Nil while the week
 	// is open: there is no outcome yet, and a zero would claim one.
 	Outcome *Outcome
+
+	// What the rep expects to get in the way, and what they say about the room
+	// they have. Both nil until the rep writes them.
+	//
+	// Nil is NOT the empty string: a rep who has written nothing has said
+	// nothing, and one who cleared the field has said there are no risks. A
+	// lead reading "no risks named" against "the rep says there are none" is
+	// reading two different weeks, so the two stay tellable apart all the way
+	// to the surface.
+	Risks        *string
+	CapacityNote *string
+
+	// Capacity is what next week's calendar already holds, counted through the
+	// seam. Nil when no calendar reader is composed — UNKNOWN, not zero, which
+	// is the difference between "nothing is booked" and "nothing has looked".
+	Capacity *Committed
 }
 
 // Commitment is one thing a rep said they would do.
@@ -211,6 +241,17 @@ func (s *Store) planForOwner(ctx context.Context, owner ids.UUID, now time.Time)
 	if err != nil {
 		return Plan{}, err
 	}
+	// Filled HERE because both readers — the rep's own Current and the lead's
+	// PlanFor — come through this one function. Filled at either call site
+	// instead, one surface would draw a capacity line and the other would not.
+	//
+	// Outside the transaction above: the seam reads other modules' tables and
+	// opens its own, and holding this one open across it would make a read of
+	// the plan wait on a read of the calendar.
+	plan.Capacity, err = s.capacityFor(ctx, owner, now)
+	if err != nil {
+		return Plan{}, err
+	}
 	return plan, nil
 }
 
@@ -219,10 +260,12 @@ func readPlan(ctx context.Context, tx pgx.Tx, owner ids.UUID, week time.Time) (P
 	plan := Plan{OwnerID: owner, LocalWeekStart: week}
 	var due, kept *int
 	err := tx.QueryRow(ctx, `
-		SELECT id, local_week_start, status, version, commitments_due, commitments_kept
+		SELECT id, local_week_start, status, version, commitments_due, commitments_kept,
+		       risks, capacity_note
 		  FROM weekly_plan
 		 WHERE owner_id = $1 AND local_week_start = $2`, owner, week).
-		Scan(&plan.ID, &plan.LocalWeekStart, &plan.Status, &plan.Version, &due, &kept)
+		Scan(&plan.ID, &plan.LocalWeekStart, &plan.Status, &plan.Version, &due, &kept,
+			&plan.Risks, &plan.CapacityNote)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Plan{}, apperrors.ErrNotFound
 	}
@@ -272,7 +315,12 @@ func readCommitments(ctx context.Context, tx pgx.Tx, planID ids.UUID) ([]Commitm
 // bounded trims and checks one field a caller supplied.
 func bounded(field, value string, limit int) (string, error) {
 	trimmed := strings.TrimSpace(value)
-	if len(trimmed) > limit {
+	// RUNES, not bytes. The message below promises characters and the column's
+	// CHECK counts characters (Postgres length() does), so len() refused text
+	// both of them accept: 1500 accented characters are 3000 bytes, and a
+	// German or Vietnamese note hit a ceiling an English one of the same length
+	// did not.
+	if utf8.RuneCountInString(trimmed) > limit {
 		return "", &values.ParseError{
 			Field: field, Code: "too_long",
 			Message: fmt.Sprintf("%s is at most %d characters", field, limit),

--- a/backend/internal/modules/weeklyplan/write.go
+++ b/backend/internal/modules/weeklyplan/write.go
@@ -74,7 +74,7 @@ func (s *Store) StartWeek(ctx context.Context, now time.Time) (Plan, error) {
 		}); err != nil {
 			return err
 		}
-		plan = Plan{ID: id, OwnerID: owner, LocalWeekStart: week, Status: "open", Version: 1}
+		plan = Plan{ID: id, OwnerID: owner, LocalWeekStart: week, Status: PlanOpen, Version: 1}
 		return nil
 	})
 	if err != nil {
@@ -195,13 +195,13 @@ func (s *Store) openPlanTx(
 			VALUES ($1, $2, $3) RETURNING id`, owner, week, capturedBy).Scan(&id); err != nil {
 			return Plan{}, fmt.Errorf("weeklyplan: opening the week: %w", err)
 		}
-		return Plan{ID: id, OwnerID: owner, LocalWeekStart: week, Status: "open", Version: 1}, nil
+		return Plan{ID: id, OwnerID: owner, LocalWeekStart: week, Status: PlanOpen, Version: 1}, nil
 	case err != nil:
 		return Plan{}, err
 	}
 	// A closed week is history. Editing it would move counts the review has
 	// already frozen, so the two would disagree about a week that is over.
-	if plan.Status != "open" {
+	if plan.Status != PlanOpen {
 		return Plan{}, &values.ParseError{
 			Field: fieldWeek, Code: codeWeekClosed,
 			Message: "that week is closed; plan the current one",

--- a/backend/migrations/core/1788659340_a_plan_names_its_risks_and_its_room.down.sql
+++ b/backend/migrations/core/1788659340_a_plan_names_its_risks_and_its_room.down.sql
@@ -1,0 +1,9 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE weekly_plan
+    DROP CONSTRAINT IF EXISTS weekly_plan_capacity_note_bounded,
+    DROP CONSTRAINT IF EXISTS weekly_plan_risks_bounded;
+
+ALTER TABLE weekly_plan
+    DROP COLUMN IF EXISTS capacity_note,
+    DROP COLUMN IF EXISTS risks;

--- a/backend/migrations/core/1788659340_a_plan_names_its_risks_and_its_room.up.sql
+++ b/backend/migrations/core/1788659340_a_plan_names_its_risks_and_its_room.up.sql
@@ -1,0 +1,36 @@
+-- What could go wrong with the week, and whether there is room for it.
+--
+-- The plan already carries what a rep MEANS to do. These two say what they
+-- expect to get in the way, and what their calendar leaves them — the half of a
+-- plan a lead actually reads, because a list of five commitments with no room
+-- to do them is a plan that has already failed and nobody has said so.
+--
+-- Both are prose the rep writes, not derived figures. Capacity is COUNTED
+-- elsewhere (booked meetings and tasks due in next week's window, through a
+-- seam) and this column is what the rep says ABOUT that count — "two days at
+-- the conference" is a fact no query has.
+--
+-- Nullable, and NULL is not an empty string: a rep who has not written their
+-- risks has said nothing, and one who cleared the field has said there are
+-- none. The surface draws those differently.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE weekly_plan
+    ADD COLUMN risks text,
+    ADD COLUMN capacity_note text;
+
+-- 2000, the same ceiling every other prose column on a plan carries
+-- (weekly_plan_commitment's help_requested and manager_response) and the same
+-- one weeklyplan.proseBound applies at the seam.
+--
+-- Held HERE as well as in Go because a column with no ceiling is one a second
+-- writer can fill without noticing. The two numbers must agree, and
+-- TestEveryPlanProseColumnMatchesItsGoBound fails in both directions if they
+-- drift.
+ALTER TABLE weekly_plan
+    ADD CONSTRAINT weekly_plan_risks_bounded
+    CHECK (risks IS NULL OR length(risks) <= 2000);
+
+ALTER TABLE weekly_plan
+    ADD CONSTRAINT weekly_plan_capacity_note_bounded
+    CHECK (capacity_note IS NULL OR length(capacity_note) <= 2000);

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (85)
+## Parity (86)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -88,6 +88,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `outboundidentity_test.go` | H1 | A remote operator sees one name for this product and decides about it: blocks it, rate-limits it, allow-lists it, or writes a robots.txt group naming it. |
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `personalpurgewindow_test.go` | H3 | The page that names a deletion date and the sweep that carries it out must read ONE window, or the product promises a date it does not keep. |
+| `planprosebounds_test.go` | H3 | A plan's prose columns are bounded twice, and the two numbers must agree. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
 | `previewauthority_test.go` | H2 | The authority levels a composer can receive are the ones the engine can send. |
 | `processingrecord_test.go` | H3 | The Art. 30 processing record names the code that enforces each entry, and this fails when that code is not there any more. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12277,6 +12277,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/weekly-plans/current/contract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Say what could go wrong this week, and what room there is for it.
+         * @description Both fields are written together and either may be omitted to leave that half alone.
+         *     Sending an explicit `null` CLEARS a field back to unwritten, which is a different
+         *     state from an empty string: cleared means nobody has said, empty means the rep says
+         *     there is nothing to name.
+         *
+         *     Opens the week if the rep has not started one — writing your risks is starting to
+         *     plan, and a rep whose first sentence could not be saved would have to invent a
+         *     commitment before they were allowed to record a worry.
+         *
+         *     A closed week is refused with `week_closed`: its counts are already frozen into the
+         *     review, and a plan that kept accepting prose would let a rep rewrite what their lead
+         *     has read.
+         */
+        put: operations["setWeeklyPlanContract"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/weekly-plans/commitments/{id}/response": {
         parameters: {
             query?: never;
@@ -24948,6 +24979,42 @@ export interface components {
              */
             status: "open" | "closed";
             commitments: components["schemas"]["WeeklyPlanCommitment"][];
+            /**
+             * @description What the rep expects to get in the way this week, in their own words.
+             *
+             *     NULL and the empty string are different answers and a reader must draw them
+             *     differently: null is a rep who has written nothing, and "" is one who looked and
+             *     says there is nothing to name. Folding the two would report an unconsidered week
+             *     as a safe one.
+             */
+            risks?: string | null;
+            /**
+             * @description What the rep says about the room they have — "two days at the conference" — which
+             *     is the half of capacity no query can know. It stands beside `capacity`, which is
+             *     counted, and never replaces it.
+             *
+             *     Null and empty carry the same distinction as `risks`.
+             */
+            capacity_note?: string | null;
+            /**
+             * @description What next week's calendar already holds, counted rather than authored.
+             *
+             *     ABSENT when the installation composed no calendar reader. Absent is NOT zero: a
+             *     week nobody has looked at is unknown, and drawing it as "nothing booked" would
+             *     tell a rep their week is free on the strength of a missing integration.
+             */
+            capacity?: components["schemas"]["WeeklyPlanCapacity"];
+        };
+        /** @description How much of the coming week is already spoken for. */
+        WeeklyPlanCapacity: {
+            /**
+             * @description Meetings BOOKED in next week's local window. Booked and not held: the week has not
+             *     happened, so a meeting there has no outcome yet, and counting `held` would only
+             *     find rows somebody backdated.
+             */
+            meetings: number;
+            /** @description Open tasks assigned to the rep and due inside next week's local window. */
+            tasks: number;
         };
         /** @description One thing a rep said they would do this week. */
         WeeklyPlanCommitment: {
@@ -50855,6 +50922,36 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    setWeeklyPlanContract: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    risks?: string | null;
+                    capacity_note?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description The plan as it now stands. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyPlan"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             422: components["responses"]["ValidationError"];
         };
     };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2665,6 +2665,23 @@ export const de = {
   "plan.state.missed": "Verpasst",
   "plan.state.dropped": "Verworfen",
   "plan.help.label": "Was brauchst du von deiner Führungskraft?",
+  "plan.contract.title": "Wogegen diese Woche antritt",
+  "plan.contract.risks": "Was dazwischenkommen könnte",
+  "plan.contract.risksHint":
+    "Was Sie erwarten, das schiefgeht — in eigenen Worten",
+  "plan.contract.capacityNote": "Ihr Spielraum",
+  "plan.contract.capacityNoteHint":
+    "Was der Kalender nicht weiß — Urlaub, Reisen, ein Launch",
+  "plan.contract.unwritten": "Noch nichts geschrieben",
+  "plan.contract.nothingToName": "Nichts zu nennen",
+  "plan.contract.edit": "Bearbeiten",
+  "plan.contract.save": "Speichern",
+  "plan.contract.cancel": "Abbrechen",
+  "plan.contract.capacityLine":
+    "Nächste Woche hält bereits {meetings} Termine und {tasks} Aufgaben.",
+  "plan.contract.crowded": "Nächste Woche ist schon voll",
+  "plan.contract.crowdedBody":
+    "{committed} Dinge sind bereits gebucht und Sie haben {commitments} Vorhaben notiert. Etwas wird weichen müssen.",
   "plan.help.ask": "Um Hilfe bitten",
   "plan.help.edit": "Anfrage bearbeiten",
   "plan.help.send": "Senden",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2748,6 +2748,25 @@ export const en = {
   "plan.state.missed": "Missed",
   "plan.state.dropped": "Dropped",
   "plan.help.label": "What do you need from your lead?",
+  // What the week is up against, beside what it is for. The two prose fields
+  // draw three states, not two: unwritten, "nothing to name", and text. A lead
+  // who cannot tell the first two apart reads an unconsidered week as a safe one.
+  "plan.contract.title": "What this week is up against",
+  "plan.contract.risks": "What could get in the way",
+  "plan.contract.risksHint": "What you expect to go wrong, in your own words",
+  "plan.contract.capacityNote": "Room you have",
+  "plan.contract.capacityNoteHint":
+    "Anything the calendar does not know — leave, travel, a launch",
+  "plan.contract.unwritten": "Not written yet",
+  "plan.contract.nothingToName": "Nothing to name",
+  "plan.contract.edit": "Edit",
+  "plan.contract.save": "Save",
+  "plan.contract.cancel": "Cancel",
+  "plan.contract.capacityLine":
+    "Next week already holds {meetings} meetings and {tasks} tasks.",
+  "plan.contract.crowded": "Next week is already full",
+  "plan.contract.crowdedBody":
+    "{committed} things are already booked and you have written {commitments} commitments. Something will have to give.",
   "plan.help.ask": "Ask for help",
   "plan.help.edit": "Edit request",
   "plan.help.send": "Send",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2638,6 +2638,22 @@ export const vi = {
   "plan.state.missed": "Bỏ lỡ",
   "plan.state.dropped": "Đã bỏ",
   "plan.help.label": "Bạn cần gì từ quản lý của mình?",
+  "plan.contract.title": "Tuần này đối mặt với điều gì",
+  "plan.contract.risks": "Điều gì có thể cản trở",
+  "plan.contract.risksHint": "Điều bạn dự đoán sẽ trục trặc, theo lời của bạn",
+  "plan.contract.capacityNote": "Khoảng trống bạn có",
+  "plan.contract.capacityNoteHint":
+    "Điều lịch không biết — nghỉ phép, đi công tác, một đợt ra mắt",
+  "plan.contract.unwritten": "Chưa viết",
+  "plan.contract.nothingToName": "Không có gì để nêu",
+  "plan.contract.edit": "Sửa",
+  "plan.contract.save": "Lưu",
+  "plan.contract.cancel": "Hủy",
+  "plan.contract.capacityLine":
+    "Tuần tới đã có {meetings} cuộc họp và {tasks} công việc.",
+  "plan.contract.crowded": "Tuần tới đã kín",
+  "plan.contract.crowdedBody":
+    "{committed} việc đã được đặt và bạn đã ghi {commitments} cam kết. Sẽ phải bỏ bớt điều gì đó.",
   "plan.help.ask": "Nhờ giúp đỡ",
   "plan.help.edit": "Sửa yêu cầu",
   "plan.help.send": "Gửi",

--- a/frontend/src/screens/brief.plan.contract.test.tsx
+++ b/frontend/src/screens/brief.plan.contract.test.tsx
@@ -1,0 +1,125 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { en } from "../i18n/en";
+import { PlanContract } from "./brief.plan.contract";
+import { jsonResponse, render, stubApi, writes } from "./home.testkit";
+import type { WeeklyPlan } from "./weeklyplan.queries";
+
+// The contract's three states are the whole subject. `null` is a rep who has
+// written nothing, `""` is one who looked and says there is nothing to name,
+// and text is text. A surface that folds the first two reports an unconsidered
+// week as a safe one, which is the mistake this panel exists not to make.
+
+afterEach(cleanup);
+
+const basePlan = {
+  id: "11111111-1111-1111-1111-111111111111",
+  local_week_start: "2026-06-15",
+  status: "open",
+  commitments: [],
+} as unknown as WeeklyPlan;
+
+const planWith = (extra: Partial<WeeklyPlan>): WeeklyPlan =>
+  ({ ...basePlan, ...extra }) as WeeklyPlan;
+
+describe("the plan's contract", () => {
+  it("draws nothing at all when there is no plan", () => {
+    const { container } = render(<PlanContract plan={null} editable />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("says a field is unwritten rather than showing it blank", () => {
+    render(<PlanContract plan={planWith({ risks: null })} editable />);
+    expect(
+      screen.getAllByText(en["plan.contract.unwritten"]).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("tells an emptied field from one never written", () => {
+    render(<PlanContract plan={planWith({ risks: "" })} editable />);
+    // The rep looked and said there is nothing. That is a statement about the
+    // week, and it must not read as silence.
+    expect(screen.getByText(en["plan.contract.nothingToName"])).toBeTruthy();
+  });
+
+  it("draws no capacity line when the server sent no capacity", () => {
+    render(<PlanContract plan={planWith({ capacity: undefined })} editable />);
+    // Absent means no calendar reader is composed. A "0 meetings" line here
+    // would tell a rep their week is free because an integration is missing.
+    expect(screen.queryByText(/meetings and/, { exact: false })).toBeNull();
+  });
+
+  it("draws a real zero when the server did count the week", () => {
+    render(
+      <PlanContract
+        plan={planWith({ capacity: { meetings: 0, tasks: 0 } })}
+        editable
+      />,
+    );
+    expect(
+      screen.getByText(
+        en["plan.contract.capacityLine"]
+          .replace("{meetings}", "0")
+          .replace("{tasks}", "0"),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("warns when next week's calendar leaves no room", () => {
+    render(
+      <PlanContract
+        plan={planWith({
+          capacity: { meetings: 7, tasks: 3 },
+          commitments: [],
+        })}
+        editable
+      />,
+    );
+    expect(screen.getByText(en["plan.contract.crowded"])).toBeTruthy();
+  });
+
+  it("does not cry crowded on an ordinary week", () => {
+    render(
+      <PlanContract
+        plan={planWith({ capacity: { meetings: 2, tasks: 1 } })}
+        editable
+      />,
+    );
+    expect(screen.queryByText(en["plan.contract.crowded"])).toBeNull();
+  });
+
+  it("offers no edit control on a week this seat may not write", () => {
+    render(<PlanContract plan={planWith({ risks: null })} editable={false} />);
+    // A control that exists in order to fail is worse than no control.
+    expect(screen.queryByText(en["plan.contract.edit"])).toBeNull();
+  });
+});
+
+describe("what the contract form sends", () => {
+  it("saves only the half being edited, so the other is left alone", async () => {
+    const calls = stubApi({
+      "PUT /weekly-plans/current/contract": () => jsonResponse({}, 200),
+    });
+    render(
+      <PlanContract
+        plan={planWith({ risks: null, capacity_note: "Conference Thursday" })}
+        editable
+      />,
+    );
+    await userEvent.click(screen.getAllByText(en["plan.contract.edit"])[0]);
+    await userEvent.type(screen.getByRole("textbox"), "Sponsor risk");
+    await userEvent.click(screen.getByText(en["plan.contract.save"]));
+
+    const sent = writes(calls).find((c) =>
+      c.path.endsWith("/weekly-plans/current/contract"),
+    );
+    expect(sent).toBeTruthy();
+    // The untouched half must be ABSENT from the body, not sent as the value
+    // this component happened to be holding: the server resolves an omitted
+    // key under its own row lock, and a stale value sent here would undo a
+    // save somebody else made in the meantime.
+    expect(Object.keys(sent?.body ?? {})).toEqual(["risks"]);
+  });
+});

--- a/frontend/src/screens/brief.plan.contract.tsx
+++ b/frontend/src/screens/brief.plan.contract.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useState } from "react";
+import { Button, Field, Textarea } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import { useSetPlanContract, type WeeklyPlan } from "./weeklyplan.queries";
+
+// What could go wrong with the week, and whether there is room for it.
+//
+// The commitments beside this say what the week is FOR. This says what it is up
+// against, and it is the half a lead reads first: five commitments with no room
+// to do them is a plan that has already failed and nobody has said so.
+
+type Capacity = NonNullable<WeeklyPlan["capacity"]>;
+
+// How many commitments a week can hold before the calendar is the problem.
+//
+// Not a server rule and deliberately not presented as one: the line WARNS, it
+// never refuses. A rep who knows their week better than this arithmetic does is
+// right, and a plan that argued with them would be a worse plan.
+const crowdedWeek = 8;
+
+export function PlanContract({
+  plan,
+  editable,
+}: Readonly<{ plan: WeeklyPlan | null | undefined; editable: boolean }>) {
+  const t = useT();
+  if (!plan) return null;
+  return (
+    <Panel title={t("plan.contract.title")}>
+      <PanelBody>
+        <CapacityLine
+          capacity={plan.capacity}
+          commitments={plan.commitments.length}
+        />
+        <ContractField
+          label={t("plan.contract.risks")}
+          hint={t("plan.contract.risksHint")}
+          value={plan.risks}
+          editable={editable}
+          field="risks"
+        />
+        <ContractField
+          label={t("plan.contract.capacityNote")}
+          hint={t("plan.contract.capacityNoteHint")}
+          value={plan.capacity_note}
+          editable={editable}
+          field="capacity_note"
+        />
+      </PanelBody>
+    </Panel>
+  );
+}
+
+// CapacityLine says what next week already holds.
+//
+// ABSENT draws nothing at all. The server omits `capacity` when no calendar
+// reader is composed, and a line reading "0 meetings booked" would tell a rep
+// their week is clear on the strength of a missing integration — the one thing
+// this panel must never do.
+function CapacityLine({
+  capacity,
+  commitments,
+}: Readonly<{ capacity: Capacity | undefined; commitments: number }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  if (!capacity) return null;
+  const n = (value: number) => formatNumber(value, locale);
+  const committed = capacity.meetings + capacity.tasks;
+  const crowded = committed + commitments > crowdedWeek;
+  const line = t("plan.contract.capacityLine", {
+    meetings: n(capacity.meetings),
+    tasks: n(capacity.tasks),
+  });
+  // A warn Callout only when the week is actually crowded. Drawn always, the
+  // tone would stop meaning anything and a reader would learn to skip it.
+  if (!crowded) return <p className="plan-capacity">{line}</p>;
+  return (
+    <Callout tone="warn" title={t("plan.contract.crowded")}>
+      {t("plan.contract.crowdedBody", {
+        committed: n(committed),
+        commitments: n(commitments),
+      })}
+    </Callout>
+  );
+}
+
+// One half of the contract, read until somebody edits it.
+//
+// UNWRITTEN AND EMPTY ARE DIFFERENT and both are drawn: null is a rep who has
+// said nothing, "" is a rep who looked and says there is nothing to name. A
+// lead who cannot tell those apart is reading a week they have not been told
+// about as if it were a safe one.
+function ContractField({
+  label,
+  hint,
+  value,
+  editable,
+  field,
+}: Readonly<{
+  label: string;
+  hint: string;
+  value: string | null | undefined;
+  editable: boolean;
+  field: "risks" | "capacity_note";
+}>) {
+  const t = useT();
+  const save = useSetPlanContract();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+
+  if (!editing) {
+    return (
+      <div className="plan-contract-field">
+        <h3>{label}</h3>
+        <p className={value == null ? "plan-contract-unwritten" : undefined}>
+          {value == null
+            ? t("plan.contract.unwritten")
+            : value === ""
+              ? t("plan.contract.nothingToName")
+              : value}
+        </p>
+        {editable && (
+          <Button
+            variant="ghost"
+            small
+            onClick={() => {
+              setDraft(value ?? "");
+              setEditing(true);
+            }}
+          >
+            {t("plan.contract.edit")}
+          </Button>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="plan-contract-field">
+      <Field label={label} hint={hint}>
+        {(control) => (
+          <Textarea
+            {...control}
+            value={draft}
+            maxLength={2000}
+            rows={3}
+            onChange={(event) => setDraft(event.target.value)}
+          />
+        )}
+      </Field>
+      <Button
+        pending={save.isPending}
+        onClick={() => {
+          // Only THIS half travels. The other is omitted, which the server
+          // reads as "leave it alone" — sending both would let a stale draft
+          // overwrite a note the rep changed in the other field.
+          save.mutate(
+            { [field]: draft },
+            { onSuccess: () => setEditing(false) },
+          );
+        }}
+      >
+        {t("plan.contract.save")}
+      </Button>
+      <Button variant="ghost" onClick={() => setEditing(false)}>
+        {t("plan.contract.cancel")}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/screens/brief.plan.tsx
+++ b/frontend/src/screens/brief.plan.tsx
@@ -18,6 +18,7 @@ import { SurfaceState } from "../design-system/surfacestate";
 import { formatDate, formatNumber } from "../format/format";
 import { useLocale, usePlural, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { PlanContract } from "./brief.plan.contract";
 import { useMe } from "./common";
 import { EntityRef } from "./entityref";
 import {
@@ -269,6 +270,10 @@ export function PlanSection() {
           )}
         </SurfaceState>
       </Panel>
+      {/* What the week is up against, after what it is for. Its own panel
+          because it is the half a lead reads first and a reader should be able
+          to find it without walking the commitment list. */}
+      <PlanContract plan={plan.data} editable={editable} />
     </section>
   );
 }

--- a/frontend/src/screens/home.testkit.tsx
+++ b/frontend/src/screens/home.testkit.tsx
@@ -78,6 +78,26 @@ const DEFAULTS: Routes = {
   // empty page carries no `readings` and no `counts`, and a screen reading a
   // required field off it fails in a way no server could produce.
   "GET /worklist": () => jsonResponse(readingsDay({}, [])),
+  // The plan panel reads `commitments` off this, which the contract marks
+  // required. The generic empty page carries none, so an unrouted read would
+  // fail the panel in a way no server could produce — the same reason
+  // /worklist is answered above. 404 is the honest default: most screens under
+  // test have not started a week.
+  // The plan panel reads `commitments` off this, which the contract marks
+  // required, so an unrouted read fails it in a way no server could produce —
+  // the same reason /worklist is answered above.
+  //
+  // A STARTED-BUT-EMPTY week rather than a 404: the shape is what the panel
+  // needs, and a 404 puts every screen that merely mounts the panel through an
+  // error path, which moved the timing of nine tests in screens with nothing to
+  // do with planning.
+  "GET /weekly-plans/current": () =>
+    jsonResponse({
+      id: "00000000-0000-0000-0000-000000000001",
+      local_week_start: "2026-06-08",
+      status: "open",
+      commitments: [],
+    }),
 };
 
 /**

--- a/frontend/src/screens/weeklyplan.queries.ts
+++ b/frontend/src/screens/weeklyplan.queries.ts
@@ -199,3 +199,37 @@ export function useAnswerCommitment(ownerId: string | undefined) {
     },
   });
 }
+
+/**
+ * What the rep says about the week ahead.
+ *
+ * Both halves travel in one request because the server writes them together in
+ * one transaction; sending them separately would put two audit rows and two
+ * events behind what a rep experiences as saving one form.
+ *
+ * A field set to `null` CLEARS it back to unwritten; a field omitted is left
+ * alone. Those are different states all the way down — null is a rep who has
+ * said nothing, "" is a rep who says there is nothing to say — so this hook
+ * passes them through rather than normalising either away.
+ */
+export function useSetPlanContract() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (
+      contract: Readonly<{
+        risks?: string | null;
+        capacity_note?: string | null;
+      }>,
+    ) => {
+      const { error } = await api.PUT("/weekly-plans/current/contract", {
+        body: contract,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: weeklyPlanKey });
+    },
+  });
+}


### PR DESCRIPTION
A weekly plan said what a rep meant to do. It did not say what the week was up against — the half a lead reads first, because five commitments with no room to do them is a plan that has already failed and nobody has said so.

Two prose fields the rep writes (`risks`, `capacity_note`) and one **counted** figure: booked meetings and open tasks in next week's local window, read through a seam because those tables belong to other modules.

## Absent, empty and unwritten are three answers

`null` is a rep who has written nothing. `""` is one who looked and says there is nothing to name. A missing `capacity` means no calendar reader is composed — not a free week.

The distinction survives the whole path: JSON body → handler → store → column → read → wire → panel. Reverting any part of it fails a test, checked by mutation.

## Fixed from review

Four defects, all in the write path:

1. **Two concurrent saves each touching one half** would both read the old values, and the second would write back the first's field as it was — silently undoing a save that reported success. The current text is now re-read **under the row lock**, and `ContractEdit` carries "was this set" separately from the value, so an omitted half is resolved there rather than by the handler beforehand.
2. **A save could rewrite a closed week.** The status was checked in `openPlanTx`, before `LockRow`, and `LockRow` selects only the id — so a request spanning the Monday rollover slipped through. Re-checked under the lock.
3. **A successful save answered with no capacity**, which a client reads as "no calendar composed" moments after a GET told it otherwise. `readPlan` reads the plan's own tables; the seam reads other modules'.
4. **Prose was bounded in bytes** against a message and a column CHECK that both count characters. 1500 accented characters are 3000 bytes, so a German or Vietnamese note hit a ceiling an English one of the same length cleared. Fixed at the shared `bounded` helper, so all five bounded fields agree.

One reviewer finding was **not** a defect: concurrent first saves cannot violate `uq_weekly_plan_owner_week`, because `openPlanTx`'s insert already carries `ON CONFLICT ... DO NOTHING`.

## A gate holds the two bounds together

`TestEveryPlanProseColumnMatchesItsGoBound` compares the Go seam bound against the SQL CHECK and **fails in both directions** — raised in SQL, lowered in Go, or the constraint dropped entirely. Its corpus is derived from the migrations rather than listed, it matches `char_length`/`character_length` case-insensitively, and it retires a bound a later migration drops. Mutation-checked all four ways.

The plan status also gained its own constant: `StateOpen` is a **commitment** state that happens to share the spelling, and reusing it here would have satisfied the linter while asserting the wrong concept.

## Fixed along the way

Both pre-existing red on `main` and unrelated to this work — I checked open PRs first, and #4551 touches different files:

- `compose.head.test.tsx` cited migration `0188`, a version that never existed in this tree. The invariant is stated instead.
- The send-permission census still expected two composers after #4553 moved the person page's drawer onto the shared one. The floor is now one, and the stale waiver is gone rather than repointed — `compose.tsx` is the only surface posting to a send door, and it asks the engine.

## Testing

`make check-backend` and `make check-fe` both green. Eight integration cases over real Postgres and nine vitest cases, each guard mutation-checked.

One of those mutations mattered: a capacity-window test passed with the window shifted a whole week, because both weeks held one meeting. The fixture now seeds two in the neighbouring week, so the counts differ and the boundary is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds risks, a capacity note, and a counted next-week load to the weekly plan, so a plan says what the week is up against as well as what it is for. Unwritten, cleared, and empty stay distinguishable end to end, and a plan with no capacity seam reports unknown rather than free.

**Bug Fixes**
- Two concurrent saves touching different halves no longer silently undo each other; the row is re-read under its lock.
- A save can no longer slip past the Monday rollover and rewrite a closed week; the status is re-checked under the lock.
- A successful save answers with the same capacity figure a read gives, not the absence that reads as "no calendar composed."
- Prose is bounded in characters, not bytes, so accented text clears the ceiling English gets, and a new gate fails if the Go seam and SQL CHECK drift apart.
- Two pre-existing failures on main are fixed along the way: a test cited a migration version that never existed, and the send census expected a composer that moved to the shared drawer.

<sup>Written for commit a8ff8cfd4864469e21ef145d82da1440aba0a0f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

