### PR TITLE
A deal nobody has agreed a next step on is one that is slipping

### DIFF
--- a/backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml
@@ -1,0 +1,37 @@
+name: a_stepless_deal_is_a_slipping_deal
+task: agent_loop
+site: loop
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  goal: Which deals have nobody agreed a next step on?
+  trigger_ref: manual:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e21
+  grounding:
+    - source_id: user:0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e0a
+      trust_tier: T1
+      content: acting rep — user_42
+  tools: catalog
+expect:
+  outcome: accepted
+  answer: whats_slipping_this_week
+  rubric: >
+    The goal asks which deals carry no agreed next step, and that is one of the
+    three risk signals whats_slipping_this_week answers — it returns "no open
+    next step on this deal" as evidence beside the momentum reasons. Score high
+    only if the turn calls whats_slipping_this_week; no id is named here and
+    none is needed.
+
+    review_commitments is the near miss, and it is the mirror of the one
+    a_promise_is_not_a_slipping_deal catches. It answers what somebody PROMISED
+    and has not delivered, which is a question about existing open work. This
+    goal asks about deals where no such work exists at all — so a turn taking
+    review_commitments has asked for the very set the goal is defined by the
+    absence of, and would answer confidently with nothing in it.
+
+    The distinction is the point of the pair: one tool reports open promises,
+    the other reports deals with none, and a surface where either answers both
+    is one where a rep cannot tell which they were told.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/slipping.go
+++ b/backend/internal/compose/slipping.go
@@ -127,6 +127,21 @@ func quietDealScan(
 			seen[candidate.DealID] = true
 			out = append(out, candidate)
 		}
+		// Asked once, of the survivors. The sweep's third named signal is an
+		// absence, so it cannot come off the deal rows the two sweeps above
+		// read — and asking it before the filter would pay for deals that are
+		// about to be dropped.
+		ids := make([]ids.UUID, 0, len(out))
+		for _, d := range out {
+			ids = append(ids, d.DealID)
+		}
+		stepless, err := dealsWithNoOpenNextStep(ctx, pool, ids)
+		if err != nil {
+			return nil, false, err
+		}
+		for i := range out {
+			out[i].NoOpenNextStep = stepless[out[i].DealID]
+		}
 		return out, cut, nil
 	}
 }

--- a/backend/internal/compose/slippingnextstep.go
+++ b/backend/internal/compose/slippingnextstep.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Which of a set of deals carries no open next step.
+//
+// The at-risk sweep's goal names three signals — no activity in 14+ days,
+// stakeholders gone quiet, and MISSING NEXT STEPS. The first two had tools that
+// answered them; the third had none, so an agent asked the question the goal
+// told it to ask and got no instrument. It was covered by attaching
+// review_commitments, which answers "what did somebody promise" — a different
+// question, and one that says nothing about a deal nobody has promised anything
+// about.
+//
+// Absence is the answer here, which is why it needs its own read: the deal list
+// carries what a deal HAS, and no field on it says what it lacks.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// dealsWithNoOpenNextStep answers which of the given deals carry none.
+//
+// WHAT COUNTS AS AN OPEN NEXT STEP, decided here because absence has edge cases
+// that decide the answer and this is the kind of predicate that ends up spelled
+// three different ways:
+//
+//   - A task DUE IN THE PAST but still open counts. It is a step somebody
+//     agreed to take and has not; that it is late is a different complaint, and
+//     the sweep's own momentum reasons already carry lateness. Reading an
+//     overdue task as no-step would report "nobody has agreed a next step" about
+//     a deal where somebody plainly did.
+//   - A task ASSIGNED TO SOMEBODY WHO HAS LEFT counts. The deal has a step;
+//     whether its owner is still here is a question about staffing, and
+//     answering it inside this predicate would make one signal quietly report
+//     two.
+//   - A task on the ORGANIZATION rather than the deal does NOT count. This tool
+//     answers about a deal, and a step filed against the account is not a step
+//     on this opportunity — counting it would silence the signal for every deal
+//     at a company where anything at all is open.
+//   - An ARCHIVED task does not count, for the reason every read here excludes
+//     archived rows: it is retired, and a retired step is not a step.
+//
+// One statement over all the candidate ids rather than a probe per deal: the
+// sweep already reads its candidates in two bounded queries, and a third that
+// grew with the set would make the lane's cost quadratic in a page.
+func dealsWithNoOpenNextStep(
+	ctx context.Context, pool *pgxpool.Pool, candidates []ids.UUID,
+) (map[ids.UUID]bool, error) {
+	none := map[ids.UUID]bool{}
+	if len(candidates) == 0 {
+		return none, nil
+	}
+	for _, id := range candidates {
+		none[id] = true
+	}
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT DISTINCT l.deal_id
+			  FROM activity a
+			  JOIN activity_link l ON l.activity_id = a.id
+			 WHERE l.deal_id = ANY($1)
+			   AND a.kind = 'task'
+			   AND a.is_done = false
+			   AND a.archived_at IS NULL`, candidates)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var dealID ids.UUID
+			if err := rows.Scan(&dealID); err != nil {
+				return err
+			}
+			delete(none, dealID)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return none, nil
+}

--- a/backend/internal/modules/agents/tools_slipping.go
+++ b/backend/internal/modules/agents/tools_slipping.go
@@ -39,10 +39,16 @@ type SlippingDeal struct {
 	// second read per deal, and nothing here widens what the list already
 	// showed the caller. Nil where the row carries none (an overlay-mirror
 	// deal has no native stage; a deal can be ownerless).
-	StageID           *ids.UUID
-	OwnerID           *ids.UUID
-	Stalled           bool
-	CloseOverdue      bool
+	StageID      *ids.UUID
+	OwnerID      *ids.UUID
+	Stalled      bool
+	CloseOverdue bool
+	// NoOpenNextStep says the deal carries no open, unarchived task of its
+	// own. It is the sweep's third named signal, and the only one that is an
+	// ABSENCE: what the deal list carries is what a deal has, so this is
+	// answered by its own read (compose.dealsWithNoOpenNextStep, which states
+	// what counts).
+	NoOpenNextStep    bool
 	LastActivityAt    *time.Time
 	CreatedAt         time.Time
 	ExpectedCloseDate *time.Time
@@ -274,6 +280,17 @@ func rankSlipping(candidates []SlippingDeal) []slippingItem {
 			it.evidence = append(it.evidence, SlippingEvidence{
 				Source:  "deal.expected_close_date",
 				Snippet: "expected close " + d.ExpectedCloseDate.UTC().Format("2006-01-02") + " is past due",
+			})
+		}
+		// The one claim grounded in an ABSENCE, so the source names the read
+		// rather than a field: there is no column whose value evidences that
+		// nothing is there. The no-guess gate below still applies — a deal
+		// reaches the answer on this flag alone only because the flag IS the
+		// finding, which the two above are not.
+		if d.NoOpenNextStep {
+			it.evidence = append(it.evidence, SlippingEvidence{
+				Source:  "activity.task",
+				Snippet: "no open next step on this deal",
 			})
 		}
 		if len(it.evidence) == 0 {

--- a/backend/internal/modules/agents/tools_slipping_test.go
+++ b/backend/internal/modules/agents/tools_slipping_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -256,5 +257,53 @@ func TestDraftFollowUpsForRefusesANegativeLimit(t *testing.T) {
 	var bad *BadArgsError
 	if _, err := tool.Handle(context.Background(), json.RawMessage(`{"segment":"slipping","limit":-1}`)); !errors.As(err, &bad) {
 		t.Fatalf("negative limit → %v, want BadArgsError", err)
+	}
+}
+
+// A deal nobody has agreed a next step on comes back, and says so.
+//
+// The sweep's goal names three signals and this was the one with no instrument:
+// an agent asked the question its own goal told it to ask and had nothing to
+// ask it with. It was covered by attaching review_commitments, which answers
+// what somebody PROMISED — and says nothing at all about a deal nobody has
+// promised anything about.
+func TestADealWithNoOpenNextStepIsReportedAsSlipping(t *testing.T) {
+	t.Parallel()
+
+	ranked := rankSlipping([]SlippingDeal{{
+		DealID: ids.NewV7(), Name: "Quiet but stepless", NoOpenNextStep: true,
+		CreatedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	}})
+
+	if len(ranked) != 1 {
+		t.Fatalf("ranked %d deal(s), want 1 — a deal whose only finding is that nothing is "+
+			"agreed on it is exactly the case the goal names and the sweep could not answer",
+			len(ranked))
+	}
+	var said bool
+	for _, e := range ranked[0].evidence {
+		if strings.Contains(e.Snippet, "no open next step") {
+			said = true
+		}
+	}
+	if !said {
+		t.Errorf("the deal came back with evidence %v and never says why — an at-risk answer a "+
+			"reader cannot check is one they have to take on trust", ranked[0].evidence)
+	}
+}
+
+// And the absence does not silently promote a deal that is otherwise fine: a
+// deal WITH an open step and no momentum problem is still dropped.
+func TestADealWithAnOpenNextStepIsNotSlippingOnThatGroundAlone(t *testing.T) {
+	t.Parallel()
+
+	ranked := rankSlipping([]SlippingDeal{{
+		DealID: ids.NewV7(), Name: "Healthy", NoOpenNextStep: false,
+		CreatedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	}})
+
+	if len(ranked) != 0 {
+		t.Errorf("ranked %d deal(s), want 0 — a deal with a step agreed and no momentum problem "+
+			"is not slipping, and reporting it teaches a reader to ignore the lane", len(ranked))
 	}
 }

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -66,7 +66,7 @@
         "whats_slipping_this_week → draft_follow_ups_for",
         "whats_slipping_this_week → run_report"
       ],
-      "temptation_weight": 8
+      "temptation_weight": 9
     }
   ],
   "tool_cost": [
@@ -421,13 +421,17 @@
       "scenarios_naming_it_as_the_wrong_reach": 1
     },
     {
+      "name": "review_commitments",
+      "scenarios_naming_it_as_the_wrong_reach": 1
+    },
+    {
       "name": "send_email",
       "scenarios_naming_it_as_the_wrong_reach": 1
     }
   ],
   "corpus": {
-    "scenarios": 23,
-    "offering_the_whole_catalog": 21,
+    "scenarios": 24,
+    "offering_the_whole_catalog": 22,
     "skipped_by_the_scan": null
   }
 }

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -31,7 +31,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2467 | 7% | 20743 | 15 | 8 |
+| `overnight_at_risk_sweep` | 7 | 2467 | 7% | 20743 | 15 | 9 |
 | _whole served catalog, for scale_ | 73 | 21594 | 65% | — | — | — |
 
 ### `morning_brief`
@@ -106,8 +106,8 @@ times the menu. And lowering it is not always an improvement — adding
 `review_commitments` to the sweep *raises* this count while cutting that agent's
 temptation weight almost in half.
 
-**Temptation weight** sums, over an agent's tools, how many of the 23 certification
-scenarios name that tool as the WRONG reach. 21 of those scenarios offer the model the
+**Temptation weight** sums, over an agent's tools, how many of the 24 certification
+scenarios name that tool as the WRONG reach. 22 of those scenarios offer the model the
 whole catalog and score which tool it picks, so the confusions it names were chosen
 against the real surface rather than guessed.
 
@@ -153,7 +153,7 @@ a term in an addition.
 | `send_message` | 431 | — |
 | `annotate_brief` | 418 | — |
 | `progress_deal` | 404 | 3 scenarios |
-| `review_commitments` | 401 | — |
+| `review_commitments` | 401 | 1 scenario |
 | `book_meeting` | 393 | — |
 | `enrich` | 393 | — |
 | `compose_analytics_report` | 390 | — |

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -5,7 +5,7 @@
     "sites_best_partial": 0,
     "sites_best_stale": 9,
     "sites_absent": 4,
-    "scenarios": 141,
+    "scenarios": 142,
     "records": 59,
     "bindings": 10
   },
@@ -274,6 +274,11 @@
           "file": "backend/internal/compose/aicert/corpus/agent_loop/a_promise_is_not_a_slipping_deal.yaml"
         },
         {
+          "name": "a_stepless_deal_is_a_slipping_deal",
+          "expects": "accepted",
+          "file": "backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml"
+        },
+        {
           "name": "a_structured_question_is_not_a_text_search",
           "expects": "accepted",
           "file": "backend/internal/compose/aicert/corpus/agent_loop/a_structured_question_is_not_a_text_search.yaml"
@@ -374,7 +379,7 @@
           "state": "stale",
           "band": "not_supported",
           "scenarios_measured": 0,
-          "scenarios_total": 23,
+          "scenarios_total": 24,
           "runs": 69,
           "passed": 59,
           "reliability": 0.855072463768116,
@@ -397,7 +402,7 @@
           "state": "stale",
           "band": "not_supported",
           "scenarios_measured": null,
-          "scenarios_total": 23,
+          "scenarios_total": 24,
           "runs": 115,
           "passed": 74,
           "reliability": 0.6434782608695652,
@@ -420,7 +425,7 @@
           "state": "stale",
           "band": "not_supported",
           "scenarios_measured": 0,
-          "scenarios_total": 23,
+          "scenarios_total": 24,
           "runs": 69,
           "passed": 39,
           "reliability": 0.5652173913043478,

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -29,7 +29,7 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | … best state `partial` | 0 |
 | … best state `stale` | 9 |
 | … `absent` on every binding | 4 |
-| Scenarios in the corpus | 141 |
+| Scenarios in the corpus | 142 |
 | Committed records | 59 |
 | Bindings measured | 10 |
 
@@ -81,7 +81,7 @@ Which model to run each site on, and what that choice rests on.
 | Site | Best model tested | Band | Reliability | State | Scenarios | Records |
 |---|---|---|---:|---|---:|---:|
 | [`account_scan/org_scan`](#account_scanorg_scan) | - | - | - | `absent` | 2 | 0 |
-| [`agent_loop/loop`](#agent_looploop) | - | - | - | `stale` | 23 | 3 |
+| [`agent_loop/loop`](#agent_looploop) | - | - | - | `stale` | 24 | 3 |
 | [`brief_ranking/rank`](#brief_rankingrank) | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
 | [`capture_classify/classify`](#capture_classifyclassify) | - | - | - | `stale` | 5 | 3 |
 | [`capture_confidentiality_verdict/thread`](#capture_confidentiality_verdictthread) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 8 | 2 |
@@ -239,7 +239,7 @@ Certified without the company context production prepends (`identity`, `position
 
 Scope a run of it can claim: `single_turn`.
 
-Scenarios (23):
+Scenarios (24):
 
 | Scenario | Expects | Case |
 |---|---|---|
@@ -248,6 +248,7 @@ Scenarios (23):
 | `a_goal_no_tool_can_serve_ends_the_turn` | `accepted` | [a_goal_no_tool_can_serve_ends_the_turn.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_goal_no_tool_can_serve_ends_the_turn.yaml) |
 | `a_name_alone_is_still_a_search` | `accepted` | [a_name_alone_is_still_a_search.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_name_alone_is_still_a_search.yaml) |
 | `a_promise_is_not_a_slipping_deal` | `accepted` | [a_promise_is_not_a_slipping_deal.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_promise_is_not_a_slipping_deal.yaml) |
+| `a_stepless_deal_is_a_slipping_deal` | `accepted` | [a_stepless_deal_is_a_slipping_deal.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml) |
 | `a_structured_question_is_not_a_text_search` | `accepted` | [a_structured_question_is_not_a_text_search.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_structured_question_is_not_a_text_search.yaml) |
 | `a_thin_relationship_is_not_a_slipping_deal` | `accepted` | [a_thin_relationship_is_not_a_slipping_deal.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_thin_relationship_is_not_a_slipping_deal.yaml) |
 | `a_total_is_still_a_report` | `accepted` | [a_total_is_still_a_report.yaml](../../backend/internal/compose/aicert/corpus/agent_loop/a_total_is_still_a_report.yaml) |
@@ -271,9 +272,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/23 | `not_supported` | 69 | 59 | 0.86 | 955ms | 1314ms | 59 | 10 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/24 | `not_supported` | 69 | 59 | 0.86 | 955ms | 1314ms | 59 | 10 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `not_supported` | 115 | 74 | 0.64 | 1804ms | 2954ms | 74 | 40 | 1 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/23 | `not_supported` | 69 | 39 | 0.57 | 7242ms | 39483ms | 39 | 19 | 11 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/24 | `not_supported` | 69 | 39 | 0.57 | 7242ms | 39483ms | 39 | 19 | 11 | 0 |
 
 ### `brief_ranking`
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (90)
+## Parity (91)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #2403. Implements the ruling recorded on the ticket.

## The gap

`overnight_at_risk_sweep`'s goal names three risk signals:

> *"find deals with no activity in 14+ days, stakeholders gone quiet, or **missing next steps**"*

Two had tools that answered them. The third had none — so an agent asked the question its own goal told it to ask and had no instrument for it. The stopgap was attaching `review_commitments`, which answers what somebody **promised** and has not delivered. That says nothing at all about a deal nobody has promised anything about, which is precisely the set this signal is defined by.

## Absence is the answer, so it needs its own read

`whats_slipping_this_week` now returns *"no open next step on this deal"* beside the momentum reasons. It is the only one of the three grounded in an **absence**, and that is why it cannot come off the deal rows the sweep already reads: what the deal list carries is what a deal *has*, and no field on it says what it lacks.

One statement over the surviving candidate ids, asked after the filter — a probe per deal would make the lane's cost quadratic in a page, and asking before the filter would pay for deals about to be dropped.

## What counts, decided rather than inherited

The ruling asks for the definition to live where the SQL is, because absence has edge cases that decide the answer. Each is picked and written down:

| case | counts as a step? | why |
|---|---|---|
| a task **due in the past**, still open | **yes** | somebody agreed to take it and has not; that it is late is a different complaint, and the momentum reasons already carry lateness. Reading it as no-step reports *"nobody agreed a next step"* about a deal where somebody plainly did |
| a task **owned by somebody who has left** | **yes** | the deal has a step; whether its owner is still here is a staffing question, and answering it inside this predicate makes one signal quietly report two |
| a task on the **organization**, not the deal | **no** | this tool answers about a deal. Counting it silences the signal for every deal at a company where anything at all is open |
| an **archived** task | **no** | retired, and a retired step is not a step |

## The corpus scenario is the mirror of an existing one

`a_stepless_deal_is_a_slipping_deal.yaml` sits opposite `a_promise_is_not_a_slipping_deal.yaml`, and the pair is the point: one tool reports open promises, the other reports deals with none. Its near-miss section names `review_commitments` for the reason that makes it wrong here — a turn taking it asks for the very set the goal is defined by the absence of, and answers confidently with nothing in it.

`review_commitments` stays attached and unchanged. It answers a different question and attaching it was the right stopgap.

## Tests

Mutation-checked: with the absence dropped as a reason, `ADealWithNoOpenNextStepIsReportedAsSlipping` fails — *"ranked 0 deal(s), want 1"*. The companion case holds the other direction, so the new reason cannot quietly promote a deal that is fine.

## Checks

`make check-backend` green (exit 0). Both goldens regenerated in this commit — the certification page (142 scenarios) and the agent tool budget.