### PR TITLE
A settings page you can only stare at is not a destination

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -41,10 +41,14 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // that card's draft is the one that OUTLIVES its dialog, so it is the only
   // settings edit a reader can still be holding while they navigate away.
   installation_settings: ["read", "update"],
-  // The consent registry's own gate, and so the Privacy & audit ENTRY's: the
-  // server reads purposes under `person:read` (consent/store.go), not under a
-  // role. Read alone, because no spec exercises a person write from here and a
-  // grant this fixture does not need is a grant it should not claim.
+  // The consent registry's own gate: the server reads purposes under
+  // `person:read` (consent/store.go), not under a role. Read alone, because no
+  // spec exercises a person write from here and a grant this fixture does not
+  // need is a grant it should not claim.
+  //
+  // It no longer opens the Privacy & audit ENTRY — every seeded role holds this
+  // read, so the page moved to `privacy_request`, which this fixture holds
+  // below. The card still needs `person`, which is why it stays.
   person: ["read"],
   // Filters & views reads the vocabulary and previews a tree under `list:read`
   // (collections/handlers.go), and saving a filter as a dynamic list is a

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -443,7 +443,10 @@ describe("useBuiltinCommands", () => {
         jsonResponse(
           meFixture({
             roles: [],
-            allow: { organization: ["read"] },
+            // The write, which is what Company profile asks: the read is held
+            // by every seat and stopped opening the page when the four
+            // configuration pages moved off the reads.
+            allow: { organization: ["read", "update"] },
             settingsAvailability:
               opts.companyContext === null
                 ? null

--- a/frontend/src/app/sormodechip.test.tsx
+++ b/frontend/src/app/sormodechip.test.tsx
@@ -11,9 +11,16 @@ import { SorModeChip } from "./sormodechip";
 function mount(
   mode: "native" | "overlay" | undefined,
   // Which seat is looking. The mode is reported to every seat; the LINK to the
-  // Integrations entry belongs to an operator, so the role is part of what this
-  // component answers rather than harness detail.
+  // Integrations entry belongs to whoever may CHANGE the installation's wiring,
+  // so what this principal holds is part of what the component answers rather
+  // than harness detail.
+  //
+  // Grants, not a role name: the chip asks the settings catalog whether this
+  // reader opens the Integrations page. A fixture naming only a role would
+  // answer a question the component no longer asks — and an edited admin role
+  // really can hold nothing, which is the case a role-name gate would get wrong.
   roles: string[] = ["admin"],
+  connects = true,
 ) {
   const fetchMock = vi.fn(async () => {
     const systemOfRecord = mode ? { system_of_record: { mode } } : {};
@@ -22,6 +29,19 @@ function mount(
         user: { id: "u1", email: "a@example.test", display_name: "A" },
         roles,
         teams: [],
+        authorization: {
+          objects: {
+            // The read is always held, because every seeded role holds it —
+            // whether capture is working shows up on the records they open.
+            // `connects` moves only the write, which is the verb the page asks.
+            overlay_connection: {
+              read: true,
+              create: connects,
+              update: connects,
+              delete: connects,
+            },
+          },
+        },
         ...systemOfRecord,
       }),
       { headers: { "Content-Type": "application/json" } },
@@ -83,9 +103,13 @@ it("links to Settings → Integrations and explains the mode in its label", asyn
 it("reports the mode to a seat that cannot open Integrations, without linking", async () => {
   // The mode changes what every screen can do, so hiding it from a rep would
   // leave them reading narrowed lists with nothing saying why. What a rep must
-  // not get is the affordance: Integrations lives in Admin settings, and a link
-  // that lands on the Account fallback is a chip that lied.
-  mount("overlay", ["rep"]);
+  // not get is the affordance: Integrations opens for whoever may change the
+  // installation's wiring, and a link that lands on the access boundary is a
+  // chip that lied.
+  //
+  // A rep really does READ `overlay_connection` — that is why the page moved to
+  // the write — so this fixture withholds the write rather than the object.
+  mount("overlay", ["rep"], false);
   // Found by its TEXT, because a plain span is not a labelable element: the
   // explanation is visually-hidden text inside the chip rather than an
   // `aria-label` a screen reader is free to ignore there.

--- a/frontend/src/app/sormodechip.tsx
+++ b/frontend/src/app/sormodechip.tsx
@@ -3,7 +3,7 @@
 
 import { useT } from "../i18n";
 import { useSorMode } from "../screens/common";
-import { useHoldsOperatorSeat } from "./capability";
+import { useVisibleSettingsPages } from "../screens/settingsnav";
 
 // The system-of-record mode chip: in overlay mode the whole installation
 // reads from an incumbent mirror, which changes what every screen can do —
@@ -15,15 +15,26 @@ import { useHoldsOperatorSeat } from "./capability";
 // costs no extra request and it never renders ahead of a real answer. Native
 // mode renders nothing — the chip is a state marker, not a permanent fixture.
 //
-// The MODE is for every seat; the DESTINATION is not. Integrations lives in
-// Admin settings, which only an operator seat reaches, so a link offered to a
-// rep would land them on the Account fallback — a chip that lied about where it
-// went. So the fact keeps its place for everyone and only an operator gets the
-// affordance, which is the same rule the rail's license chip follows.
+// The MODE is for every seat; the DESTINATION is not. A link offered to somebody
+// the page refuses would land them on the access boundary — a chip that lied
+// about where it went. So the fact keeps its place for everyone, and the link
+// is offered exactly to whoever the page opens for.
+//
+// Usually that means whoever may CHANGE the installation's wiring, but not
+// always: a composed workspace unit puts its settings on that page and nowhere
+// else, which opens it without either wiring write. Asking the catalog covers
+// both without this file having to know either rule.
+//
+// It asks the catalog whether this reader may open the page, rather than
+// re-deriving the grants: `admin || ops` matched the seeded roles by
+// coincidence and would have left a custom role holding
+// `overlay_connection:update` looking at a chip that went nowhere. Two writers
+// of one rule drift; the page's own answer cannot.
 export function SorModeChip() {
   const t = useT();
   const mode = useSorMode();
-  const operator = useHoldsOperatorSeat();
+  const pages = useVisibleSettingsPages();
+  const reaches = pages.some((page) => page.id === "integrations");
   if (mode !== "overlay") {
     return null;
   }
@@ -32,7 +43,7 @@ export function SorModeChip() {
   // the mode to a screen reader; what it no longer does is promise a page.
   const label = t("overlay.chipLabel");
   const explanation = t("overlay.chipAria");
-  return operator ? (
+  return reaches ? (
     <a
       // Integrations, not Connections: the mirror that is answering every read is
       // installation-wide wiring, and the personal Connections entry now holds

--- a/frontend/src/screens/settings-integrations.test.tsx
+++ b/frontend/src/screens/settings-integrations.test.tsx
@@ -77,12 +77,16 @@ function overlaySettingsBackend(opts: {
   });
 }
 
-// The reads the seeded matrix gives every role on the installation's wiring, and
-// the two terms of the Integrations predicate — granted wherever a case needs the
-// entry to be OPEN, so an absent card on it can only mean the card is elsewhere.
-const WIRING_READS: GrantSpec = {
-  overlay_connection: ["read"],
-  webhook_subscription: ["read"],
+// The two terms of the Integrations predicate, granted wherever a case needs the
+// entry to be OPEN — so an absent card on it can only mean the card is elsewhere.
+//
+// The WRITE, because that is what the page asks: every seeded role reads both
+// objects, and gating the page on the read put the installation's outside wiring
+// in front of a rep who could only look at it. These cases are about what the
+// page renders, so they hold the grant that reaches it.
+const WIRING_WRITES: GrantSpec = {
+  overlay_connection: ["read", "create", "update"],
+  webhook_subscription: ["read", "create", "update"],
 };
 
 describe("SettingsScreen connections and integrations tabs", () => {
@@ -91,7 +95,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
       "fetch",
       overlaySettingsBackend({
         roles: ["admin"],
-        allow: WIRING_READS,
+        allow: WIRING_WRITES,
         sorMode: "native",
       }),
     );
@@ -121,7 +125,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
       "fetch",
       overlaySettingsBackend({
         roles: ["admin"],
-        allow: WIRING_READS,
+        allow: WIRING_WRITES,
         sorMode: "overlay",
       }),
     );
@@ -138,17 +142,26 @@ describe("SettingsScreen connections and integrations tabs", () => {
     ).toBeNull();
   });
 
-  // The overlay is the installation's, so its page sits in the admin group and
-  // asks for the wiring read on top of the operator seat. An OPS principal is the
-  // case worth proving: they reach the entry, and reaching it costs no
-  // confidentiality — both cards' write and management reads are admin-only on
-  // the server, and each keeps them unsent for anyone else, so ops sees the
-  // connection card's read-only state and the mapping card's admin-only notice,
-  // never the directory.
-  it("shows Integrations to a non-admin ops with both overlay cards in their read-only state", async () => {
+  // The page opens for whoever may CHANGE the installation's wiring, and this
+  // principal may. Reaching it still costs no confidentiality: both overlay
+  // cards gate themselves on their own grants — the overlay verbs, which this
+  // fixture withholds — so this reader sees the connection card's read-only
+  // state and the mapping card's notice, never the directory.
+  //
+  // Two different questions, and the card is the narrower one — which is the
+  // safe direction, because a card narrower than its page withholds itself.
+  it("shows Integrations to a webhook writer with both overlay cards in their read-only state", async () => {
+    // Reached through the WEBHOOK write, holding only the READ on the overlay.
+    // That is the shape this case needs and the one the product produces: the
+    // two objects are separate terms of the page's requirement, and the overlay
+    // cards gate themselves on the overlay verbs. Granting both writes would
+    // reach the page and make every card writable, which is a different case.
     const fetchMock = overlaySettingsBackend({
       roles: ["ops"],
-      allow: WIRING_READS,
+      allow: {
+        overlay_connection: ["read"],
+        webhook_subscription: ["read", "create", "update"],
+      },
       sorMode: "native",
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -198,7 +211,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
       "fetch",
       overlaySettingsBackend({
         roles: ["admin"],
-        allow: WIRING_READS,
+        allow: WIRING_WRITES,
         sorMode: "native",
       }),
     );
@@ -233,7 +246,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
       "fetch",
       overlaySettingsBackend({
         roles: ["admin"],
-        allow: WIRING_READS,
+        allow: WIRING_WRITES,
         sorMode: "native",
       }),
     );

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -286,6 +286,30 @@ const UNGATED_PAGES = pagesNamed(...UNGATED_IDS);
 const floorPlus = (...ids: readonly SettingsPageId[]) =>
   pagesNamed(...UNGATED_IDS, ...ids);
 
+/**
+ * Assert the nav settles to exactly these rows, once `/me` has actually
+ * answered.
+ *
+ * A bare `waitFor(() => expect(navPages()).toEqual(floorPlus()))` is VACUOUS
+ * for a case about an absence. Every capability predicate reads false while the
+ * snapshot is in flight, so the loading nav renders precisely the ungated floor
+ * — the same rows a resolved snapshot granting nothing renders. `waitFor`
+ * succeeds on its first tick, before the page under test could have appeared,
+ * and the case passes whatever the requirement says. Granting the very page a
+ * case says is withheld still passed, which is how this was found.
+ *
+ * So every such case needs a POSITIVE CONTROL: one page that only a resolved
+ * snapshot can draw. The caller grants a witness object alongside whatever it
+ * is really testing, this waits for that witness row to appear — which cannot
+ * happen until `/me` has answered AND rendered — and only then asserts the
+ * whole list. `pipeline` is the witness: it opens exactly one page, on a plain
+ * read, and is unrelated to every requirement these cases move.
+ */
+async function expectNavSettlesTo(expected: readonly string[]) {
+  await screen.findByRole("link", { name: labelOf("pipelines") });
+  await expect.poll(() => navPages()).toEqual(expected);
+}
+
 // Every page open at once: one grant apiece for the pages that follow an
 // object, plus the reset page's `delete` — emptying an installation is not a
 // thing you read.
@@ -296,8 +320,12 @@ const floorPlus = (...ids: readonly SettingsPageId[]) =>
 // and those cards ask `extension_access:read` and `audit_log:read` instead.
 // `ai_diagnostics:read` is what `AiUsageCard` and `AiCallsCard` ask, where they
 // used to ask `automation:update`.
+// Four of these are WRITES, and that is the change rather than a slip: a page
+// whose subject is the installation's own configuration asks for the verb that
+// changes it, because the read is one every seat holds. Granting the read here
+// would leave this "every page" fixture four pages short.
 const EVERY_PAGE_GRANTED: GrantSpec = {
-  installation_settings: ["read"],
+  installation_settings: ["read", "update"],
   // Sign-in & apps, whose card reads the narrow projection.
   authentication_policy: ["read"],
   license: ["read"],
@@ -306,13 +334,15 @@ const EVERY_PAGE_GRANTED: GrantSpec = {
   tag: ["read"],
   product: ["read"],
   capture_settings: ["read"],
-  webhook_subscription: ["read"],
+  webhook_subscription: ["read", "create", "update"],
   knowledge_corpus: ["read"],
   import_run: ["read"],
   ai_routing: ["read"],
-  automation: ["read"],
+  automation: ["read", "create", "update"],
   ai_diagnostics: ["read"],
   person: ["read"],
+  // What opens Privacy & audit now that `person:read` does not.
+  retention_policy: ["read"],
   audit_log: ["read"],
   job_health: ["read"],
   embedding_reindex: ["read"],
@@ -352,11 +382,18 @@ const SALES_READS: readonly {
   { object: "tag", opens: ["tags"] },
 ];
 
-// The seeded grant matrix, READ verbs only — the only verb a page requirement
-// asks for, apart from the reset page's delete. manager, read_only and rep hold
-// the identical ten reads and differ only in the writes on top, which is exactly
-// why write-shaped predicates hid pages the server serves: the differentiation
-// the matrix carries lives in the writes, and a write is not what opens a page.
+// The seeded grant matrix's READ verbs. manager, read_only and rep hold the
+// identical ten reads and differ only in the writes on top.
+//
+// Most pages open on a read, and for those this fixture is the whole story.
+// Three exceptions ask a WRITE — company, integrations and automations — because
+// the read that used to open them is one every seat holds: the base currency,
+// whether capture is working, what an automation ran.
+//
+// Privacy is a fourth page that moved but NOT to a write. It dropped its
+// `person:read` arm and kept two reads nobody below admin and ops holds at all,
+// plus a `person` AND `consent_config` pair for the management role, which is
+// seeded the consent vocabulary and nothing else on that page.
 const SEEDED_READS: GrantSpec = {
   automation: ["read"],
   person: ["read"],
@@ -365,7 +402,12 @@ const SEEDED_READS: GrantSpec = {
   installation_settings: ["read"],
   knowledge_corpus: ["read"],
   offer_template: ["read"],
-  organization: ["read"],
+  // The write, because the seeded roles really hold it: rep carries
+  // `organization` create+update and manager carries all four. It is what keeps
+  // Company profile open for them — the company profile the AI reads is a thing
+  // a rep legitimately edits, which is why that page did not follow the other
+  // three out of her rail.
+  organization: ["read", "create", "update"],
   overlay_connection: ["read"],
   pipeline: ["read"],
   product: ["read"],
@@ -388,6 +430,15 @@ const SEEDED_OPS_READS: GrantSpec = {
   fx_rate: ["read"],
   retention_policy: ["read"],
   license: ["read"],
+  // The writes ops actually holds in the seeded matrix, and the reason it keeps
+  // the three configuration pages a rep no longer sees. Spelled here rather than
+  // left to the reads above because those pages ask the write: a fixture that
+  // gave ops only the reads would model a role the product does not seed, and
+  // would then "prove" ops loses a page it does not lose.
+  automation: ["read", "create", "update", "delete"],
+  installation_settings: ["read", "update"],
+  overlay_connection: ["read", "create", "update", "delete"],
+  webhook_subscription: ["read", "create", "update", "delete"],
 };
 
 // `authentication` is NOT on this list, and that is the fix rather than an
@@ -401,7 +452,9 @@ const SEEDED_READ_PAGES = pagesNamed(
   "agents",
   "connections",
   "capture-activity",
-  "company",
+  // `company` is NOT here: its requirement ANDs the organization write with the
+  // `company_context` deployment flag, and this fixture leaves that flag off.
+  // The page's own availability cases are the ones that turn it on.
   "members",
   "teams",
   "pipelines",
@@ -409,10 +462,7 @@ const SEEDED_READ_PAGES = pagesNamed(
   "fields",
   "products",
   "capture",
-  "integrations",
   "knowledge",
-  "automations",
-  "privacy",
 );
 
 const SEEDED_OPS_PAGES = pagesNamed(
@@ -553,26 +603,47 @@ describe("SettingsScreen page visibility", () => {
       const allow = readOn(object);
       vi.stubGlobal("fetch", settingsNavBackend({ roles: ["ops"], allow }));
       renderNav();
-      // `readOn` carries `person:read` with it, which is what opens Privacy —
-      // the floor a case about ONE object stands on rather than part of what it
-      // proves.
-      await waitFor(() =>
-        expect(navPages()).toEqual(floorPlus(...opens, "privacy")),
-      );
+      // `readOn` carries `person:read` with it as a floor, so a case about ONE
+      // object stays about one object. It no longer opens Privacy: that page
+      // asks the two governance objects nobody below admin and ops holds.
+      await waitFor(() => expect(navPages()).toEqual(floorPlus(...opens)));
     },
   );
 
   it.each(["webhook_subscription", "overlay_connection"] as const)(
-    "opens Integrations for a lone %s read",
+    "opens Integrations for a lone %s write, and not for its read",
     async (object) => {
-      // The installation's outside wiring, and the system-of-record chip in the
-      // topbar points every seat at it — so either read has to open the page on
-      // its own, or whoever follows that chip lands on the Account fallback.
-      const allow = readOn(object);
-      vi.stubGlobal("fetch", settingsNavBackend({ roles: ["ops"], allow }));
+      // The installation's outside wiring: every seeded role READS both objects,
+      // because whether capture is working shows up on the records they already
+      // open. Connecting a mirror or pointing a webhook somewhere is the work
+      // the page exists for.
+      //
+      // The system-of-record chip asks this same question before it offers a
+      // link, so the two cannot disagree about where that chip goes.
+      vi.stubGlobal(
+        "fetch",
+        settingsNavBackend({
+          roles: ["ops"],
+          // The witness alongside the object under test: `pipeline` opens
+          // Pipelines and nothing else, so waiting for that row proves the
+          // snapshot resolved before this asserts what is NOT there.
+          allow: { ...readOn(object), pipeline: ["read"] },
+        }),
+      );
+      const { unmount } = renderNav();
+      await expectNavSettlesTo(floorPlus("pipelines"));
+      unmount();
+
+      vi.stubGlobal(
+        "fetch",
+        settingsNavBackend({
+          roles: ["ops"],
+          allow: { ...readOn(object), [object]: ["read", "update"] },
+        }),
+      );
       renderNav();
       await waitFor(() =>
-        expect(navPages()).toEqual(floorPlus("integrations", "privacy")),
+        expect(navPages()).toEqual(floorPlus("integrations")),
       );
     },
   );
@@ -591,7 +662,7 @@ describe("SettingsScreen page visibility", () => {
     // `privacy` rides the floor here: meFixture grants `person:read`, which is
     // one of that page's union terms — the consent registry's own server gate.
     await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("authentication", "privacy")),
+      expect(navPages()).toEqual(floorPlus("authentication")),
     );
   });
 
@@ -601,19 +672,34 @@ describe("SettingsScreen page visibility", () => {
     // the base currency — so a page opening on it would put the installation's
     // sign-in policy in front of the whole workspace.
     //
-    // It still opens Company profile, which is one of that page's three union
-    // terms and is meant to be readable by everyone.
+    // It no longer opens Company profile either, and that is the same fix one
+    // page further on: the installation's own facts are admin and ops work, and
+    // the read was only ever there so a rep could resolve the base currency.
+    // The page asks the UPDATE now, which the second half of this case proves
+    // still lands.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
         roles: ["rep"],
-        allow: readOn("installation_settings"),
+        allow: { ...readOn("installation_settings"), pipeline: ["read"] },
+      }),
+    );
+    const { unmount } = renderNav();
+    await expectNavSettlesTo(floorPlus("pipelines"));
+    unmount();
+
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({
+        roles: ["ops"],
+        allow: {
+          ...readOn("installation_settings"),
+          installation_settings: ["read", "update"],
+        },
       }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("company", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("company")));
   });
 
   it("opens Seats & license for a lone license read", async () => {
@@ -626,9 +712,7 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("license") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("seats", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("seats")));
   });
 
   it("opens Seats & license for a lone seat_usage read", async () => {
@@ -642,19 +726,20 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("seat_usage") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("seats", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("seats")));
     cleanup();
 
     // The other half, or the assertion above would pass against a page that
     // opened for everybody: a seat holding neither read does not reach it.
     vi.stubGlobal(
       "fetch",
-      settingsNavBackend({ roles: ["ops"], allow: readOn("person") }),
+      settingsNavBackend({
+        roles: ["ops"],
+        allow: { ...readOn("person"), pipeline: ["read"] },
+      }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it("opens Capture for a lone capture_settings read", async () => {
@@ -667,9 +752,7 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("capture_settings") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("capture", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("capture")));
   });
 
   it("opens System health for a lone embedding_reindex read, for a principal who is no admin", async () => {
@@ -686,9 +769,7 @@ describe("SettingsScreen page visibility", () => {
       }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("privacy", "system-health")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("system-health")));
   });
 
   it("opens System health for a lone job_health read", async () => {
@@ -703,19 +784,20 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("job_health") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("privacy", "system-health")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("system-health")));
     cleanup();
 
     // And a seat holding neither term still does not reach it, or the case
     // above would pass against a page that opened for everybody.
     vi.stubGlobal(
       "fetch",
-      settingsNavBackend({ roles: ["ops"], allow: readOn("person") }),
+      settingsNavBackend({
+        roles: ["ops"],
+        allow: { ...readOn("person"), pipeline: ["read"] },
+      }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it("opens Extensions for a lone extension_access read", async () => {
@@ -741,9 +823,7 @@ describe("SettingsScreen page visibility", () => {
       }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("privacy", "extensions")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("extensions")));
     cleanup();
 
     // The inventory read ALONE is not the page. The card makes a second request
@@ -752,10 +832,13 @@ describe("SettingsScreen page visibility", () => {
     // rather than a narrower one.
     vi.stubGlobal(
       "fetch",
-      settingsNavBackend({ roles: ["ops"], allow: readOn("extension_access") }),
+      settingsNavBackend({
+        roles: ["ops"],
+        allow: { ...readOn("extension_access"), pipeline: ["read"] },
+      }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
     cleanup();
 
     // And the read is load-bearing rather than decorative: an ADMIN who lost it
@@ -765,11 +848,18 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: { person: ["read"], system_reset: ["delete"] },
+        allow: {
+          person: ["read"],
+          system_reset: ["delete"],
+          // The witness: `pipeline` opens Pipelines and nothing else, so
+          // waiting for that row proves /me resolved before this asserts
+          // what is NOT there.
+          pipeline: ["read"],
+        },
       }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it("opens Reset data on the delete verb, and never on a read of the same object", async () => {
@@ -799,9 +889,7 @@ describe("SettingsScreen page visibility", () => {
       }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("privacy", "reset")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("reset")));
     cleanup();
 
     // And the deployment's own consent, which is not a permission: the same
@@ -812,11 +900,18 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: { person: ["read"], system_reset: ["delete"] },
+        allow: {
+          person: ["read"],
+          system_reset: ["delete"],
+          // The witness: `pipeline` opens Pipelines and nothing else, so
+          // waiting for that row proves /me resolved before this asserts
+          // what is NOT there.
+          pipeline: ["read"],
+        },
       }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it("opens Company profile for a lone fx_rate read, and no other page with it", async () => {
@@ -828,9 +923,7 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("fx_rate") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("company", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("company")));
   });
 
   it("opens AI usage for a lone ai_model_rate read", async () => {
@@ -842,9 +935,7 @@ describe("SettingsScreen page visibility", () => {
       settingsNavBackend({ roles: ["ops"], allow: readOn("ai_model_rate") }),
     );
     renderNav();
-    await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("usage", "privacy")),
-    );
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("usage")));
   });
 
   it("opens both AI diagnostics pages for a lone ai_diagnostics read", async () => {
@@ -867,9 +958,7 @@ describe("SettingsScreen page visibility", () => {
     );
     renderNav();
     await waitFor(() =>
-      expect(navPages()).toEqual(
-        floorPlus("models", "usage", "model-calls", "privacy"),
-      ),
+      expect(navPages()).toEqual(floorPlus("models", "usage", "model-calls")),
     );
   });
 
@@ -887,23 +976,23 @@ describe("SettingsScreen page visibility", () => {
       }),
     );
     renderNav();
-    // `automations` stays shut too: it asks for `automation:read`, and the
-    // write on the same object is not it. A page is reached by reading it.
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    // `automations` is OPEN here, and naming it is the point: this fixture holds
+    // `automation:update`, which is exactly what that page asks now. The claim
+    // under test is about the three AI diagnostics pages staying shut, and
+    // asserting the whole row keeps the two facts from being confused.
+    await waitFor(() => expect(navPages()).toEqual(floorPlus("automations")));
   });
 
-  it.each(["retention_policy", "privacy_request", "person"] as const)(
+  it.each(["retention_policy", "privacy_request"] as const)(
     "opens Privacy for a lone %s read",
     async (object) => {
-      // Three terms, each opening the page alone — the retention ladder, the DSR
-      // queue, and `person`, which is the gate the registry endpoint actually
-      // applies (consent/store.go's ListPurposes calls auth.Require on
-      // person:read). A union read as one object with two decorative terms would
-      // pass any fixture granting all three.
+      // Two terms, each opening the page alone — the retention ladder and the
+      // DSR queue. A union read as one object with a decorative second term
+      // would pass any fixture granting both.
       //
-      // `consent_config` is deliberately NOT a term. It is what the purposes card
-      // ADMINISTERS, but it buys no read: only the writes moved to it. On that
-      // grant alone the page opened with every card inside it withheld.
+      // `consent_config` is deliberately NOT a term. It is what the purposes
+      // card ADMINISTERS, but it buys no read: only the writes moved to it. On
+      // that grant alone the page opened with every card inside it withheld.
       const allow: GrantSpec = {};
       allow[object] = ["read"];
       vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow }));
@@ -912,6 +1001,24 @@ describe("SettingsScreen page visibility", () => {
     },
   );
 
+  // `person` was the third term and is now the case that must NOT open it.
+  // Every seeded role holds this read — it is the gate the registry endpoint
+  // applies (consent/store.go's ListPurposes) and the Person 360 needs it — so
+  // a page opening on it was the whole workspace's governance page. The card
+  // still reads through `person`; a card narrower than its page withholds
+  // itself, which is the safe direction.
+  it("does not open Privacy for the person read every seeded role holds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({
+        roles: ["rep"],
+        allow: { person: ["read"], pipeline: ["read"] },
+      }),
+    );
+    renderNav();
+    await expectNavSettlesTo(floorPlus("pipelines"));
+  });
+
   // The term that was dropped, asserted as an absence so nobody adds it back
   // without meeting the card that would have to read on it.
   it("does not open Privacy for a lone consent_config read", async () => {
@@ -919,11 +1026,11 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["custom"],
-        allow: { consent_config: ["read", "create"] },
+        allow: { consent_config: ["read", "create"], pipeline: ["read"] },
       }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus()));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it("opens Audit log without opening Privacy, for an admin holding the trail read", async () => {
@@ -1053,7 +1160,7 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: readOn("organization"),
+        allow: { ...readOn("organization"), organization: ["read", "update"] },
         companyReadEnabled: true,
       }),
     );
@@ -1075,22 +1182,27 @@ describe("SettingsScreen page visibility", () => {
     // before the snapshot it reads. The race is gone rather than untested, which
     // is why the second moment went with it.
     //
-    // The organization read is the ONLY term of Company profile's requirement
-    // this fixture grants, which is what leaves the flag decisive. On a seeded
-    // installation every role also holds `installation_settings:read` and the
-    // page opens on that regardless — so this is about the flag's contribution
-    // to the union, not a claim that the page is ever unreachable in practice.
+    // The organization WRITE is the only term of Company profile's requirement
+    // this fixture grants, which is what leaves the flag decisive. Granting the
+    // read alone would hide the page whatever the flag said, and the case would
+    // pass while proving nothing about the flag.
     vi.stubGlobal(
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: readOn("organization"),
+        allow: {
+          ...readOn("organization"),
+          organization: ["read", "update"],
+          // The witness, so the absence below is asserted against a
+          // RESOLVED snapshot rather than the loading render.
+          pipeline: ["read"],
+        },
         companyReadEnabled: false,
       }),
     );
     renderNav();
 
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
     expect(screen.queryByRole("link", { name: labelOf("company") })).toBeNull();
   });
 
@@ -1110,13 +1222,22 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: readOn("organization"),
+        // The write, for the same reason the case above takes it: on the read
+        // alone the page is shut anyway and the absent-availability arm this
+        // case exists to hold would never be reached.
+        allow: {
+          ...readOn("organization"),
+          organization: ["read", "update"],
+          // The witness, so the absence below is asserted against a
+          // RESOLVED snapshot rather than the loading render.
+          pipeline: ["read"],
+        },
         omitAvailability: true,
       }),
     );
     renderNav();
 
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+    await expectNavSettlesTo(floorPlus("pipelines"));
     expect(screen.queryByRole("link", { name: labelOf("company") })).toBeNull();
   });
 });

--- a/frontend/src/screens/settings-routing.test.tsx
+++ b/frontend/src/screens/settings-routing.test.tsx
@@ -217,7 +217,13 @@ function companyReaderBackend() {
       return jsonResponse(
         meFixture({
           roles: ["admin"],
-          allow: readOn("installation_settings"),
+          // The UPDATE, which is what Company profile asks: the read is held by
+          // every seat and no longer opens the page. These cases are about the
+          // address rewrite, so they hold the grant that reaches the page.
+          allow: {
+            ...readOn("installation_settings"),
+            installation_settings: ["read", "update"],
+          },
         }),
       );
     }

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -381,6 +381,10 @@ describe("SettingsScreen restructured pages", () => {
         roles: ["admin"],
         allow: {
           person: ["read"],
+          // What opens Privacy now. `person:read` still reaches the purposes
+          // list — that endpoint's gate is unchanged — but it no longer opens
+          // the page, because every seeded role holds it.
+          retention_policy: ["read"],
           audit_log: ["read"],
         },
       }),
@@ -419,15 +423,20 @@ describe("SettingsScreen restructured pages", () => {
     expect(await screen.findByText("update")).toBeTruthy();
   });
 
-  // The READ alone opens it, editor included. Before this page absorbed it the
-  // automations editor was a route of its own that nothing gated, so gating the
-  // page on the WRITE grant would be the merge inheriting the spend cards'
-  // authority and dropping the door's — an operator who may read the automations
-  // would reach a page they cannot open.
-  it("opens Automations for an operator on the automations read alone, editor and all", async () => {
+  // The WRITE opens it, editor included. The page absorbed a route that nothing
+  // gated, and for a while it asked the read — which every seeded role holds,
+  // so the page that DEFINES automations stood in a rep's rail with nothing on
+  // it she could change. Reading what an automation did is answered on the
+  // records it touched, not here.
+  it("opens Automations for an operator who may change one, editor and all", async () => {
+    // The write, not the read: management and manager read `automation` to see
+    // what ran, and the page that DEFINES automations is not theirs.
     vi.stubGlobal(
       "fetch",
-      mergedEntryBackend({ roles: ["ops"], allow: { automation: ["read"] } }),
+      mergedEntryBackend({
+        roles: ["ops"],
+        allow: { automation: ["read", "create", "update"] },
+      }),
     );
     renderSettings("automations");
     await waitFor(() =>

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -102,10 +102,17 @@ export const PIPELINE_ADMIN: GrantSpec = {
 const ADMIN_GRANTS: GrantSpec = {
   ...PIPELINE_ADMIN,
   custom_field: ["read", "create", "update"],
-  // The consent registry's own gate (consent/store.go demands person:read), which
-  // every seeded role holds — so a fixture standing in for a real principal has to
-  // carry it or Privacy & audit disappears for reasons the test is not about.
+  // The consent registry's own gate (consent/store.go demands person:read),
+  // which every seeded role holds. It is the floor a fixture standing in for a
+  // real principal carries — but it no longer OPENS Privacy: that page asks
+  // `retention_policy` or `privacy_request`, neither of which anybody below
+  // admin and ops holds.
   person: ["read"],
+  // What actually opens Privacy & audit for this admin fixture. Named here
+  // rather than left to `person`, because the page moved off the read every
+  // seat holds and a fixture that did not follow would quietly stop rendering
+  // the page its cases are about.
+  retention_policy: ["read", "create", "update"],
 };
 
 // The read grant on ONE object, as a GrantSpec.
@@ -115,10 +122,14 @@ const ADMIN_GRANTS: GrantSpec = {
 // not satisfy GrantSpec, and only fails in `tsc -b`, where test files are
 // typechecked, rather than under the app project alone.
 export function readOn(object: RbacObject): GrantSpec {
-  // `person:read` rides along because Privacy asks for it, and every seeded role
-  // holds it — so a case about ONE object's entry is not also a case about losing
-  // the consent registry. Isolating the object under test means holding the floor
-  // steady, not stripping it.
+  // `person:read` rides along because every seeded role holds it and the consent
+  // registry's own endpoint demands it — so a case about ONE object's entry is
+  // not also a case about losing that read. Isolating the object under test
+  // means holding the floor steady, not stripping it.
+  //
+  // The floor no longer reaches a PAGE. Privacy used to open on it, which made
+  // every `readOn` case also a case about Privacy; the page asks the two
+  // governance objects now, and the expectations lost their trailing "privacy".
   const spec: GrantSpec = { person: ["read"] };
   spec[object] = ["read"];
   return spec;

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { meFixture } from "../app/mefixture";
+import type { RbacAction, RbacObject } from "../app/capability";
+import { type GrantSpec, meFixture } from "../app/mefixture";
 import {
   holds,
   SETTINGS_GROUPS,
@@ -53,6 +54,24 @@ describe("who may open what", () => {
     return visibleSettingsPages(snapshot).map((page) => page.id);
   }
 
+  // A reader holding exactly one object, at exactly one verb. `readOn` in the
+  // testkit carries a floor of its own, which is right for a case about one
+  // page and wrong for a case about one GRANT — the floor would supply the
+  // very read under test.
+  //
+  // Built by assignment rather than as an object literal with a computed key:
+  // a computed key widens the spec to `{ [x: string]: string[] }`, which does
+  // not satisfy GrantSpec and only fails in `tsc -b` — where test files are
+  // typechecked — rather than under vitest, which transpiles without checking.
+  function grantOf(object: RbacObject, actions: RbacAction[]) {
+    const allow: GrantSpec = {};
+    allow[object] = actions;
+    return meFixture({ roles: ["rep"], allow });
+  }
+  const readsOnly = (object: RbacObject) => grantOf(object, ["read"]);
+  const writes = (object: RbacObject) =>
+    grantOf(object, ["read", "create", "update"]);
+
   it("shows the personal pages to everyone, including before /me resolves", () => {
     // These carry no grant because they are about the reader themselves. They
     // must survive the loading window too, or the rail flashes empty on every
@@ -80,7 +99,6 @@ describe("who may open what", () => {
       "products",
       "capture",
       "knowledge",
-      "automations",
     ] satisfies SettingsPageId[]) {
       expect(seen).toContain(id);
     }
@@ -100,21 +118,83 @@ describe("who may open what", () => {
     }
   });
 
-  it("opens privacy to a rep, because its purposes list is gated on person.read", () => {
-    // Not a widening: consent/store.go's ListPurposes calls Require(person,
-    // read), so a rep already reads it. A page that refused them here would
-    // disagree with the endpoint behind it.
-    expect(visibleIds(rep)).toContain("privacy");
+  // The four pages whose subject is the installation's own configuration. Each
+  // was reachable by a rep because the grant that opened it is a READ every
+  // seeded role holds — the base currency, what an automation ran, whether
+  // capture is working, the person record behind the purposes list.
+  //
+  // Every absence below is paired with the presence that proves the case is not
+  // vacuous: an authority that refused everyone would pass the first half
+  // alone, and that is exactly how a permission test goes green while saying
+  // nothing.
+  it.each([
+    ["company", "installation_settings"],
+    ["integrations", "overlay_connection"],
+    ["automations", "automation"],
+  ] as const)(
+    "withholds %s from a rep who only reads %s, and opens it to its writer",
+    (page, object) => {
+      expect(visibleIds(readsOnly(object))).not.toContain(page);
+      expect(visibleIds(writes(object))).toContain(page);
+    },
+  );
+
+  // Privacy is the fourth page but not the same shape: its arms stay READS,
+  // because `retention_policy` and `privacy_request` are held by nobody below
+  // admin and ops — the read already says whose page it is. What was wrong was
+  // the third arm, `person:read`, which every seeded role holds and which is
+  // why a rep opened the governance page at all.
+  //
+  // The purposes card still reads through `person` server-side and must keep
+  // doing so; it feeds the Person 360. A card narrower than its page withholds
+  // itself, which is the safe direction.
+  // Management is seeded `consent_config:read` and NOTHING else on this page —
+  // no retention, no request queue. Dropping the `person` arm without this pair
+  // locked the one role deliberately granted the consent vocabulary out of the
+  // only page that renders it. The pair is what keeps them in without letting a
+  // rep back: a rep holds `person` and no consent grant at all.
+  it("opens privacy to the consent vocabulary's own reader, and to nobody else holding person", () => {
+    const management = meFixture({
+      roles: ["management"],
+      allow: { person: ["read"], consent_config: ["read"] },
+    });
+    expect(visibleSettingsPages(management).map((page) => page.id)).toContain(
+      "privacy",
+    );
+    // The same reader without the consent grant is a rep, and stays out.
+    expect(visibleIds(readsOnly("person"))).not.toContain("privacy");
+    // And the consent grant alone does not do it either: the purposes list is
+    // read through `person`, so a holder without that read would open a page
+    // whose only card is withheld.
+    expect(visibleIds(readsOnly("consent_config"))).not.toContain("privacy");
+  });
+
+  it("withholds privacy from a rep holding person, and opens it to a retention reader", () => {
+    expect(visibleIds(readsOnly("person"))).not.toContain("privacy");
+    expect(visibleIds(readsOnly("retention_policy"))).toContain("privacy");
+    expect(visibleIds(readsOnly("privacy_request"))).toContain("privacy");
+  });
+
+  // Management and manager read `automation` — they see what ran, on the
+  // records it touched. Neither may change one, and the page that DEFINES
+  // automations is therefore not theirs. This is the deliberate half of the
+  // narrowing: it is not only reps who lose a page here.
+  it("withholds automations from management, which reads automation but cannot write", () => {
+    expect(
+      visibleIds(
+        meFixture({ roles: ["management"], allow: { automation: ["read"] } }),
+      ),
+    ).not.toContain("automations");
   });
 });
 
 describe("requirements that are not permissions", () => {
   it("withholds the company page when the installation lacks the surface", () => {
-    // organization.read alone. The company profile ANDs its grant with a
+    // organization.update alone. The company profile ANDs its grant with a
     // deployment flag, so a reader holding only that grant sees nothing when
     // the flag is off — the surface may genuinely not exist here.
     const holder = meFixture({
-      allow: { organization: ["read"] },
+      allow: { organization: ["read", "update"] },
       settingsAvailability: { company_context: false },
     });
     expect(visibleSettingsPages(holder).map((p) => p.id)).not.toContain(
@@ -124,7 +204,7 @@ describe("requirements that are not permissions", () => {
 
   it("shows it once the installation has it", () => {
     const holder = meFixture({
-      allow: { organization: ["read"] },
+      allow: { organization: ["read", "update"] },
       settingsAvailability: { company_context: true },
     });
     expect(visibleSettingsPages(holder).map((p) => p.id)).toContain("company");
@@ -134,7 +214,7 @@ describe("requirements that are not permissions", () => {
     // A server older than the field, or a snapshot cached before it shipped.
     // Absent is not permission: it has to read as "no such surface here".
     const holder = meFixture({
-      allow: { organization: ["read"] },
+      allow: { organization: ["read", "update"] },
       settingsAvailability: null,
     });
     expect(visibleSettingsPages(holder).map((p) => p.id)).not.toContain(
@@ -143,11 +223,11 @@ describe("requirements that are not permissions", () => {
   });
 
   it("still shows it to a reader whose OTHER grant carries the page", () => {
-    // The flag gates one card, not the page: installation_settings.read opens
+    // The flag gates one card, not the page: installation_settings.update opens
     // the company page regardless, and treating the flag as a page-level
     // condition would hide a surface the reader may use.
     const admin = meFixture({
-      allow: { installation_settings: ["read"] },
+      allow: { installation_settings: ["read", "update"] },
       settingsAvailability: { company_context: false },
     });
     expect(visibleSettingsPages(admin).map((p) => p.id)).toContain("company");
@@ -356,9 +436,18 @@ describe("a page and its cards ask the same question", () => {
         allow: { consent_config: ["read", "create"] },
       }),
     ).toBe(false);
-    // The grant that actually reads the purposes list does open it.
+    // Nor on `person`, which every seeded role holds: the purposes card reads
+    // through it, but a page that opened on it was the whole workspace's
+    // governance page. The arms that DO open it are the two objects nobody
+    // below admin and ops holds at all.
     expect(
       opens("privacy", { roles: ["rep"], allow: { person: ["read"] } }),
+    ).toBe(false);
+    expect(
+      opens("privacy", {
+        roles: ["custom"],
+        allow: { retention_policy: ["read"] },
+      }),
     ).toBe(true);
   });
 
@@ -402,18 +491,32 @@ describe("requirements that are not permissions — the composed units", () => {
     ).toBe(false);
   });
 
-  it("opens integrations to an overlay or webhook reader", () => {
+  it("opens integrations to whoever may CONNECT one, and not to the readers", () => {
     // Spelled out rather than looped over a computed key: a computed key widens
     // `allow` to a string index and loses the object/action checking that makes
     // a misspelling here a compile error rather than a silently denied grant.
+    //
+    // The read is the same everyone-holds-it grant as `integrations` above —
+    // every seeded role reads both, because "is capture working?" shows up on
+    // the records they already open. Connecting an overlay is admin and ops work.
     expect(
       visibleSettingsPages(
         meFixture({ allow: { overlay_connection: ["read"] } }),
+      ).some((p) => p.id === "integrations"),
+    ).toBe(false);
+    expect(
+      visibleSettingsPages(
+        meFixture({ allow: { overlay_connection: ["read", "update"] } }),
       ).some((p) => p.id === "integrations"),
     ).toBe(true);
     expect(
       visibleSettingsPages(
         meFixture({ allow: { webhook_subscription: ["read"] } }),
+      ).some((p) => p.id === "integrations"),
+    ).toBe(false);
+    expect(
+      visibleSettingsPages(
+        meFixture({ allow: { webhook_subscription: ["read", "create"] } }),
       ).some((p) => p.id === "integrations"),
     ).toBe(true);
   });

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -67,6 +67,37 @@ export const reads = (object: RbacObject): CapabilityExpression => ({
   object,
   action: "read",
 });
+/**
+ * A page whose subject is the installation's own configuration asks for the
+ * verb that changes it, not the one that displays it.
+ *
+ * The seeded roles read far more than they may change — every seat reads
+ * `installation_settings` for the base currency, `automation` to see what ran,
+ * and the integration objects to see whether capture is working. Gating those
+ * pages on the read put six administration destinations in a rep's navigation
+ * that she could only look at. `writes` is how a page says its subject is
+ * somebody's job rather than everybody's reference.
+ *
+ * Either write verb counts. A custom role holding `create` without `update` may
+ * still add a webhook or an automation, and adding one is the whole reason to
+ * open the page; the seeded roles hold both together, so a stricter spelling
+ * would only ever strand a hand-built role — quietly, which is the bad way.
+ *
+ * Not a replacement for `reads`: a page a reader genuinely consults, like the
+ * sales vocabulary she works in every day, still opens on the read.
+ */
+export const writes = (
+  object: RbacObject,
+  // Which write verbs the object's own endpoints actually offer. Defaults to
+  // both, which is the common case; pass `["update"]` for an object that has no
+  // create operation, so a custom role granted a verb the API does not expose
+  // cannot open a page on it. `installation_settings` is the worked example:
+  // `/installation/settings` is GET and PATCH, and nothing else.
+  actions: readonly ("create" | "update")[] = ["update", "create"],
+): CapabilityExpression => ({
+  kind: "any",
+  of: actions.map((action) => ({ kind: "grant", object, action })),
+});
 export const available = (
   key: SettingsAvailabilityKey,
 ): CapabilityExpression => ({ kind: "availability", key });
@@ -175,11 +206,18 @@ export type SettingsScope = "self" | "team" | "workspace" | "installation";
 /**
  * Every settings page, its group, its scope and what it takes to open it.
  *
- * `requires` is a READ requirement — it says who may see the page, never who
- * may change what is on it. Each card asks its own write question, because a
- * page is routinely readable and only partly writable, and a page-level write
- * flag would either hide a page somebody may read or promise controls they
- * cannot use.
+ * `requires` says who may SEE the page. It is not automatically the read grant:
+ * a page whose subject is the installation's own configuration asks for the
+ * verb that changes it, because every seeded role reads far more than it may
+ * change and the read arm handed a rep six destinations she could only look at.
+ * A page she genuinely consults — the sales vocabulary, her own settings —
+ * still opens on the read.
+ *
+ * It never decides what a card may DO. Each card asks its own write question,
+ * because a page is routinely readable and only partly writable, and a
+ * page-level write flag would either hide a page somebody may read or promise
+ * controls they cannot use. A card narrower than its page is the safe
+ * direction: the card withholds itself.
  */
 export const SETTINGS_PAGES = [
   { id: "account", group: "me", scope: "self", requires: always },
@@ -192,13 +230,22 @@ export const SETTINGS_PAGES = [
     id: "company",
     group: "company",
     scope: "installation",
-    // The union of what the three cards on it ask for. The company profile
-    // carries a second condition that is a deployment FLAG rather than a
-    // permission, so its grant ANDs with it: the surface may simply not exist
-    // on this installation.
+    // The union of what the three cards on it ask for, and each arm is the verb
+    // that card's controls perform.
+    //
+    // `installation_settings` is asked as the UPDATE, not the read. Every
+    // seeded role reads it — a rep needs the base currency to render a deal —
+    // so the read arm opened the installation's own facts to the whole
+    // workspace. Only admin and ops may change them.
+    //
+    // The company profile is different and stays a write a rep really holds:
+    // `organization:update` is hers, and the profile the AI reads is a thing
+    // she legitimately edits. Its second condition is a deployment FLAG rather
+    // than a permission, so the grant ANDs with it — the surface may simply not
+    // exist on this installation.
     requires: anyOf(
-      reads("installation_settings"),
-      allOf(reads("organization"), available("company_context")),
+      writes("installation_settings", ["update"]),
+      allOf(writes("organization"), available("company_context")),
       reads("fx_rate"),
     ),
   },
@@ -289,9 +336,13 @@ export const SETTINGS_PAGES = [
     id: "integrations",
     group: "data",
     scope: "workspace",
+    // The writes, not the reads: every seeded role reads both objects, because
+    // "is capture working?" is everyone's question and the answer shows up on
+    // the records they already open. Connecting an overlay or pointing a
+    // webhook somewhere is admin and ops work.
     requires: anyOf(
-      reads("overlay_connection"),
-      reads("webhook_subscription"),
+      writes("overlay_connection"),
+      writes("webhook_subscription"),
       // A composed workspace-scoped unit puts its settings on this page and
       // nowhere else, so the page has to open for it even when the reader holds
       // none of the grants above.
@@ -326,7 +377,11 @@ export const SETTINGS_PAGES = [
     id: "automations",
     group: "ai",
     scope: "workspace",
-    requires: reads("automation"),
+    // The write, which admin and ops alone hold. Management and manager read
+    // `automation` — they see what ran, on the records it touched — but a role
+    // that cannot change an automation has nothing to do on the page that
+    // defines them.
+    requires: writes("automation"),
   },
   {
     id: "usage",
@@ -348,20 +403,30 @@ export const SETTINGS_PAGES = [
     id: "privacy",
     group: "governance",
     scope: "workspace",
+    // `person` is deliberately NOT an arm, though the purposes card reads
+    // through it. `person:read` is held by every seeded role, so that arm put
+    // the governance page in front of the whole workspace — the retention
+    // ladder, the subject-request queue and the restricted-record list, none of
+    // which a rep can act on.
+    //
+    // The purposes LIST stays gated on `person` server-side and must not move:
+    // that endpoint feeds the Person 360, and narrowing it would 403 every rep
+    // on a screen they use all day. A card narrower than its page is the safe
+    // direction — the card withholds itself.
+    //
+    // `consent_config` buys no read either (consent/store.go ListPurposes is on
+    // `person`), so it is not an arm; its holders all hold retention or the
+    // request queue anyway.
     requires: anyOf(
       reads("retention_policy"),
       reads("privacy_request"),
-      // The purposes list is gated on person.read server-side, which is not a
-      // role and not "any member" — moving it would 403 the Person 360 for
-      // every rep, so the page follows the gate the endpoint actually applies.
-      //
-      // `consent_config` is deliberately NOT here, though the purposes card is
-      // what that object administers. It buys no READ: the list stays on
-      // `person` (consent/store.go ListPurposes) and only the writes moved. On
-      // the consent grant alone a reader would open a page whose every card is
-      // withheld — every seeded holder of it also holds `person:read`, so this
-      // only ever bit a custom role, silently.
-      reads("person"),
+      // The consent vocabulary, as a PAIR. `person:read` is what the purposes
+      // endpoint asks (consent/store.go ListPurposes) and every seeded role
+      // holds it, so it cannot open the page alone. `consent_config` is who the
+      // vocabulary belongs to — management is seeded its read and nothing else
+      // on this page, so without this arm the one role deliberately granted the
+      // vocabulary could not reach the only page that renders it.
+      allOf(reads("person"), reads("consent_config")),
     ),
   },
   {


### PR DESCRIPTION
## What a user sees

A sales rep like Lena opened Margince's settings and found **18 of 28 pages**, nearly all of them read-only: the installation's own profile, the integration wiring, the automation definitions, the governance queue. She could change none of it.

Three of those pages asked for a READ grant that **every seeded role holds**, for reasons that have nothing to do with settings:

| Page | Opened on | Why every seat holds it |
|---|---|---|
| Company profile | `installation_settings:read` | a rep needs the base currency to render a deal |
| Automations | `automation:read` | seeing what an automation did, on the records it touched |
| Integrations | `overlay_connection` / `webhook_subscription:read` | "is capture working?" shows up on ordinary records |

They ask the **write** now. Privacy was a fourth case and moved differently — see below.

**A rep goes from 18 pages to 15.** She keeps her five personal pages, the sales vocabulary she works in every day (pipelines, leads, fields, tags, products), capture rules, knowledge — and Company profile, because she genuinely holds `organization:update` and the company profile the AI reads is hers to edit.

**Admin and ops lose nothing.** Management and manager also lose Automations, and that is the deliberate half: they read `automation` to see what ran, but neither may change one, and the page that *defines* automations is not theirs.

## Privacy is not the same shape

It keeps READ arms. Nobody below admin and ops holds `retention_policy` or `privacy_request` at all, so the read already says whose page it is. What it drops is the `person:read` arm — held by every seat, because the Person 360 needs it.

Dropping that alone would have **locked out the management role**, which is seeded `consent_config:read` and nothing else on that page. So the consent vocabulary is a *pair*: `person:read` AND `consent_config`. Management stays in; a rep, holding `person` and no consent grant, stays out.

The purposes endpoint keeps its `person:read` gate server-side and must — it feeds the Person 360. A card narrower than its page withholds itself, which is the safe direction.

## The system-of-record chip

`sormodechip.tsx` gated its link on `useHoldsOperatorSeat()` — a literal `admin || ops` check. That matched the seeded roles by coincidence and would have left a custom role holding `overlay_connection:update` staring at a chip that went nowhere. It asks the catalog now, so the chip and the page cannot disagree about where the chip goes. No new bundle edge: `topbar.tsx` already reaches `palette.tsx`, which already imports the same hook.

## How this was verified

Not from fixtures alone. The seeded grant matrix was dumped by running Go against `policy.defaults`, and the live `/me` payloads for `admin@demo.test` and `rep@demo.test` were pulled off a running API and resolved through the catalog: **admin 28/28, rep 15/28**.

That is what caught two things reasoning would have gotten wrong — a rep really holds `organization` writes, and `installation_settings` has no create verb at all (`/installation/settings` is GET and PATCH), so a page accepting a create grant would honour a permission for an operation that does not exist.

## Ten tests were passing vacuously

Every capability predicate reads false while `/me` is in flight, so the loading nav renders **exactly** the ungated floor — the same rows a resolved snapshot granting nothing renders. `waitFor` succeeded on its first tick. Granting the very page a case said was withheld **still passed**.

Mutation-testing did not catch this: reverting the guard failed the tests, so they looked sound.

Each absence assertion now waits on a witness row that only a resolved snapshot can draw, then asserts. Reverting all four narrowings now fails **26 tests**; before this fix most stayed green.

## Checks

`make check-fe` green (8053 tests), `make frontend-e2e` 251 passed / 0 failed, `tsc -b` clean. Re-run after rebasing onto current main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops opening four Settings pages on read grants that every seat holds, so people no longer land on pages they can only stare at. Sales reps now see 15 settings pages instead of 18; admin and ops still see 28.

**Behavior**
- Integrations and Automations now ask for write grants, so reps lose both.
- Company profile now requires `installation_settings:update`, `organization:update`, or `fx_rate` read; reps keep it because seeded reps hold `organization:update`.
- Privacy no longer opens on `person:read`; it opens on `retention_policy`/`privacy_request` reads, or the `person:read` + `consent_config:read` pair, so management keeps access.
- Management and manager lose Automations on purpose: they can read automation history but cannot edit automations.
- The system-of-record chip now asks the settings catalog whether Integrations opens, so custom roles with `overlay_connection:update` get a working link instead of a dead one.

**Testing**
- Ten absence assertions were passing before `/me` resolved; they now wait for a row only a resolved snapshot can render.
- Reverting all four narrowings fails 26 tests; before this fix most stayed green.

<sup>Written for commit 9cb193d0e74378366ee2ee8e12edc4bba12bf636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

