### PR TITLE
The roster asks who may administer it, not who is an admin

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -86,16 +86,21 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // some card or catalog entry reads TODAY, verified against the source rather
   // than against the object vocabulary.
   //
-  // THREE OF THE THIRTEEN ARE ABSENT because no client code reads them yet, and
+  // ONE OF THE THIRTEEN IS STILL ABSENT because no client code reads it, and
   // that is a real gap rather than a fixture decision:
-  //   user_admin        — `UsersAdminCard` still calls useHoldsAdminRole
-  //   team_admin        — `TeamsCard` still calls useHoldsAdminRole
   //   oauth_application — `OAuthAppCard` still asks capture_settings:update,
   //                       which an ordinary sales role holds
-  // Each object exists in the contract and is seeded server-side; the card that
-  // should ask for it was never repointed. Adding them here would paper over
-  // that — the sweep would pass either way, and the day somebody repoints those
-  // cards the fixture would already agree.
+  // The object exists in the contract and is seeded server-side; the card that
+  // should ask for it was never repointed. Adding it here would paper over that
+  // — the sweep would pass either way, and the day somebody repoints that card
+  // the fixture would already agree.
+  //
+  // `user_admin` and `team_admin` were on that list and are below now: the
+  // roster and team cards ask them verb by verb, and the Members and Teams
+  // ENTRIES follow them too, so a fixture without them would sweep two pages
+  // the mock cannot open.
+  user_admin: ["read", "create", "update", "delete"],
+  team_admin: ["read", "create", "update"],
   //
   // Extensions is TWO reads behind one flag — the unit inventory and every
   // role's grant on every object — and its toggles write through the update.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6678,18 +6678,18 @@ export const de = {
   "extAccess.nobodyReads":
     "Keine Rolle darf {object} lesen — jedes Mitglied sieht dort eine leere Seite, wo diese Erweiterung stehen sollte. Vergeben Sie unten mindestens einer Rolle das Leserecht.",
   "users.empty": "Noch keine Benutzer.",
-  "users.adminOnly": "Benutzer verwalten können nur Admins.",
+  "users.adminOnly": "Sie haben keine Berechtigung, Benutzer zu verwalten.",
   "users.inviteTitle": "Benutzer einladen",
   "users.teamsLabel": "Teams",
   "users.noTeamsYet": "Noch keine Teams.",
   "users.teamMembersLabel": "Wer in diesem Team ist",
   "users.teamMembersAdminOnly":
-    "Die Mitgliedschaft ist nur für Admins sichtbar.",
+    "Sie haben keine Berechtigung zu sehen, wer in diesem Team ist.",
   "users.teamNobodyToAdd": "Noch keine Benutzer zum Hinzufügen.",
   "users.teamsTitle": "Teams",
   "users.teamsSub":
     "Benannte Gruppen, mit denen Sie Datensätze teilen können. Die Mitgliedschaft allein gewährt den meisten Rollen weiterhin keinen Zugriff — Ausnahme ist die Teamleitung: wird sie einem Team hinzugefügt, kann sie dessen Datensätze lesen und bearbeiten, ohne dass eine Freigabe eingerichtet wird.",
-  "users.teamsAdminOnly": "Teams verwalten können nur Admins.",
+  "users.teamsAdminOnly": "Sie haben keine Berechtigung, Teams zu verwalten.",
   "users.deactivated": "{name} deaktiviert",
   "users.reactivated": "{name} reaktiviert",
   "users.roleSaved": "Rolle für {name} geändert",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6793,17 +6793,18 @@ export const en = {
   "extAccess.nobodyReads":
     "No role holds read on {object}, so every member sees an empty screen where this extension should be. Grant read to at least one role below.",
   "users.empty": "No users yet.",
-  "users.adminOnly": "Managing users is available to admins only.",
+  "users.adminOnly": "You do not have permission to manage users.",
   "users.inviteTitle": "Invite a user",
   "users.teamsLabel": "Teams",
   "users.noTeamsYet": "No teams yet.",
   "users.teamMembersLabel": "Who is in this team",
-  "users.teamMembersAdminOnly": "Membership is visible to admins only.",
+  "users.teamMembersAdminOnly":
+    "You do not have permission to see who is in this team.",
   "users.teamNobodyToAdd": "No users to add yet.",
   "users.teamsTitle": "Teams",
   "users.teamsSub":
     "Named groups you can share records with. Membership alone still grants no access for most roles — the exception is Team Lead: adding one to a team gives them that team's records to read and work, without a share being arranged.",
-  "users.teamsAdminOnly": "Managing teams is available to admins only.",
+  "users.teamsAdminOnly": "You do not have permission to manage teams.",
   "users.deactivated": "{name} deactivated",
   "users.reactivated": "{name} reactivated",
   "users.roleSaved": "Role changed for {name}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6601,17 +6601,18 @@ export const vi = {
   "extAccess.nobodyReads":
     "Không vai trò nào được đọc {object}, nên mọi thành viên chỉ thấy màn hình trống ở nơi lẽ ra là tiện ích này. Hãy cấp quyền đọc cho ít nhất một vai trò bên dưới.",
   "users.empty": "Chưa có người dùng nào.",
-  "users.adminOnly": "Chỉ quản trị viên mới quản lý được người dùng.",
+  "users.adminOnly": "Bạn không có quyền quản lý người dùng.",
   "users.inviteTitle": "Mời một người dùng",
   "users.teamsLabel": "Nhóm",
   "users.noTeamsYet": "Chưa có nhóm.",
   "users.teamNobodyToAdd": "Chưa có người dùng nào để thêm.",
   "users.teamMembersLabel": "Ai ở trong nhóm này",
-  "users.teamMembersAdminOnly": "Chỉ quản trị viên mới xem được thành viên.",
+  "users.teamMembersAdminOnly":
+    "Bạn không có quyền xem thành viên của nhóm này.",
   "users.teamsTitle": "Nhóm",
   "users.teamsSub":
     "Nhóm có tên để bạn chia sẻ bản ghi. Chỉ thuộc một nhóm thì hầu hết vai trò vẫn chưa có quyền gì thêm — ngoại lệ là Trưởng nhóm: thêm họ vào một nhóm sẽ cho họ đọc và xử lý bản ghi của nhóm đó mà không cần thiết lập chia sẻ.",
-  "users.teamsAdminOnly": "Chỉ quản trị viên mới có thể quản lý nhóm.",
+  "users.teamsAdminOnly": "Bạn không có quyền quản lý nhóm.",
   "users.deactivated": "Đã vô hiệu hóa {name}",
   "users.reactivated": "Đã kích hoạt lại {name}",
   "users.roleSaved": "Đã đổi vai trò cho {name}",

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -21,6 +21,7 @@ import {
   SETTINGS_PAGES,
   type SettingsGroupId,
   type SettingsPageId,
+  visibleSettingsPages,
 } from "./settingscatalog";
 import { SETTINGS_HOME_ID } from "./settingsnav";
 import { settingsHref } from "./settingsrouting";
@@ -265,19 +266,16 @@ const pagesIn = (group: SettingsGroupId) =>
 // PERSON's: gating `agents` would regress passport minting for every seat that
 // is not an admin, and a mailbox and a LinkedIn network nobody else can see are
 // not the installation's configuration.
+// The pages that ask for nothing: a reader's own five, and nothing else.
 //
-// `members` and `teams` are the floor beside them for a different reason:
-// `GET /users` answers 200 to any authenticated principal and "who is on my
-// team" is not an admin's private question, so the pages open for everyone and
-// their controls withhold themselves.
-const UNGATED_IDS = [
-  ...SETTINGS_PAGES.filter((page) => page.group === "me").map(
-    (page) => page.id,
-  ),
-  "members",
-  "teams",
-] as const satisfies readonly SettingsPageId[];
-const UNGATED_PAGES = pagesNamed(...UNGATED_IDS);
+// `members` and `teams` used to sit here. The roster endpoint still answers any
+// authenticated caller — the share and assignee pickers depend on it — but a
+// directory is not an administration page, so the settings ENTRY follows the
+// `user_admin` and `team_admin` verbs while the safe roster stays open
+// underneath it.
+const UNGATED_IDS = SETTINGS_PAGES.filter((page) => page.group === "me").map(
+  (page) => page.id,
+) as readonly SettingsPageId[];
 
 // The floor plus the pages a grant opens, in CATALOG order. Concatenating the
 // two lists instead would assert an order the catalog does not have: `company`
@@ -351,6 +349,10 @@ const EVERY_PAGE_GRANTED: GrantSpec = {
   // role's grant on every object on `role_admin` (identity/roles.go ListRoles).
   // The card fires both behind one flag, so the page needs both.
   role_admin: ["read"],
+  // The roster and team pages, which follow their own objects now rather than
+  // opening for every authenticated reader.
+  user_admin: ["read", "create", "update", "delete"],
+  team_admin: ["read", "create", "update"],
   system_reset: ["delete"],
 };
 // Home leads this list too, for the same reason it leads pagesNamed: it is a
@@ -455,8 +457,9 @@ const SEEDED_READ_PAGES = pagesNamed(
   // `company` is NOT here: its requirement ANDs the organization write with the
   // `company_context` deployment flag, and this fixture leaves that flag off.
   // The page's own availability cases are the ones that turn it on.
-  "members",
-  "teams",
+  //
+  // Nor `members`/`teams`: only the `admin` role is seeded `user_admin` or
+  // `team_admin`, so no seeded role below it reaches either page.
   "pipelines",
   "leads",
   "fields",
@@ -472,8 +475,9 @@ const SEEDED_OPS_PAGES = pagesNamed(
   "connections",
   "capture-activity",
   "company",
-  "members",
-  "teams",
+  // Not `members`/`teams`: ops holds neither `user_admin` nor `team_admin` in
+  // the seeded matrix. Administering colleagues is the admin's, and the roster
+  // ops reads for pickers is answered by the endpoint, not by this page.
   "seats",
   "pipelines",
   "leads",
@@ -532,37 +536,41 @@ describe("SettingsScreen page visibility", () => {
     }
   });
 
-  it("gives a principal holding no grant at all the pages that ask for none", async () => {
-    // The floor, and the reason removing the seat gate is not "everyone gets
-    // everything". A principal holding NOTHING reaches the five personal pages
-    // plus the member roster and the team list, which `GET /users` serves to
-    // anyone signed in and which the same handler narrows by role — a rep's page
-    // carries no role keys and no inactive members. Every other page is absent
-    // because its requirement says so, which is the same sentence for this
-    // principal as for an admin.
-    //
-    // Privacy is NOT on the floor with them: the consent registry's server gate
-    // is `person:read`, and a principal holding nothing does not hold it.
-    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow: {} }));
-    renderNav();
-    // /me has to have SETTLED before this claim means anything: a nav read
-    // mid-flight is empty for every principal. Waiting on the rows themselves is
-    // what proves it settled — the sidebar no longer prints the signed-in
-    // address, which is what this used to wait for, because the account block
-    // moved to the top bar.
-    await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));
+  // The floor, and the reason removing the seat gate is not "everyone gets
+  // everything". A principal holding NOTHING reaches the five personal pages and
+  // no others: members and teams follow `user_admin`/`team_admin` now, and every
+  // remaining page is absent because its requirement says so.
+  //
+  // ASSERTED THROUGH THE EVALUATOR, NOT THE RAIL, and that is not a shortcut.
+  // For a grantless snapshot the rendered rail is byte-identical before and
+  // after `/me` resolves — measured, not assumed — so no wait on the DOM can
+  // tell the two apart, and any `waitFor` here passes on its first tick whatever
+  // the requirements say. Granting every `user_admin` verb to this case and
+  // keeping the expectation still passed while it went through the rail.
+  //
+  // `visibleSettingsPages` takes the snapshot as an argument, so there is no
+  // in-flight state to race. The rail's own wiring is held by every other case
+  // in this file, each of which asserts a page only a resolved snapshot draws.
+  it("gives a principal holding no grant at all the pages that ask for none", () => {
+    expect(
+      visibleSettingsPages(meFixture({ roles: ["rep"], allow: {} })).map(
+        (page) => page.id,
+      ),
+    ).toEqual(UNGATED_IDS);
   });
 
-  it("gives an admin holding no grant at all exactly the same floor", async () => {
+  it("gives an admin holding no grant at all exactly the same floor", () => {
     // The role is not a gate in either direction. It used to open three pages on
     // its own — extensions, the job report and the danger zone — and each of
     // those now follows a grant an edited role can hold or lose, so an admin
     // stripped of every grant reaches what anyone else stripped of every grant
     // reaches. A role that could not lose a page is a role that cannot be
     // edited.
-    vi.stubGlobal("fetch", settingsNavBackend({ roles: ["admin"], allow: {} }));
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));
+    expect(
+      visibleSettingsPages(meFixture({ roles: ["admin"], allow: {} })).map(
+        (page) => page.id,
+      ),
+    ).toEqual(UNGATED_IDS);
   });
 
   // The grant, not the role name. These principals hold every read the seeded
@@ -590,11 +598,14 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["ops"],
-        allow: { custom_field: ["create", "update"] },
+        // The witness rides along: `pipeline:read` opens Pipelines and nothing
+        // else, so its row proves /me resolved before this asserts that the
+        // WRITES bought no page.
+        allow: { custom_field: ["create", "update"], pipeline: ["read"] },
       }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   it.each(SALES_READS)(
@@ -872,12 +883,12 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({
         roles: ["admin"],
-        allow: readOn("system_reset"),
+        allow: { ...readOn("system_reset"), pipeline: ["read"] },
         dataResetAvailable: true,
       }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));
+    await expectNavSettlesTo(floorPlus("pipelines"));
     cleanup();
 
     vi.stubGlobal(
@@ -1074,10 +1085,15 @@ describe("SettingsScreen page visibility", () => {
     // assertion above would pass against a page that opened for everybody.
     vi.stubGlobal(
       "fetch",
-      settingsNavBackend({ roles: ["management"], allow: {} }),
+      settingsNavBackend({
+        roles: ["management"],
+        // The witness: this case asserts audit is ABSENT, and a grantless
+        // fixture would assert it against the loading render.
+        allow: { pipeline: ["read"] },
+      }),
     );
     renderNav();
-    await waitFor(() => expect(navPages()).toEqual(UNGATED_PAGES));
+    await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
   // THE LICENSING SEAT, which is a THIRD axis and gates none of this: the server

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -113,6 +113,11 @@ const ADMIN_GRANTS: GrantSpec = {
   // seat holds and a fixture that did not follow would quietly stop rendering
   // the page its cases are about.
   retention_policy: ["read", "create", "update"],
+  // The roster and team pages. They used to open for every authenticated
+  // reader; they follow `user_admin` and `team_admin` now, and the layout cases
+  // that render this fixture expect both present.
+  user_admin: ["read", "create", "update", "delete"],
+  team_admin: ["read", "create", "update"],
 };
 
 // The read grant on ONE object, as a GrantSpec.

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -82,9 +82,59 @@ describe("who may open what", () => {
       "agents",
       "connections",
       "capture-activity",
-      "members",
-      "teams",
     ]);
+  });
+
+  // Members and Teams used to be on that list. `GET /users` still answers any
+  // authenticated caller and must — the share and assignee pickers read it —
+  // but a directory is not an administration page, and a reader who may not
+  // invite, change a role or switch a seat off has nothing to do on either.
+  it("withholds members from a reader holding no user_admin", () => {
+    expect(visibleIds(readsOnly("person"))).not.toContain("members");
+    // Any authority over the roster opens it, and the READ is one of them —
+    // it is what carries the role keys and the widened status view.
+    expect(visibleIds(readsOnly("user_admin"))).toContain("members");
+  });
+
+  it("withholds teams from a reader holding neither team verb nor the roster read", () => {
+    expect(visibleIds(readsOnly("person"))).not.toContain("teams");
+    // The team object's READ is not one of its arms: teams.go takes create and
+    // update, and nothing on the page answers to a `team_admin:read`.
+    expect(visibleIds(readsOnly("team_admin"))).not.toContain("teams");
+    expect(visibleIds(writes("team_admin"))).toContain("teams");
+  });
+
+  // The roster's privileged projection is what Teams RENDERS: `team_ids` rides
+  // `user_admin:read` (handlers_roster.go), not the team object. So a reader
+  // holding that read alone still opens Teams — they see who is in which team
+  // and may change none of it — and the checkboxes are disabled rather than
+  // absent, because the list IS the answer they came for.
+  it("opens teams to the roster read that carries membership", () => {
+    expect(visibleIds(readsOnly("user_admin"))).toContain("teams");
+  });
+
+  // The seat switch WITHOUT the read does not open it, and that is the fix
+  // rather than an omission. `include_inactive` is honoured only for a caller
+  // who passes `user_admin:read` (handlers_roster.go), so this holder would
+  // reach a roster that never shows them a deactivated member to reactivate —
+  // a page offering two affordances that cannot work.
+  it("does not open members for the deactivate verb without the roster read", () => {
+    const seatSwitch = meFixture({
+      roles: ["custom"],
+      allow: { user_admin: ["delete"] },
+    });
+    expect(visibleSettingsPages(seatSwitch).map((p) => p.id)).not.toContain(
+      "members",
+    );
+    // With the read beside it, the same holder gets the page.
+    expect(
+      visibleSettingsPages(
+        meFixture({
+          roles: ["custom"],
+          allow: { user_admin: ["read", "delete"] },
+        }),
+      ).map((p) => p.id),
+    ).toContain("members");
   });
 
   it("opens the sales pages a rep's own grants already carry", () => {

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -268,12 +268,43 @@ export const SETTINGS_PAGES = [
     requires: reads("authentication_policy"),
   },
 
-  // `GET /users` answers 200 to any authenticated principal and the roster is
-  // not an admin's private question — the handler decides what the answer
-  // CONTAINS, and role keys are the privileged part. So the page opens for
-  // everyone and its controls withhold themselves.
-  { id: "members", group: "people", scope: "workspace", requires: always },
-  { id: "teams", group: "people", scope: "workspace", requires: always },
+  // `GET /users` answers 200 to any authenticated principal, and that is right:
+  // the share and assignee pickers every seat uses read this roster. But a
+  // DIRECTORY is not an administration page. A reader who may not invite, change
+  // a role or switch a seat off has nothing to do here — they look a colleague
+  // up in the app, where the answer is already beside the record.
+  //
+  // So the settings ENTRY follows the verbs, and the safe roster stays open
+  // underneath it: `user_admin` gates Members, `team_admin` gates Teams, and
+  // both pages' cards still withhold their own controls verb by verb.
+  {
+    id: "members",
+    group: "people",
+    scope: "workspace",
+    // The READ, and only the read. Every write verb needs what it carries, so a
+    // holder without it has no usable page:
+    //
+    //   - `include_inactive` is honoured only for a caller who passes the read
+    //     (handlers_roster.go), so a `delete` holder without it never sees a
+    //     deactivated member to reactivate.
+    //   - the roster omits `roles` without it, and `ChangeUserRole` REPLACES
+    //     the whole set — so an `update` holder would pick a role against a
+    //     list they cannot see.
+    //
+    // Opening the page on a write alone would offer exactly those two broken
+    // affordances. The card ANDs the same way, so the page and its controls
+    // agree.
+    requires: reads("user_admin"),
+  },
+  {
+    id: "teams",
+    group: "people",
+    scope: "workspace",
+    // The team verbs, or the roster read that carries `team_ids` — a holder of
+    // `user_admin:read` alone sees who is in which team, which is the page's
+    // whole content even when they may change none of it.
+    requires: anyOf(writes("team_admin"), reads("user_admin")),
+  },
   // `roles` is NOT here, and its absence is the point.
   //
   // The plan gives it a full page — role definitions, row scope, field masks,

--- a/frontend/src/screens/users-access.test.tsx
+++ b/frontend/src/screens/users-access.test.tsx
@@ -66,6 +66,14 @@ function backend(
      * attempted.
      */
     me?: readonly string[];
+    /**
+     * The grants this principal holds, when a case needs something other than
+     * the full pair. The card asks two DIFFERENT objects — `team_admin` for the
+     * verbs and `user_admin:read` for the membership the roster carries — so a
+     * case can now describe a reader who sees who is in a team and may not
+     * change it, which one admin check could not express.
+     */
+    allow?: Record<string, Record<string, boolean>>;
   }>,
 ) {
   const calls: Call[] = [];
@@ -93,10 +101,35 @@ function backend(
         // `user` is required on MeResponse — useMe() treats a payload
         // without it as an availability failure and never resolves `.data`,
         // which would silently read every seat here as non-admin.
+        //
+        // The GRANTS matter for the same reason, one level up: the card asks
+        // `team_admin` for its verbs and `user_admin:read` for the membership
+        // the roster carries, so a payload naming a role and no authorization
+        // describes a principal the API cannot produce — and every case here
+        // would pass with nothing rendered. `allow` lets a case withhold one
+        // of the two, which is the reader the split made possible.
         return new Response(
           JSON.stringify({
             user: { email: "you@acme.test" },
             roles: opts.me ?? ["admin"],
+            authorization: {
+              objects: opts.allow ?? {
+                team_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: false,
+                },
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           }),
           { headers: { "Content-Type": "application/json" } },
         );
@@ -538,16 +571,52 @@ describe("TeamsCard membership", () => {
 
   // Team membership is admin surface, so a non-admin gets no membership
   // control and no membership LIST: the roster handler only sends `team_ids`
-  // to an admin caller (`WithRoles: isAdmin`), so a read-only render built
+  // to a caller holding `user_admin:read` (`WithRoles: mayManage`), so a
+  // read-only render built
   // from an ops seat's own roster read would show nobody as a member of
   // anything — a false statement, not an honest withholding. The card states
   // why once, and the disclosure body says the same thing rather than
   // fabricate a list.
+  // The reader one admin check could not express: they hold the roster read
+  // that CARRIES membership and neither team verb. The list is the answer they
+  // came for, so it renders — and every box is disabled rather than gone,
+  // because removing them would withhold the reading along with the writing.
+  it("shows membership read-only to a seat holding the roster read and no team verb", async () => {
+    const { fetchMock } = backend({
+      teams: [{ id: "t-1", name: "Nord", member_count: 1 }],
+      users: ROSTER,
+      me: ["custom"],
+      allow: {
+        user_admin: { read: true, create: false, update: false, delete: false },
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <Providers>
+        <TeamsCard />
+      </Providers>,
+    );
+    await openTeam();
+
+    // The positive control first: a box only a resolved snapshot draws. Without
+    // it the assertions below would run against the loading render, where every
+    // predicate reads false and nothing is drawn at all.
+    const boxes = await screen.findAllByRole("checkbox");
+    expect(boxes.length).toBeGreaterThan(0);
+    for (const box of boxes) {
+      expect(box).toBeDisabled();
+    }
+  });
+
   it("withholds membership entirely from a seat that may not read or change it", async () => {
     const { fetchMock, calls } = backend({
       teams: [{ id: "t-1", name: "Nord", member_count: 1 }],
       users: ROSTER,
+      // Ops, spelled as what ops HOLDS: neither `team_admin` nor `user_admin`
+      // is seeded to it. The role name alone used to carry this case; it says
+      // the grants now, which is what the card reads.
       me: ["ops"],
+      allow: {},
     });
     vi.stubGlobal("fetch", fetchMock);
     render(

--- a/frontend/src/screens/users-access.tsx
+++ b/frontend/src/screens/users-access.tsx
@@ -3,7 +3,7 @@ import { Trash2 } from "lucide-react";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useHoldsAdminRole } from "../app/capability";
+import { useCan, useCanWrite } from "../app/capability";
 import {
   Button,
   Checkbox,
@@ -151,7 +151,21 @@ export function TeamsCard() {
   // gates on: an ops seat reads the roster below but does not change who is
   // on a team. `me.isSuccess` below keeps the read-only line from flashing
   // at an admin while /me is still in flight.
-  const canAdminister = useHoldsAdminRole();
+  // The two verbs teams.go takes: CreateTeam is `team_admin:create`, and both
+  // UpdateTeam and SetTeamMember are `team_admin:update`.
+  //
+  // `useCanWrite`, not `useCan`: the seat ceiling sits ABOVE RBAC
+  // (identity/admission.go), so a read seat holding the grant is refused every
+  // one of these writes.
+  const canCreateTeam = useCanWrite("team_admin", "create");
+  const canEditTeam = useCanWrite("team_admin", "update");
+  // Membership is a DIFFERENT grant from the verb that changes it: `team_ids`
+  // rides the roster's privileged projection, which handlers_roster.go gates on
+  // `user_admin:read`. A holder of the team write without that read would get
+  // every entry back with no `team_ids` at all and draw a list showing nobody
+  // as a member of anything — a false statement about the team rather than an
+  // honest withholding. So membership needs BOTH.
+  const canSeeMembership = useCan("user_admin", "read");
   // The shared roster read, not a second query of this card's own. Both spell
   // the same list under the same cache key, so whichever mounted first decided
   // what the other one read back — and only one of the two follows the
@@ -215,12 +229,14 @@ export function TeamsCard() {
     // team, inside a list of teams, saying its own name twice.
     <Panel
       title={t("users.teamsTitle")}
-      titleAction={canAdminister ? <NewTeamAction /> : undefined}
+      titleAction={canCreateTeam ? <NewTeamAction /> : undefined}
     >
       <PanelBody>
         <p className="settings-panel-sub">
           {t("users.teamsSub")}
-          {me.isSuccess && !canAdminister && ` ${t("users.teamsAdminOnly")}`}
+          {me.isSuccess &&
+            !(canCreateTeam || canEditTeam) &&
+            ` ${t("users.teamsAdminOnly")}`}
         </p>
         {/* A refused archive belongs to the card, not to the row: the roster
             below is refetched on success, so the only thing left to say is that
@@ -255,7 +271,8 @@ export function TeamsCard() {
                     team={team}
                     archiving={archive.isPending}
                     onArchive={() => archive.mutate(team.id)}
-                    canAdminister={canAdminister}
+                    canEditTeam={canEditTeam}
+                    canSeeMembership={canSeeMembership}
                   />
                 ))}
               </SettingList>
@@ -282,12 +299,14 @@ function TeamRow({
   team,
   archiving,
   onArchive,
-  canAdminister,
+  canEditTeam,
+  canSeeMembership,
 }: Readonly<{
   team: Team;
   archiving: boolean;
   onArchive: () => void;
-  canAdminister: boolean;
+  canEditTeam: boolean;
+  canSeeMembership: boolean;
 }>) {
   const t = useT();
   const plural = usePlural();
@@ -310,7 +329,7 @@ function TeamRow({
         </span>
       }
       action={
-        canAdminister ? (
+        canEditTeam ? (
           <Button
             small
             variant="ghost"
@@ -324,7 +343,11 @@ function TeamRow({
         ) : undefined
       }
     >
-      <TeamMembers team={team} canAdminister={canAdminister} />
+      <TeamMembers
+        team={team}
+        canEditTeam={canEditTeam}
+        canSeeMembership={canSeeMembership}
+      />
     </Disclosure>
   );
 }
@@ -337,30 +360,36 @@ function TeamRow({
 // be a second answer to "who is in this team", and the two would disagree the
 // first time one of them was cached.
 //
-// `canAdminister` withholds the whole membership list rather than merely
-// disabling its checkboxes: an ops seat that may read this roster still gets
-// no `team_ids` on any entry in it (see the query gate below), so a list
-// built from that read would show nobody as a member of anything — a false
-// statement about the team, not an honest withholding. Both the write
-// affordance and the read it would need are the admin's, stated once at the
-// card level (`TeamsCard`'s sub line) rather than as a control that looks
-// pressable and 403s.
+// The membership list is withheld WHOLE rather than drawn with its checkboxes
+// disabled: a caller without `user_admin:read` gets no `team_ids` on any entry
+// in the roster (see the query gate below), so a list built from that read
+// would show nobody as a member of anything — a false statement about the team,
+// not an honest withholding. Stated once at the card level (`TeamsCard`'s sub
+// line) rather than as a control that looks pressable and 403s.
+//
+// Two grants, because they answer two questions. `canSeeMembership` is whether
+// the roster will carry membership at all; `canEditTeam` is whether this reader
+// may change it. A holder of the write without the read is a real principal —
+// nothing seeds the pair together — and drawing them an empty list would be the
+// falsehood above.
 function TeamMembers({
   team,
-  canAdminister,
-}: Readonly<{ team: Team; canAdminister: boolean }>) {
+  canEditTeam,
+  canSeeMembership,
+}: Readonly<{ team: Team; canEditTeam: boolean; canSeeMembership: boolean }>) {
   const t = useT();
   const qc = useQueryClient();
   // Membership is admin-only DATA, not only an admin-only write: the roster
   // handler sends `team_ids` at all only when the caller is an admin
-  // (`WithRoles: isAdmin`, backend/internal/modules/identity/handlers_roster.go)
+  // (`WithRoles: mayManage`, backend/internal/modules/identity/handlers_roster.go,
+  // which resolves that flag from `user_admin:read`)
   // — every entry a non-admin reads back carries none. A read-only list built
   // from that response would show nobody as a member of anything, which is a
   // false statement about the team rather than an honest withholding, so the
   // read is skipped rather than attempted (design-system/README.md's
   // "Absent, disabled, or withheld", permission-denial row).
-  const users = useRoster("user", canAdminister);
-  const usersPartial = useRosterPartial("user", canAdminister);
+  const users = useRoster("user", canSeeMembership);
+  const usersPartial = useRosterPartial("user", canSeeMembership);
   // Both writes are the same endpoint under two methods, so they are one
   // mutation with the membership as a variable — never a closure over the row
   // being drawn, which react-query re-arms a render late.
@@ -386,7 +415,7 @@ function TeamMembers({
     },
   });
 
-  if (!canAdminister) {
+  if (!canSeeMembership) {
     return <p className="t-caption">{t("users.teamMembersAdminOnly")}</p>;
   }
 
@@ -423,7 +452,13 @@ function TeamMembers({
                     className="t-body"
                     label={person.display_name}
                     checked={(person.team_ids ?? []).includes(team.id)}
-                    disabled={setMember.isPending}
+                    // Disabled rather than absent for a reader who may SEE
+                    // membership and not change it: the list is the answer they
+                    // came for and every box is part of it, so removing them
+                    // would withhold the reading as well as the writing. One
+                    // admin check used to cover both questions, and splitting
+                    // them made this reader possible for the first time.
+                    disabled={setMember.isPending || !canEditTeam}
                     onChange={(event) =>
                       setMember.mutate({
                         userId: person.id,

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { UsersAdminCard } from "./users-admin";
 
 // The admin member-management card renders the include-inactive roster and drives
@@ -139,10 +140,32 @@ async function rowMenu(user: ReturnType<typeof userEvent.setup>, name: string) {
 // `roles` defaults to the admin this suite is mostly about; a caller naming
 // another role gets the same routed backend, so a non-admin case differs from an
 // admin one by the principal alone and not by a second hand-rolled stub.
+//
+// GRANTS, not the role name. The card asks `user_admin` verb by verb now, and a
+// /me carrying a role and no `authorization` describes a principal the API
+// cannot produce — every gate would read false and every case would pass by
+// construction. The admin default holds all four verbs because the seeded admin
+// role does; a case wanting less passes `allow` explicitly.
+const ADMIN_USER_ADMIN: Record<string, string[]> = {
+  user_admin: ["read", "create", "update", "delete"],
+};
 function backend(
   calls: { method: string; url: string; body?: unknown }[],
-  me: { roles: string[] } = { roles: ["admin"] },
+  me: { roles: string[]; allow?: Record<string, string[]> } = {
+    roles: ["admin"],
+  },
 ) {
+  const allow =
+    me.allow ?? (me.roles.includes("admin") ? ADMIN_USER_ADMIN : {});
+  const objects: Record<string, Record<string, boolean>> = {};
+  for (const [object, verbs] of Object.entries(allow)) {
+    objects[object] = {
+      read: verbs.includes("read"),
+      create: verbs.includes("create"),
+      update: verbs.includes("update"),
+      delete: verbs.includes("delete"),
+    };
+  }
   // openapi-fetch calls fetch(request) with a Request object, so read the
   // method + body off it rather than a separate init.
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -153,6 +176,12 @@ function backend(
         user: { email: "admin@acme.test" },
         roles: me.roles,
         teams: [],
+        // The seat rides here too: `useCanWrite` folds the ceiling that
+        // identity/admission.go enforces ABOVE RBAC, so a snapshot without a
+        // seat refuses every write however wide its grants.
+        // `row_scope` is REQUIRED on Authorization (crm.yaml), so a stub without
+        // it describes a /me the server cannot send.
+        authorization: { objects, seat_type: "full", row_scope: "all" },
         // The installation CAN mint set-password links. Without this the card
         // withholds that action from every row, and any assertion that one
         // particular row lacks it passes without the row having anything to do
@@ -175,7 +204,21 @@ function backend(
       });
     }
     if (req.url.includes("/users") && req.method === "GET") {
-      return jsonResponse(ROSTER);
+      // The SAME projection the server makes: `roles` and the deactivated
+      // members ride the privileged view, which handlers_roster.go sends only
+      // to a caller passing `user_admin:read`. A fixture answering the full
+      // roster to everyone describes a response the API cannot produce — and
+      // a case asserting a rep sees "Read-only" would then be leaning on data
+      // the rep would never have received.
+      if (allow.user_admin?.includes("read")) {
+        return jsonResponse(ROSTER);
+      }
+      return jsonResponse({
+        ...ROSTER,
+        data: ROSTER.data
+          .filter((u) => u.status !== "deactivated")
+          .map(({ roles: _withheld, ...rest }) => rest),
+      });
     }
     let body: unknown;
     try {
@@ -228,19 +271,69 @@ describe("UsersAdminCard", () => {
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
     expect(screen.getByRole("heading", { name: /^Users$/ })).toBeTruthy();
 
-    // A role they cannot change is a FACT, so it reads as text rather than as a
-    // picker that could only be refused, and no row offers a verb at all — so
-    // no row offers the menu those verbs live behind either.
+    // No picker, and no menu the verbs would live behind. Nor any role TEXT:
+    // this reader is not sent `roles` at all (handlers_roster.go withholds the
+    // privileged projection), so there is no fact to state — which is why the
+    // fixture above answers them the narrow roster the server would.
     expect(screen.queryByRole("combobox")).toBeNull();
-    expect(screen.getByText("Read-only")).toBeTruthy();
+    expect(screen.queryByText("Read-only")).toBeNull();
     expect(screen.queryByRole("button", { name: /actions for/i })).toBeNull();
+    // The deactivated member is absent for the same reason: `include_inactive`
+    // is honoured only for a caller who passes that read.
+    expect(screen.queryByText("Otto Off")).toBeNull();
 
     // Inviting IS the admin's, and the card SAYS it is withheld rather than
     // simply dropping the verb: the page opens for every seat, so a roster with
     // no explanation reads as "this installation cannot add people".
     expect(screen.queryByRole("button", { name: /invite a user/i })).toBeNull();
-    expect(screen.getByText(/admins only/i)).toBeTruthy();
+    // Matched on the KEY's text, not on the words "admins only": the string
+    // stopped saying that when these became delegatable grants.
+    expect(
+      screen.getByText(new RegExp(en["users.adminOnly"], "i")),
+    ).toBeTruthy();
     expect(screen.queryByLabelText(/new user's email/i)).toBeNull();
+  });
+
+  // The escalation Codex found: `user_admin:update` WITHOUT the read. The
+  // roster omits every member's roles for this caller, `RoleCell` would read the
+  // missing field as [], and `ChangeUserRole` REPLACES the whole role set — so
+  // picking a role would silently drop every other role the target holds, none
+  // of which this reader can see. The picker is withheld until the read is
+  // there too.
+  it("offers no role picker to a write holder who cannot read the roster", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backend([], {
+        roles: ["custom"],
+        allow: { user_admin: ["create", "update", "delete"] },
+      }),
+    );
+    render(<UsersAdminCard />);
+
+    // The positive control first: a member row only a resolved snapshot draws.
+    // Without it every assertion below would run against the loading render,
+    // where each predicate reads false and nothing is offered anyway.
+    await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.queryByRole("button", { name: /actions for/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /invite a user/i })).toBeNull();
+  });
+
+  // And the same holder WITH the read gets all of it, so the case above is not
+  // passing because the fixture refuses everyone.
+  it("offers the picker once the write holder can read the roster", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backend([], {
+        roles: ["custom"],
+        allow: { user_admin: ["read", "create", "update", "delete"] },
+      }),
+    );
+    render(<UsersAdminCard />);
+
+    await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
+    expect(screen.getAllByRole("combobox").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /invite a user/i })).toBeTruthy();
   });
 
   it("carries the roster count and the invite verb in one card's header", async () => {
@@ -498,6 +591,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {
@@ -603,6 +711,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {
@@ -685,6 +808,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {
@@ -738,6 +876,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {
@@ -794,6 +947,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {
@@ -858,6 +1026,21 @@ describe("UsersAdminCard", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            // The card asks `user_admin` verb by verb and folds the seat, so a
+            // snapshot carrying a role alone refuses every control this case is
+            // about — and the case would pass with nothing rendered.
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
           });
         }
         if (req.url.includes("/teams") && req.method === "GET") {

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -19,7 +19,7 @@ import { formatNumber } from "../format/format";
 import { useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import "./users-admin.css";
-import { useHoldsAdminRole } from "../app/capability";
+import { useCan, useCanWrite } from "../app/capability";
 import { isOption } from "../app/options";
 import {
   InviteUserForm,
@@ -55,7 +55,40 @@ function useMembers() {
 
 export function UsersAdminCard() {
   const me = useMe();
-  const isAdmin = useHoldsAdminRole();
+  // The four verbs the server actually distinguishes, not one "is admin".
+  // `user_admin` has been seeded and enforced since the roster's gates moved off
+  // the literal role, and each of these is the grant its own endpoint takes:
+  // invite is CREATE (invite.go), a role change is UPDATE (users.go
+  // ChangeUserRole), and deactivate AND reactivate are both DELETE — one verb
+  // for turning a seat off and back on, because they are the same authority
+  // over the same thing.
+  //
+  // `useCanWrite`, not `useCan`: the seat ceiling is enforced ABOVE RBAC
+  // (identity/admission.go), so a read seat holding the grant is still refused
+  // every one of these. A control it was shown could only ever 403.
+  // Every roster verb ANDs with the read, because the write needs what the read
+  // carries and the server does not send it otherwise:
+  //
+  //   - `ChangeUserRole` REPLACES the whole role set with the one picked
+  //     (users.go). Without the read the roster omits `roles`, `RoleCell` reads
+  //     the missing field as [], and picking a role would silently drop every
+  //     other role the target holds — destroying authority the reader could not
+  //     see.
+  //   - `include_inactive` is honoured only for a caller who passes the read
+  //     (handlers_roster.go), so a delete holder without it never sees a
+  //     deactivated member to reactivate, nor an invited one to switch off.
+  //
+  // Inviting does not strictly need it, but a roster this reader cannot read is
+  // not a page to invite from either.
+  // Each hook on its own line and called unconditionally: `&&` short-circuits,
+  // and the number of hooks a render performs must not depend on an answer.
+  const administersRoster = useCan("user_admin", "read");
+  const mayInvite = useCanWrite("user_admin", "create");
+  const mayChangeRole = useCanWrite("user_admin", "update");
+  const maySetStatus = useCanWrite("user_admin", "delete");
+  const canInvite = administersRoster && mayInvite;
+  const canChangeRole = administersRoster && mayChangeRole;
+  const canSetStatus = administersRoster && maySetStatus;
   const members = useMembers();
   // The server answers whether THIS caller can mint set-password links: admin,
   // on an installation with no email channel and a configured base URL. Where
@@ -68,19 +101,24 @@ export function UsersAdminCard() {
   // member" — the same three words, three times, above a list nine members
   // long that a reader came here to read.
   //
-  // The ROSTER is not admin surface: `GET /users` answers 200 to any
-  // authenticated principal, and "who is on my team and what may they do" is not
-  // an admin's private question. So every seat gets the member list, and the two
-  // things the server refuses them — inviting somebody, and changing a role or a
-  // status — are the admin's. `probeSettled` is what keeps the read-only line
-  // from flashing at an admin while /me is still in flight: a probe in flight is
-  // not a denial.
+  // `GET /users` answers 200 to any authenticated principal, so the share and
+  // assignee pickers keep working for every seat. What that endpoint CONTAINS
+  // is narrowed instead: role keys and the deactivated members ride the
+  // privileged projection, which handlers_roster.go sends only to a caller
+  // holding `user_admin:read`.
+  //
+  // This settings PAGE follows the same read, because a roster nobody may act
+  // on is a directory rather than an administration surface. `probeSettled` is
+  // what keeps the read-only line from flashing while /me is still in flight: a
+  // probe in flight is not a denial.
   return (
     <MembersCard
       members={members}
       probeSettled={me.isSuccess}
       canIssueLink={canIssueLink}
-      canAdminister={isAdmin}
+      canInvite={canInvite}
+      canChangeRole={canChangeRole}
+      canSetStatus={canSetStatus}
     />
   );
 }
@@ -89,13 +127,22 @@ function MembersCard({
   members,
   probeSettled,
   canIssueLink,
-  canAdminister,
+  canInvite,
+  canChangeRole,
+  canSetStatus,
 }: Readonly<{
   members: ReturnType<typeof useMembers>;
   probeSettled: boolean;
   canIssueLink: boolean;
-  canAdminister: boolean;
+  canInvite: boolean;
+  canChangeRole: boolean;
+  canSetStatus: boolean;
 }>) {
+  // Whether this reader administers the roster AT ALL, for the one read-only
+  // line the card states once. A reader holding some verbs and not others is
+  // not read-only, and telling them so beside controls they can use would be
+  // false — the individual verbs decide what each row offers.
+  const administers = canInvite || canChangeRole || canSetStatus;
   const plural = usePlural();
   const t = useT();
   const { locale } = useLocale();
@@ -118,7 +165,7 @@ function MembersCard({
               })}
             </Badge>
           )}
-          {canAdminister && <InviteAction canIssueLink={canIssueLink} />}
+          {canInvite && <InviteAction canIssueLink={canIssueLink} />}
         </>
       }
     >
@@ -132,7 +179,7 @@ function MembersCard({
             withheld). */}
         <p className="settings-panel-sub">
           {t("users.membersSub")}
-          {probeSettled && !canAdminister && ` ${t("users.adminOnly")}`}
+          {probeSettled && !administers && ` ${t("users.adminOnly")}`}
         </p>
         <QueryGate query={members} pendingLabel={t("users.membersTitle")}>
           {(list) =>
@@ -150,7 +197,8 @@ function MembersCard({
                     key={u.id}
                     member={u}
                     canIssueLink={canIssueLink}
-                    canAdminister={canAdminister}
+                    canChangeRole={canChangeRole}
+                    canSetStatus={canSetStatus}
                   />
                 ))}
               </SettingList>
@@ -294,13 +342,13 @@ function RoleCell({
 // row draws a picker instead.
 function roleAnswer(
   member: User,
-  canAdminister: boolean,
+  canChangeRole: boolean,
   t: ReturnType<typeof useT>,
 ): string | undefined {
   if (member.is_agent) {
     return t("users.agentSeatRole");
   }
-  if (canAdminister) {
+  if (canChangeRole) {
     return undefined;
   }
   const held = (member.roles ?? []).map(roleLabel(t)).join(", ");
@@ -380,11 +428,13 @@ function statusTone(status: string): "success" | "warn" | "danger" | undefined {
 function MemberRow({
   member,
   canIssueLink,
-  canAdminister,
+  canChangeRole,
+  canSetStatus,
 }: Readonly<{
   member: User;
   canIssueLink: boolean;
-  canAdminister: boolean;
+  canChangeRole: boolean;
+  canSetStatus: boolean;
 }>) {
   const t = useT();
   const qc = useQueryClient();
@@ -494,18 +544,23 @@ function MemberRow({
   // Invited matters most here: an invitation whose link expired leaves a member
   // with no password, so the self-service reset refuses them and this is the
   // only route back into the account. Withholding it would strand them.
+  // A set-password link is a credential for somebody else's account, so it
+  // rides the role-change verb rather than the status one: `admin_password_link`
+  // already folds the deployment posture and the seat, and userpasswordlink.go
+  // asks `user_admin:update`.
   const canMintLink =
-    canAdminister &&
+    canChangeRole &&
     canIssueLink &&
     !member.is_agent &&
     (member.status === "active" || member.status === "invited");
   // Offered on an invitation too, and that is not cosmetic: an unredeemed
   // invitation holds a licensed seat, so without this an invitation sent to the
   // wrong address consumes a seat with no way to release it.
+  // Both on DELETE, which is the verb both endpoints take (users.go): turning a
+  // seat off and turning it back on are one authority over one thing.
   const canDeactivate =
-    canAdminister &&
-    (member.status === "active" || member.status === "invited");
-  const canReactivate = canAdminister && member.status === "deactivated";
+    canSetStatus && (member.status === "active" || member.status === "invited");
+  const canReactivate = canSetStatus && member.status === "deactivated";
 
   return (
     // The row's own wrapper, so a refusal reads UNDER the member it belongs to
@@ -517,7 +572,7 @@ function MemberRow({
       <SettingRow
         label={member.display_name}
         description={member.email}
-        value={roleAnswer(member, canAdminister, t)}
+        value={roleAnswer(member, canChangeRole, t)}
         // Status, then role, then the verbs — and that ORDER is what keeps nine
         // role pickers at one x. The control column packs from the right, so an
         // item's position is decided by the width of everything after it: with
@@ -533,7 +588,7 @@ function MemberRow({
                 OWNS records — a client resolving an owner has to find it — so
                 the row says what it is rather than passing for a colleague. */}
             {member.is_agent && <Badge tone="ai">{t("users.agentSeat")}</Badge>}
-            {canAdminister && !member.is_agent && (
+            {canChangeRole && !member.is_agent && (
               <RoleCell
                 member={member}
                 pending={pending}

--- a/frontend/src/screens/users-password-link.test.tsx
+++ b/frontend/src/screens/users-password-link.test.tsx
@@ -64,6 +64,21 @@ function backend(opts: {
         roles: ["admin"],
         teams: [],
         admin_password_link: opts.adminPasswordLink,
+        // Grants, not the role name: the card asks `user_admin` verb by verb
+        // and folds the seat ceiling, so a snapshot carrying a role alone
+        // refuses every control these cases are about.
+        authorization: {
+          objects: {
+            user_admin: {
+              read: true,
+              create: true,
+              update: true,
+              delete: true,
+            },
+          },
+          seat_type: "full",
+          row_scope: "all",
+        },
       });
     }
     if (req.url.includes("/password-link")) {
@@ -290,6 +305,18 @@ describe("admin-issued set-password link", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
             admin_password_link: true,
           });
         }
@@ -328,6 +355,18 @@ describe("admin-issued set-password link", () => {
             user: { email: "admin@acme.test" },
             roles: ["admin"],
             teams: [],
+            authorization: {
+              objects: {
+                user_admin: {
+                  read: true,
+                  create: true,
+                  update: true,
+                  delete: true,
+                },
+              },
+              seat_type: "full",
+              row_scope: "all",
+            },
             admin_password_link: true,
           });
         }


### PR DESCRIPTION
## What was wrong

Members and Teams gated **everything** on one predicate — `useHoldsAdminRole()`, a literal role-name check — on pages the server gates with two RBAC objects and seven distinct verbs.

`user_admin` and `team_admin` have been seeded and enforced server-side since the identity module moved off the role. **No client code read either one.** A delegated administrator holding exactly the right grant saw nothing they could use, and every seat saw a roster page with no controls on it.

## Each control asks what its own endpoint asks

| Control | Grant | Source |
|---|---|---|
| Invite | `user_admin:create` | `invite.go` |
| Change role | `user_admin:update` | `users.go` |
| Deactivate **and** reactivate | `user_admin:delete` | `users.go` — one authority over one thing |
| Set-password link | `user_admin:update` | `userpasswordlink.go` — a credential for somebody else's account |
| New team | `team_admin:create` | `teams.go` |
| Rename, membership | `team_admin:update` | `teams.go` |

## Every roster write ANDs with the read, and that is not tidiness

Two escalation paths, both found in review:

- **`ChangeUserRole` REPLACES the whole role set.** Without `user_admin:read` the roster omits `roles` entirely, so the picker would be drawn against an empty list and choosing anything would silently drop every other role the target holds — authority this reader cannot see.
- **`include_inactive` is honoured only for a caller who passes the read.** A `delete` holder without it never sees a deactivated member to reactivate, nor an invited one to switch off. The page would offer two affordances that cannot work.

Each of the three write clauses is independently mutation-checked: reverting any one fails a test.

## Team membership is the same shape from the other side

`team_ids` rides `user_admin:read`, **not** `team_admin` (`handlers_roster.go`). A team writer without it would draw a list showing nobody in any team — false rather than withheld.

So membership needs both grants, and its checkboxes are **disabled rather than absent** for a reader who may see membership and not change it. The list is the answer they came for; removing the boxes would withhold the reading along with the writing. That reader could not exist before this split.

## Who loses what

The two pages stop being `requires: always`. `GET /users` still answers every authenticated caller and must — the share and assignee pickers read it — but a directory is not an administration page.

- **A rep goes from 15 settings pages to 13.**
- **Ops loses both pages.** The seeded matrix gives them nothing on either object, so they were reading a roster with no controls under a read-only banner. Removing the pages agrees with the server, but it is a visible change for an operator seat.

Three withheld-state strings said "admins only" in all three languages. That stopped being true the day these became delegatable grants; they name the missing permission now.

## The fixtures were describing a principal the API cannot produce

Every test stubbed `roles: ["admin"]` with **no `authorization` object at all**. Every capability predicate therefore read false, and the cases passed by construction. They now carry real grants, `seat_type`, and the required `row_scope` — and the roster fixture makes the same projection the server makes, rather than answering the privileged view (role keys, deactivated members) to everyone.

One case asserted a rep sees "Read-only" beside a member. Production never sends that reader any roles, so it was leaning on a response that cannot happen.

## Five more vacuous assertions

Absence assertions comparing against the ungated floor pass on `waitFor`'s first tick, because that floor **is** the loading render. I measured it: for a grantless principal the rail's DOM is byte-identical before and after `/me` resolves.

- Three gained a witness row that only a resolved snapshot can draw.
- The two that cannot have a witness — granting anything changes their subject — assert through the pure evaluator, where the snapshot is an argument rather than a race.

Verified by probe: granting the very page a case says is hidden now **fails**. Before, it passed.

## Checks

`make check-fe` green (8070 tests), `make frontend-e2e` 254 passed / 0 failed, `tsc -b` clean. Live API confirms admin 28/28 pages and rep 13/28. Re-run after rebasing onto current main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Members and Teams now gate on their own RBAC verbs (`user_admin` / `team_admin`) instead of a literal `useHoldsAdminRole()` role-name check, so a delegated administrator holding exactly the right server-seeded grant gets working controls. Both settings entries stop opening for every authenticated seat: reps go from 15 settings pages to 13, and Ops loses both pages entirely.

**Gating changes**
- Members now requires `user_admin:read`; Teams requires a `team_admin` write verb or `user_admin:read`.
- Every write control ANDs with `user_admin:read`, because the server withholds role keys and deactivated members from anyone who lacks that read.
- Team membership checkboxes are disabled, not absent, for a reader with `user_admin:read` only — removing them would withhold the reading along with the writing.
- The set-password link rides `user_admin:update`; deactivate and reactivate both ride `user_admin:delete`.
- Withheld-state strings changed from "admins only" to "You do not have permission" in en, de, and vi.

**Tests**
- Fixtures now send real `authorization` objects (grants, seat_type, row_scope) instead of a role name with no grants, and the roster fixture returns the same narrowed projection the server sends.
- Five assertions that passed against the loading render now wait on a witness row or assert through the pure evaluator.

<sup>Written for commit 12c2b2687ece200b0b459dadd51357409e0c3a04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Members and Teams settings are now shown only to users with the required permissions.
  * Administration controls now follow individual permissions for viewing, inviting, editing, archiving, status changes, and password-link actions.
  * Users with view-only access can see membership information while editing controls remain disabled.

* **Accessibility & Localization**
  * Updated English, German, and Vietnamese permission messages with clearer access-denied wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->