### PR TITLE
The contract search has a ceiling, and says so in the reader's words

### DIFF
--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -15,10 +15,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -304,4 +310,60 @@ func hasType(hits []search.Hit, want string) bool {
 		}
 	}
 	return false
+}
+
+// The ceiling compose arms on the search surface still serves an ordinary
+// search.
+//
+// The other half of the bound — that a spent ceiling reads as an actionable
+// "too broad" rather than a 5xx — is asserted in the search module's own
+// rankingfault_test.go, where it is a pure function of an error and a context.
+// It is NOT asserted by racing a live statement against a one-millisecond
+// budget: that test times the machine it runs on, and it flaked exactly that
+// way when it was written here.
+//
+// What this one holds is the direction a unit test cannot: a ceiling that
+// refused ordinary work would satisfy every assertion about the fault and break
+// the product.
+func TestTheSearchCeilingStillServesAnOrdinarySearch(t *testing.T) {
+	e := SetupSearch(t)
+	e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by) VALUES ($1, 'Rostock Person', 'manual', 'human:x')`)
+
+	status, body := callSearch(t, e, database.CallerPredicateBudget, "Rostock")
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 under the ceiling compose arms: %s", status, body)
+	}
+	if !strings.Contains(body, "Rostock Person") {
+		t.Errorf("the seeded person did not come back — the ceiling is refusing work it should "+
+			"serve: %s", body)
+	}
+}
+
+// callSearch drives GET /search through the module's own handler, over a handle
+// bounded the way compose bounds the one it wires (server.go).
+func callSearch(t *testing.T, e *SearchEnv, budget time.Duration, q string) (int, string) {
+	t.Helper()
+	db := database.BindTo(e.Pool, ids.From[ids.WorkspaceKind](e.WS)).Bounded(budget)
+	h := search.NewHandlers(db, nil, nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/search?q="+q, nil).WithContext(searchAs(e))
+	h.Search(rec, req, crmcontracts.SearchParams{Q: q})
+	return rec.Code, rec.Body.String()
+}
+
+// searchAs is a reader who may see everything, so the assertions below are
+// about the ceiling rather than about scope.
+func searchAs(e *SearchEnv) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep1.String(), UserID: e.Rep1,
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Read: true}, "organization": {Read: true},
+				"installation_settings": {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/modules/weeklyplan"
 	"github.com/margince/margince/backend/internal/platform/agentvolume"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
 )
@@ -127,7 +128,22 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),
-		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReachBatch, activities.EmailSummariesByIDBatch),
+		// The ranking lane is the one read a page limit does not bound.
+		// search_tsv is built with the 'simple' configuration and keeps
+		// stopwords, so a high-frequency token matches nearly every row of
+		// every admitted branch, and the score ORDER BY cannot be served by
+		// the GIN index — Postgres ranks the whole corpus per branch, and the
+		// limit bounds the rows RETURNED rather than the rows visited.
+		//
+		// CallerPredicateBudget because the shape of the SQL is ours and its
+		// selectivity is the reader's, and because somebody is watching a box:
+		// a glance that takes five seconds has already failed at being a
+		// glance. The background stores built from the same module — the graph
+		// reconcile, the drift sweep, the reindex pass — answer nobody and are
+		// deliberately left unbounded here.
+		searchHandlers: search.NewHandlers(
+			InstallationDB(pool).Bounded(database.CallerPredicateBudget),
+			collections.CountTagReachBatch, activities.EmailSummariesByIDBatch),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.

--- a/backend/internal/modules/search/handlers.go
+++ b/backend/internal/modules/search/handlers.go
@@ -28,6 +28,17 @@ type Handlers struct {
 // supplies the activities store's own reader, and a nil one leaves every email
 // hit rendering the generic way.
 func NewHandlers(db *database.DB, tagReach TagReachCounter, emailRows EmailSummaryReader) Handlers {
+	// THE CEILING RIDES THE HANDLE THE CALLER PASSES, and compose passes a
+	// bounded one (server.go). It is not armed here, and that is deliberate:
+	// the ceiling is a statement about who is WAITING, and the same constructor
+	// would otherwise impose a request-path budget on any surface that reuses
+	// it. Arming it at the wiring site puts it where every other seam of this
+	// server is chosen, and lets a caller that answers nobody say so.
+	//
+	// Riding the HANDLE rather than one call site is what reaches both lanes
+	// this surface opens — the lexical ranking, and the vector one through the
+	// retriever. A ceiling armed at a single Query would leave the other lane as
+	// unbounded as it was before anybody thought about it.
 	store := NewStore(db).WithTagReach(tagReach).WithEmailSummaries(emailRows)
 	// Embedder is nil, and stays nil: the only thing this retriever serves is
 	// AssembleContext, which walks the context graph and never embeds. The

--- a/backend/internal/modules/search/rankingfault_test.go
+++ b/backend/internal/modules/search/rankingfault_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// Which stopped statement is the READER'S news, and which is not.
+//
+// Postgres raises 57014 for three different things — a spent statement_timeout,
+// an operator cancelling the backend, and the client going away — and only one
+// of them is something the person typing can do anything about. Told apart
+// wrongly, a caller whose own request was cancelled is sent to rewrite a query
+// that was fine.
+//
+// Asserted here rather than by racing a real ceiling. A test that bounded a
+// live statement to a millisecond and expected it to lose would be timing the
+// machine it runs on: on a warm cache the query finishes first and the test
+// passes for the wrong reason, or fails on a busy one. What can be wrong is the
+// judgement, and the judgement is a pure function of an error and a context.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// queryCanceled is the error Postgres actually returns, by its SQLSTATE.
+func queryCanceled() error {
+	return &pgconn.PgError{Code: "57014", Message: "canceling statement due to statement timeout"}
+}
+
+func TestASpentCeilingIsReportedAsATooBroadQuery(t *testing.T) {
+	err := rankingFault(context.Background(), queryCanceled())
+
+	var tooBroad *QueryTooBroadError
+	if !errors.As(err, &tooBroad) {
+		t.Fatalf("err = %v, want QueryTooBroadError — a spent ceiling surfacing as a raw database "+
+			"fault tells the reader nothing they can act on", err)
+	}
+	// 422 naming `q`, because `q` is what the reader can change. A 5xx would say
+	// the server is broken, and retrying the same words would not help.
+	field, code, message := tooBroad.FieldFault()
+	if field != "q" || code != "query_too_broad" {
+		t.Errorf("fault = (%q, %q), want (q, query_too_broad)", field, code)
+	}
+	if message == "" {
+		t.Error("the fault carries no message, so the reader is told the query is wrong and not what to do")
+	}
+}
+
+// THE CASE THAT MUST NOT BE MISREAD. The caller's own deadline expired, so the
+// same 57014 comes back — and calling that a too-broad query describes their
+// timeout as a property of the workspace, to nobody, since the reader is gone.
+func TestACancelledRequestIsNotATooBroadQuery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := rankingFault(ctx, queryCanceled())
+
+	var tooBroad *QueryTooBroadError
+	if errors.As(err, &tooBroad) {
+		t.Error("a cancelled request was reported as a too-broad query — the reader would be sent " +
+			"to rewrite a query that was fine, and there is nobody left to read the answer")
+	}
+}
+
+// And every other failure stays what it was. A ceiling that swallowed unrelated
+// database faults into "narrow your search" would hide them behind advice that
+// cannot work.
+func TestAnUnrelatedDatabaseFaultIsNotRewritten(t *testing.T) {
+	err := rankingFault(context.Background(), fmt.Errorf("connection refused"))
+
+	var tooBroad *QueryTooBroadError
+	if errors.As(err, &tooBroad) {
+		t.Error("an unrelated fault was reported as a too-broad query")
+	}
+	if err == nil {
+		t.Fatal("an unrelated fault was swallowed entirely")
+	}
+}

--- a/backend/internal/modules/search/rankingfault_test.go
+++ b/backend/internal/modules/search/rankingfault_test.go
@@ -45,6 +45,13 @@ func TestASpentCeilingIsReportedAsATooBroadQuery(t *testing.T) {
 	if field != "q" || code != "query_too_broad" {
 		t.Errorf("fault = (%q, %q), want (q, query_too_broad)", field, code)
 	}
+	// It still WRAPS the database error, so the query executor — which wants the
+	// same stopped statement as a degraded plan rather than a fault — can still
+	// recognise it.
+	if !errors.Is(err, tooBroad.Err) {
+		t.Error("the fault does not carry the database error, so the executor that reads the " +
+			"SQLSTATE would see a plain error where it expects a cancellation")
+	}
 	if message == "" {
 		t.Error("the fault carries no message, so the reader is told the query is wrong and not what to do")
 	}

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -188,7 +188,7 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 
 		rows, err := tx.Query(ctx, sql, args...)
 		if err != nil {
-			return fmt.Errorf("search: query: %w", err)
+			return rankingFault(ctx, err)
 		}
 		defer rows.Close()
 		if page, err = scanRankedPage(rows, limit); err != nil {
@@ -292,6 +292,56 @@ func (e *BadQueryError) Error() string { return "search: " + e.Reason }
 // FieldFault names the query input that was actually wrong.
 func (e *BadQueryError) FieldFault() (field, code, message string) {
 	return e.Field, "invalid_query", e.Reason
+}
+
+// rankingFault tells a spent ceiling apart from every other reason the ranking
+// statement stopped before answering.
+//
+// Postgres raises the same 57014 for a spent statement_timeout, an operator
+// cancelling the backend, and the client going away, so the SQLSTATE alone
+// cannot carry the judgement. The one that must not be misread is the CALLER:
+// a cancelled request is not a too-broad query, and reporting their own
+// vanished deadline as a property of their words would send them rewriting a
+// query that was fine — with nobody left to read the answer anyway. The live
+// context is what separates that case, which is why this takes one.
+//
+// An operator cancelling the backend under a live request reads as a spent
+// ceiling, and is left that way: both mean the statement was stopped before it
+// answered, and narrowing the search is the reader's move either way. The same
+// call the agent query surface makes, for the same reason.
+//
+// Only a handle the caller BOUNDED can reach this — compose bounds the request
+// path's (server.go) and leaves the background stores alone — so on a
+// background reader the raw fault is the honest one and this returns it.
+func rankingFault(ctx context.Context, err error) error {
+	if storekit.IsQueryCanceled(err) && ctx.Err() == nil {
+		return &QueryTooBroadError{}
+	}
+	return fmt.Errorf("search: query: %w", err)
+}
+
+// QueryTooBroadError is a search that could not be RANKED inside the ceiling
+// its handle carries.
+//
+// A 422 naming `q`, not a 5xx: the server is not broken, and retrying the same
+// words will not help. The corpus and the query together are what did not fit,
+// and narrowing the query is the reader's move — which is what an actionable
+// fault is supposed to say.
+//
+// Not a partial page either. This operation has no member to carry "these hits
+// are what fitted" — unlike the agent query surface, whose Coverage says so —
+// and returning the rows that happened to rank before the ceiling would present
+// an arbitrary prefix of a ranking as the ranking.
+type QueryTooBroadError struct{}
+
+func (e *QueryTooBroadError) Error() string {
+	return "search: the query could not be ranked within this surface's budget"
+}
+
+// FieldFault names `q`, because `q` is what the reader can change.
+func (e *QueryTooBroadError) FieldFault() (field, code, message string) {
+	return "q", "query_too_broad", "this search matched too much of the workspace to rank in time — " +
+		"add another word, or narrow it with types"
 }
 
 // rankedCursor is the (score, type, id) keyset position. Encoding keeps

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -191,8 +191,14 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 			return rankingFault(ctx, err)
 		}
 		defer rows.Close()
+		// Through the SAME judgement, because this is where the cancellation
+		// usually lands. pgx returns from Query before the rows are read, so a
+		// statement stopped mid-result reports through the iteration — the
+		// ceiling would otherwise surface as a raw fault from the scan and the
+		// arm above would only ever catch a statement killed before it started
+		// returning.
 		if page, err = scanRankedPage(rows, limit); err != nil {
-			return err
+			return rankingFault(ctx, err)
 		}
 		if err := s.countTagReach(ctx, tx, page.Hits); err != nil {
 			return err
@@ -315,7 +321,7 @@ func (e *BadQueryError) FieldFault() (field, code, message string) {
 // background reader the raw fault is the honest one and this returns it.
 func rankingFault(ctx context.Context, err error) error {
 	if storekit.IsQueryCanceled(err) && ctx.Err() == nil {
-		return &QueryTooBroadError{}
+		return &QueryTooBroadError{Err: err}
 	}
 	return fmt.Errorf("search: query: %w", err)
 }
@@ -332,11 +338,22 @@ func rankingFault(ctx context.Context, err error) error {
 // are what fitted" — unlike the agent query surface, whose Coverage says so —
 // and returning the rows that happened to rank before the ceiling would present
 // an arbitrary prefix of a ranking as the ranking.
-type QueryTooBroadError struct{}
+// It WRAPS the database error rather than replacing it, and that is what keeps
+// the other reader of this statement working. The agent query surface wants the
+// same spent ceiling as a DEGRADED ANSWER — rows dropped, a note, a coverage
+// verdict saying the plan was abandoned — and it recognises one by asking
+// storekit.IsQueryCanceled. A fault that hid the SQLSTATE would turn that
+// surface's honest partial answer into an error, which is the opposite of what
+// #1847 built it for.
+type QueryTooBroadError struct{ Err error }
 
 func (e *QueryTooBroadError) Error() string {
-	return "search: the query could not be ranked within this surface's budget"
+	return "search: the query could not be ranked within this surface's budget: " + e.Err.Error()
 }
+
+// Unwrap is what lets both readers see the same stopped statement: this
+// surface as an actionable 422, the query executor as a plan to abandon.
+func (e *QueryTooBroadError) Unwrap() error { return e.Err }
 
 // FieldFault names `q`, because `q` is what the reader can change.
 func (e *QueryTooBroadError) FieldFault() (field, code, message string) {


### PR DESCRIPTION
Closes #1926.

#1847 gave the agent query surface a statement budget and bound it to that executor's **own copy** of the store — deliberately, so `/search`'s failure mode did not change for callers with nothing to do with a query plan. That left two callers of the same statement unbounded: the contract `GET /v1/search`, and the retriever's `search_context` lane through `HybridSearch`.

## The ranking lane is the one read a page limit does not bound

`search_tsv` is built with the `'simple'` configuration and keeps stopwords, so a high-frequency token matches nearly every row of every admitted branch, and the score `ORDER BY` cannot be served by the GIN index. Postgres ranks the whole corpus per branch, and **the limit bounds the rows returned, never the rows visited**.

On the corpus #1847 measured, that is the same "one call holds a backend" shape — and this one is reachable by any authenticated human rather than only by a passport.

## Option (2), not (1)

The ticket recommended a role- or pool-wide default because it closes every unbounded path at once. **I did not take it.** The same handle serves the background passes — the graph reconcile, the embedding drift sweep, the reindex — and a fleet-wide ceiling would refuse them work they are entitled to take their time over. It would need per-path exemptions, which is auditing statements again with the sign flipped.

`CallerPredicateBudget` already exists as the *one* number for "somebody is waiting on this", and this is that.

**The ceiling rides the handle** — #1847's own mechanism, and the reason it reaches both lanes. A ceiling armed at a single `Query` would leave the other as unbounded as it was before anybody looked.

**Armed at the wiring site** rather than inside `NewHandlers`, so a caller that answers nobody can say so, and so the choice sits where every other seam of this server is chosen.

## A spent ceiling is the reader's news

422 naming `q`, with what to do about it.

- Not a 5xx — the server is not broken, and retrying the same words will not help.
- Not a partial page — this operation has no member to carry *"these hits are what fitted"*, unlike the agent surface's `Coverage`, and returning whatever ranked before the ceiling would present an arbitrary prefix of a ranking as the ranking.

## The judgement is tested, not the clock

Postgres raises 57014 for the ceiling, an operator cancelling the backend, and the client going away. The live context separates the one that must not be misread — reporting a caller's own vanished deadline as a too-broad query sends them rewriting a query that was fine, with nobody left to read the answer.

I first wrote this as an integration test racing a one-millisecond budget. **It passed alone and flaked in the full package**, because on a warm cache the query wins — it times the machine it runs on. So it is gone. The judgement is a pure function of an error and a context and is asserted as one (three cases: spent ceiling, cancelled request, unrelated fault), and the integration test holds the direction a unit test cannot: the ceiling still serves an ordinary search.

**What no test holds** is that compose wires the bound — that is a reviewed one-liner at the call site, and I would rather say so than imply coverage I do not have.

`make check-backend` exit 0; full `internal/compose/integration` suite green (586s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search requests now have safeguards that limit overly broad ranking operations.
  * Added a clear `query_too_broad` error with guidance to narrow the search.

* **Bug Fixes**
  * Searches that exceed the ranking limit now return a structured, actionable error instead of an unclear database failure.
  * Caller-initiated cancellations and unrelated search errors continue to be reported correctly.

* **Tests**
  * Added coverage for successful searches near the limit, broad-query handling, cancellations, and unrelated database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->