### PR TITLE
The existing-customer exception is the pack's to grant

### DIFF
--- a/backend/internal/modules/consent/authorizebasis.go
+++ b/backend/internal/modules/consent/authorizebasis.go
@@ -41,7 +41,7 @@ import (
 // message was permitted, so committing the delivery without it would put out
 // mail the installation cannot account for — which is the exact gap this table
 // exists to close.
-func recordBasis(ctx context.Context, tx pgx.Tx, subject subjectRef, res resolution, req commsauthz.Request, w windows) error {
+func recordBasis(ctx context.Context, tx pgx.Tx, subject subjectRef, res resolution, req commsauthz.Request, w packRules) error {
 	if !res.Supported || res.Basis == "" {
 		// Nothing was concluded, so there is nothing to stand behind. An
 		// unsupported resolution falls through to the legacy verdict, whose own
@@ -119,7 +119,7 @@ func subjectAuditEntity(subject subjectRef) string {
 // when the thing behind it stops supporting a send. A basis outliving its
 // evidence would be a record saying a message was lawful on a ground that had
 // already run out.
-func basisLifetime(category commsauthz.Category, w windows) time.Duration {
+func basisLifetime(category commsauthz.Category, w packRules) time.Duration {
 	if category == commsauthz.CategoryActiveDealFollowup {
 		return w.dealFollow
 	}

--- a/backend/internal/modules/consent/authorizedecide.go
+++ b/backend/internal/modules/consent/authorizedecide.go
@@ -59,7 +59,7 @@ func (g *Gate) resolveAndRecord(ctx context.Context, tx pgx.Tx, req commsauthz.R
 	// still resolved — the decision row records what the message was — but the
 	// ground is not written down.
 	if phase == commsauthz.PhaseStaging && !suppressed {
-		w, err := g.store.windowsFor(ctx, tx)
+		w, err := g.store.packRulesFor(ctx, tx)
 		if err != nil {
 			return resolution{}, err
 		}
@@ -166,11 +166,23 @@ func (g *Gate) legacyVerdictFor(ctx context.Context, tx pgx.Tx, personID, purpos
 	// (the supported arm) is covered only by the first.
 	d.Resolved = resolutionForClass(purpose.Class).Category
 
-	w, err := g.store.windowsFor(ctx, tx)
+	w, err := g.store.packRulesFor(ctx, tx)
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}
-	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, time.Now().Add(-w.reply))
+	// NO Advertises. Nothing on a send names the GOODS it advertises: the
+	// nearest field, Request.MarketingPurpose, is a consent purpose key
+	// ("newsletter"), and similar_goods_note is free text a rep typed about a
+	// sale ("espresso machines"). Comparing the two is not a weak check, it is
+	// a satisfiable one — a rep who types the purpose key into the note field
+	// would hold §7(3) authority for that person forever, which is the hole
+	// this file exists to close, relocated.
+	//
+	// So an exception requiring similarity refuses here, exactly as it does for
+	// the legacy gate and the guard, until a caller can honestly say what a
+	// message advertises.
+	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, time.Now().Add(-w.reply),
+		MarketingContext{Exception: w.marketingException})
 	if err != nil {
 		return commsauthz.Decision{}, err
 	}

--- a/backend/internal/modules/consent/authorizeresolve.go
+++ b/backend/internal/modules/consent/authorizeresolve.go
@@ -136,7 +136,7 @@ func (g *Gate) resolveFromClaimAndPurpose(ctx context.Context, tx pgx.Tx, req co
 				Reason:    commsauthz.ReasonUnknownPurpose,
 			}, nil
 		}
-		w, err := g.store.windowsFor(ctx, tx)
+		w, err := g.store.packRulesFor(ctx, tx)
 		if err != nil {
 			return resolution{}, err
 		}

--- a/backend/internal/modules/consent/authorizevalidators.go
+++ b/backend/internal/modules/consent/authorizevalidators.go
@@ -38,7 +38,7 @@ import (
 // It runs only for a claim that reached arm 3 of resolution: no thread and no
 // live deal already answered, so this is the caller saying what the message is
 // and the engine going to look.
-func (g *Gate) validate(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, category commsauthz.Category, w windows) (resolution, error) {
+func (g *Gate) validate(ctx context.Context, tx pgx.Tx, req commsauthz.Request, subject subjectRef, category commsauthz.Category, w packRules) (resolution, error) {
 	unsupported := resolution{Category: category, Supported: false, Reason: commsauthz.ReasonNoEvidence}
 	if subject.Kind != entityPerson && category != commsauthz.CategoryReplyToInbound &&
 		category != commsauthz.CategoryRequestedFollowup {
@@ -98,7 +98,7 @@ func (g *Gate) validate(ctx context.Context, tx pgx.Tx, req commsauthz.Request, 
 // trade fair" has recorded the request, and asking them to record it a second
 // time in a different table would be asking them to restate what the CRM
 // already knows.
-func (g *Gate) validateRequestedFollowup(ctx context.Context, tx pgx.Tx, subject subjectRef, w windows, category commsauthz.Category) (resolution, error) {
+func (g *Gate) validateRequestedFollowup(ctx context.Context, tx pgx.Tx, subject subjectRef, w packRules, category commsauthz.Category) (resolution, error) {
 	// AUTHORSHIP, through the shared reader. An earlier version asked
 	// activity_link — a FILING link with no author concept — which read "some
 	// inbound activity is filed under this person". A caller may post an

--- a/backend/internal/modules/consent/authorizewindows.go
+++ b/backend/internal/modules/consent/authorizewindows.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
 const (
@@ -41,12 +43,22 @@ const (
 )
 
 // windows are the spans an evidence check measures against.
-type windows struct {
+// packRules is what this installation's jurisdiction sets: the spans that bind
+// a follow-up, and the marketing exception it grants.
+//
+// One struct because it is one read. packRulesFor is already the single settings
+// read on the send path, and a second resolver would mean a second query and
+// two places that can disagree about which pack is in force.
+type packRules struct {
 	reply      time.Duration
 	dealFollow time.Duration
+	// marketingException is the exception this jurisdiction allows, nil for
+	// none — which is the answer for a pack that declares none and for an
+	// installation that names no country.
+	marketingException *messaging.MarketingException
 }
 
-// windowsFor resolves the spans that bind this installation.
+// packRulesFor resolves the rules that bind this installation.
 //
 // A jurisdiction that declares a window shortens the core default; one that
 // declares none, and an installation that names no country at all, gets the
@@ -54,11 +66,11 @@ type windows struct {
 // country stated should behave exactly as it did before jurisdiction packs
 // existed, rather than losing the ability to follow up because nobody has
 // filled in a setting.
-func (s *Store) windowsFor(ctx context.Context, tx pgx.Tx) (windows, error) {
-	out := windows{reply: defaultReplyWindow, dealFollow: defaultDealFollowUpWindow}
+func (s *Store) packRulesFor(ctx context.Context, tx pgx.Tx) (packRules, error) {
+	out := packRules{reply: defaultReplyWindow, dealFollow: defaultDealFollowUpWindow}
 	rules, applicable, err := s.applicableRules(ctx, tx)
 	if err != nil {
-		return windows{}, err
+		return packRules{}, err
 	}
 	if !applicable {
 		return out, nil
@@ -72,13 +84,24 @@ func (s *Store) windowsFor(ctx context.Context, tx pgx.Tx) (windows, error) {
 	if rules.DealFollowUpWindow > 0 && rules.DealFollowUpWindow < out.dealFollow {
 		out.dealFollow = rules.DealFollowUpWindow
 	}
+	// THE EXCEPTION IS THE PACK'S TO GRANT, and a jurisdiction that declares
+	// none grants none. Germany's §7(3) used to be read straight out of a flag
+	// table with no reference to where the installation is, so a Vietnamese
+	// installation — whose pack declares no exceptions at all — took marketing
+	// authority from a German sale.
+	for i, e := range rules.MarketingExceptions {
+		if e.Kind == messaging.ExistingCustomer {
+			out.marketingException = &rules.MarketingExceptions[i]
+			break
+		}
+	}
 	return out, nil
 }
 
 // Why installation.country is MachineryApplied, recorded here because this is
 // the reader that needs it:
 //
-// windowsFor runs inside the transaction that binds a decision, under whatever
+// packRulesFor runs inside the transaction that binds a decision, under whatever
 // principal is sending. A rep holds no settings-read grant and a dispatching
 // worker holds the system principal, so a gated read fails the send outright —
 // with a 500, not a refusal, because "the caller may not read a setting" is not

--- a/backend/internal/modules/consent/existingcustomer.go
+++ b/backend/internal/modules/consent/existingcustomer.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The existing-customer exception, asked of the pack that grants it.
+//
+// UWG §7(3) lets a seller advertise SIMILAR goods to somebody who bought from
+// them, on four conditions together. What shipped was a bare EXISTS over
+// consent_existing_customer_flag: no jurisdiction, and one of the four actually
+// enforced — the DDL's CHECK on optout_notice_given. The other three were
+// free-text columns nothing compared against anything, under a comment claiming
+// a live row "IS all four conditions".
+//
+// THE SIMILARITY CONDITION CANNOT BE ANSWERED BY THIS TREE TODAY, and that is
+// why this file refuses rather than approximating. Two facts, either sufficient:
+//
+//   - Nothing on a send names the goods it advertises. The nearest field,
+//     Request.MarketingPurpose, is a consent purpose key ("newsletter"), while
+//     similar_goods_note is free text an operator typed about a sale ("espresso
+//     machines"). Comparing them is not a weak check but a SATISFIABLE one: an
+//     operator who types the purpose key into the note field would hold the
+//     exception for that person forever, which is the hole this file exists to
+//     close, relocated.
+//   - The transmit phase carries no marketing purpose at all
+//     (commsauthz.TransmitRequest has no such field), so a check resting on it
+//     would allow at staging and deny at transmit — the disagreement
+//     VerdictForPerson's own header says it exists to prevent.
+//
+// So an exception whose pack requires similarity is refused, with a reason that
+// names WHY rather than reading as "no consent recorded". Nothing regresses: no
+// production writer for consent_existing_customer_flag exists anywhere in this
+// tree, so no installation is relying on the exception today. Making it work
+// needs a structured goods class on the flag row and a server-derived goods
+// field on the send — a schema change, not a comparison.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// existingCustomerAllows reports whether the exception the pack grants is
+// satisfied for this person.
+//
+// A nil exception is a jurisdiction that grants none, which is the answer for
+// every installation whose pack declares no MarketingExceptions and for one
+// that names no country at all.
+func existingCustomerAllows(ctx context.Context, tx pgx.Tx, personID string, exception *messaging.MarketingException) (bool, error) {
+	if exception == nil {
+		return false, nil
+	}
+	if exception.RequiresSimilarity {
+		// Unanswerable, per the note above. Refusing is the direction that
+		// costs a send rather than a complaint.
+		return false, nil
+	}
+	var (
+		saleReference string
+		optoutNotice  bool
+	)
+	// One row per person: person_id is the primary key, so there is no history
+	// to order and no newest to pick.
+	err := tx.QueryRow(ctx, `
+		SELECT sale_reference, optout_notice_given
+		  FROM consent_existing_customer_flag
+		 WHERE person_id = $1 AND revoked_at IS NULL`, personID).Scan(&saleReference, &optoutNotice)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read the existing-customer flag: %w", err)
+	}
+	return conditionsMet(*exception, saleReference, optoutNotice), nil
+}
+
+// conditionsMet is the conditions this tree can answer, against one row.
+//
+// Split from the read so every condition is reachable by a test: the DDL will
+// not store a row with optout_notice_given false, so the only way to ask what
+// this code does with one is to hand it the values directly.
+//
+// RequiresNoObjection is not read here, and the reason is structural rather
+// than an omission: VerdictForPerson blocks on a standing objection in its own
+// first arm, for every class, before this is reached. There is no state where
+// the flag matters.
+func conditionsMet(exception messaging.MarketingException, saleReference string, optoutNotice bool) bool {
+	// NOT NULL is not the same as recorded. The column accepts an empty
+	// string, so a row written by a form that skipped its fields satisfies the
+	// constraint and evidences nothing.
+	if exception.RequiresSaleEvidence && strings.TrimSpace(saleReference) == "" {
+		return false
+	}
+	// UNREACHABLE THROUGH THE SCHEMA, and kept anyway. The DDL's
+	// consent_existing_customer_notice CHECK refuses a row with
+	// optout_notice_given false, so no stored row can fail this — but the
+	// condition is the PACK's to require, and reading the column is what makes
+	// that requirement true rather than assumed. A merged exception from a
+	// jurisdiction with no such CHECK would carry it too.
+	if exception.RequiresCollectionTimeOptOut && !optoutNotice {
+		return false
+	}
+	return true
+}

--- a/backend/internal/modules/consent/existingcustomer_integration_test.go
+++ b/backend/internal/modules/consent/existingcustomer_integration_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The exception against a real flag row: who grants it, and the one condition
+// this tree cannot answer.
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// allows runs the evaluator inside a transaction, the way the verdict does.
+func (e *resolveEnv) allows(t *testing.T, exception *messaging.MarketingException) bool {
+	t.Helper()
+	var out bool
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		out, err = existingCustomerAllows(e.ctx, tx, e.person.String(), exception)
+		return err
+	}); err != nil {
+		t.Fatalf("asking the exception: %v", err)
+	}
+	return out
+}
+
+// flag records a sale. person_id is the primary key, so this is the row.
+func (e *resolveEnv) flag(t *testing.T, saleRef, goods string) {
+	t.Helper()
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO consent_existing_customer_flag
+		    (person_id, sale_reference, collected_at, similar_goods_note, optout_notice_given)
+		VALUES ($1, $2, now(), $3, true)`, e.person, saleRef, goods); err != nil {
+		t.Fatalf("recording the sale: %v", err)
+	}
+}
+
+// A GERMAN SALE AUTHORIZES NOTHING WHERE NO PACK GRANTS THE EXCEPTION.
+//
+// The flag read used to be a bare EXISTS with no reference to where the
+// installation is, so a Vietnamese installation — whose pack declares no
+// MarketingExceptions at all — took marketing authority from a German sale.
+// extensions/vn/vn.go asserts this cannot happen; until now nothing held it.
+func TestNoPackNoException(t *testing.T) {
+	e := setupResolve(t)
+	e.flag(t, "INV-2026-114", "espresso machines")
+
+	if e.allows(t, nil) {
+		t.Fatal("a jurisdiction that grants no exception granted one: evidence of a German sale " +
+			"authorized marketing where §7(3) does not apply")
+	}
+}
+
+// AN EXCEPTION REQUIRING SIMILARITY IS REFUSED, because nothing on a send names
+// the goods it advertises and the transmit phase carries no marketing purpose
+// at all. Approximating it with the purpose key would be satisfiable by an
+// operator typing that key into similar_goods_note.
+func TestSimilarityCannotBeAnsweredSoTheExceptionRefuses(t *testing.T) {
+	e := setupResolve(t)
+	e.flag(t, "INV-2026-114", "espresso machines")
+
+	if e.allows(t, &messaging.MarketingException{
+		Kind: messaging.ExistingCustomer, RequiresSimilarity: true,
+	}) {
+		t.Fatal("allowed on a similarity condition this tree cannot evaluate: one purchase " +
+			"would become a permanent mailing list")
+	}
+}
+
+// AND A PACK THAT DOES NOT REQUIRE SIMILARITY STILL GETS ITS EXCEPTION, so the
+// refusal above is about the condition and not about the exception itself.
+func TestAnExceptionWithoutSimilarityStillApplies(t *testing.T) {
+	e := setupResolve(t)
+	e.flag(t, "INV-2026-114", "espresso machines")
+
+	if !e.allows(t, &messaging.MarketingException{
+		Kind: messaging.ExistingCustomer, RequiresSaleEvidence: true,
+	}) {
+		t.Fatal("a recorded sale did not satisfy an exception asking only for one")
+	}
+}

--- a/backend/internal/modules/consent/existingcustomer_test.go
+++ b/backend/internal/modules/consent/existingcustomer_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The conditions this tree can answer, handed their values directly — because
+// the DDL will not store the failing case for one of them.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// germanConditions is what extensions/de declares.
+func germanConditions() messaging.MarketingException {
+	return messaging.MarketingException{
+		Kind:                         messaging.ExistingCustomer,
+		RequiresSaleEvidence:         true,
+		RequiresCollectionTimeOptOut: true,
+		RequiresSimilarity:           true,
+		RequiresNoObjection:          true,
+	}
+}
+
+// TestTheNoticeConditionIsAskedOfTheRow reaches what the schema will not store.
+//
+// consent_existing_customer_notice refuses a row with optout_notice_given
+// false, so no integration case can produce one — but the condition is the
+// pack's to require, and a check nothing exercises is a check nobody can trust.
+func TestTheNoticeConditionIsAskedOfTheRow(t *testing.T) {
+	all := germanConditions()
+	if conditionsMet(all, "INV-1", false) {
+		t.Error("a sale collected without the opt-out notice satisfied the exception: §7(3) " +
+			"requires the notice at collection, and the DDL not storing that shape today is " +
+			"not the same as this code asking for it")
+	}
+	// The control: the same row WITH the notice allows, so the case above fails
+	// for the notice and not for something else.
+	if !conditionsMet(all, "INV-1", true) {
+		t.Error("the same evidence with the notice on file did not allow")
+	}
+	// A pack that does not require it gets the row through either way.
+	relaxed := all
+	relaxed.RequiresCollectionTimeOptOut = false
+	if !conditionsMet(relaxed, "INV-1", false) {
+		t.Error("a pack that does not require the notice was refused for want of it: the " +
+			"condition is the pack's to declare, not this function's to assume")
+	}
+}
+
+// TestSaleEvidenceMustBeRecorded — NOT NULL is not the same as recorded.
+func TestSaleEvidenceMustBeRecorded(t *testing.T) {
+	all := germanConditions()
+	for _, empty := range []string{"", "   "} {
+		if conditionsMet(all, empty, true) {
+			t.Errorf("a flag row whose sale reference is %q satisfied the exception: the column "+
+				"is NOT NULL and an empty string passes it, so a form that skipped the field "+
+				"writes a row that evidences nothing", empty)
+		}
+	}
+	if !conditionsMet(all, "INV-1", true) {
+		t.Error("a recorded sale reference did not allow")
+	}
+}

--- a/backend/internal/modules/consent/gate.go
+++ b/backend/internal/modules/consent/gate.go
@@ -73,13 +73,19 @@ func (g *Gate) RequireGrantedForRecipients(ctx context.Context, recipients []con
 		// The window a qualifying event still supports an unprompted message
 		// within, resolved once for the whole set so two recipients of one
 		// message cannot be judged against different spans.
-		w, err := g.store.windowsFor(ctx, tx)
+		w, err := g.store.packRulesFor(ctx, tx)
 		if err != nil {
 			return err
 		}
 		since := time.Now().Add(-w.reply)
+		// The legacy gate is asked about a purpose key and never about the
+		// message, so it can make no similarity claim — and an exception whose
+		// pack requires similarity therefore refuses here. That is the honest
+		// answer for a caller that cannot say what it advertises, and it is
+		// only reached where the engine defers to this gate.
+		marketing := MarketingContext{Exception: w.marketingException}
 		for _, r := range recipients {
-			granted, err := grantedForRecipient(ctx, tx, r, purpose, since)
+			granted, err := grantedForRecipient(ctx, tx, r, purpose, since, marketing)
 			if err != nil {
 				return err
 			}
@@ -111,7 +117,7 @@ func (g *Gate) RequireGrantedForRecipients(ctx context.Context, recipients []con
 // grant predicate below. A lead carries no qualifying events and no §7(3) flag
 // — those hang off a person — so for a lead the class model has nothing extra
 // to say and the recorded grant IS the whole answer.
-func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, purpose PurposeRow, since time.Time) (bool, error) {
+func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, purpose PurposeRow, since time.Time, marketing MarketingContext) (bool, error) {
 	personID, found, err := resolvePerson(ctx, tx, r)
 	if err != nil {
 		return false, err
@@ -119,7 +125,7 @@ func grantedForRecipient(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 	if !found {
 		return grantedForLead(ctx, tx, r, purpose.ID, purpose.RequiresDOI)
 	}
-	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, since)
+	verdict, err := VerdictForPerson(ctx, tx, personID, purpose, since, marketing)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/modules/consent/guard.go
+++ b/backend/internal/modules/consent/guard.go
@@ -70,13 +70,18 @@ func (s *Store) PersonConsentGuard(ctx context.Context, personID ids.PersonID) (
 		// The SAME window the send path binds a decision to. A preview that
 		// answered on a different span would tell a rep a send is allowed that
 		// the engine then refuses, which is worse than no preview at all.
-		w, err := s.windowsFor(ctx, tx)
+		w, err := s.packRulesFor(ctx, tx)
 		if err != nil {
 			return err
 		}
 		since := s.now().Add(-w.reply)
+		// A guard reads a PERSON, not a message, so it names nothing advertised
+		// and an exception requiring similarity answers no here. The guard is
+		// advisory; the send path asks the same question with the message in
+		// hand and is what actually decides.
+		marketing := MarketingContext{Exception: w.marketingException}
 		for _, purpose := range purposes {
-			verdict, err := VerdictForPerson(ctx, tx, personID.String(), purpose, since)
+			verdict, err := VerdictForPerson(ctx, tx, personID.String(), purpose, since, marketing)
 			if err != nil {
 				return err
 			}

--- a/backend/internal/modules/consent/qualifyingevent_integration_test.go
+++ b/backend/internal/modules/consent/qualifyingevent_integration_test.go
@@ -128,7 +128,7 @@ func (e *qualifyingEnv) verdictSince(t *testing.T, since time.Time) Verdict {
 	var out Verdict
 	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = VerdictForPerson(e.ctx, tx, e.person.String(), e.correspondence, since)
+		out, err = VerdictForPerson(e.ctx, tx, e.person.String(), e.correspondence, since, MarketingContext{})
 		return err
 	}); err != nil {
 		t.Fatalf("reading the verdict: %v", err)

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
 // Class decides which question a purpose answers to.
@@ -108,6 +110,15 @@ type PurposeRow struct {
 	RequiresDOI bool
 }
 
+// MarketingContext is what a marketing verdict needs beyond the person and the
+// purpose: the exception this installation's jurisdiction grants.
+//
+// Passed in for the reason `since` is passed in — resolving it needs a settings
+// read, and VerdictForPerson is deliberately free of those.
+type MarketingContext struct {
+	Exception *messaging.MarketingException
+}
+
 // VerdictForPerson is THE decision. Both the guard endpoint and the transmit
 // gate call it, so a preview and a send answer with the same code.
 //
@@ -119,13 +130,13 @@ type PurposeRow struct {
 // suppression.
 //
 // `since` is how far back a qualifying event still supports an UNPROMPTED
-// message — the reply window, resolved by Store.windowsFor so the send path and
+// message — the reply window, resolved by Store.packRulesFor so the send path and
 // the guard endpoint answer on the same span. It is passed rather than computed
 // here because computing it needs the installation's country, and this function
 // is deliberately free of settings reads: a rep holds no settings-read grant
 // and a gated read inside the verdict would fail a send with a 500 rather than
 // an answer about consent.
-func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow, since time.Time) (Verdict, error) {
+func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow, since time.Time, marketing MarketingContext) (Verdict, error) {
 	suppressed, at, err := objectionStands(ctx, tx, personID, purpose.ID)
 	if err != nil {
 		return Verdict{}, err
@@ -148,7 +159,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{State: VerdictBlocked, Reason: "no call path is configured", Code: BlockNoChannel}, nil
 
 	default:
-		return marketingVerdict(ctx, tx, personID, purpose)
+		return marketingVerdict(ctx, tx, personID, purpose, marketing)
 	}
 }
 
@@ -223,7 +234,7 @@ func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purp
 // with all four of its conditions on the record. There is no legitimate-interest
 // escape for marketing email, B2C or B2B, and the product does not offer the
 // toggle.
-func marketingVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow) (Verdict, error) {
+func marketingVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow, marketing MarketingContext) (Verdict, error) {
 	state, granted, err := recordedState(ctx, tx, personID, purpose.ID, purpose.RequiresDOI)
 	if err != nil {
 		return Verdict{}, err
@@ -244,12 +255,12 @@ func marketingVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose P
 			Code:   BlockUnconfirmedDOI,
 		}, nil
 	}
-	flagged, err := existingCustomerFlag(ctx, tx, personID)
+	allowed, err := existingCustomerAllows(ctx, tx, personID, marketing.Exception)
 	if err != nil {
 		return Verdict{}, err
 	}
-	if flagged {
-		return Verdict{State: VerdictAllowed, Reason: "existing customer under UWG §7(3), with the sale and opt-out notice on file"}, nil
+	if allowed {
+		return Verdict{State: VerdictAllowed, Reason: "existing customer under the jurisdiction's own exception, with the sale and the opt-out notice on file"}, nil
 	}
 	return Verdict{State: VerdictUnknown, Reason: "no consent recorded"}, nil
 }
@@ -343,20 +354,6 @@ func objectionStands(ctx context.Context, tx pgx.Tx, personID, purposeID string)
 // stay on the proof log as the history they are, and authorize no send.
 func recordedState(ctx context.Context, tx pgx.Tx, personID, purposeID string, requiresDOI bool) (string, bool, error) {
 	return recordedStateFor(ctx, tx, subjectColumnPerson, personID, purposeID, requiresDOI)
-}
-
-// existingCustomerFlag reads the UWG §7(3) flag. The DDL already refuses a row
-// without the opt-out notice, so a live row here IS all four conditions.
-func existingCustomerFlag(ctx context.Context, tx pgx.Tx, personID string) (bool, error) {
-	var exists bool
-	err := tx.QueryRow(ctx, `
-		SELECT EXISTS (
-		  SELECT 1 FROM consent_existing_customer_flag
-		  WHERE person_id = $1 AND revoked_at IS NULL)`, personID).Scan(&exists)
-	if err != nil {
-		return false, fmt.Errorf("read the existing-customer flag: %w", err)
-	}
-	return exists, nil
 }
 
 // PurposesForGuard lists the purposes a guard read reports on, in a fixed order


### PR DESCRIPTION
UWG §7(3) was a bare EXISTS over consent_existing_customer_flag: no reference
to where the installation is, and one of the four declared conditions actually
enforced -- the DDL's CHECK on optout_notice_given. The other three were
free-text columns nothing compared against anything, under a comment claiming a
live row IS all four conditions. The pack's four Requires* booleans, which
extensions/de sets with care, were read by no evaluator at all.

The exception is now the jurisdiction's to grant. packRulesFor resolves it
beside the windows -- one settings read, and all three VerdictForPerson callers
already had it in hand -- so a pack that declares none grants none. A Vietnamese
installation no longer takes marketing authority from a German sale, which
extensions/vn asserts in a comment and nothing held.

SIMILARITY IS REFUSED RATHER THAN APPROXIMATED, and that is the substance of
this change. Nothing on a send names the goods it advertises: the nearest field
is a consent purpose key, and comparing it against an operator's free-text sale
note is not a weak check but a satisfiable one -- an operator who types the key
into the note field would hold the exception for that person forever. The
transmit request carries no marketing purpose at all, so a check resting on it
would also allow at staging and deny at transmit. Nothing regresses: no
production writer for the flag table exists anywhere in this tree.

RequiresNoObjection is not read, and the reason is structural rather than an
omission: VerdictForPerson blocks on a standing objection in its own first arm,
for every class, before this is reached.

conditionsMet is split from the read so every condition is reachable by a test.
The DDL will not store a row with optout_notice_given false, so the only way to
ask what this code does with one is to hand it the values directly.

## Found in review

Both reviews converged on the same conclusion from opposite directions, and it
changed what this PR does.

- **Security**: with similarity wired to `MarketingPurpose`, the exception was
  dead at transmit — `TransmitRequest` carries no marketing purpose, so every
  §7(3) send would allow at staging and park at transmit.
- **Craft**: the same wiring was *satisfiable* — an operator typing the purpose
  key into `similar_goods_note` would hold the exception for that person
  permanently, which is the hole this change exists to close, relocated.

Together they mean similarity cannot be answered with the fields that exist, so
it is refused with a reason that names why. Making it work needs a structured
goods class on the flag row and a server-derived goods field on the send — a
schema change, not a comparison.

Codex then caught the allowed-reason string still claiming "similar goods on
file" for a case that never reads that column.

## Verification

- `make check-backend` green; consent integration lane green.
- Both refusals mutation-checked independently — the nil-exception guard masks
  the similarity guard, so they were reverted one at a time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The existing-customer marketing exception (UWG §7(3)) is now granted by the installing jurisdiction's pack, and exceptions requiring goods similarity are refused because no field on a send can honestly answer that condition.

- `packRulesFor` resolves the pack's `MarketingException` beside the reply windows; a pack that declares none grants none, so a Vietnamese installation no longer takes marketing authority from a German sale.
- The similarity condition refuses rather than approximates: the nearest send field is a consent purpose key that an operator could type into the free-text sale note and hold the exception permanently.
- `RequiresNoObjection` is not read because the verdict blocks on a standing objection before this check is reached.
- The conditions are split into a testable function because the DDL won't store a row with `optout_notice_given` false.
- No production writer for the flag table exists in this tree, so nothing regresses.

<sup>Written for commit 0f6ed5e1dd158c86f3a5f2b8fa5641564d19682d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

