### PR TITLE
The settings rail carries what you can change

### DIFF
--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -608,6 +608,11 @@ function SectionSwitcher({
         <h2 id={titleId} className="t-h2">
           {t(section.titleKey)}
         </h2>
+        {/* Above the rows, exactly where the rail puts it. Without this the
+            search was unreachable at phone width — the one width where the
+            navigation is hardest to scan, since the rail is gone and the whole
+            list is behind this button. */}
+        {section.leadFor?.(close)}
         <div className="sectionpick">
           {section.groups.map((group, index) => (
             <SectionPickGroup

--- a/frontend/src/app/subnav.ts
+++ b/frontend/src/app/subnav.ts
@@ -108,6 +108,14 @@ export type NavSection = {
   // below, because the trail is what the rail actually renders: a slot added to
   // one alone is a field nothing draws.
   lead?: ReactNode;
+  // The same thing for a host that must close itself once the lead has moved
+  // the reader — the phone-width section drawer, which is a full-screen sheet
+  // and would otherwise stay open over the page just opened.
+  //
+  // A second field rather than making `lead` a function: the rail has nothing
+  // to dismiss and would have to invent an empty callback, and `navTrail`
+  // carries `lead` down to a level that never wants this one.
+  leadFor?: (onPick: () => void) => ReactNode;
 };
 
 // The attention counts the rail badges. They ride the level rather than being

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6138,6 +6138,22 @@ export const de = {
   // Überschrift wiederholt, benennt nichts.
   "settings.home": "Einstellungen-Start",
   "settings.home.yours": "Ihre Einstellungen",
+  "settings.home.manage": "Was Sie \u00e4ndern k\u00f6nnen",
+  "settings.home.manageSub":
+    "Einstellungen, f\u00fcr die Sie die Berechtigung haben.",
+  "settings.home.lookUp": "Was Sie nachschlagen k\u00f6nnen",
+  "settings.home.lookUpSub":
+    "Sie k\u00f6nnen diese lesen; das \u00c4ndern geh\u00f6rt nicht zu Ihrer Rolle.",
+  "settings.home.rolesLabel": "Ihre Rolle",
+  "settings.home.seatLabel": "Ihr Sitzplatz",
+  "settings.home.seat.full":
+    "Voller Sitzplatz \u2014 Sie k\u00f6nnen \u00c4nderungen vornehmen",
+  "settings.home.seat.read":
+    "Nur-Lese-Sitzplatz \u2014 Sie k\u00f6nnen sehen, nicht \u00e4ndern",
+  "settings.home.reachLabel": "Datens\u00e4tze, die Sie erreichen",
+  "settings.home.reach.own": "Ihre eigenen Datens\u00e4tze",
+  "settings.home.reach.team": "Die Datens\u00e4tze Ihres Teams",
+  "settings.home.reach.all": "Jeden Datensatz in der Organisation",
   "settings.home.access": "Ihr Zugriff",
   "settings.boundary.deniedTitle":
     "Diese Einstellungsseite steht Ihnen nicht offen",
@@ -6210,6 +6226,8 @@ export const de = {
   "settings.scopeAria": "Wen diese Seite betrifft: {scope}",
   "settings.scopeAriaMixed":
     "Diese Seite enth\u00e4lt Einstellungen, die unterschiedliche Personen betreffen \u2014 jede sagt es selbst.",
+  "settings.readOnlyPage":
+    "Sie k\u00f6nnen diese Einstellungen sehen, aber nicht \u00e4ndern \u2014 das \u00c4ndern geh\u00f6rt nicht zu Ihrer Rolle.",
   "settings.search.label": "Einstellungen durchsuchen",
   "settings.search.placeholder": "Einstellungen suchen",
   "settings.search.none": "Keine Einstellungsseite passt dazu.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6275,6 +6275,19 @@ export const en = {
   // is why it had to be ungated to keep a rep's own mailbox reachable.
   "settings.home": "Settings home",
   "settings.home.yours": "Your settings",
+  "settings.home.manage": "What you can change",
+  "settings.home.manageSub": "Settings you have the permission to edit.",
+  "settings.home.lookUp": "What you can look up",
+  "settings.home.lookUpSub":
+    "You can read these; changing them is not part of your role.",
+  "settings.home.rolesLabel": "Your role",
+  "settings.home.seatLabel": "Your seat",
+  "settings.home.seat.full": "Full seat \u2014 you can make changes",
+  "settings.home.seat.read": "Read-only seat \u2014 you can look, not change",
+  "settings.home.reachLabel": "Records you reach",
+  "settings.home.reach.own": "Your own records",
+  "settings.home.reach.team": "Your team\u2019s records",
+  "settings.home.reach.all": "Every record in the organization",
   "settings.home.access": "Your access",
   "settings.boundary.deniedTitle": "This settings page is not yours to open",
   "settings.boundary.deniedBody":
@@ -6342,6 +6355,8 @@ export const en = {
   "settings.scopeAria": "Who this page affects: {scope}",
   "settings.scopeAriaMixed":
     "This page holds settings that affect different people \u2014 each one says which.",
+  "settings.readOnlyPage":
+    "You can see these settings but not change them \u2014 changing them is not part of your role.",
   "settings.search.label": "Search settings",
   "settings.search.placeholder": "Search settings",
   "settings.search.none": "No settings page matches that.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6071,6 +6071,24 @@ export const vi = {
   // từ đó, và một dòng lặp lại tiêu đề của chính nó thì không gọi tên được gì.
   "settings.home": "Trang ch\u00ednh c\u00e0i \u0111\u1eb7t",
   "settings.home.yours": "C\u00e0i \u0111\u1eb7t c\u1ee7a b\u1ea1n",
+  "settings.home.manage":
+    "Nh\u1eefng g\u00ec b\u1ea1n c\u00f3 th\u1ec3 thay \u0111\u1ed5i",
+  "settings.home.manageSub":
+    "C\u00e1c c\u00e0i \u0111\u1eb7t b\u1ea1n c\u00f3 quy\u1ec1n ch\u1ec9nh s\u1eeda.",
+  "settings.home.lookUp":
+    "Nh\u1eefng g\u00ec b\u1ea1n c\u00f3 th\u1ec3 tra c\u1ee9u",
+  "settings.home.lookUpSub":
+    "B\u1ea1n c\u00f3 th\u1ec3 \u0111\u1ecdc; vi\u1ec7c thay \u0111\u1ed5i kh\u00f4ng thu\u1ed9c vai tr\u00f2 c\u1ee7a b\u1ea1n.",
+  "settings.home.rolesLabel": "Vai tr\u00f2 c\u1ee7a b\u1ea1n",
+  "settings.home.seatLabel": "Ch\u1ed7 ng\u1ed3i c\u1ee7a b\u1ea1n",
+  "settings.home.seat.full":
+    "Ch\u1ed7 \u0111\u1ea7y \u0111\u1ee7 \u2014 b\u1ea1n c\u00f3 th\u1ec3 thay \u0111\u1ed5i",
+  "settings.home.seat.read":
+    "Ch\u1ed7 ch\u1ec9 \u0111\u1ecdc \u2014 b\u1ea1n c\u00f3 th\u1ec3 xem, kh\u00f4ng th\u1ec3 thay \u0111\u1ed5i",
+  "settings.home.reachLabel": "B\u1ea3n ghi b\u1ea1n ti\u1ebfp c\u1eadn",
+  "settings.home.reach.own": "B\u1ea3n ghi c\u1ee7a ri\u00eang b\u1ea1n",
+  "settings.home.reach.team": "B\u1ea3n ghi c\u1ee7a nh\u00f3m b\u1ea1n",
+  "settings.home.reach.all": "M\u1ecdi b\u1ea3n ghi trong t\u1ed5 ch\u1ee9c",
   "settings.home.access": "Quy\u1ec1n truy c\u1eadp c\u1ee7a b\u1ea1n",
   "settings.boundary.deniedTitle":
     "Trang c\u00e0i \u0111\u1eb7t n\u00e0y kh\u00f4ng m\u1edf cho b\u1ea1n",
@@ -6145,6 +6163,8 @@ export const vi = {
     "Trang n\u00e0y \u1ea3nh h\u01b0\u1edfng \u0111\u1ebfn ai: {scope}",
   "settings.scopeAriaMixed":
     "Trang n\u00e0y c\u00f3 c\u00e1c c\u00e0i \u0111\u1eb7t \u1ea3nh h\u01b0\u1edfng \u0111\u1ebfn nh\u1eefng ng\u01b0\u1eddi kh\u00e1c nhau \u2014 m\u1ed7i c\u00e0i \u0111\u1eb7t t\u1ef1 n\u00f3i r\u00f5.",
+  "settings.readOnlyPage":
+    "B\u1ea1n c\u00f3 th\u1ec3 xem c\u00e1c c\u00e0i \u0111\u1eb7t n\u00e0y nh\u01b0ng kh\u00f4ng th\u1ec3 thay \u0111\u1ed5i \u2014 vi\u1ec7c thay \u0111\u1ed5i kh\u00f4ng thu\u1ed9c vai tr\u00f2 c\u1ee7a b\u1ea1n.",
   "settings.search.label": "T\u00ecm trong c\u00e0i \u0111\u1eb7t",
   "settings.search.placeholder": "T\u00ecm c\u00e0i \u0111\u1eb7t",
   "settings.search.none":

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -13,7 +13,9 @@ import {
   jsonResponse,
   readOn,
   render,
+  renderHome,
   renderNav,
+  renderSettings,
   settingsBackend,
 } from "./settings.testkit";
 import {
@@ -56,6 +58,8 @@ describe("SettingsScreen page layout", () => {
   });
 
   it("groups the nav by subject, Account current by default", async () => {
+    // The RAIL, at a page address: this case is about the sidebar's own shape
+    // and its current row, which the home address has no answer for.
     renderNav();
     // ONE navigation landmark in the chrome: the level names itself with a
     // heading rather than opening a second `nav` beside the sidebar's own.
@@ -195,22 +199,35 @@ function settingsNavBackend(opts: {
   });
 }
 
-// The settings pages currently in the nav, in render order. Asserting the WHOLE
-// list rather than one membership is the point: a requirement wired to the wrong
-// object shows up as an extra or a missing row, where a single getBy would pass
-// regardless.
-function navPages(): string[] {
-  return screen
-    .getAllByRole("link")
-    .filter((link) => {
-      const href = link.getAttribute("href") ?? "";
-      // `#/settings` exactly is Settings home — a row of this level whose
-      // address is the level itself. The trailing slash alone would drop it,
-      // which is how a helper quietly stops seeing the row it was meant to
-      // prove is there.
-      return href === "#/settings" || href.startsWith("#/settings/");
-    })
-    .map((link) => link.textContent ?? "");
+/**
+ * Every page this render OFFERS, rail and home together, de-duplicated and in
+ * catalog order.
+ *
+ * The rail alone stopped being the list of pages a reader may open: it carries
+ * `changes` now — the pages they can act on — and a page they may read and
+ * cannot change is deliberately absent from it while still answering its
+ * address, appearing in search, and being listed on the settings home under a
+ * heading that says which it is.
+ *
+ * So a case whose claim is "this grant opens that page" reads BOTH surfaces.
+ * Reading only the rail would turn every such case into a claim about
+ * prominence, which is a different question and one most of them never meant
+ * to ask.
+ */
+function offeredPages(): string[] {
+  const seen = new Set(
+    screen
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("href") ?? "")
+      .filter((href) => href.startsWith("#/settings/"))
+      .map((href) => href.slice("#/settings/".length)),
+  );
+  return [
+    translate("en", "settings.home"),
+    ...SETTINGS_PAGES.filter((page) => seen.has(page.id)).map((page) =>
+      labelOf(page.id),
+    ),
+  ];
 }
 
 // The rows under ONE group heading. Each group renders its heading and its own
@@ -288,7 +305,7 @@ const floorPlus = (...ids: readonly SettingsPageId[]) =>
  * Assert the nav settles to exactly these rows, once `/me` has actually
  * answered.
  *
- * A bare `waitFor(() => expect(navPages()).toEqual(floorPlus()))` is VACUOUS
+ * A bare `waitFor(() => expect(offeredPages()).toEqual(floorPlus()))` is VACUOUS
  * for a case about an absence. Every capability predicate reads false while the
  * snapshot is in flight, so the loading nav renders precisely the ungated floor
  * — the same rows a resolved snapshot granting nothing renders. `waitFor`
@@ -304,8 +321,26 @@ const floorPlus = (...ids: readonly SettingsPageId[]) =>
  * read, and is unrelated to every requirement these cases move.
  */
 async function expectNavSettlesTo(expected: readonly string[]) {
-  await screen.findByRole("link", { name: labelOf("pipelines") });
-  await expect.poll(() => navPages()).toEqual(expected);
+  await expectSnapshotResolved();
+  await expect.poll(() => offeredPages()).toEqual(expected);
+}
+
+/**
+ * Wait until `/me` has actually answered AND rendered.
+ *
+ * The witness is the settings home's seat row, which draws only when
+ * `authorization` is present on the snapshot — it is absent while the request
+ * is in flight, and the panel renders nothing rather than guessing a seat.
+ *
+ * A page row cannot do this job any more. The old witness was Pipelines, which
+ * worked only for a fixture that granted `pipeline:read`; a case about a lone
+ * `seat_usage` reader has no such row to wait for, and waiting for one that
+ * never comes fails a case whose subject is somewhere else entirely. The seat
+ * row is on every resolved snapshot regardless of grants, which is what a
+ * positive control has to be.
+ */
+async function expectSnapshotResolved() {
+  await screen.findByText(translate("en", "settings.home.seat.full"));
 }
 
 // Every page open at once: one grant apiece for the pages that follow an
@@ -323,32 +358,44 @@ async function expectNavSettlesTo(expected: readonly string[]) {
 // changes it, because the read is one every seat holds. Granting the read here
 // would leave this "every page" fixture four pages short.
 const EVERY_PAGE_GRANTED: GrantSpec = {
+  // Writing voice, whose card asks the WRITE. It needed no entry while the page
+  // was ungated; now that the rail carries what a reader can act on, an admin
+  // without this grant would consult their own voice profile rather than own it.
+  voice_profile: ["read", "create", "update"],
   installation_settings: ["read", "update"],
   // Sign-in & apps, whose card reads the narrow projection.
   authentication_policy: ["read"],
   license: ["read"],
-  pipeline: ["read"],
-  custom_field: ["read"],
-  tag: ["read"],
-  product: ["read"],
-  capture_settings: ["read"],
+  // The sales vocabulary, with its WRITES. Reads alone opened every one of these
+  // pages and still do — but the rail carries what a reader can act on, and a
+  // fixture standing for "every page at once" has to be able to act on them or
+  // the whole Sales heading is legitimately absent.
+  pipeline: ["read", "create", "update"],
+  custom_field: ["read", "create", "update"],
+  tag: ["read", "create", "update"],
+  product: ["read", "create", "update"],
+  capture_settings: ["read", "update"],
   webhook_subscription: ["read", "create", "update"],
-  knowledge_corpus: ["read"],
-  import_run: ["read"],
-  ai_routing: ["read"],
+  knowledge_corpus: ["read", "create"],
+  import_run: ["read", "create", "update"],
+  ai_routing: ["read", "update"],
   automation: ["read", "create", "update"],
   ai_diagnostics: ["read"],
+  // What ModelCostsCard writes. AI usage opens on `ai_diagnostics` and is ACTED
+  // on through the rate table beside it, so a fixture meaning "every page" needs
+  // both.
+  ai_model_rate: ["read", "create", "update"],
   person: ["read"],
   // What opens Privacy & audit now that `person:read` does not.
-  retention_policy: ["read"],
+  retention_policy: ["read", "create", "update"],
   audit_log: ["read"],
   job_health: ["read"],
-  embedding_reindex: ["read"],
+  embedding_reindex: ["read", "update"],
   extension_access: ["read"],
   // Extensions is TWO reads: the unit inventory on `extension_access` and every
   // role's grant on every object on `role_admin` (identity/roles.go ListRoles).
   // The card fires both behind one flag, so the page needs both.
-  role_admin: ["read"],
+  role_admin: ["read", "update"],
   // The roster and team pages, which follow their own objects now rather than
   // opening for every authenticated reader.
   user_admin: ["read", "create", "update", "delete"],
@@ -516,8 +563,8 @@ describe("SettingsScreen page visibility", () => {
         dataResetAvailable: true,
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(EVERY_PAGE));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(EVERY_PAGE));
     // And each page is under the heading that claims it: the flat order above
     // would read the same if a page were declared in the wrong group.
     const nav = screen.getByRole("navigation", { name: /primary navigation/i });
@@ -584,8 +631,8 @@ describe("SettingsScreen page visibility", () => {
         "fetch",
         settingsNavBackend({ roles: [role], allow: SEEDED_READS }),
       );
-      renderNav();
-      await waitFor(() => expect(navPages()).toEqual(SEEDED_READ_PAGES));
+      renderHome();
+      await waitFor(() => expect(offeredPages()).toEqual(SEEDED_READ_PAGES));
     },
   );
 
@@ -604,7 +651,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { custom_field: ["create", "update"], pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -613,11 +660,11 @@ describe("SettingsScreen page visibility", () => {
     async ({ object, opens }) => {
       const allow = readOn(object);
       vi.stubGlobal("fetch", settingsNavBackend({ roles: ["ops"], allow }));
-      renderNav();
+      renderHome();
       // `readOn` carries `person:read` with it as a floor, so a case about ONE
       // object stays about one object. It no longer opens Privacy: that page
       // asks the two governance objects nobody below admin and ops holds.
-      await waitFor(() => expect(navPages()).toEqual(floorPlus(...opens)));
+      await waitFor(() => expect(offeredPages()).toEqual(floorPlus(...opens)));
     },
   );
 
@@ -641,7 +688,7 @@ describe("SettingsScreen page visibility", () => {
           allow: { ...readOn(object), pipeline: ["read"] },
         }),
       );
-      const { unmount } = renderNav();
+      const { unmount } = renderHome();
       await expectNavSettlesTo(floorPlus("pipelines"));
       unmount();
 
@@ -652,9 +699,9 @@ describe("SettingsScreen page visibility", () => {
           allow: { ...readOn(object), [object]: ["read", "update"] },
         }),
       );
-      renderNav();
+      renderHome();
       await waitFor(() =>
-        expect(navPages()).toEqual(floorPlus("integrations")),
+        expect(offeredPages()).toEqual(floorPlus("integrations")),
       );
     },
   );
@@ -669,11 +716,11 @@ describe("SettingsScreen page visibility", () => {
         allow: readOn("authentication_policy"),
       }),
     );
-    renderNav();
+    renderHome();
     // `privacy` rides the floor here: meFixture grants `person:read`, which is
     // one of that page's union terms — the consent registry's own server gate.
     await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("authentication")),
+      expect(offeredPages()).toEqual(floorPlus("authentication")),
     );
   });
 
@@ -695,7 +742,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { ...readOn("installation_settings"), pipeline: ["read"] },
       }),
     );
-    const { unmount } = renderNav();
+    const { unmount } = renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
     unmount();
 
@@ -709,8 +756,8 @@ describe("SettingsScreen page visibility", () => {
         },
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("company")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("company")));
   });
 
   it("opens Seats & license for a lone license read", async () => {
@@ -722,8 +769,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("license") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("seats")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("seats")));
   });
 
   it("opens Seats & license for a lone seat_usage read", async () => {
@@ -736,8 +783,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("seat_usage") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("seats")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("seats")));
     cleanup();
 
     // The other half, or the assertion above would pass against a page that
@@ -749,7 +796,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { ...readOn("person"), pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -762,8 +809,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("capture_settings") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("capture")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("capture")));
   });
 
   it("opens System health for a lone embedding_reindex read, for a principal who is no admin", async () => {
@@ -779,8 +826,10 @@ describe("SettingsScreen page visibility", () => {
         allow: readOn("embedding_reindex"),
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("system-health")));
+    renderHome();
+    await waitFor(() =>
+      expect(offeredPages()).toEqual(floorPlus("system-health")),
+    );
   });
 
   it("opens System health for a lone job_health read", async () => {
@@ -794,8 +843,10 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("job_health") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("system-health")));
+    renderHome();
+    await waitFor(() =>
+      expect(offeredPages()).toEqual(floorPlus("system-health")),
+    );
     cleanup();
 
     // And a seat holding neither term still does not reach it, or the case
@@ -807,7 +858,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { ...readOn("person"), pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -833,8 +884,10 @@ describe("SettingsScreen page visibility", () => {
         },
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("extensions")));
+    renderHome();
+    await waitFor(() =>
+      expect(offeredPages()).toEqual(floorPlus("extensions")),
+    );
     cleanup();
 
     // The inventory read ALONE is not the page. The card makes a second request
@@ -848,7 +901,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { ...readOn("extension_access"), pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
     cleanup();
 
@@ -869,7 +922,7 @@ describe("SettingsScreen page visibility", () => {
         },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -887,7 +940,7 @@ describe("SettingsScreen page visibility", () => {
         dataResetAvailable: true,
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
     cleanup();
 
@@ -899,8 +952,8 @@ describe("SettingsScreen page visibility", () => {
         dataResetAvailable: true,
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("reset")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("reset")));
     cleanup();
 
     // And the deployment's own consent, which is not a permission: the same
@@ -921,7 +974,7 @@ describe("SettingsScreen page visibility", () => {
         },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -933,8 +986,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("fx_rate") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("company")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("company")));
   });
 
   it("opens AI usage for a lone ai_model_rate read", async () => {
@@ -945,8 +998,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("ai_model_rate") }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("usage")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("usage")));
   });
 
   it("opens both AI diagnostics pages for a lone ai_diagnostics read", async () => {
@@ -967,9 +1020,11 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: readOn("ai_diagnostics") }),
     );
-    renderNav();
+    renderHome();
     await waitFor(() =>
-      expect(navPages()).toEqual(floorPlus("models", "usage", "model-calls")),
+      expect(offeredPages()).toEqual(
+        floorPlus("models", "usage", "model-calls"),
+      ),
     );
   });
 
@@ -986,12 +1041,14 @@ describe("SettingsScreen page visibility", () => {
         allow: { person: ["read"], automation: ["update"] },
       }),
     );
-    renderNav();
+    renderHome();
     // `automations` is OPEN here, and naming it is the point: this fixture holds
     // `automation:update`, which is exactly what that page asks now. The claim
     // under test is about the three AI diagnostics pages staying shut, and
     // asserting the whole row keeps the two facts from being confused.
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("automations")));
+    await waitFor(() =>
+      expect(offeredPages()).toEqual(floorPlus("automations")),
+    );
   });
 
   it.each(["retention_policy", "privacy_request"] as const)(
@@ -1007,8 +1064,8 @@ describe("SettingsScreen page visibility", () => {
       const allow: GrantSpec = {};
       allow[object] = ["read"];
       vi.stubGlobal("fetch", settingsNavBackend({ roles: ["rep"], allow }));
-      renderNav();
-      await waitFor(() => expect(navPages()).toEqual(floorPlus("privacy")));
+      renderHome();
+      await waitFor(() => expect(offeredPages()).toEqual(floorPlus("privacy")));
     },
   );
 
@@ -1026,7 +1083,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { person: ["read"], pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -1040,7 +1097,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { consent_config: ["read", "create"], pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -1061,8 +1118,8 @@ describe("SettingsScreen page visibility", () => {
         allow: { audit_log: ["read"] },
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("audit")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("audit")));
   });
 
   it("opens Audit log for a delegated audit_log holder who is no admin", async () => {
@@ -1077,8 +1134,8 @@ describe("SettingsScreen page visibility", () => {
         allow: { audit_log: ["read"] },
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(floorPlus("audit")));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(floorPlus("audit")));
     cleanup();
 
     // And a management seat WITHOUT the read still does not reach it, or the
@@ -1092,7 +1149,7 @@ describe("SettingsScreen page visibility", () => {
         allow: { pipeline: ["read"] },
       }),
     );
-    renderNav();
+    renderHome();
     await expectNavSettlesTo(floorPlus("pipelines"));
   });
 
@@ -1115,8 +1172,8 @@ describe("SettingsScreen page visibility", () => {
         allow: SEEDED_OPS_READS,
       }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(SEEDED_OPS_PAGES));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(SEEDED_OPS_PAGES));
   });
 
   it("withholds the seats and system-health pages from a principal holding only the shared reads", async () => {
@@ -1128,8 +1185,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: SEEDED_READS }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(SEEDED_READ_PAGES));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(SEEDED_READ_PAGES));
     for (const page of ["seats", "system-health"] as const) {
       expect(screen.queryByRole("link", { name: labelOf(page) })).toBeNull();
     }
@@ -1144,8 +1201,8 @@ describe("SettingsScreen page visibility", () => {
       "fetch",
       settingsNavBackend({ roles: ["ops"], allow: SEEDED_OPS_READS }),
     );
-    renderNav();
-    await waitFor(() => expect(navPages()).toEqual(SEEDED_OPS_PAGES));
+    renderHome();
+    await waitFor(() => expect(offeredPages()).toEqual(SEEDED_OPS_PAGES));
   });
 
   // An EDITED role, which is the case a seat gate would swallow. This admin
@@ -1163,9 +1220,9 @@ describe("SettingsScreen page visibility", () => {
         dataResetAvailable: true,
       }),
     );
-    renderNav();
+    renderHome();
     await waitFor(() =>
-      expect(navPages()).toEqual(
+      expect(offeredPages()).toEqual(
         EVERY_PAGE.filter((label) => label !== labelOf("seats")),
       ),
     );
@@ -1180,7 +1237,7 @@ describe("SettingsScreen page visibility", () => {
         companyReadEnabled: true,
       }),
     );
-    renderNav();
+    renderHome();
     expect(
       await screen.findByRole("link", { name: labelOf("company") }),
     ).toBeTruthy();
@@ -1216,7 +1273,7 @@ describe("SettingsScreen page visibility", () => {
         companyReadEnabled: false,
       }),
     );
-    renderNav();
+    renderHome();
 
     await expectNavSettlesTo(floorPlus("pipelines"));
     expect(screen.queryByRole("link", { name: labelOf("company") })).toBeNull();
@@ -1251,7 +1308,7 @@ describe("SettingsScreen page visibility", () => {
         omitAvailability: true,
       }),
     );
-    renderNav();
+    renderHome();
 
     await expectNavSettlesTo(floorPlus("pipelines"));
     expect(screen.queryByRole("link", { name: labelOf("company") })).toBeNull();
@@ -1424,5 +1481,102 @@ describe("the settings access boundary", () => {
     expect(
       screen.getByText(translate("en", "settings.tab.audit")),
     ).toBeTruthy();
+  });
+});
+
+// The whole life of a page the rail does not carry, in one case.
+//
+// Each half was covered separately and the sequence was not, which is how a
+// tidier rail could quietly become a permission change: the rail's own tests
+// pass when a page is absent, and the reachability tests pass when it is
+// present, so nothing failed if "absent from the rail" ever turned into
+// "absent". A rep holding `pipeline:read` and no pipeline write is the case —
+// they consult the pipeline vocabulary and cannot edit it.
+describe("a page the rail does not carry is still the reader's to reach", () => {
+  // Not `as const`: that freezes `roles` to a readonly tuple, which the fixture's
+  // own `string[]` will not take. Vitest transpiles without typechecking, so
+  // this only ever fails in `tsc -b` — which is the gate, not the test run.
+  const consultingRep = { roles: ["rep"], allow: readOn("pipeline") };
+
+  it("leaves it out of the rail", async () => {
+    vi.stubGlobal("fetch", settingsNavBackend(consultingRep));
+    renderNav();
+    await screen.findByRole("link", { name: labelOf("account") });
+    // Waited on a row a resolved snapshot draws, so this absence is about the
+    // grant rather than about a rail that has not loaded.
+    expect(
+      screen.queryByRole("link", { name: labelOf("pipelines") }),
+    ).toBeNull();
+  });
+
+  it("lists it on the settings home, under what you can look up", async () => {
+    vi.stubGlobal("fetch", settingsNavBackend(consultingRep));
+    renderHome();
+    await expectSnapshotResolved();
+    const heading = await screen.findByRole("heading", {
+      name: translate("en", "settings.home.lookUp"),
+    });
+    const panel = heading.closest("section") ?? heading.parentElement;
+    if (!panel) {
+      throw new Error("the look-up panel has no container");
+    }
+    // The home row names the page, its scope and its subtitle in one accessible
+    // name — that is the whole point of the row, so the match is on the label it
+    // starts with rather than on the label alone.
+    expect(
+      within(panel).getByRole("link", {
+        name: new RegExp(`^${labelOf("pipelines")}`),
+      }),
+    ).toBeTruthy();
+  });
+
+  it("finds it in the search", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", settingsNavBackend(consultingRep));
+    renderNav();
+    await screen.findByRole("link", { name: labelOf("account") });
+    await user.type(screen.getByRole("combobox"), "pipeline");
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([expect.stringContaining(labelOf("pipelines"))]);
+  });
+
+  it("opens on its own address, with its own heading and no boundary", async () => {
+    vi.stubGlobal("fetch", settingsNavBackend(consultingRep));
+    renderSettings("pipelines");
+    // The page's own name in the chrome, not the section's. The heading comes
+    // from the rail's rows, and this page has none — so a regression here reads
+    // as a page called "Settings" rather than as a missing page.
+    expect(
+      await screen.findByRole("heading", { name: labelOf("pipelines") }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(translate("en", "settings.boundary.deniedTitle")),
+    ).toBeNull();
+  });
+
+  it("says once that it is theirs to read and not to change", async () => {
+    vi.stubGlobal("fetch", settingsNavBackend(consultingRep));
+    renderSettings("pipelines");
+    expect(
+      await screen.findByText(translate("en", "settings.readOnlyPage")),
+    ).toBeTruthy();
+  });
+
+  // The control for the case above: the same page, one grant apart. Without it
+  // the banner assertion would pass against a page that always shows it.
+  it("says nothing of the kind to a reader who can change it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      settingsNavBackend({
+        roles: ["rep"],
+        allow: { pipeline: ["read", "create", "update"] },
+      }),
+    );
+    renderSettings("pipelines");
+    await screen.findByRole("heading", { name: labelOf("pipelines") });
+    expect(
+      screen.queryByText(translate("en", "settings.readOnlyPage")),
+    ).toBeNull();
   });
 });

--- a/frontend/src/screens/settings.css
+++ b/frontend/src/screens/settings.css
@@ -391,3 +391,74 @@ p.settings-panel-sub {
   flex-direction: column;
   gap: var(--space-1);
 }
+
+/* The settings home's page rows.
+
+   A row, not a link chip. The home used to render each page as a bare
+   `.link-button` carrying only its name, which made it a second copy of the
+   sidebar — the reader who could not tell two pages apart in the rail could not
+   tell them apart here either. The subtitle and the scope were in the catalog
+   the whole time and were being thrown away, so a row now carries all three:
+   what it is called, whose state it changes, and what it is for. */
+.settings-home-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.settings-home-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border-radius: var(--r-sm);
+  color: inherit;
+  text-decoration: none;
+}
+.settings-home-row:hover {
+  background: var(--bgHover);
+}
+/* The name and its scope badge on one line, baseline-aligned so the badge sits
+   with the word rather than centred on a taller box. `flex-wrap` so a long page
+   name in a narrow column drops the badge rather than squeezing the name. */
+.settings-home-rowhead {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.settings-home-rowname {
+  font-weight: var(--fw-medium);
+}
+/* One group's heading inside a panel that holds several. Quieter than the
+   panel's own title, because the panel already said whether these are pages the
+   reader can change or only read, and this only says which part of the product
+   they belong to. */
+.settings-home-group + .settings-home-group {
+  margin-top: var(--space-4);
+}
+.settings-home-groupname {
+  margin: 0 0 var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+}
+/* Who the reader is here: role, seat, record reach. A definition list because
+   each row is a term and its answer, and none of them is operable — the way to
+   change any of it is to ask somebody, not to click here. */
+.settings-home-access {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+}
+.settings-home-access dt {
+  color: var(--textMuted);
+}
+.settings-home-access dd {
+  margin: 0;
+}
+.settings-home-roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -384,7 +384,12 @@ describe("SettingsScreen restructured pages", () => {
           // What opens Privacy now. `person:read` still reaches the purposes
           // list — that endpoint's gate is unchanged — but it no longer opens
           // the page, because every seeded role holds it.
-          retention_policy: ["read"],
+          //
+          // Every verb, because this case reaches the page through its rail row
+          // and the rail carries what a reader can act on. A seeded admin holds
+          // all four here — RetentionCard offers the delete too — so anything
+          // short of them described an account the product does not issue.
+          retention_policy: ["read", "create", "update", "delete"],
           audit_log: ["read"],
         },
       }),

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -102,6 +102,10 @@ export const PIPELINE_ADMIN: GrantSpec = {
 const ADMIN_GRANTS: GrantSpec = {
   ...PIPELINE_ADMIN,
   custom_field: ["read", "create", "update"],
+  // A seeded admin holds all four verbs on their own voice profile. It was
+  // absent while nothing asked — Writing voice opened for everybody — and its
+  // absence made this fixture describe an account the product never issues.
+  voice_profile: ["read", "create", "update", "delete"],
   // The consent registry's own gate (consent/store.go demands person:read),
   // which every seeded role holds. It is the floor a fixture standing in for a
   // real principal carries — but it no longer OPENS Privacy: that page asks

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -144,6 +144,7 @@ import {
   settingsAddress,
   settingsRouteTab,
   useSettingsEntryVisibility,
+  useSettingsReach,
   useSettingsSection,
   useVisibleSettingsPages,
 } from "./settingsnav";
@@ -470,8 +471,13 @@ function IntegrationsTab() {
  * address the product minted, rewriting it once on arrival.
  */
 export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
+  const t = useT();
   const target = settingsRouteTarget(route);
   const visible = useVisibleSettingsPages();
+  // The same pages, partitioned. `visible` still decides the BOUNDARY — may
+  // this reader open the address at all — and the partition decides only how
+  // the page presents itself once opened.
+  const reach = useSettingsReach();
   // The page the address names, if this reader may open it.
   const named =
     target.kind === "page"
@@ -499,6 +505,10 @@ export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
   // address they may not open is a boundary, and rewriting it would replace the
   // address they need to quote with one that is not theirs either.
   const legacy = target.kind === "page" && target.legacy && named !== undefined;
+  // Whether this page is one the reader consults rather than one they work in.
+  // Read off the same partition the rail is built from, so a page that left the
+  // rail for being read-only is the page that explains itself here.
+  const readOnlyPage = reach.looksUp.some((page) => page.id === active?.id);
   // A legacy admin address is answered AND rewritten: the reader gets the page
   // they asked for, and the URL bar then says where that page lives, so the
   // link they copy from it is the current one. Replaced rather than pushed, or
@@ -528,7 +538,7 @@ export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
   if (target.kind === "home") {
     return (
       <div className="wrap">
-        <SettingsHome pages={visible} />
+        <SettingsHome reach={reach} />
       </div>
     );
   }
@@ -550,7 +560,20 @@ export function SettingsScreen({ route }: Readonly<{ route: Route }>) {
           moment the reader clicked Contacts. The cards below claim through
           `useUnsavedGuard` and need to know nothing about where the answer is
           asked. */}
-      <div className="settings-stack arrive-stack">{tabContent(active.id)}</div>
+      <div className="settings-stack arrive-stack">
+        {/* Said ONCE, at the top, and only when the whole page is a read. A
+            reader who can change nothing here would otherwise have to infer it
+            from a screenful of disabled controls, one card at a time.
+
+            Only for a page with no open control at all: a page where SOME
+            surface is theirs says nothing here, because a banner claiming the
+            page is read-only above a control that works is worse than
+            silence. That is exactly the `looksUp` half of the partition. */}
+        {readOnlyPage && (
+          <Callout tone="info">{t("settings.readOnlyPage")}</Callout>
+        )}
+        {tabContent(active.id)}
+      </div>
     </div>
   );
 }

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -3,11 +3,14 @@ import type { RbacAction, RbacObject } from "../app/capability";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { translate } from "../i18n";
 import {
+  type CapabilityExpression,
   holds,
+  readingIsTheAct,
   SETTINGS_GROUPS,
   SETTINGS_PAGES,
   type SettingsPageId,
   type SettingsScope,
+  settingsReach,
   visibleSettingsPages,
 } from "./settingscatalog";
 
@@ -128,6 +131,173 @@ describe("the scope each page declares", () => {
     expect(Object.keys(DECLARED_SCOPE).sort()).toEqual(
       SETTINGS_PAGES.map((page) => page.id).sort(),
     );
+  });
+});
+
+// `changes` decides PROMINENCE, not permission: the rail carries what a reader
+// can act on, and everything else they may open stays on the settings home and
+// in search. A wrong value here does not lock anybody out — it puts a page a
+// reader cannot use in the furniture they navigate every day, or drops a page
+// they work in out of it.
+//
+// A census, for the reason the scope census exists: naming three pages per
+// value and letting twenty ride is how six wrong scopes shipped and four of
+// them passed. Each entry says which card it was read off.
+describe("what each page lets a reader change", () => {
+  // `changes` decides PROMINENCE, not permission: the rail carries what a reader
+  // can act on, and everything else they may open stays on the settings home and
+  // in search. A wrong value does not lock anybody out — it puts a page a reader
+  // cannot use in the furniture they navigate every day, or drops a page they
+  // work in out of it.
+  //
+  // The census renders the WHOLE expression, not the object names in it. An
+  // earlier version flattened to names and every one of these passed it: Import
+  // asking create-OR-update where its card needs both, the missing delete verbs
+  // on webhooks and overlays, Authentication missing the OAuth cards' own grant,
+  // and the absent seat ceiling. Verbs, AND-versus-OR and the ceiling are
+  // exactly where the defects were, so they are exactly what it has to compare.
+  function render(expression: CapabilityExpression): string {
+    switch (expression.kind) {
+      case "always":
+        return "always";
+      case "seat":
+        return "full-seat";
+      case "reading-is-the-act":
+        return "same-as-requires";
+      case "grant":
+        return `${expression.object}:${expression.action}`;
+      case "availability":
+        return `available:${expression.key}`;
+      case "flag":
+        return `flag:${expression.flag}`;
+      case "units":
+        return `units:${expression.scope}`;
+      case "any":
+        return `any(${expression.of.map(render).join(", ")})`;
+      case "all":
+        return `all(${expression.of.map(render).join(", ")})`;
+    }
+  }
+
+  // Every page, with the reason its shape is what it is. `all(full-seat, ...)`
+  // is a mutating page: the seat ceiling above the grants, exactly as
+  // `useCanWrite` folds it for the controls themselves.
+  const DECLARED_CHANGES: Record<SettingsPageId, string> = {
+    // The reader's own rows, with no grant between them and the control.
+    account: "always",
+    agents: "always",
+    connections: "always",
+    "capture-activity": "always",
+    // Under the reader's own heading and still a grant: voice-dna.tsx asks the
+    // write, so a read-only seat consults this page.
+    voice:
+      "all(full-seat, any(any(voice_profile:update, voice_profile:create)))",
+
+    company:
+      "all(full-seat, any(any(installation_settings:update), all(any(organization:update, organization:create), available:company_context), any(fx_rate:update, fx_rate:create)))",
+    // The OAuth cards save through `capture_settings`, a different grant from
+    // the sign-in card's.
+    authentication:
+      "all(full-seat, any(any(installation_settings:update), any(capture_settings:update)))",
+
+    members:
+      "all(full-seat, any(any(user_admin:update, user_admin:create), user_admin:delete))",
+    teams: "all(full-seat, any(any(team_admin:update, team_admin:create)))",
+    seats: "same-as-requires",
+
+    pipelines:
+      "all(full-seat, any(any(pipeline:update, pipeline:create), pipeline:delete))",
+    leads:
+      "all(full-seat, any(any(custom_field:update, custom_field:create), custom_field:delete))",
+    fields:
+      "all(full-seat, any(any(custom_field:update, custom_field:create)))",
+    tags: "all(full-seat, any(any(tag:update, tag:create), tag:delete))",
+    products:
+      "all(full-seat, any(any(product:update, product:create), product:delete, any(offer_template:update, offer_template:create), offer_template:delete))",
+
+    capture:
+      "all(full-seat, any(any(capture_settings:update), any(organization:update)))",
+    // Delete included on both, and the composed-unit arm outside the ceiling:
+    // ExtensionUnitsCard's Open link asks for no grant at all.
+    integrations:
+      "any(all(full-seat, any(any(integrations:update, integrations:create), integrations:delete, any(webhook_subscription:update, webhook_subscription:create), webhook_subscription:delete, any(overlay_connection:update, overlay_connection:create), overlay_connection:delete)), units:workspace)",
+    knowledge: "all(full-seat, any(any(knowledge_corpus:create)))",
+    // BOTH verbs: ImportCard's own gate is `mayCreate && mayAdvance`.
+    import:
+      "all(full-seat, any(all(any(import_run:create), any(import_run:update))))",
+
+    models: "all(full-seat, any(any(ai_routing:update)))",
+    automations:
+      "all(full-seat, any(any(automation:update, automation:create), automation:delete))",
+    usage:
+      "all(full-seat, any(any(ai_model_rate:update, ai_model_rate:create)))",
+    "model-calls": "same-as-requires",
+
+    privacy:
+      "all(full-seat, any(any(consent_config:create), any(retention_policy:update, retention_policy:create), retention_policy:delete, any(privacy_request:update), any(person:update)))",
+    audit: "same-as-requires",
+    // The reindex takes the seat; watching the queue beside it is a read, and
+    // watching a stalled queue is an operator acting.
+    "system-health":
+      "any(all(full-seat, any(any(embedding_reindex:update))), job_health:read)",
+    extensions: "all(full-seat, any(any(role_admin:update)))",
+    reset: "all(full-seat, system_reset:delete, flag:data_reset_available)",
+  };
+
+  it("declares the expression this census names, for every page", () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(`${page.id}: ${render(page.changes)}`).toBe(
+        `${page.id}: ${DECLARED_CHANGES[page.id]}`,
+      );
+    }
+  });
+
+  // The other direction: a page added with no entry fails, and an entry for a
+  // page that no longer exists fails too.
+  it("names every page in the catalog and nothing else", () => {
+    expect(Object.keys(DECLARED_CHANGES).sort()).toEqual(
+      SETTINGS_PAGES.map((page) => page.id).sort(),
+    );
+  });
+
+  // Every mutating page folds the seat, and no page's `requires` does. The
+  // second half matters as much: `requires` decides who may OPEN a page, and a
+  // read seat may open everything its grants open — folding the ceiling there
+  // would be a permission change wearing the clothes of a tidier rail.
+  it("puts the seat ceiling on what a page changes and never on what opens it", () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(render(page.requires)).not.toContain("full-seat");
+    }
+    const mutating = SETTINGS_PAGES.filter(
+      (page) =>
+        page.changes.kind !== "always" &&
+        page.changes.kind !== "reading-is-the-act",
+    );
+    for (const page of mutating) {
+      expect(`${page.id}: ${render(page.changes)}`).toContain("full-seat");
+    }
+  });
+
+  // The sentinel is only ever a `changes`, and `holds` must refuse it rather
+  // than guess: it names the page's own requirement, which no expression can
+  // carry. Anything evaluating it directly has skipped `settingsReach`.
+  it("refuses to resolve the reading-is-the-act sentinel on its own", () => {
+    expect(holds(readingIsTheAct, meFixture({ roles: ["admin"] }))).toBe(false);
+  });
+
+  // A page whose `requires` is a mutation must not use the sentinel: the
+  // sentinel resolves to `requires`, which carries no seat ceiling, so a read
+  // seat holding the grant would be told the page is theirs to work in.
+  // Automations and Reset were both written that way and both were wrong.
+  it("never resolves the sentinel to a requirement that mutates", () => {
+    for (const page of SETTINGS_PAGES) {
+      if (page.changes.kind !== "reading-is-the-act") {
+        continue;
+      }
+      expect(`${page.id}: ${render(page.requires)}`).not.toMatch(
+        /:(create|update|delete)/,
+      );
+    }
   });
 });
 
@@ -667,5 +837,122 @@ describe("requirements that are not permissions — the composed units", () => {
         meFixture({ allow: { webhook_subscription: ["read", "create"] } }),
       ).some((p) => p.id === "integrations"),
     ).toBe(true);
+  });
+});
+
+// What a page's `changes` buys a real reader: which pages reach the rail, and
+// which stay reachable from the settings home and search without cluttering it.
+//
+// Built on the SEEDED rep's grants rather than a hand-picked few. A partial
+// fixture would answer a question about a fixture — the point of this case is
+// what the product actually shows the role Lars ships, so a policy change that
+// widens a rep shows up here as a failing list rather than silently.
+describe("what the rail carries and what it leaves behind", () => {
+  const seededRep = meFixture({
+    roles: ["rep"],
+    allow: {
+      activity: ["create", "read", "update"],
+      automation: ["read"],
+      capture_settings: ["create", "read"],
+      channel_connection: ["read"],
+      commission: ["read"],
+      computed_field: ["read"],
+      contract: ["create", "read", "update"],
+      custom_field: ["read"],
+      deal: ["create", "read", "update"],
+      deal_room: ["create", "read", "update"],
+      finance: ["read"],
+      forecast: ["read"],
+      installation_settings: ["read"],
+      integrations: ["read"],
+      introduction: ["create", "read", "update"],
+      knowledge_corpus: ["read"],
+      knowledge_document: ["read"],
+      lead: ["create", "read", "update", "delete"],
+      list: ["create", "read", "update"],
+      offer: ["create", "read", "update"],
+      offer_template: ["create", "read", "update"],
+      organization: ["create", "read", "update"],
+      overlay_connection: ["read"],
+      partner: ["read"],
+      person: ["create", "read", "update"],
+      pipeline: ["read"],
+      product: ["create", "read", "update"],
+      project: ["create", "read", "update"],
+      relationship: ["create", "read", "update"],
+      saved_view: ["create", "read", "update", "delete"],
+      signal: ["create", "read", "update"],
+      tag: ["read"],
+      voice_profile: ["create", "read", "update"],
+      webhook_subscription: ["read"],
+      weekly_plan: ["create", "read", "update"],
+    },
+  });
+
+  it("gives a rep the pages they work in, and only those", () => {
+    const reach = settingsReach(seededRep);
+    expect(reach.acts.map((page) => page.id)).toEqual([
+      // Their own five, minus Voice — a rep holds voice_profile create and
+      // update, so Voice IS theirs; it is here for that reason and not because
+      // the page sits under their own heading.
+      "account",
+      "voice",
+      "agents",
+      "connections",
+      "capture-activity",
+      // The company profile the AI reads: a rep holds `organization` create and
+      // update, which is what CompanyContextCard asks. Existing behaviour that
+      // the rail is only now reporting — the card was always editable by them.
+      "company",
+      // Products and offer templates: a rep authors both.
+      "products",
+      // Capture rules, because a rep holds `organization:update` and
+      // BlockedDomainsCard writes it. If a rep editing the company's blocked
+      // domains is not wanted, that CARD's grant is the thing to change — the
+      // rail is only reporting what the card already allows.
+      "capture",
+    ]);
+  });
+
+  it("leaves the pages a rep can only read out of the rail, not out of reach", () => {
+    const reach = settingsReach(seededRep);
+    expect(reach.looksUp.map((page) => page.id)).toEqual([
+      "pipelines",
+      "leads",
+      "fields",
+      "tags",
+      "knowledge",
+    ]);
+    // Integrations and Automations are absent from BOTH halves, and that is
+    // #4650's doing rather than this change's: their `requires` asks the write,
+    // so a rep never opens them at all. A page has to be visible before the
+    // partition has anything to say about it.
+    // Still openable, every one of them: the partition decides prominence, and
+    // a page in `looksUp` answers its address, appears in search and is listed
+    // on the settings home. Losing that distinction would turn a tidier rail
+    // into a permission change nobody asked for.
+    const openable = visibleSettingsPages(seededRep).map((page) => page.id);
+    for (const page of reach.looksUp) {
+      expect(openable).toContain(page.id);
+    }
+  });
+
+  // The partition is exhaustive and disjoint — every visible page in exactly
+  // one half. Without this a page could fall out of both and vanish from the
+  // rail AND the home while still answering its address, which is the one
+  // shape of this bug nobody would report.
+  it("puts every page a reader may open in exactly one half", () => {
+    for (const snapshot of [seededRep, meFixture({ roles: ["admin"] })]) {
+      const reach = settingsReach(snapshot);
+      const partitioned = [...reach.acts, ...reach.looksUp]
+        .map((page) => page.id)
+        .sort();
+      expect(partitioned).toEqual(
+        visibleSettingsPages(snapshot)
+          .map((page) => page.id)
+          .sort(),
+      );
+      expect(new Set(partitioned).size).toBe(partitioned.length);
+    }
   });
 });

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -59,7 +59,16 @@ export type CapabilityExpression =
   // page that ignored this would strand an installation's only way in.
   | { kind: "units"; scope: UnitSecretScope }
   | { kind: "any"; of: readonly CapabilityExpression[] }
-  | { kind: "all"; of: readonly CapabilityExpression[] };
+  | { kind: "all"; of: readonly CapabilityExpression[] }
+  // Only ever a page's `changes`, and only `settingsReach` resolves it — it
+  // means "the same as this page's `requires`", which no expression can say
+  // about itself.
+  | { kind: "reading-is-the-act" }
+  // The full-seat ceiling, which sits ABOVE the object grants: a read seat keeps
+  // every grant it holds and may still not issue a mutating request. Its own arm
+  // rather than folded into `writes`, because some GETs are gated on a write
+  // verb and a read seat may genuinely see those.
+  | { kind: "seat" };
 
 /** Shorthand builders, so the table below reads as requirements rather than syntax. */
 export const reads = (object: RbacObject): CapabilityExpression => ({
@@ -97,6 +106,30 @@ export const writes = (
 ): CapabilityExpression => ({
   kind: "any",
   of: actions.map((action) => ({ kind: "grant", object, action })),
+});
+/**
+ * The delete verb alone.
+ *
+ * Separate from `writes` on purpose: `writes` answers "may this reader author
+ * something here", which is the question a page's `requires` asks, and delete is
+ * not part of it — an archive verb on an object whose create the reader lacks
+ * should not open a page for them. In a `changes` expression it belongs beside
+ * `writes`, because archiving a tag is acting on the page as much as renaming
+ * one is.
+ */
+/**
+ * The full seat, as an expression.
+ *
+ * Only ever an arm of a page's `changes`. A `requires` must NOT fold it: a read
+ * seat may open every page its grants open, and hiding one would be a
+ * permission change rather than a statement about prominence.
+ */
+export const fullSeat: CapabilityExpression = { kind: "seat" };
+
+export const destroys = (object: RbacObject): CapabilityExpression => ({
+  kind: "grant",
+  object,
+  action: "delete",
 });
 export const available = (
   key: SettingsAvailabilityKey,
@@ -137,7 +170,42 @@ export const anyOf = (
 export const allOf = (
   ...of: readonly CapabilityExpression[]
 ): CapabilityExpression => ({ kind: "all", of });
+/**
+ * What a page's `changes` says when acting on it means issuing a mutating
+ * request: the grants, AND the seat ceiling above them.
+ *
+ * This mirrors `useCanWrite`, which every mutating control in the tree already
+ * uses — grant plus `useCanMutate`. Without the ceiling, a read-seat operator
+ * keeping their create and update grants would be told a page is theirs to work
+ * in, walk into it, and find every control closed. The backend refuses the same
+ * request independently at `identity/admission.go`, so the rail would be
+ * promising something two layers below it already deny.
+ */
+export const acts = (
+  ...of: readonly CapabilityExpression[]
+): CapabilityExpression => allOf(fullSeat, anyOf(...of));
+
 export const always: CapabilityExpression = { kind: "always" };
+
+/**
+ * A page whose whole purpose is a read: the seat count, the AI usage figures,
+ * the model calls, the audit trail. Consulting it IS the act, so `changes` is
+ * whatever `requires` is.
+ *
+ * Only legitimate where `requires` is itself a read. A page whose requirement is
+ * a mutation must NOT use this — `requires` deliberately carries no seat ceiling,
+ * so the sentinel would tell a read seat that a page it cannot write is theirs to
+ * work in. Automations and Reset were both written this way and both were wrong;
+ * a test in settingscatalog.test.ts now fails that combination.
+ *
+ * A sentinel rather than the expression written twice. The two would drift —
+ * somebody narrows the requirement, misses the copy, and the page silently
+ * leaves the rail for a reader who may still open it. `settingsReach` resolves
+ * it against the page's own `requires`, so there is one spelling per page.
+ */
+export const readingIsTheAct: CapabilityExpression = {
+  kind: "reading-is-the-act",
+};
 
 /**
  * Resolve one requirement against an access snapshot.
@@ -174,6 +242,16 @@ export function holds(
       return expression.of.some((each) => holds(each, snapshot, context));
     case "all":
       return expression.of.every((each) => holds(each, snapshot, context));
+    case "seat":
+      // Fails closed on an unresolved snapshot like every other arm: absent
+      // authorization is not a full seat.
+      return snapshot?.authorization?.seat_type === "full";
+    case "reading-is-the-act":
+      // Unresolvable here by construction: it names the page's own `requires`,
+      // and `holds` is handed an expression with no page attached. Reaching
+      // this arm means a caller evaluated a `changes` field directly instead of
+      // going through `settingsReach`, so it fails closed rather than guessing.
+      return false;
   }
 }
 
@@ -233,22 +311,75 @@ export type SettingsScope =
  * page-level write flag would either hide a page somebody may read or promise
  * controls they cannot use. A card narrower than its page is the safe
  * direction: the card withholds itself.
+ *
+ * `changes` is the second question, and it is about PROMINENCE rather than
+ * permission: is this page one the reader can act on, or one they can only
+ * consult? The rail lists what they can act on; everything else they may open
+ * stays reachable from the settings home and from search. Both halves matter —
+ * a reader who cannot change the pipeline vocabulary should not have it in the
+ * furniture they navigate every day, and must still be able to look it up.
+ *
+ * Its value is read off the write verbs the page's own cards ask, never off the
+ * heading the page sits under. On a page whose entire purpose IS a read — the
+ * spend, the model calls, the audit trail, the seat count — reading is the
+ * action, so `changes` is the same expression as `requires` and says so.
  */
 export const SETTINGS_PAGES = [
-  { id: "account", group: "me", scope: "self", requires: always },
-  { id: "voice", group: "me", scope: "self", requires: always },
-  { id: "agents", group: "me", scope: "self", requires: always },
+  {
+    id: "account",
+    group: "me",
+    scope: "self",
+    requires: always,
+    // Yours to change, all of it: identity, password, signature, language.
+    changes: always,
+  },
+  {
+    id: "voice",
+    group: "me",
+    scope: "self",
+    requires: always,
+    // The profile is the reader's own, but writing one is still a grant:
+    // voice-dna.tsx asks `voice_profile` create and update, and a read-only seat
+    // holds the read alone. `always` here would have put Voice in that reader's
+    // rail with nothing on it they could touch.
+    changes: acts(writes("voice_profile")),
+  },
+  {
+    id: "agents",
+    group: "me",
+    scope: "self",
+    requires: always,
+    // Passports, connected agents and the autonomy choice are all this reader's.
+    changes: always,
+  },
   // MIXED, not self: six of its cards are the reader's own, and MailSharingCard
   // writes `capture_settings` — the installation's rule about whether captured
   // mail is shared with colleagues. A page-level "Only you" over that switch
   // would tell a reader a company-wide setting is private to them.
-  { id: "connections", group: "me", scope: "mixed", requires: always },
+  {
+    id: "connections",
+    group: "me",
+    scope: "mixed",
+    requires: always,
+    // Acting, not consulting: the mailbox, sender and LinkedIn controls are
+    // the reader's own and need no grant. The one card that is not theirs
+    // withholds itself — MailSharingCard asks `capture_settings:update`.
+    changes: always,
+  },
   // MIXED for the same reason as `connections`, one page along:
   // CaptureExclusionsCard carries BOTH scopes by design — its own comment says
   // so — and its workspace rules keep a correspondent out of the CRM for
   // everybody. The workspace activity view behind `capture_trace:read` is the
   // installation's too.
-  { id: "capture-activity", group: "me", scope: "mixed", requires: always },
+  {
+    id: "capture-activity",
+    group: "me",
+    scope: "mixed",
+    requires: always,
+    // The reader's own capture trace and their own exclusions. The workspace
+    // half of CaptureExclusionsCard asks `capture_settings:update` itself.
+    changes: always,
+  },
 
   {
     id: "company",
@@ -272,6 +403,14 @@ export const SETTINGS_PAGES = [
       allOf(writes("organization"), available("company_context")),
       reads("fx_rate"),
     ),
+    // The three cards, by the verb each performs. InstallationSettingsCard and
+    // FxRatesCard both write; CompanyContextCard asks `useCanUpsert("organization")`,
+    // which is create-or-update plus the seat — spelled here as `writes`.
+    changes: acts(
+      writes("installation_settings", ["update"]),
+      allOf(writes("organization"), available("company_context")),
+      writes("fx_rate"),
+    ),
   },
   {
     id: "authentication",
@@ -290,6 +429,19 @@ export const SETTINGS_PAGES = [
     // direction — a card narrower than its page withholds itself — and it
     // closes when they move to `oauth_application`.
     requires: reads("authentication_policy"),
+    // SignInMethodsCard writes `installation_settings:update`. The OAuth cards
+    // ask `capture_settings:update`, which is a wider audience than this page's
+    // own read, so it is not an arm: a reader who can only reach the OAuth half
+    // still consults the page rather than owning it.
+    // SignInMethodsCard writes `installation_settings:update`; the two OAuth
+    // application cards beside it save and remove through
+    // `capture_settings:update`, which is a different grant and a wider
+    // audience. Both are on this page, so either makes it the reader's to work
+    // in — a custom role holding only the OAuth half has working controls.
+    changes: acts(
+      writes("installation_settings", ["update"]),
+      writes("capture_settings", ["update"]),
+    ),
   },
 
   // `GET /users` answers 200 to any authenticated principal, and that is right:
@@ -319,6 +471,9 @@ export const SETTINGS_PAGES = [
     // affordances. The card ANDs the same way, so the page and its controls
     // agree.
     requires: reads("user_admin"),
+    // Invite, role change and deactivate — the three verbs UsersAdminCard offers,
+    // and `delete` is deactivate rather than a row removal.
+    changes: acts(writes("user_admin"), destroys("user_admin")),
   },
   {
     id: "teams",
@@ -328,6 +483,9 @@ export const SETTINGS_PAGES = [
     // `user_admin:read` alone sees who is in which team, which is the page's
     // whole content even when they may change none of it.
     requires: anyOf(writes("team_admin"), reads("user_admin")),
+    // TeamsCard creates and renames teams. Membership rides `user_admin:read`,
+    // which is a read, so it does not make this page the reader's to change.
+    changes: acts(writes("team_admin")),
   },
   // `roles` is NOT here, and its absence is the point.
   //
@@ -348,6 +506,9 @@ export const SETTINGS_PAGES = [
     // endpoint for a `seat_usage` one — management sees how full the
     // installation is without seeing what it pays.
     requires: anyOf(reads("seat_usage"), reads("license")),
+    // LicenseCard has no write of any kind. Reading the seat count IS the action
+    // here, so the two questions have one answer.
+    changes: readingIsTheAct,
   },
 
   {
@@ -355,6 +516,8 @@ export const SETTINGS_PAGES = [
     group: "sales",
     scope: "workspace",
     requires: reads("pipeline"),
+    // PipelinesCard creates, renames and removes stages.
+    changes: acts(writes("pipeline"), destroys("pipeline")),
   },
   {
     id: "leads",
@@ -366,19 +529,39 @@ export const SETTINGS_PAGES = [
     // hide the page from a holder who may read it, and open it for one whose
     // reads then 403.
     requires: reads("custom_field"),
+    // The three lead-vocabulary cards all write `custom_field`, delete included.
+    changes: acts(writes("custom_field"), destroys("custom_field")),
   },
   {
     id: "fields",
     group: "sales",
     scope: "workspace",
     requires: reads("custom_field"),
+    // customfields.tsx creates and edits; it offers no delete.
+    changes: acts(writes("custom_field")),
   },
-  { id: "tags", group: "sales", scope: "workspace", requires: reads("tag") },
+  {
+    id: "tags",
+    group: "sales",
+    scope: "workspace",
+    requires: reads("tag"),
+    // tagadmin.tsx separates create, rename/merge and archive. Applying a tag TO
+    // a record is a different question and lives on the record, not here.
+    changes: acts(writes("tag"), destroys("tag")),
+  },
   {
     id: "products",
     group: "sales",
     scope: "workspace",
     requires: anyOf(reads("product"), reads("offer_template")),
+    // Two cards, two objects: products.tsx and offertemplates.tsx, each with its
+    // own create/update/archive trio. Either one makes the page actionable.
+    changes: acts(
+      writes("product"),
+      destroys("product"),
+      writes("offer_template"),
+      destroys("offer_template"),
+    ),
   },
 
   {
@@ -386,6 +569,13 @@ export const SETTINGS_PAGES = [
     group: "data",
     scope: "workspace",
     requires: reads("capture_settings"),
+    // Four cards and, after the mail-sharing move, five. Three write
+    // `capture_settings:update`; BlockedDomainsCard writes `organization:update`,
+    // which every seeded sales role holds — so a rep keeps this page in the rail.
+    changes: acts(
+      writes("capture_settings", ["update"]),
+      writes("organization", ["update"]),
+    ),
   },
   {
     id: "integrations",
@@ -407,18 +597,49 @@ export const SETTINGS_PAGES = [
       // none of the grants above.
       composedUnits("workspace"),
     ),
+    // Provider, webhooks and the overlay pair, each with its own object.
+    // Every verb the four cards offer, delete included: WebhooksCard archives a
+    // subscription and OverlayCard disconnects a mirror, and both are acting on
+    // the page as much as creating one is.
+    //
+    // The composed-unit arm is not a grant and carries no seat: ExtensionUnitsCard
+    // renders an Open link for every composed workspace unit unconditionally, so
+    // on a build that composed one this page has a working control for anybody
+    // who can see it. That arm is what makes the page visible in the first place.
+    changes: anyOf(
+      acts(
+        writes("integrations"),
+        destroys("integrations"),
+        writes("webhook_subscription"),
+        destroys("webhook_subscription"),
+        writes("overlay_connection"),
+        destroys("overlay_connection"),
+      ),
+      composedUnits("workspace"),
+    ),
   },
   {
     id: "knowledge",
     group: "data",
     scope: "workspace",
     requires: reads("knowledge_corpus"),
+    // KnowledgeCard adds a corpus; it asks the create alone.
+    changes: acts(writes("knowledge_corpus", ["create"])),
   },
   {
     id: "import",
     group: "data",
     scope: "workspace",
     requires: reads("import_run"),
+    // ImportCard starts a run and advances it — create and update, two verbs the
+    // card asks separately.
+    // BOTH verbs, because ImportCard asks for both: `mayImport` is
+    // `mayCreate && mayAdvance` — the dry run parks the run and the approval
+    // moves it, so create alone reaches the card and is refused at the first
+    // button.
+    changes: acts(
+      allOf(writes("import_run", ["create"]), writes("import_run", ["update"])),
+    ),
   },
 
   {
@@ -434,6 +655,9 @@ export const SETTINGS_PAGES = [
     // diagnostics WITHOUT routing, so on the routing grant alone this page was
     // shut to the one role the health card was widened for.
     requires: anyOf(reads("ai_routing"), reads("ai_diagnostics")),
+    // The routing binding and the provider keys, both on `ai_routing:update`.
+    // AiHealthCard is a read and does not widen this.
+    changes: acts(writes("ai_routing", ["update"])),
   },
   {
     id: "automations",
@@ -444,6 +668,11 @@ export const SETTINGS_PAGES = [
     // that cannot change an automation has nothing to do on the page that
     // defines them.
     requires: writes("automation"),
+    // Not the sentinel: this page's `requires` is already a write, so resolving
+    // `changes` to it would inherit a requirement that deliberately carries no
+    // seat ceiling — a read seat holding the automation grants would be told the
+    // page is theirs to work in. The card offers delete as well.
+    changes: acts(writes("automation"), destroys("automation")),
   },
   {
     id: "usage",
@@ -453,12 +682,18 @@ export const SETTINGS_PAGES = [
     // Both cards on this page ask `ai_diagnostics:read` now; `ai_model_rate`
     // stays in the union because its holder authors the rate sheet here.
     requires: anyOf(reads("ai_diagnostics"), reads("ai_model_rate")),
+    // ModelCostsCard writes `ai_model_rate` through `useCanUpsert`. The spend and
+    // usage cards beside it are reads, so a reader without that grant consults
+    // this page rather than owning it.
+    changes: acts(writes("ai_model_rate")),
   },
   {
     id: "model-calls",
     group: "ai",
     scope: "workspace",
     requires: reads("ai_diagnostics"),
+    // AiCallsCard is a read of what the models were asked. Reading it is the act.
+    changes: readingIsTheAct,
   },
 
   {
@@ -494,6 +729,16 @@ export const SETTINGS_PAGES = [
       // vocabulary could not reach the only page that renders it.
       allOf(reads("person"), reads("consent_config")),
     ),
+    // Four cards, four objects. `person:update` is what PrivacyInboxCard asks to
+    // open a subject request — the request is about a person's record, so the
+    // grant is the person's, not the queue's.
+    changes: acts(
+      writes("consent_config", ["create"]),
+      writes("retention_policy"),
+      destroys("retention_policy"),
+      writes("privacy_request", ["update"]),
+      writes("person", ["update"]),
+    ),
   },
   {
     id: "audit",
@@ -503,6 +748,9 @@ export const SETTINGS_PAGES = [
     // carry `audit_log:read` reaches it and one that lost it does not — which
     // the admin role name could not say either way.
     requires: reads("audit_log"),
+    // The trail is a read by construction — nothing writes it from here, and
+    // reading it is precisely the operator's act.
+    changes: readingIsTheAct,
   },
   {
     id: "system-health",
@@ -513,6 +761,16 @@ export const SETTINGS_PAGES = [
     // the other withheld — which is the union being a union rather than one
     // object with a decorative term.
     requires: anyOf(reads("job_health"), reads("embedding_reindex")),
+    // EmbedReindexCard spends tokens to rebuild the embed store. Watching the
+    // queue beside it is a read, and watching a stalled queue is an operator
+    // acting, so the job-health read is the second arm.
+    // The reindex is a mutation and takes the seat; watching the queue beside it
+    // is a read, and watching a stalled queue is an operator acting — so that arm
+    // stands outside the ceiling.
+    changes: anyOf(
+      acts(writes("embedding_reindex", ["update"])),
+      reads("job_health"),
+    ),
   },
   {
     id: "extensions",
@@ -527,6 +785,9 @@ export const SETTINGS_PAGES = [
     // and the card 403s on its second query, which is an unreadable page rather
     // than a narrower one.
     requires: allOf(reads("extension_access"), reads("role_admin")),
+    // ExtensionAccessCard's only write is the role grant it PATCHes; the unit
+    // inventory above it is a read.
+    changes: acts(writes("role_admin", ["update"])),
   },
   {
     id: "reset",
@@ -543,12 +804,22 @@ export const SETTINGS_PAGES = [
       { kind: "grant", object: "system_reset", action: "delete" },
       flagged("data_reset_available"),
     ),
+    // Not the sentinel, for the same reason as Automations: emptying an
+    // installation is a mutating request, and a read seat holding
+    // `system_reset:delete` is refused it. The armed flag rides along, so the
+    // page cannot be acted on where the deployment has not armed it.
+    changes: allOf(
+      fullSeat,
+      { kind: "grant", object: "system_reset", action: "delete" },
+      flagged("data_reset_available"),
+    ),
   },
 ] as const satisfies readonly {
   id: string;
   group: SettingsGroupId;
   scope: SettingsScope;
   requires: CapabilityExpression;
+  changes: CapabilityExpression;
 }[];
 
 export type SettingsPageId = (typeof SETTINGS_PAGES)[number]["id"];
@@ -564,4 +835,42 @@ export function visibleSettingsPages(
   return SETTINGS_PAGES.filter((page) =>
     holds(page.requires, snapshot, context),
   );
+}
+
+/**
+ * What this reader can act on, and what they can only consult.
+ *
+ * The two halves partition `visibleSettingsPages` — every page a reader may
+ * open is in exactly one of them, and neither is a permission: a page in
+ * `looksUp` opens normally, answers its address and appears in search. The
+ * split decides PROMINENCE. The rail carries `acts`, so the furniture somebody
+ * navigates every day is the work they can do; the settings home carries both,
+ * under headings that say which is which.
+ *
+ * Splitting here rather than at each caller is what keeps the rail, the home
+ * and the read-only banner agreeing. Three readers deriving "can this person
+ * act?" separately is three chances to disagree in front of one user.
+ */
+export type SettingsReach = {
+  /** Pages with at least one control this reader may use. */
+  readonly acts: readonly SettingsPage[];
+  /** Pages they may read and cannot change. */
+  readonly looksUp: readonly SettingsPage[];
+};
+
+export function settingsReach(
+  snapshot: AccessSnapshot,
+  context: CatalogContext = {},
+): SettingsReach {
+  const acts: SettingsPage[] = [];
+  const looksUp: SettingsPage[] = [];
+  for (const page of visibleSettingsPages(snapshot, context)) {
+    // `reading-is-the-act` names the page's own requirement, which is the one
+    // thing the expression cannot carry: resolve it against `requires` here,
+    // where the page is in hand. Every other kind goes to `holds` unchanged.
+    const expression =
+      page.changes.kind === "reading-is-the-act" ? page.requires : page.changes;
+    (holds(expression, snapshot, context) ? acts : looksUp).push(page);
+  }
+  return { acts, looksUp };
 }

--- a/frontend/src/screens/settingshome.tsx
+++ b/frontend/src/screens/settingshome.tsx
@@ -4,14 +4,19 @@
 import { ArrowLeft } from "lucide-react";
 import type { MouseEvent } from "react";
 import { navigate } from "../app/router";
-import { EmptyState } from "../design-system/atoms";
+import { Badge, EmptyState } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { RoleBadge } from "../design-system/rbac";
 import { useT } from "../i18n";
 import { useMe } from "./common";
-import type { SettingsPage } from "./settingscatalog";
+import type {
+  SettingsGroupId,
+  SettingsPage,
+  SettingsReach,
+} from "./settingscatalog";
 import { SETTINGS_GROUPS } from "./settingscatalog";
 import { settingsHref } from "./settingsrouting";
+import { SettingsSearchBox } from "./settingssearchbox";
 
 /**
  * Whether this click is the plain one an SPA may answer itself.
@@ -98,65 +103,151 @@ function routeHashOf(): string {
 /**
  * The settings landing page.
  *
- * Three questions, in the order a reader asks them: what is mine to change,
- * what else may I reach, and who am I here. The first two are built from the
- * SAME visible-page list the sidebar renders, so a page can never appear in one
- * and not the other — which is what a second hand-maintained list would have
- * guaranteed eventually.
+ * Four questions, in the order a reader asks them: what is mine, what can I
+ * change, what can I only look at, and who am I here. The middle two are the
+ * `settingsReach` partition — the same one the sidebar is built from — so a page
+ * cannot be in the rail and missing here, or listed here as manageable while its
+ * every control is disabled.
+ *
+ * The "look up" panel is load-bearing rather than a courtesy. The rail carries
+ * only pages a reader can act on, so this is where a page they may read and not
+ * change goes on living: without it, dropping a page from the rail would read as
+ * taking it away.
  */
-export function SettingsHome({
-  pages,
-}: Readonly<{ pages: readonly SettingsPage[] }>) {
+export function SettingsHome({ reach }: Readonly<{ reach: SettingsReach }>) {
   const t = useT();
   const me = useMe();
-  const personal = pages.filter((page) => page.group === "me");
-  const rest = SETTINGS_GROUPS.filter((group) => group !== "me")
-    .map((group) => ({
-      group,
-      items: pages.filter((page) => page.group === group),
-    }))
-    .filter((entry) => entry.items.length > 0);
+  const personal = reach.acts.filter((page) => page.group === "me");
+  const manageable = groupsOf(reach.acts.filter((page) => page.group !== "me"));
+  const consultable = groupsOf(reach.looksUp);
 
   return (
     <div className="settings-stack arrive-stack">
+      {/* At every viewport, not only where the rail is. The rail owns the
+          desktop search box and the rail is gone at phone width, so this is the
+          one a reader on a phone reaches. */}
+      <SettingsSearchBox pages={[...reach.acts, ...reach.looksUp]} />
+
       <Panel title={t("settings.home.yours")}>
         <PanelBody>
-          <PageLinks pages={personal} />
+          <PageRows pages={personal} />
         </PanelBody>
       </Panel>
 
-      {rest.map(({ group, items }) => (
-        <Panel key={group} title={t(`settings.group.${group}`)}>
+      {manageable.length > 0 && (
+        <Panel
+          title={t("settings.home.manage")}
+          sub={t("settings.home.manageSub")}
+        >
           <PanelBody>
-            <PageLinks pages={items} />
+            {manageable.map(({ group, items }) => (
+              <GroupRows key={group} group={group} items={items} />
+            ))}
           </PanelBody>
         </Panel>
-      ))}
+      )}
+
+      {consultable.length > 0 && (
+        <Panel
+          title={t("settings.home.lookUp")}
+          sub={t("settings.home.lookUpSub")}
+        >
+          <PanelBody>
+            {consultable.map(({ group, items }) => (
+              <GroupRows key={group} group={group} items={items} />
+            ))}
+          </PanelBody>
+        </Panel>
+      )}
 
       <Panel title={t("settings.home.access")}>
         <PanelBody>
-          {/* The roles as the server resolved them, not as a role name this
-              screen guessed. A reader with a custom role sees its key, which is
-              the word they would quote when asking for more. */}
-          <div className="settings-home-roles">
-            {(me.data?.roles ?? []).map((role) => (
-              <RoleBadge key={role} roleKey={role} />
-            ))}
-          </div>
+          {/* Facts, not settings: a definition list rather than SettingRow,
+              which requires a control because every row of it is something a
+              reader can operate. Nothing here is operable — this panel answers
+              "who am I here", and the way to change any of it is to ask. */}
+          <dl className="settings-home-access">
+            <dt>{t("settings.home.rolesLabel")}</dt>
+            <dd>
+              {/* The roles as the server resolved them, not as a role name this
+                  screen guessed. A reader with a custom role sees its key,
+                  which is the word they would quote when asking for more. */}
+              <div className="settings-home-roles">
+                {(me.data?.roles ?? []).map((role) => (
+                  <RoleBadge key={role} roleKey={role} />
+                ))}
+              </div>
+            </dd>
+            {/* Seat and reach in words. Both are on the snapshot already and
+                neither was shown: a reader told "read seat" by a disabled
+                button has to guess whether it is their seat, their role or a
+                bug. `authorization` is absent while /me is in flight, and an
+                absent answer says nothing rather than guessing the narrowest —
+                a wrong claim about someone's own access is worse than a gap. */}
+            {me.data?.authorization && (
+              <>
+                <dt>{t("settings.home.seatLabel")}</dt>
+                <dd>
+                  {t(
+                    me.data.authorization.seat_type === "full"
+                      ? "settings.home.seat.full"
+                      : "settings.home.seat.read",
+                  )}
+                </dd>
+                <dt>{t("settings.home.reachLabel")}</dt>
+                <dd>
+                  {t(`settings.home.reach.${me.data.authorization.row_scope}`)}
+                </dd>
+              </>
+            )}
+          </dl>
         </PanelBody>
       </Panel>
     </div>
   );
 }
 
-function PageLinks({ pages }: Readonly<{ pages: readonly SettingsPage[] }>) {
+/** The pages of one half, bucketed by group in the catalog's own order. */
+function groupsOf(
+  pages: readonly SettingsPage[],
+): readonly { group: SettingsGroupId; items: readonly SettingsPage[] }[] {
+  return SETTINGS_GROUPS.map((group) => ({
+    group,
+    items: pages.filter((page) => page.group === group),
+  })).filter((entry) => entry.items.length > 0);
+}
+
+function GroupRows({
+  group,
+  items,
+}: Readonly<{ group: SettingsGroupId; items: readonly SettingsPage[] }>) {
+  const t = useT();
+  return (
+    <section className="settings-home-group">
+      <h3 className="t-caption settings-home-groupname">
+        {t(`settings.group.${group}`)}
+      </h3>
+      <PageRows pages={items} />
+    </section>
+  );
+}
+
+/**
+ * One row per page: its name, what it is for, and whose state it changes.
+ *
+ * A title-only link was the whole defect this replaces — it made the home a
+ * second copy of the menu, so a reader who could not tell two pages apart in
+ * the rail could not tell them apart here either. The subtitle and the scope
+ * are already in the catalog and were being thrown away.
+ */
+function PageRows({ pages }: Readonly<{ pages: readonly SettingsPage[] }>) {
   const t = useT();
   return (
     <div className="settings-home-links">
       {pages.map((page) => (
         <a
           key={page.id}
-          className="link-button"
+          className="settings-home-row"
           href={`#/settings/${page.id}`}
           onClick={(event) => {
             if (!opensInThisTab(event)) {
@@ -166,7 +257,13 @@ function PageLinks({ pages }: Readonly<{ pages: readonly SettingsPage[] }>) {
             navigate(settingsHref(page.id));
           }}
         >
-          {t(`settings.tab.${page.id}`)}
+          <span className="settings-home-rowhead">
+            <span className="settings-home-rowname">
+              {t(`settings.tab.${page.id}`)}
+            </span>
+            <Badge quiet>{t(`settings.scope.${page.scope}`)}</Badge>
+          </span>
+          <span className="t-caption">{t(`settings.page.${page.id}.sub`)}</span>
         </a>
       ))}
     </div>

--- a/frontend/src/screens/settingsnav.tsx
+++ b/frontend/src/screens/settingsnav.tsx
@@ -39,6 +39,8 @@ import {
   SETTINGS_GROUPS as CATALOG_GROUPS,
   type SettingsPage,
   type SettingsPageId,
+  type SettingsReach,
+  settingsReach,
   visibleSettingsPages,
 } from "./settingscatalog";
 import { settingsRouteTarget } from "./settingsrouting";
@@ -528,12 +530,45 @@ export const SETTINGS_HOME_ID = "home";
  * above them already carries: "Settings / Your settings / …" said it twice in a
  * 200px column.
  */
+/** One rail row for a page, with everything the chrome reads off it. */
+function navEntry(page: SettingsPage): NavLevelEntry {
+  return {
+    id: page.id,
+    labelKey: `settings.tab.${page.id}`,
+    // One line under the page's heading, saying what the label cannot: which
+    // state it changes and whose. Composed from the id like the label above it,
+    // and NOT cast — the field's own MessageKey type is what narrows the
+    // template literal, so a page whose `.sub` key is missing from the catalogs
+    // is a compile error rather than a subtitle that silently translates to
+    // nothing.
+    subKey: `settings.page.${page.id}.sub`,
+    // Whose state the page changes, from the catalog's own `scope` rather than a
+    // second table: the catalog already declares it for every page, and it had
+    // no reader until now. Same MessageKey narrowing as the subtitle above — a
+    // missing scope label is a compile error, not a silent blank.
+    scopeKey: `settings.scope.${page.scope}`,
+    icon: PAGE_ICONS[page.id],
+  };
+}
+
 export function useSettingsSection(route: Route): NavSection {
-  const pages = useVisibleSettingsPages();
+  // The rail carries what this reader can ACT on. A page they may open and
+  // cannot change is still theirs to reach — it answers its address, appears in
+  // search and is listed on the settings home under a heading that says so —
+  // but it is not furniture they navigate past every day. `reach.acts` and
+  // `reach.looksUp` partition exactly the pages `useVisibleSettingsPages`
+  // returns, so nothing leaves the product by being left out here.
+  const reach = useSettingsReach();
+  const pages = reach.acts;
+  // Everything this reader may open, rail or not. The two below need it: a page
+  // reached from the settings home or from a search hit is a real destination
+  // and has to be recognised as the current one, and the search box must offer
+  // every page the reader can open rather than only the ones they can change.
+  const openable = [...reach.acts, ...reach.looksUp];
   const target = settingsRouteTarget(route);
   const named =
     target.kind === "page"
-      ? pages.find((page) => page.id === target.page)
+      ? openable.find((page) => page.id === target.page)
       : undefined;
   // Both message keys are composed from the ids, and both annotations are what
   // make them KEYS: a template literal narrows to the catalog's union only where
@@ -549,30 +584,26 @@ export function useSettingsSection(route: Route): NavSection {
   const groups = CATALOG_GROUPS.map(
     (group): NavLevelGroup => ({
       headingKey: `settings.group.${group}`,
-      items: pages
-        .filter((page) => page.group === group)
-        .map(
-          (page): NavLevelEntry => ({
-            id: page.id,
-            labelKey: `settings.tab.${page.id}`,
-            // One line under the page's heading, saying what the label cannot:
-            // which state it changes and whose. Composed from the id like the
-            // label above it, and NOT cast — the field's own MessageKey type is
-            // what narrows the template literal, so a page whose `.sub` key is
-            // missing from the catalogs is a compile error rather than a
-            // subtitle that silently translates to nothing.
-            subKey: `settings.page.${page.id}.sub`,
-            // Whose state the page changes, from the catalog's own `scope`
-            // rather than a second table: the catalog already declares it for
-            // every page, and it had no reader until now. Same MessageKey
-            // narrowing as the subtitle above — a missing scope label is a
-            // compile error, not a silent blank.
-            scopeKey: `settings.scope.${page.scope}`,
-            icon: PAGE_ICONS[page.id],
-          }),
-        ),
+      items: pages.filter((page) => page.group === group).map(navEntry),
     }),
   ).filter((group) => group.items.length > 0);
+  // The page the reader is ON, when it is one the rail does not carry.
+  //
+  // The chrome resolves the current page by searching the rendered rows —
+  // `sectionHead` in app/pagemeta.ts does — so a page that is only on the
+  // settings home would publish an `activeId` no row matches, and the heading,
+  // the breadcrumb, the subtitle, the scope badge and the phone switcher would
+  // all fall back to the section's own name. Reaching a page from search or
+  // from the home would land the reader somewhere that says "Settings".
+  //
+  // So it joins the rail for exactly as long as it is open, in its own group.
+  // Its own rather than its catalog group's: the group heading would then
+  // appear for one page the reader cannot act on, which is the clutter the
+  // partition exists to remove.
+  const openedOffRail =
+    named !== undefined && !pages.some((page) => page.id === named.id)
+      ? [{ items: [navEntry(named)] } satisfies NavLevelGroup]
+      : [];
   // Settings home, above the seven groups and in a headingless group of its
   // own. Not a member of one: it belongs to no topic, and a group that owned it
   // would take it away on the day that group had no other visible page.
@@ -594,10 +625,14 @@ export function useSettingsSection(route: Route): NavSection {
   return {
     screen: SETTINGS_SCREEN,
     titleKey: "nav.settings",
-    // The search stands above the rows and searches exactly the pages below it
-    // — the same `pages` this function grouped, so a hit can never name a page
-    // the rail did not draw.
-    lead: <SettingsSearchBox pages={pages} />,
+    // The search stands above the rows and reaches FURTHER than they do: every
+    // page this reader may open, including the ones the rail leaves out because
+    // they cannot change them. Narrowing it to the rail's own list would make a
+    // readable page unfindable by the one affordance built to find it.
+    lead: <SettingsSearchBox pages={openable} />,
+    // The same box for the phone drawer, which has to dismiss itself once the
+    // box has moved the reader — see NavSection.leadFor.
+    leadFor: (onPick) => <SettingsSearchBox pages={openable} onPick={onPick} />,
     // No row is current on a route that is not one of the tabs. An extension
     // unit's page keeps this level in the sidebar — it is reached from here and
     // its trail says so — but it is not a settings tab, and `settingsRouteTab`
@@ -618,7 +653,7 @@ export function useSettingsSection(route: Route): NavSection {
         : target.kind === "home"
           ? SETTINGS_HOME_ID
           : (named?.id ?? ""),
-    groups: [home, ...groups],
+    groups: [home, ...groups, ...openedOffRail],
   };
 }
 
@@ -637,6 +672,22 @@ export function useVisibleSettingsPages(): readonly SettingsPage[] {
     // `@composition/screens`, and importing it there would drag React and a
     // build alias into a module whose whole purpose is being importable from
     // anywhere. The catalog takes the answer instead of fetching it.
+    composedUnitScopes:
+      unitsForSecretScope("workspace").length > 0 ? ["workspace"] : [],
+  });
+}
+
+/**
+ * The same pages, split into the ones this reader can act on and the ones they
+ * can only consult.
+ *
+ * The hook half of `settingsReach`, taking the same two facts as the visibility
+ * hook above so the rail, the settings home and the read-only banner resolve one
+ * partition rather than each deciding "can this person act?" for itself.
+ */
+export function useSettingsReach(): SettingsReach {
+  const snapshot = useMe().data;
+  return settingsReach(snapshot, {
     composedUnitScopes:
       unitsForSecretScope("workspace").length > 0 ? ["workspace"] : [],
   });

--- a/frontend/src/screens/settingssearchbox.tsx
+++ b/frontend/src/screens/settingssearchbox.tsx
@@ -27,7 +27,20 @@ import { settingsSearch } from "./settingssearch";
  */
 export function SettingsSearchBox({
   pages,
-}: Readonly<{ pages: readonly SettingsPage[] }>) {
+  onPick,
+}: Readonly<{
+  pages: readonly SettingsPage[];
+  /**
+   * Called after the box has navigated, for a host that has to get out of the
+   * way — the phone-width section drawer is the one, since it is a full-screen
+   * sheet that would otherwise stay open over the page just opened.
+   *
+   * The same contract the drawer's group rows already use, rather than a route
+   * listener inside the sheet: the box knows it moved, and a listener would
+   * also fire for a move the reader made some other way.
+   */
+  onPick?: () => void;
+}>) {
   const t = useT();
   const [typed, setTyped] = useState("");
   // -1 is "nothing active", which is where a fresh query starts: the first row
@@ -100,6 +113,7 @@ export function SettingsSearchBox({
     setTyped("");
     setActive(-1);
     navigate(settingsHref(hit.page.id));
+    onPick?.();
   }
 
   function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
@@ -216,9 +230,13 @@ export function SettingsSearchBox({
                 }}
               >
                 <span className="settingssearch-label">{hit.label}</span>
-                {/* `t-caption`, the catalogued utility, rather than a rule of
-                    its own saying the same two properties. */}
-                <span className="t-caption">{hit.group}</span>
+                {/* Where it lives AND whose state it changes. The scope comes
+                    off the hit's own page, which the hit has carried all along
+                    — a reader searching "domain" gets two hits on two pages and
+                    the badge is what tells them which one is the company's. */}
+                <span className="t-caption">
+                  {hit.group} · {t(`settings.scope.${hit.page.scope}`)}
+                </span>
               </a>
             ))
           )}


### PR DESCRIPTION
Every settings page declared what it takes to OPEN it and nothing said what it
takes to WORK IN it, so a rep's rail listed thirteen pages of which eight were
read-only reference: the pipeline vocabulary, the custom fields, the tag list.
Being allowed to read a page is not a reason to put it in the furniture somebody
navigates past every day.

Pages now declare `changes` beside `requires`. `requires` still decides who may
open a page and still drives search and the access boundary; `changes` decides
prominence. The rail carries what a reader can act on and the settings home
carries both halves, under headings that say which is which — so a page leaving
the rail loses none of its reach. It answers its address, appears in search, and
is listed on the home under "What you can look up". A page whose every control
is closed to the reader now says so once at the top instead of leaving them to
infer it from a screenful of disabled buttons.

A seeded rep goes from thirteen rail pages to eight. Admin and ops are unchanged.
The eight are their own five, plus Company profile, Products & offers and Capture
rules — a rep holds `organization` create and update, which is what the company
profile card and the blocked-domains card ask. If a rep editing the company's
blocked domains is unwanted, that card's grant is the thing to change; the rail
is only reporting what the card already allows.

`changes` is read off the write verbs each page's own cards ask, never off the
heading the page sits under. Writing that table found Writing voice: it sits
under the reader's own heading and needs `voice_profile` create or update, so a
read-only seat was being offered a page with nothing on it they could touch. Two
test fixtures were describing accounts the product does not issue — an admin
without `voice_profile`, and an "every page" grant list holding reads where the
pages ask for writes.

Three things the home was promising and not doing. Its own comment said it
answered "what is mine to change" and it rendered the pages in the `me` group
instead. It listed every page as a bare title, which made it a second copy of the
menu, though the catalog has carried a subtitle and a scope for each one all
along. And its access panel showed role badges while the seat and the record
reach sat unused on `/me` — a reader told "read seat" by a greyed button had no
way to find out whether that was their seat, their role or a bug.

Also here, because both are one line once the reach exists: the settings search
now says whose state a hit changes, and it finally appears in the phone-width
section drawer. The drawer had never rendered the search the section hands it,
so the one width where the navigation is hardest to scan was the one width with
no way to search it.

The catalog test is a census of all 28 `changes` values with a both-directions
coverage assertion, the same shape the scope census took after four wrong scopes
passed a spot check. It caught Writing voice on the first run.

Found by review, all fixed here: the seat ceiling was missing from every mutation-shaped `changes` (a read-seat operator keeping their grants would have been shown pages with no working control); an off-rail page lost its heading and breadcrumb in the shell; Authentication omitted the grant its two OAuth cards actually save through; Integrations omitted the delete verbs and the composed-extension arm; and Import asked create-OR-update where its card needs both.

The census test was rewritten to compare whole expressions rather than object names — verbs, AND-versus-OR and the seat ceiling are exactly where those defects lived, and the earlier version passed all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The settings rail now lists only the pages a reader can act on, instead of every page they can open. Pages a reader can only read move to the settings home under "What you can look up" and keep their address, search hit, and home row, so no reach is lost. A seeded rep goes from thirteen rail pages to eight; admin and ops are unchanged.

- Pages now declare `changes` beside `requires`: `requires` still decides who may open a page, and `changes` decides rail prominence.
- A page whose every control is closed to the reader now says so once at the top.
- Settings search now shows whose state a hit changes, and it appears in the phone-width section drawer.
- The settings home rows show each page's subtitle and scope, and the access panel shows the reader's seat and record reach.
- Company profile, Products & offers, and Capture rules stay in the rep's rail because the rep already holds the `organization` and `product` grants those cards ask for.

<sup>Written for commit e51e4d31b83f9ad7158b28915109e8f7d0717e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

