### PR TITLE
A settings card asks for the grant its own endpoint asks for

### DIFF
--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -111,7 +111,7 @@ const AI_CALL: AiCallSummary = {
   has_payload: false,
 };
 
-const OPERATOR: GrantSpec = { automation: ["update"], license: ["read"] };
+const OPERATOR: GrantSpec = { ai_diagnostics: ["read"], license: ["read"] };
 
 /** A month with one priced line and one the server could not price. */
 const PRICED_USAGE = {
@@ -513,7 +513,8 @@ describe("AgentRail", () => {
   it("gives neither a warning nor a licence row when the seat may not read the licence", async () => {
     const user = userEvent.setup();
     stubAgentRailApi({
-      me: () => jsonResponse(meFixture({ allow: { automation: ["update"] } })),
+      me: () =>
+        jsonResponse(meFixture({ allow: { ai_diagnostics: ["read"] } })),
       license: () => jsonResponse(LICENSE("absent")),
     });
     const { container } = render(ROUTE);
@@ -786,7 +787,7 @@ describe("AgentRail", () => {
     expect(container.querySelector(".arblock")).toBeNull();
   });
 
-  it("says the runtime row is not readable on a seat without automation:update", async () => {
+  it("says the runtime row is not readable without ai_diagnostics:read", async () => {
     const user = userEvent.setup();
     stubAgentRailApi({
       me: () => jsonResponse(meFixture({ allow: { license: ["read"] } })),
@@ -861,7 +862,7 @@ describe("AgentRail", () => {
     );
   });
 
-  // The server serves the figure on `automation:update`, which the ops seat
+  // The server serves the figure on `ai_diagnostics:read`, which the ops seat
   // holds and an edited role may hold; the cost is the administrator's figure
   // regardless, so a seat with the grant and without the role gets the runtime
   // row and no money — on the rail, in the panel head and in the meta row.

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -273,7 +273,8 @@ function useRecentCalls(): Readonly<{
   allowed: boolean;
   calls: readonly AiCall[];
 }> {
-  const allowed = useCan("automation", "update");
+  // GET /ai/calls asks for ai_diagnostics:read (ai/callread.go).
+  const allowed = useCan("ai_diagnostics", "read");
   const recent = useQuery({
     queryKey: ["ai-calls", "agentrail-recent"],
     enabled: allowed,
@@ -318,7 +319,8 @@ function useAiSpend(): Readonly<{
   daily: readonly number[];
 }> {
   const admin = useHoldsAdminRole();
-  const granted = useCan("automation", "update");
+  // GET /ai/usage asks for ai_diagnostics:read (ai/usage.go).
+  const granted = useCan("ai_diagnostics", "read");
   const allowed = admin && granted;
   const usage = useQuery({
     queryKey: ["ai-usage", "agentrail-month"],

--- a/frontend/src/app/capability.test.tsx
+++ b/frontend/src/app/capability.test.tsx
@@ -13,7 +13,6 @@ import {
   useCanUpsert,
   useCanWrite,
   useCanWriteRecord,
-  useHoldsConsentAdminRole,
   useHoldsOperatorSeat,
 } from "./capability";
 import { meFixture } from "./mefixture";
@@ -325,23 +324,20 @@ describe("useHoldsOperatorSeat — the Admin settings section's gate", () => {
   // of question that fails silently when it drifts — the section would simply
   // appear for a rep, and no other assertion in the app would move.
   //
-  // Asked together with the consent predicate on purpose: that one now READS this
-  // one, and the two have to keep answering the same set. Their NAMES stay apart
-  // because their authorities do, so nothing but a case like this would notice
-  // the delegation quietly stopping.
+  // The consent predicate that used to be asked alongside this one is gone: it
+  // was interim, waiting for `consent_config` to reach the shipped vocabulary,
+  // and the purposes card asks `useCan("consent_config", "create")` now.
   async function operator(): Promise<boolean> {
     const { result } = renderHook(
       () => ({
         me: useMe(),
         seat: useHoldsOperatorSeat(),
-        consentAdmin: useHoldsConsentAdminRole(),
       }),
       { wrapper },
     );
     await waitFor(() => {
       expect(result.current.me.isPending).toBe(false);
     });
-    expect(result.current.consentAdmin).toBe(result.current.seat);
     return result.current.seat;
   }
 

--- a/frontend/src/app/capability.ts
+++ b/frontend/src/app/capability.ts
@@ -249,28 +249,3 @@ export function useHoldsOperatorSeat(): boolean {
   const roles = useMe().data?.roles ?? [];
   return roles.includes("admin") || roles.includes("ops");
 }
-
-/**
- * Whether the principal may administer consent configuration — `admin` or
- * `ops`.
- *
- * Separate from `useHoldsAdminRole` because the authority genuinely differs:
- * the consent purpose registry is an Admin/Ops surface, while the subject-request
- * queue beside it and the audit log are the admin's alone. Collapsing the two
- * into one predicate is what put an Ops seat in front of surfaces the server
- * refuses.
- *
- * This one is interim in a way the admin predicate is not. `consent_config` IS
- * a governed object upstream; it is simply absent from the shipped `RbacObject`
- * vocabulary, so there is no grant to ask for yet. When it lands, this becomes
- * `useCan("consent_config", "read")` and disappears.
- */
-export function useHoldsConsentAdminRole(): boolean {
-  // The same seat set as `useHoldsOperatorSeat`, read through it rather than
-  // spelled a second time: two copies of one expression drift, and this is the
-  // one that is meant to disappear. The NAMES stay apart because the
-  // authorities do — when `consent_config` lands in the RbacObject vocabulary
-  // this becomes `useCan("consent_config", "read")` and the section gate above
-  // is untouched.
-  return useHoldsOperatorSeat();
-}

--- a/frontend/src/app/economybanner.test.tsx
+++ b/frontend/src/app/economybanner.test.tsx
@@ -7,10 +7,10 @@ import { LocaleProvider } from "../i18n";
 import { EconomyBanner } from "./economybanner";
 import { type GrantSpec, meFixture } from "./mefixture";
 
-// The banner reads GET /ai/usage, which the server gates on automation:update
-// — a read behind another object's write grant. The fixtures name that grant
-// directly rather than a role, so a rebinding to a more intuitive AI object
-// fails here instead of 403-ing in a browser.
+// The banner reads GET /ai/usage, which the server gates on ai_diagnostics:read
+// (ai/usage.go). The fixtures name that grant directly rather than a role, so a
+// rebinding fails here instead of 403-ing in a browser — which is what happened
+// when the server moved off automation:update and three client gates stayed.
 function mount(allow: GrantSpec, readBand: string | (() => string)) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
     const path = new URL(
@@ -46,7 +46,7 @@ function mount(allow: GrantSpec, readBand: string | (() => string)) {
 }
 
 // The one grant this surface needs, named once.
-const AI_RUNTIME_READER: GrantSpec = { automation: ["update"] };
+const AI_RUNTIME_READER: GrantSpec = { ai_diagnostics: ["read"] };
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/app/economybanner.tsx
+++ b/frontend/src/app/economybanner.tsx
@@ -13,11 +13,12 @@ import { useCan } from "./capability";
 
 export function EconomyBanner() {
   const t = useT();
-  // GET /ai/usage gates on automation:update, not on any AI-named object — the
-  // budget it reports is the automation runtime's, and the server treats
-  // seeing it as an operator concern. Binding this to a more intuitive object
-  // would 403 the banner for exactly the roles that are meant to see it.
-  const enabled = useCan("automation", "update");
+  // GET /ai/usage asks for ai_diagnostics:read (ai/usage.go). It used to ride
+  // automation:update — an AI reading behind another object's WRITE grant — and
+  // three client gates were left on that object when the server moved. The
+  // object is named here rather than a role so a rebinding fails in a test
+  // instead of 403-ing in a browser.
+  const enabled = useCan("ai_diagnostics", "read");
   const previousBand = useRef<string | undefined>(undefined);
   const [occurrence, setOccurrence] = useState(0);
   const [dismissedOccurrence, setDismissedOccurrence] = useState<string | null>(

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3937,7 +3937,7 @@ export const de = {
   "settings.jobsSub":
     "Was in der Warteschlange hängt und wessen Arbeit gescheitert ist.",
   "jobs.adminOnly":
-    "Nur ein Admin sieht den Zustand der Hintergrund-Jobs. Der Bericht umfasst die Arbeit der ganzen Installation und wird deshalb nicht breiter gezeigt.",
+    "Für den Zustand der Hintergrund-Jobs fehlt Ihrem Sitzplatz die Berechtigung. Der Bericht umfasst die Arbeit der ganzen Installation und steht deshalb nicht allen offen.",
   "jobs.empty":
     "Nichts in der Hintergrund-Warteschlange — nichts wartet, läuft, wiederholt sich oder ist tot.",
   "jobs.workspaceKinds": "Diese Organisation",
@@ -3990,7 +3990,7 @@ export const de = {
   "audit.noHumanAuthority": "Keine menschliche Autorisierung erfasst",
   "settings.auditSub": "jede Aktion, zugeordnet — Mensch, Agent oder Connector",
   "settings.auditAdminOnly":
-    "Nur Admins lesen den vollständigen Verlauf. Er hält jede handelnde Person und jeden berührten Datensatz fest — deshalb ist er nicht weiter zugänglich.",
+    "Zum Lesen des vollständigen Verlaufs fehlt Ihrem Sitzplatz die Berechtigung. Er hält jede handelnde Person und jeden berührten Datensatz fest — deshalb steht er nicht allen offen.",
   "settings.auditFilters": "Filter",
   "settings.auditEntries": "Audit-Log",
   "settings.auditTrailLabel": "Aufgezeichnete Aktionen",
@@ -4008,7 +4008,7 @@ export const de = {
   "settings.due": "fällig {date}",
 
   "privacy.purposesReadOnly":
-    "Nur-Lese-Ansicht — nur ein Admin oder Ops kann einen Zweck anlegen.",
+    "Nur-Lese-Ansicht — zum Anlegen eines Zwecks fehlt Ihrem Sitzplatz die Berechtigung.",
   "privacy.addPurpose": "Zweck hinzufügen",
   "privacy.purposesRegistry": "Erfasste Zwecke",
   "privacy.purposeKey": "Schlüssel",
@@ -4019,7 +4019,7 @@ export const de = {
     "Ein Zweck kann nach dem Anlegen nicht umbenannt oder entfernt werden — der Katalog ist append-only. Wähle den Schlüssel sorgfältig.",
   "privacy.facetAll": "Alle",
   "privacy.inboxAdminOnly":
-    "Nur Admins sehen Betroffenenanfragen. Sie nennen die Personen, die angefragt haben — deshalb ist die Liste nicht weiter zugänglich.",
+    "Für Betroffenenanfragen fehlt Ihrem Sitzplatz die Berechtigung. Sie nennen die Personen, die angefragt haben — deshalb steht die Liste nicht allen offen.",
   "privacy.overdue": "Überfällig",
   "privacy.closed":
     "Abgeschlossen — eine abgeschlossene Anfrage wird nie wieder geöffnet. Ein neues Anliegen ist eine neue Anfrage.",
@@ -6273,6 +6273,8 @@ export const de = {
   "license.refused.title": "Die Lizenz dieser Installation wurde abgelehnt",
   "license.refused.body":
     "Das Token im Deployment wurde vorgelegt und abgelehnt. Alles funktioniert weiter und unbegrenzt, bis es ersetzt wird — prüfe das Token und die Uhr der Installation.",
+  "license.seats.capacityOnly":
+    "Wie viele Vollplätze diese Installation nutzt. Was ihr zusteht, dürfen Sie nicht einsehen.",
   "license.seats.title": "Plätze",
   "license.seats.used": "Belegte Sitzplätze",
   "license.seats.granted": "Gewährte Sitzplätze",
@@ -6506,7 +6508,8 @@ export const de = {
   "extAccess.title": "Erweiterungen & Zugriff",
   "extAccess.sub":
     "Was jede zusammengesetzte Erweiterungseinheit in diese Installation eingebracht hat und welche Rolle sie nutzen darf. Nur für Admins.",
-  "extAccess.adminOnly": "Der Erweiterungszugriff steht nur Admins offen.",
+  "extAccess.adminOnly":
+    "Diese Seite braucht die Berechtigung, die Erweiterungen der Installation und ihre Rollen zu lesen. Ihr Sitzplatz hat nur eine davon oder keine.",
   "extAccess.readOnly":
     "Ihr Sitzplatz liest diese Seite. Eine Berechtigung zu ändern erfordert einen vollen Sitzplatz.",
   "extAccess.empty":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4028,7 +4028,7 @@ export const en = {
   "settings.jobs": "Background jobs",
   "settings.jobsSub": "What the queue is holding, and whose work failed.",
   "jobs.adminOnly":
-    "Only an admin can see background-job health. It reports work across the whole installation, so it is not shown more widely.",
+    "Seeing background-job health needs permission your seat does not hold. It reports work across the whole installation, so it is not open to everyone.",
   "jobs.empty":
     "Nothing in the background queue — no work waiting, running, retrying or dead.",
   "jobs.workspaceKinds": "This organization",
@@ -4081,7 +4081,7 @@ export const en = {
   "audit.noHumanAuthority": "No human authority recorded",
   "settings.auditSub": "every action, attributed — human, agent, or connector",
   "settings.auditAdminOnly":
-    "Only an admin can read the full trail. It records every actor and every record they touched, so it is not shown more widely.",
+    "Reading the full trail needs permission your seat does not hold. It records every actor and every record they touched, so it is not open to everyone.",
   "settings.auditFilters": "Filters",
   "settings.auditEntries": "Audit log",
   "settings.auditTrailLabel": "Recorded actions",
@@ -4101,7 +4101,7 @@ export const en = {
   "privacy.addPurpose": "Add purpose",
   "privacy.purposesRegistry": "Registered purposes",
   "privacy.purposesReadOnly":
-    "Read-only view — only an admin or ops can add a purpose.",
+    "Read-only view — adding a purpose needs permission your seat does not hold.",
   "privacy.purposeKey": "Key",
   "privacy.purposeLabel": "Label",
   "privacy.purposeDoi": "Requires double opt-in",
@@ -4110,7 +4110,7 @@ export const en = {
     "A purpose cannot be renamed or removed once created — the catalogue is append-only. Choose the key carefully.",
   "privacy.facetAll": "All",
   "privacy.inboxAdminOnly":
-    "Only an admin can see subject requests. They name the people who asked, so the queue is not shown more widely.",
+    "Seeing subject requests needs permission your seat does not hold. They name the people who asked, so the queue is not open to everyone.",
   "privacy.overdue": "Overdue",
   "privacy.closed":
     "Closed — a closed request never reopens. A new concern is a new request.",
@@ -6395,6 +6395,8 @@ export const en = {
   "license.refused.title": "This installation's license was refused",
   "license.refused.body":
     "The token in the deployment was presented and rejected. Everything keeps working, uncapped, until it is replaced — check the token and the installation's clock.",
+  "license.seats.capacityOnly":
+    "How many full seats this installation is using. What it is entitled to is not yours to see.",
   "license.seats.title": "Seats",
   "license.seats.used": "Seats in use",
   "license.seats.granted": "Seats granted",
@@ -6620,7 +6622,8 @@ export const en = {
   "extAccess.title": "Extensions & access",
   "extAccess.sub":
     "What each composed extension unit brought into this installation, and which role may use it. Admin-only.",
-  "extAccess.adminOnly": "Extension access is available to admins only.",
+  "extAccess.adminOnly":
+    "This page needs permission to read the installation's extensions and its roles. Your seat holds one or neither.",
   "extAccess.readOnly":
     "Your seat reads this page. Changing a grant needs a full seat.",
   "extAccess.empty": "No extension units are composed into this installation.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3882,7 +3882,7 @@ export const vi = {
   "settings.jobs": "Tác vụ nền",
   "settings.jobsSub": "Hàng đợi đang giữ gì, và công việc của ai đã thất bại.",
   "jobs.adminOnly":
-    "Chỉ quản trị viên xem được tình trạng tác vụ nền. Báo cáo này bao trùm công việc của toàn bộ bản triển khai, nên không hiển thị rộng hơn.",
+    "Xem tình trạng tác vụ nền cần quyền mà ghế của bạn không có. Báo cáo này bao trùm công việc của toàn bộ bản triển khai, nên không mở cho tất cả mọi người.",
   "jobs.empty":
     "Không có gì trong hàng đợi nền — không có việc đang chờ, đang chạy, đang thử lại hay đã chết.",
   "jobs.workspaceKinds": "Tổ chức này",
@@ -3936,7 +3936,7 @@ export const vi = {
   "settings.auditSub":
     "mọi hành động đều được quy trách — người, Agent hay connector",
   "settings.auditAdminOnly":
-    "Chỉ quản trị viên đọc được toàn bộ dấu vết. Nó ghi lại mọi người thực hiện và mọi bản ghi họ chạm tới, nên không mở rộng hơn.",
+    "Đọc toàn bộ dấu vết cần quyền mà ghế của bạn không có. Nó ghi lại mọi người thực hiện và mọi bản ghi họ chạm tới, nên không mở cho tất cả mọi người.",
   "settings.auditFilters": "Bộ lọc",
   "settings.auditEntries": "Nhật ký kiểm toán",
   "settings.auditTrailLabel": "Các hành động đã ghi",
@@ -3954,7 +3954,7 @@ export const vi = {
   "settings.due": "hạn {date}",
 
   "privacy.purposesReadOnly":
-    "Chế độ chỉ đọc — chỉ quản trị viên hoặc ops mới thêm được mục đích.",
+    "Chế độ chỉ đọc — thêm mục đích cần quyền mà ghế của bạn không có.",
   "privacy.addPurpose": "Thêm mục đích",
   "privacy.purposesRegistry": "Mục đích đã đăng ký",
   "privacy.purposeKey": "Khoá",
@@ -3965,7 +3965,7 @@ export const vi = {
     "Một mục đích đã tạo thì không đổi tên hay xoá được — danh mục chỉ thêm mới. Hãy chọn khoá thật cẩn thận.",
   "privacy.facetAll": "Tất cả",
   "privacy.inboxAdminOnly":
-    "Chỉ quản trị viên xem được yêu cầu của chủ thể dữ liệu. Danh sách nêu tên người đã yêu cầu, nên không mở rộng hơn.",
+    "Xem yêu cầu của chủ thể dữ liệu cần quyền mà ghế của bạn không có. Danh sách nêu tên người đã yêu cầu, nên không mở cho tất cả mọi người.",
   "privacy.overdue": "Quá hạn",
   "privacy.closed":
     "Đã đóng — một yêu cầu đã đóng không bao giờ mở lại. Mối lo mới là một yêu cầu mới.",
@@ -6204,6 +6204,8 @@ export const vi = {
   "license.refused.title": "Giấy phép của bản cài đặt này bị từ chối",
   "license.refused.body":
     "Token trong deployment đã được xuất trình và bị từ chối. Mọi thứ vẫn hoạt động, không giới hạn, cho đến khi token được thay — hãy kiểm tra token và đồng hồ của bản cài đặt.",
+  "license.seats.capacityOnly":
+    "Số chỗ đầy đủ mà bản cài đặt này đang dùng. Quyền hạn được cấp không thuộc phạm vi bạn xem.",
   "license.seats.title": "Số chỗ",
   "license.seats.used": "Chỗ đang dùng",
   "license.seats.granted": "Chỗ được cấp",
@@ -6431,7 +6433,7 @@ export const vi = {
   "extAccess.sub":
     "Mỗi đơn vị tiện ích đã ghép vào bản cài đặt này mang theo những gì, và vai trò nào được dùng. Chỉ dành cho quản trị viên.",
   "extAccess.adminOnly":
-    "Chỉ quản trị viên mới truy cập được phần tiện ích mở rộng.",
+    "Trang này cần quyền đọc các tiện ích mở rộng của bản triển khai và các vai trò của nó. Ghế của bạn chỉ có một hoặc không có quyền nào.",
   "extAccess.readOnly":
     "Chỗ ngồi của bạn chỉ đọc được trang này. Muốn đổi quyền cần chỗ ngồi đầy đủ.",
   "extAccess.empty":

--- a/frontend/src/screens/ai-health.test.tsx
+++ b/frontend/src/screens/ai-health.test.tsx
@@ -38,10 +38,13 @@ const DEAD: RungHealth = {
   last_call_at: "2026-09-01T09:10:00Z",
 };
 
-// The grant `GET /ai/health` is gated on server-side. Named rather than
-// implied: a fixture that grants nothing renders the withheld state, and every
-// claim below about what the table says would then pass against an empty panel.
-const OPERATOR: GrantSpec = { automation: ["read", "update"] };
+// What `GET /ai/health` is gated on server-side: `ai_diagnostics:read`. Named
+// rather than implied — a fixture that grants nothing renders the withheld
+// state, and every claim below about what the table says would then pass against
+// an empty panel.
+//
+// The card asked `automation:update` before this read got an object of its own.
+const OPERATOR: GrantSpec = { ai_diagnostics: ["read"] };
 
 function renderCard(
   rungs: RungHealth[],
@@ -115,12 +118,12 @@ describe("model lane health", () => {
   });
 
   it("withholds the lanes from a reader whose role cannot read them", async () => {
-    // The AI page opens on `automation:read`, which every seeded role holds,
-    // while this card's endpoint demands `automation:update`, which manager,
-    // rep and read_only do not. Without the card's own gate the refusal
-    // arrives as a red failure telling that reader the installation is
-    // broken, and the poll re-issues the doomed call every minute.
-    renderCard([ANSWERING], 1, { automation: ["read"] });
+    // The Automations page opens on `automation:read`, which every seeded role
+    // holds, while this card's endpoint demands `ai_diagnostics:read`, which
+    // they do not. Without the card's own gate the refusal arrives as a red
+    // failure telling that reader the installation is broken, and the poll
+    // re-issues the doomed call every minute.
+    renderCard([ANSWERING], 1, { automation: ["read", "update"] });
     expect(
       await screen.findByText(/only an operator can read whether/i),
     ).toBeInTheDocument();
@@ -133,7 +136,7 @@ describe("model lane health", () => {
     // The half a rendered EmptyState cannot show: `enabled` is what keeps a
     // withheld reader from a 403 they cannot act on, and a refetchInterval
     // left standing would resume the call the moment a grant changed.
-    renderCard([ANSWERING], 1, { automation: ["read"] });
+    renderCard([ANSWERING], 1, { automation: ["read", "update"] });
     await screen.findByText(/only an operator can read whether/i);
     const calls = (
       globalThis.fetch as unknown as { mock: { calls: unknown[][] } }

--- a/frontend/src/screens/ai-health.tsx
+++ b/frontend/src/screens/ai-health.tsx
@@ -31,7 +31,7 @@ export function AiHealthCard() {
   // with a Retry that cannot succeed, and `refetchInterval` re-issues the
   // doomed call every minute for as long as the tab is open. The keys and calls
   // cards beside it answer the same question the same way.
-  const canSee = useCan("automation", "update");
+  const canSee = useCan("ai_diagnostics", "read");
   const me = useMe();
   const query = useQuery({
     queryKey: ["ai-health"],

--- a/frontend/src/screens/ai-settings.test.tsx
+++ b/frontend/src/screens/ai-settings.test.tsx
@@ -17,7 +17,7 @@ import { ProvidersStat, SpendStat } from "./ai-settings";
 // five bodies.
 //
 // The readings are what this file is mostly about. They follow DIFFERENT grants
-// — spend on `automation:update`, the vendor keys on `ai_routing:read` — and
+// — spend on `ai_diagnostics:read`, the vendor keys on `ai_routing:read` — and
 // each has three states a reader must be able to tell apart: answered, not
 // theirs, and could not be read. The third is the one that used to say
 // "Reading…" for ever.
@@ -31,10 +31,20 @@ function jsonResponse(body: unknown, status = 200) {
 
 const OPERATOR: GrantSpec = {
   ai_routing: ["read", "update"],
+  ai_diagnostics: ["read"],
   automation: ["read", "update"],
 };
 // Reaches the page on the automations read alone: no spend, no vendor keys.
-const NO_READINGS: GrantSpec = { automation: ["read"] };
+// `automation:update` is deliberately held here and buys NEITHER reading — it
+// is the grant the spend stat used to ask for, so this fixture fails the moment
+// that gate comes back.
+const NO_READINGS: GrantSpec = { automation: ["read", "update"] };
+// The two grants the readings actually ride, and nothing else — the mirror of
+// NO_READINGS, so the pair differs by exactly what is under test.
+const BOTH_READINGS: GrantSpec = {
+  ai_diagnostics: ["read"],
+  ai_routing: ["read"],
+};
 
 const ROUTING = {
   profile: "eu_hosted",
@@ -168,11 +178,30 @@ describe("the AI readings", () => {
   // Withheld, not absent. An absent spend reading would claim this installation
   // had spent nothing, which is a statement about the DATA where the truth is
   // only about who may read it.
+  //
+  // The withheld text is ALSO what both stats say while /me is still in flight
+  // — every capability predicate reads false until the snapshot lands — so
+  // finding it proves nothing on its own. The grant has to be observed being
+  // read, which is what the paired ANSWERED case below is for: the same two
+  // stats, the same wiring, one grant apart. Assert both from one fixture pair
+  // or the refusal is vacuous.
   it("says a reading is withheld rather than dropping it", async () => {
     vi.stubGlobal("fetch", backendFor(NO_READINGS));
-    render(<BothStats />);
+    const { unmount } = render(<BothStats />);
 
     expect(await screen.findAllByText("Not yours to see")).toHaveLength(2);
+    unmount();
+    cleanup();
+
+    // The positive control, and the whole proof: swap ONLY the grants and the
+    // same two stats answer. A gate asking for the wrong object leaves this
+    // half showing "Not yours to see" and fails here.
+    vi.stubGlobal("fetch", backendFor(BOTH_READINGS));
+    render(<BothStats />);
+
+    expect(await screen.findByText(/214,000 of 1,000,000 tokens/)).toBeTruthy();
+    expect(await screen.findByText("1 keyed")).toBeTruthy();
+    expect(screen.queryByText("Not yours to see")).toBeNull();
   });
 
   // A read that FAILED and a read that has not arrived are different facts, and

--- a/frontend/src/screens/ai-settings.tsx
+++ b/frontend/src/screens/ai-settings.tsx
@@ -53,7 +53,11 @@ import "./ai-settings.css";
 export function SpendStat() {
   const t = useT();
   const { locale } = useLocale();
-  const canSee = useCan("automation", "update");
+  // The same gate the endpoint behind `useAiUsage` asks for
+  // (ai/usage.go: ai_diagnostics.read). Asking `automation.update` here read
+  // the header as withheld for a holder the server would have answered, and
+  // rendered the number for an automation editor it would have refused.
+  const canSee = useCan("ai_diagnostics", "read");
   // The current month, fixed: the header reads "this month" while the Usage tab
   // below it lets a reader step back through earlier ones, and a header that
   // followed the stepper would stop answering the question it asks.

--- a/frontend/src/screens/aicalls.test.tsx
+++ b/frontend/src/screens/aicalls.test.tsx
@@ -27,10 +27,14 @@ const summary = {
   has_payload: true,
 };
 
-// The trace is gated on automation:update — the server treats the runtime's calls as
-// operator information — so a stub that never answers /me leaves the caller holding
-// no grant and the card correctly says it is withheld instead of rendering rows.
-const OPERATOR: GrantSpec = { automation: ["read", "update"] };
+// The trace is gated on `ai_diagnostics:read`, which is what `GET /ai/calls`
+// asks for — so a stub that never answers /me leaves the caller holding no
+// grant and the card correctly says it is withheld instead of rendering rows.
+//
+// The card asked `automation:update` before the runtime's spend got an object of
+// its own: a write verb guarding a GET, which kept a management seat off a read
+// the server would have served.
+const OPERATOR: GrantSpec = { ai_diagnostics: ["read"] };
 
 function mount(
   captureEnabled = true,
@@ -165,11 +169,11 @@ it("distinguishes capture disabled from a call without payload", async () => {
   ).toBeTruthy();
 });
 
-it("withholds the trace from a principal without the automation grant, and asks the server for nothing", async () => {
+it("withholds the trace from a principal without the diagnostics read, and asks the server for nothing", async () => {
   // Withheld, not absent: an absent trace claims the installation made no model
   // calls. The card keeps its title and says whose record this is — and the list
   // read never fires, because the denial is already known.
-  const { seen } = mount(true, true, { automation: ["read"] });
+  const { seen } = mount(true, true, { automation: ["read", "update"] });
 
   expect(
     await screen.findByText(/only an operator can read the per-call trace/i),

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -173,7 +173,7 @@ function useCallTrace(task: string, enabled: boolean) {
  * over every page the reader had loaded.
  */
 export function useLastCallAt(): number | null {
-  const canSee = useCan("automation", "update");
+  const canSee = useCan("ai_diagnostics", "read");
   const query = useQuery({
     enabled: canSee,
     queryKey: ["ai-call-latest"],
@@ -200,10 +200,10 @@ export function AiCallsCard() {
   const t = useT();
   const { locale } = useLocale();
   const me = useMe();
-  // Same seam as the spend card beside it: the server gates this read on
-  // automation:update, a write verb guarding a GET, so the seat ceiling stays out
-  // of the question (capability.ts) — a read seat may still read it.
-  const canSee = useCan("automation", "update");
+  // Same seam as the spend card: `ai_diagnostics:read` (ai/callread.go). The
+  // seat ceiling stays out of the question either way (capability.ts) — a read
+  // seat may still read a diagnostic.
+  const canSee = useCan("ai_diagnostics", "read");
   const zone = viewerZone();
   const [task, setTask] = useState("");
   const [expanded, setExpanded] = useState<string | null>(null);

--- a/frontend/src/screens/aiusage.test.tsx
+++ b/frontend/src/screens/aiusage.test.tsx
@@ -20,11 +20,14 @@ vi.mock("../format/timezone", async (importOriginal) => {
 
 const budget = { monthly_tokens: 1000, spent_tokens: 850, band: "degraded" };
 
-// The card is gated on automation:update — the server treats the runtime's spend as
-// operator information — so a stub that answers every request with the usage body
-// leaves the caller holding no grant, and the card correctly says it is withheld
-// instead of rendering. Routing /me is what makes these tests about the BODY again.
-const OPERATOR: GrantSpec = { automation: ["read", "update"] };
+// The card is gated on `ai_diagnostics:read`, which is what `GET /ai/usage`
+// asks for — so a stub that answers every request with the usage body leaves the
+// caller holding no grant, and the card correctly says it is withheld instead of
+// rendering. Routing /me is what makes these tests about the BODY again.
+//
+// The card asked `automation:update` before the runtime's spend got an object of
+// its own: a write verb guarding a GET.
+const OPERATOR: GrantSpec = { ai_diagnostics: ["read"] };
 
 function mount(body: unknown, status = 200, allow: GrantSpec = OPERATOR) {
   const seen: string[] = [];
@@ -183,11 +186,13 @@ it("surfaces an unknown budget band", async () => {
   expect(await screen.findByText("unknown budget state")).toBeTruthy();
 });
 
-it("withholds the spend from a principal without the automation grant, and asks the server for nothing", async () => {
+it("withholds the spend from a principal without the diagnostics read, and asks the server for nothing", async () => {
   // Withheld, not absent: an absent spend card claims the installation spent
   // nothing. The card keeps its title and says whose figures these are — and the
   // usage read never fires, because the denial is already known.
-  const { seen } = mount({ budget, days: [] }, 200, { automation: ["read"] });
+  const { seen } = mount({ budget, days: [] }, 200, {
+    automation: ["read", "update"],
+  });
 
   expect(
     await screen.findByText(

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -335,10 +335,14 @@ export function useAiUsage(month: Month, enabled: boolean) {
 export function AiUsageCard() {
   const t = useT();
   const me = useMe();
-  // The server treats the AI runtime's spend as operator information and gates
-  // this read on automation:update — a write verb guarding a GET, which is why
-  // the seat ceiling stays out of it (capability.ts): a read seat may still read.
-  const canSee = useCan("automation", "update");
+  // `ai_diagnostics:read`, which is what the server asks for (ai/usage.go).
+  //
+  // It asked for `automation:update` once — a write verb guarding a GET,
+  // because the runtime's spend was treated as operator information. That is
+  // why the seat ceiling stays out of this (capability.ts): a read seat may
+  // still read. The object is its own now, so management sees what it spends
+  // without holding the automation editor.
+  const canSee = useCan("ai_diagnostics", "read");
   // Read once, at mount: the reader's month is what this card is about, and
   // recomputing it per render would churn the query key on the one day of the
   // month it could change.

--- a/frontend/src/screens/extension-access.test.tsx
+++ b/frontend/src/screens/extension-access.test.tsx
@@ -10,7 +10,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { meFixture } from "../app/mefixture";
+import { type GrantSpec, meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import { ExtensionAccessCard } from "./extension-access";
@@ -156,6 +156,10 @@ function backend(
   opts: {
     roles?: string[];
     seat?: "full" | "read";
+    // Defaults to `extension_access:read`, the grant the card and its endpoint
+    // both ask for — a case about the inventory should not also have to argue
+    // its way past the gate, and one that wants it REFUSED says so with `{}`.
+    allow?: GrantSpec;
     extensions?: unknown;
     // A function so a test can change what the second read answers — the
     // concurrent-edit case needs the re-read to bring back someone else's
@@ -169,10 +173,19 @@ function backend(
     const req =
       input instanceof Request ? input : new Request(String(input), init);
     if (req.url.endsWith("/v1/me")) {
+      // The card makes TWO reads: `GET /v1/extensions` on `extension_access:read`
+      // and `GET /v1/roles` on `role_admin:read`. The default principal holds
+      // both, plus the `role_admin:update` the toggles write through, because
+      // that is the only principal the server answers this whole card for. A
+      // case asserting a refusal passes a narrower `allow`.
       return jsonResponse(
         meFixture({
           roles: opts.roles ?? ["admin"],
           seat: opts.seat ?? "full",
+          allow: opts.allow ?? {
+            extension_access: ["read"],
+            role_admin: ["read", "update"],
+          },
         }),
       );
     }
@@ -180,6 +193,19 @@ function backend(
       return jsonResponse(opts.extensions ?? EXTENSIONS);
     }
     if (req.url.endsWith("/v1/roles") && req.method === "GET") {
+      // The gate the SERVER holds (identity/roles.go ListRoles), enforced here
+      // rather than assumed: a mock that answered 200 to a principal without
+      // `role_admin:read` described a world the API cannot produce, and it hid
+      // a card that opened on `extension_access:read` alone and then 403'd on
+      // this very request. A stub that admits everyone proves nothing about a
+      // gate.
+      const allow = opts.allow ?? {
+        extension_access: ["read"],
+        role_admin: ["read", "update"],
+      };
+      if (!allow.role_admin?.includes("read")) {
+        return jsonResponse({ title: "forbidden" }, 403);
+      }
       const body =
         typeof opts.rolesBody === "function"
           ? (opts.rolesBody as () => unknown)()
@@ -575,8 +601,65 @@ describe("ExtensionAccessCard", () => {
     );
     render(<ExtensionAccessCard />);
 
-    await waitFor(() => expect(screen.getByText(/admins only/i)).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /needs permission to read the installation's extensions/i,
+        ),
+      ).toBeTruthy(),
+    );
     expect(screen.queryByText("notes")).toBeNull();
+  });
+
+  // The inventory grant ALONE is not this card. `GET /v1/roles` asks for
+  // role_admin:read (identity/roles.go), and the card reads both behind one
+  // flag — so a reader holding only `extension_access:read` used to open the
+  // page, fire both requests, and take a 403 on the second. It is refused
+  // before either request now, which is the same answer the server gives.
+  it("fetches nothing for a reader who may see units but not roles", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req =
+          input instanceof Request ? input : new Request(String(input), init);
+        if (req.url.endsWith("/v1/me")) {
+          return jsonResponse(
+            meFixture({
+              roles: ["ops"],
+              allow: { extension_access: ["read"] },
+            }),
+          );
+        }
+        throw new Error(`unexpected request: ${req.method} ${req.url}`);
+      }),
+    );
+    render(<ExtensionAccessCard />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /needs permission to read the installation's extensions/i,
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  // And the mirror: holding both reads OPENS it, so the refusal above is about
+  // the missing grant rather than about a card nobody can open.
+  it("opens for a reader holding both the inventory and the role reads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backend([], {
+        allow: { extension_access: ["read"], role_admin: ["read"] },
+      }),
+    );
+    render(<ExtensionAccessCard />);
+
+    // The matrix itself, by a row only it draws — `findByRole("table")` is
+    // ambiguous here because the card renders one per unit.
+    expect(await screen.findAllByRole("table")).not.toHaveLength(0);
+    expect(screen.getAllByText("Admin").length).toBeGreaterThan(0);
   });
 
   // `enabled: false` stops the next request; it does not forget the last one. A
@@ -606,7 +689,13 @@ describe("ExtensionAccessCard", () => {
     );
     renderWith(client, <ExtensionAccessCard />);
 
-    await waitFor(() => expect(screen.getByText(/admins only/i)).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /needs permission to read the installation's extensions/i,
+        ),
+      ).toBeTruthy(),
+    );
     expect(screen.queryByRole("heading", { name: "notes" })).toBeNull();
     expect(screen.queryByText("ext_notes_note")).toBeNull();
     // And the cache itself is emptied, so a later render cannot resurrect it.
@@ -652,7 +741,15 @@ describe("ExtensionAccessCard", () => {
         const req =
           input instanceof Request ? input : new Request(String(input), init);
         if (req.url.endsWith("/v1/me")) {
-          return jsonResponse(meFixture({ roles: ["admin"] }));
+          return jsonResponse(
+            meFixture({
+              roles: ["admin"],
+              allow: {
+                extension_access: ["read"],
+                role_admin: ["read", "update"],
+              },
+            }),
+          );
         }
         return new Promise<Response>(() => {});
       }),

--- a/frontend/src/screens/extension-access.tsx
+++ b/frontend/src/screens/extension-access.tsx
@@ -13,7 +13,7 @@ import {
 import { type ReactNode, useEffect } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanMutate, useHoldsAdminRole } from "../app/capability";
+import { useCan, useCanMutate } from "../app/capability";
 import {
   composedScreens,
   EXTENSION_SCREEN,
@@ -172,6 +172,12 @@ function useSetGrant() {
           existing.key === role.key ? role : existing,
         ),
       );
+      // The matrix is not the only reader of this grant. If the role just
+      // edited is one the OPERATOR holds, every `useCan("ext_…")` affordance in
+      // the app is now answering from a /me snapshot that predates the change —
+      // for up to five minutes, or until a window focus. Re-reading the
+      // snapshot is cheap and is the only way the rest of the app learns.
+      void queryClient.invalidateQueries({ queryKey: ["me"] });
     },
     // A refused write leaves the checkbox showing the state the server holds
     // (nothing was applied locally), but another admin's concurrent change is
@@ -255,21 +261,39 @@ function grantOf(role: ExtensionRole, object: string): ObjectGrant {
 export function ExtensionAccessCard() {
   const t = useT();
   const me = useMe();
-  // Editing role permissions is admin-only server-side, so the whole card is
-  // admin-only here — the same shape UsersAdminCard uses, and for the same
-  // reason: an ops seat in the Admin settings group would otherwise be handed
-  // controls that only ever 403. The seat ceiling ANDs on top, because a read
-  // seat may read this page and may not write anything on it.
+  // `extension_access:read`, which is what `GET /v1/extensions` asks for
+  // (compose/handlers_extensions.go).
   //
-  // There is no `useCan` question to ask instead: a `role` RBAC object was
-  // considered and declined, because object RBAC narrows who among PEERS may
-  // touch a record and no such narrowing exists here — nobody but an admin
-  // should hold it, so the grant would be a constant, and an admin who revoked
-  // their own would have no way back. The role check is the ratified answer,
-  // not a stand-in for one.
-  const isAdmin = useHoldsAdminRole();
-  const canMutate = useCanMutate();
-  const query = useExtensionAccess(isAdmin);
+  // This WAS the literal admin role, and the comment here argued there was no
+  // useCan question to ask — that a `role` object would encode a constant an
+  // admin could revoke and never restore. That reasoning was about the object
+  // it declined, not about this one: `extension_access` names what an installed
+  // unit may reach, ops holds it, and the server answers ops 200. Keeping the
+  // role check meant refusing a reader the authority admits.
+  //
+  // The seat ceiling still ANDs on top, because a read seat may read this page
+  // and may not write anything on it.
+  //
+  // BOTH grants, because the card is two reads behind one flag: the inventory
+  // from `GET /v1/extensions` (extension_access:read) and every role's grant on
+  // every object from `GET /v1/roles`, which asks for role_admin:read
+  // (identity/roles.go ListRoles). On the inventory grant alone the whole card
+  // 403s on its second query — and the matrix it draws is the one surface that
+  // grants an extension's objects at all, so half of it is not a card.
+  // Each predicate on its own line: `a() && b()` short-circuits, and a hook
+  // that stops being called between renders is a hook-order violation, not a
+  // narrower gate.
+  const readsInventory = useCan("extension_access", "read");
+  const readsRoles = useCan("role_admin", "read");
+  const canSee = readsInventory && readsRoles;
+  // The toggles write through PATCH /roles/{key}/objects/{object}, which asks
+  // for role_admin:UPDATE (identity/roles.go SetRoleObjectGrant) — a strictly
+  // wider grant than the read above. Ops holds the read and not the update, so
+  // without this every tick it is shown would 403.
+  const seatMayWrite = useCanMutate();
+  const writesRoles = useCan("role_admin", "update");
+  const canMutate = seatMayWrite && writesRoles;
+  const query = useExtensionAccess(canSee);
   const composed = query.data;
 
   return (
@@ -284,11 +308,11 @@ export function ExtensionAccessCard() {
       <Panel tone="accent" title={t("extAccess.title")}>
         <PanelBody>
           <p className="t-caption ext-lead-sub">{t("extAccess.sub")}</p>
-          {/* Gate on the role probe itself so the admin-only notice appears only
-              once /me has answered — never as a flash while it loads. */}
+          {/* Gate on the /me probe itself so the withheld notice appears only
+              once it has answered — never as a flash while it loads. */}
           <QueryGate query={me} pendingLabel={t("extAccess.title")}>
             {() =>
-              isAdmin ? (
+              canSee ? (
                 <InventoryLead query={query} />
               ) : (
                 <EmptyState>{t("extAccess.adminOnly")}</EmptyState>
@@ -302,10 +326,10 @@ export function ExtensionAccessCard() {
           the heading that names the page, and a unit is a subject in its own
           right. Only reachable with data in hand, which for a non-admin the
           disabled reads never produce. */}
-      {/* Gated on the role as well as on the data: `enabled: false` is about the
-          next request, and a card rendered from a cache the reader may no longer
-          read is the same disclosure the notice above it refuses. */}
-      {isAdmin &&
+      {/* Gated on the grant as well as on the data: `enabled: false` is about
+          the next request, and a card rendered from a cache the reader may no
+          longer read is the same disclosure the notice above it refuses. */}
+      {canSee &&
         composed?.extensions.map((unit) => (
           <UnitCard
             key={unit.name}

--- a/frontend/src/screens/jobhealth.test.tsx
+++ b/frontend/src/screens/jobhealth.test.tsx
@@ -58,10 +58,13 @@ function stubRoutes(overrides: Record<string, () => Response> = {}) {
       const override = overrides[key];
       if (override) return override();
       if (key === "GET /admin/job-health") return jsonResponse(HEALTH);
-      // The endpoint gates on the admin ROLE server-side, so the default
-      // principal here holds it. A test asserting the refusal overrides this.
+      // `GET /admin/job-health` gates on `job_health:read`, so the default
+      // principal here holds that grant. A test asserting the refusal overrides
+      // this with a principal who does not.
       if (key === "GET /me")
-        return jsonResponse(meFixture({ roles: ["admin"] }));
+        return jsonResponse(
+          meFixture({ roles: ["admin"], allow: { job_health: ["read"] } }),
+        );
       return jsonResponse({});
     }),
   );
@@ -312,12 +315,12 @@ describe("JobHealthCard", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("withholds the report from a non-admin instead of asking for it", async () => {
+  it("withholds the report from a reader without the grant instead of asking for it", async () => {
     const sent = stubRoutes({
       "GET /me": () => jsonResponse(meFixture({ roles: ["ops"] })),
     });
     render(<JobHealthCard />);
-    await screen.findByText(/only an admin can see background-job health/i);
+    await screen.findByText(/background-job health needs permission/i);
     expect(screen.queryByText("capture_classify")).not.toBeInTheDocument();
     // And it never issued the call the server would only refuse. An ops seat
     // reaching this page for its other sections must not generate a 403.
@@ -382,7 +385,7 @@ describe("JobHealthCard", () => {
       "GET /me": () => jsonResponse(meFixture({ roles: ["ops"] })),
     });
     render(<JobHealthCard />);
-    await screen.findByText(/only an admin can see background-job health/i);
+    await screen.findByText(/background-job health needs permission/i);
     // No report, no stamp: a time under a withheld body would date a reading
     // this card is not showing.
     expect(screen.queryByText(/read at/i)).not.toBeInTheDocument();

--- a/frontend/src/screens/jobhealth.tsx
+++ b/frontend/src/screens/jobhealth.tsx
@@ -6,7 +6,7 @@ import { TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useHoldsAdminRole } from "../app/capability";
+import { useCan } from "../app/capability";
 import { Badge, EmptyState } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { CardBoundary } from "../design-system/cardboundary";
@@ -375,19 +375,23 @@ export function JobHealthCard() {
   // Resolved once for the card and handed down, so the stamp in the footer and
   // the failure timestamps in the body cannot read two different clocks.
   const zone = viewerZone();
-  // The probe itself, not only its answer: useHoldsAdminRole reads false while
-  // /me is in flight, so branching on `!isAdmin` alone told every administrator
-  // that job health was admin-only, on every load of the Maintenance tab,
-  // until the session landed.
+  // The probe itself, not only its answer: every capability predicate reads
+  // false while /me is in flight, so branching on `!canSee` alone told every
+  // administrator that job health was not theirs, on every load, until the
+  // session landed.
   const me = useMe();
-  // The role, not a grant: the endpoint gates on `admin` server-side and no
-  // RBAC object describes background work. `enabled` is what keeps a non-admin
-  // from issuing a call that could only 403 — a refusal the reader cannot act
-  // on has no business becoming this card's error state.
-  const isAdmin = useHoldsAdminRole();
+  // `job_health:read`, which is what the endpoint asks for (compose/jobhealth.go).
+  //
+  // It was the literal admin role while no RBAC object described background
+  // work. One does now, and ops holds it — so an operator watching a stalled
+  // queue reads it rather than being told the surface is an admin's. `enabled`
+  // is what keeps a reader without the grant from issuing a call that could
+  // only 403: a refusal they cannot act on has no business becoming this
+  // card's error state.
+  const canSee = useCan("job_health", "read");
   const query = useQuery({
     queryKey: ["job-health"],
-    enabled: isAdmin,
+    enabled: canSee,
     queryFn: async () => {
       const { data, error } = await api.GET("/admin/job-health");
       if (error) {
@@ -417,7 +421,7 @@ export function JobHealthCard() {
   });
 
   let body: ReactNode;
-  if (!isAdmin) {
+  if (!canSee) {
     // Withheld, not absent. The card keeps its place on a maintenance page a
     // non-admin reaches for its other sections, and an absent card there would
     // read as "nothing is queued" — a different claim entirely.
@@ -446,11 +450,11 @@ export function JobHealthCard() {
   // the states that have no report — withheld, pending, failed — and present
   // for every state that does, the idle one included: an operator trusting
   // "nothing is queued" needs to know how old that answer is.
-  // Behind `isAdmin` as well as behind the data, because a cache outlives a
+  // Behind `canSee` as well as behind the data, because a cache outlives a
   // grant: a role edited mid-session leaves the last report sitting in the
   // query cache, and a stamp under a withheld body would date a reading the
   // card is no longer showing.
-  const report = isAdmin ? query.data : undefined;
+  const report = canSee ? query.data : undefined;
 
   // No bottom margin: `.settings-stack` owns the gap between cards, and a card
   // that adds its own gets two.

--- a/frontend/src/screens/license.test.tsx
+++ b/frontend/src/screens/license.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
 import { LicenseCard } from "./license";
 
@@ -60,6 +61,14 @@ function backendFor(entitlement: Entitlement) {
     const req =
       input instanceof Request ? input : new Request(String(input), init);
     const url = new URL(req.url, "http://localhost");
+    // The card asks which half this reader may have before it asks for either,
+    // so /me is now part of its own read rather than ambient context.
+    if (url.pathname.endsWith("/v1/me")) {
+      return new Response(
+        JSON.stringify(meFixture({ allow: { license: ["read"] } })),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
     if (url.pathname.endsWith("/installation/license")) {
       return new Response(JSON.stringify(entitlement), {
         status: 200,
@@ -267,6 +276,107 @@ describe("LicenseCard", () => {
     const meter = screen.getByRole("meter");
     expect(meter.getAttribute("aria-valuenow")).toBe("11");
     expect(meter.getAttribute("aria-valuemax")).toBe("10");
+  });
+});
+
+describe("the capacity half, for a reader who may not see the commercial one", () => {
+  // `seat_usage` shipped so management could plan headcount without being handed
+  // what the installation pays. The card reads the entitlement for a `license`
+  // holder and falls back to `/installation/seat-usage` for a `seat_usage` one.
+  //
+  // Both cases assert which endpoint was ASKED, not only what was drawn. The
+  // wrong one is not a rendering difference: for a `seat_usage` holder the
+  // entitlement 403s, and for a `license` holder the capacity call is a second
+  // request for a number the first already carried.
+  function twoHalfBackend(
+    allow: NonNullable<Parameters<typeof meFixture>[0]>["allow"],
+    asked: string[],
+  ) {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req =
+        input instanceof Request ? input : new Request(String(input), init);
+      const url = new URL(req.url, "http://localhost");
+      asked.push(url.pathname);
+      const body = url.pathname.endsWith("/v1/me")
+        ? meFixture({ roles: ["management"], allow })
+        : url.pathname.endsWith("/installation/seat-usage")
+          ? { seats_used: 7 }
+          : {
+              state: "valid",
+              seats_used: 7,
+              over_limit: false,
+              checked_at: checkedAt,
+            };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+  }
+
+  it("reads capacity for a seat_usage holder, and never asks for the entitlement", async () => {
+    const asked: string[] = [];
+    vi.stubGlobal("fetch", twoHalfBackend({ seat_usage: ["read"] }, asked));
+    render(<LicenseCard />);
+
+    expect(await screen.findByText("7")).toBeTruthy();
+    expect(asked).toContain("/v1/installation/seat-usage");
+    expect(asked).not.toContain("/v1/installation/license");
+  });
+
+  it("reads the entitlement for a license holder, and never asks for capacity", async () => {
+    // The half that a naive `!canReadLicense` gets wrong: every capability
+    // predicate reads false while /me is in flight, so a fallback keyed on it
+    // alone fires the capacity request for a licence holder on every load,
+    // before the grant has resolved.
+    const asked: string[] = [];
+    vi.stubGlobal("fetch", twoHalfBackend({ license: ["read"] }, asked));
+    render(<LicenseCard />);
+
+    await waitFor(() => expect(asked).toContain("/v1/installation/license"));
+    expect(asked).not.toContain("/v1/installation/seat-usage");
+  });
+
+  // The third state of the snapshot, which is neither of the two above: /me
+  // FAILED. `isPending` goes false with no grants to read, so a branch keyed on
+  // `!canReadLicense` alone is true for a licence holder exactly as it is for a
+  // capacity reader — and it would pick capacity permanently, offering a retry
+  // that retries seats rather than the snapshot that actually failed.
+  it("asks for neither half when the access snapshot itself failed", async () => {
+    const asked: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req =
+          input instanceof Request ? input : new Request(String(input), init);
+        const url = new URL(req.url, "http://localhost");
+        asked.push(url.pathname);
+        if (url.pathname.endsWith("/v1/me")) {
+          return new Response(JSON.stringify({ title: "upstream" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ seats_used: 7 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+    render(<LicenseCard />);
+
+    // Waited on the FAILURE having been rendered, not merely on the request
+    // having been made: asserting an absence a beat after mount passes before
+    // the wrong branch has had a chance to fire, which is the vacuous shape
+    // this whole file is careful about. The retry button is the /me gate's own
+    // and only appears once the query has actually errored.
+    expect(
+      await screen.findByRole("button", { name: /try again|retry/i }),
+    ).toBeTruthy();
+    // Only then: no capacity reading claimed, and no request spent guessing.
+    expect(asked).not.toContain("/v1/installation/seat-usage");
+    expect(asked).not.toContain("/v1/installation/license");
+    expect(screen.queryByText("7")).toBeNull();
   });
 });
 

--- a/frontend/src/screens/license.tsx
+++ b/frontend/src/screens/license.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Info, TriangleAlert } from "lucide-react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCan } from "../app/capability";
 import { StatCard } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
@@ -11,7 +12,7 @@ import { StatStrip } from "../design-system/statstrip";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { QueryGate, throwProblem } from "./common";
+import { QueryGate, throwProblem, useMe } from "./common";
 import { LicenseHolderCard } from "./licenseholder";
 
 // The entitlement surface: what the license grants, and how many seats are using
@@ -69,9 +70,81 @@ export function useLicenseEntitlement(enabled = true) {
   });
 }
 
+/**
+ * How many seats are in use, without what the installation is entitled to.
+ *
+ * The capacity half on its own grant. `GET /installation/license` answers both
+ * questions together and takes `license:read`, so a reader who may plan
+ * headcount but may not see what the installation pays could not read either —
+ * which is what `seat_usage` and this endpoint were split out for.
+ *
+ * It is the SAME meter: both surfaces run one statement server-side, and that
+ * statement is also the ceiling that refuses the next full seat.
+ */
+function useSeatUsage(enabled: boolean) {
+  return useQuery({
+    queryKey: ["installation-seat-usage"],
+    enabled,
+    staleTime: 5 * 60_000,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/installation/seat-usage",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
 export function LicenseCard() {
   const t = useT();
-  const query = useLicenseEntitlement();
+  // Which half this reader may have. Asking the entitlement without the grant
+  // would 403 on every load and hand them a red failure with a futile Retry;
+  // asking capacity as well would spend a second request on a question the
+  // entitlement already answers.
+  const canReadLicense = useCan("license", "read");
+  // The probe itself, not only its answer. Every capability predicate reads
+  // false while /me is in flight, so `!canReadLicense` is true for EVERYBODY
+  // during that window — and a fallback keyed on it alone fires the capacity
+  // request for a licence holder on every load, before the grant resolves.
+  //
+  // Neither query runs until the snapshot lands, so exactly one of them runs.
+  //
+  // ANSWERED, not merely settled: a failed /me leaves `isPending` false with no
+  // grants to read, and `!canReadLicense` is then true for a licence holder
+  // exactly as it is for someone who may not read one. Keying the fallback on
+  // that alone picked the capacity branch permanently, and its retry retried
+  // the wrong request — seats, never the snapshot that failed. An unanswered
+  // /me is not a narrower reader; it is no reader yet.
+  const me = useMe();
+  const answered = !me.isPending && !me.isError;
+  const query = useLicenseEntitlement(answered && canReadLicense);
+  const seats = useSeatUsage(answered && !canReadLicense);
+
+  // Nothing is known about this reader, so neither branch may claim to be
+  // their answer. The gate below renders the /me failure and its retry.
+  if (me.isError) {
+    return (
+      <QueryGate query={me} pendingLabel={t("license.seats.title")}>
+        {() => null}
+      </QueryGate>
+    );
+  }
+
+  if (answered && !canReadLicense) {
+    // Capacity alone. The commercial standing is deliberately absent rather
+    // than shown empty: an unreadable entitlement is a fact about who is
+    // reading, and rendering it as "no license" would say something false
+    // about the installation.
+    return (
+      <QueryGate query={seats} pendingLabel={t("license.seats.title")}>
+        {(usage) => <SeatUsageReading seatsUsed={usage.seats_used} />}
+      </QueryGate>
+    );
+  }
+
   return (
     <QueryGate query={query} pendingLabel={t("license.seats.title")}>
       {(entitlement) => (
@@ -111,6 +184,34 @@ function stateKey(
 
 // Exported for its story: the states worth looking at are states of the READING,
 // and a story that had to stub a query to reach them would be testing the fetch.
+/**
+ * The seat count alone, for a reader holding capacity and not entitlement.
+ *
+ * Deliberately says NOTHING about a licence: not "no license configured", not
+ * an empty grant, not an uncapped meter. Those are claims about the
+ * installation, and what is actually true here is a fact about the reader —
+ * they may not see it. A card that filled the gap with "unlicensed" would tell
+ * a manager something false about the company they work for.
+ */
+function SeatUsageReading({ seatsUsed }: Readonly<{ seatsUsed: number }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  return (
+    <Panel title={t("license.card.title")}>
+      <PanelBody>
+        <p className="settings-panel-sub">{t("license.seats.capacityOnly")}</p>
+        <SettingList>
+          <SettingRow
+            label={t("license.seats.title")}
+            description={t("license.counting")}
+            control={formatNumber(seatsUsed, locale)}
+          />
+        </SettingList>
+      </PanelBody>
+    </Panel>
+  );
+}
+
 export function LicenseReading({
   entitlement,
 }: Readonly<{ entitlement: LicenseEntitlement }>) {

--- a/frontend/src/screens/privacy.assignee.test.tsx
+++ b/frontend/src/screens/privacy.assignee.test.tsx
@@ -101,9 +101,15 @@ function stub(dsr: DataSubjectRequest, roster: RosterServer) {
         "https://test.local",
       );
       if (url.pathname.endsWith("/me")) {
-        // The queue is admin-gated: its rows name the people who exercised an
-        // Art. 15/17 right.
-        return json(meFixture({ roles: ["admin"] }));
+        // The queue reads on `privacy_request:read`: its rows name the people
+        // who exercised an Art. 15/17 right, so a reader needs that grant to
+        // reach any of the rows this file is about.
+        return json(
+          meFixture({
+            roles: ["admin"],
+            allow: { privacy_request: ["read"] },
+          }),
+        );
       }
       if (url.pathname.endsWith("/data-subject-requests")) {
         return json({ data: [dsr], page: PAGE });

--- a/frontend/src/screens/privacy.test.tsx
+++ b/frontend/src/screens/privacy.test.tsx
@@ -100,11 +100,25 @@ function stubRoutes(
           data: [],
           page: { next_cursor: null, has_more: false },
         });
-      // The subject-request queue is admin-gated (its rows name the people who
-      // filed), so the default principal here holds the role that may read it.
-      // A test asserting the refusal overrides this key.
+      // The FOUR grants this screen's cards ask for, because they are four
+      // different questions and the server asks each separately:
+      //   privacy_request:read   — the subject queue (consent/dsr.go)
+      //   privacy_request:update — moving a request through its statuses
+      //   person:update          — OPENING one, which writes the person named
+      //   consent_config:create  — appending to the consent registry
+      // The default principal holds all four. A test asserting any one refusal
+      // overrides this key with the narrower set.
       if (key === "GET /me")
-        return jsonResponse(meFixture({ roles: ["admin"] }));
+        return jsonResponse(
+          meFixture({
+            roles: ["admin"],
+            allow: {
+              privacy_request: ["read", "update"],
+              person: ["update"],
+              consent_config: ["create"],
+            },
+          }),
+        );
       return jsonResponse({});
     }),
   );
@@ -218,16 +232,17 @@ describe("ConsentPurposesCard", () => {
     expect(screen.getByLabelText(/key/i)).toHaveValue("transactional");
   });
 
-  // Appending to the registry is admin/ops, so a rep's card carries no write
-  // control at all. Withheld, not absent: the card keeps its place and says
-  // which of the two it is, or the missing button reads as a broken one.
+  // Appending to the registry asks `consent_config:create`, which a rep does
+  // not hold, so their card carries no write control at all. Withheld, not
+  // absent: the card keeps its place and says which of the two it is, or the
+  // missing button reads as a broken one.
   it("states its read-only posture to a seat that cannot add a purpose", async () => {
     stubRoutes({
       "GET /me": () => jsonResponse(meFixture({ roles: ["rep"] })),
     });
     render(<ConsentPurposesCard />);
     const posture = await screen.findByText(
-      /only an admin or ops can add a purpose/i,
+      /adding a purpose needs permission/i,
     );
     // On the registry ROW rather than as a paragraph of its own between the
     // card's description and the list: the posture is about the registry, and a
@@ -246,18 +261,25 @@ describe("ConsentPurposesCard", () => {
   });
 
   // The other direction, without which the assertion above passes on a card
-  // that shows the line to everybody: an ops seat holds the grant, so the
-  // posture is not its posture and the sentence would be a false statement.
+  // that shows the line to everybody: this seat holds `consent_config:create`,
+  // so the posture is not its posture and the sentence would be a false
+  // statement.
   it("withholds the read-only line from a seat that can add a purpose", async () => {
     stubRoutes({
-      "GET /me": () => jsonResponse(meFixture({ roles: ["ops"] })),
+      "GET /me": () =>
+        jsonResponse(
+          meFixture({
+            roles: ["ops"],
+            allow: { consent_config: ["create"] },
+          }),
+        ),
     });
     render(<ConsentPurposesCard />);
     expect(
       await screen.findByRole("button", { name: /add purpose/i }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/only an admin or ops can add a purpose/i),
+      screen.queryByText(/adding a purpose needs permission/i),
     ).not.toBeInTheDocument();
   });
 });
@@ -306,21 +328,92 @@ async function findDsrRow(subjectRef: string) {
 }
 
 describe("PrivacyInboxCard", () => {
-  it("withholds the queue from a non-admin instead of asking for it", async () => {
+  it("withholds the queue from a reader without the grant instead of asking for it", async () => {
     // The rows name the people who exercised an Art. 15/17 right, so the read
-    // is the admin's. An ops seat reaches this tab for the consent registry
-    // beside it, and must find the card in its place saying why it is empty —
-    // an absent card would read as "no requests", a different claim entirely.
+    // asks `privacy_request:read`. A seat reaching this page for the consent
+    // registry beside it must find the card in its place saying why it is empty
+    // — an absent card would read as "no requests", a different claim entirely.
     const sent = stubRoutes({
       "GET /me": () => jsonResponse(meFixture({ roles: ["ops"] })),
     });
     render(<PrivacyInboxCard />);
-    await screen.findByText(/only an admin can see subject requests/i);
+    await screen.findByText(/subject requests needs permission/i);
     expect(screen.queryByText(/anna@acme.test/)).not.toBeInTheDocument();
     // And it never issued the call the server would only refuse.
     expect(
       sent.some((entry) => entry.key === "GET /data-subject-requests"),
     ).toBe(false);
+  });
+
+  // Reading the queue and WORKING it are different grants, and the server asks
+  // them separately: consent/dsr.go's UpdateDSR wants `privacy_request:update`
+  // where the list wants `read`. A delegated reader used to be shown every
+  // transition button and refused by each one.
+  it("offers no transition to a reader who may see the queue but not work it", async () => {
+    stubRoutes({
+      "GET /data-subject-requests": () => jsonResponse(DSRS),
+      "GET /me": () =>
+        jsonResponse(
+          meFixture({
+            roles: ["ops"],
+            allow: { privacy_request: ["read"], person: ["update"] },
+          }),
+        ),
+    });
+    render(<PrivacyInboxCard />);
+
+    // The OPEN request, not the fulfilled one: a terminal request offers no
+    // transition to anybody, so asserting their absence on it would pass
+    // whatever the grant said.
+    const row = await findDsrRow("8f3a-person-uuid");
+    await userEvent.click(within(row).getByRole("button"));
+
+    // …and carries no verb that would 403. Scoped to `.dsr-actions`, the
+    // container the transitions live in: a row's summary TOGGLE carries the
+    // same status words as badges, so a name-only query matches four buttons
+    // that were never verbs.
+    expect(document.querySelectorAll(".dsr-actions button")).toHaveLength(0);
+  });
+
+  // Opening a request is a THIRD grant: the POST writes the person it names, so
+  // consent/dsr.go's CreateDSR asks `person:update` rather than anything on the
+  // privacy object at all.
+  it("offers no New request to a reader who may work the queue but not write a person", async () => {
+    stubRoutes({
+      "GET /data-subject-requests": () => jsonResponse(DSRS),
+      "GET /me": () =>
+        jsonResponse(
+          meFixture({
+            roles: ["ops"],
+            allow: { privacy_request: ["read", "update"] },
+          }),
+        ),
+    });
+    render(<PrivacyInboxCard />);
+
+    // The queue answered, so this is about the missing grant and not about a
+    // card that never rendered.
+    expect(await screen.findByText(/anna@acme.test/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /new request/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // The mirror of both: the full set of grants offers both verbs, so the two
+  // refusals above are about what is missing rather than about controls nobody
+  // is ever shown.
+  it("offers the verbs to a reader holding every grant behind them", async () => {
+    stubRoutes({ "GET /data-subject-requests": () => jsonResponse(DSRS) });
+    render(<PrivacyInboxCard />);
+
+    expect(
+      await screen.findByRole("button", { name: /new request/i }),
+    ).toBeInTheDocument();
+    const row = await findDsrRow("8f3a-person-uuid");
+    await userEvent.click(within(row).getByRole("button"));
+    expect(
+      document.querySelectorAll(".dsr-actions button").length,
+    ).toBeGreaterThan(0);
   });
 
   it("binds the status filter server-side, never a client re-slice", async () => {

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -7,7 +7,7 @@ import {
 import { type ReactNode, useId, useMemo, useRef, useState } from "react";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
-import { useHoldsAdminRole, useHoldsConsentAdminRole } from "../app/capability";
+import { useCan, useCanWrite } from "../app/capability";
 import {
   Badge,
   Button,
@@ -207,7 +207,15 @@ export function ConsentPurposesCard() {
   // while /me is in flight, so branching on `!canAdminister` alone would flash
   // the read-only line at an admin on every load.
   const me = useMe();
-  const canAdminister = useHoldsConsentAdminRole();
+  // `consent_config:create`, which is what consent/store.go's CreatePurpose
+  // asks for. This was a role predicate whose own comment said it was interim —
+  // the object was governed upstream but absent from the shipped vocabulary, so
+  // there was no grant to ask for. There is now.
+  //
+  // `useCanWrite`, not `useCan`: the seat ceiling is enforced BEFORE RBAC
+  // (identity/admission.go), so a read seat holding the grant is still refused
+  // every POST. The control it was shown could only ever 403.
+  const canAdminister = useCanWrite("consent_config", "create");
   const addTitleId = useId();
   const [adding, setAdding] = useState(false);
   const query = useQuery({
@@ -571,6 +579,56 @@ function unofferedAssignee({
 // the facet bar visible while one case is worked, so `expanded` and its
 // toggle arrive as props; useRoster only fetches the workspace roster while
 // THIS row is the open one, not for every row on the page.
+/**
+ * The verbs that move one request through its statuses.
+ *
+ * Its own component because the grant is its own question: consent/dsr.go's
+ * UpdateDSR asks for `privacy_request:update`, a strictly WIDER grant than the
+ * `read` that opened this queue. A reader delegated only the inbox used to be
+ * shown every transition button and refused by each of them.
+ *
+ * `useCanWrite` rather than `useCan` — the seat ceiling refuses a read seat's
+ * mutations above RBAC (identity/admission.go), so the grant alone is not the
+ * answer.
+ */
+function DsrTransitions({
+  status,
+  answered,
+  pending,
+  onTransition,
+}: Readonly<{
+  status: DataSubjectRequest["status"];
+  // Whether this request already carries the answer that closing one needs —
+  // the draft in the field or the one already stored, either satisfies the
+  // server, so the row resolves them to one fact before asking.
+  answered: boolean;
+  pending: boolean;
+  onTransition: (next: DataSubjectRequest["status"]) => void;
+}>) {
+  const t = useT();
+  const canWork = useCanWrite("privacy_request", "update");
+  if (!canWork) {
+    return null;
+  }
+  return (
+    <div className="dsr-actions">
+      {nextStatuses(status).map((next) => (
+        <Button
+          key={next}
+          small
+          disabled={
+            ((next === "fulfilled" || next === "rejected") && !answered) ||
+            pending
+          }
+          onClick={() => onTransition(next)}
+        >
+          {t(transitionLabelKey(next))}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
 function DsrRow({
   dsr,
   expanded,
@@ -785,24 +843,12 @@ function DsrRow({
                     />
                   )}
                 </Field>
-                <div className="dsr-actions">
-                  {nextStatuses(dsr.status).map((next) => {
-                    const closingWithoutAnswer =
-                      (next === "fulfilled" || next === "rejected") &&
-                      !resolution.trim() &&
-                      !dsr.resolution;
-                    return (
-                      <Button
-                        key={next}
-                        small
-                        disabled={closingWithoutAnswer || patch.isPending}
-                        onClick={() => submitTransition(next)}
-                      >
-                        {t(transitionLabelKey(next))}
-                      </Button>
-                    );
-                  })}
-                </div>
+                <DsrTransitions
+                  status={dsr.status}
+                  answered={Boolean(resolution.trim() || dsr.resolution)}
+                  pending={patch.isPending}
+                  onTransition={submitTransition}
+                />
               </>
             )}
           </div>
@@ -999,15 +1045,19 @@ export function PrivacyInboxCard() {
   // request's new status, which is what makes it the right landing place.
   const stagedRowToggle = useRef<string | null>(null);
 
-  // The queue is the admin's: its rows name data subjects who exercised an
-  // Art. 15/17 right, so the read is gated rather than merely rendered. The
-  // fetch is disabled for anyone else, which keeps a non-admin who reaches the
-  // tab for its consent registry from issuing a call that only 403s.
-  const isAdmin = useHoldsAdminRole();
-  // The probe itself, not only its answer. useHoldsAdminRole reads the roles
-  // off the /me cache, so it is false while that read is in flight — and
-  // branching on `!isAdmin` alone flashed "the subject queue is admin only" at
-  // every administrator, on every load of this tab, until the session landed.
+  // `privacy_request:read`, which is what consent/dsr.go asks for.
+  //
+  // The queue's rows name data subjects who exercised an Art. 15/17 right, so
+  // the read is gated rather than merely rendered, and the fetch is disabled
+  // for anyone without it — which keeps a reader who came for the consent
+  // registry beside it from issuing a call that only 403s. It was the literal
+  // admin role until the queue got an object of its own.
+  const canSee = useCan("privacy_request", "read");
+  const canOpenRequest = useCanWrite("person", "update");
+  // The probe itself, not only its answer. Every capability predicate reads off
+  // the /me cache, so it is false while that read is in flight — and branching
+  // on `!canSee` alone flashed "the subject queue is not yours" at every
+  // administrator, on every load, until the session landed.
   const me = useMe();
 
   // The facet is server-side (part of the queryKey and the query param), not
@@ -1016,7 +1066,7 @@ export function PrivacyInboxCard() {
   // (the house rule at history.tsx:258).
   const query = useInfiniteQuery({
     queryKey: ["dsrs", facet],
-    enabled: isAdmin,
+    enabled: canSee,
     initialPageParam: FIRST_PAGE,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/data-subject-requests", {
@@ -1061,7 +1111,7 @@ export function PrivacyInboxCard() {
   // list here; filtering happens server-side so an empty page after a facet
   // change is a real "nothing matches", not a client-side hide.
   let body: ReactNode;
-  if (!isAdmin) {
+  if (!canSee) {
     // Withheld rather than absent: the card keeps its place on a tab an ops
     // seat reaches for the consent registry, and says why it is empty. An
     // absent card there would read as "no requests", which is a different
@@ -1122,10 +1172,17 @@ export function PrivacyInboxCard() {
       // the button's own words repeated. Opening a request is a kind, a subject
       // and a statutory deadline committed together, so the header keeps the
       // verb and the dialog keeps the form.
+      // Opening a request is a POST that asks for `person:update`
+      // (consent/dsr.go CreateDSR) — a DIFFERENT object from the one that
+      // opened this queue, because recording a subject request writes the
+      // person it names. A reader delegated only the inbox was offered the
+      // verb and refused it.
       titleAction={
-        <Button small onClick={() => setCreating(true)}>
-          {t("privacy.newRequest")}
-        </Button>
+        !canOpenRequest ? null : (
+          <Button small onClick={() => setCreating(true)}>
+            {t("privacy.newRequest")}
+          </Button>
+        )
       }
     >
       <PanelBody>

--- a/frontend/src/screens/settings-audit.test.tsx
+++ b/frontend/src/screens/settings-audit.test.tsx
@@ -30,11 +30,14 @@ afterEach(() => {
 function auditLogBackend() {
   return vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
-    // The trail is the admin's alone, so every case below needs a principal who
-    // may read it — an anonymous fixture would only ever exercise the withheld
-    // rung, which has a case of its own on the Privacy & audit page.
+    // `AuditLogCard` gates itself on `audit_log:read`, which is what
+    // `GET /v1/audit-log` asks for, so every case below needs a principal
+    // holding that grant — an anonymous fixture would only ever exercise the
+    // withheld rung, which has a case of its own on the Audit log page.
     if (url.endsWith("/v1/me")) {
-      return jsonResponse(meFixture({ roles: ["admin"] }));
+      return jsonResponse(
+        meFixture({ roles: ["admin"], allow: { audit_log: ["read"] } }),
+      );
     }
     if (url.includes("/audit-log")) {
       return jsonResponse({
@@ -126,7 +129,9 @@ describe("AuditLogCard", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) =>
         String(input instanceof Request ? input.url : input).endsWith("/v1/me")
-          ? jsonResponse(meFixture({ roles: ["admin"] }))
+          ? jsonResponse(
+              meFixture({ roles: ["admin"], allow: { audit_log: ["read"] } }),
+            )
           : jsonResponse({
               data: [],
               page: { next_cursor: null, has_more: false },
@@ -143,7 +148,9 @@ describe("AuditLogCard", () => {
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input instanceof Request ? input.url : input);
         if (url.endsWith("/v1/me")) {
-          return jsonResponse(meFixture({ roles: ["admin"] }));
+          return jsonResponse(
+            meFixture({ roles: ["admin"], allow: { audit_log: ["read"] } }),
+          );
         }
         if (url.includes("/audit-log")) {
           return jsonResponse({ title: "Upstream is down" }, 500);
@@ -206,7 +213,9 @@ describe("AuditLogCard", () => {
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input instanceof Request ? input.url : input);
         if (url.endsWith("/v1/me")) {
-          return jsonResponse(meFixture({ roles: ["admin"] }));
+          return jsonResponse(
+            meFixture({ roles: ["admin"], allow: { audit_log: ["read"] } }),
+          );
         }
         if (url.includes("/audit-log")) {
           return jsonResponse({

--- a/frontend/src/screens/settings-maintenance.test.tsx
+++ b/frontend/src/screens/settings-maintenance.test.tsx
@@ -9,9 +9,10 @@ import { IDLE_JOB_HEALTH, jsonResponse, render } from "./settings.testkit";
 import { settingsHref } from "./settingsrouting";
 
 // The danger zone on the Maintenance entry. Reset data is the one control on
-// this screen that destroys an installation's data, so it is gated twice — the
-// literal admin role AND the switch a deployment arms — and it owes the admin
-// who ran it a report of what it actually cleared.
+// this screen that destroys an installation's data, so it is gated twice —
+// `system_reset:delete`, which `POST /admin/reset-data` asks for, AND the
+// `data_reset_available` switch a deployment arms — and it owes the reader who
+// ran it a report of what it actually cleared.
 
 // No shared fetch stub: the backend a claim needs is installed beside the claim,
 // so what answered it is readable where it is asserted.
@@ -25,11 +26,11 @@ afterEach(() => {
   globalThis.localStorage.clear();
 });
 
-// The danger-zone Reset data action: server-driven, gated on the literal admin
-// role AND me.data_reset_available — the switch a deployment arms, not the
-// posture it happens to run under. A dedicated backend per test so the
-// role/capability combination is explicit rather than layered on the shared
-// default.
+// The danger-zone Reset data action: server-driven, gated on
+// `system_reset:delete` AND me.data_reset_available — the switch a deployment
+// arms, not the posture it happens to run under. A dedicated backend per test
+// so the grant/capability combination is explicit rather than layered on the
+// shared default.
 //
 // `allow` defaults to `system_reset:delete`, the grant that opens the page this
 // card now has to itself — a test about the card should not also have to argue
@@ -61,8 +62,8 @@ function resetDataBackend(opts: {
         data_reset_available: opts.dataResetAvailable,
       });
     }
-    // The job report is the danger zone's neighbour on this entry, and an admin
-    // fetches it on arrival — so it answers with the shape the endpoint serves.
+    // The job report is the danger zone's neighbour on this entry, and a
+    // `job_health:read` holder fetches it on arrival — so it answers with the shape the endpoint serves.
     // A generic `{data: []}` here would crash the card that reads it, and every
     // assertion below would fail describing the wrong thing.
     if (url.includes("/admin/job-health")) {
@@ -128,15 +129,12 @@ describe("ResetDataCard (danger zone)", () => {
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 
-  // Admin-ONLY, and narrower than the grant that opens the page: the server's
-  // auth.RequireAdmin on /admin/reset-data admits only the literal "admin"
-  // role, so an ops user holding `system_reset:delete` through an edited role
-  // must never see a button that could only 403 on confirm.
-  //
-  // The page renders for them — they hold what it asks for — and the card
-  // inside it withholds itself. That is the pair worth keeping: the page's
-  // grant and the card's role are two different questions.
-  it("opens the page for ops but never shows the control", async () => {
+  // `system_reset:delete` is the whole gate, on the page AND on the card inside
+  // it: `POST /admin/reset-data` asks for that grant (compose/datareset.go),
+  // and `ResetDataCard` asks the same object where it used to ask whether the
+  // reader WAS an admin. So a role EDITED to carry the verb reaches the
+  // control — which the role name could not express either way.
+  it("shows the control to an ops role edited to carry the delete verb", async () => {
     vi.stubGlobal(
       "fetch",
       resetDataBackend({
@@ -146,10 +144,28 @@ describe("ResetDataCard (danger zone)", () => {
       }),
     );
     render(<SettingsScreen route={settingsHref("reset")} />);
-    // The page is theirs — they hold its grant — so it renders rather than
-    // falling back. Waiting on the identity would prove the opposite, so this
-    // waits on /me settling and then asserts the control's absence.
-    await waitFor(() => expect(screen.queryByText("Reading…")).toBeNull());
+    expect(
+      await screen.findByRole("button", { name: /reset data/i }),
+    ).toBeTruthy();
+  });
+
+  // The other half, or the case above would pass against a card that showed the
+  // control to everyone: an ops seat WITHOUT the verb reaches nothing, however
+  // armed the installation is.
+  it("withholds the control from an ops seat without the delete verb", async () => {
+    vi.stubGlobal(
+      "fetch",
+      resetDataBackend({
+        roles: ["ops"],
+        dataResetAvailable: true,
+        allow: { person: ["read"] },
+      }),
+    );
+    render(<SettingsScreen route={settingsHref("reset")} />);
+    // The catalog gives this reader no reset page at all, so the address falls
+    // back — asserted through the identity card, which is what the fallback
+    // renders, rather than through an absence that is also true mid-load.
+    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -272,12 +272,12 @@ const floorPlus = (...ids: readonly SettingsPageId[]) =>
 // object, plus the reset page's `delete` — emptying an installation is not a
 // thing you read.
 //
-// Three of these are not reads, and each names a page whose CARDS decide the
-// grant. `automation:update` opens AI usage and Model calls because those cards
-// treat the runtime's spend as operator information. `system_reset:delete`
-// opens the danger zone AND stands in for "is admin" on Extensions and Audit
-// log, whose cards still call `useHoldsAdminRole`. `license:read` opens Seats
-// because `LicenseCard` calls `/installation/license` and nothing else.
+// Every term is the object its page's own cards ask for. `system_reset:delete`
+// opens the danger zone and nothing else now: it used to stand in for "is
+// admin" on Extensions and Audit log, whose cards asked `useHoldsAdminRole`,
+// and those cards ask `extension_access:read` and `audit_log:read` instead.
+// `ai_diagnostics:read` is what `AiUsageCard` and `AiCallsCard` ask, where they
+// used to ask `automation:update`.
 const EVERY_PAGE_GRANTED: GrantSpec = {
   installation_settings: ["read"],
   // Sign-in & apps, whose card reads the narrow projection.
@@ -292,11 +292,17 @@ const EVERY_PAGE_GRANTED: GrantSpec = {
   knowledge_corpus: ["read"],
   import_run: ["read"],
   ai_routing: ["read"],
-  automation: ["read", "update"],
+  automation: ["read"],
+  ai_diagnostics: ["read"],
   person: ["read"],
   audit_log: ["read"],
+  job_health: ["read"],
   embedding_reindex: ["read"],
   extension_access: ["read"],
+  // Extensions is TWO reads: the unit inventory on `extension_access` and every
+  // role's grant on every object on `role_admin` (identity/roles.go ListRoles).
+  // The card fires both behind one flag, so the page needs both.
+  role_admin: ["read"],
   system_reset: ["delete"],
 };
 const EVERY_PAGE = SETTINGS_PAGES.map((page) => labelOf(page.id));
@@ -348,10 +354,10 @@ const SEEDED_READS: GrantSpec = {
 // migration 0261 grants to admin and ops and to nobody else — is what opens
 // Seats & license.
 //
-// `ai_model_rate` opens AI usage and NOT Model calls, which is the two pages
-// disagreeing rather than a gap in this fixture: AI usage unions the model
-// prices with `automation:update`, and Model calls has only the write grant,
-// because `AiCallsCard` checks it and nothing else.
+// `ai_model_rate` opens AI usage and NOT Model calls, which is the two entries
+// differing rather than a gap in this fixture: AI usage unions the model prices
+// with `ai_diagnostics:read` because a rate-sheet author belongs on the page
+// carrying the table, and Model calls asks `ai_diagnostics:read` alone.
 const SEEDED_OPS_READS: GrantSpec = {
   ...SEEDED_READS,
   ai_model_rate: ["read"],
@@ -602,19 +608,27 @@ describe("SettingsScreen page visibility", () => {
     );
   });
 
-  it("keeps Seats & license shut for a lone seat_usage read, which no card calls", async () => {
+  it("opens Seats & license for a lone seat_usage read", async () => {
     // The capacity half of the split, and the reader it shipped for:
-    // management, which may see headcount without commercial standing. The
-    // endpoint exists and the card does not call it, so admitting this holder
-    // lands them on a failed `/installation/license` read rather than on the
-    // count.
-    //
-    // Written to FAIL when `LicenseCard` learns to call the seat-usage
-    // endpoint, which is the signal to widen the catalog entry back to the
-    // union in the same change.
+    // management, which may see headcount without commercial standing.
+    // `LicenseCard` reads `/installation/license` for a `license` holder and
+    // falls back to `/installation/seat-usage` for this one, so the page it
+    // opens has content rather than a failed entitlement read.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("seat_usage") }),
+    );
+    renderNav();
+    await waitFor(() =>
+      expect(navPages()).toEqual(floorPlus("seats", "privacy")),
+    );
+    cleanup();
+
+    // The other half, or the assertion above would pass against a page that
+    // opened for everybody: a seat holding neither read does not reach it.
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({ roles: ["ops"], allow: readOn("person") }),
     );
     renderNav();
     await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
@@ -654,55 +668,52 @@ describe("SettingsScreen page visibility", () => {
     );
   });
 
-  it("keeps System health shut for a lone job_health read, whose card still asks for the admin role", async () => {
-    // `JobHealthCard` refuses a non-admin with `useHoldsAdminRole`. The server
-    // moved the job report onto `job_health:read`; admitting that holder here
-    // offers an ops seat a page that then says "admin only", which reads as a
-    // broken screen rather than as a permission they lack.
+  it("opens System health for a lone job_health read", async () => {
+    // The job report's own object, which `GET /v1/jobs/health` asks for and
+    // which `JobHealthCard` now asks for too — where it used to ask whether the
+    // reader WAS an admin, and so refused an ops seat the server answers 200.
     //
-    // Written to FAIL when `JobHealthCard` honours the grant, which is the
-    // signal to add the `job_health` arm back in the same change.
+    // The page unions this with the reindex read, and each term has to open it
+    // alone or the union is one object with a decorative second term.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("job_health") }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
-  });
+    await waitFor(() =>
+      expect(navPages()).toEqual(floorPlus("privacy", "system-health")),
+    );
+    cleanup();
 
-  it("keeps Extensions shut for a lone extension_access read, whose card still asks for the admin role", async () => {
-    // `GET /extensions` is auth.RequireAdmin and `ExtensionAccessCard` gates
-    // itself on the literal admin role, so this ops holder would find the card
-    // refusing them on a page that opened for them.
-    //
-    // The entry therefore ANDs the read with `system_reset:delete`, which only
-    // admin holds — a stand-in for "is admin" chosen because there is no role
-    // arm in the catalog's vocabulary and there must not be: a role arm would
-    // encode the seeded matrix into the client.
-    //
-    // Written to FAIL when the card honours `extension_access`, which is the
-    // change that drops the `system_reset` term.
+    // And a seat holding neither term still does not reach it, or the case
+    // above would pass against a page that opened for everybody.
     vi.stubGlobal(
       "fetch",
-      settingsNavBackend({ roles: ["ops"], allow: readOn("extension_access") }),
+      settingsNavBackend({ roles: ["ops"], allow: readOn("person") }),
     );
     renderNav();
     await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
   });
 
-  it("opens Extensions for a holder of the read who is also an admin", async () => {
-    // The other half: the read is still load-bearing rather than decorative, so
-    // an admin who LOST `extension_access:read` does not reach the page either.
-    // Both terms are asserted, or the AND collapses into a role check nobody
-    // wrote down.
+  it("opens Extensions for a lone extension_access read", async () => {
+    // `GET /v1/extensions` asks for `extension_access:read`, and
+    // `ExtensionAccessCard` asks the same object — where it used to ask whether
+    // the reader WAS an admin, which refused an ops seat the endpoint answers.
+    //
+    // The read is the WHOLE gate now: the entry used to AND it with
+    // `system_reset:delete` as a stand-in for "is admin", and dropping that
+    // term is what lets an edited role reach the page.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
-        roles: ["admin"],
+        roles: ["ops"],
+        // `person:read` is the floor `readOn` holds steady for every other case
+        // here — without it this stops being a case about Extensions and also
+        // becomes one about losing Privacy.
         allow: {
           person: ["read"],
           extension_access: ["read"],
-          system_reset: ["delete"],
+          role_admin: ["read"],
         },
       }),
     );
@@ -712,6 +723,21 @@ describe("SettingsScreen page visibility", () => {
     );
     cleanup();
 
+    // The inventory read ALONE is not the page. The card makes a second request
+    // for every role's grants, which asks `role_admin:read` — so on this grant
+    // the page opened and the card 403'd inside it, which is an unreadable page
+    // rather than a narrower one.
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({ roles: ["ops"], allow: readOn("extension_access") }),
+    );
+    renderNav();
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    cleanup();
+
+    // And the read is load-bearing rather than decorative: an ADMIN who lost it
+    // does not reach the page, which is what says the entry stopped asking for
+    // the role.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
@@ -798,28 +824,38 @@ describe("SettingsScreen page visibility", () => {
     );
   });
 
-  it("keeps both AI diagnostics pages shut for a lone ai_diagnostics read", async () => {
-    // `ai_diagnostics` is the object the SERVER moved these reads onto. The
-    // cards did not follow: `AiUsageCard` and `AiCallsCard` both check
-    // `automation:update`, so this holder would open two pages and be refused
-    // by every card on them.
+  it("opens both AI diagnostics pages for a lone ai_diagnostics read", async () => {
+    // `ai_diagnostics` is the object the server moved these reads onto, and
+    // `AiUsageCard`, `AiCallsCard` and `AiHealthCard` all ask for it now. They
+    // used to ask `automation:update` — a write verb guarding a GET, from when
+    // the runtime's spend was operator information.
     //
-    // Written to FAIL when those cards honour `ai_diagnostics`, which is the
-    // signal to move both entries onto it in the same change.
+    // One grant opens two pages, which is what makes granting it alone worth
+    // asserting: a Model calls wired to some other object would be invisible
+    // here and everywhere else.
+    //
+    // THREE pages, not two: `AiHealthCard` reads on this object too and Models
+    // is the only page that renders it, so a Models shut on `ai_routing` alone
+    // put that card behind a door its own reader could not open. Management is
+    // seeded diagnostics WITHOUT routing, which is exactly that reader.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("ai_diagnostics") }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await waitFor(() =>
+      expect(navPages()).toEqual(
+        floorPlus("models", "usage", "model-calls", "privacy"),
+      ),
+    );
   });
 
-  it("opens both AI diagnostics pages for the automation write their cards check", async () => {
-    // A read-shaped question answered by a WRITE grant, which is why neither
-    // page can simply ask for an AI-named object: the runtime's spend is
-    // treated as operator information. One grant opens two pages, which is what
-    // makes granting it alone worth asserting — a Model calls wired to some
-    // other object would be invisible here and everywhere else.
+  it("keeps both AI diagnostics pages shut for the automation write the cards used to check", async () => {
+    // The other half of the move, and the reason it is a move rather than a
+    // widening: `automation:update` no longer reaches either page. An
+    // automation editor is not thereby entitled to the installation's model
+    // spend, and a case asserting only the positive above would pass whether or
+    // not the old term was dropped.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
@@ -828,29 +864,43 @@ describe("SettingsScreen page visibility", () => {
       }),
     );
     renderNav();
-    // `automations` stays shut: it asks for `automation:read`, and the write on
-    // the same object is not it. A page is reached by reading it.
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("usage", "model-calls", "privacy")),
-    );
+    // `automations` stays shut too: it asks for `automation:read`, and the
+    // write on the same object is not it. A page is reached by reading it.
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
   });
 
-  it.each([
-    "consent_config",
-    "retention_policy",
-    "privacy_request",
-    "person",
-  ] as const)("opens Privacy for a lone %s read", async (object) => {
-    // Four terms, each opening the page alone — the consent registry, the
-    // retention ladder, the DSR queue, and `person`, which is the gate the
-    // registry endpoint actually applies (consent/store.go's ListPurposes calls
-    // auth.Require on person:read). A union read as one object with three
-    // decorative terms would pass any fixture granting all four.
-    const allow: GrantSpec = {};
-    allow[object] = ["read"];
-    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow }));
+  it.each(["retention_policy", "privacy_request", "person"] as const)(
+    "opens Privacy for a lone %s read",
+    async (object) => {
+      // Three terms, each opening the page alone — the retention ladder, the DSR
+      // queue, and `person`, which is the gate the registry endpoint actually
+      // applies (consent/store.go's ListPurposes calls auth.Require on
+      // person:read). A union read as one object with two decorative terms would
+      // pass any fixture granting all three.
+      //
+      // `consent_config` is deliberately NOT a term. It is what the purposes card
+      // ADMINISTERS, but it buys no read: only the writes moved to it. On that
+      // grant alone the page opened with every card inside it withheld.
+      const allow: GrantSpec = {};
+      allow[object] = ["read"];
+      vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow }));
+      renderNav();
+      await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    },
+  );
+
+  // The term that was dropped, asserted as an absence so nobody adds it back
+  // without meeting the card that would have to read on it.
+  it("does not open Privacy for a lone consent_config read", async () => {
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({
+        roles: ["custom"],
+        allow: { consent_config: ["read", "create"] },
+      }),
+    );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await waitFor(() => expect(navPages()).toEqual(floorPlus()));
   });
 
   it("opens Audit log without opening Privacy, for an admin holding the trail read", async () => {
@@ -859,35 +909,42 @@ describe("SettingsScreen page visibility", () => {
     // page carrying it. Granting the trail read and NOT `person:read` is what
     // proves the split — the two pages move independently.
     //
-    // `system_reset:delete` rides along because `AuditLogCard` still gates
-    // itself on the literal admin role, so the entry ANDs the read with the one
-    // grant only admin holds. It is not what the case is about; without it the
-    // page is shut for a reason this claim is not making.
+    // The trail read is the WHOLE gate now: the entry used to AND it with
+    // `system_reset:delete` as a stand-in for "is admin", because `AuditLogCard`
+    // asked whether the reader WAS one. Both card and entry ask `audit_log:read`
+    // — what `GET /v1/audit-log` asks for — so nothing rides along.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: { audit_log: ["read"], system_reset: ["delete"] },
+        allow: { audit_log: ["read"] },
       }),
     );
     renderNav();
     await waitFor(() => expect(navPages()).toEqual(floorPlus("audit")));
   });
 
-  it("keeps Audit log shut for a delegated audit_log holder who is no admin", async () => {
-    // The server moved this read onto `audit_log`, and a management seat can
-    // hold it. `AuditLogCard` has not followed and still calls
-    // `useHoldsAdminRole`, so admitting them opens a page that then refuses
-    // them.
-    //
-    // Written to FAIL when the card honours the grant, which is the change that
-    // drops the `system_reset:delete` term from the entry.
+  it("opens Audit log for a delegated audit_log holder who is no admin", async () => {
+    // The reader the split shipped for: a management seat holding the trail
+    // read and no admin role. Both the entry and `AuditLogCard` ask
+    // `audit_log:read`, so this holder reaches the page and the trail on it —
+    // where the role check refused them a page the server answers 200.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
         roles: ["management"],
         allow: { audit_log: ["read"] },
       }),
+    );
+    renderNav();
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("audit")));
+    cleanup();
+
+    // And a management seat WITHOUT the read still does not reach it, or the
+    // assertion above would pass against a page that opened for everybody.
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({ roles: ["management"], allow: {} }),
     );
     renderNav();
     await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { pickOption } from "../design-system/select-testing";
 import { LOCALES, localeNameKey, translate } from "../i18n";
-import { SettingsScreen, tabContent } from "./settings";
+import { AuditLogCard, SettingsScreen, tabContent } from "./settings";
 import {
   auditEntry,
   IDLE_JOB_HEALTH,
@@ -62,8 +62,10 @@ function aiRateReaderBackend() {
             // of them but reaches neither on its own, so a fixture without this
             // would be testing the fallback to Account.
             //
-            // NOT the automation write grant, which is what the cards check —
-            // that is the whole fixture: reach the page, be refused the card.
+            // NOT `ai_diagnostics:read`, which is what the cards check — that
+            // is the whole fixture: reach the page, be refused the card. The
+            // cards asked `automation:update` before the runtime's spend got an
+            // object of its own.
             //
             // Usage opens on `ai_model_rate` alone, so this reader gets there
             // and finds the spend withheld. Model calls asks for the same grant
@@ -206,7 +208,7 @@ describe("SettingsScreen RBAC surfaces", () => {
   // The five-tab strip that used to carry these is gone — each card is its own
   // address now — so the two withheld readings are asserted on the two pages
   // that hold them rather than one page's tabs.
-  it("withholds the AI spend from a principal without the automation grant", async () => {
+  it("withholds the AI spend from a principal without the diagnostics read", async () => {
     vi.stubGlobal("fetch", aiRateReaderBackend());
     render(<SettingsScreen route={settingsHref("usage")} />);
 
@@ -214,7 +216,7 @@ describe("SettingsScreen RBAC surfaces", () => {
     await waitFor(() =>
       expect(screen.getByText("AI model costs")).toBeTruthy(),
     );
-    // ...and the card whose endpoint requires the automation grant KEEPS its
+    // ...and the card whose endpoint requires `ai_diagnostics:read` KEEPS its
     // place and says it is withheld. Absent, it would claim the installation had
     // spent nothing — a statement about the data, where the truth is only about
     // who may read it. No request is made for it, so a rep never hits a 403
@@ -238,7 +240,12 @@ describe("SettingsScreen RBAC surfaces", () => {
     // the card ever diverge again this fails, which is the right alarm.
     vi.stubGlobal("fetch", aiRateReaderBackend());
     render(<SettingsScreen route={settingsHref("model-calls")} />);
-    await waitFor(() => expect(screen.queryByText("Reading…")).toBeNull());
+    // Waited on the FALLBACK's own content rather than on an absence: the trace
+    // is missing before /me resolves too, so an absence alone would pass
+    // against a page that goes on to render it.
+    await waitFor(() =>
+      expect(screen.getByText("test@example.test")).toBeTruthy(),
+    );
     expect(screen.queryByText("AI call trace")).toBeNull();
   });
 });
@@ -362,11 +369,6 @@ describe("SettingsScreen restructured pages", () => {
         allow: {
           person: ["read"],
           audit_log: ["read"],
-          // Audit asks for this too, because `AuditLogCard` still gates itself
-          // on the literal admin role: `system_reset:delete` is the grant only
-          // admin holds, and it stands in for that until the card honours
-          // `audit_log`. Dropping it here would test the fallback, not the page.
-          system_reset: ["delete"],
         },
       }),
     );
@@ -393,11 +395,6 @@ describe("SettingsScreen restructured pages", () => {
         allow: {
           person: ["read"],
           audit_log: ["read"],
-          // Audit asks for this too, because `AuditLogCard` still gates itself
-          // on the literal admin role: `system_reset:delete` is the grant only
-          // admin holds, and it stands in for that until the card honours
-          // `audit_log`. Dropping it here would test the fallback, not the page.
-          system_reset: ["delete"],
         },
       }),
     );
@@ -434,31 +431,44 @@ describe("SettingsScreen restructured pages", () => {
     ).toBeTruthy();
   });
 
-  // The trail is the admin's alone, and the page carrying it opens on
-  // `audit_log:read` — a grant ops can hold. So the withholding still has to
-  // happen INSIDE the card: the page's own gate is not the card's gate, and a
-  // reader who reaches the page for the read still may not see the trail.
-  it("does not offer the audit trail to an ops seat, and asks the server for nothing", async () => {
-    // Ops holds `audit_log:read` and the server admits it — but `AuditLogCard`
-    // still gates itself on the literal admin role, so the page asks for admin
-    // too rather than opening and then refusing. That makes this absence rather
-    // than a withheld card, and it is the weaker of the two answers: a card that
-    // says "only an admin can read the full trail" tells a reader something,
-    // where a missing page tells them nothing.
-    //
-    // It is still the right answer while the card refuses, and it stops being
-    // the answer in the change that rewrites the card — at which point this
-    // fails and goes back to asserting the withheld body.
+  // The trail answers to `audit_log:read`, which is what
+  // `GET /v1/audit-log` asks for and what `AuditLogCard` asks for now — it
+  // asked whether the reader WAS an admin before. The page opens on the same
+  // grant, so the two agree: a holder reaches the page AND the trail on it.
+  it("serves the audit trail to an ops seat holding the trail read", async () => {
     const backend = mergedEntryBackend({
       roles: ["ops"],
       allow: { audit_log: ["read"] },
     });
     vi.stubGlobal("fetch", backend);
     renderSettings("audit");
-    await waitFor(() => expect(screen.queryByText("Reading…")).toBeNull());
-    expect(screen.queryByRole("heading", { name: "Audit log" })).toBeNull();
-    // And the request is never issued: it could only ever come back 403, and a
-    // red failure with a futile Retry is what the withheld body replaces.
+    expect(
+      await screen.findByRole("heading", { name: "Audit log" }),
+    ).toBeTruthy();
+    // Reached the wire rather than merely rendering a shell: the card's fetch is
+    // `enabled` on the same grant, so an entry it served is what says the read
+    // was honoured end to end.
+    expect(await screen.findByText("update")).toBeTruthy();
+  });
+
+  // The other half, and the reason opening the page is not the whole answer: a
+  // reader who reaches this page some other way still may not see the trail, so
+  // the card carries its own gate and says so rather than rendering empty.
+  it("withholds the trail from a reader without the read, and asks the server for nothing", async () => {
+    const backend = mergedEntryBackend({
+      roles: ["ops"],
+      allow: { person: ["read"] },
+    });
+    vi.stubGlobal("fetch", backend);
+    // Rendered directly: without the grant the catalog gives this reader no
+    // Audit log row at all, so the card is the only way to reach the branch.
+    render(<AuditLogCard />);
+    expect(
+      await screen.findByText(translate("en", "settings.auditAdminOnly")),
+    ).toBeTruthy();
+    // WITHHELD rather than absent, and the request is never issued: it could
+    // only ever come back 403, and a red failure with a futile Retry is what
+    // the withheld body replaces.
     const asked = backend.mock.calls.map((call) =>
       String(call[0] instanceof Request ? call[0].url : call[0]),
     );
@@ -495,7 +505,7 @@ describe("SettingsScreen restructured pages", () => {
       screen.getByRole("heading", { name: "Background jobs" }),
     ).toBeTruthy();
     expect(
-      screen.getByText(/Only an admin can see background-job health/),
+      screen.getByText(/background-job health needs permission/i),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -16,7 +16,7 @@ import {
 import { api, FIRST_PAGE } from "../api/client";
 import type { components, operations } from "../api/schema";
 import { dotTier } from "../app/autonomy";
-import { useCanWrite, useHoldsAdminRole } from "../app/capability";
+import { useCan, useCanWrite } from "../app/capability";
 import { isEntityKind } from "../app/entity";
 import { useRecordZone } from "../app/recordzone";
 import { navigate, navigateReplacing, type Route } from "../app/router";
@@ -1502,18 +1502,22 @@ function ToolRow({
 }
 
 // The danger-zone reset action: wipes the installation back to its first-boot
-// state. Double-gated client-side — the admin role AND the server-driven
+// state. Double-gated client-side — `system_reset:delete` AND the server-driven
 // `data_reset_available` flag on /me (never VITE_UI_PREVIEW_RESET, which is the
 // unrelated password-reset link) — so the affordance is invisible unless the
 // deployment armed the capability; the server gates the endpoint on that same
 // value and 404s it otherwise, regardless of what this card renders.
 //
-// This is admin-ONLY, and narrower than the Maintenance entry
-// that hosts it — that entry opens on the embedding_reindex read, so an ops seat
-// reaches it for the search index and simply finds no reset control. The
-// server's auth.RequireAdmin on /admin/reset-data admits only the literal
-// "admin" role (mirrors users-admin.tsx's isAdmin check), so neither a manager
-// nor an ops user may see a button that can only 403. The organization's name
+// Two conditions of different kinds, and it needs both: the grant says this
+// reader may wipe an installation that permits wiping, the flag says whether
+// this one does. The compiled default is false in every posture.
+//
+// The GRANT, not the admin role. compose/datareset.go asks
+// auth.Require(system_reset, delete) — it read auth.RequireAdmin while no
+// object named the verb, and this comment outlived that. A role edited to carry
+// the verb reaches the control and one that lost it does not, which the role
+// name could not say either way. The page above it now asks the same thing, so
+// a reader who gets here can use it. The organization's name
 // is not carried on MeResponse, so this never fetches or compares it
 // client-side: the input just has to be non-empty to enable the confirm
 // button, and the server is the sole judge of whether the typed text actually
@@ -1528,7 +1532,16 @@ function ResetDataCard() {
   const t = useT();
   const { locale } = useLocale();
   const me = useMe();
-  const isAdmin = useHoldsAdminRole();
+  // `system_reset:delete`, which is what POST /admin/reset-data asks for
+  // (compose/datareset.go). The literal admin role guarded it while no object
+  // named the verb; one does now, so a role edited to carry it reaches the
+  // control and one that lost it does not — which the role name could not say.
+  //
+  // `useCanWrite`: the reset is a POST, and a read seat is refused every
+  // mutation by the seat ceiling above RBAC (identity/admission.go) whatever
+  // its grants say. Offering the danger zone to one would be a button that
+  // types the workspace name and then 403s.
+  const canSee = useCanWrite("system_reset", "delete");
   const workspaceName = me.data?.workspace_name ?? "";
   const [open, setOpen] = useState(false);
   const [typed, setTyped] = useState("");
@@ -1562,7 +1575,7 @@ function ResetDataCard() {
     },
   });
 
-  if (!isAdmin || !me.data?.data_reset_available) {
+  if (!canSee || !me.data?.data_reset_available) {
     return null;
   }
 
@@ -2444,16 +2457,16 @@ function AuditLogEntries({
   meUserId,
 }: Readonly<{ filters: AuditLogFilters; meUserId?: string }>): ReactNode {
   const t = useT();
-  // The full trail is the admin's alone (AAD-ROLE-4/A91, enforced by
-  // privacy.ListAuditLog), while the page it sits on opens for ops too — the
-  // consent registry above is theirs. So the read is gated here rather than
-  // merely rendered, and the fetch is disabled for anyone else: an ops seat
-  // reaching this page must not issue a call that can only 403, and must not be
-  // handed a red failure with a Retry that cannot succeed.
-  const isAdmin = useHoldsAdminRole();
+  // `audit_log:read`, which is what privacy.ListAuditLog asks for.
+  //
+  // It was the literal admin role (AAD-ROLE-4/A91) until the trail got an
+  // object of its own. Gated here rather than merely rendered, and the fetch is
+  // disabled for anyone without it: a reader must not issue a call that can
+  // only 403, nor be handed a red failure with a Retry that cannot succeed.
+  const canSee = useCan("audit_log", "read");
   const query = useInfiniteQuery({
     queryKey: ["audit-log", filters],
-    enabled: isAdmin,
+    enabled: canSee,
     initialPageParam: FIRST_PAGE,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/audit-log", {
@@ -2473,7 +2486,7 @@ function AuditLogEntries({
   // kept as sequential branches rather than a nested ternary in the JSX below.
   // The whole trail is the control of ONE stacked row now, so no branch wraps
   // itself in a `PanelBody`: the row it sits in already owns the inset.
-  if (!isAdmin) {
+  if (!canSee) {
     // Withheld rather than absent, and the card keeps its place: an absent trail
     // on a page that opens for ops would read as "nothing has happened here",
     // which is a different claim from "this is not yours to read". The same
@@ -2531,7 +2544,7 @@ export function AuditLogCard() {
   // the viewer back to themselves. It is the BARE user id; the wire spells a
   // human actor "human:<uuid>", and ActorTag owns that difference.
   const meUserId = useMe().data?.user?.id;
-  const isAdmin = useHoldsAdminRole();
+  const canSee = useCan("audit_log", "read");
   const [filters, setFilters] = useState<AuditLogFilters>(UNFILTERED_AUDIT_LOG);
   // The row reads what is being typed; the entries read what has settled.
   const asked = useSettledAuditLogFilters(filters);
@@ -2553,7 +2566,7 @@ export function AuditLogCard() {
               inputs that narrow a list they cannot see are a control with
               nothing behind it. The TRAIL below stays and says why — absence
               there would claim nothing had happened. */}
-          {isAdmin && (
+          {canSee && (
             <Disclosure summary={t("settings.auditFilters")}>
               <AuditLogFilterFields filters={filters} onChange={setFilters} />
             </Disclosure>

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -236,84 +236,136 @@ describe("holds — the evaluator the four surfaces share", () => {
 // Each case below is a deliberate correction of a client that disagreed with
 // the server, and stating them as tests is what stops the next author reading
 // the difference as an accident.
-// A page must not open on a grant the CARDS inside it still refuse.
+// Each page opens on the grant its cards actually ask for, and the two moved
+// together.
 //
-// The server moved these reads onto narrow objects, and the plan widens each
-// page to match. The cards have not followed: JobHealthCard,
-// ExtensionAccessCard, AuditLogCard and ResetDataCard still gate on the literal
-// admin role, the AI cards still check `automation:update`, SignInMethodsCard
-// still reads the installation aggregate, and LicenseCard never calls the
-// seat-usage endpoint the split shipped.
-//
-// So each page keeps a requirement its cards actually honour, and these cases
-// hold that pairing rather than the widening — a page that opened and then said
-// "admin only" is worse than one that stayed shut, because the reader cannot
-// tell a missing permission from a broken screen.
-//
-// Every case here is written to FAIL when the card is rewritten, which is the
-// signal to widen the page in the same change.
-describe("no page promises what its cards will not give", () => {
+// The previous shape of this block held the opposite: pages narrowed to what
+// their cards honoured, with every case written to FAIL when a card was
+// rewritten. Those cases fired, which is what brought the change here — the
+// gates below are their other half.
+describe("a page and its cards ask the same question", () => {
   function opens(page: SettingsPageId, allow: Parameters<typeof meFixture>[0]) {
     return visibleSettingsPages(meFixture(allow)).some((p) => p.id === page);
   }
 
-  it("keeps extensions shut for an ops holder of the grant", () => {
-    // ExtensionAccessCard: useHoldsAdminRole.
+  it("opens extensions to an ops holder of both grants the card reads", () => {
+    // The card is TWO reads behind one flag: the unit inventory from
+    // `GET /v1/extensions` (extension_access) and every role's grant on every
+    // object from `GET /v1/roles` (role_admin, identity/roles.go). Ops is
+    // seeded both, which is why the page is ops's at all.
+    expect(
+      opens("extensions", {
+        roles: ["ops"],
+        allow: { extension_access: ["read"], role_admin: ["read"] },
+      }),
+    ).toBe(true);
+    // The inventory grant ALONE opens a page whose card 403s on its second
+    // request — an unreadable page, which is worse than a closed one.
     expect(
       opens("extensions", {
         roles: ["ops"],
         allow: { extension_access: ["read"] },
       }),
     ).toBe(false);
+    expect(opens("extensions", { roles: ["rep"], allow: {} })).toBe(false);
   });
 
-  it("keeps system-health shut for a job_health holder", () => {
-    // JobHealthCard: useHoldsAdminRole. The page opens on the reindex read,
-    // which is what its other card honours.
+  it("opens system-health on either of its two cards' grants", () => {
+    // A union that is really a union: the job report and the reindex are
+    // different reads, and a holder of one finds the other card withheld.
     expect(
       opens("system-health", {
         roles: ["ops"],
         allow: { job_health: ["read"] },
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       opens("system-health", {
         roles: ["ops"],
         allow: { embedding_reindex: ["read"] },
       }),
     ).toBe(true);
+    expect(opens("system-health", { roles: ["rep"], allow: {} })).toBe(false);
   });
 
-  it("keeps audit shut for a delegated audit_log holder", () => {
-    // AuditLogCard: useHoldsAdminRole.
+  it("opens audit on audit_log, without needing the admin role", () => {
     expect(
       opens("audit", { roles: ["management"], allow: { audit_log: ["read"] } }),
+    ).toBe(true);
+    expect(
+      opens("audit", { roles: ["rep"], allow: { person: ["read"] } }),
     ).toBe(false);
   });
 
-  it("keeps seats shut for a seat_usage holder without license", () => {
-    // LicenseCard calls /installation/license and nothing else, so this reader
-    // would land on an error rather than on the capacity count.
+  it("opens seats to a seat_usage holder, which is the reader the split shipped for", () => {
+    // LicenseCard reads the entitlement for a `license` holder and falls back
+    // to `/installation/seat-usage` for this one — capacity without commercial
+    // standing, which is what management needs and may have.
     expect(
       opens("seats", {
         roles: ["management"],
         allow: { seat_usage: ["read"] },
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       opens("seats", { roles: ["admin"], allow: { license: ["read"] } }),
+    ).toBe(true);
+    expect(opens("seats", { roles: ["rep"], allow: {} })).toBe(false);
+  });
+
+  it("opens the AI diagnostics pages on ai_diagnostics", () => {
+    // The three cards asked `automation:update` — a write verb guarding a GET,
+    // from when the runtime's spend was operator information. The object is its
+    // own now, so management reads what it spends without holding the
+    // automation editor.
+    const management = {
+      roles: ["management"],
+      allow: { ai_diagnostics: ["read"] },
+    } satisfies Parameters<typeof meFixture>[0];
+    expect(opens("usage", management)).toBe(true);
+    expect(opens("model-calls", management)).toBe(true);
+    // Models too, and NOT because the routing editor is theirs — it is not,
+    // and the card refuses them. `AiHealthCard` reads on `ai_diagnostics` and
+    // Models is the only page rendering it, so a page shut on the routing
+    // grant alone would put a card behind a door its own reader cannot open.
+    expect(opens("models", management)).toBe(true);
+  });
+
+  // The other half of that: the page opens for a diagnostics holder because of
+  // ONE card, so the routing grant must still be what opens it for a routing
+  // holder. A page requiring both would shut out the operator who came to edit
+  // the bindings.
+  it("opens models on either the routing grant or the diagnostics one", () => {
+    expect(
+      opens("models", { roles: ["ops"], allow: { ai_routing: ["read"] } }),
+    ).toBe(true);
+    expect(
+      opens("models", { roles: ["rep"], allow: { automation: ["read"] } }),
+    ).toBe(false);
+  });
+
+  // The purposes card is what `consent_config` administers, but the object
+  // buys no READ — the list stays on `person` (consent/store.go ListPurposes)
+  // and only the writes moved. A page opening on it would be a page whose every
+  // card is withheld. Invisible in the seeded roles, where every consent holder
+  // also holds `person:read`; a custom role is where it would have shown.
+  it("does not open privacy on a grant that reads nothing on it", () => {
+    expect(
+      opens("privacy", {
+        roles: ["custom"],
+        allow: { consent_config: ["read", "create"] },
+      }),
+    ).toBe(false);
+    // The grant that actually reads the purposes list does open it.
+    expect(
+      opens("privacy", { roles: ["rep"], allow: { person: ["read"] } }),
     ).toBe(true);
   });
 
   it("opens authentication on its own grant, and not on the one every role holds", () => {
-    // The one page in this describe that is FIXED rather than waiting: its card
-    // reads GET /installation/authentication-policy now, so the page can ask
-    // for the grant that endpoint takes.
-    //
-    // The second half is the point. `installation_settings:read` is held by
-    // every seeded role — a rep reads it for the base currency — so a page
-    // opening on it would put the installation's sign-in policy in front of the
-    // whole workspace, which is what the backend split existed to close.
+    // `installation_settings:read` is held by every seeded role — a rep reads
+    // it for the base currency — so a page opening on it would put the
+    // installation's sign-in policy in front of the whole workspace.
     expect(
       opens("authentication", {
         roles: ["management"],
@@ -328,28 +380,7 @@ describe("no page promises what its cards will not give", () => {
     ).toBe(false);
   });
 
-  it("opens the AI pages on the grant their cards check", () => {
-    // `automation:update`, not `ai_diagnostics`: the runtime's spend is
-    // operator information, so seeing it takes the automation WRITE grant.
-    const withDiagnostics = {
-      roles: ["management"],
-      allow: { ai_diagnostics: ["read"] },
-    } satisfies Parameters<typeof meFixture>[0];
-    expect(opens("usage", withDiagnostics)).toBe(false);
-    expect(opens("model-calls", withDiagnostics)).toBe(false);
-
-    const withAutomationWrite = {
-      roles: ["ops"],
-      allow: { automation: ["read", "update"] },
-    } satisfies Parameters<typeof meFixture>[0];
-    expect(opens("usage", withAutomationWrite)).toBe(true);
-    expect(opens("model-calls", withAutomationWrite)).toBe(true);
-  });
-
   it("opens leads on custom_field, which is what its three cards read", () => {
-    // Lead sources, disqualify reasons and handling are custom-field vocabulary
-    // server-side. Asking for `pipeline` would hide the page from a holder who
-    // may read it and open it for one whose reads then 403.
     expect(
       opens("leads", { roles: ["rep"], allow: { custom_field: ["read"] } }),
     ).toBe(true);

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -235,12 +235,11 @@ export const SETTINGS_PAGES = [
     id: "seats",
     group: "people",
     scope: "installation",
-    // `license` alone, because `LicenseCard` calls `/installation/license` and
-    // nothing else. The `seat_usage` endpoint shipped for exactly this reader —
-    // management, capacity without commercial standing — and the card does not
-    // call it yet, so admitting a `seat_usage` holder here lands them on an
-    // error rather than on the count the split was built to give them.
-    requires: reads("license"),
+    // Either grant, and they show different things: `LicenseCard` reads the
+    // entitlement for a `license` holder and falls back to the capacity
+    // endpoint for a `seat_usage` one — management sees how full the
+    // installation is without seeing what it pays.
+    requires: anyOf(reads("seat_usage"), reads("license")),
   },
 
   {
@@ -310,7 +309,12 @@ export const SETTINGS_PAGES = [
     id: "models",
     group: "ai",
     scope: "workspace",
-    requires: reads("ai_routing"),
+    // Two cards, two grants. The routing and provider-key cards read on
+    // `ai_routing`; `AiHealthCard` reads on `ai_diagnostics` (ai/health.go),
+    // and Models is the ONLY page that renders it. Management is seeded
+    // diagnostics WITHOUT routing, so on the routing grant alone this page was
+    // shut to the one role the health card was widened for.
+    requires: anyOf(reads("ai_routing"), reads("ai_diagnostics")),
   },
   {
     id: "automations",
@@ -322,26 +326,16 @@ export const SETTINGS_PAGES = [
     id: "usage",
     group: "ai",
     scope: "workspace",
-    // `automation:update`, which is what the cards on this page actually ask
-    // for. The AI runtime's spend is treated as operator information, so seeing
-    // it takes the automation WRITE grant rather than any AI-named object — a
-    // read-shaped question answered by a write grant, which is exactly why the
-    // page cannot simply ask for `ai_diagnostics` and hope.
-    //
-    // `ai_diagnostics` is the object the SERVER moved these reads to; the cards
-    // have not followed yet. When they do, this becomes that grant and the two
-    // move together.
-    requires: anyOf(
-      { kind: "grant", object: "automation", action: "update" },
-      reads("ai_model_rate"),
-    ),
+    // The diagnostics read, or the price grant that authors the table beside it.
+    // Both cards on this page ask `ai_diagnostics:read` now; `ai_model_rate`
+    // stays in the union because its holder authors the rate sheet here.
+    requires: anyOf(reads("ai_diagnostics"), reads("ai_model_rate")),
   },
   {
     id: "model-calls",
     group: "ai",
     scope: "workspace",
-    // Same as usage: `AiCallsCard` checks `automation:update`.
-    requires: { kind: "grant", object: "automation", action: "update" },
+    requires: reads("ai_diagnostics"),
   },
 
   {
@@ -349,12 +343,18 @@ export const SETTINGS_PAGES = [
     group: "governance",
     scope: "workspace",
     requires: anyOf(
-      reads("consent_config"),
       reads("retention_policy"),
       reads("privacy_request"),
       // The purposes list is gated on person.read server-side, which is not a
       // role and not "any member" — moving it would 403 the Person 360 for
       // every rep, so the page follows the gate the endpoint actually applies.
+      //
+      // `consent_config` is deliberately NOT here, though the purposes card is
+      // what that object administers. It buys no READ: the list stays on
+      // `person` (consent/store.go ListPurposes) and only the writes moved. On
+      // the consent grant alone a reader would open a page whose every card is
+      // withheld — every seeded holder of it also holds `person:read`, so this
+      // only ever bit a custom role, silently.
       reads("person"),
     ),
   },
@@ -362,46 +362,31 @@ export const SETTINGS_PAGES = [
     id: "audit",
     group: "governance",
     scope: "workspace",
-    // `AuditLogCard` still gates itself on the literal admin role, so a
-    // delegated holder of `audit_log:read` admitted here would open a page that
-    // then refuses them. The server moved this read onto the object; the card
-    // has not followed, and the page waits for it rather than promising first.
-    requires: allOf(reads("audit_log"), {
-      kind: "grant",
-      object: "system_reset",
-      action: "delete",
-    }),
+    // The trail's own object, which the card now asks for too. A role edited to
+    // carry `audit_log:read` reaches it and one that lost it does not — which
+    // the admin role name could not say either way.
+    requires: reads("audit_log"),
   },
   {
     id: "system-health",
     group: "governance",
     scope: "installation",
-    // Narrower than the grants the SERVER now accepts, and deliberately so
-    // until the cards catch up: `JobHealthCard` still refuses a non-admin with
-    // `useHoldsAdminRole`, so admitting an ops holder of `job_health:read` here
-    // would offer them a page that then says "admin only". The page opens on
-    // what its cards actually honour; widening it is the same change that
-    // rewrites those gates.
-    requires: reads("embedding_reindex"),
+    // Either card's grant. `JobHealthCard` asks `job_health:read` and the
+    // reindex card asks its own, so a reader holding one finds that card and
+    // the other withheld — which is the union being a union rather than one
+    // object with a decorative term.
+    requires: anyOf(reads("job_health"), reads("embedding_reindex")),
   },
   {
     id: "extensions",
     group: "governance",
     scope: "installation",
-    // `ExtensionAccessCard` still gates itself on the literal admin role, so an
-    // ops holder of `extension_access:read` admitted here would find the card
-    // refusing them — a page that opens and then says "admin only".
-    //
-    // There is no role arm in this vocabulary and there should not be: a role
-    // arm encodes the seeded matrix into the client, which is the inference the
-    // whole redesign removes. So the page keeps the grant it always had —
-    // `system_reset:delete`, which only admin holds — until the card is
-    // rewritten to honour `extension_access`. That rewrite widens both together.
-    requires: allOf(reads("extension_access"), {
-      kind: "grant",
-      object: "system_reset",
-      action: "delete",
-    }),
+    // BOTH reads the card makes, because it makes them behind ONE flag: the
+    // unit inventory from `GET /v1/extensions` and every role's grant on every
+    // object from `GET /v1/roles`. On the inventory grant alone the page opens
+    // and the card 403s on its second query, which is an unreadable page rather
+    // than a narrower one.
+    requires: allOf(reads("extension_access"), reads("role_admin")),
   },
   {
     id: "reset",

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -201,6 +201,9 @@ function InviteAction({ canIssueLink }: Readonly<{ canIssueLink: boolean }>) {
             // admin typed them.
             setOpen(false);
             qc.invalidateQueries({ queryKey: ["users-admin"] });
+            // An invite spends a seat, so the capacity readings move with it.
+            qc.invalidateQueries({ queryKey: ["installation-seat-usage"] });
+            qc.invalidateQueries({ queryKey: ["installation-license"] });
             if (canIssueLink) {
               setInvited(member);
               void passwordLink.mint(member.id);
@@ -404,7 +407,16 @@ function MemberRow({
   // successful change.
   const refresh = () => {
     setError(null);
-    return qc.invalidateQueries({ queryKey: ["users-admin"] });
+    return Promise.all([
+      qc.invalidateQueries({ queryKey: ["users-admin"] }),
+      // The seat COUNT moves with the roster: deactivating a member frees a
+      // seat and reactivating one spends it, and Settings → Seats reads that
+      // number from its own endpoint with a five-minute staleTime. Left alone
+      // it kept reporting the pre-change count to whoever had the page open —
+      // the same roster change, two caches.
+      qc.invalidateQueries({ queryKey: ["installation-seat-usage"] }),
+      qc.invalidateQueries({ queryKey: ["installation-license"] }),
+    ]);
   };
   const onError = (e: Error) => setError(problemMessageOf(e, t));
   const toast = useToast();


### PR DESCRIPTION
Eight cards in the settings screen asked whether the reader held the literal
admin role, or asked for an object that no longer gated their endpoint. Each now
asks the server's own question, and the catalog page that renders a card asks
the same thing the card does.

| Card | Was | Now |
|---|---|---|
| Job health | `useHoldsAdminRole` | `job_health:read` |
| Extensions | `useHoldsAdminRole` | `extension_access:read` AND `role_admin:read` |
| Audit log (×2) | `useHoldsAdminRole` | `audit_log:read` |
| Reset data | `useHoldsAdminRole` | `system_reset:delete` (write) |
| Privacy inbox | `useHoldsAdminRole` | `privacy_request:read` |
| Consent purposes | `useHoldsConsentAdminRole` | `consent_config:create` (write) |
| AI usage / calls / health | `automation:update` | `ai_diagnostics:read` |
| Seats | — | falls back to `/installation/seat-usage` |

`useHoldsConsentAdminRole` is deleted; its own comment said it would go when
`consent_config` landed.

## Gates that were wider than the server

A client gate wider than the server enables a control that 403s. Three were:

- **Extensions makes TWO reads behind one flag** — the unit inventory on
  `extension_access:read` and every role's grant on every object on
  `role_admin:read` (`identity/roles.go` `ListRoles`). Its toggles write through
  `role_admin:update`, which the seeded ops role does **not** hold. Proven from
  `MustDefaultJSON`, not from reading the table.
- **The privacy card offered two mutations with no gate.** "New request" POSTs on
  `person:update` — a different object from the queue's — and the row
  transitions PATCH on `privacy_request:update`.
- **Two POST affordances asked `useCan`, not `useCanWrite`.** The seat ceiling
  refuses a read seat every mutation above RBAC
  (`identity/admission.go`), so the grant alone was never the whole answer.

## Pages that disagreed with their own cards

- **Models** opened on `ai_routing` while rendering `AiHealthCard`, which reads
  `ai_diagnostics`. Management is seeded diagnostics **without** routing, so the
  one role that card was widened for could not reach it.
- **Privacy** opened on `consent_config`, which reads nothing there: the purposes
  list stays on `person` by design and only the writes moved. Invisible in the
  seeded roles, where every consent holder also holds `person:read`.

## The endpoint's readers, not the screen's

Four client gates had been left behind when the server moved `/ai/usage` and
`/ai/calls` to `ai_diagnostics:read`: `SpendStat`, the economy banner, and both
agent-rail readings — each carrying a comment that explained the old server
reasoning as though it were current.

## Also

- A failed `/me` used to leave the seats card on its capacity branch permanently,
  with a retry that retried the wrong request. It waits for an *answered*
  snapshot now, not merely a settled one.
- A role-grant PATCH never invalidated `["me"]`, so an operator editing their own
  role kept stale affordances. No roster mutation invalidated the seat readings.
- Denial copy in en/de/vi said "admins only" for grants an operator can now
  delegate. Each names the missing permission instead.

## Verification

Every gate is mutation-checked: the guard reverted, a test confirmed failing.
That caught two of my own tests that passed against an empty DOM — a
permission-denied branch is also what renders while `/me` is in flight, so
asserting it alone proves nothing about the gate. Both now pair the refusal with
an answered control.

One test mock was answering `GET /v1/roles` with 200 to a principal the server
refuses. It applies the real gate now.

`make check-fe` green (exit 0). Full unit suite: 7442 tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eight settings cards asked for the literal admin role or for a grant their endpoint no longer gates; each now asks for what the server asks for, and the catalog page that renders a card asks the same thing the card does. The AI spend/calls/health reads follow the server's move to `ai_diagnostics:read`, which the economy banner and four client gates had missed.

**Bug Fixes**
- Three client gates were wider than the server and enabled 403s: extensions reads two objects behind one flag, privacy's mutations had no gate, and two POST affordances used `useCan` instead of `useCanWrite`.
- The Models and Privacy pages opened on grants their cards refused; both now open on what the cards ask for.
- Seats falls back to `/installation/seat-usage` when the reader lacks the `license` grant.
- A failed `/me` left the seats card on its capacity branch forever; it waits for an answered snapshot now, and roster mutations invalidate the seat readings.
- Denial copy in en/de/vi named a role for grants operators can delegate; each names the missing permission instead.
- `useHoldsConsentAdminRole` is deleted; the consent card asks `consent_config:create`.

<sup>Written for commit 2ca7a5404c67eacea9c8e9fe796ca70a12b97876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

