### PR TITLE
fix(build): the repository picks the pnpm version, not the release schedule

### DIFF
--- a/.github/workflows/_lane-frontend.yml
+++ b/.github/workflows/_lane-frontend.yml
@@ -45,9 +45,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -80,9 +80,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -113,9 +113,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,9 +208,13 @@ jobs:
               # dependency change is exactly the kind that needs fe-drift,
               # fe-unit and fe-bundle to have an opinion. pnpm-workspace.yaml is
               # named because `overrides` lives there: it resolves versions the
-              # lockfile then merely records.
+              # lockfile then merely records, and the root package.json because
+              # `packageManager` decides WHICH pnpm reads both — a pnpm major
+              # resolves the same lockfile differently, which is how this lane
+              # went red on a commit that touched nothing else.
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'package.json'
               # And the root scripts the lane's own targets execute —
               # check-contract-frontend-drift.sh is a gate this lane is the only
               # runner of, and phase-timer.sh brackets every leg of it. The whole
@@ -866,9 +870,9 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -973,9 +977,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -87,9 +87,9 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -84,9 +84,9 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -166,9 +166,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,10 +245,12 @@ jobs:
       #     durable win is the dependency-download layer, which only busts
       #     when a module pin changes. This step exposes the Actions cache
       #     credentials buildx needs for type=gha.
-      #   - The cache MOUNTS (the Go compile cache, the pnpm store, corepack's
-      #     pnpm download, tsc's .tsbuildinfo) are not layers and no layer
-      #     cache carries them; actions/cache + buildkit-cache-dance below
-      #     save and restore their contents around the bake.
+      #   - The cache MOUNTS (the Go compile cache, the pnpm store, tsc's
+      #     .tsbuildinfo) are not layers and no layer cache carries them;
+      #     actions/cache + buildkit-cache-dance below save and restore their
+      #     contents around the bake. Corepack's download is NOT among them:
+      #     the pinned pnpm is baked into a layer of its own, so a mount over
+      #     its home would hide the version the image is supposed to run.
       #
       # Both cache steps carry continue-on-error: they only make the bake
       # faster, so a cache-service outage or a broken injection must cost this
@@ -275,8 +277,7 @@ jobs:
             {
               ".buildx-mount-cache/go-build": { "target": "/root/.cache/go-build", "id": "margince-gobuild" },
               ".buildx-mount-cache/pnpm-store": { "target": "/pnpm-store", "id": "margince-pnpm-store" },
-              ".buildx-mount-cache/tsbuildinfo": { "target": "/app/frontend/node_modules/.tmp", "id": "margince-tsbuildinfo" },
-              ".buildx-mount-cache/corepack": { "target": "/root/.cache/node/corepack", "id": "margince-corepack" }
+              ".buildx-mount-cache/tsbuildinfo": { "target": "/app/frontend/node_modules/.tmp", "id": "margince-tsbuildinfo" }
             }
           skip-extraction: ${{ steps.mount-cache.outputs.cache-hit }}
       # ghcr only for pulling the private release-management CLI image; the

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -373,9 +373,9 @@ jobs:
           else
             echo "configured=yes" >> "$GITHUB_OUTPUT"
           fi
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -506,9 +506,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -568,9 +568,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # No version input: the pin is package.json's "packageManager", which pnpm
+      # and corepack read too. A second one here is refused as a mismatch.
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 11
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ gates apply (below).
 ## A working tree in four commands
 
 You need **Go ≥ 1.26**, **Docker**, `golangci-lint`, and Node with pnpm
-for the frontend half.
+for the frontend half. *Which* pnpm is not yours to pick: `package.json`
+pins it in `packageManager`, and both Corepack and pnpm itself switch to
+that version, so the repository decides rather than the day you installed.
 
 ```
 make install    # FE deps, gate tools, and the git hooks — run once

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,27 @@ RUN --mount=type=cache,id=margince-gobuild,target=/root/.cache/go-build \
 # run provides.
 FROM --platform=$BUILDPLATFORM node:24-alpine AS web-build
 
-RUN corepack enable
+# The pnpm version is the repository's, not the build day's. `corepack enable`
+# installs the shim and nothing else: with no manifest to read, the shim
+# resolves whatever npm calls latest at build time, so a new pnpm major reaches
+# this image with nothing in the tree having changed. That is how this build
+# went red on pnpm 12 with a green commit — the composed workspace's `link:`
+# overrides resolve to dangling symlinks there and the composed typecheck
+# fails on `Cannot find module 'react'`.
+#
+# package.json's "packageManager" is the one pin, the same field the workflows
+# read. It is copied to a directory of ITS OWN because `pnpm fetch` below
+# deliberately runs with no manifest beside the lockfile — see there.
+#
+# Nothing in this stage mounts a cache over corepack's home, and that is this
+# layer's doing: a mount is not part of the image, so it would hide the version
+# activated here and leave the shim resolving latest again — with, in the fetch
+# step below, no manifest in /app to correct it. Baked into a layer instead, the
+# pinned pnpm is simply present, and BuildKit re-runs this only when the pin
+# changes.
+COPY package.json /pnpm-pin/package.json
+RUN corepack enable \
+    && corepack prepare "$(node -p 'require("/pnpm-pin/package.json").packageManager')" --activate
 
 # `pnpm fetch` lays down a virtual store, and the install that follows it
 # reorganises that directory once the workspace's members are visible. pnpm
@@ -154,7 +174,6 @@ WORKDIR /app
 # would have broken this build with an error about a missing importer.
 COPY pnpm-lock.yaml ./
 RUN --mount=type=cache,id=margince-pnpm-store,target=/pnpm-store \
-    --mount=type=cache,id=margince-corepack,target=/root/.cache/node/corepack \
     pnpm fetch --store-dir /pnpm-store
 
 # The composition: the MERGED contracts the TS types are generated from and the
@@ -185,6 +204,29 @@ COPY extensions/ ./extensions/
 # lifecycle runs, and this build needs no postinstall hook.
 RUN --mount=type=cache,id=margince-pnpm-store,target=/pnpm-store \
     pnpm install --frozen-lockfile --prefer-offline --ignore-scripts --store-dir /pnpm-store
+
+# The COMPOSED workspace, and the install that gives each enabled unit its own
+# dependencies. The install above resolves the SPA and nothing else: a unit's
+# frontend/ is not a member of the root workspace (pnpm-workspace.yaml says
+# why), so without this step a unit's screen has no react, no
+# @tanstack/react-query and no @types/react to resolve, and the composed
+# typecheck below fails on every one of them — measured, with the version
+# pinned, so it is not the pnpm question.
+#
+# Copied from gobase rather than regenerated, for the reason the registry is:
+# this image has no Go toolchain. The workspace's `host` symlink is relative,
+# so it lands on /app/frontend here exactly as it lands on frontend/ elsewhere,
+# and it must stay a symlink through the copy — resolved to a directory it would
+# be a second copy of the SPA.
+#
+# --no-frozen-lockfile, and explicitly, for the reason the make lane states: this
+# lockfile is GENERATED under ignored build output and regenerating it is the
+# point, and CI=true above would otherwise flip the default to frozen against a
+# lockfile no image carries.
+COPY --from=gobase /src/build/composition-frontend/workspace/ ./build/composition-frontend/workspace/
+RUN --mount=type=cache,id=margince-pnpm-store,target=/pnpm-store \
+    cd build/composition-frontend/workspace \
+    && pnpm install --no-frozen-lockfile --prefer-offline --ignore-scripts --store-dir /pnpm-store
 
 # Regenerate the contract types from the MERGED crm.yaml, then build the composed
 # lane. This keeps the image's types pinned to the contract it was built against
@@ -229,7 +271,6 @@ ENV MARGINCE_BUILD_REVISION=$MARGINCE_BUILD_REVISION
 ARG MARGINCE_RELEASE_VERSION=dev
 ENV MARGINCE_RELEASE_VERSION=$MARGINCE_RELEASE_VERSION
 RUN --mount=type=cache,id=margince-tsbuildinfo,target=/app/frontend/node_modules/.tmp \
-    --mount=type=cache,id=margince-corepack,target=/root/.cache/node/corepack \
     pnpm gen:composed-types && pnpm gen:events:composed && pnpm build:composed
 
 # ── api: runtime ──────────────────────────────────────────────────────────────

--- a/backend/gates/composedfrontendbuilders_test.go
+++ b/backend/gates/composedfrontendbuilders_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// Four builders compile the composed SPA — the make lane, the release image and
+// the desktop bundle on each platform — and every one of them must install the
+// composed workspace before it does.
+//
+// That install is the ONLY thing that gives a unit's frontend layer its own
+// dependencies. It stopped being the root workspace's job when a unit's
+// frontend/ stopped being a member there, and the image build was not brought
+// along: it ran `pnpm build:composed` over a tree where a unit's react,
+// @tanstack/react-query and @types/react resolved to nothing, and every unit
+// screen failed TS2307. Nothing said so, because no lane builds that image —
+// the defect waited for a release.
+//
+// The corpus is derived from the invocation rather than listed: a file that
+// drives the composed build through pnpm is a builder, whatever it is written
+// in. A list would have carried exactly the three entries that were right.
+//
+// The grain is the FILE, not the individual lane, so a Makefile that kept the
+// install on one lane and lost it on another still reads clean here. That gap is
+// covered elsewhere and not by argument: `make check-fe` runs the make lanes on
+// every pull request, so a lane that loses its install goes red the same day.
+// Nothing in the merge gate builds the image or the desktop bundles, which is
+// precisely where the defect lived and what this gate is for.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// composedBuildInvocation is a builder driving the composed lane: `pnpm
+// build:composed`, or the typecheck projects the make lane runs directly.
+// frontend/package.json DEFINES that script and does not invoke it, which is
+// why the pattern asks for pnpm on the same line.
+var composedBuildInvocation = regexp.MustCompile(`pnpm.*(build:composed|tsc -p tsconfig\.composed)`)
+
+// composedWorkspaceDirDecl reads the emitter's own constant, so this gate
+// follows the directory if it ever moves instead of holding a second spelling
+// of where it is.
+var composedWorkspaceDirDecl = regexp.MustCompile(`(?m)^const composedFrontendWorkspaceDir = "([^"]+)"`)
+
+func TestEveryComposedFrontendBuilderInstallsTheWorkspace(t *testing.T) {
+	t.Parallel()
+	workspace := composedWorkspaceDir(t)
+
+	var builders int
+	for _, file := range trackedFiles(t) {
+		// This file spells the invocation it looks for, so scanning it would
+		// report itself. The exemption is the exact path: a second file of the
+		// same basename elsewhere is scanned like everything else.
+		if file.symlink || file.path == "backend/gates/composedfrontendbuilders_test.go" {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(repoRoot, file.path))
+		if err != nil {
+			// Tracked but absent happens mid-rebase and after `git rm`.
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("reading %s: %v", file.path, err)
+		}
+		lines := strings.Split(string(body), "\n")
+		if !buildsTheComposedLane(lines) {
+			continue
+		}
+		builders++
+		if !namesInCode(lines, workspace) {
+			t.Errorf("%s builds the composed SPA without installing %s — a unit's frontend layer gets react, @tanstack/react-query and @types/react from that install and from nowhere else, so every unit screen fails TS2307",
+				file.path, workspace)
+		}
+	}
+	if builders == 0 {
+		t.Fatal("no file drives the composed build — a sweep that finds no builder reports clean exactly like one that checked every builder, so either the scripts moved or this pattern is stale")
+	}
+}
+
+// composedWorkspaceDir is the directory the generator writes, read from the
+// generator.
+func composedWorkspaceDir(t *testing.T) string {
+	t.Helper()
+	const emitter = "tools/gen-composition/emitfrontend.go"
+	body, err := os.ReadFile(emitter)
+	if err != nil {
+		t.Fatalf("reading %s: %v", emitter, err)
+	}
+	match := composedWorkspaceDirDecl.FindSubmatch(body)
+	if match == nil {
+		t.Fatalf("%s no longer declares composedFrontendWorkspaceDir — this gate cannot say what a builder has to install", emitter)
+	}
+	return string(match[1])
+}
+
+func buildsTheComposedLane(lines []string) bool {
+	for _, line := range lines {
+		if !isComment(line) && composedBuildInvocation.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// namesInCode ignores comments, so a builder cannot satisfy this by explaining
+// in prose why it skips the install.
+func namesInCode(lines []string, want string) bool {
+	for _, line := range lines {
+		// PowerShell spells the same path with backslashes.
+		if !isComment(line) && strings.Contains(strings.ReplaceAll(line, `\`, "/"), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// isComment covers the comment markers of every language a builder here is
+// written in: make, shell, Dockerfile and PowerShell use `#`, Go uses `//`.
+func isComment(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//")
+}

--- a/backend/gates/gates_test.go
+++ b/backend/gates/gates_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -77,4 +78,40 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	os.Exit(m.Run())
+}
+
+// trackedFile is one entry from the index, with the one mode bit a gate that
+// reads files cares about.
+type trackedFile struct {
+	path    string
+	symlink bool
+}
+
+// trackedFiles reads the index. `-s` carries the mode, which is how a symlink is
+// told from a file without stat-ing it; `-z` makes the output NUL-delimited, so
+// no filename can be misread.
+//
+// It lives HERE, in the one file with no build constraint, for the reason
+// repoRoot does: behind `//go:build !integration` it is invisible to `make lint`,
+// which sets that tag, so a gate that used it compiled under `go test` and
+// failed to compile under the linter.
+func trackedFiles(t *testing.T) []trackedFile {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoRoot, "ls-files", "-sz").Output()
+	if err != nil {
+		t.Fatalf("listing tracked files: %v (this test must run inside the git worktree)", err)
+	}
+	var files []trackedFile
+	for _, row := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if row == "" {
+			continue
+		}
+		// <mode> <sha> <stage>\t<path>
+		meta, path, ok := strings.Cut(row, "\t")
+		if !ok {
+			continue
+		}
+		files = append(files, trackedFile{path: path, symlink: strings.HasPrefix(meta, "120000")})
+	}
+	return files
 }

--- a/backend/gates/migrationcitations_test.go
+++ b/backend/gates/migrationcitations_test.go
@@ -53,7 +53,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -353,37 +352,6 @@ func citationScanExempt(rel string) bool {
 		return strings.HasPrefix(rel, "backend/internal/") || strings.HasPrefix(rel, "extensions/")
 	}
 	return false
-}
-
-// trackedFile is one entry from the index, with the one mode bit this gate
-// cares about.
-type trackedFile struct {
-	path    string
-	symlink bool
-}
-
-// trackedFiles reads the index. `-s` carries the mode, which is how a symlink is
-// told from a file without stat-ing it; `-z` makes the output NUL-delimited, so
-// no filename can be misread.
-func trackedFiles(t *testing.T) []trackedFile {
-	t.Helper()
-	out, err := exec.Command("git", "-C", "..", "ls-files", "-sz").Output()
-	if err != nil {
-		t.Fatalf("listing tracked files: %v (this test must run inside the git worktree)", err)
-	}
-	var files []trackedFile
-	for _, row := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
-		if row == "" {
-			continue
-		}
-		// <mode> <sha> <stage>\t<path>
-		meta, path, ok := strings.Cut(row, "\t")
-		if !ok {
-			continue
-		}
-		files = append(files, trackedFile{path: path, symlink: strings.HasPrefix(meta, "120000")})
-	}
-	return files
 }
 
 // danglingCitationsIn reports the citations in one file naming a version no

--- a/backend/gates/pnpmversionpins_test.go
+++ b/backend/gates/pnpmversionpins_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// One pnpm version, and package.json's "packageManager" field is it.
+//
+// Before that field existed the version was whatever the environment reached
+// for: the workflows asked pnpm/action-setup for the `11` range, the image
+// build ran `corepack enable` with no manifest to read and got whatever npm
+// called latest that morning, and a laptop ran whatever it had installed. So
+// the toolchain a build used was chosen by an upstream release schedule rather
+// than by this repository, and a pnpm major landed in the image with nothing in
+// the tree having changed — which is how a green commit built red.
+//
+// The obligation is derived from the field rather than listed here: a version
+// written anywhere else is a second source of the same answer, and the two
+// disagree the first time one is bumped alone. pnpm/action-setup refuses that
+// case outright (ERR_PNPM_BAD_PM_VERSION); corepack does not, and picks
+// whichever it happened to read.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// pnpmVersionLiteral matches a concrete pnpm version wherever it is written:
+// the `pnpm@11.25.0` corepack spelling and the `version: 11` input
+// pnpm/action-setup takes. Only package.json may carry one.
+var (
+	pnpmVersionLiteral = regexp.MustCompile(`pnpm@\d`)
+	actionSetupStep    = regexp.MustCompile(`(?m)^(?P<indent>[ \t]*)- uses: pnpm/action-setup@`)
+	packageManagerPin  = regexp.MustCompile(`^pnpm@\d+\.\d+\.\d+(\+[a-z0-9]+\.[0-9a-f]+)?$`)
+)
+
+func TestThePnpmVersionHasOneSource(t *testing.T) {
+	t.Parallel()
+	want := pinnedPackageManager(t)
+
+	// Every step that installs pnpm in CI must take the version from the pin
+	// rather than restate it. The scan is over the workflow directory, not a
+	// list: a lane added tomorrow is covered the day it is written.
+	t.Run("no workflow states a version of its own", func(t *testing.T) {
+		files, err := filepath.Glob(filepath.Join(repoRoot, ".github", "workflows", "*.yml"))
+		if err != nil {
+			t.Fatalf("listing workflows: %v", err)
+		}
+		var steps int
+		for _, file := range files {
+			steps += assertActionSetupReadsThePin(t, file)
+		}
+		if steps == 0 {
+			t.Fatal("no workflow installs pnpm — a scan that finds no step reports clean exactly like one that checked every step, so either the action moved or this pattern is stale")
+		}
+	})
+
+	// The image build has no action to read the field for it: `corepack enable`
+	// installs a shim, and a shim with nothing to read resolves latest. So every
+	// stage that runs pnpm must have activated the pin first.
+	t.Run("the image build activates the pin before it runs pnpm", func(t *testing.T) {
+		assertDockerfileActivatesThePin(t)
+	})
+
+	// And nowhere else. A version written a second time is the failure this
+	// gate exists for, whether it is a workflow input, a Dockerfile argument or
+	// a line of prose that goes stale.
+	t.Run("nothing else in the tree names a pnpm version", func(t *testing.T) {
+		files := trackedFiles(t)
+		if len(files) == 0 {
+			t.Fatal("the index lists no file — a sweep over nothing reports the clean tree it never read")
+		}
+		for _, file := range files {
+			if file.symlink {
+				continue
+			}
+			assertNamesNoPnpmVersion(t, file.path, want)
+		}
+	})
+}
+
+// pinnedPackageManager reads the field every other reader resolves, and holds
+// it to an EXACT version: corepack accepts a range, and a range puts the choice
+// back with npm's release schedule, which is the whole defect.
+func pinnedPackageManager(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot, "package.json"))
+	if err != nil {
+		t.Fatalf("reading the workspace root manifest: %v", err)
+	}
+	// Decoded through a map rather than a tagged struct: the field is npm's,
+	// spelled the way npm spells it, and a struct tag naming it is the one
+	// place in this tree that has to disagree with the repo's casing rule.
+	var manifest map[string]json.RawMessage
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		t.Fatalf("package.json does not parse: %v", err)
+	}
+	var pin string
+	if raw, declared := manifest["packageManager"]; declared {
+		if err := json.Unmarshal(raw, &pin); err != nil {
+			t.Fatalf("package.json declares a packageManager that is not a string: %v", err)
+		}
+	}
+	if !packageManagerPin.MatchString(pin) {
+		t.Fatalf("package.json declares packageManager %q, want an exact pnpm@<major>.<minor>.<patch> (optionally with corepack's integrity suffix) — "+
+			"a range or an empty field hands the choice back to whatever npm published this morning", pin)
+	}
+	return pin
+}
+
+// assertActionSetupReadsThePin reports every action-setup step in one workflow
+// that carries a version of its own, and returns how many steps it saw so the
+// caller can refuse a sweep that found none.
+func assertActionSetupReadsThePin(t *testing.T, file string) int {
+	t.Helper()
+	body, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading %s: %v", file, err)
+	}
+	lines := strings.Split(string(body), "\n")
+	var steps int
+	for i, line := range lines {
+		match := actionSetupStep.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		steps++
+		// The step's own block: everything indented past the `- `, which ends
+		// at the next line at or above the step's own indentation.
+		indent := match[1]
+		for _, within := range lines[i+1:] {
+			if strings.TrimSpace(within) == "" {
+				continue
+			}
+			if !strings.HasPrefix(within, indent+" ") {
+				break
+			}
+			if strings.HasPrefix(strings.TrimSpace(within), "version:") {
+				t.Errorf("%s:%d gives pnpm/action-setup a version of its own (%s) — omit it and the action reads package.json's packageManager; both is ERR_PNPM_BAD_PM_VERSION",
+					file, i+1, strings.TrimSpace(within))
+				break
+			}
+		}
+	}
+	return steps
+}
+
+// assertDockerfileActivatesThePin walks the stages rather than looking for one
+// known line: the obligation is that pnpm never runs on a version nobody chose,
+// and a stage added later inherits it.
+func assertDockerfileActivatesThePin(t *testing.T) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repoRoot, "Dockerfile"))
+	if err != nil {
+		t.Fatalf("reading the Dockerfile: %v", err)
+	}
+	var activated bool
+	var invocations int
+	for i, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "FROM ") {
+			activated = false
+			continue
+		}
+		if strings.Contains(trimmed, "corepack prepare") && strings.Contains(trimmed, "packageManager") {
+			activated = true
+			continue
+		}
+		if !strings.Contains(trimmed, "pnpm ") {
+			continue
+		}
+		invocations++
+		if !activated {
+			t.Errorf("Dockerfile:%d runs pnpm before the stage activates package.json's packageManager — corepack resolves latest here\n\t%s", i+1, trimmed)
+		}
+	}
+	if invocations == 0 {
+		t.Fatal("the Dockerfile runs no pnpm — a walk that finds nothing to check passes exactly like one that checked every stage, so either the build moved or this scan is stale")
+	}
+}
+
+// assertNamesNoPnpmVersion allows the pin itself and nothing else, over the
+// WHOLE index rather than a chosen set of file types: a stale version is stale
+// wherever it is written — a workflow, a Dockerfile, a script, a how-to — and a
+// filter in front of this sweep is a place for one to hide. Reading every
+// tracked file costs tens of megabytes once per run, which is cheaper than the
+// shape of failure a narrower scan has.
+//
+// The exemptions are exact paths: a second file of the same basename elsewhere
+// is scanned like everything else.
+func assertNamesNoPnpmVersion(t *testing.T, rel, pin string) {
+	t.Helper()
+	switch rel {
+	case "package.json":
+		// The pin itself.
+		return
+	case "backend/gates/pnpmversionpins_test.go":
+		// This file names the pattern it bans.
+		return
+	case "pnpm-lock.yaml":
+		// Generated by the pinned pnpm and rewritten wholesale; it records the
+		// version that wrote it rather than choosing one.
+		return
+	}
+	body, err := os.ReadFile(filepath.Join(repoRoot, rel))
+	if err != nil {
+		// Tracked but absent happens mid-rebase and after `git rm`; not this
+		// gate's business.
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("reading %s: %v", rel, err)
+	}
+	for i, line := range strings.Split(string(body), "\n") {
+		if pnpmVersionLiteral.MatchString(line) {
+			t.Errorf("%s:%d names a pnpm version; package.json pins %s and every reader resolves it from there\n\t%s",
+				rel, i+1, pin, strings.TrimSpace(line))
+		}
+	}
+}

--- a/backend/tools/gen-composition/emit_frontend_test.go
+++ b/backend/tools/gen-composition/emit_frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -334,5 +335,85 @@ func TestReEmittingTheWorkspaceReplacesTheMembers(t *testing.T) {
 	}
 	if strings.Contains(string(ws), "relay-probe") {
 		t.Error("a removed unit is still a member of the composed workspace")
+	}
+}
+
+// The overrides reach the host through the workspace's own `host` link, and no
+// target may climb out with `../`. pnpm 12 miscounts such a target — it writes
+// the member's symlink with two extra parent segments for every `../` the spec
+// asked for — and nothing says so: the install exits 0 and the composed lane
+// fails hundreds of lines later on `Cannot find module 'react'`. pnpm 10 and 11
+// resolve both spellings, so no lane on a pinned version can notice the
+// difference, which is what this test is for.
+func TestNoOverrideTargetClimbsOutOfTheWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	if err := emitComposedFrontendWorkspace(dir, []string{"notes"}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	ws, err := os.ReadFile(filepath.Join(dir, "pnpm-workspace.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The overrides are the file's last block, so what follows the header is
+	// all of them — read that way rather than from a list here, which would be
+	// a second copy of the emitter and would pass over an override it had not
+	// heard of.
+	_, overrides, ok := strings.Cut(string(ws), "\noverrides:\n")
+	if !ok {
+		t.Fatalf("the emitted workspace declares no overrides:\n%s", ws)
+	}
+	var checked int
+	for _, line := range strings.Split(overrides, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		checked++
+		_, target, isLink := strings.Cut(line, "link:")
+		if !isLink {
+			t.Errorf("override %q is not a link: — an installed copy is a second copy of what the host owns", line)
+			continue
+		}
+		if strings.Contains(target, "..") {
+			t.Errorf("override %q climbs out of the workspace; pnpm 12 writes that symlink two segments too deep per `../` and it dangles", line)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("the overrides block is empty — a workspace that overrides nothing resolves @margince/frontend to a package that does not exist, and this test would have reported it clean")
+	}
+}
+
+// The host link is what lets an override name its target without a `../`, so
+// where it points is the whole of that property. It is REPLACED on every
+// emission for the reason the member list is: one left behind by a move
+// resolves somewhere nobody chose.
+func TestTheWorkspaceLinksTheHostSPA(t *testing.T) {
+	dir := t.TempDir()
+	if err := emitComposedFrontendWorkspace(dir, []string{"notes"}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	link := filepath.Join(dir, hostLinkName)
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("the workspace carries no host link: %v", err)
+	}
+	// Walked from where the workspace really lives, the link must land on the
+	// host SPA — which is the `../` count checked against its own source rather
+	// than against a number written out here a second time.
+	if got := path.Join(composedFrontendWorkspaceDir, target); got != "frontend" {
+		t.Errorf("host link resolves to %q from %s, want the host SPA at frontend", got, composedFrontendWorkspaceDir)
+	}
+
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("somewhere-else", link); err != nil {
+		t.Fatal(err)
+	}
+	if err := emitComposedFrontendWorkspace(dir, []string{"notes"}); err != nil {
+		t.Fatalf("re-emit: %v", err)
+	}
+	if again, err := os.Readlink(link); err != nil || again != target {
+		t.Errorf("re-emitting left the host link at %q (err %v), want it replaced with %q", again, err, target)
 	}
 }

--- a/backend/tools/gen-composition/emitfrontend.go
+++ b/backend/tools/gen-composition/emitfrontend.go
@@ -10,7 +10,9 @@ package main
 // two locations it is written to can stay byte-identical).
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -251,7 +253,49 @@ const composedFrontendWorkspaceDir = "build/composition-frontend/workspace"
 //
 // The link targets are inside frontend/node_modules, so the ROOT install must
 // have run first. The make lanes order it that way, and a dangling link here
-// fails loudly at the next resolve rather than silently resolving twice.
+// costs the composed typecheck rather than resolving twice in silence.
+
+// hostLinkName is the symlink the emitted workspace carries to the host SPA,
+// and every override below names its target THROUGH it.
+//
+// This is the third pnpm behaviour change this file has had to absorb, and the
+// first that shows nothing. pnpm 12 miscomputes a `link:` whose target climbs
+// out of the workspace root: for a spec with N leading `../` it writes the
+// member's symlink with 2N parent segments too many, so the link dangles, the
+// install still exits 0, and the composed lane fails hundreds of lines later on
+// `Cannot find module 'react'`. Measured on 12.3.4; 10 and 11 resolve the same
+// spec correctly, which is why an unpinned build environment was the only place
+// it appeared.
+//
+// Reached through this link a target carries no `../` at all, so there is
+// nothing left to miscount and 10, 11 and 12 all land in frontend/node_modules.
+// A SYMLINK, not `file:` — which satisfies the same specifier by copying the
+// package into the virtual store, and a second @types/react under a second path
+// is precisely the "two unrelated types with this name" failure these overrides
+// exist to prevent.
+const hostLinkName = "host"
+
+// workspaceToRepoRoot is the path from the emitted workspace back up to the
+// repository root, DERIVED from composedFrontendWorkspaceDir: a hand-counted
+// `../../../` is a second spelling of that constant, and it goes stale the day
+// the directory moves without anything failing.
+func workspaceToRepoRoot() string {
+	return strings.Repeat("../", strings.Count(composedFrontendWorkspaceDir, "/")+1)
+}
+
+// linkHost points the emitted workspace at the host SPA. Replaced rather than
+// kept, for the reason the member list is: a link left behind by a move
+// resolves somewhere nobody chose.
+func linkHost(dir string) error {
+	link := filepath.Join(dir, hostLinkName)
+	if err := os.Remove(link); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("replacing the composed workspace's host link: %w", err)
+	}
+	if err := os.Symlink(workspaceToRepoRoot()+"frontend", link); err != nil {
+		return fmt.Errorf("linking the host SPA into the composed workspace: %w — on Windows creating a symlink needs Developer Mode", err)
+	}
+	return nil
+}
 
 // emitComposedFrontendWorkspace writes a pnpm workspace whose members are the
 // host SPA and each enabled unit's frontend layer.
@@ -291,6 +335,10 @@ func emitComposedFrontendWorkspace(dir string, units []string) error {
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), manifest, 0o644); err != nil { // #nosec G306 -- generated build artifact
 		return err
 	}
+	if err := linkHost(dir); err != nil {
+		return err
+	}
+	root := workspaceToRepoRoot()
 
 	// Sorted, for the same reason go.work's members are: the emitted bytes must
 	// not depend on the order the tree was walked in.
@@ -305,9 +353,12 @@ func emitComposedFrontendWorkspace(dir string, units []string) error {
 	b.WriteString("# only those. Members are reached by relative path out of this generated\n")
 	b.WriteString("# directory rather than copied, so an edit in extensions/<unit>/frontend/ is\n")
 	b.WriteString("# what the next install resolves. The host SPA is not a member — see above.\n")
+	b.WriteString("# `" + hostLinkName + "` beside this file is a symlink to the host SPA, and every\n")
+	b.WriteString("# override below names its target through that link rather than climbing out\n")
+	b.WriteString("# of this directory with `../` — which pnpm 12 miscounts.\n")
 	b.WriteString("packages:\n")
 	for _, unit := range members {
-		fmt.Fprintf(&b, "  - ../../../extensions/%s/frontend\n", unit)
+		fmt.Fprintf(&b, "  - %sextensions/%s/frontend\n", root, unit)
 	}
 	// esbuild ships a platform binary and needs its install script to run — the
 	// same carve-out the root workspace states, for the same reason.
@@ -327,12 +378,13 @@ func emitComposedFrontendWorkspace(dir string, units []string) error {
 	// rather than linked, a unit gets its own @types/react and tsc reports two
 	// unrelated types of the same name against the host's design system.
 	b.WriteString("\noverrides:\n")
+	host := "link:./" + hostLinkName
 	for _, override := range [][2]string{
-		{"@margince/frontend", "link:../../../frontend"},
-		{"react", "link:../../../frontend/node_modules/react"},
-		{"react-dom", "link:../../../frontend/node_modules/react-dom"},
-		{"@tanstack/react-query", "link:../../../frontend/node_modules/@tanstack/react-query"},
-		{"@types/react", "link:../../../frontend/node_modules/@types/react"},
+		{"@margince/frontend", host},
+		{"react", host + "/node_modules/react"},
+		{"react-dom", host + "/node_modules/react-dom"},
+		{"@tanstack/react-query", host + "/node_modules/@tanstack/react-query"},
+		{"@types/react", host + "/node_modules/@types/react"},
 	} {
 		fmt.Fprintf(&b, "  %q: %q\n", override[0], override[1])
 	}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (87)
+## Parity (89)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -34,6 +34,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `bookinginvite_test.go` | H2 | What booking a meeting CLAIMS and what it DOES, held against each other. |
 | `coachingroles_test.go` | H2 | The seats that may coach are seats that exist. |
 | `companyprofilevocabulary_test.go` | H3 | The company-profile vocabulary is spelled in eight places, and this gate is what makes widening seven of them a failure instead of a silent half-job. |
+| `composedfrontendbuilders_test.go` | H3 | Four builders compile the composed SPA — the make lane, the release image and the desktop bundle on each platform — and every one of them must install the composed workspace before it does. |
 | `configpresets_test.go` | H3 | Every preset under config/presets/ is a binding the parser accepts. |
 | `configschema_test.go` | H3 | The margince.yaml schema is editor tooling, and editor tooling that lies is worse than none: an operator trusts the squiggle. |
 | `consumergroupwiring_test.go` | H3 | Every lane the worker starts is a group the catalog declares. |
@@ -89,6 +90,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `personalpurgewindow_test.go` | H3 | The page that names a deletion date and the sweep that carries it out must read ONE window, or the product promises a date it does not keep. |
 | `planprosebounds_test.go` | H3 | A plan's prose columns are bounded twice, and the two numbers must agree. |
+| `pnpmversionpins_test.go` | H3 | One pnpm version, and package.json's "packageManager" field is it. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
 | `previewauthority_test.go` | H2 | The authority levels a composer can receive are the ones the engine can send. |
 | `processingrecord_test.go` | H3 | The Art. 30 processing record names the code that enforces each entry, and this fails when that code is not there any more. |

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -154,7 +154,7 @@ would report a documentation PR as a broken integration lane.
 |---|---|---|
 | `backend_db` | `backend/**`, `infra/**/!(*.md)`, `go.work`, `go.work.sum`, `Makefile`, `scripts/**`, `extensions/**`, `fixtures/**`, `composition/**`, `.github/workflows/ci.yml`, `.github/workflows/_lane-*.yml` (the caller plus every lane it invokes — globbed so a lane added later is covered the day it lands), `.github/actions/**`, `sonar-project.properties`, `frontend/src/mcp-apps/forbidden.json` | the integration shards and the `integration` fan-in — every lane that opens a database |
 | `backend` | `backend_db` (by YAML anchor, so the two cannot drift) plus the agent rulebooks `AGENTS.md` and `CLAUDE.md` | Go build/gate, extension reference, craftsmanship, unit coverage, vuln |
-| `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` — and the install inputs `pnpm-lock.yaml` and `pnpm-workspace.yaml`, which decide *which* dependency the SPA builds on and which one `openapi-typescript` parses the contract with (`overrides` lives in the workspace file, so it resolves versions the lockfile then merely records) | frontend lane, UAT |
+| `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types), plus the composition inputs the lane now typechecks against — `extensions/**`, `fixtures/**`, `composition/**`, `backend/tools/gen-composition/**`, `Makefile` — and the install inputs `pnpm-lock.yaml`, `pnpm-workspace.yaml` and the root `package.json`, which decide *which* dependency the SPA builds on and which one `openapi-typescript` parses the contract with (`overrides` lives in the workspace file, so it resolves versions the lockfile then merely records; `packageManager` lives in the manifest and decides which pnpm reads both) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**/!(*.md)`, `extensions/**`, `fixtures/**`, `composition/**` | full-stack live-boot |
 | `deps` | `go.work`, `go.work.sum`, `**/go.mod`, `**/go.sum`, `**/package.json`, `**/pnpm-lock.yaml`, `pnpm-workspace.yaml` (`overrides` lives there, so it decides resolved versions the way a manifest does), `.syft.yaml`, `.grant.yaml`, `sbom-schemas/**`, `Makefile`, `.github/workflows/**` (syft catalogs a `uses:` as a package, so any workflow gaining a reference changes what the gate judges — a pinned remote action brings its license, a local reusable workflow brings none), `.github/actions/**` | the license gate |
 
@@ -712,9 +712,11 @@ beside the gate, deliberately outside it:
   the runner is ephemeral: `CACHE=gha` exports the layer cache per role
   (its durable win is the dependency-download layer, which busts only on a
   module-pin change), and buildkit-cache-dance + actions/cache carry the
-  BuildKit cache-mount contents (Go compile cache, pnpm store, Corepack's
-  pnpm download, tsc `.tsbuildinfo`) across runs — mounts are not layers, so no layer cache
-  covers them. Both live in the repo's 10 GB Actions cache, which the CI
+  BuildKit cache-mount contents (Go compile cache, pnpm store, tsc
+  `.tsbuildinfo`) across runs — mounts are not layers, so no layer cache
+  covers them. Corepack's download is deliberately not among them: the image
+  bakes the pinned pnpm into a layer, and a mount over Corepack's home would
+  hide it. Both live in the repo's 10 GB Actions cache, which the CI
   lanes' Go caches keep near the cap, so entries older than a few hours are
   routinely LRU-evicted: the caches bridge releases that land close
   together — the busy-day case where they matter — and a release after a

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "margince",
   "private": true,
-  "description": "Workspace root. pnpm needs a manifest where the workspace is rooted, and the workspace is rooted here so a unit's extensions/<name>/frontend package can be a member. Nothing is built from this file — the SPA is frontend/, and every script still lives there. It declares no packageManager on purpose: CI pins pnpm through pnpm/action-setup, and a second source of that version is what ERR_PNPM_BAD_PM_VERSION is about."
+  "description": "Workspace root. pnpm needs a manifest where the workspace is rooted, and the workspace is rooted here so a unit's extensions/<name>/frontend package can be a member. Nothing is built from this file — the SPA is frontend/, and every script still lives there. What it does decide is the pnpm version: \"packageManager\" is the ONE pin, read by corepack, by pnpm's own self-management and by pnpm/action-setup, so no environment picks a major off npm's release schedule. A workflow must therefore not also pass a `version:` input — two sources of the same version is what ERR_PNPM_BAD_PM_VERSION is about, and backend/gates/pnpmversionpins_test.go fails a second one.",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956"
 }


### PR DESCRIPTION
Closes https://github.com/margince/margince/issues/4609

## What was wrong

The tree declared no `packageManager`, so every environment resolved its own pnpm — the workflows asked `pnpm/action-setup` for the `11` range, the image build ran `corepack enable` with nothing to read, and a laptop ran whatever it had installed. The version a build used was chosen by npm's release schedule rather than by this repository.

Reproduced end to end, then measured **two** defects stacked behind it.

**1. The image build is red on `main` today.** `docker build --target web-build` on unmodified `origin/main`:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-12.3.4.tgz
Error: ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
  × fetching dependencies
  ╰─▶ Cannot proceed with the frozen installation. The current "overrides"
      configuration doesn't match the value found in the lockfile
```

**2. pnpm 12 miscounts a `link:` override that climbs out of the workspace root.** For a spec with N leading `../` it writes the member's symlink with **2N parent segments too many** — measured in a minimal harness across three depths, and identical for an absolute spec, which pnpm normalises back to a relative one. The link dangles, `pnpm install` still exits 0, and `tsc -p tsconfig.composed.json` fails hundreds of lines later with the reported `TS2307`/`TS2875`. pnpm 10 and 11 resolve the same spec correctly, which is why a pinned CI never saw it.

`file:` resolves on 12 — by *copying* the package into the virtual store, which is a second `@types/react` under a second path and precisely the "two unrelated types with this name" failure these overrides exist to prevent. Only a target with **zero** `../` is safe.

**3. The image never installs the composed workspace** — found once the pin got the build past `pnpm fetch`. Membership moved out of the root workspace when a unit's `frontend/` stopped being a member there, and the image build was not brought along, so a unit's own `react`, `@tanstack/react-query` and `@types/react` resolve to nothing. Nothing in the merge gate builds an image, so it was waiting for a release.

## What changed

- **One pin.** `packageManager` in the root `package.json`, with corepack's integrity hash. The `version:` input is gone from all 11 `pnpm/action-setup` steps — the action reads the field, and both together is `ERR_PNPM_BAD_PM_VERSION`. The Dockerfile activates that field through corepack instead of resolving latest; it is copied to a directory of its own because `pnpm fetch` deliberately runs with no manifest beside the lockfile. The corepack cache mounts are gone with it: a mount is not part of the image, so it would hide the version the image is supposed to run.
- **A `..`-free override.** `gen-composition` emits a `host` symlink beside the generated workspace and writes every override through it (`link:./host/node_modules/react`). The `../` count is now derived from `composedFrontendWorkspaceDir` rather than hand-written.
- **The image installs the composed workspace**, copying it from `gobase` — the `host` link is relative, so it lands on `/app/frontend` and stays a symlink through the copy.
- The root manifest joins the frontend lane's path filter, for the same reason the lockfile is on it.

## Fitness functions, not point fixes

| Gate | Holds |
|---|---|
| `backend/gates/pnpmversionpins_test.go` | The pin is exact; no `version:` input on any action-setup step; no second pnpm version anywhere in the index; no Dockerfile stage runs pnpm before activating the pin |
| `backend/gates/composedfrontendbuilders_test.go` | Corpus derived from the invocation — a file that drives the composed build must install the composed workspace |
| `emit_frontend_test.go` | No override target climbs out of the workspace; the host link points at the SPA and is replaced on re-emission |

`trackedFiles` moved to `gates_test.go`, the one file with no build constraint — behind `//go:build !integration` it is invisible to `make lint`, which is the trap `repoRoot`'s comment already records.

Every gate was mutation-tested: each fails on the defect it names and passes once restored.

## Verification

| | |
|---|---|
| `make check-fe` | green (6m32s, composed typecheck + composed-workspace screens) |
| `make lint`, `make check-gates`, `make craft-static` | green |
| Composed workspace install | pnpm **10.32.1, 11.25.0 and 12.3.4** — no dangling links, every package realpath-ing to the host's single copy |
| `docker build --target web-build` | green, and inside the image the unit's `react` and the host's both resolve to `/app/node_modules/.pnpm/react@19.2.8/node_modules/react` |

The pin is `11.25.0` — the version CI has been green on. Renovate raises a major as a human-reviewed PR, which is the right shape for the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)