### PR TITLE
A settings page says whose state it changes

### DIFF
--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -1011,6 +1011,22 @@
   flex: 1;
   min-width: 0;
 }
+/* The heading and its scope badge on one line, the badge baseline-aligned with
+   the heading's text rather than centred on its box — a display-size heading is
+   tall enough that centring reads as floating.
+   `flex-wrap` is the last resort, not the usual behaviour. At phone width the
+   heading holds the SectionSwitcher, which takes `flex: 1` and absorbs the
+   remaining width, so its own label ellipsizes and the badge stays beside it.
+   The badge only drops to its own line when even the ellipsized name plus the
+   badge cannot fit. */
+.pagetitle-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
 .pagetitle h1 {
   margin: 0;
   font-family: var(--f-display);
@@ -1038,6 +1054,13 @@
 .pageswitchhead {
   display: flex;
   min-width: 0;
+  /* The switcher takes the row, which is what the comment above asks for. It
+     used to be the title's only child and got the width for free; inside
+     `.pagetitle-head` it is a flex ITEM beside the scope badge, and without this
+     it would size to its own text — a short page name would leave the switcher
+     stranded mid-row, and a long one would push the badge to a line of its
+     own while the label ellipsized. */
+  flex: 1;
 }
 .pageswitchhead > .pageswitch {
   flex: 1;

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "../App";
+import { en } from "../i18n/en";
 import { memoryStorage } from "../testing/appharness";
 import { parseHash, type Route } from "./router";
 import { PageTitle, Shell } from "./shell";
@@ -94,6 +95,86 @@ describe("PageTitle", () => {
     expect(screen.queryByRole("link", { name: "Analytics" })).toBeNull();
   });
 
+  // Whose state the page changes, beside its heading. Only a settings entry
+  // carries a scope, and every settings page declares one in the catalog — the
+  // field had no reader at all until this, so a person could not tell a toggle
+  // that changes their own signature from one that changes everybody's mail
+  // routing.
+  it("names whose state a settings page changes, beside its heading", () => {
+    const scoped = fixtureSection("account");
+    const you = scoped.groups[0]?.items[0];
+    if (!you) {
+      throw new Error("the fixture published no account entry");
+    }
+    render(
+      <PageTitle
+        route={parseHash("#/settings/account")}
+        section={{
+          ...scoped,
+          groups: [
+            {
+              ...scoped.groups[0],
+              items: [{ ...you, scopeKey: "settings.scope.self" }],
+            },
+            ...scoped.groups.slice(1),
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(en["settings.scope.self"])).toBeTruthy();
+    // Beside the heading, never inside it: a heading carrying the scope would
+    // read "Account Only you" in every document outline and screen reader.
+    expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain(
+      en["settings.scope.self"],
+    );
+  });
+
+  // The mixed page says something DIFFERENT to a screen reader: not who it
+  // affects, but that it has no single answer. "Who this page affects: Mixed"
+  // would be a non-sentence, and a reader relying on that line would be told
+  // less than a sighted one.
+  it("explains a mixed page rather than naming a non-answer", () => {
+    const scoped = fixtureSection("account");
+    const you = scoped.groups[0]?.items[0];
+    if (!you) {
+      throw new Error("the fixture published no account entry");
+    }
+    render(
+      <PageTitle
+        route={parseHash("#/settings/connections")}
+        section={{
+          ...scoped,
+          groups: [
+            {
+              ...scoped.groups[0],
+              items: [{ ...you, scopeKey: "settings.scope.mixed" }],
+            },
+            ...scoped.groups.slice(1),
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(en["settings.scope.mixed"])).toBeTruthy();
+    expect(screen.getByText(en["settings.scopeAriaMixed"])).toBeTruthy();
+    // And NOT the who-sentence, which is the one this replaces.
+    expect(document.body.textContent).not.toContain("Who this page affects");
+  });
+
+  // An entry with no scope draws no badge, which is every screen outside
+  // settings: there the answer is the record in front of you.
+  it("draws no scope where the entry declares none", () => {
+    render(
+      <PageTitle
+        route={parseHash("#/settings/account")}
+        section={fixtureSection("account")}
+      />,
+    );
+    // No BADGE, not "none of the two labels I happened to list": enumerating
+    // them would pass against a mutation that defaulted an absent scope to a
+    // third label.
+    expect(document.querySelector(".badge")).toBeNull();
+  });
+
   // AC-shell-1k: every authenticated route resolves to real copy. This bites on
   // a new off-rail route landing in the router without a title key — the old
   // fallback rendered the raw screen slug.
@@ -144,8 +225,10 @@ describe("PageTitle", () => {
       "bring your own agent — governed by the two-tier contract",
     );
     // Directly under the name it explains, inside the title's own text column —
-    // not beside the actions, where it would read as product chrome.
-    expect(heading.nextElementSibling).toBe(sub);
+    // not beside the actions, where it would read as product chrome. The
+    // heading's own parent is the row it shares with the scope badge, so the
+    // subtitle follows THAT rather than the heading itself.
+    expect(heading.closest(".pagetitle-head")?.nextElementSibling).toBe(sub);
     expect(container.querySelector(".pagetitle-text")?.contains(sub)).toBe(
       true,
     );

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Avatar, Button, Modal } from "../design-system/atoms";
+import { Avatar, Badge, Button, Modal } from "../design-system/atoms";
 import { CompanyLogo } from "../design-system/companylogo";
 import { Logomark } from "../design-system/logomark";
 import { useLocale, useT } from "../i18n";
@@ -701,6 +701,9 @@ export function PageTitle({
   // the screen-keyed table can only carry a sentence true of all of them. The
   // table remains for screens that ARE one page.
   const subKey = inSection?.entry.subKey ?? PAGE_SUB_KEYS[route.screen];
+  // Whose state the page changes. Only a settings entry carries one, and only
+  // then: on every other screen the answer is the record in front of you.
+  const scopeKey = inSection?.entry.scopeKey;
 
   if (recordNamesPage || unitNamesPage || selfHeaded) {
     return null;
@@ -723,12 +726,38 @@ export function PageTitle({
             own `aria-label` — "Privacy & audit — change section" — and put an
             instruction in the document's heading list. The control keeps that
             name; the heading states the page. */}
-        <h1
-          className={switcher ? "t-display pageswitchhead" : "t-display"}
-          aria-label={switcher ? title : undefined}
-        >
-          {switcher || title}
-        </h1>
+        {/* The heading and the scope share one ROW: `.pagetitle-text` stacks its
+            children, so a badge placed as a sibling would sit under the heading
+            at full width and read as a second line of the title. */}
+        <div className="pagetitle-head">
+          <h1
+            className={switcher ? "t-display pageswitchhead" : "t-display"}
+            aria-label={switcher ? title : undefined}
+          >
+            {switcher || title}
+          </h1>
+          {/* Beside the heading rather than inside it: the scope is about the
+              page, not part of its name, and a heading carrying it would read
+              "Capture rules Company" in every document outline and screen
+              reader. `quiet` because it states a fact rather than flagging one
+              — a page being company-wide is the ordinary case, not a warning.
+              `quiet` keeps the vocabulary and drops the fill (design-system
+              README, Badge); it still draws the status dot. */}
+          {scopeKey && (
+            <Badge quiet>
+              {/* The mixed page says something different from the others: not
+                  WHO it affects, but that it has no single answer and each
+                  setting states its own. "Who this page affects: Mixed" would
+                  be a non-sentence. */}
+              <span className="sr-only">
+                {scopeKey === "settings.scope.mixed"
+                  ? t("settings.scopeAriaMixed")
+                  : t("settings.scopeAria", { scope: t(scopeKey) })}
+              </span>
+              <span aria-hidden="true">{t(scopeKey)}</span>
+            </Badge>
+          )}
+        </div>
         {subKey && <p className="pagesub">{t(subKey)}</p>}
       </div>
     </div>

--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -45,6 +45,14 @@ export type NavLevelEntry = {
   // is many pages behind one screen — `PAGE_SUB_KEYS[route.screen]` can only
   // describe all of them at once, which is no description of any of them.
   subKey?: MessageKey;
+  // Whose state this page changes, in the reader's own words — "Only you",
+  // "Company", "Installation". A settings page is the one place a person cannot
+  // tell that from the controls: a toggle that changes your signature and a
+  // toggle that changes everybody's mail routing look identical.
+  //
+  // On the ENTRY for the same reason `subKey` is: the section knows which page
+  // this is, and a screen-keyed table would have to answer for all of them.
+  scopeKey?: MessageKey;
   icon: LucideIcon;
   // The level this entry opens. Grouping is possible at every depth, so the
   // children are a flat list only until one needs headings.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6160,6 +6160,13 @@ export const de = {
     "Die Einheiten, die dieser Build zusammengesetzt hat, und welche Rollen sie erreichen.",
   "settings.page.reset.sub":
     "Diese Installation leeren. Es gibt kein Zur\u00fcck.",
+  "settings.scope.self": "Nur Sie",
+  "settings.scope.mixed": "Gemischt",
+  "settings.scope.workspace": "Unternehmen",
+  "settings.scope.installation": "Installation",
+  "settings.scopeAria": "Wen diese Seite betrifft: {scope}",
+  "settings.scopeAriaMixed":
+    "Diese Seite enth\u00e4lt Einstellungen, die unterschiedliche Personen betreffen \u2014 jede sagt es selbst.",
   "settings.search.label": "Einstellungen durchsuchen",
   "settings.search.placeholder": "Einstellungen suchen",
   "settings.search.none": "Keine Einstellungsseite passt dazu.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6293,6 +6293,13 @@ export const en = {
   "settings.page.extensions.sub":
     "The units this build composed, and which roles reach them.",
   "settings.page.reset.sub": "Emptying this installation. There is no undo.",
+  "settings.scope.self": "Only you",
+  "settings.scope.mixed": "Mixed",
+  "settings.scope.workspace": "Company",
+  "settings.scope.installation": "Installation",
+  "settings.scopeAria": "Who this page affects: {scope}",
+  "settings.scopeAriaMixed":
+    "This page holds settings that affect different people \u2014 each one says which.",
   "settings.search.label": "Search settings",
   "settings.search.placeholder": "Search settings",
   "settings.search.none": "No settings page matches that.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6094,6 +6094,14 @@ export const vi = {
     "C\u00e1c \u0111\u01a1n v\u1ecb b\u1ea3n d\u1ef1ng n\u00e0y \u0111\u00e3 k\u1ebft h\u1ee3p, v\u00e0 vai tr\u00f2 n\u00e0o t\u1edbi \u0111\u01b0\u1ee3c.",
   "settings.page.reset.sub":
     "L\u00e0m r\u1ed7ng b\u1ea3n tri\u1ec3n khai n\u00e0y. Kh\u00f4ng th\u1ec3 ho\u00e0n t\u00e1c.",
+  "settings.scope.self": "Ch\u1ec9 m\u00ecnh b\u1ea1n",
+  "settings.scope.mixed": "H\u1ed7n h\u1ee3p",
+  "settings.scope.workspace": "C\u00f4ng ty",
+  "settings.scope.installation": "B\u1ea3n c\u00e0i \u0111\u1eb7t",
+  "settings.scopeAria":
+    "Trang n\u00e0y \u1ea3nh h\u01b0\u1edfng \u0111\u1ebfn ai: {scope}",
+  "settings.scopeAriaMixed":
+    "Trang n\u00e0y c\u00f3 c\u00e1c c\u00e0i \u0111\u1eb7t \u1ea3nh h\u01b0\u1edfng \u0111\u1ebfn nh\u1eefng ng\u01b0\u1eddi kh\u00e1c nhau \u2014 m\u1ed7i c\u00e0i \u0111\u1eb7t t\u1ef1 n\u00f3i r\u00f5.",
   "settings.search.label": "T\u00ecm trong c\u00e0i \u0111\u1eb7t",
   "settings.search.placeholder": "T\u00ecm c\u00e0i \u0111\u1eb7t",
   "settings.search.none":

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -6,7 +6,7 @@ import type { RbacObject } from "../app/capability";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import type { Route } from "../app/router";
 import * as router from "../app/router";
-import { SettingsRail } from "../app/shell";
+import { PageTitle, SettingsRail } from "../app/shell";
 import { translate } from "../i18n";
 import { SettingsScreen } from "./settings";
 import {
@@ -23,7 +23,7 @@ import {
   type SettingsPageId,
   visibleSettingsPages,
 } from "./settingscatalog";
-import { SETTINGS_HOME_ID } from "./settingsnav";
+import { SETTINGS_HOME_ID, useSettingsSection } from "./settingsnav";
 import { settingsHref } from "./settingsrouting";
 
 // WHICH settings pages a principal is offered at all, and which group holds each
@@ -1282,6 +1282,41 @@ it("keeps the home row's id out of the page vocabulary", () => {
 // list the rail passes — a wiring that handed it SETTINGS_PAGES would offer a
 // rep the audit log, and every one of those tests would still pass. This is the
 // case that fails when that happens.
+// The catalog has declared a `scope` for every page since it was written, and
+// nothing read it until now. Asserted through the REAL section rather than a
+// hand-built one: `shell.test.tsx` proves PageTitle renders a scope it is
+// handed — building the entry itself, since `fixtureSection` carries none — and
+// this proves the settings level actually hands it one.
+describe("the scope a settings page publishes", () => {
+  function RealTitle({ hash }: Readonly<{ hash: string }>) {
+    const route = router.parseHash(hash);
+    return <PageTitle route={route} section={useSettingsSection(route)} />;
+  }
+
+  // `company` is deliberately not among these: its requirement ANDs the
+  // organization write with the `company_context` deployment flag, which the
+  // default fixture leaves off, so the page is shut and has no heading to carry
+  // a scope. The installation scope is covered by the pure catalog test instead.
+  // `account` and `connections` are deliberately NOT here. Both open on
+  // `always`, so their heading and badge render while `/me` is still in flight
+  // — `findByText` would resolve on the loading paint, and a regression that
+  // showed the badge during loading and dropped it once the snapshot arrived
+  // would still pass. Their scope values are held by the pure catalog cases
+  // instead, where there is no in-flight state to race.
+  //
+  // `pipelines` is safe for the opposite reason: it opens on a GRANT, every
+  // grant predicate reads false against an unresolved snapshot, so its row
+  // cannot appear until /me has answered.
+  it.each([["pipelines", "settings.scope.workspace"]] as const)(
+    "says whose state %s changes",
+    async (page, key) => {
+      vi.stubGlobal("fetch", settingsBackend());
+      render(<RealTitle hash={`#/settings/${page}`} />);
+      expect(await screen.findByText(translate("en", key))).toBeTruthy();
+    },
+  );
+});
+
 describe("the settings search in the rail", () => {
   it("offers a rep no page their own sidebar does not draw", async () => {
     const user = userEvent.setup();

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -368,11 +368,16 @@ export function tabContent(id: SettingsPageId): ReactNode {
   }
 }
 
-// What YOU are connected to. Every surface here reads a per-user seam — the
-// connector list is scoped to the calling human server-side (capture is per-user,
-// RC-8), and both LinkedIn surfaces read `/me`. So this belongs to the personal
-// group, and needs no grant: a mailbox nobody else can see is not organization
-// configuration, and the entry that used to hold both kinds could not say so.
+// What YOU are connected to. Most surfaces here read a per-user seam — the
+// mail connector list is scoped to the calling human server-side (capture is
+// per-user, RC-8), and both LinkedIn surfaces read `/me`. So this belongs to the
+// personal group, and needs no grant: a mailbox nobody else can see is not
+// organization configuration, and the entry that used to hold both kinds could
+// not say so.
+//
+// It is not WHOLLY personal, which is why the catalog marks it `mixed`:
+// MailSharingCard writes the installation's mail-sharing rule, and
+// ConnectorsCard's second panel is the workspace's Telegram bot.
 function ConnectionsTab() {
   return (
     <>

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { RbacAction, RbacObject } from "../app/capability";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import { translate } from "../i18n";
 import {
   holds,
   SETTINGS_GROUPS,
   SETTINGS_PAGES,
   type SettingsPageId,
+  type SettingsScope,
   visibleSettingsPages,
 } from "./settingscatalog";
 
@@ -30,6 +32,102 @@ describe("the catalog's shape", () => {
     for (const group of SETTINGS_GROUPS) {
       expect(SETTINGS_PAGES.some((page) => page.group === group)).toBe(true);
     }
+  });
+});
+
+// Every page declares whose state it changes, and the nav turns that into a
+// label beside the heading (`scopeKey`, settingsnav.tsx). A page whose scope is
+// wrong tells a reader a company-wide switch is theirs alone, which is the one
+// mistake this field exists to prevent — so the values are checked here rather
+// than only where they render.
+describe("the scope each page declares", () => {
+  it("gives every page a scope the catalogs can label", () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(translate("en", `settings.scope.${page.scope}`)).toBeTruthy();
+    }
+  });
+
+  // A CENSUS, not a sample. The earlier version of this suite named a few
+  // pages per scope and let the rest ride, and four pages were wrong under it:
+  // `integrations`, `models` and `privacy` each said "Company" over a card
+  // writing the whole installation, and `extensions` said "Installation" over a
+  // card writing one workspace's role grants. Every one of them passed.
+  //
+  // So every page is named here with the reason, and the two directions are
+  // checked below: a new page with no entry fails, and an entry for a page that
+  // no longer exists fails too. A census that can fail SHORT has already failed.
+  //
+  // The rule being applied: scope names whose state the page CHANGES, read off
+  // the endpoints its cards write, not the heading the page sits under and not
+  // what it merely reads. A read-only page describes what it shows.
+  const DECLARED_SCOPE: Record<SettingsPageId, SettingsScope> = {
+    // Wholly the reader's own.
+    account: "self",
+    voice: "self",
+    agents: "self",
+
+    // Pages whose cards genuinely split across two scopes. `integrations`
+    // is one: PATCH /integrations/settings is "the installation's
+    // provider-lookup posture" by its own contract summary, while webhooks,
+    // the overlay mapping and the workspace extension units on the same page
+    // stay inside one workspace.
+    integrations: "mixed",
+
+    // Personal pages carrying one shared card each. A badge reading "Only you"
+    // over either would tell a reader a company-wide switch is private to them.
+    // MailSharingCard PATCHes /capture/settings — whether captured mail is
+    // shared with colleagues; CaptureExclusionsCard's workspace rules keep a
+    // correspondent out of the CRM for everybody.
+    connections: "mixed",
+    "capture-activity": "mixed",
+
+    // The installation's own facts, by their contract summaries.
+    company: "installation",
+    authentication: "installation",
+    seats: "installation",
+    // PUT /ai/routing re-points which vendor processes the installation's text;
+    // /ai/provider-keys writes the installation key vault.
+    models: "installation",
+    // Both retention endpoints are installation-wide. What this page destroys,
+    // it destroys everywhere.
+    privacy: "installation",
+    // POST /embeddings/reindex rebuilds the installation's embed store.
+    "system-health": "installation",
+    reset: "installation",
+
+    // One workspace's state.
+    members: "workspace",
+    teams: "workspace",
+    pipelines: "workspace",
+    leads: "workspace",
+    fields: "workspace",
+    tags: "workspace",
+    products: "workspace",
+    capture: "workspace",
+    knowledge: "workspace",
+    import: "workspace",
+    automations: "workspace",
+    // Read-only pages: no write at all, so the scope describes what they SHOW.
+    usage: "workspace",
+    "model-calls": "workspace",
+    audit: "workspace",
+    // Reads the installation's unit inventory, but its only write is
+    // PATCH /roles/{key}/objects/{object} — one workspace's role grants.
+    extensions: "workspace",
+  };
+
+  it("declares the scope this census names, for every page", () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(page.scope).toBe(DECLARED_SCOPE[page.id]);
+    }
+  });
+
+  // The other direction. Without this, deleting a page leaves a stale entry
+  // that nothing reads, and the census quietly describes a catalog that moved.
+  it("names every page in the catalog and nothing else", () => {
+    expect(Object.keys(DECLARED_SCOPE).sort()).toEqual(
+      SETTINGS_PAGES.map((page) => page.id).sort(),
+    );
   });
 });
 

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -201,7 +201,22 @@ export type SettingsGroupId = (typeof SETTINGS_GROUPS)[number];
  * `workspace` is the internal enum's name for it and is deliberately not shown:
  * a person reading a settings page knows "Company", not the tenancy model.
  */
-export type SettingsScope = "self" | "team" | "workspace" | "installation";
+export type SettingsScope =
+  | "self"
+  | "team"
+  | "workspace"
+  | "installation"
+  // A page whose surfaces do not agree. My connections is the case: most of its
+  // nine cards are the reader's own mailboxes and network, and two are not —
+  // MailSharingCard writes `capture_settings`, the whole installation's
+  // mail-sharing rule, and ConnectorsCard carries the workspace's Telegram bot
+  // beside the reader's own mailboxes.
+  //
+  // Its own value rather than picking the wider of the two, because "Company"
+  // over a page that is mostly personal is as wrong as "Only you" over a
+  // page carrying a company switch. The head says the page is mixed and stops
+  // claiming to answer for every card on it.
+  | "mixed";
 
 /**
  * Every settings page, its group, its scope and what it takes to open it.
@@ -223,8 +238,17 @@ export const SETTINGS_PAGES = [
   { id: "account", group: "me", scope: "self", requires: always },
   { id: "voice", group: "me", scope: "self", requires: always },
   { id: "agents", group: "me", scope: "self", requires: always },
-  { id: "connections", group: "me", scope: "self", requires: always },
-  { id: "capture-activity", group: "me", scope: "self", requires: always },
+  // MIXED, not self: six of its cards are the reader's own, and MailSharingCard
+  // writes `capture_settings` — the installation's rule about whether captured
+  // mail is shared with colleagues. A page-level "Only you" over that switch
+  // would tell a reader a company-wide setting is private to them.
+  { id: "connections", group: "me", scope: "mixed", requires: always },
+  // MIXED for the same reason as `connections`, one page along:
+  // CaptureExclusionsCard carries BOTH scopes by design — its own comment says
+  // so — and its workspace rules keep a correspondent out of the CRM for
+  // everybody. The workspace activity view behind `capture_trace:read` is the
+  // installation's too.
+  { id: "capture-activity", group: "me", scope: "mixed", requires: always },
 
   {
     id: "company",
@@ -366,7 +390,11 @@ export const SETTINGS_PAGES = [
   {
     id: "integrations",
     group: "data",
-    scope: "workspace",
+    // Mixed, and the provider card is why: `PATCH /integrations/settings` is
+    // "the installation's provider-lookup posture" in its own contract summary,
+    // while webhooks, the overlay mapping and the workspace extension units
+    // stay inside one workspace. One badge cannot name both.
+    scope: "mixed",
     // The writes, not the reads: every seeded role reads both objects, because
     // "is capture working?" is everyone's question and the answer shows up on
     // the records they already open. Connecting an overlay or pointing a
@@ -396,7 +424,10 @@ export const SETTINGS_PAGES = [
   {
     id: "models",
     group: "ai",
-    scope: "workspace",
+    // Installation, not workspace: `PUT /ai/routing` re-points which vendor
+    // processes the installation's text, and `/ai/provider-keys` writes the
+    // installation key vault. Both contract summaries say "installation".
+    scope: "installation",
     // Two cards, two grants. The routing and provider-key cards read on
     // `ai_routing`; `AiHealthCard` reads on `ai_diagnostics` (ai/health.go),
     // and Models is the ONLY page that renders it. Management is seeded
@@ -433,7 +464,11 @@ export const SETTINGS_PAGES = [
   {
     id: "privacy",
     group: "governance",
-    scope: "workspace",
+    // Installation: retention is installation-wide on both endpoints the card
+    // writes — `/retention/settings` is "the installation's retention posture"
+    // and `/retention-policies` lists "the installation's retention policies".
+    // What this page destroys, it destroys everywhere.
+    scope: "installation",
     // `person` is deliberately NOT an arm, though the purposes card reads
     // through it. `person:read` is held by every seeded role, so that arm put
     // the governance page in front of the whole workspace — the retention
@@ -482,7 +517,10 @@ export const SETTINGS_PAGES = [
   {
     id: "extensions",
     group: "governance",
-    scope: "installation",
+    // Workspace, though the page READS the installation's unit inventory. Scope
+    // names whose state a page CHANGES, and the only write here is
+    // `PATCH /roles/{key}/objects/{object}` — one workspace's role grants.
+    scope: "workspace",
     // BOTH reads the card makes, because it makes them behind ONE flag: the
     // unit inventory from `GET /v1/extensions` and every role's grant on every
     // object from `GET /v1/roles`. On the inventory grant alone the page opens

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -562,6 +562,12 @@ export function useSettingsSection(route: Route): NavSection {
             // missing from the catalogs is a compile error rather than a
             // subtitle that silently translates to nothing.
             subKey: `settings.page.${page.id}.sub`,
+            // Whose state the page changes, from the catalog's own `scope`
+            // rather than a second table: the catalog already declares it for
+            // every page, and it had no reader until now. Same MessageKey
+            // narrowing as the subtitle above — a missing scope label is a
+            // compile error, not a silent blank.
+            scopeKey: `settings.scope.${page.scope}`,
             icon: PAGE_ICONS[page.id],
           }),
         ),


### PR DESCRIPTION
Every settings page has always declared a `scope` in settingscatalog.ts and
nothing read it. A reader could not tell whether a toggle changed their own
signature or the whole company's mail routing, so the page head now carries a
badge: Only you / Company / Installation / Mixed, in en/de/vi.

Screen readers get a sentence rather than the bare label ("Who this page
affects: the installation"), and a separate one for Mixed, because "Who this
page affects: Mixed" is not a sentence.

Writing the badge meant auditing what each page's cards actually WRITE, and six
pages were declaring the wrong thing:

- `connections` and `capture-activity` said "Only you" while rendering cards
  that write the installation's mail-sharing rule and the workspace's capture
  exclusions. Both are now `mixed`.
- `integrations` said "Company" over a provider card writing
  `PATCH /integrations/settings` — "the installation's provider-lookup posture"
  by its own contract summary. Now `mixed`.
- `models` said "Company" while `PUT /ai/routing` re-points which vendor
  processes the installation's text and `/ai/provider-keys` writes the
  installation key vault. Now `installation`.
- `privacy` said "Company" over retention, which is installation-wide on both
  endpoints it writes. What that page destroys, it destroys everywhere. Now
  `installation`.
- `extensions` said "Installation" but its only write is
  `PATCH /roles/{key}/objects/{object}`, one workspace's role grants. Scope
  names what a page CHANGES, not what it reads. Now `workspace`.

The rule applied throughout: read the scope off the endpoints the page's cards
write, not off the heading it sits under. A read-only page describes what it
shows.

The test is a census, not a sample. An earlier version named a few pages per
scope and let the rest ride; all four of the last group passed under it. Every
page is now named with its reason, and a second assertion checks the census
covers the catalog in both directions, so a new page with no entry fails and a
stale entry for a deleted page fails too.

Found by review: six pages were declaring the wrong scope, four of them beyond the two I caught myself. The census test replaces a sample that all four had passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settings pages now show a badge next to the heading saying whose state the page changes — Only you / Company / Installation / Mixed, in en/de/vi. Previously every page declared a `scope` in the catalog and nothing read it, so a reader could not tell a toggle that changes their own signature from one that changes the whole company's mail routing. Screen readers get a full sentence instead of the bare label, and Mixed pages get their own sentence since "Who this page affects: Mixed" is not a sentence.

Writing the badge meant auditing what each page's cards actually write, and six pages declared the wrong scope:

- `connections` and `capture-activity` said "Only you" but render cards that write the installation's mail-sharing rule and the workspace's capture exclusions — now `mixed`.
- `integrations` said "Company" over a provider card writing `PATCH /integrations/settings` — now `mixed`.
- `models` said "Company" while its cards write the installation's AI routing and provider key vault — now `installation`.
- `privacy` said "Company" over retention endpoints that are installation-wide — now `installation`.
- `extensions` said "Installation" but its only write is `PATCH /roles/{key}/objects/{object}`, one workspace's role grants — now `workspace`.

The rule throughout: scope comes from the endpoints the page's cards write, not the heading it sits under. Read-only pages describe what they show.

**Tests**

- Replaces the sample-based scope test with a census: every page is named with its reason, and a second assertion checks the census covers the catalog in both directions, so a new page with no entry fails and a stale entry for a deleted page fails too.

<sup>Written for commit b96ab3750a0d879637d9becfaafd46cea861e7f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings pages now display a badge indicating who their settings affect, such as only you, company, installation, or mixed scopes.
  * Scope indicators include accessible descriptions for screen readers.
  * Scope information is available across settings navigation and is localized in English, German, and Vietnamese.

* **UI Improvements**
  * Page headings and scope badges align cleanly on one line, with responsive wrapping for narrow screens.
  * Section switchers use available space more effectively on phone-sized layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->