### PR TITLE
A census reads its whole subject

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
   test-contract-frontend-drift migration-versions test-migration-versions \
   test-lanes env-reads gofmt lint-modules go-file-length rls-store-path \
   check-extension-modules \
-  no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale \
+  no-jurisdiction test-no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale \
   test-selfdir pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check
 
@@ -100,7 +100,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
+.PHONY: help install dev-fresh check check-all check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing ds-spacing-roles space-tokens native-controls ext-imports action-rows fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-merge-verdict test-laneorder secret-scan test-secret-scan test-dev-dsn test-testdb-redis test-lane-timeout-report test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations check-extension-modules contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction test-no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check sbom-gate
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -1130,10 +1130,21 @@ test-selfdir:
 
 ## no-jurisdiction — pack-boundary fitness gate: no country-specific
 ## regulatory identifier (XRechnung/ZUGFeRD/DATEV/…) or ISO-3166 code appears
-## in core CODE, only in the jurisdiction seam (internal/modules/de,
-## internal/shared/ports/jurisdiction). Comments citing a statute are allowed.
+## in core CODE — Go AND SQL — only in the jurisdiction seam
+## (internal/shared/ports/jurisdiction). Comments citing a statute are allowed
+## in both languages. check-no-jurisdiction.test.sh runs beside it because the
+## gate read only *.go while claiming to guard core, so a leak in a migration
+## reported OK: under-recognition leaves no failing assertion to notice, and the
+## reach is now asserted rather than trusted.
 no-jurisdiction:
 	@./scripts/check-no-jurisdiction.sh
+
+## test-no-jurisdiction — the jurisdiction gate's own test. It is a SEPARATE
+## target like every other gate-plus-test pair here (one-spelling, money-scale,
+## migration-versions) so the fan-out runs them side by side and a reader can
+## see from the list that this gate is tested.
+test-no-jurisdiction:
+	@./scripts/check-no-jurisdiction.test.sh
 
 ## check-ext-migrations — the extension migration gate (ADR-0069): apply every
 ## enabled unit's migrations as its restricted ext_<name> role against a

--- a/backend/gates/decisioncoverage_test.go
+++ b/backend/gates/decisioncoverage_test.go
@@ -29,16 +29,28 @@ package gates
 // says so in its own comment and defends with an explicit error. Asserting the
 // guard here is what keeps that defence from being deleted as belt-and-braces.
 //
-// NOT in the corpus: comms.Store.StageControllerTx. It has no production caller
-// on main — the controller mail lane it belongs to was never wired — so it
-// stages nothing today and an obligation on it would be an assertion about code
-// that does not run. It joins the corpus the moment a caller appears, because
-// the corpus is derived from who calls the stagers rather than listed here.
+// THE CORPUS IS DERIVED FROM THE TREE, not from a file named here. It was one
+// hard-coded path — internal/compose/commsstager.go — while this header claimed
+// otherwise, and the claim went false the moment the controller mail lane was
+// wired: controllermail.go stages a delivery, carries all four obligations, and
+// the gate could not see it. That is the shape a census must never take. It
+// reads a smaller tree than its subject, finds nothing wrong, and reports PASS
+// with no failing assertion to notice.
+//
+// So the corpus is derived twice over, both times by reusing what the sibling
+// staging gate already built: parseTreeUnder walks the whole compose TIER, not
+// one directory, because a call site in a subpackage stages just as real a
+// message; and stagingMethodNames reads the comms store's own Stage…Tx
+// declarations, so a fourth door is a subject on the day it is written rather
+// than on the day somebody remembers to list it. A new staging path is a
+// subject by existing, and the two staging gates now read one corpus and ask it
+// two different questions.
 
 import (
 	"go/ast"
-	"go/parser"
 	"go/token"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -53,59 +65,95 @@ const (
 	callEnqueue   = "EnqueueTx"
 )
 
-// stagerCalls are the delivery-row writers. A method calling one of these is
-// staging a message and owes the obligations above.
-var stagerCalls = []string{"StageTx", "StageChannelTx", "StageControllerTx"}
+// stagingMethod is one method that writes a delivery row: where it lives, so a
+// failure names a file a reader can open, and what it called.
+type stagingMethod struct {
+	name   string
+	file   string
+	decl   *ast.FuncDecl
+	called map[string]bool
+}
+
+// stagingMethodsIn answers every method under a tier that stages a delivery.
+//
+// IT REUSES stagingdecision_test.go's parseTreeUnder and stagingMethodNames
+// rather than walking and listing on its own, and that is the whole correction
+// this gate needed. It parsed ONE hard-coded file while its header claimed a
+// derived corpus; replacing that with a one-level ParseDir and a hand-kept list
+// of stager names would have been the same defect twice — blind to a stager in
+// a compose subpackage, and blind to a fourth Stage…Tx on the day it is written.
+// The sibling already derives both, so the two staging gates now read ONE
+// corpus and ask it two different questions.
+func stagingMethodsIn(t *testing.T, fset *token.FileSet, root string) []stagingMethod {
+	t.Helper()
+	stagers := stagingMethodNames(t, fset)
+	var out []stagingMethod
+	for _, file := range parseTreeUnder(t, fset, root) {
+		path := fset.Position(file.Pos()).Filename
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			called := callsIn(fn)
+			if !stagesADelivery(called, stagers) {
+				continue
+			}
+			out = append(out, stagingMethod{
+				name: fn.Name.Name, file: filepath.Base(path), decl: fn, called: called,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].file != out[j].file {
+			return out[i].file < out[j].file
+		}
+		return out[i].name < out[j].name
+	})
+	return out
+}
+
+// stagingCorpusFloor is the number of staging paths that must be found before
+// any assertion below is trusted.
+//
+// Three today: mail and channel on the user lane, plus the controller lane. It
+// is a FLOOR rather than an exact count so a fourth stager does not fail the
+// gate for existing — but it must rise when one lands, because a corpus that
+// silently shrank to two would otherwise still pass. The mismatch is what a
+// reader is meant to notice.
+//
+// It is not a hard-coded copy of the subject: the tree is walked and the names
+// are derived: this only refuses to trust a walk that came back near-empty.
+const stagingCorpusFloor = 3
 
 func TestEveryStagedDeliveryCarriesItsAuthorization(t *testing.T) {
 	t.Parallel()
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset,
-		"internal/compose/commsstager.go", nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("parsing the staging seam: %v", err)
+	subjects := stagingMethodsIn(t, token.NewFileSet(), composeTier)
+	// Under-recognition is the one way this must not fail. A gate that walked
+	// the wrong directory, or a rename that made every method stop matching,
+	// would find no subjects and report PASS.
+	if len(subjects) < stagingCorpusFloor {
+		t.Fatalf("found %d staging methods in %s, want at least %d "+
+			"(mail, channel, controller): the gate is looking in the wrong place, "+
+			"the stagers were renamed, or a staging path was deleted",
+			len(subjects), composeTier, stagingCorpusFloor)
 	}
 
-	subjects := map[string]map[string]bool{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
-		}
-		called := callsIn(fn)
-		if !stagesADelivery(called) {
-			continue
-		}
-		subjects[fn.Name.Name] = called
-	}
-
-	// Under-recognition is the one way this must not fail. A gate that parsed
-	// the wrong file, or a rename that made every method stop matching, would
-	// find no subjects and report PASS.
-	if len(subjects) < 2 {
-		t.Fatalf("found %d staging methods, want at least the mail and channel pair: "+
-			"the gate is looking in the wrong place or the stagers were renamed", len(subjects))
-	}
-
-	names := map[string]bool{}
-	for name := range subjects {
-		names[name] = true
-	}
-	for _, name := range sortedKeys(names) {
-		called := subjects[name]
+	for _, subject := range subjects {
 		for _, want := range []string{callAuthorize, callRefuse} {
-			if !called[want] {
-				t.Errorf("%s stages a delivery and never calls %s: the message reaches the "+
-					"send queue with nothing on record about why it was allowed", name, want)
+			if !subject.called[want] {
+				t.Errorf("%s (%s) stages a delivery and never calls %s: the message reaches the "+
+					"send queue with nothing on record about why it was allowed",
+					subject.name, subject.file, want)
 			}
 		}
-		if !called[callEnqueue] {
+		if !subject.called[callEnqueue] {
 			// Not an obligation in itself — it is what makes the others
 			// load-bearing. A stager that does not enqueue is not on the send
 			// path, and the gate should say so rather than pass quietly.
-			t.Errorf("%s stages a delivery and never enqueues a send job: "+
-				"this gate's corpus has drifted from the send path", name)
+			t.Errorf("%s (%s) stages a delivery and never enqueues a send job: "+
+				"this gate's corpus has drifted from the send path", subject.name, subject.file)
 		}
 	}
 }
@@ -121,37 +169,36 @@ func TestEveryStagedDeliveryCarriesItsAuthorization(t *testing.T) {
 func TestAStagingPathWithNoAuthorityFailsRatherThanStages(t *testing.T) {
 	t.Parallel()
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset,
-		"internal/compose/commsstager.go", nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("parsing the staging seam: %v", err)
+	subjects := stagingMethodsIn(t, token.NewFileSet(), composeTier)
+	if len(subjects) < stagingCorpusFloor {
+		t.Fatalf("found %d staging methods in %s, want at least %d: this gate would "+
+			"otherwise report PASS having checked nothing",
+			len(subjects), composeTier, stagingCorpusFloor)
 	}
-
 	guarded := 0
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil || !stagesADelivery(callsIn(fn)) {
-			continue
-		}
-		if !guardsNilAuthority(fn) {
-			t.Errorf("%s does not refuse a missing authorization authority: without the guard a "+
-				"dropped field stages every message with no decision and still passes a call census",
-				fn.Name.Name)
+	for _, subject := range subjects {
+		if !guardsNilAuthority(subject.decl) {
+			t.Errorf("%s (%s) does not refuse a missing authorization authority: without the "+
+				"guard a dropped field stages every message with no decision and still passes "+
+				"a call census", subject.name, subject.file)
 			continue
 		}
 		guarded++
 	}
-	if guarded < 2 {
-		t.Fatalf("%d staging methods carry the nil-authority guard, want at least the mail and "+
-			"channel pair", guarded)
+	// Against the corpus, not the floor: a fourth stager with no guard would
+	// otherwise leave guarded at 3, clear the floor, and make this final check
+	// assert nothing while its message claimed "every one".
+	if guarded < len(subjects) {
+		t.Fatalf("%d of %d staging methods carry the nil-authority guard, want every one",
+			guarded, len(subjects))
 	}
 }
 
-// stagesADelivery reports whether a method writes a delivery row.
-func stagesADelivery(called map[string]bool) bool {
-	for _, stager := range stagerCalls {
-		if called[stager] {
+// stagesADelivery reports whether a method writes a delivery row, against the
+// stager names derived from the comms store rather than a list kept here.
+func stagesADelivery(called map[string]bool, stagers map[string]bool) bool {
+	for name := range stagers {
+		if called[name] {
 			return true
 		}
 	}

--- a/scripts/check-no-jurisdiction.sh
+++ b/scripts/check-no-jurisdiction.sh
@@ -14,15 +14,29 @@
 # tests (which legitimately exercise pack behavior) are out of scope — this
 # gate guards hand-written core source.
 #
-# The gate reads CODE, not documentation: a comment-only line is dropped
-# before matching, so core may name the motivating statute for a GENERIC,
-# parameterized mechanism (e.g. the retention floor whose day-count comes from
-# policy) while a hard-coded jurisdiction string in a literal or identifier
-# still fails the build.
+# CORE IS NOT ONLY GO. This scanned --include='*.go' and nothing else, while its
+# own header said "core code", so a jurisdiction string in a core migration was
+# invisible. A gate that reads a smaller tree than its subject reports PASS over
+# the part it cannot see, which is the one way a census must not fail.
+# Migrations are scanned too, with SQL's own comment marker understood.
+#
+# KNOWN LEAK, NOT CAUGHT BY THE PATTERNS BELOW: the communication basis
+# vocabulary carries 'vn_subject_agreement' and 'existing_customer_exception' —
+# in core Go (internal/shared/ports/commsauthz/decision.go) and in two CHECK
+# constraints of shipped migration 1788407500. Core must stay country-neutral,
+# so that is a real violation. Whether the vocabulary should carry per-pack
+# values is a product decision about the engine and not one a grep settles;
+# it is filed as issue #4733, not argued here.
+
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# The two core trees this gate reads. Migrations are core: an installation's
+# schema is as much the product as the code that queries it, and a CHECK
+# constraint naming one market's rule is exactly the leak this gate exists to
+# refuse.
 scan="backend/internal"
+scan_sql="backend/migrations"
 seam='/ports/jurisdiction/'
 # Anchored to the path segment of a `file:line:content` grep row (…_gen.go:NN),
 # not `$` — which would match the END of the content, so generated files never
@@ -35,13 +49,53 @@ generated='(_gen|\.gen)\.go:[0-9]'
 # statute named in a comment (the header's promise) never fails the build, while
 # the same token in a literal/identifier still does. The space before // avoids
 # eating a `scheme://…` inside a string.
+#
+# SQL's marker is `--`, and it is handled here rather than in a second function:
+# the two languages differ only in the token, and two strippers would be two
+# answers to one question — the SQL one would be the copy that goes stale.
+#
+# QUOTE-AWARE, and it has to be. An unanchored `sub` on the first `-- ` blanks
+# the rest of the line, including a jurisdiction string in the CODE that follows
+# — and `-- ` inside a single-quoted SQL string is ordinary prose, not a
+# contrivance: migrations carry sentences in COMMENT ON, in DEFAULTs and in
+# CHECK error text. A stripper that ate them would hide the very leak this gate
+# widened to find, one line below the header condemning exactly that. The Go
+# marker is scanned the same way for the same reason: `"http://x // ZUGFeRD"`
+# defeated the old unanchored strip too, which this fixes rather than inherits.
+#
+# The scan walks the line once, toggling on quote characters (a backslash
+# escapes the next one), and cuts at the first marker standing OUTSIDE a quoted
+# run.
+#
+# WHAT IT STILL CANNOT SEE, stated rather than implied: it is line-oriented, so
+# a construct spanning lines is beyond it — a Go raw string or a PostgreSQL
+# dollar-quoted body whose continuation line begins with a marker reads as a
+# comment, and a /* … */ block is matched by its opening line only. Each is a
+# false PASS for a token hidden inside one. Closing them needs a parser per
+# language, which is a different gate from this one; the shapes that actually
+# occur in this tree — a marker inside a single-line literal, in either
+# language, escaped or not — are the ones asserted in the test beside it.
 strip_comments() {
   awk '{
     if (match($0, /^[^:]+:[0-9]+:/)) { prefix=substr($0,1,RLENGTH); c=substr($0,RLENGTH+1) }
     else { prefix=""; c=$0 }
     t=c; sub(/^[[:space:]]+/,"",t)
-    if (t ~ /^(\/\/|\/\*|\*)/) next
-    sub(/[[:space:]]+\/\/.*$/,"",c)
+    if (t ~ /^(\/\/|\/\*|\*|--)/) next
+    # Walk once; q tracks the quote character we are inside, empty when outside.
+    q=""; cut=0
+    for (i = 1; i <= length(c); i++) {
+      ch = substr(c, i, 1)
+      # A backslash escapes the next character INSIDE a quoted run, so `\"`
+      # does not close it. Without this, `"a \" // ZUGFeRD"` reads as closed at
+      # the escaped quote and the leak after it is cut away as a comment.
+      # Backticks are Go raw strings, where a backslash escapes nothing.
+      if (q != "" && q != "`" && ch == "\\") { i++; continue }
+      if (q != "") { if (ch == q) q=""; continue }
+      if (ch == "\"" || ch == "'\''" || ch == "`") { q=ch; continue }
+      two = substr(c, i, 2)
+      if (two == "//" || two == "--") { cut=i; break }
+    }
+    if (cut > 0) c = substr(c, 1, cut - 1)
     print prefix c
   }'
 }
@@ -50,16 +104,25 @@ strip_comments() {
 # proper nouns with fixed spellings, and a case-insensitive match false-fires
 # on incidental substrings (e.g. DATEV inside "UpdateVoice").
 named='\b(XRechnung|ZUGFeRD|DATEV|GoBD|eIDAS|Impressum)\b'
-hits="$(grep -rnE "$named" "$scan" --include='*.go' 2>/dev/null \
+hits="$( { grep -rnE "$named" "$scan" --include='*.go' 2>/dev/null; \
+             grep -rnE "$named" "$scan_sql" --include='*.sql' 2>/dev/null; } \
   | grep -vE "$seam" | grep -vE "$generated" | grep -v '_test.go' \
   | strip_comments | grep -E "$named" || true)"
 
 # Conservative ISO-3166: a quoted UPPER-case alpha-2 only when it shares a line
 # with a country-ish keyword, so incidental two-letter strings (HTTP verbs,
 # enum codes) do not false-fire. The alpha-2 must be upper-case (no -i).
+#
+# BOTH QUOTE STYLES, because the corpus now includes SQL and SQL quotes strings
+# with a single quote. Matching only Go's double quote would have left
+# `CHECK (jurisdiction <> 'DE')` passing in a tree this gate had just claimed to
+# read — the widening would have been the announcement of a reach it did not
+# have, which is the failure this whole change is about.
 kw='[Cc]ountry|[Jj]urisdiction|[Ii][Ss][Oo][_-]?3166'
-iso="($kw).*\"[A-Z]{2}\"|\"[A-Z]{2}\".*($kw)"
-iso_hits="$(grep -rnE "$iso" "$scan" --include='*.go' 2>/dev/null \
+q="[\"']"
+iso="($kw).*${q}[A-Z]{2}${q}|${q}[A-Z]{2}${q}.*($kw)"
+iso_hits="$( { grep -rnE "$iso" "$scan" --include='*.go' 2>/dev/null; \
+                 grep -rnE "$iso" "$scan_sql" --include='*.sql' 2>/dev/null; } \
   | grep -vE "$seam" | grep -vE "$generated" | grep -v '_test.go' \
   | strip_comments | grep -E "$iso" || true)"
 

--- a/scripts/check-no-jurisdiction.test.sh
+++ b/scripts/check-no-jurisdiction.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# The jurisdiction gate's own test — it gates the gate's REACH, which is the
+# half that failed silently.
+#
+# check-no-jurisdiction.sh scanned --include='*.go' and nothing else while its
+# header said it guards "core code". Core SQL was invisible, and core SQL does
+# name a jurisdiction: the basis-kind CHECK in migration 1788407500 carries
+# 'vn_subject_agreement' twice. The gate reported OK over a leak it could not
+# see, which is the one way a census must not fail — under-recognition leaves no
+# failing assertion to notice.
+#
+# So the reach is asserted rather than trusted. Four properties, each with a
+# planted defect the gate must catch and a legitimate shape it must not:
+#
+#   1. A jurisdiction string in core GO fails.   (the original arm, still armed)
+#   2. A jurisdiction string in core SQL fails.  (the arm that did not exist)
+#   3. The same token in a GO comment passes.    (the header's own promise)
+#   4. The same token in a SQL comment passes.   (that promise, in SQL)
+#   5. A token after a `--` INSIDE a SQL literal fails. (the strip must not eat code)
+#   6. The same, after a `//` inside a Go literal.      (the older twin of it)
+#   7. The same, after an ESCAPED quote.                (a `\"` does not close a run)
+#   8. An ISO code in a SINGLE-quoted SQL literal.      (SQL does not quote like Go)
+#
+# 3 and 4 are not politeness: without them the SQL arm would fire on the very
+# first thing it meets — an Impressum named as motivation in a migration comment
+# — and the honest fix would look like narrowing the gate rather than teaching
+# it to read.
+#
+# The tree is FAKE and built here. Running the real gate against a mutated
+# working tree would be a test that edits the repo to prove a point, and a
+# failure partway through would leave the edit behind.
+#
+# Usage: bash scripts/check-no-jurisdiction.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/check-no-jurisdiction.sh"
+FAILURES=0
+
+fail() { echo "FAIL: $*" >&2; FAILURES=$((FAILURES + 1)); }
+
+# A throwaway repo shaped like this one: the gate cds to its own parent and
+# scans backend/internal plus backend/migrations, so those are what a fixture
+# needs. The gate itself is copied in rather than symlinked, because it resolves
+# its scan root from its own path.
+newtree() {
+  local root
+  root="$(mktemp -d)"
+  mkdir -p "$root/scripts" "$root/backend/internal/modules/x" "$root/backend/migrations/core"
+  cp "$GATE" "$root/scripts/"
+  # A file in each tree with nothing to find, so a fixture that fails to write
+  # its subject is not indistinguishable from a clean one.
+  printf 'package x\n\nconst ordinary = "nothing to see"\n' \
+    > "$root/backend/internal/modules/x/x.go"
+  printf 'CREATE TABLE ordinary (id uuid);\n' \
+    > "$root/backend/migrations/core/fixture_baseline.up.sql"
+  echo "$root"
+}
+
+# run answers the gate's exit status against one fixture tree.
+run() {
+  ( cd "$1" && bash scripts/check-no-jurisdiction.sh >/dev/null 2>&1 )
+}
+
+# The control: a tree with no jurisdiction string anywhere must PASS. Without
+# this every assertion below could be passing because the fixture is broken.
+clean="$(newtree)"
+if ! run "$clean"; then
+  fail "a tree with no jurisdiction string does not pass — the fixture is wrong, and every case below is meaningless"
+fi
+rm -rf "$clean"
+
+# 1. Core Go, in code.
+gohit="$(newtree)"
+printf 'package x\n\nconst format = "ZUGFeRD"\n' \
+  > "$gohit/backend/internal/modules/x/leak.go"
+if run "$gohit"; then
+  fail "a jurisdiction string in core Go passed"
+fi
+rm -rf "$gohit"
+
+# 2. Core SQL, in code. THIS is the arm that did not exist.
+sqlhit="$(newtree)"
+printf "ALTER TABLE ordinary ADD COLUMN scheme text DEFAULT 'ZUGFeRD';\n" \
+  > "$sqlhit/backend/migrations/core/fixture_leak.up.sql"
+if run "$sqlhit"; then
+  fail "a jurisdiction string in core SQL passed — the gate is reading a smaller tree than its subject"
+fi
+rm -rf "$sqlhit"
+
+# 3. Core Go, in a comment: permitted, and the header says so.
+gocomment="$(newtree)"
+printf 'package x\n\n// ZUGFeRD is the motivating standard; nothing here is bound to it.\nconst generic = "invoice"\n' \
+  > "$gocomment/backend/internal/modules/x/motivation.go"
+if ! run "$gocomment"; then
+  fail "a statute named in a GO comment failed the gate — the header promises comments are documentation, not code"
+fi
+rm -rf "$gocomment"
+
+# 4. Core SQL, in a comment: the same promise, in the language the gate just
+# learned to read. Migration 1788009369 really does name an Impressum this way.
+sqlcomment="$(newtree)"
+printf -- "-- ZUGFeRD is the motivating standard; the column below is generic.\nALTER TABLE ordinary ADD COLUMN scheme text;\n" \
+  > "$sqlcomment/backend/migrations/core/fixture_motivation.up.sql"
+if ! run "$sqlcomment"; then
+  fail "a statute named in a SQL comment failed the gate — extending the reach must not break the header's own promise"
+fi
+rm -rf "$sqlcomment"
+
+# 5. A jurisdiction string AFTER a `-- ` that sits inside a SQL string literal.
+#
+# This is the case the first version of the SQL arm fell through. An unanchored
+# strip cut at the first ` -- ` and blanked the rest of the line, so the leak
+# after it was invisible — the gate reading less than its subject, reintroduced
+# by the change that widened its reach. `-- ` inside quoted prose is ordinary in
+# a migration, so this needs no attacker.
+sqlquoted="$(newtree)"
+printf "INSERT INTO ordinary (note, scheme) VALUES ('a -- b', 'ZUGFeRD');\n" \
+  > "$sqlquoted/backend/migrations/core/fixture_quoted.up.sql"
+if run "$sqlquoted"; then
+  fail "a jurisdiction string after a '--' inside a SQL literal passed — the comment strip is eating code"
+fi
+rm -rf "$sqlquoted"
+
+# 6. The same evasion in Go, which the unanchored strip had always allowed.
+# Fixing the SQL arm without this would leave the older hole open beside it.
+goquoted="$(newtree)"
+printf 'package x\n\nconst u = "http://x // ZUGFeRD"\n' \
+  > "$goquoted/backend/internal/modules/x/quoted.go"
+if run "$goquoted"; then
+  fail "a jurisdiction string after a '//' inside a Go literal passed — the comment strip is eating code"
+fi
+rm -rf "$goquoted"
+
+# 7. A jurisdiction string after a `//` that follows an ESCAPED quote.
+#
+# The quote walker has to know that `\"` does not close a run. Without that,
+# the literal reads as closed at the escaped quote, the `//` after it looks like
+# a comment marker outside quotes, and everything past it — including the leak —
+# is cut. Codex found this; the first quote-aware version had it.
+goescaped="$(newtree)"
+printf 'package x\n\nconst s = "a \\" // ZUGFeRD"\n' \
+  > "$goescaped/backend/internal/modules/x/escaped.go"
+if run "$goescaped"; then
+  fail "a jurisdiction string after an escaped quote passed — the walker thinks the literal closed"
+fi
+rm -rf "$goescaped"
+
+# 8. An ISO country code in a SQL literal, which uses SINGLE quotes.
+#
+# The ISO pattern matched only Go's double quote. Extending the scan to SQL
+# without extending the pattern would announce a reach the gate did not have.
+sqliso="$(newtree)"
+printf "ALTER TABLE ordinary ADD CONSTRAINT c CHECK (jurisdiction <> 'DE');\n" \
+  > "$sqliso/backend/migrations/core/fixture_iso.up.sql"
+if run "$sqliso"; then
+  fail "an ISO country code in a single-quoted SQL literal passed — the pattern reads only Go quotes"
+fi
+rm -rf "$sqliso"
+
+if [[ $FAILURES -gt 0 ]]; then
+  echo "check-no-jurisdiction.test.sh: $FAILURES case(s) failed" >&2
+  exit 1
+fi
+echo "==> jurisdiction gate reach: core Go and core SQL both read, comments spared in both"


### PR DESCRIPTION
Two gates reported PASS over a smaller tree than they claimed to check. That
is the one way a census must not fail: it reads less, finds nothing wrong, and
leaves no failing assertion for anybody to notice.

decisioncoverage_test.go parsed ONE hard-coded file — commsstager.go — while
its own header said "the corpus is derived from who calls the stagers rather
than listed here". The claim went false when the controller mail lane was
wired: controllermail.go stages a delivery, carries all four obligations, and
the gate could not see it. I proved the consequence before fixing it — with
refuseAtStaging deleted from the controller lane, so a notice reaches the send
queue past its own refusal check, the old gate answers ok.

My first fix was the same defect twice more. A one-level ParseDir is blind to a
stager in a compose subpackage, and a hand-kept list of stager names is blind
to a fourth Stage…Tx on the day it is written. Both reviews caught it, and both
pointed at the sibling gate that already solved it: stagingdecision_test.go's
parseTreeUnder walks the whole tier, and its stagingMethodNames derives the
door names from the comms store's own declarations. Reusing them is the fix.
The two staging gates now read ONE corpus and ask it two questions.

check-no-jurisdiction.sh scanned --include='*.go' while its header says it
guards "core code". Migrations are core, and the basis-kind CHECK in 1788407500
names a Vietnamese basis. It now scans them, and strip_comments understands
SQL's `--`.

Making it quote-aware was not optional and not tidiness. An unanchored strip
cuts at the first ` -- ` on the line, so a jurisdiction string after ordinary
quoted prose — which migrations carry in COMMENT ON, in DEFAULTs, in CHECK
error text — is silently eaten. Both reviews confirmed the evasion, Codex then
found that an escaped quote defeated the first quote-aware version, and that
the ISO pattern still read only Go's double quote so `jurisdiction <> 'DE'`
passed in the tree the gate had just claimed to read. All three are fixed and
each has its own planted case.

The gate now has a test — eight cases and a clean-tree control, on fixture
trees rather than the working copy — wired as its own target beside the gate,
matching every other gate-plus-test pair here.

Also closes the stale claim item L records: the header no longer says
StageControllerTx has no production caller.

Known and filed, not argued in a comment: the basis vocabulary carries
vn_subject_agreement and existing_customer_exception in core Go and in a
shipped migration. Whether it should take pack-supplied values is a product
decision — issue #4733.

The stripper is line-oriented, so a marker on the continuation line of a Go raw
string or a dollar-quoted SQL body is still beyond it. That limit is written
down rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Two gates reported PASS over smaller trees than they claimed to check; both now read their whole subject. The staging coverage gate derives its corpus from the entire compose tier, and the jurisdiction gate now scans SQL migrations alongside Go with a quote-aware comment stripper; a known leak in the basis vocabulary is filed as issue #4733.

**Bug Fixes**
- The staging gate parsed one hard-coded file; it now reuses the sibling gate's tree walk and derives stager names from the comms store, so new staging paths are caught the day they're written.
- The jurisdiction gate now scans `backend/migrations` and understands SQL's `--` marker.
- The comment stripper is quote-aware: markers inside quoted literals no longer hide leaks, including after escaped quotes.
- The ISO pattern now matches single-quoted SQL literals as well as Go double quotes.
- Removed the stale claim that `StageControllerTx` has no production caller.

**New Features**
- Added `check-no-jurisdiction.test.sh` with eight planted cases and a clean-tree control, wired as `test-no-jurisdiction` beside the gate.

<sup>Written for commit 8c4595fb382186c2f6734fa967a950af34103a73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

