### PR TITLE
The disagreement reading says what it is now measuring

### DIFF
--- a/backend/internal/compose/authzdisagreement.go
+++ b/backend/internal/compose/authzdisagreement.go
@@ -5,10 +5,12 @@ package compose
 
 // The daily reading of how far apart the two outbound authorities are.
 //
-// The engine has run in observe mode since it shipped: it decides, records, and
-// the old purpose gate rules. Ending that is a decision somebody has to make on
-// evidence, and this pass is what puts the evidence in front of them without
-// anybody remembering to ask.
+// The engine decides every category the shipped posture enforces, which is all
+// fourteen — and the legacy purpose gate's answer is still recorded beside its
+// own on every TRANSMIT row (staging records no legacy verdict; it never asked
+// that gate). The two still disagree, so the reading outlived the rollout it
+// was written for: it is now how somebody notices a category enforcing against
+// mail the old gate would have allowed.
 //
 // It exists because the same reading as a typed subcommand was one nobody would
 // ever run. The number that decides a rollout is not one an operator thinks to
@@ -18,8 +20,7 @@ package compose
 //
 // It DECIDES nothing and writes no domain row. Enforcement is a setting a human
 // changes after reading this; a pass that flipped a category itself would be a
-// second authority over what may be sent, and the whole point of the observe
-// period is that there is exactly one until somebody decides otherwise.
+// second authority over what may be sent, and there is exactly one.
 
 import (
 	"context"

--- a/backend/internal/modules/consent/authorizedisagreement.go
+++ b/backend/internal/modules/consent/authorizedisagreement.go
@@ -6,11 +6,14 @@ package consent
 // How far apart the engine and the old purpose gate are, read from the record
 // rather than guessed.
 //
-// The engine has run in observe mode since it shipped: it decides, records, and
-// the old gate rules. That was always meant to end in a measurement — enforcing
-// a rule nobody has measured is how a compliance change becomes an outage, and
-// the one number that decides whether enforcement is safe is how often the two
-// already disagree, broken down by what the disagreement WAS.
+// The engine decides wherever a category is enforced, which the shipped posture
+// makes universal; an operator who moves one back to observe hands that
+// category to the old gate again, which is the rollback lever. The old gate's
+// answer is recorded beside the engine's on every TRANSMIT row, and the two
+// still disagree — so the measurement that once said whether enforcing was safe
+// now says whether it stayed safe. Enforcing a rule nobody measures is how a
+// compliance change becomes an outage, and that is as true after the flip as
+// before it.
 //
 // A count alone would not answer it. "The engine is stricter on 4,000
 // deliveries" reads as alarming and may be entirely correct — those may all be


### PR DESCRIPTION
Both disagreement files opened by stating that the engine has run in observe
mode since it shipped and the old purpose gate rules. Neither has been true
since every category moved to enforce, and one of them sat above a pass whose
whole justification was the observe period it described.

The pass is still a control worth having, so the premise is corrected rather
than the file deleted: the engine decides, the two authorities still disagree,
and the reading now says whether a category enforcing stayed safe rather than
whether enforcing it would be.

Two overclaims caught before commit: the legacy answer is recorded on every
TRANSMIT row and not on a staging one, which never asked that gate; and an
operator who moves a category back to observe hands it to the old gate again,
which is the rollback lever and not something to write out of the comment.

Comment-only. `make check-backend` green.

Completes item G of the round-8 ledger; the other four stale observe-mode
comments and the false "only reader in the tree" claim were corrected in #4706
and #4701.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects stale comments in both disagreement files so the reading describes what it measures now that every category enforces.

- Reframes the premise from "engine runs in observe mode" to "engine decides all fourteen enforced categories."
- Clarifies the reading now says whether an enforced category stayed safe, not whether enforcing it would be safe.
- Notes the legacy purpose gate's answer is recorded on every TRANSMIT row, not on staging rows.
- Documents that moving a category back to observe hands it to the old gate again, which serves as the rollback lever.
- Comment-only change; no behavior change.

<sup>Written for commit ad7a5b2ecd82e71eedb43415fc1fda3e3f837dfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

