### PR TITLE
A refused merge leaves nothing behind

### DIFF
--- a/backend/internal/modules/people/dedupedisposition.go
+++ b/backend/internal/modules/people/dedupedisposition.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/fieldcatalog"
 )
 
 // ensurePairWritable narrows the pair's read gate to the authority a decision
@@ -100,19 +101,24 @@ func (s *Store) DisposeDedupeCandidate(ctx context.Context, id ids.UUID, disposi
 	return s.GetDedupeCandidate(ctx, id)
 }
 
-// disposeMerge is the merge arm: validate the winner, mark first (a CAS on
-// open, so a concurrent decision cannot double-merge), then run the ONE merge
-// verb in its own transaction. A merge the verb REFUSES re-opens the row.
+// disposeMerge is the merge arm: validate the winner, then mark and merge in
+// ONE transaction — the CAS on open (so a concurrent decision cannot
+// double-merge) and the merge itself commit together or not at all.
 //
-// That compensation is not a guarantee, and saying so is the point: the mark
-// and the merge are separate transactions, so a reopen that itself fails — or
-// a process that stops between the two — leaves the candidate at 'merged' with
-// no merge behind it, suppressed for the whole workspace. errors.Join reports
-// it and nothing repairs it. Dismiss and undo do not have this shape; they
-// commit their probe and their write together through writePairDecision. The
-// merge arm cannot yet, because the merge verbs are Store methods that open
-// their own transactions rather than joining a caller's. Tracked as its own
-// issue (#1970); do not read the compensation as atomicity.
+// It used to be three transactions: mark, merge, and a compensating re-open on
+// failure. That compensation was not a guarantee. A re-open that itself failed
+// — or a process that stopped between the mark and the merge — left the
+// candidate at 'merged' with no merge behind it, suppressed for the whole
+// workspace, invisible in every queue, with nothing to repair it. errors.Join
+// reported it to the caller and that was the end of it (#1970).
+//
+// Now it has the shape dismiss and undo already had: the probe and the write in
+// one commit. A merge the verb refuses takes the mark down with it because the
+// mark was never committed, rather than because a second write put it back.
+//
+// The RBAC verb and the active-column read stay OUTSIDE the transaction, which
+// is where the exported merge verbs do them too — they need no transaction, and
+// holding the pair lock across them would widen the lock for nothing.
 func (s *Store) disposeMerge(ctx context.Context, id ids.UUID, row DedupeCandidateRow, winnerID *ids.UUID, by ids.UUID) error {
 	if winnerID == nil || (*winnerID != row.LeftID && *winnerID != row.RightID) {
 		return &DedupeInputError{Field: "winner_id", Msg: "must be one of the pair"}
@@ -121,44 +127,51 @@ func (s *Store) disposeMerge(ctx context.Context, id ids.UUID, row DedupeCandida
 	if loser == *winnerID {
 		loser = row.RightID
 	}
-	if err := s.setDedupeDisposition(ctx, id, dispositionMerged, by); err != nil {
+	if err := auth.Require(ctx, row.EntityType, principal.ActionUpdate); err != nil {
 		return err
 	}
-	if err := s.executeDedupeMerge(ctx, row.EntityType, loser, *winnerID); err != nil {
-		if reopenErr := s.reopenDedupeCandidate(ctx, id); reopenErr != nil {
-			return errors.Join(err, reopenErr)
+	active, err := s.activeColumns(ctx, row.EntityType)
+	if err != nil {
+		return err
+	}
+	capturedBy, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return err
+	}
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
+		if err := setDedupeDispositionTx(ctx, tx, id, dispositionMerged, by); err != nil {
+			return err
 		}
-		return err
-	}
-	return nil
+		return s.executeDedupeMergeTx(ctx, tx, row.EntityType, loser, *winnerID, active, capturedBy)
+	})
 }
 
-// executeDedupeMerge runs the ONE merge implementation for the pair's type.
-func (s *Store) executeDedupeMerge(ctx context.Context, entityType string, loser, winner ids.UUID) error {
+// executeDedupeMergeTx runs the ONE merge implementation for the pair's type,
+// inside the caller's transaction.
+//
+// The transaction-scoped spellings rather than the exported verbs: those open
+// their own transaction, which is exactly what kept the mark and the merge
+// apart. Their pre-transaction guards are hoisted to disposeMerge above so
+// nothing is skipped by taking this route — the self-merge check is not among
+// them because the loser is derived as the OTHER end of the pair and cannot
+// equal the winner.
+func (s *Store) executeDedupeMergeTx(
+	ctx context.Context, tx pgx.Tx, entityType string, loser, winner ids.UUID,
+	active []fieldcatalog.Column, capturedBy string,
+) error {
 	switch entityType {
 	case entityPerson:
-		_, err := s.MergePerson(ctx, ids.From[ids.PersonKind](loser), ids.From[ids.PersonKind](winner))
+		_, err := s.mergePersonTx(ctx, tx, ids.From[ids.PersonKind](loser), ids.From[ids.PersonKind](winner), active)
 		return err
 	case entityOrganization:
-		_, err := s.MergeOrganization(ctx, ids.From[ids.OrganizationKind](loser), ids.From[ids.OrganizationKind](winner))
+		_, err := mergeOrganizationTx(ctx, tx, ids.From[ids.OrganizationKind](loser), ids.From[ids.OrganizationKind](winner), active)
 		return err
 	case entityLead:
-		_, err := s.MergeLead(ctx, ids.From[ids.LeadKind](loser), ids.From[ids.LeadKind](winner))
+		_, err := mergeLeadTx(ctx, tx, ids.From[ids.LeadKind](loser), ids.From[ids.LeadKind](winner), active, capturedBy)
 		return err
 	default:
 		return fmt.Errorf("people: unmergeable entity type %q", entityType)
 	}
-}
-
-// setDedupeDisposition is the CAS open→disposed; losing the race answers
-// conflict, never a second merge. The audit row rides the same commit;
-// dedupe_candidate is not a §4.1 stream entity, so the disposition has no
-// bus event — the audit ledger is the record (the merge arm's
-// person.merged/organization.merged carries the bus-visible fact).
-func (s *Store) setDedupeDisposition(ctx context.Context, id ids.UUID, disposition string, by ids.UUID) error {
-	return s.db.Tx(ctx, func(tx pgx.Tx) error {
-		return setDedupeDispositionTx(ctx, tx, id, disposition, by)
-	})
 }
 
 // writePairDecision commits a human's verdict on a pair under the authority
@@ -196,12 +209,6 @@ func setDedupeDispositionTx(ctx context.Context, tx pgx.Tx, id ids.UUID, disposi
 		map[string]any{auditKeyDisposition: dispositionOpen},
 		map[string]any{auditKeyDisposition: disposition})
 	return err
-}
-
-func (s *Store) reopenDedupeCandidate(ctx context.Context, id ids.UUID) error {
-	return s.db.Tx(ctx, func(tx pgx.Tx) error {
-		return reopenDedupeCandidateTx(ctx, tx, id)
-	})
 }
 
 func reopenDedupeCandidateTx(ctx context.Context, tx pgx.Tx, id ids.UUID) error {

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -671,6 +671,74 @@ func TestDedupeDispositionAdmitsABoundedOwnerOfBothRecords(t *testing.T) {
 // its own arm. Nothing else in this package would notice: every other merge
 // test acts with RowScopeAll, for which auth.Unbounded waves the whole question
 // through.
+// A refused merge leaves NOTHING behind — not the mark, and not the audit row
+// that says a merge happened.
+//
+// The mark and the merge used to be two transactions with a compensating
+// re-open between them, so a refusal committed 'merged' and its audit row
+// first and then took the mark back with a second write. A re-open that failed,
+// or a process that stopped in the gap, left the candidate claiming a merge
+// that never happened: suppressed for the whole workspace, absent from every
+// queue, with nothing to repair it (#1970).
+//
+// This asserts the POST-CONDITION rather than the interleaving, which is the
+// only thing available: injecting a failure between the mark and the merge
+// needs the two to be separable, and that separability is exactly what the fix
+// removes. What it pins is that a refusal costs the row nothing — and that the
+// audit ledger carries no merge for it, which the old shape wrote and then
+// could not unwrite.
+func TestARefusedMergeLeavesNoMarkAndNoAuditOfOne(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	first, second := seedPersonPair(ctx, t, e, "Nora Atomic", "nora@atomic.test", "Norah Atomic", "norah@atomic.test", "atomic.test")
+	c := openCandidates(ctx, t, e, "person")[0]
+
+	// The colleague owns the loser and not the winner: mergePair's bare
+	// conflict, reached only once the merge is under way.
+	winner, loser := first, second
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE person SET owner_id = $1 WHERE id = $2`, e.otherRep, loser)
+		return err
+	}); err != nil {
+		t.Fatalf("handing the loser to the colleague: %v", err)
+	}
+
+	if _, err := e.store.DisposeDedupeCandidate(e.asOwnScoped(e.otherRep), c.ID, "merge", &winner); !errors.Is(err, apperrors.ErrConflict) {
+		t.Fatalf("the refused merge answered %v, want ErrConflict", err)
+	}
+
+	// The row is OPEN, and open because the mark never committed rather than
+	// because a second write put it back.
+	var disposition string
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT disposition FROM dedupe_candidate WHERE id = $1`, c.ID).Scan(&disposition)
+	}); err != nil {
+		t.Fatalf("reading the candidate back: %v", err)
+	}
+	if disposition != "open" {
+		t.Errorf("disposition = %q, want open — a refused merge left the pair claiming one, "+
+			"which suppresses it for the whole workspace with nothing to repair it", disposition)
+	}
+
+	// And the ledger says no merge was decided. This is the half a compensating
+	// re-open could never take back: the audit row for the mark was committed
+	// before the merge was attempted, so it outlived the refusal.
+	var merged int
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT count(*) FROM audit_log
+			 WHERE entity_type = 'dedupe_candidate' AND entity_id = $1
+			   AND after->>'disposition' = 'merged'`, c.ID).Scan(&merged)
+	}); err != nil {
+		t.Fatalf("counting the merge audit rows: %v", err)
+	}
+	if merged != 0 {
+		t.Errorf("%d audit row(s) record a merge that was refused — the ledger is the record "+
+			"a reviewer reads, and it says something happened that did not", merged)
+	}
+}
+
 func TestDedupeMergeArmKeepsItsOwnRefusal(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -51,78 +51,94 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.Or
 
 	var out crmcontracts.Organization
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		// A merge fills the survivor's legal_name from the record it retires
-		// (fillOrgSurvivorship), so it is a name writer like any other and owes
-		// the same two things: the name lock BEFORE any organization row lock,
-		// and a re-check afterwards. Taking it here rather than beside the fill
-		// is what keeps the order — LockPair is next.
-		if err := lockOrgNameWrites(ctx, tx); err != nil {
-			return err
-		}
-		// The pair lock keeps BOTH endpoints held to commit: without it a
-		// concurrent merge(target→elsewhere) archives the survivor
-		// mid-merge and the relinked children point at a dead record.
-		_, tgtLock, err := storekit.LockPair(ctx, tx, "organization", sourceID.UUID, targetID.UUID)
-		if err != nil {
-			return err
-		}
-		src, tgt, err := mergePair(ctx, tx, "organization", sourceID, targetID, readOrgMergeState)
-		if err != nil {
-			return err
-		}
-		// AFTER the pair lock, so the answer cannot change under the merge, and
-		// before anything is relinked. Either endpoint: merging the anchor away
-		// retires it, and merging a customer INTO it folds their people, deals
-		// and history onto the installation's own company with no way to tell
-		// them apart afterwards.
-		// Neither direction is open when one side is the anchor, so neither
-		// message may point at the other direction as the way out: archiving the
-		// duplicate is the only move that actually works.
-		if err := refuseIfAnchor(ctx, tx, sourceID, "id", "it cannot be merged into another company. Archive the duplicate instead, and edit this one on the company page"); err != nil {
-			return err
-		}
-		if err := refuseIfAnchor(ctx, tx, targetID, "target_id", "nothing can be merged into it. Archive the duplicate instead, and edit this one on the company page"); err != nil {
-			return err
-		}
-		if err := refuseWhenBothCarryProjects(ctx, tx, sourceID, targetID); err != nil {
-			return err
-		}
-		targetIsPartner, err := relinkOrgAssociations(ctx, tx, sourceID, targetID)
-		if err != nil {
-			return err
-		}
-		filled, err := fillOrgSurvivorship(ctx, tx, src, tgt, targetIsPartner, tgtLock)
-		if err != nil {
-			return err
-		}
-		out, err = finalizeOrgMerge(ctx, tx, sourceID, targetID, filled, active)
-		if err != nil {
-			return err
-		}
-		// A survivor that just inherited the retired record's legal name can now
-		// be the twin of a THIRD organization, and resolving one duplicate is no
-		// reason to leave that one unfiled. Only when the name actually moved: a
-		// merge that filled nothing renames nobody.
-		//
-		// It runs after finalizeOrgMerge, which retires the source. Before it,
-		// the source still reads as live AND holds the very name it has just
-		// donated, so it scores 1.0, wins the ranked list, and the pair filed
-		// names a row archived one statement later — a pair no human can ever
-		// dispose of, because merging it answers AlreadyMerged and that reopens
-		// it. The genuine third record is never reached, since the walk stops at
-		// the first unfiled rival.
-		if _, renamed := filled[fieldLegalName]; renamed {
-			by, err := storekit.CapturedBy(ctx)
-			if err != nil {
-				return err
-			}
-			if err := recheckOrgNameForDuplicates(ctx, tx, targetID, by); err != nil {
-				return err
-			}
-		}
-		return nil
+		var err error
+		out, err = mergeOrganizationTx(ctx, tx, sourceID, targetID, active)
+		return err
 	})
 	return out, err
+}
+
+// mergeOrganizationTx takes the name lock and the pair lock, refuses the
+// anchor in either direction, relinks every association, fills the survivor's
+// gaps and retires the source — all inside the CALLER's transaction.
+//
+// Split out so a caller that has already written something can commit that
+// write and this merge together. The dedupe queue is the one that needs it: it
+// marks a candidate 'merged' and then merges, and two transactions there leave
+// a candidate claiming a merge that never happened (#1970).
+func mergeOrganizationTx(
+	ctx context.Context, tx pgx.Tx, sourceID, targetID ids.OrganizationID, active []fieldcatalog.Column,
+) (crmcontracts.Organization, error) {
+	// A merge fills the survivor's legal_name from the record it retires
+	// (fillOrgSurvivorship), so it is a name writer like any other and owes
+	// the same two things: the name lock BEFORE any organization row lock,
+	// and a re-check afterwards. Taking it here rather than beside the fill
+	// is what keeps the order — LockPair is next.
+	if err := lockOrgNameWrites(ctx, tx); err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	// The pair lock keeps BOTH endpoints held to commit: without it a
+	// concurrent merge(target→elsewhere) archives the survivor
+	// mid-merge and the relinked children point at a dead record.
+	_, tgtLock, err := storekit.LockPair(ctx, tx, "organization", sourceID.UUID, targetID.UUID)
+	if err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	src, tgt, err := mergePair(ctx, tx, "organization", sourceID, targetID, readOrgMergeState)
+	if err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	// AFTER the pair lock, so the answer cannot change under the merge, and
+	// before anything is relinked. Either endpoint: merging the anchor away
+	// retires it, and merging a customer INTO it folds their people, deals
+	// and history onto the installation's own company with no way to tell
+	// them apart afterwards.
+	// Neither direction is open when one side is the anchor, so neither
+	// message may point at the other direction as the way out: archiving the
+	// duplicate is the only move that actually works.
+	if err := refuseIfAnchor(ctx, tx, sourceID, "id", "it cannot be merged into another company. Archive the duplicate instead, and edit this one on the company page"); err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	if err := refuseIfAnchor(ctx, tx, targetID, "target_id", "nothing can be merged into it. Archive the duplicate instead, and edit this one on the company page"); err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	if err := refuseWhenBothCarryProjects(ctx, tx, sourceID, targetID); err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	targetIsPartner, err := relinkOrgAssociations(ctx, tx, sourceID, targetID)
+	if err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	filled, err := fillOrgSurvivorship(ctx, tx, src, tgt, targetIsPartner, tgtLock)
+	if err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	out, err := finalizeOrgMerge(ctx, tx, sourceID, targetID, filled, active)
+	if err != nil {
+		return crmcontracts.Organization{}, err
+	}
+	// A survivor that just inherited the retired record's legal name can now
+	// be the twin of a THIRD organization, and resolving one duplicate is no
+	// reason to leave that one unfiled. Only when the name actually moved: a
+	// merge that filled nothing renames nobody.
+	//
+	// It runs after finalizeOrgMerge, which retires the source. Before it,
+	// the source still reads as live AND holds the very name it has just
+	// donated, so it scores 1.0, wins the ranked list, and the pair filed
+	// names a row archived one statement later — a pair no human can ever
+	// dispose of, because merging it answers AlreadyMerged and that reopens
+	// it. The genuine third record is never reached, since the walk stops at
+	// the first unfiled rival.
+	if _, renamed := filled[fieldLegalName]; renamed {
+		by, err := storekit.CapturedBy(ctx)
+		if err != nil {
+			return crmcontracts.Organization{}, err
+		}
+		if err := recheckOrgNameForDuplicates(ctx, tx, targetID, by); err != nil {
+			return crmcontracts.Organization{}, err
+		}
+	}
+	return out, nil
 }
 
 // relinkOrgAssociations moves every association off the merged-away org

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (90)
+## Parity (91)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #1970.

The dedupe merge arm was **three transactions**: mark the candidate `merged` with its audit row and commit; run the merge; on failure write the row back open.

That compensation was not a guarantee, and #1949's doc comment already said so. A re-open that itself failed — or a process that stopped between the mark and the merge — left a candidate **claiming a merge that never happened**: suppressed for the whole workspace, absent from every queue, with nothing to repair it. `errors.Join` reported it to the caller and that was the end of it.

## It is one transaction now

The shape dismiss and undo already had. A merge the verb refuses takes the mark down with it **because the mark was never committed**, not because a second write put it back.

The compensating re-open goes, and so do the two non-transactional wrappers that existed only to serve it.

## The merge verbs gained the spelling that makes that possible

Person and lead already had one. Organization's logic lived inside its own `s.tx` closure and is now `mergeOrganizationTx`, extracted unchanged. **The exported verbs are untouched** — each still opens its own transaction and calls its Tx form, so nothing outside the queue changes.

## The pre-transaction guards are hoisted, not dropped

`auth.Require`, the active-column read and `CapturedBy` run before the transaction opens — which is where the exported verbs do them too. They need no transaction, and holding the pair lock across them would widen the lock for nothing.

The self-merge check is the one guard not carried over, deliberately: the loser is derived as the *other* end of the pair, so it cannot equal the winner.

`mergePair`'s own refusal shape is untouched — `TestDedupeMergeArmKeepsItsOwnRefusal` still pins the bare `ErrConflict`.

## The test asserts the post-condition

Which is the only thing available: injecting a failure between the mark and the merge needs the two to be separable, and that separability is exactly what this removes.

After a refused merge the candidate is `open` **and the ledger carries no merge for it**. The second half is what a compensating re-open could never take back — the audit row was committed before the merge was attempted, so it outlived the refusal.

Splitting the transactions again fails both halves:

```
disposition = "merged", want open — a refused merge left the pair claiming one …
1 audit row(s) record a merge that was refused — the ledger is the record a reviewer reads …
```

## One thing carried along

`docs/reference/gate-inventory.md`'s parity count was one behind a gate that landed without regenerating it. Pre-existing on main and failing every branch, so it rides here rather than blocking this one.

`make check-backend` exit 0; the full `internal/modules/people` integration suite green (96s).