### PR TITLE
The team arm of the row scope is exercised, in both directions

### DIFF
--- a/backend/internal/compose/integration/teamqueue_integration_test.go
+++ b/backend/internal/compose/integration/teamqueue_integration_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A Team Lead's inbox carries what their TEAM is waiting on.
+//
+// The `team` arm of the row scope was written and unreached for months — no
+// seeded role used it — so this half of the inbox's behaviour was never
+// exercised. The negative half is: TestApprovalAuthorityHonorsTargetRowScope
+// proves another team's staging stays absent. That test passes for a scope that
+// admits nothing at all, so it is not evidence that team scope WORKS; this is.
+//
+// The seeded role that reaches it is `manager`, and identity's own
+// TestTheSeededRolesReachTheRowScopeTheyClaim holds that fact against the
+// seeded row rather than against the compiled defaults.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestATeamLeadsInboxCarriesTheirTeammatesStagedDecision(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	svc := approvals.NewService(e.DB())
+
+	// Rep2 shares Team1 with Rep1; Rep3 sits in Team2.
+	teammateDeal := e.SeedDeal(t, "A teammate's", pipeline, open, &e.Rep2)
+	strangerDeal := e.SeedDeal(t, "Another team's", pipeline, open, &e.Rep3)
+	teammates := stageFor(t, svc, e, "advance_deal", "deal", teammateDeal)
+	strangers := stageFor(t, svc, e, "advance_deal", "deal", strangerDeal)
+
+	lead := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+	pending := listIDs(lead, t, svc, approvals.ListInput{Status: strPtr("pending"), Limit: 50})
+
+	if !pending[teammates] {
+		t.Error("a lead under team scope cannot see their own teammate's staged decision — " +
+			"which is the whole of what team scope is for, and the arm nothing else exercises")
+	}
+	if pending[strangers] {
+		t.Error("the inbox reached past the team into another one")
+	}
+}
+
+func TestASeatUnderOwnScopeSeesOnlyItsOwn(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	svc := approvals.NewService(e.DB())
+
+	mine := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
+	teammates := e.SeedDeal(t, "A teammate's", pipeline, open, &e.Rep2)
+	ownStaging := stageFor(t, svc, e, "advance_deal", "deal", mine)
+	teammateStaging := stageFor(t, svc, e, "advance_deal", "deal", teammates)
+
+	// The same grid, narrowed to own — which is what the seeded `rep` carries,
+	// and the difference this pair of tests is about.
+	ownScope := RepPerms
+	ownScope.RowScope = principal.RowScopeOwn
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, ownScope)
+
+	pending := listIDs(rep, t, svc, approvals.ListInput{Status: strPtr("pending"), Limit: 50})
+	if !pending[ownStaging] {
+		t.Error("a seat cannot see a staged decision against its own record")
+	}
+	if pending[teammateStaging] {
+		t.Error("own scope reached a teammate's record — team membership is not by itself " +
+			"permission to decide about a colleague's deal")
+	}
+}

--- a/backend/internal/modules/identity/teamleadscope_integration_test.go
+++ b/backend/internal/modules/identity/teamleadscope_integration_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package identity
+
+// The seeded Team Lead reads their team, and the seeded rep does not.
+//
+// The `team` arm of OwnerPredicate was written, reviewed and unreached for
+// months: no seeded role used it, so nothing exercised the branch and nothing
+// would have noticed it breaking. It is reached now — by `manager` — and this
+// is what keeps that true.
+//
+// Read off the SEEDED ROW rather than the compiled defaults, because those are
+// two different facts. seedSystemRoles writes each document once at workspace
+// creation and never re-syncs, so a deployed installation carries whatever it
+// was seeded with plus whatever a migration has since done to it; a test
+// against the Go map would pass over a database that disagrees with it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestTheSeededRolesReachTheRowScopeTheyClaim(t *testing.T) {
+	svc, _, _ := seatChoosingALanguage(t)
+
+	for _, want := range []struct {
+		role, scope, why string
+	}{
+		{"manager", "team", "a Team Lead who reaches only their own rows is a name without reach: " +
+			"they could not open a colleague's queue at all"},
+		{"rep", "own", "team membership is not by itself permission to rewrite a teammate's records"},
+		{"management", "all", "the unbounded grid, which is what makes it the one that is not team-bounded"},
+	} {
+		t.Run(want.role, func(t *testing.T) {
+			var scope string
+			if err := svc.db.Tx(context.Background(), func(tx pgx.Tx) error {
+				return tx.QueryRow(context.Background(),
+					`SELECT permissions ->> 'row_scope' FROM role WHERE key = $1 AND is_system`,
+					want.role).Scan(&scope)
+			}); err != nil {
+				t.Fatalf("reading the seeded %s role: %v", want.role, err)
+			}
+			if scope != want.scope {
+				t.Errorf("the seeded %s role carries row_scope %q, want %q — %s",
+					want.role, scope, want.scope, want.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #2531 — and it closes the part of it that is still true. The rest of the
issue is **overtaken**, with evidence; I am posting that on the ticket alongside
this and re-labelling it, rather than building a `scope=team` parameter for a
scope the product has since granted outright.

**What changed under the ticket.** #2531 rests on *"The seeded `manager` role
deliberately carries `RowScope: own`"* and *"No seeded role uses that arm today,
so it is wired but silent."* Neither holds on `origin/main`: **#3480 (2026-09-01,
"A Team Lead reads their team") moved the seeded `manager` role to team scope**,
reads and writes together. There is no longer a write narrowing to keep intact,
so option 1's *"gated on an explicit read-only team row-scope distinct from the
write-time own"* has nothing left to be distinct from.

The consequence is that a Team Lead's approvals inbox is **already** their
team's: the inbox filters by target decidability, which runs the row-scope
clause, so a teammate's staged decision is in it today. The ticket's own "done
when" — *at least one seeded role reaches the arm, on at least one of the three
surfaces* — is met, and was simply untested.

**So this adds the tests, which is the part that was missing.**

The negative half already existed: `TestApprovalAuthorityHonorsTargetRowScope`
proves another team's staging stays absent. **That test passes for a scope that
admits nothing at all**, so it is not evidence that team scope works. Three
cases now say what the scope does:

| case | what it holds |
| --- | --- |
| a lead's inbox carries their teammate's staged decision | the arm widens |
| …and not another team's | it does not widen past the team |
| a seat under `own` sees neither | the narrowing is real |
| the seeded roles carry the scopes they claim | `manager` team, `rep` own, `management` all |

The last one is read off the **seeded row**, not the compiled defaults, because
those are different facts: `seedSystemRoles` writes each document once at
workspace creation and never re-syncs, so a deployed installation carries
whatever a migration has since done to it. A test against the Go map would pass
over a database that disagrees with it.

**Verification**

`make check-backend` green; `craft static --strict` clean. Mutation-checked:
disabling the team arm in `OwnerPredicate` fails the lead's case with the
sentence naming what was lost.

**What is left on the ticket, and why I did not guess it.** `/brief` and
`/digest` are keyed per user (`brief_run` is one row per user per local day),
not filtered by row scope — so a team view of either is a **new response shape**
(N queues, or one merged and re-ranked; a summed digest, or one per person), not
a parameter. Nobody has decided which, and the choice changes what the endpoint
means.