### PR TITLE
A dependency bump can reach an extension module again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
   make-target-parity contract-breaking-check contract-frontend-drift \
   test-contract-frontend-drift migration-versions test-migration-versions \
   test-lanes env-reads gofmt lint-modules go-file-length rls-store-path \
+  check-extension-modules \
   no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale \
   test-selfdir pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check
@@ -99,7 +100,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -1150,6 +1151,17 @@ no-jurisdiction:
 ## `make check-ext-migrations` — after `make db-up`.
 check-ext-migrations:
 	@./scripts/check-ext-migrations.sh
+
+## check-extension-modules — prove a dependency bump can reach an extension
+## module unattended: `go mod tidy` runs there, and it changes nothing.
+##
+## Without a local replace for the backend, tidy does not fail — it resolves
+## pkg/extension from the NETWORK and pins a pseudo-version of whatever commit
+## was pushed, so the unit compiles against a different backend than it ships
+## with. That is how a Renovate bump left one module's go.sum on the old version
+## with nothing in the tree noticing (#2003).
+check-extension-modules:
+	@./scripts/check-extension-modules.sh
 
 ## pkg-freeze — published-surface freeze gate (ADR-0069 §3, EXT-P3): apidiff
 ## on every backend/pkg package vs the merge target (origin/$GITHUB_BASE_REF

--- a/extensions/de/go.mod
+++ b/extensions/de/go.mod
@@ -1,3 +1,18 @@
 module github.com/margince/margince/extensions/de
 
 go 1.26.6
+
+// The backend this unit compiles against is the one IN THIS TREE, not a published
+// snapshot of it. pkg/extension has no module version — it resolves through the
+// generated build/composition/go.work — and `go mod tidy` ignores workspace `use`
+// directives, so without this it goes to the network and pins a pseudo-version of
+// whatever commit happened to be pushed. That is worse than failing: the unit then
+// compiles against a different backend than the one it ships with, silently.
+//
+// It is also what makes a dependency bump landable unattended. Renovate's artifact
+// update shells out to `go mod tidy`; with no way to resolve the backend locally it
+// rewrote go.mod, left go.sum on the old version, and reported an artifact failure
+// nobody could fix without hand-writing sums (#2003).
+replace github.com/margince/margince/backend => ../../backend
+
+require github.com/margince/margince/backend v0.0.0-00010101000000-000000000000

--- a/extensions/openchannel/go.mod
+++ b/extensions/openchannel/go.mod
@@ -1,3 +1,18 @@
 module github.com/margince/margince/extensions/openchannel
 
 go 1.26.6
+
+// The backend this unit compiles against is the one IN THIS TREE, not a published
+// snapshot of it. pkg/extension has no module version — it resolves through the
+// generated build/composition/go.work — and `go mod tidy` ignores workspace `use`
+// directives, so without this it goes to the network and pins a pseudo-version of
+// whatever commit happened to be pushed. That is worse than failing: the unit then
+// compiles against a different backend than the one it ships with, silently.
+//
+// It is also what makes a dependency bump landable unattended. Renovate's artifact
+// update shells out to `go mod tidy`; with no way to resolve the backend locally it
+// rewrote go.mod, left go.sum on the old version, and reported an artifact failure
+// nobody could fix without hand-writing sums (#2003).
+replace github.com/margince/margince/backend => ../../backend
+
+require github.com/margince/margince/backend v0.0.0-00010101000000-000000000000

--- a/extensions/vn/go.mod
+++ b/extensions/vn/go.mod
@@ -1,3 +1,18 @@
 module github.com/margince/margince/extensions/vn
 
 go 1.26.6
+
+// The backend this unit compiles against is the one IN THIS TREE, not a published
+// snapshot of it. pkg/extension has no module version — it resolves through the
+// generated build/composition/go.work — and `go mod tidy` ignores workspace `use`
+// directives, so without this it goes to the network and pins a pseudo-version of
+// whatever commit happened to be pushed. That is worse than failing: the unit then
+// compiles against a different backend than the one it ships with, silently.
+//
+// It is also what makes a dependency bump landable unattended. Renovate's artifact
+// update shells out to `go mod tidy`; with no way to resolve the backend locally it
+// rewrote go.mod, left go.sum on the old version, and reported an artifact failure
+// nobody could fix without hand-writing sums (#2003).
+replace github.com/margince/margince/backend => ../../backend
+
+require github.com/margince/margince/backend v0.0.0-00010101000000-000000000000

--- a/scripts/check-extension-modules.sh
+++ b/scripts/check-extension-modules.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# check-extension-modules.sh — prove every extension module can still be tidied,
+# and that tidying it changes nothing.
+#
+# THE FAILURE THIS REPLACES was not a broken build. A Renovate Go bump raised a
+# dependency in extensions/zalo-personal/go.mod and left that module's go.sum on
+# the old version, because its artifact update shells out to `go mod tidy` and
+# tidy could not run there: pkg/extension has no module version, it resolves only
+# through the generated build/composition/go.work, and tidy ignores workspace
+# `use` directives. The committed pair was inconsistent and nothing in the tree
+# noticed — the check that reported it was renovate/artifacts, which is advisory.
+#
+# Worse than failing, once a `replace` is absent: tidy does not stop, it goes to
+# the NETWORK and pins a pseudo-version of whatever commit happened to be pushed.
+# The unit then compiles against a different backend than the one it ships with,
+# and the go.mod says so in a line nobody reads.
+#
+# So this asserts two things at once, and the second is the one that lasts: tidy
+# RUNS, and it is a no-op. A module whose committed go.mod/go.sum already say what
+# tidy would say is one a dependency bump can land in unattended.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+failures=0
+
+for mod in "$root"/extensions/*/go.mod; do
+    [ -e "$mod" ] || continue
+    dir="$(dirname "$mod")"
+    unit="$(basename "$dir")"
+
+    # The local backend has to be reachable, or tidy resolves it from the network
+    # and the pseudo-version it writes looks like a normal dependency.
+    if ! grep -q '^replace github.com/margince/margince/backend => \.\./\.\./backend$' "$mod"; then
+        printf '  FAIL %s: go.mod has no local replace for the backend — `go mod tidy` will resolve\n' "$unit" >&2
+        printf '       pkg/extension from the network and pin a pseudo-version of some pushed commit.\n' >&2
+        printf '       Add: replace github.com/margince/margince/backend => ../../backend\n' >&2
+        failures=$((failures + 1))
+        continue
+    fi
+
+    before="$(cat "$mod")"
+    beforeSum=""
+    [ -f "$dir/go.sum" ] && beforeSum="$(cat "$dir/go.sum")"
+
+    if ! ( cd "$dir" && GOFLAGS=-mod=mod go mod tidy ) 2>/dev/null; then
+        printf '  FAIL %s: `go mod tidy` does not run here, so no dependency bump can update it\n' "$unit" >&2
+        failures=$((failures + 1))
+        continue
+    fi
+
+    afterSum=""
+    [ -f "$dir/go.sum" ] && afterSum="$(cat "$dir/go.sum")"
+    if [ "$before" != "$(cat "$mod")" ] || [ "$beforeSum" != "$afterSum" ]; then
+        printf '  FAIL %s: go.mod/go.sum are not what `go mod tidy` produces — the committed pair\n' "$unit" >&2
+        printf '       disagrees with itself, which is the shape a half-applied bump leaves.\n' >&2
+        printf '       Run: (cd extensions/%s && go mod tidy) and commit the result.\n' "$unit" >&2
+        printf '%s' "$before" > "$mod"
+        if [ -n "$beforeSum" ]; then printf '%s' "$beforeSum" > "$dir/go.sum"; else rm -f "$dir/go.sum"; fi
+        failures=$((failures + 1))
+        continue
+    fi
+    printf '  ok   %s: tidy runs and changes nothing\n' "$unit"
+done
+
+if [ "$failures" -ne 0 ]; then
+    echo "FAIL: $failures extension module(s) a dependency bump cannot update unattended" >&2
+    exit 1
+fi
+echo "OK: every extension module tidies clean"


### PR DESCRIPTION
Closes #2003.

`go mod tidy` could not resolve `pkg/extension` from an extension module: it has no module version and resolves only through the generated `build/composition/go.work`, which tidy ignores.

Renovate's artifact update shells out to tidy, so a Go bump rewrote one module's `go.mod`, left its `go.sum` on the old version, and reported an artifact failure nobody could clear without hand-writing sums. **Nothing in the tree noticed the inconsistent pair** — the check that reported it is advisory.

## It is worse than failing

That is what I found rather than what the ticket described. Tidy does not stop — it goes to the **network** and pins a pseudo-version of whatever commit happened to be pushed:

```
require github.com/margince/margince/backend v0.0.0-20260906231803-45967acae8d7
```

So the unit would compile against a different backend than the one it ships with, and the `go.mod` would say so in a line nobody reads.

## Option 1, as recommended

It is the only one that leaves a bump landable unattended, which is the point of having Renovate at all. Each unit gets a local `replace`, so tidy resolves the backend in *this tree* and writes no pseudo-version. All three then tidy to exactly what is committed.

## The gate asserts both halves

And the second is the one that lasts: **tidy runs, and it is a no-op**. A module whose committed `go.mod` already says what tidy would say is one a bump can land in unattended.

It checks the `replace` separately and first, because its absence is the case that produces a plausible-looking `require` line rather than an error.

It also **restores the files** when it finds drift — a gate that reported a difference and left the tree rewritten would turn one failure into a dirty working copy the reader has to undo before they can read the message.

## Mutations

| mutation | result |
|---|---|
| remove a `replace` | that unit is reported as one a bump cannot update |
| add a requirement tidy would drop | the pair is reported as disagreeing with itself |

Wired into `ROOT_SCRIPT_GATES`, so it runs wherever the other script gates do. `make check-backend` exit 0; `make test-extensions` green.