### PR TITLE
A certification scenario declares the tools its goal makes tempting

### DIFF
--- a/backend/internal/compose/agenttoolbudget_test.go
+++ b/backend/internal/compose/agenttoolbudget_test.go
@@ -90,6 +90,10 @@ type corpusProvenance struct {
 	Scenarios       int      `json:"scenarios"`
 	OfferingCatalog int      `json:"offering_the_whole_catalog"`
 	Skipped         []string `json:"skipped_by_the_scan"`
+	// ReadByProse names the scenarios that declare no near misses, so theirs
+	// are still read by the prose fallback. Published because a fallback that
+	// is silent about where it still applies hides the error it is shrinking.
+	ReadByProse []string `json:"read_by_prose"`
 }
 
 func TestTheAgentToolBudgetIsPublished(t *testing.T) {
@@ -182,6 +186,7 @@ func renderAgentToolBudget(t *testing.T) agentToolBudget {
 			Scenarios:       census.Scenarios,
 			OfferingCatalog: census.Catalog,
 			Skipped:         census.Skipped,
+			ReadByProse:     census.Heuristic,
 		},
 	}
 }
@@ -284,5 +289,32 @@ func TestTheWrongReachCensusIsReadFromTheCorpusAndNamesWhatItSkipped(t *testing.
 	if census.Scenarios < census.Catalog {
 		t.Errorf("the census counted %d scenarios offering the catalog out of %d total",
 			census.Catalog, census.Scenarios)
+	}
+}
+
+// The census counts what the scenarios DECLARE, and says which ones it still
+// reads by prose.
+//
+// The two halves fail in opposite directions and both matter. If the declared
+// list stops being read — the yaml key renamed, the mirror in
+// declaredNearMisses left behind — every scenario silently falls back to the
+// prose scan, and the published number goes back to the over-count the page had
+// to admit to. If the fallback stops being NAMED, a corpus that has drifted
+// back to prose looks measured.
+func TestTheWrongReachCensusReadsWhatTheScenariosDeclare(t *testing.T) {
+	specs := servedSurface(t).Specs()
+	census, err := readWrongReachCensus(agentLoopCorpusDir, specs)
+	if err != nil {
+		t.Fatalf("reading the corpus: %v", err)
+	}
+	if len(census.Heuristic) > 0 {
+		t.Errorf("%d scenario(s) still have their near misses read out of rubric prose: %s.\n"+
+			"Declare them with a `near_misses:` list under `expect:` — an empty list is a "+
+			"legitimate claim that the goal has no plausible wrong reach, and is not the same "+
+			"as leaving the key out", len(census.Heuristic), strings.Join(census.Heuristic, ", "))
+	}
+	if len(census.Counts) == 0 {
+		t.Error("no near miss was counted at all, so the census is measuring nothing — which is " +
+			"what a renamed key looks like from here")
 	}
 }

--- a/backend/internal/compose/agenttoolbudgetderive_test.go
+++ b/backend/internal/compose/agenttoolbudgetderive_test.go
@@ -29,6 +29,8 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -99,12 +101,14 @@ const agentLoopCorpusDir = "aicert/corpus/agent_loop"
 // wrongReachCensus is how often each tool is named as the WRONG reach across
 // the agent_loop certification scenarios, plus what the scan could not read.
 //
-// THE METHOD IS A PROSE HEURISTIC AND THE PAGE SAYS SO. A scenario's near
-// misses exist only inside its `rubric:` free text; only the intended answer is
-// structured. So a mention is counted when the rubric names a registered tool
-// that is not that scenario's own answer. It over-counts, because a rubric
-// quotes the right tool's copy and that copy names others, and it is sensitive
-// to how a rubric is phrased.
+// A scenario DECLARES its near misses, and that is what is counted. Where it
+// declares none the rubric's prose is scanned instead — a mention counts when
+// the rubric names a registered tool that is not that scenario's own answer —
+// and the scenario is NAMED as read that way, on the page.
+//
+// The prose scan over-counts, because a rubric quotes the right tool's copy and
+// that copy names its neighbours, and it is sensitive to how a rubric is
+// phrased. That is why it is the fallback rather than the method.
 //
 // Skipped names what the scan could not classify. It is reported rather than
 // dropped: a census that silently ignored the scenarios it could not read would
@@ -114,6 +118,14 @@ type wrongReachCensus struct {
 	Scenarios int
 	Catalog   int
 	Skipped   []string
+	// Heuristic names the scenarios whose near misses were read out of rubric
+	// PROSE because the scenario declares none of its own.
+	//
+	// Named rather than counted, and named on the published page. A fallback
+	// that is silent about which scenarios it still applies to hides exactly
+	// the error it exists to shrink: the reader sees one number and cannot tell
+	// which part of it was measured and which part guessed.
+	Heuristic []string
 }
 
 var (
@@ -176,10 +188,14 @@ func readWrongReachCensus(dir string, specs []mcp.ToolSpec) (wrongReachCensus, e
 				entry.Name()+" (this scan could not read its expected step, so a wrong reach cannot be told from the right one)")
 			continue
 		}
-		named := map[string]bool{}
-		for _, match := range toolNameInProse.FindAllString(rubric[1], -1) {
-			if registered[match] && match != answer {
-				named[match] = true
+		named := declaredNearMisses(body, registered, answer)
+		if named == nil {
+			census.Heuristic = append(census.Heuristic, entry.Name())
+			named = map[string]bool{}
+			for _, match := range toolNameInProse.FindAllString(rubric[1], -1) {
+				if registered[match] && match != answer {
+					named[match] = true
+				}
 			}
 		}
 		for name := range named {
@@ -187,7 +203,42 @@ func readWrongReachCensus(dir string, specs []mcp.ToolSpec) (wrongReachCensus, e
 		}
 	}
 	sort.Strings(census.Skipped)
+	sort.Strings(census.Heuristic)
 	return census, nil
+}
+
+// declaredNearMisses is the scenario's own list, or nil when it declares none.
+//
+// Nil and empty are different answers and the caller acts on the difference: a
+// scenario that declares none is read by the prose fallback and said to be,
+// while one declaring an empty list has said its goal has no plausible wrong
+// reach — a claim, not an absence.
+//
+// Decoded here rather than through aicert.LoadScenarioFile because aicert
+// imports this package, so a test in it cannot import aicert back. The key is
+// aicert.Expectations' own `near_misses` tag and this is a MIRROR of it: rename
+// the field there and every scenario falls to the prose fallback, which
+// TestTheWrongReachCensusReadsWhatTheScenariosDeclare below fails on.
+//
+// The answer is excluded even when a scenario names it, because a list holding
+// the tool the scenario exists to reward would count the right answer as the
+// temptation — the failure the skipped-scenario guard above is about.
+func declaredNearMisses(body []byte, registered map[string]bool, answer string) map[string]bool {
+	var declared struct {
+		Expect struct {
+			NearMisses []string `yaml:"near_misses"`
+		} `yaml:"expect"`
+	}
+	if err := yaml.Unmarshal(body, &declared); err != nil || declared.Expect.NearMisses == nil {
+		return nil
+	}
+	named := map[string]bool{}
+	for _, tool := range declared.Expect.NearMisses {
+		if registered[tool] && tool != answer {
+			named[tool] = true
+		}
+	}
+	return named
 }
 
 // temptationWeight sums the corpus's wrong-reach counts over an agent's

--- a/backend/internal/compose/agenttoolbudgetpage_test.go
+++ b/backend/internal/compose/agenttoolbudgetpage_test.go
@@ -88,18 +88,27 @@ func renderAgentToolBudgetPage(b agentToolBudget) []byte {
 	fmt.Fprintf(&p, "scenarios name that tool as the WRONG reach. %d of those scenarios offer the model the\n", b.Corpus.OfferingCatalog)
 	p.WriteString("whole catalog and score which tool it picks, so the confusions it names were chosen\n")
 	p.WriteString("against the real surface rather than guessed.\n\n")
-	p.WriteString("**It is a rubric-mention heuristic, not an observed error rate.** The count is\n")
-	p.WriteString("registered tool names appearing in a scenario's rubric prose, minus that scenario's\n")
-	p.WriteString("own expected step. A weight of 5 does not mean a model went wrong five times; it\n")
-	p.WriteString("means five scenario rubrics name a tool on this menu as the reach to avoid. The\n")
-	p.WriteString("measurement that would replace it is sampling real runs for chosen-vs-wanted.\n\n")
-	p.WriteString("**Two limits, both real.** A scenario's near-misses live only in its `rubric:` free\n")
-	p.WriteString("text, so the count is read by matching registered tool names in that prose minus the\n")
-	p.WriteString("scenario's own answer — which over-counts, because a rubric quotes the right tool's\n")
-	p.WriteString("copy and that copy names others. And each count was measured under a *different*\n")
-	p.WriteString("scenario's goal, so summing them over one agent's fixed goal borrows precision the\n")
-	p.WriteString("number does not have. Read it as an ordering of which tools cause trouble on this\n")
-	p.WriteString("surface, not as a prediction about one agent.\n\n")
+	p.WriteString("**It is an authored count, not an observed error rate.** Each scenario DECLARES\n")
+	p.WriteString("the tools its goal makes tempting, in a `near_misses:` list beside its expected\n")
+	p.WriteString("step. A weight of 5 does not mean a model went wrong five times; it means five\n")
+	p.WriteString("scenarios name a tool on this menu as the reach to avoid. The measurement that\n")
+	p.WriteString("would replace it is sampling real runs for chosen-vs-wanted.\n\n")
+	if len(b.Corpus.ReadByProse) > 0 {
+		fmt.Fprintf(&p, "**%d scenarios declare no near misses**, so theirs are read out of rubric prose by\n",
+			len(b.Corpus.ReadByProse))
+		p.WriteString("matching registered tool names minus the scenario's own answer. That is wrong in\n")
+		p.WriteString("BOTH directions — it counts a tool a rubric merely quotes, and misses one the\n")
+		p.WriteString("rubric names in words, since \"a search would re-find the person\" is search_records\n")
+		p.WriteString("to a reader and nothing to a matcher. They are named rather than absorbed:\n\n")
+		for _, name := range b.Corpus.ReadByProse {
+			fmt.Fprintf(&p, "- %s\n", name)
+		}
+		p.WriteString("\n")
+	}
+	p.WriteString("**One limit remains.** Each count was authored under a *different* scenario's goal,\n")
+	p.WriteString("so summing them over one agent's fixed goal borrows precision the number does not\n")
+	p.WriteString("have. Read it as an ordering of which tools cause trouble on this surface, not as a\n")
+	p.WriteString("prediction about one agent.\n\n")
 	if len(b.Corpus.Skipped) > 0 {
 		fmt.Fprintf(&p, "**%d scenarios were skipped by the scan** and are named here rather than dropped:\n\n", len(b.Corpus.Skipped))
 		for _, s := range b.Corpus.Skipped {

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_description_is_not_a_name.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_description_is_not_a_name.yaml
@@ -24,6 +24,9 @@ expect:
     phrasing appears on none of them, so it would answer an empty list that
     reads as "no customer ever hit this". query_workspace needs conditions in
     a closed vocabulary, and "a pilot that stalled" is not one.
+  near_misses:
+    - search_records
+    - query_workspace
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_draft_precedes_a_send.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_draft_precedes_a_send.yaml
@@ -27,6 +27,8 @@ expect:
     activity the grounding identifies. Reaching for send_email here is the
     failure that matters most on this surface, because it is the step that
     leaves the workspace.
+  near_misses:
+    - send_email
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_goal_no_tool_can_serve_ends_the_turn.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_goal_no_tool_can_serve_ends_the_turn.yaml
@@ -34,6 +34,9 @@ expect:
     the wrong reason. It is the one scenario on this band that tempts across a
     scope boundary rather than inside one, which is how the corpus checks that
     the prompt does not invite a call the admission gate would refuse.
+  near_misses:
+    - prepare_handoff
+    - update_record
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_name_alone_is_still_a_search.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_name_alone_is_still_a_search.yaml
@@ -22,6 +22,9 @@ expect:
     match a stored value exactly or return nothing — a confident empty answer
     where a text match would have found the account. read_record needs an id
     nothing in this window supplies.
+  near_misses:
+    - query_workspace
+    - read_record
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_promise_is_not_a_slipping_deal.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_promise_is_not_a_slipping_deal.yaml
@@ -30,6 +30,9 @@ expect:
     catch_me_up_on is the other reach, and it is worse: it is built around ONE
     record, the goal names none, and a turn calling it had to pick an account
     the person never asked about.
+  near_misses:
+    - whats_slipping_this_week
+    - catch_me_up_on
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_stepless_deal_is_a_slipping_deal.yaml
@@ -31,6 +31,8 @@ expect:
     The distinction is the point of the pair: one tool reports open promises,
     the other reports deals with none, and a surface where either answers both
     is one where a rep cannot tell which they were told.
+  near_misses:
+    - review_commitments
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_structured_question_is_not_a_text_search.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_structured_question_is_not_a_text_search.yaml
@@ -25,6 +25,9 @@ expect:
     three, so it would answer a wider question in a shape indistinguishable from
     the right one; run_report answers counts and totals, not the deals
     themselves.
+  near_misses:
+    - search_records
+    - run_report
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_thin_relationship_is_not_a_slipping_deal.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_thin_relationship_is_not_a_slipping_deal.yaml
@@ -33,6 +33,9 @@ expect:
     ONE deal — the goal asks it of all of them, and the window carries no
     deal_id, so a turn calling it both narrowed the question and invented the
     id it narrowed by.
+  near_misses:
+    - whats_slipping_this_week
+    - account_coverage
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_total_is_still_a_report.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_total_is_still_a_report.yaml
@@ -22,6 +22,8 @@ expect:
     for it here would hand back a page of deals and leave the arithmetic to be
     done on whatever fraction of them fitted in the page — a wrong total that
     looks like a right one.
+  near_misses:
+    - query_workspace
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/a_warm_path_is_not_a_search.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/a_warm_path_is_not_a_search.yaml
@@ -23,6 +23,9 @@ expect:
     organization the grounding identifies. search_records would return the
     account the grounding has already supplied, and account_coverage answers a
     different question — who is covered — without naming a path in.
+  near_misses:
+    - search_records
+    - account_coverage
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/ambiguity_ends_the_turn.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/ambiguity_ends_the_turn.yaml
@@ -28,6 +28,9 @@ expect:
     update_record on either one guessed, and it guessed silently, which is worse
     than guessing loudly; a turn that searches spends a call to learn what the
     window already told it.
+  near_misses:
+    - update_record
+    - search_records
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/basic_01.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/basic_01.yaml
@@ -43,6 +43,8 @@ expect:
     calls list_open_deals (the tool that can supply it) rather than jumping
     straight to log_activity or fabricating a "final" answer with no
     observations to ground it.
+  near_misses:
+    - log_activity
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/basic_02_final.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/basic_02_final.yaml
@@ -33,6 +33,8 @@ expect:
     deals) — score high only if the response answers with {"final":...}
     stating 3, grounded in the seed observation, rather than calling
     list_open_deals again for data it already has.
+  near_misses:
+    - list_open_deals
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/catchup_over_raw_reads.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/catchup_over_raw_reads.yaml
@@ -25,6 +25,10 @@ expect:
     fields and not its history, search_records finds the account the grounding
     has already found, and run_report answers a number rather than a narrative —
     a turn taking any of those did more work for a worse answer.
+  near_misses:
+    - read_record
+    - search_records
+    - run_report
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/coverage_names_the_gap.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/coverage_names_the_gap.yaml
@@ -23,6 +23,9 @@ expect:
     calls it on the deal the grounding identifies. intro_path_to finds a way in
     to an account nobody knows, which is the opposite situation; catch_me_up_on
     would narrate the deal without ever saying who is missing from it.
+  near_misses:
+    - intro_path_to
+    - catch_me_up_on
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/enrichment_is_not_search.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/enrichment_is_not_search.yaml
@@ -23,6 +23,8 @@ expect:
     it is the only step that can satisfy this goal. Score high only if the turn
     calls it on the organization the grounding identifies. search_records would
     search the very records the goal has already said are empty.
+  near_misses:
+    - search_records
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/identity_is_checked_before_a_record_is_created.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/identity_is_checked_before_a_record_is_created.yaml
@@ -24,6 +24,9 @@ expect:
     a duplicate that a person then has to merge. search_records matches text and
     would answer nothing about the address, so a miss there reads as "she is
     not here" when the record may be filed under a different spelling.
+  near_misses:
+    - create_record
+    - search_records
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/logging_what_happened_changes_nothing_else.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/logging_what_happened_changes_nothing_else.yaml
@@ -23,6 +23,9 @@ expect:
     for update_record or progress_deal has read a request to remember a
     conversation as a licence to change the deal it was about, which is a
     different act with a different consequence.
+  near_misses:
+    - update_record
+    - progress_deal
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/meeting_prep_is_not_a_catchup.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/meeting_prep_is_not_a_catchup.yaml
@@ -24,6 +24,8 @@ expect:
     person needs before they walk in — open commitments, stakeholders, the state
     of the deal. The goal names an imminent meeting, so score high only if the
     turn calls prep_for_meeting on the account the grounding identifies.
+  near_misses:
+    - catch_me_up_on
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/slipping_is_its_own_question.yaml
@@ -20,6 +20,8 @@ expect:
     on. Score high only if the turn calls whats_slipping_this_week. run_report
     could return a list of deals, but nothing in it says which are slipping, so a
     turn that reaches for it has to invent the judgement the product already owns.
+  near_misses:
+    - run_report
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/the_calendar_event_is_the_anchor.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/the_calendar_event_is_the_anchor.yaml
@@ -34,6 +34,9 @@ expect:
     grounding gives. Searching for an account the grounding never names, reading
     the event as a bare record, or ending the turn to ask which account is meant
     all score low — the anchor was in hand.
+  near_misses:
+    - search_records
+    - read_record
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/the_record_is_found_before_it_is_changed.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/the_record_is_found_before_it_is_changed.yaml
@@ -21,6 +21,9 @@ expect:
     calling update_record or progress_deal here had to invent an identifier,
     which is the failure this scenario exists to catch — and it is worse, not
     better, when the invented id happens to be well-formed.
+  near_misses:
+    - update_record
+    - progress_deal
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/the_stage_id_comes_from_the_pipeline.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/the_stage_id_comes_from_the_pipeline.yaml
@@ -20,6 +20,9 @@ expect:
     list_pipelines first. A turn that calls progress_deal or advance_deal
     straight away has to supply a to_stage_id it cannot have — the stage is named
     "negotiation" in words, and a word is not the identifier the call takes.
+  near_misses:
+    - progress_deal
+    - advance_deal
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/corpus/agent_loop/who_knows_needs_the_person.yaml
+++ b/backend/internal/compose/aicert/corpus/agent_loop/who_knows_needs_the_person.yaml
@@ -23,6 +23,9 @@ expect:
     person the grounding identifies. intro_path_to takes an organization and
     answers about an account rather than an individual, and a search would only
     re-find the person already supplied.
+  near_misses:
+    - intro_path_to
+    - search_records
   bands:
     certified_min: 70
     degraded_min: 50

--- a/backend/internal/compose/aicert/scenario.go
+++ b/backend/internal/compose/aicert/scenario.go
@@ -118,8 +118,21 @@ type Expectations struct {
 	Outcome string    `yaml:"outcome"`
 	Answer  JSONValue `yaml:"answer,omitempty"`
 	Rubric  string    `yaml:"rubric,omitempty"`
-	Bands   Bands     `yaml:"bands"`
-	Caps    Caps      `yaml:"caps,omitempty"`
+	// NearMisses names the tools this scenario's goal makes TEMPTING and its
+	// answer does not want — the wrong reaches the rubric argues against.
+	//
+	// Structured because the alternative was reading them out of the rubric's
+	// prose, and that over-counts: a rubric quotes the right tool's copy, and
+	// that copy names its neighbours. The published temptation weight was
+	// inflated by exactly that, and the page had to admit it.
+	//
+	// A scenario may legitimately carry none — a goal with no plausible wrong
+	// reach is a goal the surface answers unambiguously — so an empty list and
+	// an absent one are the same thing here, and the census names which
+	// scenarios it is still reading by heuristic rather than assuming.
+	NearMisses []string `yaml:"near_misses,omitempty"`
+	Bands      Bands    `yaml:"bands"`
+	Caps       Caps     `yaml:"caps,omitempty"`
 }
 
 // Scenario is one certification test case, parsed from

--- a/backend/internal/compose/aicert/scenariorender.go
+++ b/backend/internal/compose/aicert/scenariorender.go
@@ -37,11 +37,12 @@ type scenarioForRender struct {
 }
 
 type expectForRender struct {
-	Outcome string `yaml:"outcome"`
-	Answer  any    `yaml:"answer,omitempty"`
-	Rubric  string `yaml:"rubric,omitempty"`
-	Bands   Bands  `yaml:"bands"`
-	Caps    Caps   `yaml:"caps,omitempty"`
+	Outcome    string   `yaml:"outcome"`
+	Answer     any      `yaml:"answer,omitempty"`
+	Rubric     string   `yaml:"rubric,omitempty"`
+	NearMisses []string `yaml:"near_misses,omitempty"`
+	Bands      Bands    `yaml:"bands"`
+	Caps       Caps     `yaml:"caps,omitempty"`
 }
 
 // RenderScenario emits a scenario as the YAML the corpus format uses, suitable
@@ -53,7 +54,8 @@ func RenderScenario(sc Scenario) ([]byte, error) {
 		Source: sc.Source, SanitizedBy: sc.SanitizedBy,
 		Expect: expectForRender{
 			Outcome: sc.Expect.Outcome, Rubric: sc.Expect.Rubric,
-			Bands: sc.Expect.Bands, Caps: sc.Expect.Caps,
+			NearMisses: sc.Expect.NearMisses,
+			Bands:      sc.Expect.Bands, Caps: sc.Expect.Caps,
 		},
 	}
 	fixture, err := decodePreservingNumbers(sc.Fixture)

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -32,7 +32,7 @@
         "list_records → search_records",
         "read_brief → whats_slipping_this_week"
       ],
-      "temptation_weight": 5
+      "temptation_weight": 6
     },
     {
       "name": "overnight_at_risk_sweep",
@@ -66,7 +66,7 @@
         "whats_slipping_this_week → draft_follow_ups_for",
         "whats_slipping_this_week → run_report"
       ],
-      "temptation_weight": 9
+      "temptation_weight": 10
     }
   ],
   "tool_cost": [
@@ -366,7 +366,7 @@
   "corpus_wrong_reach": [
     {
       "name": "search_records",
-      "scenarios_naming_it_as_the_wrong_reach": 6
+      "scenarios_naming_it_as_the_wrong_reach": 9
     },
     {
       "name": "update_record",
@@ -385,6 +385,10 @@
       "scenarios_naming_it_as_the_wrong_reach": 3
     },
     {
+      "name": "read_record",
+      "scenarios_naming_it_as_the_wrong_reach": 3
+    },
+    {
       "name": "run_report",
       "scenarios_naming_it_as_the_wrong_reach": 3
     },
@@ -394,10 +398,6 @@
     },
     {
       "name": "intro_path_to",
-      "scenarios_naming_it_as_the_wrong_reach": 2
-    },
-    {
-      "name": "read_record",
       "scenarios_naming_it_as_the_wrong_reach": 2
     },
     {
@@ -432,6 +432,7 @@
   "corpus": {
     "scenarios": 24,
     "offering_the_whole_catalog": 22,
-    "skipped_by_the_scan": null
+    "skipped_by_the_scan": null,
+    "read_by_prose": null
   }
 }

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -30,8 +30,8 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
-| `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2467 | 7% | 20743 | 15 | 9 |
+| `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
+| `overnight_at_risk_sweep` | 7 | 2467 | 7% | 20743 | 15 | 10 |
 | _whole served catalog, for scale_ | 73 | 21707 | 66% | — | — | — |
 
 ### `morning_brief`
@@ -111,19 +111,16 @@ scenarios name that tool as the WRONG reach. 22 of those scenarios offer the mod
 whole catalog and score which tool it picks, so the confusions it names were chosen
 against the real surface rather than guessed.
 
-**It is a rubric-mention heuristic, not an observed error rate.** The count is
-registered tool names appearing in a scenario's rubric prose, minus that scenario's
-own expected step. A weight of 5 does not mean a model went wrong five times; it
-means five scenario rubrics name a tool on this menu as the reach to avoid. The
-measurement that would replace it is sampling real runs for chosen-vs-wanted.
+**It is an authored count, not an observed error rate.** Each scenario DECLARES
+the tools its goal makes tempting, in a `near_misses:` list beside its expected
+step. A weight of 5 does not mean a model went wrong five times; it means five
+scenarios name a tool on this menu as the reach to avoid. The measurement that
+would replace it is sampling real runs for chosen-vs-wanted.
 
-**Two limits, both real.** A scenario's near-misses live only in its `rubric:` free
-text, so the count is read by matching registered tool names in that prose minus the
-scenario's own answer — which over-counts, because a rubric quotes the right tool's
-copy and that copy names others. And each count was measured under a *different*
-scenario's goal, so summing them over one agent's fixed goal borrows precision the
-number does not have. Read it as an ordering of which tools cause trouble on this
-surface, not as a prediction about one agent.
+**One limit remains.** Each count was authored under a *different* scenario's goal,
+so summing them over one agent's fixed goal borrows precision the number does not
+have. Read it as an ordering of which tools cause trouble on this surface, not as a
+prediction about one agent.
 
 Every scenario in the corpus was read; none was skipped.
 
@@ -157,7 +154,7 @@ a term in an addition.
 | `book_meeting` | 393 | — |
 | `enrich` | 393 | — |
 | `compose_analytics_report` | 390 | — |
-| `search_records` | 385 | 6 scenarios |
+| `search_records` | 385 | 9 scenarios |
 | `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |
 | `forecast_readings` | 349 | — |
@@ -183,7 +180,7 @@ a term in an addition.
 | `qualify_lead` | 230 | — |
 | `apply_tag` | 227 | — |
 | `create_task` | 222 | — |
-| `read_record` | 222 | 2 scenarios |
+| `read_record` | 222 | 3 scenarios |
 | `whats_slipping_this_week` | 211 | 2 scenarios |
 | `at_risk_relationships` | 208 | — |
 | `read_brief` | 206 | — |

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -1,9 +1,9 @@
 {
   "totals": {
     "sites": 42,
-    "sites_best_current": 37,
+    "sites_best_current": 0,
     "sites_best_partial": 0,
-    "sites_best_stale": 5,
+    "sites_best_stale": 42,
     "sites_absent": 0,
     "scenarios": 142,
     "records": 74,
@@ -17,9 +17,9 @@
         "env": "eu_hosted"
       },
       "sites": 36,
-      "sites_current": 31,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 5,
+      "sites_stale": 36,
       "runs": 381,
       "passed": 330,
       "reliability": 0.8661417322834646,
@@ -37,9 +37,9 @@
         "env": "eu_hosted"
       },
       "sites": 6,
-      "sites_current": 2,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 4,
+      "sites_stale": 6,
       "runs": 36,
       "passed": 36,
       "reliability": 1,
@@ -57,9 +57,9 @@
         "env": "eu_hosted"
       },
       "sites": 13,
-      "sites_current": 9,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 4,
+      "sites_stale": 13,
       "runs": 90,
       "passed": 86,
       "reliability": 0.9555555555555556,
@@ -77,9 +77,9 @@
         "env": "eu_hosted"
       },
       "sites": 1,
-      "sites_current": 1,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 0,
+      "sites_stale": 1,
       "runs": 15,
       "passed": 9,
       "reliability": 0.6,
@@ -137,9 +137,9 @@
         "env": "cloud_frontier"
       },
       "sites": 5,
-      "sites_current": 4,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 1,
+      "sites_stale": 5,
       "runs": 30,
       "passed": 27,
       "reliability": 0.9,
@@ -157,9 +157,9 @@
         "env": "eu_hosted"
       },
       "sites": 6,
-      "sites_current": 6,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 0,
+      "sites_stale": 6,
       "runs": 42,
       "passed": 37,
       "reliability": 0.8809523809523809,
@@ -177,9 +177,9 @@
         "env": "eu_hosted"
       },
       "sites": 35,
-      "sites_current": 30,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 5,
+      "sites_stale": 35,
       "runs": 372,
       "passed": 298,
       "reliability": 0.8010752688172043,
@@ -197,9 +197,9 @@
         "env": "cloud_frontier"
       },
       "sites": 5,
-      "sites_current": 4,
+      "sites_current": 0,
       "sites_partial": 0,
-      "sites_stale": 1,
+      "sites_stale": 5,
       "runs": 30,
       "passed": 28,
       "reliability": 0.9333333333333333,
@@ -220,17 +220,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "supported_degraded",
-        "reliability": 0.6666666666666666,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "scan_finds_the_promise_we_did_not_keep",
@@ -250,9 +241,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 4,
@@ -265,7 +256,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: scan_finds_the_promise_we_did_not_keep, scan_finds_the_question_nobody_answered"
         },
         {
           "binding": {
@@ -273,9 +264,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 4,
@@ -288,7 +279,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: scan_finds_the_promise_we_did_not_keep, scan_finds_the_question_nobody_answered"
         }
       ]
     },
@@ -436,7 +427,7 @@
           },
           "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 24,
           "runs": 72,
           "passed": 60,
@@ -449,7 +440,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": "22 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 16 more"
+          "stale_reason": "24 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 18 more"
         },
         {
           "binding": {
@@ -482,7 +473,7 @@
           },
           "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 24,
           "runs": 72,
           "passed": 45,
@@ -495,7 +486,7 @@
             "invalid": 11,
             "abstained": 0
           },
-          "stale_reason": "22 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 16 more"
+          "stale_reason": "24 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 18 more"
         }
       ]
     },
@@ -505,17 +496,8 @@
       "key": "brief_ranking/rank",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "mistralai/mistral-large-2512",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "reorder_two_candidates_by_momentum",
@@ -530,9 +512,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -545,7 +527,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario reorder_two_candidates_by_momentum — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -553,7 +535,7 @@
             "model": "mistralai/mistral-large-2512",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 1,
@@ -568,7 +550,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         },
         {
           "binding": {
@@ -576,9 +558,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -591,7 +573,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario reorder_two_candidates_by_momentum — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -599,7 +581,7 @@
             "model": "z-ai/glm-5.2",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 1,
@@ -614,7 +596,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         }
       ]
     },
@@ -624,17 +606,8 @@
       "key": "capture_classify/classify",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_message_that_is_both_is_labelled_commitment",
@@ -669,9 +642,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 15,
@@ -684,7 +657,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_message_that_is_both_is_labelled_commitment, a_mixed_batch_keeps_every_label_on_its_own_message, a_stated_promise_is_a_commitment, an_auto_reply_carries_no_commitment_and_no_meeting, meeting_request_from_reply"
         },
         {
           "binding": {
@@ -715,9 +688,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 14,
@@ -730,7 +703,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_message_that_is_both_is_labelled_commitment, a_mixed_batch_keeps_every_label_on_its_own_message, a_stated_promise_is_a_commitment, an_auto_reply_carries_no_commitment_and_no_meeting, meeting_request_from_reply"
         }
       ]
     },
@@ -740,17 +713,8 @@
       "key": "capture_confidentiality_verdict/thread",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_live_dispute_with_counsel_stays_private",
@@ -800,9 +764,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 8,
+          "scenarios_measured": 0,
           "scenarios_total": 8,
           "runs": 24,
           "passed": 24,
@@ -815,7 +779,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "8 scenarios it scored have changed since, or the prompts built from them have: a_live_dispute_with_counsel_stays_private, a_medical_appointment_in_the_owners_mailbox_is_not_the_companys_business, a_termination_agreement_stays_private_whatever_the_attachment_note_says, an_nda_marked_thread_is_held_on_its_own_request, an_ordinary_customer_thread_is_opened_for_the_team, an_unpatched_vulnerability_is_held_until_it_is_closed and 2 more"
         },
         {
           "binding": {
@@ -823,9 +787,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 8,
+          "scenarios_measured": 0,
           "scenarios_total": 8,
           "runs": 24,
           "passed": 23,
@@ -838,7 +802,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "8 scenarios it scored have changed since, or the prompts built from them have: a_live_dispute_with_counsel_stays_private, a_medical_appointment_in_the_owners_mailbox_is_not_the_companys_business, a_termination_agreement_stays_private_whatever_the_attachment_note_says, an_nda_marked_thread_is_held_on_its_own_request, an_ordinary_customer_thread_is_opened_for_the_team, an_unpatched_vulnerability_is_held_until_it_is_closed and 2 more"
         }
       ]
     },
@@ -848,17 +812,8 @@
       "key": "capture_counterparty_verdict/verdict",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "supported_degraded",
-        "reliability": 0.9791666666666666,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_chased_cold_pitch_is_still_spam",
@@ -948,9 +903,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 16,
+          "scenarios_measured": 0,
           "scenarios_total": 16,
           "runs": 48,
           "passed": 47,
@@ -963,7 +918,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "16 scenarios it scored have changed since, or the prompts built from them have: a_chased_cold_pitch_is_still_spam, a_company_writing_as_itself_does_not_become_a_contact_named_after_it, a_department_display_name_is_not_somebodys_name, a_fluent_machine_written_pitch_is_still_spam, a_private_correspondent_is_not_a_business_contact, a_shared_mailbox_is_real_correspondence_with_nobody_to_name and 10 more"
         },
         {
           "binding": {
@@ -994,9 +949,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 16,
+          "scenarios_measured": 0,
           "scenarios_total": 16,
           "runs": 48,
           "passed": 40,
@@ -1009,7 +964,7 @@
             "invalid": 1,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "16 scenarios it scored have changed since, or the prompts built from them have: a_chased_cold_pitch_is_still_spam, a_company_writing_as_itself_does_not_become_a_contact_named_after_it, a_department_display_name_is_not_somebodys_name, a_fluent_machine_written_pitch_is_still_spam, a_private_correspondent_is_not_a_business_contact, a_shared_mailbox_is_real_correspondence_with_nobody_to_name and 10 more"
         }
       ]
     },
@@ -1019,17 +974,8 @@
       "key": "cert_judge/judge",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "mistralai/mistral-large-2512",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "grades_a_fabricated_answer_poorly",
@@ -1049,9 +995,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -1064,7 +1010,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: grades_a_fabricated_answer_poorly, grades_a_well_grounded_answer_highly"
         },
         {
           "binding": {
@@ -1072,7 +1018,7 @@
             "model": "mistralai/mistral-large-2512",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 2,
@@ -1087,7 +1033,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         },
         {
           "binding": {
@@ -1095,9 +1041,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -1110,7 +1056,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: grades_a_fabricated_answer_poorly, grades_a_well_grounded_answer_highly"
         },
         {
           "binding": {
@@ -1118,7 +1064,7 @@
             "model": "z-ai/glm-5.2",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 2,
@@ -1133,7 +1079,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         }
       ]
     },
@@ -1143,17 +1089,8 @@
       "key": "cold_start/acts",
       "scope": "single_turn",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_factual_question_about_connecting_is_answered",
@@ -1188,9 +1125,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 15,
@@ -1203,7 +1140,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_factual_question_about_connecting_is_answered, a_progress_question_is_answered_as_status, an_ambiguous_reference_is_asked_about_rather_than_guessed, asking_what_to_do_next_is_answered_as_a_recommendation, results_act_keeps_an_off_topic_request_in_scope"
         },
         {
           "binding": {
@@ -1234,9 +1171,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 15,
@@ -1249,7 +1186,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_factual_question_about_connecting_is_answered, a_progress_question_is_answered_as_status, an_ambiguous_reference_is_asked_about_rather_than_guessed, asking_what_to_do_next_is_answered_as_a_recommendation, results_act_keeps_an_off_topic_request_in_scope"
         }
       ]
     },
@@ -1259,17 +1196,8 @@
       "key": "cold_start/company_message",
       "scope": "single_turn",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "bare_answer_corrects_the_field_the_wizard_asked_for",
@@ -1284,9 +1212,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1299,7 +1227,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario bare_answer_corrects_the_field_the_wizard_asked_for — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1330,9 +1258,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1345,7 +1273,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario bare_answer_corrects_the_field_the_wizard_asked_for — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -1355,17 +1283,8 @@
       "key": "cold_start/field_extract",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "onboarding_readback_from_landing_page",
@@ -1380,9 +1299,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1395,7 +1314,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario onboarding_readback_from_landing_page — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1426,9 +1345,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1441,7 +1360,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario onboarding_readback_from_landing_page — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -1451,17 +1370,8 @@
       "key": "cold_start/sitereadmessage",
       "scope": "single_turn",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "an_administrator_agreeing_confirms_and_changes_nothing_further",
@@ -1481,9 +1391,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 3,
@@ -1496,7 +1406,7 @@
             "invalid": 3,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: an_administrator_agreeing_confirms_and_changes_nothing_further, dossier_correction_the_administrator_asked_for"
         },
         {
           "binding": {
@@ -1527,9 +1437,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -1542,7 +1452,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: an_administrator_agreeing_confirms_and_changes_nothing_further, dossier_correction_the_administrator_asked_for"
         }
       ]
     },
@@ -1552,17 +1462,8 @@
       "key": "corpus_ask/corpus_ask",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "corpus_ask_answers_only_from_the_passage_that_says_it",
@@ -1587,9 +1488,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -1602,7 +1503,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer"
         },
         {
           "binding": {
@@ -1610,9 +1511,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -1625,7 +1526,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer"
         },
         {
           "binding": {
@@ -1633,9 +1534,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 8,
@@ -1648,7 +1549,7 @@
             "invalid": 1,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer"
         }
       ]
     },
@@ -1658,17 +1559,8 @@
       "key": "deal_health/deal_status",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "deal_status_an_overdue_task_is_not_done_work",
@@ -1693,9 +1585,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -1708,7 +1600,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: deal_status_an_overdue_task_is_not_done_work, deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is"
         },
         {
           "binding": {
@@ -1716,9 +1608,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -1731,7 +1623,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: deal_status_an_overdue_task_is_not_done_work, deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is"
         }
       ]
     },
@@ -1741,17 +1633,8 @@
       "key": "document_extract/fields",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.5-flash",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "attached_document_states_none_of_them",
@@ -1781,9 +1664,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 12,
@@ -1796,7 +1679,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: attached_document_states_none_of_them, order_form_states_all_four, pdf_agreement_read_as_a_document_part, quote_states_money_but_no_close_date"
         }
       ]
     },
@@ -2041,17 +1924,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-pro-preview",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "intro_request_asks_a_colleague_without_overclaiming",
@@ -2071,9 +1945,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -2086,7 +1960,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds"
         },
         {
           "binding": {
@@ -2094,9 +1968,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -2109,7 +1983,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds"
         },
         {
           "binding": {
@@ -2117,9 +1991,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -2132,7 +2006,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds"
         },
         {
           "binding": {
@@ -2140,9 +2014,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -2155,7 +2029,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds"
         }
       ]
     },
@@ -2170,17 +2044,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "an_instruction_inside_the_stated_reason_is_data_not_a_command",
@@ -2205,9 +2070,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -2220,7 +2085,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request"
         },
         {
           "binding": {
@@ -2228,9 +2093,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -2243,7 +2108,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request"
         },
         {
           "binding": {
@@ -2251,9 +2116,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 8,
@@ -2266,7 +2131,7 @@
             "invalid": 1,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request"
         },
         {
           "binding": {
@@ -2274,9 +2139,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -2289,7 +2154,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request"
         }
       ]
     },
@@ -2567,17 +2432,8 @@
       "key": "enrich/signature",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "contact_fields_from_a_mail_signature",
@@ -2592,9 +2448,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 1,
@@ -2607,7 +2463,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario contact_fields_from_a_mail_signature — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2638,9 +2494,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2653,7 +2509,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario contact_fields_from_a_mail_signature — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -2667,17 +2523,8 @@
         "positioning",
         "proof"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.3333333333333333,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "growth_fit_reads_their_facts_against_our_offering",
@@ -2692,9 +2539,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 1,
@@ -2707,7 +2554,7 @@
             "invalid": 0,
             "abstained": 1
           },
-          "stale_reason": ""
+          "stale_reason": "scenario growth_fit_reads_their_facts_against_our_offering — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2715,9 +2562,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 0,
@@ -2730,7 +2577,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario growth_fit_reads_their_facts_against_our_offering — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -2744,17 +2591,8 @@
         "positioning",
         "proof"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.7333333333333333,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "grounded_draft_from_a_conversation_price",
@@ -2789,9 +2627,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 9,
@@ -2804,7 +2642,7 @@
             "invalid": 0,
             "abstained": 5
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: grounded_draft_from_a_conversation_price, injected_instruction_inside_evidence_is_ignored, no_captured_context_yields_no_lines, rich_context_under_a_tight_token_cap, two_sources_disagree_on_price"
         },
         {
           "binding": {
@@ -2835,9 +2673,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 11,
@@ -2850,7 +2688,7 @@
             "invalid": 2,
             "abstained": 3
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: grounded_draft_from_a_conversation_price, injected_instruction_inside_evidence_is_ignored, no_captured_context_yields_no_lines, rich_context_under_a_tight_token_cap, two_sources_disagree_on_price"
         }
       ]
     },
@@ -2860,17 +2698,8 @@
       "key": "owed_verdict/owed",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_direct_question_asks_us_and_a_report_does_not",
@@ -2895,9 +2724,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -2910,7 +2739,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_direct_question_asks_us_and_a_report_does_not, an_invitation_asks_nothing_a_calendar_reply_cannot_settle, the_recipient_line_separates_a_request_from_a_copy"
         },
         {
           "binding": {
@@ -2918,9 +2747,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 7,
@@ -2933,7 +2762,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_direct_question_asks_us_and_a_report_does_not, an_invitation_asks_nothing_a_calendar_reply_cannot_settle, the_recipient_line_separates_a_request_from_a_copy"
         }
       ]
     },
@@ -2943,17 +2772,8 @@
       "key": "propose_roles/committee",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_committee_where_four_people_state_their_own_roles",
@@ -2978,9 +2798,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -2993,7 +2813,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_committee_where_four_people_state_their_own_roles, propose_roles_reads_a_buyer_out_of_their_own_words, propose_roles_reads_no_role_out_of_a_title"
         },
         {
           "binding": {
@@ -3001,9 +2821,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 7,
@@ -3016,7 +2836,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_committee_where_four_people_state_their_own_roles, propose_roles_reads_a_buyer_out_of_their_own_words, propose_roles_reads_no_role_out_of_a_title"
         }
       ]
     },
@@ -3026,17 +2846,8 @@
       "key": "rate_extract/fx",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "mistralai/mistral-large-2512",
-          "env": "cloud_frontier"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "fx_rates_json_api_grounded",
@@ -3056,9 +2867,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -3071,7 +2882,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: fx_rates_json_api_grounded, fx_rates_two_pairs_grounded"
         },
         {
           "binding": {
@@ -3079,7 +2890,7 @@
             "model": "mistralai/mistral-large-2512",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 2,
@@ -3094,7 +2905,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         },
         {
           "binding": {
@@ -3102,9 +2913,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -3117,7 +2928,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: fx_rates_json_api_grounded, fx_rates_two_pairs_grounded"
         },
         {
           "binding": {
@@ -3125,7 +2936,7 @@
             "model": "z-ai/glm-5.2",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 2,
@@ -3140,7 +2951,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         }
       ]
     },
@@ -3150,17 +2961,8 @@
       "key": "rate_extract/pricing",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "mistralai/mistral-large-2512",
-          "env": "cloud_frontier"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "pricing_table_two_models_grounded",
@@ -3175,9 +2977,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -3190,7 +2992,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario pricing_table_two_models_grounded — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -3198,7 +3000,7 @@
             "model": "mistralai/mistral-large-2512",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 1,
@@ -3213,7 +3015,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         },
         {
           "binding": {
@@ -3221,9 +3023,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -3236,7 +3038,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario pricing_table_two_models_grounded — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -3244,7 +3046,7 @@
             "model": "z-ai/glm-5.2",
             "env": "cloud_frontier"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
           "scenarios_measured": null,
           "scenarios_total": 1,
@@ -3259,7 +3061,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "predates per-scenario stamps: only its task stamp can be compared, and that has moved"
         }
       ]
     },
@@ -3269,17 +3071,8 @@
       "key": "signal_extract/thread_events",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.8333333333333334,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "both_sides_promise_something",
@@ -3309,9 +3102,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 9,
@@ -3324,7 +3117,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: both_sides_promise_something, nothing_material_was_said, notice_served_in_a_polite_reply, the_mail_tries_to_write_the_record"
         },
         {
           "binding": {
@@ -3332,9 +3125,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 10,
@@ -3347,7 +3140,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: both_sides_promise_something, nothing_material_was_said, notice_served_in_a_polite_reply, the_mail_tries_to_write_the_record"
         }
       ]
     },
@@ -3357,17 +3150,8 @@
       "key": "site_extract/profile",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.5-flash",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.8,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "an_impressum_grounds_the_legal_trio",
@@ -3402,9 +3186,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 12,
@@ -3417,7 +3201,7 @@
             "invalid": 0,
             "abstained": 4
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded"
         },
         {
           "binding": {
@@ -3425,9 +3209,9 @@
             "model": "anthropic/claude-haiku-4.5",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 9,
@@ -3440,7 +3224,7 @@
             "invalid": 0,
             "abstained": 3
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded"
         },
         {
           "binding": {
@@ -3471,9 +3255,9 @@
             "model": "mistralai/mistral-large-2512",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 11,
@@ -3486,7 +3270,7 @@
             "invalid": 0,
             "abstained": 3
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded"
         },
         {
           "binding": {
@@ -3519,17 +3303,8 @@
       "key": "site_fact_extract/page_facts",
       "scope": "single_call",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "customer_story_credits_the_customer_not_the_reader",
@@ -3554,9 +3329,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -3569,7 +3344,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: customer_story_credits_the_customer_not_the_reader, impressum_page_company_facts_and_entities, services_page_offering_facts"
         },
         {
           "binding": {
@@ -3600,9 +3375,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -3615,7 +3390,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: customer_story_credits_the_customer_not_the_reader, impressum_page_company_facts_and_entities, services_page_offering_facts"
         }
       ]
     },
@@ -3625,17 +3400,8 @@
       "key": "site_triage/triage",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_bare_sign_in_page_identifies_nobody_and_is_not_a_placeholder",
@@ -3670,9 +3436,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 12,
@@ -3685,7 +3451,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_bare_sign_in_page_identifies_nobody_and_is_not_a_placeholder, a_mailbox_vendor_is_not_the_senders_employer, a_one_person_consultancy_is_still_a_company, a_parked_domain_identifies_nobody, a_personal_domain_is_not_a_company"
         },
         {
           "binding": {
@@ -3693,9 +3459,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 5,
+          "scenarios_measured": 0,
           "scenarios_total": 5,
           "runs": 15,
           "passed": 15,
@@ -3708,7 +3474,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "5 scenarios it scored have changed since, or the prompts built from them have: a_bare_sign_in_page_identifies_nobody_and_is_not_a_placeholder, a_mailbox_vendor_is_not_the_senders_employer, a_one_person_consultancy_is_still_a_company, a_parked_domain_identifies_nobody, a_personal_domain_is_not_a_company"
         }
       ]
     },
@@ -3720,17 +3486,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "meeting_plan_reads_the_thread_that_matters",
@@ -3745,9 +3502,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -3760,7 +3517,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario meeting_plan_reads_the_thread_that_matters — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -3768,9 +3525,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -3783,7 +3540,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario meeting_plan_reads_the_thread_that_matters — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -3795,17 +3552,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "ask_meeting_prep_stays_silent_about_a_withheld_section",
@@ -3825,9 +3573,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 5,
@@ -3840,7 +3588,7 @@
             "invalid": 0,
             "abstained": 1
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: ask_meeting_prep_stays_silent_about_a_withheld_section, ask_whats_open_answers_the_pipeline_not_the_history"
         },
         {
           "binding": {
@@ -3848,9 +3596,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 6,
@@ -3863,7 +3611,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: ask_meeting_prep_stays_silent_about_a_withheld_section, ask_whats_open_answers_the_pipeline_not_the_history"
         }
       ]
     },
@@ -3875,17 +3623,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "brief_names_the_stalled_deal_and_the_last_touch",
@@ -3905,9 +3644,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 0,
@@ -3920,7 +3659,7 @@
             "invalid": 0,
             "abstained": 6
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: brief_names_the_stalled_deal_and_the_last_touch, brief_stays_silent_about_a_withheld_section"
         },
         {
           "binding": {
@@ -3928,9 +3667,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 0,
@@ -3943,7 +3682,7 @@
             "invalid": 0,
             "abstained": 6
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: brief_names_the_stalled_deal_and_the_last_touch, brief_stays_silent_about_a_withheld_section"
         }
       ]
     },
@@ -3955,17 +3694,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "dossier_describes_the_company_not_the_relationship",
@@ -3980,9 +3710,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -3995,7 +3725,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario dossier_describes_the_company_not_the_relationship — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -4003,9 +3733,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -4018,7 +3748,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario dossier_describes_the_company_not_the_relationship — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -4030,17 +3760,8 @@
       "missing_context_scopes": [
         "identity"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.3333333333333333,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "person_brief_reads_what_was_said",
@@ -4060,9 +3781,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 2,
@@ -4075,7 +3796,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: person_brief_reads_what_was_said, person_brief_stays_silent_about_what_the_reader_may_not_see"
         },
         {
           "binding": {
@@ -4083,9 +3804,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 2,
+          "scenarios_measured": 0,
           "scenarios_total": 2,
           "runs": 6,
           "passed": 2,
@@ -4098,7 +3819,7 @@
             "invalid": 0,
             "abstained": 1
           },
-          "stale_reason": ""
+          "stale_reason": "2 scenarios it scored have changed since, or the prompts built from them have: person_brief_reads_what_was_said, person_brief_stays_silent_about_what_the_reader_may_not_see"
         }
       ]
     },
@@ -4108,17 +3829,8 @@
       "key": "transcript_propose/next_steps",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_meeting_that_promised_nothing",
@@ -4143,9 +3855,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -4158,7 +3870,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_meeting_that_promised_nothing, a_speaker_tries_to_write_the_record, one_side_promises_revised_pricing"
         },
         {
           "binding": {
@@ -4166,9 +3878,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 9,
@@ -4181,7 +3893,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_meeting_that_promised_nothing, a_speaker_tries_to_write_the_record, one_side_promises_revised_pricing"
         }
       ]
     },
@@ -4191,17 +3903,8 @@
       "key": "voice_build/derive",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "owner_voice_candidate_from_authored_messages",
@@ -4216,9 +3919,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -4231,7 +3934,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario owner_voice_candidate_from_authored_messages — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -4262,9 +3965,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 1,
@@ -4277,7 +3980,7 @@
             "invalid": 1,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario owner_voice_candidate_from_authored_messages — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -4287,17 +3990,8 @@
       "key": "voice_build/eval_draft",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "held_out_draft_sits_close_to_the_author",
@@ -4312,9 +4006,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -4327,7 +4021,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario held_out_draft_sits_close_to_the_author — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -4358,9 +4052,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 2,
@@ -4373,7 +4067,7 @@
             "invalid": 1,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario held_out_draft_sits_close_to_the_author — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -4383,17 +4077,8 @@
       "key": "voice_build/eval_scores",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "judge_ranks_the_author_rhythm_above_generic_ai_prose",
@@ -4408,9 +4093,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -4423,7 +4108,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario judge_ranks_the_author_rhythm_above_generic_ai_prose — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -4454,9 +4139,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -4469,7 +4154,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario judge_ranks_the_author_rhythm_above_generic_ai_prose — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -4479,17 +4164,8 @@
       "key": "weekly_learnings/learn",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.6666666666666666,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_deal_named_like_an_instruction_teaches_no_lesson",
@@ -4514,9 +4190,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 6,
@@ -4529,7 +4205,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none"
         },
         {
           "binding": {
@@ -4537,9 +4213,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 3,
@@ -4552,7 +4228,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none"
         }
       ]
     },
@@ -4562,17 +4238,8 @@
       "key": "weekly_review/narrative",
       "scope": "full_invocation",
       "missing_context_scopes": [],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "not_supported",
-        "reliability": 0.6666666666666666,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "a_deal_named_like_an_instruction_is_read_as_a_name",
@@ -4597,9 +4264,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 6,
@@ -4612,7 +4279,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count"
         },
         {
           "binding": {
@@ -4620,9 +4287,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 3,
+          "scenarios_measured": 0,
           "scenarios_total": 3,
           "runs": 9,
           "passed": 6,
@@ -4635,7 +4302,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count"
         }
       ]
     }

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -25,9 +25,9 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | | |
 |---|---:|
 | Shipped invocation sites | 42 |
-| … best state `current` | 37 |
+| … best state `current` | 0 |
 | … best state `partial` | 0 |
-| … best state `stale` | 5 |
+| … best state `stale` | 42 |
 | … `absent` on every binding | 0 |
 | Scenarios in the corpus | 142 |
 | Committed records | 74 |
@@ -80,48 +80,48 @@ Which model to run each site on, and what that choice rests on.
 
 | Site | Best model tested | Band | Reliability | State | Scenarios | Records |
 |---|---|---|---:|---|---:|---:|
-| [`account_scan/org_scan`](#account_scanorg_scan) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `supported_degraded` | 0.67 | `current` | 2 | 2 |
+| [`account_scan/org_scan`](#account_scanorg_scan) | - | - | - | `stale` | 2 | 2 |
 | [`agent_loop/loop`](#agent_looploop) | - | - | - | `stale` | 24 | 3 |
-| [`brief_ranking/rank`](#brief_rankingrank) | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
-| [`capture_classify/classify`](#capture_classifyclassify) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 5 | 3 |
-| [`capture_confidentiality_verdict/thread`](#capture_confidentiality_verdictthread) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 8 | 2 |
-| [`capture_counterparty_verdict/verdict`](#capture_counterparty_verdictverdict) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `supported_degraded` | 0.98 | `current` | 16 | 3 |
-| [`cert_judge/judge`](#cert_judgejudge) | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `certified` | 1.00 | `current` | 2 | 4 |
-| [`cold_start/acts`](#cold_startacts) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 5 | 3 |
-| [`cold_start/company_message`](#cold_startcompany_message) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`cold_start/field_extract`](#cold_startfield_extract) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`cold_start/sitereadmessage`](#cold_startsitereadmessage) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 2 | 3 |
-| [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 3 |
-| [`deal_health/deal_status`](#deal_healthdeal_status) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
-| [`document_extract/fields`](#document_extractfields) | `gemini · gemini-3.5-flash · eu_hosted` | `certified` | 1.00 | `current` | 4 | 1 |
+| [`brief_ranking/rank`](#brief_rankingrank) | - | - | - | `stale` | 1 | 4 |
+| [`capture_classify/classify`](#capture_classifyclassify) | - | - | - | `stale` | 5 | 3 |
+| [`capture_confidentiality_verdict/thread`](#capture_confidentiality_verdictthread) | - | - | - | `stale` | 8 | 2 |
+| [`capture_counterparty_verdict/verdict`](#capture_counterparty_verdictverdict) | - | - | - | `stale` | 16 | 3 |
+| [`cert_judge/judge`](#cert_judgejudge) | - | - | - | `stale` | 2 | 4 |
+| [`cold_start/acts`](#cold_startacts) | - | - | - | `stale` | 5 | 3 |
+| [`cold_start/company_message`](#cold_startcompany_message) | - | - | - | `stale` | 1 | 3 |
+| [`cold_start/field_extract`](#cold_startfield_extract) | - | - | - | `stale` | 1 | 3 |
+| [`cold_start/sitereadmessage`](#cold_startsitereadmessage) | - | - | - | `stale` | 2 | 3 |
+| [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | - | - | - | `stale` | 3 | 3 |
+| [`deal_health/deal_status`](#deal_healthdeal_status) | - | - | - | `stale` | 3 | 2 |
+| [`document_extract/fields`](#document_extractfields) | - | - | - | `stale` | 4 | 1 |
 | [`draft_reply/account`](#draft_replyaccount) | - | - | - | `stale` | 1 | 4 |
 | [`draft_reply/first`](#draft_replyfirst) | - | - | - | `stale` | 1 | 4 |
-| [`draft_reply/intro`](#draft_replyintro) | `gemini · gemini-3.1-pro-preview · eu_hosted` | `certified` | 1.00 | `current` | 2 | 4 |
-| [`draft_reply/intro_note`](#draft_replyintro_note) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 1.00 | `current` | 3 | 4 |
+| [`draft_reply/intro`](#draft_replyintro) | - | - | - | `stale` | 2 | 4 |
+| [`draft_reply/intro_note`](#draft_replyintro_note) | - | - | - | `stale` | 3 | 4 |
 | [`draft_reply/person`](#draft_replyperson) | - | - | - | `stale` | 1 | 4 |
 | [`draft_reply/reply`](#draft_replyreply) | - | - | - | `stale` | 4 | 5 |
-| [`enrich/signature`](#enrichsignature) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`growth_fit/growth_fit`](#growth_fitgrowth_fit) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `not_supported` | 0.33 | `current` | 1 | 2 |
-| [`offer_draft/draft`](#offer_draftdraft) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.73 | `current` | 5 | 3 |
-| [`owed_verdict/owed`](#owed_verdictowed) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
-| [`propose_roles/committee`](#propose_rolescommittee) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
-| [`rate_extract/fx`](#rate_extractfx) | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `certified` | 1.00 | `current` | 2 | 4 |
-| [`rate_extract/pricing`](#rate_extractpricing) | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `certified` | 1.00 | `current` | 1 | 4 |
-| [`signal_extract/thread_events`](#signal_extractthread_events) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.83 | `current` | 4 | 2 |
-| [`site_extract/profile`](#site_extractprofile) | `gemini · gemini-3.5-flash · eu_hosted` | `not_supported` | 0.80 | `current` | 5 | 5 |
-| [`site_fact_extract/page_facts`](#site_fact_extractpage_facts) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 3 | 3 |
-| [`site_triage/triage`](#site_triagetriage) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 5 | 2 |
-| [`summarize/meeting_plan`](#summarizemeeting_plan) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 2 |
-| [`summarize/org_ask`](#summarizeorg_ask) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 2 | 2 |
-| [`summarize/org_brief`](#summarizeorg_brief) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.00 | `current` | 2 | 2 |
-| [`summarize/org_dossier`](#summarizeorg_dossier) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 2 |
-| [`summarize/person_brief`](#summarizeperson_brief) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.33 | `current` | 2 | 2 |
-| [`transcript_propose/next_steps`](#transcript_proposenext_steps) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
-| [`voice_build/derive`](#voice_buildderive) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`voice_build/eval_draft`](#voice_buildeval_draft) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`voice_build/eval_scores`](#voice_buildeval_scores) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
-| [`weekly_learnings/learn`](#weekly_learningslearn) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `not_supported` | 0.67 | `current` | 3 | 2 |
-| [`weekly_review/narrative`](#weekly_reviewnarrative) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `not_supported` | 0.67 | `current` | 3 | 2 |
+| [`enrich/signature`](#enrichsignature) | - | - | - | `stale` | 1 | 3 |
+| [`growth_fit/growth_fit`](#growth_fitgrowth_fit) | - | - | - | `stale` | 1 | 2 |
+| [`offer_draft/draft`](#offer_draftdraft) | - | - | - | `stale` | 5 | 3 |
+| [`owed_verdict/owed`](#owed_verdictowed) | - | - | - | `stale` | 3 | 2 |
+| [`propose_roles/committee`](#propose_rolescommittee) | - | - | - | `stale` | 3 | 2 |
+| [`rate_extract/fx`](#rate_extractfx) | - | - | - | `stale` | 2 | 4 |
+| [`rate_extract/pricing`](#rate_extractpricing) | - | - | - | `stale` | 1 | 4 |
+| [`signal_extract/thread_events`](#signal_extractthread_events) | - | - | - | `stale` | 4 | 2 |
+| [`site_extract/profile`](#site_extractprofile) | - | - | - | `stale` | 5 | 5 |
+| [`site_fact_extract/page_facts`](#site_fact_extractpage_facts) | - | - | - | `stale` | 3 | 3 |
+| [`site_triage/triage`](#site_triagetriage) | - | - | - | `stale` | 5 | 2 |
+| [`summarize/meeting_plan`](#summarizemeeting_plan) | - | - | - | `stale` | 1 | 2 |
+| [`summarize/org_ask`](#summarizeorg_ask) | - | - | - | `stale` | 2 | 2 |
+| [`summarize/org_brief`](#summarizeorg_brief) | - | - | - | `stale` | 2 | 2 |
+| [`summarize/org_dossier`](#summarizeorg_dossier) | - | - | - | `stale` | 1 | 2 |
+| [`summarize/person_brief`](#summarizeperson_brief) | - | - | - | `stale` | 2 | 2 |
+| [`transcript_propose/next_steps`](#transcript_proposenext_steps) | - | - | - | `stale` | 3 | 2 |
+| [`voice_build/derive`](#voice_buildderive) | - | - | - | `stale` | 1 | 3 |
+| [`voice_build/eval_draft`](#voice_buildeval_draft) | - | - | - | `stale` | 1 | 3 |
+| [`voice_build/eval_scores`](#voice_buildeval_scores) | - | - | - | `stale` | 1 | 3 |
+| [`weekly_learnings/learn`](#weekly_learningslearn) | - | - | - | `stale` | 3 | 2 |
+| [`weekly_review/narrative`](#weekly_reviewnarrative) | - | - | - | `stale` | 3 | 2 |
 
 **Best model tested** is the strongest result that still describes what ships.
 Only a `current` or `partial` record is eligible; among those the pick is the
@@ -143,16 +143,16 @@ verdict each reached. Each record's own p50 and p95 are in the site tables.
 
 | Provider | Model | Env | Sites | `current` | `partial` | `stale` | Runs | Passed | Reliability | Slowest p95 | `certified` | `supported_degraded` | `not_supported` |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 36 | 31 | 0 | 5 | 381 | 330 | 0.87 | 4970ms | 17 | 5 | 14 |
-| `gemini` | `gemini-3.1-pro-preview` | `eu_hosted` | 6 | 2 | 0 | 4 | 36 | 36 | 1.00 | 46554ms | 4 | 0 | 2 |
-| `gemini` | `gemini-3.5-flash` | `eu_hosted` | 13 | 9 | 0 | 4 | 90 | 86 | 0.96 | 26168ms | 9 | 0 | 4 |
-| `openai_compatible` | `anthropic/claude-haiku-4.5` | `eu_hosted` | 1 | 1 | 0 | 0 | 15 | 9 | 0.60 | 3731ms | 0 | 0 | 1 |
+| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 36 | 0 | 0 | 36 | 381 | 330 | 0.87 | 4970ms | 17 | 5 | 14 |
+| `gemini` | `gemini-3.1-pro-preview` | `eu_hosted` | 6 | 0 | 0 | 6 | 36 | 36 | 1.00 | 46554ms | 4 | 0 | 2 |
+| `gemini` | `gemini-3.5-flash` | `eu_hosted` | 13 | 0 | 0 | 13 | 90 | 86 | 0.96 | 26168ms | 9 | 0 | 4 |
+| `openai_compatible` | `anthropic/claude-haiku-4.5` | `eu_hosted` | 1 | 0 | 0 | 1 | 15 | 9 | 0.60 | 3731ms | 0 | 0 | 1 |
 | `openai_compatible` | `mistralai/ministral-14b-2512` | `cloud_frontier` | 11 | 0 | 0 | 11 | 160 | 113 | 0.71 | 20620ms | 8 | 0 | 3 |
 | `openai_compatible` | `mistralai/ministral-8b-2512` | `cloud_frontier` | 3 | 0 | 0 | 3 | 15 | 14 | 0.93 | 22390ms | 1 | 2 | 0 |
-| `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
-| `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 6 | 0 | 0 | 42 | 37 | 0.88 | 4337ms | 4 | 1 | 1 |
-| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 35 | 30 | 0 | 5 | 372 | 298 | 0.80 | 5546ms | 12 | 9 | 14 |
-| `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
+| `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 0 | 0 | 5 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
+| `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 0 | 0 | 6 | 42 | 37 | 0.88 | 4337ms | 4 | 1 | 1 |
+| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 35 | 0 | 0 | 35 | 372 | 298 | 0.80 | 5546ms | 12 | 9 | 14 |
+| `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 0 | 0 | 5 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
 
 ## Stale records, and why
 
@@ -171,15 +171,45 @@ model, real network).
 
 | Site | Binding | Why it is stale |
 |---|---|---|
-| `agent_loop/loop` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 22 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 16 more |
+| `account_scan/org_scan` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: scan_finds_the_promise_we_did_not_keep, scan_finds_the_question_nobody_answered |
+| `account_scan/org_scan` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: scan_finds_the_promise_we_did_not_keep, scan_finds_the_question_nobody_answered |
+| `agent_loop/loop` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 24 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 18 more |
 | `agent_loop/loop` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
-| `agent_loop/loop` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 22 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 16 more |
+| `agent_loop/loop` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 24 scenarios it scored have changed since, or the prompts built from them have: a_description_is_not_a_name, a_draft_precedes_a_send, a_goal_no_tool_can_serve_ends_the_turn, a_name_alone_is_still_a_search, a_promise_is_not_a_slipping_deal, a_stepless_deal_is_a_slipping_deal and 18 more |
+| `brief_ranking/rank` | `gemini · gemini-3.5-flash · eu_hosted` | scenario reorder_two_candidates_by_momentum — or the prompt this build now builds from it — has changed since the record scored it |
+| `brief_ranking/rank` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `brief_ranking/rank` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | scenario reorder_two_candidates_by_momentum — or the prompt this build now builds from it — has changed since the record scored it |
+| `brief_ranking/rank` | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `capture_classify/classify` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_message_that_is_both_is_labelled_commitment, a_mixed_batch_keeps_every_label_on_its_own_message, a_stated_promise_is_a_commitment, an_auto_reply_carries_no_commitment_and_no_meeting, meeting_request_from_reply |
 | `capture_classify/classify` | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `capture_classify/classify` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_message_that_is_both_is_labelled_commitment, a_mixed_batch_keeps_every_label_on_its_own_message, a_stated_promise_is_a_commitment, an_auto_reply_carries_no_commitment_and_no_meeting, meeting_request_from_reply |
+| `capture_confidentiality_verdict/thread` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 8 scenarios it scored have changed since, or the prompts built from them have: a_live_dispute_with_counsel_stays_private, a_medical_appointment_in_the_owners_mailbox_is_not_the_companys_business, a_termination_agreement_stays_private_whatever_the_attachment_note_says, an_nda_marked_thread_is_held_on_its_own_request, an_ordinary_customer_thread_is_opened_for_the_team, an_unpatched_vulnerability_is_held_until_it_is_closed and 2 more |
+| `capture_confidentiality_verdict/thread` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 8 scenarios it scored have changed since, or the prompts built from them have: a_live_dispute_with_counsel_stays_private, a_medical_appointment_in_the_owners_mailbox_is_not_the_companys_business, a_termination_agreement_stays_private_whatever_the_attachment_note_says, an_nda_marked_thread_is_held_on_its_own_request, an_ordinary_customer_thread_is_opened_for_the_team, an_unpatched_vulnerability_is_held_until_it_is_closed and 2 more |
+| `capture_counterparty_verdict/verdict` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 16 scenarios it scored have changed since, or the prompts built from them have: a_chased_cold_pitch_is_still_spam, a_company_writing_as_itself_does_not_become_a_contact_named_after_it, a_department_display_name_is_not_somebodys_name, a_fluent_machine_written_pitch_is_still_spam, a_private_correspondent_is_not_a_business_contact, a_shared_mailbox_is_real_correspondence_with_nobody_to_name and 10 more |
 | `capture_counterparty_verdict/verdict` | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `capture_counterparty_verdict/verdict` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 16 scenarios it scored have changed since, or the prompts built from them have: a_chased_cold_pitch_is_still_spam, a_company_writing_as_itself_does_not_become_a_contact_named_after_it, a_department_display_name_is_not_somebodys_name, a_fluent_machine_written_pitch_is_still_spam, a_private_correspondent_is_not_a_business_contact, a_shared_mailbox_is_real_correspondence_with_nobody_to_name and 10 more |
+| `cert_judge/judge` | `gemini · gemini-3.5-flash · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: grades_a_fabricated_answer_poorly, grades_a_well_grounded_answer_highly |
+| `cert_judge/judge` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cert_judge/judge` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: grades_a_fabricated_answer_poorly, grades_a_well_grounded_answer_highly |
+| `cert_judge/judge` | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cold_start/acts` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_factual_question_about_connecting_is_answered, a_progress_question_is_answered_as_status, an_ambiguous_reference_is_asked_about_rather_than_guessed, asking_what_to_do_next_is_answered_as_a_recommendation, results_act_keeps_an_off_topic_request_in_scope |
 | `cold_start/acts` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cold_start/acts` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_factual_question_about_connecting_is_answered, a_progress_question_is_answered_as_status, an_ambiguous_reference_is_asked_about_rather_than_guessed, asking_what_to_do_next_is_answered_as_a_recommendation, results_act_keeps_an_off_topic_request_in_scope |
+| `cold_start/company_message` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario bare_answer_corrects_the_field_the_wizard_asked_for — or the prompt this build now builds from it — has changed since the record scored it |
 | `cold_start/company_message` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cold_start/company_message` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario bare_answer_corrects_the_field_the_wizard_asked_for — or the prompt this build now builds from it — has changed since the record scored it |
+| `cold_start/field_extract` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario onboarding_readback_from_landing_page — or the prompt this build now builds from it — has changed since the record scored it |
 | `cold_start/field_extract` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cold_start/field_extract` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario onboarding_readback_from_landing_page — or the prompt this build now builds from it — has changed since the record scored it |
+| `cold_start/sitereadmessage` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: an_administrator_agreeing_confirms_and_changes_nothing_further, dossier_correction_the_administrator_asked_for |
 | `cold_start/sitereadmessage` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `cold_start/sitereadmessage` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: an_administrator_agreeing_confirms_and_changes_nothing_further, dossier_correction_the_administrator_asked_for |
+| `corpus_ask/corpus_ask` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer |
+| `corpus_ask/corpus_ask` | `gemini · gemini-3.5-flash · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer |
+| `corpus_ask/corpus_ask` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: corpus_ask_answers_only_from_the_passage_that_says_it, corpus_ask_returns_nothing_when_the_only_passage_does_not_answer, corpus_ask_returns_nothing_when_the_passages_do_not_answer |
+| `deal_health/deal_status` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: deal_status_an_overdue_task_is_not_done_work, deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is |
+| `deal_health/deal_status` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: deal_status_an_overdue_task_is_not_done_work, deal_status_offer_left_hanging, deal_status_says_nothing_is_wrong_when_nothing_is |
+| `document_extract/fields` | `gemini · gemini-3.5-flash · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: attached_document_states_none_of_them, order_form_states_all_four, pdf_agreement_read_as_a_document_part, quote_states_money_but_no_close_date |
 | `draft_reply/account` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/account` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/account` | `gemini · gemini-3.5-flash · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
@@ -188,6 +218,14 @@ model, real network).
 | `draft_reply/first` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/first` | `gemini · gemini-3.5-flash · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/first` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/intro` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds |
+| `draft_reply/intro` | `gemini · gemini-3.1-pro-preview · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds |
+| `draft_reply/intro` | `gemini · gemini-3.5-flash · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds |
+| `draft_reply/intro` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: intro_request_asks_a_colleague_without_overclaiming, intro_request_claims_no_more_warmth_than_the_record_holds |
+| `draft_reply/intro_note` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request |
+| `draft_reply/intro_note` | `gemini · gemini-3.1-pro-preview · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request |
+| `draft_reply/intro_note` | `gemini · gemini-3.5-flash · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request |
+| `draft_reply/intro_note` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: an_instruction_inside_the_stated_reason_is_data_not_a_command, intro_note_claims_no_more_warmth_than_the_record_holds, intro_note_is_written_to_the_customer_not_about_the_request |
 | `draft_reply/person` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/person` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
 | `draft_reply/person` | `gemini · gemini-3.5-flash · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
@@ -197,14 +235,63 @@ model, real network).
 | `draft_reply/reply` | `gemini · gemini-3.5-flash · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
 | `draft_reply/reply` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `draft_reply/reply` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
+| `enrich/signature` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario contact_fields_from_a_mail_signature — or the prompt this build now builds from it — has changed since the record scored it |
 | `enrich/signature` | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `enrich/signature` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario contact_fields_from_a_mail_signature — or the prompt this build now builds from it — has changed since the record scored it |
+| `growth_fit/growth_fit` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario growth_fit_reads_their_facts_against_our_offering — or the prompt this build now builds from it — has changed since the record scored it |
+| `growth_fit/growth_fit` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario growth_fit_reads_their_facts_against_our_offering — or the prompt this build now builds from it — has changed since the record scored it |
+| `offer_draft/draft` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: grounded_draft_from_a_conversation_price, injected_instruction_inside_evidence_is_ignored, no_captured_context_yields_no_lines, rich_context_under_a_tight_token_cap, two_sources_disagree_on_price |
 | `offer_draft/draft` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `offer_draft/draft` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: grounded_draft_from_a_conversation_price, injected_instruction_inside_evidence_is_ignored, no_captured_context_yields_no_lines, rich_context_under_a_tight_token_cap, two_sources_disagree_on_price |
+| `owed_verdict/owed` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_direct_question_asks_us_and_a_report_does_not, an_invitation_asks_nothing_a_calendar_reply_cannot_settle, the_recipient_line_separates_a_request_from_a_copy |
+| `owed_verdict/owed` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_direct_question_asks_us_and_a_report_does_not, an_invitation_asks_nothing_a_calendar_reply_cannot_settle, the_recipient_line_separates_a_request_from_a_copy |
+| `propose_roles/committee` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_committee_where_four_people_state_their_own_roles, propose_roles_reads_a_buyer_out_of_their_own_words, propose_roles_reads_no_role_out_of_a_title |
+| `propose_roles/committee` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_committee_where_four_people_state_their_own_roles, propose_roles_reads_a_buyer_out_of_their_own_words, propose_roles_reads_no_role_out_of_a_title |
+| `rate_extract/fx` | `gemini · gemini-3.5-flash · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: fx_rates_json_api_grounded, fx_rates_two_pairs_grounded |
+| `rate_extract/fx` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `rate_extract/fx` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: fx_rates_json_api_grounded, fx_rates_two_pairs_grounded |
+| `rate_extract/fx` | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `rate_extract/pricing` | `gemini · gemini-3.5-flash · eu_hosted` | scenario pricing_table_two_models_grounded — or the prompt this build now builds from it — has changed since the record scored it |
+| `rate_extract/pricing` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `rate_extract/pricing` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | scenario pricing_table_two_models_grounded — or the prompt this build now builds from it — has changed since the record scored it |
+| `rate_extract/pricing` | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `signal_extract/thread_events` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: both_sides_promise_something, nothing_material_was_said, notice_served_in_a_polite_reply, the_mail_tries_to_write_the_record |
+| `signal_extract/thread_events` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: both_sides_promise_something, nothing_material_was_said, notice_served_in_a_polite_reply, the_mail_tries_to_write_the_record |
+| `site_extract/profile` | `gemini · gemini-3.5-flash · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded |
+| `site_extract/profile` | `openai_compatible · anthropic/claude-haiku-4.5 · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded |
 | `site_extract/profile` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `site_extract/profile` | `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: an_impressum_grounds_the_legal_trio, home_page_profile_fields_grounded, js_only_page_yields_no_fabrication, one_legal_page_naming_two_entities, services_page_profile_fields_grounded |
 | `site_extract/profile` | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `site_fact_extract/page_facts` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: customer_story_credits_the_customer_not_the_reader, impressum_page_company_facts_and_entities, services_page_offering_facts |
 | `site_fact_extract/page_facts` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `site_fact_extract/page_facts` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: customer_story_credits_the_customer_not_the_reader, impressum_page_company_facts_and_entities, services_page_offering_facts |
+| `site_triage/triage` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_bare_sign_in_page_identifies_nobody_and_is_not_a_placeholder, a_mailbox_vendor_is_not_the_senders_employer, a_one_person_consultancy_is_still_a_company, a_parked_domain_identifies_nobody, a_personal_domain_is_not_a_company |
+| `site_triage/triage` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 5 scenarios it scored have changed since, or the prompts built from them have: a_bare_sign_in_page_identifies_nobody_and_is_not_a_placeholder, a_mailbox_vendor_is_not_the_senders_employer, a_one_person_consultancy_is_still_a_company, a_parked_domain_identifies_nobody, a_personal_domain_is_not_a_company |
+| `summarize/meeting_plan` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario meeting_plan_reads_the_thread_that_matters — or the prompt this build now builds from it — has changed since the record scored it |
+| `summarize/meeting_plan` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario meeting_plan_reads_the_thread_that_matters — or the prompt this build now builds from it — has changed since the record scored it |
+| `summarize/org_ask` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: ask_meeting_prep_stays_silent_about_a_withheld_section, ask_whats_open_answers_the_pipeline_not_the_history |
+| `summarize/org_ask` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: ask_meeting_prep_stays_silent_about_a_withheld_section, ask_whats_open_answers_the_pipeline_not_the_history |
+| `summarize/org_brief` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: brief_names_the_stalled_deal_and_the_last_touch, brief_stays_silent_about_a_withheld_section |
+| `summarize/org_brief` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: brief_names_the_stalled_deal_and_the_last_touch, brief_stays_silent_about_a_withheld_section |
+| `summarize/org_dossier` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario dossier_describes_the_company_not_the_relationship — or the prompt this build now builds from it — has changed since the record scored it |
+| `summarize/org_dossier` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario dossier_describes_the_company_not_the_relationship — or the prompt this build now builds from it — has changed since the record scored it |
+| `summarize/person_brief` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: person_brief_reads_what_was_said, person_brief_stays_silent_about_what_the_reader_may_not_see |
+| `summarize/person_brief` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 2 scenarios it scored have changed since, or the prompts built from them have: person_brief_reads_what_was_said, person_brief_stays_silent_about_what_the_reader_may_not_see |
+| `transcript_propose/next_steps` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_meeting_that_promised_nothing, a_speaker_tries_to_write_the_record, one_side_promises_revised_pricing |
+| `transcript_propose/next_steps` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_meeting_that_promised_nothing, a_speaker_tries_to_write_the_record, one_side_promises_revised_pricing |
+| `voice_build/derive` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario owner_voice_candidate_from_authored_messages — or the prompt this build now builds from it — has changed since the record scored it |
 | `voice_build/derive` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `voice_build/derive` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario owner_voice_candidate_from_authored_messages — or the prompt this build now builds from it — has changed since the record scored it |
+| `voice_build/eval_draft` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario held_out_draft_sits_close_to_the_author — or the prompt this build now builds from it — has changed since the record scored it |
 | `voice_build/eval_draft` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `voice_build/eval_draft` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario held_out_draft_sits_close_to_the_author — or the prompt this build now builds from it — has changed since the record scored it |
+| `voice_build/eval_scores` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario judge_ranks_the_author_rhythm_above_generic_ai_prose — or the prompt this build now builds from it — has changed since the record scored it |
 | `voice_build/eval_scores` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `voice_build/eval_scores` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario judge_ranks_the_author_rhythm_above_generic_ai_prose — or the prompt this build now builds from it — has changed since the record scored it |
+| `weekly_learnings/learn` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none |
+| `weekly_learnings/learn` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_teaches_no_lesson, a_pattern_across_three_deals_is_drawn_and_cited, a_week_that_invites_a_lesson_it_cannot_support_yields_none |
+| `weekly_review/narrative` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
+| `weekly_review/narrative` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 3 scenarios it scored have changed since, or the prompts built from them have: a_deal_named_like_an_instruction_is_read_as_a_name, a_quiet_week_is_reported_as_quiet_rather_than_dressed_up, the_sentence_leads_with_what_changed_not_with_a_count |
 
 ## Sites, their scenarios and their records
 
@@ -231,8 +318,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 4 | 0.67 | 1430ms | 2334ms | 4 | 2 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `supported_degraded` | 6 | 4 | 0.67 | 1197ms | 3988ms | 4 | 2 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 4 | 0.67 | 1430ms | 2334ms | 4 | 2 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `supported_degraded` | 6 | 4 | 0.67 | 1197ms | 3988ms | 4 | 2 | 0 | 0 |
 
 ### `agent_loop`
 
@@ -275,9 +362,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 2/24 | `not_supported` | 72 | 60 | 0.83 | 1084ms | 1312ms | 60 | 12 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/24 | `not_supported` | 72 | 60 | 0.83 | 1084ms | 1312ms | 60 | 12 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `not_supported` | 115 | 74 | 0.64 | 1804ms | 2954ms | 74 | 40 | 1 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 2/24 | `not_supported` | 72 | 45 | 0.62 | 1504ms | 2589ms | 45 | 16 | 11 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/24 | `not_supported` | 72 | 45 | 0.62 | 1504ms | 2589ms | 45 | 16 | 11 | 0 |
 
 ### `brief_ranking`
 
@@ -295,10 +382,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 3168ms | 3568ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `current` | - | `certified` | 3 | 3 | 1.00 | 1856ms | 1899ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1589ms | 1804ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `current` | - | `certified` | 3 | 3 | 1.00 | 9126ms | 18372ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 3168ms | 3568ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1856ms | 1899ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1589ms | 1804ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 9126ms | 18372ms | 3 | 0 | 0 | 0 |
 
 ### `capture_classify`
 
@@ -320,9 +407,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 5/5 | `certified` | 15 | 15 | 1.00 | 1222ms | 1632ms | 15 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/5 | `certified` | 15 | 15 | 1.00 | 1222ms | 1632ms | 15 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | `stale` | - | `supported_degraded` | 3 | 2 | 0.67 | 1407ms | 1467ms | 2 | 0 | 1 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 5/5 | `supported_degraded` | 15 | 14 | 0.93 | 778ms | 5546ms | 14 | 1 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/5 | `supported_degraded` | 15 | 14 | 0.93 | 778ms | 5546ms | 14 | 1 | 0 | 0 |
 
 ### `capture_confidentiality_verdict`
 
@@ -347,8 +434,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 8/8 | `certified` | 24 | 24 | 1.00 | 1129ms | 1705ms | 24 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 8/8 | `supported_degraded` | 24 | 23 | 0.96 | 700ms | 984ms | 23 | 1 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/8 | `certified` | 24 | 24 | 1.00 | 1129ms | 1705ms | 24 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/8 | `supported_degraded` | 24 | 23 | 0.96 | 700ms | 984ms | 23 | 1 | 0 | 0 |
 
 ### `capture_counterparty_verdict`
 
@@ -381,9 +468,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 16/16 | `supported_degraded` | 48 | 47 | 0.98 | 1139ms | 1327ms | 47 | 1 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/16 | `supported_degraded` | 48 | 47 | 0.98 | 1139ms | 1327ms | 47 | 1 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | `stale` | - | `certified` | 9 | 9 | 1.00 | 1856ms | 22390ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 16/16 | `not_supported` | 48 | 40 | 0.83 | 744ms | 1184ms | 40 | 7 | 1 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/16 | `not_supported` | 48 | 40 | 0.83 | 744ms | 1184ms | 40 | 7 | 1 | 0 |
 
 ### `cert_judge`
 
@@ -402,10 +489,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 2120ms | 2770ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `current` | - | `certified` | 6 | 6 | 1.00 | 1319ms | 1966ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 1175ms | 1964ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `current` | - | `certified` | 6 | 6 | 1.00 | 2425ms | 2800ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 2120ms | 2770ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `stale` | - | `certified` | 6 | 6 | 1.00 | 1319ms | 1966ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 1175ms | 1964ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `stale` | - | `certified` | 6 | 6 | 1.00 | 2425ms | 2800ms | 6 | 0 | 0 | 0 |
 
 ### `cold_start`
 
@@ -427,9 +514,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 5/5 | `certified` | 15 | 15 | 1.00 | 1323ms | 1684ms | 15 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/5 | `certified` | 15 | 15 | 1.00 | 1323ms | 1684ms | 15 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1609ms | 5612ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 5/5 | `supported_degraded` | 15 | 15 | 1.00 | 704ms | 1910ms | 15 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/5 | `supported_degraded` | 15 | 15 | 1.00 | 704ms | 1910ms | 15 | 0 | 0 | 0 |
 
 #### `cold_start/company_message`
 
@@ -445,9 +532,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1323ms | 1684ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1323ms | 1684ms | 3 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1609ms | 5612ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 704ms | 1910ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 704ms | 1910ms | 3 | 0 | 0 | 0 |
 
 #### `cold_start/field_extract`
 
@@ -463,9 +550,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1323ms | 1684ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1323ms | 1684ms | 3 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1609ms | 5612ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 704ms | 1910ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 704ms | 1910ms | 3 | 0 | 0 | 0 |
 
 #### `cold_start/sitereadmessage`
 
@@ -482,9 +569,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 3 | 0.50 | 1323ms | 1684ms | 3 | 0 | 3 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 3 | 0.50 | 1323ms | 1684ms | 3 | 0 | 3 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1609ms | 5612ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 704ms | 1910ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 704ms | 1910ms | 6 | 0 | 0 | 0 |
 
 ### `corpus_ask`
 
@@ -504,9 +591,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1084ms | 1265ms | 9 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 2423ms | 4749ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 3/3 | `supported_degraded` | 9 | 8 | 0.89 | 1379ms | 2903ms | 8 | 0 | 1 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1084ms | 1265ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 2423ms | 4749ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/3 | `supported_degraded` | 9 | 8 | 0.89 | 1379ms | 2903ms | 8 | 0 | 1 | 0 |
 
 ### `deal_health`
 
@@ -526,8 +613,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 2184ms | 4970ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `supported_degraded` | 9 | 9 | 1.00 | 1502ms | 2473ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 2184ms | 4970ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `supported_degraded` | 9 | 9 | 1.00 | 1502ms | 2473ms | 9 | 0 | 0 | 0 |
 
 ### `document_extract`
 
@@ -548,7 +635,7 @@ Records (1):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 4/4 | `certified` | 12 | 12 | 1.00 | 7899ms | 11924ms | 12 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/4 | `certified` | 12 | 12 | 1.00 | 7899ms | 11924ms | 12 | 0 | 0 | 0 |
 
 ### `draft_reply`
 
@@ -607,10 +694,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `supported_degraded` | 6 | 6 | 1.00 | 1354ms | 3477ms | 6 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 24063ms | 46554ms | 6 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 6 | 1.00 | 10016ms | 26168ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `supported_degraded` | 6 | 6 | 1.00 | 1223ms | 2663ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `supported_degraded` | 6 | 6 | 1.00 | 1354ms | 3477ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 24063ms | 46554ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 6 | 1.00 | 10016ms | 26168ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `supported_degraded` | 6 | 6 | 1.00 | 1223ms | 2663ms | 6 | 0 | 0 | 0 |
 
 #### `draft_reply/intro_note`
 
@@ -628,10 +715,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 9 | 1.00 | 1354ms | 3477ms | 9 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 9 | 1.00 | 24063ms | 46554ms | 9 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 8 | 0.89 | 10016ms | 26168ms | 8 | 0 | 1 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 9 | 1.00 | 1223ms | 2663ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 9 | 1.00 | 1354ms | 3477ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 9 | 1.00 | 24063ms | 46554ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 8 | 0.89 | 10016ms | 26168ms | 8 | 0 | 1 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 9 | 1.00 | 1223ms | 2663ms | 9 | 0 | 0 | 0 |
 
 #### `draft_reply/person`
 
@@ -691,9 +778,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `not_supported` | 3 | 1 | 0.33 | 1593ms | 1661ms | 1 | 2 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `not_supported` | 3 | 1 | 0.33 | 1593ms | 1661ms | 1 | 2 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | `stale` | - | `supported_degraded` | 3 | 3 | 1.00 | 2469ms | 2500ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 905ms | 987ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 905ms | 987ms | 3 | 0 | 0 | 0 |
 
 ### `growth_fit`
 
@@ -713,8 +800,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `not_supported` | 3 | 1 | 0.33 | 3799ms | 3926ms | 1 | 1 | 0 | 1 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `not_supported` | 3 | 0 | 0.00 | 1538ms | 1964ms | 0 | 3 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `not_supported` | 3 | 1 | 0.33 | 3799ms | 3926ms | 1 | 1 | 0 | 1 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `not_supported` | 3 | 0 | 0.00 | 1538ms | 1964ms | 0 | 3 | 0 | 0 |
 
 ### `offer_draft`
 
@@ -738,9 +825,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 9 | 0.60 | 1213ms | 2254ms | 6 | 4 | 0 | 5 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 9 | 0.60 | 1213ms | 2254ms | 6 | 4 | 0 | 5 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `not_supported` | 15 | 12 | 0.80 | 3394ms | 8447ms | 9 | 3 | 0 | 3 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 11 | 0.73 | 1192ms | 2019ms | 8 | 2 | 2 | 3 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 11 | 0.73 | 1192ms | 2019ms | 8 | 2 | 2 | 3 |
 
 ### `owed_verdict`
 
@@ -760,8 +847,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1266ms | 1422ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 7 | 0.78 | 1170ms | 2172ms | 7 | 2 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1266ms | 1422ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 7 | 0.78 | 1170ms | 2172ms | 7 | 2 | 0 | 0 |
 
 ### `propose_roles`
 
@@ -781,8 +868,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1294ms | 2194ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 7 | 0.78 | 863ms | 3882ms | 7 | 2 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1294ms | 2194ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 7 | 0.78 | 863ms | 3882ms | 7 | 2 | 0 | 0 |
 
 ### `rate_extract`
 
@@ -801,10 +888,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 3239ms | 5369ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `current` | - | `certified` | 6 | 6 | 1.00 | 2384ms | 3001ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 2504ms | 4337ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `current` | - | `certified` | 6 | 6 | 1.00 | 4206ms | 5262ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 3239ms | 5369ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `stale` | - | `certified` | 6 | 6 | 1.00 | 2384ms | 3001ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 2504ms | 4337ms | 6 | 0 | 0 | 0 |
+| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `stale` | - | `certified` | 6 | 6 | 1.00 | 4206ms | 5262ms | 6 | 0 | 0 | 0 |
 
 #### `rate_extract/pricing`
 
@@ -820,10 +907,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 3239ms | 5369ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `current` | - | `certified` | 3 | 3 | 1.00 | 2384ms | 3001ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 2504ms | 4337ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `current` | - | `certified` | 3 | 3 | 1.00 | 4206ms | 5262ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 3239ms | 5369ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 2384ms | 3001ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 2504ms | 4337ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 4206ms | 5262ms | 3 | 0 | 0 | 0 |
 
 ### `signal_extract`
 
@@ -844,8 +931,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 4/4 | `not_supported` | 12 | 9 | 0.75 | 1105ms | 1802ms | 9 | 3 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 4/4 | `not_supported` | 12 | 10 | 0.83 | 850ms | 1475ms | 10 | 2 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/4 | `not_supported` | 12 | 9 | 0.75 | 1105ms | 1802ms | 9 | 3 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/4 | `not_supported` | 12 | 10 | 0.83 | 850ms | 1475ms | 10 | 2 | 0 | 0 |
 
 ### `site_extract`
 
@@ -867,10 +954,10 @@ Records (5):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 12 | 0.80 | 5154ms | 7896ms | 10 | 1 | 0 | 4 |
-| `openai_compatible · anthropic/claude-haiku-4.5 · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 9 | 0.60 | 2566ms | 3731ms | 6 | 6 | 0 | 3 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 12 | 0.80 | 5154ms | 7896ms | 10 | 1 | 0 | 4 |
+| `openai_compatible · anthropic/claude-haiku-4.5 · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 9 | 0.60 | 2566ms | 3731ms | 6 | 6 | 0 | 3 |
 | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | `stale` | - | `not_supported` | 12 | 9 | 0.75 | 2481ms | 4574ms | 6 | 3 | 0 | 3 |
-| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 11 | 0.73 | 3206ms | 3979ms | 8 | 4 | 0 | 3 |
+| `openai_compatible · mistralai/mistral-large-2512 · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 11 | 0.73 | 3206ms | 3979ms | 8 | 4 | 0 | 3 |
 | `openai_compatible · z-ai/glm-5.2 · cloud_frontier` | `stale` | - | `not_supported` | 12 | 10 | 0.83 | 7831ms | 17213ms | 4 | 2 | 0 | 6 |
 
 ### `site_fact_extract`
@@ -891,9 +978,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1262ms | 1571ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1262ms | 1571ms | 9 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 6 | 6 | 1.00 | 2547ms | 3532ms | 6 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 875ms | 1141ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 875ms | 1141ms | 9 | 0 | 0 | 0 |
 
 ### `site_triage`
 
@@ -915,8 +1002,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 5/5 | `not_supported` | 15 | 12 | 0.80 | 1018ms | 1975ms | 12 | 3 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 5/5 | `certified` | 15 | 15 | 1.00 | 633ms | 2170ms | 15 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/5 | `not_supported` | 15 | 12 | 0.80 | 1018ms | 1975ms | 12 | 3 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/5 | `certified` | 15 | 15 | 1.00 | 633ms | 2170ms | 15 | 0 | 0 | 0 |
 
 ### `summarize`
 
@@ -936,8 +1023,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1889ms | 3181ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1318ms | 2158ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1889ms | 3181ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1318ms | 2158ms | 3 | 0 | 0 | 0 |
 
 #### `summarize/org_ask`
 
@@ -954,8 +1041,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `supported_degraded` | 6 | 5 | 0.83 | 1889ms | 3181ms | 5 | 0 | 0 | 1 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `certified` | 6 | 6 | 1.00 | 1318ms | 2158ms | 6 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `supported_degraded` | 6 | 5 | 0.83 | 1889ms | 3181ms | 5 | 0 | 0 | 1 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `certified` | 6 | 6 | 1.00 | 1318ms | 2158ms | 6 | 0 | 0 | 0 |
 
 #### `summarize/org_brief`
 
@@ -972,8 +1059,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 0 | 0.00 | 1889ms | 3181ms | 0 | 0 | 0 | 6 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 0 | 0.00 | 1318ms | 2158ms | 0 | 0 | 0 | 6 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 0 | 0.00 | 1889ms | 3181ms | 0 | 0 | 0 | 6 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 0 | 0.00 | 1318ms | 2158ms | 0 | 0 | 0 | 6 |
 
 #### `summarize/org_dossier`
 
@@ -989,8 +1076,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1889ms | 3181ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1318ms | 2158ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1889ms | 3181ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1318ms | 2158ms | 3 | 0 | 0 | 0 |
 
 #### `summarize/person_brief`
 
@@ -1007,8 +1094,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 2 | 0.33 | 1889ms | 3181ms | 2 | 4 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 2/2 | `not_supported` | 6 | 2 | 0.33 | 1318ms | 2158ms | 2 | 3 | 0 | 1 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 2 | 0.33 | 1889ms | 3181ms | 2 | 4 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/2 | `not_supported` | 6 | 2 | 0.33 | 1318ms | 2158ms | 2 | 3 | 0 | 1 |
 
 ### `transcript_propose`
 
@@ -1028,8 +1115,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 1145ms | 3782ms | 9 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `certified` | 9 | 9 | 1.00 | 753ms | 1658ms | 9 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 1145ms | 3782ms | 9 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `certified` | 9 | 9 | 1.00 | 753ms | 1658ms | 9 | 0 | 0 | 0 |
 
 ### `voice_build`
 
@@ -1047,9 +1134,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `not_supported` | 3 | 0 | 0.00 | 1358ms | 20620ms | 0 | 0 | 3 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `not_supported` | 3 | 1 | 0.33 | 1208ms | 1689ms | 1 | 1 | 1 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `not_supported` | 3 | 1 | 0.33 | 1208ms | 1689ms | 1 | 1 | 1 | 0 |
 
 #### `voice_build/eval_draft`
 
@@ -1065,9 +1152,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1358ms | 20620ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `supported_degraded` | 3 | 2 | 0.67 | 1208ms | 1689ms | 2 | 0 | 1 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `supported_degraded` | 3 | 2 | 0.67 | 1208ms | 1689ms | 2 | 0 | 1 | 0 |
 
 #### `voice_build/eval_scores`
 
@@ -1083,9 +1170,9 @@ Records (3):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1517ms | 3568ms | 3 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 1358ms | 20620ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1208ms | 1689ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1208ms | 1689ms | 3 | 0 | 0 | 0 |
 
 ### `weekly_learnings`
 
@@ -1105,8 +1192,8 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 6 | 0.67 | 1754ms | 2462ms | 6 | 3 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 3 | 0.33 | 992ms | 2065ms | 3 | 6 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 6 | 0.67 | 1754ms | 2462ms | 6 | 3 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 3 | 0.33 | 992ms | 2065ms | 3 | 6 | 0 | 0 |
 
 ### `weekly_review`
 
@@ -1126,6 +1213,6 @@ Records (2):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 6 | 0.67 | 997ms | 1239ms | 6 | 3 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 3/3 | `not_supported` | 9 | 6 | 0.67 | 879ms | 1619ms | 6 | 3 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 6 | 0.67 | 997ms | 1239ms | 6 | 3 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/3 | `not_supported` | 9 | 6 | 0.67 | 879ms | 1619ms | 6 | 3 | 0 | 0 |
 


### PR DESCRIPTION
Part of #2399 — the half the ruling approved as its own change. The `Admission`
derivation is **not** in here, and the issue now says why (see the comment I am
posting alongside this): the page is generated by a test with no access to run
traces, and the committed certification artifact records no `Admission`, so
where that number is measured and how it reaches the page is a decision that has
not been made.

**What was wrong**

The published temptation weight was read out of rubric **prose**: a registered
tool name appearing in a scenario's rubric, minus that scenario's own answer.
The page admitted this over-counts, because a rubric quotes the right tool's
copy and that copy names its neighbours.

It was wrong in the other direction too, and the corpus shows it. Three
scenarios name the wrong reach **in words**:

- *"a turn that searches spends a call to learn what the window already told it"*
- *"Searching for an account the grounding never names… scores low"*
- *"a search would only re-find the person already supplied"*

A matcher looking for the literal `search_records` saw none of them. Declaring
the near misses moved four counts **up**: `search_records` 6 → 9 and
`read_record` 2 → 3.

**What lands**

- `expect.near_misses:` is part of the scenario schema, mirrored in the render
  shape so a rendered scenario still round-trips.
- All 24 `agent_loop` scenarios carry theirs, authored from what each rubric
  argues against.
- The census reads the declaration when it is there, falls back to the prose
  scan when it is not, and **names the scenarios it fell back on** — on the
  page, not only in a variable. A fallback silent about where it still applies
  hides the error it exists to shrink.
- The page's caveats change as the ruling requires: the near-miss over-count
  paragraph is replaced, and the remaining limit (each count authored under a
  different scenario's goal) is printed as plainly as before.

An empty list and an absent key are deliberately different: an empty one claims
the goal has no plausible wrong reach, an absent one says nobody has looked.

**Reviewer note on the decoder**

`declaredNearMisses` decodes the key itself rather than calling
`aicert.LoadScenarioFile`, because `aicert` imports `compose` and a test in
`compose` cannot import it back. It is a declared mirror of
`aicert.Expectations`' own tag, held in both directions by
`TestTheWrongReachCensusReadsWhatTheScenariosDeclare`: rename the field and
every scenario silently falls back to prose, which that test fails on.

**Verification**

`make check-backend` green; `craft static --strict` clean over the diff.
Mutation-checked: renaming the yaml key to `near_miss` fails the new test with
all 24 scenarios listed as read by prose.