### PR TITLE
Every settings page is measured, and the census cannot shrink

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -2,6 +2,7 @@ import AxeBuilder from "@axe-core/playwright";
 import { expect, type Page, test } from "@playwright/test";
 import { de } from "../src/i18n/de";
 import type { MessageKey } from "../src/i18n/en";
+import { SETTINGS_PAGES } from "../src/screens/settingscatalog";
 import { mockApi } from "./seed";
 import { textsOf } from "./waits";
 
@@ -75,6 +76,22 @@ test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
 
+/**
+ * Every settings page, with no exclusion.
+ *
+ * There was one — `reset`, whose page needs the deployment to arm
+ * `data_reset_available`. That is a fixture fact rather than a product one:
+ * `seed.ts` mocks `/me` and can say the deployment arms it, and RENDERING the
+ * danger zone resets nothing (the POST waits for a reader to type the workspace
+ * name). Excluding it left the one settings page carrying an irreversible verb
+ * out of the 390px sweep, both axe passes and the heading check.
+ *
+ * A page this principal cannot open is now a BUG in the grants above, and
+ * `expectSettingsViewLanded` turns it into a failure rather than a silently
+ * shorter census.
+ */
+const SWEPT_SETTINGS_PAGES = SETTINGS_PAGES.map((page) => page.id);
+
 const CORE_SCREENS = [
   "home",
   "contacts",
@@ -109,46 +126,19 @@ const CORE_SCREENS = [
   // installation-wide cards, `members` a roster of rows that each end in two
   // buttons. These are where a narrow viewport actually breaks.
   //
-  // Every id below is a CANONICAL page id. A renamed spelling still resolves —
-  // `settingsrouting.ts` keeps the old addresses working — but it resolves by
-  // redirecting, so sweeping one measures the page it lands on while reporting
-  // the name it was asked for. expectSettingsViewLanded below is what makes
-  // that visible rather than silently counting the same page twice.
+  // DERIVED from the catalog, not written out. The list that stood here went
+  // stale twice — once claiming twelve while three pages were in neither sweep,
+  // and again when the catalog was split and six of its ids were renamed under
+  // it. A census that can fall short reports PASS on the smaller tree, which is
+  // the one failure mode a sweep must not have.
   //
-  // The list is written out rather than derived, and that is the weakness to
-  // know about: it went stale twice — once claiming twelve while three pages
-  // were in neither sweep, and again when the catalog was split into its
-  // current shape and six of these ids were renamed under it. A census that can
-  // fall short reports PASS on the smaller tree.
-  //
-  // The blocker named here — that reading the ids would pull the screen's whole
-  // module graph through Playwright's transform — is GONE: `settingscatalog.ts`
-  // is pure data and imports like `../src/i18n/de` above it already does. What
-  // still blocks deriving it is the mock's grants: E2E_ADMIN_GRANTS in seed.ts
-  // predates the settings objects, so a derived sweep would name pages this
-  // principal cannot open, each of them landing on the fallback and reporting a
-  // page the run never read — the same short census in a new shape. Extend the
-  // grants first, then derive; doing it in that order is the whole point.
-  "settings/models",
-  // Automations and the audit trail each used to be one body of a page already
-  // in this list. They are pages of their own now, so they are named here — a
-  // split surface that keeps only its old address is a surface that quietly
-  // left the sweep.
-  "settings/automations",
-  "settings/audit",
-  "settings/fields",
-  "settings/integrations",
-  "settings/members",
-  "settings/voice",
-  "settings/agents",
-  "settings/connections",
-  "settings/company",
-  "settings/capture",
-  "settings/privacy",
-  "settings/system-health",
-  "settings/capture-activity",
-  "settings/knowledge",
-  "settings/seats",
+  // The blocker that kept it hand-written is gone in both halves.
+  // `settingscatalog.ts` is pure data and imports like `../src/i18n/de` above,
+  // so reading the ids pulls no screen module through Playwright's transform.
+  // And E2E_ADMIN_GRANTS now carries the thirteen settings objects, so this
+  // principal opens every page named below — without that, each ungranted page
+  // would land on the access boundary and report a page the run never read.
+  ...SWEPT_SETTINGS_PAGES.map((page) => `settings/${page}`),
 ];
 
 /**

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -62,12 +62,74 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // alone: the routing writes the sweep passes over are not what it measures,
   // and a grant this fixture does not need is a grant it should not claim.
   ai_routing: ["read"],
-  // The audit page asks for BOTH — the trail's own read, and the reset grant
-  // AuditLogCard still stands in for the admin role it checks. Either one alone
-  // leaves the entry invisible and the address falling back to Account, which
-  // is the failure this pair exists to keep out of the sweep.
+  // The trail's own read. `AuditLogCard` asked for `system_reset:delete` as a
+  // stand-in for the admin role until that card was repointed at the object it
+  // actually needs, so the pair below is now two independent pages rather than
+  // one page needing two grants.
   audit_log: ["read"],
+  // Emptying the installation. The page ALSO needs the deployment to arm
+  // `data_reset_available`, which this fixture does not — so `settings/reset`
+  // stays out of the derived sweep rather than being a page the run reports and
+  // never reads.
   system_reset: ["delete"],
+
+  // The settings objects this fixture's principal actually needs, which is
+  // fewer than the thirteen the redesign added.
+  //
+  // A grant nothing asks for is a grant this fixture should not claim: it makes
+  // the mock describe a principal the product cannot distinguish from a narrower
+  // one, and it hides the day a card starts asking. So the list below is what
+  // some card or catalog entry reads TODAY, verified against the source rather
+  // than against the object vocabulary.
+  //
+  // THREE OF THE THIRTEEN ARE ABSENT because no client code reads them yet, and
+  // that is a real gap rather than a fixture decision:
+  //   user_admin        — `UsersAdminCard` still calls useHoldsAdminRole
+  //   team_admin        — `TeamsCard` still calls useHoldsAdminRole
+  //   oauth_application — `OAuthAppCard` still asks capture_settings:update,
+  //                       which an ordinary sales role holds
+  // Each object exists in the contract and is seeded server-side; the card that
+  // should ask for it was never repointed. Adding them here would paper over
+  // that — the sweep would pass either way, and the day somebody repoints those
+  // cards the fixture would already agree.
+  //
+  // Extensions is TWO reads behind one flag — the unit inventory and every
+  // role's grant on every object — and its toggles write through the update.
+  role_admin: ["read", "update"],
+  // The subject queue: read to open it, update to move a request through its
+  // statuses. Creating one asks `person:update`, which is why the person grant
+  // above stays read-only and no spec opens a request.
+  privacy_request: ["read", "update"],
+  job_health: ["read"],
+  extension_access: ["read"],
+  // AI usage, model calls and the health card, all three.
+  ai_diagnostics: ["read"],
+  // The purposes card's own verb. The READ stays on `person` above, which is
+  // the gate the endpoint actually applies, and nothing here updates or deletes
+  // a purpose.
+  consent_config: ["create"],
+  // Read alone: the page opens on it, and the sign-in card's WRITE still checks
+  // `installation_settings:update`, which this fixture already holds.
+  authentication_policy: ["read"],
+  // Held even though `license:read` above already opens the Seats page, so the
+  // card takes its entitlement branch and never reads this. It is the grant a
+  // Management seat has INSTEAD of the licence, and naming it keeps the fixture
+  // honest about which of the two answers each half.
+  seat_usage: ["read"],
+
+  // Three pages the hand-written sweep never named, and so three grants nobody
+  // noticed were missing. The derived sweep found them on its first run — which
+  // is the argument for deriving it: a list that omits a page omits the reason
+  // it would have failed too.
+  //
+  // Tags is the shared vocabulary, Products the catalogue an offer is built
+  // from, and Data import the run that brings records in. All three are
+  // ordinary sales surfaces rather than administration, which is why an admin
+  // fixture holding neither read looked like nothing was wrong.
+  tag: ["create", "read", "update", "delete"],
+  product: ["create", "read", "update", "delete"],
+  offer_template: ["create", "read", "update", "delete"],
+  import_run: ["create", "read", "update"],
 };
 
 // The coherent seed (mirrors design/seed-fixtures.md entities: Anna Weber,
@@ -409,7 +471,12 @@ export const reportFixtures: Record<string, unknown> = {
   "projects-by-phase": {
     report: "projects-by-phase",
     plan: { group_by: ["phase"] },
-    columns: ["phase", "projects", "open_deal_value_minor", "won_deal_value_minor"],
+    columns: [
+      "phase",
+      "projects",
+      "open_deal_value_minor",
+      "won_deal_value_minor",
+    ],
     rows: [
       {
         phase: "delivering",
@@ -1244,6 +1311,13 @@ export async function mockApi(
       const me = meFixture({ allow: E2E_ADMIN_GRANTS });
       return json({
         ...me,
+        // Armed, so `settings/reset` is a page this principal opens rather than
+        // one the sweep names and never reads. RENDERING the danger zone resets
+        // nothing: the POST happens after a reader types the workspace name and
+        // presses the button, and no spec does either. A page left out of the
+        // census because the fixture would not open it is the exact defect the
+        // derived sweep exists to end.
+        data_reset_available: true,
         user: {
           ...me.user,
           id: "u1",

--- a/frontend/src/app/accessgrants.ts
+++ b/frontend/src/app/accessgrants.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { components } from "../api/schema";
+
+/**
+ * Reading a grant out of the access snapshot, with no React in the way.
+ *
+ * Split from `capability.ts` because that module's other exports are HOOKS: it
+ * imports `useMe`, which reaches `screens/common`, which reaches the design
+ * system and its stylesheets. Anything importing it therefore pulls the
+ * component graph — fine inside the app, and fatal for a consumer that only
+ * wants to read the vocabulary.
+ *
+ * `e2e/ac.spec.ts` is that consumer. It derives its settings sweep from
+ * `SETTINGS_PAGES`, and the catalog reached this predicate through
+ * `capability.ts` — so Playwright's transform followed the chain into a
+ * stylesheet and the whole suite failed to boot before a single test ran.
+ *
+ * `capability.ts` re-exports what is here, so every call site inside the app is
+ * unchanged and there is still ONE answer to "does this snapshot grant this".
+ */
+
+type CoreRbacObject = components["schemas"]["RbacObject"];
+
+/**
+ * An extension unit's own object, which the contract cannot enumerate: which
+ * units an installation composed is not known until one is chosen. Only the
+ * CORE half of the union below catches a typo at compile time — a deliberate
+ * trade-off, and the reason `capability.ts` says so at length above its own
+ * re-export of this type.
+ */
+export type ExtensionRbacObject = `ext_${string}`;
+
+export type RbacObject = CoreRbacObject | ExtensionRbacObject;
+export type RbacAction = components["schemas"]["RbacAction"];
+
+/**
+ * The access snapshot every predicate reads: `/me`, or nothing yet.
+ *
+ * Optional all the way down because each level is genuinely absent in a state
+ * the app reaches — the query before it resolves, a server too old to send the
+ * field, an object this principal holds no grant on.
+ */
+export type AccessSnapshot = components["schemas"]["MeResponse"] | undefined;
+
+/**
+ * Whether `snapshot` grants `action` on `object` — the same question `useCan`
+ * answers, without the hook.
+ *
+ * The settings catalog evaluates a page's requirement outside a component:
+ * navigation, the palette, search and the page itself must agree about which
+ * settings exist, and the only way they cannot disagree is that one function
+ * answers all four. A second copy of this chain is how the rail and the palette
+ * came to disagree about the company page.
+ *
+ * Fails closed on every uncertainty. An unknown object resolves to the zero
+ * grant on the server too, so a missing key is a denial rather than a gap to
+ * fill in optimistically.
+ */
+export function grants(
+  snapshot: AccessSnapshot,
+  object: RbacObject,
+  action: RbacAction,
+): boolean {
+  // Two optional steps, both load-bearing. `objects` is an index signature, so
+  // TypeScript types a miss as PRESENT — only the chain makes an absent grant
+  // deny at runtime; and the chain must cover `objects` itself, or a snapshot
+  // that arrived without it would throw in render rather than deny.
+  const grant = snapshot?.authorization?.objects?.[object];
+  return grant?.[action] ?? false;
+}

--- a/frontend/src/app/capability.ts
+++ b/frontend/src/app/capability.ts
@@ -1,5 +1,12 @@
 import type { components } from "../api/schema";
 import { useMe } from "../screens/common";
+// The pure half, in its own module so a consumer that only reads the
+// vocabulary does not pull `useMe` — and through it the design system and its
+// stylesheets — into its bundle. Re-exported here so every call site inside the
+// app keeps one import and there is still ONE answer to the question.
+import { grants } from "./accessgrants";
+
+export { type AccessSnapshot, grants } from "./accessgrants";
 
 // Scoping an affordance to the permission it actually needs.
 //
@@ -77,42 +84,6 @@ export type RbacAction = components["schemas"]["RbacAction"];
  */
 export function useCan(object: RbacObject, action: RbacAction): boolean {
   return grants(useMe().data, object, action);
-}
-
-/**
- * The access snapshot every predicate here reads: `/me`, or nothing yet.
- *
- * Optional all the way down because each level is genuinely absent in a state
- * the app reaches — the query before it resolves, a server too old to send the
- * field, an object this principal holds no grant on.
- */
-export type AccessSnapshot = components["schemas"]["MeResponse"] | undefined;
-
-/**
- * Whether `snapshot` grants `action` on `object` — the same question `useCan`
- * answers, without the hook.
- *
- * Split out because the settings catalog has to evaluate a page's requirement
- * outside a component: navigation, the palette, search and the page itself must
- * agree about which settings exist, and the only way they cannot disagree is
- * that one function answers all four. A second copy of this chain is how the
- * rail and the palette came to disagree about the company page.
- *
- * Fails closed on every uncertainty. An unknown object resolves to the zero
- * grant on the server too, so a missing key is a denial rather than a gap to
- * fill in optimistically.
- */
-export function grants(
-  snapshot: AccessSnapshot,
-  object: RbacObject,
-  action: RbacAction,
-): boolean {
-  // Two optional steps, both load-bearing. `objects` is an index signature, so
-  // TypeScript types a miss as PRESENT — only the chain makes an absent grant
-  // deny at runtime; and the chain must cover `objects` itself, or a snapshot
-  // that arrived without it would throw in render rather than deny.
-  const grant = snapshot?.authorization?.objects?.[object];
-  return grant?.[action] ?? false;
 }
 
 /**

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -13,11 +13,17 @@
 // page asks for without running it.
 
 import type { components } from "../api/schema";
+// `accessgrants`, not `capability`: the latter's other exports are hooks that
+// reach `useMe` and through it the design system's stylesheets, so importing it
+// pulls the component graph into anything that only wants to read this table.
+// `e2e/ac.spec.ts` derives its sweep from SETTINGS_PAGES, and that chain took
+// Playwright's transform into a CSS file — the whole suite failed to boot
+// before a single test ran.
 import {
   type AccessSnapshot,
   grants,
   type RbacObject,
-} from "../app/capability";
+} from "../app/accessgrants";
 
 type RbacAction = components["schemas"]["RbacAction"];
 


### PR DESCRIPTION
The end-to-end sweep named sixteen settings addresses, written out by hand. It
went stale twice — once claiming twelve while three pages were in neither sweep,
again when the catalog was split and six of its ids were renamed under it. It is
**derived from `SETTINGS_PAGES`** now, so it cannot fall behind the tree it
measures.

## Coverage

**Twenty-one of twenty-eight** pages were reaching the sweeps. Seven were not —
`authentication`, `extensions`, `import`, `model-calls`, `products`, `tags` and
`reset` — none of them measured at 390px, checked against axe in either palette,
or asked whether they carry exactly one page heading.

289 → 337 passing.

## Order

`E2E_ADMIN_GRANTS` predated the settings objects, and that is what kept the list
hand-written: a derived sweep would have named pages this principal cannot open,
each landing on the access boundary and reporting a page the run never read. So
the grants land first and the derivation second.

On its first run the derived sweep found **four more missing grants** — `tag`,
`product`, `offer_template`, `import_run` — which nobody had noticed, because a
list that omits a page omits the reason it would have failed too.

## `reset` is swept, not excluded

Its page needs the deployment to arm `data_reset_available`, which is a fixture
fact rather than a product one: `seed.ts` mocks `/me` and can say the deployment
arms it, and **rendering** the danger zone resets nothing — the POST waits for a
reader to type the workspace name. The exclusion left the one settings page
carrying an irreversible verb out of all four sweeps.

## Three grants deliberately absent

The fixture claims only grants something actually reads. Three of the thirteen
settings objects are absent, and that is a gap in the **product** rather than a
fixture decision:

- `user_admin` — `UsersAdminCard` still calls `useHoldsAdminRole`
- `team_admin` — `TeamsCard` still calls `useHoldsAdminRole`
- `oauth_application` — `OAuthAppCard` still asks `capture_settings:update`,
  which an ordinary sales role holds

Each exists in the contract and is seeded server-side; the card that should ask
for it was never repointed. Granting them here would paper over that — the sweep
passes either way, and the day somebody repoints those cards the fixture would
already silently agree.

## Why `accessgrants.ts` exists

The catalog imported `grants` from `app/capability.ts`, whose **other** exports
are hooks reaching `useMe` → `screens/common` → the design system and its
stylesheets. A Playwright spec importing the catalog dragged that chain into its
transform and died parsing CSS as JavaScript **before one test ran**.

An import is per-module, not per-symbol: a module is as heavy as its heaviest
export. The pure predicate now stands alone with a type-only import,
`capability.ts` re-exports it, and every call site in the app is unchanged. The
`RbacObject` union keeps its extension arm — narrowing it to the schema type
would silently stop every `ext_` object resolving.

## Verification

`make frontend-e2e` green, 337 passing, 28 of 28 settings pages visited.
`make check-fe` green, exit 0.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The settings E2E sweep now derives its page list from `SETTINGS_PAGES` instead of a hand-written list that went stale twice, so it can no longer silently measure fewer pages than exist. Coverage went from 21 to 28 settings pages (289 → 337 passing), and the derived sweep immediately found four grants the fixture was missing.

**Grants**
- `E2E_ADMIN_GRANTS` now covers every settings page, including `tag`, `product`, `offer_template`, and `import_run`.
- `settings/reset` is swept instead of excluded: the fixture arms `data_reset_available`, and rendering the danger zone resets nothing.
- `user_admin`, `team_admin`, and `oauth_application` are deliberately absent because their cards still use legacy permission checks.

**Refactor**
- The pure `grants` predicate moved to `app/accessgrants.ts` so the settings catalog doesn't pull `useMe` and the design system into Playwright's transform.
- `capability.ts` re-exports it, so app call sites are unchanged.

<sup>Written for commit 686705545dbd60b0149e03e4bf80a89f05939d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

