### PR TITLE
Three scripts that landed beside the sweep get the `[[` the rest of the tree has

### DIFF
--- a/scripts/check-extension-modules.sh
+++ b/scripts/check-extension-modules.sh
@@ -24,7 +24,7 @@ root="$(git rev-parse --show-toplevel)"
 failures=0
 
 for mod in "$root"/extensions/*/go.mod; do
-    [ -e "$mod" ] || continue
+    [[ -e "$mod" ]] || continue
     dir="$(dirname "$mod")"
     unit="$(basename "$dir")"
 
@@ -40,7 +40,7 @@ for mod in "$root"/extensions/*/go.mod; do
 
     before="$(cat "$mod")"
     beforeSum=""
-    [ -f "$dir/go.sum" ] && beforeSum="$(cat "$dir/go.sum")"
+    [[ -f "$dir/go.sum" ]] && beforeSum="$(cat "$dir/go.sum")"
 
     if ! ( cd "$dir" && GOFLAGS=-mod=mod go mod tidy ) 2>/dev/null; then
         printf '  FAIL %s: `go mod tidy` does not run here, so no dependency bump can update it\n' "$unit" >&2
@@ -49,20 +49,20 @@ for mod in "$root"/extensions/*/go.mod; do
     fi
 
     afterSum=""
-    [ -f "$dir/go.sum" ] && afterSum="$(cat "$dir/go.sum")"
-    if [ "$before" != "$(cat "$mod")" ] || [ "$beforeSum" != "$afterSum" ]; then
+    [[ -f "$dir/go.sum" ]] && afterSum="$(cat "$dir/go.sum")"
+    if [[ "$before" != "$(cat "$mod")" ]] || [[ "$beforeSum" != "$afterSum" ]]; then
         printf '  FAIL %s: go.mod/go.sum are not what `go mod tidy` produces — the committed pair\n' "$unit" >&2
         printf '       disagrees with itself, which is the shape a half-applied bump leaves.\n' >&2
         printf '       Run: (cd extensions/%s && go mod tidy) and commit the result.\n' "$unit" >&2
         printf '%s' "$before" > "$mod"
-        if [ -n "$beforeSum" ]; then printf '%s' "$beforeSum" > "$dir/go.sum"; else rm -f "$dir/go.sum"; fi
+        if [[ -n "$beforeSum" ]]; then printf '%s' "$beforeSum" > "$dir/go.sum"; else rm -f "$dir/go.sum"; fi
         failures=$((failures + 1))
         continue
     fi
     printf '  ok   %s: tidy runs and changes nothing\n' "$unit"
 done
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo "FAIL: $failures extension module(s) a dependency bump cannot update unattended" >&2
     exit 1
 fi

--- a/scripts/test-lane-timeout-report.sh
+++ b/scripts/test-lane-timeout-report.sh
@@ -19,7 +19,7 @@ lane="$root/scripts/test-integration-parallel.sh"
 failures=0
 
 check() { # description; reads $? style via caller
-    if [ "$1" = "yes" ]; then
+    if [[ "$1" = "yes" ]]; then
         printf '  ok   %s\n' "$2"
     else
         printf '  FAIL %s\n' "$2" >&2
@@ -66,7 +66,7 @@ check "$(grep -qF 'exceeded its ${IT_TIMEOUT} budget' "$lane" && echo yes || ech
     "the timeout names the budget it crossed"
 timeout_line="$(grep -n 'exceeded its ${IT_TIMEOUT} budget' "$lane" | head -1 | cut -d: -f1)"
 diverge_line="$(grep -n 'ran a different test set' "$lane" | head -1 | cut -d: -f1)"
-check "$([ -n "$timeout_line" ] && [ -n "$diverge_line" ] && [ "$timeout_line" -lt "$diverge_line" ] && echo yes || echo no)" \
+check "$([[ -n "$timeout_line" ]] && [[ -n "$diverge_line" ]] && [[ "$timeout_line" -lt "$diverge_line" ]] && echo yes || echo no)" \
     "the timeout is reported before the reconciliation diff"
 
 echo "and it does not bury a divergence it did not cause"
@@ -108,7 +108,7 @@ cat > "$tmp/only" <<'EOF'
   assigned but not run: backend|./internal/compose/integration|TestOne
 EOF
 lane_drop_timed_out "$tmp/only" "$tmp/timedout"
-check "$([ -s "$tmp/only" ] && echo no || echo yes)" \
+check "$([[ -s "$tmp/only" ]] && echo no || echo yes)" \
     "a diff explained entirely by the timeout is emptied"
 check "$(grep -qF 'if [[ -s "$DIVERGENCE" ]]; then' "$lane" && echo yes || echo no)" \
     "and the lane prints the header only when something survives"
@@ -125,7 +125,7 @@ echo "a package approaching its budget says so while it is still passing"
 check "$(grep -qF 'split it before it crosses' "$lane" && echo yes || echo no)" \
     "the advisory report warns before a package becomes unpassable"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo "FAIL: $failures check(s) failed" >&2
     exit 1
 fi

--- a/scripts/test-testdb-redis.sh
+++ b/scripts/test-testdb-redis.sh
@@ -19,7 +19,7 @@ root="$(git rev-parse --show-toplevel)"
 failures=0
 
 check() { # want got description
-    if [ "$1" = "$2" ]; then
+    if [[ "$1" = "$2" ]]; then
         printf '  ok   %s\n' "$3"
     else
         printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
@@ -69,7 +69,7 @@ check "$(from_make 26379)" "$(resolved 26379)" \
 check "present" "${script_default:+present}" \
     "the resolved address is not empty"
 
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo "FAIL: $failures check(s) failed" >&2
     exit 1
 fi


### PR DESCRIPTION
Follow-up to https://github.com/margince/margince/pull/4662, which converted the tree to `[[` and took SonarCloud's HIGH-reliability list from 248 findings to 16. Fifteen of those sixteen are `shelldre:S7688` in three scripts that landed on `main` while that change was in flight — `scripts/check-extension-modules.sh`, `scripts/test-lane-timeout-report.sh`, `scripts/test-testdb-redis.sh`. Their authors read a neighbour that still said `[`, which is exactly what a sweep leaves behind while it is open.

`[ "$x" = y ]` is a command whose operands are split and globbed before `test` sees them: an unset `$x` leaves `[ = y ]`, a usage error rather than the false the line was written to produce. `[[ ]]` is bash syntax and does neither.

Twelve lines, mechanical. Verified the same way as the parent: every changed line is byte-identical to its predecessor once `[[`/`]]` collapse back to `[`/`]`, no `-a`/`-o`, no escaped `\<`/`\>`, no unquoted right-hand operand that `[[ ]]` would read as a glob.

The sixteenth finding is the `godre:S8188` false positive recorded in `docs/reference/sonarcloud-deviations.md`, which stays open on purpose.

## Verification

- All three scripts run green: `bash scripts/test-lane-timeout-report.sh`, `bash scripts/test-testdb-redis.sh`, `bash scripts/check-extension-modules.sh`.
- `bash -n` over all 92 tracked bash scripts.
- The two `#!/bin/sh` container entrypoints under `scripts/deploy/` are excluded, as in the parent: `[[` is bash syntax and neither dash nor busybox has it.