### PR TITLE
Bring the drafted body back into view when the disclosure band raises it

### DIFF
--- a/frontend/src/screens/compose-draft-reveal.test.tsx
+++ b/frontend/src/screens/compose-draft-reveal.test.tsx
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
+
+// WHERE a finished draft leaves the reader.
+//
+// The draft answers into the middle of a scrolling drawer and grows everything
+// above the body as it lands: the Art. 50 band appears where the draft bar was,
+// carrying the disclosure sentence, what the draft was based on and the voice
+// version, and the head below it fills with a recipient and a subject. The
+// words the rep pressed the button for end up under all of that — off the fold
+// on any drawer shorter than the form — so the composer answered "Draft with
+// AI" with a notice about a draft the rep could not see.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const DRAFT = {
+  subject: "Following up on your pricing question",
+  body: "Hi Dung,\n\nYou asked what this would cost for 40 seats.",
+  generated_by: "model",
+  ai_generated: true,
+  ai_disclosure: "This message was drafted with AI assistance.",
+};
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+function stubRoutes() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      if (key === "POST /leads/l-1/draft-email") return jsonResponse(DRAFT);
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
+      return jsonResponse({});
+    }),
+  );
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("where a finished draft leaves the reader", () => {
+  it("brings the drafted body into view when the disclosure band raises it", async () => {
+    stubRoutes();
+    render(
+      <ComposeModal
+        entityType="lead"
+        entityId="l-1"
+        recordAddress="dung.ly@newsky.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    // jsdom has no scrollIntoView, so the composer's optional call finds
+    // nothing to spy on until one is put there. The browser always has one.
+    const editor = screen.getByRole("textbox", { name: "Body" });
+    const reveal = vi.fn();
+    editor.scrollIntoView = reveal;
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+    await screen.findByTestId("ai-disclosure-banner");
+
+    // The BODY is what is brought back, not the band that displaced it: the
+    // band is the notice, and the words are what the press was for.
+    await waitFor(() => expect(reveal).toHaveBeenCalled());
+    expect(reveal).toHaveBeenCalledWith({ block: "nearest" });
+    expect(editor.textContent).toContain("You asked what this would cost");
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -2757,13 +2757,33 @@ export function ComposeModal({
     setHtml(paragraphsFrom(drafted));
   };
 
+  // The drafted words, brought back under the reader's eyes.
+  //
+  // A draft does not only fill the body — it raises the disclosure band above
+  // it, and that band (the Art. 50 sentence, what the draft was based on, the
+  // voice version) is several times the height of the bar the rep pressed. The
+  // head below it grows too, because the same answer fills To and the subject.
+  // So the press that asks for words pushes those words down past the fold, and
+  // the rep is left reading a notice about a draft they cannot see.
+  //
+  // `block: "nearest"` rather than "start": when the body already fits, this
+  // moves nothing — which is what a rewrite wants, since the band is already
+  // standing and only the words underneath changed.
+  const revealDraftedBody = () => {
+    // After the paint that raised the band, or the body is still where it was.
+    globalThis.requestAnimationFrame(() => {
+      // jsdom has no scrollIntoView; the browser always does.
+      document.getElementById(bodyId)?.scrollIntoView?.({ block: "nearest" });
+    });
+  };
+
   const draft = useDraftMutation({
     activityId: answering,
     entityType,
     entityId,
     intent,
     onUnavailable: () => setDraftUnavailable(true),
-    onDrafted: (result, ask) =>
+    onDrafted: (result, ask) => {
       fillFromDraft(result, {
         subject,
         body,
@@ -2777,7 +2797,9 @@ export function ComposeModal({
         setProvenance,
         setReasoning: account.setReasoning,
         setScope: account.setScope,
-      }),
+      });
+      revealDraftedBody();
+    },
     resetUnavailable: () => setDraftUnavailable(false),
     t,
   });


### PR DESCRIPTION
## What

After "Draft with AI" lands, the composer scrolls the drafted body back under the reader's eyes. Before this, the drafted words were pushed below the fold by the disclosure band that arrives with them.

## Why

A finished draft does not only fill the body. At the moment it lands it replaces the plain draft bar with the Art. 50 disclosure band — the disclosure sentence, the "Based on" line, the "Why this draft?" chips, the voice version, sometimes the provisional badge — and the head under it grows too, because the same answer fills To and the subject.

All of that grows *above* the body inside one scrolling drawer whose scroll position does not move. So the press that asks for words is what pushes those words past the fold: the composer answers "Draft with AI" with a notice about a draft the reader cannot see, and the reader has to hunt for the thing they just asked for.

The invariant: a draft that lands is a draft the reader can see. `block: "nearest"` rather than `"start"` holds the other half of it — a rewrite changes the words under a band that is already standing, so nothing there needs to move, and a body that already fits stays where it is.

## How verified

`frontend/src/screens/compose-draft-reveal.test.tsx` is the spec: it presses the button, waits for the disclosure band, and asserts the body editor — the element holding the drafted text, not the band that displaced it — is the one brought into view. It fails on `main` and passes here.

- [x] `make check` is green — `make check-fe` is green in full locally (7m35s, exit 0), which is the half this diff lives in. `make check-backend` does not pass in the container this was written in, and neither failure belongs to this diff: `contract-breaking-check` compared against a stale local `origin/main` ref (green after a fetch — "No changes detected"), and `lint-modules` fails across seven unrelated modules with `golangci-lint` built against go1.25 while the tree targets go1.26. CI's own path filter reaches the same conclusion: every backend job is skipped on this PR.
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — this diff is one frontend screen and one frontend test; it touches no Go, no store, no migration
- [x] `make craft-static` reports no new blockers — no Go files in this diff, so the gate's corpus is empty for it; `make fe-lint` and `make fe-typecheck` are green
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Wholly AI-assisted: the diagnosis, the fix and the test were written by Claude Code in a remote session, working from a report that the mail body disappears once the AI draft band appears. A human reviewer owns the judgement calls in it — chiefly the choice to bring the body into view rather than shrink the disclosure band, which is a compliance surface and not this change's to trim.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2rfHMSdCmPK88pgJGyg51