### PR TITLE
Settings pages say what they are for, in three languages

### DIFF
--- a/frontend/scripts/lib/story-title.ts
+++ b/frontend/scripts/lib/story-title.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import ts from "typescript";
+
+/**
+ * The Storybook sidebar path a story file claims, or null.
+ *
+ * Resolves the DEFAULT EXPORT rather than reading the first `title:` in the
+ * file, because a story's fixture data carries titles of its own —
+ * dealroomthreads.stories.tsx opens with `title: "Commercial terms v4"`, the
+ * name of a document in the fixture, and a scanner reading the first match
+ * would file that story under a root called "Commercial terms v4".
+ *
+ * Shared rather than copied: two gates ask this question — the design-system
+ * catalog checks every story's ROOT, and the settings catalog checks that every
+ * settings story is filed under a group and page the catalog actually declares.
+ * A second parser would drift from this one and the two would disagree about
+ * which stories exist.
+ */
+export function storyTitle(path: string, text: string): string | null {
+  const source = ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const exported = source.statements.find(ts.isExportAssignment);
+  if (!exported) return null;
+  const named = unwrap(exported.expression);
+  const meta = ts.isIdentifier(named)
+    ? metaObjectNamed(source, named.text)
+    : named;
+  if (!meta || !ts.isObjectLiteralExpression(meta)) return null;
+  for (const property of meta.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    if (propertyKey(property.name) !== "title") continue;
+    const value = unwrap(property.initializer);
+    if (ts.isStringLiteralLike(value)) return value.text;
+  }
+  return null;
+}
+
+// The key, whichever way it is written. `{ title: … }` and `{ "title": … }` are
+// the same property, but reading the name's SOURCE TEXT compares the quotes
+// too, so the quoted spelling matched nothing and the story fell out of the
+// root check — skipped rather than reported, the one direction this gate must
+// not be wrong in. A computed key is deliberately not resolved: what it
+// evaluates to is not a question the parser can answer, and guessing would be
+// worse than the honest null.
+function propertyKey(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+  return null;
+}
+
+function metaObjectNamed(
+  source: ts.SourceFile,
+  name: string,
+): ts.Expression | undefined {
+  for (const statement of source.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
+        return declaration.initializer && unwrap(declaration.initializer);
+      }
+    }
+  }
+  return undefined;
+}
+
+// The type-only wrappers a story's metadata may be written through. They change
+// nothing about the object underneath, so a scanner that stops at them reads no
+// title where there is one.
+function unwrap(expression: ts.Expression): ts.Expression {
+  let node = expression;
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
+}

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -697,7 +697,10 @@ export function PageTitle({
   // Read only on the branch that prints an h1: a surface that names itself gets
   // no subtitle from here either, or the page would carry a description of a
   // heading it is not showing.
-  const subKey = PAGE_SUB_KEYS[route.screen];
+  // The ENTRY's own line first: a section is many pages behind one screen, and
+  // the screen-keyed table can only carry a sentence true of all of them. The
+  // table remains for screens that ARE one page.
+  const subKey = inSection?.entry.subKey ?? PAGE_SUB_KEYS[route.screen];
 
   if (recordNamesPage || unitNamesPage || selfHeaded) {
     return null;

--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -39,6 +39,11 @@ export type NavLevelEntry = {
   // Settings home is the only one today: it is the settings address with no
   // page segment, so its id names a row and never a destination.
   level?: true;
+  // One line under the page's heading, when the entry's own name does not say
+  // enough. On the ENTRY rather than in a screen-keyed table, because a section
+  // is many pages behind one screen — `PAGE_SUB_KEYS[route.screen]` can only
+  // describe all of them at once, which is no description of any of them.
+  subKey?: MessageKey;
   icon: LucideIcon;
   // The level this entry opens. Grouping is possible at every depth, so the
   // children are a flat list only until one needs headings.

--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -477,7 +477,7 @@ free to describe the surface rather than the file:
 |---|---|
 | `Design System/` | One node per primitive in this directory. |
 | `Records/` | The screens a rep works in, and the cards on them (`Company 360/`, `Company rail/`). |
-| `Settings/` | `You/` and `Admin settings/`, mirroring `SETTINGS_TABS` in `screens/settings.tsx` one for one — group label included — with the card as the leaf. |
+| `Settings/` | `<Group>/<Page>/<Card>`, mirroring the settings catalog one for one: the seven groups of `SETTINGS_GROUPS` and the pages of `SETTINGS_PAGES`, under their own sidebar labels. `screens/settingsstories.test.ts` holds the two together, so a story filed under a group or page the catalog does not declare fails. |
 | `Patterns/` | Screen-tier building blocks that are not a page: the query gate, the create/edit/merge/share actions, the composer. |
 | `Onboarding/`, `Signed out/`, `Shell/` | The first run, the pages reachable without a session, and the application frame. |
 | `MCP Apps/` | The governed tool surfaces and their document forms. |

--- a/frontend/src/design-system/catalog.test.ts
+++ b/frontend/src/design-system/catalog.test.ts
@@ -59,6 +59,7 @@ import { basename, join, relative, resolve } from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { filesUnder, scriptKindFor } from "../../scripts/lib/source-tree";
+import { storyTitle } from "../../scripts/lib/story-title";
 
 const frontendRoot = resolve(__dirname, "..", "..");
 const srcDir = join(frontendRoot, "src");
@@ -205,83 +206,6 @@ function rendersMarkup(node: ts.Node): boolean {
   };
   visit(node);
   return markup;
-}
-
-// storyTitle returns the sidebar path a story file claims, or null.
-//
-// It resolves the DEFAULT EXPORT rather than reading the first `title:` in the
-// file, because a story's fixture data carries titles of its own —
-// dealroomthreads.stories.tsx opens with `title: "Commercial terms v4"`, the
-// name of a document in the fixture, and a scanner reading the first match
-// would file that story under a root called "Commercial terms v4".
-function storyTitle(path: string, text: string): string | null {
-  const source = ts.createSourceFile(
-    path,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
-  const exported = source.statements.find(ts.isExportAssignment);
-  if (!exported) return null;
-  const named = unwrap(exported.expression);
-  const meta = ts.isIdentifier(named)
-    ? metaObjectNamed(source, named.text)
-    : named;
-  if (!meta || !ts.isObjectLiteralExpression(meta)) return null;
-  for (const property of meta.properties) {
-    if (!ts.isPropertyAssignment(property)) continue;
-    if (propertyKey(property.name) !== "title") continue;
-    const value = unwrap(property.initializer);
-    if (ts.isStringLiteralLike(value)) return value.text;
-  }
-  return null;
-}
-
-// The key, whichever way it is written. `{ title: … }` and `{ "title": … }` are
-// the same property, but reading the name's SOURCE TEXT compares the quotes
-// too, so the quoted spelling matched nothing and the story fell out of the
-// root check — skipped rather than reported, the one direction this gate must
-// not be wrong in. A computed key is deliberately not resolved: what it
-// evaluates to is not a question the parser can answer, and guessing would be
-// worse than the honest null.
-function propertyKey(name: ts.PropertyName): string | null {
-  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
-  return null;
-}
-
-function metaObjectNamed(
-  source: ts.SourceFile,
-  name: string,
-): ts.Expression | undefined {
-  for (const statement of source.statements) {
-    if (!ts.isVariableStatement(statement)) continue;
-    for (const declaration of statement.declarationList.declarations) {
-      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
-        return declaration.initializer && unwrap(declaration.initializer);
-      }
-    }
-  }
-  return undefined;
-}
-
-// The type-only wrappers a story's metadata may be written through. They change
-// nothing about the object underneath, so a scanner that stops at them reads no
-// title — and an absent title is SKIPPED by the root check rather than
-// reported, which is the one direction this gate must not be wrong in. This
-// tree already writes `as const satisfies` elsewhere, so the form is one edit
-// away from appearing here.
-function unwrap(expression: ts.Expression): ts.Expression {
-  let node = expression;
-  while (
-    ts.isParenthesizedExpression(node) ||
-    ts.isAsExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isTypeAssertionExpression(node)
-  ) {
-    node = node.expression;
-  }
-  return node;
 }
 
 const catalogTable = catalogSection(CATALOG_HEADING);

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6050,6 +6050,62 @@ export const de = {
   "settings.boundary.unknownBody":
     "Der Link stammt vielleicht aus einer \u00e4lteren Version oder ist vertippt. Der Einstellungen-Start listet jede Seite auf, die Ihr Sitzplatz \u00f6ffnen kann.",
   "settings.boundary.back": "Einstellungen-Start",
+  "settings.page.account.sub":
+    "Wie Sie erscheinen und sich anmelden \u2014 nur f\u00fcr Sie.",
+  "settings.page.voice.sub":
+    "Die Worte, die Entw\u00fcrfe verwenden, wenn sie in Ihrem Namen schreiben.",
+  "settings.page.agents.sub":
+    "Was ein Agent unbeaufsichtigt tun darf und welche Clients Ihre Zugangsdaten halten.",
+  "settings.page.connections.sub":
+    "Die Postf\u00e4cher und Adressen, aus denen dieser Sitzplatz liest.",
+  "settings.page.capture-activity.sub":
+    "Was die Erfassung mit Ihrer Post getan hat, und warum.",
+  "settings.page.company.sub":
+    "Name, W\u00e4hrung und Kontext, vor deren Hintergrund jeder Datensatz gelesen wird.",
+  "settings.page.authentication.sub":
+    "Wie sich Personen an dieser Installation anmelden und welche Apps f\u00fcr sie handeln d\u00fcrfen.",
+  "settings.page.members.sub":
+    "Alle mit einem Sitzplatz und was jeder erreichen darf.",
+  "settings.page.teams.sub":
+    "Wer zusammenarbeitet \u2014 daran orientiert sich der Zeilenzugriff.",
+  "settings.page.seats.sub":
+    "Wie viele Sitzpl\u00e4tze belegt sind, gemessen an dem, was dieser Installation zusteht.",
+  "settings.page.pipelines.sub":
+    "Die Phasen, die ein Gesch\u00e4ft durchl\u00e4uft \u2014 f\u00fcr das ganze Unternehmen.",
+  "settings.page.leads.sub":
+    "Die Worte, mit denen dieses Unternehmen beschreibt, woher ein Lead kam.",
+  "settings.page.fields.sub":
+    "Die Felder, die dieses Unternehmen zus\u00e4tzlich zu denen jeder Installation f\u00fchrt.",
+  "settings.page.tags.sub":
+    "Das gemeinsame Vokabular \u2014 hier umbenannt, ist es auf jedem Datensatz umbenannt.",
+  "settings.page.products.sub":
+    "Was dieses Unternehmen verkauft und die Vorlagen, aus denen ein Angebot entsteht.",
+  "settings.page.capture.sub":
+    "Welche Post zu einem Datensatz wird und welche unber\u00fchrt bleibt.",
+  "settings.page.integrations.sub":
+    "Die Systeme, mit denen diese Installation Datens\u00e4tze austauscht.",
+  "settings.page.knowledge.sub":
+    "Die Dokumente, aus denen Entw\u00fcrfe und Antworten lesen d\u00fcrfen.",
+  "settings.page.import.sub":
+    "Datens\u00e4tze aus einer Datei \u00fcbernehmen \u2014 ein Lauf nach dem anderen.",
+  "settings.page.models.sub":
+    "Welcher Anbieter welche Art von Arbeit beantwortet \u2014 und ob er es kann.",
+  "settings.page.automations.sub":
+    "Die Regeln, die laufen, ohne dass jemand etwas dr\u00fcckt.",
+  "settings.page.usage.sub":
+    "Was die KI-Laufzeit diesen Monat verbraucht hat, gemessen an ihrer Obergrenze.",
+  "settings.page.model-calls.sub":
+    "Was jeder Aufruf ein Modell gefragt hat \u2014 und wie es geantwortet hat.",
+  "settings.page.privacy.sub":
+    "Betroffenenanfragen, die Zwecke, zu denen Einwilligung erfasst wird, und wie lange Datens\u00e4tze bleiben.",
+  "settings.page.audit.sub":
+    "Jeder Akteur und jeder Datensatz, den er ber\u00fchrt hat.",
+  "settings.page.system-health.sub":
+    "Ob die Arbeit hinter den Bildschirmen mitkommt.",
+  "settings.page.extensions.sub":
+    "Die Einheiten, die dieser Build zusammengesetzt hat, und welche Rollen sie erreichen.",
+  "settings.page.reset.sub":
+    "Diese Installation leeren. Es gibt kein Zur\u00fcck.",
   "settings.tab.company": "Unternehmensprofil",
   "settings.tab.authentication": "Anmeldung & Apps",
   "settings.tab.members": "Mitglieder",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6182,6 +6182,58 @@ export const en = {
   "settings.boundary.unknownBody":
     "The link may be from an older version, or mistyped. Settings home lists every page your seat can open.",
   "settings.boundary.back": "Settings home",
+  "settings.page.account.sub": "How you appear and sign in \u2014 yours alone.",
+  "settings.page.voice.sub": "The words drafts use when they write as you.",
+  "settings.page.agents.sub":
+    "What an agent may do unattended, and which clients hold your credentials.",
+  "settings.page.connections.sub":
+    "The mailboxes and addresses this seat reads from.",
+  "settings.page.capture-activity.sub":
+    "What capture did with your mail, and why.",
+  "settings.page.company.sub":
+    "The name, currency and context every record is read against.",
+  "settings.page.authentication.sub":
+    "How people sign in to this installation, and which apps may act for it.",
+  "settings.page.members.sub":
+    "Everyone with a seat, and what each one may reach.",
+  "settings.page.teams.sub":
+    "Who works together, which is what row scope reads.",
+  "settings.page.seats.sub":
+    "How many seats are in use against what this installation is entitled to.",
+  "settings.page.pipelines.sub":
+    "The stages a deal moves through, for the whole company.",
+  "settings.page.leads.sub":
+    "The words this company uses to describe where a lead came from.",
+  "settings.page.fields.sub":
+    "The columns this company keeps beyond the ones every installation has.",
+  "settings.page.tags.sub":
+    "The shared vocabulary \u2014 renaming one here renames it on every record.",
+  "settings.page.products.sub":
+    "What this company sells, and the templates an offer starts from.",
+  "settings.page.capture.sub":
+    "Which mail becomes a record, and which is left alone.",
+  "settings.page.integrations.sub":
+    "The systems this installation exchanges records with.",
+  "settings.page.knowledge.sub":
+    "The documents drafts and answers are allowed to read from.",
+  "settings.page.import.sub":
+    "Bringing records in from a file, one run at a time.",
+  "settings.page.models.sub":
+    "Which vendor answers each kind of work, and whether it can.",
+  "settings.page.automations.sub":
+    "The rules that run without anyone pressing anything.",
+  "settings.page.usage.sub":
+    "What the AI runtime spent this month, against its ceiling.",
+  "settings.page.model-calls.sub":
+    "What each call asked a model, and how it answered.",
+  "settings.page.privacy.sub":
+    "Subject requests, the purposes consent is recorded against, and how long records are kept.",
+  "settings.page.audit.sub": "Every actor and every record they touched.",
+  "settings.page.system-health.sub":
+    "Whether the work behind the screens is keeping up.",
+  "settings.page.extensions.sub":
+    "The units this build composed, and which roles reach them.",
+  "settings.page.reset.sub": "Emptying this installation. There is no undo.",
   "settings.tab.company": "Company profile",
   "settings.tab.authentication": "Sign-in & apps",
   "settings.tab.members": "Members",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5986,6 +5986,62 @@ export const vi = {
   "settings.boundary.unknownBody":
     "Li\u00ean k\u1ebft c\u00f3 th\u1ec3 t\u1eeb phi\u00ean b\u1ea3n c\u0169 ho\u1eb7c g\u00f5 sai. Trang ch\u00ednh c\u00e0i \u0111\u1eb7t li\u1ec7t k\u00ea m\u1ecdi trang gh\u1ebf c\u1ee7a b\u1ea1n m\u1edf \u0111\u01b0\u1ee3c.",
   "settings.boundary.back": "Trang ch\u00ednh c\u00e0i \u0111\u1eb7t",
+  "settings.page.account.sub":
+    "C\u00e1ch b\u1ea1n hi\u1ec3n th\u1ecb v\u00e0 \u0111\u0103ng nh\u1eadp \u2014 ch\u1ec9 c\u1ee7a ri\u00eang b\u1ea1n.",
+  "settings.page.voice.sub":
+    "T\u1eeb ng\u1eef b\u1ea3n nh\u00e1p d\u00f9ng khi vi\u1ebft thay b\u1ea1n.",
+  "settings.page.agents.sub":
+    "T\u00e1c nh\u00e2n \u0111\u01b0\u1ee3c l\u00e0m g\u00ec khi kh\u00f4ng c\u00f3 b\u1ea1n, v\u00e0 client n\u00e0o gi\u1eef th\u00f4ng tin \u0111\u0103ng nh\u1eadp c\u1ee7a b\u1ea1n.",
+  "settings.page.connections.sub":
+    "H\u1ed9p th\u01b0 v\u00e0 \u0111\u1ecba ch\u1ec9 m\u00e0 gh\u1ebf n\u00e0y \u0111\u1ecdc.",
+  "settings.page.capture-activity.sub":
+    "Vi\u1ec7c thu th\u1eadp \u0111\u00e3 l\u00e0m g\u00ec v\u1edbi th\u01b0 c\u1ee7a b\u1ea1n, v\u00e0 t\u1ea1i sao.",
+  "settings.page.company.sub":
+    "T\u00ean, ti\u1ec1n t\u1ec7 v\u00e0 b\u1ed1i c\u1ea3nh m\u00e0 m\u1ecdi b\u1ea3n ghi \u0111\u01b0\u1ee3c \u0111\u1ecdc theo.",
+  "settings.page.authentication.sub":
+    "C\u00e1ch m\u1ecdi ng\u01b0\u1eddi \u0111\u0103ng nh\u1eadp v\u00e0o b\u1ea3n tri\u1ec3n khai n\u00e0y, v\u00e0 \u1ee9ng d\u1ee5ng n\u00e0o \u0111\u01b0\u1ee3c thay m\u1eb7t n\u00f3.",
+  "settings.page.members.sub":
+    "M\u1ecdi ng\u01b0\u1eddi c\u00f3 gh\u1ebf, v\u00e0 m\u1ed7i ng\u01b0\u1eddi t\u1edbi \u0111\u01b0\u1ee3c \u0111\u00e2u.",
+  "settings.page.teams.sub":
+    "Ai l\u00e0m vi\u1ec7c c\u00f9ng nhau \u2014 \u0111\u00f3 l\u00e0 c\u0103n c\u1ee9 c\u1ee7a ph\u1ea1m vi h\u00e0ng.",
+  "settings.page.seats.sub":
+    "Bao nhi\u00eau gh\u1ebf \u0111ang d\u00f9ng so v\u1edbi quy\u1ec1n c\u1ee7a b\u1ea3n tri\u1ec3n khai n\u00e0y.",
+  "settings.page.pipelines.sub":
+    "C\u00e1c giai \u0111o\u1ea1n m\u1ed9t th\u01b0\u01a1ng v\u1ee5 \u0111i qua, cho to\u00e0n c\u00f4ng ty.",
+  "settings.page.leads.sub":
+    "T\u1eeb ng\u1eef c\u00f4ng ty n\u00e0y d\u00f9ng \u0111\u1ec3 m\u00f4 t\u1ea3 m\u1ed9t lead \u0111\u1ebfn t\u1eeb \u0111\u00e2u.",
+  "settings.page.fields.sub":
+    "C\u00e1c c\u1ed9t c\u00f4ng ty n\u00e0y gi\u1eef th\u00eam ngo\u00e0i nh\u1eefng c\u1ed9t m\u1ecdi b\u1ea3n tri\u1ec3n khai \u0111\u1ec1u c\u00f3.",
+  "settings.page.tags.sub":
+    "T\u1eeb v\u1ef1ng d\u00f9ng chung \u2014 \u0111\u1ed5i t\u00ean \u1edf \u0111\u00e2y l\u00e0 \u0111\u1ed5i tr\u00ean m\u1ecdi b\u1ea3n ghi.",
+  "settings.page.products.sub":
+    "C\u00f4ng ty n\u00e0y b\u00e1n g\u00ec, v\u00e0 m\u1eabu m\u00e0 m\u1ed9t \u0111\u1ec1 ngh\u1ecb b\u1eaft \u0111\u1ea7u t\u1eeb \u0111\u00f3.",
+  "settings.page.capture.sub":
+    "Th\u01b0 n\u00e0o th\u00e0nh b\u1ea3n ghi, v\u00e0 th\u01b0 n\u00e0o \u0111\u1ec3 y\u00ean.",
+  "settings.page.integrations.sub":
+    "C\u00e1c h\u1ec7 th\u1ed1ng m\u00e0 b\u1ea3n tri\u1ec3n khai n\u00e0y trao \u0111\u1ed5i b\u1ea3n ghi c\u00f9ng.",
+  "settings.page.knowledge.sub":
+    "T\u00e0i li\u1ec7u m\u00e0 b\u1ea3n nh\u00e1p v\u00e0 c\u00e2u tr\u1ea3 l\u1eddi \u0111\u01b0\u1ee3c ph\u00e9p \u0111\u1ecdc.",
+  "settings.page.import.sub":
+    "\u0110\u01b0a b\u1ea3n ghi v\u00e0o t\u1eeb t\u1ec7p, m\u1ed7i l\u1ea7n m\u1ed9t l\u01b0\u1ee3t ch\u1ea1y.",
+  "settings.page.models.sub":
+    "Nh\u00e0 cung c\u1ea5p n\u00e0o tr\u1ea3 l\u1eddi t\u1eebng lo\u1ea1i c\u00f4ng vi\u1ec7c, v\u00e0 c\u00f3 l\u00e0m \u0111\u01b0\u1ee3c kh\u00f4ng.",
+  "settings.page.automations.sub":
+    "C\u00e1c quy t\u1eafc ch\u1ea1y m\u00e0 kh\u00f4ng ai b\u1ea5m g\u00ec.",
+  "settings.page.usage.sub":
+    "AI \u0111\u00e3 d\u00f9ng h\u1ebft bao nhi\u00eau trong th\u00e1ng n\u00e0y, so v\u1edbi tr\u1ea7n c\u1ee7a n\u00f3.",
+  "settings.page.model-calls.sub":
+    "M\u1ed7i l\u1ec7nh g\u1ecdi \u0111\u00e3 h\u1ecfi m\u00f4 h\u00ecnh \u0111i\u1ec1u g\u00ec, v\u00e0 n\u00f3 tr\u1ea3 l\u1eddi ra sao.",
+  "settings.page.privacy.sub":
+    "Y\u00eau c\u1ea7u c\u1ee7a ch\u1ee7 th\u1ec3, c\u00e1c m\u1ee5c \u0111\u00edch m\u00e0 s\u1ef1 \u0111\u1ed3ng \u00fd \u0111\u01b0\u1ee3c ghi theo, v\u00e0 b\u1ea3n ghi \u0111\u01b0\u1ee3c gi\u1eef bao l\u00e2u.",
+  "settings.page.audit.sub":
+    "M\u1ecdi t\u00e1c nh\u00e2n v\u00e0 m\u1ecdi b\u1ea3n ghi h\u1ecd ch\u1ea1m t\u1edbi.",
+  "settings.page.system-health.sub":
+    "C\u00f4ng vi\u1ec7c ph\u00eda sau m\u00e0n h\u00ecnh c\u00f3 theo k\u1ecbp kh\u00f4ng.",
+  "settings.page.extensions.sub":
+    "C\u00e1c \u0111\u01a1n v\u1ecb b\u1ea3n d\u1ef1ng n\u00e0y \u0111\u00e3 k\u1ebft h\u1ee3p, v\u00e0 vai tr\u00f2 n\u00e0o t\u1edbi \u0111\u01b0\u1ee3c.",
+  "settings.page.reset.sub":
+    "L\u00e0m r\u1ed7ng b\u1ea3n tri\u1ec3n khai n\u00e0y. Kh\u00f4ng th\u1ec3 ho\u00e0n t\u00e1c.",
   "settings.tab.company": "Hồ sơ công ty",
   "settings.tab.authentication": "Đăng nhập & ứng dụng",
   "settings.tab.members": "Thành viên",

--- a/frontend/src/screens/ai-health.stories.tsx
+++ b/frontend/src/screens/ai-health.stories.tsx
@@ -68,7 +68,7 @@ function story(rungs: RungHealth[]) {
 }
 
 const meta: Meta<typeof AiHealthCard> = {
-  title: "Settings/Admin/Model lanes",
+  title: "Settings/AI/Models & routing/Model lanes",
   component: AiHealthCard,
 };
 export default meta;

--- a/frontend/src/screens/ai-provider-keys.stories.tsx
+++ b/frontend/src/screens/ai-provider-keys.stories.tsx
@@ -51,7 +51,7 @@ const anthropic = {
 };
 
 const meta: Meta<typeof AiProviderKeysCard> = {
-  title: "Settings/Admin settings/AI/Model provider keys",
+  title: "Settings/AI/Models & routing/Model provider keys",
   component: AiProviderKeysCard,
 };
 export default meta;

--- a/frontend/src/screens/ai-routing.stories.tsx
+++ b/frontend/src/screens/ai-routing.stories.tsx
@@ -118,7 +118,7 @@ function story(
 }
 
 const meta: Meta<typeof AiRoutingCard> = {
-  title: "Settings/Admin settings/AI/Model routing",
+  title: "Settings/AI/Models & routing/Model routing",
   component: AiRoutingCard,
 };
 export default meta;

--- a/frontend/src/screens/ai-settings.stories.tsx
+++ b/frontend/src/screens/ai-settings.stories.tsx
@@ -126,8 +126,12 @@ function story(allow: GrantSpec) {
   };
 }
 
+// Across pages, not on one: `ProvidersStat` renders on Models & routing and
+// `SpendStat` on AI usage. The pair is the point — the two readings an operator
+// opens AI settings for — so the title says across rather than picking one and
+// misplacing the other.
 const meta: Meta<typeof AiReadings> = {
-  title: "Settings/Admin settings/AI/AI page",
+  title: "Settings/Across pages/AI readings",
   component: AiReadings,
 };
 export default meta;

--- a/frontend/src/screens/aicalls.stories.tsx
+++ b/frontend/src/screens/aicalls.stories.tsx
@@ -84,7 +84,7 @@ function list(data: unknown[], capture = true, allow: GrantSpec = OPERATOR) {
 }
 
 const meta: Meta<typeof AiCallsCard> = {
-  title: "Settings/Admin settings/AI/Model calls",
+  title: "Settings/AI/Model calls/Model calls",
   component: AiCallsCard,
 };
 export default meta;

--- a/frontend/src/screens/aiexport.stories.tsx
+++ b/frontend/src/screens/aiexport.stories.tsx
@@ -14,7 +14,7 @@ const call = {
   },
 } satisfies AiCallDetail;
 const meta: Meta<typeof ExportScenarioDialog> = {
-  title: "Settings/Admin settings/AI/Scenario export",
+  title: "Settings/AI/Model calls/Scenario export",
   component: ExportScenarioDialog,
 };
 export default meta;

--- a/frontend/src/screens/aiusage.stories.tsx
+++ b/frontend/src/screens/aiusage.stories.tsx
@@ -53,7 +53,7 @@ const task = {
   tokens_out: 240,
 };
 const meta: Meta<typeof AiUsageCard> = {
-  title: "Settings/Admin settings/AI/Usage",
+  title: "Settings/AI/AI usage/Usage",
   component: AiUsageCard,
 };
 export default meta;

--- a/frontend/src/screens/audit.stories.tsx
+++ b/frontend/src/screens/audit.stories.tsx
@@ -13,7 +13,7 @@ import { StoryProviders } from "./story-utils";
 // is a change to what an auditor reads before anything else, so every
 // attribution state gets a row rather than only the happy one.
 const meta: Meta = {
-  title: "Settings/Admin settings/Privacy & audit/Audit attribution",
+  title: "Settings/Governance/Audit log/Audit attribution",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/automationdetail.stories.tsx
+++ b/frontend/src/screens/automationdetail.stories.tsx
@@ -18,7 +18,7 @@ import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 type AutomationRun = components["schemas"]["AutomationRun"];
 
 const meta: Meta = {
-  title: "Settings/Admin settings/AI/Automation detail",
+  title: "Settings/AI/Automations/Automation detail",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/automations.stories.tsx
+++ b/frontend/src/screens/automations.stories.tsx
@@ -20,7 +20,7 @@ type Automation = components["schemas"]["Automation"];
 type CatalogEntry = components["schemas"]["AutomationCatalogEntry"];
 
 const meta: Meta = {
-  title: "Settings/Admin settings/AI/Automations",
+  title: "Settings/AI/Automations/Automations",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/autonomy-settings.stories.tsx
+++ b/frontend/src/screens/autonomy-settings.stories.tsx
@@ -47,7 +47,7 @@ function story(data: Row[]) {
 }
 
 const meta: Meta<typeof AutonomySettingsCard> = {
-  title: "Settings/Account/What answers itself",
+  title: "Settings/You/Account/What answers itself",
   component: AutonomySettingsCard,
 };
 export default meta;

--- a/frontend/src/screens/blocked-domains.stories.tsx
+++ b/frontend/src/screens/blocked-domains.stories.tsx
@@ -64,7 +64,7 @@ const OPS = { organization: ["read", "update"] } as const;
 const READER = { organization: ["read"] } as const;
 
 const meta: Meta<typeof BlockedDomainsCard> = {
-  title: "Settings/Admin settings/Capture/Refused domains",
+  title: "Settings/Data/Capture/Refused domains",
   component: BlockedDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/capture-activity.stories.tsx
+++ b/frontend/src/screens/capture-activity.stories.tsx
@@ -124,7 +124,7 @@ function story(body: Record<string, unknown>, allow: GrantSpec = {}) {
 }
 
 const meta: Meta<typeof CaptureActivityTab> = {
-  title: "Settings/You/Capture activity",
+  title: "Settings/You/Capture activity/Capture activity",
   component: CaptureActivityTab,
 };
 export default meta;

--- a/frontend/src/screens/capture-exclusions.stories.tsx
+++ b/frontend/src/screens/capture-exclusions.stories.tsx
@@ -50,7 +50,7 @@ const OPS = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof CaptureExclusionsCard> = {
-  title: "Settings/Admin settings/Capture/Keep out of capture",
+  title: "Settings/You/Capture activity/Keep out of capture",
   component: CaptureExclusionsCard,
 };
 export default meta;

--- a/frontend/src/screens/capture-owner-identities.stories.tsx
+++ b/frontend/src/screens/capture-owner-identities.stories.tsx
@@ -44,7 +44,7 @@ function story(identities: Record<string, unknown>[]) {
 }
 
 const meta: Meta<typeof OwnerIdentitiesCard> = {
-  title: "Settings/Admin settings/Capture/Your other addresses",
+  title: "Settings/You/Connections/Your other addresses",
   component: OwnerIdentitiesCard,
 };
 export default meta;

--- a/frontend/src/screens/capture-settings.stories.tsx
+++ b/frontend/src/screens/capture-settings.stories.tsx
@@ -32,7 +32,7 @@ const MANAGER = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof CaptureSettingsCard> = {
-  title: "Settings/Admin settings/Capture/Capture posture",
+  title: "Settings/Data/Capture/Capture posture",
   component: CaptureSettingsCard,
 };
 export default meta;

--- a/frontend/src/screens/company-context.card.stories.tsx
+++ b/frontend/src/screens/company-context.card.stories.tsx
@@ -99,7 +99,7 @@ const EDITOR = { organization: ["read", "update"] } as const;
 const READER = { organization: ["read"] } as const;
 
 const meta: Meta<typeof CompanyContextCard> = {
-  title: "Settings/Admin settings/General/Company profile",
+  title: "Settings/Company/Company profile/Company profile",
   component: CompanyContextCard,
 };
 export default meta;

--- a/frontend/src/screens/companymark.stories.tsx
+++ b/frontend/src/screens/companymark.stories.tsx
@@ -14,7 +14,7 @@ import { installFetchStub, StoryProviders } from "./story-utils";
 // the company sees.
 
 const meta: Meta<typeof CompanyMark> = {
-  title: "Settings/Company logo",
+  title: "Settings/Company/Company profile/Company logo",
   component: CompanyMark,
   parameters: { layout: "padded" },
 };

--- a/frontend/src/screens/consumer-mail-domains.stories.tsx
+++ b/frontend/src/screens/consumer-mail-domains.stories.tsx
@@ -44,7 +44,7 @@ const CONTRIBUTOR = { capture_settings: ["read", "create"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof ConsumerMailDomainsCard> = {
-  title: "Settings/Admin settings/Capture/Consumer mailboxes",
+  title: "Settings/Data/Capture/Consumer mailboxes",
   component: ConsumerMailDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/customfields.stories.tsx
+++ b/frontend/src/screens/customfields.stories.tsx
@@ -20,7 +20,7 @@ import {
 // screenshot three times and proved nothing about any of the three branches.
 // FieldTable is fully prop-driven, so its states are pinned by fixtures.
 const meta: Meta = {
-  title: "Settings/Admin settings/Data model/Custom fields",
+  title: "Settings/Sales/Fields/Custom fields",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/embedreindex.stories.tsx
+++ b/frontend/src/screens/embedreindex.stories.tsx
@@ -47,7 +47,7 @@ function admin(overrides: Record<string, unknown> = {}) {
 }
 
 const meta: Meta<typeof EmbedReindexCard> = {
-  title: "Settings/Admin settings/Maintenance/Embedding reindex",
+  title: "Settings/Governance/System health/Embedding reindex",
   component: EmbedReindexCard,
 };
 export default meta;

--- a/frontend/src/screens/extension-access.stories.tsx
+++ b/frontend/src/screens/extension-access.stories.tsx
@@ -74,7 +74,7 @@ function story(
 }
 
 const meta: Meta<typeof ExtensionAccessCard> = {
-  title: "Settings/Admin settings/People & access/Extensions and access",
+  title: "Settings/Governance/Extensions/Extensions and access",
   component: ExtensionAccessCard,
 };
 export default meta;

--- a/frontend/src/screens/held-threads.stories.tsx
+++ b/frontend/src/screens/held-threads.stories.tsx
@@ -98,7 +98,7 @@ function story(rows: HeldThread[]) {
 }
 
 const meta: Meta<typeof HeldThreadsCard> = {
-  title: "Settings/You/Held threads",
+  title: "Settings/You/Connections/Held threads",
   component: HeldThreadsCard,
 };
 export default meta;

--- a/frontend/src/screens/import.contexttag.stories.tsx
+++ b/frontend/src/screens/import.contexttag.stories.tsx
@@ -11,7 +11,7 @@ import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 // perform, so these would otherwise have no rendered state anywhere.
 
 const meta: Meta = {
-  title: "Settings/Admin settings/Maintenance/Import/Context tag",
+  title: "Settings/Data/Data import/Context tag",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/import.stories.tsx
+++ b/frontend/src/screens/import.stories.tsx
@@ -55,7 +55,7 @@ const openWizard: NonNullable<Story["play"]> = async ({ canvasElement }) => {
 const OPERATOR = { import_run: ["create", "read", "update"] } as const;
 
 const meta: Meta<typeof ImportCard> = {
-  title: "Settings/Admin settings/Maintenance/Import",
+  title: "Settings/Data/Data import/Import",
   component: ImportCard,
 };
 export default meta;

--- a/frontend/src/screens/installation-settings.stories.tsx
+++ b/frontend/src/screens/installation-settings.stories.tsx
@@ -52,7 +52,7 @@ const MANAGER = { installation_settings: ["read", "update"] } as const;
 const READER = { installation_settings: ["read"] } as const;
 
 const meta: Meta<typeof InstallationSettingsCard> = {
-  title: "Settings/Admin settings/General/Installation",
+  title: "Settings/Company/Company profile/Installation",
   component: InstallationSettingsCard,
 };
 export default meta;

--- a/frontend/src/screens/integrations-provider.stories.tsx
+++ b/frontend/src/screens/integrations-provider.stories.tsx
@@ -116,7 +116,7 @@ function cardStory(
 }
 
 const meta: Meta<typeof ProviderCard> = {
-  title: "Settings/Admin settings/Integrations/Contact data provider",
+  title: "Settings/Data/Integrations/Contact data provider",
   component: ProviderCard,
 };
 export default meta;

--- a/frontend/src/screens/jobhealth.stories.tsx
+++ b/frontend/src/screens/jobhealth.stories.tsx
@@ -78,7 +78,7 @@ const HEALTHY = {
 };
 
 const meta: Meta<typeof JobHealthCard> = {
-  title: "Settings/Admin settings/Maintenance/Job health",
+  title: "Settings/Governance/System health/Job health",
   component: JobHealthCard,
 };
 export default meta;

--- a/frontend/src/screens/knowledge.stories.tsx
+++ b/frontend/src/screens/knowledge.stories.tsx
@@ -167,7 +167,7 @@ const showDocuments = async ({
 };
 
 const meta: Meta<typeof KnowledgeCard> = {
-  title: "Settings/Admin settings/Knowledge/Document sets",
+  title: "Settings/Data/Knowledge/Document sets",
   component: KnowledgeCard,
 };
 export default meta;

--- a/frontend/src/screens/leadvocab.stories.tsx
+++ b/frontend/src/screens/leadvocab.stories.tsx
@@ -110,7 +110,7 @@ function story(allow: Parameters<typeof meRoute>[0], slaOn: boolean) {
 }
 
 const meta: Meta<typeof LeadSourcesCard> = {
-  title: "Settings/Admin settings/Data model/Lead vocabularies",
+  title: "Settings/Sales/Lead handling/Lead vocabularies",
   component: LeadSourcesCard,
 };
 export default meta;

--- a/frontend/src/screens/license.stories.tsx
+++ b/frontend/src/screens/license.stories.tsx
@@ -31,7 +31,7 @@ function story(entitlement: Entitlement) {
 }
 
 const meta: Meta<typeof LicenseReading> = {
-  title: "Settings/Admin settings/License/Terms",
+  title: "Settings/People/Seats & license/Terms",
   component: LicenseReading,
 };
 export default meta;

--- a/frontend/src/screens/licenseholder.stories.tsx
+++ b/frontend/src/screens/licenseholder.stories.tsx
@@ -31,7 +31,7 @@ function story(holder: LicenseHolder) {
 }
 
 const meta: Meta<typeof LicenseHolderCard> = {
-  title: "Settings/Admin settings/License/Licensee",
+  title: "Settings/People/Seats & license/Licensee",
   component: LicenseHolderCard,
 };
 export default meta;

--- a/frontend/src/screens/oauth-app.stories.tsx
+++ b/frontend/src/screens/oauth-app.stories.tsx
@@ -19,7 +19,7 @@ import { installFetchStub, jsonResponse } from "./story-utils";
 // checking exactly what the shared card is allowed to vary.
 
 const meta: Meta<typeof OAuthAppCard> = {
-  title: "Settings/Admin settings/General/Connector app",
+  title: "Settings/Company/Sign-in & apps/Connector app",
   component: OAuthAppCard,
   parameters: { layout: "padded" },
 };

--- a/frontend/src/screens/offertemplates.stories.tsx
+++ b/frontend/src/screens/offertemplates.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "./story-utils";
 
 const meta: Meta = {
-  title: "Settings/Admin settings/Data model/Offer templates",
+  title: "Settings/Sales/Products & offers/Offer templates",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/overlay-health.stories.tsx
+++ b/frontend/src/screens/overlay-health.stories.tsx
@@ -66,7 +66,7 @@ const budgetOk: Budget = {
 };
 
 const meta: Meta<typeof OverlayLiveSection> = {
-  title: "Settings/Admin settings/Integrations/Overlay health",
+  title: "Settings/Data/Integrations/Overlay health",
   component: OverlayLiveSection,
 };
 export default meta;

--- a/frontend/src/screens/overlay-usermap.stories.tsx
+++ b/frontend/src/screens/overlay-usermap.stories.tsx
@@ -182,7 +182,7 @@ function card(
 }
 
 const meta: Meta<typeof MirrorUserMapCard> = {
-  title: "Settings/Admin settings/Integrations/Mirror user map",
+  title: "Settings/Data/Integrations/Mirror user map",
   component: MirrorUserMapCard,
 };
 export default meta;

--- a/frontend/src/screens/overlay.stories.tsx
+++ b/frontend/src/screens/overlay.stories.tsx
@@ -98,7 +98,7 @@ function budgetFixture(band: Budget["band"]): Budget {
 }
 
 const meta: Meta<typeof OverlayCard> = {
-  title: "Settings/Admin settings/Integrations/Overlay",
+  title: "Settings/Data/Integrations/Overlay",
   component: OverlayCard,
 };
 export default meta;

--- a/frontend/src/screens/own-domains.stories.tsx
+++ b/frontend/src/screens/own-domains.stories.tsx
@@ -54,7 +54,7 @@ const MANAGER = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof OwnDomainsCard> = {
-  title: "Settings/Admin settings/Capture/Own domains",
+  title: "Settings/Data/Capture/Own domains",
   component: OwnDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/privacy.purposes.stories.tsx
+++ b/frontend/src/screens/privacy.purposes.stories.tsx
@@ -61,7 +61,7 @@ function purposes(roles: string[], purposeList: unknown = PURPOSES) {
 }
 
 const meta: Meta<typeof ConsentPurposesCard> = {
-  title: "Settings/Admin settings/Privacy & audit/Consent purposes",
+  title: "Settings/Governance/Privacy & audit/Consent purposes",
   component: ConsentPurposesCard,
 };
 export default meta;

--- a/frontend/src/screens/privacy.stories.tsx
+++ b/frontend/src/screens/privacy.stories.tsx
@@ -83,7 +83,7 @@ async function findRow(
 }
 
 const meta: Meta<typeof PrivacyInboxCard> = {
-  title: "Settings/Admin settings/Privacy & audit/Subject requests",
+  title: "Settings/Governance/Privacy & audit/Subject requests",
   component: PrivacyInboxCard,
 };
 export default meta;

--- a/frontend/src/screens/products.stories.tsx
+++ b/frontend/src/screens/products.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "./story-utils";
 
 const meta: Meta = {
-  title: "Settings/Admin settings/Data model/Products",
+  title: "Settings/Sales/Products & offers/Products",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/rates.stories.tsx
+++ b/frontend/src/screens/rates.stories.tsx
@@ -78,8 +78,13 @@ function RateSheets() {
   );
 }
 
+// Filed under the tree rather than under a page, because it is neither page's
+// story: `FxRatesCard` renders on Company profile and `ModelCostsCard` on AI
+// usage, and this puts them side by side on purpose — the two price sheets an
+// operator reconciles against each other. A title naming one page would say the
+// other card lives there.
 const meta: Meta<typeof RateSheets> = {
-  title: "Settings/Admin settings/Rates and model costs",
+  title: "Settings/Across pages/Rates and model costs",
   component: RateSheets,
 };
 export default meta;

--- a/frontend/src/screens/restrictedrecords.stories.tsx
+++ b/frontend/src/screens/restrictedrecords.stories.tsx
@@ -47,7 +47,7 @@ function restricted(records: unknown[], decide = false) {
 }
 
 const meta: Meta<typeof RestrictedRecordsCard> = {
-  title: "Settings/Admin settings/Privacy & audit/Restricted records",
+  title: "Settings/Governance/Privacy & audit/Restricted records",
   component: RestrictedRecordsCard,
 };
 export default meta;

--- a/frontend/src/screens/retention.stories.tsx
+++ b/frontend/src/screens/retention.stories.tsx
@@ -96,7 +96,7 @@ function retention(
 }
 
 const meta: Meta<typeof RetentionCard> = {
-  title: "Settings/Admin settings/Privacy & audit/Retention",
+  title: "Settings/Governance/Privacy & audit/Retention",
   component: RetentionCard,
 };
 export default meta;

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -554,6 +554,13 @@ export function useSettingsSection(route: Route): NavSection {
           (page): NavLevelEntry => ({
             id: page.id,
             labelKey: `settings.tab.${page.id}`,
+            // One line under the page's heading, saying what the label cannot:
+            // which state it changes and whose. Composed from the id like the
+            // label above it, and NOT cast — the field's own MessageKey type is
+            // what narrows the template literal, so a page whose `.sub` key is
+            // missing from the catalogs is a compile error rather than a
+            // subtitle that silently translates to nothing.
+            subKey: `settings.page.${page.id}.sub`,
             icon: PAGE_ICONS[page.id],
           }),
         ),

--- a/frontend/src/screens/settingsstories.test.ts
+++ b/frontend/src/screens/settingsstories.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+import { storyTitle } from "../../scripts/lib/story-title";
+import { translate } from "../i18n";
+import { SETTINGS_PAGES, type SettingsPageId } from "./settingscatalog";
+
+// Storybook's settings tree and the product's settings sidebar say the same
+// words, or the workbench describes a product that no longer exists.
+//
+// It did: 45 story files sat under `Settings/Admin settings/<old tab>/…`, the
+// two-audience grouping this redesign deleted. A reader opening the workbench
+// found "Admin settings" over a sidebar that has seven topic groups, and the
+// old tab names underneath — a map of the previous product.
+//
+// The corpus is DERIVED from the tree rather than listed: a hand-written list
+// of story files is a census that fails short, reporting PASS over a file it
+// was never told about.
+
+const SCREENS = new URL(".", import.meta.url).pathname;
+
+function storyFilesUnder(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...storyFilesUnder(path));
+    } else if (entry.name.endsWith(".stories.tsx")) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+// The group/page PAIRS the catalog declares, as the sidebar spells them. Pairs
+// rather than two independent sets: `Settings/AI/Capture/Card` names a real
+// group and a real page and is still wrong, because Capture belongs to Data.
+// Two `has` checks cannot see that; one set of "Group/Page" strings can.
+const PAGE_PATHS = new Set(
+  SETTINGS_PAGES.map(
+    (page) =>
+      `${translate("en", `settings.group.${page.group}`)}/${translate(
+        "en",
+        `settings.tab.${page.id as SettingsPageId}`,
+      )}`,
+  ),
+);
+
+// The one story that is ABOUT the tree rather than a card on a page, named
+// exactly. An `if (page === undefined) return` would exempt every two-segment
+// title — `Settings/Nonsense` included — which is a skip-list with no list.
+const TREE_STORY = "Settings/Settings screen";
+
+// The one group that is not a catalog group. Two stories put cards from
+// DIFFERENT pages side by side on purpose — the two price sheets an operator
+// reconciles, and the two AI readings — so no single page name is true of
+// either. Naming one would say the other card lives there.
+//
+// A declared exception with its members listed, not an open door: a third story
+// cannot join by accident, and the day one of these stops crossing pages, its
+// entry here fails rather than quietly staying.
+const ACROSS_PAGES = "Across pages";
+const ACROSS_PAGE_STORIES = new Set([
+  "Settings/Across pages/Rates and model costs",
+  "Settings/Across pages/AI readings",
+]);
+
+const settingsStories = storyFilesUnder(SCREENS)
+  .map((path) => ({
+    path: relative(SCREENS, path),
+    title: storyTitle(path, readFileSync(path, "utf8")),
+  }))
+  .filter(
+    (story): story is { path: string; title: string } =>
+      story.title?.startsWith("Settings/") ?? false,
+  );
+
+// Every story file under screens/, whether or not it claims a Settings title.
+// The corpus this gate must not lose a member of.
+const everyStory = storyFilesUnder(SCREENS).map((path) => ({
+  path: relative(SCREENS, path),
+  title: storyTitle(path, readFileSync(path, "utf8")),
+}));
+
+describe("the settings stories are filed where the product files them", () => {
+  // A floor is not a census. `>40` over 66 stories permits 25 to vanish — a
+  // story whose title stops resolving, or whose root is edited away from
+  // `Settings/`, drops out of the filtered corpus and is never checked again.
+  // So the count is EXACT and derived from the tree: adding or removing a
+  // settings story is a deliberate edit to this number.
+  it("reads every settings story, and says how many that is", () => {
+    expect(settingsStories.length).toBe(66);
+  });
+
+  // The filter above drops a file whose title does not resolve. That is the
+  // silent direction: a story with a computed or missing title would leave the
+  // corpus without failing anything. Every story file under screens/ must
+  // therefore yield a title at all.
+  it.each(everyStory)("resolves a title for $path", ({ title }) => {
+    expect(title).not.toBeNull();
+  });
+
+  it.each(settingsStories)(
+    "files $path at a path the catalog declares",
+    ({ title }) => {
+      if (title === TREE_STORY) {
+        return;
+      }
+      const segments = title.split("/");
+      if (segments[1] === ACROSS_PAGES) {
+        // Named, so a new one is a deliberate edit here rather than a title
+        // that quietly opts out of the check.
+        expect(ACROSS_PAGE_STORIES).toContain(title);
+        return;
+      }
+      // Exactly `Settings/<Group>/<Page>/<Card>`. A missing card segment and an
+      // extra one both used to pass, because nothing read the length.
+      expect(segments).toHaveLength(4);
+      expect(PAGE_PATHS).toContain(`${segments[1]}/${segments[2]}`);
+    },
+  );
+});
+
+// WHAT THIS GATE DOES NOT HOLD, said plainly so the next author does not assume
+// it does: that the page a story NAMES is the page whose dispatch arm renders
+// its card. Two stories were misfiled that way in this very change — the
+// autonomy card sat under Agents while `tabContent` renders it on Account, and
+// mail sharing sat under Capture while it renders on Connections. Both were
+// found by hand and fixed.
+//
+// A gate for it was written and deleted. Reading the card-to-page map out of
+// `settings.tsx` works for a card the screen renders directly, and stops at the
+// ones nested inside another card (`VoiceCorpusIntake` inside `VoiceDnaCard`).
+// Following the nesting one level then attributes a shared component to
+// whichever card reached it first, which fails four correctly-filed stories.
+// A gate that fails the honest cases teaches authors to file by whatever the
+// gate accepts, which is worse than no gate.
+//
+// The real fix is for the screen to publish its card-to-page map as data rather
+// than as a switch statement a test has to parse. That is a change to
+// `settings.tsx`, not to this file.

--- a/frontend/src/screens/sign-in-methods.stories.tsx
+++ b/frontend/src/screens/sign-in-methods.stories.tsx
@@ -14,7 +14,7 @@ import { installFetchStub, jsonResponse } from "./story-utils";
 // the DEPLOYMENT composed and what the admin chose of it.
 
 const meta: Meta<typeof SignInMethodsCard> = {
-  title: "Settings/Admin settings/General/Sign-in methods",
+  title: "Settings/Company/Sign-in & apps/Sign-in methods",
   component: SignInMethodsCard,
   parameters: { layout: "padded" },
 };

--- a/frontend/src/screens/tagadmin.stories.tsx
+++ b/frontend/src/screens/tagadmin.stories.tsx
@@ -16,7 +16,7 @@ import { TagVocabularyCard } from "./tagadmin";
 // anybody may extend is a list of everything anybody ever typed.
 
 const meta: Meta = {
-  title: "Settings/Admin settings/Data model/Tag vocabulary",
+  title: "Settings/Sales/Tags/Tag vocabulary",
   parameters: { layout: "padded" },
 };
 export default meta;

--- a/frontend/src/screens/users-access.stories.tsx
+++ b/frontend/src/screens/users-access.stories.tsx
@@ -46,7 +46,7 @@ function story(teams: Record<string, unknown>[]) {
 }
 
 const meta: Meta<typeof TeamsCard> = {
-  title: "Settings/Admin settings/People & access/Teams",
+  title: "Settings/People/Teams/Teams",
   component: TeamsCard,
 };
 export default meta;

--- a/frontend/src/screens/users-admin.stories.tsx
+++ b/frontend/src/screens/users-admin.stories.tsx
@@ -112,7 +112,7 @@ function story(
 }
 
 const meta: Meta<typeof UsersAdminCard> = {
-  title: "Settings/Admin settings/People & access/Members",
+  title: "Settings/People/Members/Members",
   component: UsersAdminCard,
 };
 export default meta;

--- a/frontend/src/screens/users-password-link.stories.tsx
+++ b/frontend/src/screens/users-password-link.stories.tsx
@@ -15,7 +15,7 @@ const LINK = {
 };
 
 const meta: Meta<typeof PasswordLinkModal> = {
-  title: "Settings/Admin settings/People & access/Password link",
+  title: "Settings/People/Members/Password link",
   component: PasswordLinkModal,
   decorators: [
     (Story) => (

--- a/frontend/src/screens/webhooks.stories.tsx
+++ b/frontend/src/screens/webhooks.stories.tsx
@@ -109,7 +109,7 @@ async function openRowActions(canvasElement: HTMLElement) {
 }
 
 const meta: Meta<typeof WebhooksCard> = {
-  title: "Settings/Admin settings/Integrations/Webhooks",
+  title: "Settings/Data/Integrations/Webhooks",
   component: WebhooksCard,
 };
 export default meta;


### PR DESCRIPTION
Every settings page now carries one line under its heading saying what it
changes and whose state that is — "The stages a deal moves through, for the
whole company" under Pipelines, "How you appear and sign in — yours alone"
under Account. Twenty-eight pages, in en/de/vi.

## The subtitle rides the nav entry

`PAGE_SUB_KEYS` is keyed by **screen**, and settings is one screen behind
twenty-eight pages — so it could only ever hold a sentence true of all of them,
which is no description of any of them. `NavLevelEntry` gains `subKey`, and
`PageTitle` reads the active entry's before falling back to the table, so the
next section with pages of its own gets the same slot.

The keys are composed from the page id and **not cast**, so the field's own
`MessageKey` type narrows the template literal: a page whose `.sub` key is
missing from any of the three catalogs is a compile error, not a subtitle that
silently translates to nothing. (Verified by deleting one — it fails in three
places.)

## Storybook stops describing the previous product

Sixty-five story files move off `Settings/Admin settings/<old tab>/…`, the
two-audience grouping this redesign deleted, onto `Settings/<Group>/<Page>`. A
reader opening the workbench found "Admin settings" over a product whose sidebar
has seven topic groups.

Two stories keep cards from **different pages** side by side on purpose — the
two price sheets an operator reconciles, and the two AI readings. Neither can
truthfully claim one page, so both are filed under `Settings/Across pages`, a
declared exception whose members are listed rather than an open door.

`storyTitle()` moves from `design-system/catalog.test.ts` to
`scripts/lib/story-title.ts`, unchanged (verified byte-for-byte), and is now
read by both gates. Two parsers answering "which stories exist" would drift into
disagreeing.

## The gate

`settingsstories.test.ts` holds the tree to the catalog:

- an **exact** story count rather than a floor — a floor over sixty-six permits
  twenty-five to vanish while passing
- a title required of **every** story file — one that stops resolving would
  otherwise drop out of the corpus and never be checked again
- group and page checked as a **pair** — `Settings/AI/Capture/Card` names a real
  group and a real page and is still wrong

All three mutation-checked.

## What this does not hold, and why

Four stories were filed under a page that does not render their card, found by
reading the screen's dispatch by hand: mail sharing and the autonomy card render
on Connections and Account, and the capture-exclusions card renders inside
Capture activity.

A gate for that placement was written and **deleted**. Reading the card-to-page
map out of a switch statement works for directly-rendered cards and stops at the
ones nested inside another card (`VoiceCorpusIntake` inside `VoiceDnaCard`);
following the nesting then attributes a shared component to whichever card
reached it first, failing four correctly-filed stories. A gate that fails honest
cases teaches authors to file by whatever the gate accepts.

The limitation is written into the file, with the real fix: the screen should
publish its card-to-page map as data rather than as a switch a test must parse.

## Also

Two subtitles promised what their page does not do. Data import has no run
history, and a model call's request is absent when payload capture is off.

`make check-fe` green, exit 0.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every settings page now shows a one-line subtitle saying what it changes and whose state that is, in English, German, and Vietnamese, and the Storybook settings tree mirrors the current seven-group sidebar instead of the removed “Admin settings” grouping.

**New Features**
- Subtitles are read from the active nav entry’s new `subKey` field, falling back to the screen-keyed table for one-page screens.
- Missing subtitle keys are compile errors: the key is composed from the page id and typed as `MessageKey`, not cast.
- Two subtitles were corrected to match what their pages do: Data import has no run history, and model-call requests are absent when payload capture is off.

**Refactors**
- 65 story files move from `Settings/Admin settings/<old tab>/…` to `Settings/<Group>/<Page>`.
- Two stories pairing cards from different pages are filed under `Settings/Across pages` with their titles listed in the test, not an open exemption.
- `storyTitle()` moved from `design-system/catalog.test.ts` to `scripts/lib/story-title.ts` so the design-system and settings gates share one parser.
- The new `settingsstories.test.ts` gate requires an exact story count, a resolvable title for every story file, and group/page checked as a pair.
- A gate for card-to-page placement was written and deleted; the limitation and the real fix (publishing the map as data) are documented in the test file.

<sup>Written for commit 80a09a89c36cc8177d5863f10e9c26f354a97918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added descriptive subtitles beneath Settings page headings for clearer navigation.
  - Added English, German, and Vietnamese translations for Settings page subtitles.
  - Improved Storybook story title resolution for more accurate sidebar placement.

- **Documentation**
  - Updated the Settings Storybook documentation to reflect the current groups, pages, and cards.

- **Tests**
  - Added validation ensuring Settings stories match the declared catalog structure and expected locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->