### PR TITLE
fix(board): a stage holds one width; the scrollbar rests neutral

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -538,6 +538,100 @@ test("AC-pipeline-7: board↔table swaps views preserving the deal set", async (
   ).toBeVisible();
 });
 
+/**
+ * The stage geometry a reader is actually handed, read off the rendered board.
+ *
+ * `inner` is the width the stages are laid out in — the board's own padding is
+ * not board a reader can see — and it is what the phone proportion below is
+ * measured against. The spills are NAMED rather than counted: a bare number
+ * says a stage is 51px too wide and nothing about which one, and every column
+ * on this board carries the stage it draws.
+ */
+async function boardGeometry(page: Page) {
+  return page.evaluate(() => {
+    const board = document.querySelector(".board");
+    if (!board) {
+      return null;
+    }
+    const style = getComputedStyle(board);
+    const columns = Array.from(board.querySelectorAll(".board-col"));
+    return {
+      inner:
+        board.clientWidth -
+        Number.parseFloat(style.paddingLeft) -
+        Number.parseFloat(style.paddingRight),
+      gap: Number.parseFloat(style.columnGap),
+      snap: style.scrollSnapType,
+      scrollsSideways: board.scrollWidth > board.clientWidth,
+      firstColumnWidth: columns[0]?.getBoundingClientRect().width ?? 0,
+      spilling: columns
+        .map((column) => ({
+          stage: column.getAttribute("data-stage") ?? "an unnamed stage",
+          past: column.scrollWidth - column.clientWidth,
+        }))
+        .filter(({ past }) => past > 0)
+        .map(({ stage, past }) => `${stage}: ${past}px past its column`),
+    };
+  });
+}
+
+// A stage is ONE width, and the window decides how many of them are on screen
+// rather than how wide one is. A column that grows into leftover room shows the
+// same pipeline as four stages to one reader and six to another, and neither
+// can say how many there are or compare a stage against the same stage on
+// somebody else's screen.
+//
+// The other half is that a stage never scrolls sideways ITSELF. Its totals are
+// `nowrap` money, and a column that scrolls its cards vertically resolves the
+// other axis to `auto` alongside it — so a figure that does not ellipsise puts
+// a scrollbar under every stage on the board, which reveals nothing a reader
+// can use and costs each of them a line.
+test("AC-pipeline-8: one stage width at every window, and no stage scrolls sideways", async ({
+  page,
+}) => {
+  await page.goto("/#/deals");
+  await expect(page.locator(".board-col").first()).toBeVisible();
+
+  // 768 is inside the fold and 1440 is a wide desktop: the point is that the
+  // stage does not care. Read as a list so a failure prints every width at
+  // once rather than stopping at the first one that disagreed.
+  const widths: number[] = [];
+  for (const width of [1440, 1280, 1024, 768]) {
+    await page.setViewportSize({ width, height: 900 });
+    const geometry = await boardGeometry(page);
+    expect(geometry, "the deals screen drew no board").not.toBeNull();
+    expect(geometry?.spilling).toEqual([]);
+    widths.push(geometry?.firstColumnWidth ?? 0);
+  }
+  expect(widths).toEqual([240, 240, 240, 240]);
+
+  // The board itself is what scrolls, and the shell around it never does.
+  await page.setViewportSize({ width: 1280, height: 800 });
+  const desktop = await boardGeometry(page);
+  expect(
+    desktop?.scrollsSideways,
+    "six stages at 240px do not fit 1280px, so the board has to scroll",
+  ).toBe(true);
+  expect(await pageOverflow(page)).toEqual([]);
+
+  // On a phone the reader swipes: one stage and the gap after it take four
+  // fifths of the board, which leaves about a quarter of the next stage on
+  // screen. That peek is the only thing saying the pipeline carries on.
+  await page.setViewportSize({ width: 390, height: 844 });
+  const phone = await boardGeometry(page);
+  expect(phone?.spilling).toEqual([]);
+  expect(await pageOverflow(page)).toEqual([]);
+  const stageAndGap = (phone?.firstColumnWidth ?? 0) + (phone?.gap ?? 0);
+  expect(Math.abs(stageAndGap - (phone?.inner ?? 0) * 0.8)).toBeLessThanOrEqual(
+    2,
+  );
+  const peek = (phone?.inner ?? 0) - stageAndGap;
+  expect(peek / (phone?.firstColumnWidth ?? 1)).toBeGreaterThan(0.2);
+  expect(peek / (phone?.firstColumnWidth ?? 1)).toBeLessThan(0.35);
+  // Snapping is what stops a swipe parking the reader between two stages.
+  expect(phone?.snap).toBe("x mandatory");
+});
+
 test("AC-deal-6: a terminal-stage drop is a 🟡 confirm — nothing runs before Confirm", async ({
   page,
 }) => {

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -761,6 +761,73 @@ async function scrollbarStates(page: Page) {
   });
 }
 
+/**
+ * The bars, plus WHAT the pointer is standing on, as `tag.class`.
+ *
+ * The rule under test picks ONE element, so which element it picked is the
+ * claim's premise: a stage that stayed grey because the pointer landed a pixel
+ * outside it is a different defect from one that stayed grey with the pointer
+ * squarely on it, and two lists of colours cannot tell those apart. Asserted
+ * only where the premise is the point — at rest and on a card the claim is
+ * "no stage is lit", which every landing inside the board satisfies equally.
+ */
+async function barsAndPointer(page: Page) {
+  const bars = await scrollbarStates(page);
+  const pointerOver = await page.evaluate(() => {
+    // Document order is ancestor-first along the one hover chain, so the last
+    // match is the element `:not(:has(:hover))` leaves standing.
+    const deepest = Array.from(document.querySelectorAll(":hover")).at(-1);
+    if (deepest === undefined) {
+      return "nothing: the pointer is outside the document";
+    }
+    return [deepest.tagName.toLowerCase(), ...deepest.classList].join(".");
+  });
+  return { ...bars, pointerOver };
+}
+
+/**
+ * A point that is the first stage's OWN box and no other element's.
+ *
+ * Not the corner a reader might reach for. A column's padding edge is one
+ * pixel's rounding from the board behind it — CI hovered `first.x + 4,
+ * first.y + 4` and got the board — and the top inset belongs to the sticky
+ * head, which is a different element again. The empty run below the last thing
+ * in the column has neither problem: inside a list surface a column is
+ * stretched to the surface's height and scrolls its own cards, so a stage the
+ * seed leaves half-empty is its own ground from its last child down to its
+ * bottom edge, and the middle of that run is nowhere near an edge of anything.
+ * A stage full enough to have no such run keeps the flex gap between its first
+ * two cards, which is the same ground.
+ */
+async function pointInsideFirstStage(page: Page) {
+  const point = await page.evaluate(() => {
+    const column = document.querySelector(".board-col");
+    if (column === null) {
+      return "the board drew no stage, so there is nothing to hover";
+    }
+    const box = column.getBoundingClientRect();
+    const x = box.left + box.width / 2;
+    const last = Array.from(column.children).at(-1)?.getBoundingClientRect();
+    // A run thinner than a card's own gap is back to being decided by
+    // rounding, which is the whole reason the padding edge was given up.
+    const roomToStand = 8;
+    if (last !== undefined && box.bottom - last.bottom >= roomToStand) {
+      return { x, y: (last.bottom + box.bottom) / 2 };
+    }
+    const cards = Array.from(column.querySelectorAll(".deal-card"), (card) =>
+      card.getBoundingClientRect(),
+    );
+    if (cards.length >= 2) {
+      return { x, y: (cards[0].bottom + cards[1].top) / 2 };
+    }
+    return "the first stage is filled to its bottom edge by a single card, so it has neither an empty run nor a gap between cards to hover";
+  });
+  if (typeof point === "string") {
+    throw new Error(point);
+  }
+  return point;
+}
+
 // ONE bar takes the accent, and it is the bar the pointer is on.
 //
 // Hover is a chain: the pointer inside a stage is inside the board, the shell's
@@ -797,20 +864,19 @@ test("AC-pipeline-10: the bar under the pointer is the one that lights", async (
     stages: everyStageNeutral,
   });
 
-  // ON THE FIRST STAGE, in the column's own padding. The seeded board holds too
-  // few cards for a stage to overflow, so there is no vertical bar to aim at —
-  // the padding is the strip that bar would be drawn in, and either way it is
-  // the deepest element at that point.
-  const first = await stages.first().boundingBox();
-  if (first === null) {
-    throw new Error("the first stage has no box, so there is nothing to hover");
-  }
-  await page.mouse.move(first.x + 4, first.y + 4);
+  // ON THE FIRST STAGE, on ground that is the column's own box and nothing
+  // else's. The seeded board holds too few cards for a stage to overflow, so
+  // there is no vertical bar to aim at — the empty run below the last card is
+  // the strip that bar would be drawn in, and either way it is the deepest
+  // element at that point.
+  const probe = await pointInsideFirstStage(page);
+  await page.mouse.move(probe.x, probe.y);
   await expect
-    .poll(() => scrollbarStates(page))
+    .poll(() => barsAndPointer(page))
     .toEqual({
       shell: "neutral",
       board: "neutral",
+      pointerOver: "section.board-col",
       stages: resting.stages.map(({ stage }, index) => ({
         stage,
         bar: index === 0 ? "accent" : "neutral",

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -539,22 +539,33 @@ test("AC-pipeline-7: board↔table swaps views preserving the deal set", async (
 });
 
 /**
+ * One stage, in pixels — `--board-col-w` in design-system/composed.css.
+ *
+ * Written out here rather than read off the sheet, and that is the point: the
+ * NUMBER is the acceptance. A test that asked the stylesheet how wide a stage
+ * should be would agree with whatever the stylesheet said, including the
+ * grow-into-the-leftover-room sizing this replaced, and would have passed on
+ * the defect it exists to catch.
+ */
+const STAGE_WIDTH_PX = 240;
+
+/**
  * The stage geometry a reader is actually handed, read off the rendered board.
  *
  * `inner` is the width the stages are laid out in — the board's own padding is
  * not board a reader can see — and it is what the phone proportion below is
- * measured against. The spills are NAMED rather than counted: a bare number
- * says a stage is 51px too wide and nothing about which one, and every column
- * on this board carries the stage it draws.
+ * measured against. A stage is named by the words in its HEAD: `data-stage`
+ * carries the stage's id, which names it to the database and to nobody reading
+ * a failure. `BoardLayout` labels every column it draws, so there is no
+ * unnamed stage to stand in for.
  */
 async function boardGeometry(page: Page) {
-  return page.evaluate(() => {
+  const geometry = await page.evaluate(() => {
     const board = document.querySelector(".board");
-    if (!board) {
+    if (board === null) {
       return null;
     }
     const style = getComputedStyle(board);
-    const columns = Array.from(board.querySelectorAll(".board-col"));
     return {
       inner:
         board.clientWidth -
@@ -563,16 +574,53 @@ async function boardGeometry(page: Page) {
       gap: Number.parseFloat(style.columnGap),
       snap: style.scrollSnapType,
       scrollsSideways: board.scrollWidth > board.clientWidth,
-      firstColumnWidth: columns[0]?.getBoundingClientRect().width ?? 0,
-      spilling: columns
-        .map((column) => ({
-          stage: column.getAttribute("data-stage") ?? "an unnamed stage",
+      columns: Array.from(board.querySelectorAll(".board-col")).map(
+        (column) => ({
+          stage: column.getAttribute("aria-label"),
+          folded: column.classList.contains("board-col-collapsed"),
+          width: Math.round(column.getBoundingClientRect().width),
           past: column.scrollWidth - column.clientWidth,
-        }))
-        .filter(({ past }) => past > 0)
-        .map(({ stage, past }) => `${stage}: ${past}px past its column`),
+          // Read rather than assumed: it decides whether `past` above means
+          // anything at all.
+          clipping: getComputedStyle(column).overflowX,
+        }),
+      ),
     };
   });
+  // Thrown rather than asserted, so what comes back has no null in it: every
+  // reader below would otherwise be optional, and a width divided by a divisor
+  // invented on the spot is an assertion that passes on a board that is not
+  // there.
+  if (geometry === null) {
+    throw new Error("this screen drew no .board, so it has no stage geometry");
+  }
+  if (geometry.columns.length === 0) {
+    throw new Error("the board drew no stages, so there is nothing to measure");
+  }
+  // A `clip` box reports `scrollWidth === clientWidth` however much it is
+  // cutting off, so on a board outside a list surface — where the column keeps
+  // the `clip` composed.css declares — the spill reading below is not a smaller
+  // answer but NO answer, and it would call any board clean however far its
+  // contents ran past the stage. Refused here rather than returned, because a
+  // caller cannot tell the two zeroes apart.
+  const unmeasurable = geometry.columns.filter(
+    ({ clipping }) => clipping !== "hidden",
+  );
+  if (unmeasurable.length > 0) {
+    throw new Error(
+      `${unmeasurable.map(({ stage, clipping }) => `${stage}: overflow-x ${clipping}`).join(", ")} — a clip box reports no horizontal overflow whatever it cuts, so this helper can only measure a board whose columns are scrollers, which is a board inside a list surface`,
+    );
+  }
+  return geometry;
+}
+
+/** The stages that scroll sideways, each naming itself and by how much. */
+function stagesSpillingSideways(
+  geometry: Awaited<ReturnType<typeof boardGeometry>>,
+) {
+  return geometry.columns
+    .filter(({ past }) => past > 0)
+    .map(({ stage, past }) => `${stage}: ${past}px past its column`);
 }
 
 // A stage is ONE width, and the window decides how many of them are on screen
@@ -593,23 +641,28 @@ test("AC-pipeline-8: one stage width at every window, and no stage scrolls sidew
   await expect(page.locator(".board-col").first()).toBeVisible();
 
   // 768 is inside the fold and 1440 is a wide desktop: the point is that the
-  // stage does not care. Read as a list so a failure prints every width at
-  // once rather than stopping at the first one that disagreed.
-  const widths: number[] = [];
+  // stage does not care. Each width is kept against the window that produced
+  // it, so a failure names the window that disagreed instead of printing four
+  // bare numbers and leaving the reader to count along.
+  const stageWidths: Record<number, number> = {};
   for (const width of [1440, 1280, 1024, 768]) {
     await page.setViewportSize({ width, height: 900 });
     const geometry = await boardGeometry(page);
-    expect(geometry, "the deals screen drew no board").not.toBeNull();
-    expect(geometry?.spilling).toEqual([]);
-    widths.push(geometry?.firstColumnWidth ?? 0);
+    expect(stagesSpillingSideways(geometry)).toEqual([]);
+    stageWidths[width] = geometry.columns[0].width;
   }
-  expect(widths).toEqual([240, 240, 240, 240]);
+  expect(stageWidths).toEqual({
+    1440: STAGE_WIDTH_PX,
+    1280: STAGE_WIDTH_PX,
+    1024: STAGE_WIDTH_PX,
+    768: STAGE_WIDTH_PX,
+  });
 
   // The board itself is what scrolls, and the shell around it never does.
   await page.setViewportSize({ width: 1280, height: 800 });
   const desktop = await boardGeometry(page);
   expect(
-    desktop?.scrollsSideways,
+    desktop.scrollsSideways,
     "six stages at 240px do not fit 1280px, so the board has to scroll",
   ).toBe(true);
   expect(await pageOverflow(page)).toEqual([]);
@@ -619,17 +672,166 @@ test("AC-pipeline-8: one stage width at every window, and no stage scrolls sidew
   // screen. That peek is the only thing saying the pipeline carries on.
   await page.setViewportSize({ width: 390, height: 844 });
   const phone = await boardGeometry(page);
-  expect(phone?.spilling).toEqual([]);
+  expect(stagesSpillingSideways(phone)).toEqual([]);
   expect(await pageOverflow(page)).toEqual([]);
-  const stageAndGap = (phone?.firstColumnWidth ?? 0) + (phone?.gap ?? 0);
-  expect(Math.abs(stageAndGap - (phone?.inner ?? 0) * 0.8)).toBeLessThanOrEqual(
-    2,
-  );
-  const peek = (phone?.inner ?? 0) - stageAndGap;
-  expect(peek / (phone?.firstColumnWidth ?? 1)).toBeGreaterThan(0.2);
-  expect(peek / (phone?.firstColumnWidth ?? 1)).toBeLessThan(0.35);
+  const stage = phone.columns[0].width;
+  const stageAndGap = stage + phone.gap;
+  expect(Math.abs(stageAndGap - phone.inner * 0.8)).toBeLessThanOrEqual(2);
+  const peek = phone.inner - stageAndGap;
+  expect(peek / stage).toBeGreaterThan(0.2);
+  expect(peek / stage).toBeLessThan(0.35);
   // Snapping is what stops a swipe parking the reader between two stages.
-  expect(phone?.snap).toBe("x mandatory");
+  expect(phone.snap).toBe("x mandatory");
+});
+
+// A FOLDED stage hands its width back, and the shared stage width is exactly
+// what it has to escape — a fold that still drew 240px would have bought the
+// stages a reader works out of nothing at all, which is the whole reason to
+// fold one. The lead board is where this ships: its two terminal stages are
+// folded until somebody opens one, beside three open ones.
+test("AC-pipeline-9: a folded stage keeps none of the shared stage width", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/#/leads?view=board");
+  await expect(page.locator(".board-col-collapsed").first()).toBeVisible();
+
+  const geometry = await boardGeometry(page);
+  const folded = geometry.columns.filter((column) => column.folded);
+  const open = geometry.columns.filter((column) => !column.folded);
+  expect(
+    open.length,
+    "a fold is only worth anything beside a stage that did not fold",
+  ).toBeGreaterThan(0);
+  expect(open.filter(({ width }) => width !== STAGE_WIDTH_PX)).toEqual([]);
+  expect(folded.filter(({ width }) => width >= STAGE_WIDTH_PX)).toEqual([]);
+  expect(stagesSpillingSideways(geometry)).toEqual([]);
+  expect(await pageOverflow(page)).toEqual([]);
+});
+
+/**
+ * Which scroller's bar is LIT, named per scroller.
+ *
+ * Read back as the words `neutral` and `accent` rather than as colours: what
+ * has to be checked is "the board is grey and the stage under the pointer is
+ * not", and a failure printing two triples of numbers makes the reader do the
+ * palette arithmetic themselves. A thumb that is neither is reported as it
+ * comes, so a third colour can never be read as one of these two.
+ *
+ * The two are resolved by asking the browser what the sheet's own declaration
+ * computes to on this page. A literal `rgb(...)` here would be a second copy of
+ * the palette: it would keep passing on a colour nobody paints any more, and
+ * fail on a token change that was correct.
+ */
+async function scrollbarStates(page: Page) {
+  return page.evaluate(() => {
+    // Off-screen, because a probe under the pointer would take the accent from
+    // the very rule being measured and report it as the resting colour.
+    function declared(thumb: string) {
+      const probe = document.createElement("span");
+      probe.style.position = "absolute";
+      probe.style.left = "-9999px";
+      probe.style.scrollbarColor = `var(${thumb}) transparent`;
+      document.body.append(probe);
+      const computed = getComputedStyle(probe).scrollbarColor;
+      probe.remove();
+      return computed;
+    }
+    const words = new Map([
+      [declared("--borderControl"), "neutral"],
+      [declared("--accent"), "accent"],
+    ]);
+    function read(element: Element | null) {
+      if (element === null) {
+        return "no such scroller on this page";
+      }
+      const painted = getComputedStyle(element).scrollbarColor;
+      return words.get(painted) ?? painted;
+    }
+    return {
+      shell: read(document.querySelector(".scroll")),
+      board: read(document.querySelector(".board")),
+      stages: Array.from(document.querySelectorAll(".board-col")).map(
+        (column) => ({
+          stage: column.getAttribute("aria-label"),
+          bar: read(column),
+        }),
+      ),
+    };
+  });
+}
+
+// ONE bar takes the accent, and it is the bar the pointer is on.
+//
+// Hover is a chain: the pointer inside a stage is inside the board, the shell's
+// content column and the document too, so a bare `*:hover` lights every
+// scroller between the cursor and the root and the accent says only "the
+// pointer is somewhere in this window". `*:hover:not(:has(:hover))` (app.css)
+// leaves the one element whose own box — its bar, its padding, its gutter —
+// the pointer is actually over. The board is where that matters most, because
+// it is the one surface that nests a scroller inside a scroller inside a
+// scroller.
+test("AC-pipeline-10: the bar under the pointer is the one that lights", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/#/deals");
+  const stages = page.locator(".board-col");
+  await expect(stages.first()).toBeVisible();
+  expect(
+    await stages.count(),
+    "this is about ONE scroller among several, so it takes at least two stages to be about anything",
+  ).toBeGreaterThan(1);
+
+  // AT REST: the pointer in the corner of the window, on the chrome beside the
+  // board rather than anywhere in it.
+  await page.mouse.move(0, 0);
+  const resting = await scrollbarStates(page);
+  const everyStageNeutral = resting.stages.map(({ stage }) => ({
+    stage,
+    bar: "neutral",
+  }));
+  expect(resting).toEqual({
+    shell: "neutral",
+    board: "neutral",
+    stages: everyStageNeutral,
+  });
+
+  // ON THE FIRST STAGE, in the column's own padding. The seeded board holds too
+  // few cards for a stage to overflow, so there is no vertical bar to aim at —
+  // the padding is the strip that bar would be drawn in, and either way it is
+  // the deepest element at that point.
+  const first = await stages.first().boundingBox();
+  if (first === null) {
+    throw new Error("the first stage has no box, so there is nothing to hover");
+  }
+  await page.mouse.move(first.x + 4, first.y + 4);
+  await expect
+    .poll(() => scrollbarStates(page))
+    .toEqual({
+      shell: "neutral",
+      board: "neutral",
+      stages: resting.stages.map(({ stage }, index) => ({
+        stage,
+        bar: index === 0 ? "accent" : "neutral",
+      })),
+    });
+
+  // ON A CARD: the deepest element is inside the stage rather than the stage,
+  // so no scroller on the page is the one under the pointer and every bar is
+  // grey again.
+  const card = await page.locator(".deal-card").first().boundingBox();
+  if (card === null) {
+    throw new Error("the board drew no deal card to hover");
+  }
+  await page.mouse.move(card.x + card.width / 2, card.y + card.height / 2);
+  await expect
+    .poll(() => scrollbarStates(page))
+    .toEqual({
+      shell: "neutral",
+      board: "neutral",
+      stages: everyStageNeutral,
+    });
 });
 
 test("AC-deal-6: a terminal-stage drop is a 🟡 confirm — nothing runs before Confirm", async ({

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -40,9 +40,14 @@ body {
  * Declared at the root because these properties INHERIT. The scrollbar pair is
  * the exception and has its own rules below: `scrollbar-width` does not inherit
  * at all, and the thumb colour answers the pointer per element, which an
- * inherited value cannot. A component that wants different can still say so
- * locally — `.mw-artifact` and the conversation thread already hide their
- * scrollbars this way, and a class selector outranks the root here.
+ * inherited value cannot. What a component can still say for itself differs
+ * between the two, and the difference is specificity. The WIDTH sits on `*`,
+ * which carries none, so one class beats it — `.mw-artifact` and the
+ * conversation thread hide their bars exactly that way. The COLOUR under the
+ * pointer is `*:hover:not(:has(:hover))`, and `:not()` and `:has()` each take
+ * their argument's, so that is (0,2,0): a single class LOSES to it, and a
+ * component that wants a thumb colour of its own needs two classes or `:hover`
+ * in its own selector.
  */
 :root {
   /* The colour only. The caret keeps the platform's own BAR: a block caret is
@@ -57,37 +62,20 @@ body {
 }
 
 /*
- * The thin scrollbar, on EVERY scroller: neutral at rest, accent under the
- * pointer.
+ * The thin scrollbar on EVERY scroller. --accent at rest would put the
+ * palette's one loud colour on every capped card, so a bar is --borderControl
+ * until the pointer says which scroller it is on.
  *
- * A bar is chrome, not content. Painted --accent everywhere it is at rest, the
- * palette's one loud colour sits on every capped card and stops meaning
- * anything; --borderControl is the grey drawn to stay visible on any ground, so
- * it can be the resting state in both themes. The accent is then a statement —
- * this is the scroller the pointer is on — and `:hover` is the whole mechanism,
- * so where there is no pointer to hover (a touch screen) the neutral bar simply
- * stands.
+ * That accent has to light ONE bar, not a stack: hover is a chain, so `*:hover`
+ * matches html, body, the pane and the board together and the shell's bar would
+ * be accent whenever the pointer was anywhere in the window. Excluding an
+ * element that has a hovered descendant leaves the one whose own box — bar,
+ * padding, gutter — the pointer is actually over.
  *
- * Both properties are declared per element rather than inherited from the root.
- * `scrollbar-width` does not inherit at all, so a root-only declaration styled
- * the document scroller and nothing else: every in-app scroller — the content
- * area, the rail, a capped card — kept the platform's default-width bar. An
- * inherited COLOUR would be worse than useless here, because a hovered scroller
- * would hand the accent down to every scroller nested inside it and hovering a
- * board would light all of its columns. Declared on `*`, each bar answers for
- * its own element only.
- *
- * The track is TRANSPARENT rather than --bgPage on purpose: a scroller is not
- * always on the page surface — the rail is a dark green field in both themes,
- * and a code block has its own fill — so naming a colour would mismatch every
- * scroller that is not on the page background. Transparent shows whatever is
- * actually behind it and cannot be wrong.
- *
- * The universal selector carries zero specificity, so a scroller that
- * deliberately hides its bar (`scrollbar-width: none` on `.mw-artifact`, the
- * conversation thread, `.lt-views`, `.recordtabs-strip`) still wins. The hover
- * rule is a pseudo-class and therefore only TIES with a single class, so a
- * component that ever needs a thumb colour of its own has to say `:hover` too.
+ * Both properties sit on `*`: `scrollbar-width` does not inherit at all, and an
+ * inherited colour would hand a hovered scroller's accent to every bar nested
+ * inside it. The track is transparent because a scroller is not always on
+ * --bgPage — the rail is a dark green field, a code block has its own fill.
  */
 *,
 ::backdrop {
@@ -95,7 +83,7 @@ body {
   scrollbar-color: var(--borderControl) transparent;
 }
 
-*:hover {
+*:hover:not(:has(:hover)) {
   scrollbar-color: var(--accent) transparent;
 }
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -37,11 +37,12 @@ body {
  * else's brand, and on a dark surface the platform's own scrollbar chrome fights
  * the palette rather than joining it.
  *
- * Declared at the root because these properties INHERIT — with one exception,
- * `scrollbar-width`, which does not and is therefore declared on every element
- * below. A component that wants different can still say so locally
- * (`.mw-artifact` and the conversation thread already hide their scrollbars this
- * way, and a class selector outranks both rules here).
+ * Declared at the root because these properties INHERIT. The scrollbar pair is
+ * the exception and has its own rules below: `scrollbar-width` does not inherit
+ * at all, and the thumb colour answers the pointer per element, which an
+ * inherited value cannot. A component that wants different can still say so
+ * locally — `.mw-artifact` and the conversation thread already hide their
+ * scrollbars this way, and a class selector outranks the root here.
  */
 :root {
   /* The colour only. The caret keeps the platform's own BAR: a block caret is
@@ -53,28 +54,49 @@ body {
      range thumbs, progress fills. This replaces the same declaration repeated in
      three screens — see onboarding-facts.css, now redundant. */
   accent-color: var(--accent);
-  /* Thumb, then track. The track is TRANSPARENT rather than --bgPage on purpose:
-     a scroller is not always on the page surface — the rail is a dark green field
-     in both themes, and a code block has its own fill — so naming a colour here
-     would mismatch every scroller that is not on the page background. Transparent
-     shows whatever is actually behind it and cannot be wrong. */
-  scrollbar-color: var(--accent) transparent;
 }
 
 /*
- * The thin scrollbar, on EVERY scroller.
+ * The thin scrollbar, on EVERY scroller: neutral at rest, accent under the
+ * pointer.
  *
- * `scrollbar-width` is the one property in the block above that does not
- * inherit, so declaring it on `:root` alone styled the document scroller and
- * nothing else: every in-app scroller — the content area, the rail, a capped
- * card — kept the platform's default-width bar next to a thumb that was already
- * painted in the accent. The universal selector carries zero specificity, so a
- * scroller that deliberately hides its bar (`scrollbar-width: none` on
- * `.mw-artifact`, the conversation thread) still wins.
+ * A bar is chrome, not content. Painted --accent everywhere it is at rest, the
+ * palette's one loud colour sits on every capped card and stops meaning
+ * anything; --borderControl is the grey drawn to stay visible on any ground, so
+ * it can be the resting state in both themes. The accent is then a statement —
+ * this is the scroller the pointer is on — and `:hover` is the whole mechanism,
+ * so where there is no pointer to hover (a touch screen) the neutral bar simply
+ * stands.
+ *
+ * Both properties are declared per element rather than inherited from the root.
+ * `scrollbar-width` does not inherit at all, so a root-only declaration styled
+ * the document scroller and nothing else: every in-app scroller — the content
+ * area, the rail, a capped card — kept the platform's default-width bar. An
+ * inherited COLOUR would be worse than useless here, because a hovered scroller
+ * would hand the accent down to every scroller nested inside it and hovering a
+ * board would light all of its columns. Declared on `*`, each bar answers for
+ * its own element only.
+ *
+ * The track is TRANSPARENT rather than --bgPage on purpose: a scroller is not
+ * always on the page surface — the rail is a dark green field in both themes,
+ * and a code block has its own fill — so naming a colour would mismatch every
+ * scroller that is not on the page background. Transparent shows whatever is
+ * actually behind it and cannot be wrong.
+ *
+ * The universal selector carries zero specificity, so a scroller that
+ * deliberately hides its bar (`scrollbar-width: none` on `.mw-artifact`, the
+ * conversation thread, `.lt-views`, `.recordtabs-strip`) still wins. The hover
+ * rule is a pseudo-class and therefore only TIES with a single class, so a
+ * component that ever needs a thumb colour of its own has to say `:hover` too.
  */
 *,
 ::backdrop {
   scrollbar-width: thin;
+  scrollbar-color: var(--borderControl) transparent;
+}
+
+*:hover {
+  scrollbar-color: var(--accent) transparent;
 }
 
 /* Selected text reads as the accent holding it, in both themes: --bgPage on

--- a/frontend/src/app/pageaside.stories.tsx
+++ b/frontend/src/app/pageaside.stories.tsx
@@ -103,8 +103,11 @@ export const Folded: Story = {
     const canvas = within(canvasElement);
     const user = userEvent.setup();
     await expect(canvasElement.querySelector("aside")).toBeNull();
+    // The switch renders nothing until the screen's `usePageAside` effect has
+    // claimed the pane, which is a commit past mount: the query has to wait for
+    // it rather than assume the first paint carried it.
     await user.click(
-      canvas.getByRole("button", { name: en["record.panel.details"] }),
+      await canvas.findByRole("button", { name: en["record.panel.details"] }),
     );
     await expect(canvasElement.querySelector("aside")).not.toBeNull();
     await expect(

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -36,15 +36,34 @@
      what a narrower window changes is how many stages are on screen, not how
      wide one is. The BOARD scrolls, a stage holds still. */
   flex: 0 0 var(--board-col-w);
+  /* The basis is the width; `min-width` only stops a flex line from squeezing
+     it. Two declarations of one number, not three — a third would be a number
+     that has to move with the other two and nothing to notice when it does
+     not. */
   min-width: var(--board-col-w);
-  width: var(--board-col-w);
   /* A STAGE NEVER SCROLLS SIDEWAYS. Everything in a column — the head, the
      totals, the cards — is bounded by the width above, so overflow on this axis
      is a child that refused to shrink, and the scrollbar it paints under every
      stage reveals nothing a reader can use. Stated rather than left implicit:
      the list surface gives a column `overflow-y: auto` for long stages, and a
-     `visible` other axis computes to `auto` alongside it. */
-  overflow-x: hidden;
+     `visible` other axis computes to `auto` alongside it.
+
+     CLIP, not `hidden`. The two cut the same; they differ in that `hidden`
+     makes the box a SCROLL CONTAINER and `clip` does not, and which of those a
+     column needs is decided by the SURFACE AROUND IT rather than by the screen
+     that drew it. Inside a list surface every column is already handed
+     `overflow-y: auto` (listtable.css), so it is a scroller whatever this says
+     and `clip` computes to `hidden` beside that `auto` — the pipeline and the
+     lead board, both of which render into `.lt`, read the same under either
+     spelling. Outside one a column is handed nothing, and there `hidden` would
+     compute the other axis from `visible` to `auto` and make every column a
+     scrollport: the sticky head would hold its place against a column that
+     never scrolls rather than against the shell's scroller, and
+     `scrollIntoView` on a card would move the column instead of the page.
+     `clip` leaves that axis `visible` and such a board where it was. Which
+     boards those are is a fact about callers and changes without this file
+     hearing about it, so the condition is the surface. */
+  overflow-x: clip;
   /* A RECESS in the surface, not a card on it. --bgCard is a card's ground and
      read as one — five of them in a row made the board a grid of grey slabs
      with the deals inside them, and the cards had to fight their own
@@ -72,12 +91,11 @@
  * two folded terminal ones. */
 .board-col-collapsed {
   /* Out of the shared width: it takes what its name and count need and gives
-     the rest back to the columns a reader is working out of. All three of the
-     sizing declarations above are overridden, or the fixed width would win and
+     the rest back to the columns a reader is working out of. Both of the
+     sizing declarations above are overridden, or the fixed basis would win and
      the fold would give nothing back. */
   flex: 0 0 auto;
   min-width: 0;
-  width: auto;
   min-height: 120px;
 }
 .board-col-collapsed .board-col-head {
@@ -145,11 +163,11 @@
   color: var(--textMeta);
   padding: 0 4px 4px;
 }
-/* Both figures are `nowrap`, because a money amount broken across lines is
-   unreadable — so each one has to be told what to do when it does not fit, or
-   it simply paints past the stage it belongs to. It ELLIPSISES: a total the
-   reader can see is cut is a total they know to open the stage for, where a
-   figure running under the next column is one they may read as complete. */
+/* A MONEY FIGURE IS ONE LINE AND ELLIPSISES; A SENTENCE WRAPS.
+   Both totals are `nowrap`, because an amount broken across lines is
+   unreadable — so each has to be told what to do when it does not fit, or it
+   paints past the stage it belongs to. Cut, a figure is visibly incomplete,
+   where one running on under the next column can be read as whole. */
 .board-col-total {
   display: flex;
   align-items: baseline;
@@ -173,20 +191,52 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* The line that stands in for a refused total is PROSE, and the rule above is
+   exactly wrong for it: ellipsised in a 240px stage it read "Loaded only —
+   filter to My deals fo…" on all six columns of the deals board, and there is
+   no fold on this board to open for the rest of it. A cut figure still says
+   "there is more of me"; a sentence cut mid-word says nothing at all. So it is
+   its own class and it wraps.
+
+   `white-space` is stated rather than left to the initial value because
+   wrapping is the whole reason this is not a `.board-col-weighted`, and
+   `overflow-wrap` is not a default: the reason is caller text, and one long
+   token would otherwise be cut off by the column's clip. */
+.board-col-refusal {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
 
 /* A phone SWIPES between stages rather than showing them all at once. One stage
  * and the gap after it take four fifths of the board, which leaves about a
  * quarter of the next one on screen — that peek is what says there is more to
- * the right, and it says it without a scrollbar. Snapping stops a swipe leaving
- * the reader parked between two stages.
+ * the right. Snapping stops a swipe leaving the reader parked between two
+ * stages.
  *
  * Sizing lives with the board rather than with the list surface, so a board
- * standing on its own — the lead presentation, a company's seats — swipes the
- * same way as the pipeline. */
-@media (max-width: 720px) {
+ * that renders outside one — a company's seat board is the one doing that
+ * today — swipes exactly the way the pipeline does.
+ *
+ * 700px is THE SHELL'S PHONE BREAKPOINT (app/shell.css, topbar.css,
+ * agentrail.css): it is the width at which the sidebar leaves the layout row
+ * altogether and becomes a fixed bottom bar, so it is also the width at which
+ * the board is handed the whole window. At 720 the swipe shape switched on
+ * while the rail was still a 224px column beside it — a 720px desktop window
+ * got mandatory snap and a stage that jumped 240 → 328px next to a full
+ * sidebar. The swipe and the phone chrome change on one line. */
+@media (max-width: 700px) {
   .board {
     --board-col-w: calc(80% - var(--space-4));
     scroll-snap-type: x mandatory;
+    /* NO BAR UNDER THE SWIPE. The peek and the snap already say the pipeline
+       carries on, and a hairline bar is a control for a pointer that is not on
+       this screen — the same reading `.lt-views` and `.recordtabs-strip` make
+       of their own strips. The desktop board keeps its bar, where the pointer
+       is what drags the board and the bar is how far along it says you are. */
+    scrollbar-width: none;
+  }
+  .board::-webkit-scrollbar {
+    display: none;
   }
   .board-col {
     scroll-snap-align: start;

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -1,13 +1,22 @@
 /* Composed surfaces (B-EP09.3b) — consume the trust primitives; staged vs
  * real vs human-typed carries through unchanged (§5c). */
 
-/* FLEX, not grid tracks. Every column used to be an implicit
- * `minmax(220px, 1fr)` track, and a track is sized by the board rather than by
- * the item in it — so a collapsed column still reserved its 220px and the fold
- * bought nothing. Flex lets one column opt out of the shared basis while the
- * rest keep it: `1 1 220px` is the same "at least 220, share what is left"
- * the track gave them. */
+/* FLEX, not grid tracks. A grid track is sized by the board rather than by the
+ * item in it, so a collapsed column still reserved a full track and folding it
+ * bought the other stages nothing. Flex lets one column opt out of the shared
+ * width while the rest keep it. */
 .board {
+  /* ONE stage width, at every window width and on every board. A column that
+     grows into whatever room is left is a different size on each screen, so two
+     readers looking at the same pipeline see a different number of stages and
+     neither can say how many there are. 240px is what puts four and a half
+     stages in the 1142px a list surface leaves inside a 1440px window with the
+     rail out: (1142 - 4 * 16) / 4.5 = 239.6. The half stage is the part that
+     matters — it is what says the board carries on past the edge.
+
+     Local to this sheet rather than a token: it is one component's measurement,
+     not a step on the scale every surface shares. */
+  --board-col-w: 240px;
   display: flex;
   gap: var(--space-4);
   align-items: flex-start;
@@ -23,8 +32,19 @@
      scroll, and dragged the shell's content scroller 807px past a 390px
      viewport. */
   position: relative;
-  flex: 1 1 220px;
-  min-width: 220px;
+  /* Neither grow nor shrink. The width above is the width at 1440 and at 768;
+     what a narrower window changes is how many stages are on screen, not how
+     wide one is. The BOARD scrolls, a stage holds still. */
+  flex: 0 0 var(--board-col-w);
+  min-width: var(--board-col-w);
+  width: var(--board-col-w);
+  /* A STAGE NEVER SCROLLS SIDEWAYS. Everything in a column — the head, the
+     totals, the cards — is bounded by the width above, so overflow on this axis
+     is a child that refused to shrink, and the scrollbar it paints under every
+     stage reveals nothing a reader can use. Stated rather than left implicit:
+     the list surface gives a column `overflow-y: auto` for long stages, and a
+     `visible` other axis computes to `auto` alongside it. */
+  overflow-x: hidden;
   /* A RECESS in the surface, not a card on it. --bgCard is a card's ground and
      read as one — five of them in a row made the board a grid of grey slabs
      with the deals inside them, and the cards had to fight their own
@@ -47,14 +67,17 @@
  *
  * It keeps its min-height: a target a reader has to hit with a dragged card
  * must stay a target, and a strip the height of one line is one a drop misses.
- * grid-column sizing is overridden per column rather than on `.board`, so a
- * board can hold both shapes at once — which is exactly the lead board, three
- * open stages beside two folded terminal ones. */
+ * Width is set per column rather than on `.board`, so one board holds both
+ * shapes at once — which is exactly the lead board, three open stages beside
+ * two folded terminal ones. */
 .board-col-collapsed {
-  /* Out of the shared basis: it takes the width its name and count need and
-     gives the rest back to the columns a reader is working out of. */
+  /* Out of the shared width: it takes what its name and count need and gives
+     the rest back to the columns a reader is working out of. All three of the
+     sizing declarations above are overridden, or the fixed width would win and
+     the fold would give nothing back. */
   flex: 0 0 auto;
   min-width: 0;
+  width: auto;
   min-height: 120px;
 }
 .board-col-collapsed .board-col-head {
@@ -67,11 +90,10 @@
  *
  * It carries the column's own ground, or the cards would slide visibly behind a
  * transparent strip. NO negative margin to bleed that ground to the column's
- * edges: a flex item wider than its container contributes that extra width to
- * the container's max-content size, and the board is a grid of `1fr` tracks
- * inside a scroller — so a 20px bleed per column widened the whole board past
- * the viewport and the page scrolled sideways at 390px. The 10px of column
- * padding either side of the band is the price of the page not panning. */
+ * edges: the column clips this axis, so a band 20px wider than its column is
+ * not bled, it is cut off — the ground would stop short of the very edges the
+ * bleed was for. The 10px of column padding either side of the band is the
+ * price of the band staying whole. */
 .board-col-head {
   position: sticky;
   top: 0;
@@ -91,9 +113,9 @@
   flex: 1;
   /* A STAGE NAME IS DATA of unbounded length, and it shares this line with the
      count. Without `min-width: 0` a flex item cannot shrink below its longest
-     word, so the name set the column's min-content width, the column set the
-     board's, and the board — a flex item with no floor of its own — pushed the
-     whole page sideways rather than scrolling. The NAME is what gives way. */
+     word, so a name longer than the stage is wide overflowed the head — and
+     the column clips, so the count at the end of the line was what got cut.
+     The NAME is what gives way. */
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -123,20 +145,52 @@
   color: var(--textMeta);
   padding: 0 4px 4px;
 }
+/* Both figures are `nowrap`, because a money amount broken across lines is
+   unreadable — so each one has to be told what to do when it does not fit, or
+   it simply paints past the stage it belongs to. It ELLIPSISES: a total the
+   reader can see is cut is a total they know to open the stage for, where a
+   figure running under the next column is one they may read as complete. */
 .board-col-total {
   display: flex;
   align-items: baseline;
   gap: var(--space-2);
   white-space: nowrap;
+  overflow: hidden;
 }
 .board-col-money {
   font-weight: 600;
   color: var(--textContent);
   font-variant-numeric: tabular-nums;
+  /* A flex item's floor is its own min-content width unless it is told
+     otherwise, and a `nowrap` amount has no shrink in it at all. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .board-col-weighted {
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* A phone SWIPES between stages rather than showing them all at once. One stage
+ * and the gap after it take four fifths of the board, which leaves about a
+ * quarter of the next one on screen — that peek is what says there is more to
+ * the right, and it says it without a scrollbar. Snapping stops a swipe leaving
+ * the reader parked between two stages.
+ *
+ * Sizing lives with the board rather than with the list surface, so a board
+ * standing on its own — the lead presentation, a company's seats — swipes the
+ * same way as the pipeline. */
+@media (max-width: 720px) {
+  .board {
+    --board-col-w: calc(80% - var(--space-4));
+    scroll-snap-type: x mandatory;
+  }
+  .board-col {
+    scroll-snap-align: start;
+  }
 }
 
 .deal-card {

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -17,6 +17,7 @@
      Local to this sheet rather than a token: it is one component's measurement,
      not a step on the scale every surface shares. */
   --board-col-w: 240px;
+
   display: flex;
   gap: var(--space-4);
   align-items: flex-start;
@@ -70,7 +71,11 @@
      containers to look like the subject. */
   background: var(--bgWell);
   border-radius: var(--r-md);
-  padding: var(--space-3);
+  /* NO INSET ABOVE THE HEAD: the head carries it (below), so the band it draws
+     reaches the column's top edge. An inset here is a strip of the scrollport
+     above a sticky child, and the cards scroll up through it in plain sight.
+     The other three sides stay the column's own. */
+  padding: 0 var(--space-3) var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -98,20 +103,27 @@
   min-width: 0;
   min-height: 120px;
 }
+/* A folded column is as wide as its head, and the head's bleed leaves that
+ * untouched: the negative inline margin comes straight back as the head's own
+ * inline padding, so the name and the count still decide the width. */
 .board-col-collapsed .board-col-head {
   writing-mode: horizontal-tb;
   white-space: nowrap;
 }
-/* STUCK TO THE TOP OF ITS COLUMN. A stage is the only thing that says which
- * pile a card belongs to, and a reader scrolled halfway down a long stage had
- * lost it, because each column scrolls on its own.
+/* STUCK TO THE TOP OF ITS COLUMN, AND IT SEALS IT. A stage is the only thing
+ * that says which pile a card belongs to, and a reader scrolled halfway down a
+ * long stage had lost it, because each column scrolls on its own.
  *
- * It carries the column's own ground, or the cards would slide visibly behind a
- * transparent strip. NO negative margin to bleed that ground to the column's
- * edges: the column clips this axis, so a band 20px wider than its column is
- * not bled, it is cut off — the ground would stop short of the very edges the
- * bleed was for. The 10px of column padding either side of the band is the
- * price of the band staying whole. */
+ * The head OWNS THE COLUMN'S TOP INSET and bleeds to the column's edges: the
+ * column keeps no padding above it, and the negative inline margin carries the
+ * band out to the padding box either side. A card scrolling up a stage passes
+ * BEHIND the band and nowhere else — not through a strip above it, not down a
+ * gutter beside it. The inline padding is the column's inset plus the head's
+ * own, so the name sits where it sat before the bleed.
+ *
+ * The bleed costs nothing: the column's width is a fixed basis and it clips
+ * this axis, so a child wider than the column widens neither the column nor the
+ * board. */
 .board-col-head {
   position: sticky;
   top: 0;
@@ -119,7 +131,8 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
-  padding: 2px 4px 4px;
+  padding: var(--space-3) calc(var(--space-3) + 4px) 4px;
+  margin-inline: calc(-1 * var(--space-3));
   /* The column's own ground, or the cards slide visibly behind a transparent
      strip. */
   background: var(--bgWell);
@@ -227,6 +240,7 @@
 @media (max-width: 700px) {
   .board {
     --board-col-w: calc(80% - var(--space-4));
+
     scroll-snap-type: x mandatory;
     /* NO BAR UNDER THE SWIPE. The peek and the snap already say the pipeline
        carries on, and a hairline bar is a control for a pointer that is not on

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLayoutEffect, useRef } from "react";
 import { Button, SegmentedControl } from "./atoms";
 import {
   type BoardDeal,
@@ -514,6 +515,92 @@ export const BoardWithAFoldedStage: StoryObj = {
       onToggleColumn={() => undefined}
     />
   ),
+};
+
+// A STAGE MID-SCROLL, which is the one state that shows what its head is for.
+//
+// At rest the head is indistinguishable from the column behind it: they carry
+// one ground, so whether the band reaches the column's edges or leaves a strip
+// of scrollport above and beside it looks identical until something scrolls
+// through that strip. A card passing under the head is what tells them apart —
+// it goes BEHIND the band and is visible nowhere above or beside it.
+//
+// Deep enough to overflow, in a frame short enough to overflow it: a column
+// takes its `overflow-y: auto` from the list surface (listtable.css) and only
+// scrolls when the surface has a bounded height to scroll inside. The second
+// stage holds one deal, so the same head reads beside it at rest.
+const scrollingStageColumns: BoardMoneyColumn[] = [
+  {
+    stage: "discovery",
+    label: "Discovery",
+    probabilityPct: 10,
+    rawMinor: 197_000,
+    weightedMinor: 19_700,
+    currency: "EUR",
+    deals: [
+      boardDeal("s1", "Contoso renewal", 12_000, 3),
+      boardDeal("s2", "Fabrikam expansion", 33_000, 9),
+      boardDeal("s3", "Globex onboarding", 28_000, 14),
+      boardDeal("s4", "Initech upgrade", 54_000, 21),
+      boardDeal("s5", "Umbrella Corp", 61_000, 2),
+      boardDeal("s6", "Northwind pilot", 9_000, 6),
+    ],
+  },
+  {
+    stage: "qualified",
+    label: "Qualified",
+    probabilityPct: 30,
+    rawMinor: 28_000,
+    weightedMinor: 8_400,
+    currency: "EUR",
+    deals: [boardDeal("s7", "Tailspin rollout", 28_000, 11)],
+  },
+];
+
+// Short enough that six deals do not fit, which is what makes the stage a
+// scroller at all; the offset is three cards deep, which catches one of them
+// halfway under the band rather than a seam between two.
+const FRAME_H_PX = 440;
+const SCROLLED_PAST_PX = 340;
+
+function StageMidScroll() {
+  const frame = useRef<HTMLDivElement>(null);
+
+  // Scrolled, not passed: the board has no prop for a stage's offset, and the
+  // same reasoning the sort-menu story presses its own trigger with — a frame
+  // of a stage that never scrolled would picture the very thing this story
+  // exists to rule out.
+  useLayoutEffect(() => {
+    const stage = frame.current?.querySelector(".board-col");
+    if (!(stage instanceof HTMLElement)) {
+      throw new Error(
+        "this frame drew no stage, so there is nothing to scroll",
+      );
+    }
+    stage.scrollTop = SCROLLED_PAST_PX;
+    // A frame that does not bound the surface leaves every stage its full
+    // height, and the story would then picture a head sealing nothing while
+    // reading as though it had.
+    if (stage.scrollTop === 0) {
+      throw new Error("the stage did not scroll: the frame left it unbounded");
+    }
+  }, []);
+
+  return (
+    <div ref={frame} style={{ display: "flex", height: FRAME_H_PX }}>
+      <ListSurface count="7 deals" action={<Button small>New deal</Button>}>
+        <PipelineBoard
+          columns={scrollingStageColumns}
+          cardHref={(d) => `#/deals/${d.id}`}
+          zone="Europe/Berlin"
+        />
+      </ListSurface>
+    </div>
+  );
+}
+
+export const BoardWithAScrolledStage: StoryObj = {
+  render: () => <StageMidScroll />,
 };
 
 /**

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -456,6 +456,66 @@ export const BoardWithALongStageName: StoryObj = {
   ),
 };
 
+// A FOLDED STAGE beside open ones, which is the only shape a fold can be read
+// in: it takes the width its name and count need and hands the rest back, and
+// "the rest" is only visible next to a stage that kept it.
+//
+// Three stages rather than the deal board above, because a fold belongs at the
+// terminal end of a pipeline and the deal board's right-hand end is past the
+// edge of every frame this catalog captures — a folded column nobody can see
+// documents nothing. Same reason it is not on the phone story: one stage takes
+// four fifths of that width, so anything but the first is off screen.
+//
+// The head is a real control here (`aria-expanded`, Enter and Space) because
+// the column carries `collapsed`; the two open stages stay the plain text they
+// have always been, which is the per-column rule the board keeps. Pressing it
+// does nothing — the catalog draws states rather than driving them.
+const foldedStageColumns: BoardMoneyColumn[] = [
+  {
+    stage: "negotiation",
+    label: "Negotiation",
+    probabilityPct: 80,
+    rawMinor: 54_000,
+    weightedMinor: 43_200,
+    currency: "EUR",
+    deals: [boardDeal("f1", "Initech upgrade", 54_000, 21)],
+  },
+  {
+    stage: "won",
+    label: "Closed Won",
+    probabilityPct: 100,
+    rawMinor: 61_000,
+    weightedMinor: 61_000,
+    currency: "EUR",
+    deals: [boardDeal("f2", "Umbrella Corp", 61_000, 2)],
+  },
+  {
+    // Its count comes from the stage rather than from the cards: a folded
+    // column draws none of them, and a figure taken from what is drawn would
+    // read zero on every stage a reader folds away.
+    stage: "lost",
+    label: "Closed Lost",
+    probabilityPct: 0,
+    rawMinor: 18_000,
+    weightedMinor: 0,
+    currency: "EUR",
+    count: 8,
+    collapsed: true,
+    deals: [],
+  },
+];
+
+export const BoardWithAFoldedStage: StoryObj = {
+  render: () => (
+    <PipelineBoard
+      columns={foldedStageColumns}
+      cardHref={(d) => `#/deals/${d.id}`}
+      zone="Europe/Berlin"
+      onToggleColumn={() => undefined}
+    />
+  ),
+};
+
 /**
  * The same board on a phone, where a reader swipes between stages instead of
  * seeing them side by side.

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -455,3 +455,29 @@ export const BoardWithALongStageName: StoryObj = {
     />
   ),
 };
+
+/**
+ * The same board on a phone, where a reader swipes between stages instead of
+ * seeing them side by side.
+ *
+ * One stage and the gap after it take four fifths of the board's width, so the
+ * next stage shows about a quarter of itself — the peek is the only thing that
+ * says the pipeline carries on, and the board snaps so a swipe cannot leave the
+ * reader parked between two stages. The frame reuses the deal board above
+ * unchanged: the phone shape is the stylesheet's, not a second component's, and
+ * a story that built its own columns could agree with the CSS while the real
+ * board did not.
+ *
+ * `uat-phone` is what makes the capture gate drive the browser to 390px —
+ * Storybook's own viewport is applied by the manager, which the gate's bare
+ * `iframe.html` never runs, so without the tag this would be captured at
+ * desktop width and would picture the very layout it exists to rule out.
+ * `fullscreen` keeps the catalog's 2rem frame off it: 390px less two frames is
+ * not a width any reader has.
+ */
+export const BoardAtPhoneWidth: StoryObj = {
+  ...BoardInSurface,
+  parameters: { layout: "fullscreen" },
+  globals: { viewport: { value: "phone" } },
+  tags: ["uat-phone"],
+};

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -198,8 +198,15 @@ describe("DealCard + PipelineBoard", () => {
         zone="Europe/Berlin"
       />,
     );
+    // Selected by CLASS, because which class it carries is the behaviour: the
+    // refusal is prose and wraps, where `.board-col-weighted` is a money line
+    // that ellipsises — sharing it cut this sentence to "several currencies —
+    // no sing…" in a 240px stage. Matched on the words alone, the assertion
+    // stayed green through exactly that.
     expect(
-      screen.getByText("several currencies — no single total"),
+      screen.getByText("several currencies — no single total", {
+        selector: ".board-col-refusal",
+      }),
     ).toBeTruthy();
     // The count is a fact and stays; no money figure is invented beside it.
     expect(screen.getByText("29 deals")).toBeTruthy();

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -585,9 +585,13 @@ function BoardLayout<Record extends BoardRecord>({
                   one total means anything" from "nobody has priced these" — a
                   column that has both a real reason and no words for it reads as
                   a column that failed to load. On a board whose stages hold
-                  euros, dollars and dong, five of six columns are this state. */}
+                  euros, dollars and dong, five of six columns are this state.
+
+                  It is a SENTENCE, and it takes the wrapping class rather than
+                  the weighted figure's: sharing that class ellipsised it to
+                  "Loaded only — filter to My deals fo…" in a 240px stage. */}
               {money && column.sumHidden && (
-                <span className="board-col-weighted">
+                <span className="board-col-refusal">
                   {column.sumHiddenReason ?? t("board.mixedCurrencies")}
                 </span>
               )}

--- a/frontend/src/design-system/interaction.stories.tsx
+++ b/frontend/src/design-system/interaction.stories.tsx
@@ -97,7 +97,8 @@ export const NativeControls: Story = {
 };
 
 /**
- * The scrollbar: thin, accent thumb, and a TRANSPARENT track. The track colour is
+ * The scrollbar: thin, a neutral thumb that takes the accent only while the
+ * pointer is over its scroller, and a TRANSPARENT track. The track colour is
  * the interesting decision — a scroller is not always on the page surface (the
  * rail is a dark green field in both themes, a code block has its own fill), so
  * naming a colour would be wrong for every scroller that sits somewhere else.

--- a/frontend/src/design-system/interaction.stories.tsx
+++ b/frontend/src/design-system/interaction.stories.tsx
@@ -98,7 +98,7 @@ export const NativeControls: Story = {
 
 /**
  * The scrollbar: thin, a neutral thumb that takes the accent only while the
- * pointer is over its scroller, and a TRANSPARENT track. The track colour is
+ * pointer is over the bar itself, and a TRANSPARENT track. The track colour is
  * the interesting decision — a scroller is not always on the page surface (the
  * rail is a dark green field in both themes, a code block has its own fill), so
  * naming a colour would be wrong for every scroller that sits somewhere else.

--- a/frontend/src/design-system/listtable.css
+++ b/frontend/src/design-system/listtable.css
@@ -1175,8 +1175,12 @@
 /* On a phone the stages are worth more than the margin around them: the swipe
  * itself (stage width and snapping) belongs to the board and is stated in
  * composed.css, so a board outside this surface behaves the same. What is this
- * surface's to say is how much of the phone's width it keeps for itself. */
-@media (max-width: 720px) {
+ * surface's to say is how much of the phone's width it keeps for itself.
+ *
+ * The same 700px the board uses, and for the same reason — it is the shell's
+ * phone breakpoint. Two widths would leave a window where the gutter had
+ * shrunk and the stages had not, or the other way about. */
+@media (max-width: 700px) {
   .lt > .board {
     padding: var(--space-3);
   }

--- a/frontend/src/design-system/listtable.css
+++ b/frontend/src/design-system/listtable.css
@@ -1172,18 +1172,13 @@
   overflow-y: auto;
 }
 
-/* A phone swipes between stages rather than showing them all: one stage takes
- * most of the width and the next one peeks, which is what says "there is more
- * to the right" without a scrollbar. Snapping stops a swipe leaving the reader
- * between two columns. */
+/* On a phone the stages are worth more than the margin around them: the swipe
+ * itself (stage width and snapping) belongs to the board and is stated in
+ * composed.css, so a board outside this surface behaves the same. What is this
+ * surface's to say is how much of the phone's width it keeps for itself. */
 @media (max-width: 720px) {
   .lt > .board {
-    grid-auto-columns: 85%;
-    scroll-snap-type: x mandatory;
     padding: var(--space-3);
-  }
-  .lt > .board .board-col {
-    scroll-snap-align: start;
   }
 }
 


### PR DESCRIPTION
## What changed

### Task 1 — scrollbar: neutral at rest, accent only under the pointer (global)
`frontend/src/app.css`. The thumb is `--borderControl` on every scroller in both themes; the track stays transparent. The accent lights only the **deepest hovered element** — `*:hover:not(:has(:hover))` — i.e. the scroller whose own box (bar, padding, gutter) the pointer is over. A plain `:hover` rule matches the whole hover chain, which made the shell's vertical bar accent whenever the pointer was anywhere in the window (caught in review, fixed in the second commit). Both `scrollbar-width` and `scrollbar-color` sit on `*` so nothing inherits a hovered ancestor's colour. No `::-webkit-scrollbar` colour rules. `:has()` is already used in 48 selectors in this tree; an engine without it drops the rule and every bar stays neutral.

### Task 2 — no horizontal scrollbar on a board column, ever
`composed.css`: `.board-col { overflow-x: clip }` (`clip`, not `hidden`, so a board outside a list surface does not become a scroll container; under `.lt > .board .board-col { overflow-y: auto }` it computes to `hidden`). Cause of the bars: the nowrap weighted-money span carrying the sum-refusal sentence ("Loaded only — filter to My deals for the total") at 244px inside a 209px column. Money figures now ellipsise; the refusal sentence is prose and gets its own `.board-col-refusal` class that wraps (`composed.tsx`).

### Task 3 — 4.5 columns by default, board scrolls
`--board-col-w: 240px`, declared on `.board` (component-local, not a design token). Derivation: a 1440px window with the sidebar expanded leaves the list surface 1142px inside the board padding; `(1142 − 4·16) / 4.5 = 239.6`. Applied to every `PipelineBoard` (deals, leads presentation, company seats board). Before: `flex: 1 1 220px` → 6 columns did not fit at 1440 either and every column had both scrollbars.

### Task 4 — columns never shrink; phone shows 1.25
`.board-col { flex: 0 0 var(--board-col-w); min-width: var(--board-col-w) }` — 240px at 1440, 1280, 1024, 768; only the board's scroll range changes. Folded columns keep `flex: 0 0 auto`. At the shell's phone breakpoint (`≤700px`, where the rail leaves the layout row) `--board-col-w: calc(80% − gap)` so one stage plus a quarter of the next is visible (measured 1.27 at 390), `scroll-snap-type: x mandatory`, and the board hides its own bar (the `.lt-views` / `.recordtabs-strip` pattern). The grid-era `grid-auto-columns: 85%` in `listtable.css` — dead since the board became flex, and why 390px showed ~1.66 columns — is deleted.

### Stories and tests
- `composed.stories.tsx`: `BoardAtPhoneWidth` (390, `uat-phone`), `BoardWithAFoldedStage` (a folded terminal stage beside open ones).
- `interaction.stories.tsx`: `Scrollbars` doc comment updated to the new invariant.
- `e2e/ac.spec.ts`: `AC-pipeline-8` (stage width 240 at 1440/1280/1024/768, no column spill, board scrolls, shell never pans; 390 geometry), `AC-pipeline-9` (folded stages narrower than open ones on the leads board), `AC-pipeline-10` (the bar under the pointer is the one that lights; colours resolved from tokens, mutation-checked).
- `composed.test.tsx`: the refusal sentence is asserted through `.board-col-refusal` (fails if the class split is reverted).

## Fixed along the way
- Four stale CSS comments that still described the board as `1fr` grid tracks / "share what is left".
- `.board-col-collapsed` no longer has to undo a `width` declaration (dead `width` dropped).

## Measurements (real app, seeded stack, Chrome)
| width | stage width | visible stages | column h-spill | board scrolls | shell pans |
|---|---|---|---|---|---|
| 1440 | 240 | 4.52 | 0 on all 6 | yes | no |
| 1280 | 240 | 3.90 | 0 | yes | no |
| 768 | 240 | 1.90 | 0 | yes | no |
| 390 (emulated) | 243.2 (= 80% inner − gap) | 1.27 | 0 | yes, snapped, no bar | no |

Scrollbar: at rest `.scroll`, `.board`, every `.board-col` = `--borderControl` in light and dark; pointer on a column's bar → that column accent, board and shell neutral; pointer on the gap between columns → board accent only; pointer on a card → nothing lit.

## Gates run
- `make check` — pass (twice, before each push).
- `make frontend-check` — pass (7956 unit tests).
- `make fe-uat` — pass, 14 stories captured; manifest `.tmp/fe-uat/manifest.json` (`base` cd14c28…, `pass: true`).
- `make native-controls` — pass.
- `make frontend-e2e` — pass, 292 passed / 55 skipped (axe sweep included).
- `make fe-clock-drift` — not run: no touched test reads a date.
- Browser audit (390 / 768 / 1280 / 1440, light + dark, keyboard path, console) on /#/deals, /#/leads?view=board and the company seats board — see measurements above; console shows only the two pre-existing backend errors (a 501, `EmbedReindexStatus … not yet implemented`).

## Screenshots
fe-uat renders are in `.tmp/fe-uat/*.png` locally (`design-system-recordview--board-at-phone-width.png`, `--board-with-a-folded-stage.png`, `--board-in-surface.png`, `design-system-interaction-colours--scrollbars.png`). Before/after captures of /#/deals at 1440 and 390 were taken during the audit; `gh` cannot attach images to a PR body from the CLI, so they are not embedded here — ask and they will be posted as a comment from a browser session.

## Left out / for a decision
- **Column width reference.** 240px is 4.5 stages at 1440 with the sidebar out, as agreed. With the sidebar collapsed the same window would take 280px; GitHub's project board uses 350px (4.5 stages at 1920). It is one token, `--board-col-w`, if a different reference is wanted.
- The company seats board (5 fixed columns = 1264px) now scrolls sideways by ~90px at 1440 where it used to grow to fill. That is the rule this PR sets; flagging it because it is visible.
- Pre-existing, not touched: the company People/coverage screen's `.scroll` overflows by 6px at 1440 (identical before this change). Worth an `area: frontend` issue.

## Proposal (not done here)
The phone swipe proportion depends on two numbers that cannot see each other: the board's `--board-col-w` and the surrounding surface's padding. A board dropped into a surface with different padding silently changes how much of the next stage peeks, and only the /#/deals e2e would notice. Either the board publishes its inner width as a custom property both rules read, or a gate asserts the 390px proportion on every surface that mounts a `PipelineBoard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pipeline board columns now maintain a consistent width on larger screens.
  - On smaller screens, the board supports horizontal swiping with snap-to-stage navigation and a visible preview of the next stage.
  - Scrollbar accents now appear only when the pointer is directly over the corresponding scroller.

- **Bug Fixes**
  - Prevented board content from overflowing horizontally.
  - Improved handling of long totals, weighted values, and refusal messages so text remains readable in narrow columns.
  - Folded stages no longer affect the shared board width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->