### PR TITLE
A meeting cancelled at the provider is cancelled here

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -99,7 +99,6 @@ backend/internal/compose/signalscan.go migration 0047
 backend/internal/modules/activities/activitylinks.go migration 1787032690
 backend/internal/modules/activities/commitments.go core 0008
 backend/internal/modules/activities/lasttouch.go migration 1787032690
-backend/internal/modules/activities/lifecycle.go migration 1787320003
 backend/internal/modules/activities/participantbackfill.go migration 0157
 backend/internal/modules/activities/relinkbatch.go migration 0008
 backend/internal/modules/activities/scheduledsendprovenance.go core 0260

--- a/backend/gates/updateguard_test.go
+++ b/backend/gates/updateguard_test.go
@@ -132,7 +132,7 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// helper shared by three write paths puts between the call site and
 	// storekit.LockRow.
 	"internal/modules/activities:SetAudience":              "held FOR UPDATE via lockActivityForWrite, one hop past what this witness's AST walk follows — see the shared rationale above",
-	"internal/modules/activities:UpdateActivity":           "held FOR UPDATE via lockActivityForWrite, one hop past what this witness's AST walk follows — see the shared rationale above",
+	"internal/modules/activities:updateActivityInTx":       "held FOR UPDATE via lockActivityForWrite, one hop past what this witness's AST walk follows — see the shared rationale above",
 	"internal/modules/activities:RefuseArchiveActivity":    "held FOR UPDATE via lockActivityForWrite, one hop past what this witness's AST walk follows — see the shared rationale above; this self-touch (SET archived_at = archived_at) never commits, since the trigger it deliberately provokes refuses every write to the held row it runs against",
 	"internal/modules/activities:finalizeRelinkedActivity": "the row is already held FOR UPDATE by relinkActivityRow, its only caller, from before this function runs — the guard is the caller's lock, held across the whole transaction, not a second one taken here; this witness's AST walk sees neither the caller's lockActivityForWrite (a second hop) nor that this function is only ever reached under it",
 	// This IS a compare-and-set write; what this gate cannot see is the shape it

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -217,7 +217,8 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 		return crmcontracts.Activity{}, false, err
 	}
 	if replay != nil {
-		return *replay, false, nil
+		moved, err := replayMovedTheMeeting(ctx, tx, *replay, in)
+		return moved, false, err
 	}
 
 	id := ids.New[ids.ActivityKind]()
@@ -288,6 +289,36 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 // scope: replaying someone else's external key must not hand over their
 // activity. Out of scope answers the same 409 the unique-index race
 // does — the key is taken, the record is not disclosed.
+// replayMovedTheMeeting applies the one thing a redelivery of the same natural
+// key may legitimately change: how the meeting went.
+//
+// A replay is otherwise the same fact arriving twice and writes nothing — that
+// is what makes capture idempotent, and it is why the subject a rep corrected
+// and the body they cleaned up survive the provider sending its own version
+// again. The status is different in kind: booked → held / no_show / canceled is
+// a vocabulary that EXISTS to change over time, and nothing on this side of
+// the connector can know it moved.
+//
+// Left untouched, the row went on rendering an upcoming meeting that had been
+// cancelled, the call answered 200 saying so, and no activity.updated fired —
+// so the lead ladder and everything else downstream never re-read it.
+//
+// Through updateActivityInTx rather than an UPDATE here, so the move takes the
+// write lock, records the transition (once, because it changed), and carries
+// the same bounded delta a human's PATCH does. A held row refuses this write
+// like any other, which is the point of the hold — the capture reports the
+// refusal rather than claiming a success it did not have.
+func replayMovedTheMeeting(
+	ctx context.Context, tx pgx.Tx, replay crmcontracts.Activity, in LogActivityInput,
+) (crmcontracts.Activity, error) {
+	if in.MeetingStatus == nil || *in.MeetingStatus == meetingStatusString(replay.MeetingStatus) {
+		return replay, nil
+	}
+	return updateActivityInTx(ctx, tx, ids.From[ids.ActivityKind](ids.UUID(replay.Id)), UpdateActivityInput{
+		MeetingStatus: in.MeetingStatus,
+	})
+}
+
 func replayedActivity(ctx context.Context, tx pgx.Tx, in LogActivityInput) (*crmcontracts.Activity, error) {
 	if in.SourceSystem == nil || in.SourceID == nil {
 		return nil, nil

--- a/backend/internal/modules/activities/activityrelink.go
+++ b/backend/internal/modules/activities/activityrelink.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Moving an activity from one record to another: the admitted write itself and
+// the two sweeps it owes — the links it displaces, and the participants those
+// links were speaking for.
+//
+// Beside RelinkActivity (relinkbatch.go) rather than in lifecycle.go, which is
+// where they were: a relink is not a patch of the activity's own fields, and
+// the file that holds the patch had grown to hold both.
+
+import (
+	"context"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// relinkAdmittedRow is the transactional half both doors share: the target
+// probe, then the guarded row write. The admission stays outside it so the
+// single door can refuse a malformed request before it opens a transaction.
+func relinkAdmittedRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in RelinkActivityInput, column string) (wrote, held bool, err error) {
+	// The relink target is a client-supplied reference (H1).
+	if err := auth.EnsureLinkTarget(ctx, tx, in.EntityType, in.EntityID); err != nil {
+		return false, false, err
+	}
+	return relinkActivityRow(ctx, tx, id, in, column)
+}
+
+// deleteVisibleLinksOfType drops the activity's links of one entity type and
+// answers the person ids that delete actually displaced. Those ids come from
+// the delete ITSELF. Inferring them instead — "whoever is a participant but no
+// longer linked" — sweeps up participants that were never linked in the first
+// place, and repoints conversations the correction never mentioned.
+//
+// Only the links this caller can SEE are replaced. An activity's own
+// visibility derives from its links, so an unscoped delete lets someone who
+// reached this activity through one link cut another — dropping a team's sight
+// of a record by rewriting an association they were never shown.
+//
+// A link outside the caller's scope survives instead, and for `project` that
+// used to leave a residual: at most one project link may exist, so the insert
+// then hit the partial index and refused, and the difference between that
+// refusal and a success told the caller a project link they could not see was
+// there. One bit escaped, and hiding a link's existence while enforcing
+// one-per-activity looked like the same question asked twice.
+//
+// It is closed, and closed on both halves rather than narrowed. A project
+// carries no own/team arm (platform/auth tableclass.go) and no capture privacy
+// either — its visibility CHECK admits 'workspace' and nothing else, because
+// nothing auto-creates a project and an owner-private one was a state no writer
+// could reach. So no project link can be invisible to a caller
+// holding the object grant: the delete reaches every one, and the move
+// succeeds. The 23505 path below still stands for the caller who asks to
+// associate rather than move.
+func deleteVisibleLinksOfType(ctx context.Context, tx pgx.Tx, id ids.ActivityID, entityType, column string) ([]ids.UUID, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos, typePos := arg(id), arg(entityType)
+	scope, err := auth.ScopeClauseFor(ctx, entityType, "t", arg)
+	if err != nil {
+		return nil, err
+	}
+	visible := "true"
+	if scope != "" {
+		visible = scope
+	}
+	rows, err := tx.Query(ctx, storekit.SQLf(`
+		DELETE FROM activity_link
+		WHERE activity_id = $%d AND entity_type = $%d
+		  AND EXISTS (SELECT 1 FROM %s t WHERE t.id = activity_link.%s AND %s)
+		RETURNING person_id`,
+		idPos, typePos, entityType, column, visible), args...)
+	if err != nil {
+		return nil, err
+	}
+	// Every id this delete actually removed. A link row of another
+	// entity type returns NULL here and contributes nothing.
+	displaced, err := pgx.CollectRows(rows, func(r pgx.CollectableRow) (ids.UUID, error) {
+		var pid *ids.UUID
+		if err := r.Scan(&pid); err != nil {
+			return ids.Nil, err
+		}
+		if pid == nil {
+			return ids.Nil, nil
+		}
+		return *pid, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(displaced, func(personID ids.UUID) bool { return personID == ids.Nil }), nil
+}
+
+// repointDisplacedParticipants moves the displaced contacts' participant rows
+// onto the relink target. A relink to a PERSON is a human saying "this
+// conversation was actually with someone else", so the participant row naming
+// the old contact is now wrong (ACT-DDL-3). Repointing it keeps the
+// participants and the links telling one story.
+//
+// The DISPLACED person carries the row scope too. The relink already gated the
+// new target; without this the old one is rewritten sight unseen, so a caller
+// could repoint a participant naming a contact they cannot read — including an
+// owner-private captured one. The link delete scopes for the same reason; this
+// is its participant twin.
+//
+// KNOWN GAP, stated rather than papered over: the graph consumer derives its
+// affected (user, person) pairs from the participant rows, and by the time it
+// runs they name the NEW contact — so the OLD edge is not recomputed and keeps
+// counting an interaction that no longer points at it. The nightly rebuild
+// clears it, which bounds the staleness to the same 24h the window counts
+// already carry, but it is a bound and not a fix.
+//
+// The fix is the additive `relinked_from` reference ADR-0078 specifies on the
+// activity.updated relink payload: the consumer needs the displaced id, and
+// this module cannot recompute the edge itself because search is a sibling.
+// That is a public-event contract change and belongs in its own slice.
+func repointDisplacedParticipants(ctx context.Context, tx pgx.Tx, id ids.ActivityID, target ids.UUID, displaced []ids.UUID) error {
+	var pargs []any
+	parg := func(v any) int { pargs = append(pargs, v); return len(pargs) }
+	idPos, targetPos, displacedPos := parg(id), parg(target), parg(displaced)
+	visible, err := auth.ScopeClauseFor(ctx, linkEntityPerson, "op", parg)
+	if err != nil {
+		return err
+	}
+	if visible == "" {
+		// An unbounded caller narrows nothing.
+		visible = "true"
+	}
+	// One merge, not a conditional rewrite. The repoint used to UPDATE each
+	// displaced row to the target and skip when the target was already a
+	// participant, which was wrong in both directions:
+	//
+	//   - the skip left the displaced row naming the OLD contact, so the
+	//     activity's links said one thing and its participants another —
+	//     exactly what the repoint exists to prevent — and that row kept
+	//     feeding a relationship-strength signal for somebody the human had
+	//     just said the conversation was not with;
+	//   - with several displaced participants and no target row, every one of
+	//     them qualified and each was rewritten to the target, colliding on
+	//     uq_activity_participant.
+	//
+	// The uniqueness is per (activity, role, user, person, address), not per
+	// person, so both the skip test and the collision are decided by the whole
+	// tuple. Within each such group exactly one displaced row is promoted to
+	// the target — and only when the target holds no row of that shape
+	// already — and the rest are deleted. Either way the target is named once
+	// and no displaced row survives.
+	const nilUUID = `'00000000-0000-0000-0000-000000000000'::uuid`
+	if _, err := tx.Exec(ctx, storekit.SQLf(`
+		WITH scoped AS (
+			SELECT ap.id, ap.role, ap.user_id, ap.address,
+			       row_number() OVER (
+			           PARTITION BY ap.role, coalesce(ap.user_id, `+nilUUID+`), coalesce(ap.address, '')
+			           ORDER BY ap.id) AS rank
+			  FROM activity_participant ap
+			 WHERE ap.activity_id = $%d
+			   -- Exactly the people the link delete removed, and no
+			   -- others. A participant can name somebody who was never
+			   -- linked at all, and inferring the displaced set from "no
+			   -- longer linked" would rewrite them too.
+			   AND ap.person_id = ANY($%d::uuid[])
+			   AND ap.person_id <> $%d
+			   AND EXISTS (SELECT 1 FROM person op WHERE op.id = ap.person_id AND (`+visible+`))
+		), promoted AS (
+			UPDATE activity_participant ap SET person_id = $%d
+			  FROM scoped s
+			 WHERE ap.id = s.id AND s.rank = 1
+			   AND NOT EXISTS (
+			       SELECT 1 FROM activity_participant other
+			        WHERE other.activity_id = ap.activity_id
+			          AND other.role = s.role
+			          AND other.person_id = $%d
+			          AND coalesce(other.user_id, `+nilUUID+`) = coalesce(s.user_id, `+nilUUID+`)
+			          AND coalesce(other.address, '') = coalesce(s.address, ''))
+			RETURNING ap.id
+		)
+		DELETE FROM activity_participant
+		 WHERE id IN (SELECT id FROM scoped)
+		   AND id NOT IN (SELECT id FROM promoted)`,
+		idPos, displacedPos, targetPos, targetPos, targetPos), pargs...); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -12,7 +12,6 @@ package activities
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -50,107 +49,153 @@ func (s *Store) UpdateActivity(ctx context.Context, id ids.ActivityID, in Update
 	}
 	var out crmcontracts.Activity
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		// The row lock makes the version compare and the coalesce update
-		// below one race-free unit: without it two concurrent edits both
-		// pass the compare and the loser silently overwrites the winner.
-		held, err := lockActivityForWrite(ctx, tx, id.UUID)
-		if err != nil {
-			return err
-		}
-		// Reading the row is not the licence to change it: customer identity
-		// is workspace-readable, so the write arm is what keeps a colleague's
-		// correspondence theirs.
-		if err := auth.EnsureActivityWritableIn(ctx, tx, id.UUID, !held); err != nil {
-			return err
-		}
-		// A held row must reach the UPDATE below so its own CHECK trigger —
-		// not this read — is what refuses the write.
-		current, err := readActivityForWrite(ctx, tx, id, held)
-		if err != nil {
-			return err
-		}
-		// held skips this: activity_refuse_restricted_mutation below refuses
-		// every write to a held row regardless of version, so it owes 423,
-		// not a 409 inviting a retry the row can never accept.
-		if !held && in.IfVersion != nil && current.Version != nil && int64(*current.Version) != *in.IfVersion {
-			return apperrors.ErrVersionSkew
-		}
-		if err := renormalizeTranscriptPatch(current, &in); err != nil {
-			return err
-		}
-		// The kind the ROW carries, not one the patch names — a patch cannot
-		// change a kind. Without this a note could be given `held` and read back
-		// afterwards as a meeting-shaped fact about something that was not one,
-		// which is the pairing create already refuses; the database CHECK
-		// constrains the vocabulary and not this.
-		//
-		// `held` skips it for the reason the version compare above skips it: a
-		// row under retention hold owes 423 whatever else is wrong with the
-		// request, and answering 422 first would invite the caller to fix the
-		// field and try again against a row that will refuse them either way.
-		if !held && in.MeetingStatus != nil && current.Kind != crmcontracts.ActivityKindMeeting {
-			return &MeetingStatusKindError{Kind: string(current.Kind)}
-		}
-		if err := ensureAssigneeCanHoldWork(ctx, tx, in.AssigneeID); err != nil {
-			return err
-		}
-		// Every placeholder is derived from the argument slice rather than
-		// typed. Nothing checks that a hand-written $N still names the value a
-		// caller appends, and this statement's list has grown twice.
-		args := []any{}
-		arg := func(v any) int { args = append(args, v); return len(args) }
-		row := arg(id)
-		// done_at travels WITH is_done (the activity_done_at CHECK):
-		// completion stamps the moment, reopening clears it — so the flag is
-		// named once and read three times.
-		done := arg(in.IsDone)
-		if _, err := tx.Exec(ctx, fmt.Sprintf(`
-			UPDATE activity SET
-			  subject = coalesce($%[2]d, subject),
-			  body = coalesce($%[3]d, body),
-			  occurred_at = coalesce($%[4]d, occurred_at),
-			  due_at = coalesce($%[5]d, due_at),
-			  remind_at = coalesce($%[6]d, remind_at),
-			  assignee_id = coalesce($%[7]d, assignee_id),
-			  is_done = coalesce($%[8]d, is_done),
-			  meeting_status = coalesce($%[9]d, meeting_status),
-			  done_at = CASE
-			    WHEN $%[8]d IS TRUE AND NOT is_done THEN now()
-			    WHEN $%[8]d IS FALSE THEN NULL
-			    ELSE done_at END
-			WHERE id = $%[1]d`,
-			row, arg(in.Subject), arg(in.Body), arg(in.OccurredAt), arg(in.DueAt),
-			arg(in.RemindAt), arg(in.AssigneeID), done, arg(in.MeetingStatus)),
-			args...); err != nil {
-			return err
-		}
-		// Read back BEFORE auditing: done_at is stamped by the statement above
-		// and a transcript body is renormalized on the way in, so the row is the
-		// only place that says what this write actually stored.
-		out, err = readActivity(ctx, tx, id, storekit.LiveOnly)
-		if err != nil {
-			return err
-		}
-		// A transition is a CHANGE. A PATCH resending the status a meeting
-		// already holds is somebody saving a form, and recording it would make
-		// "booked twice" a countable event.
-		if err := recordMeetingTransition(ctx, tx, meetingTransition{
-			ActivityID:     id,
-			Status:         changedMeetingStatus(current, out),
-			ScheduledStart: &out.OccurredAt,
-		}); err != nil {
-			return err
-		}
-		before, after := storekit.ChangedColumns(activityColumnImage(current), activityColumnImage(out))
-		auditID, err := storekit.AuditWithTrail(ctx, tx, in.Trail, "activity", id.UUID, before, after)
-		if err != nil {
-			return err
-		}
-		return storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventActivityUpdated{
-			ChangedFields: activityUpdatedChangedFields(in),
-		})
+		var err error
+		out, err = updateActivityInTx(ctx, tx, id, in)
+		return err
 	})
 	return out, err
+}
+
+// updateActivityInTx is UpdateActivity's transactional body, shared with the
+// capture replay in activity.go.
+//
+// Shared rather than copied because a second spelling of "a meeting moved"
+// would be one that could stop recording the transition, stop emitting the
+// bounded delta, or stop taking the write lock — and the only symptom would be
+// a lead ladder that never re-read a meeting somebody had cancelled.
+//
+// The RBAC check is NOT here. It sits at UpdateActivity, where a caller is
+// asking to patch a record; the replay is not asking for that authority, it is
+// finishing the capture it already had — and the row-scope arm below still
+// applies to both.
+func updateActivityInTx(
+	ctx context.Context, tx pgx.Tx, id ids.ActivityID, in UpdateActivityInput,
+) (crmcontracts.Activity, error) {
+	current, err := admitActivityPatch(ctx, tx, id, &in)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	var out crmcontracts.Activity
+	// Every placeholder is derived from the argument slice rather than
+	// typed. Nothing checks that a hand-written $N still names the value a
+	// caller appends, and this statement's list has grown twice.
+	args := []any{}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	row := arg(id)
+	// done_at travels WITH is_done (the activity_done_at CHECK):
+	// completion stamps the moment, reopening clears it — so the flag is
+	// named once and read three times.
+	done := arg(in.IsDone)
+	if _, err := tx.Exec(ctx, fmt.Sprintf(`
+		UPDATE activity SET
+		  subject = coalesce($%[2]d, subject),
+		  body = coalesce($%[3]d, body),
+		  occurred_at = coalesce($%[4]d, occurred_at),
+		  due_at = coalesce($%[5]d, due_at),
+		  remind_at = coalesce($%[6]d, remind_at),
+		  assignee_id = coalesce($%[7]d, assignee_id),
+		  is_done = coalesce($%[8]d, is_done),
+		  meeting_status = coalesce($%[9]d, meeting_status),
+		  done_at = CASE
+		    WHEN $%[8]d IS TRUE AND NOT is_done THEN now()
+		    WHEN $%[8]d IS FALSE THEN NULL
+		    ELSE done_at END
+		WHERE id = $%[1]d`,
+		row, arg(in.Subject), arg(in.Body), arg(in.OccurredAt), arg(in.DueAt),
+		arg(in.RemindAt), arg(in.AssigneeID), done, arg(in.MeetingStatus)),
+		args...); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// Read back BEFORE auditing: done_at is stamped by the statement above
+	// and a transcript body is renormalized on the way in, so the row is the
+	// only place that says what this write actually stored.
+	out, err = readActivity(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// A transition is a CHANGE. A PATCH resending the status a meeting
+	// already holds is somebody saving a form, and recording it would make
+	// "booked twice" a countable event.
+	if err := recordMeetingTransition(ctx, tx, meetingTransition{
+		ActivityID:     id,
+		Status:         changedMeetingStatus(current, out),
+		ScheduledStart: &out.OccurredAt,
+	}); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	before, after := storekit.ChangedColumns(activityColumnImage(current), activityColumnImage(out))
+	auditID, err := storekit.AuditWithTrail(ctx, tx, in.Trail, "activity", id.UUID, before, after)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventActivityUpdated{
+		ChangedFields: activityUpdatedChangedFields(in),
+	}); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	return out, nil
+}
+
+// admitActivityPatch takes the write lock and answers whether this patch may
+// land on this row, returning the row as it stood before it.
+//
+// Every refusal here is about the TARGET rather than the values: who may write
+// the row, whether the version the caller compared against is still current,
+// and whether the field being set means anything on the kind the row carries. A
+// patch that gets past all of them is one the UPDATE can apply without asking
+// anything further.
+//
+// It takes `in` by pointer for one reason: renormalizeTranscriptPatch rewrites
+// the body on the way in, and a copy would leave the caller applying the text
+// the request carried rather than the canonical form.
+func admitActivityPatch(
+	ctx context.Context, tx pgx.Tx, id ids.ActivityID, in *UpdateActivityInput,
+) (crmcontracts.Activity, error) {
+	// The row lock makes the version compare and the coalesce update
+	// below one race-free unit: without it two concurrent edits both
+	// pass the compare and the loser silently overwrites the winner.
+	held, err := lockActivityForWrite(ctx, tx, id.UUID)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// Reading the row is not the licence to change it: customer identity
+	// is workspace-readable, so the write arm is what keeps a colleague's
+	// correspondence theirs.
+	if err := auth.EnsureActivityWritableIn(ctx, tx, id.UUID, !held); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// A held row must reach the UPDATE afterwards so its own CHECK trigger —
+	// not this read — is what refuses the write.
+	current, err := readActivityForWrite(ctx, tx, id, held)
+	if err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// held skips this: activity_refuse_restricted_mutation refuses every write
+	// to a held row regardless of version, so it owes 423, not a 409 inviting a
+	// retry the row can never accept.
+	if !held && in.IfVersion != nil && current.Version != nil && int64(*current.Version) != *in.IfVersion {
+		return crmcontracts.Activity{}, apperrors.ErrVersionSkew
+	}
+	if err := renormalizeTranscriptPatch(current, in); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	// The kind the ROW carries, not one the patch names — a patch cannot
+	// change a kind. Without this a note could be given `held` and read back
+	// afterwards as a meeting-shaped fact about something that was not one,
+	// which is the pairing create already refuses; the database CHECK
+	// constrains the vocabulary and not this.
+	//
+	// `held` skips it for the reason the version compare above skips it: a
+	// row under retention hold owes 423 whatever else is wrong with the
+	// request, and answering 422 first would invite the caller to fix the
+	// field and try again against a row that will refuse them either way.
+	if !held && in.MeetingStatus != nil && current.Kind != crmcontracts.ActivityKindMeeting {
+		return crmcontracts.Activity{}, &MeetingStatusKindError{Kind: string(current.Kind)}
+	}
+	if err := ensureAssigneeCanHoldWork(ctx, tx, in.AssigneeID); err != nil {
+		return crmcontracts.Activity{}, err
+	}
+	return current, nil
 }
 
 // renormalizeTranscriptPatch re-runs ADR-0058's normalizer on a body PATCH
@@ -261,174 +306,6 @@ func (s *Store) ArchiveActivity(ctx context.Context, id ids.ActivityID, ifVersio
 		return err
 	})
 	return out, err
-}
-
-// relinkAdmittedRow is the transactional half both doors share: the target
-// probe, then the guarded row write. The admission stays outside it so the
-// single door can refuse a malformed request before it opens a transaction.
-func relinkAdmittedRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, in RelinkActivityInput, column string) (wrote, held bool, err error) {
-	// The relink target is a client-supplied reference (H1).
-	if err := auth.EnsureLinkTarget(ctx, tx, in.EntityType, in.EntityID); err != nil {
-		return false, false, err
-	}
-	return relinkActivityRow(ctx, tx, id, in, column)
-}
-
-// deleteVisibleLinksOfType drops the activity's links of one entity type and
-// answers the person ids that delete actually displaced. Those ids come from
-// the delete ITSELF. Inferring them instead — "whoever is a participant but no
-// longer linked" — sweeps up participants that were never linked in the first
-// place, and repoints conversations the correction never mentioned.
-//
-// Only the links this caller can SEE are replaced. An activity's own
-// visibility derives from its links, so an unscoped delete lets someone who
-// reached this activity through one link cut another — dropping a team's sight
-// of a record by rewriting an association they were never shown.
-//
-// A link outside the caller's scope survives instead, and for `project` that
-// used to leave a residual: at most one project link may exist, so the insert
-// then hit the partial index and refused, and the difference between that
-// refusal and a success told the caller a project link they could not see was
-// there. One bit escaped, and hiding a link's existence while enforcing
-// one-per-activity looked like the same question asked twice.
-//
-// It is closed, and closed on both halves rather than narrowed. A project
-// carries no own/team arm (platform/auth tableclass.go) and no capture privacy
-// either — migration 1787320003 narrowed its visibility CHECK to 'workspace',
-// because nothing auto-creates a project and an owner-private one was a state
-// no writer could reach. So no project link can be invisible to a caller
-// holding the object grant: the delete reaches every one, and the move
-// succeeds. The 23505 path below still stands for the caller who asks to
-// associate rather than move.
-func deleteVisibleLinksOfType(ctx context.Context, tx pgx.Tx, id ids.ActivityID, entityType, column string) ([]ids.UUID, error) {
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	idPos, typePos := arg(id), arg(entityType)
-	scope, err := auth.ScopeClauseFor(ctx, entityType, "t", arg)
-	if err != nil {
-		return nil, err
-	}
-	visible := "true"
-	if scope != "" {
-		visible = scope
-	}
-	rows, err := tx.Query(ctx, storekit.SQLf(`
-		DELETE FROM activity_link
-		WHERE activity_id = $%d AND entity_type = $%d
-		  AND EXISTS (SELECT 1 FROM %s t WHERE t.id = activity_link.%s AND %s)
-		RETURNING person_id`,
-		idPos, typePos, entityType, column, visible), args...)
-	if err != nil {
-		return nil, err
-	}
-	// Every id this delete actually removed. A link row of another
-	// entity type returns NULL here and contributes nothing.
-	displaced, err := pgx.CollectRows(rows, func(r pgx.CollectableRow) (ids.UUID, error) {
-		var pid *ids.UUID
-		if err := r.Scan(&pid); err != nil {
-			return ids.Nil, err
-		}
-		if pid == nil {
-			return ids.Nil, nil
-		}
-		return *pid, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return slices.DeleteFunc(displaced, func(personID ids.UUID) bool { return personID == ids.Nil }), nil
-}
-
-// repointDisplacedParticipants moves the displaced contacts' participant rows
-// onto the relink target. A relink to a PERSON is a human saying "this
-// conversation was actually with someone else", so the participant row naming
-// the old contact is now wrong (ACT-DDL-3). Repointing it keeps the
-// participants and the links telling one story.
-//
-// The DISPLACED person carries the row scope too. The relink already gated the
-// new target; without this the old one is rewritten sight unseen, so a caller
-// could repoint a participant naming a contact they cannot read — including an
-// owner-private captured one. The link delete scopes for the same reason; this
-// is its participant twin.
-//
-// KNOWN GAP, stated rather than papered over: the graph consumer derives its
-// affected (user, person) pairs from the participant rows, and by the time it
-// runs they name the NEW contact — so the OLD edge is not recomputed and keeps
-// counting an interaction that no longer points at it. The nightly rebuild
-// clears it, which bounds the staleness to the same 24h the window counts
-// already carry, but it is a bound and not a fix.
-//
-// The fix is the additive `relinked_from` reference ADR-0078 specifies on the
-// activity.updated relink payload: the consumer needs the displaced id, and
-// this module cannot recompute the edge itself because search is a sibling.
-// That is a public-event contract change and belongs in its own slice.
-func repointDisplacedParticipants(ctx context.Context, tx pgx.Tx, id ids.ActivityID, target ids.UUID, displaced []ids.UUID) error {
-	var pargs []any
-	parg := func(v any) int { pargs = append(pargs, v); return len(pargs) }
-	idPos, targetPos, displacedPos := parg(id), parg(target), parg(displaced)
-	visible, err := auth.ScopeClauseFor(ctx, linkEntityPerson, "op", parg)
-	if err != nil {
-		return err
-	}
-	if visible == "" {
-		// An unbounded caller narrows nothing.
-		visible = "true"
-	}
-	// One merge, not a conditional rewrite. The repoint used to UPDATE each
-	// displaced row to the target and skip when the target was already a
-	// participant, which was wrong in both directions:
-	//
-	//   - the skip left the displaced row naming the OLD contact, so the
-	//     activity's links said one thing and its participants another —
-	//     exactly what the repoint exists to prevent — and that row kept
-	//     feeding a relationship-strength signal for somebody the human had
-	//     just said the conversation was not with;
-	//   - with several displaced participants and no target row, every one of
-	//     them qualified and each was rewritten to the target, colliding on
-	//     uq_activity_participant.
-	//
-	// The uniqueness is per (activity, role, user, person, address), not per
-	// person, so both the skip test and the collision are decided by the whole
-	// tuple. Within each such group exactly one displaced row is promoted to
-	// the target — and only when the target holds no row of that shape
-	// already — and the rest are deleted. Either way the target is named once
-	// and no displaced row survives.
-	const nilUUID = `'00000000-0000-0000-0000-000000000000'::uuid`
-	if _, err := tx.Exec(ctx, storekit.SQLf(`
-		WITH scoped AS (
-			SELECT ap.id, ap.role, ap.user_id, ap.address,
-			       row_number() OVER (
-			           PARTITION BY ap.role, coalesce(ap.user_id, `+nilUUID+`), coalesce(ap.address, '')
-			           ORDER BY ap.id) AS rank
-			  FROM activity_participant ap
-			 WHERE ap.activity_id = $%d
-			   -- Exactly the people the link delete removed, and no
-			   -- others. A participant can name somebody who was never
-			   -- linked at all, and inferring the displaced set from "no
-			   -- longer linked" would rewrite them too.
-			   AND ap.person_id = ANY($%d::uuid[])
-			   AND ap.person_id <> $%d
-			   AND EXISTS (SELECT 1 FROM person op WHERE op.id = ap.person_id AND (`+visible+`))
-		), promoted AS (
-			UPDATE activity_participant ap SET person_id = $%d
-			  FROM scoped s
-			 WHERE ap.id = s.id AND s.rank = 1
-			   AND NOT EXISTS (
-			       SELECT 1 FROM activity_participant other
-			        WHERE other.activity_id = ap.activity_id
-			          AND other.role = s.role
-			          AND other.person_id = $%d
-			          AND coalesce(other.user_id, `+nilUUID+`) = coalesce(s.user_id, `+nilUUID+`)
-			          AND coalesce(other.address, '') = coalesce(s.address, ''))
-			RETURNING ap.id
-		)
-		DELETE FROM activity_participant
-		 WHERE id IN (SELECT id FROM scoped)
-		   AND id NOT IN (SELECT id FROM promoted)`,
-		idPos, displacedPos, targetPos, targetPos, targetPos), pargs...); err != nil {
-		return err
-	}
-	return nil
 }
 
 // activityUpdatedChangedFields projects the patch's touched/untouched decisions

--- a/backend/internal/modules/activities/meetingreplay_integration_test.go
+++ b/backend/internal/modules/activities/meetingreplay_integration_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// A calendar redelivering the same meeting is the case where "a replay writes
+// nothing" stops being idempotence and starts being a lie.
+//
+// The defect these exist against: logActivityInTx's (source_system, source_id)
+// replay returned the existing row untouched, so a provider that first
+// delivered a meeting as booked and later redelivered the same natural key as
+// canceled got a 200 while the row kept rendering an upcoming meeting — and no
+// activity.updated fired, so nothing downstream re-read it.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// deliverMeeting logs one meeting under a natural key, the way a calendar
+// connector does. Returns the activity the call answered with.
+func deliverMeeting(
+	t *testing.T, e *sendEnv, key, subject string, start time.Time,
+	status crmcontracts.ActivityMeetingStatus,
+) crmcontracts.Activity {
+	t.Helper()
+	system, id, s := "calendar-test", key, string(status)
+	out, _, err := meetingStore(e).LogActivity(meetingCtx(e), LogActivityInput{
+		Kind:          string(crmcontracts.ActivityKindMeeting),
+		Subject:       &subject,
+		OccurredAt:    &start,
+		MeetingStatus: &s,
+		SourceSystem:  &system,
+		SourceID:      &id,
+		Source:        "sync",
+	})
+	if err != nil {
+		t.Fatalf("delivering %s as %s: %v", key, status, err)
+	}
+	return out
+}
+
+// eventKinds reads the outbox verbs emitted for one activity, oldest first.
+func eventKinds(t *testing.T, e *sendEnv, activityID ids.ActivityID) []string {
+	t.Helper()
+	rows, err := e.owner.Query(context.Background(),
+		`SELECT envelope->>'type' FROM event_outbox
+		  WHERE envelope->'entity'->>'id' = $1::text
+		  ORDER BY id`, activityID.String())
+	if err != nil {
+		t.Fatalf("reading the outbox: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var kind string
+		if err := rows.Scan(&kind); err != nil {
+			t.Fatalf("scanning an event: %v", err)
+		}
+		out = append(out, kind)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the outbox: %v", err)
+	}
+	return out
+}
+
+// A meeting cancelled at the provider is cancelled here, on the redelivery of
+// the natural key that carried it.
+//
+// The status is the ONE field a replay may move: booked → held / no_show /
+// canceled is a vocabulary that exists to change over time, and nothing on this
+// side of the connector can know it did.
+func TestARedeliveredMeetingCarriesItsNewStatus(t *testing.T) {
+	e := setupSend(t)
+	start := time.Now().Add(48 * time.Hour)
+	first := deliverMeeting(t, e, "evt-cancel-1", "Northgate review", start,
+		crmcontracts.ActivityMeetingStatusBooked)
+	id := ids.From[ids.ActivityKind](ids.UUID(first.Id))
+
+	second := deliverMeeting(t, e, "evt-cancel-1", "Northgate review", start,
+		crmcontracts.ActivityMeetingStatusCanceled)
+
+	if ids.UUID(second.Id) != ids.UUID(first.Id) {
+		t.Fatalf("the redelivery minted a second activity (%v, was %v) — the natural key "+
+			"stopped being one", second.Id, first.Id)
+	}
+	if got := meetingStatusString(second.MeetingStatus); got != "canceled" {
+		t.Errorf("the call answered %q, want canceled", got)
+	}
+	// The ROW, not merely what the call said: a caller reading the meeting
+	// afterwards is what renders "upcoming" or does not.
+	var stored string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT meeting_status FROM activity WHERE id = $1`, id.UUID).Scan(&stored); err != nil {
+		t.Fatalf("reading the meeting back: %v", err)
+	}
+	if stored != "canceled" {
+		t.Errorf("the stored meeting_status is %q, want canceled — the meeting goes on "+
+			"rendering as upcoming and nothing says otherwise", stored)
+	}
+
+	// Both transitions, because the cancellation is a second event and not an
+	// overwrite of the first — the same rule a human's PATCH follows.
+	history := historyOf(t, e, id)
+	if len(history) != 2 {
+		t.Fatalf("recorded %d transitions, want 2 (booked, then canceled): %+v", len(history), history)
+	}
+	if history[1].Status != "canceled" {
+		t.Errorf("second transition = %q, want canceled", history[1].Status)
+	}
+
+	// And it is announced. Without this the lead ladder and every other
+	// consumer keep the meeting they last read, which is the booked one.
+	kinds := eventKinds(t, e, id)
+	activityUpdatedEvent := crmcontracts.PublicEventActivityUpdated{}.EventType()
+	if len(kinds) != 2 || kinds[1] != activityUpdatedEvent {
+		t.Errorf("events = %v, want the capture then an activity.updated — a status that "+
+			"moved without an event is one nothing downstream re-reads", kinds)
+	}
+}
+
+// A redelivery carrying the SAME status is the ordinary case, and it writes
+// nothing.
+//
+// This is what keeps capture idempotent: an at-least-once connector redelivers
+// constantly, and a transition recorded per delivery would make "booked" a
+// countable event that happened four times.
+func TestARedeliveredMeetingThatDidNotMoveWritesNothing(t *testing.T) {
+	e := setupSend(t)
+	start := time.Now().Add(48 * time.Hour)
+	first := deliverMeeting(t, e, "evt-same-1", "Kestrel sync", start,
+		crmcontracts.ActivityMeetingStatusBooked)
+	id := ids.From[ids.ActivityKind](ids.UUID(first.Id))
+
+	deliverMeeting(t, e, "evt-same-1", "Kestrel sync", start,
+		crmcontracts.ActivityMeetingStatusBooked)
+
+	if history := historyOf(t, e, id); len(history) != 1 {
+		t.Errorf("recorded %d transitions, want 1 — a redelivery of the same status is the "+
+			"same fact arriving twice, and counting it makes booked happen twice: %+v",
+			len(history), history)
+	}
+	if kinds := eventKinds(t, e, id); len(kinds) != 1 {
+		t.Errorf("events = %v, want only the capture — an update event for a change that "+
+			"did not happen wakes every consumer for nothing", kinds)
+	}
+}
+
+// A replay does not overwrite what a person wrote.
+//
+// The provider is authoritative for the meeting's lifecycle and for nothing
+// else. A rep who corrected the subject keeps their correction when the
+// calendar sends its own version again — which is why this moves the status
+// alone rather than patching every mutable field.
+func TestARedeliveryLeavesTheSubjectAPersonCorrected(t *testing.T) {
+	e := setupSend(t)
+	start := time.Now().Add(48 * time.Hour)
+	first := deliverMeeting(t, e, "evt-subject-1", "mtg", start,
+		crmcontracts.ActivityMeetingStatusBooked)
+	id := ids.From[ids.ActivityKind](ids.UUID(first.Id))
+	corrected := "Northgate — pricing walkthrough"
+	if _, err := meetingStore(e).UpdateActivity(meetingCtx(e), id,
+		UpdateActivityInput{Subject: &corrected}); err != nil {
+		t.Fatalf("correcting the subject: %v", err)
+	}
+
+	deliverMeeting(t, e, "evt-subject-1", "mtg", start,
+		crmcontracts.ActivityMeetingStatusHeld)
+
+	var subject, status string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT subject, meeting_status FROM activity WHERE id = $1`, id.UUID).
+		Scan(&subject, &status); err != nil {
+		t.Fatalf("reading the meeting back: %v", err)
+	}
+	if subject != corrected {
+		t.Errorf("subject = %q, want the rep's correction %q — the provider's own version "+
+			"came back and overwrote a person's work", subject, corrected)
+	}
+	if status != "held" {
+		t.Errorf("meeting_status = %q, want held", status)
+	}
+}


### PR DESCRIPTION
Closes #1913.

## The lie

`logActivityInTx`'s `(source_system, source_id)` replay returned the existing row **untouched**. A calendar that first delivered a meeting as `booked` and later redelivered the same natural key as `canceled` got a **200** while the row kept rendering an upcoming meeting — and no `activity.updated` fired, so the lead ladder and every other consumer went on holding the booking they last read.

Nothing anywhere said the meeting was off.

## Which writer owns the transition

That is what the ticket left open. **The replay does — for the status, and for nothing else.**

A replay is otherwise the same fact arriving twice and must write nothing: that is what makes capture idempotent under an at-least-once connector, and it is why the subject a rep corrected and the body they cleaned up survive the provider sending its own version again.

The status is different in kind. `booked → held / no_show / canceled` is a vocabulary that *exists* to change over time, and nothing on this side of the connector can know it moved. Patching every mutable field instead would let a stale redelivery overwrite a person's work — a worse defect than the one being fixed, and the third test below is what holds that line.

## One spelling of "a meeting moved"

The move goes through `UpdateActivity`'s transactional body rather than an `UPDATE` of its own, so it takes the write lock, records the transition **exactly once** (because it changed), and carries the same bounded delta a human's PATCH does. A second spelling would be one that could quietly stop doing any of those, and the only symptom would be the silence this PR is about.

The RBAC check stays at `UpdateActivity`, where a caller is *asking* to patch a record. The replay is not asking for that authority — it is finishing the capture it already had — and the row-scope arm applies to both. A row under retention hold refuses this write like any other, so the capture reports the refusal rather than claiming a success it did not have.

## Tests

| what it holds | mutation | result |
|---|---|---|
| a redelivery carries the new status | return the replay untouched | row reads `booked`, 1 transition, no event |
| an unchanged redelivery writes nothing | drop the did-it-change guard | `activity.updated` emitted for a change that did not happen |
| a redelivery leaves a rep's correction alone | — | holds the line against patching every field |

## Two moves

To stay under the length and complexity caps: the relink helpers go beside `RelinkActivity` where they belong, and the patch's admission checks come out of the statement they guard. **The gate keys that named the old function and file moved with them** — `unguardedByIDUpdates` now names `updateActivityInTx`, and one stale line left the dangling-citation register.

## Verification

`make check-backend` exit 0. `internal/modules/activities` and `internal/compose` integration suites green.