### PR TITLE
The morning queue says where each deal stood yesterday

### DIFF
--- a/backend/internal/compose/briefs/briefcontinuity.go
+++ b/backend/internal/compose/briefs/briefcontinuity.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// What the queue before this one said about the same deals.
+//
+// A daily brief that cannot see its own last edition describes a deal stuck for
+// a week exactly as it describes one that arrived overnight. The difference is
+// most of what a reader wants, and it is a deterministic fact — a rank written
+// into a row before anything read it — so it is served WITH the queue rather
+// than fetched by whoever is reading it. That is the ground the dismissal
+// lineage is served on too: a record of what happened, not something an agent
+// wrote, so a run carrying it is not a loop reading its own output.
+//
+// It is deliberately NOT a diff, and the absence is the reason. "Not in the
+// previous run" and "new" are different statements — a deal is absent because
+// it did not rank, which happens to deals that have existed for months — so the
+// only claim made here is the one the rows support: this deal stood at that
+// position on that day.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// previousRanking is what the run before `day` recorded for this rep: the local
+// day it was for, and the position each deal held in it.
+//
+// A zero day means there is no earlier run at all. That is a different state
+// from an earlier run in which a deal did not appear, and both are different
+// from a morning where nothing moved — a caller that collapsed them would tell
+// a rep on their first day that nothing had changed.
+func previousRanking(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, day time.Time,
+) (time.Time, map[ids.UUID]int, error) {
+	var runID ids.UUID
+	var was time.Time
+	err := tx.QueryRow(ctx, `
+		SELECT id, local_day FROM brief_run
+		 WHERE user_id = $1 AND local_day < $2
+		 ORDER BY local_day DESC
+		 LIMIT 1`, userID, day).Scan(&runID, &was)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, nil, nil
+	}
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("briefs: reading the previous run: %w", err)
+	}
+	// Scoped like every other read of a persisted deal reference: re-checked
+	// when it is SERVED rather than trusted from the night it was written. The
+	// ranks reach only deals today's read already answered with, so on today's
+	// shape this clause refuses nothing — it is here because the rule is
+	// uniform, and a read that decided for itself that it was the exception
+	// would be the one place the next caller inherits an unscoped door from.
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	runPos := arg(runID)
+	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	if err != nil {
+		return time.Time{}, nil, err
+	}
+	q := fmt.Sprintf(`
+		SELECT bi.deal_id, bi.rank
+		  FROM brief_item bi
+		  JOIN deal d ON d.id = bi.deal_id
+		 WHERE bi.brief_run_id = $%d`, runPos)
+	if scope != "" {
+		q += " AND " + scope
+	}
+	rows, err := tx.Query(ctx, q, args...)
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("briefs: reading the previous ranking: %w", err)
+	}
+	defer rows.Close()
+	ranks := make(map[ids.UUID]int)
+	for rows.Next() {
+		var dealID ids.UUID
+		var rank int
+		if err := rows.Scan(&dealID, &rank); err != nil {
+			return time.Time{}, nil, fmt.Errorf("briefs: reading the previous ranking: %w", err)
+		}
+		ranks[dealID] = rank
+	}
+	if err := rows.Err(); err != nil {
+		return time.Time{}, nil, fmt.Errorf("briefs: reading the previous ranking: %w", err)
+	}
+	return was, ranks, nil
+}
+
+// carryPreviousRanks stamps each item with where its deal stood in the previous
+// run, and leaves the rest untouched.
+func carryPreviousRanks(items []BriefRunItem, ranks map[ids.UUID]int) {
+	for i := range items {
+		rank, ok := ranks[items[i].DealID]
+		if !ok {
+			continue
+		}
+		items[i].PreviousRank = &rank
+	}
+}

--- a/backend/internal/compose/briefs/briefcontinuity_integration_test.go
+++ b/backend/internal/compose/briefs/briefcontinuity_integration_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package briefs
+
+// What yesterday's queue said, read back on today's.
+//
+// The three cases are one distinction told three ways, and the distinction is
+// the whole point: a deal that was ranked yesterday, a deal that was not, and a
+// morning with no yesterday at all. A reader that collapsed the second into the
+// third would call a months-old deal new; one that collapsed the third into the
+// second would tell a rep on their first morning that nothing had changed.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+)
+
+// theNextMorning is the run one day on from the fixture's own.
+var theNextMorning = briefClock.Add(24 * time.Hour)
+
+// itemFor is the queue entry for one deal, or nil when it did not rank.
+func itemFor(run BriefRun, dealID interface{ String() string }) *BriefRunItem {
+	for i := range run.Items {
+		if run.Items[i].DealID.String() == dealID.String() {
+			return &run.Items[i]
+		}
+	}
+	return nil
+}
+
+func TestADealRankedYesterdayCarriesWhereItStood(t *testing.T) {
+	b := setupBrief(t)
+	first, err := b.engine.SnapshotRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Items) == 0 {
+		t.Fatal("the fixture ranked nothing, so there is no yesterday to carry")
+	}
+	stuck := first.Items[0]
+
+	if _, err := b.engine.SnapshotRun(b.repCtx, theNextMorning); err != nil {
+		t.Fatal(err)
+	}
+	today, err := b.engine.LatestRun(b.repCtx, theNextMorning)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if today.PreviousDay.IsZero() {
+		t.Fatal("the run names no previous day, so nothing on it can be read as a comparison")
+	}
+	if got, want := today.PreviousDay, first.LocalDay; !got.Equal(want) {
+		t.Errorf("the run compares against %s, want the run before it (%s)", got, want)
+	}
+	item := itemFor(today, stuck.DealID)
+	if item == nil {
+		t.Fatalf("the deal ranked first yesterday is absent today: %v", today.Items)
+	}
+	if item.PreviousRank == nil {
+		t.Fatal("a deal on the queue two mornings running carries no previous rank — " +
+			"a brief that cannot see its own last edition reports a week-old deal as news")
+	}
+	if *item.PreviousRank != stuck.Rank {
+		t.Errorf("previous rank = %d, want %d — the position it actually held", *item.PreviousRank, stuck.Rank)
+	}
+}
+
+func TestADealThatDidNotRankYesterdayCarriesNoRankAndIsNotCalledNew(t *testing.T) {
+	b := setupBrief(t)
+	owner := integration.OwnerConn(t)
+	if _, err := b.engine.SnapshotRun(b.repCtx, briefClock); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deal C exists and has existed all along — it simply sat below the bar. An
+	// activity overnight lifts it onto today's queue without making it new.
+	late := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'they wrote back', '2026-06-05T01:00:00Z', 'manual', 'human:x')`)
+	integration.LinkActivity(t, owner, late, "deal", b.dealC)
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE stage SET win_probability = 70 WHERE id = (SELECT stage_id FROM deal WHERE id = $1)`,
+		b.dealC); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := b.engine.SnapshotRun(b.repCtx, theNextMorning); err != nil {
+		t.Fatal(err)
+	}
+	today, err := b.engine.LatestRun(b.repCtx, theNextMorning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := itemFor(today, b.dealC)
+	if item == nil {
+		t.Fatalf("the fixture did not lift the below-the-bar deal onto today's queue: %v", today.Items)
+	}
+	if item.PreviousRank != nil {
+		t.Errorf("a deal that did not rank yesterday carries previous rank %d", *item.PreviousRank)
+	}
+	// And the run still names the day it is comparing against, which is what
+	// keeps "did not rank" from reading as "there was no yesterday".
+	if today.PreviousDay.IsZero() {
+		t.Error("the run names no previous day, so an absent rank cannot be told from an absent run")
+	}
+}
+
+func TestAFirstMorningNamesNoPreviousDay(t *testing.T) {
+	b := setupBrief(t)
+	if _, err := b.engine.SnapshotRun(b.repCtx, briefClock); err != nil {
+		t.Fatal(err)
+	}
+	first, err := b.engine.LatestRun(b.repCtx, briefClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.PreviousDay.IsZero() {
+		t.Errorf("a first run compares against %s — there is nothing before it, and a rep told "+
+			"nothing changed on their first morning has been told something false", first.PreviousDay)
+	}
+	for _, item := range first.Items {
+		if item.PreviousRank != nil {
+			t.Errorf("item %s carries a previous rank on a first run", item.ID)
+		}
+	}
+}

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -60,6 +60,10 @@ type BriefRun struct {
 	// pass that ran and had nothing to say.
 	Narrative   string
 	AnnotatedAt *time.Time
+	// PreviousDay is the local day of the last run before this one, zero when
+	// there was none. See briefcontinuity.go: a first morning and a morning
+	// where nothing moved are different answers.
+	PreviousDay time.Time
 	Items       []BriefRunItem
 }
 
@@ -84,6 +88,10 @@ type BriefRunItem struct {
 	// Lineage is set when this deal is back after the rep dismissed it. Nil is
 	// the ordinary case.
 	Lineage *ItemLineage
+	// PreviousRank is where this deal stood in the run PreviousDay names. Nil
+	// when it did not appear there, which is NOT the same as the deal being
+	// new — see briefcontinuity.go.
+	PreviousRank *int
 }
 
 // SnapshotRun ranks and persists one brief run for the acting rep at the
@@ -286,6 +294,16 @@ func (e *BriefEngine) LatestRun(ctx context.Context, now time.Time) (BriefRun, e
 		if err != nil {
 			return err
 		}
+		// Read here rather than by the caller, and in this transaction: the
+		// comparison is part of what the run SAYS, and a second read outside
+		// the transaction could straddle the night's next assembly and compare
+		// today against itself.
+		previousDay, previousRanks, err := previousRanking(ctx, tx, userID, day)
+		if err != nil {
+			return err
+		}
+		run.PreviousDay = previousDay
+		carryPreviousRanks(run.Items, previousRanks)
 		// The open is recorded here and not in the handler, so it rides the
 		// same transaction as the read and counts what the rep is actually
 		// about to see (briefopened.go).

--- a/backend/internal/compose/briefseam.go
+++ b/backend/internal/compose/briefseam.go
@@ -71,8 +71,9 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 	for _, item := range run.Items {
 		items = append(items, agents.BriefItem{
 			ItemID: item.ID, DealID: item.DealID, Rank: item.Rank,
-			Lineage:   lineageForTool(item.Lineage),
-			Composite: item.Composite, Factors: agents.BriefFactors{
+			PreviousRank: item.PreviousRank,
+			Lineage:      lineageForTool(item.Lineage),
+			Composite:    item.Composite, Factors: agents.BriefFactors{
 				Winnability: item.Features.Winnability, Revenue: item.Features.Revenue,
 				Timing: item.Features.Timing, Momentum: item.Features.Momentum,
 				Warmth: item.Features.Warmth,
@@ -90,8 +91,12 @@ func briefRunToTool(run briefs.BriefRun) agents.ReadBriefResult {
 	}
 	return agents.ReadBriefResult{
 		BriefID: run.ID, GeneratedAt: run.GeneratedAt, AsOf: run.AsOf,
-		LocalDay:       run.LocalDay.Format(time.DateOnly),
-		CandidateCount: run.CandidateCount, Items: items,
+		LocalDay: run.LocalDay.Format(time.DateOnly),
+		// Omitted rather than zero-formatted when there was no earlier run: a
+		// date on the wire says a comparison exists, and "0001-01-01" would say
+		// it in a shape a model would read as a real morning.
+		PreviousLocalDay: previousDayForTool(run.PreviousDay),
+		CandidateCount:   run.CandidateCount, Items: items,
 	}
 }
 
@@ -105,4 +110,13 @@ func lineageForTool(lineage *briefs.ItemLineage) *agents.BriefItemLineage {
 		DismissedOn:  lineage.DismissedOn.Format(time.DateOnly),
 		ReturnedWith: lineage.ReturnedWith,
 	}
+}
+
+// previousDayForTool is the morning a run is compared against, empty when there
+// is none to compare it against.
+func previousDayForTool(day time.Time) string {
+	if day.IsZero() {
+		return ""
+	}
+	return day.Format(time.DateOnly)
 }

--- a/backend/internal/compose/briefseam_test.go
+++ b/backend/internal/compose/briefseam_test.go
@@ -58,12 +58,14 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 	snoozedUntil := time.Date(2026, 8, 9, 8, 44, 0, 0, time.UTC)
 	meetingID := ids.NewV7()
 	annotatedAt := time.Date(2026, 8, 8, 6, 12, 0, 0, time.UTC)
+	previousRank := 5
 	run := briefs.BriefRun{
 		ID: runID, UserID: userID, GeneratedAt: generated, AsOf: asOf,
 		LocalDay:       time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC),
 		CandidateCount: 17, RevenueNormMinor: 918_273, RevenueNormCurrency: "CHF",
 		Narrative:   "Two replies overnight, one deal went quiet.",
 		AnnotatedAt: &annotatedAt,
+		PreviousDay: time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC),
 		Items: []briefs.BriefRunItem{{
 			ID: itemID, DealID: dealID, Rank: 3, Composite: 0.815,
 			Features: briefs.BriefFeatureVector{
@@ -72,7 +74,8 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 			EvidenceIDs: []ids.UUID{evidence}, State: "snoozed",
 			StateAt: &stateAt, SnoozedUntil: &snoozedUntil,
 			ReopenOn: values.ReopenOnMeeting, ReopenRef: &meetingID,
-			Finding: "He asked about the delivery date yesterday.",
+			Finding:      "He asked about the delivery date yesterday.",
+			PreviousRank: &previousRank,
 			Lineage: &briefs.ItemLineage{
 				DismissedOn:  time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
 				ReturnedWith: time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC),
@@ -106,6 +109,7 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 		"AsOf":           `"as_of":"2026-08-08T05:22:00Z"`,
 		"LocalDay":       `"local_day":"2026-08-08"`,
 		"CandidateCount": `"candidate_count":17`,
+		"PreviousDay":    `"previous_local_day":"2026-08-07"`,
 		"Narrative":      "Two replies overnight, one deal went quiet.",
 		"AnnotatedAt":    "2026-08-08T06:12:00Z",
 		// Withheld — so the probe is what a LEAK would look like: the value
@@ -122,7 +126,8 @@ func TestEveryPersistedBriefFieldIsServedOrNamedAsWithheld(t *testing.T) {
 	assertEveryFieldSurvives(t, "BriefRunItem", reflect.TypeOf(run.Items[0]), map[string]string{
 		"ID": `"item_id":"` + itemID.String(), "DealID": `"deal_id":"` + dealID.String(),
 		"Rank": `"rank":3`, "Composite": `"composite":0.815`, "Features": `"momentum":0.44`,
-		"EvidenceIDs": `"evidence_ids":["` + evidence.String(), "State": `"state":"snoozed"`,
+		"PreviousRank": `"previous_rank":5`,
+		"EvidenceIDs":  `"evidence_ids":["` + evidence.String(), "State": `"state":"snoozed"`,
 		"StateAt": `"state_at":"2026-08-08T07:33:00Z"`, "SnoozedUntil": `"snoozed_until":"2026-08-09T08:44:00Z"`,
 		// Served, not withheld: without the condition a snooze carrying no
 		// moment reads to an agent as one that never lifts, and it would report

--- a/backend/internal/modules/agents/runner/catalog.go
+++ b/backend/internal/modules/agents/runner/catalog.go
@@ -68,6 +68,9 @@ func Catalog() []AgentSpec {
 				"Its items are the queue already ranked for this person; do not assemble a workspace-wide list. " +
 				"Read the evidence for those items, then call annotate_brief with one concise narrative " +
 				"and grounded findings: why each item matters, what changed and the next move. " +
+				"An item with a previous_rank was already on this queue on the run's previous_local_day: " +
+				"say what has changed since then rather than reporting it as new. An item without one may " +
+				"simply not have ranked that day, so do not call it new either. " +
 				"Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. " +
 				"Keep the existing order. If there are no items, finish without inventing a brief. " +
 				"A tool refusal means the findings were not saved: correct it before claiming completion.",

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -7150,6 +7150,9 @@
                     "returned_with_activity_at"
                   ]
                 },
+                "previous_rank": {
+                  "type": "integer"
+                },
                 "rank": {
                   "type": "integer"
                 },
@@ -7182,6 +7185,9 @@
             }
           },
           "local_day": {
+            "type": "string"
+          },
+          "previous_local_day": {
             "type": "string"
           }
         },

--- a/backend/internal/modules/agents/tools_brief.go
+++ b/backend/internal/modules/agents/tools_brief.go
@@ -87,6 +87,12 @@ type ReadBriefResult struct {
 	// on, and it is the one number on the run that describes the workspace
 	// rather than this rep's queue.
 	CandidateCount int `json:"candidate_count"`
+	// PreviousLocalDay is the morning of the run before this one, absent when
+	// there was none. It is what makes an item's previous_rank readable — a
+	// position is meaningless without the day it was held on — and it is also
+	// the difference between a rep's first morning and a morning where nothing
+	// moved, which an agent must not report as the same thing.
+	PreviousLocalDay string `json:"previous_local_day,omitempty"`
 	// Items is never null on the wire. An agent reading `null` has to decide
 	// whether it means "nothing is queued" or "the queue was not read".
 	Items []BriefItem `json:"items"`
@@ -139,6 +145,16 @@ type BriefItem struct {
 	// finding that ignores "you already waved this away once" is a finding that
 	// repeats an argument the reader has already rejected.
 	Lineage *BriefItemLineage `json:"lineage,omitempty"`
+	// PreviousRank is where this deal stood in the run PreviousLocalDay names,
+	// so a finding can say what has happened since rather than reporting a deal
+	// the person has been looking at all week as though it were news. It is
+	// SERVED for the reason Lineage is: a rank persisted before anything read
+	// it is a fact about the queue, not something an agent wrote.
+	//
+	// Absent means it did not appear in that run. That is NOT "new": a deal
+	// that has existed for months is absent from a queue it did not make, and a
+	// finding calling it new would be wrong about the one thing it claimed.
+	PreviousRank *int `json:"previous_rank,omitempty"`
 }
 
 // BriefItemLineage is why a dismissed deal came back.

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -13,7 +13,7 @@
   "agents": [
     {
       "name": "morning_brief",
-      "goal": "Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.",
+      "goal": "Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. An item with a previous_rank was already on this queue on the run's previous_local_day: say what has changed since then rather than reporting it as new. An item without one may simply not have ranked that day, so do not call it new either. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.",
       "tools": [
         "annotate_brief",
         "catch_me_up_on",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -36,7 +36,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 
 ### `morning_brief`
 
-> Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.
+> Prepare the acting person's existing Morning Brief. First call read_brief. Its items are the queue already ranked for this person; do not assemble a workspace-wide list. Read the evidence for those items, then call annotate_brief with one concise narrative and grounded findings: why each item matters, what changed and the next move. An item with a previous_rank was already on this queue on the run's previous_local_day: say what has changed since then rather than reporting it as new. An item without one may simply not have ranked that day, so do not call it new either. Use each returned item_id unchanged, never its deal_id, and cite only that item's evidence_ids. Keep the existing order. If there are no items, finish without inventing a brief. A tool refusal means the findings were not saved: correct it before claiming completion.
 
 Attaches 5 tools for 1634 tokens, leaving 21576 of its budget and 31134 tokens of the
 window for the goal, the grounding and everything it reads.

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 73,
     "resources": 12,
-    "tool_catalog_bytes": 209115,
+    "tool_catalog_bytes": 209189,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 53424,
+    "approx_wire_tokens_total": 53443,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 51079,
       "input_schema_bytes": 43457,
-      "output_schema_bytes": 98827,
+      "output_schema_bytes": 98901,
       "description_plus_input_schema_bytes": 94536
     }
   },
@@ -9105,6 +9105,9 @@
                         ],
                         "type": "object"
                       },
+                      "previous_rank": {
+                        "type": "integer"
+                      },
                       "rank": {
                         "type": "integer"
                       },
@@ -9139,6 +9142,9 @@
                   "type": "array"
                 },
                 "local_day": {
+                  "type": "string"
+                },
+                "previous_local_day": {
                   "type": "string"
                 }
               },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 73 |
 | Resources | 12 |
-| Tool catalog | 204.2 KB |
+| Tool catalog | 204.3 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 53424 |
+| Approx. wire tokens | 53443 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,7 +29,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 96.5 KB | 47% | **No** — a result's shape, never listed to a model |
+| Output schemas | 96.6 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 49.9 KB | 24% | Yes, every step |
 | Input schemas | 42.4 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.4 KB | 7% | Partly |
@@ -9913,6 +9913,9 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
                 ],
                 "type": "object"
               },
+              "previous_rank": {
+                "type": "integer"
+              },
               "rank": {
                 "type": "integer"
               },
@@ -9947,6 +9950,9 @@ Renders its result in [`ui://margince/account-brief.html`](#account_brief_view),
           "type": "array"
         },
         "local_day": {
+          "type": "string"
+        },
+        "previous_local_day": {
           "type": "string"
         }
       },


### PR DESCRIPTION
Closes #2402.

**The ticket's question is already answered, and not the way its body assumed.**
It asks whether `morning_brief` should be able to call `read_brief`, on the
premise that the agent *assembles* the brief and `read_brief` would hand it the
previous one. Since #4427 the agent does not assemble: the ranking is
deterministic and the agent annotates it, `read_brief` returns **today's**
queue keyed on today's local day, and the goal's first instruction is to call
it. Detaching it — the ruling recorded on the ticket on 2026-09-02, three days
before that change — would now break the agent outright. So the tool stays.

What survives is the reason that ruling did not simply refuse: *"an agent that
knew what it said yesterday could say 'still stuck' rather than re-reporting a
deal as though it were new."* That is what this builds, and as input on the
queue the agent already reads rather than as a second tool it could reach for
instead of working.

**What lands**

- `BriefRun.PreviousDay` — the local day of the run before this one, zero when
  there was none.
- `BriefRunItem.PreviousRank` — where this deal stood in that run, nil when it
  did not appear there.
- Both served on `read_brief` as `previous_local_day` and `previous_rank`, on
  the ground `lineage` is already served on: a rank persisted before anything
  read it is a fact about the queue, not something an agent wrote, so reading it
  is not a loop reading its own output.
- One clause in the goal, because a field the prompt never mentions is a field
  the run never uses.

**The distinction the whole change is about**

Three states, and collapsing any two of them produces a false sentence:

| state | wire | the lie if collapsed |
| --- | --- | --- |
| ranked yesterday | `previous_rank` present | reporting a week-old deal as news |
| not ranked yesterday | absent, `previous_local_day` present | calling a months-old deal new |
| no yesterday at all | `previous_local_day` absent | telling a rep on their first morning that nothing changed |

The goal text says all three, and the three integration tests are one per row.

**Reviewer notes**

- The read is inside `LatestRun`'s own transaction. A second read outside it
  could straddle the night's assembly and compare today against itself.
- The previous run's rows go through the same deal scope clause the queue does.
  It refuses nothing on today's shape — the ranks reach only deals the scoped
  read already answered with — and it is there because the rule is uniform, not
  because this read is the exception.
- No contract change: the HTTP brief response is untouched, so nothing here
  reaches the frontend.
- Output schemas are not in the tool listing, so the per-agent listing budget is
  unchanged. `agent-tool-budget.*` moved only because the goal text did.

**Verification**

`make check-backend` green; `make test-it DIR=backend/internal/compose/briefs`
green. `craft static --strict` clean over the diff.

Mutation-checked, each reverted after:

| mutation | test that failed |
| --- | --- |
| every item gets a rank whether or not it was ranked | the not-ranked-yesterday test |
| the previous-run query takes `<=` instead of `<` | both the ranked-yesterday and first-morning tests |