### PR TITLE
Every bash test in this tree is `[[`, so an empty variable is a false and not a syntax error

### DIFF
--- a/.claude/hooks/finish-review.sh
+++ b/.claude/hooks/finish-review.sh
@@ -42,7 +42,7 @@ payload="$(cat)"
 
 # --- locate the repo (hook cwd is the project dir) --------------------------
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-if [ -z "$root" ]; then exit 0; fi   # not a git repo → nothing to review
+if [[ -z "$root" ]]; then exit 0; fi   # not a git repo → nothing to review
 
 # Per-worktree state: --absolute-git-dir resolves to .git/ in the main
 # checkout and .git/worktrees/<name>/ in a linked worktree, where $root/.git
@@ -57,7 +57,7 @@ gitdir="$(git -C "$root" rev-parse --absolute-git-dir)"
 # this checkout. Nothing creates it automatically — a human or a session acting
 # on a human's instruction does, and clears it when done.
 review_off="$gitdir/margince-finish-review.off"
-if [ -f "$review_off" ] && [ -n "$(find "$review_off" -mmin -1440 2>/dev/null)" ]; then
+if [[ -f "$review_off" ]] && [[ -n "$(find "$review_off" -mmin -1440 2>/dev/null)" ]]; then
 	echo "finish-review: opt-out flag present (expires 24h after touch) — skipping"
 	exit 0
 fi
@@ -77,7 +77,7 @@ try:
     print(json.load(sys.stdin).get("transcript_path","") or "")
 except Exception:
     print("")')"
-if [ -z "$transcript" ] || [ ! -f "$transcript" ]; then exit 0; fi
+if [[ -z "$transcript" ]] || [[ ! -f "$transcript" ]]; then exit 0; fi
 
 # --- the backend Go files THIS session edited -----------------------------
 # Parse the transcript for Edit/Write/MultiEdit/NotebookEdit tool calls and keep
@@ -135,9 +135,9 @@ PY
 )"
 edited=()
 while IFS= read -r f; do
-	[ -n "$f" ] && edited+=("$f")
+	[[ -n "$f" ]] && edited+=("$f")
 done <<< "$session_edits"
-if [ "${#edited[@]}" -eq 0 ]; then exit 0; fi   # this session issued no backend edits → not our turn
+if [[ "${#edited[@]}" -eq 0 ]]; then exit 0; fi   # this session issued no backend edits → not our turn
 
 # Keep only those with a real NET change still in the tree, measured against
 # the merge-base with origin/main: committed-but-unmerged work stays in
@@ -149,11 +149,11 @@ files=()
 for f in "${edited[@]}"; do
 	if ! git -C "$root" diff --quiet "$base" -- "$f" 2>/dev/null; then
 		files+=("$f")   # changed vs the merge-base — committed or not
-	elif [ -n "$(git -C "$root" ls-files --others --exclude-standard -- "$f")" ]; then
+	elif [[ -n "$(git -C "$root" ls-files --others --exclude-standard -- "$f")" ]]; then
 		files+=("$f")   # new untracked file this session wrote
 	fi
 done
-if [ "${#files[@]}" -eq 0 ]; then exit 0; fi   # no net backend change from this session → nothing to review
+if [[ "${#files[@]}" -eq 0 ]]; then exit 0; fi   # no net backend change from this session → nothing to review
 
 # Identity of the change: content hash of exactly the session-edited files, so
 # any further edit to them yields a fresh hash and restarts the review flow.
@@ -170,9 +170,9 @@ branch="$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detache
 # phase/attempts are per CHANGE: the craft gate must re-run on new code, so a
 # single record is enough — it only has to survive to the next stop.
 phase="craft"; attempts=0
-if [ -f "$state_file" ]; then
+if [[ -f "$state_file" ]]; then
 	read -r saved_hash saved_phase saved_attempts < "$state_file" || true
-	if [ "${saved_hash:-}" = "$diff_hash" ]; then
+	if [[ "${saved_hash:-}" = "$diff_hash" ]]; then
 		phase="${saved_phase:-craft}"; attempts="${saved_attempts:-0}"
 	fi
 fi
@@ -185,14 +185,14 @@ fi
 # awk in a command substitution kills the hook outright, and 2>/dev/null hides the
 # message without changing the exit status.
 read_rounds() {
-	if [ ! -f "$rounds_file" ]; then printf '0\n'; return 0; fi
+	if [[ ! -f "$rounds_file" ]]; then printf '0\n'; return 0; fi
 	n="$({ awk -F'\t' -v b="$branch" '$1 == b { print $2 }' "$rounds_file" || true; } | tail -1)"
 	printf '%s\n' "${n:-0}"
 }
 rounds="$(read_rounds)"
 
 # Already fully reviewed this exact set → let the stop through.
-if [ "$phase" = "done" ]; then exit 0; fi
+if [[ "$phase" = "done" ]]; then exit 0; fi
 
 emit_block() {   # $1 = reason text → hold the stop and feed the reason back
 	printf '{"decision":"block","reason":%s}\n' "$(printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
@@ -207,11 +207,11 @@ save_state() { printf '%s %s %s\n' "$diff_hash" "$1" "$2" > "$state_file"; }
 rounds_lock="$rounds_file.lock"
 lock_rounds() {
 	i=0
-	while [ "$i" -lt 50 ]; do
+	while [[ "$i" -lt 50 ]]; do
 		if mkdir "$rounds_lock" 2>/dev/null; then return 0; fi
 		# A lock directory older than a minute is a crashed holder, not a live one;
 		# nothing here holds it for more than a few file operations.
-		if [ -n "$(find "$rounds_lock" -maxdepth 0 -mmin +1 2>/dev/null || true)" ]; then
+		if [[ -n "$(find "$rounds_lock" -maxdepth 0 -mmin +1 2>/dev/null || true)" ]]; then
 			rmdir "$rounds_lock" 2>/dev/null || true
 		fi
 		sleep 0.1
@@ -224,7 +224,7 @@ unlock_rounds() { rmdir "$rounds_lock" 2>/dev/null || true; }
 # record_round persists this branch's count, rewriting only its own line.
 record_round() {
 	tmp="$rounds_file.tmp.$$"
-	{ if [ -f "$rounds_file" ]; then awk -F'\t' -v b="$branch" '$1 != b' "$rounds_file" || true; fi
+	{ if [[ -f "$rounds_file" ]]; then awk -F'\t' -v b="$branch" '$1 != b' "$rounds_file" || true; fi
 	  printf '%s\t%s\n' "$branch" "$1"; } > "$tmp" && mv "$tmp" "$rounds_file"
 }
 
@@ -240,7 +240,7 @@ record_round() {
 reviewable() {
 	command -v gh >/dev/null 2>&1 || return 1
 	state="$( (cd "$root" && gh pr view --json state --jq '.state' 2>/dev/null) || true )"
-	[ "$state" = "OPEN" ]
+	[[ "$state" = "OPEN" ]]
 }
 
 # request_review holds the stop and asks for the subagent round, but only when
@@ -262,7 +262,7 @@ request_review() {
 		return 1
 	fi
 	rounds="$(read_rounds)"
-	if [ "$rounds" -ge "$max_review_rounds" ]; then
+	if [[ "$rounds" -ge "$max_review_rounds" ]]; then
 		unlock_rounds
 		save_state "done" 0
 		return 1
@@ -275,8 +275,8 @@ request_review() {
 }
 
 # --- phase 1: the deterministic craft gate --------------------------------
-if [ "$phase" = "craft" ]; then
-	args=(); for f in "${files[@]}"; do [ -n "$f" ] && args+=("$root/$f"); done
+if [[ "$phase" = "craft" ]]; then
+	args=(); for f in "${files[@]}"; do [[ -n "$f" ]] && args+=("$root/$f"); done
 	if craft_out="$(go run -C "$root/cli/craft" . static "${args[@]}" 2>&1)"; then
 		request_review "This branch has an open PR and craft static is green, so the one end-of-work review round for it runs now — scoped to the ${#args[@]} backend file(s) THIS session changed.
 
@@ -292,7 +292,7 @@ This is the ONLY subagent round this branch gets — craft static still re-runs 
 		exit 0
 	else
 		attempts=$((attempts + 1))
-		if [ "$attempts" -gt "$max_craft_attempts" ]; then
+		if [[ "$attempts" -gt "$max_craft_attempts" ]]; then
 			# Do not trap the session on a craft gate it cannot satisfy: stop
 			# gating, but warn loudly. A stuck craft gate is not a reason to hand
 			# out a second review round, or one on a branch with no PR — so this
@@ -318,7 +318,7 @@ fi
 
 # --- phase 2: agents were requested; the agent stopped again on the same set.
 # Treat the review as complete for this set and let the stop through.
-if [ "$phase" = "agents_requested" ]; then
+if [[ "$phase" = "agents_requested" ]]; then
 	save_state "done" 0
 	exit 0
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,7 +18,7 @@ root="$(git rev-parse --show-toplevel)"
 
 # Base = merge-base with origin/main. No base (fresh repo / no remote) → skip.
 base="$(git merge-base HEAD origin/main 2>/dev/null || true)"
-if [ -z "$base" ]; then
+if [[ -z "$base" ]]; then
 	echo "craft static: no origin/main base — skipping"
 	exit 0
 fi
@@ -27,7 +27,7 @@ fi
 # check exits early when a push changes no Go at all — and a push that adds only
 # `.sql` is exactly the push this gate is for. It is skipped when the push
 # touches no migration, so an ordinary push pays one `git diff` for it.
-if [ -n "$(git diff --name-only "$base"...HEAD -- backend/migrations)" ]; then
+if [[ -n "$(git diff --name-only "$base"...HEAD -- backend/migrations)" ]]; then
 	"$root/scripts/check-migration-versions.sh"
 fi
 
@@ -37,7 +37,7 @@ fi
 # desktop launcher is a binary that users run.
 files="$(git diff --name-only --diff-filter=d "$base"...HEAD -- backend extensions fixtures desktop \
 	| grep -E '\.go$' | grep -v '_gen\.go$' || true)"
-if [ -z "$files" ]; then
+if [[ -z "$files" ]]; then
 	echo "craft static: no changed Go files — ok"
 	exit 0
 fi
@@ -45,7 +45,7 @@ fi
 # Absolute paths, because `go run -C cli/craft` changes the working directory.
 args=()
 while IFS= read -r f; do
-	[ -n "$f" ] && args+=("$root/$f")
+	[[ -n "$f" ]] && args+=("$root/$f")
 done <<< "$files"
 
 echo "craft static: checking ${#args[@]} changed Go file(s)…"

--- a/desktop/build/build-app.sh
+++ b/desktop/build/build-app.sh
@@ -19,7 +19,7 @@ build_server_binaries() {
   (cd "$ROOT/backend" && GOWORK="$ROOT/go.work" go run ./tools/gen-composition)
 
   local composition="$ROOT/build/composition/go.work"
-  if [ ! -f "$composition" ]; then
+  if [[ ! -f "$composition" ]]; then
     echo "FAIL: gen-composition did not produce $composition" >&2
     exit 1
   fi
@@ -54,7 +54,7 @@ sign_binary() {
 build_frontend() {
   log "building the frontend (composed)"
   local registry="$ROOT/build/composition/frontend"
-  if [ ! -f "$registry/extensions.gen.ts" ]; then
+  if [[ ! -f "$registry/extensions.gen.ts" ]]; then
     echo "FAIL: gen-composition did not produce $registry/extensions.gen.ts" >&2
     exit 1
   fi
@@ -104,7 +104,7 @@ build_frontend() {
   # --no-frozen-lockfile because that lockfile is generated build output, which
   # is what the Makefile's own invocation says at greater length.
   local composed_ws="$ROOT/build/composition-frontend/workspace"
-  if [ ! -f "$composed_ws/pnpm-workspace.yaml" ]; then
+  if [[ ! -f "$composed_ws/pnpm-workspace.yaml" ]]; then
     echo "FAIL: gen-composition did not produce $composed_ws/pnpm-workspace.yaml, so a unit's frontend dependencies cannot be resolved" >&2
     exit 1
   fi
@@ -127,7 +127,7 @@ build_launcher() {
 
 main() {
   build_server_binaries
-  if [ "${SKIP_FRONTEND:-0}" != "1" ]; then
+  if [[ "${SKIP_FRONTEND:-0}" != "1" ]]; then
     build_frontend
   fi
   build_launcher

--- a/desktop/build/build-dist.sh
+++ b/desktop/build/build-dist.sh
@@ -35,7 +35,7 @@ log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
 require() {
   local path="$1" hint="$2"
-  if [ ! -e "$path" ]; then
+  if [[ ! -e "$path" ]]; then
     echo "missing $path — run $hint first" >&2
     exit 1
   fi
@@ -123,7 +123,7 @@ verify_runnable_os() {
   done < <(find "$DIST" -type f)
   # An empty list would pass this check while examining nothing — the way a
   # verification step most often fails.
-  if [ ${#binaries[@]} -eq 0 ]; then
+  if [[ ${#binaries[@]} -eq 0 ]]; then
     echo "FAIL: found no executables in $DIST to check" >&2
     exit 1
   fi

--- a/desktop/build/build-postgres.sh
+++ b/desktop/build/build-postgres.sh
@@ -42,7 +42,7 @@ require_tools() {
   for tool in curl shasum make clang install_name_tool otool codesign vtool; do
     command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
   done
-  if [ ${#missing[@]} -gt 0 ]; then
+  if [[ ${#missing[@]} -gt 0 ]]; then
     echo "missing required tools: ${missing[*]}" >&2
     echo "install the Xcode Command Line Tools: xcode-select --install" >&2
     exit 1
@@ -53,14 +53,14 @@ require_tools() {
 # truncated or tampered cache in .work can never silently reach a build.
 fetch() {
   local url="$1" dest="$2" want="$3"
-  if [ ! -f "$dest" ]; then
+  if [[ ! -f "$dest" ]]; then
     log "downloading $(basename "$dest")"
     curl -fSL --retry 3 --max-time 600 "$url" -o "$dest.part"
     mv "$dest.part" "$dest"
   fi
   local got
   got="$(shasum -a 256 "$dest" | awk '{print $1}')"
-  if [ "$got" != "$want" ]; then
+  if [[ "$got" != "$want" ]]; then
     echo "checksum mismatch for $dest" >&2
     echo "  expected $want" >&2
     echo "  actual   $got" >&2
@@ -204,7 +204,7 @@ verify() {
     done < <(otool -L "$file" | tail -n +2 | awk '{print $1}')
   done < <(mach_o_files)
 
-  if [ "$offenders" -gt 0 ]; then
+  if [[ "$offenders" -gt 0 ]]; then
     echo "FAIL: $offenders link(s) reference an absolute path outside the bundle" >&2
     exit 1
   fi
@@ -232,7 +232,7 @@ verify() {
     fi
   done < <(mach_o_files)
 
-  if [ "$missing_rpath" -gt 0 ]; then
+  if [[ "$missing_rpath" -gt 0 ]]; then
     echo "FAIL: $missing_rpath file(s) have no rpath, so their bundled libraries cannot be found" >&2
     exit 1
   fi
@@ -246,14 +246,14 @@ verify() {
   # `CREATE EXTENSION` on first launch.
   local ext
   for ext in vector unaccent pg_trgm btree_gist; do
-    if [ ! -f "$OUT/share/extension/$ext.control" ]; then
+    if [[ ! -f "$OUT/share/extension/$ext.control" ]]; then
       echo "FAIL: extension '$ext' is missing from the build" >&2
       exit 1
     fi
     # lib/<ext>.dylib, measured rather than assumed: this build installs its
     # loadable modules directly under lib/ and has no lib/postgresql at all, and
     # they are .dylib rather than the .so a Linux Postgres would produce.
-    if [ ! -f "$OUT/lib/$ext.dylib" ]; then
+    if [[ ! -f "$OUT/lib/$ext.dylib" ]]; then
       echo "FAIL: extension '$ext' has a control file but no loadable module at lib/$ext.dylib" >&2
       exit 1
     fi

--- a/desktop/build/build-valkey.sh
+++ b/desktop/build/build-valkey.sh
@@ -29,14 +29,14 @@ log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
 fetch() {
   local url="$1" dest="$2" want="$3"
-  if [ ! -f "$dest" ]; then
+  if [[ ! -f "$dest" ]]; then
     log "downloading $(basename "$dest")"
     curl -fSL --retry 3 --max-time 600 "$url" -o "$dest.part"
     mv "$dest.part" "$dest"
   fi
   local got
   got="$(shasum -a 256 "$dest" | awk '{print $1}')"
-  if [ "$got" != "$want" ]; then
+  if [[ "$got" != "$want" ]]; then
     echo "checksum mismatch for $dest" >&2
     echo "  expected $want" >&2
     echo "  actual   $got" >&2
@@ -57,7 +57,7 @@ verify() {
     esac
   done < <(otool -L "$OUT/valkey-server" | tail -n +2 | awk '{print $1}')
 
-  if [ "$offenders" -gt 0 ]; then
+  if [[ "$offenders" -gt 0 ]]; then
     echo "FAIL: valkey-server links against a package-manager prefix" >&2
     exit 1
   fi

--- a/desktop/build/macos-target.sh
+++ b/desktop/build/macos-target.sh
@@ -30,14 +30,14 @@ assert_min_os() {
   local file minos newest
   for file in "$@"; do
     minos="$(vtool -show-build "$file" 2>/dev/null | awk '/^ *minos/ {print $2; exit}')"
-    if [ -z "$minos" ]; then
+    if [[ -z "$minos" ]]; then
       echo "FAIL: $file declares no macOS build version, so the OS it needs cannot be known" >&2
       return 1
     fi
     # sort -V so 9.0 sorts below 12.0 the way a version does, not the way a
     # string does.
     newest="$(printf '%s\n%s\n' "$MACOS_MIN" "$minos" | sort -V | tail -1)"
-    if [ "$newest" != "$MACOS_MIN" ]; then
+    if [[ "$newest" != "$MACOS_MIN" ]]; then
       echo "FAIL: $file requires macOS $minos but this bundle declares $MACOS_MIN" >&2
       echo "      It was built without MACOSX_DEPLOYMENT_TARGET, so it inherited the build machine's OS" >&2
       echo "      and would refuse to launch on any older Mac." >&2

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,7 @@ budget rather than keeping its own list of which pages are generated.
 - [ai-egress.md](reference/ai-egress.md) — every declared AI task, and whether the text it reads can leave the installation. Generated from `backend/api/ai-tasks.yaml`, never hand-edited.
 - [issue-labels.md](reference/issue-labels.md) — the full issue-label taxonomy. The binding short form is in `AGENTS.md`.
 - [license-release-rule.md](reference/license-release-rule.md) — the BUSL Change-Date release-stamping rule. (The per-file SPDX license *header* rule is described in [backend-onboarding.md](explanation/backend-onboarding.md) and `AGENTS.md`.)
+- [sonarcloud-deviations.md](reference/sonarcloud-deviations.md) — the SonarCloud findings that stay open on purpose, one entry each saying what would break if somebody applied the rule. Everything not listed there is a finding to fix.
 
 ### Explanation — understand the why
 

--- a/docs/reference/sonarcloud-deviations.md
+++ b/docs/reference/sonarcloud-deviations.md
@@ -31,9 +31,12 @@ deliberately outlives its constructor, which is the one shape S8188 has no way
 to distinguish from a leak: it reads a `CancelFunc` that leaves the function and
 cannot follow it into the closure that calls it.
 
-**What holds it instead.** Returning the three values together is itself the
-guard — a caller cannot obtain the context without also obtaining the end of it,
-and cannot start a lane first, because the wait group a lane must be given comes
-from the same call. `TestJoinCancelsTheLanesAndWaitsForThem` and
-`TestJoinReportsALaneThatDoesNotStop` in `backend/cmd/worker` cover the
-ordering and the bounded overrun.
+**What holds it instead.** The caller has to defer the closure — nothing in the
+type system makes it. What returning the three values together removes is the
+*ordering* hazard — the half nothing was holding when a deleted `defer` left
+every test in the repository passing: a lane cannot exist before its own
+shutdown is registered, because the wait group a lane must be given comes from
+the same call that produced the closure. A caller that discards the closure is
+still a caller with no shutdown, and the tests are what say otherwise —
+`TestJoinCancelsTheLanesAndWaitsForThem` covers the cancel and the wait,
+`TestJoinReportsALaneThatDoesNotStop` the bounded overrun.

--- a/docs/reference/sonarcloud-deviations.md
+++ b/docs/reference/sonarcloud-deviations.md
@@ -1,0 +1,39 @@
+# SonarCloud findings this tree does not fix
+
+SonarCloud is one of the gates a pull request has to pass, so a finding it
+raises is normally something to fix rather than something to argue with. This
+page is the short list of the exceptions: findings that are open in the
+dashboard, that a reader will meet again the next time they sort the issue list,
+and that stay open on purpose.
+
+One entry per finding, each saying what the rule wants, what the code does
+instead, and what would break if somebody "fixed" it. A finding that is merely
+inconvenient does not belong here — only one where applying the rule would make
+the product worse.
+
+## godre:S8188 — `laneLifetime` in `backend/cmd/worker/lanes.go`
+
+**What the rule wants.** `context.WithCancel` should be followed by
+`defer cancel()` in the same function, so the context cannot outlive the call
+that created it.
+
+**What the code does.** `laneLifetime` creates the context the worker's event
+lanes live on and returns three values: the context, the wait group that counts
+the lanes, and a closure that cancels the context and waits for every lane to
+leave. The caller — `run` in `backend/cmd/worker/main.go` — defers that closure
+on the line after the call, before any lane exists.
+
+**Why the rule cannot be applied.** The cancel is the *shutdown* of the lanes,
+not a cleanup of the constructor. Deferring it inside `laneLifetime` would
+cancel the context as that function returns, so every lane would be handed a
+context that is already done and the worker would consume nothing. The lifetime
+deliberately outlives its constructor, which is the one shape S8188 has no way
+to distinguish from a leak: it reads a `CancelFunc` that leaves the function and
+cannot follow it into the closure that calls it.
+
+**What holds it instead.** Returning the three values together is itself the
+guard — a caller cannot obtain the context without also obtaining the end of it,
+and cannot start a lane first, because the wait group a lane must be given comes
+from the same call. `TestJoinCancelsTheLanesAndWaitsForThem` and
+`TestJoinReportsALaneThatDoesNotStop` in `backend/cmd/worker` cover the
+ordering and the bounded overrun.

--- a/e2e/llm/seed-llm-fixtures.sh
+++ b/e2e/llm/seed-llm-fixtures.sh
@@ -42,7 +42,7 @@ ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
 # keeps the file elsewhere passes BOOTSTRAP_PASSWORD; the literal is the last
 # resort for a stack booted by hand.
 BOOTSTRAP_PASSWORD_FILE="${BOOTSTRAP_PASSWORD_FILE:-config/margince-admin-password}"
-if [ -z "${BOOTSTRAP_PASSWORD:-}" ] && [ -r "$BOOTSTRAP_PASSWORD_FILE" ]; then
+if [[ -z "${BOOTSTRAP_PASSWORD:-}" ]] && [[ -r "$BOOTSTRAP_PASSWORD_FILE" ]]; then
   BOOTSTRAP_PASSWORD="$(cat "$BOOTSTRAP_PASSWORD_FILE")"
 fi
 BOOTSTRAP_PASSWORD="${BOOTSTRAP_PASSWORD:-operator-supplied-first-password}"
@@ -52,7 +52,7 @@ trap 'rm -f "$COOKIES"' EXIT
 
 api() {
   local method="$1" path="$2" body="${3:-}"
-  if [ -n "$body" ]; then
+  if [[ -n "$body" ]]; then
     curl -sS -b "$COOKIES" -c "$COOKIES" -X "$method" \
       -H 'Content-Type: application/json' -d "$body" "$API_BASE/v1$path"
   else
@@ -109,7 +109,7 @@ create_or_die() {
   id="$(printf '%s' "$response" | python3 -c 'import json,sys
 try: print(json.load(sys.stdin).get("id",""))
 except Exception: print("")')"
-  if [ -z "$id" ]; then
+  if [[ -z "$id" ]]; then
     echo "could not create $what:" >&2
     printf '  %s\n' "$response" >&2
     exit 1
@@ -126,7 +126,7 @@ status_of() {
   # -d is passed as its own argument rather than through ${body:+...}: an
   # unquoted expansion splits the JSON on its spaces and curl receives
   # fragments, which surfaced as "[: too many arguments" from the caller.
-  if [ -n "$body" ]; then
+  if [[ -n "$body" ]]; then
     curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIES" -c "$COOKIES" \
       -X "$method" -H 'Content-Type: application/json' -d "$body" "$API_BASE/v1$path"
   else
@@ -142,7 +142,7 @@ login_as() {
   local body code
   body="$(printf '{"email":"%s","password":"%s"}' "$ADMIN_EMAIL" "$1")"
   code="$(status_of POST /auth/login "$body")"
-  [ "$code" = "200" ]
+  [[ "$code" = "200" ]]
 }
 
 # THE FIRST-LOGIN HOLD. A bootstrapped installation sets must_change_password
@@ -169,7 +169,7 @@ if ! login_as "$ADMIN_PASSWORD"; then
   echo "  signed in with the operator-supplied password; replacing it"
   first_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
     "$BOOTSTRAP_PASSWORD" "$ADMIN_PASSWORD")"
-  if [ "$(status_of POST /auth/change-password "$first_body")" != "204" ]; then
+  if [[ "$(status_of POST /auth/change-password "$first_body")" != "204" ]]; then
     echo "could not replace the operator-supplied password" >&2; exit 1
   fi
   login_as "$ADMIN_PASSWORD" || {
@@ -179,18 +179,18 @@ fi
 
 # A write the admin is always allowed to attempt. 403 here means the hold, not
 # a permission problem — this account is an admin.
-if [ "$(status_of GET /users)" = "403" ]; then
+if [[ "$(status_of GET /users)" = "403" ]]; then
   echo "  admin is on the first-login hold; replacing the bootstrap password"
   rotate_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
     "$ADMIN_PASSWORD" "$DETOUR_PASSWORD")"
-  if [ "$(status_of POST /auth/change-password "$rotate_body")" != "204" ]; then
+  if [[ "$(status_of POST /auth/change-password "$rotate_body")" != "204" ]]; then
     echo "could not rotate the bootstrap password to the detour value" >&2; exit 1
   fi
   login_as "$DETOUR_PASSWORD" || {
     echo "could not sign in with the detour password" >&2; exit 1; }
   rotate_back_body="$(printf '{"current_password":"%s","new_password":"%s"}' \
     "$DETOUR_PASSWORD" "$ADMIN_PASSWORD")"
-  if [ "$(status_of POST /auth/change-password "$rotate_back_body")" != "204" ]; then
+  if [[ "$(status_of POST /auth/change-password "$rotate_back_body")" != "204" ]]; then
     echo "the admin is stranded on $DETOUR_PASSWORD — rotate it back by hand" >&2; exit 1
   fi
   login_as "$ADMIN_PASSWORD" || {
@@ -206,7 +206,7 @@ fi
 # misleading "could not resolve the colleague seat".
 colleague="$(id_of "$(api POST /users '{
   "email":"sofia.meier@demo.test","display_name":"Sofia Meier","role":"rep"}')")"
-if [ -z "$colleague" ]; then
+if [[ -z "$colleague" ]]; then
   # The list envelope is {"data": [...], "page": {...}} — reading "items" here
   # always found nothing, so a re-run (create answers 409 email_taken) resolved
   # an EMPTY colleague and every fixture below it was skipped in silence.
@@ -214,7 +214,7 @@ if [ -z "$colleague" ]; then
 rows = json.load(sys.stdin).get("data", [])
 print(rows[0]["id"] if rows else "")')"
 fi
-[ -n "$colleague" ] || { echo "could not resolve the colleague seat" >&2; exit 1; }
+[[ -n "$colleague" ]] || { echo "could not resolve the colleague seat" >&2; exit 1; }
 
 # --- CASE 4: companies in and around Köln, owned by the colleague ------------
 #
@@ -242,7 +242,7 @@ else:
 seed_cologne() {
   local name="$1" lat="$2" lon="$3" body existing
   existing="$(org_id_by_name "$name")"
-  if [ -n "$existing" ]; then
+  if [[ -n "$existing" ]]; then
     echo "  $name already present"
     return 0
   fi
@@ -257,13 +257,13 @@ seed_cologne "Vorort Systeme KG"   51.0175 6.9603
 
 # --- CASE 5: the Vietnam partner, with a promise nobody kept -----------------
 vietnam="$(org_id_by_name "Vietnam Partner JSC")"
-if [ -z "$vietnam" ]; then
+if [[ -z "$vietnam" ]]; then
   body="$(printf '{"display_name":"Vietnam Partner JSC","owner_id":"%s"}' "$colleague")"
   vietnam="$(create_or_die "/organizations" "$body" "Vietnam Partner JSC")"
 fi
 
 mai="$(person_id_by_email "Mai Nguyen" "mai.nguyen@vietnampartner.test")"
-if [ -z "$mai" ]; then
+if [[ -z "$mai" ]]; then
   body="$(printf '{"full_name":"Mai Nguyen","owner_id":"%s","emails":[{"email":"mai.nguyen@vietnampartner.test","is_primary":true}]}' "$colleague")"
   mai="$(create_or_die "/people" "$body" "Mai Nguyen")"
   body="$(printf '{"kind":"employment","person_id":"%s","organization_id":"%s"}' "$mai" "$vietnam")"
@@ -285,13 +285,13 @@ fi
 # complaint was raised "im Oktober". The record is right; the prose is wrong.
 # This is the fixture the sharpest assertion in the lane rests on.
 reply="$(org_id_by_name "Reply Deutschland Betreuerwechsel")"
-if [ -z "$reply" ]; then
+if [[ -z "$reply" ]]; then
   body="$(printf '{"display_name":"Reply Deutschland Betreuerwechsel","owner_id":"%s","industry":"Managed Services"}' "$colleague")"
   reply="$(create_or_die "/organizations" "$body" "Reply Deutschland")"
 fi
 
 katrin="$(person_id_by_email "Katrin Sommer" "katrin.sommer@reply.test")"
-if [ -z "$katrin" ]; then
+if [[ -z "$katrin" ]]; then
   body="$(printf '{"full_name":"Katrin Sommer","owner_id":"%s","emails":[{"email":"katrin.sommer@reply.test","is_primary":true}]}' "$colleague")"
   katrin="$(create_or_die "/people" "$body" "Katrin Sommer")"
   body="$(printf '{"kind":"employment","person_id":"%s","organization_id":"%s"}' "$katrin" "$reply")"
@@ -312,7 +312,7 @@ fi
 # the past" has a pattern to find rather than a single case.
 for company in "valantic AG Betreuerwechsel" "Körber Digital Betreuerwechsel"; do
   org="$(org_id_by_name "$company")"
-  [ -n "$org" ] && continue
+  [[ -n "$org" ]] && continue
   body="$(printf '{"display_name":"%s","owner_id":"%s","industry":"Managed Services"}' "$company" "$colleague")"
   org="$(create_or_die "/organizations" "$body" "$company")"
   body="$(printf '{"kind":"email","direction":"inbound","occurred_at":"2025-11-04T08:00:00Z","body":"Nach dem Wechsel des Ansprechpartners kam fünf Tage lang keine Antwort.","links":[{"entity_type":"organization","entity_id":"%s"}]}' "$org")"

--- a/scripts/check-ci-doc-parity.sh
+++ b/scripts/check-ci-doc-parity.sh
@@ -52,13 +52,13 @@ check() {
   # An extraction that silently yields nothing would pass while checking nothing,
   # which is the failure this file is written against.
   count="$(printf '%s\n' "$paths" | grep -c . || true)"
-  if [ "$count" -eq 0 ]; then
+  if [[ "$count" -eq 0 ]]; then
     echo "FAIL: extracted no paths from $workflow under '$anchor' — the anchor moved or the block changed shape, so this gate was about to pass without comparing anything" >&2
     fail=1
     return
   fi
   while IFS= read -r path; do
-    [ -n "$path" ] || continue
+    [[ -n "$path" ]] || continue
     # Matched as a backticked literal: the prose is free to add commentary around
     # an entry, but the entry itself has to appear exactly as the workflow spells
     # it, or it is not the same path.
@@ -67,7 +67,7 @@ check() {
       missing=1
     }
   done <<< "$paths"
-  [ "$missing" -eq 0 ] || fail=1
+  [[ "$missing" -eq 0 ]] || fail=1
   echo "checked $count path(s) from $workflow against $doc"
 }
 
@@ -80,7 +80,7 @@ check .github/workflows/ci.yml "filters: |" infra/ci-pipeline.md
 # line goes unchecked and this gate still reports OK, which is the one way this
 # file can now mislead. Spelled out rather than left implicit for that reason.
 
-if [ "$fail" -eq 0 ]; then
+if [[ "$fail" -eq 0 ]]; then
   echo "OK: every filtered path is documented"
 fi
 exit "$fail"

--- a/scripts/check-contract-breaking.sh
+++ b/scripts/check-contract-breaking.sh
@@ -55,14 +55,14 @@ esac
 # changing returns the gate to stable automatically.
 ALLOWLIST="${CONTRACT_BREAKING_ALLOWLIST:-scripts/contract-breaking-allowlist.txt}"
 
-if [ ! -f "$CRM_YAML" ]; then
+if [[ ! -f "$CRM_YAML" ]]; then
   echo "check-contract-breaking: contract not found at $CRM_YAML" >&2
   exit 2
 fi
 if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
   # A shallow clone has no base to diff against. CI sets REQUIRE_BASE so a
   # dropped fetch-depth surfaces as a red gate instead of a silent skip.
-  if [ "${CONTRACT_BREAKING_REQUIRE_BASE:-}" = "1" ]; then
+  if [[ "${CONTRACT_BREAKING_REQUIRE_BASE:-}" = "1" ]]; then
     echo "check-contract-breaking: base ref '$BASE_REF' not found and CONTRACT_BREAKING_REQUIRE_BASE=1 — fetch the base ref (checkout fetch-depth)" >&2
     exit 1
   fi
@@ -84,7 +84,7 @@ fi
 # A shallow clone can have both refs and still no common ancestor; keep the tip
 # in that case rather than failing, since the check above has already decided
 # whether a missing base is fatal.
-if MERGE_BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" && [ -n "$MERGE_BASE" ]; then
+if MERGE_BASE="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" && [[ -n "$MERGE_BASE" ]]; then
   BASE_REF="$MERGE_BASE"
 fi
 
@@ -94,24 +94,24 @@ if ! git cat-file -e "$BASE_REF:$CRM_YAML" 2>/dev/null; then
 fi
 
 ALLOWLISTED_RESYNC=0
-if [ "$CONTRACT_STABILITY" = stable ] && [ -f "$ALLOWLIST" ]; then
+if [[ "$CONTRACT_STABILITY" = stable ]] && [[ -f "$ALLOWLIST" ]]; then
   BASE_BLOB="$(git rev-parse "$BASE_REF:$CRM_YAML")"
   CURRENT_BLOB="$(git hash-object "$CRM_YAML")"
   while read -r old_blob new_blob reason; do
     case "$old_blob" in ''|'#'*) continue ;; esac
-    if [ "$old_blob" = "$BASE_BLOB" ] && [ "$new_blob" = "$CURRENT_BLOB" ] && [ -n "${reason:-}" ]; then
+    if [[ "$old_blob" = "$BASE_BLOB" ]] && [[ "$new_blob" = "$CURRENT_BLOB" ]] && [[ -n "${reason:-}" ]]; then
       ALLOWLISTED_RESYNC=1
       break
     fi
   done < "$ALLOWLIST"
 fi
 
-if [ "$CONTRACT_STABILITY" = pre-live ] || [ "$ALLOWLISTED_RESYNC" = 1 ]; then
+if [[ "$CONTRACT_STABILITY" = pre-live ]] || [[ "$ALLOWLISTED_RESYNC" = 1 ]]; then
   # Advisory stance: print every change (oasdiff without --fail-on never
   # exits non-zero on findings) so the deliberate breaks stay visible in
   # the log, but do not block.
   "${OASDIFF_CMD[@]}" breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" -f text
-  if [ "$ALLOWLISTED_RESYNC" = 1 ]; then
+  if [[ "$ALLOWLISTED_RESYNC" = 1 ]]; then
     echo "contract-breaking-check: advisory — this exact pre-live contract resync is ratified; any later contract edit restores the stable gate"
   else
     echo "contract-breaking-check: advisory (CONTRACT_STABILITY=pre-live) — breaking change(s) printed above, if any, are deliberately permitted for this run"

--- a/scripts/check-ext-migrations.sh
+++ b/scripts/check-ext-migrations.sh
@@ -21,11 +21,11 @@ cd "$(dirname "$0")/.."
 
 units=()
 for layer in extensions/*/migrations; do
-  [ -d "$layer" ] || continue
+  [[ -d "$layer" ]] || continue
   units+=("$(basename "$(dirname "$layer")")")
 done
 
-if [ "${#units[@]}" -eq 0 ]; then
+if [[ "${#units[@]}" -eq 0 ]]; then
   echo "OK: check-ext-migrations — no extension declares a migrations/ layer"
   exit 0
 fi

--- a/scripts/check-host-ports.sh
+++ b/scripts/check-host-ports.sh
@@ -30,7 +30,7 @@ if range="$(sysctl -n net.ipv4.ip_local_port_range 2>/dev/null)"; then
   read -r lo _ <<<"$range"
 fi
 
-if [ ! -f "$compose_file" ]; then
+if [[ ! -f "$compose_file" ]]; then
   echo "check-host-ports: $compose_file not found" >&2
   exit 1
 fi
@@ -50,7 +50,7 @@ while IFS= read -r line; do
       continue
       ;;
   esac
-  if [ "$hostport" -ge "$lo" ]; then
+  if [[ "$hostport" -ge "$lo" ]]; then
     echo "EPHEMERAL HOST PORT: $hostport is at or above the ephemeral floor ($lo) — pick one below it: $line" >&2
     fail=1
   fi
@@ -68,7 +68,7 @@ done < <(awk '
   }
 ' "$compose_file")
 
-if [ "$fail" -eq 0 ]; then
+if [[ "$fail" -eq 0 ]]; then
   echo "host ports OK (all below the ephemeral floor $lo)"
 fi
 exit "$fail"

--- a/scripts/check-image-pins.sh
+++ b/scripts/check-image-pins.sh
@@ -17,7 +17,7 @@ workflow_dir=".github/workflows"
 actions_dir=".github/actions"
 compose_files="infra/docker-compose.dev.yml"
 
-if [ ! -d "$workflow_dir" ]; then
+if [[ ! -d "$workflow_dir" ]]; then
   echo "No $workflow_dir directory found — skipping image-pin check"
   exit 0
 fi
@@ -28,7 +28,7 @@ fi
 # actions it calls. A composite action pulls those into CI exactly as a workflow
 # does, so an unpinned `uses:` one level down would otherwise ride in unread.
 scan_dirs=("$workflow_dir")
-[ -d "$actions_dir" ] && scan_dirs+=("$actions_dir")
+[[ -d "$actions_dir" ]] && scan_dirs+=("$actions_dir")
 
 # --- Workflow `uses:` actions: pinned to a commit SHA or digest ---
 while IFS= read -r line; do
@@ -38,7 +38,7 @@ while IFS= read -r line; do
     ./*) continue ;; # local composite action: versioned with the repo itself
   esac
   ref="${pin##*@}"
-  if [ "$ref" = "$pin" ] || ! grep -qE '^([0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$' <<<"$ref"; then
+  if [[ "$ref" = "$pin" ]] || ! grep -qE '^([0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$' <<<"$ref"; then
     echo "UNPINNED REF: $line" >&2
     fail=1
   fi
@@ -68,7 +68,7 @@ while IFS= read -r line; do
 done < <(grep -rnE --include='*.yml' --include='*.yaml' \
   '^[[:space:]]*(-[[:space:]]+)?image:' "${scan_dirs[@]}" $compose_files 2>/dev/null || true)
 
-if [ "$fail" -eq 0 ]; then
+if [[ "$fail" -eq 0 ]]; then
   echo "image pins OK"
 fi
 exit "$fail"

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -92,7 +92,7 @@ migrations_at() {
 # broken checkout fails loudly there instead of quietly disarming the gate,
 # which is the contract-breaking gate's convention and the same hazard.
 if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
-  if [ "${MIGRATION_VERSIONS_REQUIRE_BASE:-}" = "1" ]; then
+  if [[ "${MIGRATION_VERSIONS_REQUIRE_BASE:-}" = "1" ]]; then
     echo "check-migration-versions: base ref '$BASE_REF' not found and MIGRATION_VERSIONS_REQUIRE_BASE=1 — fetch the base ref (checkout fetch-depth: 0)" >&2
     exit 1
   fi
@@ -112,7 +112,7 @@ fi
 # the fork falls back to the tip, which is the stricter reading this gate
 # always applied.
 FORK_REF="$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)"
-if [ -z "$FORK_REF" ]; then
+if [[ -z "$FORK_REF" ]]; then
   FORK_REF="$BASE_REF"
 fi
 
@@ -158,13 +158,13 @@ baseline_reset="${MIGRATION_VERSIONS_BASELINE_RESET:-}"
 # namespace? Only when it collapses AND shares no "<version> <name>" line.
 reset_admitted() {
   local ns="$1" tree_rows="$2" base_rows="$3" shared
-  [ "$baseline_reset" = "1" ] || return 1
+  [[ "$baseline_reset" = "1" ]] || return 1
 
   # FAIL CLOSED from here down. Admitting is what disarms the gate, so anything
   # this function is not sure of has to be "no". An empty row set or a comparison
   # that did not run would otherwise yield zero shared migrations — which is
   # exactly the shape of a true consolidation.
-  if [ -z "$tree_rows" ] || [ -z "$base_rows" ]; then
+  if [[ -z "$tree_rows" ]] || [[ -z "$base_rows" ]]; then
     echo "note: $ns declares a baseline reset but one side has no migrations to compare — refusing the declaration rather than reading that as 'nothing in common'" >&2
     return 1
   fi
@@ -177,7 +177,7 @@ reset_admitted() {
   local tree_n base_n
   tree_n="$(echo "$tree_rows" | grep -c . || true)"
   base_n="$(echo "$base_rows" | grep -c . || true)"
-  if [ "${tree_n:-0}" -ge "${base_n:-0}" ]; then
+  if [[ "${tree_n:-0}" -ge "${base_n:-0}" ]]; then
     echo "note: $ns declares a baseline reset but does not collapse ($tree_n migration(s) here, $base_n on $BASE_REF) — a consolidation ends with fewer, so the findings below are enforced" >&2
     return 1
   fi
@@ -190,7 +190,7 @@ reset_admitted() {
       echo "note: $ns declares a baseline reset but the comparison produced '$shared' instead of a count — refusing the declaration" >&2
       return 1 ;;
   esac
-  if [ "$shared" -ne 0 ]; then
+  if [[ "$shared" -ne 0 ]]; then
     echo "note: $ns declares a baseline reset but keeps $shared migration(s) at the version AND name the base has — that is not a consolidation, so the findings below are enforced" >&2
     return 1
   fi
@@ -201,7 +201,7 @@ reset_admitted() {
 # fail MESSAGE — report a finding, and fail unless this namespace is an admitted
 # baseline reset.
 fail() {
-  if [ "$ns_reset" = "1" ]; then
+  if [[ "$ns_reset" = "1" ]]; then
     echo "baseline-reset (would FAIL): $1" >&2
     return
   fi
@@ -232,7 +232,7 @@ for ns in $all_namespaces; do
 
   # A namespace is a directory holding migrations, not merely a directory:
   # `testdata/` sits beside core/ and custom/ and is neither, on either side.
-  if [ -z "$tree_rows" ] && [ -z "$base_rows" ]; then
+  if [[ -z "$tree_rows" ]] && [[ -z "$base_rows" ]]; then
     continue
   fi
   checked=$((checked + 1))
@@ -241,7 +241,7 @@ for ns in $all_namespaces; do
   # gives the same answer without booting Postgres, and keeps this gate honest
   # when there is no base ref to compare against.
   dupes="$(echo "$tree_rows" | cut -d' ' -f1 | uniq -d)"
-  if [ -n "$dupes" ]; then
+  if [[ -n "$dupes" ]]; then
     echo "FAIL: $ns declares one version twice — the namespace will not load:" >&2
     for v in $dupes; do
       echo "  $v: $(echo "$tree_rows" | awk -v v="$v" '$1==v {print $2}' | tr '\n' ' ')" >&2
@@ -250,7 +250,7 @@ for ns in $all_namespaces; do
     continue
   fi
 
-  if [ -z "$base_rows" ]; then
+  if [[ -z "$base_rows" ]]; then
     continue # a namespace this branch introduces has nothing to sort after
   fi
   base_max="$(echo "$base_rows" | cut -d' ' -f1 | tail -n1)"
@@ -287,7 +287,7 @@ for ns in $all_namespaces; do
   # absence from the tree is staleness, not a rename — see FORK_REF above.
   vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1 | sort -u) <(echo "$tree_rows" | cut -d' ' -f1 | sort -u) |
     comm -12 - <(echo "$fork_rows" | cut -d' ' -f1 | sort -u))"
-  if [ -n "$vanished" ]; then
+  if [[ -n "$vanished" ]]; then
     for v in $vanished; do
       vname="$(echo "$base_rows" | awk -v v="$v" '$1==v {print $2}' | head -n1)"
       fail "$ns/$v ('$vname') is on $BASE_REF but this branch no longer has it — a migration a deployed database may already have applied cannot be renamed or removed; add a new one instead of renumbering it. MIGRATION_VERSIONS_BASELINE_RESET=1 will not admit this on its own: the namespace must also end with FEWER migrations than $BASE_REF has, which a rename alone never does — see reset_admitted"
@@ -295,7 +295,7 @@ for ns in $all_namespaces; do
   fi
 
   while read -r version name; do
-    [ -n "$version" ] || continue
+    [[ -n "$version" ]] || continue
     base_name="$(echo "$base_rows" | awk -v v="$version" '$1==v {print $2}')"
 
     # The base already carries this version. Same file: a migration this branch
@@ -303,7 +303,7 @@ for ns in $all_namespaces; do
     # migrations claiming one version — the outage, and the case a per-tree
     # loader test cannot see, because in this branch's tree the version is
     # unique and the conflict exists only against the base.
-    if [ -n "$base_name" ]; then
+    if [[ -n "$base_name" ]]; then
       # The base carries this version MORE THAN ONCE, so the base is the thing
       # that is broken and this branch is the repair. A repair leaves one of the
       # colliding migrations at the version and renumbers the other, so the
@@ -311,11 +311,11 @@ for ns in $all_namespaces; do
       # of a new collision. Without this the gate refuses every repair of the
       # outage it exists to report, and the only way back to a loadable
       # namespace is to bypass the gate.
-      if [ "$(echo "$base_name" | wc -l)" -gt 1 ] && grep -qxF "$name" <<<"$base_name"; then
+      if [[ "$(echo "$base_name" | wc -l)" -gt 1 ]] && grep -qxF "$name" <<<"$base_name"; then
         echo "note: $ns/$version is claimed twice on $BASE_REF ($(echo "$base_name" | tr '\n' ' ')); this branch keeps '$name' at it — repairing, not colliding"
         continue
       fi
-      if [ "$base_name" != "$name" ]; then
+      if [[ "$base_name" != "$name" ]]; then
         fail "$ns/$version is claimed by two different migrations — '$name' here, '$base_name' on $BASE_REF. Rename this one above $base_max and rebase (in core, re-stamp it with 'make migrate-create'). If this branch is a baseline consolidation, set MIGRATION_VERSIONS_BASELINE_RESET=1"
       fi
       continue
@@ -331,11 +331,11 @@ for ns in $all_namespaces; do
   done <<<"$tree_rows"
 done
 
-if [ "$failed" -ne 0 ]; then
+if [[ "$failed" -ne 0 ]]; then
   exit 1
 fi
 
-if [ "$baseline_reset" = "1" ]; then
+if [[ "$baseline_reset" = "1" ]]; then
   # Which namespaces the declaration actually covered is in the per-namespace
   # notes above. Saying only "a reset was declared" here would read as though it
   # applied everywhere, including to a namespace that refused it.

--- a/scripts/check-test-lanes.sh
+++ b/scripts/check-test-lanes.sh
@@ -60,7 +60,7 @@ while IFS= read -r f; do
 # craftsmanship gate tooling with its own tests, out of this gate's scope.
 done < <(find backend -name '*_test.go' 2>/dev/null | sort)
 
-if [ "$violations" -ne 0 ]; then
+if [[ "$violations" -ne 0 ]]; then
   echo "FAIL: test-lanes — real-infra tests must carry //go:build integration."
   exit 1
 fi

--- a/scripts/e2e-llm.sh
+++ b/scripts/e2e-llm.sh
@@ -55,7 +55,7 @@ ONLY="${SCENARIO:-}"
 E2E_LLM_MODEL="${E2E_LLM_MODEL:-claude-opus-5}"
 KEEP="${E2E_LLM_KEEP:-0}"
 
-if [ "${MARGINCE_E2E_LLM:-0}" != "1" ]; then
+if [[ "${MARGINCE_E2E_LLM:-0}" != "1" ]]; then
   cat >&2 <<'MSG'
 e2e-llm is opt-in: it drives a real model and bills real tokens.
 
@@ -83,11 +83,11 @@ command -v python3 >/dev/null || { echo "python3 is required to read the scenari
 # was on trial. What must not happen either way is a run that silently falls
 # back to whatever the operator's own shell is logged into, because then the
 # lane is measuring a different account's model.
-if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+if [[ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]]; then
   CREDENTIAL=ANTHROPIC_AUTH_TOKEN
-elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
   CREDENTIAL=ANTHROPIC_API_KEY
-elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
   CREDENTIAL=CLAUDE_CODE_OAUTH_TOKEN
 else
   echo "no credential is set: CLAUDE_CODE_OAUTH_TOKEN (a subscription token from" >&2
@@ -97,7 +97,7 @@ fi
 
 WORK="$(mktemp -d)"
 cleanup() {
-  if [ "$KEEP" = "1" ]; then
+  if [[ "$KEEP" = "1" ]]; then
     echo "stack left up (DEV_SLUG=$SLUG); stop it with: make dev-stop DEV_SLUG=$SLUG"
   else
     (cd "$ROOT" && make dev-stop DEV_SLUG="$SLUG" >/dev/null 2>&1) || true
@@ -180,7 +180,7 @@ mint_passport() {
     "$APP_BASE/v1/passports" | python3 -c 'import json,sys
 try: print(json.load(sys.stdin).get("token",""))
 except Exception: print("")')"
-  [ -n "$PASSPORT" ] || { echo "could not mint a passport" >&2; exit 1; }
+  [[ -n "$PASSPORT" ]] || { echo "could not mint a passport" >&2; exit 1; }
 
   python3 -c 'import json,sys
 cfg = {"mcpServers": {sys.argv[4]: {"type": "http", "url": sys.argv[1] + "/mcp",
@@ -196,7 +196,7 @@ open(sys.argv[3], "w").write(json.dumps(cfg))' \
     -H "Authorization: Bearer $PASSPORT" -H 'Content-Type: application/json' \
     -H 'Accept: application/json, text/event-stream' \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"e2e-llm","version":"1"}}}')"
-  [ "$probe" = "200" ] || {
+  [[ "$probe" = "200" ]] || {
     echo "the freshly minted passport cannot reach $APP_BASE/mcp (HTTP $probe)" >&2
     exit 1
   }
@@ -232,7 +232,7 @@ run_once() {
 
   # An unknown flag produces an empty transcript, which a naive checker reads as
   # a scenario that called nothing — a false failure that looks like a finding.
-  if [ ! -s "$out" ]; then
+  if [[ ! -s "$out" ]]; then
     echo "  the CLI produced no transcript:" >&2
     head -5 "$out.err" >&2
     return 1
@@ -265,7 +265,7 @@ for line in open(sys.argv[1]):
 else:
     print("no-system-line")
 ' "$out" "$MCP_SERVER")"
-  if [ "$status" != "connected" ]; then
+  if [[ "$status" != "connected" ]]; then
     echo "  the $MCP_SERVER MCP server is '$status', not connected — the assistant was offered" >&2
     echo "  no Margince tools at all, so every scenario would fail for a reason that is not the" >&2
     echo "  product's. A 'disabled' here means this CLI has a server of that name turned off for" >&2
@@ -283,7 +283,7 @@ REPORT="$WORK/report.txt"
 
 for scenario in "$SCENARIO_DIR"/*.yaml; do
   name="$(python3 "$ROOT/e2e/llm/check.py" --field name "$scenario")"
-  if [ -n "$ONLY" ] && [ "$ONLY" != "$name" ]; then continue; fi
+  if [[ -n "$ONLY" ]] && [[ "$ONLY" != "$name" ]]; then continue; fi
 
   runs="$(python3 "$ROOT/e2e/llm/check.py" --field runs "$scenario")"
   pass_at="$(python3 "$ROOT/e2e/llm/check.py" --field pass_at "$scenario")"
@@ -299,7 +299,7 @@ for scenario in "$SCENARIO_DIR"/*.yaml; do
     # create records; a second run against them is testing a different world.
     case "$name" in
       case1_*|case2_*|case3_*)
-        if [ "$i" -gt 1 ]; then
+        if [[ "$i" -gt 1 ]]; then
           # dev-stop FIRST. dev-fresh refuses to boot over a port its own
           # stack is already holding — "port :18081 already in use" — so
           # calling it on the running stack killed the lane after case 1
@@ -355,7 +355,7 @@ for scenario in "$SCENARIO_DIR"/*.yaml; do
     fi
   done
 
-  if [ "$ok" -ge "$pass_at" ]; then
+  if [[ "$ok" -ge "$pass_at" ]]; then
     PASSED=$((PASSED + 1))
     echo "  $name: PASS ($ok/$runs)" | tee -a "$REPORT"
   else
@@ -377,4 +377,4 @@ echo "================ e2e-llm ================"
 cat "$REPORT"
 echo "scenarios: $PASSED passed, $FAILED failed"
 echo "records:   $RECORD_DIR"
-[ "$FAILED" -eq 0 ]
+[[ "$FAILED" -eq 0 ]]

--- a/scripts/main-health-range.sh
+++ b/scripts/main-health-range.sh
@@ -42,7 +42,7 @@ last_green="$(gh run list \
   --jq '.[0].headSha // empty' 2>/dev/null || true)"
 
 range=""
-if [ -n "$last_green" ] && git cat-file -e "$last_green^{commit}" 2>/dev/null; then
+if [[ -n "$last_green" ]] && git cat-file -e "$last_green^{commit}" 2>/dev/null; then
   range="$last_green..HEAD"
   bound="since the last green health check ($(git rev-parse --short "$last_green"))"
 else
@@ -64,7 +64,7 @@ bt="$(printf '\140')"
 # shellcheck disable=SC2086 -- $range is deliberately word-split; see above.
 commits="$(git log $range --no-merges --format='- %h %an — %s' | sed -E "s/^- ([0-9a-f]+) /- ${bt}\1${bt} /" || true)"
 
-if [ -z "$commits" ]; then
+if [[ -z "$commits" ]]; then
   commits="_no commits in the range — the breakage predates it, or the range could not be computed._"
 fi
 

--- a/scripts/migration-baseline.sh
+++ b/scripts/migration-baseline.sh
@@ -161,7 +161,7 @@ capture() {
 
 cmd_verify() {
   local ref="${1:-}"
-  [ -n "$ref" ] || die "usage: migration-baseline.sh verify <base-ref>"
+  [[ -n "$ref" ]] || die "usage: migration-baseline.sh verify <base-ref>"
   require_container
   git rev-parse --verify -q "$ref" >/dev/null || die "base ref '$ref' not found — fetch it first"
 

--- a/scripts/new-migration.sh
+++ b/scripts/new-migration.sh
@@ -30,7 +30,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CORE_DIR="$ROOT/backend/migrations/core"
 
 NAME="${1:-}"
-if [ -z "$NAME" ]; then
+if [[ -z "$NAME" ]]; then
   echo "new-migration: a name is required, e.g. 'make migrate-create NAME=add_renewal_risk'" >&2
   exit 1
 fi
@@ -62,7 +62,7 @@ VERSION="$(date +%s)"
 # written, rather than in a gate whose advice is to re-stamp — which would
 # reproduce the same refused number.
 HIGHEST="$(find "$CORE_DIR" -maxdepth 1 -name '*.up.sql' -exec basename {} \; | cut -d_ -f1 | sort | tail -n1)"
-if [ -n "$HIGHEST" ] && ! [[ "$VERSION" > "$HIGHEST" ]]; then
+if [[ -n "$HIGHEST" ]] && ! [[ "$VERSION" > "$HIGHEST" ]]; then
   echo "new-migration: this machine's clock reads $VERSION, which does not sort above $HIGHEST, the highest version in backend/migrations/core — either the clock is behind, or a migration already in the tree was stamped by one that runs fast" >&2
   exit 1
 fi
@@ -73,7 +73,7 @@ DOWN="$CORE_DIR/${VERSION}_${NAME}.down.sql"
 # Two invocations inside the same second would otherwise silently overwrite the
 # first pair, which reads as the scaffold having done nothing.
 for f in "$UP" "$DOWN"; do
-  if [ -e "$f" ]; then
+  if [[ -e "$f" ]]; then
     echo "new-migration: $f already exists — wait a second and run again, or pick another name" >&2
     exit 1
   fi

--- a/scripts/overlay-hubspot-fixture.sh
+++ b/scripts/overlay-hubspot-fixture.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 BASE="https://api.hubapi.com"
 # Token from HUBSPOT_TOKEN (then the subcommand is $1), or as the first arg
 # (then the subcommand is $2): `HUBSPOT_TOKEN=pat- script seed` or `script pat- seed`.
-if [ -n "${HUBSPOT_TOKEN:-}" ]; then
+if [[ -n "${HUBSPOT_TOKEN:-}" ]]; then
   TOKEN="${HUBSPOT_TOKEN}"; SUBCMD="${1:-}"
 else
   TOKEN="${1:-}"; SUBCMD="${2:-}"
@@ -37,7 +37,7 @@ EMAIL_DOMAIN="overlay-fixture.example.com"  # contact emails end here; a valid T
                                         # (HubSpot rejects the reserved .test TLD as INVALID_EMAIL)
 NAME_PREFIX="[fixture] "                # company/deal/lead names start with this
 
-if [ -z "${TOKEN}" ]; then
+if [[ -z "${TOKEN}" ]]; then
   echo "error: set HUBSPOT_TOKEN=pat-... (a HubSpot private-app token)" >&2
   exit 2
 fi
@@ -55,7 +55,7 @@ hs() {
     ${body:+-d "$body"})"
   status="${out##*$'\n'}"
   out="${out%$'\n'*}"
-  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+  if [[ "$status" -lt 200 ]] || [[ "$status" -ge 300 ]]; then
     echo "HubSpot ${method} ${path} -> HTTP ${status}" >&2
     echo "$out" | jq . >&2 2>/dev/null || echo "$out" >&2
     return 1
@@ -70,7 +70,7 @@ resolve_owner() {
   owners="$(hs GET "/crm/v3/owners?limit=1")"
   OWNER_ID="$(printf '%s' "$owners" | jq -r '.results[0].id // empty')"
   OWNER_EMAIL="$(printf '%s' "$owners" | jq -r '.results[0].email // empty')"
-  if [ -z "$OWNER_ID" ]; then
+  if [[ -z "$OWNER_ID" ]]; then
     echo "error: no CRM owner found — the token needs crm.objects.owners.read and the account needs at least one user" >&2
     exit 1
   fi
@@ -84,7 +84,7 @@ resolve_pipeline() {
   pipelines="$(hs GET "/crm/v3/pipelines/deals")"
   DEAL_PIPELINE="$(printf '%s' "$pipelines" | jq -r '.results[0].id // empty')"
   DEAL_STAGE="$(printf '%s' "$pipelines" | jq -r '.results[0].stages[0].id // empty')"
-  if [ -z "$DEAL_PIPELINE" ] || [ -z "$DEAL_STAGE" ]; then
+  if [[ -z "$DEAL_PIPELINE" ]] || [[ -z "$DEAL_STAGE" ]]; then
     echo "error: could not resolve a deals pipeline/stage (crm.objects.deals.read / crm.schemas.deals.read)" >&2
     exit 1
   fi
@@ -109,14 +109,14 @@ archive_marked() {
   while :; do
     resp="$(hs POST "/crm/v3/objects/${object}/search" "$(printf '%s' "$search" | jq --arg a "${after:-}" '. + (if $a=="" then {} else {after:$a} end)')")" || return 1
     count="$(printf '%s' "$resp" | jq -r '.results | length')"
-    if [ "${count:-0}" -gt 0 ]; then
+    if [[ "${count:-0}" -gt 0 ]]; then
       ids="$(printf '%s' "$resp" | jq -c '[.results[].id]')"
       hs POST "/crm/v3/objects/${object}/batch/archive" \
         "$(printf '%s' "$ids" | jq '{inputs: [ .[] | {id: .} ]}')" >/dev/null || return 1
       echo "  archived ${count} ${object}"
     fi
     after="$(printf '%s' "$resp" | jq -r '.paging.next.after // empty')"
-    [ -n "$after" ] || break
+    [[ -n "$after" ]] || break
   done
 }
 

--- a/scripts/phase-timer.sh
+++ b/scripts/phase-timer.sh
@@ -36,7 +36,7 @@ start)
 	# phase's seconds are already the sum of the inner ones. Refusing at the
 	# point of nesting names the recipe that did it; without this the run dies
 	# much later, at the outer `stop`, pointing at the wrong line.
-	if [ -f "$open" ]; then
+	if [[ -f "$open" ]]; then
 		echo "phase-timer: \"$label\" starts inside \"$(cut -f2- "$open")\", which is still open —" >&2
 		echo "             phases do not nest; a sub-make's own phases replace its caller's, not sit inside it" >&2
 		exit 1
@@ -47,7 +47,7 @@ stop)
 	# No open phase means `start` never ran — a recipe edited into a shape this
 	# script no longer brackets. Say so rather than recording a phase of zero,
 	# which would read as a phase that cost nothing.
-	if [ ! -f "$open" ]; then
+	if [[ ! -f "$open" ]]; then
 		echo "phase-timer: stop with no open phase — a start line is missing from the recipe" >&2
 		exit 1
 	fi
@@ -57,7 +57,7 @@ stop)
 	rm -f "$open"
 	;;
 report)
-	[ -f "$ledger" ] || exit 0
+	[[ -f "$ledger" ]] || exit 0
 	total=$(awk -F'\t' '{s += $1} END {print s+0}' "$ledger")
 	echo ""
 	echo "  where the time went ($(printf '%dm%02ds' $((total / 60)) $((total % 60))) total)"

--- a/scripts/reap-build-caches.sh
+++ b/scripts/reap-build-caches.sh
@@ -39,7 +39,7 @@ caches="$(gh api "repos/$repo/actions/caches?per_page=100" \
 # An empty listing is ambiguous — a repository with no caches looks exactly like
 # a token that cannot read them, and the second one must not pass for a clean
 # sweep. There is always at least one cache on a repository whose CI has run.
-if [ -z "$caches" ]; then
+if [[ -z "$caches" ]]; then
 	echo "reap-build-caches: $repo listed no caches at all — refusing to report a clean sweep over a read that returned nothing" >&2
 	exit 1
 fi
@@ -50,7 +50,7 @@ freed=0
 kept=0
 
 while IFS=$'\t' read -r created id key size; do
-	[ -n "$id" ] || continue
+	[[ -n "$id" ]] || continue
 	case "$key" in
 	go-build-*) ;;
 	*) continue ;;
@@ -72,7 +72,7 @@ while IFS=$'\t' read -r created id key size; do
 	case " $seen_groups " in
 	*" $group "*)
 		printf 'delete  %6s MB  %s  (superseded)\n' "$((size / 1048576))" "$key"
-		if [ "$dry_run" != "1" ]; then
+		if [[ "$dry_run" != "1" ]]; then
 			gh api -X DELETE "repos/$repo/actions/caches/$id" --silent
 		fi
 		deleted=$((deleted + 1))
@@ -86,11 +86,11 @@ while IFS=$'\t' read -r created id key size; do
 	esac
 done <<<"$caches"
 
-if [ "$kept" -eq 0 ]; then
+if [[ "$kept" -eq 0 ]]; then
 	echo "reap-build-caches: no go-build-* cache found — the key prefix changed, so this ran over nothing" >&2
 	exit 1
 fi
 
 verb="freed"
-[ "$dry_run" = "1" ] && verb="would free"
+[[ "$dry_run" = "1" ]] && verb="would free"
 echo "reap-build-caches: kept $kept, deleted $deleted, $verb $((freed / 1048576)) MB"

--- a/scripts/seed-demo-company.sh
+++ b/scripts/seed-demo-company.sh
@@ -59,9 +59,9 @@ curl -fsS --max-time 10 "$API_BASE/readyz" >/dev/null 2>&1 \
   || fail "$API_BASE/readyz is not answering — start the stack first (make dev)"
 
 status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
-[ "$status" = "200" ] || fail "login returned HTTP $status"
+[[ "$status" = "200" ]] || fail "login returned HTTP $status"
 SESSION="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
-[ -n "$SESSION" ] || fail "the server answered OK but set no crm_session cookie"
+[[ -n "$SESSION" ]] || fail "the server answered OK but set no crm_session cookie"
 echo "  OK: logged in as $ADMIN_EMAIL"
 
 # ---- the company -----------------------------------------------------------
@@ -70,7 +70,7 @@ echo "  OK: logged in as $ADMIN_EMAIL"
 # so a demo account that is not one cannot show the cards this exists to show.
 echo "== the company =="
 org_id="$(psql_one "SELECT id FROM organization WHERE display_name = '$COMPANY' AND archived_at IS NULL LIMIT 1")"
-if [ -z "$org_id" ]; then
+if [[ -z "$org_id" ]]; then
   status="$(api POST /organizations "$(jq -n --arg n "$COMPANY" '{
     display_name: $n,
     lifecycle: "customer",
@@ -79,7 +79,7 @@ if [ -z "$org_id" ]; then
     employee_band: "51_200",
     source: "manual"
   }')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "creating $COMPANY returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "creating $COMPANY returned HTTP $status"; }
   org_id="$(jq -r .id < "$workdir/body")"
   echo "  OK: created $COMPANY"
 else
@@ -97,7 +97,7 @@ person_id() { psql_one "SELECT id FROM person WHERE full_name = '$1' AND archive
 ensure_person() { # ensure_person <name> <email> <title>
   local name="$1" email="$2" title="$3" existing status
   existing="$(person_id "$name")"
-  if [ -n "$existing" ]; then
+  if [[ -n "$existing" ]]; then
     # stderr, not stdout: stdout IS the id this function returns, and a
     # progress line on it becomes part of the value the caller captures.
     echo "  OK: $name already present" >&2
@@ -111,7 +111,7 @@ ensure_person() { # ensure_person <name> <email> <title>
     organization_id: $o,
     source: "manual"
   }')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "creating $name returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "creating $name returned HTTP $status"; }
   echo "  OK: created $name" >&2
   jq -r .id < "$workdir/body"
 }
@@ -126,15 +126,15 @@ mark_id="$(ensure_person "Mark Hughes" "mark@glazedfrog.example" "Operations Man
 # refuses to rank its deals, which is correct and shows nothing.
 echo "== the deals =="
 status="$(api GET /pipelines)"
-[ "$status" = "200" ] || fail "GET /v1/pipelines returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/pipelines returned HTTP $status"
 pipeline_id="$(jq -r '.data[] | select(.is_default) | .id' "$workdir/body")"
 stage_proposal="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Proposal") | .id' "$workdir/body")"
 stage_qualified="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Qualified") | .id' "$workdir/body")"
-[ -n "$stage_proposal" ] && [ -n "$stage_qualified" ] || fail "the default pipeline has no Proposal/Qualified stage"
+[[ -n "$stage_proposal" ]] && [[ -n "$stage_qualified" ]] || fail "the default pipeline has no Proposal/Qualified stage"
 
 ensure_deal() { # ensure_deal <name> <stage-id> <amount-minor> <close-date>
   local name="$1" stage="$2" amount="$3" closes="$4" status
-  if [ -n "$(psql_one "SELECT id FROM deal WHERE name = '$name' AND archived_at IS NULL LIMIT 1")" ]; then
+  if [[ -n "$(psql_one "SELECT id FROM deal WHERE name = '$name' AND archived_at IS NULL LIMIT 1")" ]]; then
     echo "  OK: deal $name already present"
     return
   fi
@@ -143,7 +143,7 @@ ensure_deal() { # ensure_deal <name> <stage-id> <amount-minor> <close-date>
       name: $n, pipeline_id: $p, stage_id: $s, organization_id: $o,
       amount_minor: $a, currency: "EUR", expected_close_date: $c, source: "manual"
     }')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "creating deal $name returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "creating deal $name returned HTTP $status"; }
   echo "  OK: created deal $name"
 }
 
@@ -158,12 +158,12 @@ ensure_deal "Facade retrofit programme" "$stage_qualified" 4200000 "2027-02-15"
 echo "== the history =="
 ensure_activity() { # ensure_activity <source-id> <json-body>
   local key="$1" body="$2" status
-  if [ -n "$(psql_one "SELECT id FROM activity WHERE source_id = '$key' AND archived_at IS NULL LIMIT 1")" ]; then
+  if [[ -n "$(psql_one "SELECT id FROM activity WHERE source_id = '$key' AND archived_at IS NULL LIMIT 1")" ]]; then
     echo "  OK: $key already present"
     return
   fi
   status="$(api POST /activities "$body")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "creating activity $key returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "creating activity $key returned HTTP $status"; }
   echo "  OK: created $key"
 }
 
@@ -209,7 +209,7 @@ ensure_activity demo-gf-task "$(jq -n --arg o "$org_id" '{
 # the writer the moment the mirror changes.
 echo "== the accounting source =="
 conn_id="$(psql_one "SELECT id FROM finance_connection WHERE archived_at IS NULL AND status <> 'disconnected' LIMIT 1")"
-if [ -z "$conn_id" ]; then
+if [[ -z "$conn_id" ]]; then
   conn_id="$(psql_one "INSERT INTO finance_connection
       (provider, status, credential_ref, source, captured_by)
     VALUES ('offline_demo', 'active', 'offline://demo', 'system', 'system:seed')
@@ -219,7 +219,7 @@ else
   echo "  OK: an accounting source is already connected"
 fi
 
-if [ -z "$(psql_one "SELECT 1 FROM finance_customer_link WHERE organization_id = '$org_id' AND archived_at IS NULL")" ]; then
+if [[ -z "$(psql_one "SELECT 1 FROM finance_customer_link WHERE organization_id = '$org_id' AND archived_at IS NULL")" ]]; then
   psql_one "INSERT INTO finance_customer_link
       (connection_id, organization_id, external_customer_id,
        sync_hash, source, captured_by)

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -36,7 +36,7 @@ ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
 # elsewhere (CI) passes BOOTSTRAP_PASSWORD instead, and the literal is the last
 # resort for a stack booted by hand.
 BOOTSTRAP_PASSWORD_FILE="${BOOTSTRAP_PASSWORD_FILE:-config/margince-admin-password}"
-if [ -z "${BOOTSTRAP_PASSWORD:-}" ] && [ -r "$BOOTSTRAP_PASSWORD_FILE" ]; then
+if [[ -z "${BOOTSTRAP_PASSWORD:-}" ]] && [[ -r "$BOOTSTRAP_PASSWORD_FILE" ]]; then
   BOOTSTRAP_PASSWORD="$(cat "$BOOTSTRAP_PASSWORD_FILE")"
 fi
 BOOTSTRAP_PASSWORD="${BOOTSTRAP_PASSWORD:-operator-supplied-first-password}"
@@ -91,7 +91,7 @@ api_if_match() { # api_if_match <method> <path> <version> <json-body>
 # plain-http localhost — so pull the token out and send it explicitly.
 capture_session() {
   SESSION="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
-  [ -n "$SESSION" ] || fail "the server answered OK but set no crm_session cookie"
+  [[ -n "$SESSION" ]] || fail "the server answered OK but set no crm_session cookie"
 }
 
 # A configured bootstrap has the OPERATOR choose the first admin's password, and
@@ -114,20 +114,20 @@ sign_in_as_admin() {
   # itself, so there is no direct way to lift the hold in that case. Detour
   # through an intermediate value instead: unconditional, and convergent
   # whichever state the account started in.
-  if [ "$ADMIN_PASSWORD" = "$BOOTSTRAP_PASSWORD" ]; then
+  if [[ "$ADMIN_PASSWORD" = "$BOOTSTRAP_PASSWORD" ]]; then
     rotate_admin_password_via_detour
     return
   fi
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
-  if [ "$status" = "200" ]; then
+  if [[ "$status" = "200" ]]; then
     capture_session
     echo "  OK: logged in as $ADMIN_EMAIL"
     return
   fi
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$BOOTSTRAP_PASSWORD" '{email:$e,password:$p}')")"
-  if [ "$status" != "200" ]; then
+  if [[ "$status" != "200" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "login as $ADMIN_EMAIL returned HTTP $status for both the chosen and the operator-supplied password — the api bootstraps the demo organization at boot from its margince.yaml (make dev writes it); if the credentials changed, reset the dev database and restart the stack"
@@ -137,7 +137,7 @@ sign_in_as_admin() {
 
   status="$(api POST /auth/change-password \
     "$(jq -n --arg c "$BOOTSTRAP_PASSWORD" --arg n "$ADMIN_PASSWORD" '{current_password:$c,new_password:$n}')")"
-  if [ "$status" != "204" ]; then
+  if [[ "$status" != "204" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "POST /v1/auth/change-password returned HTTP $status — the admin cannot replace the operator-supplied password, so nothing below can be seeded"
@@ -145,7 +145,7 @@ sign_in_as_admin() {
 
   # The change ends every session, including the one that made it.
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
-  if [ "$status" != "200" ]; then
+  if [[ "$status" != "200" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "login with the newly chosen password returned HTTP $status"
@@ -169,7 +169,7 @@ rotate_admin_password_via_detour() {
   local detour="${ADMIN_PASSWORD:0:240}-seed-dev-detour" status
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
-  if [ "$status" != "200" ]; then
+  if [[ "$status" != "200" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "login as $ADMIN_EMAIL returned HTTP $status — the api bootstraps the demo organization at boot from its margince.yaml (make dev writes it); if the credentials changed, reset the dev database and restart the stack"
@@ -178,14 +178,14 @@ rotate_admin_password_via_detour() {
 
   status="$(api POST /auth/change-password \
     "$(jq -n --arg c "$ADMIN_PASSWORD" --arg n "$detour" '{current_password:$c,new_password:$n}')")"
-  if [ "$status" != "204" ]; then
+  if [[ "$status" != "204" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "POST /v1/auth/change-password (rotating off the operator-supplied password) returned HTTP $status"
   fi
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$detour" '{email:$e,password:$p}')")"
-  if [ "$status" != "200" ]; then
+  if [[ "$status" != "200" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "login with the detour password returned HTTP $status — the account is now on an intermediate password (ADMIN_PASSWORD with the literal suffix '-seed-dev-detour' appended, truncated to 256 characters; see rotate_admin_password_via_detour). Recover by exporting that value as ADMIN_PASSWORD and re-running, then running once more with the original ADMIN_PASSWORD"
@@ -194,14 +194,14 @@ rotate_admin_password_via_detour() {
 
   status="$(api POST /auth/change-password \
     "$(jq -n --arg c "$detour" --arg n "$ADMIN_PASSWORD" '{current_password:$c,new_password:$n}')")"
-  if [ "$status" != "204" ]; then
+  if [[ "$status" != "204" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "POST /v1/auth/change-password (restoring the chosen password) returned HTTP $status — the account is stuck on the detour password (see rotate_admin_password_via_detour for how it's derived from ADMIN_PASSWORD)"
   fi
 
   status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
-  if [ "$status" != "200" ]; then
+  if [[ "$status" != "200" ]]; then
     echo "  response body:" >&2
     cat "$workdir/body" >&2
     fail "login with the chosen password returned HTTP $status after restoring it"
@@ -311,7 +311,7 @@ ensure_activity() { # ensure_activity <label> <subject> <source-id> <json-body>
   # carrying the demo dataset plus a real inbox can hold more — so the seeder
   # would miss both its own row and somebody else's, and write a second one.
   mine="$(find_first "$query" '.source_system == "seed" and .source_id == $k' --arg k "$key")"
-  if [ -n "$mine" ]; then
+  if [[ -n "$mine" ]]; then
     echo "  OK: $label already present"
     return
   fi
@@ -321,7 +321,7 @@ ensure_activity() { # ensure_activity <label> <subject> <source-id> <json-body>
   # demo whose result depends on which row a reader or a verification step
   # happens to open, and that is worse than a seed that stops and says so.
   theirs="$(find_first "$query" '.subject == $s' --arg s "$subject")"
-  if [ -n "$theirs" ]; then
+  if [[ -n "$theirs" ]]; then
     fail "an activity titled \"$subject\" is already here without the seed key $key — remove or rename it, because seeding beside it would leave two rows nothing can tell apart"
   fi
   # KEYED, so the write is idempotent at the database: two seed runs overlapping
@@ -416,9 +416,9 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
   while :; do
     case "$path" in *\?*) sep="&" ;; *) sep="?" ;; esac
     status="$(api GET "$path${sep}limit=100${cursor:+&cursor=$(url_encode "$cursor")}")"
-    [ "$status" = "200" ] || fail "GET /v1${path} returned HTTP $status"
+    [[ "$status" = "200" ]] || fail "GET /v1${path} returned HTTP $status"
     row="$(jq -c --arg today "$TODAY" "$@" "first(.data[] | select($select)) // empty" "$workdir/body")"
-    if [ -n "$row" ]; then
+    if [[ -n "$row" ]]; then
       printf '%s' "$row"
       return
     fi
@@ -427,7 +427,7 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
     # handles no for itself. A bare `return` here carries the test's own exit
     # status, which is 1 when the cursor is empty — and under `set -e` that
     # killed the whole script the first time a lookup legitimately found nothing.
-    [ -n "$cursor" ] || return 0
+    [[ -n "$cursor" ]] || return 0
   done
 }
 
@@ -446,7 +446,7 @@ person_id() { # person_id <full-name> <email> — prints the id, empty when abse
 }
 
 org_id="$(find_first '/organizations?domain=demo.test' '.display_name == "Demo GmbH"' | jq -r '.id // empty')"
-[ -n "$org_id" ] || fail "Demo GmbH is not in the installation the seed just wrote to"
+[[ -n "$org_id" ]] || fail "Demo GmbH is not in the installation the seed just wrote to"
 
 # The roles are the demo's own: a company page whose three contacts have no
 # titles reads as a page that failed to load them.
@@ -465,19 +465,19 @@ org_id="$(find_first '/organizations?domain=demo.test' '.display_name == "Demo G
 employ() { # employ <full-name> <email> <role>
   local name="$1" email="$2" role="$3" id edges standing rel_id rel_version status
   id="$(person_id "$name" "$email")"
-  [ -n "$id" ] || fail "$name <$email> is not in the installation the seed just wrote to"
+  [[ -n "$id" ]] || fail "$name <$email> is not in the installation the seed just wrote to"
   edges="/relationships?kind=employment&person_id=$id"
-  if [ -n "$(find_first "$edges" ".organization_id == \$org and $CURRENT_PRIMARY_JQ" --arg org "$org_id")" ]; then
+  if [[ -n "$(find_first "$edges" ".organization_id == \$org and $CURRENT_PRIMARY_JQ" --arg org "$org_id")" ]]; then
     echo "  OK: $name already employed at Demo GmbH"
     return
   fi
   standing="$(find_first "$edges" \
     '.organization_id == $org and (.ended_at == null or (.ended_at | tostring) >= $today)' \
     --arg org "$org_id")"
-  if [ -n "$standing" ]; then
+  if [[ -n "$standing" ]]; then
     rel_id="$(printf '%s' "$standing" | jq -r '.id')"
     rel_version="$(printf '%s' "$standing" | jq -r '.version // ""')"
-    [ -n "$rel_version" ] || fail "GET /v1/relationships answered $name's employment without a version to write against"
+    [[ -n "$rel_version" ]] || fail "GET /v1/relationships answered $name's employment without a version to write against"
     status="$(api_if_match PATCH "/relationships/$rel_id" "$rel_version" '{"is_current_primary":true}')"
     case "$status" in
       200) echo "  OK: $name's employment at Demo GmbH is their primary one again" ;;
@@ -503,13 +503,13 @@ employ "Carol Wagner" "carol@demo.test" "Managing Director"
 
 echo "== seed-dev: demo account lifecycle =="
 status="$(api GET "/organizations/$org_id")"
-[ "$status" = "200" ] || fail "GET /v1/organizations/$org_id returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/organizations/$org_id returned HTTP $status"
 org_lifecycle="$(jq -r '.lifecycle // ""' "$workdir/body")"
 org_version="$(jq -r '.version // ""' "$workdir/body")"
-if [ "$org_lifecycle" = "customer" ]; then
+if [[ "$org_lifecycle" = "customer" ]]; then
   echo "  OK: Demo GmbH is already a customer"
 else
-  [ -n "$org_version" ] || fail "GET /v1/organizations/$org_id answered without a version to write against"
+  [[ -n "$org_version" ]] || fail "GET /v1/organizations/$org_id answered without a version to write against"
   status="$(api_if_match PATCH "/organizations/$org_id" "$org_version" '{"lifecycle":"customer"}')"
   case "$status" in
     200) echo "  OK: Demo GmbH is a customer" ;;
@@ -526,16 +526,16 @@ echo "== seed-dev: demo deals =="
 # list before creating. Stages come from the bootstrap-seeded default
 # pipeline ("Sales": Qualified → … → Won/Lost).
 status="$(api GET /pipelines)"
-[ "$status" = "200" ] || fail "GET /v1/pipelines returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/pipelines returned HTTP $status"
 pipeline_id="$(jq -r '.data[] | select(.is_default) | .id' "$workdir/body")"
-[ -n "$pipeline_id" ] || fail "no default pipeline — the bootstrap seed did not run?"
+[[ -n "$pipeline_id" ]] || fail "no default pipeline — the bootstrap seed did not run?"
 stage_id_qualified="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Qualified") | .id' "$workdir/body")"
 stage_id_proposal="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Proposal") | .id' "$workdir/body")"
-[ -n "$stage_id_qualified" ] && [ -n "$stage_id_proposal" ] \
+[[ -n "$stage_id_qualified" ]] && [[ -n "$stage_id_proposal" ]] \
   || fail "the default pipeline is missing its seeded Qualified/Proposal stages"
 
 status="$(api GET '/deals?limit=100')"
-[ "$status" = "200" ] || fail "GET /v1/deals returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/deals returned HTTP $status"
 deals_page="$workdir/deals.json"
 cp "$workdir/body" "$deals_page"
 
@@ -564,7 +564,7 @@ ensure_deal "Globex Renewal" "$stage_id_proposal" 1200000
 echo "== seed-dev: work for the Worklist =="
 
 alice_id="$(person_id "Alice Müller" "alice@demo.test")"
-[ -n "$alice_id" ] || fail "Alice Müller is missing, so there is nobody for the demo mail to be from"
+[[ -n "$alice_id" ]] || fail "Alice Müller is missing, so there is nobody for the demo mail to be from"
 
 # A task the admin wrote themselves and did not assign. It lands on their own
 # queue because the writer stamps the author as assignee — which is the whole
@@ -623,7 +623,7 @@ ensure_conversation() { # ensure_conversation <slug> <subject> <kind> <direction
   # NOBODY SENDS A MEETING. `-` leaves the field off rather than asserting a
   # direction the event does not have; the server then stamps the roles it
   # stamps for an undirected interaction, which is what a meeting is.
-  if [ "$direction" != "-" ]; then
+  if [[ "$direction" != "-" ]]; then
     direction_field="$(jq -n --arg d "$direction" '{direction:$d}')"
   fi
   # A NATURAL KEY, so the write is idempotent at the database rather than only
@@ -643,7 +643,7 @@ ensure_conversation() { # ensure_conversation <slug> <subject> <kind> <direction
 
 bob_id="$(person_id "Bob Schmidt" "bob@demo.test")"
 carol_id="$(person_id "Carol Wagner" "carol@demo.test")"
-[ -n "$bob_id" ] && [ -n "$carol_id" ] \
+[[ -n "$bob_id" ]] && [[ -n "$carol_id" ]] \
   || fail "the demo people this seed just wrote are not readable back — nothing to hang a conversation on"
 
 # Both directions on the same contact, deliberately: the strength score's

--- a/scripts/seed-person-page.sh
+++ b/scripts/seed-person-page.sh
@@ -42,13 +42,13 @@ api() { # api <method> <path> [json-body] — prints the HTTP status, body in $w
 # plain-http localhost — so pull the token out and send it explicitly.
 capture_session() {
   SESSION="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
-  [ -n "$SESSION" ] || fail "the server answered OK but set no crm_session cookie"
+  [[ -n "$SESSION" ]] || fail "the server answered OK but set no crm_session cookie"
 }
 
 echo "== seed-person-page: sign in =="
 status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" \
   '{email:$e,password:$p}')")"
-[ "$status" = "200" ] || fail "login as $ADMIN_EMAIL returned HTTP $status (is the stack up? make dev)"
+[[ "$status" = "200" ]] || fail "login as $ADMIN_EMAIL returned HTTP $status (is the stack up? make dev)"
 capture_session
 
 # ---------------------------------------------------------------------------
@@ -58,11 +58,11 @@ capture_session
 echo "== seed-person-page: the account =="
 org_id=""
 status="$(api GET '/organizations?q=Glazed%20Frog&limit=10')"
-[ "$status" = "200" ] || fail "GET /v1/organizations returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/organizations returned HTTP $status"
 org_id="$(jq -r '.data[] | select(.display_name == "Glazed Frog") | .id' "$workdir/body" | head -1)"
-if [ -z "$org_id" ]; then
+if [[ -z "$org_id" ]]; then
   status="$(api POST /organizations '{"display_name":"Glazed Frog","domains":[{"domain":"glazedfrog.com","is_primary":true}],"source":"seed"}')"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "create organization returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "create organization returned HTTP $status"; }
   org_id="$(jq -r .id "$workdir/body")"
   echo "  OK: created Glazed Frog"
 else
@@ -77,15 +77,15 @@ fi
 ensure_person() { # ensure_person <full_name> <title> <email> — prints the id
   local name="$1" title="$2" email="$3" id status
   status="$(api GET "/people?q=$(printf '%s' "$name" | jq -sRr @uri)&limit=10")"
-  [ "$status" = "200" ] || fail "GET /v1/people returned HTTP $status"
+  [[ "$status" = "200" ]] || fail "GET /v1/people returned HTTP $status"
   id="$(jq -r --arg n "$name" '.data[] | select(.full_name == $n) | .id' "$workdir/body" | head -1)"
-  if [ -n "$id" ]; then
+  if [[ -n "$id" ]]; then
     echo "$id"
     return
   fi
   status="$(api POST /people "$(jq -n --arg n "$name" --arg t "$title" --arg e "$email" \
     '{full_name:$n,title:$t,emails:[{email:$e,is_primary:true}],source:"seed"}')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "create person $name returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "create person $name returned HTTP $status"; }
   jq -r .id "$workdir/body"
 }
 
@@ -127,28 +127,28 @@ employ "$mark_id" "Director of Operations"
 
 echo "== seed-person-page: the deal =="
 status="$(api GET /pipelines)"
-[ "$status" = "200" ] || fail "GET /v1/pipelines returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/pipelines returned HTTP $status"
 pipeline_id="$(jq -r '.data[] | select(.is_default) | .id' "$workdir/body")"
 stage_proposal="$(jq -r --arg p "$pipeline_id" \
   '.data[] | select(.id == $p) | .stages[] | select(.name == "Proposal") | .id' "$workdir/body")"
-[ -n "$stage_proposal" ] || fail "the default pipeline has no Proposal stage"
+[[ -n "$stage_proposal" ]] || fail "the default pipeline has no Proposal stage"
 
 # The mockups show "closes 30 Jun", but an open deal may not claim a close date
 # in the past and this seed has to keep working as time passes. The nearest
 # 30 June that is still ahead of today carries the mockup's figure honestly.
 close_date="$(date -u '+%Y')-06-30"
-if [ "$close_date" \< "$(date -u '+%Y-%m-%d')" ]; then
+if [[ "$close_date" < "$(date -u '+%Y-%m-%d')" ]]; then
   close_date="$(( $(date -u '+%Y') + 1 ))-06-30"
 fi
 
 status="$(api GET '/deals?limit=100')"
-[ "$status" = "200" ] || fail "GET /v1/deals returned HTTP $status"
+[[ "$status" = "200" ]] || fail "GET /v1/deals returned HTTP $status"
 deal_id="$(jq -r '.data[] | select(.name == "Expansion — Phase 2") | .id' "$workdir/body" | head -1)"
-if [ -z "$deal_id" ]; then
+if [[ -z "$deal_id" ]]; then
   status="$(api POST /deals "$(jq -n --arg p "$pipeline_id" --arg s "$stage_proposal" --arg o "$org_id" --arg c "$close_date" \
     '{name:"Expansion — Phase 2",pipeline_id:$p,stage_id:$s,organization_id:$o,
       amount_minor:9500000,currency:"EUR",expected_close_date:$c,source:"seed"}')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "create deal returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "create deal returned HTTP $status"; }
   deal_id="$(jq -r .id "$workdir/body")"
   echo "  OK: created Expansion — Phase 2 (€95k, Proposal, closes $close_date)"
 else
@@ -188,7 +188,7 @@ ahead() { date -u -v+"$1"H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "+$1 
 log_activity() { # log_activity <person-id> <kind> <direction|""> <subject> <body> <when> <label>
   local person="$1" kind="$2" direction="$3" subject="$4" body="$5" when="$6" label="$7" status
   status="$(api GET "/activities?entity_type=person&entity_id=$person&limit=50")"
-  [ "$status" = "200" ] || fail "GET /v1/activities returned HTTP $status"
+  [[ "$status" = "200" ]] || fail "GET /v1/activities returned HTTP $status"
   if jq -e --arg s "$subject" '.data[] | select(.subject == $s)' "$workdir/body" >/dev/null; then
     echo "  OK: \"$label\" already captured"
     return
@@ -198,7 +198,7 @@ log_activity() { # log_activity <person-id> <kind> <direction|""> <subject> <bod
     '{kind:$k,subject:$s,body:$b,occurred_at:$o,
       links:[{entity_type:"person",entity_id:$p}],source:"seed"}
      + (if $d == "" then {} else {direction:$d} end)')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "capture \"$label\" returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "capture \"$label\" returned HTTP $status"; }
   echo "  OK: captured \"$label\""
 }
 
@@ -244,17 +244,17 @@ echo "== seed-person-page: what was said =="
 activity_id() { # activity_id <person-id> <subject> — prints the id, empty if absent
   local person="$1" subject="$2" status
   status="$(api GET "/activities?entity_type=person&entity_id=$person&limit=50")"
-  [ "$status" = "200" ] || fail "GET /v1/activities returned HTTP $status"
+  [[ "$status" = "200" ]] || fail "GET /v1/activities returned HTTP $status"
   jq -r --arg s "$subject" '.data[] | select(.subject == $s) | .id' "$workdir/body" | head -1
 }
 
 claim() { # claim <person-id> <kind> <body> <source-subject> <quote> [due-at]
   local person="$1" kind="$2" body="$3" subject="$4" quote="$5" due="${6:-}" source status
   source="$(activity_id "$person" "$subject")"
-  [ -n "$source" ] || fail "no captured activity titled \"$subject\" to ground this claim on"
+  [[ -n "$source" ]] || fail "no captured activity titled \"$subject\" to ground this claim on"
 
   status="$(api GET "/people/$person/360")"
-  [ "$status" = "200" ] || fail "GET /v1/people/$person/360 returned HTTP $status"
+  [[ "$status" = "200" ]] || fail "GET /v1/people/$person/360 returned HTTP $status"
   if jq -e --arg b "$body" '(.claims // [])[] | select(.body == $b)' "$workdir/body" >/dev/null; then
     echo "  OK: \"$body\" already recorded"
     return
@@ -264,7 +264,7 @@ claim() { # claim <person-id> <kind> <body> <source-subject> <quote> [due-at]
     --arg a "$source" --arg q "$quote" --arg d "$due" \
     '{kind:$k,body:$b,source_activity_id:$a,source_quote:$q}
      + (if $d == "" then {} else {due_at:$d} end)')")"
-  [ "$status" = "201" ] || { cat "$workdir/body" >&2; fail "record claim returned HTTP $status"; }
+  [[ "$status" = "201" ]] || { cat "$workdir/body" >&2; fail "record claim returned HTTP $status"; }
   echo "  OK: recorded \"$body\""
 }
 

--- a/scripts/test-api-entrypoint.sh
+++ b/scripts/test-api-entrypoint.sh
@@ -42,7 +42,7 @@ failures=0
 run() {
     local probe="$1"; shift
     local password="" have_password=0 existing="" have_existing=0
-    while [ $# -gt 0 ]; do
+    while [[ $# -gt 0 ]]; do
         case "$1" in
             --password) password="$2"; have_password=1; shift 2 ;;
             --existing) existing="$2"; have_existing=1; shift 2 ;;
@@ -64,7 +64,7 @@ STUB
 
     # An EMPTY pre-existing file is a real state — a spent credential truncated
     # rather than removed — so this is gated on the flag, not on the contents.
-    if [ "$have_existing" -eq 1 ]; then
+    if [[ "$have_existing" -eq 1 ]]; then
         printf '%s' "$existing" >"$work/app/secrets/admin-password"
     fi
 
@@ -74,7 +74,7 @@ STUB
     chmod +x "$work/entrypoint.sh"
 
     local status=0
-    if [ "$have_password" -eq 1 ]; then
+    if [[ "$have_password" -eq 1 ]]; then
         out="$(
             PATH="$work/bin:$PATH" \
             MARGINCE_OWNER_DSN="postgres://owner@localhost/x" \
@@ -95,7 +95,7 @@ STUB
 }
 
 check() { # description condition-already-evaluated
-    if [ "$1" = "pass" ]; then
+    if [[ "$1" = "pass" ]]; then
         printf '  ok   %s\n' "$2"
     else
         printf '  FAIL %s\n' "$2" >&2
@@ -104,7 +104,7 @@ check() { # description condition-already-evaluated
 }
 
 verdict() { # want-true actual description
-    if [ "$1" = "$2" ]; then check pass "$3"; else check fail "$3 (got: $2)"; fi
+    if [[ "$1" = "$2" ]]; then check pass "$3"; else check fail "$3 (got: $2)"; fi
 }
 
 echo "api-entrypoint: the credential is written only onto an unprovisioned installation"
@@ -123,7 +123,7 @@ served() { # status description
 status=0
 run true --password "s3cret-passw0rd" || status=$?
 served "$status" "provisioned"
-verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict absent "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "a provisioned installation is never handed the supplied credential"
 verdict yes "$(grep -q "already has an organization" <<<"$out" && echo yes || echo no)" \
     "and says so, because an ignored credential must not look like an applied one"
@@ -133,7 +133,7 @@ verdict yes "$(grep -q "already has an organization" <<<"$out" && echo yes || ec
 status=0
 run true --existing "left-by-an-earlier-boot" || status=$?
 served "$status" "provisioned with a stale file"
-verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict absent "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "a credential left by an earlier boot is retired once the organization exists"
 
 # An empty spent file is the same defect wearing a different shape: something
@@ -141,14 +141,14 @@ verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
 status=0
 run true --existing "" || status=$?
 served "$status" "provisioned with an emptied file"
-verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict absent "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "an emptied credential file is retired too, not left behind because it holds nothing"
 
 # --- a fresh installation ----------------------------------------------------
 status=0
 run false --password "s3cret-passw0rd" || status=$?
 served "$status" "unprovisioned"
-verdict present "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict present "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "an unprovisioned installation gets the credential it was given"
 verdict s3cret-passw0rd "$(cat "$pwfile" 2>/dev/null || echo '')" \
     "written verbatim, with no trailing newline a password would absorb"
@@ -165,7 +165,7 @@ verdict 600 "$(stat -c '%a' "$pwfile" 2>/dev/null || stat -f '%OLp' "$pwfile" 2>
 status=0
 run false || status=$?
 served "$status" "unprovisioned with no variable"
-verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict absent "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "no variable, no file"
 
 # --- the probe cannot answer -------------------------------------------------
@@ -174,16 +174,16 @@ verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
 # outcome this whole block exists to prevent.
 status=0
 run fail --password "s3cret-passw0rd" || status=$?
-verdict nonzero "$([ "$status" -ne 0 ] && echo nonzero || echo zero)" \
+verdict nonzero "$([[ "$status" -ne 0 ]] && echo nonzero || echo zero)" \
     "a probe that cannot answer refuses to start"
 verdict no "$(grep -q "stub: api started" <<<"$out" && echo yes || echo no)" \
     "and the api is never reached"
-verdict absent "$([ -e "$pwfile" ] && echo present || echo absent)" \
+verdict absent "$([[ -e "$pwfile" ]] && echo present || echo absent)" \
     "and writes nothing — a failed probe is not an unprovisioned installation"
 verdict yes "$(grep -q "could not determine" <<<"$out" && echo yes || echo no)" \
     "naming what could not be determined rather than failing opaquely"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo "FAIL: $failures entrypoint expectation(s) not met" >&2
     exit 1
 fi

--- a/scripts/test-dev-cleanup.sh
+++ b/scripts/test-dev-cleanup.sh
@@ -75,7 +75,7 @@ remember() { # pid
 }
 
 check() { # want got description
-    if [ "$1" = "$2" ]; then
+    if [[ "$1" = "$2" ]]; then
         printf '  ok   %s\n' "$3"
     else
         printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
@@ -623,7 +623,7 @@ quiet_probe() {
 }
 quiet_probe
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
     printf 'FAIL: %d check(s)\n' "$failures" >&2
     exit 1
 fi

--- a/scripts/test-dev-dsn.sh
+++ b/scripts/test-dev-dsn.sh
@@ -21,7 +21,7 @@ dev="$root/scripts/dev.sh"
 failures=0
 
 check() { # want got description
-    if [ "$1" = "$2" ]; then
+    if [[ "$1" = "$2" ]]; then
         printf '  ok   %s\n' "$3"
     else
         printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
@@ -62,7 +62,7 @@ check "postgresql://u:p@h:5432/margince_dev_x" \
 for bad in "host=h port=5432 dbname=prod user=u" "mysql://u:p@h:3306/prod"; do
     status=0
     out="$(with_database "$bad" margince_dev_x 2>&1)" || status=$?
-    check nonzero "$([ "$status" -ne 0 ] && echo nonzero || echo zero)" \
+    check nonzero "$([[ "$status" -ne 0 ]] && echo nonzero || echo zero)" \
           "refused rather than rewritten: ${bad%%:*}…"
     check yes "$(grep -q "must be a postgres:// or postgresql:// URL" <<<"$out" && echo yes || echo no)" \
           "and says what shape it needs: ${bad%%:*}…"
@@ -105,7 +105,7 @@ check yes "$(grep -q 'exec docker exec -i "$container" psql' "$root/scripts/dev-
 leaks="$(grep -nE '^[^#]*(echo|printf)[^|]*\$(dev_owner_url|dev_app_url|OWNER_DSN|APP_DSN|MARGINCE_DSN|MARGINCE_OWNER_DSN)' "$dev" || true)"
 check "" "$leaks" "no DSN is ever echoed"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo "FAIL: $failures dev-stack DSN expectation(s) not met" >&2
     exit 1
 fi

--- a/scripts/test-dev-isolation.sh
+++ b/scripts/test-dev-isolation.sh
@@ -18,7 +18,7 @@ dev="$root/scripts/dev.sh"
 failures=0
 
 check() { # want got description
-    if [ "$1" = "$2" ]; then
+    if [[ "$1" = "$2" ]]; then
         printf '  ok   %s\n' "$3"
     else
         printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
@@ -308,7 +308,7 @@ claimed="$(claim_stack "alpha")"
 read -r alpha_db alpha_port <<<"$claimed"
 check "64" "$alpha_db" "the first stack claims the bottom of the Redis block"
 check "8081" "$alpha_port" "and the bottom of the port range"
-check "1" "$([ -f "$tmp_root/alpha/env" ] && echo 1 || echo 0)" \
+check "1" "$([[ -f "$tmp_root/alpha/env" ]] && echo 1 || echo 0)" \
       "the reservation is on disk BEFORE anything binds — a claim visible only once the stack is up is not a claim"
 check "1" "$(grep -c "^STARTER_PID=$$\$" "$tmp_root/alpha/env")" \
       "and it records who is starting it, which is what stops a losing run deleting a winner's claim"
@@ -399,10 +399,10 @@ fake_server "$theirs_dsn" "localhost:16379/64"; theirs=$REPLY
 # The exec'd argv has to be visible to ps before the matcher reads it. Poll for
 # it rather than sleeping a guessed interval.
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-    [ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ] && break
+    [[ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ]] && break
     sleep 0.1
 done
-check "1" "$([ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ] && echo 1 || echo 0)" \
+check "1" "$([[ -n "$(ps -o command= -p "$mine" 2>/dev/null)" ]] && echo 1 || echo 0)" \
       "the fake worker is running — without this the four checks below would pass on an empty machine"
 
 check "$mine" "$(stack_server_pids "$mine_dsn" "localhost:16379/0" | sort -u)" \
@@ -478,7 +478,7 @@ check "linked" "$(cd "$probe/linked" || exit 1; _testdb_worktree_slug)" \
 git -C "$probe/primary" worktree add -q "$probe/_" --detach
 check "" "$(dev_sanitize_slug "_")" \
       "the sanitiser really does reduce this name to nothing, which is what makes the next check the real case"
-check "1" "$([ -n "$(cd "$probe/_" || exit 1; dev_derive_slug)" ] && echo 1 || echo 0)" \
+check "1" "$([[ -n "$(cd "$probe/_" || exit 1; dev_derive_slug)" ]] && echo 1 || echo 0)" \
       "a name that sanitises to nothing still yields a slug, never the empty answer that means primary"
 
 # Two worktrees whose basenames are identical must not share one slug: that would
@@ -486,7 +486,7 @@ check "1" "$([ -n "$(cd "$probe/_" || exit 1; dev_derive_slug)" ] && echo 1 || e
 mkdir -p "$probe/a" "$probe/b"
 git -C "$probe/primary" worktree add -q "$probe/a/dup" --detach
 git -C "$probe/primary" worktree add -q "$probe/b/dup" --detach
-check "1" "$([ "$(cd "$probe/a/dup" || exit 1; dev_derive_slug)" != "$(cd "$probe/b/dup" || exit 1; dev_derive_slug)" ] && echo 1 || echo 0)" \
+check "1" "$([[ "$(cd "$probe/a/dup" || exit 1; dev_derive_slug)" != "$(cd "$probe/b/dup" || exit 1; dev_derive_slug)" ]] && echo 1 || echo 0)" \
       "two worktrees with the SAME basename get different slugs, so they cannot share a database"
 
 # And two whose names share only their FIRST 24 CHARACTERS. The readable half of a
@@ -498,9 +498,9 @@ git -C "$probe/primary" worktree add -q "$probe/$(printf 'p%.0s' $(seq 1 30))-al
 git -C "$probe/primary" worktree add -q "$probe/$(printf 'p%.0s' $(seq 1 30))-beta" --detach
 long_a="$(cd "$probe/$(printf 'p%.0s' $(seq 1 30))-alpha" || exit 1; dev_derive_slug)"
 long_b="$(cd "$probe/$(printf 'p%.0s' $(seq 1 30))-beta" || exit 1; dev_derive_slug)"
-check "1" "$([ "${long_a:0:24}" = "${long_b:0:24}" ] && echo 1 || echo 0)" \
+check "1" "$([[ "${long_a:0:24}" = "${long_b:0:24}" ]] && echo 1 || echo 0)" \
       "the two names really do share their first 24 characters, which is what makes the next check the real case"
-check "1" "$([ "$long_a" != "$long_b" ] && echo 1 || echo 0)" \
+check "1" "$([[ "$long_a" != "$long_b" ]] && echo 1 || echo 0)" \
       "and they still get different slugs — uniqueness lives in the digest, not the truncated name"
 
 # A slug must be STABLE for as long as a stack runs. An earlier version appended
@@ -524,7 +524,7 @@ check "$slug_before" "$(cd "$probe/linked-moved" || exit 1; dev_derive_slug)" \
 # and margince-dev-<slug> (S3 caps a bucket name at 63), so it has to leave room
 # for both prefixes however long the directory name is.
 long_slug="$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" || exit 1; dev_derive_slug)"
-check "1" "$([ "${#long_slug}" -le 40 ] && echo 1 || echo 0)" \
+check "1" "$([[ "${#long_slug}" -le 40 ]] && echo 1 || echo 0)" \
       "a long directory name still yields a slug short enough for the database and bucket names built from it"
 case "$long_slug" in
     www*) recognisable=1 ;;
@@ -535,13 +535,13 @@ check "1" "$recognisable" \
 
 long_one="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-one" && _testdb_worktree_slug)"
 long_two="margince_test_$(cd "$probe/$(printf 'w%.0s' $(seq 1 60))-two" && _testdb_worktree_slug)"
-check "1" "$([ "${#long_one}" -le 63 ] && echo 1 || echo 0)" \
+check "1" "$([[ "${#long_one}" -le 63 ]] && echo 1 || echo 0)" \
       "a long worktree name still yields a template name inside Postgres's 63-byte identifier limit"
-check "1" "$([ "$long_one" != "$long_two" ] && echo 1 || echo 0)" \
+check "1" "$([[ "$long_one" != "$long_two" ]] && echo 1 || echo 0)" \
       "two long names sharing a prefix still get different templates, so neither rebuilds the other's schema"
 rm -rf "$probe"
 
-if [ "$failures" -gt 0 ]; then
+if [[ "$failures" -gt 0 ]]; then
     printf 'FAIL: %d check(s) failed\n' "$failures" >&2
     exit 1
 fi

--- a/scripts/test-integration-one.sh
+++ b/scripts/test-integration-one.sh
@@ -26,15 +26,15 @@ declare_lane_budget 1
 
 DIR="${1:-}"
 RUN="${2:-}"
-if [ -z "$DIR" ]; then
+if [[ -z "$DIR" ]]; then
   echo "usage: $0 DIR [RUN]   (DIR e.g. backend/internal/compose/integration; RUN e.g. TestFoo)" >&2
   exit 2
 fi
 # Every integration package lives in the backend module; map the repo-root dir to
 # a module-relative package path.
-if [ "$DIR" = "backend" ]; then
+if [[ "$DIR" = "backend" ]]; then
   rel="."
-elif [ "${DIR#backend/}" != "$DIR" ]; then
+elif [[ "${DIR#backend/}" != "$DIR" ]]; then
   rel="./${DIR#backend/}"
 else
   echo "FAIL: '$DIR' is not under the backend module" >&2
@@ -50,7 +50,7 @@ make_clone "$db"
 trap 'st=$?; if ! drop_clone "$db"; then echo "FAIL: clone db $db was not dropped — leaked on the test cluster" >&2; if [[ "$st" -eq 0 ]]; then st=1; fi; fi; exit "$st"' EXIT
 
 run_flag=()
-[ -n "$RUN" ] && run_flag=(-run "$RUN")
+[[ -n "$RUN" ]] && run_flag=(-run "$RUN")
 echo "test-integration-one: backend $rel ${RUN:+(-run $RUN) }(db=$db)"
 
 ( cd backend \

--- a/scripts/test-migration-versions.sh
+++ b/scripts/test-migration-versions.sh
@@ -46,7 +46,7 @@ fixture() {
   hooks_path="$(git -C "$dir" config core.hooksPath 2>/dev/null)"
   hooks_status=$?
   case "$hooks_status" in
-    0) [ -z "$hooks_path" ] || return 1 ;;
+    0) [[ -z "$hooks_path" ]] || return 1 ;;
     1) : ;;
     *) return 1 ;;
   esac
@@ -62,8 +62,8 @@ fixture() {
   # Assert the repository is the one we meant to build. Without this, a git that
   # resolved somewhere else leaves an empty $dir and a green case: the gate finds
   # no namespace, skips, and exits 0, which is what four of the ten cases want.
-  [ -d "$dir/.git" ] || return 1
-  [ -f "$dir/backend/migrations/core/0001_alpha.up.sql" ] || return 1
+  [[ -d "$dir/.git" ]] || return 1
+  [[ -f "$dir/backend/migrations/core/0001_alpha.up.sql" ]] || return 1
 }
 
 # HERMETIC — and stated as the enumeration below plus a CHECK, not as a promise.
@@ -144,14 +144,14 @@ expect() {
   fi
 
   local out rc=0
-  if [ "$declared" = "declared" ]; then
+  if [[ "$declared" = "declared" ]]; then
     out="$(cd "$dir" && MIGRATION_VERSIONS_BASELINE_RESET=1 ./scripts/check-migration-versions.sh base 2>&1)" || rc=$?
   else
     out="$(cd "$dir" && ./scripts/check-migration-versions.sh base 2>&1)" || rc=$?
   fi
   rm -rf "$dir"
 
-  if [ "$rc" -ne "$want" ]; then
+  if [[ "$rc" -ne "$want" ]]; then
     printf 'FAIL  %s\n      exit %s, want %s\n' "$name" "$rc" "$want" >&2
     printf '%s\n' "$out" | sed 's/^/      | /' >&2
     fails=$((fails + 1))
@@ -371,12 +371,12 @@ expect "a declared reset does not excuse a real collision" \
 expected_cases=16
 
 declared_cases="$(grep -c '^expect "' "$SELF")"
-if [ "$ran" -ne "$declared_cases" ]; then
+if [[ "$ran" -ne "$declared_cases" ]]; then
   printf 'FAIL  ran %s case(s) but %s are declared — a case stopped running\n' \
     "$ran" "$declared_cases" >&2
   fails=$((fails + 1))
 fi
-if [ "$declared_cases" -ne "$expected_cases" ]; then
+if [[ "$declared_cases" -ne "$expected_cases" ]]; then
   printf 'FAIL  %s case(s) declared, %s expected — a case was added or removed.\n' \
     "$declared_cases" "$expected_cases" >&2
   printf '      Update expected_cases in the same change, so a deletion cannot pass as a smaller green run.\n' >&2
@@ -386,11 +386,11 @@ fi
 # case_fails and fails are counted apart, because a census failure is not a case
 # failure: reporting "1 of 10 case(s) failed" when all ten passed sends the
 # reader looking through the cases for a defect that is in the accounting.
-if [ "$fails" -ne 0 ]; then
-  if [ "$case_fails" -ne 0 ]; then
+if [[ "$fails" -ne 0 ]]; then
+  if [[ "$case_fails" -ne 0 ]]; then
     printf 'FAIL: test-migration-versions — %s of %s case(s) failed\n' "$case_fails" "$ran" >&2
   fi
-  if [ "$fails" -ne "$case_fails" ]; then
+  if [[ "$fails" -ne "$case_fails" ]]; then
     printf 'FAIL: test-migration-versions — the case census above did not add up\n' >&2
   fi
   exit 1

--- a/scripts/test-reap-build-caches.sh
+++ b/scripts/test-reap-build-caches.sh
@@ -46,7 +46,7 @@ expect() {
 	set -e
 	deleted="$(paste -sd, - <"$DELETED_LOG")"
 
-	if [ "$status" -ne "$want_exit" ] || [ "$deleted" != "$want_deleted" ]; then
+	if [[ "$status" -ne "$want_exit" ]] || [[ "$deleted" != "$want_deleted" ]]; then
 		echo "FAIL: $name"
 		echo "  exit    want $want_exit got $status"
 		echo "  deleted want '$want_deleted' got '$deleted'"
@@ -89,7 +89,7 @@ expect "a key shape change fails loudly" 1 "" $'2026-08-12T04:00:00Z\t101\tgo-bu
 # A listing with caches but no build caches means the prefix moved.
 expect "a missing build-cache prefix fails loudly" 1 "" "$unrelated"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s)" >&2
 	exit 1
 fi

--- a/scripts/test-run-golangci.sh
+++ b/scripts/test-run-golangci.sh
@@ -48,7 +48,7 @@ expect() {
 
 	case "$out" in *"STALE CACHE"*) stale=yes ;; esac
 
-	if [ "$status" -ne "$want_exit" ] || [ "$stale" != "$want_stale" ]; then
+	if [[ "$status" -ne "$want_exit" ]] || [[ "$stale" != "$want_stale" ]]; then
 		echo "FAIL: $name"
 		echo "  exit  want $want_exit got $status"
 		echo "  stale want $want_stale got $stale"
@@ -154,7 +154,7 @@ for needle in "margince-next-erase/cli/craft/main.go" "cache clean" "go env GOPA
 	esac
 done
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s) — run-golangci.sh does not separate a stale-cache run from a real one"
 	exit 1
 fi

--- a/scripts/test-scheduled-report.sh
+++ b/scripts/test-scheduled-report.sh
@@ -74,7 +74,7 @@ expect() {
 	set -e
 	got="$(paste -sd, - <"$ACTION_LOG")"
 
-	if [ "$status" -ne 0 ] || [ "$got" != "$want" ]; then
+	if [[ "$status" -ne 0 ]] || [[ "$got" != "$want" ]]; then
 		echo "FAIL: $name"
 		echo "  exit    want 0 got $status"
 		echo "  actions want '$want' got '$got'"
@@ -105,7 +105,7 @@ expect_llm() {
 	set -e
 	got="$(paste -sd, - <"$ACTION_LOG")"
 
-	if [ "$status" -ne 0 ] || [ "$got" != "create $want_title" ]; then
+	if [[ "$status" -ne 0 ]] || [[ "$got" != "create $want_title" ]]; then
 		echo "FAIL: $name"
 		echo "  exit    want 0 got $status"
 		echo "  actions want 'create $want_title' got '$got'"
@@ -199,7 +199,7 @@ expect_health() {
 	got="$(paste -sd, - <"$ACTION_LOG")"
 	body="$(cat "$BODY_LOG" 2>/dev/null || true)"
 
-	if [ "$status" -ne 0 ] || [ "$got" != "$want" ]; then
+	if [[ "$status" -ne 0 ]] || [[ "$got" != "$want" ]]; then
 		echo "FAIL: $name"
 		echo "  exit    want 0 got $status"
 		echo "  actions want '$want' got '$got'"
@@ -207,7 +207,7 @@ expect_health() {
 		failures=$((failures + 1))
 		return
 	fi
-	if [ -n "$suspects" ] && ! grep -qF -- "deadbeef" <<<"$body"; then
+	if [[ -n "$suspects" ]] && ! grep -qF -- "deadbeef" <<<"$body"; then
 		echo "FAIL: $name — the issue was filed but the suspect range never reached its body"
 		failures=$((failures + 1))
 		return
@@ -216,12 +216,12 @@ expect_health() {
 	# Without this the no-range cases pass for free: an arm that dropped the
 	# fallback would still file, and "a red lane with no range still files"
 	# would go on reporting ok over a body that says nothing about the window.
-	if [ -z "$suspects" ] && ! grep -qF -- "no suspect range was computed" <<<"$body"; then
+	if [[ -z "$suspects" ]] && ! grep -qF -- "no suspect range was computed" <<<"$body"; then
 		echo "FAIL: $name — filed without saying the suspect range is unknown"
 		failures=$((failures + 1))
 		return
 	fi
-	if [ -n "$suspects" ]; then
+	if [[ -n "$suspects" ]]; then
 		covered_with_range="$covered_with_range $lane"
 	else
 		covered_no_range="$covered_no_range $lane"
@@ -302,7 +302,7 @@ expect_merge() {
 	got="$(paste -sd, - <"$ACTION_LOG")"
 	body="$(cat "$BODY_LOG" 2>/dev/null || true)"
 
-	if [ "$status" -ne 0 ] || [ "$got" != "create $want_title" ]; then
+	if [[ "$status" -ne 0 ]] || [[ "$got" != "create $want_title" ]]; then
 		echo "FAIL: $name"
 		echo "  exit    want 0 got $status"
 		echo "  actions want 'create $want_title' got '$got'"
@@ -371,7 +371,7 @@ expect_merge "a merge with no pull request is titled for what it found" \
 lanes="$(grep -oE '^if \[\[ "\$\{MAIN_[A-Z0-9_]+_RESULT:-\}" = "failure" \]\]' \
 	"$root/scripts/scheduled-report.sh" |
 	grep -oE 'MAIN_[A-Z0-9_]+_RESULT' | sort -u || true)"
-if [ -z "$lanes" ]; then
+if [[ -z "$lanes" ]]; then
 	echo "FAIL: the census found no MAIN_*_RESULT arm in the reporter — the pattern stopped matching, it did not stop mattering"
 	failures=$((failures + 1))
 fi
@@ -492,7 +492,7 @@ health="$root/.github/workflows/main-health.yml"
 # recognise never ends the slice, so the slice swallows it and that job's wiring
 # can satisfy the census on the report job's behalf.
 report_job="$(awk '/^  report:/{inside=1} inside&&/^  [A-Za-z_][A-Za-z0-9_-]*:/&&!/^  report:/{exit} inside' "$health")"
-if [ -z "$report_job" ]; then
+if [[ -z "$report_job" ]]; then
 	echo "FAIL: no 'report' job found in main-health.yml — the wiring checks below would pass by scanning nothing"
 	failures=$((failures + 1))
 fi
@@ -509,7 +509,7 @@ for lane in $lanes; do
 	fi
 done
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
 	echo "FAIL: $failures case(s)" >&2
 	exit 1
 fi

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -49,10 +49,10 @@ login_status="$(curl -sS --max-time 15 -o "$workdir/login.json" -D "$workdir/hea
   -X POST "$API_BASE/v1/auth/login" \
   -H 'Content-Type: application/json' \
   --data "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')" || true)"
-if [ -z "$login_status" ] || [ "$login_status" = "000" ]; then
+if [[ -z "$login_status" ]] || [[ "$login_status" = "000" ]]; then
   fail "could not reach $API_BASE — is the stack up? (make dev)"
 fi
-if [ "$login_status" != "200" ]; then
+if [[ "$login_status" != "200" ]]; then
   echo "  response body:" >&2
   cat "$workdir/login.json" >&2
   fail "POST /v1/auth/login returned HTTP $login_status (expected 200). Is the stack up and seeded? (make dev, then make seed-dev)"
@@ -60,7 +60,7 @@ fi
 # The cookie is Secure, which curl's jar refuses to replay over plain-http
 # localhost — extract the token and send it explicitly.
 session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
-[ -n "$session" ] || fail "login answered 200 but set no crm_session cookie"
+[[ -n "$session" ]] || fail "login answered 200 but set no crm_session cookie"
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
 echo "== verify-boot 2/6: the installation describes itself =="
@@ -78,19 +78,19 @@ echo "== verify-boot 2/6: the installation describes itself =="
 # somebody adds a record above it.
 seeded_company="$(awk '/^describe_company\(\) \{/,/^\}/' "$REPO_DIR/scripts/seed-dev.sh" \
   | sed -n 's/.*"display_name":"\([^"]*\)".*/\1/p' | head -1)"
-[ -n "$seeded_company" ] || fail "found no {\"display_name\":\"…\"} in $REPO_DIR/scripts/seed-dev.sh — this step would pass by reading nothing"
+[[ -n "$seeded_company" ]] || fail "found no {\"display_name\":\"…\"} in $REPO_DIR/scripts/seed-dev.sh — this step would pass by reading nothing"
 company_status="$(curl -sS --max-time 15 -o "$workdir/company.json" -w '%{http_code}' \
   "$API_BASE/v1/company" --cookie "crm_session=$session" || true)"
-if [ "$company_status" = "404" ]; then
+if [[ "$company_status" = "404" ]]; then
   fail "GET /v1/company answers 404 — the installation has not described itself, so every login redirects into onboarding and no browser spec that signs in can render the shell (make seed-dev)"
 fi
-if [ "$company_status" != "200" ]; then
+if [[ "$company_status" != "200" ]]; then
   echo "  response body:" >&2
   cat "$workdir/company.json" >&2
   fail "GET /v1/company returned HTTP $company_status (expected 200)"
 fi
 company_name="$(jq -r '.display_name // empty' "$workdir/company.json")"
-[ "$company_name" = "$seeded_company" ] \
+[[ "$company_name" = "$seeded_company" ]] \
   || fail "the installation calls itself '$company_name' where scripts/seed-dev.sh describes '$seeded_company' — the stack was seeded by something else, or the seed is stale (make seed-dev)"
 echo "  OK: the installation describes itself as $company_name"
 
@@ -120,13 +120,13 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
       --get --data-urlencode "limit=100" ${cursor:+--data-urlencode "cursor=$cursor"} \
       "$API_BASE/v1$path" \
       --cookie "crm_session=$session" || true)"
-    if [ "$status" != "200" ]; then
+    if [[ "$status" != "200" ]]; then
       echo "  response body:" >&2
       cat "$workdir/page.json" >&2
       fail "GET /v1$path returned HTTP $status (expected 200)"
     fi
     row="$(jq -c --arg today "$TODAY" "$@" "first(.data[] | select($select)) // empty" "$workdir/page.json")"
-    if [ -n "$row" ]; then
+    if [[ -n "$row" ]]; then
       printf '%s' "$row"
       return
     fi
@@ -135,7 +135,7 @@ find_first() { # find_first <path> <jq-row-filter> [jq-arg...]
     # handles no for itself. A bare `return` here carries the test's own exit
     # status, which is 1 when the cursor is empty — and under `set -e` that
     # killed the whole script the first time a lookup legitimately found nothing.
-    [ -n "$cursor" ] || return 0
+    [[ -n "$cursor" ]] || return 0
   done
 }
 
@@ -166,14 +166,14 @@ seeded_payloads() { # seeded_payloads <resource> — one JSON body per line
 }
 
 seeded_people="$(seeded_payloads person)"
-[ -n "$seeded_people" ] || fail "found no 'ensure \"person …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+[[ -n "$seeded_people" ]] || fail "found no 'ensure \"person …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
 
 while IFS= read -r body; do
   name="$(printf '%s' "$body" | jq -r '.full_name')"
   email="$(printf '%s' "$body" | jq -r 'first(.emails[]?.email) // empty')"
-  [ -n "$email" ] || fail "the seeder creates '$name' with no email, so this check cannot tell them from a namesake"
+  [[ -n "$email" ]] || fail "the seeder creates '$name' with no email, so this check cannot tell them from a namesake"
   person="$(find_person "$name" "$email")"
-  if [ -z "$person" ]; then
+  if [[ -z "$person" ]]; then
     fail "seeded person '$name' <$email> missing from GET /v1/people — seed absent or stale (make seed-dev)"
   fi
   # And employed somewhere, on the edge the PRODUCT reads. A person who works
@@ -188,7 +188,7 @@ while IFS= read -r body; do
   # company page, so a boot proof that accepted one would be proving something
   # nobody can see.
   person_id="$(printf '%s' "$person" | jq -r '.id')"
-  if [ -z "$(find_first "/relationships?kind=employment&person_id=$person_id" "$CURRENT_PRIMARY_JQ")" ]; then
+  if [[ -z "$(find_first "/relationships?kind=employment&person_id=$person_id" "$CURRENT_PRIMARY_JQ")" ]]; then
     echo "  their employment rows:" >&2
     cat "$workdir/page.json" >&2
     fail "seeded person '$name' has no current primary employment — they show on no company page, and the demo dataset's verify pass refuses the installation for it"
@@ -205,25 +205,25 @@ done <<< "$seeded_people"
 # and a check that reads the first hundred of them is a check that stops finding
 # what it is looking for the day the dataset grows.
 seeded_org_bodies="$(seeded_payloads organization)"
-[ -n "$seeded_org_bodies" ] || fail "found no 'ensure \"organization …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
+[[ -n "$seeded_org_bodies" ]] || fail "found no 'ensure \"organization …\"' payloads in scripts/seed-dev.sh — this step would pass by reading nothing"
 
 # The stage the seeder actually writes, read from the seeder. "Anything but the
 # default" would accept a stage nobody wrote — a boot proof reads the state the
 # seed produces, not a range of states it might have.
 seeded_lifecycle="$(sed -n 's/.*{"lifecycle":"\([a-z_]*\)"}.*/\1/p' "$REPO_DIR/scripts/seed-dev.sh" | head -1)"
-[ -n "$seeded_lifecycle" ] || fail "scripts/seed-dev.sh writes no {\"lifecycle\":\"…\"} body — this check has no stage to hold the account to"
+[[ -n "$seeded_lifecycle" ]] || fail "scripts/seed-dev.sh writes no {\"lifecycle\":\"…\"} body — this check has no stage to hold the account to"
 
 while IFS= read -r body; do
   org_name="$(printf '%s' "$body" | jq -r '.display_name')"
   org_domain="$(printf '%s' "$body" | jq -r 'first(.domains[]?.domain) // empty')"
-  [ -n "$org_domain" ] || fail "the seeder creates '$org_name' with no domain, so this check has no way to find it"
+  [[ -n "$org_domain" ]] || fail "the seeder creates '$org_name' with no domain, so this check has no way to find it"
   org="$(find_first "/organizations?domain=$(jq -rn --arg v "$org_domain" '$v|@uri')" \
     '.display_name == $name' --arg name "$org_name")"
-  if [ -z "$org" ]; then
+  if [[ -z "$org" ]]; then
     fail "seeded account '$org_name' missing from GET /v1/organizations — seed absent or stale (make seed-dev)"
   fi
   lifecycle="$(printf '%s' "$org" | jq -r '.lifecycle // "unknown"')"
-  [ "$lifecycle" = "$seeded_lifecycle" ] || fail "seeded account '$org_name' stands at '$lifecycle' where the seed writes '$seeded_lifecycle' — an account off the stage it was seeded to answers the wrong question about who the customers are, and the demo dataset's verify pass refuses a default lifecycle outright"
+  [[ "$lifecycle" = "$seeded_lifecycle" ]] || fail "seeded account '$org_name' stands at '$lifecycle' where the seed writes '$seeded_lifecycle' — an account off the stage it was seeded to answers the wrong question about who the customers are, and the demo dataset's verify pass refuses a default lifecycle outright"
   echo "  OK: '$org_name' stands at '$lifecycle'"
 done <<< "$seeded_org_bodies"
 
@@ -260,13 +260,13 @@ echo "== verify-boot 4/6: the seeded conversations are conversations =="
 # would stop seeing it without saying so.
 seeded_conversations="$(awk -F'"' '/^[[:space:]]*ensure_conversation[[:space:]]+"/ { print $2 "\t" $4 }' \
     "$REPO_DIR/scripts/seed-dev.sh")"
-[ -n "$seeded_conversations" ] \
+[[ -n "$seeded_conversations" ]] \
   || fail "found no 'ensure_conversation \"…\"' calls in scripts/seed-dev.sh — this step would pass by reading nothing"
 
 # The closed set the server stamps participants for, spelled once here and once
 # in relstrength.interactionKinds because neither can call the other.
 while IFS="$(printf '\t')" read -r slug subject; do
-  [ -n "$slug" ] || continue
+  [[ -n "$slug" ]] || continue
   # NARROWED BY THE SUBJECT, SELECTED BY THE KEY, and the two halves are doing
   # different jobs.
   #
@@ -283,7 +283,7 @@ while IFS="$(printf '\t')" read -r slug subject; do
   # skip would agree on a demo stack whose network surfaces are empty.
   logged="$(find_first "/activities?q=$(jq -rn --arg v "$subject" '$v|@uri')" \
       '.source_system == "seed" and .source_id == $k' --arg k "$slug")"
-  [ -n "$logged" ] \
+  [[ -n "$logged" ]] \
     || fail "no activity titled '$subject' carries the seed key '$slug' in GET /v1/activities — the seed is absent or stale (make seed-dev), or something else is holding that title and the seeder seeded beside it"
   kind="$(printf '%s' "$logged" | jq -r '.kind')"
   case "$kind" in
@@ -309,12 +309,12 @@ expected_transports="$(jq -r '.channels // [] | .[].provider' "$REPO_DIR"/extens
 providers_status="$(curl -sS --max-time 15 -o "$workdir/providers.json" -w '%{http_code}' \
   "$API_BASE/v1/channel-providers" \
   --cookie "crm_session=$session" || true)"
-if [ "$providers_status" != "200" ]; then
+if [[ "$providers_status" != "200" ]]; then
   echo "  response body:" >&2
   cat "$workdir/providers.json" >&2
   fail "GET /v1/channel-providers returned HTTP $providers_status (expected 200)"
 fi
-if [ -z "$expected_transports" ]; then
+if [[ -z "$expected_transports" ]]; then
   echo "  OK: no composed unit declares a channel, nothing to register"
 else
   while read -r provider; do


### PR DESCRIPTION
Clears every HIGH-reliability finding open in SonarCloud: 247 of `shelldre:S7688` (`[` where `[[` belongs) and one `godre:S8188`, which is a false positive and is written down as one rather than fixed.

## What changed

`[ "$x" = y ]` is a command whose operands are split and globbed before `test` sees them. An unset `$x` leaves `[ = y ]` — a usage error, not the false the line was written to produce — and a value with a space arrives as two words. `[[ ]]` is bash syntax and does neither. 279 lines across 35 bash scripts now spell it the way the rest of the tree already did.

The change is mechanical and was verified as such: every changed line is byte-identical to its predecessor once `[[`/`]]` are collapsed back to `[`/`]`, plus the one deliberate exception below.

**`scripts/seed-person-page.sh` also loses a backslash.** `[ "$a" \< "$b" ]` has to escape the operator so the shell does not read a redirection; inside `[[ ]]` there is no redirection to guard against and the escape is what would need undoing.

**The two `#!/bin/sh` entrypoints keep `[`.** `scripts/deploy/api-entrypoint.sh` and `scripts/deploy/worker-entrypoint.sh` run as PID 1 in the api and worker images; `[[` is bash syntax and neither dash nor busybox has it. SonarCloud did not report them — it reads the shebang — and neither does this change touch them.

**Four files were not reported and are fixed anyway:** `.githooks/pre-push`, `.claude/hooks/finish-review.sh`, `scripts/seed-person-page.sh`, `scripts/test-integration-one.sh`. They carry the same defect. Fixing only the reported call sites would have left the next reader to meet them one report at a time.

## The finding that stays open

`godre:S8188` on `laneLifetime` in `backend/cmd/worker/lanes.go` wants `defer cancel()` beside the `context.WithCancel`. That context is the worker's event lanes' *lifetime*, not the constructor's: `laneLifetime` returns the cancel wrapped in a closure and `run` defers it on the next line, before any lane exists (the shape #454 produced). Deferring it where the rule asks would cancel the lanes' context as the constructor returns and the worker would consume nothing. Recorded, with what holds the ordering instead, in the new `docs/reference/sonarcloud-deviations.md` — which opens the list of Sonar findings that stay open on purpose, so the next person to sort that dashboard does not re-derive this.

## Verification

- `make check-backend` — green. One test, `TestPublicTreeCitesNoDocumentGitIgnores`, fails identically on a clean `origin/main` in this checkout: it reads `git check-ignore`, and `.superpowers/` is excluded through `.git/info/exclude` on this machine only. CI does not have that exclude.
- Each shell gate that exercises a changed script, run individually and green: `test-api-entrypoint`, `test-dev-dsn`, `test-dev-isolation`, `test-dev-cleanup`, `test-scheduled-report`, `test-migration-versions`, `migration-versions`, `contract-breaking-check`, `check-image-pins`, `check-host-ports`, `ci-doc-parity`, `test-lanes`, `test-golangci-guard`, `check-ext-migrations`, `test-e2e-llm-check`, `scripts/test-reap-build-caches.sh`.
- `bash -n` over all 91 tracked shell scripts.
- `make check-fe` not run: no file under `frontend/` is touched, and this machine is on Node 22 where that lane reports CLDR failures CI does not see.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boot verification by detecting successful login responses that fail to establish a session, preventing misleading startup success.

- **Documentation**
  - Added reference documentation explaining intentionally unresolved SonarCloud findings and their potential impact.

- **Maintenance**
  - Standardized shell-script condition checks across build, validation, seeding, testing, and development utilities for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->