### PR TITLE
The two drafting tools say why they answer persistence differently

### DIFF
--- a/backend/gates/draftpersistenceparity_test.go
+++ b/backend/gates/draftpersistenceparity_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind claim H3
+
+package gates
+
+// Two drafting tools answer the persistence question differently ON PURPOSE,
+// and each says so beside the other's name.
+//
+// `draft_email` returns text and files nothing — the same answer the HTTP draft
+// endpoint gives, which is the one the web app's own button calls. It drafts
+// ONE message meant to be sent now, and drafting proposes words while sending
+// is the separate consent-gated act.
+//
+// `draft_follow_ups_for` writes each draft to the deal's timeline. It drafts N
+// for later triage, and the draft id it answers is the whole point: nobody
+// triages ten drafts out of a chat scrollback.
+//
+// AGENTS.md: two writers of one invariant either share a helper or say why they
+// do not — in the code beside it, not in the PR where the next reader will not
+// see it. These legitimately do not share, so the saying why is the obligation,
+// and an undocumented deliberate inconsistency reads exactly like an oversight.
+// That is how the ticket behind this came to exist.
+//
+// So this holds the CROSS-REFERENCE rather than the prose. A gate matching
+// sentences fails on a rewording; what must not rot is that each site still
+// points at the other, because a reader who finds one and not the other draws
+// the wrong conclusion — which is the whole failure.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEachDraftingToolNamesTheOneThatAnswersDifferently(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range []struct{ file, mustName, why string }{
+		{
+			file:     "backend/internal/compose/comms.go",
+			mustName: "FollowUpDrafter",
+			why: "the tool that DOES persist. Without the pointer, a reader finding this one " +
+				"alone reads 'drafting is not a write' as a rule the other site breaks",
+		},
+		{
+			file:     "backend/internal/modules/agents/tools_slipping.go",
+			mustName: "DraftAccountEmail",
+			why: "the tool that does NOT persist. Without the pointer, a reader finding this one " +
+				"alone reads the timeline write as what drafting means everywhere",
+		},
+	} {
+		raw, err := os.ReadFile(filepath.Join(repoRoot, pair.file))
+		if err != nil {
+			t.Errorf("reading %s: %v", pair.file, err)
+			continue
+		}
+		if !strings.Contains(string(raw), pair.mustName) {
+			t.Errorf("%s no longer names %s — %s", pair.file, pair.mustName, pair.why)
+		}
+	}
+}

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -132,6 +132,23 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 // drafter takes text, not records, and reading a company's fields into the
 // opening line would make the draft's content depend on data the approving
 // human is not looking at. They are carried for the SEND to file under.
+//
+// IT PERSISTS NOTHING, and that is deliberate rather than unfinished.
+//
+// It returns text and writes no timeline row, which is the same answer the HTTP
+// draft endpoint gives — the one the web app's own draft button calls. That
+// agreement is the feature: the same act should not mean two different things
+// depending on whether a person did it through the app or through an agent.
+// Drafting proposes words; sending is the separate consent-gated act, and a
+// draft that filed itself would put messages nobody sent on the record a rep
+// goes to for what actually happened with a customer.
+//
+// agents.FollowUpDrafter deliberately does the opposite and says so at its own
+// declaration. It is not the same act: this drafts ONE message meant to be sent
+// now, and that drafts N for later triage — a batch living only in a transcript
+// would be unusable, since nobody triages ten drafts out of a chat scrollback.
+// Two writers of one invariant either share a helper or say why they do not;
+// these legitimately do not, and this is the saying why.
 func (c commsAdapter) DraftAccountEmail(
 	ctx context.Context, links []agents.RecordLink, intent string,
 ) (string, string, error) {

--- a/backend/internal/modules/agents/tools_slipping.go
+++ b/backend/internal/modules/agents/tools_slipping.go
@@ -57,6 +57,19 @@ type SlippingLister func(ctx context.Context) ([]SlippingDeal, error)
 // it as a draft activity on the deal's timeline — a proposal, never a
 // send. Compose implements it over the same deterministic draft voice
 // draft_email uses and the same provider write path every tool rides.
+//
+// IT PERSISTS, where draft_email deliberately does not, and the difference is
+// the act rather than an inconsistency.
+//
+// This tool drafts N for later triage, and the `draft_activity_id` it answers
+// is the whole point of it: a batch that lived only in the transcript would be
+// unusable, because nobody triages ten drafts out of a chat scrollback. The
+// write is what makes it a tool rather than a wall of text.
+//
+// draft_email drafts ONE message meant to be sent now, so it returns text and
+// files nothing — matching the HTTP draft endpoint the web app's own button
+// calls, which is an agreement worth keeping. compose.commsAdapter's
+// DraftAccountEmail carries that half of the reasoning.
 type FollowUpDrafter func(ctx context.Context, deal SlippingDeal) (draftActivityID ids.UUID, summary string, err error)
 
 // RegisterSlippingTools wires the pipeline-risk intents. No lister, no

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -331,11 +331,12 @@ The eight shapes, what each is for, and how each one silently passes:
 | `unitegress_test.go` | H2 | A unit dials through the installation's egress policy, not through a copy of it. |
 | `workflowhandler_test.go` | H2 | The workflow.Handler read/write contract as a fitness function (ports/workflow.Handler): Match is a pure predicate and Plan computes the typed Effect WITHOUT applying it — "this is what makes dry-run and diff preview possible". |
 
-## Claim (8)
+## Claim (9)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `consumermailonelist_test.go` | H2 | One consumer-mail list, held by a test rather than by a comment. |
+| `draftpersistenceparity_test.go` | H3 | Two drafting tools answer the persistence question differently ON PURPOSE, and each says so beside the other's name. |
 | `elapsedonespelling_test.go` | H1 | "How many days of silence" is spelled once. |
 | `employmentcurrency_test.go` | H1 | employment.IsCurrentSQL calls itself "the ONE spelling of 'this job is still theirs', and the only definition of a current employment in this product". |
 | `livemember_test.go` | H1 | "Someone who still works here" is `status = 'active' AND archived\_at IS NULL` on app\_user, and TWO functions in two different packages each called themselves the ONE spelling of it while the tree held about twenty copies. |


### PR DESCRIPTION
Closes #2371. Implements the ruling recorded on the ticket — half 1 landed in #3085; this is half 2, which the ruling says is two comments and a reason.

## The inconsistency is real and intended

`draft_email` returns text and persists nothing. `draft_follow_ups_for` writes each draft to the deal's timeline. Both are right, because they are not the same act:

- **`draft_email` drafts ONE message, meant to be sent now.** Drafting proposes words; sending is the separate consent-gated act. And it matches the HTTP draft endpoint the web app's own draft button calls — that agreement is the feature, since the same act should not mean two different things depending on whether a person did it through the app or through an agent.
- **`draft_follow_ups_for` drafts N for later triage.** Its `draft_activity_id` return is the whole point: nobody triages ten drafts out of a chat scrollback, so a batch living only in a transcript would be unusable.

Making either consistent with the other buys tidiness with something real — persisting `draft_email` fills the timeline a rep reads for *what actually happened* with messages nobody sent.

## What this change is

`AGENTS.md`: *two writers of one invariant either share a helper or say why they do not — in the code beside it, not in the PR where the next reader will not see it.* These legitimately do not share, so the saying why **is** the obligation. Each site now states its own answer and names the other.

An undocumented deliberate inconsistency reads exactly like an oversight. That is how this ticket came to exist, from a live-server verification session — so the comment is the fix rather than paperwork about one.

## The gate holds the cross-reference, not the prose

A gate matching sentences fails on a rewording and passes on a lie. What must not rot is that each site still **points at the other**: a reader who finds one and not the other draws precisely the wrong conclusion — that drafting-is-not-a-write is a rule the other site breaks, or that the timeline write is what drafting means everywhere.

Mutation-checked: with one site's reference to the other removed, `TestEachDraftingToolNamesTheOneThatAnswersDifferently` fails and names which reader would be misled.

## Checks

`make check-backend` green (exit 0).