### PR TITLE
going_cold measures against the clock that stamped the touch

### DIFF
--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -233,6 +233,13 @@ func TestGoingColdFiresOnTheReportingWindowAndCarriesTheDayCount(t *testing.T) {
 	// Age the last touch past REPORT-PARAM-2's window. Written through the
 	// owner connection because no API sets this column — it is maintained by
 	// the capture path, and the point of the test is the read, not the write.
+	//
+	// Backdated by the DATABASE's clock, which is also the clock the read
+	// measures against. This used to be the flaky half of the pair: the write
+	// took `now()` and the count took the service's, so on a machine whose
+	// database clock leads the host — a VM, Docker Desktop on macOS — the
+	// answer came back 40. It passed in CI on the coincidence that the two
+	// agreed there.
 	ageLastTouch(t, e, deal, 41)
 
 	risks := coverageRisks(t, e, deal)

--- a/backend/internal/compose/network/coveragefacts.go
+++ b/backend/internal/compose/network/coveragefacts.go
@@ -49,6 +49,11 @@ type dealFacts struct {
 	// date, so a deal nobody has contacted and one contacted the day it was
 	// written down carry the same instant.
 	everTouched bool
+	// asOf is the DATABASE's clock, read in the same statement as the row.
+	// going-cold measures against it rather than against the service's, so
+	// both ends of that subtraction come from the clock that wrote the touch —
+	// see DealCoverage.TouchedAsOf.
+	asOf time.Time
 }
 
 // readDealFacts loads the deal row the rules decide on.
@@ -60,8 +65,9 @@ func readDealFacts(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (dealFacts
 	var org *ids.UUID
 	err := tx.QueryRow(ctx, fmt.Sprintf(`
 		SELECT status, organization_id, %s,
-		       last_activity_at IS NOT NULL
-		  FROM deal WHERE id = $1`, idlebase.SQL("")), dealID).Scan(&out.status, &org, &out.lastTouchAt, &out.everTouched)
+		       last_activity_at IS NOT NULL, now()
+		  FROM deal WHERE id = $1`, idlebase.SQL("")), dealID).
+		Scan(&out.status, &org, &out.lastTouchAt, &out.everTouched, &out.asOf)
 	if err != nil {
 		return out, fmt.Errorf("network: reading the deal a coverage view describes: %w", err)
 	}

--- a/backend/internal/compose/network/risk.go
+++ b/backend/internal/compose/network/risk.go
@@ -105,6 +105,20 @@ type DealCoverage struct {
 	// that as "do not judge", so a hand-built fixture cannot accidentally
 	// assert a cold deal it never described.
 	LastTouchAt time.Time
+	// TouchedAsOf is the DATABASE's clock at the moment LastTouchAt was read,
+	// and it is the only thing going-cold may measure against.
+	//
+	// last_activity_at is written by the database (`now()` on the capture
+	// path). Subtracting it from the service's clock is a subtraction across
+	// TWO clocks, and an app container and a database container on different
+	// hosts — or a VM whose clock drifts, or Docker Desktop on macOS — do not
+	// agree. Where they disagree across a day boundary the count comes out one
+	// short, and a deal drops out of the 30/60-day view a day late.
+	//
+	// Zero for a coverage built by hand rather than read, which the fold reads
+	// as "do not judge" exactly as it reads a zero LastTouchAt: a fixture that
+	// never described a clock has not described a cold deal either.
+	TouchedAsOf time.Time
 	// EverTouched says a touch has actually been captured, as opposed to
 	// LastTouchAt standing in with the deal's creation. The engagement rules
 	// read it to tell a deal nobody has worked from one that is simply new:
@@ -196,6 +210,7 @@ func CoverageFor(ctx context.Context, tx pgx.Tx, dealID ids.DealID, now time.Tim
 		return out, err
 	}
 	out.Status, out.LastTouchAt, out.EverTouched = facts.status, facts.lastTouchAt, facts.everTouched
+	out.TouchedAsOf = facts.asOf
 
 	stakeholders, err := deals.Stakeholders(ctx, tx, dealID, now)
 	if err != nil {
@@ -301,7 +316,7 @@ func foldRisks(c DealCoverage, now time.Time) []Risk {
 	// Who has left, and REPORT-PARAM-2's silence. Both are appended last so a
 	// deal's structural findings read before its temporal ones.
 	risks = append(risks, departureRisks(c)...)
-	if r, found := goingCold(c, now); found {
+	if r, found := goingCold(c); found {
 		risks = append(risks, r)
 	}
 	return risks
@@ -355,11 +370,18 @@ func departureRisks(c DealCoverage) []Risk {
 // has been silent since the epoch — the difference between "we did not look"
 // and "nobody has spoken" is the whole finding, and reading the first as the
 // second would flag every deal in a fixture that never described one.
-func goingCold(c DealCoverage, now time.Time) (Risk, bool) {
-	if c.Status != dealStatusOpen || c.LastTouchAt.IsZero() {
+//
+// IT DOES NOT TAKE THE CALLER'S CLOCK, and that is the point rather than an
+// omission. Both ends of this subtraction have to come from the database: the
+// touch was stamped there, and measuring it against the service's clock is a
+// subtraction across two that a real deployment does not keep in step. A zero
+// TouchedAsOf is the same "do not judge" a zero LastTouchAt is — a coverage
+// built by hand described no clock, so it described no silence either.
+func goingCold(c DealCoverage) (Risk, bool) {
+	if c.Status != dealStatusOpen || c.LastTouchAt.IsZero() || c.TouchedAsOf.IsZero() {
 		return Risk{}, false
 	}
-	days := elapsed.Days(c.LastTouchAt, now)
+	days := elapsed.Days(c.LastTouchAt, c.TouchedAsOf)
 	if days < goingColdDays {
 		return Risk{}, false
 	}

--- a/backend/internal/compose/network/risk_test.go
+++ b/backend/internal/compose/network/risk_test.go
@@ -167,7 +167,7 @@ func TestTheEngagementRulesWaitForTheFirstTouch(t *testing.T) {
 func TestALongSilentDealStillReportsItsEngagementFindings(t *testing.T) {
 	old := DealCoverage{
 		DealID: ids.NewV7(), EverTouched: true, LastTouchAt: daysAgo(120),
-		Status: dealStatusOpen,
+		TouchedAsOf: testNow, Status: dealStatusOpen,
 		Stakeholders: []deals.DealStakeholder{
 			seat(false, roleChampion), seat(false, "user"),
 		},
@@ -191,12 +191,64 @@ func TestADealWithNoSeatsAtAllRaisesNoCoverageGap(t *testing.T) {
 	}
 }
 
+// The day count comes from the DATABASE's clock and does not move with the
+// caller's.
+//
+// last_activity_at is stamped by the database on the capture path, so measuring
+// it against the service's clock subtracts across two clocks that a real
+// deployment does not keep in step — an app container and a database container
+// on different hosts, a VM that drifts, Docker Desktop on macOS. Across a day
+// boundary the count came out one short, and a deal dropped out of the 30/60-day
+// view a day late.
+//
+// The caller's clock is handed a whole day of skew here, in both directions,
+// because a small one would pass on a coincidence.
+func TestGoingColdMeasuresAgainstTheClockThatStampedTheTouch(t *testing.T) {
+	cover := DealCoverage{
+		DealID: ids.NewV7(), Status: dealStatusOpen,
+		LastTouchAt: daysAgo(goingColdDays), TouchedAsOf: testNow,
+		Stakeholders: []deals.DealStakeholder{seat(true, roleChampion), seat(true, "user")},
+	}
+
+	for _, skew := range []time.Duration{-24 * time.Hour, 0, 24 * time.Hour} {
+		days := 0
+		for _, r := range foldRisks(cover, testNow.Add(skew)) {
+			if r.Kind == RiskGoingCold {
+				days = r.DaysSinceTouch
+			}
+		}
+		if days != goingColdDays {
+			t.Errorf("with the caller's clock %v out, going-cold reports %d days, want %d — "+
+				"the count moved with a clock that did not write the touch",
+				skew, days, goingColdDays)
+		}
+	}
+}
+
+// A coverage that never described a clock has not described a silence either.
+//
+// The same reading a zero LastTouchAt gets, and for the same reason: a
+// hand-built fixture must not be able to assert a cold deal by omission. It
+// matters more here, because the zero value of a time is 0001-01-01 — measured
+// against it every deal in every fixture is silent by two thousand years.
+func TestGoingColdJudgesNothingWithoutTheDatabaseClock(t *testing.T) {
+	cover := DealCoverage{
+		DealID: ids.NewV7(), Status: dealStatusOpen,
+		LastTouchAt:  daysAgo(goingColdDays * 4),
+		Stakeholders: []deals.DealStakeholder{seat(true, roleChampion), seat(true, "user")},
+	}
+
+	if kinds(foldRisks(cover, testNow))[RiskGoingCold] {
+		t.Error("a coverage carrying no database clock was judged going cold anyway")
+	}
+}
+
 func TestGoingColdFiresOnTheReportingWindowAndOnlyWhileTheDealIsOpen(t *testing.T) {
 	base := []deals.DealStakeholder{seat(true, roleChampion), seat(true, "user")}
 	cover := func(status string, touched int) DealCoverage {
 		return DealCoverage{
 			DealID: ids.NewV7(), Status: status,
-			LastTouchAt: daysAgo(touched), Stakeholders: base,
+			LastTouchAt: daysAgo(touched), TouchedAsOf: testNow, Stakeholders: base,
 		}
 	}
 
@@ -248,6 +300,7 @@ func TestGoingColdCountsTheCalendarSoTheChipAndTheCardAgree(t *testing.T) {
 	lateEvening := time.Date(2026, 5, 16, 23, 0, 0, 0, time.UTC)
 	cover := DealCoverage{
 		DealID: ids.NewV7(), Status: dealStatusOpen, LastTouchAt: lateEvening,
+		TouchedAsOf:  testNow,
 		Stakeholders: []deals.DealStakeholder{seat(true, roleChampion), seat(true, "user")},
 	}
 	risks := foldRisks(cover, testNow)


### PR DESCRIPTION
Closes #1997.

## Both ends of the subtraction now come from one clock

`last_activity_at` is written by the **database** on the capture path; the count was taking the **service's**. An app container and a database container on different hosts, a VM whose clock drifts, Docker Desktop on macOS — none of them keep those two in step, and across a day boundary the count came out one short.

`days_since_touch` is what the 30/60-day views filter on, so a deal dropped out of the view **a day late**.

The fix costs nothing: `readDealFacts` already reads the deal row, so it reads `now()` in the same statement and carries it. **The rule takes no clock argument at all any more** — that is the part that keeps this fixed, because a parameter is an invitation to pass the wrong one back in.

## A zero clock judges nothing

The same reading a zero `LastTouchAt` gets, and for a sharper reason: the zero value of a `time.Time` is `0001-01-01`, so a coverage built by hand and measured against it is silent by two thousand years. A fixture that never described a clock has not described a silence.

## What was already fixed, and what was left

The truncation half of the ticket had gone — `elapsed.Days` counts calendar days now, which **narrowed** the window but did not close it. Two clocks straddling a UTC midnight still differ by one.

## The test was the other half

It backdates with `now() - make_interval(...)` and asserted against the service's clock, so it failed on a machine whose database clock leads the host and passed in CI on the coincidence that the two agreed there. Both ends are the database's `now()` now, so it is **decided rather than lucky**. Its comment says so, because the next person to reach for a Go clock there needs to know why it is not one.

## Mutations

| mutation | result |
|---|---|
| hand the rule the caller's clock | a day of skew moves the count in both directions (30 → 0 and → 31) |
| drop the zero-clock guard | a coverage that described no clock is reported cold |

`make check-backend` exit 0; `internal/compose/integration` suite green (578s), including the test the ticket named.