### PR TITLE
feat(worklist): the one decided step a link cannot take

### DIFF
--- a/frontend/src/screens/dealstatus.tsx
+++ b/frontend/src/screens/dealstatus.tsx
@@ -1,17 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ListChecks, RefreshCw, Sparkles } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCan } from "../app/capability";
 import { navigate } from "../app/router";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { problemMessageOf, QueryStates, throwProblem } from "./common";
+import { QueryStates, throwProblem } from "./common";
 import { useDealSignals } from "./dealsignals";
-import { PersonMeetingBrief } from "./meetingbrief";
+import { hasMoveControl, MoveButton } from "./movebutton";
 import {
   CallCard,
   FoundMove,
@@ -21,7 +20,6 @@ import {
   TodayPanel,
   WrittenBy,
 } from "./record360";
-import { TaskDetailModal, useTaskUpdate } from "./taskactions";
 import "./dealstatus.css";
 
 // Deal360 — the deal page's written briefing, read before a call, in the
@@ -339,31 +337,6 @@ function verdictLabel(
   return key ? t(key) : standing;
 }
 
-// activityIdOf reads the one operand the meeting-brief verb takes. The
-// arguments object is typed open on the wire; a missing id renders no button
-// rather than a button that would 404.
-function activityIdOf(move: DealStatusCardMove): string | null {
-  const raw = move.arguments?.activity_id;
-  return typeof raw === "string" && raw !== "" ? raw : null;
-}
-
-// Whether the verb has what it needs to be drawn, decided BEFORE the slot is:
-// a slot handed a control that renders nothing still draws the slot, and an
-// empty action region reads as a verb that failed to load. MoveButton keeps
-// its own null returns for the narrowing the cases need; this is what decides
-// whether the row has a verb at all.
-function hasMoveControl(move: DealStatusCardMove): boolean {
-  switch (move.action) {
-    case "create_task":
-      return Boolean(move.arguments);
-    case "open_task":
-    case "open_meeting_brief":
-      return activityIdOf(move) !== null;
-    default:
-      return false;
-  }
-}
-
 // The move the briefing names, as the one row the agent is asking for: the
 // reason is the ask, the evidence under it is what it rests on, and the verb
 // at the row's end performs it.
@@ -390,110 +363,4 @@ function Move({
       }
     />
   );
-}
-
-function MoveButton({
-  dealId,
-  move,
-}: Readonly<{ dealId: string; move: DealStatusCardMove }>) {
-  const t = useT();
-  const queryClient = useQueryClient();
-  const [briefOpen, setBriefOpen] = useState(false);
-  const [taskOpen, setTaskOpen] = useState(false);
-  const canUpdateTask = useCan("activity", "update");
-  const taskUpdate = useTaskUpdate([
-    ["deal-status", dealId],
-    ["tasks"],
-    ["worklist"],
-  ]);
-  const activityId = activityIdOf(move);
-  const createTask = useMutation({
-    mutationKey: ["deal-status-create-task"],
-    // The arguments ARE the task body the server prepared; the click sends
-    // them as they came rather than re-deriving them from render state.
-    mutationFn: async (body: Record<string, unknown>) => {
-      const { data, error } = await api.POST("/tasks", {
-        body: body as components["schemas"]["CreateTaskRequest"],
-      });
-      if (error) {
-        throwProblem(error, t);
-      }
-      return data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["deal-status", dealId] });
-      queryClient.invalidateQueries({ queryKey: ["activities"] });
-      queryClient.invalidateQueries({ queryKey: ["tasks"] });
-    },
-  });
-
-  const taskBody = move.arguments;
-  switch (move.action) {
-    case "open_task":
-      if (!activityId) return null;
-      return (
-        <>
-          <Button small onClick={() => setTaskOpen(true)}>
-            {t("deal360.openTask")}
-          </Button>
-          {taskOpen && (
-            <TaskDetailModal
-              activityId={activityId}
-              readOnly={!canUpdateTask}
-              onClose={() => setTaskOpen(false)}
-              update={taskUpdate}
-            />
-          )}
-        </>
-      );
-    case "create_task":
-      // No body, no button: a click that sent {} would only be refused.
-      if (!taskBody) {
-        return null;
-      }
-      return (
-        <>
-          <Button
-            variant="primary"
-            small
-            pending={createTask.isPending}
-            onClick={() => createTask.mutate(taskBody)}
-          >
-            <ListChecks aria-hidden />
-            {t("deal360.createTask")}
-          </Button>
-          {createTask.isError ? (
-            <p className="t-caption t-danger">
-              {problemMessageOf(createTask.error, t)}
-            </p>
-          ) : null}
-        </>
-      );
-    case "draft_email":
-      // No button here. Writing to the buyer is the email box's job, in the
-      // right-hand column under the Deal Room — one place a rep goes to send
-      // mail, whether or not this move happens to rank first. Deal360 still
-      // says WHY the mail is the move; it just does not carry a second door
-      // to the same composer.
-      return null;
-    case "open_meeting_brief":
-      if (!activityId) {
-        return null;
-      }
-      return (
-        <>
-          <Button variant="primary" small onClick={() => setBriefOpen(true)}>
-            <Sparkles aria-hidden />
-            {t("deal360.openBrief")}
-          </Button>
-          <PersonMeetingBrief
-            activityId={activityId}
-            open={briefOpen}
-            onClose={() => setBriefOpen(false)}
-          />
-        </>
-      );
-    default:
-      return null;
-  }
 }

--- a/frontend/src/screens/movebutton.test.ts
+++ b/frontend/src/screens/movebutton.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Whether a decided step has what it needs to be drawn.
+//
+// Asked BEFORE the slot is, which is the whole reason this is a function and
+// not a null return inside the button: a caller that mounts MoveButton
+// unconditionally still draws the surrounding action region, and an empty one
+// reads as a control that failed to load. MoveButton keeps its own null returns
+// for the narrowing each case needs; this decides whether there is a verb at
+// all.
+
+import { describe, expect, it } from "vitest";
+import { hasMoveControl } from "./movebutton";
+
+describe("whether a move can be drawn", () => {
+  it("needs the operand its own verb takes", () => {
+    const ACTIVITY = "01a05500-0000-7000-8000-0000000000e1";
+    for (const [move, drawable, because] of [
+      [
+        { action: "create_task", arguments: { subject: "x" } },
+        true,
+        "the body the server prepared is present",
+      ],
+      [
+        { action: "create_task" },
+        false,
+        "no body: a click would post {} and only be refused",
+      ],
+      [
+        { action: "open_task", arguments: { activity_id: ACTIVITY } },
+        true,
+        "names the task to open",
+      ],
+      [
+        { action: "open_task", arguments: {} },
+        false,
+        "names no task, so the button would 404",
+      ],
+      [
+        { action: "open_meeting_brief", arguments: { activity_id: ACTIVITY } },
+        true,
+        "names the meeting",
+      ],
+      [{ action: "open_meeting_brief" }, false, "names no meeting"],
+      [
+        { action: "draft_email", arguments: { activity_id: ACTIVITY } },
+        false,
+        "writing to the buyer is the composer's job, not this button's",
+      ],
+      [{ action: "none" }, false, "the producer's own word for nothing to do"],
+      [
+        { action: "a_verb_from_a_newer_server" },
+        false,
+        "an unknown verb draws nothing rather than an unpressable control",
+      ],
+    ] as const) {
+      expect(hasMoveControl(move), `${move.action}: ${because}`).toBe(drawable);
+    }
+  });
+
+  it("refuses an activity id that is not one", () => {
+    // The arguments object is typed open on the wire, so the id can arrive as
+    // anything. A non-string reaching the button would render a control that
+    // opens nothing.
+    for (const raw of [42, null, "", { id: "x" }, []]) {
+      expect(
+        hasMoveControl({
+          action: "open_task",
+          arguments: { activity_id: raw },
+        }),
+        `activity_id ${JSON.stringify(raw)} must not be drawable`,
+      ).toBe(false);
+    }
+  });
+});

--- a/frontend/src/screens/movebutton.tsx
+++ b/frontend/src/screens/movebutton.tsx
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Performing the next step a producer already decided.
+//
+// TWO surfaces draw the same move. The deal status card names it beside its
+// reason and evidence; the worklist row names it on a queue line. They differ
+// in what they say ABOUT the move and not in what pressing it does, so the
+// button lives here and both mount it — a second implementation would be two
+// answers to "what does Create task do", and they would drift until a rep
+// pressed the same words on two screens and got different results.
+//
+// Typed on the pair both wire shapes carry rather than on either of them.
+// DealStatusCardMove requires a reason and evidence, WorklistMove carries
+// neither, and nothing here reads either one: the verb needs its action and its
+// operand and nothing else.
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ListChecks, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCan } from "../app/capability";
+import { Button } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { problemMessageOf, throwProblem } from "./common";
+import { PersonMeetingBrief } from "./meetingbrief";
+import { TaskDetailModal, useTaskUpdate } from "./taskactions";
+
+// What a move must carry to be performed. Both producers' shapes satisfy it.
+export type PerformableMove = {
+  action: string;
+  arguments?: Record<string, unknown>;
+};
+
+// activityIdOf reads the one operand the meeting-brief verb takes. The
+// arguments object is typed open on the wire; a missing id renders no button
+// rather than a button that would 404.
+export function activityIdOf(move: PerformableMove): string | null {
+  const raw = move.arguments?.activity_id;
+  return typeof raw === "string" && raw !== "" ? raw : null;
+}
+
+// Whether the verb has what it needs to be drawn, decided BEFORE the slot is:
+// a slot handed a control that renders nothing still draws the slot, and an
+// empty action region reads as a verb that failed to load. MoveButton keeps
+// its own null returns for the narrowing the cases need; this is what decides
+// whether the row has a verb at all.
+export function hasMoveControl(move: PerformableMove): boolean {
+  switch (move.action) {
+    case "create_task":
+      return Boolean(move.arguments);
+    case "open_task":
+    case "open_meeting_brief":
+      return activityIdOf(move) !== null;
+    default:
+      return false;
+  }
+}
+
+export function MoveButton({
+  dealId,
+  move,
+}: Readonly<{
+  // The deal whose card to refresh after the verb writes, where the caller has
+  // one. OPTIONAL because the worklist does not: a queue row's move may belong
+  // to a deal, a person or nothing at all, and passing an empty string would
+  // invalidate a key naming no deal — a call that does nothing, spelled as one
+  // that does something.
+  dealId?: string;
+  move: PerformableMove;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [briefOpen, setBriefOpen] = useState(false);
+  const [taskOpen, setTaskOpen] = useState(false);
+  const canUpdateTask = useCan("activity", "update");
+  const taskUpdate = useTaskUpdate([
+    ...(dealId ? [["deal-status", dealId]] : []),
+    ["tasks"],
+    ["worklist"],
+  ]);
+  const activityId = activityIdOf(move);
+  const createTask = useMutation({
+    mutationKey: ["deal-status-create-task"],
+    // The arguments ARE the task body the server prepared; the click sends
+    // them as they came rather than re-deriving them from render state.
+    mutationFn: async (body: Record<string, unknown>) => {
+      const { data, error } = await api.POST("/tasks", {
+        body: body as components["schemas"]["CreateTaskRequest"],
+      });
+      if (error) {
+        throwProblem(error, t);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      if (dealId) {
+        queryClient.invalidateQueries({ queryKey: ["deal-status", dealId] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["activities"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      // And the queue, which is now one of the two surfaces this button is
+      // pressed from. The deal card refreshes itself above; the worklist row
+      // that ASKED for this task would otherwise keep asking for it, because
+      // the queue does not poll. The open_task arm gets this for free from
+      // useTaskUpdate's own key list; this arm has its own onSuccess and so
+      // needs it spelled.
+      queryClient.invalidateQueries({ queryKey: ["worklist"] });
+    },
+  });
+
+  const taskBody = move.arguments;
+  switch (move.action) {
+    case "open_task":
+      if (!activityId) return null;
+      return (
+        <>
+          <Button small onClick={() => setTaskOpen(true)}>
+            {t("deal360.openTask")}
+          </Button>
+          {taskOpen && (
+            <TaskDetailModal
+              activityId={activityId}
+              readOnly={!canUpdateTask}
+              onClose={() => setTaskOpen(false)}
+              update={taskUpdate}
+            />
+          )}
+        </>
+      );
+    case "create_task":
+      // No body, no button: a click that sent {} would only be refused.
+      if (!taskBody) {
+        return null;
+      }
+      return (
+        <>
+          <Button
+            variant="primary"
+            small
+            pending={createTask.isPending}
+            onClick={() => createTask.mutate(taskBody)}
+          >
+            <ListChecks aria-hidden />
+            {t("deal360.createTask")}
+          </Button>
+          {createTask.isError ? (
+            <p className="t-caption t-danger">
+              {problemMessageOf(createTask.error, t)}
+            </p>
+          ) : null}
+        </>
+      );
+    case "draft_email":
+      // No button here. Writing to the buyer is the email box's job, in the
+      // right-hand column under the Deal Room — one place a rep goes to send
+      // mail, whether or not this move happens to rank first. Deal360 still
+      // says WHY the mail is the move; it just does not carry a second door
+      // to the same composer.
+      return null;
+    case "open_meeting_brief":
+      if (!activityId) {
+        return null;
+      }
+      return (
+        <>
+          <Button variant="primary" small onClick={() => setBriefOpen(true)}>
+            <Sparkles aria-hidden />
+            {t("deal360.openBrief")}
+          </Button>
+          <PersonMeetingBrief
+            activityId={activityId}
+            open={briefOpen}
+            onClose={() => setBriefOpen(false)}
+          />
+        </>
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend/src/screens/worklist.move.test.tsx
+++ b/frontend/src/screens/worklist.move.test.tsx
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The step the server already decided, performed from the row.
+//
+// The backend computes one next move per deal, from records, deterministically,
+// and caches it per reader. Until now nothing on this page read it: the row
+// named a problem and the answer travelled in the response unrendered, so a rep
+// was told a deal had gone quiet and left to work out what to do about it.
+
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  day,
+  jsonResponse,
+  renderWorklist,
+  row,
+  stub,
+} from "./worklist.testkit";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const TASK_BODY = { subject: "Ask about the renewal", link_type: "deal" };
+const ACTIVITY = "01a05500-0000-7000-8000-0000000000e9";
+
+function aQuietDeal(over = {}) {
+  return row({
+    id: "01a05500-0000-7000-8000-0000000000d1",
+    source: "deal_at_risk",
+    category: "deals_at_risk",
+    title: "Turbinenbau — renewal",
+    band: "keep_momentum",
+    destination: "today",
+    actions: ["open"],
+    subject: { type: "deal", id: "01a05500-0000-7000-8000-0000000000d2" },
+    move: { action: "create_task", arguments: TASK_BODY },
+    ...over,
+  });
+}
+
+function aDayWith(item: ReturnType<typeof aQuietDeal>) {
+  return day({
+    queue: [item],
+    summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+  });
+}
+
+describe("a deal row carrying a decided next step", () => {
+  it("offers the step, rather than naming the problem alone", async () => {
+    stub(aDayWith(aQuietDeal()));
+    renderWorklist();
+
+    await screen.findByText(/Turbinenbau/);
+    expect(
+      await screen.findByRole("button", { name: /add this task/i }),
+    ).not.toBeNull();
+  });
+
+  it("sends the server's own arguments, not a body the row rebuilt", async () => {
+    // The move's arguments ARE the task the server prepared. A row that
+    // re-derived them from what it happens to render would send a different
+    // task than the one the reason on screen describes.
+    const sent: unknown[] = [];
+    stub(aDayWith(aQuietDeal()));
+    const passthrough = globalThis.fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.endsWith("/tasks")) {
+          const body =
+            input instanceof Request
+              ? await input.clone().text()
+              : String(init?.body ?? "");
+          sent.push(JSON.parse(body));
+          return jsonResponse({ id: "01a05500-0000-7000-8000-0000000000d3" });
+        }
+        return passthrough(input, init);
+      }),
+    );
+    const user = userEvent.setup();
+    renderWorklist();
+
+    await user.click(
+      await screen.findByRole("button", { name: /add this task/i }),
+    );
+    await waitFor(() => expect(sent).toEqual([TASK_BODY]));
+  });
+
+  it("leaves every other move to the link that already draws it", async () => {
+    // Only create_task is drawn here. The other moves reach the reader as
+    // anchors through moveHref — draft_reply and draft_email open the composer,
+    // open_task and open_meeting_brief open what they name — so drawing a
+    // button for them too would put two controls for one step on one row, and
+    // for open_task two controls that go to different places.
+    for (const action of [
+      "draft_reply",
+      "draft_email",
+      "open_task",
+      "open_meeting_brief",
+    ]) {
+      cleanup();
+      stub(
+        aDayWith(
+          aQuietDeal({
+            move: { action, arguments: { activity_id: ACTIVITY } },
+          }),
+        ),
+      );
+      renderWorklist();
+
+      await screen.findByText(/Turbinenbau/);
+      // Each verb's OWN control, not create_task's: open_task draws "Open
+      // existing task" and open_meeting_brief "Open the meeting brief", so
+      // asserting on the create_task label alone would pass over exactly the
+      // duplicate this test is for.
+      for (const label of [
+        /add this task/i,
+        /open existing task/i,
+        /open the meeting brief/i,
+      ]) {
+        expect(
+          screen.queryByRole("button", { name: label }),
+          `${action} drew a button beside the link that already draws it`,
+        ).toBeNull();
+      }
+    }
+  });
+
+  it("does not take a brief item's own verbs away", async () => {
+    // A brief item carries a deal subject, and the backend attaches a cached
+    // move to any deal-subject row that has none. Drawn before BriefVerbs, the
+    // task button would replace Act, Set aside and Dismiss on a row whose own
+    // verbs are the whole point of it.
+    stub(
+      aDayWith(
+        aQuietDeal({
+          source: "brief_item",
+          actions: ["act", "set_aside", "dismiss"],
+          move: { action: "create_task", arguments: TASK_BODY },
+        }),
+      ),
+    );
+    renderWorklist();
+
+    await screen.findByText(/Turbinenbau/);
+    expect(
+      screen.queryByRole("button", { name: /add this task/i }),
+      "a brief item lost its own verbs to a move button",
+    ).toBeNull();
+  });
+
+  it("draws no button for a step it cannot perform", async () => {
+    // Two undrawable moves: a create_task with no body would post {} and only
+    // be refused, and `draft_email` deliberately has no control here.
+    for (const move of [{ action: "create_task" }, { action: "draft_email" }]) {
+      cleanup();
+      stub(aDayWith(aQuietDeal({ move })));
+      renderWorklist();
+
+      await screen.findByText(/Turbinenbau/);
+      expect(
+        screen.queryByRole("button", { name: /add this task/i }),
+        `${move.action} drew a button`,
+      ).toBeNull();
+    }
+  });
+});

--- a/frontend/src/screens/worklist.reply.test.tsx
+++ b/frontend/src/screens/worklist.reply.test.tsx
@@ -22,7 +22,7 @@ function aWaitingBuyer(over = {}) {
     source: "customer_waiting",
     category: "customer_waiting",
     title: "can you resend the quote?",
-    band: "answer_people",
+    band: "now",
     destination: "today",
     actions: ["open", "reply"],
     subject: { type: "person", id: "01a05500-0000-7000-8000-0000000000c2" },

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -21,6 +21,7 @@ import { tomorrowMorning } from "./briefqueue";
 import { problemMessageOf } from "./common";
 import { ChannelReplyAction, RELINK_KINDS, type RelinkKind } from "./compose";
 import { type BriefMarkRequest, useBriefItemMark } from "./home.queries";
+import { hasMoveControl, MoveButton } from "./movebutton";
 import {
   useAutomationRetry,
   useMeetingOutcome,
@@ -343,6 +344,32 @@ function RowAnswer({ item }: Readonly<{ item: WorklistItem }>) {
   // share a surface and the component picks among them.
   if (item.source === "brief_item" && !item.batch) {
     return <BriefVerbs item={item} />;
+  }
+  // The one decided step a link cannot take.
+  //
+  // Every other move the server sends already reaches the reader, as an anchor
+  // through moveHref — draft_reply and draft_email open the composer,
+  // open_task and open_meeting_brief open what they name. `create_task` POSTS a
+  // task body, which is a write and not a destination, so NAVIGABLE_MOVES
+  // excludes it and the row could name the step and offer no way to take it.
+  //
+  // The button is the deal status card's own, mounted a second time rather than
+  // written again: one answer to "what does Add this task do", on the two
+  // surfaces that draw the same move.
+  //
+  // LAST, and after brief_item deliberately. A brief item carries a deal
+  // subject, and the backend attaches a cached move to any deal-subject row
+  // that has none — so an earlier position here would replace Act, Set aside
+  // and Dismiss with a task button on a row whose own verbs are the point.
+  if (item.move?.action === "create_task" && hasMoveControl(item.move)) {
+    return (
+      <div className="worklist-row-verbs">
+        <MoveButton
+          dealId={item.subject?.type === "deal" ? item.subject.id : undefined}
+          move={item.move}
+        />
+      </div>
+    );
   }
   return null;
 }


### PR DESCRIPTION
The server computes a next step per deal — deterministically, from records, cached per reader — and sends it on the row. **Four of the six kinds already reach the reader** as anchors through `moveHref`: `draft_reply` and `draft_email` open the composer, `open_task` and `open_meeting_brief` open what they name.

`create_task` is the one that could not. It POSTs a task body, which is a write and not a destination, so `NAVIGABLE_MOVES` excludes it — and the row named the step with no way to take it. That is now a button.

## Reuse, not a second implementation

The button is the deal status card's own. `MoveButton`, `hasMoveControl` and `activityIdOf` move into their own module and both surfaces mount them. Two implementations of *"what does Add this task do"* would drift until a rep pressed the same words on two screens and got different results.

Nothing about the deal page changes. `dealId` becomes optional because a queue row's move may belong to a deal, a person, or nothing — and an empty string would invalidate a key naming no deal, a call that does nothing spelled as one that does something.

`create_task` now invalidates the worklist too. The `open_task` path gets that free from `useTaskUpdate`'s key list; this arm has its own `onSuccess`, and without it the row that *asked* for the task would keep asking, because the queue does not poll.

## Two dispatch defects a review caught

Both fixed, both now held by a test that fails without the fix:

1. **The control is drawn only for `create_task`.** Written for every drawable move, a deal row with an `open_task` move drew **two controls with the same label and different effects** — the existing link goes to the record, the button opens the task modal.

2. **It is drawn after `brief_item`.** The backend attaches a cached move to any row whose subject is a deal, brief items included, so an earlier position replaced Act, Set aside and Dismiss with a task button on a row whose own verbs are the point of it.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `offers the step, rather than naming the problem alone` |
| Correct write | `sends the server's own arguments, not a body the row rebuilt` — asserts the POST body is the move's own arguments |
| No duplicate control | `leaves every other move to the link that already draws it` — checks each verb's **own** label, not just create_task's; the earlier version asserted the wrong label and passed over the defect |
| Brief items keep their verbs | `does not take a brief item's own verbs away` |
| Drawability | `movebutton.test.ts` — 9 action/operand pairs plus 5 malformed `activity_id` values, unit-testing `hasMoveControl` directly |
| Extraction is behaviour-preserving | `dealstatus` suite, 10 tests, unchanged |
| Mutation strength | widen the branch to every move → the duplicate-control test; `create_task` always drawable → the unit test, naming the reason; loose id parsing → the malformed-id test |
| Full lane | `make check-backend` EXIT=0; `make check-fe` clean apart from a known flake (below) |

## Also fixed

`worklist.reply.test.tsx` (merged in #4610) named a `band` the contract has no word for. It reached main because the file was untracked when its gate ran — `tsc -b` reads a fixture's enums, and it reads the project, not the working directory.

## Not fixed here, and pre-existing

The move rides a fingerprinted card cache that only `Service.Get` refreshes, which the worklist never calls. A step can go stale after the write that answers it — already true of the `open_task` and `open_meeting_brief` links shipping today. Invalidating that cache on a task write is its own change.

`make check-fe` flagged `onboarding-conversation/company-act.test.tsx`, which passes alone, is untouched here, and has failed on a different subtest each time — a test-isolation flake. All 327 worklist, movebutton and dealstatus tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Worklist rows now render a button for `create_task` moves, so reps can take the server-decided next step instead of just reading that one exists.

**Bug Fixes**
- The button is drawn only for `create_task`, so a row with an `open_task` move no longer shows two controls with the same label but different effects.
- It is drawn after the `brief_item` branch, so brief items keep their own verbs (Act, Set aside, Dismiss).

**Refactors**
- `MoveButton`, `hasMoveControl` and `activityIdOf` move into their own module; both the deal status card and worklist row mount them.
- `dealId` becomes optional because a queue row's move may belong to a deal, a person, or nothing.
- `create_task` invalidates the worklist cache after success, so the row that asked for a task doesn't keep asking.
- Fixed `worklist.reply.test.tsx` to use the `now` band, which the contract allows.

<sup>Written for commit 3a22b54936d3e21b71384e7dd9ece19066240781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

