### PR TITLE
A stalled read says its way out, and the account scan has one

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31193,13 +31193,21 @@ components:
         honestly omitted. A reading that is still running carries empty lists; that is not
         the same answer as a finished reading that grounded nothing, which is why `status`
         is required rather than inferable from the lists (RD-AC-N-2).
-      required: [id, status, fields, omitted, created_at]
+      required: [id, status, stalled, fields, omitted, created_at]
       properties:
         id: { type: string, format: uuid, description: This reading's own id. }
         status:
           type: string
           enum: [queued, running, done, failed]
           description: queued/running are live; done and failed are terminal. `done` with zero grounded fields is a correct answer, not a failure.
+        stalled:
+          type: boolean
+          description: |
+            true when a live reading has aged past the lease its worker holds: the worker
+            died, timed out, or never claimed it, and nothing will move the reading on its
+            own. Derived at read time, never stored. Asking for the file to be read again
+            then starts a fresh attempt instead of joining this one. Always false once the
+            reading is done or failed.
         status_detail:
           type: [string, 'null']
           description: |

--- a/backend/internal/compose/integration/org360/orgscanlifecycle_integration_test.go
+++ b/backend/internal/compose/integration/org360/orgscanlifecycle_integration_test.go
@@ -7,10 +7,11 @@ package org360
 
 // The scan's lifecycle over a real database, branch by branch: an unchanged
 // account is served from what was read, a changed one is marked stale under
-// the floor and read again past it, a deployment with no worker settles on
-// the floor in-request, a lane that breaks or defers leaves the reader with
-// the rules and the row with the truth, and a reader the account refuses —
-// or who is not a person — gets no read at all.
+// the floor and read again past it, a read whose worker died is re-armed by
+// the next open and reclaimed by the worker's own retry, a deployment with no
+// worker settles on the floor in-request, a lane that breaks or defers leaves
+// the reader with the rules and the row with the truth, and a reader the
+// account refuses — or who is not a person — gets no read at all.
 
 import (
 	"context"
@@ -133,12 +134,7 @@ func TestAnUnchangedAccountIsServedFromWhatWasReadAndAChangedOneIsMarkedStale(t 
 	}
 	// The re-armed row is a later attempt of the same occurrence, so the
 	// rail — which takes only a later attempt's transitions — draws it.
-	var attempt int
-	if err := integration.OwnerConn(t).QueryRow(context.Background(),
-		`SELECT attempt FROM org_scan WHERE id = $1`, queued[1].ScanID).Scan(&attempt); err != nil {
-		t.Fatalf("read the attempt: %v", err)
-	}
-	if attempt != 2 {
+	if attempt := scanAttempt(t, queued[1].ScanID); attempt != 2 {
 		t.Errorf("attempt after a forced re-read = %d, want 2", attempt)
 	}
 }
@@ -161,6 +157,111 @@ func TestAChangedAccountPastTheFloorIsReadAgainOnItsOwn(t *testing.T) {
 	}
 	if got.State != crmcontracts.OrganizationScanStateQueued || len(queued) != 2 {
 		t.Errorf("past the floor = %q with %d queued; want a fresh read", got.State, len(queued))
+	}
+}
+
+// killWorker leaves the read as a worker that died mid-read leaves it: running,
+// claimed `ago` before now, with nobody coming back for it.
+func killWorker(t *testing.T, scanID ids.UUID, ago time.Duration) {
+	t.Helper()
+	if _, err := integration.OwnerConn(t).Exec(context.Background(), `
+		UPDATE org_scan SET status = 'running', started_at = now() - ($2 * interval '1 microsecond')
+		 WHERE id = $1`, scanID, ago.Microseconds()); err != nil {
+		t.Fatalf("leave the read running with a dead worker: %v", err)
+	}
+}
+
+func scanAttempt(t *testing.T, scanID ids.UUID) int {
+	t.Helper()
+	var attempt int
+	if err := integration.OwnerConn(t).QueryRow(context.Background(),
+		`SELECT attempt FROM org_scan WHERE id = $1`, scanID).Scan(&attempt); err != nil {
+		t.Fatalf("read the attempt: %v", err)
+	}
+	return attempt
+}
+
+// A worker that dies leaves the row running, and nothing but the reader
+// opening the account again could ever move it: the page polls a live row,
+// the rail calls it stalled past the lease, and neither starts anything.
+// Inside the lease the open joins the read — a real worker may hold it —
+// and past it the open re-arms the same occurrence as a later attempt.
+func TestAReadWhoseWorkerDiedIsReadAgainWhenTheAccountIsOpened(t *testing.T) {
+	e := integration.Setup(t)
+	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Nordlicht", &e.Rep1))
+	seedInboundAsk(t, e, org.UUID, "workspace")
+	var queued []orgscan.Queued
+	svc := scanClocked(e, &failingLane{}, &queued, time.Now)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	if _, err := svc.Ensure(rep, org, false); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	killWorker(t, queued[0].ScanID, orgscan.ScanLease-time.Minute)
+	held, err := svc.Ensure(rep, org, true)
+	if err != nil {
+		t.Fatalf("ensure inside the lease: %v", err)
+	}
+	if held.State != crmcontracts.OrganizationScanStateRunning || len(queued) != 1 {
+		t.Errorf("inside the lease: %q with %d queued; want the held read served, nothing queued", held.State, len(queued))
+	}
+
+	killWorker(t, queued[0].ScanID, orgscan.ScanLease+time.Second)
+	rearmed, err := svc.Ensure(rep, org, false)
+	if err != nil {
+		t.Fatalf("ensure past the lease: %v", err)
+	}
+	if rearmed.State != crmcontracts.OrganizationScanStateQueued || len(queued) != 2 {
+		t.Errorf("past the lease: %q with %d queued; want the read queued again", rearmed.State, len(queued))
+	}
+	if attempt := scanAttempt(t, queued[0].ScanID); queued[1].ScanID != queued[0].ScanID || attempt != 2 {
+		t.Errorf("re-armed as %s attempt %d; want the same occurrence at attempt 2", queued[1].ScanID, attempt)
+	}
+}
+
+// The worker's own retry finds the row its earlier attempt left running. A
+// holder inside its lease is left alone — reading the account twice bills it
+// twice — and one past it is taken over as a new attempt and read to the end.
+func TestTheWorkerReclaimsAReadItsDeadPredecessorLeftRunning(t *testing.T) {
+	e := integration.Setup(t)
+	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Nordlicht", &e.Rep1))
+	message := seedInboundAsk(t, e, org.UUID, "workspace")
+	lane := &quotingLane{messageID: message.String(), quote: "wants to see a sample of the driver reports"}
+	var queued []orgscan.Queued
+	svc := scanClocked(e, lane, &queued, time.Now)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	if _, err := svc.Ensure(rep, org, false); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	scanID := queued[0].ScanID
+	worker := principal.WithCorrelationID(rep, scanID)
+
+	killWorker(t, scanID, orgscan.ScanLease-time.Minute)
+	if err := svc.Run(worker, scanID, org); err != nil {
+		t.Fatalf("run against a live holder: %v", err)
+	}
+	held, err := svc.Get(rep, org)
+	if err != nil {
+		t.Fatalf("get while held: %v", err)
+	}
+	if held.State != crmcontracts.OrganizationScanStateRunning || lane.calls != 0 {
+		t.Errorf("a holder inside its lease: %q after %d model calls; want left running, unread", held.State, lane.calls)
+	}
+
+	killWorker(t, scanID, orgscan.ScanLease+time.Second)
+	if err := svc.Run(worker, scanID, org); err != nil {
+		t.Fatalf("run against a dead holder: %v", err)
+	}
+	got, err := svc.Get(rep, org)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != crmcontracts.OrganizationScanStateDone || lane.calls != 1 {
+		t.Errorf("a holder past its lease: %q after %d model calls; want read to done", got.State, lane.calls)
+	}
+	if attempt := scanAttempt(t, scanID); attempt != 2 {
+		t.Errorf("attempt after the reclaim = %d, want 2 so the rail draws the retry", attempt)
 	}
 }
 

--- a/backend/internal/compose/jobs_accountscan.go
+++ b/backend/internal/compose/jobs_accountscan.go
@@ -49,14 +49,17 @@ func (a AccountScanArgs) WorkspaceID() ids.UUID { return a.Workspace }
 // transcript reading's, for the reason api/jobs.yaml gives.
 const accountScanQueue = "transcript_read"
 
-// accountScanInsertOpts routes the job and deduplicates it by args: the scan
-// row's id is unique per read, so a re-submitted enqueue of the SAME read
-// collapses while a fresh read always queues.
+// accountScanInsertOpts routes the job and deduplicates it by args, only
+// while a job is still active — for the reason documentExtractInsertOpts
+// gives. The scan reaches that trap through a retry inside the lease: it
+// declines the claim and returns, the job completes while the row stays
+// live, and the re-arm's enqueue under the same scan id must not collapse
+// against it.
 func accountScanInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
 		Queue:       accountScanQueue,
 		MaxAttempts: sweptJobMaxAttempts,
-		UniqueOpts:  river.UniqueOpts{ByArgs: true},
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 }
 

--- a/backend/internal/compose/jobs_accountscan_test.go
+++ b/backend/internal/compose/jobs_accountscan_test.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/riverqueue/river"
@@ -20,6 +21,23 @@ func TestAnAccountScanIsQueuedOnceOnTheTranscriptLane(t *testing.T) {
 	opts := accountScanInsertOpts()
 	if opts.Queue != accountScanQueue || !opts.UniqueOpts.ByArgs {
 		t.Errorf("insert opts = %+v, want the transcript queue, unique by args", opts)
+	}
+}
+
+// Every reading a door re-arms after its worker died queues the replacement
+// under the SAME read id as the job that finished without it. River's default
+// uniqueness window counts finished jobs, so anything wider than the active
+// states swallows the replacement and leaves the re-armed row queued with
+// nothing behind it — the strand the re-arm exists to end.
+func TestARearmableReadingDedupesItsJobOnlyWhileOneIsStillActive(t *testing.T) {
+	for name, opts := range map[string]*river.InsertOpts{
+		"document extract":   documentExtractInsertOpts(),
+		"account scan":       accountScanInsertOpts(),
+		"transcript propose": transcriptProposeInsertOpts(),
+	} {
+		if !opts.UniqueOpts.ByArgs || !slices.Equal(opts.UniqueOpts.ByState, activeSweepStates) {
+			t.Errorf("%s: unique %+v; want by args, over the active states only", name, opts.UniqueOpts)
+		}
 	}
 }
 

--- a/backend/internal/compose/jobs_transcript.go
+++ b/backend/internal/compose/jobs_transcript.go
@@ -50,8 +50,11 @@ func (TranscriptProposeArgs) Kind() string { return "transcript_propose" }
 func (a TranscriptProposeArgs) WorkspaceID() ids.UUID { return a.Workspace }
 
 // transcriptProposeInsertOpts routes the job to its own queue and deduplicates
-// by args: the read id is unique per reading, so a re-submitted enqueue of the
-// SAME reading collapses while a fresh reading always queues.
+// by args, only while a job is still active: the read id is unique per
+// reading, so a re-submitted enqueue of the SAME reading collapses while a
+// fresh reading always queues — and a reading rearmIfAbandoned hands back
+// after a dead worker carries the same id as the job that finished without
+// it, for the reason documentExtractInsertOpts gives.
 func transcriptProposeInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
 		Queue: transcriptReadQueue,
@@ -59,7 +62,7 @@ func transcriptProposeInsertOpts() *river.InsertOpts {
 		// re-asks, so the ladder carries the blob-store blip and the unreadable
 		// transcript alone — the same reading document_extract is sized for.
 		MaxAttempts: oneOffJobMaxAttempts,
-		UniqueOpts:  river.UniqueOpts{ByArgs: true},
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 }
 

--- a/backend/internal/compose/orgscan/service.go
+++ b/backend/internal/compose/orgscan/service.go
@@ -164,14 +164,23 @@ const (
 )
 
 // decide is the ensure rule, pure so a test can hold every branch: a live
-// read is never started twice; a matching fingerprint is served; a changed
-// account is read again only past the floor, unless forced. stored is nil
-// for a reader who has never asked.
+// read is never started twice, unless nobody is working it any more; a
+// matching fingerprint is served; a changed account is read again only past
+// the floor, unless forced. stored is nil for a reader who has never asked.
+//
+// The abandoned arm is the reader's only way out of a read whose worker
+// died: the page polls a live row for as long as it stays live, the rail
+// calls it stalled past the lease, and neither could start anything until
+// this did. Opening the account again is what a person tries unprompted, so
+// it is what re-arms the read.
 func decide(stored *row, fingerprint string, now time.Time, force bool) decision {
 	if stored == nil {
 		return queueRead
 	}
 	if stored.live() {
+		if stored.abandoned(now) {
+			return queueRead
+		}
 		return serveCurrent
 	}
 	if !stored.settled() {
@@ -188,17 +197,19 @@ func decide(stored *row, fingerprint string, now time.Time, force bool) decision
 
 // queue writes the row and the job together, or — with no runner on this
 // role — settles the floor in the same transaction, so the reader is never
-// left polling a read nothing will pick up.
+// left polling a read nothing will pick up. A row the write left as it
+// stands — a read a worker claimed between the decision and this — is served
+// as it now stands, with nothing queued behind it.
 func (s *Service) queue(ctx context.Context, userID ids.UserID, orgID ids.OrganizationID) (*row, error) {
 	var out *row
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		queued, err := queue(ctx, tx, userID, orgID)
-		if err != nil {
+		queued, rearmed, err := queue(ctx, tx, userID, orgID)
+		if err != nil || !rearmed {
 			return err
 		}
 		out = &queued
 		if s.enqueue == nil {
-			return settle(ctx, tx, queued.ID, outcome{
+			return settle(ctx, tx, queued.ID, nil, outcome{
 				Status: StatusDegraded, GeneratedBy: crmcontracts.Deterministic,
 				DegradeReason: "No worker runs account scans in this deployment, so the rules' own advice stands alone.",
 			})
@@ -208,7 +219,7 @@ func (s *Service) queue(ctx context.Context, userID ids.UserID, orgID ids.Organi
 	if err != nil {
 		return nil, err
 	}
-	if s.enqueue == nil {
+	if out == nil || s.enqueue == nil {
 		return s.load(ctx, userID, orgID)
 	}
 	return out, nil
@@ -224,18 +235,19 @@ func (s *Service) Run(ctx context.Context, scanID ids.UUID, orgID ids.Organizati
 	if err != nil || !ok {
 		return err
 	}
+	h := claimed.claim()
 	in, fingerprint, err := s.assemble(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, apperrors.ErrPermissionDenied) || errors.Is(err, apperrors.ErrNotFound) {
-			return s.fail(ctx, claimed.ID, "The account could not be opened for this reader, so it was not read.")
+			return s.fail(ctx, h, "The account could not be opened for this reader, so it was not read.")
 		}
-		return s.fail(ctx, claimed.ID, "The account could not be read. Try again later.")
+		return s.fail(ctx, h, "The account could not be read. Try again later.")
 	}
 	lang := identity.BaseLanguageForPrompt(ctx, s.pool)
 	findings, by, err := Read(ctx, s.lane, orgID, in, lang)
 	var deferral *ai.BudgetDeferralError
 	if errors.As(err, &deferral) {
-		if deferErr := s.deferBudget(ctx, claimed.ID, deferral.NextAttemptAt); deferErr != nil {
+		if deferErr := s.deferBudget(ctx, h, deferral.NextAttemptAt); deferErr != nil {
 			return errors.Join(err, deferErr)
 		}
 		return err
@@ -255,14 +267,14 @@ func (s *Service) Run(ctx context.Context, scanID ids.UUID, orgID ids.Organizati
 		// The row is claimed: left running it would be served as a read in
 		// flight for as long as it sat there. It closes with the reason the
 		// reader can act on, and the cause goes back to the carrier.
-		return errors.Join(err, s.fail(ctx, claimed.ID, "The account could not be read. Try again later."))
+		return errors.Join(err, s.fail(ctx, h, "The account could not be read. Try again later."))
 	case s.lane == nil:
 		out.Status, out.DegradeReason = StatusDegraded, "No model lane is configured, so the rules' own advice stands alone."
 	case len(in.Messages) == 0:
 		out.Status, out.DegradeReason = StatusDegraded, "There are no exchanges this reader may read, so there was nothing to read the account from."
 	}
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return settle(ctx, tx, claimed.ID, out)
+		return settle(ctx, tx, h.ID, &h.ClaimedAt, out)
 	})
 }
 
@@ -424,9 +436,9 @@ func (s *Service) claim(ctx context.Context, scanID ids.UUID) (row, bool, error)
 	return r, ok, err
 }
 
-func (s *Service) deferBudget(ctx context.Context, scanID ids.UUID, next time.Time) error {
+func (s *Service) deferBudget(ctx context.Context, h held, next time.Time) error {
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return deferBudget(ctx, tx, scanID, next)
+		return deferBudget(ctx, tx, h, next)
 	})
 }
 
@@ -434,11 +446,11 @@ func (s *Service) deferBudget(ctx context.Context, scanID ids.UUID, next time.Ti
 // read's own cancellation, bounded so a dead database cannot hold the worker:
 // the one failure a cancelled read must still record is that it was
 // cancelled, and the row's update and the rail's announcement both ride it.
-func (s *Service) fail(ctx context.Context, scanID ids.UUID, reason string) error {
+func (s *Service) fail(ctx context.Context, h held, reason string) error {
 	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failWriteTimeout)
 	defer cancel()
 	return database.WithWorkspaceTx(recordCtx, s.pool, func(tx pgx.Tx) error {
-		return fail(recordCtx, tx, scanID, reason)
+		return fail(recordCtx, tx, h, reason)
 	})
 }
 

--- a/backend/internal/compose/orgscan/service_test.go
+++ b/backend/internal/compose/orgscan/service_test.go
@@ -31,12 +31,59 @@ func TestAReaderWhoNeverAskedGetsARead(t *testing.T) {
 	}
 }
 
+// liveRow is a read whose current attempt began `ago` before ensureNow: a
+// running one from its claim, a queued one from its request. A running read's
+// request is ancient on purpose — it ages from its claim, and a fixture that
+// dated both alike could not tell a read judged by the wrong instant.
+func liveRow(status string, ago time.Duration) *row {
+	at := ensureNow.Add(-ago)
+	if status == StatusRunning {
+		return &row{Status: status, RequestedAt: ensureNow.Add(-2 * time.Hour), StartedAt: &at}
+	}
+	return &row{Status: status, RequestedAt: at}
+}
+
 func TestAReadInFlightIsNeverStartedTwice(t *testing.T) {
 	for _, status := range []string{StatusQueued, StatusRunning} {
-		live := &row{Status: status}
+		live := liveRow(status, ScanLease-time.Second)
 		if got := decide(live, "fp", ensureNow, true); got != serveCurrent {
 			t.Errorf("a %s read was started again (force or not): %v", status, got)
 		}
+	}
+}
+
+// A live read past its lease has no worker behind it: it was killed, timed
+// out, or never claimed. Left alone the page would poll it forever and the
+// rail would call it stalled forever, so opening the account is what starts
+// it again — whether or not the reader forced.
+func TestAReadNobodyIsWorkingAnyMoreIsReadAgain(t *testing.T) {
+	for _, status := range []string{StatusQueued, StatusRunning} {
+		for _, force := range []bool{false, true} {
+			dead := liveRow(status, ScanLease+time.Second)
+			if got := decide(dead, "fp", ensureNow, force); got != queueRead {
+				t.Errorf("a %s read past its lease (force=%v) was served as in flight: %v", status, force, got)
+			}
+		}
+	}
+}
+
+// A deferred read ages from the instant it resumes, not from the request an
+// hour before it: a budget window parks a read for as long as the window is,
+// and a park that counted as abandonment would re-queue it into the same
+// window.
+func TestADeferredReadIsNotAbandonedUntilItsResumeHasAged(t *testing.T) {
+	resumes := ensureNow.Add(-time.Second)
+	parked := &row{Status: StatusQueued, RequestedAt: ensureNow.Add(-2 * time.Hour), NextAttemptAt: &resumes}
+	if parked.abandoned(ensureNow) {
+		t.Error("a read parked two hours ago that resumed a second ago counts as abandoned")
+	}
+	if got := decide(parked, "fp", ensureNow, false); got != serveCurrent {
+		t.Errorf("decide = %v, want the parked read served as in flight", got)
+	}
+	resumedLongAgo := ensureNow.Add(-ScanLease - time.Second)
+	long := &row{Status: StatusQueued, RequestedAt: ensureNow.Add(-2 * time.Hour), NextAttemptAt: &resumedLongAgo}
+	if !long.abandoned(ensureNow) {
+		t.Error("a read whose resume passed a whole lease ago is still in flight")
 	}
 }
 

--- a/backend/internal/compose/orgscan/store.go
+++ b/backend/internal/compose/orgscan/store.go
@@ -27,6 +27,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -53,6 +54,11 @@ const (
 	// ScanLease is how long a live occurrence stays believable. Past the
 	// job's own timeout with a margin for the settle write, so the rail calls
 	// a dead attempt stalled only once the worker would have given up on it.
+	//
+	// One number, read by every side: the rail ages a live row by it, the
+	// door re-arms a row past it, and the worker reclaims one past it. A
+	// second number would let a read count as dead to one side and alive to
+	// another, which is the state nothing can get out of.
 	ScanLease = 5 * time.Minute
 )
 
@@ -78,6 +84,66 @@ type row struct {
 
 func (r row) live() bool    { return r.Status == StatusQueued || r.Status == StatusRunning }
 func (r row) settled() bool { return r.GeneratedAt != nil }
+
+// queuedSince is the instant THIS attempt was queued. A budget deferral
+// re-queues under a later instant, and an hour-old requested_at would put a
+// freshly deferred read past its lease before any worker saw it.
+func (r row) queuedSince() time.Time {
+	if r.NextAttemptAt != nil {
+		return *r.NextAttemptAt
+	}
+	return r.RequestedAt
+}
+
+// liveSince is the instant the current attempt began to age: a running read
+// from its claim, a queued one from when it was queued. The rail applies the
+// same rule to the payload announce sends — aiactivity's staleAfter ages a
+// running attempt from StartedAt and any other from QueuedAt — and it is
+// mirrored here rather than shared because the rail reads a wire payload
+// and this reads a row; announce sends exactly these two instants.
+func (r row) liveSince() time.Time {
+	if r.Status == StatusRunning && r.StartedAt != nil {
+		return *r.StartedAt
+	}
+	return r.queuedSince()
+}
+
+// abandoned reports a live read nobody is working: its attempt has aged past
+// the lease, so the worker that held it was killed, timed out, or never
+// claimed it at all. Nothing else would ever move such a row — a finished
+// job is not re-enqueued — and a page that served it as "in flight" would
+// serve it that way for good.
+//
+// This is the door's DECISION, against the snapshot it read and its own
+// clock. The write that acts on it is a second transaction, so queue spells
+// the same predicate again in SQL, against the database clock the row was
+// written with, as the guard on the re-arm; the two are kept beside each
+// other's comments because they must not drift.
+func (r row) abandoned(now time.Time) bool {
+	return r.live() && now.Sub(r.liveSince()) > ScanLease
+}
+
+// held names the attempt a worker holds: the row and the instant it claimed
+// it. Every write that closes a read is scoped to it, so a worker whose lease
+// expired mid-read — its row since reclaimed by another — cannot land its
+// late answer on the attempt that replaced it. The same guard
+// activities.ExtractionReadOutcome carries as ClaimedAt, per table because
+// each carrier owns its own.
+type held struct {
+	ID        ids.UUID
+	ClaimedAt time.Time
+}
+
+// claim is the attempt this row's holder has, as the closing writes name it.
+// A running row always carries its start, so the zero time only ever reaches
+// a write that finds no row and is refused.
+func (r row) claim() held {
+	var at time.Time
+	if r.StartedAt != nil {
+		at = *r.StartedAt
+	}
+	return held{ID: r.ID, ClaimedAt: at}
+}
 
 const rowColumns = `id, user_id, organization_id, status, attempt, requested_at, started_at, finished_at,
 	next_attempt_at, fingerprint, generated_at, generated_by, degrade_reason, read_exchanges, read_deals, findings`
@@ -118,29 +184,61 @@ func load(ctx context.Context, tx pgx.Tx, userID ids.UserID, orgID ids.Organizat
 // Re-arming counts a new attempt rather than starting the count over: the
 // rail keys the row as one occurrence and takes only a later attempt's
 // transitions, so an attempt that ran backwards would never be drawn.
-func queue(ctx context.Context, tx pgx.Tx, userID ids.UserID, orgID ids.OrganizationID) (row, error) {
+//
+// A live row is re-armed only past its lease, and that guard is IN the write:
+// the door decided on a snapshot in another transaction, and a worker may
+// have claimed or reclaimed the read since. Without it a read somebody holds
+// would be set back to queued under a live claim. The predicate is
+// row.abandoned in SQL — started_at for a running read, else the instant this
+// attempt was queued — judged by the database clock the row was written
+// with. false says the row was left as it stands, and nothing is announced.
+func queue(ctx context.Context, tx pgx.Tx, userID ids.UserID, orgID ids.OrganizationID) (row, bool, error) {
 	r, err := scanRow(tx.QueryRow(ctx, `
 		INSERT INTO org_scan (user_id, organization_id, status)
 		VALUES ($1, $2, 'queued')
 		ON CONFLICT (user_id, organization_id) DO UPDATE
 		SET status = 'queued', attempt = org_scan.attempt + 1, requested_at = now(),
 		    started_at = NULL, finished_at = NULL, next_attempt_at = NULL
-		RETURNING `+rowColumns, userID, orgID))
-	if err != nil {
-		return row{}, fmt.Errorf("orgscan: queue the scan: %w", err)
+		WHERE org_scan.status NOT IN ('queued','running')
+		   OR COALESCE(org_scan.started_at, org_scan.next_attempt_at, org_scan.requested_at)
+		        < now() - ($3 * interval '1 microsecond')
+		RETURNING `+rowColumns, userID, orgID, ScanLease.Microseconds()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return row{}, false, nil
 	}
-	return r, announce(ctx, tx, r)
+	if err != nil {
+		return row{}, false, fmt.Errorf("orgscan: queue the scan: %w", err)
+	}
+	return r, true, announce(ctx, tx, r)
 }
 
-// begin claims a queued read for this attempt. A row that is not queued —
-// settled by a rival, or never queued — is not claimable, and the worker
-// treats that as nothing to do rather than as a failure.
+// begin claims a queued read for this attempt, or takes a running one away
+// from a holder whose lease ran out.
+//
+// Two arms because a redelivery of the job means two different things. A
+// live holder inside its lease is left alone — reading the account twice
+// bills it twice. A holder past its lease is a dead attempt, and taking it
+// over is a NEW attempt: the projection orders events by (attempt, state),
+// so a reclaim under the old attempt number would keep the dead worker's
+// claim instant and render the retry as stalled for its whole run. Both arms
+// are one statement, so the CASE reads the row's status BEFORE the update —
+// which is what tells a reclaim from the ordinary claim of a queued read.
+//
+// This is the same two-armed claim as activities.BeginExtractionRead, per
+// table rather than shared because each carrier owns its own table and its
+// own lease.
+//
+// A row that is settled, or that nobody ever queued, is not claimable, and
+// the worker treats that as nothing to do rather than as a failure.
 func begin(ctx context.Context, tx pgx.Tx, scanID ids.UUID) (row, bool, error) {
 	r, err := scanRow(tx.QueryRow(ctx, `
 		UPDATE org_scan
-		   SET status = 'running', started_at = now(), next_attempt_at = NULL
-		 WHERE id = $1 AND status = 'queued'
-		RETURNING `+rowColumns, scanID))
+		   SET status = 'running', started_at = now(), next_attempt_at = NULL,
+		       attempt = attempt + CASE WHEN status = 'running' THEN 1 ELSE 0 END
+		 WHERE id = $1
+		   AND (status = 'queued'
+		     OR (status = 'running' AND started_at < now() - ($2 * interval '1 microsecond')))
+		RETURNING `+rowColumns, scanID, ScanLease.Microseconds()))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return row{}, false, nil
 	}
@@ -152,19 +250,27 @@ func begin(ctx context.Context, tx pgx.Tx, scanID ids.UUID) (row, bool, error) {
 
 // deferBudget parks a running read until the next budget window, as a new
 // attempt of the same occurrence.
-func deferBudget(ctx context.Context, tx pgx.Tx, scanID ids.UUID, next time.Time) error {
+func deferBudget(ctx context.Context, tx pgx.Tx, h held, next time.Time) error {
 	r, err := scanRow(tx.QueryRow(ctx, `
 		UPDATE org_scan
 		   SET status = 'queued', next_attempt_at = $2, attempt = attempt + 1, started_at = NULL
-		 WHERE id = $1 AND status = 'running'
-		RETURNING `+rowColumns, scanID, next.UTC()))
+		 WHERE id = $1 AND status = 'running' AND started_at = $3
+		RETURNING `+rowColumns, h.ID, next.UTC(), h.ClaimedAt))
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil
+		return lostClaim(h)
 	}
 	if err != nil {
 		return fmt.Errorf("orgscan: defer the scan: %w", err)
 	}
 	return announce(ctx, tx, r)
+}
+
+// lostClaim is the refusal every closing write answers when the row is no
+// longer running under this claim: reclaimed past its lease, or already
+// closed. The late writer has done everything it could, and the answer that
+// lands is the live attempt's.
+func lostClaim(h held) error {
+	return fmt.Errorf("%w: scan %s is not running under the claim of %s", apperrors.ErrConflict, h.ID, h.ClaimedAt.UTC().Format(time.RFC3339Nano))
 }
 
 // outcome is what a read that ran leaves on the row.
@@ -179,7 +285,11 @@ type outcome struct {
 }
 
 // settle writes a finished read — done or degraded — and announces it.
-func settle(ctx context.Context, tx pgx.Tx, scanID ids.UUID, out outcome) error {
+//
+// claimedAt scopes the write to the attempt the worker holds. It is nil only
+// for the floor a deployment with no worker settles in the same transaction
+// that queued the row: nothing claimed it, so there is no claim to name.
+func settle(ctx context.Context, tx pgx.Tx, scanID ids.UUID, claimedAt *time.Time, out outcome) error {
 	findings := out.Findings
 	if findings == nil {
 		findings = []crmcontracts.Organization360Suggestion{}
@@ -194,9 +304,13 @@ func settle(ctx context.Context, tx pgx.Tx, scanID ids.UUID, out outcome) error 
 		       generated_by = $4, degrade_reason = NULLIF($5, ''), read_exchanges = $6,
 		       read_deals = $7, findings = $8, next_attempt_at = NULL
 		 WHERE id = $1
+		   AND ($9::timestamptz IS NULL OR (status = 'running' AND started_at = $9))
 		RETURNING `+rowColumns,
 		scanID, out.Status, out.Fingerprint, string(out.GeneratedBy), out.DegradeReason,
-		out.ReadExchanges, out.ReadDeals, encoded))
+		out.ReadExchanges, out.ReadDeals, encoded, claimedAt))
+	if errors.Is(err, pgx.ErrNoRows) && claimedAt != nil {
+		return lostClaim(held{ID: scanID, ClaimedAt: *claimedAt})
+	}
 	if err != nil {
 		return fmt.Errorf("orgscan: settle the scan: %w", err)
 	}
@@ -206,12 +320,15 @@ func settle(ctx context.Context, tx pgx.Tx, scanID ids.UUID, out outcome) error 
 // fail closes a read that could not run, keeping whatever findings settled
 // before it: the rules still answer, and the reason says what stopped the
 // model.
-func fail(ctx context.Context, tx pgx.Tx, scanID ids.UUID, reason string) error {
+func fail(ctx context.Context, tx pgx.Tx, h held, reason string) error {
 	r, err := scanRow(tx.QueryRow(ctx, `
 		UPDATE org_scan
 		   SET status = 'failed', finished_at = now(), degrade_reason = $2, next_attempt_at = NULL
-		 WHERE id = $1
-		RETURNING `+rowColumns, scanID, reason))
+		 WHERE id = $1 AND status = 'running' AND started_at = $3
+		RETURNING `+rowColumns, h.ID, reason, h.ClaimedAt))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return lostClaim(h)
+	}
 	if err != nil {
 		return fmt.Errorf("orgscan: fail the scan: %w", err)
 	}
@@ -242,12 +359,6 @@ func announce(ctx context.Context, tx pgx.Tx, r row) error {
 	).Scan(&label); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("orgscan: read the account's name for the rail: %w", err)
 	}
-	// The instant THIS attempt was enqueued: a deferral re-queues under a new
-	// attempt, and the rail ages a live row from here.
-	queuedAt := r.RequestedAt
-	if r.NextAttemptAt != nil {
-		queuedAt = *r.NextAttemptAt
-	}
 	task := ActivityAITask
 	subjectType := "organization"
 	subjectID := openapi_types.UUID(r.OrgID.UUID)
@@ -258,7 +369,7 @@ func announce(ctx context.Context, tx pgx.Tx, r row) error {
 		AiTask:        &task,
 		Attempt:       r.Attempt,
 		State:         r.Status,
-		QueuedAt:      queuedAt,
+		QueuedAt:      r.queuedSince(),
 		StartedAt:     r.StartedAt,
 		FinishedAt:    r.FinishedAt,
 		LeaseSeconds:  lease(r),

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17934,6 +17934,13 @@ type AttachmentExtraction struct {
 	Id      openapi_types.UUID       `json:"id"`
 	Omitted []OmittedExtractionField `json:"omitted"`
 
+	// Stalled true when a live reading has aged past the lease its worker holds: the worker
+	// died, timed out, or never claimed it, and nothing will move the reading on its
+	// own. Derived at read time, never stored. Asking for the file to be read again
+	// then starts a fresh attempt instead of joining this one. Always false once the
+	// reading is done or failed.
+	Stalled bool `json:"stalled"`
+
 	// Status queued/running are live; done and failed are terminal. `done` with zero grounded fields is a correct answer, not a failure.
 	Status AttachmentExtractionStatus `json:"status"`
 

--- a/backend/internal/modules/activities/extraction.go
+++ b/backend/internal/modules/activities/extraction.go
@@ -14,6 +14,7 @@ package activities
 
 import (
 	"net/http"
+	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -39,17 +40,20 @@ func (h Handlers) GetAttachmentExtraction(w http.ResponseWriter, r *http.Request
 		writeStoreErr(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, http.StatusOK, extractionReport(read))
+	httperr.WriteJSON(w, http.StatusOK, extractionReport(read, time.Now()))
 }
 
 // extractionReport maps the run record onto the contract's wire shape,
 // splitting a grounded field (always carrying its evidence) from one the
 // reading honestly could not offer. Both slices stay non-nil even when empty,
-// so the wire body is `[]`, never `null`.
-func extractionReport(read ExtractionRead) crmcontracts.AttachmentExtraction {
+// so the wire body is `[]`, never `null`. Stalled is derived here against
+// `now` and never stored, for the reason the AI-activity rail derives its own:
+// nothing has to remember to mark a reading whose worker died.
+func extractionReport(read ExtractionRead, now time.Time) crmcontracts.AttachmentExtraction {
 	out := crmcontracts.AttachmentExtraction{
 		Id:           openapi_types.UUID(read.ID),
 		Status:       crmcontracts.AttachmentExtractionStatus(read.Status),
+		Stalled:      read.Abandoned(now),
 		StatusDetail: read.StatusDetail,
 		CreatedAt:    read.CreatedAt,
 		FinishedAt:   read.FinishedAt,

--- a/backend/internal/modules/activities/extraction_test.go
+++ b/backend/internal/modules/activities/extraction_test.go
@@ -33,7 +33,7 @@ func TestExtractionReportSplitsGroundedFromOmitted(t *testing.T) {
 		},
 	}
 
-	got := extractionReport(read)
+	got := extractionReport(read, created)
 
 	want := crmcontracts.AttachmentExtraction{
 		Id:        openapi_types.UUID(readID),
@@ -63,7 +63,7 @@ func TestExtractionReportKeepsTheTwoOmissionReasonsApart(t *testing.T) {
 			{Field: "currency", Omitted: true, OmittedReason: "not_stated_in_file"},
 			{Field: "amount_minor", Omitted: true, OmittedReason: "not_confidently_stated"},
 		},
-	})
+	}, time.Time{})
 
 	reasons := map[string]string{}
 	for _, o := range got.Omitted {
@@ -81,15 +81,42 @@ func TestExtractionReportKeepsTheTwoOmissionReasonsApart(t *testing.T) {
 // a different answer from a finished reading that grounded none, and the wire
 // has to be able to say so (RD-AC-N-2).
 func TestExtractionReportOfALiveReadingIsEmptyNotNil(t *testing.T) {
-	got := extractionReport(ExtractionRead{Status: ExtractionReadRunning})
-	if got.Status != crmcontracts.AttachmentExtractionStatusRunning {
-		t.Errorf("Status = %q, want running", got.Status)
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	got := extractionReport(ExtractionRead{Status: ExtractionReadRunning, StartedAt: &now, AttemptAt: now}, now)
+	if got.Status != crmcontracts.AttachmentExtractionStatusRunning || got.Stalled {
+		t.Errorf("Status = %q stalled %v, want running, inside its lease", got.Status, got.Stalled)
 	}
 	if got.Fields == nil || len(got.Fields) != 0 {
 		t.Errorf("Fields = %#v, want a non-nil empty slice", got.Fields)
 	}
 	if got.Omitted == nil || len(got.Omitted) != 0 {
 		t.Errorf("Omitted = %#v, want a non-nil empty slice", got.Omitted)
+	}
+}
+
+// A live reading past its lease has no worker behind it, and the poll says
+// so: a running one ages from its claim, a queued one from when THIS attempt
+// was queued — never from its creation, or a reading re-queued an hour after
+// it was first asked for would be stalled before any worker saw it. A settled
+// reading is never stalled, however old.
+func TestTheStalledReadingIsTheLiveOneWhoseAttemptOutlivedItsLease(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	fresh, dead := now.Add(-ExtractionReadLease+time.Minute), now.Add(-ExtractionReadLease-time.Second)
+	longAgo := now.Add(-time.Hour)
+	for name, tc := range map[string]struct {
+		read    ExtractionRead
+		stalled bool
+	}{
+		"running inside its lease": {ExtractionRead{Status: ExtractionReadRunning, StartedAt: &fresh, AttemptAt: longAgo}, false},
+		"running past its lease":   {ExtractionRead{Status: ExtractionReadRunning, StartedAt: &dead, AttemptAt: longAgo}, true},
+		"re-queued a moment ago":   {ExtractionRead{Status: ExtractionReadQueued, AttemptAt: fresh, CreatedAt: longAgo}, false},
+		"queued and never claimed": {ExtractionRead{Status: ExtractionReadQueued, AttemptAt: dead, CreatedAt: longAgo}, true},
+		"done, however long ago":   {ExtractionRead{Status: ExtractionReadDone, StartedAt: &longAgo, AttemptAt: longAgo}, false},
+		"failed, however long ago": {ExtractionRead{Status: ExtractionReadFailed, StartedAt: &longAgo, AttemptAt: longAgo}, false},
+	} {
+		if got := extractionReport(tc.read, now).Stalled; got != tc.stalled {
+			t.Errorf("%s: stalled = %v, want %v", name, got, tc.stalled)
+		}
 	}
 }
 

--- a/backend/internal/modules/activities/extractionread.go
+++ b/backend/internal/modules/activities/extractionread.go
@@ -99,6 +99,27 @@ func (r ExtractionRead) Live() bool {
 	return r.Status == ExtractionReadQueued || r.Status == ExtractionReadRunning
 }
 
+// liveSince is the instant the current attempt began to age: a running
+// reading from its claim, a queued one from when this attempt was queued. It
+// is the origin the AI-activity rail ages the reading by, and the one the
+// door's re-arm and the worker's reclaim read in SQL, so all three agree on
+// when a reading stopped being believable.
+func (r ExtractionRead) liveSince() time.Time {
+	if r.Status == ExtractionReadRunning && r.StartedAt != nil {
+		return *r.StartedAt
+	}
+	return r.AttemptAt
+}
+
+// Abandoned reports a live reading nobody is working: its attempt has aged
+// past the lease, so the worker that held it was killed, timed out, or never
+// claimed it. It is what the poll reports as stalled, and the reason the
+// panel then offers a fresh read where it showed "reading…" with nothing to
+// press — the only surface a rep has from which to reach the re-arm.
+func (r ExtractionRead) Abandoned(now time.Time) bool {
+	return r.Live() && now.Sub(r.liveSince()) > ExtractionReadLease
+}
+
 const extractionReadColumns = `id, attachment_id, status, status_detail, fields,
 	requested_by, started_at, finished_at, created_at, attempt, attempt_at`
 
@@ -217,13 +238,18 @@ func (s *Store) rearmIfAbandonedExtraction(
 	// attempts, or lost with the queue — and it strands exactly as hard, because
 	// the in-flight index makes the corpse block every new reading of the
 	// document while `rearm` is the only thing that could clear it.
+	//
+	// A queued row ages from attempt_at, not created_at: a reading released or
+	// re-armed a moment ago and dated by its creation would be re-armed again
+	// on the very next press, under a rising attempt, for as long as it waited.
+	// The predicate is ExtractionRead.Abandoned spelled in SQL.
 	rearmed, err := scanExtractionRead(tx.QueryRow(ctx, `
 		UPDATE attachment_extraction
 		   SET status = 'queued', started_at = NULL, status_detail = NULL,
 		       attempt = attempt + 1, attempt_at = now()
 		 WHERE id = $1
 		   AND status IN ('queued','running')
-		   AND COALESCE(started_at, created_at) < now() - ($2 * interval '1 microsecond')
+		   AND COALESCE(started_at, attempt_at) < now() - ($2 * interval '1 microsecond')
 		RETURNING `+extractionReadColumns, read.ID, ExtractionReadLease.Microseconds()))
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Inside its lease: a real worker holds it, and joining is correct.

--- a/backend/internal/modules/knowledge/handbook/what-the-ai-does.md
+++ b/backend/internal/modules/knowledge/handbook/what-the-ai-does.md
@@ -366,6 +366,13 @@ Each shows as queued, running, done, degraded, failed — or **stalled**.
 The app says exactly that: "Reading your document has taken unusually long. It
 may have stopped."
 
+Where there is a way out, the same line says it. An account whose read stalled
+is read again when you open it again: the open starts a fresh attempt, and the
+stalled one gives way to it. A document whose read stalled offers "Try reading
+it again" where it showed "Reading this file…", and pressing it does the same.
+A read still inside its time is joined rather than restarted, so opening a page
+twice, or pressing twice, never reads anything twice.
+
 It is worked out fresh each time you look, and never written down. That is
 deliberate. Nothing has to remember to mark it, which is what stops a job that
 died halfway from being shown as working forever.

--- a/docs/handbook/what-the-ai-does.md
+++ b/docs/handbook/what-the-ai-does.md
@@ -366,6 +366,13 @@ Each shows as queued, running, done, degraded, failed — or **stalled**.
 The app says exactly that: "Reading your document has taken unusually long. It
 may have stopped."
 
+Where there is a way out, the same line says it. An account whose read stalled
+is read again when you open it again: the open starts a fresh attempt, and the
+stalled one gives way to it. A document whose read stalled offers "Try reading
+it again" where it showed "Reading this file…", and pressing it does the same.
+A read still inside its time is joined rather than restarted, so opening a page
+twice, or pressing twice, never reads anything twice.
+
 It is worked out fresh each time you look, and never written down. That is
 deliberate. Nothing has to remember to mark it, which is what stops a job that
 died halfway from being shown as working forever.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22589,6 +22589,14 @@ export interface components {
              */
             status: "queued" | "running" | "done" | "failed";
             /**
+             * @description true when a live reading has aged past the lease its worker holds: the worker
+             *     died, timed out, or never claimed it, and nothing will move the reading on its
+             *     own. Derived at read time, never stored. Asking for the file to be read again
+             *     then starts a fresh attempt instead of joining this one. Always false once the
+             *     reading is done or failed.
+             */
+            stalled: boolean;
+            /**
              * @description Why the reading ended as it did, in words a rep can act on. Always present on
              *     `failed`, and on a `done` reading that grounded nothing — an empty result that
              *     does not explain itself reads as a broken feature.

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -967,8 +967,10 @@ function derive(
   }
   // A live run past the lease its own source declared. The server derives it, so
   // a worker that died without saying so cannot go on being displayed as busy,
-  // and amber is right for it: the work may yet land, and there is nothing for
-  // the reader to do but know.
+  // and amber is right for it: the work may yet land. Where a kind has a way
+  // out — opening the account or the document again re-arms its read — the
+  // kind's own line says so, because a warning with no next step is only a
+  // worry.
   const stalled = server.running.find((item) => item.state === "stalled");
   if (stalled) {
     return { state: "warning", cause: stalled, register: "agent" };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3169,6 +3169,8 @@ export const de = {
     "Diese Datei konnte nicht zum Lesen übergeben werden. Es wurde nichts geändert.",
   "extraction.loading": "Prüfe, ob diese Datei bereits gelesen wurde…",
   "extraction.reading": "Diese Datei wird gelesen…",
+  "extraction.stalled":
+    "Das Lesen dieser Datei dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
   "extraction.failed": "Diese Datei konnte nicht gelesen werden.",
   "extraction.groundedNothing":
     "Die KI hat diese Datei gelesen — sie nennt keines der Deal-Felder.",
@@ -3777,7 +3779,7 @@ export const de = {
     "Dein Dokument steht zum Lesen in der Warteschlange.",
   "agent.activity.documentExtract.running": "Ich lese dein Dokument.",
   "agent.activity.documentExtract.stalled":
-    "Das Lesen deines Dokuments dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
+    "Das Lesen deines Dokuments dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen. Öffne die Datei und lass sie erneut lesen.",
   "agent.activity.documentExtract.done": "Ich habe dein Dokument gelesen.",
   "agent.activity.documentExtract.degraded":
     "Ich bin bei deinem Dokument nur teilweise durchgekommen und habe gestoppt.",
@@ -3787,7 +3789,7 @@ export const de = {
     "{name} steht zum Lesen in der Warteschlange.",
   "agent.activity.documentExtractNamed.running": "Ich lese {name}.",
   "agent.activity.documentExtractNamed.stalled":
-    "Das Lesen von {name} dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
+    "Das Lesen von {name} dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen. Öffne die Datei und lass sie erneut lesen.",
   "agent.activity.documentExtractNamed.done": "Ich habe {name} gelesen.",
   "agent.activity.documentExtractNamed.degraded":
     "Ich bin bei {name} nur teilweise durchgekommen und habe gestoppt.",
@@ -3798,7 +3800,7 @@ export const de = {
   "agent.activity.accountScan.running":
     "Ich lese die Korrespondenz und die Deals eines Accounts.",
   "agent.activity.accountScan.stalled":
-    "Das Lesen eines Accounts dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
+    "Das Lesen eines Accounts dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen. Öffne den Account erneut, damit er neu gelesen wird.",
   "agent.activity.accountScan.done": "Was ein Account braucht, ist fertig.",
   "agent.activity.accountScan.degraded":
     "Ich habe einen Account so weit gelesen, wie die Datensätze es zuließen, und dann aufgehört.",
@@ -3809,7 +3811,7 @@ export const de = {
   "agent.activity.accountScanNamed.running":
     "Ich lese die Korrespondenz und die Deals von {name}.",
   "agent.activity.accountScanNamed.stalled":
-    "Das Lesen von {name} dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen.",
+    "Das Lesen von {name} dauert ungewöhnlich lange. Möglicherweise wurde es abgebrochen. Öffne den Account erneut, damit er neu gelesen wird.",
   "agent.activity.accountScanNamed.done": "Was {name} braucht, ist fertig.",
   "agent.activity.accountScanNamed.degraded":
     "Ich habe {name} so weit gelesen, wie die Datensätze es zuließen, und dann aufgehört.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3251,6 +3251,8 @@ export const en = {
     "That file could not be sent for reading. Nothing was changed.",
   "extraction.loading": "Checking whether this file has been read…",
   "extraction.reading": "Reading this file…",
+  "extraction.stalled":
+    "Reading this file has taken unusually long. It may have stopped.",
   "extraction.failed": "This file could not be read.",
   "extraction.groundedNothing":
     "AI read this file and it states none of the deal fields.",
@@ -3867,7 +3869,7 @@ export const en = {
     "Your document is queued to be read.",
   "agent.activity.documentExtract.running": "I'm reading your document.",
   "agent.activity.documentExtract.stalled":
-    "Reading your document has taken unusually long. It may have stopped.",
+    "Reading your document has taken unusually long. It may have stopped. Open the file and ask for it to be read again.",
   "agent.activity.documentExtract.done": "I've read your document.",
   "agent.activity.documentExtract.degraded":
     "I got partway through your document and stopped.",
@@ -3880,7 +3882,7 @@ export const en = {
   "agent.activity.documentExtractNamed.queued": "{name} is queued to be read.",
   "agent.activity.documentExtractNamed.running": "I'm reading {name}.",
   "agent.activity.documentExtractNamed.stalled":
-    "Reading {name} has taken unusually long. It may have stopped.",
+    "Reading {name} has taken unusually long. It may have stopped. Open the file and ask for it to be read again.",
   "agent.activity.documentExtractNamed.done": "I've read {name}.",
   "agent.activity.documentExtractNamed.degraded":
     "I got partway through {name} and stopped.",
@@ -3917,7 +3919,7 @@ export const en = {
   "agent.activity.accountScan.running":
     "I'm reading an account's exchanges and deals.",
   "agent.activity.accountScan.stalled":
-    "Reading an account has taken unusually long. It may have stopped.",
+    "Reading an account has taken unusually long. It may have stopped. Opening the account again starts a fresh read.",
   "agent.activity.accountScan.done": "What an account needs is ready.",
   "agent.activity.accountScan.degraded":
     "I read an account as far as the records let me and stopped.",
@@ -3926,7 +3928,7 @@ export const en = {
   "agent.activity.accountScanNamed.running":
     "I'm reading {name}'s exchanges and deals.",
   "agent.activity.accountScanNamed.stalled":
-    "Reading {name} has taken unusually long. It may have stopped.",
+    "Reading {name} has taken unusually long. It may have stopped. Opening the account again starts a fresh read.",
   "agent.activity.accountScanNamed.done": "What {name} needs is ready.",
   "agent.activity.accountScanNamed.degraded":
     "I read {name} as far as the records let me and stopped.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3132,6 +3132,8 @@ export const vi = {
     "Không gửi được tệp này để đọc. Không có gì bị thay đổi.",
   "extraction.loading": "Đang kiểm tra xem tệp này đã được đọc chưa…",
   "extraction.reading": "Đang đọc tệp này…",
+  "extraction.stalled":
+    "Việc đọc tệp này kéo dài bất thường. Có thể nó đã dừng.",
   "extraction.failed": "Không đọc được tệp này.",
   "extraction.groundedNothing":
     "AI đã đọc tệp này và tệp không nêu trường nào của deal.",
@@ -3734,7 +3736,7 @@ export const vi = {
     "Tài liệu của bạn đang chờ được đọc.",
   "agent.activity.documentExtract.running": "Tôi đang đọc tài liệu của bạn.",
   "agent.activity.documentExtract.stalled":
-    "Việc đọc tài liệu của bạn kéo dài bất thường. Có thể nó đã dừng.",
+    "Việc đọc tài liệu của bạn kéo dài bất thường. Có thể nó đã dừng. Mở tệp và yêu cầu đọc lại.",
   "agent.activity.documentExtract.done": "Tôi đã đọc xong tài liệu của bạn.",
   "agent.activity.documentExtract.degraded":
     "Tôi mới đọc được một phần tài liệu của bạn rồi dừng.",
@@ -3743,7 +3745,7 @@ export const vi = {
   "agent.activity.documentExtractNamed.queued": "{name} đang chờ được đọc.",
   "agent.activity.documentExtractNamed.running": "Tôi đang đọc {name}.",
   "agent.activity.documentExtractNamed.stalled":
-    "Việc đọc {name} kéo dài bất thường. Có thể nó đã dừng.",
+    "Việc đọc {name} kéo dài bất thường. Có thể nó đã dừng. Mở tệp và yêu cầu đọc lại.",
   "agent.activity.documentExtractNamed.done": "Tôi đã đọc xong {name}.",
   "agent.activity.documentExtractNamed.degraded":
     "Tôi mới đọc được một phần {name} rồi dừng.",
@@ -3752,7 +3754,7 @@ export const vi = {
   "agent.activity.accountScan.running":
     "Tôi đang đọc các trao đổi và giao dịch của một tài khoản.",
   "agent.activity.accountScan.stalled":
-    "Việc đọc một tài khoản kéo dài bất thường. Có thể nó đã dừng.",
+    "Việc đọc một tài khoản kéo dài bất thường. Có thể nó đã dừng. Mở lại tài khoản để bắt đầu đọc lại từ đầu.",
   "agent.activity.accountScan.done": "Những gì một tài khoản cần đã sẵn sàng.",
   "agent.activity.accountScan.degraded":
     "Tôi đã đọc một tài khoản đến mức các bản ghi cho phép rồi dừng.",
@@ -3762,7 +3764,7 @@ export const vi = {
   "agent.activity.accountScanNamed.running":
     "Tôi đang đọc các trao đổi và giao dịch của {name}.",
   "agent.activity.accountScanNamed.stalled":
-    "Việc đọc {name} kéo dài bất thường. Có thể nó đã dừng.",
+    "Việc đọc {name} kéo dài bất thường. Có thể nó đã dừng. Mở lại tài khoản để bắt đầu đọc lại từ đầu.",
   "agent.activity.accountScanNamed.done": "Những gì {name} cần đã sẵn sàng.",
   "agent.activity.accountScanNamed.degraded":
     "Tôi đã đọc {name} đến mức các bản ghi cho phép rồi dừng.",

--- a/frontend/src/screens/documentextraction.test.tsx
+++ b/frontend/src/screens/documentextraction.test.tsx
@@ -23,6 +23,7 @@ type Extraction = components["schemas"]["AttachmentExtraction"];
 const GROUNDED: Extraction = {
   id: "11111111-1111-1111-1111-111111111111",
   status: "done",
+  stalled: false,
   created_at: "2026-08-15T09:00:00Z",
   fields: [
     {
@@ -59,7 +60,10 @@ function serve(body: unknown, status = 200) {
       const method = request?.method ?? init?.method ?? "GET";
       let sent: unknown;
       if (request && method !== "GET") {
-        sent = JSON.parse(await request.clone().text());
+        // A read request carries no body at all, and parsing "" would throw
+        // inside the stub — recording nothing for the very call under test.
+        const text = await request.clone().text();
+        sent = text === "" ? undefined : JSON.parse(text);
       } else if (init?.body) {
         sent = JSON.parse(String(init.body));
       }
@@ -108,6 +112,31 @@ describe("the three answers a reading can give", () => {
     // The distinction under test: a running reading must not be describable as
     // a document that states nothing.
     expect(screen.queryByText(/states none of the deal fields/i)).toBeNull();
+  });
+
+  it("offers a fresh read of a reading whose worker died, where it showed reading", async () => {
+    const calls = serve({
+      ...GROUNDED,
+      status: "running",
+      stalled: true,
+      fields: [],
+      omitted: [],
+    });
+    show();
+    expect(await screen.findByText(/taken unusually long/i)).toBeTruthy();
+    // A stalled reading is not a reading in progress: the line that says the
+    // file is being read would keep a rep waiting on a worker that is gone.
+    expect(screen.queryByText("Reading this file…")).toBeNull();
+    // The button is the only way back — the server re-arms the reading on
+    // this request — so the press has to reach it.
+    await userEvent.click(
+      screen.getByRole("button", { name: /try reading it again/i }),
+    );
+    await waitFor(() => {
+      expect(
+        calls.some((c) => c.method === "POST" && c.url.endsWith("/extraction")),
+      ).toBe(true);
+    });
   });
 
   it("reports a document that states none of them as an ANSWER, with its reason", async () => {

--- a/frontend/src/screens/documentextraction.tsx
+++ b/frontend/src/screens/documentextraction.tsx
@@ -326,6 +326,18 @@ function ExtractionBody({
   const { locale } = useLocale();
 
   if (extraction.status === "queued" || extraction.status === "running") {
+    // A live reading past its lease has no worker behind it — the server says
+    // so, so the panel never has to know the lease — and a line with nothing
+    // to press would leave the file unreadable for good: the fresh read the
+    // button starts is the one path back.
+    if (extraction.stalled) {
+      return (
+        <div className="staging-card">
+          <p className="t-caption">{t("extraction.stalled")}</p>
+          <Button onClick={onReadAgain}>{t("extraction.readAgain")}</Button>
+        </div>
+      );
+    }
     return <p className="t-caption">{t("extraction.reading")}</p>;
   }
   if (extraction.status === "failed") {


### PR DESCRIPTION
## What

Signing in could open on "Reading <account> has taken unusually long. It may have stopped." with nothing to press and nothing that would ever clear it. After this PR:

- An account scan whose worker died is read again when the account is opened, and the worker's own retry reclaims it; the rail line says "Opening the account again starts a fresh read."
- A document reading whose worker died is reported `stalled` by the poll, and the panel offers "Try reading it again" where it showed "Reading this file…" with nothing to press; the rail line says "Open the file and ask for it to be read again."
- The handbook's "stalled" paragraph says the same.

## Why

The invariant: a live read past the lease its source declared has no worker behind it, and every surface that shows it must offer the one path back — a fresh attempt. Three places broke it for the account scan (`compose/orgscan`, `compose/jobs_accountscan.go`):

- `decide` served any live row as in flight, so an open could never re-arm a dead read, forced or not.
- `begin` claimed only `queued` rows, so a River retry or rescue declined a running corpse and completed.
- The scan job's uniqueness lacked `ByState: activeSweepStates`, so a re-armed row's job would have been silently swallowed by its completed predecessor — the trap `documentExtractInsertOpts` already documents. `transcriptProposeInsertOpts` had the same gap and is fixed alongside; one table-driven test now holds all three re-armable readings.

The fix keeps one origin for "when did this attempt start to age" (`row.liveSince`, the same instants `announce` sends the rail), spells the abandonment guard inside the re-arm UPDATE so a read a worker reclaimed between the decision and the write is left alone, and scopes every closing write (`settle`, `fail`, `deferBudget`) to the claim the worker holds, mirroring `activities.BeginExtractionRead`/`FinishExtractionRead`.

For documents, the door's re-arm existed but was unreachable: the panel rendered a live reading as "Reading this file…" with no button. `AttachmentExtraction` gains a required `stalled` boolean (derived at read time, never stored, like the rail's own state; oasdiff reports no breaking change), and `rearmIfAbandonedExtraction` now ages a queued reading from `attempt_at` rather than `created_at`, as the rail and the worker's reclaim already did.

Fixed along the way: the panel test's fetch stub threw on a bodyless POST, so a read request could never be recorded.

## How verified

- `make check-go`-equivalent: `go build ./...`, unit tests for `internal/compose`, `internal/compose/orgscan`, `internal/modules/activities` green; `go test ./gates/` green except `TestBaselineEraFixtureIsTheMatrixTheBaselineSeeded`, which needs full git history and fails in this shallow clone before any change.
- Integration lane on a local Postgres 16 + pgvector: `make test-it DIR=backend/internal/compose/integration/org360` (all 21 tests, including the two new ones: re-arm on open, reclaim by the worker's retry) and `make test-it DIR=backend/internal/compose/integration RUN='Extraction|Rearm|Abandon|AiActivity'` green.
- `craft static --strict` on every changed Go file: no findings. `scripts/check-contract-breaking.sh`: no breaking changes since the merge base.
- Frontend: `pnpm lint` clean, `tsc --noEmit` clean, vitest for `documentextraction`, `agentrail`, `ai-activity-lines`, `ai-activity` and `i18n` green.
- Not run: the full `make check` / `make test-integration` (no Docker in this session; the lanes above were run on a hand-started cluster).

- [x] `make check` is green — the narrower lanes named above; the full target was not runnable here
- [x] `make test-integration` is green — the two packages this change touches, on a local cluster
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

The whole diff was written by Claude Code from a report and a screenshot, including the tests, the copy in three locales and the handbook paragraph; the repo's craft reviewer agent reviewed the backend diff and its findings were applied before push.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nzmMtsiQHKcMfsiy61b3o