### PR TITLE
A lead reads where the team's week was landing

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -39021,6 +39021,21 @@ components:
             Who was on the team that week — the frozen membership, which a join against the
             live team could never answer. Ordered by name, because that is what a membership
             list is read as; the order a MEETING takes them in is `agenda`.
+        outlook:
+          type: array
+          items: { $ref: '#/components/schemas/WeeklyReviewOutlook' }
+          description: |
+            Where the TEAM's week was landing, one entry per horizon — the week, the month and
+            the fiscal quarter.
+
+            NOT the sum of its members' outlooks. A deal owned by nobody on the team is in
+            neither, and one the team works but a member owns is in both, so adding six personal
+            landings would answer a question nobody asked. This is read over the team's own book.
+
+            EMPTY when no forecast was composed when the snapshot was written, which is not the
+            same as a team that landed on nothing — a reader says "no forecast" rather than
+            drawing zeros. Every figure is a COPY, so it still reads after the snapshots it came
+            from age out under retention.
         agenda:
           type: array
           items: { type: string, format: uuid }

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 41
+	wantFixtureAnnotations = 42
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/teamoutlookmirror_test.go
+++ b/backend/gates/teamoutlookmirror_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The team's frozen outlook and the rep's are the same fact over different
+// books, so they are the same SHAPE or one of them is lying.
+//
+// They cannot be one table: the rep's hangs off weekly_review by foreign key
+// and the team's off team_weekly_review. That leaves two column lists which a
+// person maintains, and a figure added to one and not the other is invisible —
+// the panel for the table that has it draws it, the other draws nothing, and
+// nothing fails.
+//
+// So the mirror is declared and this holds it, in BOTH directions: a column
+// added to either side, or a type changed on one, fails here. The parent key
+// and the primary key are the two deliberate differences and are named below.
+//
+// The corpus is DERIVED from the migrations rather than listed: a gate that
+// hard-codes the columns it protects stops protecting the next one somebody
+// adds, and reports PASS while doing it.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A column line inside a CREATE TABLE body: a name and the type that follows.
+var outlookColumn = regexp.MustCompile(`^\s{4}(\w+)\s+([\w()]+)`)
+
+// gatekit:fixture each table's own parent column, which is the one difference
+// between the two and cannot be read off either side
+//
+// The two columns that MUST differ, and nothing else may.
+//
+// Each table names its own parent, which is the whole reason there are two.
+// Everything else — every figure, every window bound, every snapshot pointer —
+// is the same question asked of a different book.
+var outlookParentKeys = map[string]string{
+	"weekly_review_outlook":      "weekly_review_id",
+	"team_weekly_review_outlook": "team_weekly_review_id",
+}
+
+func TestTheTeamOutlookMirrorsTheRepOutlook(t *testing.T) {
+	t.Parallel()
+
+	rep := outlookColumns(t, "weekly_review_outlook")
+	team := outlookColumns(t, "team_weekly_review_outlook")
+
+	// Under-recognition is the failure that reports PASS: a scan that found no
+	// columns would agree with itself perfectly.
+	if len(rep) < 10 || len(team) < 10 {
+		t.Fatalf("read %d rep and %d team outlook columns: the scan has stopped "+
+			"seeing its subject, which agrees with itself and holds nothing",
+			len(rep), len(team))
+	}
+
+	for name, repType := range rep {
+		teamType, found := team[name]
+		if !found {
+			t.Errorf("weekly_review_outlook has %q and team_weekly_review_outlook does not: "+
+				"the team's landing would silently lack a figure the rep's reports", name)
+			continue
+		}
+		if repType != teamType {
+			t.Errorf("column %q is %s on the rep's outlook and %s on the team's: "+
+				"the same figure must be the same type or one of them rounds differently",
+				name, repType, teamType)
+		}
+	}
+	for name := range team {
+		if _, found := rep[name]; !found {
+			t.Errorf("team_weekly_review_outlook has %q and weekly_review_outlook does not: "+
+				"add it to both, or the two panels answer differently about the same week", name)
+		}
+	}
+}
+
+// outlookColumns reads one table's columns out of the migration that creates
+// it, with the parent key and the id removed — those are the two deliberate
+// differences, and comparing them would fail every run.
+func outlookColumns(t *testing.T, table string) map[string]string {
+	t.Helper()
+	body := createTableBody(t, table)
+	cols := map[string]string{}
+	for _, line := range strings.Split(body, "\n") {
+		m := outlookColumn.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name := m[1]
+		if name == "id" || name == outlookParentKeys[table] {
+			continue
+		}
+		// CONSTRAINT lines start with the keyword, not a column name.
+		if strings.EqualFold(name, "constraint") {
+			continue
+		}
+		cols[name] = m[2]
+	}
+	return cols
+}
+
+// createTableBody is the text between CREATE TABLE <name> ( and its closing
+// paren, from whichever migration creates it.
+func createTableBody(t *testing.T, table string) string {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join("migrations", "core", "*.up.sql"))
+	if err != nil {
+		t.Fatalf("listing migrations: %v", err)
+	}
+	open := "CREATE TABLE " + table + " ("
+	for _, file := range files {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		text := string(raw)
+		start := strings.Index(text, open)
+		if start < 0 {
+			continue
+		}
+		rest := text[start+len(open):]
+		end := strings.Index(rest, "\n);")
+		if end < 0 {
+			t.Fatalf("%s: CREATE TABLE %s is not closed", file, table)
+		}
+		return rest[:end]
+	}
+	t.Fatalf("no migration creates %s: the gate's subject is gone, which is not a pass", table)
+	return ""
+}

--- a/backend/internal/compose/integration/teamoutlook_integration_test.go
+++ b/backend/internal/compose/integration/teamoutlook_integration_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration_test
+
+// Where the TEAM's week was landing, over real migrated Postgres.
+//
+// The one thing worth proving here is that the team's outlook is read over the
+// TEAM's book. It is not the sum of its members': a deal owned by nobody on the
+// team is in neither, and one the team works but a member owns is in both. A
+// team snapshot that quietly took a rep's landing would look identical on the
+// page and be a different number.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// teamScopeSpy is a ForecastWeek that records WHICH book it was asked for.
+//
+// A stub is right here: the question is which scope the team path resolves, and
+// the arithmetic behind a landing belongs to forecasting's own suite. What this
+// cannot fake is the id — the seam is handed a team id or it is not.
+type teamScopeSpy struct {
+	repCalls  int
+	teamCalls int
+	askedFor  ids.UUID
+	outlooks  []weekly.Outlook
+}
+
+func (s *teamScopeSpy) CloseWeek(
+	_ context.Context, _ pgx.Tx, _, _ time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
+	s.repCalls++
+	return s.outlooks, nil, nil, nil
+}
+
+func (s *teamScopeSpy) CloseTeamWeek(
+	_ context.Context, _ pgx.Tx, teamID ids.UUID, _, _ time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
+	s.teamCalls++
+	s.askedFor = teamID
+	return s.outlooks, nil, nil, nil
+}
+
+func oneTeamHorizon() []weekly.Outlook {
+	return []weekly.Outlook{{
+		PeriodKind:     "quarter",
+		PeriodStart:    time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:      time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		BaseCurrency:   "EUR",
+		WonMinor:       180_000_00,
+		CommitMinor:    120_000_00,
+		BestCaseMinor:  390_000_00,
+		WeightedMinor:  260_000_00,
+		ForwardMeasure: "commit_evidence",
+		Closing: weekly.OutlookSide{
+			Known: true, SnapshotID: ids.NewV7(), LandingMinor: 300_000_00,
+		},
+	}}
+}
+
+// THE TEAM OUTLOOK IS READ OVER THE TEAM'S BOOK, and the seam is asked for the
+// team being snapshotted rather than for whoever happened to be assembling it.
+func TestTheTeamOutlookFreezesTheTeamScopeSnapshot(t *testing.T) {
+	e := setupTeamWeekly(t)
+	spy := &teamScopeSpy{outlooks: oneTeamHorizon()}
+	engine := weekly.NewEngine(e.Pool, identity.NewService(e.Pool)).WithForecast(spy)
+
+	written, created, err := engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("the first assembly of a team week writes it")
+	}
+	if spy.teamCalls != 1 {
+		t.Fatalf("the team path asks the team seam once, got %d calls", spy.teamCalls)
+	}
+	if spy.repCalls != 0 {
+		t.Fatal("a team snapshot must not take a rep's landing: the two are different books")
+	}
+	if spy.askedFor != e.Team1 {
+		t.Fatalf("the seam was asked for %s, wanted the team being snapshotted (%s)",
+			spy.askedFor, e.Team1)
+	}
+	if len(written.Outlook) != 1 {
+		t.Fatalf("the returned snapshot carries its outlook, got %d horizons", len(written.Outlook))
+	}
+}
+
+// FROZEN, and readable after the snapshots it was read from are gone. The whole
+// reason the figures are copied rather than pointed at.
+func TestTheTeamOutlookSurvivesItsSnapshots(t *testing.T) {
+	e := setupTeamWeekly(t)
+	spy := &teamScopeSpy{outlooks: oneTeamHorizon()}
+	engine := weekly.NewEngine(e.Pool, identity.NewService(e.Pool)).WithForecast(spy)
+
+	if _, _, err := engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock); err != nil {
+		t.Fatal(err)
+	}
+	// Retention removes the snapshots. The copied figures must stand.
+	e.WsExec(t, `DELETE FROM forecast_snapshot`)
+
+	read, err := engine.LatestTeamReview(e.leadCtx, e.Team1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(read.Outlook) != 1 {
+		t.Fatalf("a retrospective that empties out is not a record, got %d horizons",
+			len(read.Outlook))
+	}
+	if read.Outlook[0].WonMinor != 180_000_00 {
+		t.Fatalf("the frozen figure must read back unchanged, got %d", read.Outlook[0].WonMinor)
+	}
+}
+
+// AN ABSENT SEAM LEAVES THE SNAPSHOT WITHOUT AN OUTLOOK, and that is not a
+// failure: an installation that composed no forecast still gets its team week.
+func TestAnAbsentForecastSeamStillWritesTheTeamWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+	// setupTeamWeekly builds the engine WITHOUT a forecast, which is the state
+	// under test.
+	written, created, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatalf("a team with no forecast lane still has a week: %v", err)
+	}
+	if !created {
+		t.Fatal("the first assembly writes the week")
+	}
+	if len(written.Outlook) != 0 {
+		t.Fatalf("no forecast composed means no outlook, got %d", len(written.Outlook))
+	}
+}
+
+// refusingForecast is a seam that refuses, the way forecasting's scope
+// authority refuses a team the caller is not on.
+type refusingForecast struct{ calls int }
+
+func (r *refusingForecast) CloseWeek(
+	_ context.Context, _ pgx.Tx, _, _ time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
+	return nil, nil, nil, apperrors.ErrNotFound
+}
+
+func (r *refusingForecast) CloseTeamWeek(
+	_ context.Context, _ pgx.Tx, _ ids.UUID, _, _ time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
+	r.calls++
+	return nil, nil, nil, apperrors.ErrNotFound
+}
+
+// A REFUSED OUTLOOK COSTS THE OUTLOOK, NOT THE WEEK.
+//
+// forecasting's scope authority refuses ScopeTeam to a caller who is not in the
+// team, and that refusal arrives INSIDE the transaction that has already
+// written the snapshot and its reps. Letting it escape rolls all of that back,
+// so a lead whose row scope is narrower than the team they are snapshotting
+// loses the whole retrospective rather than just its landing — the counts, the
+// membership, the focus lines, everything.
+//
+// The rep-level review had exactly this bug once. This is the team-level one.
+func TestARefusedTeamOutlookStillLeavesTheWeekWritten(t *testing.T) {
+	e := setupTeamWeekly(t)
+	refusing := &refusingForecast{}
+	engine := weekly.NewEngine(e.Pool, identity.NewService(e.Pool)).WithForecast(refusing)
+
+	written, created, err := engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatalf("a refused landing must not cost the team its week: %v", err)
+	}
+	if !created {
+		t.Fatal("the week is still written")
+	}
+	if refusing.calls != 1 {
+		t.Fatalf("the seam was asked once, got %d", refusing.calls)
+	}
+	if len(written.Outlook) != 0 {
+		t.Fatalf("a refused landing is absent, got %d horizons", len(written.Outlook))
+	}
+
+	// And it is READABLE, which is what the rollback destroyed: the row exists
+	// and answers for the week it was written about. Reps are counted as
+	// UNREAD here because this fixture seeds no member weeks — that is the
+	// snapshot working, and the figure only exists because the row survived.
+	read, err := engine.LatestTeamReview(e.leadCtx, e.Team1, nil)
+	if err != nil {
+		t.Fatalf("the snapshot must still be there to read: %v", err)
+	}
+	if read.TeamName != "Team One" {
+		t.Fatalf("the frozen snapshot was rolled back with the outlook, got %q", read.TeamName)
+	}
+	if read.RepsUnread != len(members(e)) {
+		t.Fatalf("the membership pass ran and recorded %d unread of %d",
+			read.RepsUnread, len(members(e)))
+	}
+}

--- a/backend/internal/compose/weekly/teamreview.go
+++ b/backend/internal/compose/weekly/teamreview.go
@@ -72,6 +72,12 @@ type TeamReview struct {
 	// is the claim that every member's week was counted.
 	RepsUnread int
 	Reps       []TeamRep
+
+	// Outlook is where the team's week was landing, per horizon, frozen at
+	// close. EMPTY when no forecast was composed — which is not the same as a
+	// team that landed on nothing, so a reader says "no forecast" rather than
+	// drawing zeros.
+	Outlook []Outlook
 }
 
 // TeamCounts are the team's totals over its member weeks.
@@ -143,7 +149,57 @@ func (e *Engine) AssembleTeamFor(
 			return nil
 		}
 		review.ID = id
-		return insertTeamReps(ctx, tx, id, review.Reps)
+		if err := insertTeamReps(ctx, tx, id, review.Reps); err != nil {
+			return err
+		}
+		// Where the team's week was landing, frozen in the same transaction as
+		// the counts. Split across two, a snapshot could exist with no outlook
+		// and no way to tell that from an installation that forecasts nothing.
+		//
+		// Only on the branch that WROTE the snapshot: the loser of the insert
+		// race returned above, and freezing an outlook onto somebody else's row
+		// would give it two.
+		if e.forecast == nil {
+			// No forecast composed. The team's week stands without one.
+			return nil
+		}
+		start, end, err := localWeekWindow(ctx, tx, week)
+		if err != nil {
+			return err
+		}
+		// A REFUSED LANDING COSTS THE LANDING, NOT THE WEEK.
+		//
+		// forecasting's scope authority refuses ScopeTeam to a caller who is
+		// not in the team, and that refusal arrives here — inside the
+		// transaction that has already written the snapshot, its reps and their
+		// focus lines. Letting it escape rolls all of that back, so a lead
+		// whose row scope is narrower than the team they are snapshotting loses
+		// the whole retrospective rather than just its outlook.
+		//
+		// Held by: TestARefusedTeamOutlookStillLeavesTheWeekWritten
+		// (backend/internal/compose/integration/teamoutlook_integration_test.go)
+		//
+		// Only a REFUSAL is absorbed. A broken query or a dead connection is
+		// not a statement about this caller's reach and still fails the week,
+		// because a snapshot silently missing its landing for a reason nobody
+		// recorded is worse than one that did not get written.
+		outlooks, _, _, err := e.forecast.CloseTeamWeek(ctx, tx, teamID, start, end)
+		switch {
+		case errors.Is(err, apperrors.ErrNotFound),
+			errors.Is(err, apperrors.ErrPermissionDenied):
+			return nil
+		case err != nil:
+			return err
+		}
+		for _, outlook := range outlooks {
+			if err := insertOutlookInto(ctx, tx, teamOutlook, id, outlook); err != nil {
+				return err
+			}
+		}
+		// Carried on the returned value as well as written, so the caller that
+		// just assembled a week reads the same thing a later reader will.
+		review.Outlook = outlooks
+		return nil
 	})
 	if err != nil {
 		return TeamReview{}, false, err

--- a/backend/internal/compose/weekly/teamreview_test.go
+++ b/backend/internal/compose/weekly/teamreview_test.go
@@ -9,7 +9,10 @@ package weekly
 // nothing else — no database, no clock. What it defends is that EVERY rep gets
 // a row, and that a request already made outranks any metric.
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestARepWhoAskedForHelpIsRaisedFirst(t *testing.T) {
 	// A week with something to raise on every other rung too, so this asserts
@@ -104,5 +107,39 @@ func TestOneReadsAsOne(t *testing.T) {
 	}
 	if got := plural(3, "lead"); got != "3 leads" {
 		t.Errorf("plural(3) = %q, want %q", got, "3 leads")
+	}
+}
+
+// THE TEAM'S LANDING REACHES THE WIRE, rendered by the SAME function the rep's
+// outlook uses. A landing mapped to the wrong field, or not mapped at all,
+// reads to the frontend as a team that forecasts nothing.
+func TestTheTeamOutlookTravelsOnTheWire(t *testing.T) {
+	review := TeamReview{
+		TeamName: "Team One",
+		Outlook: []Outlook{{
+			PeriodKind:     "quarter",
+			PeriodStart:    time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			PeriodEnd:      time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+			BaseCurrency:   "EUR",
+			WonMinor:       180_000_00,
+			ForwardMeasure: "commit_evidence",
+		}},
+	}
+	wire := teamReviewToWire(review)
+	if wire.Outlook == nil || len(*wire.Outlook) != 1 {
+		t.Fatal("a team week with a landing must carry it on the wire")
+	}
+	if (*wire.Outlook)[0].WonMinor != 180_000_00 {
+		t.Fatalf("the figure must survive the mapping, got %d", (*wire.Outlook)[0].WonMinor)
+	}
+}
+
+// A team week with NO landing sends no outlook at all, rather than an empty
+// array: absent says "no forecast was composed", and a reader draws nothing
+// instead of zeros.
+func TestATeamWeekWithoutAForecastSendsNoOutlook(t *testing.T) {
+	wire := teamReviewToWire(TeamReview{TeamName: "Team One"})
+	if wire.Outlook != nil {
+		t.Fatalf("no forecast means no outlook on the wire, got %d horizons", len(*wire.Outlook))
 	}
 }

--- a/backend/internal/compose/weekly/teamreviewhandlers.go
+++ b/backend/internal/compose/weekly/teamreviewhandlers.go
@@ -53,7 +53,7 @@ func teamReviewToWire(review TeamReview) crmcontracts.TeamWeeklyReview {
 		})
 	}
 	c := review.Counts
-	return crmcontracts.TeamWeeklyReview{
+	out := crmcontracts.TeamWeeklyReview{
 		Id:             openapi_types.UUID(review.ID),
 		TeamId:         openapi_types.UUID(review.TeamID),
 		TeamName:       review.TeamName,
@@ -76,6 +76,16 @@ func teamReviewToWire(review TeamReview) crmcontracts.TeamWeeklyReview {
 		// before the agenda existed answers one anyway.
 		Agenda: agendaToWire(agendaOrder(review.Reps)),
 	}
+	// Rendered by the SAME function the rep's outlook uses, so the two panels
+	// cannot disagree about how a landing is put on the wire.
+	if len(review.Outlook) > 0 {
+		outlook := make([]crmcontracts.WeeklyReviewOutlook, 0, len(review.Outlook))
+		for _, horizon := range review.Outlook {
+			outlook = append(outlook, outlookToWire(horizon))
+		}
+		out.Outlook = &outlook
+	}
+	return out
 }
 
 // agendaToWire renders the agenda's order in the contract's uuid type.

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -283,6 +283,15 @@ func scanTeamReview(ctx context.Context, tx pgx.Tx, row pgx.Row) (TeamReview, er
 		return TeamReview{}, err
 	}
 	review.Reps = reps
+	// Filled here because BOTH readers — TeamReview and LatestTeamReview — come
+	// through this scan. Filled at either call site instead, one surface would
+	// draw the team's landing and the other would not.
+	//
+	// A snapshot written before the outlook existed simply has no rows, which
+	// reads as an empty list and draws "no forecast" rather than failing.
+	if review.Outlook, err = readOutlookFrom(ctx, tx, teamOutlook, review.ID); err != nil {
+		return TeamReview{}, err
+	}
 	return review, nil
 }
 

--- a/backend/internal/compose/weekly/weeklyoutlook.go
+++ b/backend/internal/compose/weekly/weeklyoutlook.go
@@ -143,12 +143,41 @@ func writeOutlook(
 }
 
 func insertOutlook(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, out Outlook) error {
+	return insertOutlookInto(ctx, tx, repOutlook, reviewID, out)
+}
+
+// outlookTable names one of the two tables that freeze a landing.
+//
+// Two, because the parent differs — a rep's hangs off weekly_review and a
+// team's off team_weekly_review — and one table cannot have two foreign keys of
+// which exactly one is set. The FIGURES are a deliberate mirror, held in both
+// directions by TestTheTeamOutlookMirrorsTheRepOutlook, and this type is what
+// keeps the WRITER single: the column list below is spelled once, so a figure
+// added for a rep cannot be forgotten for a team.
+//
+// Held by: TestTheTeamOutlookMirrorsTheRepOutlook
+// (backend/gates/teamoutlookmirror_test.go)
+type outlookTable struct {
+	name   string
+	parent string
+}
+
+var (
+	repOutlook  = outlookTable{name: "weekly_review_outlook", parent: "weekly_review_id"}
+	teamOutlook = outlookTable{
+		name: "team_weekly_review_outlook", parent: "team_weekly_review_id",
+	}
+)
+
+func insertOutlookInto(
+	ctx context.Context, tx pgx.Tx, table outlookTable, reviewID ids.UUID, out Outlook,
+) error {
 	cols, args := insertColumns{}, []any(nil)
 	add := func(name string, value any) {
 		cols = append(cols, name)
 		args = append(args, value)
 	}
-	add("weekly_review_id", reviewID)
+	add(table.parent, reviewID)
 	add("period_kind", out.PeriodKind)
 	add("period_start", out.PeriodStart)
 	add("period_end", out.PeriodEnd)
@@ -170,10 +199,12 @@ func insertOutlook(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, out Outloo
 		add("forward_measure", out.ForwardMeasure)
 	}
 
+	// The table and its parent column are IDENTIFIERS, formatted in from this
+	// package's own two constants and never from anything a request carries.
 	_, err := tx.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO weekly_review_outlook (%s) VALUES (%s)
-		ON CONFLICT (weekly_review_id, period_kind) DO NOTHING`,
-		cols.names(), cols.placeholders()), args...)
+		INSERT INTO %s (%s) VALUES (%s)
+		ON CONFLICT (%s, period_kind) DO NOTHING`,
+		table.name, cols.names(), cols.placeholders(), table.parent), args...)
 	if err != nil {
 		return fmt.Errorf("weekly: freezing the %s outlook: %w", out.PeriodKind, err)
 	}
@@ -221,14 +252,24 @@ func insertDriver(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, driver Driv
 // the snapshot still exists. Reading through the id would make a retrospective
 // answer differently before and after retention ran.
 func readOutlook(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) ([]Outlook, error) {
-	rows, err := tx.Query(ctx, `
+	return readOutlookFrom(ctx, tx, repOutlook, reviewID)
+}
+
+// readOutlookFrom reads one frozen outlook, from whichever of the two tables
+// holds it. One column list for both, for the reason insertOutlookInto states:
+// a figure read for a rep and not for a team is a panel that quietly differs.
+func readOutlookFrom(
+	ctx context.Context, tx pgx.Tx, table outlookTable, reviewID ids.UUID,
+) ([]Outlook, error) {
+	// Identifiers from this package's own constants, never from a request.
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT period_kind, period_start, period_end, base_currency,
 		       won_minor, commit_minor, best_case_minor, weighted_minor,
 		       opening_snapshot_id, opening_landing_minor,
 		       closing_snapshot_id, closing_landing_minor, forward_measure
-		  FROM weekly_review_outlook
-		 WHERE weekly_review_id = $1
-		 ORDER BY period_kind`, reviewID)
+		  FROM %s
+		 WHERE %s = $1
+		 ORDER BY period_kind`, table.name, table.parent), reviewID)
 	if err != nil {
 		return nil, fmt.Errorf("weekly: reading the frozen outlook: %w", err)
 	}

--- a/backend/internal/compose/weekly/weeklyoutlook_integration_test.go
+++ b/backend/internal/compose/weekly/weeklyoutlook_integration_test.go
@@ -33,12 +33,26 @@ type stubForecast struct {
 	movements []Movement
 	drivers   []Driver
 	calls     int
+	// teamCalls and teamID record what the TEAM path asked for, which is the
+	// one thing a stub can prove about it: the seam is what decides the book,
+	// and a team snapshot that quietly took the rep's would look identical
+	// here without this.
+	teamCalls int
+	teamID    ids.UUID
 }
 
 func (s *stubForecast) CloseWeek(
 	_ context.Context, _ pgx.Tx, _, _ time.Time,
 ) ([]Outlook, []Movement, []Driver, error) {
 	s.calls++
+	return s.outlooks, s.movements, s.drivers, nil
+}
+
+func (s *stubForecast) CloseTeamWeek(
+	_ context.Context, _ pgx.Tx, teamID ids.UUID, _, _ time.Time,
+) ([]Outlook, []Movement, []Driver, error) {
+	s.teamCalls++
+	s.teamID = teamID
 	return s.outlooks, s.movements, s.drivers, nil
 }
 

--- a/backend/internal/compose/weekly/weeklystore.go
+++ b/backend/internal/compose/weekly/weeklystore.go
@@ -229,6 +229,13 @@ type ForecastWeek interface {
 	// one, which would give the next week two candidate openings.
 	CloseWeek(ctx context.Context, tx pgx.Tx, weekStart, weekEnd time.Time) (
 		[]Outlook, []Movement, []Driver, error)
+
+	// CloseTeamWeek is the same over a TEAM's book. Not the sum of its
+	// members': a deal owned by nobody on the team is in neither, and one the
+	// team works but a member owns is in both, so adding six personal outlooks
+	// would answer a question nobody asked.
+	CloseTeamWeek(ctx context.Context, tx pgx.Tx, teamID ids.UUID, weekStart, weekEnd time.Time) (
+		[]Outlook, []Movement, []Driver, error)
 }
 
 // NewEngine binds the engine to the installation pool and to the membership

--- a/backend/internal/compose/weeklyforecastseam.go
+++ b/backend/internal/compose/weeklyforecastseam.go
@@ -68,7 +68,39 @@ func (w *WeeklyForecast) CloseWeek(
 		return nil, nil, nil, apperrors.ErrPermissionDenied
 	}
 	owner := ids.UUID(actor.UserID)
-	scope := forecasting.Scope{Kind: forecasting.ScopeOwner, ID: &owner}
+	return w.closeHorizons(ctx, tx,
+		forecasting.Scope{Kind: forecasting.ScopeOwner, ID: &owner}, weekStart, weekEnd)
+}
+
+// CloseTeamWeek is CloseWeek over the TEAM's book.
+//
+// A separate entry point and not a flag, because the scope is the whole
+// difference and it is the part that can be refused: forecasting's scope
+// authority admits ScopeTeam only to a caller who is IN the team
+// (scopeauthority.go), so the lead the weekly job binds passes and anybody else
+// gets ErrNotFound.
+//
+// The team's landing is NOT the sum of its members'. A deal owned by nobody on
+// the team is in neither, and one the team works but a member owns is in both —
+// so summing six personal outlooks would answer a question nobody asked.
+func (w *WeeklyForecast) CloseTeamWeek(
+	ctx context.Context, tx pgx.Tx, teamID ids.UUID, weekStart, weekEnd time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
+	if teamID.IsZero() {
+		return nil, nil, nil, apperrors.ErrNotFound
+	}
+	return w.closeHorizons(ctx, tx,
+		forecasting.Scope{Kind: forecasting.ScopeTeam, ID: &teamID}, weekStart, weekEnd)
+}
+
+// closeHorizons freezes every window this review reports, over one book.
+//
+// Shared by the rep's and the team's entry points above so the three horizons,
+// their order and their bar folding are decided once: two copies would let a
+// team's outlook quietly report two windows where a rep's reports three.
+func (w *WeeklyForecast) closeHorizons(
+	ctx context.Context, tx pgx.Tx, scope forecasting.Scope, weekStart, weekEnd time.Time,
+) ([]weekly.Outlook, []weekly.Movement, []weekly.Driver, error) {
 	var outlooks []weekly.Outlook
 	var movements []weekly.Movement
 	var drivers []weekly.Driver

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32953,6 +32953,19 @@ type TeamWeeklyReview struct {
 	Id             openapi_types.UUID   `json:"id"`
 	LocalWeekStart openapi_types.Date   `json:"local_week_start"`
 
+	// Outlook Where the TEAM's week was landing, one entry per horizon — the week, the month and
+	// the fiscal quarter.
+	//
+	// NOT the sum of its members' outlooks. A deal owned by nobody on the team is in
+	// neither, and one the team works but a member owns is in both, so adding six personal
+	// landings would answer a question nobody asked. This is read over the team's own book.
+	//
+	// EMPTY when no forecast was composed when the snapshot was written, which is not the
+	// same as a team that landed on nothing — a reader says "no forecast" rather than
+	// drawing zeros. Every figure is a COPY, so it still reads after the snapshots it came
+	// from age out under retention.
+	Outlook *[]WeeklyReviewOutlook `json:"outlook,omitempty"`
+
 	// Pipeline What the team's week did to the pipeline. ABSENT when any member's week could not
 	// be converted — summing only the ones that did would be a confident number quietly
 	// missing a rep.

--- a/backend/migrations/core/1788671200_the_team_week_remembers_where_it_was_landing.down.sql
+++ b/backend/migrations/core/1788671200_the_team_week_remembers_where_it_was_landing.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+DROP TABLE IF EXISTS team_weekly_review_outlook;

--- a/backend/migrations/core/1788671200_the_team_week_remembers_where_it_was_landing.up.sql
+++ b/backend/migrations/core/1788671200_the_team_week_remembers_where_it_was_landing.up.sql
@@ -1,0 +1,78 @@
+-- Where the TEAM's week was landing, frozen beside the snapshot that reports it.
+--
+-- The same fact the rep's weekly_review_outlook holds, over a different book: a
+-- lead reads their team's landing, not the sum of six personal ones, because
+-- the two differ wherever a deal is owned by nobody on the team or by two
+-- people at once.
+--
+-- A SEPARATE TABLE and not a nullable column on the rep's, because the parent
+-- differs: that one hangs off weekly_review by foreign key and this hangs off
+-- team_weekly_review. The COLUMNS are a deliberate mirror — same names, same
+-- types, same invariants — and TestTheTeamOutlookMirrorsTheRepOutlook holds
+-- them together in both directions, so a column added to one and not the other
+-- fails rather than drifting.
+SET LOCAL lock_timeout = '3s';
+
+CREATE TABLE team_weekly_review_outlook (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    team_weekly_review_id uuid NOT NULL,
+    -- Which window this landing is over.
+    period_kind text NOT NULL,
+    -- The window's own local days, copied rather than re-derived: the reporting
+    -- zone and the fiscal year start are operator-mutable settings, and
+    -- re-cutting an old week's quarter later would re-label a landing that was
+    -- already reported.
+    period_start date NOT NULL,
+    period_end date NOT NULL,
+
+    -- Which snapshots this was read from, WITHOUT a foreign key. Retention may
+    -- remove them; the figures below survive, and a dangling id is honest
+    -- about where the numbers came from.
+    opening_snapshot_id uuid,
+    closing_snapshot_id uuid,
+
+    -- The copied figures. Nullable as a GROUP: an opening side is absent when
+    -- no Monday snapshot exists, and absent is not zero — a zero opening would
+    -- draw a week that started from nothing and made everything.
+    opening_landing_minor bigint,
+    closing_landing_minor bigint,
+    won_minor bigint,
+    commit_minor bigint,
+    best_case_minor bigint,
+    weighted_minor bigint,
+    -- Which measure the landing was built from, frozen: the installation
+    -- setting can change, and a past week must keep saying what it was read
+    -- under rather than silently re-meaning.
+    forward_measure text,
+    base_currency text NOT NULL,
+
+    CONSTRAINT team_weekly_review_outlook_pkey PRIMARY KEY (id),
+    CONSTRAINT team_weekly_review_outlook_period_kind_check
+        CHECK (period_kind IN ('week', 'month', 'quarter')),
+    -- A window that ends before it starts is a broken writer, not a short week.
+    CONSTRAINT team_weekly_review_outlook_window_ordered CHECK (period_end >= period_start),
+    -- The opening side travels together or not at all. Written with
+    -- IS NOT DISTINCT FROM because a CHECK evaluating to NULL PASSES in
+    -- Postgres, so a plain = would admit exactly the half-written row this
+    -- refuses.
+    CONSTRAINT team_weekly_review_outlook_opening_whole CHECK (
+        (opening_snapshot_id IS NULL) IS NOT DISTINCT FROM (opening_landing_minor IS NULL)),
+    -- A measure is present exactly when there is a landing to have been built
+    -- by it.
+    CONSTRAINT team_weekly_review_outlook_measure_with_landing CHECK (
+        (forward_measure IS NULL) IS NOT DISTINCT FROM (closing_landing_minor IS NULL)),
+    CONSTRAINT team_weekly_review_outlook_measure_known CHECK (
+        forward_measure IS NULL
+        OR forward_measure IN ('commit_evidence', 'weighted', 'manager_call')),
+    CONSTRAINT team_weekly_review_outlook_currency_present CHECK (btrim(base_currency) <> '')
+);
+
+ALTER TABLE team_weekly_review_outlook
+    ADD CONSTRAINT team_weekly_review_outlook_review_fkey
+    FOREIGN KEY (team_weekly_review_id)
+    REFERENCES team_weekly_review(id) ON DELETE CASCADE;
+
+-- One landing per horizon per snapshot. A second row for the same window would
+-- give the panel two answers and no way to choose.
+CREATE UNIQUE INDEX uq_team_weekly_review_outlook_period
+    ON team_weekly_review_outlook (team_weekly_review_id, period_kind);

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (86)
+## Parity (87)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -102,6 +102,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this person currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |
 | `seedresetparity_test.go` | H3 | "What survives a reset" is one decision, and it is written down twice: the in-product data reset applies it in Go (internal/compose/datasweep.go's preservedResetTables), and the developer's `make seed-reset` applies it in SQL (scripts/seed-reset.sql). |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
+| `teamoutlookmirror_test.go` | H3 | The team's frozen outlook and the rep's are the same fact over different books, so they are the same SHAPE or one of them is lying. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -29225,6 +29225,20 @@ export interface components {
              */
             reps: components["schemas"]["TeamWeeklyRep"][];
             /**
+             * @description Where the TEAM's week was landing, one entry per horizon — the week, the month and
+             *     the fiscal quarter.
+             *
+             *     NOT the sum of its members' outlooks. A deal owned by nobody on the team is in
+             *     neither, and one the team works but a member owns is in both, so adding six personal
+             *     landings would answer a question nobody asked. This is read over the team's own book.
+             *
+             *     EMPTY when no forecast was composed when the snapshot was written, which is not the
+             *     same as a team that landed on nothing — a reader says "no forecast" rather than
+             *     drawing zeros. Every figure is a COPY, so it still reads after the snapshots it came
+             *     from age out under retention.
+             */
+            outlook?: components["schemas"]["WeeklyReviewOutlook"][];
+            /**
              * @description The Monday agenda: every id in `reps`, permuted into the order a lead should raise
              *     them. Derived on read from the same focus ranking that picked each rep's
              *     `focus_kind` — a rep who ASKED for help first, a quiet week last — so the meeting

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -364,3 +364,62 @@ describe("the team picker", () => {
     expect(screen.queryByLabelText(en["teamweekly.pickTeam"])).toBeNull();
   });
 });
+
+// The team's landing, drawn through the SAME panel the rep's retrospective
+// uses. What matters here is not the arithmetic — that is the server's — but
+// that a team which forecast nothing and one that landed on nothing are drawn
+// differently.
+describe("the team's landing", () => {
+  const horizon = {
+    period_kind: "quarter",
+    period_start: "2026-04-01",
+    period_end: "2026-06-30",
+    base_currency: "EUR",
+    won_minor: 180_000_00,
+    commit_minor: 120_000_00,
+    best_case_minor: 390_000_00,
+    weighted_minor: 260_000_00,
+    forward_measure: "commit_evidence",
+  };
+
+  it("says no forecast rather than drawing zeros when none was composed", async () => {
+    stubApi({
+      "GET /teams": () =>
+        jsonResponse({
+          data: [{ id: "t1", name: "Nord" }],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /weekly-reviews/team": () => jsonResponse(review()),
+    });
+    render(<TeamWeeklyPanel offered />);
+
+    // Said in WORDS, not drawn as an absence: a team nobody forecast and a
+    // team that landed on nothing are different facts, and only the panel can
+    // tell the reader which this is.
+    await screen.findByText(en["home.weekly.outlook.none"]);
+  });
+
+  it("draws the frozen landing when the snapshot carries one", async () => {
+    stubApi({
+      "GET /teams": () =>
+        jsonResponse({
+          data: [{ id: "t1", name: "Nord" }],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(
+          review({}, { outlook: [horizon] } as Partial<TeamWeeklyReview>),
+        ),
+    });
+    render(<TeamWeeklyPanel offered />);
+
+    // The panel is the rep's own, so finding its heading proves the team page
+    // reuses it rather than having grown a second one.
+    // The horizon control is the rep panel's own, so finding it by its
+    // accessible name proves the team page reuses that component rather than
+    // having grown a second one.
+    await screen.findByRole("group", { name: en["home.weekly.outlook"] });
+    // And the "no forecast" line is gone, so the two states are really distinct.
+    expect(screen.queryByText(en["home.weekly.outlook.none"])).toBeNull();
+  });
+});

--- a/frontend/src/screens/brief.teamweekly.tsx
+++ b/frontend/src/screens/brief.teamweekly.tsx
@@ -13,6 +13,7 @@ import { formatDate, formatMoney, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { AgendaPanel, AgendaSummary } from "./brief.teamweeklyagenda";
+import { OutlookPanel } from "./home.waterfall";
 import {
   type TeamWeeklyReview,
   useTeams,
@@ -172,8 +173,33 @@ export function TeamWeeklySection({
           )}
         </SurfaceState>
       </Panel>
+      {/* Where the team's week was landing, before the agenda: a lead reads
+          the outcome first and the conversation it implies second. The SAME
+          panel the rep's retrospective draws — a second one would be two
+          answers to "what does a landing look like". */}
+      {review && <TeamOutlook review={review} />}
       {review && <AgendaPanel review={review} />}
     </section>
+  );
+}
+
+// The team's landing, drawn through the rep panel's own component.
+//
+// Its own horizon state, held here rather than lifted: the team page and the
+// rep page are different surfaces a person reads at different moments, and a
+// shared dial would move one when they turned the other.
+function TeamOutlook({
+  review,
+}: Readonly<{ review: NonNullable<TeamWeeklyReview> }>) {
+  const { locale } = useLocale();
+  const [horizon, setHorizon] = useState("quarter");
+  return (
+    <OutlookPanel
+      outlook={review.outlook ?? []}
+      locale={locale}
+      horizon={horizon}
+      onHorizon={setHorizon}
+    />
   );
 }
 


### PR DESCRIPTION
The team's weekly snapshot froze its counts, its membership and one focus per rep. It did not say where the week was **landing** — the first thing a lead looks for. The team page carried a retrospective the rep pages had, and the outcome they did not.

## The team's landing is not the sum of its members'

A deal owned by nobody on the team is in neither. One the team works but a member owns is in both. So adding six personal outlooks would answer a question nobody asked.

It is read over the team's own book through `forecasting.ScopeTeam`, which the scope authority admits only to a caller whose `TeamIDs` contains the team. The weekly job binds the lead's own principal with their real teams, so the snapshot passes and nobody else's does.

## A refused landing costs the landing, not the week

Found in review, and it is **the same defect the rep-level review had once**, one level up.

The refusal arrives *inside* the transaction that has already written the snapshot, its reps and their focus lines. Letting it escape rolled all of that back — so a lead whose row scope was narrower than the team they were snapshotting lost the entire retrospective rather than just its outlook.

Only the refusal sentinels are absorbed. A broken query or a dead connection still fails the week, because a snapshot silently missing its landing for a reason nobody recorded is worse than one that was not written.

`TestARefusedTeamOutlookStillLeavesTheWeekWritten` reproduces it: it failed with *"a refused landing must not cost the team its week: not found"* before the fix, and fails again if the fix is reverted.

## Two tables, one writer

The team's outlook cannot be a column on the rep's — the parents differ, and one table cannot have two foreign keys of which exactly one is set. So the **columns are a declared mirror**, and `TestTheTeamOutlookMirrorsTheRepOutlook` holds them in both directions, deriving its corpus from the migrations rather than listing it. Mutation-checked three ways: a column on one side only, a type changed, a column missing — each fails with its own message.

The insert and the read are shared between the two tables, so a figure added for a rep cannot be forgotten for a team.

The panel is the rep's own. The team page passes its outlook to the same component, and a team that forecast nothing draws "no forecast" rather than zeros.

## Scope cut — most of the plan's WP7 is not here

This ships the team outlook alone. **Not built:** the ten-pattern list per rep, funnel deviations, live deal exceptions, frozen operating quality, the deterministic executive summary, the replan recommendation, and `GET /weekly-plans/team`.

The reason for the cut is worth stating: the per-rep focus **already ships six of the plan's ten patterns** — `help_requested`, `leads_breached`, `commitments_missed`, `meetings_without_next_step`, `strong_week`, `quiet_week` — as a priority chain returning exactly one, with its own migration-controlled CHECK and a written rationale for its ordering. Widening that to a list is a schema change to a frozen vocabulary and deserves its own piece of work rather than being folded in here.

## Testing

`make check-backend` and `make check-fe` both green, before the rebase and again after main moved four commits.

Codex reviewed scope, the shared writer's SQL identifiers, idempotence under a race, the read path's row draining, and the migration's null-safe CHECKs. It found the rollback defect; the other four came back clean with specific reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the team's landing (outlook) to the weekly team snapshot, so a lead reads where the week was heading without summing six member outlooks. A refused team outlook previously rolled back the entire snapshot write; now only the outlook is dropped and the week still stands.

- Adds `team_weekly_review_outlook` as a mirror of `weekly_review_outlook`, with a parity gate holding the two column lists in sync in both directions.
- Shares the insert and read paths between both tables, so a figure added for a rep cannot be forgotten for a team.
- Reuses the rep's outlook panel on the team page; a team with no forecast draws "no forecast" rather than zeros.
- Ships the team outlook only. Not built: per-rep ten-pattern lists, funnel deviations, live deal exceptions, frozen operating quality, the deterministic executive summary, the replan recommendation, and `GET /weekly-plans/team`. Widening the per-rep focus chain (which already ships six patterns) to a list is a schema change and deserves its own piece of work.

<sup>Written for commit 4eab7c8212594a32d921e635db4dfd30f9579435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

