### PR TITLE
The role images build again on a PR that changes what they are

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,14 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend == 'true' || github.event_name == 'merge_group' }}
       e2e: ${{ steps.filter.outputs.e2e == 'true' || github.event_name == 'merge_group' }}
       deps: ${{ steps.filter.outputs.deps == 'true' || github.event_name == 'merge_group' }}
+      # The three paths that decide what the role images ARE. Deliberately not
+      # backend/** or frontend/**: the images copy build output, so a source
+      # change can break one without touching these — but a three-role bake on
+      # every backend PR is most of the cost the release-trigger cleanup was
+      # removing, and the compile that would catch nearly all of it already runs
+      # in deterministic-gates. The trade is written down in infra/ci-pipeline.md
+      # rather than left to be inferred from this filter.
+      images: ${{ steps.filter.outputs.images == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -252,6 +260,10 @@ jobs:
             # /pnpm-lock.yaml now, which `**/` still matches because it matches
             # zero segments, so this keeps firing and needs no edit next time the
             # workspace moves.
+            images:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'docker-bake.hcl'
             deps:
               - 'go.work'
               - 'go.work.sum'
@@ -1057,6 +1069,49 @@ jobs:
   # three under a gate that blocks.
   # Promote them once the queue has a measured baseline, as their own change, so a
   # regression has one explanation.
+  # The role images BUILD on a PR that changes what they are.
+  #
+  # Nothing built them between two correct changes. ci.yml's old
+  # `docker images` job was removed because release.yml baked on every push to
+  # main, so that build was the de-facto gate and a break surfaced within a
+  # commit of landing — a Dockerfile-only PR matching no scope was an accepted
+  # trade against that net. release.yml then became dispatch-only, to stop ~400
+  # release runs a week competing for the org-wide runner ceiling. Right on its
+  # own terms, and it removed the net the trade depended on: the first person to
+  # notice a broken image became whoever cut the next release, with the offending
+  # commit arbitrarily far back.
+  #
+  # BUILD ONLY, PUSH NOTHING. No registry credentials, no digest, no release side
+  # effect — this answers "does it still build", which is the question that went
+  # unasked. Through docker-bake.hcl so the PR exercises the same definition the
+  # release does; a second spelling here would be a gate that passes while the
+  # release breaks.
+  #
+  # Gated at the JOB level like every other lane, so a path skip reports as
+  # passing rather than producing no check run — the same trap the license gate
+  # above is written to avoid.
+  images:
+    name: images (build only)
+    timeout-minutes: 30
+    needs: [changes]
+    if: >-
+      needs.changes.outputs.images == 'true'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The default group is the three roles. No --push and no --set that names
+      # a registry: the images stay in the runner's builder and go nowhere.
+      - name: Build the role images
+        run: docker buildx bake -f docker-bake.hcl default
+
   ci:
     name: ci
     timeout-minutes: 10
@@ -1073,6 +1128,7 @@ jobs:
       - integration
       - frontend
       - license-gate
+      - images
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // suppressPerson records an Art. 21 marketing objection against a person.
@@ -43,32 +44,47 @@ import (
 // liveSuppression reads, and when that writer arrives this helper is what
 // should be repointed at it.
 //
-// decided_by_level is named rather than defaulted, because the column has no
-// default: the migration that added it dropped the scaffolding one on purpose,
-// so that a writer states who decided or the INSERT fails where its author can
-// see it. 'subject' is what this row IS — a marketing objection is the person's
-// own act under Art. 21, the one tier no seat in the installation may lift —
-// and it is the level that migration's own backfill gives the same kind.
+// A SUBJECT REQUEST, not a marketing objection, and the difference is the whole
+// reason this helper is written out rather than inlined.
+//
+// These two tests are about STAGING — that a refused send leaves no delivery row
+// behind — and they need a suppression that actually binds the message they
+// send. #4701 narrowed an Art. 21 marketing objection to bind marketing alone,
+// deliberately: objecting to direct marketing had been refusing that person's
+// invoice. Both sends below are non-marketing, so a marketing objection stopped
+// stopping them, and these tests began asserting the behaviour that change
+// existed to remove.
+//
+// ReasonSubjectRequest binds every category — the subject asked us to stop, in
+// their own words — so the refusal is real again and the assertion is once more
+// about the transaction rather than about the category rule. The category rule
+// has its own tests, in the module that owns it.
+//
+// Written directly rather than through a store method because there is no
+// production writer for communication_suppression yet — the unsubscribe path
+// that will own it lands with the preference centre. The row shape is the one
+// liveSuppression reads, and when that writer arrives this helper is what
+// should be repointed at it.
 func suppressPerson(t *testing.T, e *apptest.AppEnv, personID string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
 		// decided_by_level is stated rather than defaulted, because the column
 		// deliberately has no default: a writer names who decided or the INSERT
-		// fails where the author can see it. `subject` is what this row IS — a
-		// marketing objection is Art. 21 by definition, which is the same
-		// classification the migration gave the rows that predate the column.
+		// fails where the author can see it. `subject` is what this row IS — the
+		// person's own request, the one tier no seat in the installation may
+		// lift.
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO communication_suppression (person_id, kind, source, captured_by, decided_by_level)
-			VALUES ($1, 'marketing_objection', 'test', $2, 'subject')`, personID, "test")
+			VALUES ($1, $3, 'test', $2, 'subject')`, personID, "test", commsauthz.ReasonSubjectRequest)
 		return err
 	}); err != nil {
-		t.Fatalf("recording the objection: %v", err)
+		t.Fatalf("recording the subject's request to stop: %v", err)
 	}
 }
 
-// The mail door. A staged send to an objecting recipient is refused with the
+// The mail door. A staged send to a recipient who asked us to stop is refused with the
 // whole transaction, so no delivery row survives it.
-func TestAMailSendToAnObjectingRecipientStagesNothing(t *testing.T) {
+func TestAMailSendToASuppressedRecipientStagesNothing(t *testing.T) {
 	p := setupPreflight(t)
 	p.connect(t, gmailReadonlyScope, gmailSendScope)
 	suppressPerson(t, p.AppEnv, p.personID)
@@ -76,7 +92,7 @@ func TestAMailSendToAnObjectingRecipientStagesNothing(t *testing.T) {
 	status, code, _ := p.send(t)
 
 	if status != http.StatusConflict || code != "consent_not_granted" {
-		t.Fatalf("mail to an objecting recipient → %d %q, want 409 consent_not_granted", status, code)
+		t.Fatalf("mail to a recipient who asked us to stop → %d %q, want 409 consent_not_granted", status, code)
 	}
 	if n := p.stagedDeliveries(t); n != 0 {
 		t.Fatalf("%d deliveries staged behind a refused send, want 0 — "+
@@ -87,7 +103,7 @@ func TestAMailSendToAnObjectingRecipientStagesNothing(t *testing.T) {
 // The channel door, which is a second implementation of staging rather than a
 // variant of the mail one. A fix to the mail path does not reach it, so it is
 // asserted separately.
-func TestAChannelSendToAnObjectingRecipientStagesNothing(t *testing.T) {
+func TestAChannelSendToASuppressedRecipientStagesNothing(t *testing.T) {
 	c := setupChannelSend(t)
 	c.grantConsent(t, "transactional")
 	suppressPerson(t, c.AppEnv, c.personID)
@@ -95,9 +111,9 @@ func TestAChannelSendToAnObjectingRecipientStagesNothing(t *testing.T) {
 	status, code, _ := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusConflict || code != "consent_not_granted" {
-		t.Fatalf("channel reply to an objecting recipient → %d %q, want 409 consent_not_granted", status, code)
+		t.Fatalf("channel reply to a recipient who asked us to stop → %d %q, want 409 consent_not_granted", status, code)
 	}
-	c.assertNoOutboundEffect(t, "a send to an objecting recipient")
+	c.assertNoOutboundEffect(t, "a send to a recipient who asked us to stop")
 }
 
 // stagingDecisions reads back what the engine wrote for one delivery at the

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -174,16 +174,27 @@ Consequences:
   queue closes it: the docs-only entry is gated against the full tree it is
   merging into.
 - A **Dockerfile-only PR** (the root `Dockerfile`, `.dockerignore`,
-  `docker-bake.hcl`) also matches no scope, and **nothing else builds the role
-  images either**. `ci.yml` dropped its `docker images (api + web + worker)` job
-  on the reasoning that `release.yml` baked the images on every push to `main`,
-  so a break surfaced within a commit. That reasoning expired when `release.yml`
-  became dispatch-only: the images are now built only when somebody cuts a
-  release, so a broken `Dockerfile` can sit on `main` indefinitely and the person
-  who finds it is whoever tries to release next. Stated plainly because it is a
-  real regression in coverage, not a trade that still balances — restoring a
-  build-only, push-nothing image job scoped to those three paths is
-  https://github.com/margince/margince/issues/1965.
+  `docker-bake.hcl`) matches the `images` scope and runs the **`images (build
+  only)`** job: a `docker buildx bake` of the default group — the three roles —
+  that pushes nothing. No registry credentials, no digest, no release side
+  effect. It answers "does it still build", which for a while nothing asked.
+
+  That gap was real and is worth remembering. `ci.yml` dropped its `docker
+  images (api + web + worker)` job on the reasoning that `release.yml` baked on
+  every push to `main`, so a break surfaced within a commit of landing. The
+  reasoning expired when `release.yml` became dispatch-only — right on its own
+  terms, to stop ~400 release runs a week competing for the org-wide runner
+  ceiling, and it removed the net the earlier trade depended on. Between the two
+  changes the first person to notice a broken image was whoever cut the next
+  release, with the offending commit arbitrarily far back.
+
+  **The scope is those three paths and not `backend/**` or `frontend/**`**, and
+  that is a deliberate trade rather than an oversight. The images copy build
+  output, so a source change *can* break one without touching any of the three —
+  but a three-role bake on every backend PR is most of the cost the release
+  cleanup was removing, and the compile that catches nearly all of that class
+  already runs in `deterministic-gates`. What is left uncovered is a source
+  change that builds and then fails to package, which the release still finds.
 - A **backend-only PR** skips the frontend + UAT lanes; a **frontend-only PR**
   skips the Go build/gate + the integration lane — except for
   `frontend/src/mcp-apps/forbidden.json`, which is authored under `frontend/`


### PR DESCRIPTION
Closes #1965.

Nothing built them, between two changes that were each correct.

`ci.yml` dropped its `docker images (api + web + worker)` job on the reasoning that `release.yml` baked on every push to `main` — so that build was the de-facto gate and a break surfaced within a commit of landing. A Dockerfile-only PR matching no scope was an accepted trade against that net.

`release.yml` then became **dispatch-only**, to stop ~400 release runs a week competing for the org-wide runner ceiling. Right on its own terms — and it removed the net the earlier trade depended on. Between the two, the first person to notice a broken image became whoever cut the next release, with the offending commit arbitrarily far back.

## Build only, push nothing

No registry credentials, no digest, no release side effect. It answers *"does it still build"*, which is the question that went unasked.

Through `docker-bake.hcl`'s own default group, so the PR exercises the same definition the release does — a second spelling in the workflow would be a gate that passes while the release breaks.

**Gated at the job level** like every other lane, so a path skip reports as passing rather than producing no check run (the trap the `license gate` job is written to avoid), and named in the `ci` aggregate's `needs` so a failure is a merge verdict rather than a check somebody has to notice.

## The scope is the three paths, not `backend/**`

That is the decision the ticket left open, and it is a trade rather than an oversight.

The images copy build output, so a source change *can* break one without touching `Dockerfile`, `.dockerignore` or `docker-bake.hcl`. But a three-role bake on every backend PR is most of the cost the release cleanup was removing, and the compile that catches nearly all of that class already runs in `deterministic-gates`.

**What stays uncovered**: a change that builds and then fails to package. The release still finds that one.

## The doc

`infra/ci-pipeline.md` carried this gap as a known regression naming this issue. It now describes the job, and states the scope trade *and what it leaves uncovered* — rather than leaving either to be inferred from the filter.

## Verification

Ran the bake this job runs — all three roles build, nothing pushed. `ci-doc-parity` and `make-target-parity` OK; `make check-backend` exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for container image build configuration changes.
  * Container images are now built without being pushed when relevant files change.
  * Image build results are included in the overall CI status.

* **Documentation**
  * Documented image validation scope, registry behavior, and current coverage limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also carries a main fix

Two tests in `compose/integration` are red on main, asserting the behaviour #4701 **deliberately removed**: that change narrowed an Art. 21 marketing objection to bind marketing alone (objecting to direct marketing had been refusing that person's invoice), and both of these sends are non-marketing — so the objection stopped stopping them.

They are about **staging** — that a refused send leaves no delivery row behind — so the fixture needs a suppression that binds the message it sends, not a rule about categories. `ReasonSubjectRequest` binds every category, which makes the refusal real again and returns the assertion to the transaction. Renamed with it, since a fixture whose name says "objecting recipient" while its row says something else is how the next reader learns the wrong rule.