### PR TITLE
feat(tasks): a task can be moved to a day the reader names

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3436,6 +3436,7 @@ export const de = {
 
   "tasks.complete": "Erledigt",
   "tasks.snooze": "1 Tag später",
+  "tasks.moveTo": "Verschieben auf",
   "tasks.detail": "Aufgabe",
   "tasks.detailLoading": "Aufgabe wird gelesen…",
   "tasks.isDone": "Abgeschlossen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3523,6 +3523,7 @@ export const en = {
 
   "tasks.complete": "Done",
   "tasks.snooze": "Snooze 1d",
+  "tasks.moveTo": "Move to",
   "tasks.detail": "Task",
   "tasks.detailLoading": "Reading this task…",
   "tasks.isDone": "Completed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3396,6 +3396,7 @@ export const vi = {
 
   "tasks.complete": "Đánh dấu xong",
   "tasks.snooze": "Hoãn 1 ngày",
+  "tasks.moveTo": "Dời sang",
   "tasks.detail": "Công việc",
   "tasks.detailLoading": "Đang đọc công việc này…",
   "tasks.isDone": "Đã hoàn thành",

--- a/frontend/src/screens/taskactions.tsx
+++ b/frontend/src/screens/taskactions.tsx
@@ -12,9 +12,12 @@ import {
   Badge,
   Button,
   Checkbox,
+  Field,
   Modal,
   PendingBody,
 } from "../design-system/atoms";
+import { DateInput, isISODate } from "../design-system/dateinput";
+import { calendarDay, dueInstant } from "../format/calendarday";
 import { formatDate, formatDateTime } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
@@ -116,22 +119,38 @@ export function TaskCompleteCheck({
 }
 
 /**
- * TaskQuickActions is the verb a rep needs on a next-step row beyond the tick:
- * snooze, offered only for a dated task, since there is no day to move a task
- * to that never had one. Complete lives on `TaskCompleteCheck` instead —
- * `showComplete` keeps it here too for the one caller (the detail modal) that
- * has no row-level checkbox of its own to tick.
+ * TaskQuickActions is the verbs a rep needs on a next-step row beyond the tick.
+ *
+ * Snooze, offered only for a DATED task, since one day after nothing is
+ * nothing. And a date picker, offered always — an undated task is exactly the
+ * one a rep wants to put a day on, and it is the one the snooze cannot serve.
+ *
+ * The two are not the same verb spelled twice. Snooze answers "not yet" in one
+ * press and moves the task's own due date by a day; the picker answers
+ * "Tuesday", which the snooze cannot reach in principle rather than merely in
+ * clicks — a task three days overdue snoozes to two days overdue.
+ *
+ * Complete lives on `TaskCompleteCheck` instead — `showComplete` keeps it here
+ * too for the one caller (the detail modal) that has no row-level checkbox of
+ * its own to tick.
  */
 export function TaskQuickActions({
   activityId,
   dueAt,
   update,
   showComplete = true,
+  showDuePicker = false,
 }: Readonly<{
   activityId: string;
   dueAt?: string | null;
   update: ReturnType<typeof useTaskUpdate>;
   showComplete?: boolean;
+  // Whether the reader may name a day, rather than only step the due date on.
+  // OFF by default, and the default is the point: this is a per-row action slot
+  // on the 360 next-steps lists, where a date box in every row is heavier than
+  // the surface intends. The detail modal opts in, because that is where a
+  // reader already came to work on one task.
+  showDuePicker?: boolean;
 }>) {
   const t = useT();
   const nextDue = snoozedDueAt(dueAt);
@@ -161,7 +180,82 @@ export function TaskQuickActions({
           {t("tasks.snooze")}
         </Button>
       )}
+      {showDuePicker && (
+        <TaskDueDatePick
+          activityId={activityId}
+          dueAt={dueAt}
+          update={update}
+        />
+      )}
     </>
+  );
+}
+
+// Moving a task to a day the reader names.
+//
+// Beside the snooze rather than instead of it, because they answer different
+// questions. Snooze is "not yet" and takes one press; this is "Tuesday",
+// which no number of presses reaches — and the snooze cannot reach it in
+// principle, not just in clicks: it adds a day to the task's OWN due date, so
+// a task three days overdue snoozes to two days overdue and the reader presses
+// it four times to mean tomorrow.
+//
+// It is offered on an UNDATED task too, where the snooze is not. A task with no
+// day has nothing to move but is exactly the one a rep wants to put a date on,
+// and the button above is hidden for it — snoozedDueAt returns null, because
+// one day after nothing is nothing.
+function TaskDueDatePick({
+  activityId,
+  dueAt,
+  update,
+}: Readonly<{
+  activityId: string;
+  dueAt?: string | null;
+  update: ReturnType<typeof useTaskUpdate>;
+}>) {
+  const t = useT();
+  const pending = update.isPending && update.variables?.id === activityId;
+  // Seeded from the task's own day in the VIEWER's zone, matching what the
+  // meta line above reads it in: a picker opening on a different day than the
+  // one displayed beside it would be two answers to "when is this due".
+  const seeded = dueAt ? calendarDay(new Date(dueAt), viewerZone()) : "";
+  // Narrowed rather than asserted. calendarDay returns a string, and the
+  // control's type says it takes a calendar day or nothing — so a value that
+  // is neither opens the picker empty instead of feeding the element something
+  // it would silently reject.
+  const current = isISODate(seeded) ? seeded : "";
+  return (
+    <Field label={t("tasks.moveTo")}>
+      {(field) => (
+        <DateInput
+          {...field}
+          value={current}
+          disabled={pending}
+          onChange={(event) => {
+            const day = event.target.value;
+            // Narrowed with the control's own guard, not merely tested for
+            // empty. A `type="date"` box clears itself for anything it cannot
+            // parse — `2026-02-30` arrives as "" — but HTML permits a year of
+            // FOUR OR MORE digits, so `10000-09-15` is a value the element
+            // reports happily and `dueInstant` throws a RangeError on. A year
+            // typo would have reached an uncaught exception with nothing on
+            // screen to say the date was refused.
+            //
+            // isISODate requires exactly four, which refuses that and the
+            // cleared box in one question — and clearing IS a case to refuse:
+            // it is the browser's own empty state, not a request to undate the
+            // task.
+            if (!isISODate(day)) {
+              return;
+            }
+            update.mutate({
+              id: activityId,
+              body: { due_at: dueInstant(day) },
+            });
+          }}
+        />
+      )}
+    </Field>
   );
 }
 
@@ -249,6 +343,7 @@ export function TaskDetailModal({
                 activityId={task.id}
                 dueAt={task.due_at}
                 update={update}
+                showDuePicker
               />
             </div>
           )}

--- a/frontend/src/screens/taskduedate.guard.test.ts
+++ b/frontend/src/screens/taskduedate.guard.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// What the due-date picker is allowed to send.
+//
+// Asked of the guard directly rather than through the control, because jsdom's
+// date input is STRICTER than the HTML spec: it clears itself for a five-digit
+// year that a real browser reports happily, so a test driving the input can
+// never deliver the value this guard exists to refuse. Driving the box would
+// pass with no guard at all — measured, not assumed.
+
+import { describe, expect, it } from "vitest";
+import { isISODate } from "../design-system/dateinput";
+import { dueInstant } from "../format/calendarday";
+
+describe("the days a task may be moved to", () => {
+  it("refuses what dueInstant cannot convert", () => {
+    // HTML permits a year of four OR MORE digits, so this is a value a native
+    // date box reports — and dueInstant throws a RangeError on it. Without the
+    // guard a year typo reaches an uncaught exception with nothing on screen
+    // to say the date was refused.
+    expect(isISODate("10000-09-15")).toBe(false);
+    expect(() => dueInstant("10000-09-15")).toThrow();
+  });
+
+  it("refuses the cleared box", () => {
+    // Clearing is the browser's own empty state, not a request to undate the
+    // task. It is also what the element reports for anything it could not
+    // parse, so one question answers both.
+    expect(isISODate("")).toBe(false);
+  });
+
+  it("admits an ordinary day, which dueInstant then converts", () => {
+    // The guard has to ADMIT as well as refuse: one that said no to everything
+    // would pass both tests above and break the feature.
+    expect(isISODate("2026-09-15")).toBe(true);
+    expect(new Date(dueInstant("2026-09-15")).getTime()).toBe(
+      new Date("2026-09-15T23:59:59").getTime(),
+    );
+  });
+});

--- a/frontend/src/screens/taskduedate.test.tsx
+++ b/frontend/src/screens/taskduedate.test.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Moving a task to a day the reader names.
+//
+// The snooze beside this one adds a day to the task's OWN due date, so it
+// cannot reach a named day in principle rather than merely in clicks: a task
+// three days overdue snoozes to two days overdue, and a rep who means tomorrow
+// presses it four times.
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { TaskQuickActions, useTaskUpdate } from "./taskactions";
+
+const TASK = "01a05500-0000-7000-8000-000000000a01";
+
+// The task's due instant, minted the way the product mints one: the end of a
+// calendar day in the RUNNING machine's zone. A fixed UTC string would name a
+// different calendar day depending on where the suite runs — 23:59:59Z on the
+// 1st is already the 2nd anywhere east of UTC — and the picker reads the day in
+// the viewer's zone, correctly, so the fixture has to speak the same clock.
+const DUE_DAY = "2026-09-01";
+const DUE_AT = new Date(`${DUE_DAY}T23:59:59`).toISOString();
+
+let sent: unknown[] = [];
+
+beforeEach(() => {
+  sent = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/activities/")) {
+        const body =
+          input instanceof Request
+            ? await input.clone().text()
+            : String(init?.body ?? "");
+        sent.push(JSON.parse(body));
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderVerbs(dueAt?: string | null) {
+  function Harness() {
+    const update = useTaskUpdate([["tasks"]]);
+    return (
+      <TaskQuickActions
+        activityId={TASK}
+        dueAt={dueAt}
+        update={update}
+        showDuePicker
+      />
+    );
+  }
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <Harness />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The picker is a native type="date" input, which exposes no role of its own.
+// The same harness with the picker prop left out entirely.
+function renderDefaults(dueAt?: string | null) {
+  function Harness() {
+    const update = useTaskUpdate([["tasks"]]);
+    return <TaskQuickActions activityId={TASK} dueAt={dueAt} update={update} />;
+  }
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <Harness />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function picker(container: HTMLElement): HTMLInputElement {
+  const found = container.querySelector<HTMLInputElement>('input[type="date"]');
+  if (!found) {
+    throw new Error("no date picker rendered");
+  }
+  return found;
+}
+
+describe("moving a task to a named day", () => {
+  it("sends the picked day as the task's due date", async () => {
+    const { container } = renderVerbs(DUE_AT);
+    fireEvent.change(picker(container), { target: { value: "2026-09-15" } });
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    // The END of the picked day, so a task due "the 15th" is not overdue at
+    // nine that morning. dueInstant owns that rule; this asserts the row uses
+    // it rather than sending midnight.
+    const body = sent[0] as { due_at: string };
+    expect(new Date(body.due_at).getTime()).toBe(
+      new Date("2026-09-15T23:59:59").getTime(),
+    );
+  });
+
+  it("opens on the day the task is already due", async () => {
+    // A picker opening on a different day than the meta line beside it reads
+    // as two answers to "when is this due".
+    const { container } = renderVerbs(DUE_AT);
+    expect(picker(container).value).toBe(DUE_DAY);
+  });
+
+  it("is offered on an undated task, where the snooze is not", async () => {
+    // The one a rep most wants to date, and the snooze is hidden for it —
+    // one day after nothing is nothing.
+    const { container } = renderVerbs(null);
+    expect(picker(container)).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /snooze/i })).toBeNull();
+  });
+
+  it("is off unless the caller asks for it", () => {
+    // The default is the point: this component is a per-row action slot on the
+    // 360 next-steps lists, where a date box in every row is heavier than the
+    // surface intends. The detail modal opts in.
+    // The prop is OMITTED, not passed false: the default is what the 360 rows
+    // get, and a test that spelled it out would pass over a default flipped on.
+    const { container } = renderDefaults(DUE_AT);
+    expect(
+      container.querySelector('input[type="date"]'),
+      "a caller that did not ask for the picker was given one",
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
The queue could snooze a task and not **date** one.

Snooze adds a day to the task's *own* due date, so it cannot reach a named day in principle rather than merely in clicks: a task three days overdue snoozes to two days overdue, and a rep who means tomorrow presses it four times. A task with no date at all had no verb — `snoozedDueAt` returns null, because one day after nothing is nothing.

The detail modal now carries a date picker beside the snooze, seeded from the task's own day in the same zone the line above reads it in. It is offered on an undated task too, which is the one a rep most wants to date.

## Off by default

`TaskQuickActions` is also a per-row action slot on the 360 next-steps lists, where a date box in every row is heavier than that surface intends. The detail modal opts in, because that is where a reader already came to work on one task.

## A blocker a review caught

HTML permits a year of **four or more digits**, so `10000-09-15` is a value a native date box reports happily — and `dueInstant` throws a `RangeError` on it. A year typo would have reached an uncaught exception with nothing on screen to say the date was refused.

The handler now narrows with the control's own `isISODate`, which requires exactly four digits and so refuses that and the cleared box in one question. Clearing is worth refusing on its own: it is the browser's empty state, not a request to undate the task.

## Why the guard is tested directly

`isISODate` is asserted against, not driven through the input, and the reason is measured rather than assumed: **jsdom's date box is stricter than the HTML spec.** It clears itself for the five-digit year a real browser reports, so a test driving the control passes with **no guard at all**.

Two earlier versions of that test did exactly that before this one replaced them. A third — asserting that clearing the box sends nothing — was deleted rather than kept, because `fireEvent.change` to `""` fires no event on a date input and the test was vacuous in both directions. The branch it would have covered says so in the source instead.

## Evidence

| Obligation | Evidence |
|---|---|
| User-visible outcome | `sends the picked day as the task's due date` — asserts the PATCH body is the **end** of the picked day, so a task due "the 15th" is not overdue at nine that morning |
| No two answers on screen | `opens on the day the task is already due` — the picker and the meta line beside it read the same instant in the same zone |
| The case snooze cannot serve | `is offered on an undated task, where the snooze is not` |
| Default is off | `is off unless the caller asks for it` — omits the prop rather than passing false, so a default flipped on fails it |
| Guard | `taskduedate.guard.test.ts` — refuses the five-digit year and the cleared box, **and admits an ordinary day**, so a guard that said no to everything fails too |
| Mutation strength | 4 mutations, each failing only its own test: midnight instead of end-of-day, drop the seeded day, default the picker on, and the guard reverted to empty-only (which is what exposed the two vacuous tests) |
| Full lane | `make check-fe` EXIT=0. Frontend-only diff — six files, all under `frontend/` — so the backend gate has nothing to say about it |

Three locales carry the new label; the locale record is typed so a missing one does not compile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a date picker beside the task snooze in the detail modal, so a task can be moved to a specific day the reader names. Snooze only advances the task's own due date by one day, so it can't reach a named day, and undated tasks previously had no date verb.

**New Features**
- The picker is seeded from the task's due day in the viewer's zone and is offered on undated tasks too.
- The picker is off by default; the detail modal opts in so the 360 next-steps rows stay light.
- Invalid dates (a five-digit year, a cleared box) are refused before `dueInstant` can throw.
- The guard is tested directly because jsdom's date input clears values a real browser reports, so driving the input would pass without any guard.

<sup>Written for commit daeead010366a17d99848f9da3deeb269acc0e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

