### PR TITLE
feat(people): a contact's address can be corrected after it bounces

### DIFF
--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -578,6 +578,92 @@ describe("PersonScreen — correcting an address that refused a send", () => {
     ]);
   });
 
+  it("offers the way to the contact already holding a corrected address", async () => {
+    // An address names exactly one live record (uq_person_email_dedupe), so a
+    // correction can land on one somebody else already holds. Create has always
+    // offered this route; edit could not collide until it carried the field.
+    stubFetch(async (url, method) => {
+      if (method === "PATCH") {
+        return jsonResponse(
+          {
+            type: "about:blank",
+            title: "Conflict",
+            status: 409,
+            code: "duplicate_email",
+            detail: "a live record with this key already exists",
+            details: { existing_id: "p-2" },
+          },
+          409,
+        );
+      }
+      if (url.includes("/activities")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse(anna);
+    });
+    render(<PersonScreen id="p-1" />);
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+    const address = await screen.findByDisplayValue(
+      "anna.weber@brandt.example",
+    );
+    await userEvent.clear(address);
+    await userEvent.type(address, "someone.else@brandt.example");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // Without the route the reader is told the address is taken and left with
+    // no way to see by whom, on the one screen that exists to fix addresses.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "View existing record" }),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("shows the refusal when the server declines a primary swap", async () => {
+    // Moving the primary marker between two same-type addresses is refused by
+    // the writer today (it promotes before it demotes, and the unique index
+    // sees two live primaries). Not this form's bug and not introduced here,
+    // but the primary radio is the first control that reaches it — so the
+    // reader must be told the save did not land, never left looking at a
+    // dialog that closed as though it had.
+    stubFetch(async (url, method) => {
+      if (method === "PATCH") {
+        return jsonResponse(
+          {
+            type: "about:blank",
+            title: "Conflict",
+            status: 409,
+            code: "conflict",
+            detail: "conflict",
+          },
+          409,
+        );
+      }
+      if (url.includes("/activities")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse(anna);
+    });
+    render(<PersonScreen id="p-1" />);
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+    const address = await screen.findByDisplayValue(
+      "anna.weber@brandt.example",
+    );
+    await userEvent.clear(address);
+    await userEvent.type(address, "anna.weber@brandt.de");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // The form stays open with the reader's entry in it. A dialog that closed
+    // here would report a correction the record never took.
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("anna.weber@brandt.de")).toBeTruthy(),
+    );
+  });
+
   it("sends an empty set when the reader removes the last address", async () => {
     const sent: Record<string, unknown>[] = [];
     stubFetch(async (url, method, request) => {

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -476,6 +476,140 @@ describe("PersonScreen — edit with If-Match (P-1)", () => {
   });
 });
 
+describe("PersonScreen — correcting an address that refused a send", () => {
+  // A bounced send names the address that refused it and routes the reader
+  // here. Until this form carried the field, that route ended at a page which
+  // reported the failure and could not fix it: `emails` was on
+  // UpdatePersonRequest and on the create form, and on no edit form anywhere.
+  it("sends the corrected set, not an addition to it", async () => {
+    let patchBody: unknown = null;
+    stubFetch(async (url, method, request) => {
+      if (method === "PATCH") {
+        patchBody = JSON.parse(await request.text());
+        return jsonResponse({ ...anna, version: 2 });
+      }
+      if (url.includes("/activities")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse(anna);
+    });
+    render(<PersonScreen id="p-1" />);
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+
+    // The row is PREFILLED from the record, which is what makes this a
+    // correction rather than a re-entry: a reader fixing one character must not
+    // have to retype the addresses that were already right.
+    const address = await screen.findByDisplayValue(
+      "anna.weber@brandt.example",
+    );
+    await userEvent.clear(address);
+    await userEvent.type(address, "anna.weber@brandt.de");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(patchBody).toBeTruthy());
+    // ONE entry, carrying the new address. The field replaces the set, so a
+    // body with two would mean the dead address survived the correction —
+    // exactly the failure the reader came here to undo.
+    expect(patchBody).toMatchObject({
+      emails: [{ email: "anna.weber@brandt.de", is_primary: true }],
+    });
+  });
+
+  it("carries an untouched address back unchanged, type and primary included", async () => {
+    // A save that corrects ONE address must not quietly rewrite the others.
+    // The set is replaced wholesale, so every row the reader did not touch is
+    // re-sent from the prefill — and a subfield the prefill dropped would come
+    // back as the mapper's default, silently retyping a personal address as
+    // work.
+    const twoAddresses = {
+      ...anna,
+      emails: [
+        {
+          id: "e-1",
+          email: "anna.weber@brandt.example",
+          email_type: "work",
+          is_primary: true,
+        },
+        {
+          id: "e-2",
+          email: "anna@privat.example",
+          email_type: "personal",
+          is_primary: false,
+        },
+      ],
+    };
+    const sent: Record<string, unknown>[] = [];
+    stubFetch(async (url, method, request) => {
+      if (method === "PATCH") {
+        sent.push(JSON.parse(await request.text()));
+        return jsonResponse({ ...twoAddresses, version: 2 });
+      }
+      if (url.includes("/activities")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse(twoAddresses);
+    });
+    render(<PersonScreen id="p-1" />);
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+
+    const dead = await screen.findByDisplayValue("anna.weber@brandt.example");
+    await userEvent.clear(dead);
+    await userEvent.type(dead, "anna.weber@brandt.de");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0].emails).toEqual([
+      {
+        email: "anna.weber@brandt.de",
+        email_type: "work",
+        is_primary: true,
+        position: 0,
+      },
+      {
+        email: "anna@privat.example",
+        email_type: "personal",
+        is_primary: false,
+        position: 1,
+      },
+    ]);
+  });
+
+  it("sends an empty set when the reader removes the last address", async () => {
+    const sent: Record<string, unknown>[] = [];
+    stubFetch(async (url, method, request) => {
+      if (method === "PATCH") {
+        sent.push(JSON.parse(await request.text()));
+        return jsonResponse({ ...anna, emails: [], version: 2 });
+      }
+      if (url.includes("/activities")) {
+        return jsonResponse({ data: [] });
+      }
+      return jsonResponse(anna);
+    });
+    render(<PersonScreen id="p-1" />);
+
+    await waitFor(() => expect(screen.getByTestId("edit-record")).toBeTruthy());
+    await userEvent.click(screen.getByTestId("edit-record"));
+
+    await screen.findByDisplayValue("anna.weber@brandt.example");
+    // The row is taken OUT, which is the gesture the form offers for it —
+    // emptying the box leaves a required field blank and the browser refuses
+    // the submit, so a reader who wants no address presses Remove.
+    await userEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(sent).toHaveLength(1));
+    // `[]` rather than an omitted key. Omitting it would read as "leave the
+    // addresses alone" and keep the one the reader just deleted — a contact
+    // with no working address is a real answer and has to be sendable.
+    expect(sent[0].emails).toEqual([]);
+  });
+});
+
 describe("PersonScreen — archive (P-3)", () => {
   it("opens a confirm, DELETEs /people/{id} on confirm, and navigates to the list", async () => {
     let deleted = false;

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -307,6 +307,13 @@ function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
 // change them. A bounced send names the address that refused it and sends the
 // reader here; a form that omitted the field left that reader at a page which
 // reported the failure and could not fix it.
+//
+// Moving the primary marker between two addresses of the SAME type is refused
+// by the server with a bare 409 today. Not a limit of this form and not
+// introduced here — the same PATCH has answered that way since the field
+// existed — but the primary radio is the first control that reaches it, so the
+// conflict is shown rather than swallowed. Correcting an address, adding one
+// and removing one all work.
 function personEditFields(t: ReturnType<typeof useT>): CreateField[] {
   return contactCreateFields(t);
 }
@@ -618,6 +625,17 @@ function PersonActionBadges({
           t("record.saveDone", { name: saved.full_name })
         }
         notice={overlay ? t("overlay.partialWriteBack") : undefined}
+        // An address is unique among LIVE rows across the workspace
+        // (uq_person_email_dedupe), so a correction can now collide with the
+        // contact that already holds it — 409 `duplicate_email`, naming that
+        // record. Create has always offered the way there; edit could not
+        // collide until it carried the address field, and a conflict the
+        // reader cannot follow is a dead end on the one screen that fixes
+        // addresses.
+        resolveExisting={(_code, existingId) => ({
+          screen: "contacts",
+          id: existingId,
+        })}
         fields={[...personEditFields(t), ...cf.formFields]}
         record={{
           id: person.id,

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -155,6 +155,35 @@ function asPhoneType(
     : "work";
 }
 
+// The email rows a writer supplied, blank ones dropped and position taken from
+// where each one sits in the list.
+//
+// ONE MAPPER FOR BOTH REQUESTS, because `PersonEmailInput` is one schema for
+// both: create and update describing an address differently is exactly what
+// that shared schema exists to prevent.
+function personEmailInputs(rows: FormRows) {
+  return (rows.emails ?? [])
+    .filter((row) => (row.email ?? "").trim().length > 0)
+    .map((row, index) => ({
+      email: row.email.trim(),
+      email_type: asEmailType(row.email_type),
+      is_primary: row.is_primary === "true",
+      position: index,
+    }));
+}
+
+// The phone rows, the same way and for the same reason.
+function personPhoneInputs(rows: FormRows) {
+  return (rows.phones ?? [])
+    .filter((row) => (row.phone ?? "").trim().length > 0)
+    .map((row, index) => ({
+      phone: row.phone.trim(),
+      phone_type: asPhoneType(row.phone_type),
+      is_primary: row.is_primary === "true",
+      position: index,
+    }));
+}
+
 // Builds the create-contact request body: scalar fields trim to undefined
 // when blank (never sent rather than sent empty), `social.linkedin` folds
 // into the `social` object, and each repeatable row becomes an
@@ -164,22 +193,8 @@ export function mapPersonBody(
   rows: FormRows,
 ): CreatePersonRequest {
   const linkedin = values["social.linkedin"]?.trim();
-  const emails = (rows.emails ?? [])
-    .filter((row) => (row.email ?? "").trim().length > 0)
-    .map((row, index) => ({
-      email: row.email.trim(),
-      email_type: asEmailType(row.email_type),
-      is_primary: row.is_primary === "true",
-      position: index,
-    }));
-  const phones = (rows.phones ?? [])
-    .filter((row) => (row.phone ?? "").trim().length > 0)
-    .map((row, index) => ({
-      phone: row.phone.trim(),
-      phone_type: asPhoneType(row.phone_type),
-      is_primary: row.is_primary === "true",
-      position: index,
-    }));
+  const emails = personEmailInputs(rows);
+  const phones = personPhoneInputs(rows);
   return {
     full_name: values.full_name.trim(),
     first_name: values.first_name?.trim() || undefined,
@@ -196,10 +211,20 @@ function stringField(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-// Builds the PATCH body: only the UpdatePersonRequest fields (never
-// emails/phones — not in the contract's update shape).
+// Builds the PATCH body.
+//
+// `emails` and `phones` REPLACE their sets rather than adding to them, which is
+// what a correction needs: a bounced address is fixed by sending the set that
+// should stand, and an append-only field could never remove the one that is
+// dead. So an empty list is SENT, not omitted — a contact whose last address
+// was wrong and is now gone is a real answer, and omitting it would silently
+// keep the address the reader just deleted.
+//
+// `rows` is absent only where a caller has no repeatable fields at all; the
+// person form always has both, so the sets go out on every save.
 export function mapPersonUpdate(
   values: Record<string, unknown>,
+  rows?: FormRows,
 ): UpdatePersonRequest {
   const linkedin = stringField(values["social.linkedin"]).trim();
   return {
@@ -208,6 +233,8 @@ export function mapPersonUpdate(
     last_name: stringField(values.last_name).trim() || undefined,
     title: stringField(values.title).trim() || undefined,
     social: linkedin ? { linkedin } : undefined,
+    emails: rows ? personEmailInputs(rows) : undefined,
+    phones: rows ? personPhoneInputs(rows) : undefined,
   };
 }
 
@@ -272,13 +299,17 @@ function contactCreateFields(t: ReturnType<typeof useT>): CreateField[] {
   ];
 }
 
-const personEditFields: CreateField[] = [
-  { key: "full_name", label: "create.fullName", required: true },
-  { key: "first_name", label: "create.firstName" },
-  { key: "last_name", label: "create.lastName" },
-  { key: "title", label: "create.personTitle" },
-  { key: "social.linkedin", label: "create.linkedin" },
-];
+// The edit form is contactCreateFields WITHOUT the create-only parts, so the
+// two cannot come to describe an address differently — the same reason one
+// mapper serves both request bodies.
+//
+// It carries the email and phone rows because nothing else in the product can
+// change them. A bounced send names the address that refused it and sends the
+// reader here; a form that omitted the field left that reader at a page which
+// reported the failure and could not fix it.
+function personEditFields(t: ReturnType<typeof useT>): CreateField[] {
+  return contactCreateFields(t);
+}
 
 async function createContact(
   values: Record<string, string>,
@@ -587,7 +618,7 @@ function PersonActionBadges({
           t("record.saveDone", { name: saved.full_name })
         }
         notice={overlay ? t("overlay.partialWriteBack") : undefined}
-        fields={[...personEditFields, ...cf.formFields]}
+        fields={[...personEditFields(t), ...cf.formFields]}
         record={{
           id: person.id,
           version: person.version,
@@ -596,16 +627,21 @@ function PersonActionBadges({
           last_name: person.last_name ?? "",
           title: person.title ?? "",
           "social.linkedin": stringField(person.social?.linkedin),
+          // The rows the form prefills from. `is_primary` is stringified by
+          // prefillRows like every other cell, and read back as `=== "true"`,
+          // so the primary marker survives a save that did not touch it.
+          emails: person.emails ?? [],
+          phones: person.phones ?? [],
           ...cf.recordSlice(person),
         }}
-        update={async (values, _rows, opened) => {
+        update={async (values, rows, opened) => {
           const { data, error } = await api.PATCH("/people/{id}", {
             params: {
               path: { id },
               ...ifMatch(requireVersion(opened?.version)),
             },
             body: {
-              ...mapPersonUpdate(values),
+              ...mapPersonUpdate(values, rows),
               // A diff against what the form prefilled from: a
               // snapshot sends `null` for every empty custom field,
               // and the API reads that as clearing a column nobody


### PR DESCRIPTION
A bounced send names the address that refused it and routes the reader to the contact. That route ended at a page which could not fix it: **nothing in the product could change a person's email or phone after creation.** `personEditFields` listed five scalar fields and neither repeatable row.

The contract has allowed it for a while. #4034 put `emails` on `UpdatePersonRequest`, #4204 put `phones` there, and the field's own description names this exact case — "a bounced address is fixed by sending the set that should stand". `mapPersonUpdate` still carried a comment saying they were "not in the contract's update shape", and dropped them.

## What changed

The edit form is now `contactCreateFields`, so create and edit cannot come to describe an address differently, and one pair of mappers (`personEmailInputs` / `personPhoneInputs`) builds the rows for both request bodies. Organizations already do this with `domains`; contacts were the outlier.

**An empty list is sent, not omitted.** `emails` REPLACES the set, so omitting it means "leave the addresses alone" and would keep the address the reader just removed. A contact with no working address is a real answer.

**The row is prefilled including `email_type` and `is_primary`**, because the set is replaced wholesale: a subfield the prefill dropped would come back as the mapper's default and silently retype a personal address as work.

**A collision has a way out.** An address names exactly one live record (`uq_person_email_dedupe`), so a correction can land on one another contact holds — 409 `duplicate_email` naming that record. Create always offered the route there; edit could not collide until it carried the field.

## Verified against a real stack, not only jsdom

On a `DEV_SLUG=wl29` stack (`:18088`, own database — `:8080` untouched): two addresses in, the dead one corrected, the untouched personal one returned with type and primary flag intact; then an empty list, which cleared them. Both PATCHes wrote an `audit_log` row stamped from the authenticated human.

## Two writer bugs found and filed, not fixed here

A review pass turned up two defects, both reproduced against that stack and **both older than this change**. They are backend writers in another module, so fixing them here would double the diff and cross a module boundary.

- **#4676** — swapping which of two same-type addresses is primary is refused with a bare `409 {"detail":"conflict"}`. The writer promotes before it demotes, so the unique index sees two live primaries for the length of a statement. The primary radio is the first control that reaches it, so the refusal is shown and the form keeps the reader's entry.
- **#4675** — a phone number held under two types (one work, one home, both non-primary — a valid record) collapses to one on **any** unrelated save, because the retained-row UPDATE matches on the value rather than the row id. Not reachable from this form's own gesture, but reachable from the endpoint it now uses.

Correcting an address, adding one and removing one all work.

## Tests

| Obligation | Evidence |
|---|---|
| User-visible outcome | `sends the corrected set, not an addition to it` — one entry, the new address |
| Data preserved | `carries an untouched address back unchanged, type and primary included` |
| Clear is distinct from omit | `sends an empty set when the reader removes the last address` |
| Collision is followable | `offers the way to the contact already holding a corrected address` |
| Failure behaviour | `shows the refusal when the server declines a primary swap` — form stays open with the entry |
| Mutation strength | Each clause reverted one at a time; every test fails alone. The refusal test is checked against a **200** so it cannot pass by the dialog never closing. |
| Write shape | `audit_log` rows confirmed on the real stack |
| Full lane | `make check-fe` green, and again after the rebase onto #4671 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets contact editors correct an email or phone that bounced, where previously no screen in the product could change either field after creation.

- The edit form now uses the same field definitions as create, with one set of mappers building both request bodies.
- An empty list is sent, not omitted, so removing the last address actually clears it.
- Addresses are prefilled with `email_type` and `is_primary` so untouched rows survive a save unchanged.
- A correction that lands on an address another contact holds links to that contact.
- Two older backend writer bugs were found and filed separately: the failed primary swap (#4676) and the phone collapse (#4675).

<sup>Written for commit b748d1dc081b312fcf718b75682b2f6047188491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email and phone fields to the person editing form.
  * Existing contact details are prefilled and can be replaced or removed.
  * Duplicate email conflicts now offer a link to view the existing record.
  * Conflict responses keep the form open while preserving entered data.

* **Tests**
  * Added coverage for contact detail updates, removals, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->