### PR TITLE
The pipeline rollup is asked for a date rather than reading a clock

### DIFF
--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -57,11 +58,17 @@ func directOpenPipelineReadPriced(
 	ctx context.Context, t *testing.T, e *Env, orgID ids.UUID,
 ) (minor *int64, count, priced int, found bool) {
 	t.Helper()
+	// The same day the reader binds (people.rollupAsOf): the rollup is asked for
+	// a date, and a test that let the database pick its own CURRENT_DATE would
+	// be reading a rollup at a date the product never asks for — a whole day
+	// apart at midnight in the database's zone, which is the divergence binding
+	// the date removed.
+	asOf := time.Now().UTC().Truncate(24 * time.Hour)
 	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
 			`SELECT open_pipeline_minor_base, open_deal_count, priced_deal_count
-			 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
-			orgID).Scan(&minor, &count, &priced)
+			 FROM organization_open_pipeline_rollup($2) WHERE organization_id = $1`,
+			orgID, asOf).Scan(&minor, &count, &priced)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, 0, 0, false

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -125,8 +125,8 @@ func computedFieldsVisible(ctx context.Context) bool {
 func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (roll openPipeline, err error) {
 	err = tx.QueryRow(ctx,
 		`SELECT open_pipeline_minor_base, open_deal_count, priced_deal_count
-		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
-		orgID).Scan(&roll.minorBase, &roll.dealCount, &roll.pricedCount)
+		 FROM organization_open_pipeline_rollup($2) WHERE organization_id = $1`,
+		orgID, rollupAsOf()).Scan(&roll.minorBase, &roll.dealCount, &roll.pricedCount)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Scan never ran, so roll is still its zero value — return it, not
 		// literal zeroes: the honest "nothing to sum" case above, not a

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -12,6 +12,7 @@ package people
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -122,11 +123,11 @@ func computedFieldsVisible(ctx context.Context) bool {
 // all, every deal priced, and some priced while others could not be. Without
 // pricedCount the third is indistinguishable from the second, and a total
 // covering half the pipeline would be reported as the pipeline.
-func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (roll openPipeline, err error) {
+func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, asOf time.Time) (roll openPipeline, err error) {
 	err = tx.QueryRow(ctx,
 		`SELECT open_pipeline_minor_base, open_deal_count, priced_deal_count
 		 FROM organization_open_pipeline_rollup($2) WHERE organization_id = $1`,
-		orgID, rollupAsOf()).Scan(&roll.minorBase, &roll.dealCount, &roll.pricedCount)
+		orgID, asOf).Scan(&roll.minorBase, &roll.dealCount, &roll.pricedCount)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Scan never ran, so roll is still its zero value — return it, not
 		// literal zeroes: the honest "nothing to sum" case above, not a

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -10,6 +10,7 @@ package people
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -36,7 +37,7 @@ import (
 // shown no count of a pipeline it may not see. Absent means withheld; every
 // visible account carries a number, zero included, so a reader can tell
 // "none" from "not yours to know".
-func attachOrgCounts(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organization) error {
+func attachOrgCounts(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organization, asOf time.Time) error {
 	if len(orgs) == 0 {
 		return nil
 	}
@@ -81,7 +82,7 @@ func attachOrgCounts(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organiz
 	if !dealsVisible {
 		return nil
 	}
-	return fillOpenDealCounts(ctx, tx, idx, orgIDs)
+	return fillOpenDealCounts(ctx, tx, idx, orgIDs, asOf)
 }
 
 // grantVisible is the object-grant half of a read, answered from the
@@ -137,11 +138,11 @@ func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUI
 // list's count and the company page's open-pipeline tile derive from the
 // same rows and cannot disagree.
 // Held by: TestEveryOpenDealCountComesFromTheRollup (backend/internal/modules/people/opendealcount_test.go)
-func fillOpenDealCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID) error {
+func fillOpenDealCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID, asOf time.Time) error {
 	return fillCount(ctx, tx, idx,
 		`SELECT organization_id, open_deal_count
 		 FROM organization_open_pipeline_rollup($2)
-		 WHERE organization_id = ANY($1)`, []any{orgIDs, rollupAsOf()},
+		 WHERE organization_id = ANY($1)`, []any{orgIDs, asOf},
 		func(o *crmcontracts.Organization, n int) { o.OpenDealCount = &n })
 }
 

--- a/backend/internal/modules/people/organization_counts.go
+++ b/backend/internal/modules/people/organization_counts.go
@@ -140,8 +140,8 @@ func fillContactCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUI
 func fillOpenDealCounts(ctx context.Context, tx pgx.Tx, idx map[openapi_types.UUID]*crmcontracts.Organization, orgIDs []ids.UUID) error {
 	return fillCount(ctx, tx, idx,
 		`SELECT organization_id, open_deal_count
-		 FROM organization_open_pipeline_rollup
-		 WHERE organization_id = ANY($1)`, []any{orgIDs},
+		 FROM organization_open_pipeline_rollup($2)
+		 WHERE organization_id = ANY($1)`, []any{orgIDs, rollupAsOf()},
 		func(o *crmcontracts.Organization, n int) { o.OpenDealCount = &n })
 }
 

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -229,7 +229,9 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 				func(o *crmcontracts.Organization, tags []storekit.RowTag) { o.Tags = wireRowTags(tags) }); err != nil {
 				return err
 			}
-			return attachOrgCounts(ctx, tx, orgs)
+			// One sample for the page, for the reason the single read binds
+			// one: every row on it is counted against the same day.
+			return attachOrgCounts(ctx, tx, orgs, rollupAsOf())
 		},
 		cursorKey: func(last crmcontracts.Organization) (time.Time, ids.UUID) {
 			return last.CreatedAt, ids.UUID(last.Id)

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -77,11 +77,18 @@ func getOrganizationInTx(ctx context.Context, tx pgx.Tx, id ids.OrganizationID,
 	if err != nil {
 		return crmcontracts.Organization{}, err
 	}
+	// Sampled ONCE for this read, and handed to both rollup readers below. The
+	// row count and the computed pipeline total are two queries against the
+	// same function, and a clock read separately by each would pick different
+	// FX dates for one response whenever UTC midnight fell between them —
+	// which is the divergence binding the date exists to remove, reappearing
+	// one level down.
+	asOf := rollupAsOf()
 	// The two list-row counts, on the single read too, so the page a row
 	// opens into agrees with the row. Attached here rather than in
 	// readOrganization: a write's before-image has no use for them.
 	single := []crmcontracts.Organization{out}
-	if err := attachOrgCounts(ctx, tx, single); err != nil {
+	if err := attachOrgCounts(ctx, tx, single, asOf); err != nil {
 		return crmcontracts.Organization{}, fmt.Errorf("read organization counts: %w", err)
 	}
 	out = single[0]
@@ -90,7 +97,7 @@ func getOrganizationInTx(ctx context.Context, tx pgx.Tx, id ids.OrganizationID,
 	// rollup read below, and out.ComputedFields stays its nil zero
 	// value — omitempty then drops the key entirely on marshal (T1).
 	if computedFieldsVisible(ctx) {
-		open, err := openPipelineRollup(ctx, tx, id)
+		open, err := openPipelineRollup(ctx, tx, id, asOf)
 		if err != nil {
 			return crmcontracts.Organization{}, fmt.Errorf("read open pipeline rollup: %w", err)
 		}

--- a/backend/internal/modules/people/rollupasofonce_integration_test.go
+++ b/backend/internal/modules/people/rollupasofonce_integration_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// One company read, one as-of date.
+//
+// The read asks the rollup twice — once for the open-deal count on the row,
+// once for the pipeline total in the computed fields — and both take a date to
+// convert at. Sampled separately they can straddle UTC midnight, and the page
+// then shows a count from one day beside a total from the next: the same
+// unreproducible disagreement binding the date was meant to end, one level
+// further down.
+//
+// The clock advances a full day per call here, so a second sample cannot be
+// mistaken for the first.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestOneCompanyReadBindsOneAsOfDate(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Midnight Glazing GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := rollupClock
+	t.Cleanup(func() { rollupClock = original })
+	day := time.Date(2026, 6, 2, 23, 59, 0, 0, time.UTC)
+	var samples []time.Time
+	rollupClock = func() time.Time {
+		samples = append(samples, day)
+		day = day.AddDate(0, 0, 1)
+		return samples[len(samples)-1]
+	}
+
+	if _, err := e.store.GetOrganization(ctx,
+		ids.From[ids.OrganizationKind](ids.UUID(org.Id)), storekit.LiveOnly); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(samples) != 1 {
+		t.Fatalf("the read sampled the clock %d times, want once — the count and the pipeline "+
+			"total would be asked for different days whenever midnight fell between them", len(samples))
+	}
+}

--- a/backend/internal/modules/people/rollupclock.go
+++ b/backend/internal/modules/people/rollupclock.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The date the open-pipeline rollup converts at.
+//
+// It used to be the database's CURRENT_DATE, which made two clocks: org360
+// samples Go's and honours an injected one, and this read asked Postgres. Two
+// readers of one account's pipeline could therefore select different FX rates in
+// the same response — a whole day apart at midnight in the database's zone.
+//
+// The consequence is rare and, worse, unreproducible: reported once, impossible
+// to reproduce, closed as the reporter's mistake. A money figure that is wrong
+// unreproducibly is the worst kind, because the product's own defence against
+// the report is indistinguishable from the bug.
+//
+// So the date is bound by the caller, from ONE clock. A package var rather than
+// a field, matching leadSLAClock beside it: both are read by free functions on
+// a transaction rather than by methods, and threading a clock through them would
+// change every signature to say what one line says here.
+
+import "time"
+
+// rollupClock is the clock the as-of date comes from. Overridden in tests, and
+// nowhere else — a second production writer would be the second clock again.
+var rollupClock = time.Now
+
+// rollupAsOf is the date the conversion is asked for.
+//
+// UTC, deliberately. The rate table is keyed by date and the alternative is the
+// server's local zone, which would make the same installation convert
+// differently depending on where its process happens to run.
+func rollupAsOf() time.Time {
+	return rollupClock().UTC().Truncate(24 * time.Hour)
+}

--- a/backend/internal/modules/people/rollupclock_test.go
+++ b/backend/internal/modules/people/rollupclock_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// One clock decides which FX rate an account's pipeline converts at.
+//
+// The rollup used to read the database's CURRENT_DATE while org360 sampled Go's,
+// so two readers of one response could select rates a whole day apart — at
+// midnight in the database's zone, and only then. A money figure that is wrong
+// rarely and cannot be reproduced afterwards is the worst kind: the product's
+// own defence against the report is indistinguishable from the bug.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTheAsOfDateComesFromTheInjectedClock(t *testing.T) {
+	original := rollupClock
+	t.Cleanup(func() { rollupClock = original })
+
+	frozen := time.Date(2026, 6, 2, 14, 30, 0, 0, time.UTC)
+	rollupClock = func() time.Time { return frozen }
+
+	if got := rollupAsOf(); !got.Equal(time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("as-of = %s, want the 2nd — a date read from anywhere but the caller's clock is "+
+			"the second clock this change exists to remove", got)
+	}
+}
+
+// Two calls within one response answer the same date even across a midnight the
+// wall clock crosses, because the caller binds it once. What this holds is the
+// narrower half a unit test can: the date does not depend on the time of day.
+func TestTheAsOfDateDoesNotMoveWithTheTimeOfDay(t *testing.T) {
+	original := rollupClock
+	t.Cleanup(func() { rollupClock = original })
+
+	day := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	for _, hour := range []int{0, 9, 23} {
+		rollupClock = func() time.Time { return day.Add(time.Duration(hour) * time.Hour) }
+		if got := rollupAsOf(); !got.Equal(day) {
+			t.Errorf("at %02d:00 the as-of date is %s, want %s — a rate selected by the hour is "+
+				"one two readers of the same page can disagree about", hour, got, day)
+		}
+	}
+}
+
+// UTC, not the server's local zone. The rate table is keyed by date, and a
+// local-zone answer makes one installation convert differently depending on
+// where its process happens to run.
+func TestTheAsOfDateIsUTC(t *testing.T) {
+	original := rollupClock
+	t.Cleanup(func() { rollupClock = original })
+
+	// 01:00 on the 3rd in a +02:00 zone is still the 2nd in UTC.
+	east := time.FixedZone("east", 2*60*60)
+	rollupClock = func() time.Time { return time.Date(2026, 6, 3, 1, 0, 0, 0, east) }
+
+	if got := rollupAsOf(); !got.Equal(time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("as-of = %s, want the 2nd in UTC — reading the server's zone makes the same "+
+			"installation convert differently depending on where it runs", got)
+	}
+}

--- a/backend/internal/shared/gatekit/sqlreads.go
+++ b/backend/internal/shared/gatekit/sqlreads.go
@@ -41,12 +41,19 @@ import (
 //     table name is invisible unless the text has been unquoted — which is what
 //     LiteralText is for, and what TableReads does.
 //
+// An OPENING PAREN counts as a delimiter, because a set-returning function in a
+// FROM clause is a read of the relation it names: `FROM rollup($1)` reads the
+// rollup exactly as `FROM rollup` did. Without it, turning a view into a
+// function to take a parameter makes every census over that relation report a
+// clean tree — the readers are still there and the pattern has stopped seeing
+// them, which is under-recognition rather than a finding.
+//
 // The table name is quoted into the pattern rather than interpolated raw: a
 // caller naming a table with a regex metacharacter would otherwise silently
 // widen or break its own census, and a census that matches the wrong thing
 // reads exactly like a clean tree.
 func TableReadPattern(table string) *regexp.Regexp {
-	return regexp.MustCompile(`(?i)\b(FROM|JOIN)\s+` + regexp.QuoteMeta(table) + `(\s|$|[,;)])`)
+	return regexp.MustCompile(`(?i)\b(FROM|JOIN)\s+` + regexp.QuoteMeta(table) + `(\s|$|[,;()])`)
 }
 
 // LiteralText is a string literal's content without its quoting.

--- a/backend/migrations/core/1788718671_the_pipeline_rollup_is_asked_for_a_date.down.sql
+++ b/backend/migrations/core/1788718671_the_pipeline_rollup_is_asked_for_a_date.down.sql
@@ -1,0 +1,92 @@
+SET LOCAL lock_timeout = '3s';
+
+DROP FUNCTION IF EXISTS organization_open_pipeline_rollup(date);
+
+CREATE VIEW organization_open_pipeline_rollup WITH (security_invoker='true') AS
+ SELECT d.organization_id,
+    -- The SUM is bounded too, and separately from its summands. sum(bigint)
+    -- answers in numeric, so a set of individually representable deals can add
+    -- to a figure no bigint holds — and the reader scans this column into an
+    -- int64. Guarding one deal and not the total would have moved the same
+    -- failure one level up: the record unreadable because the deals are large
+    -- rather than because one of them is.
+    --
+    -- Out of range answers NULL, which the caller already knows how to report:
+    -- the deals were priced, the total cannot be stated, and a figure nobody
+    -- can represent is not a figure to publish.
+    CASE
+      WHEN sum(conv.minor_base)
+           BETWEEN -9223372036854775808 AND 9223372036854775807
+        THEN sum(conv.minor_base)
+      ELSE NULL
+    END AS open_pipeline_minor_base,
+    count(*) AS open_deal_count,
+    -- How many deals actually reached the sum. SUM ignores a null summand
+    -- silently, so without this a total covering one of two deals is
+    -- indistinguishable from one covering both — a confident figure that is
+    -- quietly short, which is worse than the "not computable" it replaces.
+    --
+    -- It counts the CONVERSION rather than restating when one is possible: a
+    -- deal with no rate and a deal whose converted amount does not fit are both
+    -- deals the sum did not reach, and one predicate answers for both.
+    count(*) FILTER (WHERE conv.minor_base IS NOT NULL) AS priced_deal_count
+   FROM deal d
+   -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
+   -- must still report its open_deal_count. A cross join would return no row at
+   -- all for the organization, which reads as "no open deals" — the one answer
+   -- that is definitely wrong. With no base currency nothing converts, every
+   -- deal contributes null, and the sum is null: not computable, honestly.
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= CURRENT_DATE
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+   -- Both currencies' minor-unit scales, each absent for an ordinary two-digit
+   -- code and coalesced to ISO's default below. LEFT so a code the table does
+   -- not name still converts, at two digits, rather than dropping the deal out
+   -- of the sum — an unnamed exception renders wrong for that code, where a
+   -- dropped deal silently shortens a total for every code.
+   LEFT JOIN currency_minor_digits deal_digits ON deal_digits.currency = d.currency
+   LEFT JOIN currency_minor_digits base_digits ON base_digits.currency = base.code
+   -- What this deal contributes to the total, or NULL when it contributes
+   -- nothing. Three cases, and the bound is written once here so the count
+   -- predicate below reads the same answer the sum does.
+   LEFT JOIN LATERAL (
+     SELECT CASE
+       -- Already in the installation's own currency: no rate needed, no scale
+       -- to cross, and none should be looked for. This is the ordinary deal.
+       WHEN d.currency = base.code THEN d.amount_minor
+       -- Converted, and only when the result is a number the column can hold.
+       -- The comparison runs in numeric, where the product already is, so it
+       -- decides the question BEFORE a cast can raise it.
+       --
+       -- amount × rate × 10^digits(base) ÷ 10^digits(deal), as ONE expression
+       -- so the single round() is the only rounding. numeric is exact, so the
+       -- intermediate carries no error to accumulate.
+       WHEN live.rate IS NOT NULL
+        AND round(d.amount_minor * live.rate
+                    * power(10::numeric, coalesce(base_digits.digits, 2))
+                    / power(10::numeric, coalesce(deal_digits.digits, 2)))
+            BETWEEN -9223372036854775808 AND 9223372036854775807
+         THEN round(d.amount_minor * live.rate
+                      * power(10::numeric, coalesce(base_digits.digits, 2))
+                      / power(10::numeric, coalesce(deal_digits.digits, 2)))::bigint
+       -- No usable rate, or a result too large to represent. Nothing is ever
+       -- converted at an invented rate of 1 — that would report ¥5,000,000 as
+       -- €5,000,000 — and nothing is ever clamped to the biggest number that
+       -- fits, which is the same lie with more digits.
+       ELSE NULL
+     END AS minor_base
+   ) conv ON true
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;

--- a/backend/migrations/core/1788718671_the_pipeline_rollup_is_asked_for_a_date.up.sql
+++ b/backend/migrations/core/1788718671_the_pipeline_rollup_is_asked_for_a_date.up.sql
@@ -1,0 +1,137 @@
+-- The open-pipeline rollup takes its as-of date rather than reading a clock.
+--
+-- Two readers of the same account's pipeline could select DIFFERENT FX rates in
+-- one response. org360 samples Go's clock and honours an injected one; this view
+-- asked the DATABASE for CURRENT_DATE. Two clocks, and the window between them
+-- is a whole day wide at midnight in the database's zone — a figure that is
+-- wrong rarely and cannot be reproduced afterwards, which is the worst kind of
+-- wrong money figure: the product's own defence against the report is
+-- indistinguishable from the bug.
+--
+-- The midnight window is the symptom. The defect is the second clock, so the
+-- fix removes it: a function taking `as_of`, bound by the caller from the same
+-- clock every other derived figure on the page reads.
+--
+-- A FUNCTION rather than a parameterised view because a view cannot take one.
+-- Everything else about the definition is unchanged, character for character,
+-- so this migration is readable as what it is: one predicate, and the shape
+-- around it held still.
+SET LOCAL lock_timeout = '3s';
+
+DROP VIEW IF EXISTS organization_open_pipeline_rollup;
+
+-- SECURITY INVOKER, stated. It is the default for a view since PG15 and was
+-- declared on the view it replaces; for a FUNCTION the default is the same, and
+-- saying so is what stops a later definer-rights edit passing as a formatting
+-- change. The rows this reads are the caller's own: it discloses no deal a
+-- SELECT by that caller would not.
+--
+-- STABLE, not IMMUTABLE: it reads tables. STABLE is what lets the planner run
+-- it once per statement, and it is true now in a way it was not before —
+-- CURRENT_DATE made the old view's result depend on when in the day it ran.
+CREATE FUNCTION organization_open_pipeline_rollup(as_of date)
+RETURNS TABLE (
+  organization_id uuid,
+  open_pipeline_minor_base bigint,
+  open_deal_count bigint,
+  priced_deal_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $fn$
+ SELECT d.organization_id,
+    -- The SUM is bounded too, and separately from its summands. sum(bigint)
+    -- answers in numeric, so a set of individually representable deals can add
+    -- to a figure no bigint holds — and the reader scans this column into an
+    -- int64. Guarding one deal and not the total would have moved the same
+    -- failure one level up: the record unreadable because the deals are large
+    -- rather than because one of them is.
+    --
+    -- Out of range answers NULL, which the caller already knows how to report:
+    -- the deals were priced, the total cannot be stated, and a figure nobody
+    -- can represent is not a figure to publish.
+    CASE
+      WHEN sum(conv.minor_base)
+           BETWEEN -9223372036854775808 AND 9223372036854775807
+        THEN sum(conv.minor_base)
+      ELSE NULL
+    END AS open_pipeline_minor_base,
+    count(*) AS open_deal_count,
+    -- How many deals actually reached the sum. SUM ignores a null summand
+    -- silently, so without this a total covering one of two deals is
+    -- indistinguishable from one covering both — a confident figure that is
+    -- quietly short, which is worse than the "not computable" it replaces.
+    --
+    -- It counts the CONVERSION rather than restating when one is possible: a
+    -- deal with no rate and a deal whose converted amount does not fit are both
+    -- deals the sum did not reach, and one predicate answers for both.
+    count(*) FILTER (WHERE conv.minor_base IS NOT NULL) AS priced_deal_count
+   FROM deal d
+   -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
+   -- must still report its open_deal_count. A cross join would return no row at
+   -- all for the organization, which reads as "no open deals" — the one answer
+   -- that is definitely wrong. With no base currency nothing converts, every
+   -- deal contributes null, and the sum is null: not computable, honestly.
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= as_of
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+   -- Both currencies' minor-unit scales, each absent for an ordinary two-digit
+   -- code and coalesced to ISO's default below. LEFT so a code the table does
+   -- not name still converts, at two digits, rather than dropping the deal out
+   -- of the sum — an unnamed exception renders wrong for that code, where a
+   -- dropped deal silently shortens a total for every code.
+   LEFT JOIN currency_minor_digits deal_digits ON deal_digits.currency = d.currency
+   LEFT JOIN currency_minor_digits base_digits ON base_digits.currency = base.code
+   -- What this deal contributes to the total, or NULL when it contributes
+   -- nothing. Three cases, and the bound is written once here so the count
+   -- predicate below reads the same answer the sum does.
+   LEFT JOIN LATERAL (
+     SELECT CASE
+       -- Already in the installation's own currency: no rate needed, no scale
+       -- to cross, and none should be looked for. This is the ordinary deal.
+       WHEN d.currency = base.code THEN d.amount_minor
+       -- Converted, and only when the result is a number the column can hold.
+       -- The comparison runs in numeric, where the product already is, so it
+       -- decides the question BEFORE a cast can raise it.
+       --
+       -- amount × rate × 10^digits(base) ÷ 10^digits(deal), as ONE expression
+       -- so the single round() is the only rounding. numeric is exact, so the
+       -- intermediate carries no error to accumulate.
+       WHEN live.rate IS NOT NULL
+        AND round(d.amount_minor * live.rate
+                    * power(10::numeric, coalesce(base_digits.digits, 2))
+                    / power(10::numeric, coalesce(deal_digits.digits, 2)))
+            BETWEEN -9223372036854775808 AND 9223372036854775807
+         THEN round(d.amount_minor * live.rate
+                      * power(10::numeric, coalesce(base_digits.digits, 2))
+                      / power(10::numeric, coalesce(deal_digits.digits, 2)))::bigint
+       -- No usable rate, or a result too large to represent. Nothing is ever
+       -- converted at an invented rate of 1 — that would report ¥5,000,000 as
+       -- €5,000,000 — and nothing is ever clamped to the biggest number that
+       -- fits, which is the same lie with more digits.
+       ELSE NULL
+     END AS minor_base
+   ) conv ON true
+  WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
+  GROUP BY d.organization_id;
+$fn$;
+
+-- The app EXECUTEs it; nothing else changes about who may read what, because
+-- SECURITY INVOKER means the caller's own privileges still decide every row.
+GRANT EXECUTE ON FUNCTION organization_open_pipeline_rollup(date) TO margince_app;
+
+COMMENT ON FUNCTION organization_open_pipeline_rollup(date) IS
+  'Open pipeline per organization in the installation base currency, as of the date the CALLER names. Open deals hold no frozen rate — that happens on close — so each foreign-currency deal converts at the latest fx_rate on or before as_of, across both currencies'' minor-unit scales (currency_minor_digits). The date is a parameter rather than CURRENT_DATE because two readers of one response must not select two different rates: the caller binds it from the same clock every other derived figure reads. A deal with no usable rate, or whose converted amount does not fit a bigint, contributes nothing and is still counted in open_deal_count, so a partial sum is detectable rather than silently short. The total itself answers NULL when it does not fit either.';

--- a/backend/migrations/headschema_integration_test.go
+++ b/backend/migrations/headschema_integration_test.go
@@ -292,15 +292,23 @@ var schemaMoves = []struct {
 			 WHERE n.nspname = 'public' AND NOT t.tgisinternal
 			 ORDER BY t.tgname LIMIT 1`)
 	}},
-	{"a view stops being security_invoker", func(t *testing.T, conn *pgx.Conn) string {
+	// A relation that reads across records, quietly gaining the DEFINER's
+	// privileges. It was spelled against a VIEW's security_invoker option until
+	// the one such view became a function to take its as-of date; a probe whose
+	// subject has left the schema plants nothing and proves nothing, which is
+	// the shape a census must not have.
+	//
+	// The invariant did not move — a cross-record read still runs as the caller
+	// — so the probe follows it to where Postgres now records it.
+	{"a function stops running as the caller", func(t *testing.T, conn *pgx.Conn) string {
 		return scanOne(t, conn, `
-			SELECT 'ALTER VIEW ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) ||
-			       ' SET (security_invoker = false)'
-			  FROM pg_class c
-			  JOIN pg_namespace n ON n.oid = c.relnamespace
-			 WHERE n.nspname = 'public' AND c.relkind = 'v'
-			   AND array_to_string(c.reloptions, ',') LIKE '%security_invoker=true%'
-			 ORDER BY c.relname LIMIT 1`)
+			SELECT 'ALTER FUNCTION ' || quote_ident(n.nspname) || '.' || quote_ident(p.proname) ||
+			       '(' || pg_get_function_identity_arguments(p.oid) || ') SECURITY DEFINER'
+			  FROM pg_proc p
+			  JOIN pg_namespace n ON n.oid = p.pronamespace
+			 WHERE n.nspname = 'public' AND NOT p.prosecdef
+			   AND p.proname = 'organization_open_pipeline_rollup'
+			 ORDER BY p.proname LIMIT 1`)
 	}},
 	{"a trigger function's body is replaced", func(t *testing.T, conn *pgx.Conn) string {
 		// The class a dropped trigger CANNOT stand in for: the trigger

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -122,33 +122,37 @@ func TestSchema_amountMinorBaseHasOneWriter(t *testing.T) {
 }
 
 // TestSchema_organizationOpenPipelineRollupIsSecurityInvoker closes the
-// RD-AC-N-1 half of the same boundary proof: the cross-record roll-up MUST
-// run as security_invoker (inheriting the caller's own RLS), never as the
-// view owner's elevated privilege — a view created without the option, or
-// with it later stripped by a careless CREATE OR REPLACE, would silently
-// leak every workspace's pipeline total to every other workspace.
+// RD-AC-N-1 half of the same boundary proof: the cross-record roll-up MUST run
+// with the CALLER's own privileges, never the definer's — one created or
+// redefined the other way would silently hand every workspace's pipeline total
+// to every other workspace.
+//
+// It asks pg_proc now rather than pg_class.reloptions, because the rollup is a
+// FUNCTION taking its as-of date (a view cannot take a parameter). The
+// invariant is unchanged; where Postgres records it moved. Asked of the
+// catalogue rather than of the migration text, so a later CREATE OR REPLACE
+// that quietly drops the property is caught by what the database ended up
+// with — which is the failure this test exists for.
 func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
 	headSchema(t, owner)
 	ctx := context.Background()
 
-	var reloptions []string
+	var definerRights bool
 	if err := owner.QueryRow(
 		ctx, `
-		SELECT COALESCE(reloptions, '{}') FROM pg_class
-		WHERE relname = 'organization_open_pipeline_rollup' AND relnamespace = 'public'::regnamespace`,
-	).Scan(&reloptions); err != nil {
-		t.Fatalf("querying pg_class.reloptions for organization_open_pipeline_rollup: %v", err)
+		SELECT prosecdef FROM pg_proc
+		WHERE proname = 'organization_open_pipeline_rollup'
+		  AND pronamespace = 'public'::regnamespace`,
+	).Scan(&definerRights); err != nil {
+		t.Fatalf("querying pg_proc.prosecdef for organization_open_pipeline_rollup: %v — a rollup "+
+			"the catalogue does not carry is one this proof cannot make at all", err)
 	}
-	found := false
-	for _, opt := range reloptions {
-		if opt == "security_invoker=true" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("organization_open_pipeline_rollup view reloptions %v do not include security_invoker=true", reloptions)
+	if definerRights {
+		t.Error("organization_open_pipeline_rollup runs with DEFINER rights: it reads deals across " +
+			"records, so the caller's own privileges are the only thing standing between one " +
+			"workspace's pipeline total and every other workspace")
 	}
 }
 

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3840,37 +3840,95 @@ BEGIN
   RETURN NEW;
 END;
 
-public.organization_open_pipeline_rollup acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
-public.organization_open_pipeline_rollup opts=security_invoker=true  SELECT d.organization_id,
-        CASE
-            WHEN ((sum(conv.minor_base) >= ('-9223372036854775808'::bigint)::numeric) AND (sum(conv.minor_base) <= ('9223372036854775807'::bigint)::numeric)) THEN sum(conv.minor_base)
-            ELSE NULL::numeric
-        END AS open_pipeline_minor_base,
+public.organization_open_pipeline_rollup(as_of date) secdef=false cfg=- acl==X/margince_owner,margince_owner=X/margince_owner,margince_app=X/margince_owner 
+ SELECT d.organization_id,
+    -- The SUM is bounded too, and separately from its summands. sum(bigint)
+    -- answers in numeric, so a set of individually representable deals can add
+    -- to a figure no bigint holds — and the reader scans this column into an
+    -- int64. Guarding one deal and not the total would have moved the same
+    -- failure one level up: the record unreadable because the deals are large
+    -- rather than because one of them is.
+    --
+    -- Out of range answers NULL, which the caller already knows how to report:
+    -- the deals were priced, the total cannot be stated, and a figure nobody
+    -- can represent is not a figure to publish.
+    CASE
+      WHEN sum(conv.minor_base)
+           BETWEEN -9223372036854775808 AND 9223372036854775807
+        THEN sum(conv.minor_base)
+      ELSE NULL
+    END AS open_pipeline_minor_base,
     count(*) AS open_deal_count,
-    count(*) FILTER (WHERE (conv.minor_base IS NOT NULL)) AS priced_deal_count
-   FROM (((((deal d
-     LEFT JOIN LATERAL ( SELECT (setting.value #>> '{}'::text[]) AS code
-           FROM setting
-          WHERE (setting.key = 'installation.base_currency'::text)) base ON (true))
-     LEFT JOIN LATERAL ( SELECT r.rate
-           FROM fx_rate r
-          WHERE (((d.currency)::text IS DISTINCT FROM base.code) AND (r.from_currency = d.currency) AND ((r.to_currency)::text = base.code) AND (r.rate_date <= CURRENT_DATE))
-          ORDER BY r.rate_date DESC
-         LIMIT 1) live ON (true))
-     LEFT JOIN currency_minor_digits deal_digits ON ((deal_digits.currency = d.currency)))
-     LEFT JOIN currency_minor_digits base_digits ON (((base_digits.currency)::text = base.code)))
-     LEFT JOIN LATERAL ( SELECT
-                CASE
-                    WHEN ((d.currency)::text = base.code) THEN d.amount_minor
-                    WHEN ((live.rate IS NOT NULL) AND ((round(((((d.amount_minor)::numeric * live.rate) * power((10)::numeric, (COALESCE((base_digits.digits)::integer, 2))::numeric)) / power((10)::numeric, (COALESCE((deal_digits.digits)::integer, 2))::numeric))) >= ('-9223372036854775808'::bigint)::numeric) AND (round(((((d.amount_minor)::numeric * live.rate) * power((10)::numeric, (COALESCE((base_digits.digits)::integer, 2))::numeric)) / power((10)::numeric, (COALESCE((deal_digits.digits)::integer, 2))::numeric))) <= ('9223372036854775807'::bigint)::numeric))) THEN (round(((((d.amount_minor)::numeric * live.rate) * power((10)::numeric, (COALESCE((base_digits.digits)::integer, 2))::numeric)) / power((10)::numeric, (COALESCE((deal_digits.digits)::integer, 2))::numeric))))::bigint
-                    ELSE NULL::bigint
-                END AS minor_base) conv ON (true))
+    -- How many deals actually reached the sum. SUM ignores a null summand
+    -- silently, so without this a total covering one of two deals is
+    -- indistinguishable from one covering both — a confident figure that is
+    -- quietly short, which is worse than the "not computable" it replaces.
+    --
+    -- It counts the CONVERSION rather than restating when one is possible: a
+    -- deal with no rate and a deal whose converted amount does not fit are both
+    -- deals the sum did not reach, and one predicate answers for both.
+    count(*) FILTER (WHERE conv.minor_base IS NOT NULL) AS priced_deal_count
+   FROM deal d
+   -- LEFT, not CROSS: an installation whose base-currency row is somehow absent
+   -- must still report its open_deal_count. A cross join would return no row at
+   -- all for the organization, which reads as "no open deals" — the one answer
+   -- that is definitely wrong. With no base currency nothing converts, every
+   -- deal contributes null, and the sum is null: not computable, honestly.
+   LEFT JOIN LATERAL (
+     SELECT (value #>> '{}')::text AS code
+       FROM setting
+      WHERE key = 'installation.base_currency'
+   ) base ON true
+   LEFT JOIN LATERAL (
+     SELECT r.rate
+       FROM fx_rate r
+      WHERE d.currency IS DISTINCT FROM base.code
+        AND r.from_currency = d.currency
+        AND r.to_currency = base.code
+        AND r.rate_date <= as_of
+      ORDER BY r.rate_date DESC
+      LIMIT 1
+   ) live ON true
+   -- Both currencies' minor-unit scales, each absent for an ordinary two-digit
+   -- code and coalesced to ISO's default below. LEFT so a code the table does
+   -- not name still converts, at two digits, rather than dropping the deal out
+   -- of the sum — an unnamed exception renders wrong for that code, where a
+   -- dropped deal silently shortens a total for every code.
+   LEFT JOIN currency_minor_digits deal_digits ON deal_digits.currency = d.currency
+   LEFT JOIN currency_minor_digits base_digits ON base_digits.currency = base.code
+   -- What this deal contributes to the total, or NULL when it contributes
+   -- nothing. Three cases, and the bound is written once here so the count
+   -- predicate below reads the same answer the sum does.
+   LEFT JOIN LATERAL (
+     SELECT CASE
+       -- Already in the installation's own currency: no rate needed, no scale
+       -- to cross, and none should be looked for. This is the ordinary deal.
+       WHEN d.currency = base.code THEN d.amount_minor
+       -- Converted, and only when the result is a number the column can hold.
+       -- The comparison runs in numeric, where the product already is, so it
+       -- decides the question BEFORE a cast can raise it.
+       --
+       -- amount × rate × 10^digits(base) ÷ 10^digits(deal), as ONE expression
+       -- so the single round() is the only rounding. numeric is exact, so the
+       -- intermediate carries no error to accumulate.
+       WHEN live.rate IS NOT NULL
+        AND round(d.amount_minor * live.rate
+                    * power(10::numeric, coalesce(base_digits.digits, 2))
+                    / power(10::numeric, coalesce(deal_digits.digits, 2)))
+            BETWEEN -9223372036854775808 AND 9223372036854775807
+         THEN round(d.amount_minor * live.rate
+                      * power(10::numeric, coalesce(base_digits.digits, 2))
+                      / power(10::numeric, coalesce(deal_digits.digits, 2)))::bigint
+       -- No usable rate, or a result too large to represent. Nothing is ever
+       -- converted at an invented rate of 1 — that would report ¥5,000,000 as
+       -- €5,000,000 — and nothing is ever clamped to the biggest number that
+       -- fits, which is the same lie with more digits.
+       ELSE NULL
+     END AS minor_base
+   ) conv ON true
   WHERE ((d.status = 'open'::text) AND (d.organization_id IS NOT NULL) AND (d.archived_at IS NULL))
   GROUP BY d.organization_id;
-public.organization_open_pipeline_rollup.open_deal_count bigint gen=- def=-
-public.organization_open_pipeline_rollup.open_pipeline_minor_base numeric gen=- def=-
-public.organization_open_pipeline_rollup.organization_id uuid gen=- def=-
-public.organization_open_pipeline_rollup.priced_deal_count bigint gen=- def=-
+
 public.organization_pkey CREATE UNIQUE INDEX organization_pkey ON public.organization USING btree (id)
 public.organization_profile_field acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.organization_profile_field.captured_at timestamp with time zone NOT NULL gen=- def=now()


### PR DESCRIPTION
Closes #2467. Implements the recorded ruling.

## Two clocks, not a midnight window

Two readers of one account's open pipeline could select **different FX rates in the same response**. `org360` samples Go's clock and honours an injected one; `organization_open_pipeline_rollup` asked the database for `CURRENT_DATE`. A whole day apart, at midnight in the database's zone.

The midnight window is the symptom. **The defect is the second clock**, and any fix leaving two clocks in place leaves the number non-reproducible — so the view becomes a function taking `as_of`, and both readers bind it from one clock.

**Both readers**, because they read the same rollup and disagreeing is the entire complaint; fixing one would have been half a fix.

The ticket is right that the consequence is *"rare and unreproducible… reported once, cannot be reproduced, and closed as a mistake by the reporter"* — and that is the argument for fixing it rather than for leaving it. A money figure that is wrong unreproducibly is the worst kind, because the product's own defence against the report is indistinguishable from the bug.

## What was preserved

- `SECURITY INVOKER`, stated explicitly. It is the default for a function as it now is for a view, and saying so is what stops a later definer-rights edit passing as a formatting change.
- `priced_deal_count` beside `open_deal_count`, and the rule behind it: a deal with no usable rate contributes nothing and is still counted. *Nothing is ever converted at an invented rate of 1 — that would report ¥5,000,000 as €5,000,000.*
- The definition is otherwise unchanged character for character, so the migration reads as what it is: one predicate, and the shape around it held still.

## Three gates needed to follow the invariant

This is the part worth reviewing, because each would otherwise have gone quiet rather than failed:

1. **`gatekit.TableReadPattern`** matched `FROM rollup` but not `FROM rollup($1)`. Left alone, turning a view into a function makes *every* census over that relation report a clean tree — the readers still there, the pattern no longer seeing them. An opening paren now counts as a delimiter, because a set-returning function in a `FROM` clause is a read of the relation it names.
2. **`TestSchema_organizationOpenPipelineRollupIsSecurityInvoker`** read `pg_class.reloptions`, which only a view carries. It asks `pg_proc.prosecdef` now — the catalogue, not the migration text, so a later `CREATE OR REPLACE` that drops the property is caught by what the database ended up with.
3. **The head-schema digest's probe** planted `ALTER VIEW … security_invoker = false` on *any* such view. The rollup was the only one, so after this change the probe would have planted nothing and proved nothing. It follows the invariant to `ALTER FUNCTION … SECURITY DEFINER`.

Mutation-checked: with the function declared `SECURITY DEFINER`, the fitness test fails with *"the caller's own privileges are the only thing standing between one workspace's pipeline total and every other workspace"*.

## Checks

`make check-backend` green (exit 0). `make test-it DIR=backend/migrations` green in full (136s). `head_catalog.txt` regenerated in the same commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved open pipeline totals and deal counts by ensuring currency conversions use a consistent UTC-based as-of date.
  - Prevented discrepancies caused by time-zone differences or requests crossing a calendar-day boundary.
  - Preserved accurate reporting for deals with missing currency conversion data and values outside supported numeric ranges.

- **Reliability**
  - Strengthened access controls around pipeline rollup data while maintaining existing reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->