### PR TITLE
A settings page is found by the word the reader already has for it

### DIFF
--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -414,6 +414,10 @@ export function NavLevelView({
       {levelTitle(level, t) && (
         <h2 className="navtitle">{levelTitle(level, t)}</h2>
       )}
+      {/* Above the rows and below the level's own name: a reader looking for a
+          page reaches for the search before they start reading a list of
+          twenty-eight. */}
+      {level.lead && <div className="navlead">{level.lead}</div>}
       {level.groups.map((group, index) => (
         <NavLevelGroupView
           key={group.headingKey ?? `group-${index}`}

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -1779,3 +1779,101 @@
   container-type: inline-size;
   container-name: work;
 }
+
+/* Settings search, standing above the rail's rows.
+ *
+ * The rows below it are twenty-eight on an admin seat, so the box is the first
+ * thing a reader reaches for. Every interval and colour is a token: a raw value
+ * here would be the one gap in the rail that does not move when the scale does.
+ *
+ * Not `.suggest-popup`'s geometry, and deliberately: that list is PORTALLED and
+ * measured against the viewport because its anchor can sit anywhere in a form.
+ * This one lives in the rail, which is a positioned column of known width, so
+ * it hangs off its own wrapper and needs no measuring at all. */
+.navlead {
+  padding: var(--space-2) var(--space-3);
+}
+
+/* Absent in the collapsed rail, which is 56px wide: a text field in there is a
+   box too narrow to read your own typing in, over a result list narrower still.
+   The rail's own rows survive collapse because each is an icon with a tooltip;
+   a search box has no icon-sized form, so it stands down rather than shrinking
+   into an unusable one. Expanding the rail brings it back. */
+.rail.collapsed .navlead {
+  display: none;
+}
+
+.settingssearch {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.settingssearch > svg {
+  position: absolute;
+  left: var(--space-2);
+  width: 16px;
+  height: 16px;
+  color: var(--textMeta);
+  /* Decoration over the field: it must not eat a click aimed at the box. */
+  pointer-events: none;
+}
+
+.settingssearch input {
+  width: 100%;
+  height: var(--control-h-sm);
+  padding-inline: calc(var(--space-2) + 16px + var(--space-1)) var(--space-2);
+  border: 1px solid var(--borderStrong);
+  border-radius: var(--r-sm);
+  background: var(--bgElevated);
+  color: var(--textPrimary);
+  font-family: var(--f-body);
+  font-size: var(--fs-body);
+}
+
+.settingssearch input:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* Over the rows rather than pushing them down: a rail that grew by four rows
+   while a reader typed would move the destination they were reaching for. */
+.settingssearch-list {
+  position: absolute;
+  z-index: 70;
+  top: calc(100% + var(--space-1));
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-1);
+  border: 1px solid var(--borderStrong);
+  border-radius: var(--r-sm);
+  background: var(--bgElevated);
+  box-shadow: var(--shadow-pop);
+  max-height: 60vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.settingssearch-hit {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--r-sm);
+  color: var(--textPrimary);
+  text-decoration: none;
+}
+
+/* One state for keyboard and pointer, because the list tracks one active
+   option through `aria-activedescendant` whichever input moved it. */
+.settingssearch-hit.active,
+.settingssearch-hit:hover {
+  background: var(--bgHover);
+}
+
+.settingssearch-empty {
+  padding: var(--space-1) var(--space-2);
+  color: var(--textMeta);
+  font-size: var(--fs-body);
+}

--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import type { Locale } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { type CustomLabel, resolveCustomLabel } from "./custom";
@@ -94,6 +95,11 @@ export type NavSection = {
   titleKey: MessageKey;
   groups: readonly NavLevelGroup[];
   activeId?: string;
+  // Something that stands ABOVE the level's rows without being one of them —
+  // settings puts its search box here. On the section AND on NavTrailLevel
+  // below, because the trail is what the rail actually renders: a slot added to
+  // one alone is a field nothing draws.
+  lead?: ReactNode;
 };
 
 // The attention counts the rail badges. They ride the level rather than being
@@ -105,6 +111,9 @@ export type NavCounts = Partial<Record<string, number>>;
 // level does not know its own depth: `path` is the route prefix its entries hang
 // off, which is the only thing depth changes.
 export type NavTrailLevel = {
+  // See NavSection.lead. Carried down by navTrail, which is the only path from
+  // a section to a rendered level.
+  lead?: ReactNode;
   // Absent on the primary level, which the navigation landmark already names.
   // Present, it prints the level's own heading and pushes the group labels a
   // heading level down.
@@ -237,6 +246,7 @@ export function navTrail(
   let level: NavTrailLevel = {
     titleKey: section.titleKey,
     groups: section.groups,
+    lead: section.lead,
     activeId: section.activeId ?? route.id,
     // The SECTION's screen, which every row in it points under. Identical to the
     // route's for a route of that screen, and the only correct one for a unit

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6125,6 +6125,10 @@ export const de = {
     "Die Einheiten, die dieser Build zusammengesetzt hat, und welche Rollen sie erreichen.",
   "settings.page.reset.sub":
     "Diese Installation leeren. Es gibt kein Zur\u00fcck.",
+  "settings.search.label": "Einstellungen durchsuchen",
+  "settings.search.placeholder": "Einstellungen suchen",
+  "settings.search.none": "Keine Einstellungsseite passt dazu.",
+  "settings.search.count": "{n} Einstellungsseiten passen.",
   "settings.tab.company": "Unternehmensprofil",
   "settings.tab.authentication": "Anmeldung & Apps",
   "settings.tab.members": "Mitglieder",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6260,6 +6260,10 @@ export const en = {
   "settings.page.extensions.sub":
     "The units this build composed, and which roles reach them.",
   "settings.page.reset.sub": "Emptying this installation. There is no undo.",
+  "settings.search.label": "Search settings",
+  "settings.search.placeholder": "Search settings",
+  "settings.search.none": "No settings page matches that.",
+  "settings.search.count": "{n} settings pages match.",
   "settings.tab.company": "Company profile",
   "settings.tab.authentication": "Sign-in & apps",
   "settings.tab.members": "Members",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6061,6 +6061,11 @@ export const vi = {
     "C\u00e1c \u0111\u01a1n v\u1ecb b\u1ea3n d\u1ef1ng n\u00e0y \u0111\u00e3 k\u1ebft h\u1ee3p, v\u00e0 vai tr\u00f2 n\u00e0o t\u1edbi \u0111\u01b0\u1ee3c.",
   "settings.page.reset.sub":
     "L\u00e0m r\u1ed7ng b\u1ea3n tri\u1ec3n khai n\u00e0y. Kh\u00f4ng th\u1ec3 ho\u00e0n t\u00e1c.",
+  "settings.search.label": "T\u00ecm trong c\u00e0i \u0111\u1eb7t",
+  "settings.search.placeholder": "T\u00ecm c\u00e0i \u0111\u1eb7t",
+  "settings.search.none":
+    "Kh\u00f4ng c\u00f3 trang c\u00e0i \u0111\u1eb7t n\u00e0o kh\u1edbp.",
+  "settings.search.count": "{n} trang c\u00e0i \u0111\u1eb7t kh\u1edbp.",
   "settings.tab.company": "Hồ sơ công ty",
   "settings.tab.authentication": "Đăng nhập & ứng dụng",
   "settings.tab.members": "Thành viên",

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RbacObject } from "../app/capability";
 import { type GrantSpec, meFixture } from "../app/mefixture";
@@ -1136,6 +1137,47 @@ describe("SettingsScreen page visibility", () => {
 // hand would agree with itself while the catalog moved underneath it.
 it("keeps the home row's id out of the page vocabulary", () => {
   expect(SETTINGS_PAGES.map((page) => page.id)).not.toContain(SETTINGS_HOME_ID);
+});
+
+// The search box in the rail searches the READER'S pages, not the catalog.
+//
+// The box's own tests hand it a page list directly, so they cannot see which
+// list the rail passes — a wiring that handed it SETTINGS_PAGES would offer a
+// rep the audit log, and every one of those tests would still pass. This is the
+// case that fails when that happens.
+describe("the settings search in the rail", () => {
+  it("offers a rep no page their own sidebar does not draw", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow: {} }));
+    renderNav();
+
+    // Waited on a row a resolved snapshot draws, so the empty result below is
+    // about the grants rather than about a rail that has not loaded.
+    await screen.findByRole("link", { name: labelOf("account") });
+    await user.type(screen.getByRole("combobox"), "audit");
+
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+
+  // The control: the same word, one grant apart. Without it the case above
+  // would pass against a search that finds nothing for anybody.
+  it("offers the page to a reader who holds its grant", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({ roles: ["admin"], allow: readOn("audit_log") }),
+    );
+    renderNav();
+
+    await screen.findByRole("link", { name: labelOf("audit") });
+    await user.type(screen.getByRole("combobox"), "audit");
+
+    expect(
+      screen
+        .queryAllByRole("option")
+        .some((option) => option.textContent?.includes(labelOf("audit"))),
+    ).toBe(true);
+  });
 });
 
 describe("the settings access boundary", () => {

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -42,6 +42,7 @@ import {
   visibleSettingsPages,
 } from "./settingscatalog";
 import { settingsRouteTarget } from "./settingsrouting";
+import { SettingsSearchBox } from "./settingssearchbox";
 
 // The entry register: one section nav entry per settings SUBJECT. Only surfaces
 // this app actually renders get one — the mockup's Booking / Flow /
@@ -587,6 +588,10 @@ export function useSettingsSection(route: Route): NavSection {
   return {
     screen: SETTINGS_SCREEN,
     titleKey: "nav.settings",
+    // The search stands above the rows and searches exactly the pages below it
+    // — the same `pages` this function grouped, so a hit can never name a page
+    // the rail did not draw.
+    lead: <SettingsSearchBox pages={pages} />,
     // No row is current on a route that is not one of the tabs. An extension
     // unit's page keeps this level in the sidebar — it is reached from here and
     // its trail says so — but it is not a settings tab, and `settingsRouteTab`

--- a/frontend/src/screens/settingssearch.test.ts
+++ b/frontend/src/screens/settingssearch.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import { translate } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import {
+  SETTINGS_PAGES,
+  type SettingsPage,
+  type SettingsPageId,
+} from "./settingscatalog";
+import { settingsSearch } from "./settingssearch";
+
+const t = (key: MessageKey) => translate("en", key);
+const de = (key: MessageKey) => translate("de", key);
+
+// Every page, as an admin holding everything sees them.
+//
+// Widened to the readonly array `settingsSearch` takes: `SETTINGS_PAGES` is a
+// 28-element TUPLE, so a filtered subset is not assignable to it and every case
+// that narrows the reader's pages would fail to compile.
+const ALL: readonly SettingsPage[] = SETTINGS_PAGES;
+
+function ids(
+  query: string,
+  pages: readonly SettingsPage[] = ALL,
+  translator = t,
+): SettingsPageId[] {
+  return settingsSearch(query, pages, translator).map((hit) => hit.page.id);
+}
+
+describe("settingsSearch", () => {
+  it("finds a page by its own name", () => {
+    expect(ids("audit")).toContain("audit");
+  });
+
+  // The whole point of aliases: a reader searches for the THING they want to
+  // change, not for the page that happens to hold it. Nobody looking for their
+  // password types "account".
+  it.each([
+    ["password", "account"],
+    ["gdpr", "privacy"],
+    ["webhook", "integrations"],
+    ["csv", "import"],
+    ["licence", "seats"],
+    ["stage", "pipelines"],
+  ] as const)("finds the page that owns %s", (query, page) => {
+    expect(ids(query)).toContain(page);
+  });
+
+  // A reader types a phrase as one thought, and its words live in different
+  // fields — "email" in one alias, "signature" in another beside it. Demanding
+  // the whole phrase be one substring answered nothing for exactly the queries
+  // a person composes naturally.
+  it.each([
+    ["email signature", "account"],
+    ["lead source", "leads"],
+    ["sign in", "authentication"],
+  ] as const)("answers the phrase %p", (query, page) => {
+    expect(ids(query)).toContain(page);
+  });
+
+  // Every word must land, or a reader who typed two words gets pages that
+  // answer only one of them — which is a longer list, not a better one.
+  it("answers nothing when only half the phrase matches", () => {
+    expect(ids("audit kubernetes")).toEqual([]);
+  });
+
+  // "billing" used to reach Seats & license, which reads the entitlement the
+  // deployment file sets and carries no control at all — a reader looking to
+  // change what they pay would have been sent to a page that cannot.
+  it("does not promise a page that cannot answer the word", () => {
+    expect(ids("billing")).toEqual([]);
+  });
+
+  // The old vocabulary still works. A reader who learnt this product before the
+  // redesign, or who has a bookmark, types the word they know.
+  it("still answers the names the redesign replaced", () => {
+    expect(ids("general")).toContain("company");
+    expect(ids("users")).toContain("members");
+    expect(ids("data model")).toContain("fields");
+  });
+
+  // Two pages can each honestly answer one word, and picking one would make the
+  // search wrong for everybody who meant the other.
+  it("offers both pages a shared word reaches", () => {
+    const hits = ids("email");
+    expect(hits).toContain("connections");
+    expect(hits).toContain("capture");
+  });
+
+  // The page's own name outranks a word it merely answers to.
+  it("puts a name match above an alias match", () => {
+    const hits = ids("tags");
+    expect(hits[0]).toBe("tags");
+  });
+
+  // A prefix is a stronger signal than a substring: somebody typing "au" is
+  // starting a word, not naming a fragment.
+  it("puts a prefix above a contained match", () => {
+    const hits = settingsSearch("audit", ALL, t);
+    expect(hits[0]?.page.id).toBe("audit");
+  });
+
+  // PERMISSION IS THE CALLER'S LIST. The search cannot widen it, because it
+  // never asks who is reading — it is handed the pages the sidebar drew.
+  it("finds nothing a reader's own page list does not contain", () => {
+    const personal = ALL.filter((page) => page.group === "me");
+    expect(ids("audit", personal)).toEqual([]);
+    expect(ids("gdpr", personal)).toEqual([]);
+    // …and still finds what IS theirs, so the empty results above are about the
+    // missing pages rather than about a search that answers nothing.
+    expect(ids("password", personal)).toContain("account");
+  });
+
+  // An empty query is not a request for everything. The sidebar is already the
+  // list of everything, and repeating it under a search box would tell the
+  // reader they had searched.
+  it.each(["", "   "])("answers nothing for the empty query %p", (query) => {
+    expect(ids(query)).toEqual([]);
+  });
+
+  it("answers nothing for a word no page holds", () => {
+    expect(ids("kubernetes")).toEqual([]);
+  });
+
+  // A reader types what their keyboard gives them. Folding one direction only
+  // would make the unaccented spelling miss the accented label.
+  it("matches a German label with and without its diacritics", () => {
+    const accented = de("settings.tab.reset");
+    const plain = accented.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+    expect(ids(accented, ALL, de)).toContain("reset");
+    expect(ids(plain, ALL, de)).toContain("reset");
+  });
+
+  // Case is not a signal either.
+  it("ignores case", () => {
+    expect(ids("AUDIT")).toContain("audit");
+    expect(ids("AuDiT")).toContain("audit");
+  });
+
+  // Every hit carries where it lives, because "Tags" alone does not say whether
+  // the reader has found the vocabulary or something else.
+  it("says which group each hit sits under", () => {
+    const [hit] = settingsSearch("audit", ALL, t);
+    expect(hit?.group).toBe(translate("en", "settings.group.governance"));
+    expect(hit?.label).toBe(translate("en", "settings.tab.audit"));
+  });
+
+  // A gate reading no pages would pass every claim above.
+  it("has pages to search at all", () => {
+    expect(ALL.length).toBeGreaterThan(20);
+  });
+});

--- a/frontend/src/screens/settingssearch.ts
+++ b/frontend/src/screens/settingssearch.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { foldForMatch } from "../format/collate";
+import type { MessageKey } from "../i18n/en";
+import type { SettingsPage, SettingsPageId } from "./settingscatalog";
+
+/**
+ * Finding a setting by the word a reader already has for it.
+ *
+ * Pure, and deliberately: it takes the pages this reader may open rather than
+ * asking who they are, so the same list that draws the sidebar decides what the
+ * search can find. A search that resolved permission separately would eventually
+ * disagree with the navigation beside it, and the disagreement a reader notices
+ * is the one where search offers a page that then refuses them.
+ *
+ * It never calls an endpoint. Twenty-eight rows is not a query.
+ */
+
+/**
+ * The words a page answers to besides its own name.
+ *
+ * Three kinds, and each earns its place:
+ *
+ *   - the OLD name, so a reader who learnt "General" still finds Company
+ *     profile and a stale bookmark's word still works;
+ *   - the plain noun, because a reader searches for the thing they want to
+ *     change ("password", "logo", "vat") rather than the page that holds it;
+ *   - the neighbouring word, where two pages could each plausibly answer —
+ *     "email" reaches both Connections and Capture, and letting one of them
+ *     hide the other would make the search wrong for half of its askers.
+ *
+ * English only, on purpose. These are search aliases rather than copy: a
+ * German reader's query lands on the translated LABEL, which is already
+ * indexed, and inventing a German alias for a word nobody types would be a
+ * translation of a guess.
+ */
+const ALIASES: Partial<Record<SettingsPageId, readonly string[]>> = {
+  account: [
+    "password",
+    "name",
+    "email",
+    "language",
+    "signature",
+    "profile",
+    "brief",
+    "theme",
+    "appearance",
+  ],
+  voice: ["writing", "tone", "style", "drafts"],
+  agents: ["passport", "token", "api", "mcp", "credentials", "automation"],
+  connections: ["mailbox", "imap", "gmail", "outlook", "email", "linkedin"],
+  "capture-activity": ["mail", "email", "held", "judgement", "why"],
+  company: [
+    "general",
+    "installation",
+    "currency",
+    "logo",
+    "vat",
+    "address",
+    "timezone",
+    "fiscal year",
+    "context",
+  ],
+  authentication: [
+    "sign in",
+    "login",
+    "sso",
+    "oidc",
+    "oauth",
+    "google",
+    "microsoft",
+    "app",
+  ],
+  members: ["users", "people", "invite", "seat", "deactivate", "roles"],
+  teams: ["team", "group", "manager"],
+  seats: ["license", "licence", "entitlement", "capacity", "headcount"],
+  pipelines: ["stage", "deal", "funnel", "won", "lost"],
+  leads: ["lead", "source", "vocabulary", "qualification"],
+  fields: ["custom field", "data model", "column", "attribute"],
+  tags: ["tag", "label", "vocabulary"],
+  products: ["product", "offer", "template", "price", "catalog"],
+  capture: ["mail", "email", "domain", "sharing", "inbox", "rules"],
+  integrations: ["webhook", "overlay", "hubspot", "mirror", "sync"],
+  knowledge: ["document", "corpus", "rag", "upload"],
+  import: ["csv", "upload", "migration", "bulk"],
+  models: ["ai", "routing", "provider", "anthropic", "openai", "key"],
+  automations: ["rule", "workflow", "trigger", "automation"],
+  usage: ["spend", "cost", "budget", "tokens", "money"],
+  "model-calls": ["trace", "log", "call", "debug", "prompt"],
+  privacy: ["gdpr", "dsr", "consent", "retention", "erasure", "purpose"],
+  audit: ["trail", "log", "who", "history", "compliance"],
+  "system-health": ["jobs", "queue", "reindex", "maintenance", "stuck"],
+  extensions: ["unit", "plugin", "module", "extension"],
+  reset: ["empty", "wipe", "delete everything", "danger"],
+};
+
+/**
+ * A form of the text that matches the way people actually type.
+ *
+ * Diacritics folded, because a reader searching a German or Vietnamese label
+ * types what their keyboard gives them and a fold in one direction only would
+ * make "Zurucksetzen" miss "Zurücksetzen" while the reverse worked.
+ *
+ * The CASE fold is `foldForMatch`, not `toLocaleLowerCase`: a locale-aware fold
+ * maps Turkish `I` to a dotless `ı`, so a needle folded under one locale stops
+ * matching a haystack folded under another — and both sides of this comparison
+ * are strings the product holds rather than a sentence anybody reads.
+ */
+function fold(text: string): string {
+  return foldForMatch(text.normalize("NFD").replace(/\p{Diacritic}/gu, ""));
+}
+
+export type SettingsHit = {
+  page: SettingsPage;
+  /** The page's own name, already translated — what the row shows. */
+  label: string;
+  /** The group it sits under, so a hit says where it lives. */
+  group: string;
+};
+
+/**
+ * The pages matching `query`, best first.
+ *
+ * `pages` is the reader's OWN visible list, so nothing here can offer a page
+ * the sidebar would not. An empty query returns nothing rather than everything:
+ * the sidebar is already the list of everything, and repeating it under a
+ * search box would say the reader had searched for something.
+ */
+export function settingsSearch(
+  query: string,
+  pages: readonly SettingsPage[],
+  t: (key: MessageKey) => string,
+): readonly SettingsHit[] {
+  // Split on whitespace, and every word must land somewhere. A reader types
+  // "email signature" as one thought, but the two words live in different
+  // fields — "email" in the page's aliases, "signature" in another alias
+  // beside it — so demanding that the whole phrase be one substring answered
+  // nothing for exactly the queries a person composes naturally.
+  const words = fold(query)
+    .split(/\s+/)
+    .filter((word) => word !== "");
+  if (words.length === 0) {
+    return [];
+  }
+  const scored: { hit: SettingsHit; rank: number }[] = [];
+  for (const page of pages) {
+    const label = t(`settings.tab.${page.id}`);
+    const group = t(`settings.group.${page.group}`);
+    const sub = t(`settings.page.${page.id}.sub`);
+    const fields = [
+      // Order is the ranking: a hit on the page's own name beats one on its
+      // description, which beats one on a word it merely answers to.
+      fold(label),
+      fold(group),
+      ...(ALIASES[page.id] ?? []).map(fold),
+      fold(sub),
+    ];
+    // Every word, or the page does not answer. Ranked by the BEST field any
+    // one word reached, so "email signature" ranks under the same rule a
+    // single word would — and a page matching only half the phrase is out
+    // rather than ranked low, because a reader who typed two words meant both.
+    const ranks = words.map((word) => rankOf(word, fields));
+    if (ranks.every((rank) => rank !== undefined)) {
+      scored.push({
+        hit: { page, label, group },
+        rank: Math.min(...(ranks as number[])),
+      });
+    }
+  }
+  return scored
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        // Ties keep CATALOG order rather than falling to alphabetical: the
+        // reader has just been looking at that order in the sidebar.
+        pages.indexOf(a.hit.page) - pages.indexOf(b.hit.page),
+    )
+    .map((entry) => entry.hit);
+}
+
+/**
+ * How well the needle matches, lower being better, or undefined for no match.
+ *
+ * A prefix beats a contained substring at the same field, so typing "au" puts
+ * Audit log above the pages that merely contain those letters. Beyond that the
+ * FIELD decides, which is what the caller's ordering above encodes.
+ */
+function rankOf(needle: string, fields: readonly string[]): number | undefined {
+  for (const [index, field] of fields.entries()) {
+    if (field.startsWith(needle)) {
+      return index * 2;
+    }
+    if (field.includes(needle)) {
+      return index * 2 + 1;
+    }
+  }
+  return undefined;
+}
+
+export { fold as foldForSearch };

--- a/frontend/src/screens/settingssearchbox.test.tsx
+++ b/frontend/src/screens/settingssearchbox.test.tsx
@@ -1,0 +1,232 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as router from "../app/router";
+import { LocaleProvider } from "../i18n";
+import { SETTINGS_PAGES, type SettingsPage } from "./settingscatalog";
+import { SettingsSearchBox } from "./settingssearchbox";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// The readonly array the box takes, not the 28-element tuple `SETTINGS_PAGES`
+// is: a case narrowing the reader's pages hands it a filtered subset.
+function mount(pages: readonly SettingsPage[] = SETTINGS_PAGES) {
+  return render(
+    <LocaleProvider initial="en">
+      <SettingsSearchBox pages={pages} />
+    </LocaleProvider>,
+  );
+}
+
+const box = () => screen.getByRole("combobox");
+const options = () => screen.queryAllByRole("option");
+
+describe("the settings search box", () => {
+  it("offers nothing until something is typed", () => {
+    mount();
+    expect(options()).toHaveLength(0);
+    expect(box().getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("offers the pages a word reaches", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "audit");
+
+    expect(options().length).toBeGreaterThan(0);
+    expect(
+      options().some((option) => option.textContent?.includes("Audit log")),
+    ).toBe(true);
+    expect(box().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  // The search is handed the reader's own pages, so it cannot offer one the
+  // sidebar did not draw. Asserted through the CONTROL rather than only through
+  // the pure function, because the wiring is where a widening would happen.
+  it("cannot offer a page the reader was not given", async () => {
+    const user = userEvent.setup();
+    mount(SETTINGS_PAGES.filter((page) => page.group === "me"));
+    await user.type(box(), "audit");
+
+    expect(options()).toHaveLength(0);
+    expect(screen.getByRole("status").textContent).toMatch(/0 settings pages/);
+  });
+
+  // A word that matches nothing is SAID. A box that did nothing would leave a
+  // reader wondering whether it was still thinking.
+  it("says so when nothing matches", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "kubernetes");
+
+    expect(options()).toHaveLength(0);
+    expect(screen.getByText(/no settings page matches/i)).toBeTruthy();
+  });
+
+  it("moves the active option with the arrows, and wraps", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "e");
+    const count = options().length;
+    expect(count).toBeGreaterThan(1);
+
+    await user.keyboard("{ArrowDown}");
+    expect(options()[0]?.getAttribute("aria-selected")).toBe("true");
+    expect(box().getAttribute("aria-activedescendant")).toBe(options()[0]?.id);
+
+    // Up from the first wraps to the last rather than stopping: a reader
+    // reaching past the top means the other end.
+    await user.keyboard("{ArrowUp}");
+    expect(options()[count - 1]?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("opens the active option on Enter", async () => {
+    const user = userEvent.setup();
+    const navigate = vi.spyOn(router, "navigate").mockImplementation(() => {});
+    mount();
+    await user.type(box(), "audit");
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(navigate).toHaveBeenCalledWith({ screen: "settings", id: "audit" });
+  });
+
+  // Enter on an untouched query opens nothing: the first row is a candidate,
+  // not a choice the reader has made.
+  it("opens nothing on Enter before an option is chosen", async () => {
+    const user = userEvent.setup();
+    const navigate = vi.spyOn(router, "navigate").mockImplementation(() => {});
+    mount();
+    await user.type(box(), "audit");
+    await user.keyboard("{Enter}");
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  // Escape clears the query and KEEPS the focus. A reader who clears a search
+  // is still searching; throwing them out would make them find the box again.
+  it("clears on Escape and keeps the focus", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "audit");
+    expect(options().length).toBeGreaterThan(0);
+
+    await user.keyboard("{Escape}");
+    expect(options()).toHaveLength(0);
+    expect((box() as HTMLInputElement).value).toBe("");
+    expect(document.activeElement).toBe(box());
+  });
+
+  // Pointer and keyboard reach the same place, by the same route.
+  it("opens a hit on click", async () => {
+    const user = userEvent.setup();
+    const navigate = vi.spyOn(router, "navigate").mockImplementation(() => {});
+    mount();
+    await user.type(box(), "audit");
+    // The option IS the anchor now — a link nested inside one would be a
+    // second interactive element inside an interactive row.
+    const hit = options().find((option) =>
+      option.textContent?.includes("Audit log"),
+    );
+    await user.click(hit as HTMLElement);
+
+    expect(navigate).toHaveBeenCalledWith({ screen: "settings", id: "audit" });
+  });
+
+  // Every hit is a real link, so it can be opened in a tab and copied like any
+  // other row in the rail beside it.
+  it("gives every hit an address of its own", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "audit");
+
+    // The loop proves nothing over an empty list, which is what it would be
+    // if the search had answered nothing.
+    expect(options().length).toBeGreaterThan(0);
+    for (const option of options()) {
+      expect(option.getAttribute("href")).toMatch(/^#\/settings\/[a-z-]+$/);
+    }
+  });
+
+  // A modified click is the reader asking the BROWSER for a new tab, and
+  // preventDefault on it would silently take that away — which is why these
+  // rows are anchors rather than buttons.
+  it("leaves a cmd-click to the browser", async () => {
+    const user = userEvent.setup();
+    const navigate = vi.spyOn(router, "navigate").mockImplementation(() => {});
+    mount();
+    await user.type(box(), "audit");
+    const hit = options().find((option) =>
+      option.textContent?.includes("Audit log"),
+    );
+    await user.keyboard("{Meta>}");
+    await user.click(hit as HTMLElement);
+    await user.keyboard("{/Meta}");
+
+    // The SPA did not answer it; the href did.
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  // A no-result query still SHOWS a popup, so the combobox must say it is
+  // expanded. It used to report collapsed while the "nothing matches" panel
+  // stood open, which is a control describing itself wrongly to the one reader
+  // who depends on the description.
+  it("reports itself expanded whenever the panel is on screen", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "kubernetes");
+
+    expect(screen.getByText(/no settings page matches/i)).toBeTruthy();
+    expect(box().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  // The rows are driven from the input by aria-activedescendant, so they must
+  // not join the page's Tab sequence — Tab from the box goes to the next
+  // control, not into the list.
+  it("keeps the options out of the tab sequence", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "audit");
+
+    for (const option of options()) {
+      expect(option.getAttribute("tabindex")).toBe("-1");
+    }
+  });
+
+  // A click elsewhere closes the list and KEEPS the query: a reader who looks
+  // away has not abandoned what they typed.
+  it("closes on a click outside without losing the query", async () => {
+    const user = userEvent.setup();
+    mount();
+    await user.type(box(), "audit");
+    expect(options().length).toBeGreaterThan(0);
+
+    await user.click(document.body);
+    expect(options()).toHaveLength(0);
+    expect((box() as HTMLInputElement).value).toBe("audit");
+
+    // …and typing brings it back, rather than leaving the reader with a box
+    // that has stopped answering.
+    await user.type(box(), "x{Backspace}");
+    expect(options().length).toBeGreaterThan(0);
+  });
+
+  // The query goes when the reader arrives: a list left standing over the page
+  // they just opened is a list they have to dismiss before reading it.
+  it("clears itself after opening a page", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(router, "navigate").mockImplementation(() => {});
+    mount();
+    await user.type(box(), "audit");
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect((box() as HTMLInputElement).value).toBe("");
+    expect(options()).toHaveLength(0);
+  });
+});

--- a/frontend/src/screens/settingssearchbox.tsx
+++ b/frontend/src/screens/settingssearchbox.tsx
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Search } from "lucide-react";
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
+import { navigate } from "../app/router";
+import { useT } from "../i18n";
+import type { SettingsPage } from "./settingscatalog";
+import { settingsHref } from "./settingsrouting";
+import { settingsSearch } from "./settingssearch";
+
+/**
+ * Finding a settings page by typing.
+ *
+ * NOT `ComboBox` or `useSuggestList`, and the reason is the contract rather
+ * than the looks. Those bind a VALUE: the list is help toward what goes in the
+ * box, they do their own matching (`matchingSuggestions`), and an empty query
+ * offers everything because everything is a candidate value. This one
+ * NAVIGATES: the box is never the answer, the ranking is
+ * permission-filtered and computed by `settingsSearch`, and an empty query must
+ * offer nothing — the sidebar beside it is already the list of everything.
+ *
+ * Wiring this to that hook would mean overriding its matcher, its empty case
+ * and its pick semantics, which is the shape of reuse that leaves both callers
+ * worse. The keyboard grammar below is deliberately the SAME grammar, because a
+ * reader should not have to learn two.
+ */
+export function SettingsSearchBox({
+  pages,
+}: Readonly<{ pages: readonly SettingsPage[] }>) {
+  const t = useT();
+  const [typed, setTyped] = useState("");
+  // -1 is "nothing active", which is where a fresh query starts: the first row
+  // is not chosen until the reader reaches for it, so Enter on an untouched
+  // query does nothing rather than opening a page they never looked at.
+  const [active, setActive] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const activeRef = useRef<HTMLAnchorElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  // Closed by a click outside or by Escape, without clearing what was typed —
+  // a reader who looks away has not abandoned their query.
+  const [dismissed, setDismissed] = useState(false);
+  const listboxId = useId();
+
+  // The active row kept in view. The list is capped at 60vh, so wrapping
+  // ArrowUp from the first hit selects the LAST one — and without this, Enter
+  // then opens a page the reader never saw selected.
+  useEffect(() => {
+    // `active` is read here rather than only in the dependency list, so the
+    // effect's subject is visible in its own body: it runs BECAUSE the active
+    // row moved, and a dependency array carrying a value the body never
+    // mentions is the shape a linter is right to question.
+    if (active < 0) {
+      return;
+    }
+    // Guarded on the METHOD, not the element: jsdom implements neither
+    // scrolling nor this call, and a keyboard test should fail on the keyboard
+    // rather than on a browser API the environment does not have.
+    activeRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [active]);
+
+  const hits = settingsSearch(typed, pages, t);
+  // Whether the popup is ON SCREEN, which is what `aria-expanded` must report.
+  // It was `hits.length > 0`, so a query matching nothing rendered a visible
+  // popup while the combobox told assistive technology it was collapsed.
+  const showList = typed.trim() !== "" && !dismissed;
+  const open = showList;
+
+  // A click anywhere else closes the popup, without clearing the query. Without
+  // it the list stayed over the page after the reader had plainly moved on.
+  useEffect(() => {
+    if (!showList) {
+      return;
+    }
+    function onPointerDown(event: MouseEvent) {
+      if (!wrapRef.current?.contains(event.target as Node)) {
+        setDismissed(true);
+      }
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [showList]);
+  // The id of one option's element, built HERE rather than interpolated at each
+  // call site. Two reasons, and the second is why it is a function: the row and
+  // the `aria-activedescendant` pointing at it must spell the same id or the
+  // reference dangles, and an index interpolated into JSX is what
+  // `format/jsx-magnitude.test.ts` reads as an unformatted magnitude reaching a
+  // reader. This one never reaches one — it is a DOM id — and the same shape
+  // (`optionDomId` in design-system/suggestlist.tsx) is how the rest of the
+  // tree says so.
+  const optionDomId = (index: number) => `${listboxId}-option-${index}`;
+
+  function go(index: number) {
+    const hit = hits[index];
+    if (!hit) {
+      return;
+    }
+    // Closed before the move, or the list would flash over the page the reader
+    // has just arrived at.
+    setTyped("");
+    setActive(-1);
+    navigate(settingsHref(hit.page.id));
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      // The text goes and the focus STAYS. A reader who clears a search is
+      // still searching; throwing them back to the page would make them find
+      // the box again to type the next word.
+      event.preventDefault();
+      setTyped("");
+      setActive(-1);
+      return;
+    }
+    if (!open) {
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActive((current) => (current + 1) % hits.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActive((current) => (current <= 0 ? hits.length - 1 : current - 1));
+      return;
+    }
+    if (event.key === "Enter" && active >= 0) {
+      event.preventDefault();
+      go(active);
+    }
+  }
+
+  return (
+    <div className="settingssearch" ref={wrapRef}>
+      {/* The combobox is the INPUT, not the wrapper: a wrapper carrying the
+          role would put the text field inside its own combobox, and a screen
+          reader would announce a group where there is a control. */}
+      <Search aria-hidden="true" />
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        // `list` rather than `both`: nothing is written into the box on
+        // arrowing, so claiming inline completion would promise a behaviour
+        // this control does not have.
+        aria-autocomplete="list"
+        aria-activedescendant={active >= 0 ? optionDomId(active) : undefined}
+        aria-label={t("settings.search.label")}
+        placeholder={t("settings.search.placeholder")}
+        value={typed}
+        onChange={(event) => {
+          setTyped(event.target.value);
+          setActive(-1);
+          // Typing is the reader coming back to it.
+          setDismissed(false);
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {showList && (
+        /* A div rather than ul/li: `role="listbox"` on a list element is a
+           second role over one that already means something. */
+        <div className="settingssearch-list" id={listboxId} role="listbox">
+          {hits.length === 0 ? (
+            /* Not an option: there is nothing to choose, and a listbox with one
+               unselectable row would let a reader arrow onto a sentence. */
+            <p className="settingssearch-empty">{t("settings.search.none")}</p>
+          ) : (
+            hits.map((hit, index) => (
+              /* An anchor, so a hit is a real address — copyable, and openable
+                 in a tab by every modifier the browser understands.
+
+                 `tabIndex={-1}`: a combobox's popup is driven by
+                 `aria-activedescendant` from the input, and its rows must not
+                 join the page's Tab sequence. Tab from the box goes on to the
+                 next control, as the pattern requires.
+
+                 `onClick`, not `onMouseDown`: activating on mousedown fires
+                 before the click completes, which takes a drag-to-cancel away
+                 and beats the browser to its own modifier handling. The blur
+                 problem it was solving is solved by `onMouseDown`'s
+                 preventDefault below, which keeps focus in the input WITHOUT
+                 acting. */
+              <a
+                key={hit.page.id}
+                id={optionDomId(index)}
+                role="option"
+                tabIndex={-1}
+                aria-selected={index === active}
+                ref={index === active ? activeRef : undefined}
+                className={
+                  index === active
+                    ? "settingssearch-hit active"
+                    : "settingssearch-hit"
+                }
+                href={`#/settings/${hit.page.id}`}
+                onMouseDown={(event) => {
+                  // Focus stays in the box; nothing is opened here.
+                  event.preventDefault();
+                }}
+                onClick={(event) => {
+                  // Every modified click belongs to the BROWSER — a new tab, a
+                  // new window, a download. Only the plain one is ours.
+                  if (
+                    event.metaKey ||
+                    event.ctrlKey ||
+                    event.shiftKey ||
+                    event.altKey
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  go(index);
+                }}
+              >
+                <span className="settingssearch-label">{hit.label}</span>
+                {/* `t-caption`, the catalogued utility, rather than a rule of
+                    its own saying the same two properties. */}
+                <span className="t-caption">{hit.group}</span>
+              </a>
+            ))
+          )}
+        </div>
+      )}
+      {/* The count, for a reader who cannot see the list appear. Polite, so it
+          waits for a pause in typing rather than interrupting every keystroke. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {typed.trim() === ""
+          ? ""
+          : t("settings.search.count").replace("{n}", String(hits.length))}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Typing "password" reaches Account, "gdpr" reaches Privacy, "webhook" reaches
Integrations. Nobody looking for their password searches for "account", so each
page carries the words a reader actually types: the name it had before this
redesign, the noun for the thing they mean to change, and the neighbouring word
where two pages could each honestly answer.

## Permission

The search is handed the reader's **own visible pages** — the same list that
drew the sidebar beside it. It never resolves permission a second time, so it
cannot offer a page the navigation would not. A search that answered its own
permission question would eventually disagree with the rail, in the direction a
reader notices: a hit that then refuses them.

The mutation check for this was instructive. Reverting the filter — passing the
whole catalog — left **all 30 search tests green**, because they hand the box a
page list directly and cannot see which list the rail passes. Two cases in
`settings-nav.test.tsx` now drive the real rail; the mutation fails.

## Matching

Every **word** must land, not the whole phrase as one substring. "email
signature" is one thought to a reader and two fields to the catalog, so
demanding a single substring answered nothing for exactly the queries a person
composes naturally. A page matching only half a phrase is excluded rather than
ranked low — somebody who typed two words meant both.

The case fold is `foldForMatch`, which this tree already owns: a locale-aware
fold maps Turkish `I` to a dotless `ı`, so a needle folded under one locale
stops matching a haystack folded under another. I had written a second, wrong
copy; `format/one-locale.test.ts` caught it.

## Why not ComboBox

`ComboBox` and `useSuggestList` bind a **value**: the list is help toward what
goes in the box, they match internally, and an empty query offers everything
because everything is a candidate. This one **navigates**, ranks by a
permission-filtered relevance computed elsewhere, and must offer nothing when
empty — the sidebar is already the list of everything. Wiring to that hook would
mean overriding its matcher, its empty case and its pick semantics. The keyboard
grammar is deliberately the same, because a reader should not have to learn two.

## The slot

`NavSection` and `NavTrailLevel` gain `lead`, carried through `navTrail` and
rendered once by `NavLevelView`. Both types, because the trail is what the rail
draws — a slot on the section alone is a field nothing renders. Absent in the
collapsed 56px rail, where a text field is a box too narrow to read your own
typing in.

## Accessibility and pointer

Options carry `tabIndex={-1}` and are driven from the input by
`aria-activedescendant`; `aria-expanded` reports what is actually on screen (a
no-result panel is still a panel); the active row is scrolled into view so Enter
never opens a page the reader could not see selected; a click outside closes the
list while keeping the query.

Every modified click belongs to the browser — Cmd, Ctrl, Shift and Alt reach the
href. Only the plain primary click is answered here, on `click` rather than
`mousedown` so a drag away still cancels.

## Verification

`make check-fe` green, exit 0. One earlier run failed on
`settings-integrations.test.tsx` with a 2113ms timeout; it passes alone, and
5716 tests pass twice under the gate's own load with this change in place, so
the failure does not reproduce.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a search box above the settings sidebar rows so a page can be found by the word the reader already has for it — "password" reaches Account, "gdpr" reaches Privacy, "webhook" reaches Integrations.

The box searches the same page list the sidebar drew, so it can never offer a page the reader cannot open.

**Implementation**

- Every word in a query must match; a page matching only half a phrase is excluded.
- Aliases are English-only; labels match in their translated form.
- Deliberately not `ComboBox` or `useSuggestList` — they bind a value, while this navigates and offers nothing when empty.
- Uses the existing `foldForMatch` case fold.
- Adds a `lead` slot on `NavSection` and `NavTrailLevel`, hidden in the collapsed rail.
- Options follow the combobox pattern (`aria-activedescendant`, `tabIndex={-1}`); modified clicks reach the href.

<sup>Written for commit ff9bb3d70ad62fc59fe53fc2442db4062d9b6027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

