### PR TITLE
A branch with nothing in it is not a decision, and a lane that outlives a request says so with `WithoutCancel`

### DIFF
--- a/backend/cmd/api/relay.go
+++ b/backend/cmd/api/relay.go
@@ -26,23 +26,23 @@ import (
 // api is ready on Postgres alone).
 //
 // The returned stop is the ONLY thing that ends these goroutines. They run on a
-// context of their own, rooted at context.Background() below, so neither the ctx
-// passed here nor the process signal cancels them — which is why the caller must
-// stop the lane on EVERY return path and not only the one that served. cmd/api
-// defers it the moment the lane exists; on the served path that lands after the
-// HTTP drain, so late-committing requests usually ship before exit, and anything
+// context of their own, detached from the one passed here, so neither that ctx
+// nor the process signal cancels them — which is why the caller must stop the
+// lane on EVERY return path and not only the one that served. cmd/api defers it
+// the moment the lane exists; on the served path that lands after the HTTP
+// drain, so late-committing requests usually ship before exit, and anything
 // still unshipped waits durably in the outbox for the next boot.
-//
-//nolint:contextcheck // the relay + webhook consumer are process-lifetime lanes, deliberately rooted at context.Background() and stopped by the returned stop(), never by the request ctx.
 func startInlineRelay(ctx context.Context, pool *pgxpool.Pool, redisAddr, webhookKey string, logger *slog.Logger) (compose.Option, func(), error) {
 	rdb, err := events.NewClient(ctx, redisAddr)
 	if err != nil {
 		return nil, nil, err
 	}
-	// The relay/consumer lanes outlive any single request by design — a bus
-	// lane must drain on shutdown, not cancel with an inbound request — so
-	// they run on a fresh cancelable context, not the request ctx.
-	relayCtx, cancel := context.WithCancel(context.Background())
+	// WithoutCancel, the same spelling cmd/api's app-view refresh loop uses:
+	// the relay and consumer lanes outlive any single request by design — a bus
+	// lane must drain on shutdown, not cancel with an inbound request — so what
+	// they run on carries this context's values and none of its cancellation,
+	// and the returned stop is what ends them.
+	relayCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	var relay sync.WaitGroup
 	relay.Go(func() {
 		events.NewRelay(pool, rdb, logger).Run(relayCtx)

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -69,14 +69,11 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 	// category back to observe deliberately does. The dispatcher used to ask it
 	// a second time after the ticket already said yes; that call is gone.
 	legacyErr := g.RequireGrantedForRecipients(ctx, req.Recipients, req.PurposeKey)
-	switch {
-	case legacyErr == nil:
-	case errors.Is(legacyErr, apperrors.ErrConsentNotGranted):
-	default:
-		// NOT an answer. Whether that matters depends on the posture, and the
-		// posture is not known until the modes are read inside the transaction
-		// below — so the error is carried there rather than decided here.
-	}
+	// Three outcomes, and only two of them are answers: granted, not granted,
+	// and anything else. That third one is NOT a no — whether it matters
+	// depends on the posture, and the posture is not known until the modes are
+	// read inside the transaction below, so it is carried there as a value
+	// rather than decided here.
 	legacyUnanswerable := legacyErr != nil && !errors.Is(legacyErr, apperrors.ErrConsentNotGranted)
 	legacyAllowed := legacyErr == nil
 


### PR DESCRIPTION
The Go half of SonarCloud's reliability list: `go:S3923` and `godre:S8239`. Both are the same defect underneath — code that says nothing, or says in a second spelling what the file next door already says once.

## The empty switch — `consent/authorizetransmit.go`

`AuthorizeTransmit` ran a three-branch `switch` over the legacy gate's error where all three branches were empty. It decided nothing: the two lines beneath it (`legacyUnanswerable`, `legacyAllowed`) compute the answer, and the switch's only content was a comment in its `default`.

That comment is worth keeping — the third outcome genuinely is *not a no*, and why it is carried into the transaction rather than decided at the call site is not obvious. So the prose moves onto the line that does the work, and the branch structure that pretended to be a decision goes.

## The second spelling of a process-lifetime lane — `cmd/api/relay.go`

`startInlineRelay` rooted its relay and webhook-consumer lanes at `context.Background()` and carried a `//nolint:contextcheck` explaining why.

The lifetime is right — a bus lane must drain on shutdown, not cancel with an inbound request — but `cmd/api` already spells exactly this, one file over in `mcpapps.go`:

```go
// WithoutCancel: the refresh loop outlives the boot context and is ended by
// the returned stop, which the caller defers.
refreshCtx, stop := context.WithCancel(context.WithoutCancel(ctx))
```

`context.WithoutCancel(ctx)` detaches the cancellation without also discarding the values the boot context carries, and the resulting context *is* derived from the parent — so the suppression is not reworded, it is deleted. One binary, one spelling for "this lane outlives the request".

Behaviour is unchanged: both `context.Background()` and `context.WithoutCancel(ctx)` are never cancelled and have no deadline, and `stop()` remains the only thing that ends the goroutines.

## Verification

- `make check-go` — lint 0 issues, all packages pass. One test, `TestPublicTreeCitesNoDocumentGitIgnores`, fails identically on a clean `origin/main` in this checkout: it reads `git check-ignore`, and `.superpowers/` is excluded through `.git/info/exclude` on this machine only. CI has no such exclude.
- `make craft-static` — PASS, 0 blocker / 0 major / 0 minor.
- `go test ./cmd/api/ ./internal/modules/consent/` green.

The frontend reliability findings (a11y roles, super-linear regexes, Storybook defaults) are a separate change — they are a different tree half and a different reviewer.