### PR TITLE
fix(seed-demo): a seeded grant records the wording it stands for

### DIFF
--- a/backend/tools/seed-demo/consent.go
+++ b/backend/tools/seed-demo/consent.go
@@ -74,7 +74,7 @@ func seedConsent(c *client, cfg demoConfig, companies []company, refs pipelineRe
 			skippedDOI = append(skippedDOI, want.Purpose)
 			continue
 		}
-		body := jsonBody{"purpose_id": purpose.id, "new_state": want.State, "source": seedSource}
+		body := consentBody(purpose, want)
 		// Recording the state a person is already in is a no-op the API
 		// accepts, so the count reflects what CHANGED rather than what was
 		// sent — otherwise every run reports the same six as fresh.
@@ -95,6 +95,65 @@ func seedConsent(c *client, cfg demoConfig, companies []company, refs pipelineRe
 			len(skippedDOI), strings.Join(skippedDOI, ", "))
 	}
 	return recorded, nil
+}
+
+// consentBody is the request one seeded consent state sends.
+//
+// Split out from the loop so the wording rule is testable without a workspace
+// behind it: the asymmetry between a grant and a withdrawal is the part worth
+// pinning, and it is invisible in an end-to-end seeding run that only reports
+// how many rows changed.
+func consentBody(purpose consentPurpose, want demoConsent) jsonBody {
+	body := jsonBody{"purpose_id": purpose.id, "new_state": want.State, "source": seedSource}
+	// Sent only with a grant. The writer drops wording passed with a
+	// withdrawal, so including it would be dead weight that also reads, to
+	// anybody looking at the request, like a withdrawal claiming a screen.
+	if want.State == "granted" {
+		body["wording"] = grantWording(want, purpose.label)
+	}
+	return body
+}
+
+// maxWordingRunes is the contract's ceiling on a recorded wording
+// (CreateConsentRequest.wording, and the CHECK behind it). Duplicated here
+// because the seeder speaks to the API over HTTP and cannot import the module's
+// unexported bound — and a fallback that overran it would 422 the whole run,
+// which is the failure this function exists to prevent.
+const maxWordingRunes = 2000
+
+// grantWording settles what a seeded GRANT claims the subject was shown.
+//
+// A dataset that has authored real form copy wins outright: the consent
+// surfaces read this back, and a demo is worth more when what it shows is the
+// sentence a person would really have agreed to.
+//
+// The fallback deliberately does NOT read like consent copy. #4583 removed the
+// old 'recorded via API' placeholder because a proof row carrying it "reads
+// like evidence and holds none", and a seeder inventing a plausible "I agree
+// to…" would put that back with better grammar. So the stand-in names the
+// purpose it covers and then says what it is, on the row, where anybody reading
+// the consent history or a subject access export sees it.
+//
+// Only grants reach here. A withdrawal demonstrates nothing, the writer drops
+// any wording passed with one, and the API requires none.
+func grantWording(want demoConsent, label string) string {
+	if authored := strings.TrimSpace(want.Wording); authored != "" {
+		return authored
+	}
+	name := strings.TrimSpace(label)
+	if name == "" {
+		// A purpose the workspace does not label still has its machine key, and
+		// a stand-in that names nothing is worse than one naming that.
+		name = want.Purpose
+	}
+	const suffix = " — seeded demo data; no subject was shown this text."
+	// The label is dataset-supplied and nothing upstream bounds it, so the
+	// truncation happens on the part that can grow, not on the sentence that
+	// carries the disclosure.
+	if room := maxWordingRunes - len([]rune(suffix)); len([]rune(name)) > room {
+		name = string([]rune(name)[:room])
+	}
+	return name + suffix
 }
 
 // consentState reads what a person has already agreed to for one purpose.
@@ -140,6 +199,7 @@ func findPersonByName(c *client, name string) (string, bool, error) {
 type consentPurpose struct {
 	id          string
 	requiresDOI bool
+	label       string
 }
 
 func loadPurposes(c *client, mode runMode) (map[string]consentPurpose, error) {
@@ -151,6 +211,7 @@ func loadPurposes(c *client, mode runMode) (map[string]consentPurpose, error) {
 		Data []struct {
 			ID                  string `json:"id"`
 			Key                 string `json:"key"`
+			Label               string `json:"label"`
 			RequiresDoubleOptIn bool   `json:"requires_double_opt_in"`
 		} `json:"data"`
 	}
@@ -158,7 +219,7 @@ func loadPurposes(c *client, mode runMode) (map[string]consentPurpose, error) {
 		return nil, fmt.Errorf("listing consent purposes: %w", err)
 	}
 	for _, row := range page.Data {
-		out[row.Key] = consentPurpose{id: row.ID, requiresDOI: row.RequiresDoubleOptIn}
+		out[row.Key] = consentPurpose{id: row.ID, requiresDOI: row.RequiresDoubleOptIn, label: row.Label}
 	}
 	return out, nil
 }

--- a/backend/tools/seed-demo/consent_test.go
+++ b/backend/tools/seed-demo/consent_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGrantWordingPrefersTheDatasetsOwnSentence is the point of the field. A
+// demo exists to be read, and the consent surfaces read back what the subject
+// was shown — so a dataset that has authored real form copy must see that copy
+// on the proof row, not a sentence the seeder made up around it.
+func TestGrantWordingPrefersTheDatasetsOwnSentence(t *testing.T) {
+	want := "I agree to receive product news from Gradion by email."
+	got := grantWording(demoConsent{Wording: want}, "Marketing email")
+	if got != want {
+		t.Errorf("grantWording = %q, want the dataset's own sentence %q", got, want)
+	}
+}
+
+// TestGrantWordingFallbackNamesItselfAsSeeded is the constraint #4583 argues
+// for. That change DELETED the old 'recorded via API' placeholder because a row
+// carrying it "reads like evidence and holds none" — so the fallback here must
+// not be plausible consent copy. It has to say, on the row itself, that no
+// subject was shown anything, or this fix reintroduces exactly what upstream
+// removed.
+func TestGrantWordingFallbackNamesItselfAsSeeded(t *testing.T) {
+	got := grantWording(demoConsent{Purpose: "marketing_email"}, "Marketing email")
+	if got == "" {
+		t.Fatal("grantWording returned empty, which the API refuses for a grant")
+	}
+	for _, forbidden := range []string{"I agree", "I consent", "Yes, please"} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("fallback %q reads as real consent copy (%q); a seeded row must not claim a screen existed", got, forbidden)
+		}
+	}
+	if !strings.Contains(got, "Marketing email") {
+		t.Errorf("fallback %q does not name the purpose it stands in for", got)
+	}
+	if !strings.Contains(got, "seeded") {
+		t.Errorf("fallback %q does not say it is seeded demo data", got)
+	}
+}
+
+// TestGrantWordingStaysUnderTheContractsBound guards the 2000-rune ceiling the
+// API enforces. A label is dataset-supplied and nothing upstream bounds it, so
+// a long one must not push the fallback over a limit that would 422 the whole
+// seeding run — which is the failure this fix exists to remove.
+func TestGrantWordingStaysUnderTheContractsBound(t *testing.T) {
+	long := ""
+	for range 3000 {
+		long += "x"
+	}
+	if n := len([]rune(grantWording(demoConsent{}, long))); n > 2000 {
+		t.Errorf("fallback is %d runes, over the contract's 2000", n)
+	}
+}
+
+// TestConsentBodyCarriesWordingOnlyForAGrant pins the asymmetry #4583 built
+// into the writer. A grant must carry wording or the API refuses it; a
+// withdrawal must not, because wordingFor drops it anyway and a withdrawal row
+// that arrived holding the sentence from a GRANT is the exact false claim that
+// change exists to make impossible.
+func TestConsentBodyCarriesWordingOnlyForAGrant(t *testing.T) {
+	purpose := consentPurpose{id: "11111111-1111-1111-1111-111111111111", label: "Marketing email"}
+
+	granted := consentBody(purpose, demoConsent{State: "granted", Wording: "I agree to receive product news."})
+	if got := granted["wording"]; got != "I agree to receive product news." {
+		t.Errorf("granted body wording = %v, want the authored sentence", got)
+	}
+
+	withdrawn := consentBody(purpose, demoConsent{State: "withdrawn", Wording: "I agree to receive product news."})
+	if _, present := withdrawn["wording"]; present {
+		t.Error("withdrawal body carries wording; a withdrawal demonstrates nothing and must claim no screen")
+	}
+}
+
+// TestConsentBodyKeepsTheFieldsTheSeederAlreadySent guards the rest of the body
+// while wording is added beside it. purpose_id, new_state and source are what
+// make a seeded row addressable and identifiable as seeded, and losing one of
+// them to a refactor would be invisible until a demo looked wrong.
+func TestConsentBodyKeepsTheFieldsTheSeederAlreadySent(t *testing.T) {
+	purpose := consentPurpose{id: "22222222-2222-2222-2222-222222222222", label: "Transactional"}
+	body := consentBody(purpose, demoConsent{State: "granted", Wording: "ok"})
+
+	if body["purpose_id"] != purpose.id {
+		t.Errorf("purpose_id = %v, want %q", body["purpose_id"], purpose.id)
+	}
+	if body["new_state"] != "granted" {
+		t.Errorf("new_state = %v, want %q", body["new_state"], "granted")
+	}
+	if body["source"] != seedSource {
+		t.Errorf("source = %v, want %q", body["source"], seedSource)
+	}
+}

--- a/backend/tools/seed-demo/demo.go
+++ b/backend/tools/seed-demo/demo.go
@@ -289,6 +289,11 @@ type demoConsent struct {
 	PersonIndex int    `json:"person_index"`
 	Purpose     string `json:"purpose"`
 	State       string `json:"state"`
+	// The exact sentence this person was shown, stored verbatim on the proof
+	// row. Optional, and only a grant uses it: a dataset that leaves it out
+	// gets a stand-in that says it is seeded rather than one that impersonates
+	// consent copy. See grantWording.
+	Wording string `json:"wording"`
 }
 
 // demoPartner is one channel partner: a company the installation SELLS WITH


### PR DESCRIPTION
**AI disclosure: Generated** — AI produced substantial portions, reviewed and owned by me.

## The break

#4583 made `wording` required on a consent grant and cleared the tree of every
door that did not send one. `seed-demo` speaks to the API over HTTP and was not
in that tree, so it still posts `{purpose_id, new_state, source}` and the first
granted consent in any dataset now fails:

```
seed-demo: consent for <person>: POST /v1/people/<id>/consent: HTTP 422
detail: a grant records the exact wording shown to the subject
```

That is every seeding run against `main`, and it lands *after* organizations,
people, employments and partners are written — so a demo install stops
half-built rather than never starting. Found cutting a downstream release: both
desktop bundles built, then died seeding.

## The fix

**The dataset answers first.** `demoConsent` takes a `wording`, because the
consent surfaces read it back and a demo is worth more showing the sentence a
person would really have agreed to than a generated stand-in.

**Where a dataset says nothing, the stand-in does not impersonate consent
copy.** This is the direct descendant of the placeholder #4583 deleted —
`'recorded via API'`, removed because a proof row carrying it "reads like
evidence and holds none" — and a seeder inventing a fluent "I agree to
receive…" would restore exactly that with better grammar. So it names the
purpose and then says what it is:

```
Marketing email — seeded demo data; no subject was shown this text.
```

A reader of the consent history, or of a subject access export, sees the
disclosure on the row. That is the only honest thing a seeder can put there.

**Only a grant carries it.** `wordingFor` already drops wording passed with a
withdrawal, so sending one would be dead weight that also reads, at the
request, like a withdrawal claiming a screen that never existed.

The label comes from the purpose the workspace already defines, so an existing
dataset loads with nothing newly authored. It is dataset-supplied and unbounded
upstream, so the fallback truncates the *label* rather than the sentence
carrying the disclosure, keeping the whole under the contract's 2000. An
authored wording is sent verbatim and left to the API to judge: silently
trimming what somebody recorded as shown would be the same class of lie this
change avoids.

## Tests

Five, written before the code:

- `grantWording` prefers the dataset's own sentence
- the fallback names itself as seeded and contains no "I agree"/"I consent"
- the fallback stays under 2000 runes when the label is pathological
- `consentBody` carries wording for a grant and omits it for a withdrawal
- `consentBody` keeps `purpose_id`, `new_state` and `source`

## Verification

`go test ./tools/seed-demo/` green; `gofmt`, `go vet` clean. The Go half of
`make check` passes locally, including the gates and linter.

One limitation, stated plainly: I could not get core's **frontend** unit suite
green on my machine, and it is red there *without* this change too — 11
failures reducing to Intl compact notation (`expected '€186.4K' to be
'€186.4k'`) because I am on Node 22 / ICU 77.1 while the workflows pin Node 24.
I verified the identical failures on `2f3aa798` with this commit absent. This
change touches three Go files under `backend/tools/seed-demo/`; nothing in the
frontend imports them.
