### PR TITLE
fix(worklist): the waiting-buyer fixture names a band that exists

### DIFF
--- a/frontend/src/screens/worklist.reply.test.tsx
+++ b/frontend/src/screens/worklist.reply.test.tsx
@@ -22,7 +22,7 @@ function aWaitingBuyer(over = {}) {
     source: "customer_waiting",
     category: "customer_waiting",
     title: "can you resend the quote?",
-    band: "answer_people",
+    band: "now",
     destination: "today",
     actions: ["open", "reply"],
     subject: { type: "person", id: "01a05500-0000-7000-8000-0000000000c2" },


### PR DESCRIPTION
## What

`main` does not typecheck. One character of a test fixture; every PR opened since inherits the red lane.

```
src/screens/worklist.reply.test.tsx(25,5): error TS2322: Type '"answer_people"' is not
assignable to type '"now" | "review" | "build_pipeline" | "keep_momentum" | undefined'.
```

## Why

`answer_people` is not a band. It is not in the contract, not in the classifier, not in the row — the only enum the reply arc widened is the action list, which gained `reply`. So this is a fixture typo, not a contract addition that was missed, and adding the band would be inventing one.

A live customer wait is the top band. `classify.go` says so in as many words, and the sibling fixture for a waiting buyer already carries `band: "now"`.

Worth naming, because it is the reason this reached `main` green: the file's own vitest run transforms the TSX and never typechecks it, so `fe-bundle` (`tsc -b && vite build`) is the only lane that reads this line at all. A test can be passing and not compiling at the same time.

## How verified

- `npx tsc -b` clean on this branch; it fails on `origin/main` at `666b6d6d2` with exactly the error above.
- `vitest run src/screens/worklist.reply.test.tsx` — 3 passed. The band is fixture data the three cases do not assert on, so the change is to what the row is handed, not to what is proved about it.

- [x] `make check` is green (the failing lane, `fe-bundle`, is the one this fixes)
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — does not touch it
- [x] `make craft-static` reports no new blockers — no Go files in the diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Wholly AI-assisted: found by Claude Code while driving an unrelated PR to green, diagnosed against the contract and the classifier rather than by trying values until it compiled, and written up here.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC


---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a type error in the worklist reply test fixture by changing the band from `answer_people` to `now`, which is the correct value for a waiting buyer. This makes `tsc -b` pass on `main`, where it currently fails because the test file is never typechecked by its own vitest run.

<sup>Written for commit be742f68ddca9bca5f4c720eca99fe7f43a19ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

