### PR TITLE
feat(shell): the agent keeps a reduced foot on a section's rail

### DIFF
--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -140,8 +140,13 @@
      width in one axis and the viewport in the other would give the ball two
      different diameters. 172px is a step under the width the card could give
      it — the ball leads the rail without crowding the destinations above it —
-     and 18vh is what a short window can, whichever is smaller. */
-  --coreSize: min(172px, 18vh);
+     and 18vh is what a short window can, whichever is smaller.
+     Named, because the short-window ladder below moves it and the reduced foot
+     (`.rail.leveled`) has to stay SMALLER than it at every step: a second rule
+     that spelled its own length would be drawing the reduction larger than the
+     ball it reduces on any window where the ladder had already fired. */
+  --arBall: min(172px, 18vh);
+  --coreSize: var(--arBall);
   --coreGlass: calc(var(--coreSize) - 6px);
   /* The viewport cap is for a hero standing in a content column; the rail's own
      width and height are the only caps this one needs. */
@@ -289,8 +294,9 @@
     text-align: left;
   }
   .arorb {
-    --coreSize: 56px;
-    --coreGlass: 50px;
+    /* The glass is derived from the ball at the top of this file, and its
+       56px less 6px is the 50px this step used to spell for itself. */
+    --arBall: 56px;
   }
   .arwords {
     align-items: flex-start;
@@ -334,6 +340,47 @@
   --coreSize: 56px;
   --coreGlass: 48px;
   --coreHalo: 0.5;
+}
+
+/* ===== The rail showing one section's entries =====
+ *
+ * The agent belongs to the SESSION rather than to a destination, so walking into
+ * settings does not put it away: an amber orb is the same fact on every screen,
+ * and a report that goes quiet on the screens where somebody would go to fix it
+ * is a report nobody acts on. What changes is its WEIGHT. The level above it is
+ * one section's own pages, and a ball at the size that leads the workspace rail
+ * would read as the thing that list is about.
+ *
+ * So the foot is reduced to the orb, which is the whole report at every width
+ * the words are gone at. The panel it opens is where the line and the month's
+ * spend are said, and the button keeps its accessible name, so nothing here is
+ * lost to a screen reader.
+ */
+.rail.leveled .arwords,
+.rail.leveled .archev,
+.rail.leveled .argo {
+  display: none;
+}
+/* `:not(.collapsed)` rather than source order: the collapsed rail reduces the
+   same ball further, the two selectors weigh the same, and a tie decided by
+   which rule this file prints last is a tie the next edit re-decides. */
+.rail.leveled:not(.collapsed) .arhit {
+  /* Centred in both directions the block can run: it is a column of one thing
+     here, and the short-window step above turns it into a ROW whose only other
+     cell — the words — this level has just dropped. */
+  justify-content: center;
+  padding: var(--space-2) 0;
+}
+.rail.leveled:not(.collapsed) .arorb {
+  /* Against the rail's OWN ball rather than a length of its own, so this is a
+     reduction at every window height: the short-window ladder above already
+     takes that ball to 56px, and a flat 72px there would draw the reduced foot
+     larger than the full one it reduces. */
+  --coreSize: min(72px, var(--arBall));
+  /* The collapsed rail's halo, for the collapsed rail's reason: below the size
+     where the ribbons inside the ball can be read, the bloom is what makes the
+     foot read as lit from within rather than as a marble set on the rail. */
+  --coreHalo: 0.4;
 }
 
 /* ===== The phone bar's centre cell =====

--- a/frontend/src/app/agentrail.stories.tsx
+++ b/frontend/src/app/agentrail.stories.tsx
@@ -81,19 +81,29 @@ function callRow(task: string, minutesAgo: number, index: number) {
   };
 }
 
+// The three feet the block has to look right in, named by the class the shell
+// puts on the rail (app/shell.tsx) — the stylesheet keys the reduction off that
+// state, so a story that dressed itself would be showing a rail this app never
+// renders.
+type RailState = "expanded" | "collapsed" | "leveled";
+
 function Rail({
-  collapsed,
+  state,
   children,
-}: Readonly<{ collapsed?: boolean; children: ReactNode }>) {
+}: Readonly<{ state: RailState; children: ReactNode }>) {
   return (
-    <nav className={collapsed ? "rail collapsed" : "rail expanded"}>
+    <nav className={`rail ${state}`}>
       <div className="grow" />
       <div className="railagent">{children}</div>
     </nav>
   );
 }
 
-function story(answers: Answers, collapsed = false, grants = OPERATOR) {
+function story(
+  answers: Answers,
+  rail: RailState = "expanded",
+  grants = OPERATOR,
+) {
   return () => {
     installFetchStub({
       "GET /me": meRoute(grants),
@@ -157,7 +167,7 @@ function story(answers: Answers, collapsed = false, grants = OPERATOR) {
     });
     return (
       <StoryProviders>
-        <Rail collapsed={collapsed}>
+        <Rail state={rail}>
           <AgentRail route={{ screen: "companies" }} />
         </Rail>
       </StoryProviders>
@@ -266,7 +276,13 @@ export const NothingHasRunYet: Story = {
 /** The collapsed rail: the orb is the whole report at 56px, the words and the
  *  chevron gone. */
 export const CollapsedRail: Story = {
-  render: story(HEALTHY, true),
+  render: story(HEALTHY, "collapsed"),
+};
+
+/** The rail showing one section's entries: the agent keeps its foot, at the size
+ *  that says it is still reporting without leading a list it is not about. */
+export const LeveledRail: Story = {
+  render: story(HEALTHY, "leveled"),
 };
 
 /**
@@ -301,7 +317,7 @@ export const PanelOpen: Story = {
  * that would fail if that ever changed.
  */
 export const LicenceWithheld: Story = {
-  render: story({ ...HEALTHY, licenseState: "absent" }, false, {
+  render: story({ ...HEALTHY, licenseState: "absent" }, "expanded", {
     automation: ["update"],
   }),
 };

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -685,10 +685,13 @@ describe("Shell", () => {
   });
 
   // A sidebar showing a section's entries is navigation inside ONE destination,
-  // and the agent belongs to the whole session — so it is absent there rather
-  // than re-parented under a sub-level. The foot goes with it: an empty box would
-  // leave the band and the rule that divide a reading from the rows above it.
-  it("mounts no agent while the rail shows a section's own entries", async () => {
+  // and the agent belongs to the whole SESSION — so it keeps its foot there
+  // rather than going quiet because a reader walked into settings, which is
+  // where they would go to fix whatever the orb is amber about. Still one block,
+  // reduced by the rail's own state (app/agentrail.css) rather than by a second
+  // component: two Cores reporting one session is the thing that rule exists to
+  // stop, at any size.
+  it("keeps the one agent at the foot while the rail shows a section's own entries", async () => {
     window.location.hash = "#/settings/account";
     const { container } = render(
       <Shell onOpenSearch={ignoreSearch}>{null}</Shell>,
@@ -703,8 +706,11 @@ describe("Shell", () => {
     expect(
       await within(rail).findByRole("link", { name: "Account" }),
     ).toBeTruthy();
-    expect(container.querySelector(".arblock")).toBeNull();
-    expect(container.querySelector(".railagent")).toBeNull();
+    expect(rail.className).toContain("leveled");
+    expect(container.querySelectorAll(".arblock")).toHaveLength(1);
+    expect(
+      container.querySelector(".rail .railagent")?.querySelector(".arblock"),
+    ).not.toBeNull();
   });
 
   it("renders rail-less for the documented exceptions (AC-shell layout exception)", () => {

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -447,12 +447,15 @@ export function WorkspaceRail({
             page. What the installation is ENTITLED to used to sit here as its
             own grey row, and it now reaches a reader through the Core instead: a
             licence fault turns the orb amber, which is a thing somebody notices.
-            The whole foot goes on a drilled-in level, element and all: an empty
-            box left behind would still hold the band and the rule that divide a
-            reading from the rows above it. And it goes at phone width, where
-            there is no column to have a foot: the bar's centre cell above is
-            where the agent stands there, and two of these would be two Cores. */}
-        {!leveled && !phone && (
+            It keeps the foot on a drilled-in level, REDUCED rather than removed
+            (app/agentrail.css): the agent belongs to the whole session, so an
+            amber orb has to survive a reader walking into settings — but the
+            column it stands under there is one section's own pages, and the ball
+            at rail size would lead a list it is not about. Same block, same
+            Core, smaller. It still goes at phone width, where there is no column
+            to have a foot: the bar's centre cell above is where the agent stands
+            there, and two of these would be two Cores. */}
+        {!phone && (
           <div className="railagent">
             <AgentRail route={route} />
           </div>

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -11,6 +11,7 @@ import { translate } from "../i18n";
 import { SettingsScreen } from "./settings";
 import {
   jsonResponse,
+  keyedEnvelope,
   readOn,
   render,
   renderNav,
@@ -187,6 +188,13 @@ function settingsNavBackend(opts: {
         ...me,
         data_reset_available: opts.dataResetAvailable ?? false,
       });
+    }
+    // The rail carries the agent at its foot, and the agent reads endpoints that
+    // answer with a KEYED envelope rather than the paged one below — an unrouted
+    // one throws mid-render, which surfaces here as the nav being empty.
+    const keyed = keyedEnvelope(url);
+    if (keyed) {
+      return keyed;
     }
     return jsonResponse({
       data: [],

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -146,9 +146,11 @@ export function readOn(object: RbacObject): GrantSpec {
 // promised, gets undefined, and throws mid-render — which takes the whole entry
 // down and surfaces as its OTHER cards being absent, nowhere near the cause.
 //
-// Shared because this screen has two fetch fakes (`settingsBackend` here and
-// `mergedEntryBackend`, which parameterizes the seat), and a keyed endpoint
-// added to one of them alone leaves the other failing exactly that way.
+// Shared because this screen has several fetch fakes — `settingsBackend` here,
+// `mergedEntryBackend` parameterizing the seat, `settingsNavBackend` the grant
+// map — and a keyed endpoint added to one of them alone leaves the others
+// failing exactly that way. Every fake routes through here for that reason;
+// counting them in this comment is how the sentence goes stale, so it does not.
 export function keyedEnvelope(url: string) {
   // `providers` is required in the contract, so a card is right to index it
   // directly; an empty list is the honest answer for an installation that has
@@ -161,6 +163,16 @@ export function keyedEnvelope(url: string) {
   // no model in the window — which is what a test fixture is.
   if (url.includes("/ai/health")) {
     return jsonResponse({ window_hours: 1, rungs: [] });
+  }
+  // `budget` is required too, and the agent at the foot of the settings rail
+  // indexes it for the currency its spend figure is in. A month with no call is
+  // the honest answer for a fixture, and the figure it draws is then absent
+  // rather than a confident zero (app/agentrail.tsx).
+  if (url.includes("/ai/usage")) {
+    return jsonResponse({
+      days: [],
+      budget: { monthly_tokens: 0, spent_tokens: 0, band: "normal" },
+    });
   }
   return null;
 }


### PR DESCRIPTION
## What

The settings sidebar now carries the AI orb at its foot, reduced: 72px against
the workspace rail's 172px, with the caption line, the chevron and the CTA gone.
The block, the panel it opens and the button's accessible name are unchanged, so
there is still exactly one agent in the document at any width.

Before, the whole foot was removed on a drilled-in level (`!leveled && !phone`);
now only its weight changes, through the `leveled` class the rail already
carries.

## Why

The agent belongs to the SESSION rather than to a destination. Removing it on a
section's own level meant the one object in the chrome that reports rather than
navigates went quiet on exactly the screens somebody walks into to fix whatever
it is amber about — a licence fault, an unreachable source, an unconfigured
model all reach a reader through that orb.

What did NOT survive the move is its size. The level above the foot there is one
section's own pages, and a ball at the size that leads the workspace rail reads
as the thing that list is about.

The reduced ball is expressed against the rail's own (`--arBall`) rather than as
a length of its own. The short-window ladder in `agentrail.css` already takes
that ball to 56px at `max-height: 780px`, so a flat 72px would have drawn the
reduction LARGER than the thing it reduces on any window where the ladder had
fired. Naming the ball once and reducing against it is what makes "smaller" true
at every step rather than at the one that was measured. The `@media` step's own
`--coreGlass: 50px` went with it: the glass was already `--coreSize` less 6px,
and 56 − 6 is that same 50.

## How verified

- `make check-fe` green (ds gates, contract drift, lint, 8100 unit tests, build).
- `make check-backend` green — no Go in this diff, run to keep `make check`'s
  claim honest.
- Driven in Storybook with a real browser at 1440×960, measuring the rendered
  orb and the computed `--coreSize` rather than trusting the stylesheet:
  top level `rail expanded` → 172px with its caption; settings level
  `rail expanded leveled` → 72px, caption hidden; `rail collapsed leveled` →
  39px, unchanged from the collapsed rail today. The same run at a 720px-tall
  viewport is what caught the ladder defect above: both read 56px, i.e. the
  reduction is a no-op there rather than an enlargement.
- `shell.test.tsx` inverts the rule it used to hold — the block is present,
  once, under `.rail .railagent`, on a rail carrying `leveled` — and a
  `LeveledRail` story joins the expanded and collapsed ones in the catalog.

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend chrome only, no tenant data
- [x] `make craft-static` reports no new blockers — no Go files in this diff
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Entirely AI-assisted: the shell condition, the stylesheet, the story, the test
updates and the fixture change were all written by Claude Code, then verified by
running the gates and by measuring the rendered orb in a browser.

One fix fell out along the way and is in this diff rather than in an issue: the
settings nav fixture answered `/ai/usage` with the paged `{data, page}` envelope,
so the agent — which the rail now mounts there — indexed `budget` on it and threw
mid-render. `/ai/usage` joins the shared `keyedEnvelope` helper, and
`settingsNavBackend` routes through it like the screen's other fakes. That
helper's comment counted the fakes; it names them now and says why counting them
is what goes stale.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZEhy3kdDBgjDPRtfLYtA5


---
_Generated by [Claude Code](https://claude.ai/code/session_014ZEhy3kdDBgjDPRtfLYtA5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The settings sidebar keeps the agent at the foot of a section's own rail, reduced to the orb instead of removed. The orb reads 72px against the rail's 172px, with the caption, chevron, and CTA hidden; the panel, accessible name, and one-agent-per-document guarantee are unchanged.

- The reduction is `min(72px, var(--arBall))`, so it stays smaller than the full foot at every window height, including the 56px short-window step.
- `settingsNavBackend` now routes `/ai/usage` through `keyedEnvelope`; the agent mounts in settings, and the old paged response threw mid-render.

<sup>Written for commit a82786f2514ff233b62f8ecc6e57892ed2360451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

