### PR TITLE
fix(worklist): the reason for hiding an agent seat names the refusal that exists

### DIFF
--- a/frontend/src/screens/worklist.manager.tsx
+++ b/frontend/src/screens/worklist.manager.tsx
@@ -73,11 +73,11 @@ export function OwnerPicker({
 
 // Who the reader may hand work to, as options.
 //
-// AGENT SEATS ARE EXCLUDED. `PATCH /activities/{id}` accepts any active user id
-// — its check is existence, not seat kind — so an agent seat would take the
-// task and hold it where no person's queue shows it. That is a wider hole than
-// this control (issue on the endpoint), and offering the seat here would be
-// this page walking a reader into it.
+// AGENT SEATS ARE EXCLUDED. An agent seat is an Agent Runner identity, not a
+// person: it opens no Worklist, and the task lane is read per human. The server
+// refuses one — `ensureAssigneeCanHoldWork` in the activities module answers a
+// field fault on `assignee_id` — so offering the seat here would draw a control
+// whose only outcome is a refusal.
 //
 // Everyone else the roster carries is offered. Narrowing to teammates would
 // need a membership read this screen does not have, and the server refuses a


### PR DESCRIPTION
The reassign picker on the manager screen excludes agent seats. Its comment explained why with a hole that has since been closed.

## The stale reason

`worklist.manager.tsx` said `PATCH /activities/{id}` "accepts any active user id — its check is existence, not seat kind — so an agent seat would take the task and hold it where no person's queue shows it", and called this filter a guard against "a wider hole than this control (issue on the endpoint)".

`ensureAssigneeCanHoldWork` (`backend/internal/modules/activities/assignee.go`) now refuses an agent seat with a field fault on `assignee_id`, and the issue that comment pointed at is closed.

## Why the filter stays

The exclusion is still right, for a reason that is now the true one: the server refuses the seat, so offering it would draw a control whose only outcome is a refusal. The new comment says that and names the function, so the next reader can go and check it rather than taking the claim.

Comment only — no behaviour changes.

## Gate

`make check-fe` EXIT=0. Backend untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the reassign picker's comment in `worklist.manager.tsx` to name the real reason agent seats are excluded: the server refuses them via `ensureAssigneeCanHoldWork`, so offering one would only lead to a refusal.

The old comment referenced a backend gap that has since been closed. The filter stays, but the comment now points readers to the function that enforces the refusal. No behavior changes.

<sup>Written for commit 6e20182f1df9b7390057a6d36695d89a3cdc5d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal explanatory documentation to reflect current assignee validation behavior.
  * No user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->