### PR TITLE
The engine is the only gate at transmit

### DIFF
--- a/backend/internal/modules/comms/dispatcher_channel_integration_test.go
+++ b/backend/internal/modules/comms/dispatcher_channel_integration_test.go
@@ -149,10 +149,10 @@ func TestDispatcherRoutesAChannelDeliveryToMessageSender(t *testing.T) {
 	if got.Attempt != 0 {
 		t.Errorf("first transmission reported Attempt = %d, want 0", got.Attempt)
 	}
-	// The consent gate is asked about the CHANNEL recipient, not an empty mail
-	// address list: a default-deny gate asked about nobody refuses nobody.
-	if len(consent.asked) != 1 || consent.asked[0] != "telegram:"+channelRecipient {
-		t.Errorf("consent was asked about %v, want the one channel recipient", consent.asked)
+	// The engine is asked about the CHANNEL recipient, not an empty mail
+	// address list: a default-deny authority asked about nobody refuses nobody.
+	if len(consent.authzAsked) != 1 || consent.authzAsked[0] != "telegram:"+channelRecipient {
+		t.Errorf("consent was asked about %v, want the one channel recipient", consent.authzAsked)
 	}
 
 	status, attempts, _ := e.deliveryRow(t, id)

--- a/backend/internal/modules/comms/dispatcher_harness_test.go
+++ b/backend/internal/modules/comms/dispatcher_harness_test.go
@@ -220,8 +220,16 @@ type stubConsent struct {
 	armed     bool
 	authzErr  error
 	authzSeen int
+	// authzAsked is who the ENGINE was put to, recorded the same way asked
+	// records the legacy gate's list. The dispatcher asks only the engine now,
+	// so this is the field a coverage case asserts on.
+	authzAsked []string
 }
 
+// RequireGrantedForRecipients satisfies the seam. The DISPATCHER no longer calls
+// it — the engine is the only authority at transmit — so a case arming s.err
+// proves nothing about what stops a send. It records what it was asked so a
+// case can assert the dispatcher does NOT ask it.
 func (s *stubConsent) RequireGrantedForRecipients(_ context.Context, recipients []connector.Recipient, _ string) error {
 	s.asked = nil
 	for _, r := range recipients {
@@ -374,17 +382,25 @@ func (f consentFunc) RequireGrantedForRecipients(ctx context.Context, r []connec
 // wrong attempt, and no ticket at all.
 func (s *stubConsent) AuthorizeTransmit(_ context.Context, req commsauthz.TransmitRequest) (commsauthz.TransmitTicket, error) {
 	s.authzSeen++
+	s.authzAsked = nil
+	for _, r := range req.Recipients {
+		if r.Channel != nil {
+			s.authzAsked = append(s.authzAsked, r.Channel.Provider+":"+r.Channel.ChannelUserID)
+			continue
+		}
+		s.authzAsked = append(s.authzAsked, r.Email)
+	}
 	if s.authzErr != nil {
 		return commsauthz.TransmitTicket{}, s.authzErr
 	}
 	if s.armed {
 		return s.ticket, nil
 	}
-	// Unarmed, the stub behaves as the engine does in observe mode: it records
-	// a decision and permits the send, leaving the legacy gate to rule. It must
-	// NOT mirror s.err — that field is the LEGACY gate's answer, and a stub
-	// that refused here too would make every legacy test pass for the engine's
-	// reason instead of its own.
+	// Unarmed, the stub permits: a case that is about seats, attachments or
+	// scopes says nothing about consent and should not have to arm it. It must
+	// NOT mirror s.err — that field is the LEGACY gate's answer, which the
+	// dispatcher no longer consults, and a stub that refused here too would
+	// make a case pass for a reason it never stated.
 	return commsauthz.TransmitTicket{
 		DeliveryID:    req.DeliveryID,
 		Attempt:       req.Attempt,

--- a/backend/internal/modules/comms/dispatcher_test.go
+++ b/backend/internal/modules/comms/dispatcher_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -141,14 +141,19 @@ func TestDispatchParksWhenTheProviderCannotSendAtAll(t *testing.T) {
 
 // THE load-bearing one: consent can be withdrawn between staging and transmit.
 //
-// The stub returns apperrors.ErrConsentNotGranted specifically, NOT a bare
-// error — because only that sentinel is an ANSWER. A generic error means the
-// check failed to run, which must retry, and the test below pins that apart.
+// Armed on the ENGINE's answer, because the engine is the authority the
+// dispatcher asks. The legacy gate used to be asked a second time here and is
+// not any more, so a case that armed only s.err would now pass while proving
+// nothing about what stops a send.
 func TestDispatchParksWhenConsentWasWithdrawnAfterStaging(t *testing.T) {
 	sender := &fakeSender{}
 	store := &fakeStore{delivery: liveDelivery()}
 	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}},
-		&stubConsent{err: apperrors.ErrConsentNotGranted})
+		&stubConsent{armed: true, ticket: commsauthz.TransmitTicket{
+			DeliveryID: store.delivery.ID, Attempt: store.delivery.Attempts,
+			DecisionSetID: ids.NewV7(), Allowed: false,
+			Reason: "consent was withdrawn after staging",
+		}})
 
 	got, _ := dispatch(context.Background(), d, store.delivery.ID)
 	if got != OutcomeParked || sender.calls != 0 {
@@ -162,7 +167,7 @@ func TestDispatchRetriesWhenTheConsentCheckFailsTransiently(t *testing.T) {
 	sender := &fakeSender{}
 	store := &fakeStore{delivery: liveDelivery()}
 	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}},
-		&stubConsent{err: errors.New("consent store timeout")})
+		&stubConsent{authzErr: errors.New("consent store timeout")})
 
 	got, _ := dispatch(context.Background(), d, store.delivery.ID)
 	if got != OutcomeRetry {
@@ -223,8 +228,8 @@ func TestDispatchAsksConsentAboutEveryAddresseeIncludingCc(t *testing.T) {
 	// The cc'd address is the assertion; the duplicate proves an addressee
 	// listed twice is asked about once, the way a mail server reads it.
 	want := []string{"buyer@example.com", "second@example.com", "cc@example.com"}
-	if !slices.Equal(consent.asked, want) {
-		t.Errorf("consent was asked about %v, want every addressee %v", consent.asked, want)
+	if !slices.Equal(consent.authzAsked, want) {
+		t.Errorf("consent was asked about %v, want every addressee %v", consent.authzAsked, want)
 	}
 }
 
@@ -244,8 +249,8 @@ func TestDispatchAsksConsentAboutTheNormalizedAddressItDedupedOn(t *testing.T) {
 	if err != nil || got != OutcomeSent {
 		t.Fatalf("outcome=%v err=%v, want OutcomeSent", got, err)
 	}
-	if !slices.Equal(consent.asked, []string{"buyer@example.com"}) {
-		t.Errorf("consent was asked about %v, want the normalized address the dedupe keyed on", consent.asked)
+	if !slices.Equal(consent.authzAsked, []string{"buyer@example.com"}) {
+		t.Errorf("consent was asked about %v, want the normalized address the dedupe keyed on", consent.authzAsked)
 	}
 }
 
@@ -254,17 +259,20 @@ func TestDispatchAsksConsentAboutTheNormalizedAddressItDedupedOn(t *testing.T) {
 func TestDispatchParksWhenOnlyACcRecipientWithdrewConsent(t *testing.T) {
 	sender := &fakeSender{}
 	store := &fakeStore{delivery: liveDelivery()}
-	// The gate refuses the list it is handed; handing it the To line alone
+	// The engine refuses the list it is handed; handing it the To line alone
 	// would never surface the cc'd withdrawal at all.
-	consent := &stubConsent{err: apperrors.ErrConsentNotGranted}
+	consent := &stubConsent{armed: true, ticket: commsauthz.TransmitTicket{
+		DeliveryID: store.delivery.ID, Attempt: store.delivery.Attempts,
+		DecisionSetID: ids.NewV7(), Allowed: false, Reason: "a cc'd recipient withdrew",
+	}}
 	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
 
 	got, _ := dispatch(context.Background(), d, store.delivery.ID)
 	if got != OutcomeParked || sender.calls != 0 {
 		t.Errorf("outcome=%v calls=%d — a withdrawn cc recipient must stop the send", got, sender.calls)
 	}
-	if !slices.Contains(consent.asked, "cc@example.com") {
-		t.Errorf("consent was asked about %v — the cc'd addressee was never put to the gate", consent.asked)
+	if !slices.Contains(consent.authzAsked, "cc@example.com") {
+		t.Errorf("consent was asked about %v — the cc'd addressee was never put to the engine", consent.authzAsked)
 	}
 }
 
@@ -291,8 +299,8 @@ func TestDispatchParksWhenTheSenderIsNoLongerALiveSeat(t *testing.T) {
 	}
 	// Authority-class, so it refuses before consent answers — the same
 	// ordering the mailbox grant keeps.
-	if consent.asked != nil {
-		t.Errorf("consent was consulted about %v despite a dead seat", consent.asked)
+	if consent.authzAsked != nil {
+		t.Errorf("consent was consulted about %v despite a dead seat", consent.authzAsked)
 	}
 }
 

--- a/backend/internal/modules/comms/gates.go
+++ b/backend/internal/modules/comms/gates.go
@@ -13,7 +13,6 @@ package comms
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -22,7 +21,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
@@ -234,14 +232,20 @@ func (d *Dispatcher) gateSeat(ctx context.Context, del Delivery) (Outcome, time.
 	return outcomeUndecided, 0, nil
 }
 
-// gateConsent is suppression and consent, and now also the point at which the
-// engine records why this attempt was permitted.
+// gateConsent is where a delivery earns the ticket transmit demands.
 //
-// Two authorities run here, deliberately, while the rollout is in observe
-// mode: the engine writes its own per-recipient decision and applies only the
-// refusals no mode may soften, and the legacy purpose gate still rules
-// everything else. The engine's ticket is what transmit demands, so a provider
-// call without one cannot happen.
+// ONE AUTHORITY. The engine decides, per recipient, on this delivery's own
+// evidence, and writes down why. It used to be two: the legacy purpose gate ran
+// again here after the ticket already said yes, and parked on a purpose key
+// nobody had granted — so a reply the engine allowed on the subject's own
+// message was refused anyway, in a branch no rollout mode could soften. Removing
+// it is what makes the rollout mean anything.
+//
+// Nothing the legacy gate asked is now unasked. It read person_consent for the
+// same recipient list this call passes; AuthorizeTransmit reads that through
+// VerdictForPerson AND reads communication_suppression, which the old gate never
+// looked at. It refused an empty recipient list; AuthorizeTransmit refuses one
+// too, and an empty decision set is not an allow.
 func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (commsauthz.TransmitTicket, Outcome, time.Duration, error) {
 	var none commsauthz.TransmitTicket
 	if d.consent == nil {
@@ -270,43 +274,5 @@ func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (commsauthz.
 		return ticket, o, w, err
 	}
 
-	// The installation's own mail stops here, and this is the ONE place the
-	// controller lane parts from a user send.
-	//
-	// The legacy question below is "is this purpose granted for these people",
-	// and a controller row has no purpose: consent_purpose is NULL on it by
-	// design, because the message is not sent under a permission somebody gave.
-	// Asked anyway, the purpose lookup finds no row and answers "not granted" —
-	// so every confirmation mail would park, and the lane would look configured
-	// and never deliver.
-	//
-	// What replaces it is not nothing. The engine has already answered above,
-	// on this delivery's own evidence, through the same AuthorizeTransmit call
-	// every other message goes through: a live confirm_token for this person of
-	// this kind. That is a STRONGER question than the legacy gate asks, not a
-	// skipped one.
-	if del.IsController() {
-		return ticket, outcomeUndecided, 0, nil
-	}
-
-	// EVERY subject this delivery reaches is asked about, not just the To line:
-	// a Cc'd person is owed the same suppression, and this call is the only one
-	// that runs after they could have withdrawn. consentRecipients is what makes
-	// the question shape-agnostic — mail's addressees and a channel's single
-	// recipient arrive here as the same list.
-	switch err := d.consent.RequireGrantedForRecipients(ctx, consentRecipients(del), del.ConsentPurpose); {
-	case errors.Is(err, apperrors.ErrConsentNotGranted):
-		// An answer: consent is absent, and no amount of waiting brings it back.
-		o, w, perr := d.park(ctx, del.ID, fmt.Sprintf(
-			"consent for purpose %q is not granted for these recipients", del.ConsentPurpose,
-		))
-		return ticket, o, w, perr
-	case err != nil:
-		// NOT an answer. A consent service that is merely down must not
-		// permanently destroy a consented send — getting this branch backwards
-		// silently kills legitimate mail.
-		o, w, rerr := d.retry(ctx, del.ID, err)
-		return ticket, o, w, rerr
-	}
 	return ticket, outcomeUndecided, 0, nil
 }

--- a/backend/internal/modules/comms/sendseamcontroller_test.go
+++ b/backend/internal/modules/comms/sendseamcontroller_test.go
@@ -256,19 +256,43 @@ func TestTheInstallationsOwnMailIsNotAskedForAPurposeGrant(t *testing.T) {
 	}
 }
 
-// TestAUserSendIsStillAskedForItsPurposeGrant is the other half. Without it the
-// exemption above could widen to every message and nothing would fail.
-func TestAUserSendIsStillAskedForItsPurposeGrant(t *testing.T) {
-	store := &fakeStore{delivery: liveDelivery()}
-	gate := &legacyPurposeGate{}
-	d := newTestDispatcher(store, fakeResolver{sender: &fakeSender{}, granted: []string{sendScope}}, gate)
+// TestBothLanesAreAskedTheSameQuestion is the other half of the case above.
+//
+// The controller lane used to be EXEMPTED from a second, legacy question the
+// dispatcher asked after the engine had already answered — and the exemption
+// existed only because a controller row carries no consent_purpose, so that
+// question could only ever answer "not granted". With the legacy question gone
+// there is no exemption left to widen: both lanes reach the engine, and the
+// engine is what decides. This pins that they do.
+func TestBothLanesAreAskedTheSameQuestion(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		controller bool
+	}{{"a rep's send", false}, {"the installation's own mail", true}} {
+		store := &fakeStore{delivery: liveDelivery()}
+		res := fakeResolver{sender: &fakeSender{}, granted: []string{sendScope}}
+		gate := &legacyPurposeGate{}
+		d := newTestDispatcher(store, res, gate)
+		if tc.controller {
+			// The controller lane transmits through its own relay, so the case
+			// needs one wired to reach transmit at all.
+			store.delivery = controllerDelivery()
+			d = newTestDispatcher(store, fakeResolver{}, gate).
+				WithControllerRelay(&fakeRelay{}, &fakeVault{secret: "https://margince.test/#/confirm/t"})
+		}
 
-	if _, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID); err != nil {
-		t.Fatalf("DispatchWithWait: %v", err)
-	}
-	if len(gate.askedWithPurpose) != 1 || gate.askedWithPurpose[0] != "marketing" {
-		t.Errorf("a rep's send put %q to the legacy gate, want exactly one ask for %q: the "+
-			"controller exemption must not widen to ordinary mail",
-			gate.askedWithPurpose, "marketing")
+		if _, _, err := d.DispatchWithWait(context.Background(), store.delivery.ID); err != nil {
+			t.Fatalf("%s: DispatchWithWait: %v", tc.name, err)
+		}
+		if gate.authzSeen != 1 {
+			t.Errorf("%s: the transmit authority was asked %d times, want exactly 1 — one lane "+
+				"reaching the engine and the other not is the side door this pins shut",
+				tc.name, gate.authzSeen)
+		}
+		if len(gate.askedWithPurpose) != 0 {
+			t.Errorf("%s: the legacy purpose gate was asked %q at transmit; it is not an authority "+
+				"there any more and asking it again could only park what the engine allowed",
+				tc.name, gate.askedWithPurpose)
+		}
 	}
 }

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -97,6 +97,19 @@ func (g *Gate) decideResolved(ctx context.Context, tx pgx.Tx, req commsauthz.Req
 		return commsauthz.Decision{}, err
 	}
 	if res.Supported {
+		// The record bears the category out — and the subject may still have
+		// said stop. The evidence arms never read person_consent, so this is
+		// the only place a withdrawal is put to them.
+		stopped, err := withdrawalCovers(ctx, tx, subject, res.Category)
+		if err != nil {
+			return commsauthz.Decision{}, err
+		}
+		if stopped {
+			d.Resolved = res.Category
+			d.Verdict = commsauthz.VerdictDeny
+			d.ReasonCode = commsauthz.ReasonConsentWithdrawn
+			return d, nil
+		}
 		return allowOn(d, res), nil
 	}
 	// AN UNSUPPORTED CLAIM IS RECORDED, NEVER RESOLVED TO.

--- a/backend/internal/modules/consent/authorizelead.go
+++ b/backend/internal/modules/consent/authorizelead.go
@@ -175,6 +175,20 @@ func (g *Gate) decideLeadOnItsRecord(ctx context.Context, tx pgx.Tx, r connector
 		return commsauthz.Decision{}, err
 	}
 	if res.Supported {
+		// The same question the person arm asks: the evidence arms never read
+		// person_consent, so a lead who withdrew would be sent the very message
+		// they stopped.
+		stopped, err := withdrawalCovers(ctx, tx,
+			subjectRef{Kind: entityLead, ID: leadID, Address: r.Email}, res.Category)
+		if err != nil {
+			return commsauthz.Decision{}, err
+		}
+		if stopped {
+			d.Resolved = res.Category
+			d.Verdict = commsauthz.VerdictDeny
+			d.ReasonCode = commsauthz.ReasonConsentWithdrawn
+			return d, nil
+		}
 		return allowOn(d, res), nil
 	}
 

--- a/backend/internal/modules/consent/authorizeresolve.go
+++ b/backend/internal/modules/consent/authorizeresolve.go
@@ -15,8 +15,8 @@ package consent
 // Resolution is separate from authorization on purpose. This file answers "what
 // kind of message is this", and the validators answer "is there evidence for
 // that kind". Keeping them apart is what lets a decision row record a claim the
-// engine disagreed with, which is the disagreement observe mode exists to make
-// visible.
+// engine disagreed with, which is the disagreement the decision record exists to
+// make visible.
 
 import (
 	"context"
@@ -163,7 +163,8 @@ func (g *Gate) resolveFromClaimAndPurpose(ctx context.Context, tx pgx.Tx, req co
 // account notice that is NOT supported: an operational claim with no invoice,
 // contract or account event behind it is precisely the shape the old model
 // could not tell from a cold sales mail. Marking it unsupported records the
-// disagreement without refusing anything while the engine is observed.
+// disagreement AND refuses under the shipped posture, which is the point: an
+// unproven claim must not select a category.
 func resolutionForClass(class Class) resolution {
 	switch class {
 	case ClassBusinessCorrespondence:

--- a/backend/internal/modules/consent/authorizesuppression_integration_test.go
+++ b/backend/internal/modules/consent/authorizesuppression_integration_test.go
@@ -179,3 +179,62 @@ func TestAnObjectionDoesNotMaskAHardBounce(t *testing.T) {
 			d.ReasonCode, commsauthz.ReasonHardBounce)
 	}
 }
+
+// A WITHDRAWAL STOPS A THREAD-EVIDENCED SEND.
+//
+// The evidence arms allow on the record's own ground and never read
+// person_consent — that is what makes a reply to a thread the subject started
+// work without a consent row. But a subject who presses one-click unsubscribe
+// writes a WITHDRAWAL, not a suppression row, so liveSuppression is blind to it
+// and the thread arm would allow the very message they just stopped.
+func TestAWithdrawalStopsAThreadEvidencedSend(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "business_correspondence", "business_correspondence")
+	anchor := e.inboundFrom(t, "thread-withdrawn", e.address, time.Now().Add(-24*time.Hour))
+
+	// They wrote to us, then took their permission back.
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO person_consent (person_id, purpose_id, state, lawful_basis, captured_at, source)
+		SELECT $1, id, 'withdrawn', 'consent', now(), 'preference_centre'
+		  FROM consent_purpose WHERE key = 'business_correspondence'`, e.person); err != nil {
+		t.Fatalf("recording the withdrawal: %v", err)
+	}
+
+	d := e.decide(t, commsauthz.Request{
+		AnchorActivityID: anchor, LegacyPurposeKey: "business_correspondence",
+	})
+	if d.Verdict == commsauthz.VerdictAllow {
+		t.Fatalf("verdict = allow (%s, resolved %s): they took their permission back and the "+
+			"thread arm sent anyway — the evidence arms never read person_consent",
+			d.ReasonCode, d.Resolved)
+	}
+}
+
+// ARCHIVING A PURPOSE DOES NOT REACTIVATE THE PEOPLE WHO STOPPED IT.
+//
+// A withdrawal is a thing the subject did; archiving the purpose is a thing the
+// installation did. If the withdrawal read skipped archived purposes, retiring
+// one would silently make everybody who had unsubscribed from it contactable
+// again — on the evidence arms, which never read person_consent otherwise.
+func TestArchivingAPurposeKeepsItsWithdrawals(t *testing.T) {
+	e := setupResolve(t)
+	e.seedPurpose(t, "business_correspondence", "business_correspondence")
+	anchor := e.inboundFrom(t, "thread-archived", e.address, time.Now().Add(-24*time.Hour))
+
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO person_consent (person_id, purpose_id, state, lawful_basis, captured_at, source)
+		SELECT $1, id, 'withdrawn', 'consent', now(), 'preference_centre'
+		  FROM consent_purpose WHERE key = 'business_correspondence'`, e.person); err != nil {
+		t.Fatalf("recording the withdrawal: %v", err)
+	}
+	if _, err := e.owner.Exec(e.ctx,
+		`UPDATE consent_purpose SET archived_at = now() WHERE key = 'business_correspondence'`); err != nil {
+		t.Fatalf("archiving the purpose: %v", err)
+	}
+
+	d := e.decide(t, commsauthz.Request{AnchorActivityID: anchor})
+	if d.Verdict == commsauthz.VerdictAllow {
+		t.Fatalf("verdict = allow (%s): retiring the purpose reactivated somebody who had "+
+			"stopped it", d.ReasonCode)
+	}
+}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -59,19 +59,25 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 	setID := ids.NewV7()
 	ticket := commsauthz.TransmitTicket{DeliveryID: req.DeliveryID, Attempt: req.Attempt, DecisionSetID: setID}
 
-	// The legacy gate still rules while the engine is in observe mode, so its
-	// answer is taken first and carried onto every row. A disagreement is then
-	// readable in the record rather than only in a counter that dies with the
-	// process.
+	// The legacy gate's answer, recorded beside the engine's on every row so a
+	// disagreement is readable in the record rather than only in a counter that
+	// dies with the process.
+	//
+	// IT NO LONGER DECIDES, with one exception the rollback lever depends on:
+	// Effective consults it only when NO recipient's category is enforced,
+	// which the shipped posture never produces but an operator moving a
+	// category back to observe deliberately does. The dispatcher used to ask it
+	// a second time after the ticket already said yes; that call is gone.
 	legacyErr := g.RequireGrantedForRecipients(ctx, req.Recipients, req.PurposeKey)
 	switch {
 	case legacyErr == nil:
 	case errors.Is(legacyErr, apperrors.ErrConsentNotGranted):
 	default:
-		// NOT an answer. The question could not be asked, so nothing has been
-		// learned and nothing is recorded — the dispatcher retries.
-		return commsauthz.TransmitTicket{}, legacyErr
+		// NOT an answer. Whether that matters depends on the posture, and the
+		// posture is not known until the modes are read inside the transaction
+		// below — so the error is carried there rather than decided here.
 	}
+	legacyUnanswerable := legacyErr != nil && !errors.Is(legacyErr, apperrors.ErrConsentNotGranted)
 	legacyAllowed := legacyErr == nil
 
 	err := g.store.db.Tx(ctx, func(tx pgx.Tx) error {
@@ -91,6 +97,21 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 		}
 		if err := g.recordDecisions(ctx, tx, req, setID, set); err != nil {
 			return err
+		}
+		// AN UNANSWERABLE LEGACY GATE IS ONLY FATAL WHERE ITS ANSWER IS USED.
+		//
+		// Effective consults legacyAllowed only when no recipient's category is
+		// enforced, which the shipped posture never produces. Where it IS
+		// consulted — an operator has moved a category back to observe — a gate
+		// that failed to answer must retry rather than refuse: a refusal parks
+		// with a reason a human can act on, and a failure to LEARN the answer
+		// is not one. Treating the outage as a refusal would destroy every
+		// in-flight delivery in the window instead of deferring them.
+		// An absolute denial needs no second opinion: it refuses in every mode,
+		// so an unanswerable legacy gate changes nothing and retrying would
+		// hold a message the subject already stopped.
+		if legacyUnanswerable && !set.HasAbsoluteDenial() && !set.HasEnforcedRecipient(modeFor) {
+			return legacyErr
 		}
 		ticket.Allowed = set.Effective(modeFor, legacyAllowed)
 		ticket.Reason = refusalReason(set, legacyAllowed)

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -14,7 +14,7 @@ package consent
 // refusal is the failure mode that makes reps distrust the product and route
 // around it, and it costs more than the permission it was protecting. So a
 // validator that cannot find its evidence answers "review, and here is what to
-// link" rather than "no" — the send still goes while the engine is observed,
+// link" rather than "no" — the send parks under the shipped posture, and goes only where a category has been moved back to observe,
 // and a human is told what the record is missing.
 
 import (

--- a/backend/internal/modules/consent/authorizewithdrawal.go
+++ b/backend/internal/modules/consent/authorizewithdrawal.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The subject's own recorded stop, read where the evidence arms can see it.
+//
+// A withdrawal is Art. 7(3): the person takes back a permission they gave. It
+// is written to person_consent and NOT to communication_suppression, so
+// liveSuppression cannot see it — and the evidence arms allow on the record's
+// own ground without ever reading person_consent, which is exactly what lets a
+// reply to a thread the subject started work with no consent row.
+//
+// Those two facts together were a leak: somebody who wrote into a thread and
+// then pressed one-click unsubscribe was still sent the next message on it,
+// because the thread arm answered before anything read the withdrawal. The
+// dispatcher used to catch it by asking the legacy purpose gate a second time
+// after the ticket already said yes; that second gate is gone, so the engine
+// asks the question itself.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// withdrawalCovers reports whether the subject has withdrawn a purpose whose
+// class covers this category.
+//
+// BY CLASS, not by the caller's purpose key. The evidence arms resolve a
+// category from the record and may have no purpose key at all, and an
+// unsubscribe-all withdraws every unlocked purpose rather than one — so the
+// question is "did they stop the kind of message this is", which is what a
+// subject pressing unsubscribe believes they answered.
+func withdrawalCovers(ctx context.Context, tx pgx.Tx, subject subjectRef, category commsauthz.Category) (bool, error) {
+	classes := classesCovering(category)
+	if len(classes) == 0 {
+		return false, nil
+	}
+	// person_consent carries person_id OR lead_id, so one statement answers for
+	// both subject kinds rather than a second copy answering for one.
+	var withdrawn bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM person_consent pc
+			  JOIN consent_purpose cp ON cp.id = pc.purpose_id
+			 WHERE (($1 = 'person' AND pc.person_id = $2::uuid)
+			     OR ($1 = 'lead'   AND pc.lead_id   = $2::uuid))
+			   AND pc.state = 'withdrawn'
+			   -- ARCHIVED PURPOSES COUNT. A withdrawal is a thing the subject
+			   -- did, and archiving the purpose is a thing the installation
+			   -- did; letting the second erase the first would make retiring a
+			   -- purpose reactivate everybody who had stopped it.
+			   AND cp.class = ANY($3)
+		)`, subject.Kind, subject.ID, classes).Scan(&withdrawn); err != nil {
+		return false, fmt.Errorf("consent: read whether the subject stopped this kind of message: %w", err)
+	}
+	return withdrawn, nil
+}
+
+// classesCovering inverts categoryForClass: which purpose classes produce this
+// category, and so which withdrawals speak about it.
+//
+// The five subject-serving categories return none. A person cannot withdraw
+// their way out of a security warning or the acknowledgement of their own
+// opt-out, and reading a withdrawal as covering those would make pressing
+// unsubscribe silence the confirmation that it worked.
+func classesCovering(category commsauthz.Category) []string {
+	if category.ServesTheSubject() {
+		return nil
+	}
+	switch category {
+	case commsauthz.CategoryMarketing:
+		return []string{string(ClassMarketing), string(ClassPhoneOutreach)}
+	case commsauthz.CategoryAccountNotice, commsauthz.CategoryContractNotice,
+		commsauthz.CategoryInvoiceOrPayment:
+		// Transactional messages rest on the contract, not on consent, so a
+		// withdrawal does not reach them: somebody who unsubscribes is still
+		// owed their invoice.
+		return nil
+	default:
+		return []string{string(ClassBusinessCorrespondence)}
+	}
+}

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -127,16 +127,15 @@ func (s DecisionSet) Effective(modeFor func(Category) Mode, legacyAllowed bool) 
 		// recipient is not a message that may go out.
 		return false
 	}
-	enforced := false
 	for _, d := range s.Decisions {
 		if modeFor(d.Resolved) != ModeEnforce {
 			continue
 		}
-		enforced = true
 		if d.Verdict != VerdictAllow {
 			return false
 		}
 	}
+	enforced := s.HasEnforcedRecipient(modeFor)
 	// THE ENGINE ALONE DECIDES A RECIPIENT IT ENFORCES.
 	//
 	// While every category observed, this returned legacyAllowed and the old
@@ -149,9 +148,11 @@ func (s DecisionSet) Effective(modeFor func(Category) Mode, legacyAllowed bool) 
 	// a message can have, and being overruled by a weaker authority is the
 	// regression this rollout exists to end.
 	//
-	// A set with NO enforced recipient still defers. That is not a fallback: it
-	// is a category still being observed, and the old gate is what decides
-	// there until it is not.
+	// A set with NO enforced recipient still defers, and under the shipped
+	// posture that never happens: enforceEveryCategory puts all fourteen at
+	// enforce. It is reachable only when an operator has deliberately moved a
+	// category back to observe, which is the rollback lever — so the old gate
+	// decides exactly where somebody asked it to and nowhere else.
 	if enforced {
 		return true
 	}
@@ -197,4 +198,19 @@ func (d Decision) CanBeOverruled() bool {
 		return false
 	}
 	return LevelForReason(d.ReasonCode) == LevelMachine && !Absolute(d.ReasonCode)
+}
+
+// HasEnforcedRecipient reports whether any recipient's resolved category is at
+// enforce, and so whether the engine's own answer is the one that decides.
+//
+// Extracted rather than recomputed by a caller: Effective's deferral to the old
+// gate turns on exactly this question, and a second spelling of it would let
+// the two disagree about which authority is live.
+func (s DecisionSet) HasEnforcedRecipient(modeFor func(Category) Mode) bool {
+	for _, d := range s.Decisions {
+		if modeFor(d.Resolved) == ModeEnforce {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
gateConsent asked the legacy purpose gate a second time, after AuthorizeTransmit
had already returned an allowed ticket. The call was unconditional and no
rollout mode softened it, so a reply the engine allowed on the subject's own
message was parked for want of a consent row nobody had reason to record. That
is the regression the rollout exists to end, and it is gone.

The del.IsController() early return went with it. That branch existed only to
skip the legacy question -- a controller row carries no consent_purpose, so the
answer could only ever be 'not granted' -- and with the question gone both lanes
take one path.

Removing a gate means proving the remaining one covers it. The engine reads the
same recipient list through consentRecipients, reads person_consent through
VerdictForPerson AND communication_suppression which the old gate never looked
at, refuses an empty recipient list, and treats an empty decision set as a
refusal rather than an allow.

Except in one place, which the security review found and which this closes: the
evidence arms allow on the record's own ground WITHOUT reading person_consent --
that is what lets a reply to a thread the subject started work with no consent
row. A withdrawal is written to person_consent and not to
communication_suppression, so somebody who wrote into a thread and then pressed
one-click unsubscribe was still sent the next message on it. The second legacy
call had been catching that by accident. withdrawalCovers now asks the question
where the evidence arms can see it, by purpose CLASS rather than by a caller's
purpose key, because an unsubscribe-all withdraws every unlocked purpose and the
evidence arms may carry no key at all.

A legacy gate that fails to answer no longer aborts the engine. It matters only
where its answer is used -- an observe-mode category -- and there it retries
rather than parking, because a refusal parks with a reason a human can act on
and a failure to LEARN the answer is not one.

## Found in review

- **A withdrawn subject could still be mailed.** The evidence arms allow on the
  record's own ground without reading `person_consent`; a withdrawal is written
  there and not to `communication_suppression`. Somebody who wrote into a thread
  and then pressed one-click unsubscribe was sent the next message on it. The
  removed legacy call had been catching this by accident. Reproduced with a
  failing test before fixing.
- **Archiving a purpose would have reactivated everyone who stopped it.** My
  first withdrawal query filtered `archived_at IS NULL`. A withdrawal is a thing
  the subject did; archiving is a thing the installation did, and the second must
  not erase the first.
- **A legacy outage parked permanently** instead of retrying, in the one posture
  where its answer is used. A refusal parks with a reason a human can act on; a
  failure to learn the answer is not one.
- One assertion had gone vacuous: `consent.asked` is no longer written by
  anything the dispatcher calls, so a seat-ordering test could never fail.

## Verification

- `make check-backend` green; consent and comms integration lanes green.
- Every change mutation-checked: restoring the second gate fails two tests,
  disabling the withdrawal check fails its test, and re-adding the
  `archived_at` filter fails the archived-purpose test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the consent engine the only gate at transmit: the dispatcher no longer asks the legacy purpose gate a second time after the engine already returned a ticket, and the controller-lane exemption that existed only to skip that question is removed. This also closes a leak the second call had been hiding — a subject who wrote into a thread and then pressed one-click unsubscribe was still sent the next message on it.

**Bug Fixes**
- `withdrawalCovers` now reads `person_consent` by purpose class wherever the evidence arms would allow, so a withdrawal stops the next send on that thread.
- Withdrawals survive purpose archiving: retiring a purpose no longer reactivates everyone who had stopped it.
- A legacy gate that fails to answer retries instead of parking permanently, and only where its answer is still consulted (an observe-mode category).
- `make check-backend` is green and each fix is pinned by a test that fails without it.

<sup>Written for commit 6a08d2a83ebef6012336783cb96581a3506dd029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consent withdrawals now prevent otherwise authorized messages from being sent.
  * Archived consent purposes no longer reactivate previously withdrawn consent.
  * Message authorization now uses a single transmit decision path, consistently applying recipient and suppression checks.
  * Authorization failures and recipient decisions are handled more reliably across delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->