### PR TITLE
A mirrored record says whether this caller may change it

### DIFF
--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -28,6 +28,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/overlay"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -105,7 +106,9 @@ func overlayWirePerson(ctx context.Context, rec datasource.Record) (crmcontracts
 		fullName = overlayUnnamed
 	}
 	personID := openapi_types.UUID(rec.Ref.ID)
+	mayEdit := overlay.Writable(ctx, datasource.EntityPerson)
 	return crmcontracts.Person{
+		Writable:   &mayEdit,
 		Id:         personID,
 		Source:     overlaySource,
 		CapturedBy: ptrString(overlayCapturedByValue),
@@ -143,7 +146,9 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 	}
 	orgID := openapi_types.UUID(rec.Ref.ID)
 	domains := overlayOrganizationDomains(orgID, fields)
+	mayEdit := overlay.Writable(ctx, datasource.EntityOrganization)
 	org := crmcontracts.Organization{
+		Writable:    &mayEdit,
 		Id:          orgID,
 		Source:      overlaySource,
 		CapturedBy:  ptrString(overlayCapturedByValue),
@@ -217,7 +222,9 @@ func overlayWireDeal(ctx context.Context, rec datasource.Record) (crmcontracts.D
 	if name == "" {
 		name = overlayUnnamed
 	}
+	mayEdit := overlay.Writable(ctx, datasource.EntityDeal)
 	deal := crmcontracts.Deal{
+		Writable:   &mayEdit,
 		Id:         openapi_types.UUID(rec.Ref.ID),
 		Source:     overlaySource,
 		CapturedBy: ptrString(overlayCapturedByValue),
@@ -261,7 +268,9 @@ func overlayWireLead(ctx context.Context, rec datasource.Record) (crmcontracts.L
 		return crmcontracts.Lead{}, err
 	}
 	syncedAt := rec.Freshness.LastSyncedAt
+	mayEdit := overlay.Writable(ctx, datasource.EntityLead)
 	lead := crmcontracts.Lead{
+		Writable:    &mayEdit,
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		Source:      overlaySource,
 		CapturedBy:  ptrString(overlayCapturedByValue),

--- a/backend/internal/compose/overlaywritable_test.go
+++ b/backend/internal/compose/overlaywritable_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every overlay wire assembler stamps `writable`.
+//
+// Absent means NOT writable, so an assembler that forgets produces a record
+// nothing complains about and every client draws read-only. That is what hid
+// this for a release: four assemblers, a fail-closed default, and an absence
+// that looked like a considered answer.
+//
+// Held over the SOURCE as well as by behaviour, because behaviour alone only
+// covers the assemblers a case remembers to call — which is the same shape of
+// omission one level up.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+const overlayWireFile = "overlaywire.go"
+
+// TestEveryOverlayWireAssemblerStampsWritable reads the file for the functions
+// that build a contract record and requires each to set the slot.
+func TestEveryOverlayWireAssemblerStampsWritable(t *testing.T) {
+	t.Parallel()
+
+	file, err := parser.ParseFile(token.NewFileSet(), overlayWireFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", overlayWireFile, err)
+	}
+
+	assemblers := 0
+	for _, decl := range file.Decls {
+		fn, isFn := decl.(*ast.FuncDecl)
+		if !isFn || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "overlayWire") {
+			continue
+		}
+		if !carriesTheSlot(t, returnedTypeName(fn)) {
+			continue
+		}
+		assemblers++
+		if !stampsWritable(fn.Body) {
+			t.Errorf("%s builds a record and never sets Writable — absent means NOT writable, so "+
+				"every record it assembles reaches the client read-only and a caller entitled to "+
+				"edit one is given no way to", fn.Name.Name)
+		}
+	}
+	// A file this reads nothing out of certifies nothing. The four that exist
+	// are the floor: fewer means the naming changed and this stopped looking.
+	if assemblers < 4 {
+		t.Errorf("found %d overlayWire* assembler(s) building a record that carries the slot, want "+
+			"at least 4 — the scan is keyed on the name and on the contract type, so fewer means it "+
+			"has stopped seeing its subject rather than that the subject shrank", assemblers)
+	}
+}
+
+// stampsWritable reports whether a function body assigns the Writable slot.
+func stampsWritable(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		kv, isKV := n.(*ast.KeyValueExpr)
+		if !isKV {
+			return true
+		}
+		if ident, isIdent := kv.Key.(*ast.Ident); isIdent && ident.Name == "Writable" {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// returnedTypeName is the contract type an assembler builds, or "" when its
+// first result is not a named contract type.
+func returnedTypeName(fn *ast.FuncDecl) string {
+	if fn.Type.Results == nil || len(fn.Type.Results.List) == 0 {
+		return ""
+	}
+	sel, isSel := fn.Type.Results.List[0].Type.(*ast.SelectorExpr)
+	if !isSel {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// carriesTheSlot reports whether that contract type declares Writable at all.
+//
+// Asked of the CONTRACT rather than of a list here: which records carry the
+// slot is the contract's business, and a list would have to be corrected by
+// whoever added the next one — who is exactly the author this test exists to
+// catch. An assembler for a type with no such field is not a finding, and
+// naming those by hand is how the scan would come to skip one that does.
+func carriesTheSlot(t *testing.T, typeName string) bool {
+	t.Helper()
+	if typeName == "" {
+		return false
+	}
+	for _, sample := range []any{
+		crmcontracts.Person{},
+		crmcontracts.Organization{},
+		crmcontracts.Deal{},
+		crmcontracts.Lead{},
+		crmcontracts.Project{},
+		crmcontracts.Activity{},
+	} {
+		v := reflect.TypeOf(sample)
+		if v.Name() != typeName {
+			continue
+		}
+		_, has := v.FieldByName("Writable")
+		return has
+	}
+	return false
+}

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -152,7 +152,7 @@ var personBindings = EntityBinding{
 	Bindings: append([]FieldBinding{
 		{
 			WireSlot: "writable", Disposition: DispositionNativeOnly,
-			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
+			Reason: "Whether THIS caller may change the row. An incumbent CRM's permission model is not this installation's, so a mirrored value would be a different question's answer wearing this field's name — but the slot is SERVER-COMPUTED rather than unanswerable, and in overlay mode it is computed differently: the write-back contract supporting an update of this type, and the seat holding the grant. overlay.Writable is the one spelling of that. The row-scope term the native answer adds is already true of any record an assembler is filling, because the mirror read that produced it is visibility-joined.",
 		},
 		{
 			WireSlot: "visibility", Disposition: DispositionNativeOnly,
@@ -219,7 +219,7 @@ var organizationBindings = EntityBinding{
 		},
 		{
 			WireSlot: "writable", Disposition: DispositionNativeOnly,
-			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
+			Reason: "Whether THIS caller may change the row. An incumbent CRM's permission model is not this installation's, so a mirrored value would be a different question's answer wearing this field's name — but the slot is SERVER-COMPUTED rather than unanswerable, and in overlay mode it is computed differently: the write-back contract supporting an update of this type, and the seat holding the grant. overlay.Writable is the one spelling of that. The row-scope term the native answer adds is already true of any record an assembler is filling, because the mirror read that produced it is visibility-joined.",
 		},
 		{
 			WireSlot: "visibility", Disposition: DispositionNativeOnly,

--- a/backend/internal/modules/overlay/writable.go
+++ b/backend/internal/modules/overlay/writable.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// Whether an overlay-assembled record is this caller's to change.
+//
+// `writable` rides on the wire so a client draws its edit affordances from the
+// server's answer instead of guessing, and absent means NOT writable — the
+// fail-closed default a client needs when it cannot tell. The overlay
+// assemblers did not set it, so every mirrored record reached the client as
+// read-only and a user fully entitled to edit one saw no way to. They do not
+// conclude "the flag is absent"; they conclude the product cannot edit the
+// incumbent's records.
+//
+// The answer is a DIFFERENT computation from the native one, not the same one
+// applied to another table. Natively the question is ownership, teams and
+// record grants; a mirrored row has none of those — it carries no local
+// owner_id — and Update gates on the write-back contract plus the seat.
+//
+// The row-scope term that completes the native answer is already true of any
+// record an assembler is filling: the mirror read that produced it is
+// visibility-joined, so a row this caller cannot see never reaches here at
+// all. Update's third gate says so itself — a row the actor cannot see is
+// ErrNotFound there, exactly as on read.
+//
+// It answers "may this caller change this row", never "will this succeed". A
+// write can still lose the incumbent's drift check and come back as version
+// skew, which is a fact about the moment rather than about authority — the
+// native flag makes the same distinction.
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// Writable reports whether this caller may update an overlay record of this
+// type: the write-back contract supports it AND the seat holds the grant.
+//
+// ONE computation with two callers — the REST assembler in compose and the
+// provider's own. A second spelling is how the two would answer differently
+// for one record, and the surface a client sees is whichever it asked.
+//
+// It deliberately says nothing about CREATE. SupportsWrite answers false for
+// every type on that verb today, and a client reading this flag as permission
+// to create would offer a button for a write the overlay refuses.
+func Writable(ctx context.Context, et datasource.EntityType) bool {
+	if !SupportsWrite(WriteUpdate, et) {
+		return false
+	}
+	return auth.Require(ctx, string(et), principal.ActionUpdate) == nil
+}

--- a/backend/internal/modules/overlay/writable_test.go
+++ b/backend/internal/modules/overlay/writable_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// What `writable` answers on a mirrored record.
+//
+// Absent means NOT writable, which is the right default for a client that
+// cannot tell and the wrong permanent answer for a server that can: an overlay
+// user entitled to edit a record saw no way to, on every row, and concluded the
+// product cannot edit the incumbent's records at all.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// seatWith binds an actor holding exactly the named actions on every object.
+func seatWith(actions ...principal.Action) context.Context {
+	grant := principal.ObjectGrant{}
+	for _, a := range actions {
+		switch a {
+		case principal.ActionRead:
+			grant.Read = true
+		case principal.ActionUpdate:
+			grant.Update = true
+		case principal.ActionCreate:
+			grant.Create = true
+		}
+	}
+	objects := map[string]principal.ObjectGrant{}
+	for _, object := range []string{"person", "organization", "deal", "lead", "project", "activity"} {
+		objects[object] = grant
+	}
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:u-1",
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"}, Objects: objects, RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func TestASupportedTypeWithTheGrantIsWritable(t *testing.T) {
+	t.Parallel()
+	ctx := seatWith(principal.ActionRead, principal.ActionUpdate)
+
+	for _, et := range []datasource.EntityType{
+		datasource.EntityPerson, datasource.EntityOrganization,
+		datasource.EntityDeal, datasource.EntityLead,
+	} {
+		if !SupportsWrite(WriteUpdate, et) {
+			t.Fatalf("%s is no longer an updatable overlay type, so this case is asserting about "+
+				"a type the write-back contract has dropped", et)
+		}
+		if !Writable(ctx, et) {
+			t.Errorf("%s reads as not writable to a seat that holds the update grant — the edit "+
+				"affordances disappear on a record the overlay would have accepted", et)
+		}
+	}
+}
+
+func TestASupportedTypeWithoutTheGrantIsNotWritable(t *testing.T) {
+	t.Parallel()
+	ctx := seatWith(principal.ActionRead)
+
+	if Writable(ctx, datasource.EntityPerson) {
+		t.Error("a read-only seat reads as writable: the flag would offer an edit the write refuses")
+	}
+}
+
+// An unsupported type is not writable however entitled the seat. The two terms
+// are AND, and the contract half is the one a grant cannot argue with.
+//
+// The type is FOUND rather than named: which types the write-back contract
+// supports is its business and changes, and a case anchored on one that gains
+// support would skip — proving nothing while reading as a pass.
+func TestAnUnsupportedTypeIsNotWritableEvenWithTheGrant(t *testing.T) {
+	t.Parallel()
+	ctx := seatWith(principal.ActionRead, principal.ActionUpdate, principal.ActionCreate)
+
+	var unsupported datasource.EntityType
+	for _, et := range datasource.EntityTypes() {
+		if !SupportsWrite(WriteUpdate, et) {
+			unsupported = et
+			break
+		}
+	}
+	if unsupported == "" {
+		t.Fatal("every entity type is updatable through the overlay, so the contract half of this " +
+			"answer can no longer be observed — if that is deliberate, this case has to say so " +
+			"rather than quietly stop checking")
+	}
+	if Writable(ctx, unsupported) {
+		t.Errorf("%s reads as writable though the write-back contract does not support updating it",
+			unsupported)
+	}
+}
+
+// The flag says nothing about CREATE, and a client reading it that way would
+// offer a button for a write the overlay refuses on every type.
+func TestNoOverlayTypeSupportsCreate(t *testing.T) {
+	t.Parallel()
+
+	for _, et := range datasource.EntityTypes() {
+		if SupportsWrite(WriteCreate, et) {
+			t.Errorf("%s reports create support: `writable` answers the UPDATE question, so a type "+
+				"that gained create needs the flag's meaning revisited rather than inherited", et)
+		}
+	}
+}
+
+// An actor with no seat at all is not writable, and does not panic answering.
+// The assemblers run on read paths that a system principal also reaches.
+func TestAnUnseatedCallerIsNotWritable(t *testing.T) {
+	t.Parallel()
+
+	if Writable(context.Background(), datasource.EntityPerson) {
+		t.Error("a context with no actor read as writable")
+	}
+}


### PR DESCRIPTION
Closes #2363. Implements the ruling recorded on the ticket.

## What was wrong

`writable` rides on Person, Organization, Lead, Deal and Project so a client draws its edit affordances from the server's answer rather than guessing, and **absent means NOT writable** — the right default for a client that cannot tell.

The overlay assemblers never set it. So every mirrored record reached the client read-only, including records `provider_writes.go`'s `Update` would have accepted. That is not cosmetic: a user fully entitled to edit sees no way to, permanently, on every row. They do not conclude "the flag is absent" — they conclude the product cannot edit the incumbent's records.

## The computation, and why it is a different one

`writable` = the write-back contract supports updating this type **AND** this seat holds the update grant.

The row-scope term the native answer adds drops out, and it drops out because it is **already true**: a mirrored row has no local `owner_id`, and the mirror read that produced the record is visibility-joined — so a row this caller cannot see never reaches an assembler at all. `Update`'s own third gate says the same thing, answering `ErrNotFound` for such a row exactly as a read does.

It answers *"may this caller change this row"*, never *"will this succeed"*. A write can still lose the incumbent's drift check and come back as version skew, which is a fact about the moment rather than about authority — the native flag draws the same line.

**One computation, two callers.** `overlay.Writable` is called by the REST assembler and available to the provider; a second spelling is how the two would answer differently for one record, and the client sees whichever it asked.

## The registry entry

The ruling asked for `writable` to be re-pointed from `native_only`. I changed the **reason** and not the disposition, because the disposition is right: `DispositionNativeOnly` is defined as *"the field is derived or server-stamped, so no mirror could ever supply it"*, which is exactly what this is. What was wrong was the reason, which read as though the field were unanswerable in overlay mode. It now names the computation.

## Tests

| case | holds |
|---|---|
| a supported type with the grant | writable, for all four types |
| a supported type without the grant | not writable |
| an unsupported type with every grant | not writable — the type is **found**, not named, so a case cannot skip itself into a pass when its type gains support |
| no type supports create | the flag is the UPDATE question; a client reading it as permission to create would offer a button for a refused write |
| an unseated caller | not writable, and does not panic |
| every wire assembler stamps it | over the source, since behaviour only covers the assemblers a case remembers to call |

The last one asks the **contract** which records carry the slot, rather than listing them here: a list would have to be corrected by whoever adds the next record type, who is precisely the author the test exists to catch.

Mutations, each verified then restored:

| mutation | fails |
|---|---|
| the person assembler stops stamping | `EveryOverlayWireAssemblerStampsWritable` |
| the computation drops the contract half | `AnUnsupportedTypeIsNotWritableEvenWithTheGrant` |
| the computation drops the seat half | `ASupportedTypeWithoutTheGrantIsNotWritable` **and** `AnUnseatedCallerIsNotWritable` |

## Checks

`make check-backend` green (exit 0).