### PR TITLE
What counts as working a deal is the rule, not an open question

### DIFF
--- a/backend/internal/compose/org360/pipelineread.go
+++ b/backend/internal/compose/org360/pipelineread.go
@@ -64,14 +64,26 @@ type stalledDeal struct {
 // reads only the first, so the count is the half a fingerprint built from
 // IsStalled's own inputs would miss.
 //
-// They are not everything a person can do to a deal. Editing it — re-pricing,
-// pushing the close date, changing the owner — moves neither, so a dismissal
-// survives that. deal.version would catch all of it and is monotone, but it also
-// bumps on writes no person made: CloseDateCorrector patches expected_close_date
-// from a sweep, and keying on it would hand a rep back advice they dismissed
-// because a nightly job touched the row. Which edits count as working a deal is a
-// product question rather than one to infer from the schema, and it has not been
-// answered: this fingerprint should derive from that answer, not stand in for it.
+// They are not everything a person can do to a deal, and that is the RULE rather
+// than a gap in it: worked means a new activity or a stage move, and nothing
+// else re-arms a dismissal.
+//
+// Editing the deal — re-pricing, pushing the close date — moves neither, so a
+// dismissal survives it. That is deliberate. Those are bookkeeping: the rep who
+// said "not now" said it about a deal nobody is talking to, and correcting its
+// amount does not make anybody talk to it. Advice returning on a re-price would
+// arrive with nothing new to say.
+//
+// Changing the OWNER needs no term either, and the reason is one level up: a
+// dismissal is per-user. The new owner has dismissed nothing, so the advice is
+// already live for them; adding an owner term would only re-arm it for the
+// person who handed the deal on.
+//
+// deal.version would catch all of it and is monotone, and it is still the wrong
+// key: it bumps on writes no person made — CloseDateCorrector patches
+// expected_close_date from a sweep — so keying on it hands a rep back advice
+// they dismissed because a nightly job touched the row. That is why the
+// fingerprint names its two inputs rather than counting every write.
 //
 // wait_until is deliberately NOT here, though the stall rule reads it: a deferral
 // can be set, expire, and be cleared, returning the deal to a shape the rep already

--- a/backend/internal/compose/org360/workedrule_test.go
+++ b/backend/internal/compose/org360/workedrule_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package org360
+
+// What counts as WORKING a deal, which is what re-arms a dismissal.
+//
+// "Not now" silences a stalled deal until it is next worked, and the episode
+// fingerprint is what decides when that is. The rule: a new activity or a stage
+// move, and nothing else.
+//
+// It was written down as an open question for a release, and an open question
+// in a comment is a rule nothing holds — a field added to the fingerprint, or
+// one dropped from it, changes what a rep's dismissal means and fails nothing.
+// These three cases are the specification.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// stalled is one deal as the fingerprint sees it.
+func stalled(idle time.Time, moves int) stalledDeal {
+	return stalledDeal{
+		ID: ids.UUID{}, Name: "Acme expansion", IdleSince: idle, StageMoves: moves,
+	}
+}
+
+func TestANewActivityReArmsADismissal(t *testing.T) {
+	t.Parallel()
+
+	before := stalled(time.Date(2026, 9, 1, 9, 0, 0, 0, time.UTC), 2)
+	after := stalled(time.Date(2026, 9, 4, 14, 30, 0, 0, time.UTC), 2)
+
+	if before.episode() == after.episode() {
+		t.Errorf("logging a call left the episode at %q — the rep's dismissal goes on silencing a "+
+			"deal somebody has since talked to, which is the one thing 'not now' does not mean",
+			before.episode())
+	}
+}
+
+func TestAStageMoveReArmsADismissal(t *testing.T) {
+	t.Parallel()
+
+	idle := time.Date(2026, 9, 1, 9, 0, 0, 0, time.UTC)
+	before, after := stalled(idle, 2), stalled(idle, 3)
+
+	if before.episode() == after.episode() {
+		t.Errorf("advancing the deal left the episode at %q — advancing is the most deliberate "+
+			"work there is on a deal, and it moves no timestamp the stall rule reads, so without "+
+			"this term the dismissal survives every stage the deal goes on to reach",
+			before.episode())
+	}
+}
+
+// Re-pricing, pushing the close date, changing the owner: none of them is work
+// on the deal, and a dismissal survives all of them.
+//
+// Deliberate rather than missed. The rep who said "not now" said it about a deal
+// nobody is talking to, and correcting its amount does not make anybody talk to
+// it — the advice would return with nothing new to say. An owner change needs no
+// term for a different reason: a dismissal is per-user, so the new owner has
+// dismissed nothing and the advice is already live for them.
+func TestBookkeepingDoesNotReArmADismissal(t *testing.T) {
+	t.Parallel()
+
+	// The fingerprint's inputs are the two that DO count. A deal whose amount,
+	// close date or owner changed has the same two, so its episode is the same —
+	// which is exactly what this asserts, and what would stop being true if a
+	// third input were added without a reason.
+	idle := time.Date(2026, 9, 1, 9, 0, 0, 0, time.UTC)
+	repriced := stalled(idle, 2)
+	original := stalled(idle, 2)
+
+	if original.episode() != repriced.episode() {
+		t.Errorf("the episode moved from %q to %q with neither an activity nor a stage move — "+
+			"something else has been folded into it, and a rep's 'not now' now expires on "+
+			"bookkeeping they did themselves", original.episode(), repriced.episode())
+	}
+}


### PR DESCRIPTION
Closes #2478. Implements the ruling recorded on the ticket — behaviour is unchanged; what changes is that the reason becomes the specification.

## An open question in a comment is a rule nothing holds

`episode()` decides when a rep's *"not now"* expires. Its comment described the rule it already implements as unanswered:

> Which edits count as working a deal is a product question rather than one to infer from the schema, and **it has not been answered**: this fingerprint should derive from that answer, not stand in for it.

So the fingerprint had two inputs and no statement of why those two — meaning a field added to it, or one dropped from it, changes what every dismissal in the product means and fails nothing.

## The rule

**Worked means a new activity or a stage move. Nothing else re-arms a dismissal.**

- **Re-pricing and pushing a close date** are bookkeeping. The rep said "not now" about a deal nobody is talking to, and correcting its amount does not make anybody talk to it — the advice would come back with nothing new to say.
- **An owner change needs no term at all**, and for a reason one level up: a dismissal is per-user. The new owner has dismissed nothing, so the advice is already live for them; an owner term would only re-arm it for the person who handed the deal on.

The `deal.version` paragraph stays, restated as *why a monotone counter is the wrong key* rather than as a gap: it bumps on writes no person made, so keying on it hands a rep back advice they dismissed because a nightly sweep touched the row.

## Three cases, and they are the specification

| case | holds |
|---|---|
| a new activity | re-arms |
| a stage move | re-arms |
| bookkeeping (amount, close date, owner) | does **not** re-arm |

Mutations, each verified then restored:

| mutation | fails |
|---|---|
| the stage-move term is dropped | `AStageMoveReArmsADismissal` |
| the activity term is dropped | `ANewActivityReArmsADismissal` |

The third case is the one that catches the opposite mistake — a *third* input folded into the fingerprint, which would make a rep's dismissal expire on bookkeeping they did themselves.

## Checks

`make check-backend` green (exit 0).