### PR TITLE
Read the project's phase and key beside its name

### DIFF
--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -155,7 +155,12 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
       name={project.name}
       subtitle={<ProjectSubtitle view={view} />}
       zone={recordZone}
-      badges={
+      // The phase and the key read beside the name, not at the far end of
+      // the header among the verbs: both are tags ON the record — where it
+      // stands and what a human calls it in a subject line — and a reader
+      // looking at the name was finding them across the page, above the
+      // buttons that act on it.
+      nameBadge={
         <>
           <PhaseBadge phase={project.phase} />
           {project.key && <ProjectKeyChip projectKey={project.key} />}


### PR DESCRIPTION
## What

The project page's phase badge ("Initiative") and key chip (`TEST123-1`) now sit on the title's own line, right after the project name, instead of at the far right of the header next to the action buttons.

## Why

Every other record page reads its standing on the name's own line via `RecordView`'s `nameBadge` slot; the deal page made the same move for its status. The project page was the one record whose phase and key a reader had to find across the page, above the verbs. Both are tags on the record, so both belong with its name. One-file change in `frontend/src/screens/project360.tsx`: the two elements move from the `badges` slot to `nameBadge`.

## How verified

- [x] `pnpm biome check` on the touched file, `tsc -b`, and the `project360` / `projects` screen tests pass; the full frontend unit suite was still running at push time and CI runs it in full
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend layout only
- [x] `make craft-static` reports no new blockers — no Go touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Entirely AI-assisted from a screenshot and a one-line request; the slot choice follows the existing pattern on the deal page.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3HnTo2xvpAhpS1WGZYVmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3HnTo2xvpAhpS1WGZYVmS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relocates the project page's phase badge and key chip from the far end of the header to the title line, so they read beside the project name. This matches how every other record page shows its status, and it's a frontend layout-only change with no effect on data or behavior.

<sup>Written for commit fccfc08a241a0164782df402d430466960e396d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

