### PR TITLE
A document git ignores is a dead pointer, and now it fails

### DIFF
--- a/backend/gates/publicreferences_test.go
+++ b/backend/gates/publicreferences_test.go
@@ -24,10 +24,15 @@ package gates
 // somebody eventually widens.
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -112,4 +117,161 @@ func assertFileCitesNothingPrivate(t *testing.T, rel string) {
 			}
 		}
 	}
+}
+
+// A document git ignores is the same dead pointer as a private repository, and
+// it arrives by a route the patterns above cannot see: no name gives it away.
+// Four accumulated in tracked prose with every gate green.
+//
+// THE DISTINCTION IS WHAT IS CITED, not where it sits. A gitignored path a
+// COMMAND WRITES is a fact worth documenting — "artifacts land in the
+// gitignored aitask directory" tells a reader exactly what to expect, and they
+// get the directory by running the command. A gitignored DOCUMENT is different:
+// there is nothing to run, the reader cannot produce it, and the sentence
+// citing it is asking them to read something that does not exist in their
+// clone. So this asks only about `.md` citations, which is why it can be
+// absolute where a rule about every ignored path would have to be a judgement.
+//
+// GIT ANSWERS, rather than a list of ignored roots kept here. A list is a
+// second copy of .gitignore, and the copy that stopped matching would let the
+// next scratch root through silently.
+
+// citedDocument matches a Markdown path as prose writes one — in backticks, in
+// a link, or bare. The extension is what bounds it: without one this would have
+// to guess where a sentence stops being a path.
+var citedDocument = regexp.MustCompile(`[\w.][\w./-]*\.md\b`)
+
+func TestPublicTreeCitesNoDocumentGitIgnores(t *testing.T) {
+	t.Parallel()
+	tracked := trackedPaths(t)
+
+	type citation struct {
+		rel  string
+		line int
+		text string
+	}
+	cited := map[string][]citation{}
+	for rel := range tracked {
+		// MARKDOWN ONLY, and the boundary is not laziness. The obligation is
+		// that a reader can follow what this repository TELLS them, and what it
+		// tells them is prose. A path inside a Go string literal is usually a
+		// fixture building a temp tree — cli/craft's assembler tests write an
+		// AGENTS.md under an extensions/ path that git ignores, and nothing is
+		// wrong with that — and a fixture cannot be told from a citation by
+		// looking at it. Reporting those would either add a waiver list or teach
+		// people to spell paths so this gate cannot see them.
+		if filepath.Ext(rel) != ".md" {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("..", rel))
+		if err != nil {
+			// Absent mid-rebase or after `git rm`; not this gate's business.
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			for _, cand := range citedDocument.FindAllString(line, -1) {
+				for _, resolved := range unresolvedTargets(rel, cand, tracked) {
+					cited[resolved] = append(cited[resolved],
+						citation{rel: rel, line: i + 1, text: line})
+				}
+			}
+		}
+	}
+	if len(cited) == 0 {
+		t.Fatal("no Markdown path is cited anywhere in tracked prose — this gate has stopped " +
+			"seeing its subject rather than the tree having stopped citing documents")
+	}
+
+	// Reported once per SITE, not once per reading: a citation that is ignored
+	// under both the relative and the root reading is one mistake, and printing
+	// it twice makes a four-line sweep look like an eight-line one.
+	said := map[string]bool{}
+	for _, ignored := range gitIgnores(t, cited) {
+		for _, c := range cited[ignored] {
+			where := fmt.Sprintf("%s:%d", c.rel, c.line)
+			if said[where] {
+				continue
+			}
+			said[where] = true
+			t.Errorf("%s cites a document git ignores — it does not exist in a fresh clone, so "+
+				"a reader cannot follow it. State the fact here, or cite something this repository "+
+				"ships.\n\t%s", where, strings.TrimSpace(c.text))
+		}
+	}
+}
+
+// unresolvedTargets is where a cited path could point, minus everywhere it
+// resolves to something this repository ships.
+//
+// Prose writes a Markdown link BOTH ways — relative to the file it sits in, and
+// from the repository root — and neither spelling is wrong. So both are tried,
+// and a citation that lands on a tracked file under EITHER reading is settled
+// without asking git, which is the ordinary case and by far the common one.
+//
+// A reading that climbs out of the repository is dropped rather than reported:
+// a nested module citing ../../AGENTS.md is naming the root file, and the
+// join above already produced that reading. What is left over points outside
+// the tree, which git cannot answer about and this gate does not ask.
+func unresolvedTargets(rel, cand string, tracked map[string]bool) []string {
+	readings := []string{path.Clean(cand), path.Clean(path.Join(path.Dir(rel), cand))}
+	var out []string
+	for _, r := range readings {
+		if tracked[r] {
+			return nil
+		}
+		if r == ".." || strings.HasPrefix(r, "../") || path.IsAbs(r) || slices.Contains(out, r) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// trackedPaths is the index as a set. It reads the shared trackedFiles helper
+// rather than shelling out again: one spelling of "what does git know about".
+func trackedPaths(t *testing.T) map[string]bool {
+	t.Helper()
+	tracked := map[string]bool{}
+	for _, f := range trackedFiles(t) {
+		tracked[f.path] = true
+	}
+	return tracked
+}
+
+// gitIgnores asks git which of these paths it excludes, in one call.
+//
+// check-ignore exits 1 when it matches nothing, which is the ordinary clean
+// answer and not a failure — so the exit status is read through the output
+// rather than treated as an error.
+func gitIgnores[T any](t *testing.T, paths map[string][]T) []string {
+	t.Helper()
+	candidates := make([]string, 0, len(paths))
+	for path := range paths {
+		candidates = append(candidates, path)
+	}
+	sort.Strings(candidates)
+
+	cmd := exec.Command("git", "-C", "..", "check-ignore", "--stdin")
+	cmd.Stdin = strings.NewReader(strings.Join(candidates, "\n") + "\n")
+	out, err := cmd.Output()
+	if err != nil {
+		var exit *exec.ExitError
+		// 1 is "nothing matched". Anything else is git failing to answer, and a
+		// gate that read that as a clean tree would report PASS over an
+		// unanswered question.
+		if !errors.As(err, &exit) || exit.ExitCode() != 1 {
+			t.Fatalf("asking git which cited documents it ignores: %v", err)
+		}
+	}
+	var ignored []string
+	for _, path := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if path != "" {
+			ignored = append(ignored, path)
+		}
+	}
+	sort.Strings(ignored)
+	return ignored
 }

--- a/docs/evidence/extension-tier/NOTES-SCOPE.md
+++ b/docs/evidence/extension-tier/NOTES-SCOPE.md
@@ -138,7 +138,7 @@ slice adds a **fall-through**: unmatched screen → look up the composed extensi
 
 ## 4. Acceptance — the click-through
 
-This is the UAT attached to the PR, per `.tmp/TEMPLATE.md`:
+This is the UAT attached to the PR:
 
 1. `make composition && make run` with `notes` present → boot inventory lists it
 2. Navigate `#/ext/notes` → screen renders, "not connected"

--- a/docs/explanation/outbound-webhooks.md
+++ b/docs/explanation/outbound-webhooks.md
@@ -324,9 +324,8 @@ genuinely ownerless *forces* you to add it to the allow-list. The choice is forc
 
 **Ratified deferred delivery — subscribable but not delivered, on purpose.** Two families are
 catalogued, valid subscription targets, and match `matchingSubscriptions`, yet `entityVisibleTo` returns
-"not visible" for them **unconditionally** — not a bug, a documented gap raised upstream for spec
-reconciliation (`.tmp/webhooks-contract-ui/UPSTREAM-P3.md`), because neither has an ownership model the
-fan-out gate can bound delivery by:
+"not visible" for them **unconditionally** — not a bug, a known gap awaiting spec reconciliation,
+because neither has an ownership model the fan-out gate can bound delivery by:
 
 - **The overlay `mirror.*` family** (`mirror.conflict`, `mirror.budget_degraded`, `mirror.deleted`, the
   reserved `mirror.write_rejected`) — keyed by EVENT type (`deferredDeliveryEvents`). Each emit site
@@ -512,7 +511,6 @@ viewer with read-only access sees the list and deliveries but not the mutating a
 | The payload generator | `backend/tools/gen-payloads/` → `internal/contracts/publicevents_gen.go` |
 | The typed emit seam (compile-time payload↔event binding) | `internal/platform/database/storekit/storekit.go` (`EmitEvent`, `EmitEventForEntity`) |
 | The whole-catalog fitness gate (coverage/no-orphan/version/delivery-resolvability, A15) | `backend/gates/publicevents_test.go` |
-| The upstream-reconciliation note for the two deferred-delivery families | `.tmp/webhooks-contract-ui/UPSTREAM-P3.md` |
 | The Settings → Integrations UI (§9) | `frontend/src/screens/webhooks.tsx` |
 | The generated frontend event-type projection | `frontend/src/api/public-events.ts` |
 

--- a/docs/explanation/overlay-augmentation.md
+++ b/docs/explanation/overlay-augmentation.md
@@ -6,9 +6,8 @@ cached mirror alongside it. This page is the mental model — the two SoR modes,
 mirror is a cache and not a copy of authority, how it stays in sync, how it fails closed, and what
 happens on teardown.
 
-The full design (decisions, spike findings, review trail) lives in the working design doc at
-`.tmp/hubspot-overlay/design.md` (an internal build artifact, not tracked in git); this page is the
-durable summary. Cross-references: [write-backbone.md](write-backbone.md) (the audit+outbox shape overlay
+The decisions, spike findings and review trail behind it are not in this repository; this page is the
+durable summary, and it is the whole of what a reader here needs. Cross-references: [write-backbone.md](write-backbone.md) (the audit+outbox shape overlay
 *ingest* deliberately does not use), [authorization.md](authorization.md) (the RBAC gate overlay's
 connection lifecycle rides), [contract-first.md](contract-first.md) (the frozen contract this seam
 binds to), [composition-layer.md](composition-layer.md) (where the per-workspace dispatch lives).


### PR DESCRIPTION
Closes #1957.

This repository is public, and the rule it holds itself to is that a contributor can follow every instruction it gives them. A citation of a document git ignores breaks that as squarely as a private repository name does — the file is not in a fresh clone, so the sentence asks somebody to read something that is not there.

## It arrives by a route the existing patterns cannot see

Nothing about the path gives it away: no private repository name, no `specs/` prefix, no upstream reference. **Four accumulated in tracked prose with every gate green** — the shape *"prefer fitness functions over point fixes"* exists for.

## The distinction is what is cited, not where it sits

Getting this wrong would have made the gate unusable.

An ignored path a **command writes** is a fact worth documenting: *"artifacts land in the gitignored aitask directory"* tells a reader exactly what to expect, and they get the directory by running the command.

A **document** is different — there is nothing to run and nothing to produce. So this asks only about Markdown citations, which is why it can be absolute where a rule about every ignored path would have to be a judgement call.

## Git answers, rather than a list

A list of ignored roots kept in the test is a second copy of `.gitignore`, and the copy that stopped matching would let the next scratch root through silently. `git check-ignore` is asked instead, in one batched call.

Both readings of a cited path are tried — relative to the file it sits in, and from the repository root — because prose writes links both ways and neither is wrong. A citation that lands on a tracked file under either reading is settled without asking git, which is the common case.

## Markdown only, and the boundary is stated rather than left to be discovered

A path inside a Go string literal is usually a fixture building a temp tree — `cli/craft`'s assembler tests write one under an ignored path, and nothing is wrong with that — and **a fixture cannot be told from a citation by looking at it**. Reporting those would mean either a waiver list or teaching people to spell paths the gate cannot see.

## The four are swept in the same change

So the tree cannot regress the moment it is clean. Two dropped a pointer and kept the sentence, one lost a table row that only ever pointed outward, and one now says plainly that the trail behind it is not in this repository.

## Verification

Adding a fresh citation of an ignored document is reported — **once for the site**, not once per reading. `make check-backend` exit 0 with the sweep in place.