### PR TITLE
A preference link says which address it was sent to

### DIFF
--- a/backend/internal/modules/consent/handlers_public.go
+++ b/backend/internal/modules/consent/handlers_public.go
@@ -29,7 +29,7 @@ func (h Handlers) GetPreferenceCenter(w http.ResponseWriter, r *http.Request, to
 		writeConsentErr(w, r, err)
 		return
 	}
-	view, err := h.store.PublicPreferenceView(r.Context(), ref.PersonID)
+	view, err := h.store.PublicPreferenceView(r.Context(), ref)
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return
@@ -83,7 +83,7 @@ func (h Handlers) unsubscribeTargets(
 	if params.Purpose != nil && strings.TrimSpace(*params.Purpose) != "" {
 		return []string{strings.ToLower(strings.TrimSpace(*params.Purpose))}, nil
 	}
-	view, err := h.store.PublicPreferenceView(ctx, personID)
+	view, err := h.store.PublicPreferenceView(ctx, PreferenceRef{PersonID: personID})
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (h Handlers) UpdatePreferences(w http.ResponseWriter, r *http.Request, toke
 		writeConsentErr(w, r, err)
 		return
 	}
-	view, err := h.store.PublicPreferenceView(r.Context(), ref.PersonID)
+	view, err := h.store.PublicPreferenceView(r.Context(), ref)
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -49,9 +49,15 @@ func LockedPurpose(key string) bool {
 	return normalizedPurposeKey(key) == PurposeTransactional
 }
 
-// PreferenceRef is a token's resolution: whose consent.
+// PreferenceRef is a token's resolution: whose consent, and at which address.
+//
+// EmailID is nil for a token minted before the address was recorded, and for
+// one whose address the subject has since erased. The page falls back to the
+// person's primary address there, which is what it always did — a NULL is the
+// honest record of "not known" rather than a guess that would read like a fact.
 type PreferenceRef struct {
 	PersonID ids.PersonID
+	EmailID  *ids.UUID
 }
 
 // PurposeChoice is one row of the preference center: the purpose, the
@@ -110,9 +116,9 @@ func (s *Store) ResolvePreferenceToken(ctx context.Context, token string) (Prefe
 	var ref PreferenceRef
 	err := database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
 		err := tx.QueryRow(ctx, `
-			SELECT person_id FROM preference_token
+			SELECT person_id, person_email_id FROM preference_token
 			 WHERE token = $1 AND revoked_at IS NULL AND expires_at > now()`,
-			token).Scan(&ref.PersonID)
+			token).Scan(&ref.PersonID, &ref.EmailID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -122,6 +128,16 @@ func (s *Store) ResolvePreferenceToken(ctx context.Context, token string) (Prefe
 		return PreferenceRef{}, err
 	}
 	return ref, nil
+}
+
+// addressedPerson is one live address and the person who holds it — the pair a
+// preference token is minted for. The ADDRESS is half of it: a token that
+// remembered only the person would open a page naming whichever address the
+// record happens to call primary, which for a person holding several is one the
+// link's holder was never written at.
+type addressedPerson struct {
+	PersonID ids.PersonID
+	EmailID  ids.UUID
 }
 
 // PreferenceTokenForEmail resolves a recipient address to their live
@@ -154,7 +170,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 		// impossible; this refuses anyway rather than trusting an invariant it
 		// does not check.
 		rows, err := tx.Query(ctx, `
-			SELECT DISTINCT pe.person_id
+			SELECT DISTINCT pe.person_id, pe.id
 			FROM person_email pe
 			JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
 			WHERE lower(pe.email) = $1 AND pe.archived_at IS NULL
@@ -162,7 +178,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 		if err != nil {
 			return err
 		}
-		matches, err := pgx.CollectRows(rows, pgx.RowTo[ids.PersonID])
+		matches, err := pgx.CollectRows(rows, pgx.RowToStructByPos[addressedPerson])
 		if err != nil {
 			return err
 		}
@@ -173,7 +189,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 			return fmt.Errorf("consent: the recipient address is live on more than one person, so no unsubscribe link can name which: %w",
 				apperrors.ErrConflict)
 		}
-		personID := matches[0]
+		personID := matches[0].PersonID
 		// The token this mints is a bearer credential over the recipient's
 		// consent record — it reads their per-purpose state, withdraws, and
 		// grants, all with no session. So the mint carries the SAME row-scope
@@ -199,7 +215,7 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 			return err
 		}
 		found = true
-		token, err = ensurePreferenceTokenTx(ctx, tx, personID)
+		token, err = ensurePreferenceTokenTx(ctx, tx, personID, matches[0].EmailID)
 		return err
 	})
 	if err != nil {
@@ -220,15 +236,18 @@ func (s *Store) PreferenceTokenForEmail(ctx context.Context, email string) (toke
 // accident — it falls through to rotation. Reuse is deliberate (the
 // preference centre is revisitable, and one message's link must keep working
 // after the next one goes out); what 0144 ends is reuse without a bound.
-func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (string, error) {
+func ensurePreferenceTokenTx(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID, emailID ids.UUID,
+) (string, error) {
 	var token string
 	err := tx.QueryRow(ctx, `
 		UPDATE preference_token
 		   SET expires_at = now() + make_interval(days => $2)
-		 WHERE person_id = $1 AND revoked_at IS NULL
+		 WHERE person_id = $1 AND person_email_id = $4 AND revoked_at IS NULL
 		   AND expires_at > now()
 		   AND created_at > now() - make_interval(days => $3)
-		RETURNING token`, personID, preferenceTokenTTLDays, preferenceTokenMaxAgeDays).Scan(&token)
+		RETURNING token`,
+		personID, preferenceTokenTTLDays, preferenceTokenMaxAgeDays, emailID).Scan(&token)
 	if err == nil {
 		return token, nil
 	}
@@ -243,7 +262,8 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 	// declared for in 0048 and never had.
 	if _, err := tx.Exec(ctx, `
 		UPDATE preference_token SET revoked_at = now()
-		 WHERE person_id = $1 AND revoked_at IS NULL`, personID); err != nil {
+		 WHERE person_id = $1 AND person_email_id = $2 AND revoked_at IS NULL`,
+		personID, emailID); err != nil {
 		return "", err
 	}
 	fresh, err := newPreferenceToken()
@@ -251,17 +271,18 @@ func ensurePreferenceTokenTx(ctx context.Context, tx pgx.Tx, personID ids.Person
 		return "", err
 	}
 	err = tx.QueryRow(ctx, `
-		INSERT INTO preference_token (person_id, token, expires_at)
-		VALUES ($1, $2, now() + make_interval(days => $3))
-		ON CONFLICT (person_id) WHERE revoked_at IS NULL DO NOTHING
-		RETURNING token`, personID, fresh, preferenceTokenTTLDays).Scan(&token)
+		INSERT INTO preference_token (person_id, person_email_id, token, expires_at)
+		VALUES ($1, $4, $2, now() + make_interval(days => $3))
+		ON CONFLICT (person_id, person_email_id) WHERE revoked_at IS NULL DO NOTHING
+		RETURNING token`, personID, fresh, preferenceTokenTTLDays, emailID).Scan(&token)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// A concurrent send won the INSERT — read the winner. Scanned into
 		// token and returned only after, so the caller receives the winning
 		// value rather than the zero one this scan is about to overwrite.
 		if err := tx.QueryRow(ctx, `
 			SELECT token FROM preference_token
-			 WHERE person_id = $1 AND revoked_at IS NULL`, personID).Scan(&token); err != nil {
+			 WHERE person_id = $1 AND person_email_id = $2 AND revoked_at IS NULL`,
+			personID, emailID).Scan(&token); err != nil {
 			return "", err
 		}
 		return token, nil

--- a/backend/internal/modules/consent/preferenceaddress_integration_test.go
+++ b/backend/internal/modules/consent/preferenceaddress_integration_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// Which address the preference page names.
+//
+// The token used to carry only person_id, so the page masked whichever address
+// the record calls primary. For a person holding more than one — a personal
+// address and a shared team one, say — a link delivered to the second opened a
+// page showing the first character and the full domain of the first. The
+// holder of that link was never written at that address, and the link stays
+// valid for thirty days.
+//
+// The mint knows the address: it resolved the recipient FROM it. So the token
+// records which one, keyed on the pair rather than on the person, and the page
+// reads it back.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// address gives the env's person a live address. The shared harness seeds a
+// Telegram-only subject with no person_email row at all, which is the right
+// default for the suites around this one and no use here: the disclosure this
+// file is about needs a person who holds MORE THAN ONE address.
+func address(t *testing.T, e *channelConsentEnv, email string, primary bool) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO person_email (id, person_id, email, is_primary, source, captured_by)
+		 VALUES ($1, $2, lower($3), $4, 'manual', 'system:test')`,
+		ids.NewV7(), e.person, email, primary); err != nil {
+		t.Fatalf("seeding %s: %v", email, err)
+	}
+}
+
+func TestThePreferencePageNamesTheAddressTheLinkWentTo(t *testing.T) {
+	e := setupChannelConsent(t)
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:public_preferences",
+	})
+
+	const own = "hedda@anon.test"
+	const shared = "team@anon.test"
+	address(t, e, own, true)
+	address(t, e, shared, false)
+
+	// Minted the way a send mints it: from the address the message is going to.
+	token, found, err := e.store.PreferenceTokenForEmail(ctx, shared)
+	if err != nil {
+		t.Fatalf("minting the token: %v", err)
+	}
+	if !found {
+		t.Fatal("no token for a live address the person carries")
+	}
+
+	ref, err := e.store.ResolvePreferenceToken(ctx, token)
+	if err != nil {
+		t.Fatalf("resolving the token: %v", err)
+	}
+	view, err := e.store.PublicPreferenceView(ctx, ref)
+	if err != nil {
+		t.Fatalf("reading the page: %v", err)
+	}
+
+	if want := MaskEmail(shared); view.MaskedEmail != want {
+		t.Errorf("the page names %q, want %q — the link went to %s, and naming any other address "+
+			"discloses one its holder was never written at",
+			view.MaskedEmail, want, shared)
+	}
+}
+
+// A token minted before the address was recorded still opens a working page.
+// There is no way to learn after the fact which address it went to, so the
+// primary is the honest fallback — and it is what the page always showed.
+func TestAPreferenceTokenWithNoAddressStillOpensThePage(t *testing.T) {
+	e := setupChannelConsent(t)
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:public_preferences",
+	})
+
+	const own = "hedda@anon.test"
+	address(t, e, own, true)
+
+	token := seedPreferenceToken(t, e)
+	ref, err := e.store.ResolvePreferenceToken(ctx, token)
+	if err != nil {
+		t.Fatalf("resolving the token: %v", err)
+	}
+	if ref.EmailID != nil {
+		t.Fatalf("the seeded token names an address (%s) — this case is about the ones that do not",
+			*ref.EmailID)
+	}
+	view, err := e.store.PublicPreferenceView(ctx, ref)
+	if err != nil {
+		t.Fatalf("reading the page: %v", err)
+	}
+	if want := MaskEmail(own); view.MaskedEmail != want {
+		t.Errorf("the page names %q, want the primary %q — a token minted before the column "+
+			"existed must still open, and the primary is what it always showed",
+			view.MaskedEmail, want)
+	}
+}
+
+// Two addresses on one person are two credentials, not one reused. A single
+// live token per PERSON would hand the second send the first send's token, and
+// the page would name the first address again — the defect one level down from
+// the column.
+func TestEachAddressGetsItsOwnPreferenceToken(t *testing.T) {
+	e := setupChannelConsent(t)
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:public_preferences",
+	})
+
+	const own = "hedda@anon.test"
+	const shared = "team@anon.test"
+	address(t, e, own, true)
+	address(t, e, shared, false)
+
+	first, foundFirst, err := e.store.PreferenceTokenForEmail(ctx, own)
+	if err != nil {
+		t.Fatalf("minting for the primary address: %v", err)
+	}
+	second, foundSecond, err := e.store.PreferenceTokenForEmail(ctx, shared)
+	if err != nil {
+		t.Fatalf("minting for the shared address: %v", err)
+	}
+	// Both have to have been MINTED, or the inequality below is two empty
+	// strings failing to differ and the case proves nothing.
+	if !foundFirst || !foundSecond {
+		t.Fatalf("minted %t and %t: an address the person carries must yield a token",
+			foundFirst, foundSecond)
+	}
+	if first == second {
+		t.Fatal("both addresses were handed one token, so the second send's link opens a page " +
+			"naming the first address — which is the disclosure this change is about")
+	}
+
+	// And the reuse a send depends on still holds: asking again for the same
+	// address answers the same credential rather than rotating it, or the link
+	// in a message already delivered stops working.
+	again, foundAgain, err := e.store.PreferenceTokenForEmail(ctx, shared)
+	if err != nil {
+		t.Fatalf("minting again for the shared address: %v", err)
+	}
+	if !foundAgain {
+		t.Fatal("the second ask for one address yielded no token at all")
+	}
+	if again != second {
+		t.Error("a second send to one address minted a new token: the link in the message already " +
+			"delivered is dead, which is what the reuse exists to prevent")
+	}
+}

--- a/backend/internal/modules/consent/preferenceview.go
+++ b/backend/internal/modules/consent/preferenceview.go
@@ -19,6 +19,7 @@ package consent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"unicode/utf8"
 
@@ -52,10 +53,14 @@ const (
 
 // PreferenceView is the whole public read.
 type PreferenceView struct {
-	// MaskedEmail is the person's primary address, masked. NOT necessarily
-	// the mailbox that received the link: preference_token resolves to a
-	// person, and the delivered address is not recorded. The page shows it
-	// as account context and its copy never claims "this address".
+	// MaskedEmail is the address the link was delivered to, masked — the token
+	// records which one it was minted for, so a person holding several sees the
+	// mailbox that actually received the message.
+	//
+	// A token minted before that was recorded, or one whose address the subject
+	// has since erased, falls back to the person's primary. That is the older
+	// behaviour and the reason the page's copy still presents this as account
+	// context rather than claiming "this address".
 	MaskedEmail string
 	// WorkspaceName can be empty on an unnamed installation; every string
 	// that interpolates it needs an omission variant.
@@ -64,7 +69,12 @@ type PreferenceView struct {
 }
 
 // PublicPreferenceView reads everything the page needs in one transaction.
-func (s *Store) PublicPreferenceView(ctx context.Context, personID ids.PersonID) (PreferenceView, error) {
+//
+// Takes the token's whole resolution rather than the person id: which address
+// the link went to is part of what the page reports, and a signature carrying
+// only the person is one a caller cannot answer that from.
+func (s *Store) PublicPreferenceView(ctx context.Context, ref PreferenceRef) (PreferenceView, error) {
+	personID := ref.PersonID
 	if err := auth.Require(ctx, entityPerson, principal.ActionRead); err != nil {
 		return PreferenceView{}, err
 	}
@@ -86,7 +96,7 @@ func (s *Store) PublicPreferenceView(ctx context.Context, personID ids.PersonID)
 		if err != nil {
 			return err
 		}
-		email, err := primaryEmailTx(ctx, tx, personID)
+		email, err := deliveredEmailTx(ctx, tx, personID, ref.EmailID)
 		if err != nil {
 			return err
 		}
@@ -117,6 +127,34 @@ func primaryEmailSQL(ref string) string {
 	return `coalesce((SELECT pe.email FROM person_email pe
 	                    WHERE pe.person_id = ` + ref + ` AND pe.archived_at IS NULL
 	                    ORDER BY pe.is_primary DESC, pe.created_at LIMIT 1), '')`
+}
+
+// deliveredEmailTx reads the address the link was sent to, falling back to the
+// person's primary when the token does not name one.
+//
+// The named address is still checked against the person and against
+// archived_at: the token is a bearer credential thirty days long, and a row
+// that has since moved to another person or been erased must not be read back
+// out of it. A named address that no longer qualifies falls back the same way a
+// missing one does, which keeps the page working rather than failing a reader
+// who did nothing wrong.
+func deliveredEmailTx(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID, emailID *ids.UUID,
+) (string, error) {
+	if emailID != nil {
+		var email string
+		err := tx.QueryRow(ctx, `
+			SELECT email FROM person_email
+			 WHERE id = $1 AND person_id = $2 AND archived_at IS NULL`,
+			*emailID, personID).Scan(&email)
+		if err == nil {
+			return email, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return "", err
+		}
+	}
+	return primaryEmailTx(ctx, tx, personID)
 }
 
 // primaryEmailTx reads the address on its own, for the preference centre.

--- a/backend/migrations/core/1788680100_a_preference_link_remembers_which_address_it_went_to.down.sql
+++ b/backend/migrations/core/1788680100_a_preference_link_remembers_which_address_it_went_to.down.sql
@@ -1,0 +1,10 @@
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock on a table the
+-- send path writes on every tokenized send: an open transaction holding a
+-- conflicting lock would otherwise stall every one of those writes for as long
+-- as this migration is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS uq_preference_token_person_address;
+CREATE UNIQUE INDEX uq_preference_token_person
+    ON preference_token (person_id) WHERE revoked_at IS NULL;
+ALTER TABLE preference_token DROP COLUMN IF EXISTS person_email_id;

--- a/backend/migrations/core/1788680100_a_preference_link_remembers_which_address_it_went_to.up.sql
+++ b/backend/migrations/core/1788680100_a_preference_link_remembers_which_address_it_went_to.up.sql
@@ -1,0 +1,40 @@
+-- A preference link says which address it was sent to.
+--
+-- The token carried only person_id, so the page it opens masked the person's
+-- PRIMARY address. For a person holding more than one, a link delivered to a
+-- secondary or shared address showed the first character and the full domain of
+-- an address its holder was never written at — a disclosure to whoever reads
+-- the shared mailbox, on a credential that stays valid for thirty days.
+--
+-- Nullable, because every token minted before this migration was minted without
+-- one and there is no way to learn after the fact which address it went to. A
+-- token with no address falls back to the primary exactly as before; the view
+-- is what decides, and a NULL is the honest record of "not known" rather than a
+-- guess that would read like a fact.
+--
+-- ON DELETE SET NULL rather than CASCADE: an address the subject erased must
+-- not take the unsubscribe credential with it. Suppression is what you most
+-- want still working once somebody has asked to be forgotten, and a token that
+-- vanished with the address would leave the last message's link dead.
+-- Bounded, because ALTER TABLE takes an ACCESS EXCLUSIVE lock on a table the
+-- send path writes on every tokenized send: an open transaction holding a
+-- conflicting lock would otherwise stall every one of those writes for as long
+-- as this migration is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE preference_token
+    ADD COLUMN person_email_id uuid REFERENCES person_email(id) ON DELETE SET NULL;
+
+-- One live token per (person, ADDRESS) rather than per person.
+--
+-- The token is the credential for a pair, not for a person: reusing one minted
+-- for a first address on a send to a second is what would make the page name
+-- the wrong one again, one level down from the column above.
+--
+-- NULLS NOT DISTINCT so the pre-migration rows keep their old guarantee: two
+-- live tokens for one person with no address recorded would be exactly the
+-- duplicate the old index forbade.
+DROP INDEX uq_preference_token_person;
+CREATE UNIQUE INDEX uq_preference_token_person_address
+    ON preference_token (person_id, person_email_id) NULLS NOT DISTINCT
+    WHERE revoked_at IS NULL;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -4337,7 +4337,9 @@ public.preference_token acl=margince_owner=arwdDxt/margince_owner,margince_app=a
 public.preference_token.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.preference_token.expires_at timestamp with time zone NOT NULL gen=- def=-
 public.preference_token.id uuid NOT NULL gen=- def=uuidv7()
+public.preference_token.person_email_id uuid gen=- def=-
 public.preference_token.person_id uuid NOT NULL gen=- def=-
+public.preference_token.preference_token_person_email_id_fkey FOREIGN KEY (person_email_id) REFERENCES person_email(id) ON DELETE SET NULL
 public.preference_token.preference_token_person_fkey FOREIGN KEY (person_id) REFERENCES person(id) ON DELETE CASCADE
 public.preference_token.preference_token_pkey PRIMARY KEY (id)
 public.preference_token.preference_token_token_key UNIQUE (token)
@@ -5379,7 +5381,7 @@ public.uq_person_email_primary CREATE UNIQUE INDEX uq_person_email_primary ON pu
 public.uq_person_phone_primary CREATE UNIQUE INDEX uq_person_phone_primary ON public.person_phone USING btree (person_id, phone_type) WHERE (is_primary AND (archived_at IS NULL))
 public.uq_person_profile_field CREATE UNIQUE INDEX uq_person_profile_field ON public.person_profile_field USING btree (person_id, field)
 public.uq_pipeline_default CREATE UNIQUE INDEX uq_pipeline_default ON public.pipeline USING btree ((true)) WHERE (is_default AND (archived_at IS NULL))
-public.uq_preference_token_person CREATE UNIQUE INDEX uq_preference_token_person ON public.preference_token USING btree (person_id) WHERE (revoked_at IS NULL)
+public.uq_preference_token_person_address CREATE UNIQUE INDEX uq_preference_token_person_address ON public.preference_token USING btree (person_id, person_email_id) NULLS NOT DISTINCT WHERE (revoked_at IS NULL)
 public.uq_product_sku CREATE UNIQUE INDEX uq_product_sku ON public.product USING btree (sku) WHERE ((sku IS NOT NULL) AND (archived_at IS NULL))
 public.uq_product_ws_id CREATE UNIQUE INDEX uq_product_ws_id ON public.product USING btree (id)
 public.uq_project_key CREATE UNIQUE INDEX uq_project_key ON public.project USING btree (lower(key)) WHERE ((key IS NOT NULL) AND (archived_at IS NULL))


### PR DESCRIPTION
Closes #3413.

## The disclosure

`preference_token` stored only `person_id`. The token is minted **from** a recipient address, but the address was never recorded — so `PublicPreferenceView` fell back to `primaryEmailTx`.

For a person carrying more than one address, a link delivered to a secondary or shared mailbox opened a page showing the masked form of a *different* address: the first character and the full domain of one the link's holder was never written at. Whoever reads the shared mailbox sees it, and the link stays valid for thirty days.

## The address the mint already had

`PreferenceTokenForEmail` resolves the recipient **from** the address, so it knows which one this token is for. It now records it: `preference_token.person_email_id`, and `ResolvePreferenceToken` reads it back on `PreferenceRef`.

`PublicPreferenceView` takes the whole resolution rather than the person id — which address the link went to is part of what the page reports, and a signature carrying only the person is one a caller cannot answer that from.

## Keyed on the pair, not the person

Recording the column is not enough on its own. There was one live token **per person**, reused across sends, so a token minted for the first address would be handed to the second send and the page would name the first address again — the same defect one level down.

So the live-token index becomes `(person_id, person_email_id)`. Reuse still holds within a pair, which is what keeps the link in a message already delivered working.

## The rows that already exist

`person_email_id` is nullable, and stays NULL for every token minted before this migration: there is no way to learn after the fact which address one went to. Those fall back to the primary exactly as before, which is why the page's copy still presents this as account context rather than claiming "this address".

`ON DELETE SET NULL`, not `CASCADE`: an address the subject erased must not take the unsubscribe credential with it. Suppression is what you most want still working once somebody has asked to be forgotten.

The read re-checks the named address against the person and against `archived_at` — the token is a bearer credential thirty days long, and a row that has since moved or been erased falls back rather than being read back out of it.

## Tests

| case | holds |
|---|---|
| `ThePreferencePageNamesTheAddressTheLinkWentTo` | a person with two addresses, link sent to the second |
| `APreferenceTokenWithNoAddressStillOpensThePage` | the pre-migration row falls back to the primary |
| `EachAddressGetsItsOwnPreferenceToken` | two addresses are two credentials, and a second send to one address reuses its own |

Mutations, both restored:

| mutation | fails |
|---|---|
| the page reads the primary again | `NamesTheAddressTheLinkWentTo` |
| the mint stops keying on the address | that one **and** `EachAddressGetsItsOwnPreferenceToken` |

The third case guards against a vacuous pass: the shared harness seeds a Telegram-only subject with no `person_email` row at all, so an earlier draft compared two empty strings and "passed". It now asserts both mints were actually found.

## Checks

`make check-backend` green (exit 0) — the merge gate, not just `check-go`. `make test-it DIR=backend/internal/modules/consent` green, whole package. `head_catalog.txt` updated in this commit, and both migration files bound their lock (`SET LOCAL lock_timeout`) because `ALTER TABLE` here takes ACCESS EXCLUSIVE on a table the send path writes on every tokenized send.