### PR TITLE
A room's steward has to be somebody who can answer

### DIFF
--- a/backend/gates/livemember_test.go
+++ b/backend/gates/livemember_test.go
@@ -79,6 +79,7 @@ var cannotReachIdentity = gatekit.Waive(map[string]string{
 	"internal/modules/activities/audience.go":        "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/activities/assignee.go":        "activities cannot import identity (ADR-0054 §3); the predicate must move tier first. This one asks a second question of the same row — whether the seat is an agent — which identity.LiveMemberSQL does not answer and which the assignee refusal is entirely about",
 	"internal/modules/dealrooms/store_public.go":     "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/dealrooms/room_write.go":       "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first. It arrived here from namesTheSeatRatherThanOffersIt, where it did NOT belong: a steward is somebody a buyer is pointed at for help, so the seat is being offered rather than named, and the entry was recording the defect (a deactivated colleague could be one) instead of a reason. Fixed in issue 2596",
 	"internal/modules/capture/owneridentitystore.go": "capture cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/people/counterpartyname.go":    "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
 	"internal/modules/people/leadrouting.go":         "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
@@ -126,7 +127,6 @@ var deliberatelyNotLiveness = gatekit.Waive(map[string]string{
 // here on a guess — and it stays listed so it reads as open rather than settled.
 var namesTheSeatRatherThanOffersIt = gatekit.Waive(map[string]string{
 	"internal/modules/dealrooms/preview.go":      "renders a steward's name and address on a room that already exists; a departed colleague's name is still the right label on what they did",
-	"internal/modules/dealrooms/room_write.go":   "DEFECT, not a decision: a deactivated seat can be a new room's steward. Product call on who may be one, so it is issue 2596",
 	"internal/modules/identity/access.go":        "UserAccess evaluates an EXISTING member's roles and teams as they stand, which an admin needs precisely when the seat is deactivated",
 	"internal/modules/identity/actoridentity.go": "resolves the display name and address of whoever performed a past action; the actor of an audit row does not stop having a name",
 	"internal/modules/identity/seatnames.go":     "answers \"what is this id called\" for ids the caller already holds; a name that blanks on deactivation makes historical rows unreadable",

--- a/backend/internal/compose/integration/dealroomsteward_integration_test.go
+++ b/backend/internal/compose/integration/dealroomsteward_integration_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Who a buyer can be pointed at for help.
+//
+// A room without a steward is a real state the schema admits, repaired by
+// transferring one. A steward who EXISTS BUT CANNOT ACT is worse: the room
+// looks staffed, so a buyer waits on somebody whose access was withdrawn and
+// nothing prompts anyone to transfer it. Absence is at least visible.
+//
+// The old check asked only `archived_at IS NULL`, which admits the ordinary
+// shape of somebody who has left — deactivated, not archived.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/dealrooms"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// deactivate withdraws a colleague's access without archiving the record — the
+// shape a seat takes when somebody leaves.
+func deactivate(t *testing.T, e *Env, user ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.As(e.AdminUser, nil, roomStewardAdmin), e.DB().Pool(),
+		func(tx pgx.Tx) error {
+			_, err := tx.Exec(context.Background(),
+				`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, user)
+			return err
+		}); err != nil {
+		t.Fatalf("deactivating the colleague: %v", err)
+	}
+}
+
+// own gives the deal an owner, which the fixture seeder does not.
+func own(t *testing.T, e *Env, deal, user ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.As(e.AdminUser, nil, roomStewardAdmin), e.DB().Pool(),
+		func(tx pgx.Tx) error {
+			_, err := tx.Exec(context.Background(),
+				`UPDATE deal SET owner_id = $2 WHERE id = $1`, deal, user)
+			return err
+		}); err != nil {
+		t.Fatalf("giving the deal an owner: %v", err)
+	}
+}
+
+func TestARoomRefusesADeactivatedColleagueTheCallerNamed(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.AdminUser, nil, roomStewardAdmin)
+	dealID := e.SeedWonDealLinkedTo(t)
+	deactivate(t, e, e.Rep1)
+
+	steward := ids.From[ids.UserKind](e.Rep1)
+	_, err := dealrooms.NewStore(e.DB()).CreateRoom(ctx, dealrooms.CreateRoomInput{
+		DealID: ids.From[ids.DealKind](dealID), Title: "Acme — Deal Room",
+		StewardUserID: &steward, Source: "ui",
+	})
+
+	if err == nil {
+		t.Fatal("a room opened with a deactivated colleague as its steward: the room looks staffed " +
+			"and the buyer is pointed at somebody whose access was withdrawn")
+	}
+	// The refusal must be ABOUT THE STEWARD. A seat missing a grant fails this
+	// call too, and a case that accepted any error would pass without the fix
+	// ever running — which is how a test comes to certify nothing.
+	if !strings.Contains(err.Error(), "steward") {
+		t.Fatalf("the room was refused for some other reason: %v", err)
+	}
+	// Refused rather than silently dropped: the caller CHOSE this person, and
+	// telling them is what lets them choose again. The refusal must not read as
+	// a missing DEAL, which sends them looking in the wrong place.
+	if errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("the refusal reads as a missing deal rather than an ineligible steward: %v", err)
+	}
+}
+
+// A DEAL OWNER who has been deactivated is a different case: nobody made a
+// mistake in this request, so the room opens with no steward rather than being
+// refused over a staffing change.
+func TestARoomOpensWithNoStewardWhenTheDealsOwnerHasBeenDeactivated(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.AdminUser, nil, roomStewardAdmin)
+	dealID := e.SeedWonDealLinkedTo(t)
+	// The seeder leaves the deal unowned, and an unowned deal reads as "no
+	// steward" whatever this function does — so the case would pass over the
+	// defect it is named for. The owner is what makes it a case at all.
+	own(t, e, dealID, e.Rep1)
+	deactivate(t, e, e.Rep1)
+
+	room, err := dealrooms.NewStore(e.DB()).CreateRoom(ctx, dealrooms.CreateRoomInput{
+		DealID: ids.From[ids.DealKind](dealID), Title: "Acme — Deal Room", Source: "ui",
+	})
+	if err != nil {
+		t.Fatalf("opening a room on a deal whose owner has left: %v — refusing here blocks a room "+
+			"over a staffing change, which is the outcome the function's own doc rejects", err)
+	}
+	if room.StewardUserId != nil {
+		t.Errorf("the room named %v as its steward, and that seat cannot act — no steward is the "+
+			"honest answer, and it is the one somebody can see and repair", *room.StewardUserId)
+	}
+}
+
+// roomStewardAdmin is the seat that opens a room.
+var roomStewardAdmin = principal.Permissions{
+	RoleKeys: []string{"admin"},
+	Objects: map[string]principal.ObjectGrant{
+		"deal":      {Create: true, Read: true, Update: true},
+		"deal_room": {Create: true, Read: true, Update: true},
+	},
+	RowScope: principal.RowScopeAll,
+}

--- a/backend/internal/modules/dealrooms/errors.go
+++ b/backend/internal/modules/dealrooms/errors.go
@@ -147,11 +147,16 @@ var errRoomAlreadyOpen = &messageError{
 	msg:  "this deal already has an active Deal Room: archive it before opening another",
 }
 
-// errStewardUnknown refuses a steward nobody can be pointed at.
+// errStewardUnknown refuses a steward nobody can be pointed at — an id no seat
+// carries, and one whose seat cannot act.
+//
+// One refusal for both, because they are one answer to the caller: the person
+// they named cannot be contacted for help. Telling them WHICH would say whether
+// a given id belongs to a colleague, on an input a caller supplies freely.
 var errStewardUnknown = &fieldError{
 	field: "steward_user_id",
 	code:  "unknown_user",
-	msg:   "no live user with that id: the steward is the person a buyer contacts for help",
+	msg:   "no active user with that id: the steward is the person a buyer contacts for help",
 }
 
 // errAlreadyInvited refuses a second live seat for one address. It names

--- a/backend/internal/modules/dealrooms/room_write.go
+++ b/backend/internal/modules/dealrooms/room_write.go
@@ -127,15 +127,26 @@ func createRoomTx(ctx context.Context, tx pgx.Tx, in CreateRoomInput, by string)
 // failure. The room is still created: a room without a steward is a real state
 // the schema admits (the column is nullable and a deleted user nulls it), and
 // it is repaired by transferring one rather than by refusing to open the room.
+//
+// ELIGIBLE means live AND active, not merely un-archived. A deactivated seat is
+// worse than no steward: the room LOOKS staffed, so a buyer waits on somebody
+// who cannot answer and nobody is prompted to transfer it. Absence is at least
+// visible.
+//
+// The two paths answer a deactivated seat differently, and the difference is
+// whose mistake it is. A steward the caller NAMED is refused — they chose a
+// person who cannot act, and telling them so is what lets them choose again.
+// A deal OWNER who has been deactivated is not a mistake anybody made in this
+// request, so it reads as no steward and the room opens without one; refusing
+// there would block opening a room over a staffing change, which is the outcome
+// this function's own doc rejects.
 func resolveSteward(ctx context.Context, tx pgx.Tx, in CreateRoomInput) (ids.UserID, bool, error) {
 	if in.StewardUserID != nil {
-		var exists bool
-		if err := tx.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM app_user WHERE id = $1 AND archived_at IS NULL)`,
-			in.StewardUserID).Scan(&exists); err != nil {
-			return ids.UserID{}, false, fmt.Errorf("check steward: %w", err)
+		eligible, err := stewardIsEligible(ctx, tx, *in.StewardUserID)
+		if err != nil {
+			return ids.UserID{}, false, err
 		}
-		if !exists {
+		if !eligible {
 			return ids.UserID{}, false, errStewardUnknown
 		}
 		return *in.StewardUserID, true, nil
@@ -151,7 +162,39 @@ func resolveSteward(ctx context.Context, tx pgx.Tx, in CreateRoomInput) (ids.Use
 	if owner == nil {
 		return ids.UserID{}, false, nil
 	}
-	return ids.From[ids.UserKind](*owner), true, nil
+	ownerID := ids.From[ids.UserKind](*owner)
+	eligible, err := stewardIsEligible(ctx, tx, ownerID)
+	if err != nil {
+		return ids.UserID{}, false, err
+	}
+	if !eligible {
+		return ids.UserID{}, false, nil
+	}
+	return ownerID, true, nil
+}
+
+// stewardIsEligible reports whether a seat can actually be pointed a buyer at.
+//
+// Both halves, and neither implies the other: `archived_at` retires the record,
+// `status` retires the person's access. A seat deactivated but not archived is
+// the ordinary shape of somebody who has left, and it is exactly the one the
+// old existence check admitted.
+//
+// This is identity.LiveMemberSQL's predicate, spelled here character for
+// character because a module never imports a sibling (ADR-0054 §3) and identity
+// owns app_user. The employment-currency gate's twin of this problem was
+// settled by moving the definition to a tier everything can reach; if a second
+// module ever needs this one, that is the move rather than a third copy.
+func stewardIsEligible(ctx context.Context, tx pgx.Tx, user ids.UserID) (bool, error) {
+	var eligible bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+		     SELECT 1 FROM app_user
+		      WHERE id = $1 AND status = 'active' AND archived_at IS NULL)`,
+		user).Scan(&eligible); err != nil {
+		return false, fmt.Errorf("check steward: %w", err)
+	}
+	return eligible, nil
 }
 
 // UpdateRoom edits the room's title and welcome message — the words a buyer

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (90)
+## Parity (91)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Closes #2596. Implements the ruling recorded on the ticket.

## The hole

`resolveSteward` asked `archived_at IS NULL` and nothing else, which admits the ordinary shape of somebody who has left: **deactivated, not archived**.

The ticket puts the cost better than I can:

> a room without one is a real state the schema admits, and it is repaired by transferring one rather than by refusing to open the room. **A steward who exists but cannot act is the case it does not cover, and it is worse than no steward: the room looks staffed.**

A buyer waits on somebody whose access was withdrawn, and nothing prompts anyone to transfer it. Absence is at least visible.

## Both paths, answered differently on purpose

The ruling is about the steward a caller names; the deal-owner fallback had the same hole. They do not get the same answer, and the difference is **whose mistake it is**:

- A steward the caller **named** is refused. They chose a person who cannot act, and telling them is what lets them choose again.
- A deal **owner** who has been deactivated is nobody's mistake in this request, so it reads as *no steward* and the room opens without one. Refusing there would block opening a room over a staffing change — the outcome this function's own doc already rejects.

`errStewardUnknown` covers both an unknown id and an ineligible seat, and says why: distinguishing them would tell a caller whether a given id belongs to a colleague, on an input they supply freely.

## One spelling, and its waiver moved to the map that fits

The predicate is `identity.LiveMemberSQL`'s, spelled here character for character because a module never imports a sibling and `identity` owns `app_user`. `TestOnlyOneSpellingOfALiveMember` caught this immediately — which is the gate working.

Its waiver for this file sat in **`namesTheSeatRatherThanOffersIt`**, which is the opposite of what a steward is: a steward is somebody a buyer is *pointed at for help*, so the seat is being offered. The entry was also recording the defect rather than a reason — *"DEFECT, not a decision: a deactivated seat can be a new room's steward"*. It moves to `cannotReachIdentity` with the reason its neighbours carry, and the new entry says where it came from so the next reader is not puzzled by the move.

## Tests, and the one that was vacuous

Two integration cases, one per path. Mutations verified, each restored:

| mutation | fails |
|---|---|
| back to the existence check | `ARoomRefusesADeactivatedColleagueTheCallerNamed` |
| the owner path stops checking eligibility | `ARoomOpensWithNoStewardWhenTheDealsOwnerHasBeenDeactivated` |

The second only became a real case after a fix to the **test**: the fixture seeder leaves the deal unowned, and an unowned deal reads as "no steward" whatever the code does — so the first version passed under its own mutation. It now gives the deal an owner first, and says in the comment why that line is load-bearing.

The first case had the same shape of problem: it asserted only that *some* error came back, which a missing `deal_room` grant also satisfies. It now requires the refusal to be about the steward.

## Checks

`make check-backend` green (exit 0). `make test-it DIR=backend/internal/compose/integration RUN=…` green for both cases.