### PR TITLE
Mail sharing moves to Capture rules, and appearance comes back to Settings

### DIFF
--- a/backend/internal/modules/knowledge/handbook/README.md
+++ b/backend/internal/modules/knowledge/handbook/README.md
@@ -41,8 +41,8 @@ its own, so you can also come straight to the one you need.
   read seats, the six roles, why reading a customer record ignores row scope,
   teams, sharing one record, inviting and removing people, and what a refusal
   looks like.
-- **[Settings](settings.md)** — every settings page, what is on it, and which
-  role can open it.
+- **[Settings](settings.md)** — every settings page, what is on it, whose state
+  it changes, and which permission opens it.
 
 ## Related reading
 

--- a/backend/internal/modules/knowledge/handbook/retention-exports-and-deletion.md
+++ b/backend/internal/modules/knowledge/handbook/retention-exports-and-deletion.md
@@ -239,7 +239,7 @@ held — every erasure so far could be completed in full."
 
 ## Consent
 
-**Settings → Privacy & audit** carries a registry of **purposes** — the reasons
+**Settings → Privacy & retention** carries a registry of **purposes** — the reasons
 this organization processes personal data. Each purpose has a key, a label, and
 a flag for whether it requires double opt-in.
 
@@ -267,7 +267,7 @@ Agents cannot write consent at all. See
 
 ## The audit trail
 
-**Settings → Privacy & audit → Audit log** records "every action, attributed —
+**Settings → Audit log** records "every action, attributed —
 human, agent, or connector."
 
 You can filter it by actor, entity type, entity id, action, and a date range,

--- a/backend/internal/modules/knowledge/handbook/settings.md
+++ b/backend/internal/modules/knowledge/handbook/settings.md
@@ -2,12 +2,41 @@
 
 Settings is reached from the **account menu**, not from the main navigation.
 
-It has two groups. **You** — five pages every member gets. **Admin settings** —
-ten pages that appear only for an Admin or an Ops seat.
+It has **seven groups** and 28 pages. Which of them you see depends on what your
+role lets you do, and the rule has two halves worth knowing, because they answer
+two different questions.
 
-If you are not an operator, the admin group is simply absent. It does not show
-you a row of locked cards, because a page announcing that it exists and is not
-yours is the one thing an absent section is chosen to avoid saying.
+**The sidebar lists what you can change.** A page whose every control is closed
+to you is not in it. That is about prominence, not permission — it keeps the list
+you navigate past every day down to the work you can actually do.
+
+**The settings home lists everything you can open**, in two parts: *What you can
+change*, which is the sidebar again, and *What you can look up*, which is the
+rest. Search finds both. So a page missing from your sidebar is still yours to
+read: open the settings home, or search for it, or follow a link straight to it.
+
+If a page is genuinely not yours, opening its address says so plainly and leaves
+the address alone, so you can quote it to whoever can grant it.
+
+A page you can read and not change says so once, at the top, instead of leaving
+you to work it out from a screenful of greyed-out buttons.
+
+## Whose settings am I changing?
+
+Every page carries a badge beside its heading saying who a change there affects:
+
+| Badge | What it means |
+|---|---|
+| **Only you** | Your own seat. Nobody else sees the difference. |
+| **Your team** | The people on your team. |
+| **Company** | Everyone in this organization. |
+| **Installation** | Every organization on this deployment. |
+| **Mixed** | The page holds settings of more than one kind. Read the card. |
+
+Three pages are **Mixed**, and each for a named reason: *Connections* and
+*Capture activity* sit among your own settings but each carries one card that
+binds everybody, and *Integrations* holds an installation-wide provider setting
+beside workspace-level wiring.
 
 ---
 
@@ -15,9 +44,11 @@ yours is the one thing an absent section is chosen to avoid saying.
 
 ## Account
 
-Your account as one card: who you are, and the three answers that belong to you —
-how you sign in, how you sign off, and which language the product speaks to you
-in. English, German and Vietnamese are available.
+Your account as one card: who you are, and the answers that belong to you alone
+— how you sign in, how you sign off, which language the product speaks to you in
+(English, German and Vietnamese), and how it looks. **Appearance** is here as
+well as in the account menu; they are one setting with two doors, so changing it
+in either place moves the other.
 
 **Your email signature** lives here. It is appended below every message you send,
 above the unsubscribe footer. Leave it empty to send unsigned.
@@ -93,9 +124,15 @@ page says once above them; that is the default and not a misconfiguration.
 
 ---
 
-# Administrator settings
+# The rest of settings
 
-## General
+Six groups beyond your own. Which pages you see, and whether you can change them
+rather than only read them, follows your role — see the table at the end.
+
+## Company
+
+*Group: Company.* Sign-in methods and OAuth applications moved to their own
+**Sign-in & apps** page in the same group.
 
 **Installation settings** — the organization's name, timezone and base currency.
 
@@ -107,9 +144,11 @@ last quarter reported.
 **Company context** — what Margince knows about your own company, and where it
 read it from. You can also tell it directly.
 
-## Users & teams
+## Members, Teams, and Seats & license
 
-Two cards.
+*Group: People.* One page each now — the roster, the team list, and the seat
+count with the licence beside it. **Roles & permissions** is not built yet, and
+is deliberately absent from the navigation rather than present and empty.
 
 **Users** — "Everyone who holds a seat here, deactivated accounts included."
 Invite, change role, deactivate, reactivate. Reading the roster is open to every
@@ -117,12 +156,15 @@ user; managing it is administrators only.
 
 **Teams** — named groups you can share records with. Create one, archive it, and
 open a team to add or remove the users in it. Being in a team grants no access on
-its own: no shipped role is team-scoped, so a team matters when a record is
-shared with it.
+its own — with one exception: a **Team Lead** reads and works their team's
+records, so for them a team is what "their team" means. For every other shipped
+role a team matters when a record is shared with it.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md).
 
 ## Integrations
+
+*Group: Data.*
 
 What the installation is wired to, as opposed to what one person connected.
 
@@ -134,6 +176,8 @@ What the installation is wired to, as opposed to what one person connected.
   mode, and the one-way switch to running natively.
 
 ## Extensions
+
+*Group: Governance.*
 
 Every extension unit this installation was built with, and what each may reach.
 
@@ -151,10 +195,15 @@ A unit that registers no permission objects — a jurisdiction pack, for instanc
 which only supplies retention policy the core consults — is listed with nothing to
 grant, which is the correct and common answer.
 
-Admin only, and the admin role specifically: Ops administers the rest of this
-half of settings and not this page.
+Admin and Ops both reach it: the page asks for the extension inventory read and
+the role-directory read, and Ops holds both.
 
-## Capture
+## Capture rules
+
+*Group: Data.* The **Email sharing** rule now lives here, at the top: it decides
+whether captured mail is shared with colleagues, which is everybody's business
+rather than one seat's. Your own connections page states what it currently says
+and links here to change it.
 
 The posture that decides what enters the CRM at all. In the order the page puts
 them:
@@ -174,7 +223,16 @@ a consumer mailbox still creates the person — it just never creates a company.
 decided each one — a model verdict, a heuristic, or a person. "Letting a domain
 back in re-opens the company question rather than merely clearing a flag."
 
-## Data model
+## Pipelines, Lead handling, Fields, Tags, and Products & offers
+
+*Group: Sales.* Five pages now, one per subject, where this was one page with a
+tab strip.
+
+Every seat can READ all five. Four of them — pipelines, lead handling, fields and
+tags — are an operator's to change, so for most people they appear under *What
+you can look up* on the settings home rather than in the sidebar. **Products &
+offers** is the exception: a sales seat authors both, so it stays in their
+sidebar.
 
 The shape a record takes: which fields it carries, which stages it moves through,
 and the priced things that go on an offer.
@@ -187,7 +245,9 @@ and the priced things that go on an offer.
   default.
 - **Products** and **Offer templates**.
 
-## AI
+## Models & routing, Automations, AI usage, and Model calls
+
+*Group: AI.* Four pages, split from one.
 
 **Model routing** — which model serves each tier. "Changes take effect without a
 restart, and every process picks them up within a minute."
@@ -201,13 +261,18 @@ also run entirely against a local model with no cloud key at all.
 
 ## Knowledge
 
+*Group: Data.* **Data import** is its own page in the same group.
+
 **Document sets**: "Bodies of text this organization can be asked questions of.
 An answer comes only from what is filed here, and a question they do not cover is
 refused rather than guessed at."
 
 See [Documents and files](documents-and-files.md#document-sets--asking-your-documents-questions).
 
-## Privacy & audit
+## Privacy & retention
+
+*Group: Governance.* The **Audit log** is its own page now, beside it: the two
+answer to different permissions, so a reader could hold one and not the other.
 
 Five things, and they are the heart of the compliance story:
 
@@ -227,14 +292,20 @@ person who asked.
 Full detail in
 [What is kept, what is destroyed](retention-exports-and-deletion.md).
 
-## License
+## Seats & license
+
+*Group: People.*
 
 **License and seats.** How many seats are in use, how many are granted, and
 whether the licence is present and valid.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
-## Maintenance
+## System health, Data import, and Reset
+
+*Group: Governance and Data.* Three pages, split so that a reindex, a queue
+reading and "empty the installation" are no longer three buttons on one screen.
+**Reset** appears only where the deployment has armed it.
 
 - **Import a file** — a CSV of companies, up to 10 MB.
 - **Search index** — rebuilding the index behind search and the AI's retrieval.
@@ -246,18 +317,44 @@ See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
 ---
 
-## Which settings need which role
+## Which settings you get
 
-| Page | Who |
-|---|---|
-| Account, Writing voice, Agents, Connections, Capture activity | every user |
-| General, Users & teams, Integrations, Capture, Data model, AI, Knowledge, License, Maintenance | Admin or Ops |
-| Privacy & audit | Admin or Ops; the audit log and privacy inbox inside it are Admin only |
-| Extensions | Admin only — Ops does not reach it |
-| Job health, Reset data, user administration | Admin only |
+Pages follow **permissions**, not role names. A custom role holding the right
+permission reaches the page with no change to the product, and an Admin whose
+role lost a permission stops reaching the page that needs it.
 
-A few things sit outside the role system entirely and need the Admin role, full
-stop: user administration, privacy erasure, and reading the audit log.
+Two questions, and they have different answers:
+
+- **Can I open it?** Search finds it, the settings home lists it, and its address
+  works.
+- **Can I change it?** It is in the sidebar, and its controls are live.
+
+A **read-only seat** is the clearest case of the two coming apart: it keeps every
+page it could read before and loses every control that writes to the server.
+Your own preferences still work — the language and the appearance are settings
+about your browser, not about anyone's records.
+
+| You are | You can change | You can also look up |
+|---|---|---|
+| A sales seat | Your own five pages, Products & offers, Company profile, Capture rules | Pipelines, Lead handling, Fields, Tags, Knowledge |
+| A team lead | The same | The same |
+| Management | The same | The above plus AI usage, model calls, seat counts and the sign-in status — all of them readable and none of them theirs to change |
+| Ops | Most of the operational catalog, including the model rates and the extension inventory | The rest |
+| Admin | Everything the deployment has armed | — |
+
+That first row surprises people, so it is worth saying plainly: a sales seat can
+edit **Capture rules** and the **company profile**, because those cards ask for a
+permission every sales role holds. If that is not what you want, the fix is the
+permission, not the page.
+
+Nearly everything is a permission now, including the three that used to be role
+checks: administering members answers to `user_admin`, reading the audit log to
+`audit_log`, and the privacy queue to `privacy_request`. A custom role granted
+one of those reaches the page, and an Admin whose role lost it does not.
+
+A handful of paths still ask for the literal Admin role, and they are the ones
+about recovering access rather than using the product: the last-admin rule, and
+the deployment-level resets.
 
 ## Two things administrators should decide early
 

--- a/backend/internal/modules/knowledge/handbook/what-the-ai-does.md
+++ b/backend/internal/modules/knowledge/handbook/what-the-ai-does.md
@@ -388,5 +388,5 @@ winnability, revenue, timing, momentum, warmth — with the evidence rows behind
 them.
 
 **Settings → AI** and **Settings → Agents** are where the models and the agent
-registry are configured. **Settings → Privacy & audit** holds the full audit
+registry are configured. **Settings → Audit log** holds the full audit
 trail: every action, attributed to a human, an agent or a connector.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -41,8 +41,8 @@ its own, so you can also come straight to the one you need.
   read seats, the six roles, why reading a customer record ignores row scope,
   teams, sharing one record, inviting and removing people, and what a refusal
   looks like.
-- **[Settings](settings.md)** — every settings page, what is on it, and which
-  role can open it.
+- **[Settings](settings.md)** — every settings page, what is on it, whose state
+  it changes, and which permission opens it.
 
 ## Related reading
 

--- a/docs/handbook/retention-exports-and-deletion.md
+++ b/docs/handbook/retention-exports-and-deletion.md
@@ -239,7 +239,7 @@ held — every erasure so far could be completed in full."
 
 ## Consent
 
-**Settings → Privacy & audit** carries a registry of **purposes** — the reasons
+**Settings → Privacy & retention** carries a registry of **purposes** — the reasons
 this organization processes personal data. Each purpose has a key, a label, and
 a flag for whether it requires double opt-in.
 
@@ -267,7 +267,7 @@ Agents cannot write consent at all. See
 
 ## The audit trail
 
-**Settings → Privacy & audit → Audit log** records "every action, attributed —
+**Settings → Audit log** records "every action, attributed —
 human, agent, or connector."
 
 You can filter it by actor, entity type, entity id, action, and a date range,

--- a/docs/handbook/settings.md
+++ b/docs/handbook/settings.md
@@ -2,12 +2,41 @@
 
 Settings is reached from the **account menu**, not from the main navigation.
 
-It has two groups. **You** — five pages every member gets. **Admin settings** —
-ten pages that appear only for an Admin or an Ops seat.
+It has **seven groups** and 28 pages. Which of them you see depends on what your
+role lets you do, and the rule has two halves worth knowing, because they answer
+two different questions.
 
-If you are not an operator, the admin group is simply absent. It does not show
-you a row of locked cards, because a page announcing that it exists and is not
-yours is the one thing an absent section is chosen to avoid saying.
+**The sidebar lists what you can change.** A page whose every control is closed
+to you is not in it. That is about prominence, not permission — it keeps the list
+you navigate past every day down to the work you can actually do.
+
+**The settings home lists everything you can open**, in two parts: *What you can
+change*, which is the sidebar again, and *What you can look up*, which is the
+rest. Search finds both. So a page missing from your sidebar is still yours to
+read: open the settings home, or search for it, or follow a link straight to it.
+
+If a page is genuinely not yours, opening its address says so plainly and leaves
+the address alone, so you can quote it to whoever can grant it.
+
+A page you can read and not change says so once, at the top, instead of leaving
+you to work it out from a screenful of greyed-out buttons.
+
+## Whose settings am I changing?
+
+Every page carries a badge beside its heading saying who a change there affects:
+
+| Badge | What it means |
+|---|---|
+| **Only you** | Your own seat. Nobody else sees the difference. |
+| **Your team** | The people on your team. |
+| **Company** | Everyone in this organization. |
+| **Installation** | Every organization on this deployment. |
+| **Mixed** | The page holds settings of more than one kind. Read the card. |
+
+Three pages are **Mixed**, and each for a named reason: *Connections* and
+*Capture activity* sit among your own settings but each carries one card that
+binds everybody, and *Integrations* holds an installation-wide provider setting
+beside workspace-level wiring.
 
 ---
 
@@ -15,9 +44,11 @@ yours is the one thing an absent section is chosen to avoid saying.
 
 ## Account
 
-Your account as one card: who you are, and the three answers that belong to you —
-how you sign in, how you sign off, and which language the product speaks to you
-in. English, German and Vietnamese are available.
+Your account as one card: who you are, and the answers that belong to you alone
+— how you sign in, how you sign off, which language the product speaks to you in
+(English, German and Vietnamese), and how it looks. **Appearance** is here as
+well as in the account menu; they are one setting with two doors, so changing it
+in either place moves the other.
 
 **Your email signature** lives here. It is appended below every message you send,
 above the unsubscribe footer. Leave it empty to send unsigned.
@@ -93,9 +124,15 @@ page says once above them; that is the default and not a misconfiguration.
 
 ---
 
-# Administrator settings
+# The rest of settings
 
-## General
+Six groups beyond your own. Which pages you see, and whether you can change them
+rather than only read them, follows your role — see the table at the end.
+
+## Company
+
+*Group: Company.* Sign-in methods and OAuth applications moved to their own
+**Sign-in & apps** page in the same group.
 
 **Installation settings** — the organization's name, timezone and base currency.
 
@@ -107,9 +144,11 @@ last quarter reported.
 **Company context** — what Margince knows about your own company, and where it
 read it from. You can also tell it directly.
 
-## Users & teams
+## Members, Teams, and Seats & license
 
-Two cards.
+*Group: People.* One page each now — the roster, the team list, and the seat
+count with the licence beside it. **Roles & permissions** is not built yet, and
+is deliberately absent from the navigation rather than present and empty.
 
 **Users** — "Everyone who holds a seat here, deactivated accounts included."
 Invite, change role, deactivate, reactivate. Reading the roster is open to every
@@ -117,12 +156,15 @@ user; managing it is administrators only.
 
 **Teams** — named groups you can share records with. Create one, archive it, and
 open a team to add or remove the users in it. Being in a team grants no access on
-its own: no shipped role is team-scoped, so a team matters when a record is
-shared with it.
+its own — with one exception: a **Team Lead** reads and works their team's
+records, so for them a team is what "their team" means. For every other shipped
+role a team matters when a record is shared with it.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md).
 
 ## Integrations
+
+*Group: Data.*
 
 What the installation is wired to, as opposed to what one person connected.
 
@@ -134,6 +176,8 @@ What the installation is wired to, as opposed to what one person connected.
   mode, and the one-way switch to running natively.
 
 ## Extensions
+
+*Group: Governance.*
 
 Every extension unit this installation was built with, and what each may reach.
 
@@ -151,10 +195,15 @@ A unit that registers no permission objects — a jurisdiction pack, for instanc
 which only supplies retention policy the core consults — is listed with nothing to
 grant, which is the correct and common answer.
 
-Admin only, and the admin role specifically: Ops administers the rest of this
-half of settings and not this page.
+Admin and Ops both reach it: the page asks for the extension inventory read and
+the role-directory read, and Ops holds both.
 
-## Capture
+## Capture rules
+
+*Group: Data.* The **Email sharing** rule now lives here, at the top: it decides
+whether captured mail is shared with colleagues, which is everybody's business
+rather than one seat's. Your own connections page states what it currently says
+and links here to change it.
 
 The posture that decides what enters the CRM at all. In the order the page puts
 them:
@@ -174,7 +223,16 @@ a consumer mailbox still creates the person — it just never creates a company.
 decided each one — a model verdict, a heuristic, or a person. "Letting a domain
 back in re-opens the company question rather than merely clearing a flag."
 
-## Data model
+## Pipelines, Lead handling, Fields, Tags, and Products & offers
+
+*Group: Sales.* Five pages now, one per subject, where this was one page with a
+tab strip.
+
+Every seat can READ all five. Four of them — pipelines, lead handling, fields and
+tags — are an operator's to change, so for most people they appear under *What
+you can look up* on the settings home rather than in the sidebar. **Products &
+offers** is the exception: a sales seat authors both, so it stays in their
+sidebar.
 
 The shape a record takes: which fields it carries, which stages it moves through,
 and the priced things that go on an offer.
@@ -187,7 +245,9 @@ and the priced things that go on an offer.
   default.
 - **Products** and **Offer templates**.
 
-## AI
+## Models & routing, Automations, AI usage, and Model calls
+
+*Group: AI.* Four pages, split from one.
 
 **Model routing** — which model serves each tier. "Changes take effect without a
 restart, and every process picks them up within a minute."
@@ -201,13 +261,18 @@ also run entirely against a local model with no cloud key at all.
 
 ## Knowledge
 
+*Group: Data.* **Data import** is its own page in the same group.
+
 **Document sets**: "Bodies of text this organization can be asked questions of.
 An answer comes only from what is filed here, and a question they do not cover is
 refused rather than guessed at."
 
 See [Documents and files](documents-and-files.md#document-sets--asking-your-documents-questions).
 
-## Privacy & audit
+## Privacy & retention
+
+*Group: Governance.* The **Audit log** is its own page now, beside it: the two
+answer to different permissions, so a reader could hold one and not the other.
 
 Five things, and they are the heart of the compliance story:
 
@@ -227,14 +292,20 @@ person who asked.
 Full detail in
 [What is kept, what is destroyed](retention-exports-and-deletion.md).
 
-## License
+## Seats & license
+
+*Group: People.*
 
 **License and seats.** How many seats are in use, how many are granted, and
 whether the licence is present and valid.
 
 See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
-## Maintenance
+## System health, Data import, and Reset
+
+*Group: Governance and Data.* Three pages, split so that a reindex, a queue
+reading and "empty the installation" are no longer three buttons on one screen.
+**Reset** appears only where the deployment has armed it.
 
 - **Import a file** — a CSV of companies, up to 10 MB.
 - **Search index** — rebuilding the index behind search and the AI's retrieval.
@@ -246,18 +317,44 @@ See [Seats, roles and who can see what](seats-roles-and-access.md#the-licence).
 
 ---
 
-## Which settings need which role
+## Which settings you get
 
-| Page | Who |
-|---|---|
-| Account, Writing voice, Agents, Connections, Capture activity | every user |
-| General, Users & teams, Integrations, Capture, Data model, AI, Knowledge, License, Maintenance | Admin or Ops |
-| Privacy & audit | Admin or Ops; the audit log and privacy inbox inside it are Admin only |
-| Extensions | Admin only — Ops does not reach it |
-| Job health, Reset data, user administration | Admin only |
+Pages follow **permissions**, not role names. A custom role holding the right
+permission reaches the page with no change to the product, and an Admin whose
+role lost a permission stops reaching the page that needs it.
 
-A few things sit outside the role system entirely and need the Admin role, full
-stop: user administration, privacy erasure, and reading the audit log.
+Two questions, and they have different answers:
+
+- **Can I open it?** Search finds it, the settings home lists it, and its address
+  works.
+- **Can I change it?** It is in the sidebar, and its controls are live.
+
+A **read-only seat** is the clearest case of the two coming apart: it keeps every
+page it could read before and loses every control that writes to the server.
+Your own preferences still work — the language and the appearance are settings
+about your browser, not about anyone's records.
+
+| You are | You can change | You can also look up |
+|---|---|---|
+| A sales seat | Your own five pages, Products & offers, Company profile, Capture rules | Pipelines, Lead handling, Fields, Tags, Knowledge |
+| A team lead | The same | The same |
+| Management | The same | The above plus AI usage, model calls, seat counts and the sign-in status — all of them readable and none of them theirs to change |
+| Ops | Most of the operational catalog, including the model rates and the extension inventory | The rest |
+| Admin | Everything the deployment has armed | — |
+
+That first row surprises people, so it is worth saying plainly: a sales seat can
+edit **Capture rules** and the **company profile**, because those cards ask for a
+permission every sales role holds. If that is not what you want, the fix is the
+permission, not the page.
+
+Nearly everything is a permission now, including the three that used to be role
+checks: administering members answers to `user_admin`, reading the audit log to
+`audit_log`, and the privacy queue to `privacy_request`. A custom role granted
+one of those reaches the page, and an Admin whose role lost it does not.
+
+A handful of paths still ask for the literal Admin role, and they are the ones
+about recovering access rather than using the product: the last-admin rule, and
+the deployment-level resets.
 
 ## Two things administrators should decide early
 

--- a/docs/handbook/what-the-ai-does.md
+++ b/docs/handbook/what-the-ai-does.md
@@ -388,5 +388,5 @@ winnability, revenue, timing, momentum, warmth — with the evidence rows behind
 them.
 
 **Settings → AI** and **Settings → Agents** are where the models and the agent
-registry are configured. **Settings → Privacy & audit** holds the full audit
+registry are configured. **Settings → Audit log** holds the full audit
 trail: every action, attributed to a human, an agent or a connector.

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -331,7 +331,7 @@ test("AC-shell-1k: one h1 per railed page, and on a record it is the record's ow
   await page.goto("/#/settings/privacy");
   const settingsHeading = page.getByRole("heading", { level: 1 });
   await expect(settingsHeading).toHaveCount(1);
-  await expect(settingsHeading).toHaveText("Datenschutz & Audit");
+  await expect(settingsHeading).toHaveText("Datenschutz & Aufbewahrung");
   await expect(page.locator(".rail .navtitle")).toHaveText("Einstellungen");
   await expect(page.locator("main")).not.toContainText("privacy");
 });
@@ -430,23 +430,21 @@ test("features/10 §7: the locale switch flips the chrome DE↔EN", async ({
   await expect(page.getByRole("combobox", { name: "Language" })).toBeVisible();
 });
 
-// Appearance is chosen from the account menu now — it is the setting a reader
-// changes most often, and from wherever they happen to be standing. The account
-// card keeps the preferences that are not appearance, so this asserts what the
-// page LOST rather than that the card went away: the language control beside it
-// has to still be there, or an account card that failed to render would pass.
-test("features/10 §7: Settings → Account keeps language and offers no theme control", async ({
+// Appearance is chosen from Settings AND from the account menu — one setting
+// with two doors, because it is the setting a reader changes most often and from
+// wherever they happen to be standing.
+//
+// The language control beside it has to still be there, or an account card that
+// failed to render entirely would pass this.
+test("features/10 §7: Settings → Account offers language and appearance", async ({
   page,
 }) => {
   await page.goto("/#/settings/account");
   await expect(page.getByRole("heading", { name: "Ihr Konto" })).toBeVisible();
   await expect(page.getByRole("combobox", { name: "Sprache" })).toBeVisible();
-  for (const name of ["Hell", "Dunkel", "System", "Design"]) {
-    await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
-      0,
-    );
-    await expect(page.getByRole("group", { name, exact: true })).toHaveCount(0);
-  }
+  await expect(
+    page.getByRole("combobox", { name: "Darstellung" }),
+  ).toBeVisible();
 });
 
 /**

--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -174,7 +174,9 @@ test.describe("Analytics sections", () => {
     ).toBeVisible();
   });
 
-  test("a section with nothing to report says so in words", async ({ page }) => {
+  test("a section with nothing to report says so in words", async ({
+    page,
+  }) => {
     await openAnalytics(page, "delivery");
     // projects-gone-quiet answers no rows, which is a real answer — "nothing
     // has gone quiet" — and an empty table would leave a reader wondering
@@ -222,7 +224,9 @@ test.describe("Analytics sections", () => {
           overflow: element.scrollWidth - element.clientWidth,
         }))
         .filter(({ overflow }) => overflow > 1)
-        .map(({ name, overflow }) => `${name}: ${overflow}px past the viewport`),
+        .map(
+          ({ name, overflow }) => `${name}: ${overflow}px past the viewport`,
+        ),
     );
     expect(
       overflowing,

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -46,7 +46,7 @@ const E2E_ADMIN_GRANTS: GrantSpec = {
   // spec exercises a person write from here and a grant this fixture does not
   // need is a grant it should not claim.
   //
-  // It no longer opens the Privacy & audit ENTRY — every seeded role holds this
+  // It no longer opens the Privacy & retention ENTRY — every seeded role holds this
   // read, so the page moved to `privacy_request`, which this fixture holds
   // below. The card still needs `person`, which is why it stays.
   person: ["read"],

--- a/frontend/src/app/account.tsx
+++ b/frontend/src/app/account.tsx
@@ -37,7 +37,7 @@ type SessionUser = components["schemas"]["MeResponse"]["user"];
 const SETTINGS_HREF = routeHash({ screen: SETTINGS_SCREEN });
 
 /** The appearance choices, in the order the submenu shows them, named. */
-const THEME_LABEL_KEYS = {
+export const THEME_LABEL_KEYS = {
   light: "theme.light",
   dark: "theme.dark",
   system: "theme.system",

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -418,10 +418,10 @@ describe("Rail levels (a section's entries as the second level)", () => {
     // The destinations are GONE, not pushed below a second list: 56px cannot
     // carry two levels and 224px carrying both is a list of twenty places to go.
     expect(screen.queryByRole("link", { name: "Pipeline" })).toBeNull();
-    expect(levelLabels()).toEqual(["Account", "Privacy & audit"]);
+    expect(levelLabels()).toEqual(["Account", "Privacy & retention"]);
     expect(
       screen
-        .getByRole("link", { name: "Privacy & audit" })
+        .getByRole("link", { name: "Privacy & retention" })
         .getAttribute("href"),
     ).toBe("#/settings/deep");
     // Exactly one row claims the current page, and it is the entry the SECTION
@@ -446,7 +446,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
     ).toEqual(["Settings"]);
     expect(
       screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent),
-    ).toEqual(["You", "Admin settings"]);
+    ).toEqual(["You", "Governance"]);
   });
 
   // A section belongs to ONE screen. Without this the fixture's entries would
@@ -736,7 +736,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
     expect(document.querySelectorAll('[aria-current="page"]')).toHaveLength(0);
     expect(
       screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent),
-    ).toEqual(["Privacy & audit"]);
+    ).toEqual(["Privacy & retention"]);
   });
 
   it("renders a third level from the data, addressed under the entry that opens it", () => {
@@ -753,7 +753,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
     ).toBe("#/settings/deep/deeper");
     expect(
       screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent),
-    ).toEqual(["Privacy & audit"]);
+    ).toEqual(["Privacy & retention"]);
   });
 
   // One step at a time, and the step is an ADDRESS: below the section's own
@@ -784,7 +784,9 @@ describe("Rail levels (a section's entries as the second level)", () => {
       />,
     );
     const account = screen.getByRole("link", { name: "Account" });
-    const privacyEntry = screen.getByRole("link", { name: "Privacy & audit" });
+    const privacyEntry = screen.getByRole("link", {
+      name: "Privacy & retention",
+    });
     expect(screen.queryByRole("tooltip")).toBeNull();
 
     account.focus();
@@ -797,7 +799,9 @@ describe("Rail levels (a section's entries as the second level)", () => {
 
     privacyEntry.focus();
     await waitFor(() =>
-      expect(screen.getByRole("tooltip").textContent).toBe("Privacy & audit"),
+      expect(screen.getByRole("tooltip").textContent).toBe(
+        "Privacy & retention",
+      ),
     );
     expect(screen.getAllByRole("tooltip")).toHaveLength(1);
 
@@ -823,7 +827,9 @@ describe("Rail levels (a section's entries as the second level)", () => {
     expect(levelLabels()).toEqual(CANONICAL_ORDER);
     // No level at all: no entries, no way back up, and no `leveled` arrangement
     // for the bar to be rearranged by.
-    expect(screen.queryByRole("link", { name: "Privacy & audit" })).toBeNull();
+    expect(
+      screen.queryByRole("link", { name: "Privacy & retention" }),
+    ).toBeNull();
     expect(screen.queryByRole("button", { name: /^Back/ })).toBeNull();
     expect(
       screen.getByRole("navigation", { name: "Primary navigation" }).className,
@@ -833,7 +839,9 @@ describe("Rail levels (a section's entries as the second level)", () => {
     // still no entry of the section the reader is standing in.
     await user.click(screen.getByRole("button", { name: "More" }));
     expect(levelLabels()).toEqual(CANONICAL_ORDER);
-    expect(screen.queryByRole("link", { name: "Privacy & audit" })).toBeNull();
+    expect(
+      screen.queryByRole("link", { name: "Privacy & retention" }),
+    ).toBeNull();
   });
 
   // The other half: above the breakpoint the level is exactly what it was. Either
@@ -846,7 +854,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
         section={fixtureSection("account")}
       />,
     );
-    expect(levelLabels()).toEqual(["Account", "Privacy & audit"]);
+    expect(levelLabels()).toEqual(["Account", "Privacy & retention"]);
     expect(
       screen.getByRole("navigation", { name: "Primary navigation" }).className,
     ).toContain("leveled");

--- a/frontend/src/app/shell.stories.tsx
+++ b/frontend/src/app/shell.stories.tsx
@@ -5,7 +5,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   Building2,
-  Database,
   KeyRound,
   Mail,
   Mic,
@@ -459,42 +458,43 @@ const SETTINGS_SECTION: NavSection = {
   activeId: "privacy",
   groups: [
     {
-      headingKey: "settings.group.you",
+      headingKey: "settings.group.me",
       items: [
         { id: "account", labelKey: "settings.tab.account", icon: UserRound },
         { id: "voice", labelKey: "settings.tab.voice", icon: Mic },
         { id: "agents", labelKey: "settings.tab.agents", icon: KeyRound },
+        { id: "connections", labelKey: "settings.tab.connections", icon: Plug },
       ],
     },
     {
-      headingKey: "settings.group.admin",
+      headingKey: "settings.group.company",
       items: [
-        { id: "general", labelKey: "settings.tab.general", icon: Building2 },
-        { id: "users", labelKey: "settings.tab.users", icon: UsersRound },
-        { id: "connections", labelKey: "settings.tab.connections", icon: Plug },
-        { id: "capture", labelKey: "settings.tab.capture", icon: Mail },
+        { id: "company", labelKey: "settings.tab.company", icon: Building2 },
+      ],
+    },
+    {
+      headingKey: "settings.group.people",
+      items: [
+        { id: "members", labelKey: "settings.tab.members", icon: UsersRound },
+      ],
+    },
+    {
+      headingKey: "settings.group.data",
+      items: [{ id: "capture", labelKey: "settings.tab.capture", icon: Mail }],
+    },
+    {
+      headingKey: "settings.group.ai",
+      items: [
+        { id: "models", labelKey: "settings.tab.models", icon: Sparkles },
+      ],
+    },
+    {
+      headingKey: "settings.group.governance",
+      items: [
+        { id: "privacy", labelKey: "settings.tab.privacy", icon: ShieldCheck },
         {
-          id: "data-model",
-          labelKey: "settings.tab.data-model",
-          icon: Database,
-        },
-        { id: "ai", labelKey: "settings.tab.ai", icon: Sparkles },
-        {
-          id: "privacy",
-          labelKey: "settings.tab.privacy",
-          icon: ShieldCheck,
-          children: [
-            { id: "users", labelKey: "settings.tab.users", icon: UsersRound },
-            {
-              id: "data-model",
-              labelKey: "settings.tab.data-model",
-              icon: Database,
-            },
-          ],
-        },
-        {
-          id: "maintenance",
-          labelKey: "settings.tab.maintenance",
+          id: "system-health",
+          labelKey: "settings.tab.system-health",
           icon: Wrench,
         },
       ],

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -326,7 +326,7 @@ describe("Section switcher (the page title at phone width)", () => {
   it("renders no switcher above the phone breakpoint", () => {
     render(<PageTitle route={deepRoute} section={fixtureSection("deep")} />);
     expect(
-      screen.getByRole("heading", { level: 1, name: "Privacy & audit" }),
+      screen.getByRole("heading", { level: 1, name: "Privacy & retention" }),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: /change section/ })).toBeNull();
   });
@@ -340,12 +340,12 @@ describe("Section switcher (the page title at phone width)", () => {
     render(<PageTitle route={deepRoute} section={fixtureSection("deep")} />);
     const heading = screen.getByRole("heading", { level: 1 });
     const switcher = screen.getByRole("button", {
-      name: "Privacy & audit — change section",
+      name: "Privacy & retention — change section",
     });
     expect(heading.contains(switcher)).toBe(true);
     // The visible word is the entry, and it is part of the name (WCAG 2.5.3), so
     // a reader driving the app by voice says what they can see.
-    expect(switcher.textContent).toContain("Privacy & audit");
+    expect(switcher.textContent).toContain("Privacy & retention");
     expect(switcher.getAttribute("aria-expanded")).toBe("false");
     // One heading, and the entry's name is in it once — not once in a heading
     // and again in a control under it.
@@ -359,7 +359,9 @@ describe("Section switcher (the page title at phone width)", () => {
     stubPhoneViewport();
     render(<PageTitle route={deepRoute} section={fixtureSection("deep")} />);
     await user.click(
-      screen.getByRole("button", { name: "Privacy & audit — change section" }),
+      screen.getByRole("button", {
+        name: "Privacy & retention — change section",
+      }),
     );
     const dialog = screen.getByRole("dialog");
     // Named by the section, with its groups and every entry it publishes.
@@ -370,7 +372,7 @@ describe("Section switcher (the page title at phone width)", () => {
       within(dialog)
         .getAllByRole("heading", { level: 3 })
         .map((heading) => heading.textContent),
-    ).toEqual(["You", "Admin settings"]);
+    ).toEqual(["You", "Governance"]);
     expect(
       within(dialog)
         .getAllByRole("link")
@@ -388,7 +390,9 @@ describe("Section switcher (the page title at phone width)", () => {
     stubPhoneViewport();
     render(<PageTitle route={deepRoute} section={fixtureSection("deep")} />);
     await user.click(
-      screen.getByRole("button", { name: "Privacy & audit — change section" }),
+      screen.getByRole("button", {
+        name: "Privacy & retention — change section",
+      }),
     );
     await user.click(
       within(screen.getByRole("dialog")).getByRole("link", { name: "Account" }),
@@ -405,7 +409,9 @@ describe("Section switcher (the page title at phone width)", () => {
     stubPhoneViewport();
     render(<PageTitle route={deepRoute} section={fixtureSection("deep")} />);
     await user.click(
-      screen.getByRole("button", { name: "Privacy & audit — change section" }),
+      screen.getByRole("button", {
+        name: "Privacy & retention — change section",
+      }),
     );
     await user.click(
       within(screen.getByRole("dialog")).getByRole("button", { name: "Close" }),

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -731,7 +731,7 @@ export function PageTitle({
       <div className="pagetitle-text">
         {/* The heading is named by the PAGE even when a control is all it
             contains. Name-from-content would otherwise reach into the switcher's
-            own `aria-label` — "Privacy & audit — change section" — and put an
+            own `aria-label` — "Privacy & retention — change section" — and put an
             instruction in the document's heading list. The control keeps that
             name; the heading states the page. */}
         {/* The heading and the scope share one ROW: `.pagetitle-text` stacks its

--- a/frontend/src/app/testing/shellharness.tsx
+++ b/frontend/src/app/testing/shellharness.tsx
@@ -82,13 +82,13 @@ export function fixtureSection(activeId?: string): NavSection {
     activeId,
     groups: [
       {
-        headingKey: "settings.group.you",
+        headingKey: "settings.group.me",
         items: [
           { id: "account", labelKey: "settings.tab.account", icon: UserRound },
         ],
       },
       {
-        headingKey: "settings.group.admin",
+        headingKey: "settings.group.governance",
         items: [
           {
             // The child level is SYNTHETIC: no settings entry publishes children,

--- a/frontend/src/app/topbar.stories.tsx
+++ b/frontend/src/app/topbar.stories.tsx
@@ -362,20 +362,21 @@ const SETTINGS_SECTION: NavSection = {
   activeId: "privacy",
   groups: [
     {
-      headingKey: "settings.group.you",
+      headingKey: "settings.group.me",
       items: [
         { id: "account", labelKey: "settings.tab.account", icon: UserRound },
       ],
     },
     {
-      headingKey: "settings.group.admin",
+      headingKey: "settings.group.governance",
       items: [
         { id: "privacy", labelKey: "settings.tab.privacy", icon: ShieldCheck },
-        {
-          id: "data-model",
-          labelKey: "settings.tab.data-model",
-          icon: Database,
-        },
+      ],
+    },
+    {
+      headingKey: "settings.group.sales",
+      items: [
+        { id: "fields", labelKey: "settings.tab.fields", icon: Database },
       ],
     },
   ],

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3696,6 +3696,9 @@ export const de = {
     "Ob der Rückblick am Montag zusätzlich per E-Mail kommt.",
   "delivery.byEmail": "Per E-Mail",
   "delivery.none": "Nicht per E-Mail",
+  "settings.appearance": "Darstellung",
+  "settings.appearanceHelp":
+    "Hell, dunkel oder was dieses Ger\u00e4t eingestellt hat. Das Kontomen\u00fc \u00e4ndert es ebenfalls.",
   "settings.languageHelp": "Gilt für diese Sitzung.",
   "role.admin": "Admin",
   "role.management": "Geschäftsleitung",
@@ -4770,6 +4773,11 @@ export const de = {
     "Einzelne Nachrichten lassen sich nachträglich einschränken, Adressen und Domains vorab ausschließen.",
   "mailSharing.danger":
     "ACHTUNG: E-Mail-Freigabe ausschalten macht die Nutzung des CRM schwierig. Neue E-Mails sind dann nur noch für die Beteiligten der jeweiligen Nachricht sichtbar.",
+  "mailSharing.posture.shared":
+    "Neu erfasste Post ist f\u00fcr Kolleginnen und Kollegen lesbar, die die Person sehen.",
+  "mailSharing.posture.private":
+    "Neu erfasste Post bleibt bei den Beteiligten der Nachricht und dem erfassenden Postfach.",
+  "mailSharing.posture.where": "Dies unter Erfassungsregeln \u00e4ndern",
   "mailSharing.sharedPosture.label": "Postfächern erlauben, sofort zu teilen",
   "mailSharing.sharedPosture.help":
     "Erlaubt Kolleginnen und Kollegen, das eigene Postfach auf „geteilt“ zu stellen — eine erfasste Nachricht ist dann für das Team lesbar, sobald sie ankommt, bevor sie eingestuft wurde. Standardmäßig aus.",
@@ -6265,7 +6273,7 @@ export const de = {
   "settings.tab.users": "Benutzer & Teams",
   "settings.tab.extensions": "Erweiterungen",
   "settings.tab.integrations": "Integrationen",
-  "settings.tab.capture": "Erfassung",
+  "settings.tab.capture": "Erfassungsregeln",
   "settings.tab.data-model": "Datenmodell",
   "settings.tab.ai": "KI",
   "settings.tab.knowledge": "Wissen",
@@ -6326,7 +6334,7 @@ export const de = {
   "knowledge.new.topicHint":
     "Schreiben Sie einen Satz, kein Schlagwort. Er wird demjenigen zitiert, dessen Frage diese Sammlung nicht abdeckt — also im ungeduldigsten Moment gelesen.",
   "knowledge.new.submit": "Sammlung anlegen",
-  "settings.tab.privacy": "Datenschutz & Audit",
+  "settings.tab.privacy": "Datenschutz & Aufbewahrung",
   "settings.tab.capture-activity": "Erfassungsaktivität",
   "captureActivity.title": "Erfassungsaktivität",
   "captureActivity.sub":
@@ -6508,8 +6516,6 @@ export const de = {
     "Die Lizenz läuft am {expiry} ab. Vor diesem Datum ändert sich nichts.",
   "license.counting":
     "Volle Sitzplätze, die weder deaktiviert noch gesperrt sind, Agenten eingeschlossen. Lesende Sitzplätze sind unbegrenzt und werden nie gezählt. Gegen diese Zahl wird ein neues Mitglied zugelassen.",
-  "settings.group.you": "Persönlich",
-  "settings.group.admin": "Admin-Einstellungen",
   "settings.rates.fxTitle": "Währungskurse",
   "settings.rates.fxIntro":
     "Wechselkurse, die Fremdwährungsbeträge in deine Basiswährung umrechnen. Neue Kurse gelten ab heute oder später; vergangene Kurse werden nie geändert.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3783,6 +3783,9 @@ export const en = {
   "delivery.weeklyHelp": "Whether Monday's review also arrives by email.",
   "delivery.byEmail": "By email",
   "delivery.none": "Not by email",
+  "settings.appearance": "Appearance",
+  "settings.appearanceHelp":
+    "Light, dark, or whatever this device is set to. The account menu changes it too.",
   "settings.languageHelp": "Lasts for this session.",
   "role.admin": "Admin",
   "role.management": "Management",
@@ -4868,6 +4871,11 @@ export const en = {
     "Individual messages can be limited afterwards, and addresses or domains excluded up front.",
   "mailSharing.danger":
     "DANGER: Switching off email sharing will make usage of the CRM difficult. New mail will be visible only to the people on each message.",
+  "mailSharing.posture.shared":
+    "Newly captured mail is readable by colleagues who can see the person.",
+  "mailSharing.posture.private":
+    "Newly captured mail is held to the people on the message and the mailbox that captured it.",
+  "mailSharing.posture.where": "Change this on Capture rules",
   "mailSharing.sharedPosture.label": "Allow mailboxes to share on arrival",
   "mailSharing.sharedPosture.help":
     "Lets a colleague put their own mailbox in the shared posture, where a captured message is readable by the team the moment it lands, before anything has judged it. Off by default.",
@@ -6394,7 +6402,7 @@ export const en = {
   "settings.tab.users": "Users & teams",
   "settings.tab.extensions": "Extensions",
   "settings.tab.integrations": "Integrations",
-  "settings.tab.capture": "Capture",
+  "settings.tab.capture": "Capture rules",
   "settings.tab.data-model": "Data model",
   "settings.tab.ai": "AI",
   "settings.tab.knowledge": "Knowledge",
@@ -6453,7 +6461,7 @@ export const en = {
   "knowledge.new.topicHint":
     "Write a sentence, not a label. It is quoted back to whoever asks a question this set does not cover, so it is read at their least patient moment.",
   "knowledge.new.submit": "Create set",
-  "settings.tab.privacy": "Privacy & audit",
+  "settings.tab.privacy": "Privacy & retention",
   "settings.tab.capture-activity": "Capture activity",
   "captureActivity.title": "Capture activity",
   "captureActivity.sub":
@@ -6628,8 +6636,6 @@ export const en = {
     "The license expires on {expiry}. Nothing changes before that date.",
   "license.counting":
     "Full seats that are neither deactivated nor suspended, agents included. Read-only seats are unlimited and never counted. This is the count a new member is admitted against.",
-  "settings.group.you": "You",
-  "settings.group.admin": "Admin settings",
   "settings.rates.fxTitle": "Currency rates",
   "settings.rates.fxIntro":
     "Exchange rates that convert foreign-currency amounts to your base currency. New rates take effect today or later; past rates are never changed.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3652,6 +3652,9 @@ export const vi = {
   "delivery.weeklyHelp": "Đánh giá thứ Hai có được gửi qua email hay không.",
   "delivery.byEmail": "Qua email",
   "delivery.none": "Không qua email",
+  "settings.appearance": "Giao di\u1ec7n",
+  "settings.appearanceHelp":
+    "S\u00e1ng, t\u1ed1i, ho\u1eb7c theo thi\u1ebft b\u1ecb n\u00e0y. Menu t\u00e0i kho\u1ea3n c\u0169ng \u0111\u1ed5i \u0111\u01b0\u1ee3c.",
   "settings.languageHelp": "Chỉ giữ trong phiên làm việc.",
   "role.admin": "Quản trị",
   "role.management": "Ban lãnh đạo",
@@ -4708,6 +4711,12 @@ export const vi = {
     "Có thể giới hạn từng tin nhắn sau đó, và loại trừ địa chỉ hoặc tên miền ngay từ đầu.",
   "mailSharing.danger":
     "NGUY HIỂM: Tắt chia sẻ email sẽ khiến việc sử dụng CRM trở nên khó khăn. Email mới chỉ hiển thị với những người trong từng tin nhắn.",
+  "mailSharing.posture.shared":
+    "Th\u01b0 m\u1edbi thu th\u1eadp \u0111\u01b0\u1ee3c \u0111\u1ed3ng nghi\u1ec7p th\u1ea5y \u0111\u01b0\u1ee3c ng\u01b0\u1eddi \u0111\u00f3 \u0111\u1ecdc.",
+  "mailSharing.posture.private":
+    "Th\u01b0 m\u1edbi thu th\u1eadp ch\u1ec9 d\u00e0nh cho ng\u01b0\u1eddi trong th\u01b0 v\u00e0 h\u1ed9p th\u01b0 \u0111\u00e3 thu.",
+  "mailSharing.posture.where":
+    "Thay \u0111\u1ed5i \u1edf Quy t\u1eafc thu th\u1eadp",
   "mailSharing.sharedPosture.label": "Cho phép hộp thư chia sẻ ngay khi nhận",
   "mailSharing.sharedPosture.help":
     "Cho phép đồng nghiệp đặt hộp thư của họ ở chế độ chia sẻ, khi đó thư thu thập được cả nhóm đọc ngay lúc đến, trước khi có bất kỳ đánh giá nào. Mặc định tắt.",
@@ -6203,7 +6212,7 @@ export const vi = {
   "settings.tab.users": "Người dùng & nhóm",
   "settings.tab.extensions": "Tiện ích mở rộng",
   "settings.tab.integrations": "Tích hợp",
-  "settings.tab.capture": "Thu thập",
+  "settings.tab.capture": "Quy tắc thu thập",
   "settings.tab.data-model": "Mô hình dữ liệu",
   "settings.tab.ai": "AI",
   "settings.tab.knowledge": "Tri thức",
@@ -6262,7 +6271,7 @@ export const vi = {
   "knowledge.new.topicHint":
     "Viết một câu, đừng viết nhãn. Câu này được trích lại cho người hỏi điều bộ này không bao gồm — họ đọc nó vào lúc kém kiên nhẫn nhất.",
   "knowledge.new.submit": "Tạo bộ",
-  "settings.tab.privacy": "Quyền riêng tư & kiểm toán",
+  "settings.tab.privacy": "Quyền riêng tư & lưu trữ",
   "settings.tab.capture-activity": "Hoạt động thu thập",
   "captureActivity.title": "Hoạt động thu thập",
   "captureActivity.sub":
@@ -6441,8 +6450,6 @@ export const vi = {
     "Giấy phép hết hạn vào {expiry}. Không có gì thay đổi trước ngày đó.",
   "license.counting":
     "Chỗ đầy đủ chưa bị vô hiệu hoá và chưa bị tạm ngưng, bao gồm cả agent. Chỗ chỉ đọc là không giới hạn và không bao giờ được tính. Thành viên mới được xét theo con số này.",
-  "settings.group.you": "Cá nhân",
-  "settings.group.admin": "Cài đặt quản trị",
   "settings.rates.fxTitle": "Tỷ giá",
   "settings.rates.fxIntro":
     "Tỷ giá quy đổi số tiền ngoại tệ về tiền tệ gốc của bạn. Tỷ giá mới có hiệu lực từ hôm nay trở đi; tỷ giá quá khứ không bao giờ bị sửa.",

--- a/frontend/src/screens/autonomy-settings.tsx
+++ b/frontend/src/screens/autonomy-settings.tsx
@@ -13,9 +13,11 @@ import { problemMessageOf, QueryGate, throwProblem } from "./common";
 
 // Which kinds of proposal answer themselves, for the reader and nobody else.
 //
-// It sits on the account tab rather than beside the admin cards because the
+// It sits on the AGENTS page rather than beside the admin cards because the
 // answer is one person's: an admin does not decide how much of a rep's queue
 // applies without asking, so there is no role gating here and no refusal copy.
+// Under the tier reference it is written in terms of, on the page about agents
+// deciding without you.
 // The only thing that can stop a row is a write already in flight.
 //
 // The contract calls this `autonomy`; the copy calls it what a rep would. The

--- a/frontend/src/screens/blocked-domains.stories.tsx
+++ b/frontend/src/screens/blocked-domains.stories.tsx
@@ -64,7 +64,7 @@ const OPS = { organization: ["read", "update"] } as const;
 const READER = { organization: ["read"] } as const;
 
 const meta: Meta<typeof BlockedDomainsCard> = {
-  title: "Settings/Data/Capture/Refused domains",
+  title: "Settings/Data/Capture rules/Refused domains",
   component: BlockedDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/capture-settings.stories.tsx
+++ b/frontend/src/screens/capture-settings.stories.tsx
@@ -32,7 +32,7 @@ const MANAGER = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof CaptureSettingsCard> = {
-  title: "Settings/Data/Capture/Capture posture",
+  title: "Settings/Data/Capture rules/Capture posture",
   component: CaptureSettingsCard,
 };
 export default meta;

--- a/frontend/src/screens/consumer-mail-domains.stories.tsx
+++ b/frontend/src/screens/consumer-mail-domains.stories.tsx
@@ -44,7 +44,7 @@ const CONTRIBUTOR = { capture_settings: ["read", "create"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof ConsumerMailDomainsCard> = {
-  title: "Settings/Data/Capture/Consumer mailboxes",
+  title: "Settings/Data/Capture rules/Consumer mailboxes",
   component: ConsumerMailDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/mail-sharing.stories.tsx
+++ b/frontend/src/screens/mail-sharing.stories.tsx
@@ -33,7 +33,7 @@ const MANAGER = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof MailSharingCard> = {
-  title: "Settings/You/Connections/Email sharing",
+  title: "Settings/Data/Capture rules/Email sharing",
   component: MailSharingCard,
 };
 export default meta;

--- a/frontend/src/screens/mail-sharing.test.tsx
+++ b/frontend/src/screens/mail-sharing.test.tsx
@@ -13,7 +13,7 @@ import { type GrantSpec, meFixture } from "../app/mefixture";
 import { LocaleProvider } from "../i18n";
 import { MailSharingCard } from "./mail-sharing";
 
-// The workspace mail-sharing posture (Settings → Connections): every role
+// The workspace mail-sharing posture (Settings → Capture rules): every role
 // reads it, only capture_settings:update holders change it, and switching it
 // off is a deliberate act — the danger callout and an explicit Save stand
 // between the flip and the write.

--- a/frontend/src/screens/mail-sharing.tsx
+++ b/frontend/src/screens/mail-sharing.tsx
@@ -212,3 +212,59 @@ export function MailSharingCard() {
     </Panel>
   );
 }
+
+/**
+ * What the sharing rule currently SAYS, on the reader's own connections page.
+ *
+ * A value, not a control. The card that changes these two settings lives on
+ * Capture rules, because it writes the WORKSPACE's posture — everybody's mail,
+ * not this reader's — and this page is the reader's own mailboxes. The rule
+ * still governs the mail those mailboxes bring in, so a reader looking at their
+ * connections and wondering who else can read it deserves the answer where the
+ * question occurs to them.
+ *
+ * The link appears only for a reader who may CHANGE the rule — the same grant
+ * and seat the switch itself asks for. Testing whether they may open the page
+ * would be a wider question than the link makes: every seeded role may read the
+ * capture posture, so a rep would follow "Change this" to a disabled switch.
+ */
+export function MailSharingPostureRow() {
+  const t = useT();
+  const query = useMailSharing();
+  // The same question the switch on the other page asks, not "may they open
+  // that page". Every seeded role may READ the capture posture, so a visibility
+  // test offered "Change this" to a rep who would arrive at a disabled switch —
+  // an invitation to a refusal, which is worse than no invitation.
+  const canChangeIt = useCanWrite("capture_settings", "update");
+  const shared = query.data?.mail_sharing ?? false;
+  return (
+    <Panel title={t("mailSharing.title")}>
+      <PanelBody>
+        {/* A fact, not a setting: a definition list rather than SettingRow,
+            which requires a control because every row of it is something a
+            reader can operate. This one is operated on Capture rules. */}
+        <dl className="settings-facts">
+          <dt>{t("mailSharing.label")}</dt>
+          <dd>
+            {/* The stored answer in words. `query.data` is absent while the read
+                is in flight, and an absent answer says nothing rather than
+                claiming the narrower one — a wrong statement about who can read
+                somebody's mail is worse than a moment with no statement. */}
+            {query.isSuccess
+              ? t(
+                  shared
+                    ? "mailSharing.posture.shared"
+                    : "mailSharing.posture.private",
+                )
+              : null}
+          </dd>
+        </dl>
+        {canChangeIt && (
+          <p className="t-caption">
+            <a href="#/settings/capture">{t("mailSharing.posture.where")}</a>
+          </p>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/own-domains.stories.tsx
+++ b/frontend/src/screens/own-domains.stories.tsx
@@ -54,7 +54,7 @@ const MANAGER = { capture_settings: ["read", "update"] } as const;
 const READER = { capture_settings: ["read"] } as const;
 
 const meta: Meta<typeof OwnDomainsCard> = {
-  title: "Settings/Data/Capture/Own domains",
+  title: "Settings/Data/Capture rules/Own domains",
   component: OwnDomainsCard,
 };
 export default meta;

--- a/frontend/src/screens/own-domains.tsx
+++ b/frontend/src/screens/own-domains.tsx
@@ -144,7 +144,7 @@ export function OwnDomainsCard() {
               description={
                 <>
                   {t("ownDomains.fromCompany")}{" "}
-                  <a href="#/settings/general">{t("ownDomains.openCompany")}</a>
+                  <a href="#/settings/company">{t("ownDomains.openCompany")}</a>
                 </>
               }
               layout="stack"

--- a/frontend/src/screens/privacy.purposes.stories.tsx
+++ b/frontend/src/screens/privacy.purposes.stories.tsx
@@ -11,7 +11,7 @@ import {
   StoryProviders,
 } from "./story-utils";
 
-// The consent registry (the Privacy & audit tab's ConsentPurposesCard). Its own
+// The consent registry (the Privacy & retention tab's ConsentPurposesCard). Its own
 // file rather than a second component in privacy.stories.tsx, so each surface
 // keeps one story title: `fe-uat` keys on the co-located name, and a card with
 // no story of its own is a card nobody looks at in either theme.
@@ -61,7 +61,7 @@ function purposes(roles: string[], purposeList: unknown = PURPOSES) {
 }
 
 const meta: Meta<typeof ConsentPurposesCard> = {
-  title: "Settings/Governance/Privacy & audit/Consent purposes",
+  title: "Settings/Governance/Privacy & retention/Consent purposes",
   component: ConsentPurposesCard,
 };
 export default meta;

--- a/frontend/src/screens/privacy.stories.tsx
+++ b/frontend/src/screens/privacy.stories.tsx
@@ -83,7 +83,7 @@ async function findRow(
 }
 
 const meta: Meta<typeof PrivacyInboxCard> = {
-  title: "Settings/Governance/Privacy & audit/Subject requests",
+  title: "Settings/Governance/Privacy & retention/Subject requests",
   component: PrivacyInboxCard,
 };
 export default meta;

--- a/frontend/src/screens/restrictedrecords.stories.tsx
+++ b/frontend/src/screens/restrictedrecords.stories.tsx
@@ -47,7 +47,7 @@ function restricted(records: unknown[], decide = false) {
 }
 
 const meta: Meta<typeof RestrictedRecordsCard> = {
-  title: "Settings/Governance/Privacy & audit/Restricted records",
+  title: "Settings/Governance/Privacy & retention/Restricted records",
   component: RestrictedRecordsCard,
 };
 export default meta;

--- a/frontend/src/screens/retention.stories.tsx
+++ b/frontend/src/screens/retention.stories.tsx
@@ -96,7 +96,7 @@ function retention(
 }
 
 const meta: Meta<typeof RetentionCard> = {
-  title: "Settings/Governance/Privacy & audit/Retention",
+  title: "Settings/Governance/Privacy & retention/Retention",
   component: RetentionCard,
 };
 export default meta;

--- a/frontend/src/screens/retention.tsx
+++ b/frontend/src/screens/retention.tsx
@@ -467,7 +467,7 @@ export function RetentionCard() {
   // After every hook, so the hook call order stays unconditional.
   //
   // Withheld, not absent: a permission is what denies this, so the card keeps
-  // its place and says so. It shares the Privacy & audit page with the consent
+  // its place and says so. It shares the Privacy & retention page with the consent
   // registry an ops seat comes here for, and beside a subject queue that
   // explains its own emptiness — a card that simply vanished would leave that
   // reader to conclude this installation keeps everything forever.

--- a/frontend/src/screens/settings-audit.test.tsx
+++ b/frontend/src/screens/settings-audit.test.tsx
@@ -9,7 +9,7 @@ import { SEARCH_DEBOUNCE_MS } from "./listquery";
 import { AuditLogCard } from "./settings";
 import { auditEntry, jsonResponse, render } from "./settings.testkit";
 
-// The audit trail card, read on its own rather than through the Privacy & audit
+// The audit trail card, read on its own rather than through the Privacy & retention
 // entry that hosts it: one card carrying its own filters, the wire as the only
 // honest witness that a typed filter narrowed the question, and a change detail
 // that stays folded away until a reader asks for it.

--- a/frontend/src/screens/settings-integrations.test.tsx
+++ b/frontend/src/screens/settings-integrations.test.tsx
@@ -115,7 +115,7 @@ describe("SettingsScreen connections and integrations tabs", () => {
   });
 
   // A retired id is what a bookmark still carries: the audit trail was an entry
-  // of its own before it moved onto Privacy & audit, so `#/settings/audit` names
+  // of its own before it moved onto Privacy & retention, so `#/settings/audit` names
   // nothing. It has to land on the first entry this principal can see rather than
   // on a blank screen. The wiring reads are granted so Integrations is genuinely
   // open — a fallback that happens because an entry is hidden proves nothing

--- a/frontend/src/screens/settings-nav.test.tsx
+++ b/frontend/src/screens/settings-nav.test.tsx
@@ -89,7 +89,7 @@ describe("SettingsScreen page layout", () => {
       "Members",
       "Fields",
       "Pipelines",
-      "Privacy & audit",
+      "Privacy & retention",
     ]) {
       expect(screen.getByRole("link", { name: label })).toBeTruthy();
     }
@@ -394,7 +394,7 @@ const EVERY_PAGE_GRANTED: GrantSpec = {
   // both.
   ai_model_rate: ["read", "create", "update"],
   person: ["read"],
-  // What opens Privacy & audit now that `person:read` does not.
+  // What opens Privacy & retention now that `person:read` does not.
   retention_policy: ["read", "create", "update"],
   audit_log: ["read"],
   job_health: ["read"],

--- a/frontend/src/screens/settings.css
+++ b/frontend/src/screens/settings.css
@@ -442,19 +442,21 @@ p.settings-panel-sub {
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
 }
-/* Who the reader is here: role, seat, record reach. A definition list because
-   each row is a term and its answer, and none of them is operable — the way to
-   change any of it is to ask somebody, not to click here. */
-.settings-home-access {
+/* A term and its answer, where the answer is a FACT rather than a setting: who
+   the reader is on the settings home, what the mail-sharing rule currently says
+   on their connections page. A definition list because none of it is operable —
+   the way to change any of it is to ask somebody, or to open the page that owns
+   it. */
+.settings-facts {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-2) var(--space-4);
   margin: 0;
 }
-.settings-home-access dt {
+.settings-facts dt {
   color: var(--textMuted);
 }
-.settings-home-access dd {
+.settings-facts dd {
   margin: 0;
 }
 .settings-home-roles {

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { isValidElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountMenu } from "../app/account";
 import { type GrantSpec, meFixture } from "../app/mefixture";
 import { pickOption } from "../design-system/select-testing";
 import { LOCALES, localeNameKey, translate } from "../i18n";
@@ -98,22 +99,59 @@ describe("SettingsScreen RBAC surfaces", () => {
     expect(screen.queryByText("admin")).toBeNull();
   });
 
-  // Appearance is chosen from the account menu, not from here: it is the
-  // setting a reader changes most often and from wherever they are standing.
-  // Language stays, so the claim is that the account card lost ONE control
-  // rather than that the surface went away — and it is made against the
-  // rendered page, because an import that no longer exists is not evidence
-  // about what a reader sees.
-  it("offers no theme control on the Account tab", async () => {
+  // Appearance is chosen from Settings AND from the account menu. The menu keeps
+  // its shortcut — it is the setting a reader changes most often and from
+  // wherever they are standing — and this is where somebody who came looking for
+  // it in Settings finds it.
+  it("offers the appearance choice on the Account tab", async () => {
     render(<SettingsScreen route={settingsHref("account")} />);
     await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
 
     expect(screen.getByRole("heading", { name: "Your account" })).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Language" })).toBeTruthy();
-    for (const name of ["Light", "Dark", "System", "Theme"]) {
-      expect(screen.queryByRole("button", { name })).toBeNull();
-      expect(screen.queryByRole("group", { name })).toBeNull();
-    }
+    // Opened, because a Margince `Select` renders its options in a listbox on
+    // click rather than as children of the control.
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Appearance" }));
+    expect(
+      within(screen.getByRole("listbox"))
+        .getAllByRole("option")
+        .map((option) => option.textContent),
+    ).toEqual(["Light", "Dark", "System"]);
+  });
+
+  // ONE state, two faces, and BOTH of them are on screen for this.
+  //
+  // Asserting localStorage alone would pass for a row that writes the key and
+  // never notifies anybody — the menu would sit there stale, which is the exact
+  // failure "one state" is supposed to rule out. So the real account menu is
+  // mounted beside the settings screen, and the assertion is that it followed.
+  it("shares its answer with the account menu", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <SettingsScreen route={settingsHref("account")} />
+        <AccountMenu />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
+
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Appearance" }),
+      "Dark",
+    );
+
+    // The menu's own radio, read through the menu rather than through the store
+    // underneath it. `setThemeChoice` publishes to `useSyncExternalStore`
+    // subscribers, and this is one of them.
+    await user.click(screen.getByRole("button", { name: "Account" }));
+    await user.click(screen.getByRole("menuitem", { name: "Theme" }));
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "Dark" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
   });
 
   // Identity, credential, sign-off and language are ONE card, not four: a
@@ -398,7 +436,7 @@ describe("SettingsScreen restructured pages", () => {
     await waitFor(() =>
       expect(
         screen
-          .getByRole("link", { name: "Privacy & audit" })
+          .getByRole("link", { name: "Privacy & retention" })
           .getAttribute("aria-current"),
       ).toBe("page"),
     );

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -112,7 +112,7 @@ const ADMIN_GRANTS: GrantSpec = {
   // `retention_policy` or `privacy_request`, neither of which anybody below
   // admin and ops holds.
   person: ["read"],
-  // What actually opens Privacy & audit for this admin fixture. Named here
+  // What actually opens Privacy & retention for this admin fixture. Named here
   // rather than left to `person`, because the page moved off the read every
   // seat holds and a fixture that did not follow would quietly stop rendering
   // the page its cases are about.

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -15,11 +15,13 @@ import {
 } from "react";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components, operations } from "../api/schema";
+import { THEME_LABEL_KEYS } from "../app/account";
 import { dotTier } from "../app/autonomy";
 import { useCan, useCanWrite } from "../app/capability";
 import { isEntityKind } from "../app/entity";
 import { useRecordZone } from "../app/recordzone";
 import { navigate, navigateReplacing, type Route } from "../app/router";
+import { setThemeChoice, THEME_CHOICES, useThemeChoice } from "../app/theme";
 import { useUnsavedGuard } from "../app/unsaved";
 import {
   Avatar,
@@ -107,7 +109,7 @@ import { LicenseCard } from "./license";
 import { LinkedInImportCard } from "./linkedin-import";
 import { LinkedInReachCard } from "./linkedin-reach";
 import { SEARCH_DEBOUNCE_MS } from "./listquery";
-import { MailSharingCard } from "./mail-sharing";
+import { MailSharingCard, MailSharingPostureRow } from "./mail-sharing";
 import { OAuthAppCard } from "./oauth-app";
 import { OfferTemplatesAdmin } from "./offertemplates";
 import { OverlayCard } from "./overlay";
@@ -176,16 +178,7 @@ export function tabContent(id: SettingsPageId): ReactNode {
   switch (id) {
     // ---- me ----
     case "account":
-      return (
-        <>
-          <AccountCard />
-          {/* Under the identity because it is a statement about this reader
-              rather than about the workspace: which kinds of proposal stop
-              asking them. No admin card belongs on this page, and this one is
-              not an exception — nobody else sets it. */}
-          <AutonomySettingsCard />
-        </>
-      );
+      return <AccountCard />;
     case "voice":
       return <VoiceDnaCard />;
     case "agents":
@@ -265,9 +258,14 @@ export function tabContent(id: SettingsPageId): ReactNode {
     case "capture":
       return (
         <>
-          {/* Which domains are OURS, then what to do with mail from the rest,
-              then which of the rest are consumer mailboxes — the posture, then
-              the two judgements that read it. */}
+          {/* The sharing rule first, because it is the widest thing on the page:
+              whether captured mail is one seat's or the whole workspace's. It
+              used to sit on the reader's own Connections page, where "Only you"
+              was written over a switch that binds everybody. */}
+          <MailSharingCard />
+          {/* Then which domains are OURS, then what to do with mail from the
+              rest, then which of the rest are consumer mailboxes — the posture,
+              then the two judgements that read it. */}
           <OwnDomainsCard />
           <CaptureSettingsCard />
           <ConsumerMailDomainsCard />
@@ -378,15 +376,17 @@ export function tabContent(id: SettingsPageId): ReactNode {
 // not say so.
 //
 // It is not WHOLLY personal, which is why the catalog marks it `mixed`:
-// MailSharingCard writes the installation's mail-sharing rule, and
-// ConnectorsCard's second panel is the workspace's Telegram bot.
+// ConnectorsCard's second panel is the workspace's Telegram bot, and the
+// mail-sharing row states a rule that is changed on Capture rules.
 function ConnectionsTab() {
   return (
     <>
       {/* The rule first, then the mailboxes that live under it: sharing is a
-          workspace posture every user works under, not a property of any one
-          connection below. */}
-      <MailSharingCard />
+          posture every user works under, not a property of any one connection
+          below. It is STATED here and CHANGED on Capture rules — this page is
+          the reader's own mailboxes, and the switch that decides whether
+          everybody's captured mail is shared does not belong among them. */}
+      <MailSharingPostureRow />
       <ConnectorsCard />
       {/* Directly under the mailboxes and before what they brought in, because
           it changes what COUNTS as correspondence: an address declared here is
@@ -598,6 +598,12 @@ function AgentsTab() {
       <ConnectedAgentsCard />
       <AgentToolsCard />
       <AutonomyCard />
+      {/* Which kinds of proposal stop asking this reader. It sat on Account,
+          under the identity, because it is a statement about them rather than
+          about the organization — but every other thing on this page is also
+          theirs alone, and this is the page about agents deciding without them.
+          Directly under the tier reference it is written in terms of. */}
+      <AutonomySettingsCard />
     </>
   );
 }
@@ -676,6 +682,7 @@ function AccountCard() {
           <PasswordSettingRow />
           <SignatureSettingRow toast={toast} />
           <LanguageSettingRow />
+          <AppearanceSettingRow />
           <BriefDeliveryRows />
         </SettingList>
       </PanelBody>
@@ -836,12 +843,54 @@ function SignatureSettingRow({ toast }: Readonly<{ toast: Toast }>) {
 /**
  * The language this installation speaks to this reader in.
  *
- * Appearance used to stand beside it and is now picked from the ACCOUNT MENU:
- * it is the setting a reader changes most often and from wherever they happen
- * to be standing, so it lives where they already are rather than three screens
- * away. What is left is one dropdown, which is one row — the locale context is
- * where the answer lives, so nothing here is a second source of truth.
+ * Appearance stands beside it again, in the row below. It is ALSO in the account
+ * menu — the setting a reader changes most often, from wherever they happen to
+ * be standing — and the two are one state rather than two: both read
+ * `useThemeChoice` and write `setThemeChoice`.
+ *
+ * One dropdown here, which is one row: the locale context is where the answer
+ * lives, so nothing here is a second source of truth.
  */
+/**
+ * The appearance choice, in Settings as well as in the account menu.
+ *
+ * ONE state, two faces: both read `useThemeChoice` and write `setThemeChoice`
+ * from app/theme.ts, so changing it in either place moves the other. The menu
+ * keeps its shortcut — appearance is the setting a reader changes most often and
+ * from wherever they are standing — and this is where somebody who came to
+ * Settings looking for it finds it.
+ */
+function AppearanceSettingRow() {
+  const t = useT();
+  const choice = useThemeChoice();
+  return (
+    <SettingRow
+      label={t("settings.appearance")}
+      description={t("settings.appearanceHelp")}
+      control={(control) => (
+        <Select
+          {...control}
+          className="settingrow-measure"
+          value={choice}
+          // `Select` reports a string, narrowed back through the same list the
+          // options were built from — no assertion, and nothing acted on that
+          // the control was never offering.
+          onChange={(next) => {
+            const picked = THEME_CHOICES.find((option) => option === next);
+            if (picked) {
+              setThemeChoice(picked);
+            }
+          }}
+          options={THEME_CHOICES.map((option) => ({
+            value: option,
+            label: t(THEME_LABEL_KEYS[option]),
+          }))}
+        />
+      )}
+    />
+  );
+}
+
 function LanguageSettingRow() {
   const t = useT();
   const { locale, setLocale } = useLocale();

--- a/frontend/src/screens/settingscatalog.test.ts
+++ b/frontend/src/screens/settingscatalog.test.ts
@@ -76,11 +76,11 @@ describe("the scope each page declares", () => {
     // stay inside one workspace.
     integrations: "mixed",
 
-    // Personal pages carrying one shared card each. A badge reading "Only you"
-    // over either would tell a reader a company-wide switch is private to them.
-    // MailSharingCard PATCHes /capture/settings — whether captured mail is
-    // shared with colleagues; CaptureExclusionsCard's workspace rules keep a
-    // correspondent out of the CRM for everybody.
+    // Personal pages carrying one shared surface each. A badge reading "Only
+    // you" over either would tell a reader a company-wide switch is private to
+    // them. ConnectorsCard's second panel connects the workspace's Telegram
+    // bot; CaptureExclusionsCard's workspace rules keep a correspondent out of
+    // the CRM for everybody.
     connections: "mixed",
     "capture-activity": "mixed",
 

--- a/frontend/src/screens/settingscatalog.ts
+++ b/frontend/src/screens/settingscatalog.ts
@@ -285,10 +285,10 @@ export type SettingsScope =
   | "workspace"
   | "installation"
   // A page whose surfaces do not agree. My connections is the case: most of its
-  // nine cards are the reader's own mailboxes and network, and two are not —
-  // MailSharingCard writes `capture_settings`, the whole installation's
-  // mail-sharing rule, and ConnectorsCard carries the workspace's Telegram bot
-  // beside the reader's own mailboxes.
+  // cards are the reader's own mailboxes and network, and one is not —
+  // ConnectorsCard's second panel is the workspace's Telegram bot, connected
+  // once for everybody, sitting beside the mailboxes each reader connects for
+  // themselves.
   //
   // Its own value rather than picking the wider of the two, because "Company"
   // over a page that is mostly personal is as wrong as "Only you" over a
@@ -352,18 +352,30 @@ export const SETTINGS_PAGES = [
     // Passports, connected agents and the autonomy choice are all this reader's.
     changes: always,
   },
-  // MIXED, not self: six of its cards are the reader's own, and MailSharingCard
-  // writes `capture_settings` — the installation's rule about whether captured
-  // mail is shared with colleagues. A page-level "Only you" over that switch
-  // would tell a reader a company-wide setting is private to them.
+  // MIXED, not self: most of its cards are the reader's own, and ConnectorsCard
+  // carries the workspace's Telegram bot beside them. A page-level "Only you"
+  // over that panel would tell a reader a shared connection is private to them.
+  //
+  // The mail-sharing SWITCH left this page for Capture rules, where the rest of
+  // the installation's capture posture lives. What stays is a value-only row
+  // saying what the rule currently is, which claims nothing about who may
+  // change it.
   {
     id: "connections",
     group: "me",
     scope: "mixed",
     requires: always,
-    // Acting, not consulting: the mailbox, sender and LinkedIn controls are
-    // the reader's own and need no grant. The one card that is not theirs
-    // withholds itself — MailSharingCard asks `capture_settings:update`.
+    // Acting, not consulting: the mailbox, sender and LinkedIn controls are the
+    // reader's own and need no grant, and the mail-sharing row states a value
+    // and offers no control at all.
+    //
+    // The Telegram panel is the exception and it is NOT gated — connectors.tsx
+    // asks no capability question, so its Connect, Edit and Disconnect are
+    // offered to every reader and refused by the server (`channel_connection`
+    // is admin/ops to mutate). That is a pre-existing gap in that card rather
+    // than something this field can fix: `changes` decides which pages reach
+    // the rail, and it cannot withhold one control on a page whose other nine
+    // surfaces are genuinely the reader's.
     changes: always,
   },
   // MIXED for the same reason as `connections`, one page along:
@@ -569,9 +581,10 @@ export const SETTINGS_PAGES = [
     group: "data",
     scope: "workspace",
     requires: reads("capture_settings"),
-    // Four cards and, after the mail-sharing move, five. Three write
-    // `capture_settings:update`; BlockedDomainsCard writes `organization:update`,
-    // which every seeded sales role holds — so a rep keeps this page in the rail.
+    // Five cards. Four write `capture_settings:update` — the sharing rule, the
+    // posture, the own-domain list and the consumer-mailbox list; the fifth,
+    // BlockedDomainsCard, writes `organization:update`, which every seeded sales
+    // role holds — so a rep keeps this page in the rail.
     changes: acts(
       writes("capture_settings", ["update"]),
       writes("organization", ["update"]),

--- a/frontend/src/screens/settingsdispatch.test.ts
+++ b/frontend/src/screens/settingsdispatch.test.ts
@@ -93,12 +93,14 @@ const CARDS_THE_REGISTER_REACHED = [
 describe("the split lost no card", () => {
   function renderedComponents(): Set<string> {
     const source = readFileSync(join(here, "settings.tsx"), "utf8");
-    const start = source.indexOf("export function tabContent");
-    const end = source.indexOf("\n}\n", start);
+    // The WHOLE file, not just `tabContent`. Several pages dispatch to a tab
+    // function that renders their cards — `AgentsTab`, `ConnectionsTab` — and
+    // those functions sit below `tabContent`, so a window ending at its closing
+    // brace reports a card missing the moment it moves into one. That is a
+    // scan that fails SHORT: it reads a smaller tree and reports a loss that
+    // did not happen, which is the same shape of wrong as missing a real one.
     return new Set(
-      [...source.slice(start, end).matchAll(/<([A-Z][A-Za-z]+)\b/g)].map(
-        (match) => match[1],
-      ),
+      [...source.matchAll(/<([A-Z][A-Za-z]+)\b/g)].map((match) => match[1]),
     );
   }
 
@@ -108,6 +110,46 @@ describe("the split lost no card", () => {
       (card) => !rendered.has(card),
     );
     expect(lost).toEqual([]);
+  });
+
+  // The scan above proves no card was LOST. It cannot prove where one sits, and
+  // deliberately so — it reads the whole file. So the two cards this change
+  // moved are asserted by page, against the dispatch, because a widened scan
+  // that no longer notices a card sliding back to its old page is exactly the
+  // regression the widening could introduce.
+  it("dispatches the moved cards to the pages they moved to", () => {
+    const source = readFileSync(join(here, "settings.tsx"), "utf8");
+    /** One tab function's body, for a page whose case dispatches to one. */
+    function bodyOf(fn: string): string {
+      const start = source.indexOf(`function ${fn}()`);
+      if (start < 0) {
+        throw new Error(`settings.tsx has no ${fn}`);
+      }
+      return source.slice(start, source.indexOf("\n}\n", start));
+    }
+    function cardsOn(page: string): string {
+      const start = source.indexOf(`case "${page}":`);
+      if (start < 0) {
+        throw new Error(`the dispatch has no case for ${page}`);
+      }
+      const end = source.indexOf('    case "', start + 1);
+      return source.slice(start, end);
+    }
+    // The mail-sharing switch writes the WORKSPACE's posture. It belongs with
+    // the rest of the capture rules, not among the reader's own mailboxes.
+    expect(cardsOn("capture")).toContain("<MailSharingCard />");
+    expect(cardsOn("connections")).not.toContain("<MailSharingCard />");
+    // And the personal autonomy choice belongs on the page about agents
+    // deciding without you, under the tier reference it is written in terms of.
+    // `agents` dispatches to a tab FUNCTION, so the case body names the
+    // function and the cards are inside it — asserting on the case alone would
+    // be satisfied by the card being nowhere at all.
+    expect(cardsOn("account")).not.toContain("<AutonomySettingsCard />");
+    expect(bodyOf("AgentsTab")).toContain("<AutonomySettingsCard />");
+    // The same for the card that left Connections, which is also a tab
+    // function: gone from the tab, not merely gone from the case line.
+    expect(bodyOf("ConnectionsTab")).not.toContain("<MailSharingCard />");
+    expect(bodyOf("ConnectionsTab")).toContain("<MailSharingPostureRow />");
   });
 
   it("names enough cards to make that meaningful", () => {

--- a/frontend/src/screens/settingshome.tsx
+++ b/frontend/src/screens/settingshome.tsx
@@ -166,7 +166,7 @@ export function SettingsHome({ reach }: Readonly<{ reach: SettingsReach }>) {
               which requires a control because every row of it is something a
               reader can operate. Nothing here is operable — this panel answers
               "who am I here", and the way to change any of it is to ask. */}
-          <dl className="settings-home-access">
+          <dl className="settings-facts">
             <dt>{t("settings.home.rolesLabel")}</dt>
             <dd>
               {/* The roles as the server resolved them, not as a role name this

--- a/frontend/src/screens/settingsstories.test.ts
+++ b/frontend/src/screens/settingsstories.test.ts
@@ -126,10 +126,12 @@ describe("the settings stories are filed where the product files them", () => {
 
 // WHAT THIS GATE DOES NOT HOLD, said plainly so the next author does not assume
 // it does: that the page a story NAMES is the page whose dispatch arm renders
-// its card. Two stories were misfiled that way in this very change — the
-// autonomy card sat under Agents while `tabContent` renders it on Account, and
-// mail sharing sat under Capture while it renders on Connections. Both were
-// found by hand and fixed.
+// its card. Two stories were misfiled that way once — the autonomy card sat
+// under Agents while `tabContent` rendered it on Account, and mail sharing sat
+// under Capture while it rendered on Connections. Both were found by hand, and
+// both were resolved the other way in the end: the CARDS moved to the pages
+// their stories had always named, because the stories were right about where
+// each belonged.
 //
 // A gate for it was written and deleted. Reading the card-to-page map out of
 // `settings.tsx` works for a card the screen renders directly, and stops at the


### PR DESCRIPTION
Four corrections a redesign review found, none of them big on their own.

**The company mail-sharing switch was the first card on your personal
Connections page.** It writes `/capture/settings` — whether everybody's captured
mail is shared with colleagues — so opening your own page to connect a mailbox
put a switch binding the whole workspace above the mailbox controls. It moves to Capture
rules, at the top, above the domains it governs. Connections keeps a value-only
row saying what the rule currently is, with a link to change it shown only to a
reader who may open that page: offering a way to a page that answers with the
access boundary is worse than not offering it.

**Two labels described a shape that had already changed.** "Privacy & audit"
promised an audit destination that has its own page now, and "Capture" sat beside
"Capture activity" with nothing to tell them apart. They are Privacy & retention
and Capture rules, in all three catalogs, and the German end-to-end assertion
moves with them.

**Settings had no appearance control.** The account menu had one and Settings did
not, so a reader who went where settings live could not find the setting they
were looking for. The row and the menu share one state through `useThemeChoice`
and `setThemeChoice`, and a test flips the row and reads the store the menu
subscribes to — a row keeping its own copy fails it.

**The autonomy card sat on Account.** It says which kinds of proposal stop asking
you, which is the subject of the Agents page, and it now sits under the tier
reference it is written in terms of.

The handbook still described two groups and fifteen pages. It describes seven
groups and 28, says which of the two questions each answer belongs to — can I
open it, can I change it — and explains the scope badge. Its role table was
keyed on the old page names and on role names the product stopped consulting;
it now says plainly that a sales seat can edit Capture rules and the company
profile, because those cards ask for a permission every sales role holds, and
that the fix for that is the permission rather than the page.

One gate widened rather than moved: `settingsdispatch.test.ts` scanned only
`tabContent` for the cards a page reaches, so a card moving into one of the tab
functions below it read as a lost card. It scans the file. Mutation-checked
against a genuinely deleted card.

Found by review and fixed here:
- The "Change this on Capture rules" link tested page VISIBILITY, which every seeded role has. A rep would have followed it to a disabled switch. It now asks the same grant and seat the switch itself asks.
- The posture copy said private mail "stays with the seat that received it". The backend holds it to the message participants and the capturing mailbox owner, and only from then on. Corrected in all three catalogs.
- A catalog comment claimed the Telegram panel gates its own controls. It does not — `connectors.tsx` asks no capability question at all, so Connect, Edit and Disconnect are offered to everyone and refused by the server. Filed as #4731; the comment now says so instead of the opposite.
- The Playwright case still asserted "offers no theme control" and passed vacuously, because it looked for a button and the new control is a combobox.
- The theme-sharing test asserted localStorage only, so it would have passed for a row that writes the key without notifying subscribers. It now mounts the real account menu and reads its radio. Mutation-checked against exactly that.
- Six handbook claims were false: Ops does reach Extensions, Management holds reads and not writes on AI usage and sign-in, a Team Lead IS team-scoped, and user administration and the audit log are grant-gated rather than role-gated.

The widened card scan lost placement, so a second case asserts the two moved cards by page and inside their tab functions. Mutation-checked by moving one back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the workspace mail-sharing switch to Capture rules and brings the appearance setting into Settings, along with several label and handbook corrections from a redesign review.

- Connections now shows the current mail-sharing posture as a read-only value, with a link to change it only for users who can update.
- Renames "Privacy & audit" to "Privacy & retention" and "Capture" to "Capture rules" in all three locales and story titles.
- Settings Account now offers an Appearance control that shares state with the account menu via `useThemeChoice`.
- Moves the autonomy card from Account to the Agents page, under the tier reference.
- Updates the settings handbook to describe seven groups, 28 pages, permission-based access, and corrects six false claims.
- Widens `settingsdispatch.test.ts` to scan the whole file and adds placement assertions for the moved cards.

<sup>Written for commit 61f18199e113fa1e5d14a872ea2ef757ea236ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

