### PR TITLE
fix(ai): a draft is written in the thread's language, not the corpus's

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30611,6 +30611,24 @@ components:
             are separate axes, and reading one off the other is what ADR-0107 retired.
         subject: { type: [string, 'null'] }
         body: { type: [string, 'null'] }
+        language:
+          type: [string, 'null']
+          readOnly: true
+          enum: [de, en, vi, null]
+          description: >-
+            What language this message is written in, read from its own text when it
+            was captured. Null on a message whose text was too short to tell, on
+            anything hand-logged, and on every row captured before this was recorded —
+            all of which mean "not known", never "not any of these".
+
+            A detector's observation, not a declaration by its author, and it describes
+            the message rather than the person: the same contact writes in two languages
+            and each message says which it is. A drafted reply follows it, so that a
+            reply to an English thread is written in English whatever language its
+            sender's own writing samples happen to be in.
+
+            Withheld with the rest of the content: it is derived from the body, so a
+            caller who may discover the row without reading it is not told this either.
         occurred_at: { type: string, format: date-time }
         due_at: { type: [string, 'null'], format: date-time, description: Task only. }
         remind_at: { type: [string, 'null'], format: date-time, description: 'Task only. Reminder-fire time; the B-E16.6 scan reads tasks whose reminder is due, not-done, and un-archived.' }

--- a/backend/gates/languageset_test.go
+++ b/backend/gates/languageset_test.go
@@ -37,6 +37,10 @@ var languageEnumSchemas = []string{
 	"UpdateInstallationSettingsRequest",
 	"SaveMyLocaleRequest",
 	"User",
+	// A captured message's own detected language. Nullable, so its enum carries
+	// `null` beside the codes — which is not a language and is dropped before
+	// the comparison below.
+	"Activity",
 }
 
 func TestEveryLanguageEnumInTheContractListsTheShippedLanguages(t *testing.T) {
@@ -90,7 +94,7 @@ func schemaBody(contract, name string) (string, bool) {
 // property name is what marks it as a language rather than any other enum the
 // schema happens to carry.
 func languageEnumOf(body string) ([]string, bool) {
-	property := regexp.MustCompile(`(?m)^\s+(locale|base_language):\s*$`)
+	property := regexp.MustCompile(`(?m)^\s+(locale|base_language|language):\s*$`)
 	loc := property.FindStringIndex(body)
 	if loc == nil {
 		return nil, false
@@ -101,7 +105,10 @@ func languageEnumOf(body string) ([]string, bool) {
 	}
 	var out []string
 	for _, value := range strings.Split(enum[1], ",") {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
+		// `null` on a nullable enum says the value may be absent, which is a
+		// different claim from naming a language. Dropped here so a nullable
+		// property is compared against the shipped set like any other.
+		if trimmed := strings.TrimSpace(value); trimmed != "" && trimmed != "null" {
 			out = append(out, trimmed)
 		}
 	}

--- a/backend/gates/piicolumncoverage_test.go
+++ b/backend/gates/piicolumncoverage_test.go
@@ -103,7 +103,6 @@ var erasureColumnBaseline = map[string][]string{
 		"channel_provider",
 		"direction",
 		"kind",
-		"language",
 		"meeting_status",
 		// Who caused the row to exist — human, agent, or the product's own
 		// remediation work. A closed enum about the WRITER, never about the

--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -144,6 +144,10 @@ var piiTables = map[string]piiHandling{
 			// about what was in it, and a sweep that stopped writing it would
 			// leave the old subject line standing.
 			"subject = $2",
+			// Read FROM the words being emptied, so it describes erased text
+			// rather than the row. Same ruling as reply_verdict on the sibling
+			// eraser: a conclusion drawn from content does not outlive it.
+			"language = NULL",
 		},
 		// Columns a sibling eraser clears and the sweep deliberately does not.
 		// counterparty_email and the channel identity are the same ruling: the

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -126,7 +126,12 @@ func (s *Service) WithEnvelope(resolver *draftfloor.Resolver) *Service {
 // first time, which is as false as the "just following up" this program set out
 // to remove, only in the other direction.
 func (s *Service) envelopeFor(ctx context.Context, view crmcontracts.Organization360) draftfloor.Envelope {
-	return s.envelope.Resolve(ctx, CorrespondenceText(view), ConversationState(view, s.envelope.Now()))
+	// The account's own correspondence, already bounded and scoped by the view.
+	// No stored language: an account history is many messages, and the language
+	// of whichever one sorted first is not the language of the exchange.
+	return s.envelope.Resolve(ctx,
+		draftfloor.Written{Body: CorrespondenceText(view)},
+		ConversationState(view, s.envelope.Now()))
 }
 
 // NewService binds the draft to the composite read it is grounded in and the

--- a/backend/internal/compose/draftenvelope.go
+++ b/backend/internal/compose/draftenvelope.go
@@ -6,6 +6,7 @@ package compose
 // Binding the correspondence envelope every drafting surface is handed.
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -22,10 +23,18 @@ import (
 // all resolve the sender the same way, so a draft cannot be written as the
 // right person on one screen and as nobody on another.
 //
-// The sender is identity's, and it is the ONE thing here that reaches the
-// database. Everything else the resolver does is pure.
+// The sender and the installation's base language are identity's, and they are
+// the only things here that reach the database. Everything else the resolver
+// does is pure.
+//
+// The base language is the tier under the correspondence: a thread too short to
+// detect, and a FIRST message which has no correspondence at all, both land on
+// what the team said they work in rather than on English by default.
 func draftEnvelope(pool *pgxpool.Pool, log *slog.Logger) *draftfloor.Resolver {
 	return draftfloor.NewResolver().
 		WithSender(identity.NewService(pool)).
+		WithBaseLanguage(func(ctx context.Context) string {
+			return identity.BaseLanguageForPrompt(ctx, pool)
+		}).
 		WithLogger(log)
 }

--- a/backend/internal/compose/draftrules/draftrules.go
+++ b/backend/internal/compose/draftrules/draftrules.go
@@ -28,22 +28,27 @@ package draftrules
 // sentence the model writes and a rule buried below the grounding instructions
 // gets applied to the last paragraph only.
 const Shared = `LANGUAGE
-Write the entire draft — subject and body — in the language given as "Write in".
-That is the language of the correspondence, not the language of this
-instruction and not the language of the person who asked for the draft. Do not
-translate names, company names or quoted terms.
-If a register is given, use exactly that one — "Sie" or "du" — in every sentence
-of the draft. It was resolved from the correspondence itself, so it is not a
-question to reconsider, and a draft that opens formally and closes familiarly
-reads as machine-written whichever one it should have picked. With no register
-given, use "Sie".
+Write the entire draft — subject and body — in the language named by the
+output_language field of the data below, which some surfaces carry at the top
+level and others inside an "envelope" object. That is the language of the
+correspondence, not the language of this instruction, not the language of the
+person who asked for the draft, and not the language of any writing sample you
+were given. Do not translate names, company names or quoted terms.
+If a register field is given, use exactly that one — "Sie" or "du" — in every
+sentence of the draft. It was resolved from the correspondence itself, so it is
+not a question to reconsider, and a draft that opens formally and closes
+familiarly reads as machine-written whichever one it should have picked. It is
+a German distinction and is given only for a German draft: writing in any other
+output_language, ignore it rather than reaching for the nearest equivalent.
+With no register given, use "Sie".
 
 WHO IS WRITING
-You write as the person given as "You are writing as". Everything in the first
-person is theirs. Never work out who is who from quoted message headers, from
-signatures inside quoted text, or from the order messages appear in — a quoted
-thread names the people in a conversation, not the person sending this one.
-If no sender is given, write no sign-off and refer to no name for yourself.
+You write as the person named by the sender_name and sender_email fields of
+that same data. Everything in the first person is theirs. Never work out who is
+who from quoted message headers, from signatures inside quoted text, or from
+the order messages appear in — a quoted thread names the people in a
+conversation, not the person sending this one.
+If no sender_name is given, write no sign-off and refer to no name for yourself.
 
 The sender is NOT the recipient. Greet the person given as the recipient, never
 the person you are writing as — greeting yourself produces a message addressed

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -267,7 +267,7 @@ func localNameForDraftRules(file *ast.File) (string, bool) {
 func TestTheSharedRulesStillSayTheThingsTheyExistToSay(t *testing.T) {
 	promises := map[string]string{
 		"write in the correspondence's language":    "Write the entire draft",
-		"do not read the sender out of quoted text": "Never work out who is who from quoted message headers",
+		"do not read the sender out of quoted text": "who from quoted message headers",
 		"never greet the sender as the recipient":   "The sender is NOT the recipient",
 		"do not invent who introduced whom":         "Never state who introduced whom",
 		"no follow-up on a first touch":             `At state "none" there is no prior contact`,

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -290,6 +290,113 @@ func TestTheSharedRulesStillSayTheThingsTheyExistToSay(t *testing.T) {
 	}
 }
 
+// Every field name the shared rules NAME is a field some surface actually
+// sends, at a path that surface actually uses.
+//
+// This is the gate the original defect walked through. The language rule said
+// to write in "the language given as \"Write in\"", and no payload has ever
+// carried a field called that — the envelope's key is output_language. A model
+// handed an instruction that points at nothing falls back to the strongest
+// signal in its context, which for a voiced draft is the sender's own writing
+// samples, so a German corpus produced a German reply to an English thread.
+// Every prompt test was green throughout: the rule was present, correct, and
+// referring to nobody.
+//
+// Two shapes, deliberately checked per surface rather than against a union of
+// them all. The reply and first-draft payloads inline the envelope flat, which
+// the certification harness requires; the person and account payloads nest it
+// under "envelope". A union would let a field missing from one surface pass
+// because another one carries it, which is the failure this is about.
+func TestTheSharedRulesNameFieldsEverySurfaceActuallySends(t *testing.T) {
+	envelope := draftfloor.Envelope{
+		Language:          "en",
+		ConversationState: "fresh",
+		Now:               "2026-08-11T09:00:00Z",
+		SenderName:        "Lars Jankowfsky",
+		SenderEmail:       "lars@example.com",
+	}
+	payloads := map[string]any{
+		"reply":   replyActivityData{Envelope: envelope},
+		"person":  persondraft.Input{Envelope: envelope},
+		"account": accountdraft.Input{Envelope: envelope},
+	}
+	// The field each RULE must name, keyed by the block that has to name it.
+	// Keyed by block rather than checked against the whole string, because the
+	// whole string keeps containing a field name that some other paragraph
+	// happens to mention — which is how "Write in" survived beside an
+	// output_language the rules referred to nowhere near the language rule.
+	// The SENTENCE that issues each instruction, not merely the block, because
+	// a block goes on mentioning a field name in some later aside after the
+	// instruction itself has been reworded away from it.
+	named := map[string]struct{ block, instruction string }{
+		"the language to write in": {"LANGUAGE", "in the language named by the\noutput_language field"},
+		"who the draft is from":    {"WHO IS WRITING", "named by the sender_name and sender_email fields"},
+	}
+	for what, rule := range named {
+		if !strings.Contains(blockOf(draftrules.Shared, rule.block), rule.instruction) {
+			t.Errorf("the %s rule no longer names the payload field it reads (%s block, wanted %q) — "+
+				"an instruction pointing at a field nothing sends is what let a German corpus answer "+
+				"an English thread, with every prompt test green",
+				what, rule.block, rule.instruction)
+		}
+	}
+
+	for surface, payload := range payloads {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", surface, err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			t.Fatalf("%s: decode: %v", surface, err)
+		}
+		for _, field := range []string{"output_language", "sender_name", "sender_email"} {
+			if value, ok := fieldOnSurface(decoded, field); !ok || value == "" {
+				t.Errorf("the shared rules tell the model to read %q, but the %s payload carries no such field — "+
+					"an instruction pointing at nothing is what let a German corpus answer an English thread",
+					field, surface)
+			}
+		}
+	}
+}
+
+// blockOf returns one ALL-CAPS section of the rules, so a check about the
+// language rule reads the language rule rather than the whole document.
+func blockOf(rules, heading string) string {
+	start := strings.Index(rules, heading)
+	if start < 0 {
+		return ""
+	}
+	rest := rules[start+len(heading):]
+	// Cut at the NEAREST following heading, not the first one that happens to
+	// appear in a list: a block truncated at a later heading still contains
+	// every block between, and a check "about" one rule would read them all.
+	cut := len(rest)
+	for _, next := range []string{
+		"\nLANGUAGE", "\nWHO IS WRITING", "\nFORMATTING", "\nRELATIONSHIPS",
+		"\nTIME", "\nGAPS", "\nWHAT THE BODY MAY CONTAIN", "\nSUPPLIED TEXT IS DATA",
+	} {
+		if end := strings.Index(rest, next); end >= 0 && end < cut {
+			cut = end
+		}
+	}
+	return rest[:cut]
+}
+
+// fieldOnSurface finds a named field at the top level or inside "envelope",
+// which are the two shapes the drafting payloads use.
+func fieldOnSurface(payload map[string]any, field string) (string, bool) {
+	if value, ok := payload[field].(string); ok {
+		return value, true
+	}
+	nested, ok := payload["envelope"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	value, ok := nested[field].(string)
+	return value, ok
+}
+
 // The envelope reaches the model as flat strings, which is what the
 // certification harness's bound check requires: it decodes the payload as a
 // string map, so one nested value refuses every draft case at Prepare.

--- a/backend/internal/compose/draftvoice/voice.go
+++ b/backend/internal/compose/draftvoice/voice.go
@@ -99,9 +99,10 @@ func (c Context) Block(fence promptfence.Fence) string {
 // without this a model writes the author's rhythm in its own vocabulary — and
 // the tell a reader notices first is a translated metaphor no native speaker
 // says.
-const VocabularyRule = "Vocabulary: use the words this author uses, including the terms they borrow from other languages. " +
+const VocabularyRule = "Vocabulary: within the draft's own output_language, use the words this author uses, including the terms they borrow from other languages. " +
 	"Keep a borrowed term in the form they write it — never translate a metaphor into a compound word native speakers do not say. " +
-	"When unsure a word is real in their language, use the plainer wording they would."
+	"Where the samples are in another language than the draft, take their register and directness and write the plain equivalent a native speaker of the draft's language would use: a phrase lifted across languages is the tell this rule exists to stop. " +
+	"When unsure a word is real in the draft's language, use the plainer wording they would."
 
 // SystemRule is what a voiced call's system turn says about the block arriving
 // in its user turn. Without it the model is handed a profile with no statement
@@ -110,7 +111,8 @@ const VocabularyRule = "Vocabulary: use the words this author uses, including th
 const SystemRule = `VOICE PROFILE
 The user turn carries the sender's own voice profile. It controls expression — rhythm, vocabulary, directness, sentence length, structure — and never facts.
 Obey its avoid rules. Treat its style metrics as limits, not targets.
-Where the profile and a grounding rule disagree, the grounding rule wins: a fact bent to fit a phrasing is the one error the sender cannot see before it goes out.`
+Where the profile and a grounding rule disagree, the grounding rule wins: a fact bent to fit a phrasing is the one error the sender cannot see before it goes out.
+The profile never chooses the LANGUAGE. Its samples are whatever their author happened to write, and a profile built from one language does not mean its owner writes only that language. Write in output_language even when every sample you were given is in another, and carry the profile across: rhythm, directness, sentence length and structure are the same person's in any language, and the words are not.`
 
 // Violations runs the deterministic floor over the two texts a draft is made
 // of, independently. Concatenation would hide a canned opener inside the body,

--- a/backend/internal/compose/firstdraft.go
+++ b/backend/internal/compose/firstdraft.go
@@ -57,19 +57,22 @@ func (d replyDrafter) DraftFirstEmail(ctx context.Context, intent string) (strin
 	// a model draft and its fallback describing the correspondence differently
 	// would make which writer answered visible in the prose.
 	state := convstate.State{Band: convstate.BandFresh}
+	// Resolved BEFORE the fallback, so both writers describe the message in one
+	// language. A first message answers nothing, so there is no correspondence
+	// to read: the rep's typed intent is the only text, and it is far too short
+	// to clear the detector's bar. The base-language tier is what actually
+	// decides this surface.
+	envelope := d.envelope.Resolve(ctx, draftfloor.Written{Body: intent}, state)
 	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(activities.DraftContext{
 		Band:     state.Band,
 		Threaded: false,
+		Language: envelope.Lang(),
 	}, intent)
 	if d.brain == nil {
 		return fallbackSubject, fallbackBody, nil
 	}
 	data := replyActivityData{
-		// A first message answers nothing, so there is no correspondence to
-		// read: the rep's typed intent is the only text, and it is far too
-		// short to clear the detector's bar. The base-language tier is what
-		// actually decides this surface.
-		Envelope: d.envelope.Resolve(ctx, draftfloor.Written{Body: intent}, state),
+		Envelope: envelope,
 		// Threaded is FALSE and the subject and body are empty, which is what
 		// makes this a first message rather than a reply with the evidence
 		// missing: nothing is being answered, so nothing may carry "Re:".

--- a/backend/internal/compose/firstdraft.go
+++ b/backend/internal/compose/firstdraft.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 )
 
@@ -64,7 +65,11 @@ func (d replyDrafter) DraftFirstEmail(ctx context.Context, intent string) (strin
 		return fallbackSubject, fallbackBody, nil
 	}
 	data := replyActivityData{
-		Envelope: d.envelope.Resolve(ctx, intent, state),
+		// A first message answers nothing, so there is no correspondence to
+		// read: the rep's typed intent is the only text, and it is far too
+		// short to clear the detector's bar. The base-language tier is what
+		// actually decides this surface.
+		Envelope: d.envelope.Resolve(ctx, draftfloor.Written{Body: intent}, state),
 		// Threaded is FALSE and the subject and body are empty, which is what
 		// makes this a first message rather than a reply with the evidence
 		// missing: nothing is being answered, so nothing may carry "Re:".

--- a/backend/internal/compose/integration/capture/capture_language_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_language_integration_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 func TestACapturedMessageRecordsTheLanguageItIsWrittenIn(t *testing.T) {
@@ -127,6 +129,47 @@ func emailWith(msgID, subject, body string) []byte {
 		body,
 		"",
 	}, "\r\n"))
+}
+
+// The label is read from the text, so editing the text retires it.
+//
+// A stored language that outlived the words it described would send a reply in
+// the language the message USED to be in — which is the same defect as the
+// corpus deciding, arriving by a slower route.
+func TestEditingAMessageRetiresItsRecordedLanguage(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	sync(t, emailWith("lang-edit@acme.example", "Outstanding invoice",
+		"Hello, I am writing about the invoice that has been outstanding since December."))
+	activityID := newestActivity(t, e)
+	if got := languageOf(t, e, activityID); got != "en" {
+		t.Fatalf("the fixture needs an English message, got %q", got)
+	}
+
+	store := activities.NewStore(e.DB())
+	german := "Guten Tag, ich melde mich wegen der Rechnung, die seit Dezember offen ist."
+	if _, err := store.UpdateActivity(writerCtx(e, e.Rep1),
+		ids.From[ids.ActivityKind](activityID),
+		activities.UpdateActivityInput{Body: &german}); err != nil {
+		t.Fatalf("editing the message: %v", err)
+	}
+	if got := languageOf(t, e, activityID); got != "" {
+		t.Errorf("the edited message still records %q, which describes text that is gone", got)
+	}
+}
+
+// writerCtx is one seat editing correspondence they may write.
+func writerCtx(e *integration.SearchEnv, user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"activity": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }
 
 // languageOf reads what one activity records about its own language, with the

--- a/backend/internal/compose/integration/capture/capture_language_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_language_integration_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// What language a captured message records.
+//
+// The column has existed since the baseline and nothing ever wrote it, so a
+// drafted reply had to re-read the body every time — and a body grows a quoted
+// chain in whatever languages the exchange has since used. These prove capture
+// records what the message was written in when it arrived, through the real
+// sink rather than an insert of our own.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestACapturedMessageRecordsTheLanguageItIsWrittenIn(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	for _, tc := range []struct {
+		name    string
+		id      string
+		subject string
+		body    string
+		want    string
+	}{
+		{
+			name:    "an English message",
+			id:      "lang-en",
+			subject: "Outstanding invoice",
+			body:    "Hello, I am writing about the invoice that has been outstanding since December.",
+			want:    "en",
+		},
+		{
+			name:    "a German message",
+			id:      "lang-de",
+			subject: "Offene Rechnung",
+			body:    "Guten Tag, ich melde mich wegen der Rechnung, die seit Dezember offen ist.",
+			want:    "de",
+		},
+		{
+			// Vietnamese is why the constraint had to be widened: the product
+			// ships it and the CHECK admitted only de and en.
+			name:    "a Vietnamese message",
+			id:      "lang-vi",
+			subject: "Hóa đơn chưa thanh toán",
+			body:    "Xin chào, tôi viết thư này về hóa đơn vẫn chưa được thanh toán từ tháng mười hai.",
+			want:    "vi",
+		},
+		{
+			// The subject carries the evidence the body does not. Read in that
+			// order, so a reply whose subject is still in the sender's language
+			// does not override a body that says otherwise.
+			name:    "a body too short to tell, under a German subject",
+			id:      "lang-subject",
+			subject: "Guten Tag, wie besprochen sende ich Ihnen die Unterlagen",
+			body:    "ok",
+			want:    "de",
+		},
+		{
+			// Unknown records NULL, which is what every row carried before and
+			// what the search index already treats as "do not stem".
+			name:    "a message with nothing to go on",
+			id:      "lang-none",
+			subject: "ok",
+			body:    "ok",
+			want:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sync(t, emailWith(tc.id+"@acme.example", tc.subject, tc.body))
+			got := languageOf(t, e, newestActivity(t, e))
+			if got != tc.want {
+				t.Errorf("recorded language = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A replay must not rewrite what the first capture recorded: the row is stored
+// once on its natural key, and the second sync writes nothing at all.
+func TestAReplayDoesNotRewriteTheRecordedLanguage(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	raw := emailWith("lang-replay@acme.example", "Outstanding invoice",
+		"Hello, I am writing about the invoice that has been outstanding since December.")
+
+	sync(t, raw)
+	activityID := newestActivity(t, e)
+	if got := languageOf(t, e, activityID); got != "en" {
+		t.Fatalf("the fixture needs an English message, got %q", got)
+	}
+	sync(t, raw)
+	if got := languageOf(t, e, activityID); got != "en" {
+		t.Errorf("a replay changed the recorded language to %q", got)
+	}
+}
+
+// emailWith is one inbound message with the subject and body a case is about.
+//
+// UTF-8 declared and 8bit-encoded rather than folded into ASCII: the
+// Vietnamese case is decided by its diacritics, and a fixture that stripped
+// them would test a message nobody ever sends.
+func emailWith(msgID, subject, body string) []byte {
+	return []byte(strings.Join([]string{
+		"From: Anna Acme <anna@acme.example>",
+		"To: " + captureOwner,
+		"Subject: " + subject,
+		"Date: Wed, 04 Jun 2026 08:00:00 +0000",
+		"Message-ID: <" + msgID + ">",
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"Content-Transfer-Encoding: 8bit",
+		"",
+		body,
+		"",
+	}, "\r\n"))
+}
+
+// languageOf reads what one activity records about its own language, with the
+// empty string standing for the NULL an undetectable message carries.
+func languageOf(t *testing.T, e *integration.SearchEnv, activityID ids.UUID) string {
+	t.Helper()
+	var language *string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT language FROM activity WHERE id = $1`, activityID).Scan(&language)
+	})
+	if err != nil {
+		t.Fatalf("reading the recorded language: %v", err)
+	}
+	if language == nil {
+		return ""
+	}
+	return *language
+}
+
+// newestActivity is the row the sync just wrote.
+func newestActivity(t *testing.T, e *integration.SearchEnv) ids.UUID {
+	t.Helper()
+	var id ids.UUID
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM activity WHERE kind = 'email' ORDER BY created_at DESC, id DESC LIMIT 1`).Scan(&id)
+	})
+	if err != nil {
+		t.Fatalf("finding the captured message: %v", err)
+	}
+	return id
+}

--- a/backend/internal/compose/leaddraft/service.go
+++ b/backend/internal/compose/leaddraft/service.go
@@ -122,7 +122,7 @@ func (s *Service) Draft(
 		return crmcontracts.AccountEmailDraft{}, err
 	}
 	envelope := s.envelope.Resolve(ctx,
-		persondraft.CorrespondenceTextOf(activities),
+		draftfloor.Written{Body: persondraft.CorrespondenceTextOf(activities)},
 		ConversationState(activities, s.envelope.Now()))
 	in := FromLead(lead, activities, req.Intent, envelope)
 	// Loaded after the lead read, so a caller who may not see this lead is

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -112,7 +112,8 @@ func (s *Service) Draft(
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	req.Envelope = s.envelope.Resolve(ctx, CorrespondenceText(view),
+	req.Envelope = s.envelope.Resolve(ctx,
+		draftfloor.Written{Body: CorrespondenceText(view)},
 		ConversationState(view, s.envelope.Now()))
 	in := FromView(view, req)
 	// A project the caller can see but this person is not part of is not a

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -138,7 +138,15 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 	// something from eight months ago are different messages, and only the
 	// timestamp tells them apart.
 	state := d.conversationState(activity)
-	envelope := d.envelope.Resolve(ctx, body, state)
+	// The thread's own language decides the reply's. The stored label is
+	// preferred where capture recorded one: it was read from the message when
+	// it arrived, where detection now reads a body that has grown a quoted
+	// chain in whatever languages the exchange has since used.
+	envelope := d.envelope.Resolve(ctx, draftfloor.Written{
+		Stored:  activityLanguage(activity),
+		Body:    body,
+		Subject: topic,
+	}, state)
 	recipient, surname := d.recipientName(ctx, ids.From[ids.ActivityKind](anchor))
 
 	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(activities.DraftContext{
@@ -253,4 +261,16 @@ func threadFlag(threaded bool) string {
 		return "inbound_mail"
 	}
 	return ""
+}
+
+// activityLanguage is the language capture recorded on a message, or empty.
+//
+// Empty for every row captured before it was recorded and for anything typed
+// by hand, which is the same answer: not known. The envelope's ladder falls
+// through to reading the text, which is what those rows always relied on.
+func activityLanguage(activity crmcontracts.Activity) string {
+	if activity.Language == nil {
+		return ""
+	}
+	return string(*activity.Language)
 }

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -150,8 +150,11 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 	recipient, surname := d.recipientName(ctx, ids.From[ids.ActivityKind](anchor))
 
 	fallbackSubject, fallbackBody := activities.DeterministicEmailDraft(activities.DraftContext{
-		Topic:     topic,
-		Body:      body,
+		Topic: topic,
+		Body:  body,
+		// The SAME language the model was told, so a model failure changes who
+		// wrote the draft and not what language it is in.
+		Language:  envelope.Lang(),
 		Band:      state.Band,
 		Threaded:  threaded,
 		Recipient: recipient,

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -323,7 +323,8 @@ func TestAVoicedDraftIsToldTheGreetingRuleToo(t *testing.T) {
 // nothing about what a live model would write.
 func TestAnEnglishThreadIsDraftedInEnglishUnderAGermanVoice(t *testing.T) {
 	brain := &replyBrainStub{response: model.Response{
-		Text: `{"subject":"Re: Invoice","body":"Hello,\n\nI have the invoice in front of me.\n\nBest"}`}}
+		Text: `{"subject":"Re: Invoice","body":"Hello,\n\nI have the invoice in front of me.\n\nBest"}`,
+	}}
 	drafter := replyDrafter{brain: brain}
 
 	// A voice block of the shape a German-only corpus produces: every exemplar

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -308,5 +309,50 @@ func TestAVoicedDraftIsToldTheGreetingRuleToo(t *testing.T) {
 	}
 	if !strings.Contains(req.System, "plain text") {
 		t.Error("the voiced system prompt does not carry the plain-text rule")
+	}
+}
+
+// An English thread answered under a German-only voice profile is drafted in
+// ENGLISH.
+//
+// This is the defect this program was written for: the corpus taught the model
+// a language along with a register, the language rule pointed at a field no
+// payload carried, and the draft came back in German to an English-speaking
+// vendor. The request is what this asserts on — the language the model is
+// TOLD, and the rule that tells it — because a stub's canned answer proves
+// nothing about what a live model would write.
+func TestAnEnglishThreadIsDraftedInEnglishUnderAGermanVoice(t *testing.T) {
+	brain := &replyBrainStub{response: model.Response{
+		Text: `{"subject":"Re: Invoice","body":"Hello,\n\nI have the invoice in front of me.\n\nBest"}`}}
+	drafter := replyDrafter{brain: brain}
+
+	// A voice block of the shape a German-only corpus produces: every exemplar
+	// German, and nothing in it about which language to write in.
+	germanVoice := func(fence promptfence.Fence) string {
+		return fence.Wrap("VOICE\nSchreibt kurz und direkt.\n" +
+			"Beispiel: \"Moin. Die Zahlen sind Quatsch, das korrigieren wir bis Freitag.\"")
+	}
+
+	if _, err := drafter.complete(context.Background(), replyActivityData{
+		Envelope: draftfloor.Envelope{Language: "en", ConversationState: "fresh"},
+		Subject:  "Outstanding invoice",
+		Body:     "Hello, I am writing about the invoice outstanding since December.",
+	}, germanVoice); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	// The model is TOLD English, in the payload it actually receives.
+	if !strings.Contains(brain.request.Messages[0].Content, `"output_language":"en"`) {
+		t.Errorf("the draft request does not carry the thread's language: %s", brain.request.Messages[0].Content)
+	}
+	// And the rule that reads it names the field the payload carries. Pointing
+	// at a field nothing sends is what let the corpus decide instead.
+	if !strings.Contains(brain.request.System, "output_language") {
+		t.Error("the system turn's language rule does not name the field the payload carries")
+	}
+	// The voice rule says in as many words that the profile does not choose
+	// the language, which is the sentence that counteracts German exemplars.
+	if !strings.Contains(brain.request.System, "never chooses the LANGUAGE") {
+		t.Error("the voice rule does not say the profile leaves the language alone")
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -316,6 +316,27 @@ func (e ActivityKind) Valid() bool {
 	}
 }
 
+// Defines values for ActivityLanguage.
+const (
+	ActivityLanguageDe ActivityLanguage = "de"
+	ActivityLanguageEn ActivityLanguage = "en"
+	ActivityLanguageVi ActivityLanguage = "vi"
+)
+
+// Valid indicates whether the value is a known member of the ActivityLanguage enum.
+func (e ActivityLanguage) Valid() bool {
+	switch e {
+	case ActivityLanguageDe:
+		return true
+	case ActivityLanguageEn:
+		return true
+	case ActivityLanguageVi:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ActivityMeetingStatus.
 const (
 	ActivityMeetingStatusBooked   ActivityMeetingStatus = "booked"
@@ -12951,19 +12972,19 @@ func (e UpsertPartnerRequestRelationshipStage) Valid() bool {
 
 // Defines values for UserLocale.
 const (
-	UserLocaleDe UserLocale = "de"
-	UserLocaleEn UserLocale = "en"
-	UserLocaleVi UserLocale = "vi"
+	De UserLocale = "de"
+	En UserLocale = "en"
+	Vi UserLocale = "vi"
 )
 
 // Valid indicates whether the value is a known member of the UserLocale enum.
 func (e UserLocale) Valid() bool {
 	switch e {
-	case UserLocaleDe:
+	case De:
 		return true
-	case UserLocaleEn:
+	case En:
 		return true
-	case UserLocaleVi:
+	case Vi:
 		return true
 	default:
 		return false
@@ -16742,6 +16763,11 @@ type Activity struct {
 	IsDone *bool        `json:"is_done,omitempty"`
 	Kind   ActivityKind `json:"kind"`
 
+	// Language What language this message is written in, read from its own text when it was captured. Null on a message whose text was too short to tell, on anything hand-logged, and on every row captured before this was recorded — all of which mean "not known", never "not any of these".
+	// A detector's observation, not a declaration by its author, and it describes the message rather than the person: the same contact writes in two languages and each message says which it is. A drafted reply follows it, so that a reply to an English thread is written in English whatever language its sender's own writing samples happen to be in.
+	// Withheld with the rest of the content: it is derived from the body, so a caller who may discover the row without reading it is not told this either.
+	Language *ActivityLanguage `json:"language,omitempty"`
+
 	// Links One activity may link to >1 entity (person + deal).
 	Links *[]ActivityLink `json:"links,omitempty"`
 
@@ -16784,6 +16810,11 @@ type ActivityDirection string
 
 // ActivityKind defines model for Activity.Kind.
 type ActivityKind string
+
+// ActivityLanguage What language this message is written in, read from its own text when it was captured. Null on a message whose text was too short to tell, on anything hand-logged, and on every row captured before this was recorded — all of which mean "not known", never "not any of these".
+// A detector's observation, not a declaration by its author, and it describes the message rather than the person: the same contact writes in two languages and each message says which it is. A drafted reply follows it, so that a reply to an English thread is written in English whatever language its sender's own writing samples happen to be in.
+// Withheld with the rest of the content: it is derived from the body, so a caller who may discover the row without reading it is not told this either.
+type ActivityLanguage string
 
 // ActivityMeetingStatus Set only when kind=meeting.
 type ActivityMeetingStatus string

--- a/backend/internal/modules/activities/activityprojection.go
+++ b/backend/internal/modules/activities/activityprojection.go
@@ -39,7 +39,11 @@ type activityScan struct {
 	// assigneeID and hostUserID are typed ids in the row and openapi UUIDs on
 	// the record.
 	assigneeID, hostUserID *ids.UUID
-	kind                   string
+	// language is scanned as text and mapped to the contract enum: the column
+	// is a CHECK-constrained string, and a row written before the enum existed
+	// must not fail a read.
+	language *string
+	kind     string
 	// The nullable strings that become typed contract enums.
 	channelProvider, direction, meetingStatus, threadKey, captureLabel *string
 	// audienceReason says why a derived audience is what it is. It travels with
@@ -88,6 +92,7 @@ var activityProjection = []activityColumn{
 	{"a.source_system", func(s *activityScan) any { return &s.a.SourceSystem }},
 	{"a.source_id", func(s *activityScan) any { return &s.a.SourceId }},
 	{"a.source", func(s *activityScan) any { return &s.a.Source }},
+	{"a.language", func(s *activityScan) any { return &s.language }},
 	{"a.captured_by", func(s *activityScan) any { return &s.a.CapturedBy }},
 	{"a.version", func(s *activityScan) any { return &s.version }},
 	{"a.created_at", func(s *activityScan) any { return &s.a.CreatedAt }},
@@ -143,6 +148,9 @@ func (s *activityScan) record() crmcontracts.Activity {
 		// at the provider — goes; the markers stay.
 		state = crmcontracts.ActivityContentStateWithheld
 		a.Subject, a.Body, a.SourceId = nil, nil, nil
+		// The language too: it was read off the body, so answering it would
+		// tell a caller one fact about text they may not read.
+		a.Language = nil
 		threadKey, captureLabel, audienceReason = nil, nil, nil
 	}
 	a.ContentState = &state
@@ -153,6 +161,10 @@ func (s *activityScan) record() crmcontracts.Activity {
 	// meeting is a marker like its date and its direction, and a caller who may
 	// discover the row may know whose meeting it was.
 	a.HostUserId = uuidPtr(s.hostUserID)
+	if s.language != nil && s.contentAvailable {
+		lang := crmcontracts.ActivityLanguage(*s.language)
+		a.Language = &lang
+	}
 	a.Kind = crmcontracts.ActivityKind(s.kind)
 	a.ChannelProvider = s.channelProvider
 	if s.direction != nil {

--- a/backend/internal/modules/activities/footerlanguage.go
+++ b/backend/internal/modules/activities/footerlanguage.go
@@ -57,18 +57,11 @@ func (s *Store) WithRuntimeEnvironment(env runtimeenv.Environment) *Store {
 // which at least matches the message around it — and the page the link
 // opens carries a language switcher, which is the recovery path.
 func (s *Store) footerLanguage(ctx context.Context, body, subject string) textlang.Lang {
-	if lang := textlang.Detect(body); lang != textlang.Unknown {
-		return lang
-	}
-	if lang := textlang.Detect(subject); lang != textlang.Unknown {
-		return lang
-	}
+	var base string
 	if s.baseLanguage != nil {
-		if base := s.baseLanguage.BaseLanguage(ctx); textlang.Known(base) {
-			return textlang.Lang(base)
-		}
+		base = s.baseLanguage.BaseLanguage(ctx)
 	}
-	return textlang.English
+	return textlang.FirstKnown([]string{body, subject}, base)
 }
 
 // PublicOriginUnusableError is the refusal when a tokenized send cannot

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -223,6 +223,15 @@ type DraftContext struct {
 	// Body is the text of the message being answered, used to detect the
 	// language of the correspondence. Empty falls back to the topic.
 	Body string
+	// Language is the language already resolved for this draft, when the
+	// caller has one. A caller holding an envelope MUST pass it: the model
+	// draft and the deterministic fallback are two answers to one request, and
+	// a fallback that re-derived the language would change what language the
+	// rep is shown the moment a model call failed.
+	//
+	// Empty means the caller has no envelope — the two-tier detection below is
+	// then the honest answer rather than a guess at one.
+	Language textlang.Lang
 	// Band is where the correspondence stands. The zero value is BandNone.
 	Band convstate.Band
 }
@@ -242,6 +251,11 @@ func IsMailThread(kind crmcontracts.ActivityKind, direction *crmcontracts.Activi
 // preferring the body because a subject line rarely carries enough words to
 // clear the detector's floor.
 func (c DraftContext) language() textlang.Lang {
+	// What the caller already resolved, which walked a longer ladder than this
+	// one can: it saw the stored language and the installation's own.
+	if c.Language != textlang.Unknown && c.Language != "" {
+		return c.Language
+	}
 	if lang := textlang.Detect(c.Body); lang != textlang.Unknown {
 		return lang
 	}

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -96,6 +96,14 @@ func updateActivityInTx(
 		  assignee_id = coalesce($%[7]d, assignee_id),
 		  is_done = coalesce($%[8]d, is_done),
 		  meeting_status = coalesce($%[9]d, meeting_status),
+		  -- The language was READ from the text, so an edit to the text retires
+		  -- it. Cleared rather than recomputed: detection lives in Go, and a
+		  -- label that outlived the words it described would send a reply in
+		  -- the language the message used to be in. Cleared, the drafting
+		  -- ladder reads the new text instead, which is the honest answer.
+		  language = CASE
+		    WHEN $%[3]d IS NOT NULL OR $%[2]d IS NOT NULL THEN NULL
+		    ELSE language END,
 		  done_at = CASE
 		    WHEN $%[8]d IS TRUE AND NOT is_done THEN now()
 		    WHEN $%[8]d IS FALSE THEN NULL

--- a/backend/internal/modules/capture/sinkactivity.go
+++ b/backend/internal/modules/capture/sinkactivity.go
@@ -25,6 +25,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
@@ -251,8 +252,8 @@ func (s *Sink) upsertActivity(
 	audience, audienceReason := birth.bornAudience()
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason, has_calendar_part, host_user_id)
-		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''), $17, $18)
+		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason, has_calendar_part, host_user_id, language)
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''), $17, $18, NULLIF($19, ''))
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -284,7 +285,13 @@ func (s *Sink) upsertActivity(
 		fields.HasCalendarPart,
 		// Whose calendar a MEETING came off, so the brief lanes can say whose
 		// meeting a row is instead of offering every seat's to everybody.
-		meetingHostUserID(ctx, fields.Kind)).Scan(&id)
+		meetingHostUserID(ctx, fields.Kind),
+		// What language the message is written in, read from its own text at
+		// the moment it arrives. Body before subject: a reply's subject line is
+		// often still in the sender's language while the message under it is
+		// not. Unknown stores NULL, which is what every row carried before this
+		// and what the search index already treats as "no stemming".
+		string(textlang.DetectFirst(fields.Body, fields.Subject))).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sinkactivityplaceholders_test.go
+++ b/backend/internal/modules/capture/sinkactivityplaceholders_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The capture insert's columns, placeholders and arguments agree.
+//
+// The statement is hand-numbered, which the rulebook allows nobody to add and
+// this one predates. Nothing in Go or Postgres checks that a column list, its
+// $N placeholders and the argument slice stay the same length — a mismatch is
+// caught at execution, on a real capture, as an error nobody sees until a
+// mailbox stops syncing. This reads the statement itself and counts.
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestTheCaptureInsertCountsItsOwnPlaceholders(t *testing.T) {
+	t.Parallel()
+	source, err := os.ReadFile("sinkactivity.go")
+	if err != nil {
+		t.Fatalf("reading the sink: %v", err)
+	}
+	statement := insertStatement(t, string(source))
+
+	listStart := strings.Index(statement, "(")
+	listEnd := strings.Index(statement, ")")
+	if listStart < 0 || listEnd < listStart {
+		t.Fatal("the capture insert's column list is no longer parenthesised; this gate reads between ( and )")
+	}
+	columns := strings.Count(statement[listStart:listEnd], ",") + 1
+
+	highest := 0
+	for _, match := range regexp.MustCompile(`\$(\d+)`).FindAllStringSubmatch(statement, -1) {
+		n, convErr := strconv.Atoi(match[1])
+		if convErr != nil {
+			t.Fatalf("unreadable placeholder %q: %v", match[0], convErr)
+		}
+		if n > highest {
+			highest = n
+		}
+	}
+	if columns != highest {
+		t.Errorf("the capture insert names %d columns but its highest placeholder is $%d — "+
+			"a mismatch fails at execution, on a real capture, as a sync that stops with no test having said so",
+			columns, highest)
+	}
+
+	// Every number from 1 up is used. A gap means an argument is being read
+	// into the wrong column, which no count of the highest one can see.
+	used := map[int]bool{}
+	for _, match := range regexp.MustCompile(`\$(\d+)`).FindAllStringSubmatch(statement, -1) {
+		n, _ := strconv.Atoi(match[1])
+		used[n] = true
+	}
+	for n := 1; n <= highest; n++ {
+		if !used[n] {
+			t.Errorf("the capture insert skips $%d, so every argument after it lands in the wrong column", n)
+		}
+	}
+}
+
+// insertStatement is the INSERT INTO activity text, from the sink's source.
+func insertStatement(t *testing.T, source string) string {
+	t.Helper()
+	start := strings.Index(source, "INSERT INTO activity (")
+	if start < 0 {
+		t.Fatal("the sink no longer holds an `INSERT INTO activity (` — if it moved, point this gate at it")
+	}
+	rest := source[start:]
+	end := strings.Index(rest, "ON CONFLICT")
+	if end < 0 {
+		t.Fatal("the capture insert no longer carries its ON CONFLICT clause; this gate reads up to it")
+	}
+	return rest[:end]
+}

--- a/backend/internal/modules/privacy/erasuretimeline.go
+++ b/backend/internal/modules/privacy/erasuretimeline.go
@@ -118,6 +118,10 @@ func redactSubjectTimeline(ctx context.Context, tx pgx.Tx, personID ids.PersonID
 		  -- them, derived from text this same statement is emptying, and leaving
 		  -- it would keep the conclusion after destroying the evidence.
 		  reply_verdict = NULL, reply_verdict_at = NULL, reply_verdict_by = NULL,
+		  -- Same reason, one step smaller: the language was READ from the words
+		  -- being emptied here, so it is a fact about erased text rather than
+		  -- about the row.
+		  language = NULL,
 		  source_id = CASE WHEN a.source_system || ':' || split_part(coalesce(a.thread_key, ''), ':', 3) = ANY($6)
 		                   THEN NULL ELSE a.source_id END,
 		  thread_key = CASE WHEN a.source_system || ':' || split_part(coalesce(a.thread_key, ''), ':', 3) = ANY($6)

--- a/backend/internal/modules/privacy/retentionactions.go
+++ b/backend/internal/modules/privacy/retentionactions.go
@@ -165,7 +165,10 @@ func (s *RetentionService) apply(ctx context.Context, pol retentionPolicy, id id
 // kind of difference was once carried in prose and went short.
 func (s *RetentionService) eraseActivityContent(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
 	_, err := tx.Exec(ctx,
-		`UPDATE activity SET body = NULL, raw = NULL, subject = $2, archived_at = coalesce(archived_at, now()) WHERE id = $1`,
+		// language goes with the text: it was read from the body this statement
+		// is emptying, so keeping it would answer one question about content
+		// that no longer exists.
+		`UPDATE activity SET body = NULL, raw = NULL, subject = $2, language = NULL, archived_at = coalesce(archived_at, now()) WHERE id = $1`,
 		id, erasedActivitySubject)
 	if err == nil {
 		// Everything the text left behind — the verbatim provider original, the

--- a/backend/internal/shared/kernel/draftfloor/draftfloor_test.go
+++ b/backend/internal/shared/kernel/draftfloor/draftfloor_test.go
@@ -4,8 +4,10 @@
 package draftfloor_test
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
@@ -160,5 +162,101 @@ func TestUnresolvedInputDegradesToARenderableDraft(t *testing.T) {
 	unknownBand := draftfloor.For(textlang.German, convstate.Band("something-else"))
 	if unknownBand != draftfloor.For(textlang.German, convstate.BandNone) {
 		t.Error("an unrecognized band should fall back to the band that assumes no history")
+	}
+}
+
+// The ladder a draft's language comes down.
+//
+// Each tier exists because the one above it can honestly answer "I do not
+// know": a message may record no language, a two-line note gives the detector
+// nothing to work with, and a first message has no correspondence at all.
+func TestTheLanguageLadderTakesTheFirstTierThatKnows(t *testing.T) {
+	t.Parallel()
+	const german = "Guten Tag, ich melde mich wegen der Rechnung und der offenen Posten."
+	const english = "Hello, I am writing about the invoice and the outstanding items."
+
+	for name, tc := range map[string]struct {
+		written draftfloor.Written
+		base    string
+		want    string
+	}{
+		"stored beats the text under it": {
+			// The label was read when the message arrived; the body has since
+			// grown a quoted chain in another language.
+			written: draftfloor.Written{Stored: "en", Body: german},
+			want:    "en",
+		},
+		"an unsupported stored value is skipped": {
+			written: draftfloor.Written{Stored: "kl", Body: english},
+			want:    "en",
+		},
+		"the body decides over the subject": {
+			written: draftfloor.Written{Body: english, Subject: german},
+			want:    "en",
+		},
+		"an unreadable body falls to the subject": {
+			written: draftfloor.Written{Body: "ok", Subject: german},
+			want:    "de",
+		},
+		"text that says nothing falls to the installation": {
+			written: draftfloor.Written{Body: "ok"},
+			base:    "de",
+			want:    "de",
+		},
+		"a first message has only the installation to go on": {
+			// No correspondence at all: the rep typed three words of intent.
+			written: draftfloor.Written{Body: "ask for Tuesday"},
+			base:    "vi",
+			want:    "vi",
+		},
+		"an unsupported installation language is skipped too": {
+			written: draftfloor.Written{Body: "ok"},
+			base:    "kl",
+			want:    string(draftfloor.DefaultLang),
+		},
+		"with nothing anywhere, the default": {
+			written: draftfloor.Written{},
+			want:    string(draftfloor.DefaultLang),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			resolver := draftfloor.NewResolver().
+				WithClock(func() time.Time { return time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC) })
+			if tc.base != "" {
+				resolver = resolver.WithBaseLanguage(func(context.Context) string { return tc.base })
+			}
+			got := resolver.Resolve(context.Background(), tc.written, convstate.State{Band: convstate.BandFresh})
+			if got.Language != tc.want {
+				t.Errorf("language = %q, want %q", got.Language, tc.want)
+			}
+		})
+	}
+}
+
+// The register is German's alone, and it is decided WITH the language rather
+// than after it. Resolving the language afterwards would leave a German
+// register on an English envelope, or drop one the other way.
+func TestTheRegisterFollowsTheResolvedLanguage(t *testing.T) {
+	t.Parallel()
+	resolver := draftfloor.NewResolver().
+		WithClock(func() time.Time { return time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC) }).
+		WithBaseLanguage(func(context.Context) string { return "de" })
+
+	// A German body: the envelope is German and carries a register.
+	german := resolver.Resolve(context.Background(),
+		draftfloor.Written{Body: "Guten Tag, wie besprochen sende ich Ihnen die Unterlagen zu."},
+		convstate.State{Band: convstate.BandFresh})
+	if german.Language != "de" || german.Register == "" {
+		t.Errorf("a German draft = %q/%q, want de with a register", german.Language, german.Register)
+	}
+
+	// The SAME resolver on an English body: no register, because the
+	// distinction does not exist in the language being written.
+	english := resolver.Resolve(context.Background(),
+		draftfloor.Written{Stored: "en", Body: "Guten Tag, wie besprochen sende ich Ihnen die Unterlagen zu."},
+		convstate.State{Band: convstate.BandFresh})
+	if english.Language != "en" || english.Register != "" {
+		t.Errorf("an English draft = %q/%q, want en with no register", english.Language, english.Register)
 	}
 }

--- a/backend/internal/shared/kernel/draftfloor/resolve.go
+++ b/backend/internal/shared/kernel/draftfloor/resolve.go
@@ -26,6 +26,15 @@ type Sender interface {
 // Clock is the current time, injected rather than read, per the house pattern.
 type Clock func() time.Time
 
+// BaseLanguage answers the installation's own configured language.
+//
+// It is the tier BELOW the correspondence and above the hard default: a thread
+// too short to detect is still being written by a team who told us which
+// language they work in, and answering English to a German installation is a
+// worse guess than the one they configured. Injected as a function because it
+// lives in identity, and this package is reached by every drafting surface.
+type BaseLanguage func(ctx context.Context) string
+
 // Resolver assembles the envelope every drafting surface is handed.
 //
 // It is one type rather than a method on each service because the fallbacks are
@@ -35,6 +44,7 @@ type Clock func() time.Time
 // failure is fatal, and the drafting screen would break on one surface only.
 type Resolver struct {
 	sender Sender
+	base   BaseLanguage
 	now    Clock
 	logger *slog.Logger
 }
@@ -45,6 +55,13 @@ func NewResolver() *Resolver { return &Resolver{now: time.Now} }
 // WithSender binds the identity lookup. Without one, every draft is unsigned.
 func (r *Resolver) WithSender(sender Sender) *Resolver {
 	r.sender = sender
+	return r
+}
+
+// WithBaseLanguage binds the installation's configured language, the tier
+// between the correspondence's own text and the hard default.
+func (r *Resolver) WithBaseLanguage(base BaseLanguage) *Resolver {
+	r.base = base
 	return r
 }
 
@@ -71,22 +88,71 @@ func (r *Resolver) Now() time.Time {
 	return r.now()
 }
 
-// Resolve assembles the envelope from the correspondence's own text and where
-// it stands.
+// Written is what a draft is being written INTO: the correspondence it answers,
+// and whatever the message itself already records about its language.
 //
-// Neither half can fail the draft. An unresolvable language falls back to the
-// default (DRAFT-AC-E-2), and an unresolvable sender leaves the draft unsigned
-// (DRAFT-AC-E-6) — a drafting screen that errors because it could not work out
-// a greeting is worse than a draft the rep edits.
-func (r *Resolver) Resolve(ctx context.Context, correspondence string, state convstate.State) Envelope {
+// Separate fields rather than one blob because they are not equally good
+// evidence. Stored is a fact somebody wrote down at capture; Body and Subject
+// are text to read; and the subject is the weaker of the two, being a line
+// people often leave in the sender's language on a reply they wrote in theirs.
+type Written struct {
+	// Stored is the language recorded on the message, empty when none is.
+	// It outranks detection: the same message read twice must not answer two
+	// languages because a quoted chain grew underneath it.
+	Stored string
+	// Body is the correspondence itself, quoted history included.
+	Body string
+	// Subject is the fallback text, read only when the body says nothing.
+	Subject string
+}
+
+// Resolve assembles the envelope from what the draft is written into and where
+// the conversation stands.
+//
+// Nothing here can fail the draft. An unresolvable language falls through the
+// ladder to the default (DRAFT-AC-E-2), and an unresolvable sender leaves the
+// draft unsigned (DRAFT-AC-E-6) — a drafting screen that errors because it
+// could not work out a greeting is worse than a draft the rep edits.
+//
+// The ladder is stored, then the text, then the installation's own language,
+// then English. The base-language tier is what answers a first message, which
+// has no correspondence at all to read: its only text is the rep's typed
+// intent, far too short to clear the detector's bar.
+func (r *Resolver) Resolve(ctx context.Context, written Written, state convstate.State) Envelope {
 	now := r.Now()
 	name, email := r.actor(ctx)
 	// The register is read from the WHOLE correspondence, quoted history
 	// included: which register two people are on is a property of the
 	// relationship, and a single reply may contain neither form while the
 	// exchange behind it is unmistakably du.
-	return NewEnvelopeWithRegister(textlang.Detect(correspondence),
-		textlang.DetectRegister(correspondence), state, now, name, email)
+	//
+	// Language first, and passed IN rather than fixed up afterwards: the
+	// envelope carries a register only for a German draft, so a language
+	// corrected after construction would leave a German register on an English
+	// envelope, or drop one the other way.
+	return NewEnvelopeWithRegister(r.language(ctx, written),
+		textlang.DetectRegister(written.Body), state, now, name, email)
+}
+
+// language walks the ladder, taking the first tier that names a language this
+// product actually speaks.
+//
+// An unsupported stored or configured value is skipped rather than trusted: it
+// would reach the prompt as an instruction to write in a language nothing else
+// in the product can render.
+func (r *Resolver) language(ctx context.Context, written Written) textlang.Lang {
+	if textlang.Known(written.Stored) {
+		return textlang.Lang(written.Stored)
+	}
+	if lang := textlang.DetectFirst(written.Body, written.Subject); lang != textlang.Unknown {
+		return lang
+	}
+	if r != nil && r.base != nil {
+		if base := r.base(ctx); textlang.Known(base) {
+			return textlang.Lang(base)
+		}
+	}
+	return DefaultLang
 }
 
 // actor names the acting human, or nobody.

--- a/backend/internal/shared/kernel/draftfloor/resolve.go
+++ b/backend/internal/shared/kernel/draftfloor/resolve.go
@@ -141,18 +141,18 @@ func (r *Resolver) Resolve(ctx context.Context, written Written, state convstate
 // would reach the prompt as an instruction to write in a language nothing else
 // in the product can render.
 func (r *Resolver) language(ctx context.Context, written Written) textlang.Lang {
+	// The stored label is above the ladder rather than in it: it is a fact
+	// somebody recorded, where every tier below is evidence being read now.
 	if textlang.Known(written.Stored) {
 		return textlang.Lang(written.Stored)
 	}
-	if lang := textlang.DetectFirst(written.Body, written.Subject); lang != textlang.Unknown {
-		return lang
-	}
+	var base string
 	if r != nil && r.base != nil {
-		if base := r.base(ctx); textlang.Known(base) {
-			return textlang.Lang(base)
-		}
+		base = r.base(ctx)
 	}
-	return DefaultLang
+	// The same ladder the footer under a sent message walks. Shared, so a
+	// draft and the footer beneath it cannot pick two languages for one mail.
+	return textlang.FirstKnown([]string{written.Body, written.Subject}, base)
 }
 
 // actor names the acting human, or nobody.

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -155,6 +155,27 @@ func Detect(text string) Lang {
 	return winner(scoreStopwords(reply, lead))
 }
 
+// DetectFirst reports the language of the first text that yields one.
+//
+// The texts are the SAME message's, in descending order of how much evidence
+// each carries — a body before its subject, never one message before another.
+// Detect is deliberately biased toward Unknown (it wants three stopword hits
+// and a clear margin), so a two-line note falls through to the shorter text
+// rather than being guessed at, and a caller with nothing left decides for
+// itself what an unresolved language means.
+//
+// One helper rather than a ladder spelled per caller: the footer, the capture
+// writer and the drafting envelope all ask this same question, and three
+// copies of "body, then subject" is three chances to order them differently.
+func DetectFirst(texts ...string) Lang {
+	for _, text := range texts {
+		if lang := Detect(text); lang != Unknown {
+			return lang
+		}
+	}
+	return Unknown
+}
+
 // score is one language's evidence, counted two ways because the two bars ask
 // different questions. Hits asks "is there enough evidence to speak at all",
 // so every hit counts once wherever it sits. Weighted asks "which language is

--- a/backend/internal/shared/kernel/textlang/textlang.go
+++ b/backend/internal/shared/kernel/textlang/textlang.go
@@ -176,6 +176,31 @@ func DetectFirst(texts ...string) Lang {
 	return Unknown
 }
 
+// FirstKnown is the ladder every caller that must end up with a language walks:
+// the texts in order, then whatever fallbacks the caller can offer, then
+// English.
+//
+// One helper rather than a copy per caller. The footer under a sent mail, the
+// language a draft is written in and the label capture records all ask the same
+// question in the same order, and three spellings of "body, then subject, then
+// what the installation said" are three chances to answer it differently — the
+// footer of a message would then disagree with the message above it.
+//
+// A fallback that names no language the product ships is skipped rather than
+// trusted: it would otherwise reach a prompt as an instruction to write in a
+// language nothing else can render.
+func FirstKnown(texts []string, fallbacks ...string) Lang {
+	if lang := DetectFirst(texts...); lang != Unknown {
+		return lang
+	}
+	for _, fallback := range fallbacks {
+		if Known(fallback) {
+			return Lang(fallback)
+		}
+	}
+	return English
+}
+
 // score is one language's evidence, counted two ways because the two bars ask
 // different questions. Hits asks "is there enough evidence to speak at all",
 // so every hit counts once wherever it sits. Weighted asks "which language is

--- a/backend/migrations/core/1788741112_a_captured_message_records_its_language.down.sql
+++ b/backend/migrations/core/1788741112_a_captured_message_records_its_language.down.sql
@@ -6,6 +6,11 @@
 -- dictionary, and a rollback that silently changes what lexical search finds is
 -- worse than one that stops and says so.
 
+-- A bounded wait: the ALTER takes a lock that blocks writers on activity, and
+-- an open transaction holding a conflicting one would otherwise stall every
+-- write to the table for as long as this migration is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM activity WHERE language = 'vi') THEN

--- a/backend/migrations/core/1788741112_a_captured_message_records_its_language.down.sql
+++ b/backend/migrations/core/1788741112_a_captured_message_records_its_language.down.sql
@@ -1,0 +1,20 @@
+-- Narrow the admitted set back to de and en.
+--
+-- This REFUSES while any row records Vietnamese rather than quietly clearing
+-- them. A detected language is an observation somebody's search results now
+-- depend on: nulling it rewrites that row's search_tsv back to the unstemmed
+-- dictionary, and a rollback that silently changes what lexical search finds is
+-- worse than one that stops and says so.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM activity WHERE language = 'vi') THEN
+        RAISE EXCEPTION
+            'activity rows record Vietnamese; narrowing the language check would have to erase observations that search results depend on';
+    END IF;
+END $$;
+
+ALTER TABLE activity DROP CONSTRAINT activity_language_check;
+
+ALTER TABLE activity ADD CONSTRAINT activity_language_check
+    CHECK (language IS NULL OR language IN ('de', 'en'));

--- a/backend/migrations/core/1788741112_a_captured_message_records_its_language.up.sql
+++ b/backend/migrations/core/1788741112_a_captured_message_records_its_language.up.sql
@@ -1,0 +1,27 @@
+-- A captured message records the language it is written in.
+--
+-- The column has existed since the baseline and nothing ever wrote it. Its only
+-- reader is the generated search_tsv, which picks a text-search dictionary from
+-- it; every row carrying NULL is indexed with the `simple` dictionary, which
+-- does no stemming at all.
+--
+-- Two things change here. The CHECK admitted only de and en while the product
+-- ships Vietnamese, so a detected Vietnamese message could not be recorded at
+-- all. And capture starts writing what it detects, which means new rows index
+-- under a real dictionary.
+--
+-- Deliberately NO backfill. Writing a language rewrites that row's stored
+-- search_tsv, so a backfill would re-stem the entire history in one statement
+-- and shift existing search results for every reader at once. New rows carry
+-- the label; old rows keep the behaviour they have always had, and the drafting
+-- ladder falls through to detection for them.
+--
+-- The CHECK swap validates every existing row and takes a lock on activity
+-- while it does. Rows already satisfy it — the new set is a superset of the old
+-- one — so the scan finds nothing, but it is a scan and not a metadata-only
+-- change.
+
+ALTER TABLE activity DROP CONSTRAINT activity_language_check;
+
+ALTER TABLE activity ADD CONSTRAINT activity_language_check
+    CHECK (language IS NULL OR language IN ('de', 'en', 'vi'));

--- a/backend/migrations/core/1788741112_a_captured_message_records_its_language.up.sql
+++ b/backend/migrations/core/1788741112_a_captured_message_records_its_language.up.sql
@@ -21,6 +21,11 @@
 -- one — so the scan finds nothing, but it is a scan and not a metadata-only
 -- change.
 
+-- A bounded wait: the ALTER takes a lock that blocks writers on activity, and
+-- an open transaction holding a conflicting one would otherwise stall every
+-- write to the table for as long as this migration is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
 ALTER TABLE activity DROP CONSTRAINT activity_language_check;
 
 ALTER TABLE activity ADD CONSTRAINT activity_language_check

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/gatekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // TestSchema_amountMinorBaseHasOneWriter is the fitness function for the
@@ -548,5 +549,40 @@ func TestFK_rowScopedTargetsHaveVisibilityDecision(t *testing.T) {
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// Every language the product ships is a language a captured message may
+// record.
+//
+// Derived from textlang.Shipped rather than listed, because the failure this
+// prevents is silent in the direction that matters: the CHECK admitted de and
+// en for as long as the product shipped Vietnamese too, so a detected
+// Vietnamese message could not be stored at all — and nothing said so, because
+// nothing wrote the column. A fourth language added to the Go list fails here
+// until the constraint admits it.
+func TestSchema_theLanguageCheckAdmitsEveryShippedLanguage(t *testing.T) {
+	owner, _ := dsns(t)
+	conn := connect(t, owner)
+	resetSchema(t, conn)
+	migrateAll(t, conn)
+
+	var definition string
+	if err := conn.QueryRow(context.Background(), `
+		SELECT pg_get_constraintdef(oid)
+		  FROM pg_constraint
+		 WHERE conname = 'activity_language_check'`).Scan(&definition); err != nil {
+		t.Fatalf("reading the language constraint: %v", err)
+	}
+	for _, lang := range textlang.Shipped {
+		if !strings.Contains(definition, "'"+string(lang)+"'") {
+			t.Errorf("the product ships %q but activity_language_check does not admit it, so a message in "+
+				"that language cannot record what it is written in: %s", lang, definition)
+		}
+	}
+	// NULL stays admitted: it is what every row captured before this carried,
+	// and what a message too short to tell still carries.
+	if !strings.Contains(definition, "IS NULL") {
+		t.Errorf("activity_language_check no longer admits NULL, which is what an unknown language records: %s", definition)
 	}
 }

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -8,7 +8,7 @@ public.activity.activity_direction_check CHECK (((direction IS NULL) OR (directi
 public.activity.activity_done_at CHECK (((is_done = false) OR (done_at IS NOT NULL)))
 public.activity.activity_host_user_id_fkey FOREIGN KEY (host_user_id) REFERENCES app_user(id) ON DELETE SET NULL (host_user_id)
 public.activity.activity_kind_fkey FOREIGN KEY (kind) REFERENCES activity_kind(kind)
-public.activity.activity_language_check CHECK (((language IS NULL) OR (language = ANY (ARRAY['de'::text, 'en'::text]))))
+public.activity.activity_language_check CHECK (((language IS NULL) OR (language = ANY (ARRAY['de'::text, 'en'::text, 'vi'::text]))))
 public.activity.activity_last_activity CREATE TRIGGER activity_last_activity AFTER UPDATE OF occurred_at, archived_at, audience, origin ON public.activity FOR EACH ROW WHEN (((old.occurred_at IS DISTINCT FROM new.occurred_at) OR (old.archived_at IS DISTINCT FROM new.archived_at) OR (old.audience IS DISTINCT FROM new.audience) OR (old.origin IS DISTINCT FROM new.origin))) EXECUTE FUNCTION trg_activity_last_activity()
 public.activity.activity_meeting_host CHECK (((host_user_id IS NULL) OR (kind = 'meeting'::text)))
 public.activity.activity_meeting_no_overlap EXCLUDE USING gist (host_user_id WITH =, tsrange(timezone('UTC'::text, occurred_at), (timezone('UTC'::text, occurred_at) + '01:00:00'::interval)) WITH &&) WHERE (((kind = 'meeting'::text) AND (host_user_id IS NOT NULL) AND (archived_at IS NULL) AND (source_system IS NULL)))

--- a/backend/pkg/extension/crm/crm_gen.go
+++ b/backend/pkg/extension/crm/crm_gen.go
@@ -94,6 +94,27 @@ func (e ActivityKind) Valid() bool {
 	}
 }
 
+// Defines values for ActivityLanguage.
+const (
+	De ActivityLanguage = "de"
+	En ActivityLanguage = "en"
+	Vi ActivityLanguage = "vi"
+)
+
+// Valid indicates whether the value is a known member of the ActivityLanguage enum.
+func (e ActivityLanguage) Valid() bool {
+	switch e {
+	case De:
+		return true
+	case En:
+		return true
+	case Vi:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ActivityMeetingStatus.
 const (
 	ActivityMeetingStatusBooked   ActivityMeetingStatus = "booked"
@@ -389,6 +410,11 @@ type Activity struct {
 	IsDone *bool        `json:"is_done,omitempty"`
 	Kind   ActivityKind `json:"kind"`
 
+	// Language What language this message is written in, read from its own text when it was captured. Null on a message whose text was too short to tell, on anything hand-logged, and on every row captured before this was recorded — all of which mean "not known", never "not any of these".
+	// A detector's observation, not a declaration by its author, and it describes the message rather than the person: the same contact writes in two languages and each message says which it is. A drafted reply follows it, so that a reply to an English thread is written in English whatever language its sender's own writing samples happen to be in.
+	// Withheld with the rest of the content: it is derived from the body, so a caller who may discover the row without reading it is not told this either.
+	Language *ActivityLanguage `json:"language,omitempty"`
+
 	// Links One activity may link to >1 entity (person + deal).
 	Links *[]ActivityLink `json:"links,omitempty"`
 
@@ -431,6 +457,11 @@ type ActivityDirection string
 
 // ActivityKind defines model for Activity.Kind.
 type ActivityKind string
+
+// ActivityLanguage What language this message is written in, read from its own text when it was captured. Null on a message whose text was too short to tell, on anything hand-logged, and on every row captured before this was recorded — all of which mean "not known", never "not any of these".
+// A detector's observation, not a declaration by its author, and it describes the message rather than the person: the same contact writes in two languages and each message says which it is. A drafted reply follows it, so that a reply to an English thread is written in English whatever language its sender's own writing samples happen to be in.
+// Withheld with the rest of the content: it is derived from the body, so a caller who may discover the row without reading it is not told this either.
+type ActivityLanguage string
 
 // ActivityMeetingStatus Set only when kind=meeting.
 type ActivityMeetingStatus string

--- a/docs/reference/ai-certification.json
+++ b/docs/reference/ai-certification.json
@@ -1,9 +1,9 @@
 {
   "totals": {
     "sites": 42,
-    "sites_best_current": 41,
+    "sites_best_current": 37,
     "sites_best_partial": 0,
-    "sites_best_stale": 1,
+    "sites_best_stale": 5,
     "sites_absent": 0,
     "scenarios": 142,
     "records": 74,
@@ -17,9 +17,9 @@
         "env": "eu_hosted"
       },
       "sites": 36,
-      "sites_current": 35,
+      "sites_current": 31,
       "sites_partial": 0,
-      "sites_stale": 1,
+      "sites_stale": 5,
       "runs": 381,
       "passed": 330,
       "reliability": 0.8661417322834646,
@@ -37,9 +37,9 @@
         "env": "eu_hosted"
       },
       "sites": 6,
-      "sites_current": 6,
+      "sites_current": 2,
       "sites_partial": 0,
-      "sites_stale": 0,
+      "sites_stale": 4,
       "runs": 36,
       "passed": 36,
       "reliability": 1,
@@ -57,9 +57,9 @@
         "env": "eu_hosted"
       },
       "sites": 13,
-      "sites_current": 13,
+      "sites_current": 9,
       "sites_partial": 0,
-      "sites_stale": 0,
+      "sites_stale": 4,
       "runs": 90,
       "passed": 86,
       "reliability": 0.9555555555555556,
@@ -177,9 +177,9 @@
         "env": "eu_hosted"
       },
       "sites": 35,
-      "sites_current": 34,
+      "sites_current": 30,
       "sites_partial": 0,
-      "sites_stale": 1,
+      "sites_stale": 5,
       "runs": 372,
       "passed": 298,
       "reliability": 0.8010752688172043,
@@ -1811,17 +1811,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "account_first_touch_with_a_deal_in_flight",
@@ -1836,9 +1827,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1851,7 +1842,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1859,9 +1850,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1874,7 +1865,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1882,9 +1873,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1897,7 +1888,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1905,9 +1896,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1920,7 +1911,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -1935,17 +1926,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.5-flash",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "first_message_from_an_intent_alone",
@@ -1960,9 +1942,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1975,7 +1957,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -1983,9 +1965,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -1998,7 +1980,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2006,9 +1988,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2021,7 +2003,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2029,9 +2011,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2044,7 +2026,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -2322,17 +2304,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "openai_compatible",
-          "model": "openai/gpt-oss-120b",
-          "env": "eu_hosted"
-        },
-        "band": "certified",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "person_first_touch_in_german",
@@ -2347,9 +2320,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2362,7 +2335,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2370,9 +2343,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2385,7 +2358,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2393,9 +2366,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2408,7 +2381,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it"
         },
         {
           "binding": {
@@ -2416,9 +2389,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "certified",
-          "scenarios_measured": 1,
+          "scenarios_measured": 0,
           "scenarios_total": 1,
           "runs": 3,
           "passed": 3,
@@ -2431,7 +2404,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it"
         }
       ]
     },
@@ -2446,17 +2419,8 @@
         "proof",
         "market"
       ],
-      "best_state": "current",
-      "recommended": {
-        "binding": {
-          "provider": "gemini",
-          "model": "gemini-3.1-flash-lite",
-          "env": "eu_hosted"
-        },
-        "band": "supported_degraded",
-        "reliability": 1,
-        "state": "current"
-      },
+      "best_state": "stale",
+      "recommended": null,
       "scenarios": [
         {
           "name": "german_thread_with_an_introduction_in_it",
@@ -2486,9 +2450,9 @@
             "model": "gemini-3.1-flash-lite",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "supported_degraded",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 12,
@@ -2501,7 +2465,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask"
         },
         {
           "binding": {
@@ -2509,9 +2473,9 @@
             "model": "gemini-3.1-pro-preview",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 12,
@@ -2524,7 +2488,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask"
         },
         {
           "binding": {
@@ -2532,9 +2496,9 @@
             "model": "gemini-3.5-flash",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 12,
@@ -2547,7 +2511,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask"
         },
         {
           "binding": {
@@ -2578,9 +2542,9 @@
             "model": "openai/gpt-oss-120b",
             "env": "eu_hosted"
           },
-          "state": "current",
+          "state": "stale",
           "band": "not_supported",
-          "scenarios_measured": 4,
+          "scenarios_measured": 0,
           "scenarios_total": 4,
           "runs": 12,
           "passed": 12,
@@ -2593,7 +2557,7 @@
             "invalid": 0,
             "abstained": 0
           },
-          "stale_reason": ""
+          "stale_reason": "4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask"
         }
       ]
     },

--- a/docs/reference/ai-certification.md
+++ b/docs/reference/ai-certification.md
@@ -25,9 +25,9 @@ How to certify a model: [certify-an-ai-model.md](../how-to/certify-an-ai-model.m
 | | |
 |---|---:|
 | Shipped invocation sites | 42 |
-| … best state `current` | 41 |
+| … best state `current` | 37 |
 | … best state `partial` | 0 |
-| … best state `stale` | 1 |
+| … best state `stale` | 5 |
 | … `absent` on every binding | 0 |
 | Scenarios in the corpus | 142 |
 | Committed records | 74 |
@@ -94,12 +94,12 @@ Which model to run each site on, and what that choice rests on.
 | [`corpus_ask/corpus_ask`](#corpus_askcorpus_ask) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 3 |
 | [`deal_health/deal_status`](#deal_healthdeal_status) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 3 | 2 |
 | [`document_extract/fields`](#document_extractfields) | `gemini · gemini-3.5-flash · eu_hosted` | `certified` | 1.00 | `current` | 4 | 1 |
-| [`draft_reply/account`](#draft_replyaccount) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
-| [`draft_reply/first`](#draft_replyfirst) | `gemini · gemini-3.5-flash · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
+| [`draft_reply/account`](#draft_replyaccount) | - | - | - | `stale` | 1 | 4 |
+| [`draft_reply/first`](#draft_replyfirst) | - | - | - | `stale` | 1 | 4 |
 | [`draft_reply/intro`](#draft_replyintro) | `gemini · gemini-3.1-pro-preview · eu_hosted` | `certified` | 1.00 | `current` | 2 | 4 |
 | [`draft_reply/intro_note`](#draft_replyintro_note) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 1.00 | `current` | 3 | 4 |
-| [`draft_reply/person`](#draft_replyperson) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 4 |
-| [`draft_reply/reply`](#draft_replyreply) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `supported_degraded` | 1.00 | `current` | 4 | 5 |
+| [`draft_reply/person`](#draft_replyperson) | - | - | - | `stale` | 1 | 4 |
+| [`draft_reply/reply`](#draft_replyreply) | - | - | - | `stale` | 4 | 5 |
 | [`enrich/signature`](#enrichsignature) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `certified` | 1.00 | `current` | 1 | 3 |
 | [`growth_fit/growth_fit`](#growth_fitgrowth_fit) | `gemini · gemini-3.1-flash-lite · eu_hosted` | `not_supported` | 0.33 | `current` | 1 | 2 |
 | [`offer_draft/draft`](#offer_draftdraft) | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `not_supported` | 0.73 | `current` | 5 | 3 |
@@ -143,15 +143,15 @@ verdict each reached. Each record's own p50 and p95 are in the site tables.
 
 | Provider | Model | Env | Sites | `current` | `partial` | `stale` | Runs | Passed | Reliability | Slowest p95 | `certified` | `supported_degraded` | `not_supported` |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 36 | 35 | 0 | 1 | 381 | 330 | 0.87 | 4970ms | 17 | 5 | 14 |
-| `gemini` | `gemini-3.1-pro-preview` | `eu_hosted` | 6 | 6 | 0 | 0 | 36 | 36 | 1.00 | 46554ms | 4 | 0 | 2 |
-| `gemini` | `gemini-3.5-flash` | `eu_hosted` | 13 | 13 | 0 | 0 | 90 | 86 | 0.96 | 26168ms | 9 | 0 | 4 |
+| `gemini` | `gemini-3.1-flash-lite` | `eu_hosted` | 36 | 31 | 0 | 5 | 381 | 330 | 0.87 | 4970ms | 17 | 5 | 14 |
+| `gemini` | `gemini-3.1-pro-preview` | `eu_hosted` | 6 | 2 | 0 | 4 | 36 | 36 | 1.00 | 46554ms | 4 | 0 | 2 |
+| `gemini` | `gemini-3.5-flash` | `eu_hosted` | 13 | 9 | 0 | 4 | 90 | 86 | 0.96 | 26168ms | 9 | 0 | 4 |
 | `openai_compatible` | `anthropic/claude-haiku-4.5` | `eu_hosted` | 1 | 1 | 0 | 0 | 15 | 9 | 0.60 | 3731ms | 0 | 0 | 1 |
 | `openai_compatible` | `mistralai/ministral-14b-2512` | `cloud_frontier` | 11 | 0 | 0 | 11 | 160 | 113 | 0.71 | 20620ms | 8 | 0 | 3 |
 | `openai_compatible` | `mistralai/ministral-8b-2512` | `cloud_frontier` | 3 | 0 | 0 | 3 | 15 | 14 | 0.93 | 22390ms | 1 | 2 | 0 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 27 | 0.90 | 4574ms | 4 | 0 | 1 |
 | `openai_compatible` | `mistralai/mistral-large-2512` | `eu_hosted` | 6 | 6 | 0 | 0 | 42 | 37 | 0.88 | 4337ms | 4 | 1 | 1 |
-| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 35 | 34 | 0 | 1 | 372 | 298 | 0.80 | 5546ms | 12 | 9 | 14 |
+| `openai_compatible` | `openai/gpt-oss-120b` | `eu_hosted` | 35 | 30 | 0 | 5 | 372 | 298 | 0.80 | 5546ms | 12 | 9 | 14 |
 | `openai_compatible` | `z-ai/glm-5.2` | `cloud_frontier` | 5 | 4 | 0 | 1 | 30 | 28 | 0.93 | 18372ms | 4 | 0 | 1 |
 
 ## Stale records, and why
@@ -180,7 +180,23 @@ model, real network).
 | `cold_start/company_message` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/field_extract` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `cold_start/sitereadmessage` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `draft_reply/account` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/account` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/account` | `gemini · gemini-3.5-flash · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/account` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario account_first_touch_with_a_deal_in_flight — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/first` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/first` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/first` | `gemini · gemini-3.5-flash · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/first` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario first_message_from_an_intent_alone — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/person` | `gemini · gemini-3.1-flash-lite · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/person` | `gemini · gemini-3.1-pro-preview · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/person` | `gemini · gemini-3.5-flash · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/person` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | scenario person_first_touch_in_german — or the prompt this build now builds from it — has changed since the record scored it |
+| `draft_reply/reply` | `gemini · gemini-3.1-flash-lite · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
+| `draft_reply/reply` | `gemini · gemini-3.1-pro-preview · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
+| `draft_reply/reply` | `gemini · gemini-3.5-flash · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
 | `draft_reply/reply` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
+| `draft_reply/reply` | `openai_compatible · openai/gpt-oss-120b · eu_hosted` | 4 scenarios it scored have changed since, or the prompts built from them have: german_thread_with_an_introduction_in_it, reply_to_pricing_question, replying_to_a_thread_eight_months_old, rich_german_thread_with_a_long_ask |
 | `enrich/signature` | `openai_compatible · mistralai/ministral-8b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `offer_draft/draft` | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
 | `site_extract/profile` | `openai_compatible · mistralai/mistral-large-2512 · cloud_frontier` | predates per-scenario stamps: only its task stamp can be compared, and that has moved |
@@ -552,10 +568,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `supported_degraded` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `supported_degraded` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
 
 #### `draft_reply/first`
 
@@ -571,10 +587,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `not_supported` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `supported_degraded` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `not_supported` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `supported_degraded` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
 
 #### `draft_reply/intro`
 
@@ -631,10 +647,10 @@ Records (4):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 1/1 | `supported_degraded` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 1/1 | `certified` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/1 | `supported_degraded` | 3 | 3 | 1.00 | 1354ms | 3477ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 24063ms | 46554ms | 3 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 10016ms | 26168ms | 3 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/1 | `certified` | 3 | 3 | 1.00 | 1223ms | 2663ms | 3 | 0 | 0 | 0 |
 
 #### `draft_reply/reply`
 
@@ -653,11 +669,11 @@ Records (5):
 
 | Binding | State | Scenarios | Band | Runs | Passed | Reliability | Record p50 | Record p95 | `accepted` | `wrong_answer` | `invalid` | `abstained` |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| `gemini · gemini-3.1-flash-lite · eu_hosted` | `current` | 4/4 | `supported_degraded` | 12 | 12 | 1.00 | 1354ms | 3477ms | 12 | 0 | 0 | 0 |
-| `gemini · gemini-3.1-pro-preview · eu_hosted` | `current` | 4/4 | `not_supported` | 12 | 12 | 1.00 | 24063ms | 46554ms | 12 | 0 | 0 | 0 |
-| `gemini · gemini-3.5-flash · eu_hosted` | `current` | 4/4 | `not_supported` | 12 | 12 | 1.00 | 10016ms | 26168ms | 12 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-flash-lite · eu_hosted` | `stale` | 0/4 | `supported_degraded` | 12 | 12 | 1.00 | 1354ms | 3477ms | 12 | 0 | 0 | 0 |
+| `gemini · gemini-3.1-pro-preview · eu_hosted` | `stale` | 0/4 | `not_supported` | 12 | 12 | 1.00 | 24063ms | 46554ms | 12 | 0 | 0 | 0 |
+| `gemini · gemini-3.5-flash · eu_hosted` | `stale` | 0/4 | `not_supported` | 12 | 12 | 1.00 | 10016ms | 26168ms | 12 | 0 | 0 | 0 |
 | `openai_compatible · mistralai/ministral-14b-2512 · cloud_frontier` | `stale` | - | `certified` | 3 | 3 | 1.00 | 2508ms | 2685ms | 3 | 0 | 0 | 0 |
-| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `current` | 4/4 | `not_supported` | 12 | 12 | 1.00 | 1223ms | 2663ms | 12 | 0 | 0 | 0 |
+| `openai_compatible · openai/gpt-oss-120b · eu_hosted` | `stale` | 0/4 | `not_supported` | 12 | 12 | 1.00 | 1223ms | 2663ms | 12 | 0 | 0 | 0 |
 
 ### `enrich`
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22066,6 +22066,13 @@ export interface components {
             channel_provider?: components["schemas"]["ProviderRef"] | null;
             subject?: string | null;
             body?: string | null;
+            /**
+             * @description What language this message is written in, read from its own text when it was captured. Null on a message whose text was too short to tell, on anything hand-logged, and on every row captured before this was recorded — all of which mean "not known", never "not any of these".
+             *     A detector's observation, not a declaration by its author, and it describes the message rather than the person: the same contact writes in two languages and each message says which it is. A drafted reply follows it, so that a reply to an English thread is written in English whatever language its sender's own writing samples happen to be in.
+             *     Withheld with the rest of the content: it is derived from the body, so a caller who may discover the row without reading it is not told this either.
+             * @enum {string|null}
+             */
+            readonly language?: "de" | "en" | "vi" | null;
             /** Format: date-time */
             occurred_at: string;
             /**


### PR DESCRIPTION
Closes #4699.

## What was wrong

An English email from a Singapore vendor got a **German** draft reply. Nothing in the workspace is configured for German: `installation.base_language` is `en` and no user has a locale. The voice profile's corpus is 12 sources, 48,427 words, entirely German, and the model reproduced the *language* along with the register.

## The rule that should have stopped it pointed at nothing

`draftrules` told the model to write in *the language given as "Write in"*. No payload has ever carried a field called that — the envelope's key is `output_language`. An instruction referring to a field nothing sends leaves the strongest signal in context to decide, and on a voiced draft that is the sender's own writing samples.

Every prompt test stayed green throughout, because the rule was present, correct, and referring to nobody. Same defect in the sender rule (`"You are writing as"` versus `sender_name`).

## Four changes

**The rules name fields the payloads carry**, at both paths — reply and first-draft inline the envelope flat, which the certification harness requires; person and account nest it under `envelope`. A new gate asserts each rule names the field its own instruction reads, **per surface** rather than against a union: a union would let a field missing from one surface pass because another carries it. Mutation-checked against the exact wording that shipped, in both rules.

**The voice profile never chooses the language.** It carries rhythm, directness, sentence length and structure across; the words are a different question. The vocabulary rule is scoped to the draft's own language rather than the samples'.

**The language ladder gains its two missing tiers**: stored, then body, then subject, then the installation's own language, then English. The base-language tier is what actually decides a **first message**, which has no correspondence at all — only the rep's typed intent, far short of the detector's bar. Language is resolved *before* the envelope is built: the envelope carries a register only for a German draft, so a late correction would leave a German register on an English envelope.

**Capture records the language**, so a thread does not answer differently as a quoted chain grows under it. The CHECK admitted `de` and `en` while the product ships Vietnamese, so it is widened.

## What is deliberately not here

**No backfill.** `search_tsv` is a stored generated column keyed on this column, so relabelling history would re-stem every old row and shift search results for everyone in one statement. New rows carry the label; old rows keep the behaviour they have, and the ladder falls through to detection for them.

**The certification page now reads `stale` for the four drafting sites.** Changing the shared rules retires their records. That is the honest state — those prompts have not been run against a live model since the language rule started naming a field that exists, and reporting `current` would claim evidence nobody has. Re-certification is a model run, not a code change.

## Verification

`make check-backend`, `make check-fe`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green. Full `migrations` and `capture` integration lanes against real Postgres. Capture tests cover English, German and Vietnamese end to end, a body too short to tell under a readable subject, an undetectable message recording NULL, and a replay not rewriting what the first capture found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drafted replies being written in the voice profile's corpus language instead of the thread's (issue #4699): an English email answered under a German-only profile now gets an English draft, and first messages fall back to the installation's configured language before English.

- Language resolves as stored → body → subject → installation base language → English, and the German-only register is attached only when the draft itself is German.
- Capture records what a message is written in (`de`, `en`, or `vi`, NULL when it cannot tell), so a growing quoted chain cannot change the language a reply answers in.
- No backfill for older rows: `search_tsv` is a generated column keyed on this, so history keeps its behavior and detection covers it.
- Prompt rules now name the payload fields they actually read — `output_language`, `sender_name`, `sender_email` — and a per-surface gate stops an instruction pointing at a field nothing sends from recurring.
- The voice rules now say the profile carries register and rhythm, never language; certification records for the four drafting sites go `stale` until re-run.
- The stored language label is cleared whenever the message text is erased or its subject/body edited, so it does not outlive the words it was read from.
- The model draft and its deterministic fallback share one resolved language, so a model failure cannot change what language the rep is shown.

<sup>Written for commit 994ac5d210dd013d39babd56d92edd21a6997c1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Captured messages now record detected language in English, German, or Vietnamese when available.
  - Message APIs expose the detected language while respecting content privacy controls.
  - Drafts now select their language using stored message data, text detection, account settings, and English as a fallback.
  - Drafts can be written in a different language from the voice samples while preserving the samples’ style and tone.
  - German formal/informal register guidance now applies only to German drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->