### PR TITLE
The recency number and the record explaining it are one snapshot

### DIFF
--- a/backend/internal/modules/deals/health.go
+++ b/backend/internal/modules/deals/health.go
@@ -281,17 +281,39 @@ func (s *Store) DealHealth(ctx context.Context, dealID ids.DealID, now time.Time
 // transaction: the deal row, its stage-entry instant, the won-deal
 // stage-duration median, and the per-factor evidence rows.
 func healthInputs(ctx context.Context, tx pgx.Tx, now time.Time, in *dealHealthInputs) error {
+	// The deal's own fields AND the record behind last_activity_at, in ONE
+	// statement.
+	//
+	// Read apart, they are two snapshots: this transaction is READ COMMITTED,
+	// so an activity committed between the two statements is counted by the
+	// later one and not by the earlier. The evidence would then name a row the
+	// timestamp does not, and the card would cite a message as the reason for a
+	// staleness the message disproves — a contradiction a reader can see and
+	// nothing can explain.
+	//
+	// The subquery's filters must match last_activity_of_deal exactly, or the
+	// evidence points at a row the timestamp does not count even when nothing
+	// raced.
 	var pipelineID ids.PipelineID
+	var recent *ids.UUID
 	err := tx.QueryRow(ctx, `
-		SELECT status, created_at, last_activity_at, wait_until, stage_id, pipeline_id
-		FROM deal WHERE id = $1 AND archived_at IS NULL`, in.dealID).
-		Scan(&in.status, &in.createdAt, &in.lastActivityAt, &in.waitUntil, &in.stageID, &pipelineID)
+		SELECT d.status, d.created_at, d.last_activity_at, d.wait_until, d.stage_id, d.pipeline_id,
+		       (SELECT a.id FROM activity a
+		          JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = d.id
+		         WHERE a.archived_at IS NULL
+		           `+auth.OriginIsEngagement("a")+auth.AudienceWorkspaceOnly("a")+`
+		         ORDER BY a.occurred_at DESC, a.id DESC
+		         LIMIT 1)
+		FROM deal d WHERE d.id = $1 AND d.archived_at IS NULL`, in.dealID).
+		Scan(&in.status, &in.createdAt, &in.lastActivityAt, &in.waitUntil, &in.stageID, &pipelineID, &recent)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return apperrors.ErrNotFound
 	}
 	if err != nil {
 		return err
 	}
+	// No activity ever: recency is 0.0 with no record to point at.
+	in.mostRecentActivityID = recent
 
 	// Days in current stage: the latest entry INTO this stage; a deal
 	// that never moved has sat there since creation.
@@ -369,27 +391,6 @@ func healthActivityEvidence(ctx context.Context, tx pgx.Tx, now time.Time, in *d
 		return err
 	}
 	in.engagedStakeholderIDs = engaged
-
-	// Recency evidence: the freshest live activity on the deal — the
-	// record behind deal.last_activity_at. Its filters must match
-	// last_activity_of_deal exactly, or this points at a row the timestamp
-	// does not count and the evidence contradicts the number it explains.
-	var recent ids.UUID
-	err = tx.QueryRow(ctx, `
-		SELECT a.id FROM activity a
-		JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
-		WHERE a.archived_at IS NULL
-		  `+auth.OriginIsEngagement("a")+auth.AudienceWorkspaceOnly("a")+`
-		ORDER BY a.occurred_at DESC, a.id DESC
-		LIMIT 1`, in.dealID).Scan(&recent)
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		// No activity ever: recency is 0.0 with no record to point at.
-	case err != nil:
-		return err
-	default:
-		in.mostRecentActivityID = &recent
-	}
 
 	// Commitments evidence: the open overdue tasks on the deal. No audience
 	// clause, and that is the difference rather than an omission: a task is

--- a/backend/internal/modules/deals/healthevidencesnapshot_test.go
+++ b/backend/internal/modules/deals/healthevidencesnapshot_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The recency number and the record that explains it come from ONE snapshot.
+//
+// The composite runs at READ COMMITTED, where every statement takes its own
+// snapshot. Read apart, `deal.last_activity_at` and the freshest activity on
+// the deal are two answers about two moments: an activity committed between
+// them is counted by the later statement and not by the earlier, so the card
+// cites a message as the reason for a staleness that message disproves. A
+// reader can see the contradiction and nothing in the product can explain it.
+//
+// Held STRUCTURALLY rather than by a race, and that is the honest instrument
+// here: once the two values come from one statement the defect is impossible by
+// construction, so there is no interleaving left for a behavioural test to
+// arrange — a sequential one passes just as well against the two-statement
+// version it is meant to refuse.
+//
+// What this reads is the SQL the file sends, through the same reader every
+// census uses, so a statement assembled with `+` is judged whole rather than in
+// fragments.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+func TestTheRecencyNumberAndItsEvidenceAreReadTogether(t *testing.T) {
+	t.Parallel()
+
+	const source = "health.go"
+	text, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("reading %s: %v", source, err)
+	}
+
+	var carriesTheTimestamp []string
+	for _, statement := range gatekit.SQLStatementsIn(t, source, string(text)) {
+		if strings.Contains(statement, "last_activity_at") {
+			carriesTheTimestamp = append(carriesTheTimestamp, statement)
+		}
+	}
+	if len(carriesTheTimestamp) == 0 {
+		t.Fatal("no statement in health.go reads last_activity_at — the composite no longer " +
+			"reads the timestamp this test is about, so it is checking nothing")
+	}
+	for _, statement := range carriesTheTimestamp {
+		// The evidence is the freshest activity ON THE DEAL, which is what the
+		// link join says. A statement reading the timestamp without it is
+		// reading half the answer and leaving the other half to a second
+		// snapshot.
+		if !strings.Contains(statement, "activity_link") {
+			t.Errorf("a statement reads last_activity_at without the activity it names:\n%s\n\n"+
+				"\tRead them together. Apart, they are two snapshots under READ COMMITTED, and an "+
+				"activity committed between them makes the evidence contradict the number it explains.",
+				strings.TrimSpace(statement))
+		}
+	}
+}


### PR DESCRIPTION
Addresses #2303.

## The half that is still a defect

> the evidence activity id is read in a second statement after `deal.last_activity_at`, so an activity committed between the two can pair a newer id with an older timestamp.

Still true, and worth naming precisely: the composite runs at READ COMMITTED (`pgx.TxOptions{}`), where every statement takes its own snapshot. An activity committed between the two is counted by the later statement and not by the earlier — so the card cites a message as the reason for a staleness **that message disproves**. A reader can see the contradiction and nothing in the product can explain it.

One statement answers both now, through a correlated subquery carrying the same filters, so the two cannot disagree by construction.

**The test is structural, and that is the honest instrument here.** Once the values come from one statement there is no interleaving left to arrange: a sequential integration test passes just as well against the two-statement version it is meant to refuse. So `TestTheRecencyNumberAndItsEvidenceAreReadTogether` reads the SQL the file sends — through `gatekit.SQLStatementsIn`, so a statement assembled with `+` is judged whole — and requires the one carrying `last_activity_at` to carry the activity it names. Mutation-checked: severing the link join fails it.

## The half the ticket names first, which has been overtaken

The i18n half describes three surfaces, and **#2430 deleted all three**:

- `GET /deals/{id}/health` — no longer in `crm.yaml`
- `GET /deals/{id}/next-best-action` — likewise
- `backend/internal/modules/deals/handlers_health.go`, `frontend/src/screens/dealhealth.tsx` — both deleted in `0103721fb`

What survives is `deals.HealthReasons`, whose only caller is now the deal status card. So the defect has changed shape rather than gone: the card's own code says it is *"written in the installation's base language … a status card is filed on the deal and read by anyone who opens it"*, and the deterministic sentences inside it are English regardless. A German installation gets a card whose model-written lines are German and whose blocker lines are not.

**I have not fixed that here, deliberately.** It is not four sentences: `dealstatus` composes roughly twenty, plus the day phrases and the role words, and #2493 says exactly why doing one and leaving the rest is worse than the uniform English floor — *"a tree where some explanations follow the base language and some do not, with nothing saying which is which"*. Doing all twenty means hand-writing German and Vietnamese product copy without a reviewer who reads them, which is a translation decision rather than an engineering one.

What I have done is put the finding on #2493, which owns the general question: the deal status card is the strongest case for it, because unlike the other ~34 sites it **declares** a language and then contradicts itself. I have left #2303 open for that half.

## Checks

`make check-backend` green (exit 0). `make test-it DIR=backend/internal/modules/deals` green.