### PR TITLE
An objection binds what it objected to

### DIFF
--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -33,7 +33,7 @@ import (
 // not, the caller asks its own subject kind's grant, which is the ONLY part
 // that differs: a person's is VerdictForPerson and a lead's is grantedForLead,
 // and each reads a column the other's query does not.
-func (g *Gate) resolveAndRecord(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, phase commsauthz.Phase) (resolution, error) {
+func (g *Gate) resolveAndRecord(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, phase commsauthz.Phase, suppressed bool) (resolution, error) {
 	res, err := g.resolveCategory(ctx, tx, req, subject)
 	if err != nil {
 		return resolution{}, err
@@ -52,7 +52,13 @@ func (g *Gate) resolveAndRecord(ctx context.Context, tx pgx.Tx, req commsauthz.R
 	// UNSCOPED row matching every other unscoped one, collapsing the thread
 	// separation staging established. Transmit still re-checks the
 	// evidence; what it does not do is write a second, weaker record of it.
-	if phase == commsauthz.PhaseStaging {
+	// NOT WHILE A SUPPRESSION STANDS. A basis row asserts we hold a lawful
+	// ground to write to this person; writing one about somebody whose
+	// processing is restricted is itself processing, and it lands in their own
+	// Art. 15 export as a claim made after they said stop. The category is
+	// still resolved — the decision row records what the message was — but the
+	// ground is not written down.
+	if phase == commsauthz.PhaseStaging && !suppressed {
 		w, err := g.store.windowsFor(ctx, tx)
 		if err != nil {
 			return resolution{}, err
@@ -85,8 +91,8 @@ func allowOn(d commsauthz.Decision, res resolution) commsauthz.Decision {
 // engine measurable: a row can say "this is a reply, and the old gate refused
 // it", which is exactly the disagreement a rollout needs to see before anybody
 // flips a mode.
-func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, d commsauthz.Decision, phase commsauthz.Phase) (commsauthz.Decision, error) {
-	res, err := g.resolveAndRecord(ctx, tx, req, subject, phase)
+func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, d commsauthz.Decision, phase commsauthz.Phase, suppressed bool) (commsauthz.Decision, error) {
+	res, err := g.resolveAndRecord(ctx, tx, req, subject, phase, suppressed)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
@@ -116,7 +122,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 	// TestAnUnsupportedClaimIsRecordedButNeverResolvedTo, which is what that
 	// test's own comment records.
 	d.Requested = res.Category
-	return g.legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, res, d)
+	return g.legacyVerdictFor(ctx, tx, subject.ID, req.LegacyPurposeKey, res, d, suppressed)
 }
 
 // legacyVerdictFor answers on the old purpose model when the record supports no
@@ -127,7 +133,7 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 // answering with one body of code about one person. A second implementation
 // here would be a second answer, and the one that stopped matching would look
 // exactly like the one that still did.
-func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey string, res resolution, d commsauthz.Decision) (commsauthz.Decision, error) {
+func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purposeKey string, res resolution, d commsauthz.Decision, suppressed bool) (commsauthz.Decision, error) {
 	purpose, defined, err := purposeRowFor(ctx, tx, purposeKey)
 	if err != nil {
 		return commsauthz.Decision{}, err
@@ -161,7 +167,10 @@ func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purpos
 		// it (Art. 5(2)). The engine is the only authority now, so it is the
 		// only thing left that can make that record: grantedForRecipient used
 		// to stamp here, and nothing calls it on the send path any more.
-		if err := stampDerivedBasis(ctx, tx, personID, verdict); err != nil {
+		// Not while a suppression stands, for recordBasis's reason: the stamp
+		// writes a consent_qualifying_event asserting a ground to correspond,
+		// and the send is about to be refused anyway.
+		if err := stampDerivedBasis(ctx, tx, personID, verdict, suppressed); err != nil {
 			return commsauthz.Decision{}, err
 		}
 		d.Verdict = commsauthz.VerdictAllow

--- a/backend/internal/modules/consent/authorizelead.go
+++ b/backend/internal/modules/consent/authorizelead.go
@@ -112,7 +112,6 @@ func purposeRowFor(ctx context.Context, tx pgx.Tx, purposeKey string) (PurposeRo
 // because no suppression, objection or consent state can be read for a subject
 // nobody identified.
 func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient, req commsauthz.Request, d commsauthz.Decision, phase commsauthz.Phase) (commsauthz.Decision, error) {
-	purposeKey := req.LegacyPurposeKey
 	leadID, found, err := resolveLead(ctx, tx, r)
 	if err != nil {
 		return commsauthz.Decision{}, err
@@ -130,16 +129,36 @@ func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient,
 
 	// A suppression binds a lead exactly as it binds a person: the row may
 	// name a lead_id or bare address, and liveSuppression already reads both.
-	suppressed, kind, err := liveSuppression(ctx, tx, leadID, r)
+	kinds, err := liveSuppression(ctx, tx, leadID, r)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
-	if suppressed {
+	if kind, absolute := bindsEveryCategory(kinds); absolute {
 		d.Verdict = commsauthz.VerdictDeny
 		d.ReasonCode = kind
 		d.Suppression = kind
 		return d, nil
 	}
+
+	// ONE EXIT for the suppression, so the rule is applied in one place rather
+	// than at each arm below. The person arm has the same shape in decideOne;
+	// an earlier version applied it at three separate returns and the third was
+	// a hand-inlined partial copy that set Suppression without consulting the
+	// rule.
+	decided, err := g.decideLeadOnItsRecord(ctx, tx, r, req, d, phase, leadID, len(kinds) > 0)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	decided = applySuppression(decided, kinds)
+	return decided, nil
+}
+
+// decideLeadOnItsRecord answers about a lead from evidence and grant alone.
+//
+// Suppression is its caller's business: this reaches a verdict as though the
+// recipient had said nothing, and decideLead narrows it once.
+func (g *Gate) decideLeadOnItsRecord(ctx context.Context, tx pgx.Tx, r connector.Recipient, req commsauthz.Request, d commsauthz.Decision, phase commsauthz.Phase, leadID string, suppressed bool) (commsauthz.Decision, error) {
+	purposeKey := req.LegacyPurposeKey
 
 	// The evidence arms, before any purpose key is consulted, through the same
 	// helper the person arm uses so the basis is recorded the same way.
@@ -151,7 +170,7 @@ func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient,
 	// checked against lead grants.
 	res, err := g.resolveAndRecord(ctx, tx, req, subjectRef{
 		Kind: entityLead, ID: leadID, Address: r.Email,
-	}, phase)
+	}, phase, suppressed)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
@@ -168,6 +187,7 @@ func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient,
 		d.ReasonCode = commsauthz.ReasonUnknownPurpose
 		return d, nil
 	}
+
 	d.Resolved = categoryForClass(purpose.Class)
 	granted, err := grantedForLead(ctx, tx, r, purpose.ID, purpose.RequiresDOI)
 	if err != nil {

--- a/backend/internal/modules/consent/authorizesuppression.go
+++ b/backend/internal/modules/consent/authorizesuppression.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What a suppression binds, and what it leaves alone.
+//
+// A suppression is not one rule. Three kinds of "do not write to this person"
+// exist and they bind different things, so applying the strongest one to every
+// message refuses mail nobody objected to — an Art. 21 marketing objection
+// stopping that person's INVOICE is the case this file exists to prevent.
+
+import (
+	"slices"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// applySuppression narrows a decision by a live suppression, against the
+// category the record actually resolved to.
+//
+// Called AFTER resolution, which is the whole point: liveSuppression can say a
+// row exists, but only the resolved category says whether it binds THIS
+// message.
+func applySuppression(d commsauthz.Decision, kinds []string) commsauthz.Decision {
+	if len(kinds) == 0 {
+		return d
+	}
+	// EVERY kind is asked, and the first that binds refuses. A person may
+	// carry several at once, and since this change they no longer agree: an
+	// objection binds only marketing while a hard bounce binds everything, so
+	// picking one and asking it alone lets the others through.
+	//
+	// The row records the binding kind when one binds, and otherwise the first
+	// that stood — a message that went out while a suppression stood is exactly
+	// what a later reader needs to see, with the verdict beside it saying the
+	// engine knew and let it through.
+	for _, kind := range kinds {
+		if suppressionBinds(kind, d.Resolved) {
+			d.Verdict = commsauthz.VerdictDeny
+			d.ReasonCode = kind
+			d.Suppression = kind
+			return d
+		}
+	}
+	// None of them binds this category, so the send stands and the row records
+	// that one stood anyway. Sorted for the record's sake only: an unordered
+	// read would make this field depend on the planner, and the same message
+	// would describe itself differently on two runs.
+	sorted := slices.Clone(kinds)
+	slices.Sort(sorted)
+	d.Suppression = sorted[0]
+	return d
+}
+
+// suppressionBinds reports whether one kind of suppression stops one category.
+//
+// FOUR RULES, and the default refuses. Each widening below is a deliberate line
+// naming the reason code it applies to, because the one time this was written
+// as a permissive default it swallowed subject_request — the only kind a seat
+// can write, and so the only kind a real installation holds — and turned
+// "please stop emailing me" into permission to send five categories of mail.
+//
+//   - A MARKETING OBJECTION binds marketing and nothing else. Art. 21 is an
+//     objection to direct marketing, so it beats consent and every exception
+//     for that category, and says nothing about the invoice the same person is
+//     owed. Today's objectionStands is already purpose-scoped for the legacy
+//     gate; this is the same scoping, one layer up.
+//   - A STATUTORY RESTRICTION (Art. 18) binds everything except the three
+//     categories Art. 18(2) does not reach: a security warning is an Art. 34
+//     obligation, a privacy notice discharges Art. 13/14, and an opt-out
+//     acknowledgement is Art. 12(3) confirmation of the subject's own act.
+//     NOT the other two subject-serving categories: a record confirmation is
+//     an unsolicited invitation to review a record and a consent confirmation
+//     solicits a NEW grant, and Art. 18(2) offers no gateway for either.
+//   - A SUBJECT'S REQUEST binds everything. Somebody said stop, in words a rep
+//     wrote down; answering it with mail they did not ask for is the thing they
+//     asked us not to do.
+//   - Everything else binds every category too, which is where a hard bounce
+//     lands and where an unrecognised reason code lands. No template makes a
+//     dead address accept mail, and a code this function does not know must
+//     refuse rather than pick a narrower rule — the direction liveSuppression,
+//     blockedReasonCode and the validators all already fail in.
+func suppressionBinds(kind string, category commsauthz.Category) bool {
+	switch kind {
+	case commsauthz.ReasonObjection:
+		return category == commsauthz.CategoryMarketing
+	case commsauthz.ReasonRestricted:
+		return !survivesARestriction(category)
+	default:
+		return true
+	}
+}
+
+// survivesARestriction reports whether Art. 18(2) leaves room for a category.
+//
+// Three, not the five ServesTheSubject names: that predicate answers "does this
+// exist to serve the recipient", which is the right question for a HARD
+// suppression and too wide for a statutory restriction.
+func survivesARestriction(c commsauthz.Category) bool {
+	switch c {
+	case commsauthz.CategorySecurityNotice, commsauthz.CategoryPrivacyNotice,
+		commsauthz.CategoryOptoutConfirmation:
+		return true
+	default:
+		return false
+	}
+}
+
+// bindsEveryCategory names a kind among these that stops every category the
+// engine can resolve to, so the caller may answer without resolving at all.
+//
+// MUST AGREE WITH suppressionBinds's unconditional arm, and a restatement is
+// how the two drift: an earlier version had this naming hard bounce while
+// suppressionBinds spared the five for a restriction, and the comment on each
+// described the other's rule. Held by TestTheEarlyExitAgreesWithTheRule, which
+// asserts the implication over every category and every reason code.
+func bindsEveryCategory(kinds []string) (string, bool) {
+	for _, kind := range kinds {
+		if kind != commsauthz.ReasonObjection && kind != commsauthz.ReasonRestricted {
+			return kind, true
+		}
+	}
+	return "", false
+}

--- a/backend/internal/modules/consent/authorizesuppression_integration_test.go
+++ b/backend/internal/modules/consent/authorizesuppression_integration_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What each kind of suppression binds, measured against a real resolved
+// category. Three kinds with three different reaches: applying the strongest to
+// every message refuses mail nobody objected to.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// suppress records one live suppression against the env's person.
+func (e *resolveEnv) suppress(t *testing.T, kind string) {
+	t.Helper()
+	// decided_by_level as the machinery writes it: an objection and a
+	// restriction are legal facts and a bounce is the provider's answer, so
+	// none of the three is a user-level decision.
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO communication_suppression
+		    (person_id, kind, source, captured_by, decided_by_level)
+		VALUES ($1, $2, 'test', 'human:x', 'subject')`, e.person, kind); err != nil {
+		t.Fatalf("recording the %s: %v", kind, err)
+	}
+}
+
+// AN ART. 21 OBJECTION IS ABOUT MARKETING, AND BINDS MARKETING.
+//
+// It beats consent, the German existing-customer exception and every other
+// basis for that category, and no mode softens it.
+func TestAMarketingObjectionStopsMarketing(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "newsletter", "marketing")
+	e.suppress(t, "marketing_objection")
+
+	d := e.decide(t, commsauthz.Request{LegacyPurposeKey: "newsletter"})
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny: they objected to exactly this", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonObjection {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonObjection)
+	}
+}
+
+// AND IT DOES NOT STOP THEIR INVOICE.
+//
+// This is the defect the split exists for: the objection was applied before the
+// category was known, so an Art. 21 objection to marketing refused the invoice
+// the same person is owed. An objection to direct marketing says nothing about
+// a message the law requires us to send.
+func TestAMarketingObjectionDoesNotStopAReply(t *testing.T) {
+	e := setupResolve(t)
+	e.suppress(t, "marketing_objection")
+
+	// A thread the subject wrote into: the reply arm, on their own evidence.
+	anchor := e.inboundFrom(t, "thread-invoice", e.address, time.Now().Add(-24*time.Hour))
+
+	d := e.decide(t, commsauthz.Request{AnchorActivityID: anchor})
+	if d.Verdict != commsauthz.VerdictAllow {
+		t.Fatalf("verdict = %q (%s), want allow: they objected to MARKETING, and this is a reply "+
+			"to their own message", d.Verdict, d.ReasonCode)
+	}
+	// The objection is still on the record, which is what a later reader needs.
+	if d.Suppression != "marketing_objection" {
+		t.Errorf("suppression = %q, want the objection recorded on the row even though it did not bind",
+			d.Suppression)
+	}
+}
+
+// A PROCESSING RESTRICTION BINDS EVERYTHING THE SUBJECT IS NOT OWED.
+func TestAProcessingRestrictionStopsOrdinaryCorrespondence(t *testing.T) {
+	e := setupResolve(t)
+	e.suppress(t, "processing_restriction")
+	anchor := e.inboundFrom(t, "thread-restricted", e.address, time.Now().Add(-24*time.Hour))
+
+	d := e.decide(t, commsauthz.Request{AnchorActivityID: anchor})
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny: a restriction stops correspondence", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonRestricted {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonRestricted)
+	}
+}
+
+// A HARD BOUNCE STOPS EVEN WHAT THE SUBJECT IS OWED.
+//
+// No template makes a dead address accept mail, so the five subject-serving
+// categories are not an exception here — a message nobody receives serves them
+// no better than one nobody sent.
+func TestAHardBounceStopsEvenASubjectServingMessage(t *testing.T) {
+	e := setupResolve(t)
+	e.suppress(t, "hard_bounce")
+
+	d := e.decide(t, commsauthz.Request{Context: commsauthz.CategorySecurityNotice})
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny: the address does not accept mail", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonHardBounce {
+		t.Errorf("reason = %q, want %q", d.ReasonCode, commsauthz.ReasonHardBounce)
+	}
+}
+
+// SOMEBODY WHO PHONED AND SAID STOP IS NOT SENT A RECORD CONFIRMATION.
+//
+// subject_request is the ONLY kind a seat may write, so it is the kind a real
+// installation actually holds. An earlier version of the rules folded it into
+// the statutory restriction and let the five subject-serving categories through
+// — and POST /people/{id}/consent/confirm-request mails record_confirmation
+// with no further consent question, so the person who asked us to stop received
+// an invitation to review their record.
+func TestSomebodyWhoAskedUsToStopIsNotSentARecordConfirmation(t *testing.T) {
+	e := setupResolve(t)
+	e.suppress(t, "subject_request")
+
+	d := e.decide(t, commsauthz.Request{Context: commsauthz.CategoryRecordConfirmation})
+	if d.Verdict == commsauthz.VerdictAllow {
+		t.Fatalf("verdict = allow (%s): they asked us to stop writing, and this is mail they "+
+			"did not ask for", d.ReasonCode)
+	}
+	if d.ReasonCode != commsauthz.ReasonSubjectRequest {
+		t.Errorf("reason = %q, want %q: calling their request a statutory restriction misstates "+
+			"a legal fact on a row they can obtain", d.ReasonCode, commsauthz.ReasonSubjectRequest)
+	}
+}
+
+// A RESTRICTED SUBJECT GETS NO NEW BASIS ROW WRITTEN ABOUT THEM.
+//
+// Resolution now runs before the suppression is applied, so the category is
+// known — but a communication_basis row asserts we hold a lawful ground to
+// write to this person, and writing one about a restricted subject is itself
+// processing, disclosed back to them under Art. 15.
+func TestARestrictedSubjectGetsNoNewBasisRow(t *testing.T) {
+	e := setupResolve(t)
+	e.suppress(t, "processing_restriction")
+	anchor := e.inboundFrom(t, "thread-nobasis", e.address, time.Now().Add(-24*time.Hour))
+
+	if d := e.decide(t, commsauthz.Request{AnchorActivityID: anchor}); d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny", d.Verdict)
+	}
+	var rows int
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT count(*) FROM communication_basis WHERE person_id = $1`, e.person).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Errorf("communication_basis rows = %d, want 0: a ground was recorded for a subject "+
+			"whose processing is restricted", rows)
+	}
+}
+
+// A WEAKER SUPPRESSION DOES NOT MASK A STRONGER ONE.
+//
+// The reader used to take a single row ordered by a fixed strength, which was
+// sound while every kind refused everything. It stopped being sound when reach
+// became category-dependent: a marketing objection sorts first and binds the
+// LEAST, so a person carrying both an objection and a hard bounce had the
+// bounce masked and their invoice sent to a dead mailbox.
+func TestAnObjectionDoesNotMaskAHardBounce(t *testing.T) {
+	e := setupResolve(t)
+	// Recorded objection-first, which is the order the old strength sort put
+	// first and the order that hid the bounce.
+	e.suppress(t, "marketing_objection")
+	e.suppress(t, "hard_bounce")
+	anchor := e.inboundFrom(t, "thread-masked", e.address, time.Now().Add(-24*time.Hour))
+
+	d := e.decide(t, commsauthz.Request{AnchorActivityID: anchor})
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q (%s), want deny: the objection does not bind a reply, but the "+
+			"hard bounce binds everything and was read past", d.Verdict, d.ReasonCode)
+	}
+	if d.ReasonCode != commsauthz.ReasonHardBounce {
+		t.Errorf("reason = %q, want %q: the binding kind is the one that answers",
+			d.ReasonCode, commsauthz.ReasonHardBounce)
+	}
+}

--- a/backend/internal/modules/consent/authorizesuppression_test.go
+++ b/backend/internal/modules/consent/authorizesuppression_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The suppression rules are a pure predicate over two values, so they are
+// asked here rather than through a database. The DB-backed half — that
+// decideOne actually applies them in the right order — lives in
+// authorizesuppression_integration_test.go.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// serviceCategories is the five, written out. Naming them here rather than
+// asking ServesTheSubject is the point: an expectation computed the way the
+// code computes it agrees with a wrong rule.
+var serviceCategories = []commsauthz.Category{
+	commsauthz.CategorySecurityNotice, commsauthz.CategoryPrivacyNotice,
+	commsauthz.CategoryRecordConfirmation, commsauthz.CategoryConsentConfirmation,
+	commsauthz.CategoryOptoutConfirmation,
+}
+
+// survivesArt18 is the THREE a statutory restriction leaves room for — fewer
+// than the five above, and the difference is the point: a record confirmation
+// and a consent confirmation are messages Art. 18(2) offers no gateway for.
+var survivesArt18 = []commsauthz.Category{
+	commsauthz.CategorySecurityNotice, commsauthz.CategoryPrivacyNotice,
+	commsauthz.CategoryOptoutConfirmation,
+}
+
+// everythingButTheFive lists the categories that are not in serviceCategories,
+// also written out.
+//
+// Held by: TestWhatEachSuppressionBinds, whose first assertion is that these
+// two lists together are exactly the vocabulary — so a category added to
+// commsauthz and to neither list fails rather than being silently unjudged.
+var everythingButTheFive = []commsauthz.Category{
+	commsauthz.CategoryReplyToInbound, commsauthz.CategoryRequestedFollowup,
+	commsauthz.CategoryPrecontractQuote, commsauthz.CategoryActiveDealFollowup,
+	commsauthz.CategoryCustomerService, commsauthz.CategoryAccountNotice,
+	commsauthz.CategoryContractNotice, commsauthz.CategoryInvoiceOrPayment,
+	commsauthz.CategoryMarketing,
+}
+
+// TestWhatEachSuppressionBinds spells out every answer.
+func TestWhatEachSuppressionBinds(t *testing.T) {
+	all := append(append([]commsauthz.Category{}, everythingButTheFive...), serviceCategories...)
+	if len(all) != len(commsauthz.Categories()) {
+		t.Fatalf("this table names %d categories and the vocabulary holds %d — a category was added "+
+			"without deciding which suppressions reach it", len(all), len(commsauthz.Categories()))
+	}
+
+	// What a restriction stops: everything except the three Art. 18(2) spares.
+	restricted := []commsauthz.Category{}
+	for _, c := range all {
+		if !slices.Contains(survivesArt18, c) {
+			restricted = append(restricted, c)
+		}
+	}
+
+	bound := map[string][]commsauthz.Category{
+		commsauthz.ReasonObjection:  {commsauthz.CategoryMarketing},
+		commsauthz.ReasonRestricted: restricted,
+		// The five included: no template makes a dead address live.
+		commsauthz.ReasonHardBounce: all,
+		// The subject said stop, so nothing goes.
+		commsauthz.ReasonSubjectRequest: all,
+		// A reason code this function does not recognise refuses everything.
+		"a_code_nobody_added_here": all,
+	}
+	for kind, stops := range bound {
+		for _, c := range all {
+			want := slices.Contains(stops, c)
+			if got := suppressionBinds(kind, c); got != want {
+				t.Errorf("%s against %s: binds = %v, want %v", kind, c, got, want)
+			}
+		}
+	}
+}
+
+// TestTheEarlyExitAgreesWithTheRule holds the two spellings together.
+//
+// bindsEveryCategory lets decideOne answer without resolving the record, which
+// is only sound when the kind stops every category. A restatement is how the
+// two drift, so the implication is asserted rather than trusted.
+func TestTheEarlyExitAgreesWithTheRule(t *testing.T) {
+	for _, kind := range []string{
+		commsauthz.ReasonObjection, commsauthz.ReasonRestricted,
+		commsauthz.ReasonHardBounce, "a_code_nobody_added_here",
+	} {
+		if _, absolute := bindsEveryCategory([]string{kind}); !absolute {
+			continue
+		}
+		for _, c := range commsauthz.Categories() {
+			if !suppressionBinds(kind, c) {
+				t.Errorf("%s skips resolution but does not bind %s: a message in that category "+
+					"is refused without the engine ever working out what it is", kind, c)
+			}
+		}
+	}
+}
+
+// TestEveryLiveKindIsAsked holds the loop in applySuppression.
+//
+// A person may carry several suppressions at once, and since reach became
+// category-dependent they no longer agree: an objection binds only marketing
+// while a hard bounce binds everything. Asking one and stopping — which the
+// reader did for years, ordered by a fixed strength — lets the others through.
+// Asserted at BOTH orderings so the answer cannot depend on which row the
+// planner returned first.
+func TestEveryLiveKindIsAsked(t *testing.T) {
+	reply := commsauthz.CategoryReplyToInbound
+	for _, order := range [][]string{
+		{commsauthz.ReasonObjection, commsauthz.ReasonHardBounce},
+		{commsauthz.ReasonHardBounce, commsauthz.ReasonObjection},
+	} {
+		d := applySuppression(
+			commsauthz.Decision{Resolved: reply, Verdict: commsauthz.VerdictAllow}, order)
+		if d.Verdict != commsauthz.VerdictDeny {
+			t.Errorf("%v against %s: verdict = %q, want deny — the objection does not bind a "+
+				"reply, so the hard bounce beside it must be the one that answers",
+				order, reply, d.Verdict)
+		}
+		if d.ReasonCode != commsauthz.ReasonHardBounce {
+			t.Errorf("%v: reason = %q, want %q — the BINDING kind answers, not the first read",
+				order, d.ReasonCode, commsauthz.ReasonHardBounce)
+		}
+	}
+}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -193,19 +193,30 @@ func (g *Gate) decideOne(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 	}
 	d.SubjectKind, d.SubjectID = entityPerson, parsed
 
-	suppressed, kind, err := liveSuppression(ctx, tx, personID, r)
+	// READ FIRST, APPLY AFTER THE CATEGORY IS KNOWN. What a suppression binds
+	// depends on what the message is, and nothing knows that until the record
+	// has been resolved — see applySuppression.
+	kinds, err := liveSuppression(ctx, tx, personID, r)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
-	if suppressed {
+	if kind, absolute := bindsEveryCategory(kinds); absolute {
+		// Nothing a category could say would change this answer, so the record
+		// is not resolved at all. An objection and a restriction do NOT come
+		// through here — both need the category before they can be applied.
 		d.Verdict = commsauthz.VerdictDeny
 		d.ReasonCode = kind
 		d.Suppression = kind
 		return d, nil
 	}
-	return g.decideResolved(ctx, tx, req, subjectRef{
+	d, err = g.decideResolved(ctx, tx, req, subjectRef{
 		Kind: entityPerson, ID: personID, Address: r.Email,
-	}, d, phase)
+	}, d, phase, len(kinds) > 0)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	d = applySuppression(d, kinds)
+	return d, nil
 }
 
 // blockedReasonCode translates the verdict's own code into the engine's
@@ -341,47 +352,65 @@ func nullableText(s string) *string {
 // bounce is a fact about a MAILBOX, so it is recorded against the address and
 // keeps applying when the same address later appears on a different record.
 // The person arm carries objections and restrictions, which follow the human.
-func liveSuppression(ctx context.Context, tx pgx.Tx, personID string, r connector.Recipient) (bool, string, error) {
-	var kind string
-	// STRONGEST first, not newest. Ordering by time would let a weaker
-	// suppression recorded later mask an objection recorded earlier, and the
-	// reason code is what decides whether a refusal survives observe mode — so
-	// a masked objection is a message that goes out to somebody who said stop.
-	// This is also the only reader in the tree that applies these rows: the
-	// legacy gate reads person_consent and never looks here.
-	err := tx.QueryRow(ctx, `
-		SELECT kind FROM communication_suppression
+func liveSuppression(ctx context.Context, tx pgx.Tx, personID string, r connector.Recipient) ([]string, error) {
+	// EVERY live kind, not the strongest one.
+	//
+	// An earlier version took one row ordered by a fixed strength, which was
+	// sound while every kind refused everything: whichever won, the answer was
+	// the same. It stopped being sound when reach became category-dependent —
+	// a marketing objection sorts first and binds the LEAST, so a person
+	// carrying both an objection and a hard bounce had the bounce masked and
+	// their invoice sent to a dead mailbox. Strength is no longer a total
+	// order, so the caller is given all of them and applies each.
+	//
+	// Reading the row is not applying it: what a suppression BINDS depends on
+	// the category, which is not known here. applySuppression decides that,
+	// after resolution.
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT kind FROM communication_suppression
 		 WHERE revoked_at IS NULL
 		   AND (person_id = $1
 		        OR lead_id = $1
-		        OR (address IS NOT NULL AND $2 <> '' AND lower(address) = lower($2)))
-		 ORDER BY CASE kind
-		            WHEN 'marketing_objection'    THEN 0
-		            WHEN 'processing_restriction' THEN 1
-		            WHEN 'subject_request'        THEN 2
-		            WHEN 'hard_bounce'            THEN 3
-		            ELSE 4
-		          END, recorded_at DESC
-		 LIMIT 1`, personID, r.Email).Scan(&kind)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return false, "", nil
-	}
+		        OR (address IS NOT NULL AND $2 <> '' AND lower(address) = lower($2)))`,
+		personID, r.Email)
 	if err != nil {
-		return false, "", fmt.Errorf("consent: read the recipient's suppressions: %w", err)
+		return nil, fmt.Errorf("consent: read the recipient's suppressions: %w", err)
 	}
+	defer rows.Close()
+	var kinds []string
+	for rows.Next() {
+		var kind string
+		if err := rows.Scan(&kind); err != nil {
+			return nil, fmt.Errorf("consent: read the recipient's suppressions: %w", err)
+		}
+		kinds = append(kinds, reasonForSuppressionKind(kind))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("consent: read the recipient's suppressions: %w", err)
+	}
+	return kinds, nil
+}
+
+// reasonForSuppressionKind maps a stored kind onto the reason code a decision
+// row carries.
+//
+// A kind this code does not recognise gets its OWN code rather than being
+// folded onto a known one: suppressionBinds refuses an unrecognised code
+// outright, and folding it onto a recognised one would hand it that code's
+// narrower reach. That is exactly how subject_request came to permit five
+// categories of mail while wearing the statutory restriction's name.
+func reasonForSuppressionKind(kind string) string {
 	switch kind {
 	case "marketing_objection":
-		return true, commsauthz.ReasonObjection, nil
+		return commsauthz.ReasonObjection
 	case "processing_restriction":
-		return true, commsauthz.ReasonRestricted, nil
+		return commsauthz.ReasonRestricted
+	case "subject_request":
+		return commsauthz.ReasonSubjectRequest
 	case "hard_bounce":
-		return true, commsauthz.ReasonHardBounce, nil
+		return commsauthz.ReasonHardBounce
 	default:
-		// A kind this code does not recognise still SUPPRESSES, and absolutely.
-		// Somebody added a row shape to the constraint and not to this switch;
-		// treating the unknown case as the weaker one would let the next kind
-		// added to the table be the one that sends.
-		return true, commsauthz.ReasonRestricted, nil
+		return "unrecognised_suppression:" + kind
 	}
 }
 

--- a/backend/internal/modules/consent/gate.go
+++ b/backend/internal/modules/consent/gate.go
@@ -128,7 +128,10 @@ func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 	if verdict.State != VerdictAllowed {
 		return false, nil
 	}
-	if err := stampDerivedBasis(ctx, tx, personID, verdict); err != nil {
+	// false: this is the legacy gate's own path, which reads person_consent and
+	// never looks at communication_suppression, so it has no suppression to
+	// report. The engine's arms pass their own answer.
+	if err := stampDerivedBasis(ctx, tx, personID, verdict, false); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -140,8 +143,15 @@ func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 // A lawful basis nobody wrote down is an assertion, and the controller carries
 // the burden of showing it. A basis read from a stored row needs nothing: it is
 // already the record.
-func stampDerivedBasis(ctx context.Context, tx pgx.Tx, personID string, verdict Verdict) error {
+func stampDerivedBasis(ctx context.Context, tx pgx.Tx, personID string, verdict Verdict, suppressed bool) error {
 	if !verdict.QualifyingDerived || verdict.Qualifying == nil {
+		return nil
+	}
+	if suppressed {
+		// A stamp asserts we hold a ground to correspond with this person.
+		// Writing one about somebody carrying a live suppression is itself
+		// processing, and it lands in their own Art. 15 export as a claim made
+		// after they said stop. The same reason recordBasis skips.
 		return nil
 	}
 	by, err := storekit.CapturedBy(ctx)

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -9,8 +9,17 @@ package commsauthz
 const (
 	// ReasonObjection is Art. 21 — the subject objected to direct marketing.
 	ReasonObjection = "marketing_objection"
-	// ReasonRestricted is a statutory or subject-requested processing restriction.
+	// ReasonRestricted is a STATUTORY processing restriction (Art. 18).
 	ReasonRestricted = "processing_restricted"
+	// ReasonSubjectRequest is the subject asking us to stop, in their own
+	// words, relayed by whoever took the call.
+	//
+	// Distinct from ReasonRestricted because they are different facts and the
+	// difference decides two things: a statutory restriction is nobody's to
+	// overrule, where a request the subject made can be lifted by the subject;
+	// and a decision row that called one the other misstates a legal fact in a
+	// record the subject can obtain under Art. 15.
+	ReasonSubjectRequest = "subject_request"
 	// ReasonHardBounce is an address that does not accept mail.
 	ReasonHardBounce = "hard_bounce"
 	// ReasonUnconfirmedDOI is a marketing grant whose round trip never happened.
@@ -53,6 +62,7 @@ const (
 var absoluteDenials = map[string]bool{
 	ReasonObjection:      true,
 	ReasonRestricted:     true,
+	ReasonSubjectRequest: true,
 	ReasonHardBounce:     true,
 	ReasonUnconfirmedDOI: true,
 	// A recipient the engine cannot resolve to exactly one subject is the

--- a/backend/internal/shared/ports/commsauthz/authority.go
+++ b/backend/internal/shared/ports/commsauthz/authority.go
@@ -102,10 +102,10 @@ func (l AuthorityLevel) CanOverrule(decided AuthorityLevel) bool {
 // which fails when a new absolute reason is added without an arm here.
 func LevelForReason(reasonCode string) AuthorityLevel {
 	switch reasonCode {
-	// THE SUBJECT'S OWN ACT. An objection, a withdrawal and a restriction are
-	// things the person did, and Art. 21 makes the first absolute. Nobody in
-	// the installation lifts these, admin included.
-	case ReasonObjection, ReasonRestricted, ReasonConsentWithdrawn:
+	// THE SUBJECT'S OWN ACT. An objection, a withdrawal, a restriction and a
+	// request to stop are things the person did, and Art. 21 makes the first
+	// absolute. Nobody in the installation lifts these, admin included.
+	case ReasonObjection, ReasonRestricted, ReasonSubjectRequest, ReasonConsentWithdrawn:
 		return LevelSubject
 
 	// EVERYTHING ELSE IS THE ENGINE READING AN INCOMPLETE RECORD, and a seat

--- a/backend/internal/shared/ports/commsauthz/authority_test.go
+++ b/backend/internal/shared/ports/commsauthz/authority_test.go
@@ -168,6 +168,7 @@ func TestEveryAbsoluteReasonIsClassifiedDeliberately(t *testing.T) {
 		// The subject's own act. Nothing lifts these.
 		ReasonObjection:        LevelSubject,
 		ReasonRestricted:       LevelSubject,
+		ReasonSubjectRequest:   LevelSubject,
 		ReasonConsentWithdrawn: LevelSubject,
 		// Absolute, but nobody's decision — each names a fact a human corrects.
 		ReasonHardBounce:          LevelMachine,

--- a/backend/internal/shared/ports/commsauthz/category.go
+++ b/backend/internal/shared/ports/commsauthz/category.go
@@ -103,6 +103,11 @@ func (c Category) CarriesUnsubscribe() bool { return c == CategoryMarketing }
 // an objection to marketing.
 //
 // A hard bounce still stops all five. No template makes a dead address live.
+//
+// Held by: TestWhatEachSuppressionBinds (modules/consent), which names all
+// fourteen categories against each reason code rather than deriving them from
+// this predicate — so a change here fails there and asks whether the
+// suppression rules were meant to move with it.
 func (c Category) ServesTheSubject() bool {
 	switch c {
 	case CategorySecurityNotice, CategoryPrivacyNotice, CategoryOptoutConfirmation,

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3373,6 +3373,8 @@ export const de = {
     "Diese Person hat ihre Einwilligung zurückgezogen. Das kann hier niemand aufheben, auch keine Administration.",
   "sendPermission.reason.restricted":
     "Die Daten dieser Person sind in der Verarbeitung eingeschränkt. Das kann hier niemand aufheben, auch keine Administration.",
+  "sendPermission.reason.askedUsToStop":
+    "Diese Person hat uns gebeten, ihr nicht mehr zu schreiben. Das kann hier niemand aufheben, auch keine Administration.",
   "sendPermission.reason.bounced":
     "Diese Adresse nimmt keine Mails an. Sie zu korrigieren ist die Lösung, nicht eine Ausnahme.",
   "sendPermission.reason.tooMany":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3457,6 +3457,8 @@ export const en = {
     "They took back their permission. Nobody here can lift that, including an administrator.",
   "sendPermission.reason.restricted":
     "Their data is under a processing restriction. Nobody here can lift that, including an administrator.",
+  "sendPermission.reason.askedUsToStop":
+    "They asked us to stop writing to them. Nobody here can lift that, including an administrator.",
   "sendPermission.reason.bounced":
     "That address does not accept mail. Correcting it is the fix, not an override.",
   "sendPermission.reason.tooMany":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3336,6 +3336,8 @@ export const vi = {
     "Họ đã rút lại sự đồng ý. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
   "sendPermission.reason.restricted":
     "Dữ liệu của họ đang bị hạn chế xử lý. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
+  "sendPermission.reason.askedUsToStop":
+    "Họ đã yêu cầu chúng ta ngừng gửi thư cho họ. Không ai ở đây có thể gỡ bỏ điều đó, kể cả quản trị viên.",
   "sendPermission.reason.bounced":
     "Địa chỉ đó không nhận được thư. Sửa lại địa chỉ mới là cách giải quyết, không phải bỏ qua.",
   "sendPermission.reason.tooMany":

--- a/frontend/src/screens/sendpermission.tsx
+++ b/frontend/src/screens/sendpermission.tsx
@@ -176,6 +176,8 @@ function reasonKey(recipient: Recipient | undefined) {
       return "sendPermission.reason.withdrawn" as const;
     case "processing_restricted":
       return "sendPermission.reason.restricted" as const;
+    case "subject_request":
+      return "sendPermission.reason.askedUsToStop" as const;
     case "hard_bounce":
       return "sendPermission.reason.bounced" as const;
     case "frequency_cap_reached":


### PR DESCRIPTION
liveSuppression took no category and decideOne returned on a suppression
before the record was resolved, so the strongest stop applied to every message.
An Art. 21 objection to direct marketing refused that person's invoice.

The order is now read, resolve, apply. suppressionBinds carries four rules and
a refusing default: a marketing objection binds marketing alone; a statutory
restriction binds everything but the three categories Art. 18(2) does not reach;
a subject's own request to stop binds everything; anything else, a hard bounce
and an unrecognised reason code included, binds everything too.

Security review caught the first draft sending mail to somebody who had asked
us to stop. subject_request is the only kind a seat may write, so it is the kind
a real installation holds -- and liveSuppression folded it into the statutory
restriction, where a permissive default handed it the restriction's narrower
reach. POST /people/{id}/consent/confirm-request then mails record_confirmation
with no further consent question. It now has its own reason code, which also
stops a decision row calling a phone call a statutory restriction in a record
the subject can obtain under Art. 15.

The restriction spares three categories rather than five. A security warning is
an Art. 34 obligation, a privacy notice discharges Art. 13/14, and an opt-out
acknowledgement is Art. 12(3) confirmation of the subject's own act. A record
confirmation is an unsolicited invitation to review a record and a consent
confirmation solicits a new grant; Art. 18(2) offers no gateway for either.

Resolution now runs for a suppressed subject, so recordBasis is skipped while a
suppression stands: a basis row asserts a lawful ground to write to somebody,
and writing one about a restricted subject is itself processing, disclosed back
to them under Art. 15.

decideLead applies the rule at one exit rather than three.

## Found in review, and worth naming

Three defects were caught after the first draft, all in the same shape — a rule
that was safe while every suppression refused everything, and stopped being safe
once reach depended on the category.

1. **subject_request passed five categories.** It is the only kind a seat may
   write, so it is the kind a real installation holds, and `liveSuppression`
   folded it onto the statutory restriction where a permissive default handed it
   the restriction's narrower reach. `POST /people/{id}/consent/confirm-request`
   then mails `record_confirmation` with no further consent question.
2. **A weaker suppression masked a stronger one.** The reader took one row
   ordered by a fixed strength. A marketing objection sorts first and binds the
   least, so somebody carrying both an objection and a hard bounce had the bounce
   masked and their invoice sent to a dead mailbox. It now reads every live kind
   and applies each.
3. **An unrecognised kind was folded onto `processing_restricted`**, taking that
   code's narrower reach instead of the refusing default. It now gets its own
   code and refuses.

## Verification

- `make check-backend` and `make check-fe` green.
- Consent integration lane green.
- Every rule mutation-checked. One mutation initially PASSED and the reason is
  worth recording: a `slices.Sort` I had added for determinism put
  `hard_bounce` first alphabetically, so a mutation that only asked the first
  kind still found it. The sort moved off the decision path onto the record-only
  branch, and the mutation then fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppressions used to refuse every message before the engine knew what the message was, so an Art. 21 marketing objection stopped a person's invoice. Suppressions now bind against the message's resolved category: a marketing objection binds marketing alone, a statutory restriction spares the three categories Art. 18(2) reaches, and a subject's own stop request, a hard bounce, and any unrecognised reason code bind everything.

- Resolution runs while a suppression stands, so no new basis row asserts a ground to write to a restricted subject.
- `subject_request` now has its own reason code and binds everything; it previously wore the statutory restriction's narrower reach, so a record confirmation reached somebody who had asked us to stop.
- All live suppressions are read and applied, so a weaker kind like a marketing objection no longer masks a harder one like a hard bounce.

<sup>Written for commit ae09ee8b75b61c49387afd1fea5ead8704ac64e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

