### PR TITLE
The boot names a token file only when there is one

### DIFF
--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -134,12 +134,7 @@ const setupTokenFile = "config/margince-setup-token" // #nosec G101 -- a path, n
 func announceSetupToken(ctx context.Context, svc *identity.Service, log *slog.Logger) error {
 	raw, err := svc.MintSetupToken(ctx)
 	if errors.Is(err, identity.ErrSetupTokenExists) {
-		abs, pathErr := filepath.Abs(setupTokenFile)
-		if pathErr != nil {
-			abs = setupTokenFile
-		}
-		log.Warn("installation is unprovisioned and a setup token is already outstanding — the one issued earlier is still the credential; if it was lost, replace it with `margince-migrate setup-token`",
-			"token_file", abs)
+		announceOutstandingToken(log)
 		return nil
 	}
 	if err != nil {
@@ -161,6 +156,39 @@ func announceSetupToken(ctx context.Context, svc *identity.Service, log *slog.Lo
 	log.Warn("installation is unprovisioned: claim it with the one-time setup token in the token file",
 		"token_file", path)
 	return nil
+}
+
+// announceOutstandingToken reports a token minted by an earlier boot, and NAMES
+// THE FILE ONLY IF THE FILE IS THERE.
+//
+// The earlier boot may have failed to write it — a read-only config directory,
+// or a path already taken, which O_EXCL refuses on principle — and announced the
+// token in its own log instead. That is a sanctioned fallback, and it leaves
+// this boot in a position where the path is computable and the file is not
+// there. Naming it anyway sends an operator to a path that does not exist, with
+// nothing saying the credential went somewhere else; the file became the channel
+// a successful boot points at, so the name carries weight it did not use to.
+//
+// A stat that fails for any OTHER reason is treated the same way. The point is
+// not whether the file is absent, it is whether this process can VOUCH for it —
+// a path named on the strength of a permission error is the same false promise
+// as one named on the strength of nothing.
+//
+// Either way the token itself is not reprinted: it is not in reach here, and the
+// replacement command is the honest end of the trail once both channels are
+// gone.
+func announceOutstandingToken(log *slog.Logger) {
+	abs, pathErr := filepath.Abs(setupTokenFile)
+	if pathErr != nil {
+		abs = setupTokenFile
+	}
+	if _, statErr := os.Stat(abs); statErr != nil {
+		log.Warn("installation is unprovisioned and a setup token is already outstanding, but no readable token file is here — an earlier boot announced it in its own log instead, or the file has since gone. Issue a replacement with `margince-migrate setup-token`",
+			"looked_in", abs, "stat_error", statErr)
+		return
+	}
+	log.Warn("installation is unprovisioned and a setup token is already outstanding — the one issued earlier is still the credential; if it was lost, replace it with `margince-migrate setup-token`",
+		"token_file", abs)
 }
 
 // writeSetupTokenFile writes the plaintext 0600 and returns the path it used,

--- a/backend/internal/compose/setuptoken_test.go
+++ b/backend/internal/compose/setuptoken_test.go
@@ -4,6 +4,7 @@
 package compose
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -285,4 +286,63 @@ func TestWriteSetupTokenFileRefusesADirectoryPathItCannotOwn(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A boot that finds a token already outstanding names the file only when the
+// file is there.
+//
+// The sequence this exists for: the first boot minted the token, the write
+// failed — a read-only config directory, or a path already taken — and the token
+// went to that boot's log, which is the sanctioned fallback. The process
+// restarts. The second boot can compute the path and the file is not there, so
+// naming it sends an operator somewhere they will find nothing, with nothing
+// saying the credential was announced elsewhere.
+func TestAnOutstandingTokenNamesNoFileWhenThereIsNone(t *testing.T) {
+	t.Chdir(t.TempDir())
+	log, lines := recordingLogger()
+
+	announceOutstandingToken(log)
+
+	entry := lines.String()
+	if strings.Contains(entry, "token_file") {
+		t.Errorf("the log names a token_file that is not there:\n\t%s", entry)
+	}
+	// It still says WHERE it looked — an operator debugging a missing file needs
+	// the path — but under a key that reports a search rather than a location.
+	if !strings.Contains(entry, "looked_in") {
+		t.Errorf("the log does not say where it looked:\n\t%s", entry)
+	}
+	if !strings.Contains(entry, "margince-migrate setup-token") {
+		t.Errorf("the log does not point at the replacement, which is the only "+
+			"honest end of the trail once both channels are gone:\n\t%s", entry)
+	}
+}
+
+// And it does name the file when the file IS there, which is the ordinary case
+// and the whole reason the branch says anything at all.
+func TestAnOutstandingTokenNamesTheFileWhenItIsThere(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(setupTokenFile), 0o700); err != nil {
+		t.Fatalf("prepare the config directory: %v", err)
+	}
+	if err := os.WriteFile(setupTokenFile, []byte("an earlier boot's token"), 0o600); err != nil {
+		t.Fatalf("write the token file: %v", err)
+	}
+	log, lines := recordingLogger()
+
+	announceOutstandingToken(log)
+
+	entry := lines.String()
+	if !strings.Contains(entry, "token_file") {
+		t.Errorf("the log does not name the token file that is right there:\n\t%s", entry)
+	}
+	if strings.Contains(entry, "looked_in") {
+		t.Errorf("the log reports a search for a file it found:\n\t%s", entry)
+	}
+}
+
+// recordingLogger is a logger whose output the caller can read back.
+func recordingLogger() (*slog.Logger, *strings.Builder) {
+	var lines strings.Builder
+	return slog.New(slog.NewTextHandler(&lines, &slog.HandlerOptions{Level: slog.LevelWarn})), &lines
 }


### PR DESCRIPTION
Closes #1993.

## The sequence

1. First boot mints the setup token. **The write fails** — a read-only config directory, or a path already taken, which `O_EXCL` refuses on principle — so the token goes to that boot's log, which is the sanctioned fallback.
2. The process restarts. The second boot finds a token already outstanding, computes the path, and names it.

**The file is not there.** An operator following that log lands on nothing, with no line saying the credential was announced somewhere else.

#1990 is what makes this matter rather than what caused it: the file became the channel a successful boot points at, so the name carries weight it did not use to.

## Stat before naming

| the file | what the log says |
|---|---|
| present | what it said before — `token_file`, and the outstanding token is still the credential |
| absent | says so, says where it looked under `looked_in`, and points at `margince-migrate setup-token` |

`looked_in` rather than `token_file` on that arm because an operator debugging a missing file still needs the path — but under a key that reports a **search**, not a location.

**A stat failing for any other reason takes the same arm**, and that is the part worth stating: the question is not whether the file is absent, it is whether this process can *vouch* for it. A path named on the strength of a permission error is the same false promise as one named on the strength of nothing.

The token is not reprinted either way — it is not in reach here, and the replacement command is what an operator who has lost both copies actually needs.

## Verification

Two unit tests, running everywhere the unit lane runs. **Mutation:** skip the stat and the absent case names a `token_file` again, with nothing saying where the credential went.

`make check-backend` exit 0; `internal/compose` integration suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved setup-token startup messages to avoid exposing token values.
  - Token file locations are shown only when the file can be confirmed to exist.
  - When the file cannot be found, the message provides the recommended `margince-migrate setup-token` command instead of an invalid or misleading path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->