### PR TITLE
Both integration entry points name one Redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,12 @@ jobs:
       - name: the dev stack resolves DSNs the way the product does
         working-directory: .
         run: make test-dev-dsn
+      # And the same class again, one lane over: the two integration entry
+      # points have to name ONE Redis, or a run reads as broken when it is only
+      # under-provisioned by its own launcher.
+      - name: both integration entry points resolve one Redis address
+        working-directory: .
+        run: make test-testdb-redis
       # The pin gate rides along here, and only here, because it reads the WHOLE
       # workflow directory while the backend scope names one file: sbom.yml and
       # patch.yml match no scope, so gated on the classifier this check would

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -865,6 +865,15 @@ test-api-entrypoint:
 ## keeps a query string like ?sslmode=require, and never echoes a DSN.
 test-dev-dsn:
 	@./scripts/test-dev-dsn.sh
+
+## test-testdb-redis — prove `make test-it` and scripts/test-integration-one.sh
+## settle on ONE Redis address, and that REDIS_PORT reaches both.
+##
+## The failure it replaces: the script route left MARGINCE_TEST_REDIS unset, so
+## every Redis-using test in the package failed naming Redis and telling the
+## reader to run `make db-up` — on a machine where Redis was already up.
+test-testdb-redis:
+	@./scripts/test-testdb-redis.sh
 
 ## test-dev-isolation — prove two worktrees get two stacks: the slug comes from
 ## the worktree, the Redis database and the port pair are CLAIMED from one

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -25,6 +25,30 @@
 #     do FLUSHDB between tests — so a shared index is a corruption, not
 #     contention. See REDIS_DBS in scripts/test-integration-parallel.sh.
 
+# resolve_test_redis: settle MARGINCE_TEST_REDIS for a lane launched from a
+# script rather than from make.
+#
+# The Redis-using fixtures fail loudly and never skip, so an unset address is
+# not a thinner run — it is nine failures naming Redis and telling the reader to
+# run `make db-up`, on a machine where Redis is already up. The failure reads as
+# an environment problem and the remedy it names is already done, which costs a
+# detour to disprove.
+#
+# It arrives from backend/Makefile when the lane is reached through `make
+# test-it`, and did not when test-integration-one.sh was run the way its own
+# usage block invites. Resolved HERE because every script entry point sources
+# this file, so both routes now settle it in one place instead of one of them
+# inheriting it by accident.
+#
+# REDIS_PORT is the same knob the Makefile and the compose file turn, read from
+# the environment so an override reaches both routes. The literal default is the
+# Makefile's, and test-testdb-redis.sh compares them rather than a comment
+# promising they agree.
+resolve_test_redis() {
+  export MARGINCE_TEST_REDIS="${MARGINCE_TEST_REDIS:-localhost:${REDIS_PORT:-16379}}"
+  export MARGINCE_TEST_REDIS_DB="${MARGINCE_TEST_REDIS_DB:-15}"
+}
+
 # parse_test_dsn: split MARGINCE_TEST_DSN (owner) and MARGINCE_TEST_APP_DSN (app)
 # into the reusable prefix/suffix each clone DSN is built from. Both DSNs point
 # at the same template db in normal use; we only ever swap the db name segment,

--- a/scripts/test-integration-one.sh
+++ b/scripts/test-integration-one.sh
@@ -19,6 +19,10 @@ cd "$ROOT"
 # shellcheck source=scripts/lib-testdb.sh
 source "$ROOT/scripts/lib-testdb.sh"
 resolve_it_timeout
+# The Redis address the fixtures need. Reached through `make test-it` it arrives
+# from backend/Makefile; run directly — which the usage block above invites — it
+# did not, and every Redis-using test in the package failed naming Redis.
+resolve_test_redis
 # One package oversubscribes nothing, but the harness ASSERTS the ceiling and the
 # budget rather than skipping when they are absent — a skipped capacity check
 # reads exactly like a passing one.
@@ -59,5 +63,6 @@ echo "test-integration-one: backend $rel ${RUN:+(-run $RUN) }(db=$db)"
        MARGINCE_TEST_DSN="$(owner_clone_dsn "$db")" \
        MARGINCE_TEST_APP_DSN="$(app_clone_dsn "$db")" \
        MARGINCE_TEST_BLOBSTORE_BUCKET="$(bucket_for one)" \
-       MARGINCE_TEST_REDIS_DB="${MARGINCE_TEST_REDIS_DB:-15}" \
+       MARGINCE_TEST_REDIS="$MARGINCE_TEST_REDIS" \
+       MARGINCE_TEST_REDIS_DB="$MARGINCE_TEST_REDIS_DB" \
     go test -p 1 -tags=integration -v -count=1 -timeout="$IT_TIMEOUT" "${run_flag[@]+"${run_flag[@]}"}" "$rel" ${IT_ARGS:+$IT_ARGS} )

--- a/scripts/test-testdb-redis.sh
+++ b/scripts/test-testdb-redis.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# test-testdb-redis.sh — prove both integration entry points settle on the SAME
+# Redis address, and that an override reaches either of them.
+#
+# The failure this replaces: test-integration-one.sh, invoked the way its own
+# usage block invites, left MARGINCE_TEST_REDIS unset. The Redis-using fixtures
+# fail loudly and never skip, so nine tests in one package failed naming Redis
+# and telling the reader to run `make db-up` — on a machine where Redis was
+# already up. The message pointed at the environment and its remedy was already
+# done, so it cost a detour to establish the tests had nothing to do with the
+# change under test.
+#
+# The lane's posture is that a thinner run must never read as a passing one.
+# This is the mirror of that: a run must never read as broken when it is only
+# under-provisioned by its own launcher.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+failures=0
+
+check() { # want got description
+    if [ "$1" = "$2" ]; then
+        printf '  ok   %s\n' "$3"
+    else
+        printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# What the script route resolves, from a shell carrying neither variable.
+resolved() { # [REDIS_PORT]
+    env -u MARGINCE_TEST_REDIS -u MARGINCE_TEST_REDIS_DB ${1:+REDIS_PORT="$1"} \
+        bash -c "source '$root/scripts/lib-testdb.sh'; resolve_test_redis; echo \"\$MARGINCE_TEST_REDIS\""
+}
+
+# What the make route resolves, asked of make itself rather than parsed out of
+# the Makefile: a regex over the assignment would agree with a line that no
+# longer takes effect.
+from_make() { # [REDIS_PORT]
+    # Asked as a make VARIABLE EXPANSION, through a throwaway target appended
+    # with a second -f. `make -p` reports the assignment unexpanded — the answer
+    # would be the literal `localhost:$(REDIS_PORT)`, which agrees with nothing
+    # and proves nothing.
+    ( cd "$root/backend" \
+        && make -s --no-print-directory ${1:+REDIS_PORT="$1"} \
+             -f Makefile -f <(printf 'margince-test-redis-addr:;@echo $(MARGINCE_TEST_REDIS)\n') \
+             margince-test-redis-addr )
+}
+
+echo "the two integration entry points agree on the Redis address"
+
+# THE DEFAULT. Two entry points that disagree here send one lane at a Redis the
+# other is not using, and the fixtures FLUSHDB — so a disagreement is a
+# corruption of somebody else's run, not merely a miss.
+script_default="$(resolved)"
+make_default="$(from_make)"
+check "$make_default" "$script_default" \
+    "the script route resolves the same default the make route does ($make_default)"
+
+# AND AN OVERRIDE REACHES BOTH. A default that agreed while an override reached
+# only one is the same defect one turn of the knob later.
+check "$(from_make 26379)" "$(resolved 26379)" \
+    "REDIS_PORT reaches both routes"
+
+# The address is never empty, which is the specific shape the failure took: the
+# variable was ABSENT rather than wrong, and the fixtures reported that as a
+# provisioning problem. A check that only compared the two routes would pass on
+# two empties.
+check "present" "${script_default:+present}" \
+    "the resolved address is not empty"
+
+if [ "$failures" -ne 0 ]; then
+    echo "FAIL: $failures check(s) failed" >&2
+    exit 1
+fi
+echo "OK: both entry points resolve one Redis address"


### PR DESCRIPTION
Closes #1998.

`MARGINCE_TEST_REDIS` was exported by `backend/Makefile` and by nothing else. A lane reached through `make test-it` got it; the same lane launched from `scripts/test-integration-one.sh` — **the way that script's own usage block invites** — did not.

The Redis-using fixtures fail loudly and never skip, so the package came back with every one of them failing, naming Redis, and telling the reader to run `make db-up` on a machine where Redis was already up.

## Why it costs more than its size

The message points at the environment and the remedy it names **is already done**, so the only way through is to disprove it — nine failures in one package that had nothing to do with the change under test.

The lane's posture is that a thinner run must never read as a passing one. This is the mirror: a run reading as *broken* when it is only under-provisioned by its own launcher.

## Resolved in one place

`lib-testdb.sh` — which every script entry point already sources — so both routes settle it there rather than one inheriting it by accident. `REDIS_PORT` is the same knob the Makefile and the compose file turn, read from the environment so an override reaches both.

## The two defaults are compared, not promised

The literal is the Makefile's, and a comment saying so would be the thing that stops being true. `scripts/test-testdb-redis.sh` asks make for the **expanded** value — `make -p` reports the assignment unexpanded, and an answer of `localhost:$(REDIS_PORT)` agrees with nothing and proves nothing — then checks the default, an override, and that the result is not empty.

That last one is not redundant: the failure was an **absent** variable, and a check that only compared the two routes would pass on two empties.

## Verification

Against the reported failure itself, on `platform/testdb`:

```
BEFORE:  redis_integration_test.go:82: MARGINCE_TEST_REDIS not set — run `make db-up` …
         --- FAIL: TestRedisDBCountAgreesWithTheLaneAndTheServer
AFTER:   ok  github.com/margince/margince/backend/internal/platform/testdb  2.073s
```

| mutation | result |
|---|---|
| resolver sets nothing | all three checks fail |
| port default drifts (16379 → 6379) | the parity check alone fails |

`make check-backend` exit 0; `make-target-parity` and `ci-doc-parity` both OK. Wired into CI beside `test-dev-dsn`, which guards the same class of silent misconfiguration one lane over.