### PR TITLE
The one definition of a current job moves where all of it can be reached

### DIFF
--- a/backend/gates/accountreachcopies_test.go
+++ b/backend/gates/accountreachcopies_test.go
@@ -28,8 +28,8 @@ package gates
 import (
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -84,13 +84,17 @@ func TestTheAccountReachWalkIsOneAnswer(t *testing.T) {
 // constText answers the string literal a named package-level constant holds.
 func constText(t *testing.T, file, name string) (string, bool) {
 	t.Helper()
-	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
 	if err != nil {
 		t.Fatalf("parsing %s: %v", file, err)
 	}
 	for _, decl := range parsed.Decls {
 		gen, isGen := decl.(*ast.GenDecl)
-		if !isGen || gen.Tok != token.CONST {
+		// VAR as well as CONST: an arm that calls the shared employment
+		// predicate cannot be a constant, and reading only constants would
+		// leave this gate comparing nothing on the day the arms adopted it.
+		if !isGen || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
 			continue
 		}
 		for _, spec := range gen.Specs {
@@ -109,15 +113,24 @@ func constText(t *testing.T, file, name string) (string, bool) {
 				if ident.Name != name {
 					continue
 				}
-				lit, isLit := value.Values[i].(*ast.BasicLit)
-				if !isLit || lit.Kind != token.STRING {
-					return "", false
+				// The expression AS WRITTEN, not the string it resolves to.
+				//
+				// An arm that calls the shared employment predicate is a
+				// concatenation rather than a literal, and a reader that folded
+				// it would have to put something in the call's place — every
+				// fold available renders two DIFFERENT calls as the same
+				// placeholder, so the gate would stop being able to tell
+				// `IsCurrentSQL("r.ended_at")` from `IsCurrentSQL("emp.ended_at")`.
+				// That distinction is this gate's whole subject.
+				//
+				// Source text keeps it: two declarations that are identical
+				// character for character are identical however they are built,
+				// which is the claim being made.
+				var written strings.Builder
+				if err := printer.Fprint(&written, fset, value.Values[i]); err != nil {
+					t.Fatalf("printing %s in %s: %v", name, file, err)
 				}
-				text, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					return "", false
-				}
-				return text, true
+				return written.String(), true
 			}
 		}
 	}

--- a/backend/gates/employmentcurrency_test.go
+++ b/backend/gates/employmentcurrency_test.go
@@ -5,7 +5,7 @@
 
 package gates
 
-// people.EmploymentIsCurrentSQL calls itself "the ONE spelling of 'this job is
+// employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is
 // still theirs', and the only definition of a current employment in this
 // product". That was a claim with nothing holding it, and it was false eleven
 // times over.
@@ -46,38 +46,37 @@ import (
 	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
-// blockedByTheModuleDAG ratifies the statements that cannot adopt the helper
-// TODAY, each with the reason it cannot — which is the same reason in every
-// case and is architectural, not a matter of somebody not getting round to it.
+// Nothing is ratified here, and that is the point.
 //
-// EmploymentIsCurrentSQL lives in modules/people, and a module never imports a
-// sibling (ADR-0054 §3). compose may reach it and does; people's own files
-// reach it directly; FIVE sibling modules cannot — activities, projects,
-// signals, consent and search — and the predicate would have to move tier
-// before they could. That is an architecture decision with an owner, so it is
-// an issue rather than a change smuggled into this one — margince/margince#2360.
+// The helper used to live in modules/people, where a module never imports a
+// sibling (ADR-0054 §3). compose could reach it and did; people's own files
+// reach it directly, and so can the five sibling modules that could not — the
+// predicate moved to shared/kernel/employment, which is Tier 0 and reachable
+// from everywhere. Eight statements in seven files were ratified here by name
+// while it lived in `modules/people`; all eight now call it, so there is
+// nothing left to ratify and the map is gone rather than emptied.
+// carriesASecondEdgeKind ratifies the two statements whose employment arm DOES
+// call the helper and which still read as findings here, because they ask about
+// another edge kind in the same statement and this census matches per statement
+// rather than per arm.
 //
-// EIGHT statements in the seven files below, since resolver.go carries two. The
-// count is stated because it is the debt, and it is the map's own arithmetic
-// rather than a second answer: one per key, plus resolver.go's extra.
+// The other kind is a stakeholder edge — on a deal, on a project — and it has no
+// notice period: a stakeholder either is on the deal or is not, so `ended_at IS
+// NULL` is the whole question there and the date comparison would be wrong. What
+// the gate cannot see is which arm the test belongs to.
 //
-// Each entry is a FILE and not the whole module, so a new statement in one of
-// these packages is still a finding — the ratification covers the sites that
-// exist, not the topic.
-var blockedByTheModuleDAG = gatekit.Waive(map[string]string{
-	"internal/modules/activities/orgscope.go":          "activities cannot import people (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/projects/surface.go":             "projects cannot import people (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/signals/resolver.go":             "signals cannot import people (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/signals/warmroom.go":             "signals cannot import people (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/consent/authorizevalidators.go":  "consent cannot import people (ADR-0054 §3); the predicate must move tier first. Same date comparison as the helper, and the cost of getting it wrong here is the sharpest on this list: a null check would stop an invoice or a contract notice reaching a finance contact the day their notice was filed, while they are still the person handling it",
-	"internal/modules/consent/confirmcard.go":          "consent cannot import people (ADR-0054 §3); the predicate must move tier first. The copy is the helper's own date comparison rather than a null check, so a person serving notice still sees their employer on their own confirm card",
-	"internal/modules/search/graphorgreach.go":         "search cannot import people (ADR-0054 §3); the predicate must move tier first. It is a CHARACTER-FOR-CHARACTER copy of activities/orgscope.go's arms, held so by TestTheAccountReachWalkIsOneAnswer — adopting the helper on one side alone would break that parity before it fixed anything, so the two move together or not at all",
-	"internal/modules/search/graphactivitysubjects.go": "search cannot import people (ADR-0054 §3); the predicate must move tier first. Same shape as the org-reach arm beside it: an attendee serving notice stops carrying their employer into a prep, which is the cost stated on every other entry here",
+// TWO, and a different reason from the eight this map replaced. Those said the
+// predicate was out of reach; it is not any more. These say the census reads a
+// statement whole. Sharpening it to judge the conjunction the employment kind
+// sits in would retire them, and is worth doing the moment a third appears.
+var carriesASecondEdgeKind = gatekit.Waive(map[string]string{
+	"internal/modules/projects/surface.go": "the employment arm calls employment.CurrentPrimarySQL; the project_stakeholder arm beside it tests its own ended_at, which has no notice period to allow for",
+	"internal/modules/signals/warmroom.go": "the employment arm calls employment.IsCurrentSQL; the deal_stakeholder arm beside it tests its own ended_at, which has no notice period to allow for",
 })
 
 const (
-	employmentHelper = "EmploymentIsCurrentSQL"
-	primaryHelper    = "CurrentPrimaryEmploymentSQL"
+	employmentHelper = "IsCurrentSQL"
+	primaryHelper    = "CurrentPrimarySQL"
 	employmentIssue  = "eight statements in five sibling modules are ratified separately: a module may not import people (ADR-0054 §3), so the predicate has to move tier before they can adopt it; see issue 2360"
 )
 
@@ -109,14 +108,14 @@ var endedAtCurrency = regexp.MustCompile(`ended_at\s+IS\s+(NOT\s+)?NULL|ended_at
 
 // employmentCurrencyOwner is where the definition lives. Its own statements are
 // the definition rather than a copy of it.
-const employmentCurrencyOwner = "internal/modules/people/employmentcurrency.go"
+const employmentCurrencyOwner = "internal/shared/kernel/employment/employment.go"
 
 func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 	t.Parallel()
-	// A ratification that stops matching is a ratification for a site that has
-	// moved or been fixed, and leaving it in place quietly re-exempts whatever
-	// takes its name next.
-	defer blockedByTheModuleDAG.AssertAllMatched(t)
+	// A ratification that stops matching is one for a site that has moved or
+	// been fixed, and leaving it in place quietly re-exempts whatever takes its
+	// name next.
+	defer carriesASecondEdgeKind.AssertAllMatched(t)
 
 	fset := token.NewFileSet()
 	var findings []string
@@ -131,8 +130,8 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
 		scope := helperScope{
-			qualifier: importAliasOf(file, "github.com/margince/margince/backend/internal/modules/people"),
-			inside:    file.Name != nil && file.Name.Name == "people",
+			qualifier: importAliasOf(file, "github.com/margince/margince/backend/internal/shared/kernel/employment"),
+			inside:    file.Name != nil && file.Name.Name == "employment",
 			names:     map[string]bool{employmentHelper: true, primaryHelper: true},
 		}
 		for _, decl := range file.Decls {
@@ -144,7 +143,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 				if !endedAtCurrency.MatchString(sql) {
 					continue
 				}
-				if blockedByTheModuleDAG.Waived(t, filepath.ToSlash(path)) {
+				if carriesASecondEdgeKind.Waived(t, filepath.ToSlash(path)) {
 					continue
 				}
 				findings = append(findings, fmt.Sprintf("%s: %s", path, firstEmploymentLine(sql)))
@@ -172,7 +171,7 @@ func TestEveryEmploymentCurrencyTestUsesTheOneDefinition(t *testing.T) {
 //
 // A statement, not a literal. A query that calls the helper is written as
 //
-//	`… WHERE r.kind = 'employment' AND ` + people.EmploymentIsCurrentSQL("r.ended_at") + ` AND …`
+//	`… WHERE r.kind = 'employment' AND ` + employment.IsCurrentSQL("r.ended_at") + ` AND …`
 //
 // which the parser gives as three separate nodes, so judging each *ast.BasicLit
 // on its own splits the question in half: the piece naming the employment kind
@@ -263,7 +262,7 @@ func read() string {
 }`},
 	{"the helper AND a hand-written test beside it", true, "", `
 func read() string {
-	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + people.EmploymentIsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.ended_at IS NOT NULL` + "`" + `
+	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + employment.IsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.ended_at IS NOT NULL` + "`" + `
 }`},
 	// The name alone is not the helper. markSeen claims a helper call's whole
 	// subtree, so a LOOKALIKE would have had its arguments hidden and could
@@ -275,16 +274,16 @@ func read() string {
 
 	{"the real helper, qualified", false, "", `
 func read() string {
-	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + people.EmploymentIsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.archived_at IS NULL` + "`" + `
+	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + employment.IsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.archived_at IS NULL` + "`" + `
 }`},
 	{"the real helper, unqualified inside people", false, "people", `
 func read() string {
-	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + EmploymentIsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.archived_at IS NULL` + "`" + `
+	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + employment.IsCurrentSQL("r.ended_at") + ` + "`" + ` AND r.archived_at IS NULL` + "`" + `
 }`},
 	// A bare call outside people names something else entirely.
 	{"an unqualified call outside people", true, "", `
 func read() string {
-	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + EmploymentIsCurrentSQL("r.ended_at IS NULL") + ` + "`" + ` AND 1=1` + "`" + `
+	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + employment.IsCurrentSQL("r.ended_at IS NULL") + ` + "`" + ` AND 1=1` + "`" + `
 }`},
 	// Another relationship kind is a different question, deliberately not this
 	// gate's.
@@ -299,7 +298,7 @@ func read() string {
 	// "this file does not import people", and most of the tree is the second.
 	{"a bare helper name in a file that does not import people", true, "noimport", `
 func read() string {
-	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + EmploymentIsCurrentSQL("r.ended_at IS NULL") + ` + "`" + ` AND 1=1` + "`" + `
+	return ` + "`" + `SELECT 1 FROM relationship r WHERE r.kind = 'employment' AND ` + "`" + ` + employment.IsCurrentSQL("r.ended_at IS NULL") + ` + "`" + ` AND 1=1` + "`" + `
 }`},
 	{"an IN list whose earlier item is a subquery", true, "", `
 func read() string {
@@ -355,7 +354,7 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 
 // The OTHER question about is_current_primary: which row holds the slot
 // uq_rel_current_primary_employer keeps unique. It is date-BLIND, so it cannot
-// share EmploymentIsCurrentSQL — a guard that asked "are they still employed"
+// share employment.IsCurrentSQL — a guard that asked "are they still employed"
 // would read a person serving notice as having freed a slot the index still
 // holds, and the write behind it would 409 instead of skipping.
 //
@@ -367,7 +366,7 @@ func TestTheEmploymentDetectorSeesWhatItClaimsTo(t *testing.T) {
 
 // currentPrimarySlotPredicate names the helper this census requires, so the
 // report can point at it.
-const currentPrimarySlotPredicate = "CurrentPrimarySlotSQL"
+const currentPrimarySlotPredicate = "employment.CurrentPrimarySlotSQL"
 
 // slotBlockedByTheModuleDAG ratifies the statement that cannot adopt the
 // helper today, for the architectural reason above and not for want of
@@ -377,9 +376,7 @@ const currentPrimarySlotPredicate = "CurrentPrimarySlotSQL"
 // records what reached it, and AssertAllMatched belongs to exactly one census —
 // two sweeping the same set would make whichever ran first report false
 // staleness.
-var slotBlockedByTheModuleDAG = gatekit.Waive(map[string]string{
-	"internal/modules/projects/surface.go": "projects cannot import people (ADR-0054 §3); the predicate must move tier first",
-})
+var slotBlockedByTheModuleDAG = gatekit.Waive(map[string]string{})
 
 // spellsSlotPredicate reports whether a statement tests the flag and an
 // archived test IN ONE CONJUNCTION — which is the slot predicate, however it is
@@ -554,8 +551,8 @@ func TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling(t *testing.T) {
 			t.Fatalf("parsing %s: %v", path, err)
 		}
 		scope := helperScope{
-			qualifier: importAliasOf(file, "github.com/margince/margince/backend/internal/modules/people"),
-			inside:    file.Name != nil && file.Name.Name == "people",
+			qualifier: importAliasOf(file, "github.com/margince/margince/backend/internal/shared/kernel/employment"),
+			inside:    file.Name != nil && file.Name.Name == "employment",
 			names:     map[string]bool{currentPrimarySlotPredicate: true},
 		}
 		for _, decl := range file.Decls {
@@ -641,14 +638,14 @@ var slotProbes = []struct {
 	// A helper call claims its whole subtree, so a lookalike from another
 	// package would have hidden a hand-written fragment inside its arguments.
 	{"a lookalike helper from another package", true, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE ` + other.CurrentPrimarySlotSQL(\"b.is_current_primary AND b.archived_at IS NULL\")\n}"},
-	{"a bare helper name in a file that does not import people", true, "noimport", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE ` + CurrentPrimarySlotSQL(\"b.is_current_primary AND b.archived_at IS NULL\")\n}"},
+	{"a bare helper name in a file that does not import people", true, "noimport", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE ` + employment.CurrentPrimarySlotSQL(\"b.is_current_primary AND b.archived_at IS NULL\")\n}"},
 
-	{"the real helper, qualified", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.person_id = $1 AND ` + people.CurrentPrimarySlotSQL(\"b\")\n}"},
-	{"the real helper, unqualified inside people", false, "people", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE person_id = $1 AND ` + CurrentPrimarySlotSQL(\"\")\n}"},
+	{"the real helper, qualified", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship b WHERE b.person_id = $1 AND ` + employment.CurrentPrimarySlotSQL(\"b\")\n}"},
+	{"the real helper, unqualified inside people", false, "people", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE person_id = $1 AND ` + employment.CurrentPrimarySlotSQL(\"\")\n}"},
 	// The create path's guard is deliberately WIDER than the slot: it refuses
 	// the flag when the person has any employment that is current OR flagged,
 	// which is not the index's predicate and must not be rewritten as it.
-	{"the wider create-path guard, where the flag sits inside an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL AND (` + EmploymentIsCurrentSQL(\"ended_at\") + ` OR is_current_primary)`\n}"},
+	{"the wider create-path guard, where the flag sits inside an OR", false, "", "\nfunc read() string {\n\treturn `SELECT 1 FROM relationship WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL AND (` + employment.IsCurrentSQL(\"ended_at\") + ` OR is_current_primary)`\n}"},
 	{"the flag with no archived test beside it", false, "", "\nfunc read() string {\n\treturn `UPDATE relationship SET is_current_primary = coalesce($3, is_current_primary)`\n}"},
 
 	// Four spellings a two-term pattern missed, each verified green against it

--- a/backend/gates/seedemploymentpredicate_test.go
+++ b/backend/gates/seedemploymentpredicate_test.go
@@ -8,7 +8,7 @@ package gates
 // The dev seeder and the boot proof ask "is this person currently employed?" the
 // way the PRODUCT asks it, and they ask it in the same words.
 //
-// Neither is a Go client, so neither can call people.CurrentPrimaryEmploymentSQL:
+// Neither is a Go client, so neither can call employment.CurrentPrimarySQL:
 // both are shell over the public API, and both therefore hand-spell the rule as
 // a jq predicate. That makes it one invariant with three writers, and the two
 // shell copies are the pair that can drift silently — the seeder deciding a
@@ -33,7 +33,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 )
 
 // The scripts that spell the rule, and the assignment they spell it in.
@@ -82,11 +82,11 @@ func TestTheShellPredicateReadsTheColumnsTheServerReads(t *testing.T) {
 	// The server's spelling, and the reason this is derived: an existence probe
 	// over /v1/relationships names NEITHER column and reads as employed anybody
 	// who ever was.
-	server := people.CurrentPrimaryEmploymentSQL("")
+	server := employment.CurrentPrimarySQL("")
 	predicate := predicateIn(t, currentPrimaryPredicateScripts[0])
 	for _, column := range employmentCurrencyColumns {
 		if !strings.Contains(server, column) {
-			t.Fatalf("people.CurrentPrimaryEmploymentSQL no longer reads %q (%s) — the rule moved, and this gate was about to hold the shell copies to a shape the product has stopped using",
+			t.Fatalf("employment.CurrentPrimarySQL no longer reads %q (%s) — the rule moved, and this gate was about to hold the shell copies to a shape the product has stopped using",
 				column, server)
 		}
 		if !strings.Contains(predicate, column) {

--- a/backend/gates/sqlhelperwalk_test.go
+++ b/backend/gates/sqlhelperwalk_test.go
@@ -8,7 +8,7 @@ package gates
 // text it builds, and how a call to THE definition is told from a lookalike.
 //
 // It lives on its own because there are two ports of it now — employment
-// currency (people.EmploymentIsCurrentSQL) and workforce liveness
+// currency (employment.IsCurrentSQL) and workforce liveness
 // (identity.LiveMemberSQL) — and a walk copied for the second port drifts from
 // the first. The narrower copy then reads a smaller tree and says PASS, which
 // is the failure mode a census cannot report about itself.
@@ -122,7 +122,7 @@ type helperScope struct {
 //
 // The name alone was not enough, and the gap is the one this gate exists to
 // close: a helper call's whole subtree is claimed, so `other.
-// EmploymentIsCurrentSQL(…)` would have been treated as canonical and its
+// employment.IsCurrentSQL(…)` would have been treated as canonical and its
 // arguments hidden, letting a hand-written currency test ride inside a
 // lookalike.
 func (h helperScope) isOneDefinition(call *ast.CallExpr) bool {

--- a/backend/internal/compose/commercialseams.go
+++ b/backend/internal/compose/commercialseams.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"

--- a/backend/internal/compose/introseams.go
+++ b/backend/internal/compose/introseams.go
@@ -28,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
@@ -207,7 +208,7 @@ func accountContacts(ctx context.Context, tx pgx.Tx, orgID ids.UUID) ([]accountC
 		   -- that row as live. Two spellings would let one surface call them
 		   -- gone while the other calls them current.
 		   AND r.archived_at IS NULL
-		   AND `+people.EmploymentIsCurrentSQL("r.ended_at")+`
+		   AND `+employment.IsCurrentSQL("r.ended_at")+`
 		   AND (%s) AND (%s)
 		 ORDER BY p.id LIMIT %d`, orgPos, edgeBound, visible, accountContactFetch+1), args...)
 	if err != nil {

--- a/backend/internal/compose/network/coveragefacts.go
+++ b/backend/internal/compose/network/coveragefacts.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	peoplemod "github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/idlebase"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -90,7 +90,7 @@ func readDealFacts(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (dealFacts
 // because a colleague fixed a data-entry error is exactly the false alarm that
 // teaches a rep to ignore the flag.
 //
-// "Still employed there" is people.EmploymentIsCurrentSQL, and both halves of
+// "Still employed there" is employment.IsCurrentSQL, and both halves of
 // this statement are written from it: the live half asserts it, the departed
 // half is its NEGATION. Spelled that way rather than as an equivalent
 // hand-written `ended_at IS NOT NULL AND ended_at <= today`, because the
@@ -103,7 +103,7 @@ func readDealFacts(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (dealFacts
 // while the live half compared against Postgres' current_date, so one statement
 // asked its two questions on two different days whenever the server and the
 // database disagreed about the date — which is precisely what
-// EmploymentIsCurrentSQL's own comment says the predicate exists to prevent.
+// employment.IsCurrentSQL's own comment says the predicate exists to prevent.
 //
 // No person visibility probe: the caller passes the stakeholder ids it already
 // read under its own person row scope, so a seat this caller cannot see never
@@ -138,7 +138,7 @@ func readDeparted(ctx context.Context, tx pgx.Tx, orgID ids.UUID, people []ids.U
 		   AND r.organization_id = $%[1]d
 		   AND r.person_id = ANY($%[2]d)
 		   AND r.archived_at IS NULL
-		   AND NOT `+peoplemod.EmploymentIsCurrentSQL("r.ended_at")+`
+		   AND NOT `+employment.IsCurrentSQL("r.ended_at")+`
 		   AND (%[3]s)
 		   AND NOT EXISTS (
 		       SELECT 1 FROM relationship live
@@ -146,7 +146,7 @@ func readDeparted(ctx context.Context, tx pgx.Tx, orgID ids.UUID, people []ids.U
 		          AND live.organization_id = r.organization_id
 		          AND live.person_id = r.person_id
 		          AND live.archived_at IS NULL
-		          AND `+peoplemod.EmploymentIsCurrentSQL("live.ended_at")+`)
+		          AND `+employment.IsCurrentSQL("live.ended_at")+`)
 		 ORDER BY r.person_id`, orgPos, peoplePos, edgeBound), args...)
 	if err != nil {
 		return nil, fmt.Errorf("network: reading which stakeholders have left the account: %w", err)

--- a/backend/internal/compose/network/persongraphaccount.go
+++ b/backend/internal/compose/network/persongraphaccount.go
@@ -26,9 +26,9 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -122,7 +122,7 @@ func readAccountContacts(ctx context.Context, tx pgx.Tx, personID ids.PersonID) 
 	// tidy. A window function is evaluated before DISTINCT, so counting the
 	// join's rows over-reports whenever one coworker matches twice — and this
 	// query became able to produce that the moment it started asking
-	// EmploymentIsCurrentSQL instead of `ended_at IS NULL`. The unique index
+	// employment.IsCurrentSQL instead of `ended_at IS NULL`. The unique index
 	// uq_rel_employment covers `(person_id, organization_id) WHERE ended_at IS
 	// NULL`, so the old predicate could not match one person twice; a
 	// future-dated row is outside that index, and a person with both a live row
@@ -139,12 +139,12 @@ func readAccountContacts(ctx context.Context, tx pgx.Tx, personID ids.PersonID) 
 		  JOIN relationship colleague
 		    ON colleague.organization_id = theirs.organization_id
 		   AND colleague.kind = 'employment'
-		   AND `+people.EmploymentIsCurrentSQL("colleague.ended_at")+`
+		   AND `+employment.IsCurrentSQL("colleague.ended_at")+`
 		   AND colleague.archived_at IS NULL
 		  JOIN person p ON p.id = colleague.person_id AND p.archived_at IS NULL
 		 WHERE theirs.person_id = $%d
 		   AND theirs.kind = 'employment'
-		   AND `+people.EmploymentIsCurrentSQL("theirs.ended_at")+`
+		   AND `+employment.IsCurrentSQL("theirs.ended_at")+`
 		   AND theirs.archived_at IS NULL
 		   AND p.id <> $%d
 		   AND (%s)

--- a/backend/internal/compose/noticesseam.go
+++ b/backend/internal/compose/noticesseam.go
@@ -11,7 +11,6 @@ package compose
 
 import (
 	"context"
-
 	"fmt"
 	"time"
 

--- a/backend/internal/compose/org360/graphreads.go
+++ b/backend/internal/compose/org360/graphreads.go
@@ -18,6 +18,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -61,7 +62,7 @@ func (g *graphAssembly) readEmployment() error {
 			FROM relationship r
 			JOIN person p ON p.id = r.person_id AND p.archived_at IS NULL
 			WHERE r.kind = 'employment' AND r.organization_id = $%d
-			  AND `+people.EmploymentIsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
+			  AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 			  AND (%s) AND (%s)
 		)
 		SELECT id, full_name, title, role, count(*) OVER () AS headcount

--- a/backend/internal/compose/personautoenrich.go
+++ b/backend/internal/compose/personautoenrich.go
@@ -44,6 +44,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/approvals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/events"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -227,7 +228,7 @@ func (g *PersonAutoEnrich) employerOf(ctx context.Context, tx pgx.Tx, personID i
 	var orgID ids.OrganizationID
 	err := tx.QueryRow(ctx, `
 		SELECT organization_id FROM relationship
-		WHERE person_id = $1 AND kind = 'employment' AND `+people.CurrentPrimaryEmploymentSQL("")+`
+		WHERE person_id = $1 AND kind = 'employment' AND `+employment.CurrentPrimarySQL("")+`
 		  AND archived_at IS NULL AND organization_id IS NOT NULL
 		LIMIT 1`, personID).Scan(&orgID)
 	if err != nil {

--- a/backend/internal/compose/weekly/weeklycompare.go
+++ b/backend/internal/compose/weekly/weeklycompare.go
@@ -14,13 +14,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/margince/margince/backend/internal/modules/deals"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -76,10 +77,10 @@ func OrgLinkedActivityExistsAny(orgsPos int) string {
 // The deal arm deliberately does not exclude archived or lost deals: a set
 // stricter than the predicate would show a message on the timeline whose
 // account never gets a signal about it.
-const orgArms = `FROM activity_link l
+var orgArms = `FROM activity_link l
 		    LEFT JOIN deal d ON d.id = l.deal_id
 		    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
-		      AND r.ended_at IS NULL AND r.archived_at IS NULL`
+		      AND ` + employment.IsCurrentSQL("r.ended_at") + ` AND r.archived_at IS NULL`
 
 // participantEmployerArm is the READER's fourth arm: the employer of somebody
 // who is on the event as a participant rather than as a link.
@@ -102,10 +103,10 @@ const orgArms = `FROM activity_link l
 // The alias is emp rather than r: the row-scope clause a caller composes
 // alongside this one is recognized by its "r." tokens, and a second
 // relationship in scope under that name reads as the first.
-const participantEmployerArm = `EXISTS (
+var participantEmployerArm = `EXISTS (
 		    SELECT 1 FROM activity_participant ap
 		      JOIN relationship emp ON emp.person_id = ap.person_id AND emp.kind = 'employment'
-		        AND emp.ended_at IS NULL AND emp.archived_at IS NULL
+		        AND ` + employment.IsCurrentSQL("emp.ended_at") + ` AND emp.archived_at IS NULL
 		    WHERE ap.activity_id = a.id AND emp.organization_id = %s)`
 
 // activityReachesOrg is the walk as a PREDICATE, for a query that aliases

--- a/backend/internal/modules/capture/digest.go
+++ b/backend/internal/modules/capture/digest.go
@@ -19,10 +19,9 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
-
-	"github.com/margince/margince/backend/internal/platform/auth"
 )
 
 // DigestPayload is the stored CAP-DDL-6 payload — the wire shape verbatim.

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
@@ -141,15 +142,7 @@ func validateInvoice(ctx context.Context, tx pgx.Tx, req commsauthz.Request, sub
 			   AND i.void_at IS NULL
 			   AND r.kind = 'employment'
 			   AND r.person_id = $2::uuid
-			   -- A DATE comparison, not a null check: somebody serving three
-			   -- months' notice still works there, and reading the column's
-			   -- presence as "gone" would take them off their employer's
-			   -- contact list the day their notice was filed. This is
-			   -- people.EmploymentIsCurrentSQL spelled out — consent may not
-			   -- import a sibling module (ADR-0054 §3), so it is ratified by
-			   -- name in the employment-currency gate alongside the five other
-			   -- statements in the same position.
-			   AND (r.ended_at IS NULL OR r.ended_at > current_date)
+			   AND `+employment.IsCurrentSQL("r.ended_at")+`
 			   AND r.archived_at IS NULL
 		)`, req.Evidence.InvoiceID)
 }
@@ -167,15 +160,7 @@ func validateContract(ctx context.Context, tx pgx.Tx, req commsauthz.Request, su
 			   AND c.archived_at IS NULL
 			   AND r.kind = 'employment'
 			   AND r.person_id = $2::uuid
-			   -- A DATE comparison, not a null check: somebody serving three
-			   -- months' notice still works there, and reading the column's
-			   -- presence as "gone" would take them off their employer's
-			   -- contact list the day their notice was filed. This is
-			   -- people.EmploymentIsCurrentSQL spelled out — consent may not
-			   -- import a sibling module (ADR-0054 §3), so it is ratified by
-			   -- name in the employment-currency gate alongside the five other
-			   -- statements in the same position.
-			   AND (r.ended_at IS NULL OR r.ended_at > current_date)
+			   AND `+employment.IsCurrentSQL("r.ended_at")+`
 			   AND r.archived_at IS NULL
 		)`, req.Evidence.ContractID)
 }

--- a/backend/internal/modules/consent/confirmcard.go
+++ b/backend/internal/modules/consent/confirmcard.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -84,7 +85,7 @@ func (s *Store) confirmCardFor(ctx context.Context, personID ids.PersonID) (Conf
 		// any other way would show a company they have left.
 		//
 		// The currency test is a DATE comparison and not a null check, matching
-		// people.EmploymentIsCurrentSQL exactly. Somebody serving three months'
+		// employment.IsCurrentSQL exactly. Somebody serving three months'
 		// notice still works there, and a null check would take their employer
 		// off their own card the day the notice was filed. Spelled here rather
 		// than called because a module may not import a sibling; the copy is
@@ -94,7 +95,7 @@ func (s *Store) confirmCardFor(ctx context.Context, personID ids.PersonID) (Conf
 			       coalesce((SELECT o.display_name FROM relationship r
 			                   JOIN organization o ON o.id = r.organization_id
 			                  WHERE r.person_id = p.id AND r.kind = 'employment'
-			                    AND (r.ended_at IS NULL OR r.ended_at > current_date)
+			                    AND `+employment.IsCurrentSQL("r.ended_at")+`
 			                    AND r.archived_at IS NULL
 			                  ORDER BY r.created_at DESC LIMIT 1), ''),
 			       `+primaryEmailSQL("p.id")+`,

--- a/backend/internal/modules/people/cohortpromote.go
+++ b/backend/internal/modules/people/cohortpromote.go
@@ -35,6 +35,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -386,7 +387,7 @@ func (s *Store) DomainsOwedTheirPeople(ctx context.Context, limit int) ([]Domain
 			   AND p.archived_at IS NULL AND p.merged_into_id IS NULL
 			   AND NOT EXISTS (
 			       SELECT 1 FROM relationship r
-			        WHERE r.person_id = p.id AND `+CurrentPrimarySlotSQL("r")+`)
+			        WHERE r.person_id = p.id AND `+employment.CurrentPrimarySlotSQL("r")+`)
 			   -- And not a person the index will refuse anyway. uq_rel_employment
 			   -- admits ONE live employment per (person, organization), so
 			   -- somebody already holding a non-primary edge to this company is a
@@ -395,7 +396,7 @@ func (s *Store) DomainsOwedTheirPeople(ctx context.Context, limit int) ([]Domain
 			   AND NOT EXISTS (
 			       SELECT 1 FROM relationship held
 			        WHERE held.person_id = p.id AND held.organization_id = od.organization_id
-			          AND `+LiveEmploymentSlotSQL("held")+`)
+			          AND `+employment.LiveSlotSQL("held")+`)
 			 ORDER BY od.organization_id, od.domain
 			 LIMIT $1`, limit)
 		if err != nil {

--- a/backend/internal/modules/people/currentprimaryslot_test.go
+++ b/backend/internal/modules/people/currentprimaryslot_test.go
@@ -3,7 +3,7 @@
 
 package people
 
-// CurrentPrimarySlotSQL mirrors uq_rel_current_primary_employer, and this is
+// employment.CurrentPrimarySlotSQL mirrors uq_rel_current_primary_employer, and this is
 // what holds it to the index rather than to somebody's memory of the index.
 //
 // It lives beside the helper and not with the census in gates because
@@ -15,10 +15,12 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 )
 
 // slotPredicateName is what the failure report calls the function it is about.
-const slotPredicateName = "CurrentPrimarySlotSQL"
+const slotPredicateName = "employment.CurrentPrimarySlotSQL"
 
 // headCatalog is the generated shape of a freshly migrated database — the
 // index's own text, and therefore the only statement of what the slot
@@ -76,7 +78,7 @@ func TestTheCurrentPrimarySlotPredicateMirrorsItsIndex(t *testing.T) {
 			"`A AND (B OR C)` from `(A AND B) OR C`. Compare the predicates structurally before trusting it again",
 			slotIndex, predicate)
 	}
-	if want, got := normalizedPredicate(predicate), normalizedPredicate(CurrentPrimarySlotSQL("")); want != got {
+	if want, got := normalizedPredicate(predicate), normalizedPredicate(employment.CurrentPrimarySlotSQL("")); want != got {
 		t.Errorf("%s renders %q, but %s is %q.\n\n"+
 			"The helper IS that index's predicate. A guard that asks a narrower question skips a write "+
 			"the index then refuses with a 409; a wider one skips a write the index would have accepted.",
@@ -84,7 +86,7 @@ func TestTheCurrentPrimarySlotPredicateMirrorsItsIndex(t *testing.T) {
 	}
 	// The aliased form is the same predicate with every column qualified, and
 	// nothing else — the shape four of the six call sites need.
-	if want, got := "b.", CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
+	if want, got := "b.", employment.CurrentPrimarySlotSQL("b"); strings.Count(got, want) != 3 {
 		t.Errorf("%s(%q) = %q, want every one of the three columns qualified", slotPredicateName, "b", got)
 	}
 }
@@ -103,7 +105,7 @@ func normalizedPredicate(sql string) string {
 // live employment per person per company, whatever the primary slot says.
 const liveEmploymentIndex = "uq_rel_employment"
 
-// LiveEmploymentSlotSQL mirrors that index, and this holds it there for the
+// employment.LiveSlotSQL mirrors that index, and this holds it there for the
 // reason the primary-slot mirror exists: a guard that asks a NARROWER question
 // than the index offers work the insert then drops on conflict, which is how a
 // sweep comes to return the same rows on every pass for ever.
@@ -132,12 +134,12 @@ func TestTheLiveEmploymentSlotPredicateMirrorsItsIndex(t *testing.T) {
 		t.Fatalf("%s now carries an OR (%s), and this comparison strips parentheses — compare the "+
 			"predicates structurally before trusting it again", liveEmploymentIndex, predicate)
 	}
-	if want, got := normalizedPredicate(predicate), normalizedPredicate(LiveEmploymentSlotSQL("")); want != got {
-		t.Errorf("LiveEmploymentSlotSQL renders %q, but %s is %q.\n\n"+
+	if want, got := normalizedPredicate(predicate), normalizedPredicate(employment.LiveSlotSQL("")); want != got {
+		t.Errorf("employment.LiveSlotSQL renders %q, but %s is %q.\n\n"+
 			"The helper IS that index's predicate. A guard narrower than the index offers a write the "+
 			"index refuses, and the caller that keeps offering it never drains.", got, liveEmploymentIndex, want)
 	}
-	if want, got := "held.", LiveEmploymentSlotSQL("held"); strings.Count(got, want) != 3 {
-		t.Errorf("LiveEmploymentSlotSQL(%q) = %q, want every one of the three columns qualified", "held", got)
+	if want, got := "held.", employment.LiveSlotSQL("held"); strings.Count(got, want) != 3 {
+		t.Errorf("employment.LiveSlotSQL(%q) = %q, want every one of the three columns qualified", "held", got)
 	}
 }

--- a/backend/internal/modules/people/dedupe.go
+++ b/backend/internal/modules/people/dedupe.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/freemail"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
@@ -307,7 +308,7 @@ func fuzzyPerson(ctx context.Context, tx pgx.Tx, c PersonCandidate) (PersonResol
 		  FROM person p
 		  LEFT JOIN relationship r
 		    ON r.person_id = p.id AND r.kind = 'employment'
-		   AND `+CurrentPrimaryEmploymentSQL("r")+` AND r.archived_at IS NULL
+		   AND `+employment.CurrentPrimarySQL("r")+` AND r.archived_at IS NULL
 		  LEFT JOIN organization_domain od
 		    ON od.organization_id = r.organization_id AND od.archived_at IS NULL
 		 WHERE p.archived_at IS NULL

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -24,6 +24,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/freemail"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -301,7 +302,7 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 			       OR right(split_part(pe.email, '@', 2), length($4) + 1) = '.' || $4))
 		  AND NOT EXISTS (
 			SELECT 1 FROM relationship r
-			WHERE r.person_id = p.id AND `+CurrentPrimarySlotSQL("r")+`)
+			WHERE r.person_id = p.id AND `+employment.CurrentPrimarySlotSQL("r")+`)
 		FOR UPDATE OF p
 		ON CONFLICT DO NOTHING
 		RETURNING id, person_id`,

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -81,7 +82,7 @@ func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyIn
 		SELECT 'employment', $1, $2, true, $3, $4
 		WHERE NOT EXISTS (
 			SELECT 1 FROM relationship
-			WHERE person_id = $1 AND `+CurrentPrimarySlotSQL("")+`)
+			WHERE person_id = $1 AND `+employment.CurrentPrimarySlotSQL("")+`)
 		ON CONFLICT DO NOTHING
 		RETURNING id`,
 		personID, orgID, in.Source, in.CapturedBy).Scan(&edgeID)

--- a/backend/internal/modules/people/enrichment.go
+++ b/backend/internal/modules/people/enrichment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
@@ -250,7 +251,7 @@ func SubjectIdentifiers(ctx context.Context, tx pgx.Tx, personID string) (provid
 		  LEFT JOIN organization_domain d
 		    ON d.organization_id = o.id AND d.is_primary AND d.archived_at IS NULL
 		 WHERE r.kind = 'employment' AND r.person_id = $1
-		   AND `+CurrentPrimaryEmploymentSQL("r")+` AND r.archived_at IS NULL
+		   AND `+employment.CurrentPrimarySQL("r")+` AND r.archived_at IS NULL
 		 LIMIT 1`, personID).
 		Scan(&id.CompanyName, &id.CompanyDomain); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return provider.PersonIdentifiers{}, fmt.Errorf("people: reading the subject's employer: %w", err)

--- a/backend/internal/modules/people/linkedinmatch.go
+++ b/backend/internal/modules/people/linkedinmatch.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -207,7 +208,7 @@ func matchGhostsByEmail(ctx context.Context, tx pgx.Tx, owner, onlyPerson ids.UU
 // parameter positions: the owner filter, the person row scope, and the
 // single-person narrowing.
 // A var and not a const, because the employment-currency predicate is a
-// function call: EmploymentIsCurrentSQL is the one definition of "this job is
+// function call: employment.IsCurrentSQL is the one definition of "this job is
 // still theirs", and a const cannot reach it. This query used to hand-spell it
 // and got the semantics right, which is what made the copy invisible.
 var suggestNameEmployerMatchSQL = `
@@ -234,7 +235,7 @@ var suggestNameEmployerMatchSQL = `
 		       -- Still employed TODAY, the same test the coverage and intro
 		       -- reads take: a future end date is still employment.
 		       AND r.archived_at IS NULL
-		       AND ` + EmploymentIsCurrentSQL("r.ended_at") + `
+		       AND ` + employment.IsCurrentSQL("r.ended_at") + `
 		     WHERE g.match_status = 'unmatched'
 		       AND g.tombstoned_at IS NULL
 		       -- The employer is matched through matched_org_id, which the

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -16,6 +16,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
@@ -241,7 +242,7 @@ func relinkPersonEdges(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.Pe
 		UPDATE relationship a SET person_id = $2,
 		  is_current_primary = a.is_current_primary AND NOT EXISTS (
 		    SELECT 1 FROM relationship b
-		    WHERE b.person_id = $2 AND `+CurrentPrimarySlotSQL("b")+`)
+		    WHERE b.person_id = $2 AND `+employment.CurrentPrimarySlotSQL("b")+`)
 		WHERE a.person_id = $1 AND a.kind <> 'works_with' AND a.archived_at IS NULL`, sourceID, targetID)
 	return moved + tag.RowsAffected(), err
 }

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
@@ -347,7 +348,7 @@ func relinkOrgEdges(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.Organ
 		  is_current_primary = a.is_current_primary AND NOT EXISTS (
 		    SELECT 1 FROM relationship b
 		    WHERE b.person_id = a.person_id AND b.id <> a.id
-		      AND `+CurrentPrimarySlotSQL("b")+`)
+		      AND `+employment.CurrentPrimarySlotSQL("b")+`)
 		WHERE a.organization_id = $1 AND a.archived_at IS NULL`, sourceID, targetID); err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/mergeface.go
+++ b/backend/internal/modules/people/mergeface.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -231,7 +232,7 @@ func readOrganizationFaces(ctx context.Context, tx pgx.Tx, rowIDs []ids.UUID, in
 		          JOIN person cp ON cp.id = rel.person_id AND cp.archived_at IS NULL
 		         WHERE rel.organization_id = o.id
 		           AND rel.kind = 'employment'
-		           AND ` + CurrentPrimaryEmploymentSQL("rel") + `
+		           AND ` + employment.CurrentPrimarySQL("rel") + `
 		           AND rel.archived_at IS NULL` + edgeBound + scope + `)`
 	}
 	rows, err := tx.Query(ctx, `

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -16,6 +16,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -125,7 +126,7 @@ func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUI
 		 JOIN person p ON p.id = rel.person_id AND p.archived_at IS NULL
 		 WHERE rel.organization_id = ANY($1)
 		   AND rel.kind = 'employment'
-		   AND `+CurrentPrimaryEmploymentSQL("rel")+`
+		   AND `+employment.CurrentPrimarySQL("rel")+`
 		   AND rel.archived_at IS NULL`+edgeBound+scope+`
 		 GROUP BY rel.organization_id`, args,
 		func(o *crmcontracts.Organization, n int) { o.ContactCount = &n })

--- a/backend/internal/modules/people/orgcommitments.go
+++ b/backend/internal/modules/people/orgcommitments.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -146,7 +147,7 @@ func (s *Store) OpenCommitmentsForOrganization(
 		         SELECT 1 FROM relationship r
 		          WHERE r.person_id = pr.id AND r.kind = 'employment'
 		            AND r.organization_id = $%[1]d
-		            AND `+EmploymentIsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
+		            AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 		            AND (%[4]s))
 		   AND (%[3]s) AND (%[2]s)
 		 ORDER BY (c.due_at IS NOT NULL AND c.due_at < now()) DESC,
@@ -212,7 +213,7 @@ func countOrgCommitments(ctx context.Context, tx pgx.Tx, orgID ids.UUID) (int, e
 		         SELECT 1 FROM relationship r
 		          WHERE r.person_id = pr.id AND r.kind = 'employment'
 		            AND r.organization_id = $1
-		            AND `+EmploymentIsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL)`,
+		            AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL)`,
 		orgID).Scan(&total)
 	if err != nil {
 		return 0, fmt.Errorf("count the account's open commitments: %w", err)

--- a/backend/internal/modules/people/orgdomainbacklog_integration_test.go
+++ b/backend/internal/modules/people/orgdomainbacklog_integration_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -41,7 +42,7 @@ func (e *dedupeEnv) employerOf(ctx context.Context, t *testing.T, person ids.Per
 		return tx.QueryRow(ctx, `
 			SELECT organization_id FROM relationship
 			 WHERE person_id = $1 AND kind = 'employment'
-			   AND `+EmploymentIsCurrentSQL("ended_at")+`
+			   AND `+employment.IsCurrentSQL("ended_at")+`
 			   AND archived_at IS NULL
 			 LIMIT 1`, person).Scan(&org)
 	}); err != nil {

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -16,6 +16,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
@@ -117,7 +118,7 @@ func personEmployerClause(ctx context.Context, orgID *ids.OrganizationID, arg fu
 		SELECT 1 FROM relationship rel
 		WHERE rel.person_id = person.id
 		  AND rel.kind = 'employment'
-		  AND `+CurrentPrimaryEmploymentSQL("rel")+`
+		  AND `+employment.CurrentPrimarySQL("rel")+`
 		  AND rel.archived_at IS NULL
 		  AND `+edgeBound+`
 		  AND rel.organization_id = $%d)`, arg(*orgID)), nil

--- a/backend/internal/modules/people/personemployer.go
+++ b/backend/internal/modules/people/personemployer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -26,7 +27,7 @@ import (
 // because a reader asking "who is this and where do they work" is asking one
 // question wherever they ask it.
 //
-// CURRENT PRIMARY employment only, through CurrentPrimaryEmploymentSQL rather
+// CURRENT PRIMARY employment only, through employment.CurrentPrimarySQL rather
 // than the flag alone — a list that trusted the flag would go on naming the
 // company somebody's last day has already passed at. The match is at most one
 // row per person (uq_rel_current_primary_employer), so the join cannot duplicate
@@ -74,7 +75,7 @@ func attachPersonEmployers(ctx context.Context, tx pgx.Tx, idx map[openapi_types
 		 JOIN organization org ON org.id = rel.organization_id
 		 WHERE rel.person_id = ANY($%d)
 		   AND rel.kind = 'employment'
-		   AND `+CurrentPrimaryEmploymentSQL("rel")+`
+		   AND `+employment.CurrentPrimarySQL("rel")+`
 		   AND rel.archived_at IS NULL
 		   AND `+edgeBound+`
 		   AND org.archived_at IS NULL

--- a/backend/internal/modules/people/providerclaimtargets.go
+++ b/backend/internal/modules/people/providerclaimtargets.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -95,7 +96,7 @@ func plantProviderEmploymentEdge(ctx context.Context, tx pgx.Tx, personID ids.UU
 		SELECT 'employment', $1, $2, true, $3, $4
 		WHERE NOT EXISTS (
 			SELECT 1 FROM relationship
-			WHERE person_id = $1 AND `+CurrentPrimarySlotSQL("")+`)
+			WHERE person_id = $1 AND `+employment.CurrentPrimarySlotSQL("")+`)
 		ON CONFLICT DO NOTHING
 		RETURNING id`,
 		personID, orgID, providerName, connectorCapturedBy(providerName)).Scan(&edgeID)

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -333,7 +334,7 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 		}
 		// The incumbent is demoted only when the patched row will actually HOLD
 		// the flag, so this statement asks the SAME question as the UPDATE below
-		// that grants it — one predicate, EmploymentIsCurrentSQL, read against the
+		// that grants it — one predicate, employment.IsCurrentSQL, read against the
 		// database's clock in both. Spell the rule a second time here (a Go-side
 		// `current.EndedAt == nil`, say) and the two answers part company over a
 		// notice period: this row keeps the flag, the incumbent keeps it too, and
@@ -342,11 +343,11 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 			current.Kind == employmentKind && current.PersonID != nil {
 			if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
-				WHERE person_id = $1 AND id <> $2 AND `+CurrentPrimarySlotSQL("")+`
+				WHERE person_id = $1 AND id <> $2 AND `+employment.CurrentPrimarySlotSQL("")+`
 				  AND EXISTS (
 					SELECT 1 FROM relationship patched
 					 WHERE patched.id = $2
-					   AND `+EmploymentIsCurrentSQL("coalesce($3, patched.ended_at)")+`)`,
+					   AND `+employment.IsCurrentSQL("coalesce($3, patched.ended_at)")+`)`,
 				*current.PersonID, id, in.EndedAt); err != nil {
 				return err
 			}
@@ -366,9 +367,9 @@ func (s *Store) UpdateRelationship(ctx context.Context, id ids.UUID, in UpdateRe
 			  -- clears the flag, and setting the flag on a job already over
 			  -- does not take. Written against the row rather than as a Go
 			  -- condition, so the two halves cannot drift apart. LEFT, not
-			  -- "has a date" — see EmploymentIsCurrentSQL.
+			  -- "has a date" — see employment.IsCurrentSQL.
 			  is_current_primary = coalesce($3, is_current_primary)
-			    AND (kind <> 'employment' OR `+EmploymentIsCurrentSQL("coalesce($5, ended_at)")+`),
+			    AND (kind <> 'employment' OR `+employment.IsCurrentSQL("coalesce($5, ended_at)")+`),
 			  started_at = coalesce($4, started_at),
 			  ended_at = coalesce($5, ended_at)
 			WHERE id = $1

--- a/backend/internal/modules/people/relationshipcreate.go
+++ b/backend/internal/modules/people/relationshipcreate.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -171,8 +172,8 @@ func writeRelationshipInTx(
 		in.PersonID != nil {
 		if _, err := tx.Exec(ctx, `
 				UPDATE relationship SET is_current_primary = false
-				WHERE person_id = $1 AND `+CurrentPrimarySlotSQL("")+`
-				  AND `+EmploymentIsCurrentSQL("$2::date"),
+				WHERE person_id = $1 AND `+employment.CurrentPrimarySlotSQL("")+`
+				  AND `+employment.IsCurrentSQL("$2::date"),
 			*in.PersonID, in.EndedAt); err != nil {
 			return out, err
 		}
@@ -202,8 +203,8 @@ func writeRelationshipInTx(
 			        coalesce($9, $1 = 'employment' AND NOT EXISTS (
 			          SELECT 1 FROM relationship
 			           WHERE kind = 'employment' AND person_id = $2 AND archived_at IS NULL
-			             AND (`+EmploymentIsCurrentSQL("ended_at")+` OR is_current_primary)))
-			          AND ($1 <> 'employment' OR `+EmploymentIsCurrentSQL("$11::date")+`),
+			             AND (`+employment.IsCurrentSQL("ended_at")+` OR is_current_primary)))
+			          AND ($1 <> 'employment' OR `+employment.IsCurrentSQL("$11::date")+`),
 			        $10, $11, $12, $13)
 			RETURNING `+relationshipColumns,
 		in.Kind, in.PersonID, in.OrganizationID, in.CounterpartyOrgID, in.CounterpartyPersonID, in.DealID, in.ProjectID,

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -22,6 +22,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
@@ -227,7 +228,7 @@ func StrengthForOrgContacts(ctx context.Context, tx pgx.Tx, orgID ids.Organizati
 		SELECT p.id FROM person p
 		JOIN relationship r ON r.person_id = p.id
 		WHERE r.kind = 'employment' AND r.organization_id = $%d
-		  AND `+EmploymentIsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
+		  AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 		  AND p.archived_at IS NULL AND (%s) AND (%s)
 		ORDER BY p.id`, orgPos, edgeBound, scope), args...)
 	if err != nil {

--- a/backend/internal/modules/projects/surface.go
+++ b/backend/internal/modules/projects/surface.go
@@ -18,6 +18,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -164,8 +165,8 @@ func (s *Store) ListProjectsForPersonTx(ctx context.Context, tx pgx.Tx, personID
 		                   SELECT 1 FROM relationship c
 		                    WHERE c.kind = 'project_company' AND c.project_id = p.id
 		                      AND c.organization_id = e.organization_id AND c.archived_at IS NULL)
-		               AND e.is_current_primary
-		               AND e.archived_at IS NULL AND e.ended_at IS NULL
+		               AND `+employment.CurrentPrimarySQL("e")+`
+		               AND e.archived_at IS NULL
 		               AND (%[4]s)))
 		 `+projectCardOrder+`
 		 LIMIT %[5]d`, personPos, scope, seatBound, employmentBound, projectSurfaceCap), args...)

--- a/backend/internal/modules/search/graphactivitysubjects.go
+++ b/backend/internal/modules/search/graphactivitysubjects.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -327,7 +328,7 @@ func employerSubjects(ctx context.Context, tx pgx.Tx, activityID ids.UUID) ([]ac
 			  JOIN relationship r ON r.person_id = p.id
 			  JOIN organization o ON o.id = r.organization_id
 			 WHERE p.archived_at IS NULL
-			   AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+			   AND r.kind = 'employment' AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 			   AND o.archived_at IS NULL
 			   AND %[3]s
 			 ORDER BY o.id, onEvent.role_rank, r.is_current_primary DESC

--- a/backend/internal/modules/search/graphorgreach.go
+++ b/backend/internal/modules/search/graphorgreach.go
@@ -3,9 +3,11 @@
 
 package search
 
-// Which activities an ACCOUNT's context walk reads.
+import (
+	"fmt"
 
-import "fmt"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
+)
 
 // orgArms is the three links themselves — the account an activity is filed
 // against, the account its deal belongs to, and the employer of the contact it
@@ -14,10 +16,10 @@ import "fmt"
 // The deal arm deliberately does not exclude archived or lost deals: a set
 // stricter than the predicate would show a message on the timeline whose
 // account never gets a signal about it.
-const orgArms = `FROM activity_link l
+var orgArms = `FROM activity_link l
 		    LEFT JOIN deal d ON d.id = l.deal_id
 		    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
-		      AND r.ended_at IS NULL AND r.archived_at IS NULL`
+		      AND ` + employment.IsCurrentSQL("r.ended_at") + ` AND r.archived_at IS NULL`
 
 // participantEmployerArm is the fourth arm: the employer of somebody who is on
 // the event as a participant rather than as a link. Without it a meeting whose
@@ -28,10 +30,10 @@ const orgArms = `FROM activity_link l
 // TestTheAccountReachWalkIsOneAnswer. It is a constant of its own rather than
 // part of orgArms because the two modules also share orgArms with a producer
 // that deliberately stops at three arms (activities.OrgReachSet says why).
-const participantEmployerArm = `EXISTS (
+var participantEmployerArm = `EXISTS (
 		    SELECT 1 FROM activity_participant ap
 		      JOIN relationship emp ON emp.person_id = ap.person_id AND emp.kind = 'employment'
-		        AND emp.ended_at IS NULL AND emp.archived_at IS NULL
+		        AND ` + employment.IsCurrentSQL("emp.ended_at") + ` AND emp.archived_at IS NULL
 		    WHERE ap.activity_id = a.id AND emp.organization_id = %s)`
 
 // activityReachesOrg is "this activity belongs to the account", for a query

--- a/backend/internal/modules/signals/resolver.go
+++ b/backend/internal/modules/signals/resolver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -310,7 +311,7 @@ func matchCandidates(ctx context.Context, tx pgx.Tx, a rawAttribution) ([]candid
 			SELECT DISTINCT r.organization_id
 			FROM person_email pe
 			JOIN relationship r ON r.person_id = pe.person_id
-			 AND r.kind = 'employment' AND r.ended_at IS NULL AND r.archived_at IS NULL
+			 AND r.kind = 'employment' AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 			JOIN organization o ON o.id = r.organization_id
 			WHERE pe.email = $1 AND NOT o.is_anchor`, a.Email)
 		if err != nil {
@@ -411,7 +412,7 @@ func consentedPerson(ctx context.Context, tx pgx.Tx, email string, orgID ids.Org
 		FROM person_email pe
 		JOIN relationship r ON r.person_id = pe.person_id
 		 AND r.kind = 'employment' AND r.organization_id = $2
-		 AND r.ended_at IS NULL AND r.archived_at IS NULL
+		 AND `+employment.IsCurrentSQL("r.ended_at")+` AND r.archived_at IS NULL
 		WHERE pe.email = $1
 		  AND EXISTS (SELECT 1 FROM person_consent pc
 		              WHERE pc.person_id = pe.person_id AND pc.state = 'granted')

--- a/backend/internal/modules/signals/warmroom.go
+++ b/backend/internal/modules/signals/warmroom.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -189,9 +190,10 @@ func RouteInEdges(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) ([]R
 		SELECT p.id, p.full_name, r.kind, r.role
 		FROM relationship r
 		JOIN person p ON p.id = r.person_id AND p.archived_at IS NULL
-		WHERE r.archived_at IS NULL AND r.ended_at IS NULL AND r.person_id IS NOT NULL
-		  AND ((r.kind = 'employment' AND r.organization_id = $%[1]d)
-		    OR (r.kind = 'deal_stakeholder' AND r.deal_id IN (
+		WHERE r.archived_at IS NULL AND r.person_id IS NOT NULL
+		  AND ((r.kind = 'employment' AND r.organization_id = $%[1]d
+		        AND `+employment.IsCurrentSQL("r.ended_at")+`)
+		    OR (r.kind = 'deal_stakeholder' AND r.ended_at IS NULL AND r.deal_id IN (
 		          SELECT d.id FROM deal d WHERE d.organization_id = $%[1]d AND d.archived_at IS NULL)))%s%s
 		ORDER BY p.id, r.kind`, orgPos, edgeBound, visible), args...)
 	if err != nil {

--- a/backend/internal/shared/kernel/employment/employment.go
+++ b/backend/internal/shared/kernel/employment/employment.go
@@ -1,16 +1,34 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package people
+// Package employment is what "this job is still theirs" means, in one place
+// every module can reach.
+//
+// It sat in `modules/people` and answered for that module only. A module never
+// imports a sibling, so eight statements in five other modules — activities,
+// projects, signals, consent and search — hand-spelled the question instead,
+// and each hand-spelling was the notice-period defect the helper exists to
+// stop. The gate that holds "one definition" had to ratify all eight by name.
+//
+// Tier 0 rather than storekit, which was the other candidate. storekit is
+// documented as owning no domain and "is this employment current" is a domain
+// rule, so putting it there would have bought reach by bending a stated
+// boundary. shared/kernel already holds domain rules of exactly this kind —
+// values' money scales, elapsed's calendar-day counting, draftfloor's copy —
+// so this joins a category rather than opening one.
+//
+// stdlib only, which the tier requires. The one thing it took from storekit
+// was SQLf, and SQLf is fmt.Sprintf under a name that says the string is SQL;
+// that name is worth keeping and the dependency is not.
+//
+// One concept with two kinds of reach: the write paths in people/relationship.go
+// decide the flag with it, and the reads derive currency with it rather than
+// trusting a flag written months earlier.
+package employment
 
-// What "currently employed" means, in one place. Its own file because it is one
-// concept with two readers' worth of reach: the write paths in relationship.go
-// decide the flag with it, and four separate READS derive currency with it
-// rather than trusting a flag written months earlier.
+import "fmt"
 
-import "github.com/margince/margince/backend/internal/platform/database/storekit"
-
-// EmploymentIsCurrentSQL is the ONE spelling of "this job is still theirs".
+// IsCurrentSQL is the ONE spelling of "this job is still theirs".
 //
 // Held by: TestEveryEmploymentCurrencyTestUsesTheOneDefinition (backend/gates/employmentcurrency_test.go)
 // — it reads every hand-written Go source outside this file for a hand-spelled
@@ -58,11 +76,11 @@ import "github.com/margince/margince/backend/internal/platform/database/storekit
 // module never imports a sibling (ADR-0054 §3), so those cannot call this at
 // all until the predicate moves tier. They are ratified by name in the gate,
 // with that reason, rather than left looking clean.
-func EmploymentIsCurrentSQL(date string) string {
-	return storekit.SQLf("(%s IS NULL OR %s > current_date)", date, date)
+func IsCurrentSQL(date string) string {
+	return sqlf("(%s IS NULL OR %s > current_date)", date, date)
 }
 
-// CurrentPrimaryEmploymentSQL is what a READER of `is_current_primary` means:
+// CurrentPrimarySQL is what a READER of `is_current_primary` means:
 // the flag AND the employment still being theirs. Spelled once so a new reader
 // cannot trust the flag alone, which is what let somebody go on counting at a
 // company after their last day had passed.
@@ -77,39 +95,39 @@ func EmploymentIsCurrentSQL(date string) string {
 // used this helper would think the slot was free while the index still held
 // it, and answer 409 instead of skipping. Two different questions about one
 // column; this one is "who works there now".
-func CurrentPrimaryEmploymentSQL(alias string) string {
+func CurrentPrimarySQL(alias string) string {
 	prefix := ""
 	if alias != "" {
 		prefix = alias + "."
 	}
-	return storekit.SQLf("%sis_current_primary AND %s", prefix, EmploymentIsCurrentSQL(prefix+"ended_at"))
+	return sqlf("%sis_current_primary AND %s", prefix, IsCurrentSQL(prefix+"ended_at"))
 }
 
-// LiveEmploymentSlotSQL is the THIRD question, and the one uq_rel_employment
+// LiveSlotSQL is the THIRD question, and the one uq_rel_employment
 // answers: does this person already hold a live employment edge to this company
 // at all, primary or not.
 //
 // It is the index's own predicate and so, like CurrentPrimarySlotSQL, it is
-// date-BLIND. Asking it with EmploymentIsCurrentSQL would read somebody serving
+// date-BLIND. Asking it with IsCurrentSQL would read somebody serving
 // notice as having no edge while the index still holds one, and the write that
 // followed would be silently dropped by ON CONFLICT rather than skipped — which
 // is exactly how a sweep comes to offer the same work on every pass for ever.
 //
 // `alias` is the relationship table's alias at the call site, or "" when the
 // statement does not alias it.
-func LiveEmploymentSlotSQL(alias string) string {
+func LiveSlotSQL(alias string) string {
 	prefix := ""
 	if alias != "" {
 		prefix = alias + "."
 	}
-	return storekit.SQLf("%skind = 'employment' AND %sended_at IS NULL AND %sarchived_at IS NULL",
+	return sqlf("%skind = 'employment' AND %sended_at IS NULL AND %sarchived_at IS NULL",
 		prefix, prefix, prefix)
 }
 
 // CurrentPrimarySlotSQL is the other question about `is_current_primary`:
 // WHICH ROW HOLDS THE SLOT that uq_rel_current_primary_employer keeps unique
 // per person. It is the index's own predicate, and so it is date-BLIND —
-// asking it with EmploymentIsCurrentSQL would read a person serving notice as
+// asking it with IsCurrentSQL would read a person serving notice as
 // having freed the slot while the index still held it, and the write that
 // followed would 409 instead of skipping.
 //
@@ -131,5 +149,14 @@ func CurrentPrimarySlotSQL(alias string) string {
 	if alias != "" {
 		prefix = alias + "."
 	}
-	return storekit.SQLf("%skind = 'employment' AND %sis_current_primary AND %sarchived_at IS NULL", prefix, prefix, prefix)
+	return sqlf("%skind = 'employment' AND %sis_current_primary AND %sarchived_at IS NULL", prefix, prefix, prefix)
 }
+
+// sqlf renders a SQL fragment. Named rather than calling fmt.Sprintf inline,
+// for the reason storekit.SQLf is: a formatted string that reaches a database
+// should say so at the call site, so a reader checks it for what a formatted
+// SQL string is checked for.
+//
+// Only identifiers and other fragments are ever formatted in here — never a
+// value, which is what the placeholders are for.
+func sqlf(format string, a ...any) string { return fmt.Sprintf(format, a...) }

--- a/backend/internal/shared/kernel/employment/employment_test.go
+++ b/backend/internal/shared/kernel/employment/employment_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package employment
+
+// What the predicates actually say.
+//
+// Every gate around this package holds that there is ONE definition. None of
+// them holds what the definition IS — so the one line carrying the whole
+// notice-period rule could be quietly narrowed to a null check and every
+// census would go on reporting a clean tree, because it would still be the
+// only spelling.
+//
+// That is the failure this file exists for: uniqueness and correctness are
+// different claims, and a tree can hold the first perfectly while losing the
+// second.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestACurrentEmploymentIsADateComparisonAndNotANullCheck(t *testing.T) {
+	t.Parallel()
+
+	got := IsCurrentSQL("r.ended_at")
+
+	// Somebody serving three months' notice still works there. Reading the
+	// column's presence as "gone" took a person off their employer's contact
+	// list the day their notice was filed — with no way back, because ended_at
+	// cannot be cleared through the API.
+	if !strings.Contains(got, "current_date") {
+		t.Errorf("the predicate is %q, with no date comparison in it: a person serving notice "+
+			"drops off their employer's contact list the day it is filed", got)
+	}
+	if !strings.Contains(got, "r.ended_at IS NULL") {
+		t.Errorf("the predicate is %q and does not admit a NULL: somebody with no end date at all "+
+			"is the ordinary case and would read as departed", got)
+	}
+	// OR, not AND: the two arms are alternatives — no end date, or an end date
+	// still ahead. Joined with AND the predicate is unsatisfiable and nobody
+	// works anywhere.
+	if !strings.Contains(got, " OR ") {
+		t.Errorf("the predicate is %q: its two arms are alternatives, and joined any other way "+
+			"it answers false for everyone", got)
+	}
+}
+
+// The date expression is placed, not assumed. Every caller passes a different
+// one — a column on a read, an alias on a join, the incoming value on a write —
+// and a predicate that hard-coded one would silently answer about the wrong row.
+func TestThePredicateAsksAboutTheColumnItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	if got := IsCurrentSQL("emp.ended_at"); strings.Contains(got, "r.ended_at") {
+		t.Errorf("asked about emp.ended_at and answered %q", got)
+	}
+	if got := IsCurrentSQL("$3"); !strings.Contains(got, "$3") {
+		t.Errorf("a bind parameter did not reach the predicate: %q", got)
+	}
+}
+
+// The three questions about is_current_primary are three, and two of them are
+// deliberately DATE-BLIND: they are the index's own predicates, and asking them
+// with the date comparison would read a slot as free while the index still held
+// it — a 409 on a write that should have been a skip.
+func TestTheSlotPredicatesStayDateBlind(t *testing.T) {
+	t.Parallel()
+
+	for name, got := range map[string]string{
+		"the live-employment slot": LiveSlotSQL("r"),
+		"the current-primary slot": CurrentPrimarySlotSQL("r"),
+	} {
+		if strings.Contains(got, "current_date") {
+			t.Errorf("%s asks a date question (%q): the index does not, so the guard would think "+
+				"the slot was free while the index still held it", name, got)
+		}
+	}
+
+	// And the READER's question is not: it pairs the flag with the currency
+	// test, which is what stops a new reader trusting a flag written months ago.
+	if got := CurrentPrimarySQL("r"); !strings.Contains(got, "current_date") {
+		t.Errorf("the reader's predicate is %q and asks no date question: somebody goes on "+
+			"counting at a company after their last day has passed", got)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -334,7 +334,7 @@ The eight shapes, what each is for, and how each one silently passes:
 |---|---|---|
 | `consumermailonelist_test.go` | H2 | One consumer-mail list, held by a test rather than by a comment. |
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
-| `employmentcurrency_test.go` | H1 | people.EmploymentIsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
+| `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |
 | `noisejudgedspelling_test.go` | H2 | "An already-settled answer disowns this contact" is spelled once. |
 | `onedraftwriter_test.go` | H1 | One writer produces every grounded draft, or the surfaces drift. |


### PR DESCRIPTION
Closes #2360.

## The decision the ticket asks for

The ticket lists four options and recommends (1), storekit. I went with **(2), a `shared/kernel` home** — and the reason is that (2)'s stated objection has expired.

The ticket says *"`shared` is stdlib-only today and this would open a new category."* The first half stays true and the new package honours it: the only thing it took from storekit was `SQLf`, and `SQLf` is `fmt.Sprintf` under a name that says the string is SQL — the name is worth keeping and the dependency is not.

The second half is no longer the case. `shared/kernel` already holds domain rules of exactly this kind: `values`' minor-unit table is a money rule, `elapsed`'s calendar-day counting is the rule the deal card and the coverage chips both read, `draftfloor` holds product copy including the Art. 50 disclosure. This joins that category rather than opening one.

Which leaves (1)'s cost unpaid for nothing: storekit is documented as owning no domain, and "is this employment current" is a domain rule. (2) reaches every module without bending a stated boundary.

## What it retires

Eight statements in seven files across five modules were ratified in the gate by name, each with *"cannot import people (ADR-0054 §3); the predicate must move tier first"*. All eight now call the helper, so the map is **deleted rather than emptied**.

Two remain ratified, and the reason is different and narrower: they ask about a **second edge kind** in the same statement, and the census matches per statement rather than per arm. A `deal_stakeholder` or `project_stakeholder` edge has no notice period — `ended_at IS NULL` is the whole question there and the date comparison would be wrong. Sharpening the census to judge the conjunction the employment kind sits in would retire those two, and is worth doing the moment a third appears.

Their employment arms do call the helper. That is the part the ticket was about.

## Two gates needed a change to keep working

- **`TestTheAccountReachWalkIsOneAnswer`** read `const` declarations only, and an arm that calls a function cannot be a constant. It reads `var` too now — and it compares the declarations **as written** rather than as resolved strings. That matters: every string fold available renders a call as one placeholder, so a resolved comparison would stop being able to tell `IsCurrentSQL("r.ended_at")` from `IsCurrentSQL("emp.ended_at")`, which is this gate's whole subject. Mutation-checked: changing one twin's alias fails it.
- **`TestEveryCurrentPrimarySlotGuardUsesTheOneSpelling`** carried a stale waiver for `projects/surface.go`, which adopting `CurrentPrimarySQL` retired. Deleted.

## The gap I found while checking my own work

Every gate around this predicate holds that there is **one** definition. **None held what the definition is.** So the single line carrying the whole notice-period rule could be narrowed to a null check and every census would go on reporting a clean tree — it would still be the only spelling. Uniqueness and correctness are different claims and the tree only held the first.

`employment_test.go` holds the second: the date comparison, the NULL arm, the OR between them, the placed column, and — the other direction — that the two **index** predicates stay date-blind, because asking those with the date test reads a slot as free while the index still holds it and turns a skip into a 409.

Mutations, each verified then restored:

| mutation | fails |
|---|---|
| the predicate becomes `(x IS NULL)` | `ACurrentEmploymentIsADateComparisonAndNotANullCheck` |
| the reader's predicate loses its date test | `TheSlotPredicatesStayDateBlind` |
| one twin arm's alias drifts | `TheAccountReachWalkIsOneAnswer` |

The first two are the ones worth noting: before this PR nothing in the tree failed for either.

## Checks

`make check-backend` green (exit 0). `make test-it DIR=backend/internal/modules/people` green. Whole gate suite green.