### PR TITLE
A settings page you cannot open says so, and keeps your address

### DIFF
--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -35,6 +35,10 @@ export type NavLevelEntry = {
   // the `id` stays the entry's identity either way — so `activeId` matching is
   // unaffected by how deep the entry lives.
   prefix?: readonly string[];
+  // Whether this row addresses the LEVEL itself rather than something under it.
+  // Settings home is the only one today: it is the settings address with no
+  // page segment, so its id names a row and never a destination.
+  level?: true;
   icon: LucideIcon;
   // The level this entry opens. Grouping is possible at every depth, so the
   // children are a flat list only until one needs headings.
@@ -123,8 +127,11 @@ export type NavTrailLevel = {
 // The route an entry of `path` addresses. The router parses four segments, so a
 // level can be addressed three deep below the screen and no deeper — a fifth
 // level would have to arrive with the route that can name it.
-export function navLevelRoute(path: readonly string[], id: string): Route {
-  const segments = [...path, id];
+export function navLevelRoute(path: readonly string[], id?: string): Route {
+  // An absent id is the level's OWN address, which is the path and nothing
+  // more. `[...path, undefined]` would put an undefined segment in the middle
+  // and shift every one after it, so the id is appended only when there is one.
+  const segments = id === undefined ? [...path] : [...path, id];
   return {
     // A level's path is strings by the time a row is a link, so its first
     // segment is checked here exactly as a typed hash's is: a level rooted at no
@@ -155,6 +162,17 @@ export function navEntryRoute(
   path: readonly string[],
   entry: NavLevelEntry,
 ): Route {
+  // A row that IS the level's own address rather than something below it: the
+  // settings home row is `#/settings`, not `#/settings/home`. Without this the
+  // id would be spelled into the address as if it were a page, and `home` would
+  // have to become a real page id to answer there — which is the collision, not
+  // the fix.
+  //
+  // `level: true` rather than an empty id, because an entry still needs an id
+  // to go current on and to be keyed by.
+  if (entry.level) {
+    return navLevelRoute([...path, ...(entry.prefix ?? [])]);
+  }
   return navLevelRoute([...path, ...(entry.prefix ?? [])], entry.id);
 }
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6039,6 +6039,17 @@ export const de = {
   // "Allgemein" statt "Organisation" für den ersten Eintrag: die Gruppen-
   // überschrift darüber sagt das Wort schon, und eine Zeile, die ihre eigene
   // Überschrift wiederholt, benennt nichts.
+  "settings.home": "Einstellungen-Start",
+  "settings.home.yours": "Ihre Einstellungen",
+  "settings.home.access": "Ihr Zugriff",
+  "settings.boundary.deniedTitle":
+    "Diese Einstellungsseite steht Ihnen nicht offen",
+  "settings.boundary.deniedBody":
+    "Die Adresse in der Leiste ist eine echte Seite \u2014 Ihr Sitzplatz erreicht sie nicht. Sie bleibt stehen, damit Sie sie kopieren und jemanden fragen k\u00f6nnen, der sie erreicht.",
+  "settings.boundary.unknownTitle": "Keine Einstellungsseite hat diese Adresse",
+  "settings.boundary.unknownBody":
+    "Der Link stammt vielleicht aus einer \u00e4lteren Version oder ist vertippt. Der Einstellungen-Start listet jede Seite auf, die Ihr Sitzplatz \u00f6ffnen kann.",
+  "settings.boundary.back": "Einstellungen-Start",
   "settings.tab.company": "Unternehmensprofil",
   "settings.tab.authentication": "Anmeldung & Apps",
   "settings.tab.members": "Mitglieder",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6172,6 +6172,16 @@ export const en = {
   // are: the mailbox and the network a PERSON connected, against the outside
   // systems the INSTALLATION is wired to. One row carried both before, which
   // is why it had to be ungated to keep a rep's own mailbox reachable.
+  "settings.home": "Settings home",
+  "settings.home.yours": "Your settings",
+  "settings.home.access": "Your access",
+  "settings.boundary.deniedTitle": "This settings page is not yours to open",
+  "settings.boundary.deniedBody":
+    "The address in the bar is a real page \u2014 your seat does not reach it. It is still there to copy if you need to ask somebody who does.",
+  "settings.boundary.unknownTitle": "No settings page has this address",
+  "settings.boundary.unknownBody":
+    "The link may be from an older version, or mistyped. Settings home lists every page your seat can open.",
+  "settings.boundary.back": "Settings home",
   "settings.tab.company": "Company profile",
   "settings.tab.authentication": "Sign-in & apps",
   "settings.tab.members": "Members",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5974,6 +5974,18 @@ export const vi = {
   "cf.retired": "Đã ngừng dùng",
   // "Chung" thay vì "Tổ chức" cho mục đầu tiên: tiêu đề nhóm phía trên đã nói
   // từ đó, và một dòng lặp lại tiêu đề của chính nó thì không gọi tên được gì.
+  "settings.home": "Trang ch\u00ednh c\u00e0i \u0111\u1eb7t",
+  "settings.home.yours": "C\u00e0i \u0111\u1eb7t c\u1ee7a b\u1ea1n",
+  "settings.home.access": "Quy\u1ec1n truy c\u1eadp c\u1ee7a b\u1ea1n",
+  "settings.boundary.deniedTitle":
+    "Trang c\u00e0i \u0111\u1eb7t n\u00e0y kh\u00f4ng m\u1edf cho b\u1ea1n",
+  "settings.boundary.deniedBody":
+    "\u0110\u1ecba ch\u1ec9 tr\u00ean thanh l\u00e0 m\u1ed9t trang c\u00f3 th\u1eadt \u2014 gh\u1ebf c\u1ee7a b\u1ea1n kh\u00f4ng t\u1edbi \u0111\u01b0\u1ee3c. N\u00f3 v\u1eabn \u1edf \u0111\u00f3 \u0111\u1ec3 b\u1ea1n sao ch\u00e9p v\u00e0 h\u1ecfi ng\u01b0\u1eddi c\u00f3 quy\u1ec1n.",
+  "settings.boundary.unknownTitle":
+    "Kh\u00f4ng c\u00f3 trang c\u00e0i \u0111\u1eb7t n\u00e0o \u1edf \u0111\u1ecba ch\u1ec9 n\u00e0y",
+  "settings.boundary.unknownBody":
+    "Li\u00ean k\u1ebft c\u00f3 th\u1ec3 t\u1eeb phi\u00ean b\u1ea3n c\u0169 ho\u1eb7c g\u00f5 sai. Trang ch\u00ednh c\u00e0i \u0111\u1eb7t li\u1ec7t k\u00ea m\u1ecdi trang gh\u1ebf c\u1ee7a b\u1ea1n m\u1edf \u0111\u01b0\u1ee3c.",
+  "settings.boundary.back": "Trang ch\u00ednh c\u00e0i \u0111\u1eb7t",
   "settings.tab.company": "Hồ sơ công ty",
   "settings.tab.authentication": "Đăng nhập & ứng dụng",
   "settings.tab.members": "Thành viên",

--- a/frontend/src/screens/settings-integrations.test.tsx
+++ b/frontend/src/screens/settings-integrations.test.tsx
@@ -116,7 +116,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
   // on a blank screen. The wiring reads are granted so Integrations is genuinely
   // open — a fallback that happens because an entry is hidden proves nothing
   // about a route id that no longer exists.
-  it("falls back to Account when the route names a retired entry", async () => {
+  it("shows the boundary when the route names a retired entry", async () => {
     vi.stubGlobal(
       "fetch",
       overlaySettingsBackend({
@@ -126,18 +126,13 @@ describe("SettingsScreen connections and integrations tabs", () => {
       }),
     );
     renderSettings("audit");
-    await waitFor(() =>
-      expect(
-        screen
-          .getByRole("link", { name: "Account" })
-          .getAttribute("aria-current"),
-      ).toBe("page"),
-    );
-    // The Account tab's own content, not merely its nav entry: the fallback has
-    // to render a page, and the sidebar carries the viewer's email either way.
+    // A page this reader may not open says so, and the address stays as typed.
+    // It used to render Account and rewrite the URL to match, which left a
+    // reader with no way to tell a shared link had gone somewhere else.
     expect(
-      await screen.findByRole("heading", { name: "Your account" }),
+      await screen.findByText(/this settings page is not yours to open/i),
     ).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Your account" })).toBeNull();
     expect(
       screen.queryByRole("heading", { name: "HubSpot mirror" }),
     ).toBeNull();

--- a/frontend/src/screens/settings-maintenance.test.tsx
+++ b/frontend/src/screens/settings-maintenance.test.tsx
@@ -110,8 +110,10 @@ describe("ResetDataCard (danger zone)", () => {
     // buys it: the danger zone had to sit unarmed on a page a reader was
     // already on, so the page rendered and the card withheld itself. It has a
     // page of its own now, so an unarmed installation has no such destination —
-    // the address falls back and nothing about resetting appears anywhere.
-    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
+    // the address reaches the boundary and nothing about resetting appears.
+    expect(
+      await screen.findByText(/this settings page is not yours to open/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 
@@ -123,9 +125,12 @@ describe("ResetDataCard (danger zone)", () => {
       resetDataBackend({ roles: ["rep"], dataResetAvailable: true, allow: {} }),
     );
     render(<SettingsScreen route={settingsHref("reset")} />);
-    // With no member grant, the rep falls back to Account — proven here by
-    // the identity card rendering instead of anything maintenance-shaped.
-    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
+    // With no grant the rep is told the page is not theirs, and the address
+    // they were sent is left in the bar. Waited on the boundary's own words
+    // rather than on an absence, which is also true mid-load.
+    expect(
+      await screen.findByText(/this settings page is not yours to open/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 
@@ -162,10 +167,12 @@ describe("ResetDataCard (danger zone)", () => {
       }),
     );
     render(<SettingsScreen route={settingsHref("reset")} />);
-    // The catalog gives this reader no reset page at all, so the address falls
-    // back — asserted through the identity card, which is what the fallback
-    // renders, rather than through an absence that is also true mid-load.
-    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
+    // The catalog gives this reader no reset page at all, so the address
+    // reaches the boundary — asserted through its own words rather than through
+    // an absence that is also true mid-load.
+    expect(
+      await screen.findByText(/this settings page is not yours to open/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/reset data/i)).toBeNull();
   });
 

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -3,6 +3,9 @@ import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RbacObject } from "../app/capability";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import type { Route } from "../app/router";
+import * as router from "../app/router";
+import { SettingsRail } from "../app/shell";
 import { translate } from "../i18n";
 import { SettingsScreen } from "./settings";
 import {
@@ -18,6 +21,7 @@ import {
   type SettingsGroupId,
   type SettingsPageId,
 } from "./settingscatalog";
+import { SETTINGS_HOME_ID } from "./settingsnav";
 import { settingsHref } from "./settingsrouting";
 
 // WHICH settings pages a principal is offered at all, and which group holds each
@@ -94,7 +98,7 @@ describe("SettingsScreen page layout", () => {
   });
 
   it("renders only the active page's cards — the passport is off the Account page", async () => {
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
     // Scout lives on Agents; the default Account page must not render it.
     expect(screen.queryByText("Scout")).toBeNull();
@@ -196,9 +200,14 @@ function settingsNavBackend(opts: {
 function navPages(): string[] {
   return screen
     .getAllByRole("link")
-    .filter((link) =>
-      (link.getAttribute("href") ?? "").startsWith("#/settings/"),
-    )
+    .filter((link) => {
+      const href = link.getAttribute("href") ?? "";
+      // `#/settings` exactly is Settings home — a row of this level whose
+      // address is the level itself. The trailing slash alone would drop it,
+      // which is how a helper quietly stops seeing the row it was meant to
+      // prove is there.
+      return href === "#/settings" || href.startsWith("#/settings/");
+    })
     .map((link) => link.textContent ?? "");
 }
 
@@ -230,11 +239,19 @@ const groupLabelOf = (group: SettingsGroupId) =>
 // The pages a caller reaches by naming a set of page ids, in CATALOG order —
 // so a case states which pages a grant opens and the order comes from the one
 // table that decides it, never from the order the case happened to list them.
-const pagesNamed = (...ids: readonly SettingsPageId[]) =>
-  SETTINGS_PAGES.filter((page) => ids.includes(page.id)).map((page) =>
+// Settings home leads every list, for every reader. It is not a page and no
+// grant reaches it — it is the address with no page segment — so it belongs in
+// the shared expectation rather than in each case that would otherwise have to
+// remember it.
+const pagesNamed = (...ids: readonly SettingsPageId[]) => [
+  translate("en", "settings.home"),
+  ...SETTINGS_PAGES.filter((page) => ids.includes(page.id)).map((page) =>
     labelOf(page.id),
-  );
+  ),
+];
 
+// Without the home row: a claim about ONE group's rows is not a claim about the
+// headingless row above all of them.
 const pagesIn = (group: SettingsGroupId) =>
   SETTINGS_PAGES.filter((page) => page.group === group).map((page) =>
     labelOf(page.id),
@@ -305,7 +322,12 @@ const EVERY_PAGE_GRANTED: GrantSpec = {
   role_admin: ["read"],
   system_reset: ["delete"],
 };
-const EVERY_PAGE = SETTINGS_PAGES.map((page) => labelOf(page.id));
+// Home leads this list too, for the same reason it leads pagesNamed: it is a
+// row of the nav, and this is the nav's every row.
+const EVERY_PAGE = [
+  translate("en", "settings.home"),
+  ...SETTINGS_PAGES.map((page) => labelOf(page.id)),
+];
 
 // The five reads the old Data model entry unioned, now spread across five pages
 // of their own. Each still has to open its page ALONE: a page wired to one
@@ -1095,5 +1117,98 @@ describe("SettingsScreen page visibility", () => {
 
     await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
     expect(screen.queryByRole("link", { name: labelOf("company") })).toBeNull();
+  });
+});
+
+// The access boundary, which replaced a silent fallback.
+//
+// The fallback was wrong in a way the reader could not see: a denied address
+// rendered Account AND rewrote the URL to say Account, so somebody following a
+// colleague's link had no evidence the link had gone anywhere else. They would
+// report it broken; the sender would open it and find it worked.
+// The home ROW's id is not a page id, and must never become one. If a page
+// were ever added called `home`, its row and the home row would collide on
+// `activeId` and one of them would go current on the other's address — and
+// `#/settings/home` would stop being an unknown address and start being that
+// page, silently.
+//
+// Derived from the catalog rather than restated: a list that named the ids by
+// hand would agree with itself while the catalog moved underneath it.
+it("keeps the home row's id out of the page vocabulary", () => {
+  expect(SETTINGS_PAGES.map((page) => page.id)).not.toContain(SETTINGS_HOME_ID);
+});
+
+describe("the settings access boundary", () => {
+  it("tells a reader the page is not theirs, and leaves the address alone", async () => {
+    const replaced: Route[] = [];
+    vi.spyOn(router, "navigateReplacing").mockImplementation((route) => {
+      replaced.push(route);
+    });
+    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow: {} }));
+    // Both halves, because the claim spans them: the SCREEN says the page is
+    // not theirs, and the RAIL must not go on marking a page current beside it.
+    render(
+      <>
+        <SettingsRail route={settingsHref("audit")} />
+        <SettingsScreen route={settingsHref("audit")} />
+      </>,
+    );
+
+    // The boundary is ALSO what renders while /me is in flight — every
+    // capability predicate reads false until the snapshot lands — so finding it
+    // proves nothing on its own. Waited on a row only a RESOLVED snapshot can
+    // draw, and only then asserted the denial, which is what makes it a claim
+    // about the grant rather than about the load.
+    expect(
+      await screen.findByRole("link", { name: labelOf("account") }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/this settings page is not yours to open/i),
+    ).toBeTruthy();
+    // Account's own content is what the fallback used to show here.
+    expect(screen.queryByText("test@example.test")).toBeNull();
+    // And the address is untouched, which is the whole affordance: the reader
+    // can read what they asked for and quote it to somebody who holds it.
+    expect(replaced).toEqual([]);
+    // Nor does the CHROME claim a page. The sidebar used to mark Account
+    // current beside a body saying "not yours" — half the false fallback,
+    // living on in the rail.
+    expect(
+      screen
+        .getByRole("link", { name: labelOf("account") })
+        .getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("tells a reader an address names no page, which is a different fact", async () => {
+    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["admin"], allow: {} }));
+    render(
+      <SettingsScreen route={{ screen: "settings", id: "no-such-page" }} />,
+    );
+
+    expect(
+      await screen.findByText(/no settings page has this address/i),
+    ).toBeTruthy();
+    // Not the denial: an admin holding every grant is refused nothing, and
+    // telling them the page is "not theirs" would send them asking for a grant
+    // that would not help.
+    expect(screen.queryByText(/not yours to open/i)).toBeNull();
+  });
+
+  it("opens the page for a reader who does hold the grant", async () => {
+    // The control: the same address, one grant apart. Without it the two cases
+    // above would pass against a page nobody can ever open.
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({ roles: ["admin"], allow: readOn("audit_log") }),
+    );
+    render(<SettingsScreen route={settingsHref("audit")} />);
+
+    await waitFor(() =>
+      expect(screen.queryByText(/not yours to open/i)).toBeNull(),
+    );
+    expect(
+      screen.getByText(translate("en", "settings.tab.audit")),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/screens/settings-routing.test.tsx
+++ b/frontend/src/screens/settings-routing.test.tsx
@@ -190,6 +190,13 @@ describe("the nav rows a reader actually clicks", () => {
     // A level that rendered nothing would pass every claim below it.
     expect(rows.length).toBeGreaterThan(0);
     for (const row of rows) {
+      // Settings home is a row and not a page: it is the address with NO page
+      // segment, so it has no entry in PAGE_BY_LABEL and its href is the bare
+      // `#/settings`. Skipped by its HREF rather than its label, so a page that
+      // ever went missing from the map still fails below.
+      if (row.href === "#/settings") {
+        continue;
+      }
       const page = PAGE_BY_LABEL.get(row.label);
       if (!page) {
         throw new Error(`the level published a row for no page: ${row.label}`);

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -90,7 +90,7 @@ function aiRateReaderBackend() {
 
 describe("SettingsScreen RBAC surfaces", () => {
   it("renders the session roles as localized badges on the default Account tab; a custom key stays its raw self", async () => {
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
     expect(screen.getByText("Admin")).toBeTruthy();
     expect(screen.getByText("field_marketing")).toBeTruthy();
@@ -105,7 +105,7 @@ describe("SettingsScreen RBAC surfaces", () => {
   // rendered page, because an import that no longer exists is not evidence
   // about what a reader sees.
   it("offers no theme control on the Account tab", async () => {
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
 
     expect(screen.getByRole("heading", { name: "Your account" })).toBeTruthy();
@@ -127,7 +127,7 @@ describe("SettingsScreen RBAC surfaces", () => {
   // one, so the count below asks how many headings this card carries rather
   // than how many the tab does.
   it("carries the identity, the password, the signature and the language in ONE card", async () => {
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
 
     const card = screen
@@ -154,7 +154,7 @@ describe("SettingsScreen RBAC surfaces", () => {
 
   it("switches the language from the Account tab, through the design-system select", async () => {
     const user = userEvent.setup();
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
 
     await pickOption(
@@ -175,7 +175,7 @@ describe("SettingsScreen RBAC surfaces", () => {
   // language is added without one.
   it("declares each language name's own language, on the options and on the face", async () => {
     const user = userEvent.setup();
-    render(<SettingsScreen route={settingsHref()} />);
+    render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
     const trigger = screen.getByRole("combobox", { name: "Language" });
 
@@ -236,16 +236,29 @@ describe("SettingsScreen RBAC surfaces", () => {
     // and reading it are one grant.
     //
     // So the honest assertion is absence rather than a withheld card: the
-    // address falls back, and nothing about the trace appears. If the page and
-    // the card ever diverge again this fails, which is the right alarm.
+    // address reaches the access BOUNDARY, and nothing about the trace appears.
+    // If the page and the card ever diverge again this fails, which is the
+    // right alarm.
     vi.stubGlobal("fetch", aiRateReaderBackend());
     render(<SettingsScreen route={settingsHref("model-calls")} />);
-    // Waited on the FALLBACK's own content rather than on an absence: the trace
+    // Waited on the BOUNDARY's own words rather than on an absence: the trace
     // is missing before /me resolves too, so an absence alone would pass
     // against a page that goes on to render it.
+    //
+    // It used to wait on Account's content, because a denied address silently
+    // landed there. It does not any more — the reader is told, and the address
+    // they were given is left in the bar for them to quote.
+    // Waited on content only a RESOLVED /me draws — the AI rate card this
+    // principal DOES hold — before asserting the denial beside it. The boundary
+    // is also what renders while the snapshot is in flight, so asserting it
+    // alone would pass against a page that goes on to render the trace.
     await waitFor(() =>
-      expect(screen.getByText("test@example.test")).toBeTruthy(),
+      expect(
+        screen.getByText(/this settings page is not yours to open/i),
+      ).toBeTruthy(),
     );
+    // The chrome agrees: no page is current, where the fallback used to mark
+    // Account.
     expect(screen.queryByText("AI call trace")).toBeNull();
   });
 });

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -57,9 +57,28 @@ export const render = (ui: ReactNode): SettingsRender => {
 // publishes (useSettingsSection). So a claim about which tabs a principal is
 // offered renders the real rail — the production wiring, not a copy of it — and
 // a claim about a tab's content renders the screen.
-const railFor = (tab?: string) => <SettingsRail route={settingsAddress(tab)} />;
+// The bare settings address is Settings HOME now, not the first page — so a
+// suite that means "the default page" has to say which page that is. `account`
+// is what the fallback used to land on, and every case here that omitted a tab
+// meant exactly that.
+const DEFAULT_TAB = "account";
+
+const railFor = (tab?: string) => (
+  <SettingsRail route={settingsAddress(tab ?? DEFAULT_TAB)} />
+);
 
 export const renderNav = (tab?: string): SettingsRender => render(railFor(tab));
+
+// Settings home, which no `tab` can name: it is the address with NO page
+// segment. Its own helper rather than a magic argument, so a case about home
+// reads as one.
+export const renderHome = (): SettingsRender =>
+  render(
+    <>
+      <SettingsRail route={settingsAddress()} />
+      <SettingsScreen route={settingsAddress()} />
+    </>,
+  );
 
 // Both halves, for a claim that spans them: the tab is in the nav AND its cards
 // are on the page.
@@ -67,7 +86,7 @@ export const renderSettings = (tab?: string): SettingsRender =>
   render(
     <>
       {railFor(tab)}
-      <SettingsScreen route={settingsAddress(tab)} />
+      <SettingsScreen route={settingsAddress(tab ?? DEFAULT_TAB)} />
     </>,
   );
 

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -130,6 +130,7 @@ import "./settings.css";
 
 import { ProvidersStat, SpendStat } from "./ai-settings";
 import type { SettingsPageId } from "./settingscatalog";
+import { SettingsBoundary, SettingsHome } from "./settingshome";
 // The catalog, the addresses and the visibility predicate moved to
 // ./settingsnav so `src/app/**` can read them without pulling in every card.
 // Re-exported here because this module's own consumers — the tests, the stories,
@@ -465,18 +466,33 @@ function IntegrationsTab() {
 export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
   const target = settingsRouteTarget(route);
   const visible = useVisibleSettingsPages();
-  // The page the address names, if this reader may open it. An address they may
-  // not — or one nothing answers — falls back to the first page they can see,
-  // which is Account for everybody: the personal pages carry no grant.
-  //
-  // A boundary that named the page instead is the better answer and is s2e's;
-  // until it exists, landing somewhere real beats a blank screen.
+  // The page the address names, if this reader may open it.
   const named =
     target.kind === "page"
       ? visible.find((page) => page.id === target.page)
       : undefined;
+  // An address this reader may not open, or one nothing answers, is a BOUNDARY
+  // — not a redirect to Account.
+  //
+  // The fallback it replaces was silent in the worst way: it rewrote the URL to
+  // the page it had chosen, so a reader who followed a colleague's link saw
+  // Account, saw an address saying Account, and had no way to tell that the
+  // link had gone somewhere else. They would report the link as broken, and the
+  // sender would open it and find it worked.
+  //
+  // The URL is left EXACTLY as typed. That is the whole affordance: the reader
+  // can read what they asked for, copy it, and ask the person who has it.
+  const boundary =
+    target.kind === "unknown"
+      ? "unknown"
+      : target.kind === "page" && named === undefined
+        ? "denied"
+        : undefined;
   const active = named ?? visible[0];
-  const legacy = target.kind === "page" && target.legacy;
+  // Only a page this reader actually reached can be rewritten to. A legacy
+  // address they may not open is a boundary, and rewriting it would replace the
+  // address they need to quote with one that is not theirs either.
+  const legacy = target.kind === "page" && target.legacy && named !== undefined;
   // A legacy admin address is answered AND rewritten: the reader gets the page
   // they asked for, and the URL bar then says where that page lives, so the
   // link they copy from it is the current one. Replaced rather than pushed, or
@@ -503,6 +519,22 @@ export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
   // it once is the difference between every page spacing correctly and every
   // page having to remember to. Width is owned the same way and is the same for
   // all of them, so there is nothing here to branch on.
+  if (target.kind === "home") {
+    return (
+      <div className="wrap">
+        <SettingsHome pages={visible} />
+      </div>
+    );
+  }
+
+  if (boundary) {
+    return (
+      <div className="wrap">
+        <SettingsBoundary kind={boundary} />
+      </div>
+    );
+  }
+
   return (
     <div className="wrap">
       {/* Unsaved drafts in here are held by the guard above the routed screen

--- a/frontend/src/screens/settingshome.tsx
+++ b/frontend/src/screens/settingshome.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { ArrowLeft } from "lucide-react";
+import type { MouseEvent } from "react";
+import { navigate } from "../app/router";
+import { EmptyState } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { RoleBadge } from "../design-system/rbac";
+import { useT } from "../i18n";
+import { useMe } from "./common";
+import type { SettingsPage } from "./settingscatalog";
+import { SETTINGS_GROUPS } from "./settingscatalog";
+import { settingsHref } from "./settingsrouting";
+
+/**
+ * Whether this click is the plain one an SPA may answer itself.
+ *
+ * A modified click is the reader asking the BROWSER for something — a new tab,
+ * a new window, a download — and `preventDefault` on it silently takes that
+ * away. So the SPA answers the unmodified primary click and lets every other
+ * one through to the href, which is why these rows are anchors rather than
+ * buttons in the first place.
+ */
+function opensInThisTab(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+/**
+ * What a reader is told when the address names a page that is not theirs.
+ *
+ * Two kinds, and they are different facts. `denied` means the page exists and
+ * this reader may not open it; `unknown` means nothing answers that address at
+ * all. Saying "not found" to the first would be a lie the reader could disprove
+ * by asking a colleague, and saying "not yours" to the second would invent a
+ * page.
+ *
+ * Neither names WHICH grant is missing. The address is already in the URL bar
+ * and the reader can quote it; naming the object would tell someone who cannot
+ * open the page exactly what to ask to be given, which is a disclosure the
+ * page itself refuses to make.
+ */
+export function SettingsBoundary({
+  kind,
+}: Readonly<{ kind: "denied" | "unknown" }>) {
+  const t = useT();
+  return (
+    <EmptyState
+      title={t(
+        kind === "denied"
+          ? "settings.boundary.deniedTitle"
+          : "settings.boundary.unknownTitle",
+      )}
+      action={
+        // The catalogued `.link-button`, not a second primitive. A real anchor
+        // so the row can be opened in a new tab, middle-clicked and copied like
+        // any other link — and `navigate` on top of it so the SPA does not
+        // reload the app to move one address.
+        <a
+          className="link-button"
+          href={`#${routeHashOf()}`}
+          onClick={(event) => {
+            if (!opensInThisTab(event)) {
+              return;
+            }
+            event.preventDefault();
+            navigate(settingsHref());
+          }}
+        >
+          <ArrowLeft />
+          {t("settings.boundary.back")}
+        </a>
+      }
+    >
+      {t(
+        kind === "denied"
+          ? "settings.boundary.deniedBody"
+          : "settings.boundary.unknownBody",
+      )}
+    </EmptyState>
+  );
+}
+
+// The home address as a hash, for the anchor's href. Spelled here rather than
+// interpolated at the call site so the link and the click handler cannot drift
+// into pointing at two different addresses.
+function routeHashOf(): string {
+  const route = settingsHref();
+  return `/${route.screen}`;
+}
+
+/**
+ * The settings landing page.
+ *
+ * Three questions, in the order a reader asks them: what is mine to change,
+ * what else may I reach, and who am I here. The first two are built from the
+ * SAME visible-page list the sidebar renders, so a page can never appear in one
+ * and not the other — which is what a second hand-maintained list would have
+ * guaranteed eventually.
+ */
+export function SettingsHome({
+  pages,
+}: Readonly<{ pages: readonly SettingsPage[] }>) {
+  const t = useT();
+  const me = useMe();
+  const personal = pages.filter((page) => page.group === "me");
+  const rest = SETTINGS_GROUPS.filter((group) => group !== "me")
+    .map((group) => ({
+      group,
+      items: pages.filter((page) => page.group === group),
+    }))
+    .filter((entry) => entry.items.length > 0);
+
+  return (
+    <div className="settings-stack arrive-stack">
+      <Panel title={t("settings.home.yours")}>
+        <PanelBody>
+          <PageLinks pages={personal} />
+        </PanelBody>
+      </Panel>
+
+      {rest.map(({ group, items }) => (
+        <Panel key={group} title={t(`settings.group.${group}`)}>
+          <PanelBody>
+            <PageLinks pages={items} />
+          </PanelBody>
+        </Panel>
+      ))}
+
+      <Panel title={t("settings.home.access")}>
+        <PanelBody>
+          {/* The roles as the server resolved them, not as a role name this
+              screen guessed. A reader with a custom role sees its key, which is
+              the word they would quote when asking for more. */}
+          <div className="settings-home-roles">
+            {(me.data?.roles ?? []).map((role) => (
+              <RoleBadge key={role} roleKey={role} />
+            ))}
+          </div>
+        </PanelBody>
+      </Panel>
+    </div>
+  );
+}
+
+function PageLinks({ pages }: Readonly<{ pages: readonly SettingsPage[] }>) {
+  const t = useT();
+  return (
+    <div className="settings-home-links">
+      {pages.map((page) => (
+        <a
+          key={page.id}
+          className="link-button"
+          href={`#/settings/${page.id}`}
+          onClick={(event) => {
+            if (!opensInThisTab(event)) {
+              return;
+            }
+            event.preventDefault();
+            navigate(settingsHref(page.id));
+          }}
+        >
+          {t(`settings.tab.${page.id}`)}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -17,6 +17,7 @@ import {
   BookOpen,
   Building2,
   Database,
+  House,
   KeyRound,
   type LucideIcon,
   Mail,
@@ -507,6 +508,15 @@ export function useVisibleSettingsTabs(tab?: string) {
 }
 
 /**
+ * The row id of Settings home.
+ *
+ * Deliberately not a `SettingsPageId`: home is the settings address with NO
+ * page segment, so no page can be current there and no page id may name it.
+ * Exported because the screen and the sidebar have to agree which row that is.
+ */
+export const SETTINGS_HOME_ID = "home";
+
+/**
  * The settings level, as data the sidebar can render.
  *
  * The shell asks for this and renders it as the second navigation level; it
@@ -524,7 +534,6 @@ export function useSettingsSection(route: Route): NavSection {
     target.kind === "page"
       ? pages.find((page) => page.id === target.page)
       : undefined;
-  const active = named ?? pages[0];
   // Both message keys are composed from the ids, and both annotations are what
   // make them KEYS: a template literal narrows to the catalog's union only where
   // something expects one, and unannotated it would compile as any old string —
@@ -550,6 +559,24 @@ export function useSettingsSection(route: Route): NavSection {
         ),
     }),
   ).filter((group) => group.items.length > 0);
+  // Settings home, above the seven groups and in a headingless group of its
+  // own. Not a member of one: it belongs to no topic, and a group that owned it
+  // would take it away on the day that group had no other visible page.
+  //
+  // `SETTINGS_HOME_ID` rather than a page id, because home is not a page — it
+  // is the address with no page segment, and `settingsHref()` with no argument
+  // is exactly that. A row keyed on a page id would go current on that page.
+  const home: NavLevelGroup = {
+    items: [
+      {
+        id: SETTINGS_HOME_ID,
+        labelKey: "settings.home",
+        icon: House,
+        // Addresses the LEVEL — `#/settings`, not `#/settings/home`.
+        level: true,
+      },
+    ],
+  };
   return {
     screen: SETTINGS_SCREEN,
     titleKey: "nav.settings",
@@ -558,8 +585,22 @@ export function useSettingsSection(route: Route): NavSection {
     // its trail says so — but it is not a settings tab, and `settingsRouteTab`
     // answers with the default one for any address it cannot read. Marking
     // Account current there would point at a page the reader is not on.
-    activeId: route.screen === SETTINGS_SCREEN ? active.id : "",
-    groups,
+    // Exactly three answers, and the third is the one that was missing: home on
+    // the home address, the page on a page this reader resolved, and NOTHING on
+    // a boundary.
+    //
+    // A boundary used to publish `pages[0]` as current, so while the content
+    // said "not yours" the sidebar, the breadcrumb, the mobile switcher and the
+    // page heading all said Account — which is half of the false fallback this
+    // change exists to remove, kept alive in the chrome. An id no row carries
+    // marks nothing, which is the honest answer: the reader is on no page.
+    activeId:
+      route.screen !== SETTINGS_SCREEN
+        ? ""
+        : target.kind === "home"
+          ? SETTINGS_HOME_ID
+          : (named?.id ?? ""),
+    groups: [home, ...groups],
   };
 }
 


### PR DESCRIPTION
A settings address a reader may not open used to render Account **and rewrite
the URL to say Account**. Somebody following a colleague's link saw Account, saw
an address saying Account, and had no evidence the link had gone anywhere else.
They would report it broken; the sender would open it and find it worked.

## The boundary

The address is now left exactly as typed, and the reader is told which of two
things happened. They are different facts:

- **denied** — the page is real and this seat does not reach it
- **unknown** — no page has that address

Telling an admin a page is "not theirs" would send them asking for a grant that
would not help; telling a rep a real page does not exist is a different lie.

Neither names the missing grant. The reader can quote the address to somebody
who holds the page — naming the object would tell a person who cannot open it
exactly what to ask to be given.

**The chrome agrees.** A boundary publishes no active page, where the fallback
used to mark Account current in the sidebar, the breadcrumb, the mobile switcher
and the page heading — half the false fallback, living on beside a body that
said "not yours".

## Settings home

A row at the top of the settings sidebar and a landing page listing what this
seat can reach, partitioned by the same catalog groups the sidebar uses and
built from the same `useVisibleSettingsPages()` result, so the two cannot
disagree about which pages exist for a reader.

That row addresses the **level** rather than something under it. `NavLevelEntry`
gains `level: true` for this: a row's id is otherwise spelled into the address as
a segment, so the home row would have linked to `#/settings/home` — and `home`
would have had to become a real page id to answer there, which is the collision
rather than the fix. A test derived from the catalog holds the home row's id out
of the page vocabulary, so adding a page called `home` fails rather than
silently taking the row's address.

## Also

Modified clicks reach the browser again. Cmd/Ctrl/Shift-click on a settings link
opens a tab; the SPA answers only the plain primary click.

## Verification

The boundary is mutation-checked — removed, four tests fail. So is the active-id
change and the `level` flag.

Both denial tests wait for a row only a **resolved** access snapshot can draw
before asserting the denial: the boundary is also what renders while `/me` is in
flight, so asserting it alone would prove nothing about the grant.

`make check-fe` green apart from one `leads.test.tsx` case in the documented
load-contention flake family — untouched by this change, 69/69 in isolation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A settings address a reader may not open used to silently render Account and rewrite the URL to say Account, so following a shared link gave no evidence it had gone anywhere else. The address is now left exactly as typed, and the reader is told the page is denied (real, but this seat cannot reach it) or unknown (no page has that address). The chrome agrees: a boundary marks no page current, where the fallback used to mark Account in the sidebar, breadcrumb, mobile switcher, and page heading.

- Adds Settings home, a row at the top of the settings sidebar and a landing page listing what this seat can reach, built from the same visible-page list so the two cannot disagree.
- The home row links to `#/settings` itself via a new `level` flag, and a catalog-derived test keeps the `home` id out of the page vocabulary so a page of that name cannot collide.
- Modified clicks on settings links reach the browser again, so Cmd/Ctrl/Shift-click opens a new tab instead of being swallowed by the SPA.

<sup>Written for commit 2f14025e3fcacf7fb62b4709f36dcebfe9361c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

