### PR TITLE
feat(assurance): the nightly check hands a rep one task per deal, not one per finding

### DIFF
--- a/backend/internal/compose/assurancebundle.go
+++ b/backend/internal/compose/assurancebundle.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Turning the night's findings into work somebody can pick up.
+//
+// The scan raises exceptions and three surfaces render them. What nobody had
+// was ONE thing to act on: a deal with four problems produced four findings,
+// and a rep clearing them cleared the same deal four times. This is the seam
+// that groups them — one task per deal per pass — and it lives in compose
+// because it spans two modules that may not import each other: assurance owns
+// the cycle and the bundling, activities owns the task.
+//
+// THE CYCLE IS THE RUN. Its scope is the scan's own run id, which makes the
+// pass idempotent for free: River retries this job, and a retry that re-scanned
+// would produce a new run and therefore a new cycle, while a retry landing on
+// the same run re-finds the cycle it already opened. Neither mints a second task
+// for one deal. The alternative — a long-lived cycle somebody closes by hand —
+// needs a surface to close it, and until that surface exists an unclosed cycle
+// would silently stop the next night's bundling.
+//
+// A TASK ALREADY DONE IS LEFT DONE. OpenTaskFor answers with the cycle's task
+// for a subject whether or not somebody has completed it, and a finding arriving
+// afterwards files under that same task rather than minting a fresh one. Within
+// one night a rep is asked once. If the condition is still there tomorrow, it is
+// tomorrow's cycle that asks again — which is the honest re-ask, because a night
+// has passed and the finding was re-observed.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/assurance"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// bundleDeps are the two doors this seam needs, named as functions so the
+// worker can hand in the real stores and a test can hand in the same stores
+// built over its own pool.
+type bundleDeps struct {
+	bundles    *assurance.Store
+	activities *activities.Store
+	// exceptions reads the findings THIS RUN observed and nobody has deferred.
+	// It is bundleableFindings in production.
+	exceptions func(ctx context.Context, tx pgx.Tx, runID ids.UUID) ([]assurance.Exception, error)
+}
+
+// bundleRunFindings groups one run's open findings into one task per subject.
+//
+// It reports how many tasks it minted, which is what the sweep logs: a pass that
+// found work and a pass that found none are different facts, and a count of zero
+// beside a non-zero finding count is the shape that says this seam stopped
+// working.
+//
+// It never returns an error for a finding it could not bundle. The scan has
+// already committed — the exceptions are recorded and the surfaces render them —
+// so failing the job here would leave River retrying a pass whose real output
+// already landed, and the retry would re-scan and re-mint. What a failure costs
+// instead is one deal's task, which the next night's cycle mints again.
+func bundleRunFindings(
+	ctx context.Context, deps bundleDeps, runID ids.UUID,
+) (minted int, err error) {
+	cycle, err := deps.bundles.OpenCycle(ctx, cycleScopeForRun(runID))
+	if err != nil {
+		return 0, fmt.Errorf("compose: opening the cycle for run %s: %w", runID, err)
+	}
+
+	// The close is registered THE MOMENT the cycle exists, before the read that
+	// could fail below it.
+	//
+	// An open cycle is what the partial unique index refuses a second of, and
+	// the scope is a run id nobody revisits — so a cycle left open is left open
+	// for ever, and one bad night turns into a feature that never runs again.
+	// Two earlier versions of this function each left one path out: the first
+	// returned on a subject's error and skipped the close, the second installed
+	// the defer only after the exception read, so a read failure walked past it.
+	// Registering here is what makes every return below it pass through the
+	// close, which is the property, not the placement.
+	defer func() {
+		if closeErr := deps.bundles.CloseCycle(ctx, cycle); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"compose: closing the cycle for run %s: %w", runID, closeErr))
+		}
+	}()
+
+	var open []assurance.Exception
+	if readErr := deps.bundles.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		var scanErr error
+		open, scanErr = deps.exceptions(ctx, tx, runID)
+		return scanErr
+	}); readErr != nil {
+		return 0, fmt.Errorf("compose: reading the findings run %s observed: %w", runID, readErr)
+	}
+
+	// Grouped before anything is minted, because the task's subject line names
+	// how many findings it stands for — and that count is only known once the
+	// whole list has been walked. Minting on first sight would title every task
+	// "1 finding" and then bundle three more onto it.
+	//
+	// ONE SUBJECT'S FAILURE IS NOT THE NIGHT'S. The list is ordered by severity
+	// and then by money at stake, so aborting on the first error would suppress
+	// every task below it — a single deal whose owner has left the company would
+	// silently cost the whole workspace its remaining tasks. Each failure is
+	// carried and the walk continues.
+	var failed []error
+	for _, subject := range groupBySubject(open) {
+		wasMinted, subjectErr := bundleSubject(ctx, deps, cycle, subject)
+		if subjectErr != nil {
+			failed = append(failed, subjectErr)
+			continue
+		}
+		if wasMinted {
+			minted++
+		}
+	}
+	if len(failed) > 0 {
+		return minted, errors.Join(failed...)
+	}
+	return minted, nil
+}
+
+// bundleableFindings reads the open findings THIS RUN observed, minus the ones
+// somebody has deferred.
+//
+// Two narrowings the surface read (AssuranceExceptions) does not make, and both
+// are the difference between a task somebody should act on and one that will
+// annoy them:
+//
+//   - JOINED TO assurance_run_finding. Scan returns early when a source cannot
+//     be read, finishing the run INCOMPLETE with nothing observed — and the
+//     bundler still runs. Reading every open exception would then mint a full
+//     night of tasks for conditions nothing verified, including deals somebody
+//     fixed that morning. A run's own membership is what says "still true as of
+//     tonight", and RecordRunFindings writes it for exactly this.
+//   - DEFERRED FINDINGS EXCLUDED. Resolve with remind_later deliberately leaves
+//     the exception open, and CloseCleared carves the same rows out of its own
+//     sweep. Without the matching clause a rep who deferred a finding for two
+//     weeks is handed a fresh task about it every night for fourteen nights,
+//     which makes the deferral a no-op against this feature. The outcome is
+//     bound from assurance.OutcomeRemindLater rather than written in: the
+//     sibling clause in CloseCleared still said 'deferred' — the vocabulary the
+//     table shipped with, renamed by migration 1788416000 — and so had never
+//     matched a row.
+//
+// It reads assurance_exception directly rather than going through the deal join
+// AssuranceExceptions uses. The pass runs as PrincipalSystem over the whole
+// pipeline — that is what the scan is unscoped for — so a scope clause here
+// would narrow nothing while implying it narrows something. What keeps a finding
+// from a reader who may not see its deal is the surface read, which is
+// unchanged.
+func bundleableFindings(
+	ctx context.Context, tx pgx.Tx, runID ids.UUID,
+) ([]assurance.Exception, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT `+exceptionColumns+`
+		  FROM assurance_exception e
+		  JOIN assurance_run_finding f ON f.exception_id = e.id AND f.run_id = $1
+		 WHERE e.status = 'open'
+		   AND e.subject_kind = 'deal'
+		   AND NOT EXISTS (SELECT 1 FROM assurance_resolution r
+		                    WHERE r.exception_id = e.id
+		                      AND r.outcome = $2
+		                      AND r.remind_at > now())
+		 ORDER BY
+		   CASE e.severity WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
+		   e.affected_minor DESC NULLS LAST,
+		   e.last_seen_at DESC`, runID, assurance.OutcomeRemindLater)
+	if err != nil {
+		return nil, fmt.Errorf("compose: reading the findings to bundle: %w", err)
+	}
+	defer rows.Close()
+
+	// scanException, shared with AssuranceExceptions: one select list, one
+	// scanner. Two copies of a positional scan drift into reading a currency
+	// into a status, and nothing fails loudly when they do.
+	return pgx.CollectRows(rows, scanException)
+}
+
+// cycleScopeForRun names the cycle a run's findings bundle into.
+//
+// The run id, prefixed so the scope says what it is when an operator reads the
+// row. OpenCycle enforces one open cycle per scope, so this is also what makes
+// the pass safe to retry: the same run resolves to the same scope, and a second
+// attempt finds the cycle already open rather than minting a parallel one.
+func cycleScopeForRun(runID ids.UUID) string {
+	return "assurance_run:" + runID.String()
+}
+
+// bundleTaskSubject is what a rep reads on their list.
+//
+// The count and nothing else, because the findings themselves render on the
+// deal — three surfaces already show them, and a body listing them here would
+// go stale the moment one of them cleared. The deal is named by the task's LINK
+// rather than in this string: the list renders the record beside the subject, so
+// putting the name in both spells it twice, and the copy in the text is the one
+// nothing keeps current.
+func bundleTaskSubject(findings int) string {
+	if findings == 1 {
+		return "1 forecast input needs attention"
+	}
+	return fmt.Sprintf("%d forecast inputs need attention", findings)
+}
+
+// subjectFindings is one subject and every open finding about it, in the order
+// the scoped read returned them — severity first, then money at stake.
+type subjectFindings struct {
+	kind     string
+	id       ids.UUID
+	findings []assurance.Exception
+}
+
+// groupBySubject collects the findings per subject, KEEPING the read's order.
+//
+// A map alone would not: ranging one is randomised, so the task minted for a
+// subject would take a different finding's owner from night to night, and the
+// order findings bundle in would vary for no reason a reader could see. The
+// order matters because the first finding is the one whose owner becomes the
+// assignee, and the read already sorted by severity and amount — so the owner
+// carried is the one on the most material finding.
+func groupBySubject(open []assurance.Exception) []subjectFindings {
+	var out []subjectFindings
+	at := map[string]int{}
+	for _, exception := range open {
+		key := exception.SubjectKind + ":" + exception.SubjectID.String()
+		index, seen := at[key]
+		if !seen {
+			at[key] = len(out)
+			out = append(out, subjectFindings{kind: exception.SubjectKind, id: exception.SubjectID})
+			index = len(out) - 1
+		}
+		out[index].findings = append(out[index].findings, exception)
+	}
+	return out
+}
+
+// bundleSubject files one subject's findings under one task, minting it if the
+// cycle has none yet, and says whether it minted.
+func bundleSubject(
+	ctx context.Context, deps bundleDeps, cycle ids.UUID, subject subjectFindings,
+) (bool, error) {
+	task, found, err := deps.bundles.OpenTaskFor(ctx, cycle, subject.kind, subject.id)
+	if err != nil {
+		return false, fmt.Errorf("compose: asking for the subject's task: %w", err)
+	}
+
+	minted := false
+	if !found {
+		task, err = mintBundleTask(ctx, deps, subject)
+		if err != nil {
+			return false, err
+		}
+		minted = true
+	}
+
+	for _, exception := range subject.findings {
+		if _, err := deps.bundles.BundleException(ctx, assurance.BundleInput{
+			CycleID:        cycle,
+			ExceptionID:    exception.ID,
+			TaskActivityID: task,
+		}); err != nil {
+			return minted, fmt.Errorf("compose: bundling the finding: %w", err)
+		}
+	}
+	return minted, nil
+}
+
+// mintBundleTask writes the task a subject's findings hang from.
+//
+// The assignee is the exception's own owner — the deal's owner as the scan saw
+// it — and NOT the actor, which is the system principal this pass runs as.
+// activities.taskAssignee leaves the column NULL for a system principal that
+// names nobody, and an unassigned remediation task is one that reaches the
+// unassigned queue rather than the person whose deal it is about.
+func mintBundleTask(
+	ctx context.Context, deps bundleDeps, subject subjectFindings,
+) (ids.UUID, error) {
+	line := bundleTaskSubject(len(subject.findings))
+	in := activities.LogActivityInput{
+		Kind:    activityKindTask,
+		Subject: &line,
+		Source:  systemActor,
+		// system_remediation, and the whole feature depends on it.
+		//
+		// Every recency reading folds the newest activity into last_activity_at,
+		// and this task is filed AGAINST the deal it is about. Left as the
+		// default `human`, the system asking a question about a silent deal
+		// would make that deal look freshly touched — so buyer_silent would stop
+		// firing, CloseCleared would close its own finding as
+		// condition_cleared, and the engine would switch itself off one deal at
+		// a time with nothing failing. Migration 1788386600 carved this origin
+		// out of all four recency helpers FOR this writer, before the writer
+		// existed.
+		Origin: activities.OriginSystemRemediation,
+		Links: []activities.ActivityLinkInput{
+			{EntityType: subject.kind, EntityID: subject.id},
+		},
+	}
+	// The owner of the FIRST finding, which the read sorted to the front by
+	// severity and then by money at stake. A subject's findings can carry
+	// different owners only if the deal changed hands mid-pass; taking the most
+	// material one is the answer that does not depend on map order.
+	if owner := subject.findings[0].OwnerID; owner != nil {
+		assignee := ids.From[ids.UserKind](*owner)
+		in.AssigneeID = &assignee
+	}
+
+	task, err := writeBundleTask(ctx, deps, in)
+	if err == nil {
+		return task, nil
+	}
+
+	// A SEAT THAT CANNOT HOLD WORK COSTS THE TASK ITS ASSIGNEE, NOT ITS
+	// EXISTENCE.
+	//
+	// owner_id is a snapshot the scan took, and nothing revalidates it: a rep
+	// who has left the company still owns their open deals, and
+	// ensureAssigneeCanHoldWork refuses a seat that is deactivated, archived or
+	// an agent. Losing the task there would mean the deals of everyone who left
+	// silently stop being checked — the one population most likely to be
+	// carrying findings nobody is watching. Unassigned is where taskAssignee
+	// itself puts work nobody can be given, so this lands in the same queue.
+	if in.AssigneeID == nil || !unassignableSeat(err) {
+		return ids.UUID{}, fmt.Errorf("compose: minting the task: %w", err)
+	}
+	in.AssigneeID = nil
+	task, err = writeBundleTask(ctx, deps, in)
+	if err != nil {
+		return ids.UUID{}, fmt.Errorf("compose: minting the task unassigned: %w", err)
+	}
+	return task, nil
+}
+
+// unassignableSeat reports whether the refusal was about WHO the task was aimed
+// at rather than about the task.
+//
+// The two shapes ensureAssigneeCanHoldWork answers with, and only those: a seat
+// that is missing, inactive or archived is ErrNotFound — deliberately
+// indistinguishable from a guessed id — and an agent seat is AgentAssigneeError.
+// Anything else is a real failure and must not be retried into a task nobody is
+// asked to do.
+func unassignableSeat(err error) bool {
+	var agent *activities.AgentAssigneeError
+	return errors.Is(err, apperrors.ErrNotFound) || errors.As(err, &agent)
+}
+
+// writeBundleTask mints the activity in the bundling store's transaction.
+func writeBundleTask(
+	ctx context.Context, deps bundleDeps, in activities.LogActivityInput,
+) (ids.UUID, error) {
+	var task ids.UUID
+	err := deps.bundles.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		created, _, err := deps.activities.LogActivityTx(ctx, tx, in)
+		if err != nil {
+			return err
+		}
+		task = ids.UUID(created.Id)
+		return nil
+	})
+	return task, err
+}

--- a/backend/internal/compose/assurancebundle_integration_test.go
+++ b/backend/internal/compose/assurancebundle_integration_test.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The nightly pass turns its findings into work, against a real database.
+//
+// This suite exists because the store's own tests could not prove it. Every one
+// of them calls the bundling store directly and seeds its task rows with raw
+// SQL, so all of them stayed green while NOTHING in the tree called the store —
+// a running installation had zero cycles and zero task items, and no assertion
+// anywhere said so.
+//
+// So these drive the WORKER, through the same assureWorkspace River calls per
+// tenant, and read the result as a rep would: an ordinary task, linked to the
+// deal, on somebody's list.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/assurance"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// bundledTask is one task the pass minted, read back the way a list renders it.
+type bundledTask struct {
+	id       ids.UUID
+	subject  string
+	assignee *ids.UUID
+	dealID   *ids.UUID
+	findings int
+}
+
+// The pass hands a rep ONE task for a deal with several findings.
+//
+// This is the whole of #4004: a deal with four problems produced four findings,
+// and a rep clearing them cleared the same deal four times. One task, several
+// findings filed under it.
+func TestTheNightlyPassBundlesADealsFindingsIntoOneTask(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the nightly check: %v", err)
+	}
+
+	tasks := e.bundledTasks(t)
+	if len(tasks) != 1 {
+		t.Fatalf("the pass minted %d task(s), want exactly 1 for the one deal the "+
+			"fixture faults: %+v", len(tasks), tasks)
+	}
+	task := tasks[0]
+	if task.findings < 2 {
+		t.Fatalf("the task carries %d finding(s); this suite is about BUNDLING, so it "+
+			"needs a deal the scan faults more than once — the fixture's faulted deal "+
+			"no longer produces several findings and the assertion below cannot see a "+
+			"grouping bug it would have caught", task.findings)
+	}
+
+	// THE assertion this test turns on, because a count of tasks cannot see the
+	// grouping at all.
+	//
+	// OpenTaskFor re-finds the cycle's first task for a subject whatever the
+	// seam grouped by, so a version minting one task PER FINDING still ends with
+	// one task row and three items — the store absorbs the bug and every count
+	// agrees. What does not agree is the subject line: it takes the size of the
+	// group its task was minted for. Grouped by subject it says three; grouped
+	// by finding it says one, on a task that then collects two more.
+	want := bundleTaskSubject(task.findings)
+	if task.subject != want {
+		t.Errorf("the task carrying %d findings is titled %q, want %q — the subject "+
+			"line is written from the group the task was minted for, so a wrong "+
+			"count here means the findings were not grouped by their subject",
+			task.findings, task.subject, want)
+	}
+
+	if task.dealID == nil {
+		t.Error("the task is linked to no deal, so it renders on nobody's record and " +
+			"a rep opening it cannot see what it is about")
+	}
+}
+
+// The task goes to the DEAL'S OWNER, not to the system principal the pass runs
+// as.
+//
+// activities.taskAssignee leaves the column NULL for a system actor that names
+// nobody, and an unassigned remediation task waits in the unassigned queue that
+// nobody opens. A task about a rep's own deal that never reaches their list is
+// the failure this whole feature would quietly have.
+func TestTheBundledTaskIsAssignedToTheDealsOwner(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the nightly check: %v", err)
+	}
+
+	tasks := e.bundledTasks(t)
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 task, got %d", len(tasks))
+	}
+	if tasks[0].assignee == nil {
+		t.Fatal("the bundled task is unassigned — it waits in the unassigned queue " +
+			"rather than reaching the rep whose deal it is about")
+	}
+	if *tasks[0].assignee != e.Rep1 {
+		t.Errorf("the task is assigned to %s, want the deal's owner %s",
+			*tasks[0].assignee, e.Rep1)
+	}
+}
+
+// A SECOND pass mints a second task, and that is the design rather than a leak.
+//
+// The cycle is the run, so tomorrow night is a new cycle and a finding still
+// present is a fresh ask. What must NOT happen is two tasks from one pass, or
+// the second pass filing its findings onto the first night's task — the first is
+// the duplication the cycle exists to prevent, the second would leave a rep
+// looking at a task whose findings kept changing under them.
+func TestASecondPassOpensItsOwnCycleRatherThanReusingTheFirst(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the first check: %v", err)
+	}
+	first := e.bundledTasks(t)
+	if len(first) != 1 {
+		t.Fatalf("the first pass minted %d task(s), want 1", len(first))
+	}
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the second check: %v", err)
+	}
+	second := e.bundledTasks(t)
+	if len(second) != 2 {
+		t.Fatalf("after two passes there are %d task(s), want 2 — one per pass. "+
+			"Fewer means the second pass bundled onto the first night's task; more "+
+			"means a pass minted two tasks for one deal", len(second))
+	}
+	if second[0].id == second[1].id {
+		t.Error("both passes filed onto the same task id")
+	}
+}
+
+// Every cycle the pass opens is CLOSED when it finishes.
+//
+// A partial unique index admits one open cycle per scope, and a cycle left open
+// is one nothing closes later — the scope is a run id nobody revisits. The cost
+// is not this night: it is that assurance_cycle accumulates open rows for ever,
+// and any future move to a longer-lived scope finds them in the way.
+func TestThePassClosesTheCycleItOpened(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the nightly check: %v", err)
+	}
+
+	var open int
+	if err := e.Pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM assurance_cycle WHERE closed_at IS NULL`).Scan(&open); err != nil {
+		t.Fatalf("counting the open cycles: %v", err)
+	}
+	if open != 0 {
+		t.Errorf("%d cycle(s) left open after the pass finished — the next pass over "+
+			"the same scope is refused by the partial unique index", open)
+	}
+}
+
+// The task is filed as system_remediation, so asking about a silent deal does
+// not make it look freshly touched.
+//
+// This is the feedback loop migration 1788386600 was written to prevent, before
+// this writer existed: every recency reading folds the newest activity into
+// last_activity_at, and the four helpers carve out exactly this origin. Left as
+// the default `human`, buyer_silent would stop firing on a deal it had just
+// faulted, CloseCleared would close its own finding as condition_cleared, and
+// the engine would switch itself off one deal at a time with nothing failing.
+func TestTheBundledTaskIsNotBuyerActivity(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the nightly check: %v", err)
+	}
+
+	var origin string
+	if err := e.Pool.QueryRow(context.Background(),
+		`SELECT origin FROM activity WHERE kind = 'task'`).Scan(&origin); err != nil {
+		t.Fatalf("reading the task's origin: %v", err)
+	}
+	if origin != "system_remediation" {
+		t.Errorf("the bundled task's origin is %q, want system_remediation — as %q it "+
+			"counts as buyer activity, and the deal this task ASKS ABOUT reads as "+
+			"freshly touched by the asking", origin, origin)
+	}
+
+	// The consequence, asserted rather than inferred: the deal the task is
+	// filed against must not have had its recency moved by the filing.
+	var moved bool
+	if err := e.Pool.QueryRow(context.Background(), `
+		SELECT EXISTS (
+		    SELECT 1 FROM deal d
+		      JOIN activity_link l ON l.deal_id = d.id
+		      JOIN activity a ON a.id = l.activity_id AND a.kind = 'task'
+		     WHERE d.last_activity_at = a.occurred_at)`).Scan(&moved); err != nil {
+		t.Fatalf("reading the deal's recency: %v", err)
+	}
+	if moved {
+		t.Error("the deal's last_activity_at is the remediation task's own timestamp — " +
+			"the rule that noticed the silence will not fire again")
+	}
+}
+
+// A finding somebody DEFERRED is not asked again tonight.
+//
+// remind_later leaves the exception open on purpose, and CloseCleared carves the
+// same rows out of its own sweep. Without the matching clause here a rep who
+// deferred a finding for two weeks is handed a fresh task about it every night
+// for fourteen nights, which makes the deferral a no-op against this feature.
+func TestADeferredFindingIsNotBundledAgain(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	// One pass, so there are findings to defer.
+	if err := e.run(t); err != nil {
+		t.Fatalf("the first check: %v", err)
+	}
+	if got := len(e.bundledTasks(t)); got != 1 {
+		t.Fatalf("the first pass minted %d task(s), want 1", got)
+	}
+
+	// The rep answers "remind me later" on every one of them.
+	if _, err := e.Pool.Exec(context.Background(), `
+		INSERT INTO assurance_resolution (exception_id, actor_id, outcome, reason, remind_at, captured_by)
+		SELECT id, $1, 'remind_later', 'not this week', now() + interval '14 days', 'human:test'
+		  FROM assurance_exception WHERE status = 'open'`, e.Rep1); err != nil {
+		t.Fatalf("deferring the findings: %v", err)
+	}
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the second check: %v", err)
+	}
+	if got := len(e.bundledTasks(t)); got != 1 {
+		t.Errorf("after deferring every finding the second pass left %d task(s), want "+
+			"the original 1 — a deferred finding was bundled into a new task, so the "+
+			"rep is asked again tonight and every night until the deferral expires", got)
+	}
+}
+
+// The cycle closes even when the pass FAILS after opening it.
+//
+// The happy-path test above cannot see this: it is the failure paths that leave
+// a cycle behind, and a cycle left behind is left behind for ever — its scope is
+// a run id nobody revisits, and the partial unique index refuses a second open
+// cycle over the same scope. The failure is injected at the exception read
+// because that is the return the close was originally registered BELOW, so this
+// fails against that ordering and passes against the current one.
+func TestAFailedPassStillClosesItsCycle(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	run, err := e.runWithFindings(t, func(context.Context, pgx.Tx, ids.UUID) ([]assurance.Exception, error) {
+		return nil, errors.New("the findings could not be read")
+	})
+	if err == nil {
+		t.Fatal("a pass whose read failed reported success")
+	}
+	if run != 0 {
+		t.Errorf("minted %d task(s) from a failed read, want 0", run)
+	}
+
+	var open int
+	if err := e.Pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM assurance_cycle WHERE closed_at IS NULL`).Scan(&open); err != nil {
+		t.Fatalf("counting the open cycles: %v", err)
+	}
+	if open != 0 {
+		t.Errorf("%d cycle(s) left open after the pass failed — nothing closes them "+
+			"later, and the next pass over that scope is refused by the partial "+
+			"unique index", open)
+	}
+}
+
+// runWithFindings drives the bundler directly with a read of the caller's
+// choosing, which is how a failing read is reached: the worker's own read is
+// wired to the real one, and a failure there is not otherwise producible.
+func (e *assuranceJobEnv) runWithFindings(
+	t *testing.T,
+	read func(context.Context, pgx.Tx, ids.UUID) ([]assurance.Exception, error),
+) (int, error) {
+	t.Helper()
+	ctx := principal.WithCorrelationID(
+		principal.WithActor(
+			principal.WithWorkspaceID(context.Background(), e.WS),
+			principal.Principal{Type: principal.PrincipalSystem, ID: assuranceActor}),
+		ids.NewV7())
+	return bundleRunFindings(ctx, bundleDeps{
+		bundles:    assurance.NewStore(InstallationDB(e.Pool)),
+		activities: activities.NewStore(InstallationDB(e.Pool)),
+		exceptions: read,
+	}, ids.NewV7())
+}
+
+// bundledTasks reads back what the pass minted, joined to the finding count each
+// task stands for.
+//
+// It reads the ACTIVITY table rather than assurance_task_item alone, because the
+// question this suite asks is whether a rep gets a task — a bundle row pointing
+// at an activity that was never written would satisfy the module's own tests and
+// none of these.
+func (e *assuranceJobEnv) bundledTasks(t *testing.T) []bundledTask {
+	t.Helper()
+	// activity_link is polymorphic by COLUMN, not by a shared entity_id: a shape
+	// CHECK admits exactly one of person_id/organization_id/deal_id/lead_id/
+	// project_id per row. A finding's subject is a deal, so deal_id is the one
+	// this reads — and reading the wrong column would return NULL for every row
+	// rather than failing, which is why it is named rather than coalesced.
+	rows, err := e.Pool.Query(context.Background(), `
+		SELECT a.id, a.subject, a.assignee_id, l.deal_id, count(i.id)
+		  FROM assurance_task_item i
+		  JOIN activity a ON a.id = i.task_activity_id
+		  LEFT JOIN activity_link l ON l.activity_id = a.id
+		 WHERE a.kind = 'task'
+		 GROUP BY a.id, a.subject, a.assignee_id, l.deal_id
+		 ORDER BY a.created_at`)
+	if err != nil {
+		t.Fatalf("reading the bundled tasks: %v", err)
+	}
+	defer rows.Close()
+
+	var out []bundledTask
+	for rows.Next() {
+		var task bundledTask
+		var subject *string
+		if err := rows.Scan(&task.id, &subject, &task.assignee, &task.dealID, &task.findings); err != nil {
+			t.Fatalf("scanning a bundled task: %v", err)
+		}
+		if subject != nil {
+			task.subject = *subject
+		}
+		out = append(out, task)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("walking the bundled tasks: %v", err)
+	}
+	return out
+}

--- a/backend/internal/compose/assurancejob_integration_test.go
+++ b/backend/internal/compose/assurancejob_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/assurance"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
@@ -55,12 +56,32 @@ func setupAssuranceJob(t *testing.T) *assuranceJobEnv {
 		pipeline, open, e.Rep1, at.AddDate(0, 0, 3)); err != nil {
 		t.Fatalf("seeding the deal the check examines: %v", err)
 	}
+
+	// A deal the rules FAULT, and fault more than once: its expected close is in
+	// the past (close_past, high) and it is committed with no next step
+	// (no_next_step, low). The healthy deal above is what keeps the eligible
+	// count honest; this one is what gives the bundling suite something to
+	// bundle. Two findings on ONE deal is the shape #4004 is about — a rep
+	// clearing them should clear one task, not two.
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO deal (pipeline_id, stage_id, name, owner_id, status, source, captured_by,
+		                  amount_minor, currency, expected_close_date, forecast_category)
+		VALUES ($1, $2, 'Assurance Faulted', $3, 'open', 'manual', 'test', 3100000, 'EUR', $4, 'commit')`,
+		pipeline, open, e.Rep1, at.AddDate(0, 0, -7)); err != nil {
+		t.Fatalf("seeding the deal the check faults: %v", err)
+	}
+
 	return &assuranceJobEnv{
 		Env: e,
 		worker: &assuranceSweepWorker{
 			pool: e.Pool,
 			now:  func() time.Time { return at },
 			log:  slog.New(slog.DiscardHandler),
+			// The REAL activities store, not a double. The task a finding is
+			// bundled onto has to be one the rest of the product renders, so a
+			// stub here would prove the seam calls something rather than that a
+			// rep is handed a task.
+			activities: activities.NewStore(InstallationDB(e.Pool)),
 		},
 		at: at,
 	}

--- a/backend/internal/compose/assurancelist.go
+++ b/backend/internal/compose/assurancelist.go
@@ -55,9 +55,7 @@ func AssuranceExceptions(ctx context.Context, tx pgx.Tx) ([]assurance.Exception,
 	// visibility decision having been made about it. A LEFT join would let
 	// exactly the rows nobody can gate through.
 	sql := fmt.Sprintf(`
-		SELECT e.id, e.type, e.subject_kind, e.subject_id, e.severity,
-		       e.affected_minor, e.currency, e.owner_id, e.status,
-		       e.claim, e.observed, e.first_seen_at, e.last_seen_at
+		SELECT `+exceptionColumns+`
 		FROM assurance_exception e
 		JOIN deal d ON d.id = e.subject_id
 		WHERE e.status = 'open'
@@ -78,25 +76,40 @@ func AssuranceExceptions(ctx context.Context, tx pgx.Tx) ([]assurance.Exception,
 	}
 	defer rows.Close()
 
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (assurance.Exception, error) {
-		var out assurance.Exception
-		var id, subjectID ids.UUID
-		var owner *ids.UUID
-		var currency *string
-		var firstSeen, lastSeen time.Time
-		err := row.Scan(&id, &out.Type, &out.SubjectKind, &subjectID, &out.Severity,
-			&out.AffectedMinor, &currency, &owner, &out.Status,
-			&out.Claim, &out.Observed, &firstSeen, &lastSeen)
-		out.ID = id
-		out.SubjectID = subjectID
-		out.FirstSeenAt = firstSeen
-		out.LastSeenAt = lastSeen
-		if currency != nil {
-			out.Currency = *currency
-		}
-		if owner != nil {
-			out.OwnerID = owner
-		}
-		return out, err
-	})
+	return pgx.CollectRows(rows, scanException)
+}
+
+// exceptionColumns is the select list every read of a finding shares, aliased
+// `e`. Two readers exist — this one and bundleableFindings, which asks a
+// different question of the same rows — and the column ORDER is what scanException
+// below binds to positionally, so the two have to move together or the scan
+// silently reads a currency into a status.
+const exceptionColumns = `e.id, e.type, e.subject_kind, e.subject_id, e.severity,
+	       e.affected_minor, e.currency, e.owner_id, e.status,
+	       e.claim, e.observed, e.first_seen_at, e.last_seen_at`
+
+// scanException reads one row of exceptionColumns.
+//
+// The nullable columns are read through pointers and folded in afterwards
+// because assurance.Exception carries a plain string for the currency: SQL NULL
+// there is "no money was named", which is a different fact from the empty
+// string only in that nothing may print it as a currency.
+func scanException(row pgx.CollectableRow) (assurance.Exception, error) {
+	var out assurance.Exception
+	var id, subjectID ids.UUID
+	var owner *ids.UUID
+	var currency *string
+	var firstSeen, lastSeen time.Time
+	err := row.Scan(&id, &out.Type, &out.SubjectKind, &subjectID, &out.Severity,
+		&out.AffectedMinor, &currency, &owner, &out.Status,
+		&out.Claim, &out.Observed, &firstSeen, &lastSeen)
+	out.ID = id
+	out.SubjectID = subjectID
+	out.FirstSeenAt = firstSeen
+	out.LastSeenAt = lastSeen
+	if currency != nil {
+		out.Currency = *currency
+	}
+	out.OwnerID = owner
+	return out, err
 }

--- a/backend/internal/compose/jobs_assurance.go
+++ b/backend/internal/compose/jobs_assurance.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/assurance"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -53,6 +54,11 @@ type assuranceSweepWorker struct {
 	pool *pgxpool.Pool
 	now  func() time.Time
 	log  *slog.Logger
+	// activities is the door the bundled task is minted through — the same one
+	// REST CreateTask and MCP create_task use. It is held here rather than built
+	// per pass because a store is a handle, and the seam that needs it takes it
+	// as a dependency so a test can hand in one over its own pool.
+	activities *activities.Store
 }
 
 func (w *assuranceSweepWorker) Work(ctx context.Context, _ *river.Job[AssuranceSweepArgs]) error {
@@ -88,17 +94,32 @@ func (w *assuranceSweepWorker) assureWorkspace(ctx context.Context, workspace id
 // that had stopped running entirely would otherwise be visible only as a page
 // that stopped changing.
 func (w *assuranceSweepWorker) check(ctx context.Context, ws ids.UUID) error {
-	scanner := assurance.NewScanner(
-		assurance.NewStore(InstallationDB(w.pool)),
-		AssuranceSubjects, AssuranceCoverage, assurance.DefaultConfig(),
-	)
+	store := assurance.NewStore(InstallationDB(w.pool))
+	scanner := assurance.NewScanner(store, AssuranceSubjects, AssuranceCoverage, assurance.DefaultConfig())
 	result, err := scanner.Scan(ctx, w.now())
 	if err != nil {
 		return err
 	}
+
+	// Bundling runs AFTER the scan has committed, and its failure does NOT fail
+	// the job. The findings are recorded and the three surfaces render them
+	// either way; returning an error here would have River retry a pass whose
+	// real output already landed, re-scanning and re-minting on every attempt.
+	// A night that scanned but did not bundle is a night without tasks, which
+	// the next pass mints again — the loss is bounded, and the log says so.
+	minted, bundleErr := bundleRunFindings(ctx, bundleDeps{
+		bundles:    store,
+		activities: w.activities,
+		exceptions: bundleableFindings,
+	}, result.RunID)
+	if bundleErr != nil {
+		w.log.ErrorContext(ctx, "the findings were recorded but not bundled into tasks",
+			"workspace_id", ws, "run_id", result.RunID, "error", bundleErr)
+	}
+
 	w.log.InfoContext(ctx, "the forecast's inputs were checked",
 		"workspace_id", ws, "run_id", result.RunID,
 		"eligible_deals", result.EligibleDeals, "findings", result.Findings, "cleared", result.Cleared,
-		"readiness", result.Readiness, "status", result.Status)
+		"readiness", result.Readiness, "status", result.Status, "tasks_minted", minted)
 	return nil
 }

--- a/backend/internal/compose/jobs_databasesweeps.go
+++ b/backend/internal/compose/jobs_databasesweeps.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/identity"
 )
 
@@ -39,6 +40,7 @@ func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Lo
 	addDeclaredWorker[FollowUpReconcileArgs](reg, &followUpReconcileWorker{pool: pool, reconciler: NewFollowUpReconciler(pool, log)})
 	addDeclaredWorker[AssuranceSweepArgs](reg, &assuranceSweepWorker{
 		pool: pool, now: func() time.Time { return time.Now().UTC() }, log: log,
+		activities: activities.NewStore(InstallationDB(pool)),
 	})
 	addDeclaredWorker[ForecastSnapshotSweepArgs](reg, &forecastSnapshotSweepWorker{
 		pool: pool, now: func() time.Time { return time.Now().UTC() }, log: log,

--- a/backend/internal/modules/assurance/bundle.go
+++ b/backend/internal/modules/assurance/bundle.go
@@ -28,15 +28,16 @@ package assurance
 // was that a team sees each other's — which is what makes "what is still open in
 // this cycle" answerable at all rather than one seat at a time.
 //
-// NOTHING CALLS THIS YET. The nightly sweep in compose/jobs_assurance.go still
-// only scans and logs; it opens no cycle and bundles nothing, so no cycle and
-// no task item exists in a running installation. The orchestration is a compose
-// seam of its own — read the open exceptions, group them by subject, mint one
-// task per subject through the activities door, bundle each finding — carrying
-// its own questions about who a task is assigned to and what it says. Tracked
-// in margince/margince#4593 rather than smuggled in here, and until it lands
-// the tests are the only caller. Stated plainly so a reader does not conclude
-// from green tests that the feature runs.
+// THE CALLER IS compose/assurancebundle.go, driven by the nightly sweep: it
+// reads the open exceptions, groups them by subject, mints one task per subject
+// through the activities door and bundles each finding under it. A cycle's scope
+// is the scan's own run id, so one night is one cycle.
+//
+// The tests below call this store directly and seed their task rows with raw
+// SQL, which is what a store's own suite should do — and it means none of them
+// would fail if that caller were deleted. The suite that would is
+// compose/assurancebundle_integration_test.go, which drives the worker and reads
+// the task back the way a rep's list renders it.
 
 import (
 	"context"

--- a/backend/internal/modules/assurance/scan_integration_test.go
+++ b/backend/internal/modules/assurance/scan_integration_test.go
@@ -305,6 +305,75 @@ func TestAFixedRecordClearsItsFindingOnTheNextScan(t *testing.T) {
 	}
 }
 
+// A finding somebody DEFERRED is not swept away when its condition clears.
+//
+// "Remind me later" is an answer about WHEN, not about whether, so the finding
+// stays open and comes back at remind_at. CloseCleared carves those rows out —
+// and its clause compared outcome against 'deferred', the vocabulary this table
+// shipped with, renamed to remind_later by migration 1788416000 before any row
+// existed. So the carve-out had never matched: a deferred finding cleared like
+// any other the first night its condition went away, and the reminder never
+// came. Nothing covered CloseCleared at all, which is how a dead literal
+// survived a rename.
+func TestADeferredFindingSurvivesItsConditionClearing(t *testing.T) {
+	t.Parallel()
+	e := setupScan(t)
+	ctx := e.as()
+
+	past := time.Now().UTC().AddDate(0, 0, -10)
+	sick := Subject{
+		DealID: ids.NewV7().String(), Owner: e.rep.String(),
+		ExpectedClose: &past, Category: "commit", HasNextStep: true, HasEconomicBuyer: true,
+	}
+	subjects := []Subject{sick}
+	scanner := NewScanner(e.store,
+		func(context.Context, pgx.Tx) ([]Subject, error) { return subjects, nil },
+		checkedCoverage, DefaultConfig())
+
+	if _, err := scanner.Scan(ctx, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The deferral goes through Resolve, the real door. A hand-written
+	// assurance_resolution row could carry a spelling the writer never
+	// produces — and a disagreement between writer and reader is exactly the
+	// defect this test exists for, so seeding one by hand would hide it.
+	var exception ids.UUID
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT id FROM assurance_exception WHERE subject_id = $1 AND type = $2`,
+			sick.DealID, TypeClosePast).Scan(&exception)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	remind := time.Now().UTC().AddDate(0, 0, 14)
+	if err := e.store.Resolve(ctx, exception, Resolution{
+		Outcome: OutcomeRemindLater, Reason: "not this week", RemindAt: &remind,
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("deferring the finding: %v", err)
+	}
+
+	// Tonight the condition goes away on its own.
+	future := time.Now().UTC().AddDate(0, 0, 20)
+	subjects[0].ExpectedClose = &future
+	if _, err := scanner.Scan(ctx, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	var status string
+	if err := e.store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status FROM assurance_exception WHERE id = $1`, exception).Scan(&status)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if status != "open" {
+		t.Errorf("the deferred finding is %q, want %q — a rep who asked to be reminded "+
+			"in two weeks is not reminded at all once the sweep closes it",
+			status, "open")
+	}
+}
+
 // A finding whose rule needs a source that went unread tonight stays open:
 // on such a night "not observed" means "not looked", not "not there".
 func TestAFindingWhoseSourceWentUnreadStaysOpen(t *testing.T) {

--- a/backend/internal/modules/assurance/store.go
+++ b/backend/internal/modules/assurance/store.go
@@ -235,6 +235,13 @@ func (s *Store) CloseCleared(ctx context.Context, tx pgx.Tx, types []string, sub
 		// exactly the night everything should clear.
 		seen = []string{}
 	}
+	// The deferral carve-out compares against OutcomeRemindLater, spelled from
+	// the constant rather than written into the SQL. It read 'deferred' until
+	// this fix — the vocabulary this table shipped with, renamed by migration
+	// 1788416000 before any row existed — so the clause matched nothing and a
+	// deferred finding cleared like any other. A literal here agrees with the
+	// writer only until somebody renames an outcome, which is exactly what
+	// happened.
 	tag, err := tx.Exec(ctx, `
 		UPDATE assurance_exception
 		SET status = $1, updated_at = now()
@@ -245,9 +252,9 @@ func (s *Store) CloseCleared(ctx context.Context, tx pgx.Tx, types []string, sub
 		  AND NOT (logical_key = ANY($4))
 		  AND NOT EXISTS (SELECT 1 FROM assurance_resolution r
 		                   WHERE r.exception_id = assurance_exception.id
-		                     AND r.outcome = 'deferred'
+		                     AND r.outcome = $5
 		                     AND r.remind_at > now())`,
-		ExceptionConditionCleared, subjects, types, seen)
+		ExceptionConditionCleared, subjects, types, seen, OutcomeRemindLater)
 	if err != nil {
 		return 0, fmt.Errorf("assurance: closing cleared findings: %w", err)
 	}


### PR DESCRIPTION
feat(assurance): the nightly check hands a rep one task per deal, not one per finding

The bundling store landed in #4597 and nothing called it, so a running
installation had zero cycles and zero task items: the nightly pass recorded
exceptions exactly as before and nobody was handed anything to act on. This
is the seam. It lives in compose because it spans two modules that may not
import each other — assurance owns the cycle, activities owns the task.

A deal with four findings becomes ONE task, assigned to the deal's owner,
linked to the deal, on their ordinary list. The cycle's scope is the scan's
own run id, so a night is a cycle: a finding still present tomorrow is
tomorrow's ask, and a task a rep already completed is left completed.

Four defects the security review found, all in code this PR wrote or touched:

THE TASK IS NOT BUYER ACTIVITY. The mint left Origin empty, which
logActivityInTx defaults to `human`, so filing a question about a silent deal
folded into that deal's last_activity_at — buyer_silent would stop firing on
the deal it had just faulted, CloseCleared would close its own finding as
condition_cleared, and the engine would switch itself off one deal at a time
with nothing failing. Migration 1788386600 carved system_remediation out of
all four recency helpers FOR this writer, before the writer existed; the mint
now sets it. TestTheBundledTaskIsNotBuyerActivity asserts the origin and the
consequence.

A DEFERRED FINDING IS NOT RE-ASKED. The read took every open exception, so a
rep who answered "remind me later" got a fresh task nightly until the
deferral expired. The read is now joined to assurance_run_finding — tonight's
observations, not every open row, which also stops an INCOMPLETE run minting
a full night of tasks for conditions nothing verified — and carries the
deferral carve-out.

CloseCleared HAD THAT CARVE-OUT AND IT NEVER WORKED. It compared outcome
against 'deferred', the vocabulary the table shipped with, renamed to
remind_later by migration 1788416000 before any row existed. Nothing covered
CloseCleared, so the dead literal survived the rename: every deferred finding
was swept to condition_cleared the first night its condition cleared, and the
reminder never came. Both sites now bind the constant.
TestADeferredFindingSurvivesItsConditionClearing fails against the old
literal.

ONE SUBJECT'S FAILURE IS NOT THE NIGHT'S. The loop returned on the first
error and skipped CloseCycle, contradicting the comment above it: the cycle
stayed open for ever, and since the scope is a run id nobody revisits, the
partial unique index would refuse every later cycle over it. The close is now
deferred, and a subject that fails is carried rather than aborting the walk —
the list is ordered by severity and money, so aborting suppressed every task
below it. An owner who has left the company refuses assignment
(ensureAssigneeCanHoldWork), which now costs the task its assignee, not its
existence.

The store's header said nothing called it; it now names its caller and says
which suite would fail if that caller were deleted — its own tests would not,
because they seed task rows with raw SQL.

Closes #4593.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The nightly assurance check now bundles each deal's findings into one task for the deal's owner, instead of minting nothing to act on. The bundling store had no caller, so a running installation produced zero tasks.

Bug Fixes:
- Tasks are filed as `system_remediation` so asking about a silent deal no longer counts as buyer activity and silences the rules that flagged it.
- The read is joined to the run's own findings and excludes deferred ones, so "remind me later" is not re-asked nightly and an incomplete run mints no tasks.
- `CloseCleared`'s deferral carve-out compared against a literal that never matched after the outcome was renamed; deferred findings were cleared when their condition improved. Both sites now bind the constant.
- The cycle always closes, and one failing subject no longer aborts the walk and suppresses the tasks below it.

Closes #4593.

<sup>Written for commit bb26b8ee410c640bf4ac0f31f5b1de2212f30cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly assurance scans now consolidate open findings into one remediation task per deal.
  * Tasks include the deal’s findings, are assigned to the deal owner when possible, and identify their system-generated origin.
  * Repeated scans create separate processing cycles and avoid duplicating deferred findings.

* **Bug Fixes**
  * Deferred findings remain open when their underlying condition clears, preserving their reminder status.
  * System-generated remediation tasks do not count as buyer activity or update deal activity timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->