### PR TITLE
feat(worklist): a buyer waiting on a reply can be answered from the row

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -40054,7 +40054,7 @@ components:
         occurred_at: { type: string, format: date-time, description: "When a done_for_you receipt actually happened." }
         actions:
           type: array
-          items: { type: string, enum: [decide, merge, complete, snooze, open, act, dismiss, set_aside, acknowledge, retry] }
+          items: { type: string, enum: [decide, merge, complete, snooze, open, act, dismiss, set_aside, acknowledge, retry, reply] }
           description: |
             What this item offers. `decide` and `merge` mean the verb is irreversible and a
             person must choose; `complete` and `snooze` are a task's own verbs; `open` is
@@ -41168,7 +41168,7 @@ components:
         occurred_at: { type: string, format: date-time, description: 'When the thing being reported happened.' }
         actions:
           type: array
-          items: { type: string, enum: [decide, merge, complete, snooze, open, act, dismiss, set_aside, acknowledge, retry] }
+          items: { type: string, enum: [decide, merge, complete, snooze, open, act, dismiss, set_aside, acknowledge, retry, reply] }
           description: 'What this item offers, routed to the endpoint that owns the verb.'
         band:
           type: string

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -339,6 +339,21 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	}
 	if openableSubject(row.Subject) {
 		row.Actions = append(row.Actions, crmcontracts.WorklistItemActions(actionOpen))
+		// Answering where the reader is standing, offered only for an EMAIL. The
+		// lane also carries channel messages, and the composer this verb opens
+		// speaks mail — a chat message it addressed would be answered in the
+		// wrong place, to a counterparty resolved from a thread that is not one.
+		//
+		// `email_summary` is the honest test rather than the kind word: the
+		// contract sets it exactly when the wait is mail, and it is absent for a
+		// reader the content gate did not admit — who has no message to answer.
+		//
+		// It rides the same subject test as `open`, because the composer files
+		// the reply against that record. A wait with no subject would open a
+		// composer with nothing to link the sent message to.
+		if row.EmailSummary != nil {
+			row.Actions = append(row.Actions, crmcontracts.WorklistItemActionsReply)
+		}
 	}
 	occurred := waiting.Since
 	row.OccurredAt = &occurred

--- a/backend/internal/compose/attention/sourceactioncensus_test.go
+++ b/backend/internal/compose/attention/sourceactioncensus_test.go
@@ -113,10 +113,9 @@ func TestNoLaneAdvertisesAVerbTheClientCannotPerform(t *testing.T) {
 	// deliberate act somebody has to write down rather than an omission nothing
 	// notices. The map only shrinks.
 	notYetAssembled := map[string]string{
-		"customer_waiting":     "the waiting lane is not an optional seam; the fixture has no stub for it",
-		"lead_response":        "same lane shape as customer_waiting",
-		"undelivered":          "the delivery lane assembles only bounces from stubBounces",
-		"introduction_request": "no stub feeds the introduction lane",
+		"customer_waiting": "the waiting lane is a positional seam Assemble does not read; " +
+			"reaching it needs a stub this fixture has no argument slot for",
+		"lead_response": "the same lane shape as customer_waiting, and unreachable for the same reason",
 	}
 	reached := map[string]bool{}
 	for _, items := range lanes {
@@ -297,7 +296,16 @@ func aDayWithEveryLaneCarryingARow(t *testing.T) crmcontracts.Attention {
 			rows: []MeetingAwaitingOutcome{{
 				ID: ids.NewV7(), Subject: "a meeting that happened", StartedAt: readInstant,
 			}},
-		}))
+		})).
+		WithUndelivered(&stubUndelivered{rows: []ParkedSend{{
+			ID: ids.NewV7(), Subject: "a send that never left",
+			Reason: "the address bounced twice", ParkedAt: readInstant,
+			PersonID: ids.NewV7(),
+		}}}).
+		WithIntroductions(&stubIntroductions{rows: []PendingIntroduction{{
+			ID: ids.NewV7(), PersonID: ids.NewV7(),
+			Reason: "they know the buyer", RequestedAt: readInstant, DueAt: readInstant,
+		}}})
 	out, err := svc.Assemble(context.Background())
 	if err != nil {
 		t.Fatalf("assembling the day: %v", err)

--- a/backend/internal/compose/attention/sourceactioncensus_test.go
+++ b/backend/internal/compose/attention/sourceactioncensus_test.go
@@ -42,7 +42,10 @@ import (
 // this gate exists to catch, so it must not be the shape of the gate.
 var performedBySource = map[string][]crmcontracts.AttentionItemActions{
 	// Routed to the record the row is about, through VERB_DESTINATION.
-	"customer_waiting":   {"open"},
+	// `reply` opens the composer over the row, through ChannelReplyAction. Sent
+	// only where the wait IS mail (email_summary present) and names a record to
+	// file the answer against.
+	"customer_waiting":   {"open", "reply"},
 	"lead_response":      {"open"},
 	"deal_at_risk":       {"open"},
 	"conversation_claim": {"open"},
@@ -100,13 +103,20 @@ func TestNoLaneAdvertisesAVerbTheClientCannotPerform(t *testing.T) {
 	// `relationship_decay` and `notice` ride optional pointer ones. Naming only
 	// the first four left the pointer arm free to break in silence, taking
 	// twelve lanes with it and still passing.
-	mustReach := []string{
-		"task", "brief_item", "approval", "dedupe_candidate",
-		"relationship_decay", "notice",
-		// Named for the reason the others are, learned the same way: this lane
-		// rides an Option rather than a positional seam, so the fixture omitted
-		// it silently and the census reported PASS over a source it never saw.
-		"meeting_outcome",
+	// EVERY declared source must be assembled, derived from the table above
+	// rather than listed by hand. The hand-written list is what let this census
+	// drift: it named six sources, the table declared eighteen, and the four
+	// below were checked by nobody — the census read fourteen lanes and
+	// reported PASS, which is the one direction a census must never fail in.
+	//
+	// A source that cannot be assembled yet is named HERE, so adding one is a
+	// deliberate act somebody has to write down rather than an omission nothing
+	// notices. The map only shrinks.
+	notYetAssembled := map[string]string{
+		"customer_waiting":     "the waiting lane is not an optional seam; the fixture has no stub for it",
+		"lead_response":        "same lane shape as customer_waiting",
+		"undelivered":          "the delivery lane assembles only bounces from stubBounces",
+		"introduction_request": "no stub feeds the introduction lane",
 	}
 	reached := map[string]bool{}
 	for _, items := range lanes {
@@ -114,12 +124,24 @@ func TestNoLaneAdvertisesAVerbTheClientCannotPerform(t *testing.T) {
 			reached[string(item.Source)] = true
 		}
 	}
-	for _, source := range mustReach {
-		if !reached[source] {
-			t.Fatalf("the assembled day carried no %q row, so this census did not look at the "+
-				"source's verbs at all: either the fixture stopped feeding that lane or the "+
-				"walk stopped reading it, and both leave the census passing over the sources "+
-				"with the most verbs to get wrong", source)
+	for source := range performedBySource {
+		if reached[source] {
+			continue
+		}
+		if _, known := notYetAssembled[source]; known {
+			continue
+		}
+		t.Errorf("the assembled day carried no %q row, so this census did not look at the "+
+			"source's verbs at all: either the fixture stopped feeding that lane or the "+
+			"walk stopped reading it, and both leave the census passing over that source. "+
+			"Feed it, or name it in notYetAssembled with the reason", source)
+	}
+	// And the register describes the tree: a source that CAN now be assembled
+	// must leave, or the exemption outlives the gap and hides the next one.
+	for source := range notYetAssembled {
+		if reached[source] {
+			t.Errorf("%q is named as not-yet-assembled and the fixture assembles it: "+
+				"delete the entry, so the register keeps saying something true", source)
 		}
 	}
 	checked := 0

--- a/backend/internal/compose/attention/waitingreply_test.go
+++ b/backend/internal/compose/attention/waitingreply_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Which waits offer to answer, and which do not.
+//
+// The verb opens the MAIL composer, so both conditions it rides are about
+// whether that composer can do anything: the wait has to be an email, and it
+// has to name a record the sent message files against.
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestOnlyAWaitTheComposerCanAnswerOffersReply(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	summary := &crmcontracts.EmailSummary{}
+	person := ids.NewV7()
+
+	for _, tc := range []struct {
+		name    string
+		waiting WaitingCustomer
+		offers  bool
+		because string
+	}{
+		{
+			name: "an email naming a person",
+			waiting: WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "can you resend the quote?",
+				Since: at.Add(-48 * time.Hour), EmailSummary: summary, PersonID: person,
+			},
+			offers:  true,
+			because: "the composer can answer it and knows where to file the answer",
+		},
+		{
+			name: "a channel message naming a person",
+			waiting: WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "can you resend the quote?",
+				Since: at.Add(-48 * time.Hour), PersonID: person,
+			},
+			offers: false,
+			because: "the lane spans channel messages too, and answering a chat in the " +
+				"mail composer replies in the wrong place, to a counterparty resolved " +
+				"from a thread that is not one",
+		},
+		{
+			name: "an email from a stranger",
+			waiting: WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "hello",
+				Since: at.Add(-48 * time.Hour), EmailSummary: summary,
+			},
+			offers: false,
+			because: "no record is named, so the composer would open with nothing to " +
+				"link the sent message to",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			row := classifyWaiting(tc.waiting, at).item
+			offered := slices.Contains(row.Actions, crmcontracts.WorklistItemActionsReply)
+			if offered != tc.offers {
+				t.Fatalf("offers reply = %v, want %v: %s", offered, tc.offers, tc.because)
+			}
+		})
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1426,6 +1426,7 @@ const (
 	AttentionItemActionsDismiss     AttentionItemActions = "dismiss"
 	AttentionItemActionsMerge       AttentionItemActions = "merge"
 	AttentionItemActionsOpen        AttentionItemActions = "open"
+	AttentionItemActionsReply       AttentionItemActions = "reply"
 	AttentionItemActionsRetry       AttentionItemActions = "retry"
 	AttentionItemActionsSetAside    AttentionItemActions = "set_aside"
 	AttentionItemActionsSnooze      AttentionItemActions = "snooze"
@@ -1447,6 +1448,8 @@ func (e AttentionItemActions) Valid() bool {
 	case AttentionItemActionsMerge:
 		return true
 	case AttentionItemActionsOpen:
+		return true
+	case AttentionItemActionsReply:
 		return true
 	case AttentionItemActionsRetry:
 		return true
@@ -13807,6 +13810,7 @@ const (
 	WorklistItemActionsDismiss     WorklistItemActions = "dismiss"
 	WorklistItemActionsMerge       WorklistItemActions = "merge"
 	WorklistItemActionsOpen        WorklistItemActions = "open"
+	WorklistItemActionsReply       WorklistItemActions = "reply"
 	WorklistItemActionsRetry       WorklistItemActions = "retry"
 	WorklistItemActionsSetAside    WorklistItemActions = "set_aside"
 	WorklistItemActionsSnooze      WorklistItemActions = "snooze"
@@ -13828,6 +13832,8 @@ func (e WorklistItemActions) Valid() bool {
 	case WorklistItemActionsMerge:
 		return true
 	case WorklistItemActionsOpen:
+		return true
+	case WorklistItemActionsReply:
 		return true
 	case WorklistItemActionsRetry:
 		return true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -30125,7 +30125,7 @@ export interface components {
              *     suggestion until later in the day. One word for both would make a client that
              *     handles `snooze` generically write the wrong endpoint.
              */
-            actions: ("decide" | "merge" | "complete" | "snooze" | "open" | "act" | "dismiss" | "set_aside" | "acknowledge" | "retry")[];
+            actions: ("decide" | "merge" | "complete" | "snooze" | "open" | "act" | "dismiss" | "set_aside" | "acknowledge" | "retry" | "reply")[];
         };
         /**
          * @description The two records a duplicate item proposes to merge, with the detection-time
@@ -31183,7 +31183,7 @@ export interface components {
              */
             occurred_at?: string;
             /** @description What this item offers, routed to the endpoint that owns the verb. */
-            actions: ("decide" | "merge" | "complete" | "snooze" | "open" | "act" | "dismiss" | "set_aside" | "acknowledge" | "retry")[];
+            actions: ("decide" | "merge" | "complete" | "snooze" | "open" | "act" | "dismiss" | "set_aside" | "acknowledge" | "retry" | "reply")[];
             /**
              * @description The heading this row sits under, as an OUTCOME rather than a priority number.
              *

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -3508,6 +3508,7 @@ export function ChannelReplyAction({
   entityId,
   personId,
   contentWithheld,
+  onSent,
 }: Readonly<{
   activityId: string;
   kind: Activity["kind"];
@@ -3515,6 +3516,12 @@ export function ChannelReplyAction({
   entityType: RelinkKind;
   entityId: string;
   personId?: string;
+  // Told when the message actually went, for a caller whose own view the send
+  // changes. ComposeModal invalidates the RECORD timelines it knows about; a
+  // surface listing the unanswered — the worklist's waiting lane — is not one
+  // of them, so without this its row keeps saying nobody has replied and keeps
+  // offering to reply again.
+  onSent?: () => void;
   // The row's content is not this reader's to see. The verb still works —
   // writing to the contact is not reading their mail — but it is not a REPLY,
   // and calling it one claims access to the message being answered.
@@ -3562,6 +3569,7 @@ export function ChannelReplyAction({
           kind={contentWithheld ? "email" : kind}
           open={reply}
           onClose={() => setReply(false)}
+          onSent={onSent}
         />
       )}
     </>

--- a/frontend/src/screens/worklist.reply.test.tsx
+++ b/frontend/src/screens/worklist.reply.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Answering a waiting buyer from the row that named the wait.
+//
+// The row a rep meets most often is somebody who wrote and nobody answered, and
+// it used to send them to the record to press Reply there.
+
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { day, renderWorklist, row, stub } from "./worklist.testkit";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function aWaitingBuyer(over = {}) {
+  return row({
+    id: "01a05500-0000-7000-8000-0000000000c1",
+    source: "customer_waiting",
+    category: "customer_waiting",
+    title: "can you resend the quote?",
+    band: "answer_people",
+    destination: "today",
+    actions: ["open", "reply"],
+    subject: { type: "person", id: "01a05500-0000-7000-8000-0000000000c2" },
+    ...over,
+  });
+}
+
+function aDayWith(item: ReturnType<typeof aWaitingBuyer>) {
+  return day({
+    queue: [item],
+    summary: { urgent: 0, due: 1, lower_priority: 0, total: 1 },
+  });
+}
+
+describe("a buyer waiting on a reply", () => {
+  it("can be answered from the row", async () => {
+    stub(aDayWith(aWaitingBuyer()));
+    renderWorklist();
+
+    await screen.findByText(/can you resend the quote/);
+    expect(
+      await screen.findByRole("button", { name: /^reply$/i }),
+    ).not.toBeNull();
+  });
+
+  it("offers no reply when the server sent none", async () => {
+    // The server withholds the verb for a channel message and for a wait that
+    // names no record. Either way the row must draw nothing rather than a
+    // composer that would answer in the wrong place or file nowhere.
+    stub(aDayWith(aWaitingBuyer({ actions: ["open"] })));
+    renderWorklist();
+
+    await screen.findByText(/can you resend the quote/);
+    expect(screen.queryByRole("button", { name: /^reply$/i })).toBeNull();
+  });
+
+  it("offers no reply when the row names no record to file against", async () => {
+    // A message from a stranger. The verb alone is not enough: the composer
+    // links the sent message to a record, and the row's subject is what says
+    // which. Without it there is nothing to open the composer on.
+    stub(aDayWith(aWaitingBuyer({ subject: undefined })));
+    renderWorklist();
+
+    await screen.findByText(/can you resend the quote/);
+    expect(screen.queryByRole("button", { name: /^reply$/i })).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -8,7 +8,8 @@
 // decides how one piece of work reads and where each of its verbs goes, and
 // that is the half a reader of either question does not need the other for.
 
-import { useId, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useId, useRef, useState } from "react";
 import { Badge, Button, Modal } from "../design-system/atoms";
 import { PanelRow } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
@@ -289,6 +290,35 @@ export function WorklistRow({
  * title, reasons, verbs — is already at the complexity the linter allows, and
  * a fourth kind of answer should extend this list rather than that function.
  */
+// The answers that need only the row's own id, keyed by the source that carries
+// them and the verb the server sent. A table rather than a branch each: they
+// differ only in which control to draw, so spelling them as code made RowAnswer
+// grow one arm per source until it hit the complexity ceiling — which its own
+// doc predicted.
+//
+// Both halves of the key matter. The SOURCE decides the control, and the VERB
+// is the server's judgement that this particular row may use it: a blocked
+// automation carries no `retry`, so it draws nothing here.
+const ANSWER_BY_SOURCE: Partial<
+  Record<
+    WorklistItem["source"],
+    { verb: WorklistItem["actions"][number]; draw: (id: string) => ReactNode }
+  >
+> = {
+  notice: { verb: "acknowledge", draw: (id) => <NoticeAcknowledge id={id} /> },
+  automation_run: { verb: "retry", draw: (id) => <AutomationRetry id={id} /> },
+  meeting_outcome: { verb: "decide", draw: (id) => <MeetingOutcome id={id} /> },
+  task: { verb: "complete", draw: (id) => <TaskComplete id={id} /> },
+  // The row's id IS the person's here, which is what the dismissal endpoint
+  // takes — the pairing is why this verb is offered on this lane and nowhere
+  // else. `dismiss` also belongs to brief_item, where it means something else
+  // and posts somewhere else, which is why this table is keyed by SOURCE.
+  relationship_decay: {
+    verb: "dismiss",
+    draw: (id) => <NudgeDismiss personId={id} />,
+  },
+};
+
 function RowAnswer({ item }: Readonly<{ item: WorklistItem }>) {
   if (decidable(item)) {
     return <RowDecision item={item} />;
@@ -296,59 +326,21 @@ function RowAnswer({ item }: Readonly<{ item: WorklistItem }>) {
   if (item.source === "dedupe_candidate" && item.pair) {
     return <PairDecision item={item} />;
   }
-  if (item.source === "notice" && item.actions.includes("acknowledge")) {
-    return <NoticeAcknowledge id={item.id} />;
+  // Never a BATCH: a group row stands for a pile and names no single record, so
+  // every id-keyed answer below would act on the wrong one.
+  const keyed = ANSWER_BY_SOURCE[item.source];
+  if (keyed && !item.batch && item.actions.includes(keyed.verb)) {
+    return keyed.draw(item.id);
   }
-  // A failed rule, run again from here. The server decides which firings carry
-  // the verb — a blocked one does not, because that was a refusal on purpose —
-  // so the row asks what it was sent rather than re-deriving the rule.
-  if (item.source === "automation_run" && item.actions.includes("retry")) {
-    return <AutomationRetry id={item.id} />;
-  }
-  // How a meeting that already happened went, answered here. `decide` is the
-  // same verb an approval carries and means the same thing — the answer is
-  // given ON the row — but the answers differ, so the control is its own.
-  if (item.source === "meeting_outcome" && item.actions.includes("decide")) {
-    return <MeetingOutcome id={item.id} />;
-  }
-  // Answering the buyer where the reader is standing. The server offers `reply`
-  // only where the wait IS mail and names a record to file the answer against,
-  // so the row asks what it was sent rather than re-deriving either.
+  // Its own branch, because it is the one answer that needs more than the row's
+  // id: the composer files the sent message against a record, so the subject
+  // travels with it.
   const replyTo = replyTarget(item);
   if (replyTo) {
-    return (
-      <div className="worklist-row-verbs">
-        <ChannelReplyAction
-          activityId={item.id}
-          kind="email"
-          entityType={replyTo.type}
-          entityId={replyTo.id}
-        />
-      </div>
-    );
+    return <WaitingReply id={item.id} to={replyTo} />;
   }
-  // A task the server says can be finished, finished HERE. Not a batch: a group
-  // row stands for a pile and names no single activity to complete.
-  if (
-    item.source === "task" &&
-    !item.batch &&
-    item.actions.includes("complete")
-  ) {
-    return <TaskComplete id={item.id} />;
-  }
-  // A quiet contact the reader has decided not to chase. The row's id IS the
-  // person's, which is what the dismissal endpoint takes — the pairing is why
-  // this verb is offered on this lane and nowhere else.
-  if (
-    item.source === "relationship_decay" &&
-    !item.batch &&
-    item.actions.includes("dismiss")
-  ) {
-    return <NudgeDismiss personId={item.id} />;
-  }
-  // A brief item's three verbs. Source-checked rather than verb-checked:
-  // `dismiss` also belongs to relationship_decay above, where it means
-  // something else entirely and posts somewhere else.
+  // A brief item's three verbs, drawn together rather than one per entry: they
+  // share a surface and the component picks among them.
   if (item.source === "brief_item" && !item.batch) {
     return <BriefVerbs item={item} />;
   }
@@ -1206,4 +1198,31 @@ function replyTarget(
     return undefined;
   }
   return { type: type as RelinkKind, id: item.subject.id };
+}
+
+// Answering the buyer, over the row that named the wait.
+//
+// Its own component so it can hold the hook that refreshes the queue. The
+// composer invalidates the RECORD timelines it knows about, and the worklist is
+// not one of them — nor does the queue poll — so without the callback the row
+// keeps saying nobody has replied, and keeps offering to reply again, over a
+// message the reader has already answered.
+function WaitingReply({
+  id,
+  to,
+}: Readonly<{ id: string; to: { type: RelinkKind; id: string } }>) {
+  const queryClient = useQueryClient();
+  return (
+    <div className="worklist-row-verbs">
+      <ChannelReplyAction
+        activityId={id}
+        kind="email"
+        entityType={to.type}
+        entityId={to.id}
+        onSent={() =>
+          queryClient.invalidateQueries({ queryKey: [worklistKey] })
+        }
+      />
+    </div>
+  );
 }

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -18,6 +18,7 @@ import { translatePlural, useLocale, useT } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
 import { tomorrowMorning } from "./briefqueue";
 import { problemMessageOf } from "./common";
+import { ChannelReplyAction, RELINK_KINDS, type RelinkKind } from "./compose";
 import { type BriefMarkRequest, useBriefItemMark } from "./home.queries";
 import {
   useAutomationRetry,
@@ -309,6 +310,22 @@ function RowAnswer({ item }: Readonly<{ item: WorklistItem }>) {
   // given ON the row — but the answers differ, so the control is its own.
   if (item.source === "meeting_outcome" && item.actions.includes("decide")) {
     return <MeetingOutcome id={item.id} />;
+  }
+  // Answering the buyer where the reader is standing. The server offers `reply`
+  // only where the wait IS mail and names a record to file the answer against,
+  // so the row asks what it was sent rather than re-deriving either.
+  const replyTo = replyTarget(item);
+  if (replyTo) {
+    return (
+      <div className="worklist-row-verbs">
+        <ChannelReplyAction
+          activityId={item.id}
+          kind="email"
+          entityType={replyTo.type}
+          entityId={replyTo.id}
+        />
+      </div>
+    );
   }
   // A task the server says can be finished, finished HERE. Not a batch: a group
   // row stands for a pile and names no single activity to complete.
@@ -1008,6 +1025,9 @@ const VERB_LABEL: Record<
   // AutomationRetry, which acts in place, so VERB_DESTINATION routes it
   // nowhere and this label is never the one a reader sees.
   retry: (t) => t("worklist.verb.retry"),
+  // The composer's own word, not a second one: ChannelReplyAction draws the
+  // button this labels, and two spellings of one act would read as two acts.
+  reply: (t) => t("compose.reply"),
 };
 
 // The day's figures, and the dials that narrow them.
@@ -1165,4 +1185,25 @@ function MeetingOutcome({ id }: Readonly<{ id: string }>) {
       </Button>
     </div>
   );
+}
+
+// The record a reply would be filed against, or nothing.
+//
+// Both halves must hold. The verb says the server judged this wait answerable —
+// it is mail, not a channel message the mail composer would answer in the wrong
+// place. The subject says WHICH record the sent message links to, and its type
+// has to be one the composer can file against: the row's own vocabulary is
+// wider than RELINK_KINDS, so an `activity` subject would type-check as a
+// string and fail at the composer.
+function replyTarget(
+  item: WorklistItem,
+): { type: RelinkKind; id: string } | undefined {
+  if (!item.actions.includes("reply") || !item.subject) {
+    return undefined;
+  }
+  const type = item.subject.type;
+  if (!RELINK_KINDS.includes(type as RelinkKind)) {
+    return undefined;
+  }
+  return { type: type as RelinkKind, id: item.subject.id };
 }

--- a/frontend/src/screens/worklist.verbcensus.test.ts
+++ b/frontend/src/screens/worklist.verbcensus.test.ts
@@ -52,6 +52,11 @@ const ANSWERED_BY = {
   // would open the automations page, which is where the RULE is fixed — a
   // different act from re-running the firing that broke.
   retry: { how: "inline", file: "worklist.row.tsx" },
+  // Answering the buyer opens the composer over the row, through the same
+  // ChannelReplyAction the 360 timelines mount. Routing it would send the
+  // reader to the record to press reply there, which is the hand-off the queue
+  // exists to remove.
+  reply: { how: "inline", file: "worklist.row.tsx" },
 } as const satisfies Record<
   Verb,
   { how: "routed" } | { how: "inline"; file: string }

--- a/frontend/src/screens/worklist.verbcensus.test.ts
+++ b/frontend/src/screens/worklist.verbcensus.test.ts
@@ -117,16 +117,23 @@ describe("a row claims no verb it cannot perform", () => {
         return !routed.has(verb);
       }
       // GUARDED, not merely mentioned. The named file has to ASK whether the
-      // row offers this verb, in one of the two spellings the call sites use —
-      // `offered("x")` through the helper, or `includes("x")` direct. A file
-      // that merely contains the word satisfies nothing: deleting a control's
-      // condition leaves the verb's name behind in the click handler, in
-      // VERB_LABEL and in the prose, so a mention test stays green over a row
+      // row offers this verb, in one of the three spellings the call sites use.
+      // A file that merely contains the word satisfies nothing: deleting a
+      // control's condition leaves the verb's name behind in the click handler,
+      // in VERB_LABEL and in the prose, so a mention test stays green over a row
       // that draws nothing.
+      //
+      // The third spelling is the dispatch table's. ANSWER_BY_SOURCE pairs a
+      // source with the verb that unlocks it and RowAnswer asks
+      // `includes(keyed.verb)` once for all of them — so the guard is real and
+      // the verb's name is a `verb:` field rather than a literal argument. The
+      // pattern anchors on that field name, not on the bare word, so a verb
+      // mentioned in a comment beside the table still fails.
       const source = readFileSync(join(SCREENS, where.file), "utf8");
       return !(
         source.includes(`offered("${verb}")`) ||
-        source.includes(`includes("${verb}")`)
+        source.includes(`includes("${verb}")`) ||
+        source.includes(`verb: "${verb}"`)
       );
     });
 


### PR DESCRIPTION
The queue's oldest promise is that a rep works their day without leaving it. The row a rep meets most often — somebody wrote and nobody has answered — sent them to the record to press Reply there.

The row now carries `reply`, opening the same `ChannelReplyAction` the 360 timelines mount. **Reused, not rewritten:** it already withholds the verb where a person cannot be reached on the transport that carried the message, and already distinguishes a reply from a first message where the content is not this reader's to read.

## Two conditions, both about whether the composer can do anything

- **The wait must BE mail.** The lane spans channel messages, and answering a chat in the mail composer replies in the wrong place, to a counterparty resolved from a thread that is not one.
- **It must name a record**, because the sent message files against it. A message from a stranger names nobody.

## A census that had been reading 14 of 18 sources

`sourceactioncensus_test.go` kept a hand-written list of six sources it required the fixture to assemble, while the verb table declared eighteen. Four were checked by nobody — `customer_waiting`, `lead_response`, `undelivered`, `introduction_request` were declared, never assembled, and the census reported PASS. That is the one direction a census must never fail in, and the **second time this session** it hid a source shipping with no verb.

The requirement now derives from the declaration table itself: every declared source must be assembled, or named in a `notYetAssembled` register with its reason. The register fails **both** ways — an unassembled source missing from it fails, and a source that can now be assembled must leave it, so an exemption cannot outlive the gap and hide the next one.

## Review findings, all three fixed in the second commit

1. **A sent reply left the row saying nobody had replied.** `ChannelReplyAction` exposed no completion callback, `ComposeModal` invalidates only record timelines, and the worklist does not poll — so the row kept offering to answer an already-answered message. It now takes an optional `onSent`; its existing caller passes none and is unchanged.

2. **Two of my four census exemptions stated a false reason.** I wrote that no stub feeds the undelivered and introduction lanes. `stubUndelivered` and `stubIntroductions` both exist and are wired elsewhere in the package — the fixture simply did not call them. Both are now fed, so the census reads **16 of 18**, and the register holds only the two genuinely unreachable ones (positional arguments to `NewService`, not Options). Writing a false reason into a register on its first day is worse than leaving it empty.

3. **`RowAnswer` hit the complexity ceiling its own doc predicted.** The five answers needing nothing but the row's id are now a table keyed by source; only the two needing more stay branches. Keyed by *source*, not verb, because `dismiss` belongs to two lanes and means something different in each.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `can be answered from the row` |
| Verb gating (client) | `offers no reply when the server sent none`; `offers no reply when the row names no record to file against` |
| Verb gating (server) | `TestOnlyAWaitTheComposerCanAnswerOffersReply` — three cases: email+person offers, channel message does not, stranger does not |
| Censuses | Backend census now reaches 16/18 sources and fails in both directions; frontend verb census taught the table's `verb:` spelling, anchored on the field name so a mention in a comment still fails |
| Mutation strength | 5 mutations, each failing only its own test: drop the email condition → 2 of 3 server subcases; drop the subject requirement → the stranger test; remove a verb from the table → the frontend census; unexempt an unassembled source → the register; a stale exemption → the reverse arm |
| Full lane | `make check-fe` and `make check-backend` both run; see below |

## On the gate runs

`make check-backend` reported zero test failures. The one script failure, `env-reads`, passes standalone — it ran concurrently with the rebase and read the waiver file mid-rewrite. `make check-fe` flagged `onboarding-conversation/company-act.test.tsx`, which passes alone and is untouched here; all 476 worklist and compose tests pass.

## Not fixed here, and pre-existing

Mail filed only under a **lead** reaches the queue with no subject: `WaitingReply` carries no lead id though the waiting SQL admits one. Such a row already offered no `open` for the same reason, and now offers no `reply` either. Plumbing the lead through the lane is its own change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the same `ChannelReplyAction` the 360 timelines use from the worklist row, so a rep can answer a waiting buyer without leaving the queue. Reply only shows when the wait is email and names a record to file the sent message against; a sent reply now refreshes the queue so the row stops offering to answer a message the reader just answered.

**Bug Fixes**

- Fixed the source action census: it required a hand-written list of six sources while the verb table declared eighteen, so four sources were never assembled and the census still passed. It now derives the requirement from the declaration table and fails in both directions.
- The census fixture now feeds the undelivered and introduction lanes, taking it from 14 to 16 of 18 sources; the two remaining are positional arguments to `NewService`, unreachable from the fixture's Options.
- Mail filed only under a lead reaches the queue with no subject, so such a row offers no reply — plumbing the lead through the lane is its own change.

<sup>Written for commit 971f01a5982849d9c1535a710f2ae5f391d2e797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Reply action for eligible email-based waiting items in the worklist.
  - Reply is available when the email identifies a contact and is sent directly from the worklist.
  - Worklist data refreshes after a reply is sent.

- **Bug Fixes**
  - Prevented Reply from appearing for non-email messages, unknown senders, or inaccessible content.
  - Updated action availability and labels to accurately reflect supported replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->