### PR TITLE
make check-all, and the shipping loop stops promising what check cannot do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,11 @@ check monitoring. Read-only inspection (`git status`, `diff`, `log`) can stay
 sandboxed.
 
 1. Branch off `main`: `git switch -c <type>/<slug> origin/main`.
-2. Run `make check` before pushing — both halves, `frontend/` included. **Touching
-   backend Go, run `make check-all`**: `check` reaches the integration lane not at
-   all, so a green one says nothing about it. The pre-push hook runs `craft static
-   --strict` diff-scoped too — fix what it finds, never bypass it; install it via
-   `make hooks`.
+2. Run `make check` before pushing — both halves, `frontend/` included. **For a
+   change touching backend Go, run `make check-all` instead**: `check` reaches the
+   integration lane not at all, so a green one says nothing about it. The pre-push
+   hook runs `craft static --strict` diff-scoped too — fix what it finds, never
+   bypass it; install it via `make hooks`.
 3. Push and open a PR.
 4. CI, CodeRabbit and SonarCloud must all pass. Address review findings
    rather than dismissing them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,11 @@ check monitoring. Read-only inspection (`git status`, `diff`, `log`) can stay
 sandboxed.
 
 1. Branch off `main`: `git switch -c <type>/<slug> origin/main`.
-2. Run `make check` before pushing — it is both halves, `frontend/` included,
-   with nothing to add on top. The pre-push hook runs `craft static --strict`
-   diff-scoped too — fix what it finds, never bypass it; install it via `make hooks`.
+2. Run `make check` before pushing — both halves, `frontend/` included. **Touching
+   backend Go, run `make check-all`**: `check` reaches the integration lane not at
+   all, so a green one says nothing about it. The pre-push hook runs `craft static
+   --strict` diff-scoped too — fix what it finds, never bypass it; install it via
+   `make hooks`.
 3. Push and open a PR.
 4. CI, CodeRabbit and SonarCloud must all pass. Address review findings
    rather than dismissing them.

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -188,6 +188,31 @@ check:
 	@bash scripts/phase-timer.sh reset
 	@PHASE_TIMER_OWNED=1 $(MAKE) check-backend
 	@PHASE_TIMER_OWNED=1 $(MAKE) check-fe
+	@bash scripts/phase-timer.sh report
+
+## check-all — `check` plus the integration lane, which is what a change touching
+## backend Go actually has to pass. `check` reaches the integration lane NOT AT
+## ALL: its `test` target is `go test ./...`, and every integration file carries
+## `//go:build integration`, so the lane's packages compile into nothing and a
+## green `check` says nothing about them.
+##
+## Its own target rather than folding the lane into `check`, because `check` is
+## what a docs or frontend change runs and that is most changes: the lane takes
+## minutes and needs Postgres up, so paying it on a README edit would train
+## everybody to skip the gate that also holds the security cases.
+##
+## Not in the pre-push hook either, and the reason is this machine rather than
+## principle: parallel sessions share one test template, so a hook running the
+## lane on every push would have them rebuilding each other's schema mid-run —
+## failures that are schema-shaped and look nothing like their cause. The hook
+## keeps the checks that are fast, need nothing running, and cannot collide.
+check-all:
+	@bash scripts/phase-timer.sh reset
+	@PHASE_TIMER_OWNED=1 $(MAKE) check-backend
+	@PHASE_TIMER_OWNED=1 $(MAKE) check-fe
+	@bash scripts/phase-timer.sh start "backend: integration lane (real Postgres)"
+	@PHASE_TIMER_OWNED=1 $(MAKE) -C backend test-integration
+	@bash scripts/phase-timer.sh stop
 	@bash scripts/phase-timer.sh report
 
 ## check-q — quiet `make check`: the full log lands in .tmp/check.log and only an

--- a/backend/gates/shippingloopreachesthelane_test.go
+++ b/backend/gates/shippingloopreachesthelane_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The routine the rulebook tells a contributor to run reaches the integration
+// lane.
+//
+// It did not, and nothing said so. The shipping loop's step 2 named `make check`
+// and added "with nothing to add on top" — while `check`'s test target is
+// `go test ./...` and every integration file carries `//go:build integration`,
+// so those packages compile into nothing. A contributor followed the documented
+// routine exactly and pushed backend changes no local run had exercised. The
+// lane's own security cases are in there.
+//
+// Two claims, and either alone rots into the same silence: the rulebook must
+// name a target that reaches the lane, and that target must still reach it. A
+// gate on the prose alone passes over a target that stopped running the lane;
+// one on the Makefile alone passes over a rulebook that stopped naming it.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const integrationRoutine = "check-all"
+
+func TestTheShippingLoopNamesARoutineThatReachesTheIntegrationLane(t *testing.T) {
+	t.Parallel()
+
+	rules := readRepoFile(t, filepath.Join(repoRoot, "AGENTS.md"))
+	shipping := section(t, rules, "## Shipping a change")
+	if !strings.Contains(shipping, integrationRoutine) {
+		t.Errorf("the shipping loop does not name `make %s`, so the routine a contributor is told "+
+			"to run stops at `check` — which reaches the integration lane not at all, because its "+
+			"test target is `go test ./...` and every integration file is behind a build tag",
+			integrationRoutine)
+	}
+
+	root := readRepoFile(t, filepath.Join(repoRoot, "Makefile"))
+	recipe := section(t, root, "\n"+integrationRoutine+":")
+	if !strings.Contains(recipe, "test-integration") {
+		t.Errorf("`make %s` no longer runs test-integration, so the rulebook now points at a "+
+			"routine as blind as the one it replaced — and blind in the way that reports success",
+			integrationRoutine)
+	}
+}
+
+// section is the text from a heading or a recipe's first line to the start of
+// the next one — a markdown "## " heading, or a Makefile recipe's unindented
+// target line. Enough to read one step or one recipe whole without parsing
+// either format, and it must be WHOLE: a reader that stopped at the first blank
+// line would miss a numbered step two paragraphs down and report it missing.
+func section(t *testing.T, text, start string) string {
+	t.Helper()
+	at := strings.Index(text, start)
+	if at < 0 {
+		t.Fatalf("%q is no longer in the file — this gate is reading a shape that is gone, which "+
+			"is how a census comes to certify nothing", start)
+	}
+	rest := text[at+len(start):]
+	for _, boundary := range []string{"\n## ", "\n\n\n"} {
+		if end := strings.Index(rest, boundary); end >= 0 {
+			rest = rest[:end]
+		}
+	}
+	return rest
+}

--- a/backend/gates/shippingloopreachesthelane_test.go
+++ b/backend/gates/shippingloopreachesthelane_test.go
@@ -33,7 +33,10 @@ func TestTheShippingLoopNamesARoutineThatReachesTheIntegrationLane(t *testing.T)
 
 	rules := readRepoFile(t, filepath.Join(repoRoot, "AGENTS.md"))
 	shipping := section(t, rules, "## Shipping a change")
-	if !strings.Contains(shipping, integrationRoutine) {
+	// The COMMAND, not the word: a step that mentions check-all while telling a
+	// contributor to run something else reads to this gate exactly like one that
+	// tells them to run it.
+	if !strings.Contains(shipping, "`make "+integrationRoutine+"`") {
 		t.Errorf("the shipping loop does not name `make %s`, so the routine a contributor is told "+
 			"to run stops at `check` — which reaches the integration lane not at all, because its "+
 			"test target is `go test ./...` and every integration file is behind a build tag",
@@ -42,11 +45,28 @@ func TestTheShippingLoopNamesARoutineThatReachesTheIntegrationLane(t *testing.T)
 
 	root := readRepoFile(t, filepath.Join(repoRoot, "Makefile"))
 	recipe := section(t, root, "\n"+integrationRoutine+":")
-	if !strings.Contains(recipe, "test-integration") {
+	if !invokes(recipe, "test-integration") {
 		t.Errorf("`make %s` no longer runs test-integration, so the rulebook now points at a "+
 			"routine as blind as the one it replaced — and blind in the way that reports success",
 			integrationRoutine)
 	}
+}
+
+// invokes reports whether a recipe RUNS a target rather than merely mentioning
+// it. The recipe carries the reasoning for what it does and does not run, so
+// the lane's name appears in its comments whatever the commands do — and a
+// recipe that stopped running the lane would keep every one of those words.
+func invokes(recipe, target string) bool {
+	for _, line := range strings.Split(recipe, "\n") {
+		command := strings.TrimSpace(line)
+		if strings.HasPrefix(command, "#") {
+			continue
+		}
+		if strings.Contains(command, "$(MAKE)") && strings.Contains(command, target) {
+			return true
+		}
+	}
+	return false
 }
 
 // section is the text from a heading or a recipe's first line to the start of

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (92)
+## Parity (93)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -107,6 +107,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this person currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |
 | `seedresetparity_test.go` | H3 | "What survives a reset" is one decision, and it is written down twice: the in-product data reset applies it in Go (internal/compose/datasweep.go's preservedResetTables), and the developer's `make seed-reset` applies it in SQL (scripts/seed-reset.sql). |
 | `sendattachmentcap_test.go` | H3 | The attachment-per-message cap as a fitness function. |
+| `shippingloopreachesthelane_test.go` | H2 | The routine the rulebook tells a contributor to run reaches the integration lane. |
 | `teamoutlookmirror_test.go` | H3 | The team's frozen outlook and the rep's are the same fact over different books, so they are the same SHAPE or one of them is lying. |
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -41,6 +41,7 @@ UAT guides call by name (`docs/target-minimum-setup.md §3`). `check-q`,
 | Target | What it does |
 |---|---|
 | `check` | **The merge gate.** Backend `make check` = build + vet + lint + arch-lint + test + drift. Root `make check` runs that **plus** the craft-doc floor, image pins, contract breaking-change (`oasdiff`), test-lane hygiene, and the file-length ratchet |
+| `check-all` | **What a change touching backend Go has to pass**: `check` plus the integration lane. `check` reaches that lane **not at all** — its `test` target is `go test ./...`, and every integration file carries `//go:build integration`, so those packages compile into nothing and a green `check` says nothing about them. Needs `make db-up`, and takes minutes: `check` stays the target for docs and frontend work, which is most changes. Deliberately not in the pre-push hook — parallel sessions on one machine share the test template, so a hook running the lane on every push would have them rebuilding each other's schema mid-run |
 | `check-backend` / `check-fe` | The two halves of the root gate, runnable alone: `check-backend` = backend `check` + the root script gates below (what CI's deterministic-gates job runs; it needs no frontend toolchain — `contract-frontend-drift` skips loudly without pnpm); `check-fe` = the composed typecheck, `frontend-check`, and the unit screens' own suites (`fe-test-ext`), with a loud fail if `frontend/node_modules` is missing |
 | `build` | `go build ./...` |
 | `vet` | `go vet ./...` |


### PR DESCRIPTION
Closes #2433. Implements the ruling recorded on the ticket.

## The sentence was false

The shipping loop said:

> Run `make check` before pushing — it is both halves, `frontend/` included, **with nothing to add on top.**

`check` reaches the integration lane **not at all**. Its `test` target is `go test ./...`; every integration file carries `//go:build integration`; so those packages compile into nothing. A contributor who followed the documented routine exactly pushed backend changes no local run had exercised — and the lane holds the RLS, erasure and HTTP e2e cases.

## What landed

- **`make check-all`** = `check` + the integration lane, with the timing ledger the other targets keep.
- The shipping loop names it for a change touching backend Go, and the false clause is gone.
- `docs/reference/make-targets.md` carries the reasoning — which is where it belongs rather than in the rulebook, whose own economics say every line is paid for by every session. Trimming step 2 back to the rule is also what kept `AGENTS.md` under its 330-line ceiling; the ratchet caught my first draft at 333.

## Why not the hook, and why not fold it into `check`

Both were considered and both cost something real:

- **Folding it into `check`** makes a README edit pay minutes and require Postgres. `check` stays the target for docs and frontend work, which is most changes — and a gate everybody learns to skip protects nothing.
- **The pre-push hook** was rejected on a reason specific to this machine: parallel sessions share one test template, so a hook running the lane on every push would have concurrent sessions rebuilding each other's schema mid-run. Those failures are schema-shaped and look nothing like their cause. The hook keeps `craft static` and the greps, which are fast, need nothing running, and cannot collide.

## The gate

`TestTheShippingLoopNamesARoutineThatReachesTheIntegrationLane` holds **both** claims, because either alone rots into the same silence: a gate on the prose passes over a target that stopped running the lane, and one on the Makefile passes over a rulebook that stopped naming it.

Mutations, each verified then restored:

| mutation | fails with |
|---|---|
| the rulebook names `check` again | *"the shipping loop does not name `make check-all` … which reaches the integration lane not at all"* |
| `check-all` stops running `test-integration` | *"the rulebook now points at a routine as blind as the one it replaced — and blind in the way that reports success"* |

## Checks

`make check-backend` green (exit 0), including `make-target-parity` and `ci-doc-parity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `check-all` validation target, combining standard checks with backend integration tests against a real PostgreSQL database.
  - Updated the recommended backend development workflow to use `check-all` for changes affecting backend Go code.

- **Documentation**
  - Documented the new validation target and clarified which checks are covered.

- **Tests**
  - Added coverage to verify that the documented workflow runs the integration test lane and matches the validation command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->