### PR TITLE
fix(brief): the section label sits on the panel's margin, above its own row

### DIFF
--- a/frontend/src/screens/brief.feed.css
+++ b/frontend/src/screens/brief.feed.css
@@ -10,11 +10,39 @@
 
 /* The label sits ABOVE its first row rather than beside it, so a reader
    scanning the left edge sees the morning's shape without the badges competing
-   with the rank numbers for the same column. */
+   with the rank numbers for the same column.
+
+   It takes the PANEL'S OWN MARGIN. The list is a direct child of the panel and
+   the rows under it are `PanelRow`s, which carry that margin themselves — so
+   an unpadded label started at the card's edge, 20px left of everything it
+   labels, and read as chrome on the card rather than as a heading over rows.
+
+   The interval is asymmetric because a run-length label binds DOWNWARD: it
+   takes its air from the section it ends, not from the row it names. */
 .brief-feed-section {
-  margin: var(--space-3) 0 var(--space-1);
+  margin: var(--space-4) 0 var(--space-1);
+  padding-inline: var(--padPanel);
 }
 
+/* The first label has the header's hairline above it rather than a row, so it
+   pays for its own interval — the same one the first row would have taken.
+   At zero the badge sat against that line and read as part of the band. */
 .brief-feed-list > li:first-child .brief-feed-section {
-  margin-top: 0;
+  margin-top: var(--space-3);
+}
+
+/* THE RULE BETWEEN TWO ROWS, put back at the boundary it belongs to.
+   `PanelRow` draws its hairline against whatever precedes it and drops it on a
+   panel's first row. Wrapping each row in its own <li> handed that reset to
+   EVERY row, so the queue drew no rule between rows at all — and a labelled
+   row is no longer its item's first child, so the one rule the feed did draw
+   fell between a label and the row it labels, which is the one place panel.css
+   says a rule must never fall. A section boundary takes air and no line, like
+   every other boundary in a card that wants one. */
+.brief-feed-section + .panel-row::before {
+  content: none;
+}
+
+.brief-feed-list > li + li > .panel-row:first-child::before {
+  content: "";
 }


### PR DESCRIPTION
## What

On the Brief's "Today" feed, the run-length section label ("Respond now", "Move revenue") started at the card's edge — 20px left of every row it labels — sat against the header hairline with no interval of its own, and had a rule drawn immediately under it, cutting it from the row it names. After this change the label takes the panel's own margin, binds downward to its row, and the hairline goes back to the boundary between two rows.

## Why

`BriefFeed` passes its `<ol>` as a direct child of `Panel`, so the list carries no padding, while every row inside it is a `PanelRow` carrying the panel's own margin. Three things followed:

1. An unpadded label started 20px left of everything under it and read as chrome on the card rather than as a heading over rows.
2. `.panel-row:first-child::before` is the design system's reset for a panel's **first** row. Wrapping each row in its own `<li>` handed that reset to *every* row, so the queue drew no rule between rows at all.
3. A labelled row is not its item's first child, so the one rule the feed did draw fell between a label and the row it labels — which `panel.css` names as the one place a rule must never fall.

The invariant restored: a label sits on the panel's margin with the rows it names, a rule falls between two rows, and a section boundary takes air and no line — the same either/or `panel.css` states for every boundary inside a card.

## How verified

- `make check-fe` — green, exit 0.
- `make ds-spacing`, `make space-tokens`, `make ds-purity` — green (no new raw-px spacing, every custom property defined, every colour a token).
- `vitest run src/screens/brief.feed.test.tsx src/screens/home.test.tsx` — 37 passed.
- Rendered `Shell/Home parts → Feed` and `→ Feed Repeated Section` from the built Storybook catalog before and after, and read both screenshots: the badges now align with the rows, the first one clears the header rule, no rule falls between a label and its row, and two rows of one section are separated by a hairline. Both story states already existed; no new story was needed.

`check-backend` was not run locally — the diff is one stylesheet and reaches no Go tree. CI is the authority on the full `make check`.

- [x] `make check` is green — the frontend half locally (`make check-fe`, exit 0); the backend half is untouched by this diff and left to CI
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — CSS only, touches neither
- [x] `make craft-static` reports no new blockers — the diff is one stylesheet, outside the Go trees the catalog sweeps
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Written by an agent end to end: the diagnosis (reading `brief.feed.tsx`, `panel.css` and `worklist.css`, then dumping the rendered item structure to confirm which child each row was), the stylesheet change and its comments, and the before/after Storybook capture used to check it. Reviewed against the seam rule `panel.css` already states rather than invented fresh.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wms5TVJ328yMZA8jSpUXm7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Brief "Today" feed so section labels ("Respond now", "Move revenue") sit on the panel's margin aligned with the rows they name instead of starting 20px left at the card's edge, and restores the hairline rule to the boundary between rows rather than cutting a label off from its row.

- The label's interval is asymmetric because it binds downward to its row; the first label pays its own interval so it clears the header hairline.
- Section boundaries take air and no line, while the rule falls only between two rows of one section.

<sup>Written for commit 351370395f5e3058294f937edc804e74e04ea5ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing and visual hierarchy for section labels in the feed.
  - Adjusted row dividers to better distinguish section boundaries from rows within the same section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->