### PR TITLE
The duplicate queue says which pairs this caller could decide

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23112,7 +23112,7 @@ components:
     DedupeCandidate:
       type: object
       description: 'One DH-DDL-1 review-queue row: the canonical unordered pair, its confidence, and the detection-time evidence snapshot (DH-N-8).'
-      required: [id, entity_type, left_id, right_id, confidence, evidence, status, created_at]
+      required: [id, entity_type, left_id, right_id, confidence, evidence, status, created_at, can_decide]
       properties:
         id: { type: string, format: uuid }
         entity_type: { type: string, enum: [person, organization, lead], description: 'A pair is always same-type (ADR-0118/A169 §2): a lead is proposed as a duplicate of a lead or of nothing.' }
@@ -23132,6 +23132,21 @@ components:
               signal: { type: string, description: 'agree | collide | one_sided' }
               score: { type: [number, 'null'], description: 'The field''s contribution where scored (e.g. name_sim).' }
         status: { type: string, enum: [open, merged, not_a_duplicate] }
+        can_decide:
+          type: boolean
+          description: |
+            Whether THIS caller could dispose of the pair — merge it, dismiss it,
+            or undo a decision. Deciding needs write authority over BOTH ends:
+            dismissing suppresses both records as duplicates for the whole
+            workspace, and merging rewrites one into the other.
+
+            A pair whose ends have different owners is therefore undecidable by
+            any bounded seat, and it is a common shape — capture creates the
+            near-duplicate owned by the mailbox owner while the incumbent belongs
+            to whoever worked it. The pair is still LISTED, because the person
+            who can see a duplicate is the person best placed to notice it; this
+            says whether the buttons will work, which the client should gate on
+            rather than discovering through a 403 after the POST.
         disposed_by: { type: [string, 'null'], format: uuid }
         disposed_at: { type: [string, 'null'], format: date-time }
         created_at: { type: string, format: date-time }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22573,6 +22573,20 @@ type DecideCommissionRequestDecision string
 
 // DedupeCandidate One DH-DDL-1 review-queue row: the canonical unordered pair, its confidence, and the detection-time evidence snapshot (DH-N-8).
 type DedupeCandidate struct {
+	// CanDecide Whether THIS caller could dispose of the pair — merge it, dismiss it,
+	// or undo a decision. Deciding needs write authority over BOTH ends:
+	// dismissing suppresses both records as duplicates for the whole
+	// workspace, and merging rewrites one into the other.
+	//
+	// A pair whose ends have different owners is therefore undecidable by
+	// any bounded seat, and it is a common shape — capture creates the
+	// near-duplicate owned by the mailbox owner while the incumbent belongs
+	// to whoever worked it. The pair is still LISTED, because the person
+	// who can see a duplicate is the person best placed to notice it; this
+	// says whether the buttons will work, which the client should gate on
+	// rather than discovering through a 403 after the POST.
+	CanDecide bool `json:"can_decide"`
+
 	// Confidence The PO-F-1/PO-F-2 fuzzy score at detection.
 	Confidence float32             `json:"confidence"`
 	CreatedAt  time.Time           `json:"created_at"`

--- a/backend/internal/modules/people/dedupequeue.go
+++ b/backend/internal/modules/people/dedupequeue.go
@@ -57,6 +57,20 @@ type DedupeCandidateRow struct {
 	DisposedBy  *ids.UUID
 	DisposedAt  *time.Time
 	CreatedAt   time.Time
+	// CanDecide says whether THIS caller could actually dispose of the pair.
+	//
+	// Deciding needs write authority over BOTH ends — dismissing suppresses
+	// both records as duplicates for the whole workspace, and merging rewrites
+	// one into the other. A pair whose ends have different owners is therefore
+	// undecidable by any bounded seat, and it is a common shape: capture creates
+	// the near-duplicate owned by the mailbox owner while the incumbent belongs
+	// to whoever worked it.
+	//
+	// The queue lists it anyway, because the person who can SEE a duplicate is
+	// the person best placed to notice it. What was missing is the truth about
+	// the buttons: they were rendered unconditionally and the refusal arrived
+	// only after the POST.
+	CanDecide bool
 }
 
 // DedupeQueueInput filters one list page.
@@ -144,67 +158,6 @@ func requireDedupeWrite(ctx context.Context, entityType string) error {
 	return auth.Require(ctx, entityType, principal.ActionUpdate)
 }
 
-// dedupeVisibilityClause renders the queue's row-scope filter: a candidate
-// surfaces only when BOTH sides of its pair are visible to the caller —
-// the evidence snapshot reads both records, so listing a pair IS a read of
-// them (H1). Empty for unbounded callers.
-func dedupeVisibilityClause(ctx context.Context, arg func(any) int, mustBeLive bool) (string, error) {
-	personClause, err := auth.ScopeClauseFor(ctx, entityPerson, "vp", arg)
-	if err != nil {
-		return "", err
-	}
-	orgClause, err := auth.ScopeClauseFor(ctx, entityOrganization, "vo", arg)
-	if err != nil {
-		return "", err
-	}
-	leadClause, err := auth.ScopeClauseFor(ctx, entityLead, "vl", arg)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf(`((entity_type = 'person' AND %s) OR (entity_type = 'organization' AND %s) OR (entity_type = 'lead' AND %s))`,
-		bothSidesServable(entityPerson, "vp", "left_person_id", "right_person_id", personClause, mustBeLive),
-		bothSidesServable(entityOrganization, "vo", "left_org_id", "right_org_id", orgClause, mustBeLive),
-		bothSidesServable(entityLead, "vl", "left_lead_id", "right_lead_id", leadClause, mustBeLive)), nil
-}
-
-// bothSidesServable is the per-side predicate for one entity type: the subject
-// row must EXIST, be LIVE, and pass whatever row scope the caller has.
-//
-// Emitted unconditionally, where the predicate this replaced was skipped whole
-// when no record type narrowed the caller. That was not the bug — person and
-// organization are capture-private, so even an all-scope human is bounded on
-// them and the clause was built anyway — but it made the liveness term depend on
-// a scope the reader might not have. A system principal is unbounded on all
-// three (auth.Unbounded), so on the day one reads this queue the old shape would
-// have served it every archived pair in the installation.
-//
-// The liveness term is not part of the scope clause and cannot be folded into
-// it. auth.EnsureVisibleLive says why in its own words: erasure anonymizes a
-// person in place and stamps archived_at while LEAVING owner_id alone, so a
-// scope predicate answers "yes, still yours" for a record every live read path
-// refuses. The same is true of a plain archive.
-//
-// Without it a decision outlives both records it is about. The candidate carries
-// its own archived_at and nothing sweeps it when a SUBJECT is archived, so the
-// pair keeps the confidence it was filed with and holds its rank in a lane that
-// serves ten by score. Archiving one of two duplicates is a reasonable way to
-// resolve a pair — the most natural one for a company entered twice, since it
-// needs no merge decision — so the more diligently a workspace resolves them
-// that way, the faster its queue fills with its own finished work.
-func bothSidesServable(entityType, alias, leftColumn, rightColumn, scopeClause string, mustBeLive bool) string {
-	side := func(column string) string {
-		terms := fmt.Sprintf("%[1]s.id = dedupe_candidate.%[2]s", alias, column)
-		if mustBeLive {
-			terms += fmt.Sprintf(" AND %s.archived_at IS NULL", alias)
-		}
-		if scopeClause != "" {
-			terms += " AND " + scopeClause
-		}
-		return fmt.Sprintf("EXISTS (SELECT 1 FROM %s %s WHERE %s)", entityType, alias, terms)
-	}
-	return "(" + side(leftColumn) + " AND " + side(rightColumn) + ")"
-}
-
 // ListDedupeCandidates pages the queue, confidence-sorted (AC-dedupe-1).
 func (s *Store) ListDedupeCandidates(ctx context.Context, in DedupeQueueInput) ([]DedupeCandidateRow, string, error) {
 	if err := requireDedupeRead(ctx, in.EntityType); err != nil {
@@ -217,19 +170,27 @@ func (s *Store) ListDedupeCandidates(ctx context.Context, in DedupeQueueInput) (
 		in.Limit = dedupeQueueDefaultLimit
 	}
 
+	args := []any{in.Status}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	// Computed in the SAME statement as the page rather than probed per row: the
+	// answer is a predicate over the two subject rows, and asking it row by row
+	// would be two round trips per candidate for a fact the query already has
+	// the joins for.
+	decidable, err := dedupeDecidableExpr(ctx, arg, in.Status == dispositionOpen)
+	if err != nil {
+		return nil, "", err
+	}
 	query := `
 		SELECT id, entity_type, coalesce(left_person_id, left_org_id, left_lead_id), coalesce(right_person_id, right_org_id, right_lead_id),
-		       confidence, evidence, disposition, disposed_by, disposed_at, created_at
+		       confidence, evidence, disposition, disposed_by, disposed_at, created_at,
+		       ` + decidable + `
 		FROM dedupe_candidate
 		WHERE disposition = $1 AND archived_at IS NULL`
-	args := []any{in.Status}
 	// Liveness binds the OPEN lane only. A decided pair is a record of what
 	// somebody decided, and every merge archives the loser by definition — so
 	// asking both sides to be live on `status=merged` would hide every row that
 	// filter exists to serve.
-	visClause, err := dedupeVisibilityClause(ctx,
-		func(v any) int { args = append(args, v); return len(args) },
-		in.Status == dispositionOpen)
+	visClause, err := dedupeVisibilityClause(ctx, arg, in.Status == dispositionOpen)
 	if err != nil {
 		return nil, "", err
 	}
@@ -261,7 +222,8 @@ func (s *Store) ListDedupeCandidates(ctx context.Context, in DedupeQueueInput) (
 		for res.Next() {
 			var r DedupeCandidateRow
 			if err := res.Scan(&r.ID, &r.EntityType, &r.LeftID, &r.RightID, &r.Confidence,
-				&r.Evidence, &r.Disposition, &r.DisposedBy, &r.DisposedAt, &r.CreatedAt); err != nil {
+				&r.Evidence, &r.Disposition, &r.DisposedBy, &r.DisposedAt, &r.CreatedAt,
+				&r.CanDecide); err != nil {
 				return err
 			}
 			rows = append(rows, r)
@@ -407,11 +369,7 @@ func (s *Store) OpenCandidatesNaming(ctx context.Context, entityType string, id 
 	if err := requireDedupeRead(ctx, entityType); err != nil {
 		return nil, err
 	}
-	column, ok := map[string][2]string{
-		entityPerson:       {"left_person_id", "right_person_id"},
-		entityOrganization: {"left_org_id", "right_org_id"},
-		entityLead:         {"left_lead_id", "right_lead_id"},
-	}[entityType]
+	side, ok := dedupePairSideFor(entityType)
 	if !ok {
 		// Not an error: most record types have no dedupe queue at all, and a
 		// create of one is entitled to ask and be told nothing was filed.
@@ -424,7 +382,7 @@ func (s *Store) OpenCandidatesNaming(ctx context.Context, entityType string, id 
 		       confidence, evidence, disposition, disposed_by, disposed_at, created_at
 		  FROM dedupe_candidate
 		 WHERE disposition = $1 AND archived_at IS NULL
-		   AND (%s = $2 OR %s = $2)`, column[0], column[1])
+		   AND (%s = $2 OR %s = $2)`, side.left, side.right)
 	visClause, err := dedupeVisibilityClause(ctx,
 		func(v any) int { args = append(args, v); return len(args) }, true)
 	if err != nil {

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -739,6 +739,66 @@ func TestARefusedMergeLeavesNoMarkAndNoAuditOfOne(t *testing.T) {
 	}
 }
 
+// The queue says whether the caller could actually decide each pair.
+//
+// Capture creates the near-duplicate owned by the mailbox owner while the
+// incumbent belongs to whoever worked it, so a pair whose ends have different
+// owners is the common shape — and deciding one needs write authority over
+// BOTH ends, because dismissing suppresses both records for the whole workspace
+// and merging rewrites one into the other. Neither owner holds that.
+//
+// The pair is still LISTED: the person who can see a duplicate is the person
+// best placed to notice it, and narrowing the list would hide a real duplicate
+// rather than merely leave it stuck. What was missing is the truth about the
+// buttons — they rendered unconditionally and the refusal arrived after the
+// POST.
+func TestTheQueueSaysWhichPairsThisCallerCouldDecide(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	_, second := seedPersonPair(ctx, t, e, "Otto Split", "otto@split.test", "Ottoo Split", "ottoo@split.test", "split.test")
+	c := openCandidates(ctx, t, e, "person")[0]
+
+	// An unbounded reader can decide it, which is the control: a flag that were
+	// false for everybody would pass the assertion below for the wrong reason.
+	if !c.CanDecide {
+		t.Fatal("an unbounded reader cannot decide a pair it can see — can_decide is false for everyone")
+	}
+
+	// Hand ONE end to a colleague. Now neither owner holds both.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE person SET owner_id = $1 WHERE id = $2`, e.otherRep, second)
+		return err
+	}); err != nil {
+		t.Fatalf("handing one end to the colleague: %v", err)
+	}
+
+	colleague := e.asOwnScoped(e.otherRep)
+	listed := openCandidates(colleague, t, e, "person")
+	if len(listed) != 1 {
+		t.Fatalf("the colleague sees %d pair(s), want 1 — a duplicate they can see must stay "+
+			"listed even when they cannot settle it", len(listed))
+	}
+	if listed[0].CanDecide {
+		t.Error("can_decide is true for a caller who owns one end of the pair — the buttons will " +
+			"render and the POST will answer 403, which is the whole defect")
+	}
+
+	// And the flag is not merely pessimistic for a bounded seat: give the
+	// colleague both ends and it turns true.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE person SET owner_id = $1 WHERE id IN ($2, $3)`,
+			e.otherRep, listed[0].LeftID, listed[0].RightID)
+		return err
+	}); err != nil {
+		t.Fatalf("handing both ends to the colleague: %v", err)
+	}
+	both := openCandidates(colleague, t, e, "person")
+	if len(both) != 1 || !both[0].CanDecide {
+		t.Errorf("can_decide = %v for a caller who owns BOTH ends, want true — a flag that is "+
+			"always false hides the buttons from everyone", both)
+	}
+}
+
 func TestDedupeMergeArmKeepsItsOwnRefusal(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()

--- a/backend/internal/modules/people/dedupescope.go
+++ b/backend/internal/modules/people/dedupescope.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Which duplicate pairs a caller may SEE, and which of those they could
+// actually SETTLE.
+//
+// Two different questions over the same two subject rows, and keeping them
+// beside each other is the point: they share the both-ends shape, they differ
+// only in which halves of authority each demands, and a reader comparing them
+// can see that the second is the first plus the write arm. Split out of
+// dedupequeue.go, which is the queue's reads and writes.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+)
+
+// dedupePairSides is the three entity types a pair can be, with the columns
+// each one's two ends live in.
+//
+// ONE table, read by both clauses below. They walk the same three types over
+// the same six columns and differ only in which halves of authority each
+// demands, so a second copy of the column names is a chance for the filter and
+// the flag to come to disagree about which rows a pair is even about.
+type dedupePairSide struct{ entity, left, right string }
+
+var dedupePairSides = []dedupePairSide{
+	{entityPerson, "left_person_id", "right_person_id"},
+	{entityOrganization, "left_org_id", "right_org_id"},
+	{entityLead, "left_lead_id", "right_lead_id"},
+}
+
+// dedupePairSideFor answers which columns hold a pair's ends for one entity
+// type, or false for a record type that has no dedupe queue at all.
+func dedupePairSideFor(entityType string) (dedupePairSide, bool) {
+	for _, side := range dedupePairSides {
+		if side.entity == entityType {
+			return side, true
+		}
+	}
+	return dedupePairSide{}, false
+}
+
+// dedupePairArms renders one OR-arm per entity type, each asking `authority` of
+// both ends under an alias prefixed to keep the two clauses' subqueries apart in
+// one statement.
+func dedupePairArms(
+	prefix string, mustBeLive bool,
+	authority func(entity, alias string) (string, error),
+) (string, error) {
+	arms := make([]string, 0, len(dedupePairSides))
+	for i, side := range dedupePairSides {
+		alias := fmt.Sprintf("%s%d", prefix, i)
+		clause, err := authority(side.entity, alias)
+		if err != nil {
+			return "", err
+		}
+		arms = append(arms, fmt.Sprintf("(entity_type = '%s' AND %s)", side.entity,
+			bothSidesServable(side.entity, alias, side.left, side.right, clause, mustBeLive)))
+	}
+	return "(" + strings.Join(arms, " OR ") + ")", nil
+}
+
+// dedupeVisibilityClause renders the queue's row-scope filter: a candidate
+// surfaces only when BOTH sides of its pair are visible to the caller —
+// the evidence snapshot reads both records, so listing a pair IS a read of
+// them (H1). Empty for unbounded callers.
+func dedupeVisibilityClause(ctx context.Context, arg func(any) int, mustBeLive bool) (string, error) {
+	return dedupePairArms("v", mustBeLive, func(entity, alias string) (string, error) {
+		return auth.ScopeClauseFor(ctx, entity, alias, arg)
+	})
+}
+
+// bothSidesServable is the per-side predicate for one entity type: the subject
+// row must EXIST, be LIVE, and pass whatever row scope the caller has.
+//
+// Emitted unconditionally, where the predicate this replaced was skipped whole
+// when no record type narrowed the caller. That was not the bug — person and
+// organization are capture-private, so even an all-scope human is bounded on
+// them and the clause was built anyway — but it made the liveness term depend on
+// a scope the reader might not have. A system principal is unbounded on all
+// three (auth.Unbounded), so on the day one reads this queue the old shape would
+// have served it every archived pair in the installation.
+//
+// The liveness term is not part of the scope clause and cannot be folded into
+// it. auth.EnsureVisibleLive says why in its own words: erasure anonymizes a
+// person in place and stamps archived_at while LEAVING owner_id alone, so a
+// scope predicate answers "yes, still yours" for a record every live read path
+// refuses. The same is true of a plain archive.
+//
+// Without it a decision outlives both records it is about. The candidate carries
+// its own archived_at and nothing sweeps it when a SUBJECT is archived, so the
+// pair keeps the confidence it was filed with and holds its rank in a lane that
+// serves ten by score. Archiving one of two duplicates is a reasonable way to
+// resolve a pair — the most natural one for a company entered twice, since it
+// needs no merge decision — so the more diligently a workspace resolves them
+// that way, the faster its queue fills with its own finished work.
+func bothSidesServable(entityType, alias, leftColumn, rightColumn, scopeClause string, mustBeLive bool) string {
+	side := func(column string) string {
+		terms := fmt.Sprintf("%[1]s.id = dedupe_candidate.%[2]s", alias, column)
+		if mustBeLive {
+			terms += fmt.Sprintf(" AND %s.archived_at IS NULL", alias)
+		}
+		if scopeClause != "" {
+			terms += " AND " + scopeClause
+		}
+		return fmt.Sprintf("EXISTS (SELECT 1 FROM %s %s WHERE %s)", entityType, alias, terms)
+	}
+	return "(" + side(leftColumn) + " AND " + side(rightColumn) + ")"
+}
+
+// dedupeDecidableExpr renders the per-row "could this caller dispose of it"
+// answer, in the same both-sides shape the visibility filter uses.
+//
+// BOTH halves of authority, and both ENDS. The visibility clause is not enough:
+// a seat can read a record it may not change, and disposing of a pair changes
+// both — dismissing suppresses them for the whole workspace and merging rewrites
+// one into the other. So each side must pass the read scope AND the write arm,
+// which is exactly what EnsureWritable checks one row at a time on the way in.
+//
+// It answers about the CALLER, so it is a column and not a filter. Narrowing the
+// list to decidable pairs would hide a real duplicate from the person best
+// placed to notice it, and a pair nobody can decide would become invisible
+// rather than merely stuck.
+func dedupeDecidableExpr(ctx context.Context, arg func(any) int, mustBeLive bool) (string, error) {
+	expr, err := dedupePairArms("d", mustBeLive, func(entity, alias string) (string, error) {
+		scope, err := auth.ScopeClauseFor(ctx, entity, alias, arg)
+		if err != nil {
+			return "", err
+		}
+		write, err := auth.WriteAuthorityClauseFor(ctx, entity, alias, arg)
+		if err != nil {
+			return "", err
+		}
+		return andClauses(scope, write), nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return expr + " AS can_decide", nil
+}
+
+// andClauses joins the two authority halves, skipping an empty one — an
+// unbounded caller narrows on neither, and "true AND true" in every row of
+// every arm is noise in an EXPLAIN somebody will one day read.
+func andClauses(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + " AND " + b
+	}
+}

--- a/backend/internal/modules/people/handlers_dedupe.go
+++ b/backend/internal/modules/people/handlers_dedupe.go
@@ -117,6 +117,7 @@ func toContractDedupeCandidate(row DedupeCandidateRow) (crmcontracts.DedupeCandi
 		Status:     crmcontracts.DedupeCandidateStatus(row.Disposition),
 		CreatedAt:  row.CreatedAt,
 		DisposedAt: row.DisposedAt,
+		CanDecide:  row.CanDecide,
 	}
 	if row.DisposedBy != nil {
 		u := openapi_types.UUID(*row.DisposedBy)

--- a/backend/internal/platform/auth/writeauthorityclause.go
+++ b/backend/internal/platform/auth/writeauthorityclause.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// The write arm as a CLAUSE, for a list that has to say whether the caller
+// could act on each row rather than probe one row at a time.
+//
+// Beside writescope.go's probes rather than inside them: a probe answers about
+// one row and refuses, a clause answers about every row and reports. They share
+// the predicate underneath, and that sharing is what keeps a list's answer and
+// the write's own refusal from drifting apart.
+
+import (
+	"context"
+	"fmt"
+)
+
+// WriteAuthorityClauseFor renders the write arm as a CLAUSE, for a list that
+// has to say whether the caller could act on each row rather than probe one row
+// at a time — ScopeClauseFor's write-level twin.
+//
+// It is the write half ONLY. The visibility half is ScopeClauseFor's, and a
+// caller asking "may this seat change this row" owes both: EnsureWritable runs
+// the visibility probe first for a reason its own comment gives, and a clause
+// that carried only this one would answer yes for a row the caller cannot even
+// read. Composing them is the caller's job because a list already has the
+// visibility clause in hand and would otherwise apply it twice.
+//
+// Empty means "no narrowing" — an unbounded caller, or a table nothing can be
+// shared on — which the caller reads the way ScopeClauseFor's empty is read.
+func WriteAuthorityClauseFor(ctx context.Context, table, alias string, arg func(any) int) (string, error) {
+	if !ownerScopedTables[table] {
+		return "", fmt.Errorf("auth: %q is not a row-scoped table", table)
+	}
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return "", err
+	}
+	if Unbounded(p) || !shareableTables[table] {
+		return "", nil
+	}
+	if alias == "" {
+		alias = table
+	}
+	return writeAuthorityPredicateAs(p, table, alias, arg), nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16016,6 +16016,21 @@ export interface components {
             }[];
             /** @enum {string} */
             status: "open" | "merged" | "not_a_duplicate";
+            /**
+             * @description Whether THIS caller could dispose of the pair — merge it, dismiss it,
+             *     or undo a decision. Deciding needs write authority over BOTH ends:
+             *     dismissing suppresses both records as duplicates for the whole
+             *     workspace, and merging rewrites one into the other.
+             *
+             *     A pair whose ends have different owners is therefore undecidable by
+             *     any bounded seat, and it is a common shape — capture creates the
+             *     near-duplicate owned by the mailbox owner while the incumbent belongs
+             *     to whoever worked it. The pair is still LISTED, because the person
+             *     who can see a duplicate is the person best placed to notice it; this
+             *     says whether the buttons will work, which the client should gate on
+             *     rather than discovering through a 403 after the POST.
+             */
+            can_decide: boolean;
             /** Format: uuid */
             disposed_by?: string | null;
             /** Format: date-time */

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -80,6 +80,10 @@ const CANDIDATE = (id: string): Candidate => ({
   right_id: "o-2",
   confidence: 0.91,
   evidence: [],
+  // The rail only counts what is waiting; it renders no decide button, so this
+  // fixture says the caller could decide rather than leaving the count and the
+  // authority tangled in a test about neither.
+  can_decide: true,
   status: "open",
   created_at: "2026-08-01T09:00:00Z",
 });


### PR DESCRIPTION
Closes #1952.

Deciding a pair needs write authority over **both** ends — dismissing suppresses both records as duplicates for the whole workspace, and merging rewrites one into the other. So a pair whose ends have different owners is undecidable by any bounded seat, and that is the **common** shape rather than an edge: capture creates the near-duplicate owned by the mailbox owner while the incumbent belongs to whoever worked it.

The pair was listed anyway — correctly, because the person who can see a duplicate is the person best placed to notice it. What was missing is the truth about the buttons: `/dedupe-candidates` carried no *"could I act on this"* field, so a client rendered the CTAs unconditionally and the refusal arrived after the POST.

## `can_decide`

Answered the way the write path answers it: each end must pass the read scope **and** the write arm — what `EnsureWritable` checks one row at a time on the way in.

It is a **column, not a filter**. Narrowing the list would hide a real duplicate from the person best placed to notice it, and a pair nobody can decide would become invisible rather than merely stuck. (Option 1 in the issue; option 2 is what landed, as recommended.)

**Computed in the same statement as the page.** The answer is a predicate over the two subject rows and the query already has the shape for it; probing per row would be two round trips per candidate for a fact one statement can carry.

## The write arm became sayable

`auth` had the predicate and no way to ask it of a list. `WriteAuthorityClauseFor` is `ScopeClauseFor`'s write-level twin, sharing the predicate underneath — which is what keeps a list's answer and the write's own refusal from drifting apart.

It is the write half **only**, and says so: a clause carrying just that would answer yes for a row the caller cannot read. Composing the two is the caller's job, because a list already holds the visibility clause and would otherwise apply it twice.

## The three column pairs are one table now

The visibility filter, the new flag, and `OpenCandidatesNaming` each spelled out which columns hold a pair's ends — three copies, and **the third predates this change**. They walk the same three types over the same six columns and differ only in which halves of authority they demand.

## Not a new rule

The worklist's pair card already gates on this question and says so in words when the answer is no. This is the other surface catching up.

## Mutation

Drop the write half and the flag reads `true` for a caller who owns one end — the buttons render and the POST answers 403, which is the whole defect.

`make check-backend` exit 0; `make check-fe` green; full `internal/modules/people` suite passes.