### PR TITLE
The per-field rail names the person too

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -35072,6 +35072,17 @@ components:
         changed_at: { type: string, format: date-time }
         actor_type: { type: string, enum: [human, agent, system, connector, buyer] }
         actor_id: { type: string }
+        actor_name:
+          type: [string, 'null']
+          description: |
+            The actor's display name, resolved from `app_user` on the read path
+            (PD-002) — the same resolution `/audit-log` and the record history
+            do, so two rails on one screen name the same person the same way.
+            Present only for a human actor: agent, connector and system ids name
+            a machine, and their human authority is `on_behalf_of_name`. Null
+            when no user row resolves — a deactivated or deleted member still has
+            audit rows, and an honest identifier is better than an invented name.
+        on_behalf_of_name: { type: [string, 'null'], description: Resolved display name for the human whose authority a machine acted under. }
         passport_id: { type: [string, 'null'], format: uuid, description: Agent Seat Passport that authorized the change; present for agent actors only. }
         evidence: { type: [object, 'null'], additionalProperties: true, description: Grounding evidence for an agent-authored change; present for agent actors only. }
         undid_audit_log_id:

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -41,6 +42,8 @@ type fieldHistoryEntryWire struct {
 	ChangedAt  string         `json:"changed_at"`
 	ActorType  string         `json:"actor_type"`
 	ActorID    string         `json:"actor_id"`
+	ActorName  *string        `json:"actor_name"`
+	OnBehalfOf *string        `json:"on_behalf_of_name"`
 	PassportID *string        `json:"passport_id"`
 	Evidence   map[string]any `json:"evidence"`
 }
@@ -103,6 +106,43 @@ func fieldHistoryHTTPEnv(t *testing.T, e *apptest.AppEnv) *Env {
 	return &Env{Pool: pool, WS: ws}
 }
 
+// seedHumanFieldHistoryRow seeds a human-actor diff against a REAL seat.
+//
+// The shared seeder writes a placeholder actor id, which is fine where the
+// actor is only a discriminator. It is not fine here: the name resolution this
+// rail now does joins app_user on the 'human:' || id key the writer actually
+// produces, so a made-up id would exercise the join against a shape no write
+// makes and report a null name as correct.
+func seedHumanFieldHistoryRow(t *testing.T, app *apptest.AppEnv, e *Env, entityID ids.UUID,
+	before, after map[string]any, occurredAt time.Time,
+) {
+	t.Helper()
+	var seat ids.UUID
+	// identity.LiveMemberSQL rather than the pair spelled out here. Both halves
+	// matter — deactivating sets status and leaves archived_at NULL, so either
+	// alone picks a seat the workspace does not have — and identity owns what
+	// "still works here" means. A fixture attributing an audit row to a departed
+	// colleague would test the name resolution against a state no write produces.
+	if err := app.Owner.QueryRow(context.Background(),
+		`SELECT id FROM app_user WHERE `+identity.LiveMemberSQL("")+
+			` ORDER BY created_at LIMIT 1`).
+		Scan(&seat); err != nil {
+		t.Fatalf("reading the workspace's own seat: %v", err)
+	}
+	beforeJSON, afterJSON := auditImageJSON(t, before), auditImageJSON(t, after)
+	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO audit_log (id, actor_type, actor_id, action,
+			                        entity_type, entity_id, before, after, occurred_at)
+			 VALUES ($1, 'human', $2, 'update', 'person', $3, $4, $5, $6)`,
+			ids.NewV7(), "human:"+seat.String(), entityID, beforeJSON, afterJSON, occurredAt)
+		return err
+	}); err != nil {
+		t.Fatalf("seed human audit row: %v", err)
+	}
+}
+
 // seedAgentFieldHistoryRow seeds an agent-actor audit diff row carrying a
 // passport id and evidence — the one shape seedAuditDiffRow cannot
 // produce (it never binds those two columns) and the only shape that
@@ -162,7 +202,7 @@ func seedFieldHistoryHTTPFixture(t *testing.T, e *apptest.AppEnv, dbEnv *Env) fi
 	// (fieldhistory_integration_test.go's own convention).
 	humanAt := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Microsecond)
 	agentAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Microsecond)
-	seedAuditDiffRow(t, dbEnv, "person", personID, "human",
+	seedHumanFieldHistoryRow(t, e, dbEnv, personID,
 		map[string]any{"title": "VP"}, map[string]any{"title": "CTO"}, humanAt)
 
 	passportID := ids.NewV7()
@@ -205,12 +245,30 @@ func assertFieldHistoryHappyPath(t *testing.T, e *apptest.AppEnv, fx fieldHistor
 		t.Errorf("agent entry evidence = %v, want the seeded evidence map", newest.Evidence)
 	}
 
+	// A MACHINE ACTOR NAMES NO HUMAN, which is the honest half: the id is a
+	// passport, not a person, and the human behind it rides on_behalf_of_name.
+	if newest.ActorName != nil {
+		t.Errorf("agent entry actor_name = %q, want null — the actor is a machine "+
+			"and naming it as a person is the confusion PD-002 is about", *newest.ActorName)
+	}
+
 	var sawHumanTitle bool
 	for _, en := range page.Data {
 		if en.Field == "title" && en.ActorType == "human" {
 			sawHumanTitle = true
 			if en.PassportID != nil || en.Evidence != nil {
 				t.Errorf("human entry carries passport/evidence, want both absent: %+v", en)
+			}
+			// THE POINT OF THIS CHANGE. This rail renders beside the record
+			// timeline on one screen, and until now it resolved no name at all
+			// — so two adjacent rails disagreed about whether attribution names
+			// anybody. The id was accurate and unreadable.
+			if en.ActorName == nil {
+				t.Errorf("human entry actor_name is null — the rail still shows a raw id "+
+					"beside a record-history row that names the person: %+v", en)
+			} else if *en.ActorName == "" {
+				t.Errorf("human entry actor_name is empty — absent and blank are different " +
+					"answers, and a blank one renders as a person with no name")
 			}
 		}
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -23047,7 +23047,16 @@ type ExtractedFieldConfidence string
 // the same mutation share it. `old_value`/`new_value` are display-form strings; null means
 // the empty/created origin.
 type FieldHistoryEntry struct {
-	ActorId    string                      `json:"actor_id"`
+	ActorId string `json:"actor_id"`
+
+	// ActorName The actor's display name, resolved from `app_user` on the read path
+	// (PD-002) — the same resolution `/audit-log` and the record history
+	// do, so two rails on one screen name the same person the same way.
+	// Present only for a human actor: agent, connector and system ids name
+	// a machine, and their human authority is `on_behalf_of_name`. Null
+	// when no user row resolves — a deactivated or deleted member still has
+	// audit rows, and an honest identifier is better than an invented name.
+	ActorName  *string                     `json:"actor_name,omitempty"`
 	ActorType  FieldHistoryEntryActorType  `json:"actor_type"`
 	ChangedAt  time.Time                   `json:"changed_at"`
 	EntityId   openapi_types.UUID          `json:"entity_id"`
@@ -23059,6 +23068,9 @@ type FieldHistoryEntry struct {
 	Id       openapi_types.UUID      `json:"id"`
 	NewValue *string                 `json:"new_value,omitempty"`
 	OldValue *string                 `json:"old_value,omitempty"`
+
+	// OnBehalfOfName Resolved display name for the human whose authority a machine acted under.
+	OnBehalfOfName *string `json:"on_behalf_of_name,omitempty"`
 
 	// PassportId Agent Seat Passport that authorized the change; present for agent actors only.
 	PassportId *openapi_types.UUID `json:"passport_id,omitempty"`

--- a/backend/internal/modules/privacy/fieldhistory.go
+++ b/backend/internal/modules/privacy/fieldhistory.go
@@ -48,8 +48,14 @@ type FieldHistoryEntry struct {
 	ChangedAt  time.Time
 	ActorType  string
 	ActorID    string
-	PassportID *ids.UUID
-	Evidence   map[string]any
+	// ActorName and OnBehalfOfName are the resolved humans behind the row
+	// (PD-002): who acted, and whose authority a machine acted under. Nil where
+	// no user row resolves — a deactivated or deleted member still has audit
+	// rows, and an honest identifier beats an invented name.
+	ActorName      *string
+	OnBehalfOfName *string
+	PassportID     *ids.UUID
+	Evidence       map[string]any
 	// UndidAuditLogID is the entry this one REVERSES — the same link the record
 	// spine carries, because this projection is interleaved into the same
 	// chronology and a reversal reads as a fresh change on either of them.
@@ -327,10 +333,15 @@ func latestScrubTombstone(ctx context.Context, tx pgx.Tx, entityType string, ent
 // and the has-more probe build on it, so the two can never disagree on
 // which rows are projectable.
 func fieldHistorySpineWhere(f FieldHistoryFilter, boundary scrubBoundary, args []any) ([]string, []any) {
-	conds := []string{"entity_type = $1", "entity_id = $2", "action = ANY($3)"}
+	// QUALIFIED with the audit row's alias, because the batch read below joins
+	// app_user twice to resolve the actor's name and `id` is a column on both.
+	// Unqualified it is ambiguous, and Postgres refuses the statement rather
+	// than guessing — which is the good outcome, but only if the qualification
+	// is here where both readers share it.
+	conds := []string{"a.entity_type = $1", "a.entity_id = $2", "a.action = ANY($3)"}
 	args = append(args, f.EntityType, f.EntityID, fieldHistoryProjectedActionList)
 	if boundary.exists() {
-		conds = append(conds, fmt.Sprintf("(occurred_at, id) > ($%d, $%d)", len(args)+1, len(args)+2))
+		conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) > ($%d, $%d)", len(args)+1, len(args)+2))
 		args = append(args, boundary.occurredAt, boundary.id)
 	}
 	return conds, args
@@ -344,15 +355,21 @@ func queryFieldHistoryBatch(ctx context.Context, tx pgx.Tx, f FieldHistoryFilter
 ) ([]auditDiffRow, int, error) {
 	conds, args := fieldHistorySpineWhere(f, boundary, nil)
 	if useCursor {
-		conds = append(conds, fmt.Sprintf("(occurred_at, id) < ($%d, $%d)", len(args)+1, len(args)+2))
+		conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) < ($%d, $%d)", len(args)+1, len(args)+2))
 		args = append(args, cursorTime, cursorID)
 	}
 	args = append(args, fieldHistoryScanBatch)
+	// auditActorNameJoins, the SAME spelling the compliance log and the record
+	// timeline resolve attribution through. Two rails on one screen answering
+	// "who did this" differently is how a reader comes to trust one and doubt
+	// the other, and this was the rail that named nobody.
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT id, action, actor_type, actor_id, passport_id, evidence, occurred_at, before, after
-		FROM audit_log
+		SELECT a.id, a.action, a.actor_type, a.actor_id, a.passport_id, a.evidence,
+		       a.occurred_at, a.before, a.after,
+		       actor_user.display_name, obo.display_name
+		FROM audit_log a`+auditActorNameJoins+`
 		WHERE %s
-		ORDER BY occurred_at DESC, id DESC
+		ORDER BY a.occurred_at DESC, a.id DESC
 		LIMIT $%d`, strings.Join(conds, " AND "), len(args)), args...)
 	if err != nil {
 		return nil, 0, err
@@ -364,7 +381,8 @@ func queryFieldHistoryBatch(ctx context.Context, tx pgx.Tx, f FieldHistoryFilter
 		var r auditDiffRow
 		var evidenceJSON, beforeJSON, afterJSON []byte
 		if err := rows.Scan(&r.id, &r.action, &r.actorType, &r.actorID, &r.passportID,
-			&evidenceJSON, &r.occurredAt, &beforeJSON, &afterJSON); err != nil {
+			&evidenceJSON, &r.occurredAt, &beforeJSON, &afterJSON,
+			&r.actorName, &r.onBehalfOfName); err != nil {
 			return nil, 0, err
 		}
 		r.entityType, r.entityID = f.EntityType, f.EntityID
@@ -414,11 +432,13 @@ func hasFollowingAuditRow(ctx context.Context, tx pgx.Tx, f FieldHistoryFilter,
 	cursorTime time.Time, cursorID ids.UUID, boundary scrubBoundary,
 ) (bool, error) {
 	conds, args := fieldHistorySpineWhere(f, boundary, nil)
-	conds = append(conds, fmt.Sprintf("(occurred_at, id) < ($%d, $%d)", len(args)+1, len(args)+2))
+	conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) < ($%d, $%d)", len(args)+1, len(args)+2))
 	args = append(args, cursorTime, cursorID)
 	var exists bool
+	// Aliased to match the shared WHERE above; this read joins nothing, so the
+	// alias costs it only the two letters.
 	err := tx.QueryRow(ctx, fmt.Sprintf(`
-		SELECT EXISTS(SELECT 1 FROM audit_log WHERE %s)`,
+		SELECT EXISTS(SELECT 1 FROM audit_log a WHERE %s)`,
 		strings.Join(conds, " AND ")), args...).Scan(&exists)
 	return exists, err
 }

--- a/backend/internal/modules/privacy/fieldhistorydiff.go
+++ b/backend/internal/modules/privacy/fieldhistorydiff.go
@@ -73,9 +73,15 @@ type auditDiffRow struct {
 	// image itself surfaces for agent actors only and the link must surface for
 	// every actor — a restore's actor is a human.
 	undidAuditLogID *ids.UUID
-	occurredAt      time.Time
-	before          map[string]any
-	after           map[string]any
+	// actorName and onBehalfOfName are the two display names every audit read
+	// in this package owes its reader: the human who acted, and the human whose
+	// authority a machine acted under. Nil where the actor is not a human, or
+	// the member is gone — no name is honest where an invented one would not be.
+	actorName      *string
+	onBehalfOfName *string
+	occurredAt     time.Time
+	before         map[string]any
+	after          map[string]any
 }
 
 // diffAuditRowFields projects one audit row into per-field entries:
@@ -149,6 +155,8 @@ func makeFieldHistoryEntry(row auditDiffRow, field string, oldValue, newValue *s
 		ChangedAt:       row.occurredAt,
 		ActorType:       row.actorType,
 		ActorID:         row.actorID,
+		ActorName:       row.actorName,
+		OnBehalfOfName:  row.onBehalfOfName,
 		PassportID:      passportID,
 		Evidence:        evidence,
 		UndidAuditLogID: row.undidAuditLogID,

--- a/backend/internal/modules/privacy/handlers_fieldhistory.go
+++ b/backend/internal/modules/privacy/handlers_fieldhistory.go
@@ -81,6 +81,11 @@ func fieldHistoryEntryToWire(e FieldHistoryEntry) crmcontracts.FieldHistoryEntry
 		ChangedAt:  e.ChangedAt,
 		ActorType:  crmcontracts.FieldHistoryEntryActorType(e.ActorType),
 		ActorId:    e.ActorID,
+		// Nil passes through as nil rather than as an empty string: a member
+		// who is gone has no name, and "" would render as one that is blank
+		// instead of one that is absent.
+		ActorName:      e.ActorName,
+		OnBehalfOfName: e.OnBehalfOfName,
 	}
 	if e.PassportID != nil {
 		id := openapi_types.UUID(*e.PassportID)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -25645,6 +25645,18 @@ export interface components {
             actor_type: "human" | "agent" | "system" | "connector" | "buyer";
             actor_id: string;
             /**
+             * @description The actor's display name, resolved from `app_user` on the read path
+             *     (PD-002) — the same resolution `/audit-log` and the record history
+             *     do, so two rails on one screen name the same person the same way.
+             *     Present only for a human actor: agent, connector and system ids name
+             *     a machine, and their human authority is `on_behalf_of_name`. Null
+             *     when no user row resolves — a deactivated or deleted member still has
+             *     audit rows, and an honest identifier is better than an invented name.
+             */
+            actor_name?: string | null;
+            /** @description Resolved display name for the human whose authority a machine acted under. */
+            on_behalf_of_name?: string | null;
+            /**
              * Format: uuid
              * @description Agent Seat Passport that authorized the change; present for agent actors only.
              */

--- a/frontend/src/screens/historyfields.tsx
+++ b/frontend/src/screens/historyfields.tsx
@@ -100,7 +100,15 @@ function ChangeWho({ change }: Readonly<{ change: FieldHistoryEntry }>) {
   const viewerId = useViewerId();
   return (
     <span className="who t-caption">
-      <ProvenanceTag provenance={provenanceOfEntry(change, viewerId)} />
+      <ProvenanceTag
+        provenance={provenanceOfEntry(change, viewerId)}
+        // Handed in for the same reason the record rail hands it in: the design
+        // system has no record lookups, so a resolved name only reaches the chip
+        // if the caller passes it. Without this the two rails render side by
+        // side on one screen and only one of them names anybody — which is what
+        // teaches a reader that attribution here is unreliable.
+        renderUser={() => change.actor_name}
+      />
       <ChangeGrounding change={change} />
     </span>
   );


### PR DESCRIPTION
Closes #1969.

Third audit read surface with the PD-002 defect, and the last. The compliance log and the record timeline resolve the human behind a row; this one returned `actor_type` and `actor_id` and nothing else.

The frontend maps a machine actor to `agent:<passport uuid>` and a human to *"typed by a person"* with no name. So on **one screen** — where the field rail renders beside the record timeline — two adjacent rails disagreed about whether attribution names anybody. No data was wrong; the ids were accurate and unreadable.

## One spelling

It resolves through `auditActorNameJoins`, the *same* helper the other two use. Two surfaces answering "who did this" differently is how a reader comes to trust one and doubt the other — a second join written here would be the drift that helper's comment exists against.

## The shared WHERE is qualified

The one thing the join forced. It brings `app_user` in twice and `id` is a column on both, so unqualified conditions are ambiguous and Postgres refuses the statement — the good outcome, but only if the qualification lives where both readers share it. Done in `fieldHistorySpineWhere` rather than at one call site; the exists-probe alias costs it two letters and nothing else.

## The fixture seeded a human nobody could resolve

The shared audit seeder writes a placeholder actor id. That is fine where the actor is only a discriminator — it is **not** fine for a test of name resolution, because the join matches the `'human:' || id` key a real write produces, and a made-up id would report a null name as correct.

The human row now names a live seat, through `identity.LiveMemberSQL`: identity owns what *"still works here"* means, and either half of that pair alone picks a seat the workspace does not have.

And the agent row asserts the opposite — **a machine actor names no human**. The id is a passport, not a person, and the human behind it rides `on_behalf_of_name`. Naming the machine as a person is the confusion PD-002 is about.

## Verification

**Mutation:** return `NULL` for both names and the human row's assertion fails, with the raw id in the message.

`make check-backend` exit 0, `make check-fe` green (including the contract-drift gate, with `schema.d.ts` regenerated). `internal/modules/privacy` and the `fieldhistory` HTTP suites pass.