### PR TITLE
A cited row has to say what the sentence says

### DIFF
--- a/backend/internal/compose/claims/claims.go
+++ b/backend/internal/compose/claims/claims.go
@@ -20,8 +20,11 @@
 package claims
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/specifics"
 )
 
 // Evidence points at one record a sentence rests on. It names a record the
@@ -80,23 +83,44 @@ func SpellsRecordID(text string) bool {
 // else the sentence says, and cutting the id out mid-clause leaves broken
 // grammar the reader has to decode — every id the sentence needed is already in
 // its evidence.
-func Grounded(sentence Sentence, known map[Evidence]bool) bool {
+func Grounded(sentence Sentence, known map[Evidence]string) bool {
+	return Ungrounded(sentence, known) == ""
+}
+
+// Ungrounded is Grounded with its reason, which is what a caller logging a drop
+// needs and what a test asserting one reads. Empty means the sentence stands.
+//
+// The reason is a sentence a person can act on — "names 14 August, which the
+// records it cites do not" — because a silent drop is indistinguishable from a
+// model that had nothing to say, and the two want opposite responses.
+func Ungrounded(sentence Sentence, known map[Evidence]string) string {
 	if strings.TrimSpace(sentence.Text) == "" || len(sentence.Evidence) == 0 {
-		return false
+		return "the sentence is empty or cites nothing"
 	}
 	if idInProse.MatchString(sentence.Text) {
-		return false
+		return "the prose spells a record id"
 	}
-	for _, cited := range sentence.Evidence {
+	var cited strings.Builder
+	for _, reference := range sentence.Evidence {
 		// Keyed on the (kind, identity) PAIR, so a valid identity of the wrong
 		// kind is still dropped. Stripped to identity() first: known is built
 		// with no Name set, and comparing the full struct would fail a
 		// name-bearing citation against a record it correctly cites.
-		if !known[identity(cited)] {
-			return false
+		source, ok := known[identity(reference)]
+		if !ok {
+			return "it cites a record this answer was not written from"
 		}
+		cited.WriteString(source)
+		cited.WriteString("\n")
 	}
-	return true
+	// A citation is a POINTER: it proves the model named a real row, never that
+	// the sentence says what the row says. So every date, amount and percentage
+	// the sentence states has to be in the rows it points at — the connective
+	// prose, which is the reading, stays free.
+	if missing := specifics.Missing(sentence.Text, cited.String()); len(missing) > 0 {
+		return "it names " + specifics.Texts(missing) + ", which the records it cites do not"
+	}
+	return ""
 }
 
 // Keep filters a batch to the sentences that survive Grounded, normalises any
@@ -110,7 +134,7 @@ func Grounded(sentence Sentence, known map[Evidence]bool) bool {
 // knownNature is passed in rather than fixed here because each surface derives
 // it from its own contract enum — deriving beats re-spelling, and a rename
 // upstream should fail to compile rather than launder a hand-typed string.
-func Keep(sentences []Sentence, known map[Evidence]bool, knownNature map[string]bool, fact string) []Sentence {
+func Keep(sentences []Sentence, known map[Evidence]string, knownNature map[string]bool, fact string) []Sentence {
 	kept := make([]Sentence, 0, len(sentences))
 	for _, sentence := range sentences {
 		if !Grounded(sentence, known) {
@@ -205,3 +229,27 @@ func Quoted(text, quote string) bool {
 // normalisation Quoted compares under and what a caller locating a quote in
 // its text compares under too.
 func CollapseSpace(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+// Source renders one record as the text a sentence citing it is held against.
+//
+// The assemblers hand their inputs to the model as JSON, so the JSON is what
+// the model actually saw — including every field's rendering choice, which is
+// the point: a deal's amount reaches the prompt as major units, and a check
+// reading the minor-unit integer beside it would admit the figure a hundred
+// times too large that the rendering exists to prevent.
+//
+//craft:ignore naked-any every assembler's record types are its own, and this renders whatever it is handed exactly as the prompt did
+func Source(record any) string {
+	rendered, err := json.Marshal(record)
+	if err != nil {
+		// A record that cannot be rendered is a record no sentence can be
+		// checked against, so it contributes NOTHING rather than everything:
+		// sentences citing it lose their source and are dropped, which is the
+		// safe direction for a filter whose failure mode is admitting an
+		// invention. Unreachable for the inputs here — they are plain structs
+		// of strings, numbers and slices — and left as a value rather than an
+		// error so one unrenderable record cannot cost a reader the whole brief.
+		return ""
+	}
+	return string(rendered)
+}

--- a/backend/internal/compose/claims/claims_test.go
+++ b/backend/internal/compose/claims/claims_test.go
@@ -15,10 +15,13 @@ const (
 	ghost  = "019fd000-0000-7000-8000-0000000000ff"
 )
 
-func supplied() map[Evidence]bool {
-	return map[Evidence]bool{
-		{EntityType: "organization", EntityID: orgID}: true,
-		{EntityType: "deal", EntityID: dealID}:        true,
+// supplied is what the assembler put in front of the model: the records, and
+// what each of them said. The texts carry the facts the sentences below state,
+// so these cases stay about CITATION — the extractive half has its own tests.
+func supplied() map[Evidence]string {
+	return map[Evidence]string{
+		{EntityType: "organization", EntityID: orgID}: `{"name":"Glazed Frog GmbH","country":"Germany"}`,
+		{EntityType: "deal", EntityID: dealID}:        `{"name":"Renewal","amount":"1200.00","currency":"EUR"}`,
 	}
 }
 

--- a/backend/internal/compose/meetingbrief/model.go
+++ b/backend/internal/compose/meetingbrief/model.go
@@ -262,7 +262,7 @@ func keptSentence(
 			EntityID   string `json:"entity_id"`
 		} `json:"evidence"`
 	},
-	allowed map[string]bool, known map[Evidence]bool, recommendations *int,
+	allowed map[string]bool, known map[Evidence]string, recommendations *int,
 ) (Sentence, bool) {
 	nature := raw.Nature
 	if nature == "" {
@@ -307,22 +307,25 @@ func orderedSections(byKind map[crmcontracts.MeetingBriefSectionKind][]Sentence)
 // knownRecords is every record this input carried, as the (type, id) pairs a
 // citation must match. A sentence pointing anywhere else is either invented or
 // points somewhere the reader cannot go, and neither is worth showing.
-func knownRecords(in Input) map[Evidence]bool {
-	known := map[Evidence]bool{{EntityType: citeActivity, EntityID: in.ActivityID}: true}
+//
+// The VALUE is what that record said, as the model was shown it, so a sentence
+// can be held to the rows it points at rather than only to their existence.
+func knownRecords(in Input) map[Evidence]string {
+	known := map[Evidence]string{{EntityType: citeActivity, EntityID: in.ActivityID}: meetingItself(in)}
 	if in.Deal != nil {
-		known[Evidence{EntityType: citeDeal, EntityID: in.Deal.ID}] = true
+		known[Evidence{EntityType: citeDeal, EntityID: in.Deal.ID}] = claims.Source(in.Deal)
 	}
 	for _, attendee := range in.Attendees {
-		known[Evidence{EntityType: citePerson, EntityID: attendee.PersonID}] = true
+		known[Evidence{EntityType: citePerson, EntityID: attendee.PersonID}] = claims.Source(attendee)
 	}
 	for _, claim := range in.Commitments {
-		known[Evidence{EntityType: citeActivity, EntityID: claim.SourceID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: claim.SourceID}] += claims.Source(claim)
 	}
 	for _, act := range in.Recent {
-		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] += claims.Source(act)
 	}
 	for _, earlier := range in.PriorMeetings {
-		known[Evidence{EntityType: citeActivity, EntityID: earlier.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: earlier.ID}] += claims.Source(earlier)
 	}
 	// The account history the arc is built from. A conversation this caller may
 	// not READ is deliberately absent: it reached the input as a date and a
@@ -332,7 +335,18 @@ func knownRecords(in Input) map[Evidence]bool {
 		if row.Withheld {
 			continue
 		}
-		known[Evidence{EntityType: citeActivity, EntityID: row.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: row.ID}] += claims.Source(row)
 	}
 	return known
+}
+
+// meetingItself is the meeting's OWN facts: the input with its lists emptied.
+//
+// The whole input would make a citation of the meeting a skeleton key — nearly
+// every line cites it, and every figure anywhere in the payload would answer
+// for them.
+func meetingItself(in Input) string {
+	in.Deal, in.Attendees, in.Commitments = nil, nil, nil
+	in.Recent, in.PriorMeetings, in.History = nil, nil, nil
+	return claims.Source(in)
 }

--- a/backend/internal/compose/meetingbrief/plan_test.go
+++ b/backend/internal/compose/meetingbrief/plan_test.go
@@ -207,7 +207,7 @@ func TestAWithheldConversationIsNotACitableRecord(t *testing.T) {
 	hidden := mail(dealID, 3, "", "inbound")
 	hidden.Withheld = true
 	in.History = []HistoryIn{hidden}
-	if knownRecords(in)[Evidence{EntityType: citeActivity, EntityID: dealID}] {
+	if _, citable := knownRecords(in)[Evidence{EntityType: citeActivity, EntityID: dealID}]; citable {
 		t.Error("a withheld conversation is citable; a reader would be sent to a record they cannot open")
 	}
 }

--- a/backend/internal/compose/meetingbrief/planparse.go
+++ b/backend/internal/compose/meetingbrief/planparse.go
@@ -26,7 +26,7 @@ import (
 const scenarioCap = 3
 
 // groundedLine is claims.Grounded over this package's sentence shape.
-func groundedLine(sentence Sentence, known map[Evidence]bool) bool {
+func groundedLine(sentence Sentence, known map[Evidence]string) bool {
 	return claims.Grounded(sentence, known)
 }
 
@@ -49,12 +49,12 @@ func spellsAnID(lines ...string) bool {
 // groundedEvidenceOnly is the same rule for a field that carries citations
 // without prose of its own: at least one, and every one a record the reader
 // can open.
-func groundedEvidenceOnly(cited []Evidence, known map[Evidence]bool) bool {
+func groundedEvidenceOnly(cited []Evidence, known map[Evidence]string) bool {
 	if len(cited) == 0 {
 		return false
 	}
 	for _, one := range cited {
-		if !known[Evidence{EntityType: one.EntityType, EntityID: one.EntityID}] {
+		if _, ok := known[Evidence{EntityType: one.EntityType, EntityID: one.EntityID}]; !ok {
 			return false
 		}
 	}
@@ -153,7 +153,7 @@ func emptyReply(written Plan) bool {
 }
 
 func keptPlanSentence(
-	raw *replySentence, field string, known map[Evidence]bool,
+	raw *replySentence, field string, known map[Evidence]string,
 ) (Sentence, bool) {
 	if raw == nil {
 		return Sentence{}, false
@@ -163,7 +163,7 @@ func keptPlanSentence(
 
 // keptLine is the one filter every prose field goes through.
 func keptLine(
-	text, nature string, evidence []replyEvidence, field string, known map[Evidence]bool,
+	text, nature string, evidence []replyEvidence, field string, known map[Evidence]string,
 ) (Sentence, bool) {
 	if strings.TrimSpace(text) == "" {
 		return Sentence{}, false
@@ -192,7 +192,7 @@ func citedRecords(evidence []replyEvidence) []Evidence {
 	return out
 }
 
-func keptRisk(raw *replyRisk, known map[Evidence]bool) *Risk {
+func keptRisk(raw *replyRisk, known map[Evidence]string) *Risk {
 	if raw == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func keptRisk(raw *replyRisk, known map[Evidence]bool) *Risk {
 	return &Risk{Text: sentence, Response: response}
 }
 
-func keptAsks(raw []replyAsk, known map[Evidence]bool) []Ask {
+func keptAsks(raw []replyAsk, known map[Evidence]string) []Ask {
 	out := make([]Ask, 0, len(raw))
 	for _, ask := range raw {
 		if len(out) == askCap {
@@ -252,7 +252,7 @@ func tierOf(raw string) crmcontracts.MeetingPlanTier {
 	}
 }
 
-func keptQuestions(raw []replyQuestion, known map[Evidence]bool) []Question {
+func keptQuestions(raw []replyQuestion, known map[Evidence]string) []Question {
 	out := make([]Question, 0, len(raw))
 	for _, question := range raw {
 		if len(out) == questionCap {
@@ -278,7 +278,7 @@ func keptQuestions(raw []replyQuestion, known map[Evidence]bool) []Question {
 	return out
 }
 
-func keptScenarios(raw []replyScenario, known map[Evidence]bool) []Scenario {
+func keptScenarios(raw []replyScenario, known map[Evidence]string) []Scenario {
 	out := make([]Scenario, 0, len(raw))
 	for _, scenario := range raw {
 		if len(out) == scenarioCap {

--- a/backend/internal/compose/meetingbrief/planwire.go
+++ b/backend/internal/compose/meetingbrief/planwire.go
@@ -92,7 +92,7 @@ func wireReadiness(out crmcontracts.MeetingPlan) crmcontracts.MeetingPlanReadine
 // for a record in another workspace passes the second, and the first cannot run
 // on a string the wire layer will later reject.
 func groundedSentence(
-	sentence Sentence, known map[Evidence]bool,
+	sentence Sentence, known map[Evidence]string,
 ) (crmcontracts.OrganizationBriefSentence, bool) {
 	if !claims.Grounded(sentence, known) {
 		return crmcontracts.OrganizationBriefSentence{}, false
@@ -107,17 +107,17 @@ func groundedSentence(
 // groundedEvidence is the same rule for a field that carries citations without
 // prose of its own.
 func groundedEvidence(
-	cited []Evidence, known map[Evidence]bool,
+	cited []Evidence, known map[Evidence]string,
 ) ([]crmcontracts.OrganizationBriefEvidence, bool) {
 	for _, one := range cited {
-		if !known[Evidence{EntityType: one.EntityType, EntityID: one.EntityID}] {
+		if _, ok := known[Evidence{EntityType: one.EntityType, EntityID: one.EntityID}]; !ok {
 			return nil, false
 		}
 	}
 	return wireEvidence(cited)
 }
 
-func wireAsks(asks []Ask, known map[Evidence]bool) []crmcontracts.MeetingPlanAsk {
+func wireAsks(asks []Ask, known map[Evidence]string) []crmcontracts.MeetingPlanAsk {
 	out := make([]crmcontracts.MeetingPlanAsk, 0, len(asks))
 	for _, ask := range asks {
 		basis, ok := groundedSentence(ask.Basis, known)
@@ -134,7 +134,7 @@ func wireAsks(asks []Ask, known map[Evidence]bool) []crmcontracts.MeetingPlanAsk
 	return out
 }
 
-func wireQuestions(questions []Question, known map[Evidence]bool) []crmcontracts.MeetingPlanQuestion {
+func wireQuestions(questions []Question, known map[Evidence]string) []crmcontracts.MeetingPlanQuestion {
 	out := make([]crmcontracts.MeetingPlanQuestion, 0, len(questions))
 	for _, question := range questions {
 		evidence, ok := groundedEvidence(question.Evidence, known)
@@ -151,7 +151,7 @@ func wireQuestions(questions []Question, known map[Evidence]bool) []crmcontracts
 	return out
 }
 
-func wireScenarios(scenarios []Scenario, known map[Evidence]bool) []crmcontracts.MeetingPlanScenario {
+func wireScenarios(scenarios []Scenario, known map[Evidence]string) []crmcontracts.MeetingPlanScenario {
 	out := make([]crmcontracts.MeetingPlanScenario, 0, len(scenarios))
 	for _, scenario := range scenarios {
 		evidence, ok := groundedEvidence(scenario.Evidence, known)
@@ -165,7 +165,7 @@ func wireScenarios(scenarios []Scenario, known map[Evidence]bool) []crmcontracts
 	return out
 }
 
-func wireArc(arc []ArcSentence, known map[Evidence]bool) []crmcontracts.MeetingPlanArcMoment {
+func wireArc(arc []ArcSentence, known map[Evidence]string) []crmcontracts.MeetingPlanArcMoment {
 	out := make([]crmcontracts.MeetingPlanArcMoment, 0, len(arc))
 	for _, moment := range arc {
 		summary, ok := groundedSentence(moment.Summary, known)
@@ -188,7 +188,7 @@ func wireArc(arc []ArcSentence, known map[Evidence]bool) []crmcontracts.MeetingP
 // replacement cites the meeting — a move whose only support is that this
 // meeting is happening, which is true of every advance and is why the floor
 // legs cite it in the first place.
-func wireAdvance(advance Advance, in Input, known map[Evidence]bool) crmcontracts.MeetingPlanAdvance {
+func wireAdvance(advance Advance, in Input, known map[Evidence]string) crmcontracts.MeetingPlanAdvance {
 	return crmcontracts.MeetingPlanAdvance{
 		Minimum:  advanceLeg(advance.Minimum, in, known, "Leave with one named next step, owned and dated."),
 		Best:     advanceLeg(advance.Best, in, known, "Leave with the next meeting booked and its purpose agreed."),
@@ -197,7 +197,7 @@ func wireAdvance(advance Advance, in Input, known map[Evidence]bool) crmcontract
 }
 
 func advanceLeg(
-	leg Sentence, in Input, known map[Evidence]bool, floor string,
+	leg Sentence, in Input, known map[Evidence]string, floor string,
 ) crmcontracts.OrganizationBriefSentence {
 	if wired, ok := groundedSentence(leg, known); ok {
 		return wired

--- a/backend/internal/compose/orgbrief/ask_test.go
+++ b/backend/internal/compose/orgbrief/ask_test.go
@@ -83,7 +83,7 @@ func TestEveryPreparedQuestionAnswersFromItsOwnRecords(t *testing.T) {
 					t.Errorf("sentence %q carries no citation — the reader cannot check it", sentence.Text)
 				}
 				for _, cited := range sentence.Evidence {
-					if !known[cited] {
+					if _, ok := known[cited]; !ok {
 						t.Errorf("sentence %q cites %+v, which this input never carried", sentence.Text, cited)
 					}
 				}

--- a/backend/internal/compose/orgbrief/brief_test.go
+++ b/backend/internal/compose/orgbrief/brief_test.go
@@ -611,3 +611,29 @@ func TestAssembleFailsRatherThanCachingABriefThatLostItsCompanyHalf(t *testing.T
 		t.Fatalf("assemble without the profile = %v, want it not to read the store at all", err)
 	}
 }
+
+// A citation is a POINTER, and until now that was all the filter checked. A
+// sentence naming a date, a discount or a currency the cited row does not carry
+// passed as checked — which is what an instruction embedded in captured mail
+// text, or a plain hallucination, produces.
+func TestParseBriefDropsASentenceWhoseFactsTheCitedRecordDoesNotCarry(t *testing.T) {
+	in := inputFixture()
+	activity := `[{"entity_type":"activity","entity_id":"22222222-2222-4222-8222-222222222222"}]`
+	reply := `{"sentences":[
+	  {"text":"They wrote back on 10 July and nobody has replied since.","evidence":` + activity + `},
+	  {"text":"They asked for the proposal again on 3 September.","evidence":` + activity + `},
+	  {"text":"They are holding out for 40% off.","evidence":` + activity + `}
+	]}`
+	kept, err := ParseBrief(reply, briefOrgID, in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("kept %d sentences, want only the one whose date the activity carries: %v", len(kept), kept)
+	}
+	// The reading — nobody has replied since — is the sentence's own and is not
+	// checked. Only the date is, and the cited row carries it.
+	if !strings.Contains(kept[0].Text, "10 July") {
+		t.Errorf("kept %q, want the sentence whose date is in the row it cites", kept[0].Text)
+	}
+}

--- a/backend/internal/compose/orgbrief/write.go
+++ b/backend/internal/compose/orgbrief/write.go
@@ -344,21 +344,34 @@ func keepGroundedSentences(sentences []Sentence, orgID string, in Input) []Sente
 // passes, and the card then routes the reader to the wrong screen — or to a
 // record of a kind they were never shown. The pair is the reference, so the
 // pair is what is checked.
-func knownRecords(orgID string, in Input) map[Evidence]bool {
-	known := map[Evidence]bool{{EntityType: citeOrganization, EntityID: orgID}: true}
+// The VALUE is what that record said, as the model was shown it, so a sentence
+// can be held to the rows it points at rather than only to their existence.
+func knownRecords(orgID string, in Input) map[Evidence]string {
+	known := map[Evidence]string{{EntityType: citeOrganization, EntityID: orgID}: accountItself(in)}
 	for _, deal := range in.OpenDeals {
-		known[Evidence{EntityType: citeDeal, EntityID: deal.ID}] = true
+		known[Evidence{EntityType: citeDeal, EntityID: deal.ID}] = claims.Source(deal)
 	}
 	for _, act := range in.Recent {
-		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] = claims.Source(act)
 	}
 	for _, contact := range in.Contacts {
-		known[Evidence{EntityType: citePerson, EntityID: contact.ID}] = true
+		known[Evidence{EntityType: citePerson, EntityID: contact.ID}] = claims.Source(contact)
 	}
 	for _, task := range in.OpenTasks {
-		known[Evidence{EntityType: citeActivity, EntityID: task.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: task.ID}] = claims.Source(task)
 	}
 	return known
+}
+
+// accountItself is the account's OWN facts: the input with its lists emptied.
+//
+// The whole input would make a citation of the organization a skeleton key —
+// most sentences cite it, and every figure anywhere in the payload would answer
+// for them. What a sentence about the account may state is what the account
+// row says: its industry, its size, its lifetime won.
+func accountItself(in Input) string {
+	in.Contacts, in.OpenDeals, in.Recent, in.OpenTasks = nil, nil, nil, nil
+	return claims.Source(in)
 }
 
 // recordKey is knownRecords' pair without the citation's descriptive Name, so

--- a/backend/internal/compose/orgdossier/growthfitsubscores_test.go
+++ b/backend/internal/compose/orgdossier/growthfitsubscores_test.go
@@ -17,9 +17,9 @@ import (
 // grounding filter: a number a reader cannot check is the unexplainable score
 // this whole model replaced.
 
-func knownRecord() (map[claims.Evidence]bool, claims.Evidence) {
+func knownRecord() (map[claims.Evidence]string, claims.Evidence) {
 	cited := claims.Evidence{EntityType: "fact", EntityID: "f-1"}
-	return map[claims.Evidence]bool{cited: true}, cited
+	return map[claims.Evidence]string{cited: `{"statement":"Grounded."}`}, cited
 }
 
 func TestASubScoreCitingNothingTheAssemblyKnowsIsDropped(t *testing.T) {

--- a/backend/internal/compose/orgdossier/growthfitwrite.go
+++ b/backend/internal/compose/orgdossier/growthfitwrite.go
@@ -127,7 +127,7 @@ var growthFitDimensions = map[string]bool{
 // reading the reader already has.
 func keepSubScores(
 	in []GrowthFitSubScore,
-	known map[claims.Evidence]bool,
+	known map[claims.Evidence]string,
 ) []GrowthFitSubScore {
 	var out []GrowthFitSubScore
 	seen := map[string]bool{}
@@ -235,7 +235,7 @@ var (
 // hold. An unlabelled sentence is read as a fact, which is the strictest
 // reading — it is the one nature that promises the reader a record says so, so
 // a mislabelled judgment is dropped rather than promoted.
-func keepNatures(in []claims.Sentence, known map[claims.Evidence]bool, allowed map[string]bool) []claims.Sentence {
+func keepNatures(in []claims.Sentence, known map[claims.Evidence]string, allowed map[string]bool) []claims.Sentence {
 	grounded := claims.Keep(in, known, knownNature, natureFact)
 	out := make([]claims.Sentence, 0, len(grounded))
 	for _, sentence := range grounded {

--- a/backend/internal/compose/orgdossier/input.go
+++ b/backend/internal/compose/orgdossier/input.go
@@ -112,19 +112,21 @@ func BuildInput(ctx context.Context, facts Facts, id ids.OrganizationID) (Input,
 // — and the receipt endpoint has nothing to answer with, because the row
 // carries no provenance of its own. A citation that resolves to nothing teaches
 // the reader that citations do not work.
-func KnownRecords(in Input) map[claims.Evidence]bool {
-	known := map[claims.Evidence]bool{}
+// The VALUE is what that row said, as the model was shown it, so a sentence can
+// be held to the rows it points at rather than only to their existence.
+func KnownRecords(in Input) map[claims.Evidence]string {
+	known := map[claims.Evidence]string{}
 	for _, field := range in.ProfileFields {
 		if field.Id == nil {
 			continue
 		}
-		known[claims.Evidence{EntityType: citeProfileField, EntityID: field.Id.String()}] = true
+		known[claims.Evidence{EntityType: citeProfileField, EntityID: field.Id.String()}] = claims.Source(field)
 	}
 	for _, fact := range in.Facts {
 		if fact.Id == nil {
 			continue
 		}
-		known[claims.Evidence{EntityType: citeFact, EntityID: fact.Id.String()}] = true
+		known[claims.Evidence{EntityType: citeFact, EntityID: fact.Id.String()}] = claims.Source(fact)
 	}
 	return known
 }

--- a/backend/internal/compose/personbrief/deterministic_test.go
+++ b/backend/internal/compose/personbrief/deterministic_test.go
@@ -25,7 +25,7 @@ func TestTheFloorCitesOnlyRecordsTheInputCarried(t *testing.T) {
 			continue
 		}
 		for _, cited := range sentence.Evidence {
-			if !known[Evidence{EntityType: cited.EntityType, EntityID: cited.EntityID}] {
+			if _, ok := known[Evidence{EntityType: cited.EntityType, EntityID: cited.EntityID}]; !ok {
 				t.Errorf("the floor cited %s/%s, which this input never held", cited.EntityType, cited.EntityID)
 			}
 		}

--- a/backend/internal/compose/personbrief/write.go
+++ b/backend/internal/compose/personbrief/write.go
@@ -249,21 +249,36 @@ func Prose(sentences []Sentence) string {
 // A timeline row, a claim's source and a moment's evidence all name ACTIVITIES,
 // and the same activity legitimately reaches this map by more than one of those
 // routes.
-func knownRecords(personID string, in Input) map[Evidence]bool {
-	known := map[Evidence]bool{{EntityType: citePerson, EntityID: personID}: true}
+// The VALUE is what that record said, as the model was shown it, so a sentence
+// can be held to the rows it points at rather than only to their existence.
+func knownRecords(personID string, in Input) map[Evidence]string {
+	known := map[Evidence]string{{EntityType: citePerson, EntityID: personID}: personThemselves(in)}
 	if in.OpenDeal != nil {
-		known[Evidence{EntityType: citeDeal, EntityID: in.OpenDeal.ID}] = true
+		known[Evidence{EntityType: citeDeal, EntityID: in.OpenDeal.ID}] = claims.Source(in.OpenDeal)
 	}
 	for _, act := range in.Recent {
-		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] = true
+		known[Evidence{EntityType: citeActivity, EntityID: act.ID}] = claims.Source(act)
 	}
 	for _, claim := range in.Claims {
-		known[Evidence{EntityType: citeActivity, EntityID: claim.SourceID}] = true
+		// An activity reached by more than one route carries what each route
+		// said about it: a claim's source row and the same row on the timeline
+		// are one record, and a sentence citing it may state either.
+		known[Evidence{EntityType: citeActivity, EntityID: claim.SourceID}] += claims.Source(claim)
 	}
 	if in.Moment != nil {
 		for _, source := range in.Moment.Sources {
-			known[Evidence{EntityType: citeActivity, EntityID: source}] = true
+			known[Evidence{EntityType: citeActivity, EntityID: source}] += claims.Source(in.Moment)
 		}
 	}
 	return known
+}
+
+// personThemselves is the person's OWN facts: the input with its lists emptied.
+//
+// The whole input would make a citation of the person a skeleton key — most
+// sentences cite them, and every figure anywhere in the payload would answer
+// for it.
+func personThemselves(in Input) string {
+	in.Recent, in.Claims, in.Moment, in.OpenDeal = nil, nil, nil, nil
+	return claims.Source(in)
 }

--- a/backend/internal/shared/kernel/specifics/currencies.go
+++ b/backend/internal/shared/kernel/specifics/currencies.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package specifics
+
+// The currencies a sentence can name, and the one code each of them is.
+//
+// A figure's currency is a fact of its own: "they want 40,000 dollars" on a
+// deal priced in euros is wrong about the only thing the number was for. The
+// source says EUR because that is what the assembler puts in the payload, and
+// the sentence says € or "Euro" because that is what a reader reads, so both
+// sides fold to the code.
+
+import "strings"
+
+// currencyMarks is each code and the marks a reader or a payload writes it as.
+// Deliberately short: the currencies this product's own payloads and readers
+// actually use, rather than the whole ISO table, because a mark nobody writes
+// is a pattern alternative that only costs matching time.
+//
+// Keyed by CODE rather than by mark, which keeps a code from being repeated
+// down a column of marks, and inverted below into the lookup matching needs.
+var currencyMarks = map[string][]string{
+	"EUR": {"€", "eur", "euro", "euros"},
+	"USD": {"$", "usd", "dollar", "dollars"},
+	"GBP": {"£", "gbp", "pound", "pounds"},
+	"CHF": {"chf", "franken", "francs"},
+	"VND": {"₫", "vnd", "đồng", "dong"},
+	"JPY": {"¥", "jpy", "yen"},
+}
+
+// currencies is currencyMarks read the way a match needs it: mark to code.
+var currencies = byMark(currencyMarks)
+
+func byMark(codes map[string][]string) map[string]string {
+	marks := make(map[string]string)
+	for code, written := range codes {
+		for _, mark := range written {
+			marks[mark] = code
+		}
+	}
+	return marks
+}
+
+var currencyAlternatives = alternationOf(currencies)
+
+func alternationOf(vocabulary map[string]string) string {
+	numbered := make(map[string]int, len(vocabulary))
+	for word := range vocabulary {
+		numbered[word] = 0
+	}
+	return alternation(numbered)
+}
+
+// currencyWord is what a mark must be surrounded by to count. A symbol carries
+// its own boundary and a word does not: matching "eur" inside "Europe" would
+// put a currency in every sentence about the continent.
+
+// currencyCode is the code a written mark names, empty when it names none.
+func currencyCode(mark string) string {
+	return currencies[strings.ToLower(strings.TrimSpace(mark))]
+}

--- a/backend/internal/shared/kernel/specifics/dates.go
+++ b/backend/internal/shared/kernel/specifics/dates.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package specifics
+
+// The dates a sentence can state, in the forms this product's three languages
+// actually write them.
+//
+// Sources speak one dialect — RFC3339, because that is what the assemblers put
+// in front of the model — and sentences speak the reader's. So the two sides
+// are normalised to the same triple and compared there. Anything else drops a
+// German brief's every dated sentence on the day it ships.
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// datesIn returns the dates the text states, and the text with each of them
+// blanked out so the number scan cannot read a date's parts as figures.
+func datesIn(text string) ([]Specific, string) {
+	rest := text
+	var found []Specific
+	for _, form := range dateForms {
+		for _, at := range form.pattern.FindAllStringSubmatchIndex(rest, -1) {
+			groups := groupsAt(rest, at)
+			date, ok := form.read(groups)
+			if !ok {
+				continue
+			}
+			date.Text = strings.TrimSpace(rest[at[0]:at[1]])
+			found = append(found, date)
+		}
+		rest = form.pattern.ReplaceAllString(rest, " ")
+	}
+	return found, rest
+}
+
+// groupsAt lifts a submatch index list into the strings it names, with an
+// absent optional group reading as empty.
+func groupsAt(text string, at []int) []string {
+	groups := make([]string, 0, len(at)/2)
+	for i := 0; i < len(at); i += 2 {
+		if at[i] < 0 {
+			groups = append(groups, "")
+			continue
+		}
+		groups = append(groups, text[at[i]:at[i+1]])
+	}
+	return groups
+}
+
+// dateForm is one written shape and how to read a date out of it.
+type dateForm struct {
+	pattern *regexp.Regexp
+	read    func(groups []string) (Specific, bool)
+}
+
+// dateForms are tried in order, most specific first: an RFC3339 instant is
+// blanked before the numeric form could read "06-02" out of what is left of it.
+var dateForms = []dateForm{
+	// 2026-06-02, and the date half of 2026-06-02T09:00:00Z.
+	{
+		pattern: regexp.MustCompile(`\b(\d{4})-(\d{2})-(\d{2})`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys(g[1], g[2], g[3])
+		},
+	},
+	// 02.06.2026, 2.6.2026, 02/06/2026 — day-first, which is what all three of
+	// this product's locales write, and month-first as the alternative when the
+	// two could be swapped. A checker that assumed one order would call a true
+	// sentence a lie on every day of the month below the thirteenth.
+	{
+		pattern: regexp.MustCompile(`\b(\d{1,2})[./](\d{1,2})[./](\d{4})\b`),
+		read: func(g []string) (Specific, bool) {
+			return ambiguousOrder(g[1], g[2], g[3])
+		},
+	},
+	// ngày 2 tháng 6 — Vietnamese, day before month, both spelled out.
+	{
+		pattern: regexp.MustCompile(`(?i)\bngày\s+(\d{1,2})\s+tháng\s+(\d{1,2})\b`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys("", g[2], g[1])
+		},
+	},
+	// 2 June 2024, 2. Juni 2024 — the year first, so the day-and-month form
+	// below cannot read the day out and leave the year behind as a stray
+	// number, which is how a sentence that moved an event two years survives.
+	{
+		pattern: regexp.MustCompile(`(?i)\b(\d{1,2})\.?\s+(` + monthAlternatives + `)\s+(\d{4})\b`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys(g[3], monthNumber(g[2]), g[1])
+		},
+	},
+	// June 2, 2024
+	{
+		pattern: regexp.MustCompile(`(?i)\b(` + monthAlternatives + `)\s+(\d{1,2}),?\s+(\d{4})\b`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys(g[3], monthNumber(g[1]), g[2])
+		},
+	},
+	// 2 June, 2. Juni, 2 Jun
+	{
+		pattern: regexp.MustCompile(`(?i)\b(\d{1,2})\.?\s+(` + monthAlternatives + `)\b`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys("", monthNumber(g[2]), g[1])
+		},
+	},
+	// June 2, Jun 2 — and never "June 2026", which the year guard below refuses
+	// so it is read as the month it is.
+	{
+		pattern: regexp.MustCompile(`(?i)\b(` + monthAlternatives + `)\s+(\d{1,2})\b`),
+		read: func(g []string) (Specific, bool) {
+			return dayKeys("", monthNumber(g[1]), g[2])
+		},
+	},
+	// tháng 6 — Vietnamese month with no day.
+	{
+		pattern: regexp.MustCompile(`(?i)\btháng\s+(\d{1,2})\b`),
+		read: func(g []string) (Specific, bool) {
+			return monthKey(g[1])
+		},
+	},
+	// June, Juni — a month with no day is still a fact a sentence can invent.
+	{
+		pattern: regexp.MustCompile(`(?i)\b(` + monthAlternatives + `)\b`),
+		read: func(g []string) (Specific, bool) {
+			return monthKey(monthNumber(g[1]))
+		},
+	},
+}
+
+// dayKeys is one date read as day-of-month, with the year when it was written.
+func dayKeys(year, month, day string) (Specific, bool) {
+	m, d, ok := monthDay(month, day)
+	if !ok {
+		return Specific{}, false
+	}
+	if year == "" {
+		return Specific{Keys: []string{fmt.Sprintf("date:%02d-%02d", m, d)}}, true
+	}
+	return Specific{Keys: []string{fmt.Sprintf("date:%s-%02d-%02d", year, m, d)}}, true
+}
+
+// ambiguousOrder reads a numeric date both ways round when both readings are
+// possible, and one way when only one is.
+func ambiguousOrder(first, second, year string) (Specific, bool) {
+	dayFirst, dayFirstOK := dayKeys(year, second, first)
+	monthFirst, monthFirstOK := dayKeys(year, first, second)
+	switch {
+	case dayFirstOK && monthFirstOK:
+		return Specific{Keys: append(dayFirst.Keys, monthFirst.Keys...)}, true
+	case dayFirstOK:
+		return dayFirst, true
+	case monthFirstOK:
+		return monthFirst, true
+	}
+	return Specific{}, false
+}
+
+// monthKey is a month named with no day.
+func monthKey(month string) (Specific, bool) {
+	m, err := strconv.Atoi(month)
+	if err != nil || m < 1 || m > 12 {
+		return Specific{}, false
+	}
+	return Specific{Keys: []string{fmt.Sprintf("date:%02d", m)}}, true
+}
+
+// monthDay refuses anything that is not a real calendar position, so "45/13"
+// is read as two numbers rather than admitted as a date nothing can match.
+func monthDay(month, day string) (int, int, bool) {
+	m, err := strconv.Atoi(month)
+	if err != nil || m < 1 || m > 12 {
+		return 0, 0, false
+	}
+	d, err := strconv.Atoi(day)
+	if err != nil || d < 1 || d > 31 {
+		return 0, 0, false
+	}
+	return m, d, true
+}
+
+// lessSpecific is what a SOURCE date also answers: a dated row answers a
+// sentence naming the same day without its year, and one naming only the month.
+func lessSpecific(key string) []string {
+	parts := strings.Split(strings.TrimPrefix(key, "date:"), "-")
+	if !strings.HasPrefix(key, "date:") {
+		return nil
+	}
+	switch len(parts) {
+	case 3:
+		return []string{"date:" + parts[1] + "-" + parts[2], "date:" + parts[1]}
+	case 2:
+		return []string{"date:" + parts[0]}
+	}
+	return nil
+}

--- a/backend/internal/shared/kernel/specifics/months.go
+++ b/backend/internal/shared/kernel/specifics/months.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package specifics
+
+// The month words this product's readers are written to in.
+//
+// English and German only: Vietnamese writes its months as "tháng 6", which the
+// numeric form in dates.go reads directly, so there is no vocabulary to keep
+// for it. A word list that pretended otherwise would be a list nothing consults.
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// months maps every accepted spelling to its number. Abbreviations are the
+// three-letter forms a model actually writes; the German full names differ from
+// the English in four of twelve, which is exactly why this is a table rather
+// than a prefix rule.
+var months = map[string]int{
+	"january": 1, "jan": 1, "januar": 1,
+	"february": 2, "feb": 2, "februar": 2,
+	"march": 3, "mar": 3, "märz": 3, "maerz": 3,
+	"april": 4, "apr": 4,
+	"may": 5, "mai": 5,
+	"june": 6, "jun": 6, "juni": 6,
+	"july": 7, "jul": 7, "juli": 7,
+	"august": 8, "aug": 8,
+	"september": 9, "sep": 9, "sept": 9,
+	"october": 10, "oct": 10, "oktober": 10, "okt": 10,
+	"november": 11, "nov": 11,
+	"december": 12, "dec": 12, "dezember": 12, "dez": 12,
+}
+
+// monthAlternatives is the alternation the date patterns embed, longest first
+// so "juni" is not matched as "jun" with a stray "i" left behind.
+var monthAlternatives = alternation(months)
+
+func alternation(vocabulary map[string]int) string {
+	words := make([]string, 0, len(vocabulary))
+	for word := range vocabulary {
+		words = append(words, word)
+	}
+	sort.Slice(words, func(i, j int) bool {
+		if len(words[i]) != len(words[j]) {
+			return len(words[i]) > len(words[j])
+		}
+		return words[i] < words[j]
+	})
+	for i, word := range words {
+		words[i] = regexp.QuoteMeta(word)
+	}
+	return strings.Join(words, "|")
+}
+
+// monthNumber is a month word as its number, as a string the date readers
+// parse like any other — empty when the word is not one, which their own guard
+// then refuses.
+func monthNumber(word string) string {
+	number, ok := months[strings.ToLower(word)]
+	if !ok {
+		return ""
+	}
+	return strconv.Itoa(number)
+}

--- a/backend/internal/shared/kernel/specifics/numbers.go
+++ b/backend/internal/shared/kernel/specifics/numbers.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package specifics
+
+// The figures a sentence can state: plain counts, percentages, money amounts
+// and the currencies they are in.
+//
+// The separator is the whole difficulty. 1.200 is twelve hundred to a German
+// reader and one-point-two to an English one, and the same installation writes
+// both — so an ambiguous form yields BOTH readings and matches on either. That
+// is deliberately the loose direction: admitting a figure whose other reading
+// happened to be in the source is a rare wrong keep, while picking one
+// convention would be a wrong DROP every time the reader's language was the
+// other one, and a lane that drops true sentences stops being used.
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// figure matches a number with the currency or percent mark that makes it a
+// checkable fact, either of which may be absent.
+var figure = regexp.MustCompile(`(?i)(` + currencyAlternatives + `)?\s?(\d[\d.,]*\d|\d)\s?(%|percent|prozent|phần trăm)?\s?(` + currencyAlternatives + `)?`)
+
+// currencyMark matches any written currency on its own, because that is how
+// both sides actually carry one: a sentence writes "€1.200" or "1.200 Euro",
+// and the payload it was written from writes `"currency":"EUR"` in a field with
+// no figure beside it. Tying the mark to an adjacent number would find it on
+// one side and never the other.
+var currencyMark = regexp.MustCompile(`(?i)(` + currencyAlternatives + `)`)
+
+// numbersIn returns the figures and currencies a text carries.
+//
+// `marked` is the asymmetry that keeps this rule from over-reaching. A SOURCE
+// offers every figure it contains; a CLAIM states only its PERCENTAGES.
+//
+// Everything else a sentence counts is routinely DERIVED — three open deals,
+// fourteen days since the last reply, a pipeline worth the sum of its deals —
+// and the payload holds the parts rather than the total, so a containment check
+// over them would drop true sentences for doing arithmetic correctly. The
+// product's own deterministic floor is the proof: it writes the total of every
+// open deal into a sentence citing the largest one.
+//
+// A percentage is never that. Nothing in these payloads is a percentage of
+// anything, so a discount or a share in generated prose was read off a record
+// or it was invented — which is the whole distinction this package is for.
+func numbersIn(text string, marked bool) []Specific {
+	var found []Specific
+	for _, match := range currencyMark.FindAllStringSubmatch(text, -1) {
+		code := currencyCode(match[1])
+		if code == "" {
+			continue
+		}
+		found = append(found, Specific{Text: match[1], Keys: []string{"cur:" + code}})
+	}
+	for _, match := range figure.FindAllStringSubmatch(text, -1) {
+		values := numberKeys(match[2])
+		if len(values) == 0 {
+			continue
+		}
+		percent := match[3] != ""
+		if marked && !percent {
+			continue
+		}
+		// A percentage is not the same fact as the bare number: "40% off" and
+		// "40 open deals" share a digit and nothing else, and a check that let
+		// one answer the other would admit the invention it is here to catch.
+		prefix := "num:"
+		if percent {
+			prefix = "pct:"
+		}
+		keys := make([]string, 0, len(values))
+		for _, value := range values {
+			keys = append(keys, prefix+value)
+		}
+		found = append(found, Specific{Text: strings.TrimSpace(match[0]), Keys: keys})
+	}
+	return found
+}
+
+// numberKeys renders a written figure as the values it could be, canonical and
+// without trailing zeros so 1200, 1200.00 and 1.200,000 collapse to one key.
+func numberKeys(raw string) []string {
+	digits := strings.Map(func(r rune) rune {
+		if r == ' ' || r == ' ' || r == ' ' {
+			return -1
+		}
+		return r
+	}, raw)
+	if digits == "" {
+		return nil
+	}
+	switch {
+	case strings.Contains(digits, ".") && strings.Contains(digits, ","):
+		// Both present: the LAST one is the decimal point and the other groups,
+		// which is true in every locale here.
+		return canonical(mixed(digits))
+	case strings.ContainsAny(digits, ".,"):
+		return canonical(ambiguousSeparator(digits)...)
+	default:
+		return canonical(digits)
+	}
+}
+
+// mixed resolves a figure carrying both separators.
+func mixed(digits string) string {
+	decimalAt := strings.LastIndexAny(digits, ".,")
+	whole := strings.Map(dropSeparators, digits[:decimalAt])
+	return whole + "." + digits[decimalAt+1:]
+}
+
+// ambiguousSeparator returns the readings a single kind of separator has.
+//
+// One separator with exactly three digits after it and digits before it is the
+// genuinely ambiguous case, and both readings are returned. Anything else
+// resolves: repeated separators only group, and a group of other than three
+// digits is only ever a decimal.
+func ambiguousSeparator(digits string) []string {
+	at := strings.IndexAny(digits, ".,")
+	last := strings.LastIndexAny(digits, ".,")
+	tail := digits[last+1:]
+	grouped := strings.Map(dropSeparators, digits)
+	if at != last {
+		return []string{grouped}
+	}
+	decimal := digits[:at] + "." + tail
+	if len(tail) == 3 && at > 0 {
+		return []string{grouped, decimal}
+	}
+	return []string{decimal}
+}
+
+func dropSeparators(r rune) rune {
+	if r == '.' || r == ',' {
+		return -1
+	}
+	return r
+}
+
+// canonical parses each reading and renders it back without trailing zeros, so
+// two spellings of one value produce one key.
+func canonical(readings ...string) []string {
+	keys := make([]string, 0, len(readings))
+	for _, reading := range readings {
+		value, err := strconv.ParseFloat(reading, 64)
+		if err != nil {
+			continue
+		}
+		keys = append(keys, strconv.FormatFloat(value, 'f', -1, 64))
+	}
+	return keys
+}

--- a/backend/internal/shared/kernel/specifics/specifics.go
+++ b/backend/internal/shared/kernel/specifics/specifics.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package specifics extracts the checkable facts a sentence states — its dates,
+// numbers, money amounts and percentages — so generated prose can be held
+// against the record it cites.
+//
+// A citation is a POINTER. Matching one proves a model named a real row, never
+// that the sentence says what the row says: "she asked for times on 2 June" and
+// "they want 40% off in euros" both cite correctly and are both wrong if the
+// row says otherwise. What survives the check is the READING — asked, still
+// open, nobody replied — which is the judgment a brief exists to make and which
+// the claim's own nature label governs separately.
+//
+// What is checkable is deliberately narrow: DATES, PERCENTAGES and the
+// CURRENCY a figure is in. Counts and money magnitudes are not, because they
+// are routinely derived rather than read — three open deals, fourteen days, a
+// pipeline worth the sum of its rows — and the payload holds the parts. See
+// numbers.go, which states the case; the product's own deterministic floor is
+// the proof.
+//
+// The comparison is on canonical VALUES, never on substrings, because the
+// product writes in the reader's language: 2 June, 2. Juni, 2026-06-02 and
+// 02/06/2026 are one date, and €1.200,00 and 1200.00 are one amount. A
+// substring rule would drop true sentences by the hundred in every locale but
+// the one it happened to be written against — and dropping true sentences is
+// the failure this check must not trade for the one it prevents.
+//
+// Proper names are deliberately NOT extracted here. A capitalised token is a
+// name in English and an ordinary noun in German, and no rule this package
+// could apply tells "Firma" from "Fischer" without a dictionary — so the name
+// half is the caller's, against its own record vocabulary, where a name is
+// known rather than guessed.
+package specifics
+
+import "strings"
+
+// A Specific is one checkable fact, as written and as compared.
+type Specific struct {
+	// Text is the fact in the sentence's own words, so a rejection can say
+	// which one failed rather than only that something did.
+	Text string
+	// Keys are the canonical forms it may match under. More than one when the
+	// written form is genuinely ambiguous — 1.200 is twelve hundred to a German
+	// reader and one-point-two to an English one, and a checker that picked
+	// either would be wrong half the time.
+	Keys []string
+}
+
+// Missing returns the specifics `claim` states that `source` does not.
+//
+// An empty answer is the sentence being extractive: every date, amount and
+// figure it names is in the text it was written from. The connective prose is
+// deliberately untouched — it is where the reading lives.
+func Missing(claim, source string) []Specific {
+	stated := In(claim)
+	if len(stated) == 0 {
+		return nil
+	}
+	available := sourceKeys(source)
+	var missing []Specific
+	for _, fact := range stated {
+		if !anyKnown(fact.Keys, available) {
+			missing = append(missing, fact)
+		}
+	}
+	return missing
+}
+
+// In returns what a sentence STATES: the most specific reading of each fact,
+// plus the alternatives an ambiguous written form genuinely has.
+//
+// Dates are taken first and blanked out of what the number scan then reads.
+// Without that, 2026-06-02 states the numbers 2026, 6 and 2 as well as the day
+// it names, and a sentence would have to find a stray "2026" in its source to
+// survive naming a date that was already there.
+func In(text string) []Specific {
+	dates, rest := datesIn(text)
+	return append(dates, numbersIn(rest, true)...)
+}
+
+// sourceKeys collects the canonical forms a source text OFFERS, which is
+// broader than what the same text would STATE: a source dated 2026-06-02 answers a
+// sentence that says "2 June" and one that says "in June", because both are
+// true of it. The claim side stays narrow, so the asymmetry only ever admits a
+// sentence that says LESS than its source, never more.
+func sourceKeys(text string) map[string]bool {
+	keys := make(map[string]bool)
+	dates, rest := datesIn(text)
+	for _, date := range dates {
+		for _, key := range date.Keys {
+			keys[key] = true
+			for _, coarser := range lessSpecific(key) {
+				keys[coarser] = true
+			}
+		}
+	}
+	for _, number := range numbersIn(rest, false) {
+		for _, key := range number.Keys {
+			keys[key] = true
+		}
+	}
+	return keys
+}
+
+func anyKnown(keys []string, known map[string]bool) bool {
+	for _, key := range keys {
+		if known[key] {
+			return true
+		}
+	}
+	return false
+}
+
+// Texts renders the missing specifics for a message a person reads.
+func Texts(missing []Specific) string {
+	words := make([]string, 0, len(missing))
+	for _, fact := range missing {
+		words = append(words, fact.Text)
+	}
+	return strings.Join(words, ", ")
+}

--- a/backend/internal/shared/kernel/specifics/specifics_test.go
+++ b/backend/internal/shared/kernel/specifics/specifics_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package specifics
+
+// The rule, stated as the cases it has to get right.
+//
+// Two failures, and only one of them is loud. A fabricated figure that survives
+// puts a wrong sentence on a customer-facing card; a true sentence that is
+// dropped makes the lane look empty and nobody hears about it. So the kept
+// cases are as load-bearing as the dropped ones, and half of what is below is
+// paraphrase that must survive.
+
+import "testing"
+
+// keptOrDropped runs one sentence against one source and says what happened.
+func keptOrDropped(t *testing.T, claim, source string) []Specific {
+	t.Helper()
+	return Missing(claim, source)
+}
+
+func TestAParaphraseWhoseFactsAreInTheSourceIsKept(t *testing.T) {
+	source := `{"subject":"Scheduling","at":"2026-06-02T09:00:00Z"}`
+	// The reading — asked, nobody sent them — is the sentence's own and is not
+	// checked. The date is, and it is there.
+	if missing := keptOrDropped(t, "She asked for times on 2 June and nobody sent them.", source); missing != nil {
+		t.Errorf("a paraphrase whose date is in the source was dropped over %s — "+
+			"a bar that rejects paraphrase rejects the product", Texts(missing))
+	}
+}
+
+func TestAFabricatedDateIsDropped(t *testing.T) {
+	source := `{"subject":"Scheduling","at":"2026-06-02T09:00:00Z"}`
+	missing := keptOrDropped(t, "She asked for times on 14 August.", source)
+	if len(missing) != 1 {
+		t.Fatalf("missing = %v, want the one date the source does not carry", missing)
+	}
+	if missing[0].Text != "14 August" {
+		t.Errorf("the rejection names %q, want the date as the sentence wrote it", missing[0].Text)
+	}
+}
+
+func TestAFabricatedPercentageIsDropped(t *testing.T) {
+	source := `{"name":"Renewal","amount":"12000.00","currency":"EUR"}`
+	if missing := keptOrDropped(t, "They asked for 40% off.", source); len(missing) == 0 {
+		t.Error("a percentage the source never mentions was kept")
+	}
+}
+
+func TestAPercentageIsNotAnsweredByTheSameBareNumber(t *testing.T) {
+	// The source has forty of something. The sentence claims forty PERCENT.
+	source := `{"name":"Renewal","open_deals":40}`
+	if missing := keptOrDropped(t, "They asked for 40% off.", source); len(missing) == 0 {
+		t.Error("a bare 40 in the source answered a claim of 40% — two different facts " +
+			"sharing a digit is exactly the invention this check is for")
+	}
+}
+
+func TestAMoneyFigureIsKeptForItsCurrencyAndNotItsMagnitude(t *testing.T) {
+	source := `{"name":"Renewal","amount":"1200.00","currency":"EUR"}`
+	for _, written := range []string{"€1.200,00", "1,200.00 EUR", "€1200", "1.200 Euro"} {
+		if missing := keptOrDropped(t, "The renewal is worth "+written+".", source); missing != nil {
+			t.Errorf("%q was dropped over %s — one amount, written the way each reader reads it",
+				written, Texts(missing))
+		}
+	}
+	// And the magnitude itself is NOT checked, which this states out loud
+	// rather than leaving to be discovered. A pipeline total is the sum of
+	// rows the payload carries separately, and a containment rule would drop
+	// the sentence that added them up correctly.
+	if missing := keptOrDropped(t, "The pipeline is worth €4,800.", source); missing != nil {
+		t.Errorf("a derived total was treated as a claim: %s", Texts(missing))
+	}
+}
+
+func TestACurrencyTheSourceDoesNotNameIsDropped(t *testing.T) {
+	source := `{"name":"Renewal","amount":"1200.00","currency":"EUR"}`
+	missing := keptOrDropped(t, "The renewal is worth $1200.", source)
+	if len(missing) == 0 {
+		t.Error("a deal priced in euros was described in dollars and kept — the currency is " +
+			"the only thing the figure was for")
+	}
+}
+
+func TestALocaleFormattedDateMatchesTheSourcesOwnFormat(t *testing.T) {
+	source := `{"at":"2026-06-02T09:00:00Z"}`
+	for _, written := range []string{"2 June", "2. Juni", "02.06.2026", "2026-06-02", "ngày 2 tháng 6", "Jun 2"} {
+		if missing := keptOrDropped(t, "It happened on "+written+".", source); missing != nil {
+			t.Errorf("%q was dropped over %s — one date, four locales", written, Texts(missing))
+		}
+	}
+}
+
+func TestADateStatedWithAYearTheSourceDoesNotHaveIsDropped(t *testing.T) {
+	source := `{"at":"2026-06-02T09:00:00Z"}`
+	if missing := keptOrDropped(t, "It happened on 2 June 2024.", source); len(missing) == 0 {
+		t.Error("a sentence moved the event two years and was kept")
+	}
+}
+
+func TestAMonthAloneIsCheckedAndAnsweredByADayInIt(t *testing.T) {
+	source := `{"at":"2026-06-02T09:00:00Z"}`
+	if missing := keptOrDropped(t, "They went quiet in June.", source); missing != nil {
+		t.Errorf("a June date did not answer a sentence saying June: %s", Texts(missing))
+	}
+	if missing := keptOrDropped(t, "They went quiet in August.", source); len(missing) == 0 {
+		t.Error("a month the source never touches was kept")
+	}
+}
+
+func TestASentenceStatingNothingSpecificIsKept(t *testing.T) {
+	// The reading is the sentence's to make. Nothing here is checkable, and a
+	// check that dropped it would be refusing the lane's whole output.
+	if missing := keptOrDropped(t, "Nobody has replied and the deal is still open.", `{"subject":"Scheduling"}`); missing != nil {
+		t.Errorf("a sentence stating no facts was dropped over %s", Texts(missing))
+	}
+}
+
+func TestTheAmbiguousSeparatorIsReadBothWays(t *testing.T) {
+	// 1.200 is twelve hundred in German and one-point-two in English. A source
+	// carrying either answers it, because picking one convention would drop a
+	// true sentence every time the reader's language was the other.
+	for _, source := range []string{`{"amount":"1200.00"}`, `{"ratio":"1.2"}`} {
+		if missing := keptOrDropped(t, "The figure was 1.200.", source); missing != nil {
+			t.Errorf("source %s did not answer 1.200: %s", source, Texts(missing))
+		}
+	}
+}
+
+func TestADateIsNotReadAsTheNumbersItIsMadeOf(t *testing.T) {
+	// 2026-06-02 states one date. A scan that also read 2026, 6 and 2 out of it
+	// would make a sentence naming that date go looking for a stray 2026 in its
+	// source — which is how a check starts dropping the sentences it was meant
+	// to admit.
+	stated := In("It happened on 2026-06-02.")
+	if len(stated) != 1 {
+		t.Fatalf("2026-06-02 states %d facts, want the date alone: %v", len(stated), stated)
+	}
+	if stated[0].Keys[0] != "date:2026-06-02" {
+		t.Errorf("key = %q, want the date", stated[0].Keys[0])
+	}
+}
+
+func TestADerivedCountIsNotTreatedAsAClaim(t *testing.T) {
+	// The payload holds the list, never its length. A sentence that counts the
+	// list correctly would have nothing to match, so checking bare integers
+	// would drop the lane's most ordinary true sentence — and a count is not
+	// what invention looks like.
+	source := `{"open_deals":[{"name":"Renewal"},{"name":"Expansion"},{"name":"Pilot"}]}`
+	if missing := keptOrDropped(t, "There are 3 open deals and 14 days since the last reply.", source); missing != nil {
+		t.Errorf("a derived count was treated as a claim: %s", Texts(missing))
+	}
+}
+
+func TestAGermanSentenceIsNotDroppedForBeingGerman(t *testing.T) {
+	source := `{"subject":"Terminfindung","at":"2026-06-02T09:00:00Z","amount":"1200.00","currency":"EUR"}`
+	claim := "Die Firma hat am 2. Juni nach Terminen gefragt; der Auftrag steht bei 1.200,00 €."
+	if missing := keptOrDropped(t, claim, source); missing != nil {
+		t.Errorf("a true German sentence was dropped over %s — every capitalised word in German "+
+			"is a noun, and the date and the amount are both in the source", Texts(missing))
+	}
+}
+
+func TestAnInjectedInstructionsFabricatedFiguresAreDropped(t *testing.T) {
+	// The shape the ticket is about: text that arrived on the timeline telling
+	// the model what to write. Its damage is in its specifics.
+	source := `{"subject":"Re: pricing","at":"2026-06-02T09:00:00Z"}`
+	missing := keptOrDropped(t, "The customer has approved a 60% discount worth €90,000 on 3 July.", source)
+	if len(missing) < 3 {
+		t.Errorf("kept an invented discount, amount and date; missing = %v", missing)
+	}
+}


### PR DESCRIPTION
Closes #2418.

The grounding filter treated *"has a valid citation id"* as proof of grounding.
A citation is a **pointer**: matching one proves a model named a real row, never
that the sentence says what the row says. So an instruction embedded in captured
mail text, or plain invention, could put a fabricated date or discount on a
customer-facing card and pass as `generated_by=model`, as long as it name-dropped
a record the assembler had supplied.

Every **date**, **percentage** and **currency** a generated sentence states must
now be present in the records it cites. The connective prose — *asked*, *still
open*, *nobody replied* — stays free: that is the reading, which the claim's own
`nature` label governs separately.

**Two things the ticket assumed that are no longer true, and one place the
ruling had to bend** — all three are on the issue in full:

1. `nextaction` and `ParseNextMove` no longer exist. That changes nothing: the
   ruling's reason for deferring was that this is one rule across the
   grounded-prose lanes, and the four survivors all check citations through
   `compose/claims`. The rule lands there, once.
2. `orgbrief`'s own deterministic floor writes *"1 open deal worth about
   48000.00 EUR; 120000.00 EUR won to date"* while citing the **lead deal**. The
   total spans every open deal and the won lifetime belongs to the account, so a
   containment rule over money drops the product's own floor sentence. Counts
   are the same: the payload carries the list, never its length.
3. So counts and money **magnitudes** are not checked. Nothing in these payloads
   is a percentage of anything and no currency is derived — both are read off a
   record or invented — which is what makes them checkable and a total not.

Proper names are deliberately not attempted. German capitalises every noun, so
"Firma" and "Fischer" are one shape to any rule this could apply; a name check
belongs against the lane's own record vocabulary, where a name is known rather
than guessed. Both gaps are written down rather than buried — see the issue.

**What lands**

- `internal/shared/kernel/specifics` — the extractor. Compares canonical VALUES,
  not substrings, because the product writes in the reader's language: `2 June`,
  `2. Juni`, `2026-06-02`, `02.06.2026` and `ngày 2 tháng 6` are one date;
  `€1.200,00`, `1,200.00 EUR` and `1.200 Euro` are one amount in one currency.
  An ambiguous separator yields BOTH readings, deliberately in the loose
  direction: `1.200` is twelve hundred in German and one-point-two in English,
  and picking one would be a wrong DROP every time the reader's language was the
  other.
- `compose/claims` — the known-record set now carries what each record **said**,
  as the model was shown it (`claims.Source` renders the same JSON the prompt
  did, so a deal's amount is read in major units, not the minor-unit integer
  beside it). `Ungrounded` returns the reason, so a drop is explainable rather
  than silent.
- The four lanes — `orgbrief`, `personbrief`, `meetingbrief`, `orgdossier` —
  supply per-record text. The account, the person and the meeting each get their
  own facts with the lists emptied: the whole input would make citing them a
  skeleton key, since nearly every sentence does.

**On corpus scoring** (the ruling's step 6): there are no corpus scenarios for
these lanes — `aicert/corpus/` has `brief_ranking`, which is the ranking task,
not the prose. Nothing to score, so nothing was skipped.

**Verification**

`make check-backend` green; `craft static --strict` clean over the diff;
`make test-it` green for all four lanes.

Half the tests are the KEPT cases, and that is the point — a bar that rejects
paraphrase rejects the product:

| case | outcome |
| --- | --- |
| paraphrase whose date is in the cited row | kept |
| locale-formatted date matching the source's own format | kept |
| a German sentence full of capitalised nouns | kept |
| a derived count, and a derived total | kept |
| a sentence stating nothing specific | kept |
| a fabricated date | dropped |
| a date moved to another year | dropped |
| a fabricated percentage | dropped |
| a bare number answering a percentage claim | dropped |
| a figure in a currency the row does not name | dropped |
| an injected instruction's discount, amount and date | dropped |

Mutation-checked at the lane: disabling the extractive branch in `claims` keeps
all three planted sentences in `orgbrief`, and
`TestParseBriefDropsASentenceWhoseFactsTheCitedRecordDoesNotCarry` fails.