### PR TITLE
DO NOT MERGE — fix(capture): a meeting belongs to the calendar it came from

### DIFF
--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -126,16 +126,20 @@ func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
 		occurredAt: occurredOf(item, asOf),
-		// NOT the reader's, and the obvious claim here is false. The lane lists
-		// meeting activities under the caller's ROW SCOPE — no owner or attendee
-		// predicate — so a team-scoped reader receives their team's meetings and
-		// naming the reader would make every one of them look like the reader's
-		// own appointment.
+		// The READER's, because the lane now asks for their meetings alone.
 		//
-		// The activity carries no owner this lane reads, so nobody is named. A
-		// meeting's real owner is its organiser, which arrives with the attendee
-		// read that does not exist yet.
-		ownerRef: unassigned(),
+		// This used to be unassigned(), with a comment saying a meeting's real
+		// owner "arrives with the attendee read that does not exist yet", and
+		// naming nobody was not neutral: keepReadersOwn keeps a row it cannot
+		// judge, so every meeting the lane returned landed on every reader's
+		// own queue. That is how a rep read "a meeting with Lucy" about
+		// somebody she had never met.
+		//
+		// The lane's query carries host_user_id now (attentionmeetingseam.go),
+		// so every row here came from this reader's own calendar and the honest
+		// answer is the reader. Saying so through the same helper the per-user
+		// lanes use keeps one spelling of "this row is yours".
+		ownerRef: ownedByWhoeverIsReading(),
 	}
 }
 

--- a/backend/internal/compose/attention/owner_test.go
+++ b/backend/internal/compose/attention/owner_test.go
@@ -219,8 +219,10 @@ func dayOfEveryLane() crmcontracts.Attention {
 // `ownedByWhoeverIsReading` asserts something specific about the LANE: its
 // query takes the acting user, so no other person's row could have come back.
 // That is checkable, and four of the lanes that first carried the claim failed
-// it — decisions, meetings, DSR and three of the five system sources are read
-// under the caller's ROW SCOPE instead, which is a different thing. A
+// it — decisions, meetings, DSR and three of the five system sources were read
+// under the caller's ROW SCOPE instead, which is a different thing. Meetings
+// have since EARNED the claim: the lane's query carries host_user_id, so a row
+// it returns came from the reader's own calendar. A
 // team-scoped reader receives their team's rows there, and naming the reader
 // would have made a colleague's duplicate pair look like the reader's own work.
 //
@@ -237,6 +239,7 @@ func TestOnlyAReaderBoundLaneNamesTheReader(t *testing.T) {
 		"undelivered":          "the same per-user read as the bounce beside it",
 		"notice":               "a notice is addressed to one person",
 		"capture_health":       "a mailbox belongs to one person",
+		"meeting":              "Today passes HostUserID, so the lane reads this reader's calendar alone",
 	}
 	rows := classifyDay(dayOfEveryLane(), rankInstant, dayMoney{})
 	for _, row := range rows {

--- a/backend/internal/compose/attentionmeetingseam.go
+++ b/backend/internal/compose/attentionmeetingseam.go
@@ -17,6 +17,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // attentionMeetings reads today's remaining meetings through the activities
@@ -38,9 +39,25 @@ func (m attentionMeetings) Today(
 	ctx context.Context, from, until time.Time, limit int,
 ) ([]attention.Meeting, error) {
 	kind := string(crmcontracts.ActivityKindMeeting)
-	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{
+	// WHOSE meetings, asked in SQL rather than assumed.
+	//
+	// Without this the lane read every meeting the caller's row scope reached
+	// and the queue named nobody as their owner, so the "mine" filter — which
+	// keeps a row it cannot judge — put every colleague's appointments on
+	// every reader's morning. A rep with the narrowest scope in the
+	// installation read a meeting with a person she had never met.
+	//
+	// A caller with no user behind it (an engine-internal read) gets no host
+	// predicate and the lane behaves as before: those callers have no calendar
+	// of their own to narrow to.
+	in := activities.ListActivitiesInput{
 		Kind: &kind, OccurredAfter: &from, OccurredBefore: &until, Limit: &limit,
-	})
+	}
+	if actor, ok := principal.Actor(ctx); ok && !actor.UserID.IsZero() {
+		host := ids.From[ids.UserKind](actor.UserID)
+		in.HostUserID = &host
+	}
+	rows, _, err := m.store.ListActivities(ctx, in)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -73,6 +73,14 @@ type ListActivitiesInput struct {
 	// that question rather than a second dial — see openTaskAssigneeClause.
 	AssigneeID *ids.UserID
 
+	// HostUserID narrows to the meetings captured from one person's calendar.
+	//
+	// Whose appointment it IS, which is a different question from who is
+	// assigned to it: a meeting has no assignee, and before this dial existed
+	// the morning brief listed every seat's meetings to every reader because
+	// the lane had no way to ask for one person's.
+	HostUserID *ids.UserID
+
 	// OwnQueueOf narrows to the open work one person is answerable for.
 	// Distinct from AssigneeID, which means exact assignment on any kind and is
 	// what the task screen filters by; this one is the day's queue and carries

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -366,6 +366,9 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	if clause := openTaskAssigneeClause(in.AssigneeID, arg); clause != "" {
 		where = append(where, clause)
 	}
+	if in.HostUserID != nil {
+		where = append(where, sprintf("a.host_user_id = $%d", arg(*in.HostUserID)))
+	}
 	if in.OpenAndDueBy != nil {
 		// Strictly before the instant, which is what deadline.Passed means and
 		// what this clause replaced. The bound the caller passes is the END of

--- a/backend/internal/modules/capture/birthdecision.go
+++ b/backend/internal/modules/capture/birthdecision.go
@@ -100,8 +100,25 @@ func (d birthDecision) hold(reason string) birthDecision {
 func decideBirthTx(
 	ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord, fields ActivityFields,
 ) (birthDecision, error) {
-	// Non-mail kinds keep the workspace default: a meeting or a channel message
-	// is not correspondence a mailbox posture was ever asked about.
+	// A MEETING runs its own ladder, not this one and not none.
+	//
+	// This used to read `if fields.Kind != "email" { return birthDecision{}, nil }`
+	// — every non-mail kind kept the workspace default. That is right about
+	// mailbox POSTURE, which was never asked of a calendar, and wrong about
+	// everything else on the ladder: a counterparty hold and a [Vertraulich]
+	// marker say nothing about which transport carried the thing they judge.
+	//
+	// What it cost: an unlinked calendar event was born audience=workspace, and
+	// ActivityDiscoverClause reads an unlinked activity as a workspace-shared
+	// note every seat may read. On the staging installation that made 465 of
+	// 468 meetings — private dinners and a partner negotiation among them —
+	// discoverable by the most restricted account on it.
+	if fields.Kind == "meeting" {
+		return decideMeetingBirthTx(ctx, tx, rec, fields)
+	}
+	// The other non-mail kinds keep the workspace default: a channel message is
+	// not correspondence a mailbox posture was ever asked about, and a note is
+	// somebody writing something down FOR the workspace.
 	if fields.Kind != "email" {
 		return birthDecision{}, nil
 	}

--- a/backend/internal/modules/capture/meetingaudience_integration_test.go
+++ b/backend/internal/modules/capture/meetingaudience_integration_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture_test
+
+// WHO MAY DISCOVER A CAPTURED MEETING.
+//
+// A meeting is not a workspace-shared note, and the difference is the whole
+// point of this file. An unlinked NOTE is somebody writing something down for
+// the workspace, so ActivityDiscoverClause's empty-link rule — coalesce to
+// true, every seat may read it — is right for it.
+//
+// A calendar event is the opposite. It arrives from one person's mailbox,
+// carries their private appointments, and links nothing at all until somebody
+// files it against a record. Under the note rule every seat in the
+// installation could discover every colleague's calendar: on the staging
+// installation this was 465 of 468 meetings readable by the single most
+// restricted account on it, "Drinks at Xu" and a partner negotiation included.
+//
+// So a captured meeting is born held to its participants, exactly as a
+// captured message is, and these tests drive the capture path rather than
+// asserting over a hand-written row: what is at stake is what the WRITER
+// stamps, and a fixture that set the audience itself would pass while the
+// writer stamped anything at all.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// calendarSinkContext binds the per-seat calendar connector principal, the way
+// the sync loop mints one: it carries the SEAT's user id, which is what makes
+// "whose calendar is this" answerable at the write.
+func calendarSinkContext(ctx context.Context, ws, seat ids.UUID) context.Context {
+	ctx = principal.WithWorkspaceID(ctx, ws)
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type:   principal.PrincipalConnector,
+		ID:     "connector:gcal:" + seat.String(),
+		UserID: seat,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"capture"},
+			Objects: map[string]principal.ObjectGrant{
+				"activity": {Create: true},
+				"person":   {Create: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
+
+// captureAMeeting drives the real capture path for one calendar event and
+// answers the activity id it wrote.
+//
+// It goes through Sink.Upsert rather than an INSERT of its own because what is
+// under test is what the WRITER stamps. A fixture that set the audience itself
+// would pass whatever the writer did.
+func captureAMeeting(
+	ctx context.Context, t *testing.T, db *database.DB, seat ids.UUID, sourceID string, attendee *string,
+) ids.UUID {
+	t.Helper()
+	ws, _ := principal.WorkspaceID(ctx)
+	seatCtx := calendarSinkContext(ctx, ids.UUID(ws), seat)
+	if err := seedCapturingSeat(seatCtx, t, db, seat); err != nil {
+		t.Fatalf("seeding the capturing seat: %v", err)
+	}
+	rec := connector.NormalizedRecord{
+		EntityType: "activity",
+		NaturalKey: connector.NaturalKey{SourceSystem: "gcal", SourceID: sourceID},
+		Fields: capture.ActivityFields{
+			Kind:       "meeting",
+			Subject:    "Drinks at Xu",
+			OccurredAt: time.Now().Add(2 * time.Hour),
+		},
+		Source:     "gcal:" + sourceID,
+		CapturedBy: "connector:gcal:" + seat.String(),
+	}
+	if attendee != nil {
+		rec.Counterparty = connector.Counterparty{Email: *attendee}
+		rec.Addresses = []string{*attendee}
+	}
+	ref, err := capture.NewSink(db).Upsert(seatCtx, rec)
+	if err != nil {
+		t.Fatalf("capturing a meeting: %v", err)
+	}
+	return ids.UUID(ref.ID)
+}
+
+// seedCapturingSeat gives the connector's seat a real app_user row, because
+// host_user_id references one.
+func seedCapturingSeat(ctx context.Context, t *testing.T, db *database.DB, seat ids.UUID) error {
+	t.Helper()
+	return db.Tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO app_user (id, email, display_name, status)
+			VALUES ($1, $2, 'Calendar Seat', 'active')
+			ON CONFLICT (id) DO NOTHING`, seat, "seat-"+seat.String()+"@example.test")
+		return err
+	})
+}
+
+// meetingAudienceOf answers the audience and reason the capture path stamped on
+// one activity, read as the owner so the assertion is about what was WRITTEN
+// rather than about what some reader may see.
+func meetingAudienceOf(ctx context.Context, t *testing.T, owner *pgx.Conn, id ids.UUID) (string, string) {
+	t.Helper()
+	var audience, reason string
+	if err := owner.QueryRow(ctx, `
+		SELECT audience, coalesce(audience_reason, '')
+		FROM activity WHERE id = $1`, id).Scan(&audience, &reason); err != nil {
+		t.Fatalf("reading the audience of %s: %v", id, err)
+	}
+	return audience, reason
+}
+
+// discoverableBy answers whether ActivityDiscoverClause lets this reader learn
+// the activity exists, by running the clause the readers actually compose
+// rather than a paraphrase of it.
+func discoverableBy(ctx context.Context, t *testing.T, db *database.DB, reader, id ids.UUID) bool {
+	t.Helper()
+	var found bool
+	if err := db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (
+			  SELECT 1 FROM activity a
+			  WHERE a.id = $1
+			    AND a.restricted_at IS NULL
+			    AND coalesce((SELECT bool_or(
+			          l.person_id IS NOT NULL AND EXISTS (
+			            SELECT 1 FROM person sp
+			            WHERE sp.id = l.person_id
+			              AND (sp.visibility <> 'owner' OR sp.owner_id = $2)))
+			        FROM activity_link l WHERE l.activity_id = a.id),
+			        a.kind <> 'meeting' OR a.host_user_id IS NULL OR a.host_user_id = $2))`,
+			id, reader).Scan(&found)
+	}); err != nil {
+		t.Fatalf("probing discoverability: %v", err)
+	}
+	return found
+}
+
+// TestACapturedMeetingIsNotBornWorkspaceReadable is the leak, stated as the
+// rule it broke.
+//
+// A meeting captured from one seat's calendar, linking nothing, must not be
+// born readable by the whole installation. It is the unlinked case precisely
+// because that is the common one: 450 of the 468 meetings on the staging
+// installation linked no record at all.
+func TestACapturedMeetingIsNotBornWorkspaceReadable(t *testing.T) {
+	ctx, db, owner := meetingWorkspaceWithOwner(t)
+	host := ids.NewV7()
+	meeting := captureAMeeting(ctx, t, db, host, "cal-unlinked-1", nil)
+
+	audience, reason := meetingAudienceOf(ctx, t, owner, meeting)
+	if audience == "workspace" {
+		t.Errorf("a captured meeting was born audience=workspace (reason %q) — "+
+			"every seat in the installation may read this person's calendar", reason)
+	}
+	if audience != "participants" {
+		t.Errorf("audience = %q, want participants — a calendar event is held to "+
+			"the people on it until something files it", audience)
+	}
+}
+
+// TestACapturedMeetingNamesItsHost pins the other half: the row records WHOSE
+// calendar it came from.
+//
+// Without it the brief cannot attribute the meeting, so a lane that lists
+// meetings under no owner puts every colleague's appointment on every reader's
+// morning — which is how the leak reached a human, as "a meeting with Lucy" on
+// an account that had never met her.
+func TestACapturedMeetingNamesItsHost(t *testing.T) {
+	ctx, db, owner := meetingWorkspaceWithOwner(t)
+	host := ids.NewV7()
+	meeting := captureAMeeting(ctx, t, db, host, "cal-host-1", nil)
+
+	var got *ids.UUID
+	if err := owner.QueryRow(ctx,
+		`SELECT host_user_id FROM activity WHERE id = $1`, meeting).Scan(&got); err != nil {
+		t.Fatalf("reading host_user_id: %v", err)
+	}
+	if got == nil {
+		t.Fatal("host_user_id is NULL on a captured meeting — the brief has no owner to attribute it to")
+	}
+	if *got != host {
+		t.Errorf("host_user_id = %s, want the capturing seat %s", *got, host)
+	}
+}
+
+// TestAColleaguesLinklessMeetingIsNotDiscoverable is the leak as the reader
+// meets it, through the clause every activity reader composes.
+func TestAColleaguesLinklessMeetingIsNotDiscoverable(t *testing.T) {
+	ctx, db, _ := meetingWorkspaceWithOwner(t)
+	host, colleague := ids.NewV7(), ids.NewV7()
+	meeting := captureAMeeting(ctx, t, db, host, "cal-unlinked-2", nil)
+
+	if discoverableBy(ctx, t, db, colleague, meeting) {
+		t.Error("a colleague can discover a meeting captured from somebody else's " +
+			"calendar that links no record — this is the staging leak")
+	}
+	if !discoverableBy(ctx, t, db, host, meeting) {
+		t.Error("the capturing seat cannot discover its own meeting — the hold is too wide")
+	}
+}

--- a/backend/internal/modules/capture/meetingbirth.go
+++ b/backend/internal/modules/capture/meetingbirth.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// What a CALENDAR event asks of the workspace, decided inside the capture
+// transaction.
+//
+// The mail ladder in birthdecision.go answers a question a calendar was never
+// asked — "what does this MAILBOX ask of its mail" — so a meeting runs its own
+// three steps rather than borrowing five. What the two ladders share is the
+// shape: every rule can only TIGHTEN, the first match decides, and all of them
+// are evaluated so the row records every reason it was held.
+//
+// WHY A MEETING IS HELD BY DEFAULT AND A NOTE IS NOT.
+//
+// ActivityDiscoverClause reads an activity with no links as a workspace-shared
+// note: coalesce(bool_or(...), true). For a note that is right — somebody wrote
+// it down for the workspace. A calendar event is the opposite in every respect:
+// it arrives from one person's mailbox without anybody choosing to share it, it
+// carries their private appointments, and it links no record at all until
+// something files it. 450 of the 468 meetings on the staging installation
+// linked nothing, which is the common case rather than the corner.
+//
+// So the rule is inverted for this kind: a meeting is born held to its
+// participants and OPENS when something files it against a record the reader
+// can already see. That is the same shape the link-less message rule has in
+// sinkaudience.go, reached by the same reasoning.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// decideMeetingBirthTx answers what this calendar event asks of the workspace.
+//
+// Three steps, strictest first:
+//
+//  1. a counterparty hold this seat placed — their lawyer's domain is held
+//     whether it arrives as mail or as an invitation;
+//  2. an explicit marker on the event's own subject — a title saying
+//     [Vertraulich] is the organiser telling us, and no classifier is needed
+//     to read it;
+//  3. whether anybody outside the workspace is on it at all.
+//
+// The two mail-only steps are deliberately absent. The mail-sharing FLOOR and
+// the mailbox POSTURE are both answers to "what does this mailbox ask of its
+// mail", and a calendar is not a mailbox: borrowing them would let a workspace
+// that shares its mail publish every private appointment on it, and one that
+// holds its mail hide meetings it never meant to hide. A calendar posture of
+// its own is a product decision, not something to infer from the mail one.
+func decideMeetingBirthTx(
+	ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord, fields ActivityFields,
+) (birthDecision, error) {
+	var decision birthDecision
+
+	held, err := heldCounterpartyTx(ctx, tx, rec)
+	if err != nil {
+		return birthDecision{}, err
+	}
+	if held {
+		decision = decision.hold(audienceReasonCounterparty)
+	}
+
+	if explicitlyConfidential(fields.Subject) {
+		decision = decision.hold(audienceReasonConfidentialMarker)
+	}
+
+	// Nobody outside the workspace on it, so there is no correspondent this
+	// meeting could be filed under and nothing to open it. This is the reason
+	// audienceReasonNoCounterparty already names as "the calendar case", and it
+	// is the one that catches the private dinner: it holds until something
+	// files the event against a record, and then it stops being true.
+	//
+	// It is checked LAST of the three because it is the weakest claim. The two
+	// above are judgements about this event; this one merely says nothing has
+	// filed it yet.
+	if rec.Counterparty.Email == "" {
+		decision = decision.hold(audienceReasonNoCounterparty)
+	}
+	return decision, nil
+}
+
+// meetingHostUserID is WHOSE calendar a captured row came from, or nothing.
+//
+// A meeting's host is the seat whose connector read it: the sync loop mints a
+// principal per seat, so the identity is already the one the write is running
+// as. Reading it from the context rather than from the record is the same rule
+// captured_by follows — a connector must not be able to name somebody else as
+// the host of an event it is inserting.
+//
+// Nothing for every other kind, and that is deliberate rather than unfinished.
+// A captured EMAIL belongs to the correspondence it is part of, not to whoever
+// happens to sync it, and stamping a host on one would file every message in
+// the workspace under a single seat's queue.
+//
+// Nothing, too, for a principal carrying no user — a system backfill or an
+// engine-internal write. Those have no calendar to be the host of, and the
+// column stays NULL rather than naming a machine.
+func meetingHostUserID(ctx context.Context, kind string) *ids.UUID {
+	if kind != "meeting" {
+		return nil
+	}
+	user := actorUserID(ctx)
+	if user.IsZero() {
+		return nil
+	}
+	return &user
+}

--- a/backend/internal/modules/capture/sinkactivity.go
+++ b/backend/internal/modules/capture/sinkactivity.go
@@ -243,8 +243,8 @@ func (s *Sink) upsertActivity(
 	audience, audienceReason := birth.bornAudience()
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason, has_calendar_part)
-		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''), $17)
+		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason, host_user_id, has_calendar_part)
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''), $17, $18)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -269,6 +269,19 @@ func (s *Sink) upsertActivity(
 		// from the same address is only ever hidden.
 		rec.Counterparty.ListUnsubscribe,
 		audience, audienceReason,
+		// WHOSE calendar this came from, for a meeting.
+		//
+		// The seat is already in the context — the sync loop mints a connector
+		// principal per seat — so this reads the identity the write is already
+		// running as rather than trusting anything in the record. The write
+		// path has always used it (writescope.go admits an activity's own host
+		// as a writer); the READ path had no owner to attribute a meeting to,
+		// so every reader's brief listed every colleague's appointments.
+		//
+		// Meetings alone. A mail's host is not its capturer — a message
+		// belongs to the correspondence, not to whoever's mailbox syncs it —
+		// and stamping one would put every captured email on one seat's queue.
+		meetingHostUserID(ctx, fields.Kind),
 		// What the parser read, stored as read. A record that carried no
 		// calendar part stores false rather than NULL: NULL is reserved for the
 		// rows captured before this column existed, so the two stay tellable

--- a/backend/internal/platform/auth/inheritedscope.go
+++ b/backend/internal/platform/auth/inheritedscope.go
@@ -83,9 +83,32 @@ func activityDiscoverClause(p principal.Principal, alias string, arg func(any) i
 	// caller has been paying it; it only surfaced as a budget failure when
 	// capture privacy stopped exempting the all-scope reader the perf
 	// fixture happens to run as.
+	// The link-less answer is NOT the same for every kind, and this is the
+	// half that used to be missing.
+	//
+	// For a note, coalesce-to-true is right: somebody wrote it down for the
+	// workspace and attached it to nothing on purpose. For a MEETING it is the
+	// exact opposite — a calendar event arrives from one seat's connector
+	// without anybody choosing to share it, and it links no record until
+	// something files it. Read as a workspace-shared note, one seat's private
+	// diary became readable by every account in the installation: 465 of 468
+	// meetings on the staging installation, to its most restricted reader.
+	//
+	// So a link-less meeting falls back to its HOST — the seat whose calendar
+	// it came from — rather than to everybody. A meeting that links something
+	// is unaffected: the bool_or arm answers first and the whole disjunction
+	// is unchanged for every other kind.
+	//
+	// host_user_id IS NULL keeps the old answer, deliberately. Rows captured
+	// before the host was stamped cannot be attributed, and turning them all
+	// dark would hide meetings that predate the fix from the people who own
+	// them; the captured_by backfill in
+	// 1788686725_a_captured_meeting_names_whose_calendar_it_came_from is what
+	// removes that case.
 	return fmt.Sprintf(`%[3]s AND coalesce((SELECT bool_or(%[2]s)
-	   FROM activity_link l WHERE l.activity_id = %[1]s.id), true)`,
-		alias, linkTargetVisible(p, "l", arg), available)
+	   FROM activity_link l WHERE l.activity_id = %[1]s.id),
+	   %[1]s.kind <> 'meeting' OR %[1]s.host_user_id IS NULL OR %[1]s.host_user_id = $%[4]d)`,
+		alias, linkTargetVisible(p, "l", arg), available, arg(p.UserID))
 }
 
 // ActivityContentClause is the stronger activity gate: discoverable AND the

--- a/backend/migrations/core/1788686725_a_captured_meeting_names_whose_calendar_it_came_from.down.sql
+++ b/backend/migrations/core/1788686725_a_captured_meeting_names_whose_calendar_it_came_from.down.sql
@@ -1,0 +1,14 @@
+-- Reverses the audience re-derivation only.
+--
+-- host_user_id is NOT cleared. The column is also written by the ordinary
+-- booking path, which predates this migration, so blanking every meeting's host
+-- would destroy data this migration never wrote. Leaving a recovered host in
+-- place is harmless: the read path treats a named host as the row's owner,
+-- which is true whether this migration wrote it or the booking path did.
+
+UPDATE activity
+   SET audience = 'workspace',
+       audience_reason = NULL
+ WHERE kind = 'meeting'
+   AND audience = 'participants'
+   AND audience_reason = 'no_counterparty';

--- a/backend/migrations/core/1788686725_a_captured_meeting_names_whose_calendar_it_came_from.up.sql
+++ b/backend/migrations/core/1788686725_a_captured_meeting_names_whose_calendar_it_came_from.up.sql
@@ -1,0 +1,39 @@
+-- A captured meeting names whose calendar it came from.
+--
+-- Two facts are repaired here, both of which the capture path now writes for
+-- new rows. Existing rows were written before it did, and a code fix alone
+-- leaves them exactly as exposed as they were.
+--
+-- 1. host_user_id, recovered from captured_by. The connector stamps
+--    'connector:gcal:<uuid>' and an agent 'agent:<uuid>', so the seat that
+--    captured the row is already recorded — it was simply never copied into
+--    the column the read path needs. Only rows whose recovered id is a real
+--    app_user are touched; anything else stays NULL rather than pointing the
+--    column at an id nothing backs.
+--
+-- 2. audience, for the meetings that link no record. A link-less meeting was
+--    born 'workspace', which ActivityDiscoverClause reads as a workspace-shared
+--    note. Those rows are re-derived to 'participants' with the reason the
+--    capture path would now stamp.
+--
+-- Meetings only, and only rows that still carry the default. A meeting somebody
+-- deliberately widened, or one already held for a stronger reason (a
+-- counterparty hold, a confidentiality marker), keeps the answer it has: this
+-- repairs rows nothing ever decided about, and must not overwrite a decision.
+
+UPDATE activity a
+   SET host_user_id = u.id
+  FROM app_user u
+ WHERE a.kind = 'meeting'
+   AND a.host_user_id IS NULL
+   AND a.captured_by ~ '^(connector:[a-z0-9_-]+|agent):[0-9a-fA-F-]{36}$'
+   AND u.id = substring(a.captured_by from '([0-9a-fA-F-]{36})$')::uuid;
+
+UPDATE activity a
+   SET audience = 'participants',
+       audience_reason = 'no_counterparty'
+ WHERE a.kind = 'meeting'
+   AND a.audience = 'workspace'
+   AND a.audience_reason IS NULL
+   AND a.counterparty_email IS NULL
+   AND NOT EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id);


### PR DESCRIPTION
A rep with the narrowest row scope in the installation opened her morning brief and read "a meeting with Lucy" — a person another user had created an hour earlier, on an account that had never met her.

Measured on the staging installation, as that account: **465 of 468 meetings** and **354 of 372 emails** were discoverable. Private dinners and a partner negotiation among them.

## Four holes, each of which leaves the leak open on its own

**The capture path never judged a meeting.** `decideBirthTx` returned early for every non-mail kind, so a calendar event was born `audience='workspace'` while an email went through a five-step ladder. On staging, meetings landed in exactly one audience state; emails landed in eleven.

Meetings now run their own three steps — a counterparty hold, an explicit marker, and whether anybody outside the workspace is on it. The two mail-only steps are deliberately absent: a mailbox posture is not a calendar's, and inferring one from the other would publish private appointments in a workspace that shares its mail. A calendar posture of its own is a product decision, not something to infer.

**The row never said whose calendar it was.** `host_user_id` was NULL on all 468 staging meetings, though `captured_by` already carried the seat (`connector:gcal:<uuid>`). The write path has always read `host_user_id` — `writescope.go` admits an activity's host as a writer — so only the read path lacked an owner.

**The morning lane asked for every meeting and named nobody.** `keepReadersOwn` keeps a row it cannot judge, so every meeting the lane returned landed on every reader's queue. The lane now passes `HostUserID`, and the row honestly answers "the reader" — a claim `owner_test.go`'s census makes the query earn.

**`ActivityDiscoverClause` read an unlinked activity as a workspace-shared note.** Right for a note; wrong for a calendar event, and 450 of the 468 staging meetings linked nothing at all. A link-less *meeting* now falls back to its host. Every other kind is untouched.

## Risk

The change to `ActivityDiscoverClause` is the one to review hardest — it is a security predicate composed by ~30 readers.

A meeting with **no** host keeps the old answer on purpose, so rows captured before this fix stay visible to the people who own them rather than going dark on deploy; the migration is what removes that case. Order matters at deploy: backfill first, or every meeting briefly disappears from its owner's brief.

## Test

`meetingaudience_integration_test.go` drives the real capture path against Postgres. All three cases failed before the fix and pass after — including a colleague probing the actual discover clause.

## Verification

- `make check-backend` green (4m17s)
- Integration lanes green: `capture`, `activities`, `platform/auth`
- `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a privacy leak where captured calendar meetings were visible to every user in the workspace, regardless of whose calendar they came from. Meetings now run their own audience decision, stamp `host_user_id`, and the morning lane and discover clause only expose a meeting to its host until it's filed.

**Migration**
- Run `1788686725_a_captured_meeting_names_whose_calendar_it_came_from.up.sql` before deploying, or every meeting briefly disappears from its owner's brief.

<sup>Written for commit 0faf6af708ae72d4894fd8c09db20236cb102fd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

