### PR TITLE
The private-reference gate reads CSS too

### DIFF
--- a/backend/gates/publicreferences_test.go
+++ b/backend/gates/publicreferences_test.go
@@ -22,6 +22,13 @@ package gates
 // automatically. There is no exemption list: the one file that could not be
 // cleaned was moved out of this repository instead, and an exemption is a hole
 // somebody eventually widens.
+//
+// WHAT A GREEN RUN HERE DOES NOT MEAN. The rule covers commit messages and PR
+// bodies as well as the tree, and no test can reach either — they are not files
+// this or any checkout holds. That half stays judgement, and it is said here
+// rather than left for a reader to assume: a gate that covers most of a rule
+// and says nothing about the rest is read as covering all of it, which is how
+// the half nobody checks becomes the half nobody thinks about.
 
 import (
 	"errors"
@@ -68,6 +75,11 @@ var forbidden = []struct {
 var scanned = map[string]bool{
 	".go": true, ".md": true, ".yml": true, ".yaml": true,
 	".json": true, ".ts": true, ".tsx": true, ".sh": true, ".sql": true,
+	// .css because prose lives there too: a design-system file explains a
+	// colour decision in a comment, and a comment is where a citation of an
+	// unreachable document goes unnoticed. It was the last extension the
+	// frontend writes in that this gate could not see.
+	".css": true,
 }
 
 func TestPublicTreeCitesNothingPrivate(t *testing.T) {

--- a/frontend/src/design-system/trust.css
+++ b/frontend/src/design-system/trust.css
@@ -1,6 +1,5 @@
 /*
- * Trust primitives — the Margince-specific vocabulary (design-language §4,
- * foundation v0: specs/design/design-system/margince.css).
+ * Trust primitives — the Margince-specific vocabulary (design-language §4).
  * Staged / real / human-typed are three DISTINGUISHABLE styles (§5c);
  * confidence is a first-class glyph, low shown as low, never hidden (§4.2).
  * Colours read from tokens only — the conformance gate enforces it.


### PR DESCRIPTION
Closes #1765.

The rule is unqualified — *never refer to a private repository, document, path or link* — and the gate enforced it over every extension the frontend writes in **except one**.

Prose lives in CSS too. A design-system file explains a colour decision in a comment, and a comment is exactly where a citation of a document nobody outside can open goes unnoticed.

## It was already being broken, once

Adding the extension found precisely the line the ticket named:

```
frontend/src/design-system/trust.css:3 carries a private specification path
```

The sentence it sat in explains a colour decision and does not need the citation to make sense, so it is gone rather than reworded around it.

## And the test now says what a green run does not mean

The rule covers **commit messages and PR bodies** as well as the tree, and no test can reach either — they are not files any checkout holds. That half stays judgement.

Said in the gate rather than left to be assumed: a gate that covers most of a rule and is silent about the rest is read as covering all of it, which is how the half nobody checks becomes the half nobody thinks about.

## Verification

**Mutation**: a fresh citation in a `.css` comment is reported, which it was not before. `make check-backend` exit 0; biome clean on the touched file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the scope and limitations of public-reference checks, including what commit messages and pull request descriptions are not covered.
  - Updated trust stylesheet documentation by removing an outdated foundation reference.

- **Tests**
  - Expanded reference scanning coverage to include CSS files, helping detect private references in design-system stylesheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->