### PR TITLE
A header too large to index skips its record, not the whole import

### DIFF
--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -248,8 +248,9 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 // Every refusal is about the record's own shape rather than its content: who
 // is presenting it, whether it can be written idempotently at all, whether it
 // claims a provenance other than the presenter's, whether a mail record uses
-// the one mail identity, and whether the counterparty it names is one the
-// resolver can act on. None needs a transaction, so none should hold one.
+// the one mail identity, whether the counterparty it names is one the resolver
+// can act on, and whether its indexed identity values are small enough to be
+// written at all. None needs a transaction, so none should hold one.
 func admitRecord(ctx context.Context, rec connector.NormalizedRecord) (principal.Principal, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.Type != principal.PrincipalConnector {
@@ -270,6 +271,9 @@ func admitRecord(ctx context.Context, rec connector.NormalizedRecord) (principal
 		return principal.Principal{}, err
 	}
 	if err := admitCounterpartyKeys(rec.Counterparty); err != nil {
+		return principal.Principal{}, err
+	}
+	if err := admitIndexableKeys(rec); err != nil {
 		return principal.Principal{}, err
 	}
 	return actor, nil

--- a/backend/internal/modules/capture/sinkindexbounds.go
+++ b/backend/internal/modules/capture/sinkindexbounds.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The bound between a sender-controlled header and a btree index.
+//
+// Postgres caps a btree index entry at 8191 bytes and refuses the write above
+// it (SQLSTATE 54000). Three columns on `activity` are indexed and filled from
+// headers the sender wrote — thread_key, source_id and counterparty_email — so
+// whoever sends the mail chooses whether the row can be written at all.
+//
+// Unbounded, the refusal arrives as a plain driver error from inside the page
+// transaction. It matches none of the connector sentinels, so classifySyncError
+// calls it `internal`, recordPageFault treats it as a fault no delay repairs,
+// and the run ends. One message costs every message behind it: a mailbox that
+// stopped this way had imported 300 of 1124 and could not resume, because the
+// offending message sits at a fixed position and every retry reaches it again.
+//
+// So the record is refused HERE, at the sink door, where a refusal is already
+// the record's own shape rather than a fault (`admitRecord`), and refused as a
+// SKIP: connector.ErrSkip is counted by every sync loop and fails nothing, so
+// the page keeps its remaining messages and the import continues.
+//
+// This is the same hazard mailmap's DSN parsing already guards on its own path,
+// where a non-UTF-8 header would fail the write and wedge the mailbox. Same
+// reachability — anyone who can send mail to a connected mailbox — and the same
+// remedy, applied to size rather than encoding.
+//
+// The activities module writes the same three columns and does NOT repeat this
+// bound, which is deliberate rather than an oversight: every value that arrives
+// from outside reaches the row through this sink. Mail and calendar come through
+// the connectors, and an extension's inbound webhook builds a NormalizedRecord
+// and enters by this same door. What the activities path receives is either
+// derived inside the installation or read back off a row this guard already
+// admitted, so a second copy of the rule there would bind nothing.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+const (
+	// maxIndexedHeaderChars bounds a header that becomes an indexed identity:
+	// the thread key and the natural key's source id. RFC 5322 §2.1.1 caps a
+	// header line at 998 octets, so a longer single value is malformed rather
+	// than merely large — no legitimate Message-ID or References root reaches
+	// it, and the observed maxima in real traffic are under 200.
+	maxIndexedHeaderChars = 998
+
+	// maxIndexedAddressChars bounds the counterparty address, which carries two
+	// btree indexes of its own. RFC 5321 §4.5.3.1.3 caps a forward path at 320
+	// octets; the trace ledger already holds the same number for the same
+	// reason.
+	maxIndexedAddressChars = 320
+)
+
+// admitIndexableKeys refuses a record whose sender-controlled identity values
+// are too large for the indexes they land in.
+//
+// The count is in BYTES, not runes, because the limit Postgres enforces is on
+// the stored index entry. A rune count would admit a multi-byte header three
+// times over the byte limit and hand the page the very write error this refusal
+// exists to prevent.
+//
+// The message names the field and the bound but never the value: it reaches an
+// operator's log, and the value is somebody's mail.
+func admitIndexableKeys(rec connector.NormalizedRecord) error {
+	for _, field := range []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{"thread key", rec.ThreadKey, maxIndexedHeaderChars},
+		{"source id", rec.NaturalKey.SourceID, maxIndexedHeaderChars},
+		{"counterparty address", rec.Counterparty.Email, maxIndexedAddressChars},
+	} {
+		if len(field.value) > field.limit {
+			return fmt.Errorf(
+				"capture: the record's %s is %d bytes, over the %d-byte bound its index can hold: %w",
+				field.name, len(field.value), field.limit, connector.ErrSkip)
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/capture/sinkindexbounds_test.go
+++ b/backend/internal/modules/capture/sinkindexbounds_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// The bound has to be enforced where the sink admits records, not only in
+// isolation. Checked any later and the oversized value is already inside the
+// page transaction, where the write error ends the run before any skip can be
+// counted — which is the whole failure.
+//
+// The nil pool is the assertion: reaching the database at all would panic, so a
+// clean skip proves the refusal happened at the door.
+func TestTheSinkSkipsAnUnindexableRecordBeforeTouchingThePool(t *testing.T) {
+	sink := NewSink(nil)
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalConnector, ID: "connector:gmail",
+	})
+	rec := connector.NormalizedRecord{
+		EntityType: "activity",
+		NaturalKey: connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "m-1"},
+		CapturedBy: "connector:gmail",
+		ThreadKey:  strings.Repeat("r", maxIndexedHeaderChars+1),
+	}
+
+	if _, err := sink.Upsert(ctx, rec); !errors.Is(err, connector.ErrSkip) {
+		t.Errorf("Upsert = %v, want an error wrapping connector.ErrSkip", err)
+	}
+}
+
+// The bound exists because Postgres refuses to index a value it cannot fit in a
+// btree entry, and every value below is a header the sender wrote. A refusal
+// arrives as a write error deep inside the page transaction, which the capture
+// error vocabulary cannot classify — so the run ends and every message behind
+// the offending one is lost. Skipping the one record is the whole remedy.
+func TestARecordTooLargeToIndexIsSkippedRatherThanFailingItsPage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rec  connector.NormalizedRecord
+	}{
+		{
+			// The observed failure: a References header with no usable
+			// separator yields the whole header as the thread's identity, and
+			// thread_key carries three btree indexes.
+			name: "a thread key past the bound",
+			rec: connector.NormalizedRecord{
+				NaturalKey: connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "m-1"},
+				ThreadKey:  strings.Repeat("r", maxIndexedHeaderChars+1),
+			},
+		},
+		{
+			name: "a source id past the bound",
+			rec: connector.NormalizedRecord{
+				NaturalKey: connector.NaturalKey{
+					SourceSystem: connector.EmailSourceSystem,
+					SourceID:     strings.Repeat("m", maxIndexedHeaderChars+1),
+				},
+			},
+		},
+		{
+			name: "a counterparty address past the bound",
+			rec: connector.NormalizedRecord{
+				NaturalKey:   connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "m-2"},
+				Counterparty: connector.Counterparty{Email: strings.Repeat("a", maxIndexedAddressChars+1) + "@acme.example"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := admitIndexableKeys(tc.rec)
+			if !errors.Is(err, connector.ErrSkip) {
+				t.Errorf("admitIndexableKeys = %v, want an error wrapping connector.ErrSkip — a hard error here ends the whole run", err)
+			}
+		})
+	}
+}
+
+// The bound must not turn ordinary mail away. A value AT the limit is legal:
+// off-by-one here would discard real correspondence, which is the failure this
+// change exists to stop rather than to reproduce in the other direction.
+func TestOrdinaryMailAndExactlyBoundedValuesAreAdmitted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rec  connector.NormalizedRecord
+	}{
+		{
+			name: "an ordinary message",
+			rec: connector.NormalizedRecord{
+				NaturalKey:   connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "CADq0J2y@mail.example"},
+				ThreadKey:    "CADq0J2y@mail.example",
+				Counterparty: connector.Counterparty{Email: "tuyen@acme.example"},
+			},
+		},
+		{
+			name: "values exactly at the bound",
+			rec: connector.NormalizedRecord{
+				NaturalKey: connector.NaturalKey{
+					SourceSystem: connector.EmailSourceSystem,
+					SourceID:     strings.Repeat("m", maxIndexedHeaderChars),
+				},
+				ThreadKey:    strings.Repeat("r", maxIndexedHeaderChars),
+				Counterparty: connector.Counterparty{Email: strings.Repeat("a", maxIndexedAddressChars)},
+			},
+		},
+		{
+			// A record naming no counterparty and no thread is the common
+			// shape for a calendar or channel record; absent is not oversized.
+			name: "a record carrying neither a thread nor an address",
+			rec: connector.NormalizedRecord{
+				NaturalKey: connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "m-3"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := admitIndexableKeys(tc.rec); err != nil {
+				t.Errorf("admitIndexableKeys = %v, want nil — this record indexes fine", err)
+			}
+		})
+	}
+}
+
+// Multi-byte headers are the case a byte bound and a rune bound disagree about.
+// The index limit Postgres enforces is in BYTES, so the guard has to count them:
+// a rune count would admit a value three times over the byte limit and hand the
+// page the very write error the guard exists to prevent.
+func TestTheBoundCountsBytesNotRunes(t *testing.T) {
+	// Three bytes per rune in UTF-8, so this is under the bound by runes and
+	// well over it by bytes.
+	wide := strings.Repeat("あ", maxIndexedHeaderChars-1)
+
+	rec := connector.NormalizedRecord{
+		NaturalKey: connector.NaturalKey{SourceSystem: connector.EmailSourceSystem, SourceID: "m-4"},
+		ThreadKey:  wide,
+	}
+	if err := admitIndexableKeys(rec); !errors.Is(err, connector.ErrSkip) {
+		t.Errorf("admitIndexableKeys = %v, want ErrSkip: %d runes is %d bytes, past the %d-byte bound",
+			err, len([]rune(wide)), len(wide), maxIndexedHeaderChars)
+	}
+}


### PR DESCRIPTION
Closes #4646 for the case that made it deterministic.

Postgres caps a btree index entry at 8191 bytes. Three columns on `activity` are indexed and filled from headers the sender wrote — `thread_key`, `source_id` and `counterparty_email` — so whoever sends the mail decides whether the row can be written at all.

Over the cap, the refusal arrived as a driver error from inside the page transaction:

```
capture: activity upsert: ERROR: index row requires 11992 bytes, maximum size is 8191 (SQLSTATE 54000)
```

That matches no connector sentinel, so `classifySyncError` fell to its default and called it `internal`, `recordPageFault` treated it as a fault no delay repairs, and the run ended. One message cost every message behind it — and permanently, because the offending message sits at a fixed position in the window, so each retry reached it again. The mailbox this was found on had imported 300 of 1124 and could not be made to finish.

## What changes

The record is refused at the sink door, where a refusal is already about the record's own shape rather than a fault, and refused as a SKIP. `connector.ErrSkip` is counted by every sync loop and fails nothing, so the page keeps its other messages and the import continues past the bad one. No new machinery — this is the affordance the module already had for a record it cannot take.

The bounds are the RFCs the headers come from: 998 octets for a header line (RFC 5322 §2.1.1) and 320 for a forward path (RFC 5321 §4.5.3.1.3), the latter already spelled in the trace ledger. Real traffic on the mailboxes examined maxes out at 125, 181 and 100 bytes, so nothing legitimate is near either bound.

Counted in **bytes**, not runes: the limit Postgres enforces is on the stored entry, and a rune count would admit a multi-byte header three times over it and hand the page the very write error the guard exists to prevent. There is a test for exactly that.

## On the sibling writers

`thread_key` flows on into `capture_thread_verdict`, `activity_sales_state` and the thread-owner ledger, each with a btree constraint of its own; bounding at the door covers all of them rather than one call site at a time.

The `activities` module writes the same three columns and deliberately does not repeat the bound — noted in the code beside it. Every value arriving from outside reaches the row through this sink: mail and calendar through the connectors, and an extension's inbound webhook builds a `NormalizedRecord` and enters by the same door. What `activities` receives is derived inside the installation or read back off a row this guard already admitted.

## Prior art in the same package

`mailmap`'s DSN parsing already guards this hazard class on its own path, where a non-UTF-8 header would fail the write and, in its words, wedge the mailbox. Same reachability — anyone who can send mail to a connected mailbox — and the same remedy, applied to size rather than encoding.

## Not in this change

#4646 also asks that a run ending on a terminal fault be resumable. That needs a product call on what the affordance is (an operator action, a sweep, or an automatic retry once the connection is healthy) and would be a much larger diff, so the issue stays open for it. This change removes the cause that made the loss unrecoverable rather than merely unlucky.

## Checks

`make check-backend` green. `craft static --strict` reports 0 blocker / 0 major / 0 minor. New tests fail before the change and pass after — including the byte-versus-rune case and a wiring test that proves the refusal happens before the pool is touched.
