### PR TITLE
The lead queue opens on what the seat may read, and no screen asks for a role again

### DIFF
--- a/backend/gates/frontendrolekeys_test.go
+++ b/backend/gates/frontendrolekeys_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The screens ask what a seat MAY DO, not which role it holds.
+//
+// /me carries the server's own answer — the object grants and the row scope it
+// computed from the stored policy — precisely so a screen never re-derives one
+// from role keys. A client that reads the keys instead is a second reading of
+// the policy, and the two disagree exactly where it matters: an operator edits
+// a seeded role's grants or its row scope (the role editor allows both), or an
+// installation adds a role of its own, and the server answers correctly while
+// the screen shows the wrong view.
+//
+// This is not hypothetical. The lead queue decided its opening view from
+// `roles.some(r => r === "admin" || "manager" || "management")` until #4728,
+// which is the shape this gate now refuses.
+//
+// The vocabulary is READ FROM THE SEEDED ROLES rather than typed here, so a
+// renamed or added role is covered without editing this file — a hard-coded
+// list would be a second copy of the thing it protects.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// capabilityModule is the one file allowed to read role keys. It holds the
+// two fixed-role helpers (useHoldsAdminRole, useHoldsOperatorSeat) that cover
+// authorities the RbacObject vocabulary does not name yet, and it documents
+// each as exceptional. Every other screen asks it, or asks useCan.
+const capabilityModule = "src/app/capability.ts"
+
+// roleKeyComparison matches a role key being COMPARED, not merely mentioned.
+//
+// Comparison and not presence, because the keys are legitimate vocabulary in
+// other roles: users-admin.tsx renders them as a typed picker, i18n names them,
+// and settings.tsx carries a navigation group that happens to be spelled
+// "admin". None of those decides an authorization question. What does is a key
+// tested against a value — which is what these three shapes are.
+func roleKeyComparisons(src string, keys []string) []string {
+	var found []string
+	for _, key := range keys {
+		for _, shape := range []*regexp.Regexp{
+			// role === "admin", "admin" === role, and the !== halves. The left
+			// operand is captured so a comparison about something ELSE spelled
+			// with the same word can be told apart below.
+			regexp.MustCompile(`(\w*)\s*[!=]==\s*"` + key + `"`),
+			regexp.MustCompile(`"` + key + `"\s*[!=]==\s*(\w*)`),
+			// roles.includes("admin"); .some(r => r === "admin") is caught above.
+			regexp.MustCompile(`(\w*)\.includes\(\s*"` + key + `"\s*\)`),
+		} {
+			for _, m := range shape.FindAllStringSubmatch(src, -1) {
+				if decidesAboutARole(m[1]) {
+					found = append(found, key)
+					break
+				}
+			}
+		}
+	}
+	return found
+}
+
+// decidesAboutARole says whether the compared operand is a PRINCIPAL's role.
+//
+// The seeded keys are ordinary English words, and two other vocabularies in
+// this tree spell one of them the same way: the settings navigation groups its
+// pages as "you" or "admin", and a buying committee seat can be a "champion".
+// Neither decides an authorization question, and failing them would teach the
+// next reader that this gate cries wolf.
+//
+// So the operand has to name the principal's roles. An unnamed operand — the
+// comparison is against a call, an index, a property chain — is treated as a
+// role decision, because that is the direction a census must fail in: an
+// under-recognizing scan reports PASS and nothing is there to notice.
+func decidesAboutARole(operand string) bool {
+	switch operand {
+	case "group", "kind", "type", "id", "tab", "mode", "variant", "status":
+		return false
+	}
+	return true
+}
+
+func TestNoScreenDecidesAuthorizationFromARoleKey(t *testing.T) {
+	t.Parallel()
+
+	keys := seededRoleKeyList(t)
+	if len(keys) == 0 {
+		t.Fatal("read no seeded role keys out of identity — the declaration this gate reads has moved")
+	}
+
+	// The gate must bite. A key every screen legitimately mentions but never
+	// compares would make this scan pass over a tree it never really read, so
+	// the shapes are pinned against text that must match and text that must not.
+	mustMatch := []string{
+		`role === "admin"`,
+		`session.roles.some((r) => r === "manager")`,
+		`roles.includes("ops")`,
+		`if (role !== "rep") {`,
+	}
+	for _, sample := range mustMatch {
+		if len(roleKeyComparisons(sample, keys)) == 0 {
+			t.Errorf("the scan does not recognize %q as a role comparison, so it would pass a screen that decides from one", sample)
+		}
+	}
+	mustNotMatch := []string{
+		`group: "admin"`, // settings navigation, not a role
+		`const ROLES: readonly Role[] = ["admin", "ops"]`, // the typed picker vocabulary
+		`t("role.admin")`,          // an i18n key
+		`seat.role === "champion"`, // a buying-committee role, a different vocabulary
+	}
+	for _, sample := range mustNotMatch {
+		if hits := roleKeyComparisons(sample, keys); len(hits) > 0 {
+			t.Errorf("the scan reads %q as a role comparison (%v), which would fail a screen that decides nothing", sample, hits)
+		}
+	}
+
+	scanned := 0
+	err := filepath.WalkDir("../frontend/src", func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".ts") && !strings.HasSuffix(name, ".tsx") {
+			return nil
+		}
+		// Tests and stories BUILD principals rather than decide about them: a
+		// fixture saying roles: ["admin"] is the input to the thing under test.
+		if strings.Contains(name, ".test.") || strings.Contains(name, ".stories.") {
+			return nil
+		}
+		rel, relErr := filepath.Rel("../frontend", path)
+		if relErr != nil {
+			return relErr
+		}
+		if filepath.ToSlash(rel) == capabilityModule {
+			return nil
+		}
+		src, readErr := os.ReadFile(path) // #nosec G304 -- a .ts file from walking the trusted source tree
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+		if hits := roleKeyComparisons(string(src), keys); len(hits) > 0 {
+			sort.Strings(hits)
+			t.Errorf("%s compares the role key(s) %v.\n"+
+				"A screen decides from what /me says the seat MAY DO — `useCan(object, action)` for an\n"+
+				"object grant, `authorization.row_scope` for the row question — never from the role the\n"+
+				"grant came from. The two disagree as soon as an operator edits a role or adds one.\n"+
+				"An authority the RbacObject vocabulary cannot name yet belongs in %s beside the other\n"+
+				"exceptions, with a comment saying why and what retires it.",
+				filepath.ToSlash(rel), hits, capabilityModule)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the frontend source: %v", err)
+	}
+	// A scan that read nothing reports PASS, which is the one way this gate
+	// could fail silently: the tree moved and nobody was told.
+	if scanned < 200 {
+		t.Fatalf("scanned only %d frontend sources — the tree has moved and this gate is reading the wrong place", scanned)
+	}
+}
+
+// seededRoleKeyList is seededRoleKeys as a stable slice, so the failure message
+// and the scan order do not depend on map iteration.
+func seededRoleKeyList(t *testing.T) []string {
+	t.Helper()
+	keys := make([]string, 0, 6)
+	for key := range seededRoleKeys(t) {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/backend/gates/frontendrolekeys_test.go
+++ b/backend/gates/frontendrolekeys_test.go
@@ -11,13 +11,12 @@ package gates
 // computed from the stored policy — precisely so a screen never re-derives one
 // from role keys. A client that reads the keys instead is a second reading of
 // the policy, and the two disagree exactly where it matters: an operator edits
-// a seeded role's grants or its row scope (the role editor allows both), or an
-// installation adds a role of its own, and the server answers correctly while
-// the screen shows the wrong view.
+// a seeded role's grants, or an installation adds a role of its own, and the
+// server answers correctly while the screen shows the wrong view.
 //
 // This is not hypothetical. The lead queue decided its opening view from
-// `roles.some(r => r === "admin" || "manager" || "management")` until #4728,
-// which is the shape this gate now refuses.
+// `roles.some(r => r === "admin" || "manager" || "management")` until the change
+// that added this gate, which is the shape it now refuses.
 //
 // The vocabulary is READ FROM THE SEEDED ROLES rather than typed here, so a
 // renamed or added role is covered without editing this file — a hard-coded
@@ -48,41 +47,102 @@ const capabilityModule = "src/app/capability.ts"
 func roleKeyComparisons(src string, keys []string) []string {
 	var found []string
 	for _, key := range keys {
-		for _, shape := range []*regexp.Regexp{
-			// role === "admin", "admin" === role, and the !== halves. The left
-			// operand is captured so a comparison about something ELSE spelled
-			// with the same word can be told apart below.
-			regexp.MustCompile(`(\w*)\s*[!=]==\s*"` + key + `"`),
-			regexp.MustCompile(`"` + key + `"\s*[!=]==\s*(\w*)`),
-			// roles.includes("admin"); .some(r => r === "admin") is caught above.
-			regexp.MustCompile(`(\w*)\.includes\(\s*"` + key + `"\s*\)`),
-		} {
-			for _, m := range shape.FindAllStringSubmatch(src, -1) {
-				if decidesAboutARole(m[1]) {
-					found = append(found, key)
-					break
-				}
-			}
+		if roleKeyIsDecidedOn(src, key) {
+			found = append(found, key)
 		}
 	}
 	return found
 }
 
+// roleKeyIsDecidedOn answers whether this source DECIDES on the key.
+//
+// The scan is textual, so the question is which spellings it can be sure about.
+// Two families:
+//
+// The QUOTED-COMPARISON family is a key compared where it is written —
+// `role === "admin"`, a `case "admin":`, a template literal, an indexOf, an
+// array of keys tested for membership. Each is a decision unless the compared
+// operand names something that is not a role, which is the second function
+// below.
+//
+// The BOUND-KEY family is a key bound to a name first — `const ADMIN = "admin"`
+// — and compared against that name later. The comparison carries no literal, so
+// it is found in two steps: bind the name, then look for that name being
+// compared against something that is not exempt. Binding alone is NOT the
+// finding, because a URL segment is also spelled "admin" (settingsrouting.ts's
+// LEGACY_ADMIN_SEGMENT), and failing a constant nobody decides a role with is
+// the noise that gets a gate ignored.
+func roleKeyIsDecidedOn(src, key string) bool {
+	quoted := "(?:\"" + key + "\"|'" + key + "'|`" + key + "`)"
+	for _, shape := range []*regexp.Regexp{
+		// role === "admin" / role == "admin", and the negated halves. The
+		// operand is captured so a comparison about something else spelled the
+		// same way can be told apart.
+		regexp.MustCompile(`(?:\w+[.?]+)*(\w*)\s*[!=]==?\s*` + quoted),
+		regexp.MustCompile(quoted + `\s*[!=]==?\s*(?:\w+[.?]+)*(\w*)`),
+		// roles.includes("admin"), roles.indexOf("admin"), and the same two
+		// with the array on the literal side: ["admin","ops"].includes(role).
+		regexp.MustCompile(`(\w*)\.(?:includes|indexOf)\(\s*` + quoted),
+		regexp.MustCompile(quoted + `[^)\n]*\]\s*\.(?:includes|indexOf)\(\s*(\w*)`),
+		// switch (role) { case "admin": — the operand is on the switch line, so
+		// it cannot be read here. A case arm naming a role key is a decision.
+		regexp.MustCompile(`case\s+` + quoted + `\s*:()`),
+	} {
+		for _, m := range shape.FindAllStringSubmatch(src, -1) {
+			if decidesAboutARole(m[len(m)-1]) {
+				return true
+			}
+		}
+	}
+	return boundKeyIsComparedOn(src, quoted)
+}
+
+// boundKeyIsComparedOn finds the two-step spelling: the key bound to a name,
+// then that name compared. Both halves are required — the binding says which
+// name to look for, and the comparison says the name decides something.
+func boundKeyIsComparedOn(src, quoted string) bool {
+	binding := regexp.MustCompile(`(?:const|let|var)\s+(\w+)\s*(?::[^=\n]+)?=\s*` + quoted + `\s*[;,\n]`)
+	for _, bound := range binding.FindAllStringSubmatch(src, -1) {
+		name := bound[1]
+		for _, shape := range []*regexp.Regexp{
+			regexp.MustCompile(`(?:\w+[.?]+)*(\w*)\s*[!=]==?\s*` + name + `\b`),
+			regexp.MustCompile(`\b` + name + `\s*[!=]==?\s*(?:\w+[.?]+)*(\w*)`),
+			regexp.MustCompile(`(\w*)\.(?:includes|indexOf)\(\s*` + name + `\s*\)`),
+		} {
+			for _, m := range shape.FindAllStringSubmatch(src, -1) {
+				if decidesAboutARole(m[len(m)-1]) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // decidesAboutARole says whether the compared operand is a PRINCIPAL's role.
 //
-// The seeded keys are ordinary English words, and two other vocabularies in
-// this tree spell one of them the same way: the settings navigation groups its
-// pages as "you" or "admin", and a buying committee seat can be a "champion".
-// Neither decides an authorization question, and failing them would teach the
-// next reader that this gate cries wolf.
+// The seeded keys are ordinary English words, and another vocabulary in this
+// tree spells one of them the same way: the settings navigation groups its
+// pages as "you" or "admin" (settingsnav.tsx). That comparison decides which
+// heading a settings page sits under and no authorization question, and failing
+// it would teach the next reader that this gate cries wolf.
 //
-// So the operand has to name the principal's roles. An unnamed operand — the
-// comparison is against a call, an index, a property chain — is treated as a
-// role decision, because that is the direction a census must fail in: an
-// under-recognizing scan reports PASS and nothing is there to notice.
+// So ONE name is exempt, and it is the one the tree actually uses. The list is
+// deliberately not a catalogue of plausible discriminators: every name added
+// here is a name a role decision can hide behind, and `kind => kind === "admin"`
+// inside a roles.some() is a real decision that an over-broad list would miss.
+// An unnamed operand — the comparison is against a call, an index, a property
+// chain, or a case arm — is treated as a role decision, because that is the
+// direction a census must fail in: an under-recognizing scan reports PASS and
+// nothing is there to notice.
 func decidesAboutARole(operand string) bool {
 	switch operand {
-	case "group", "kind", "type", "id", "tab", "mode", "variant", "status":
+	// The settings navigation's group ("you" or "admin"), and a route segment
+	// compared against route.id. Both are spelled like a role and decide a
+	// PAGE, not an authority. These two names are the tree's real collisions;
+	// the list is deliberately short, because every name on it is a name a role
+	// decision could hide behind.
+	case "group", "id":
 		return false
 	}
 	return true
@@ -104,21 +164,41 @@ func TestNoScreenDecidesAuthorizationFromARoleKey(t *testing.T) {
 		`session.roles.some((r) => r === "manager")`,
 		`roles.includes("ops")`,
 		`if (role !== "rep") {`,
+		// The spellings a quoted-comparison-only scan would miss. Each one is a
+		// real way to write the prohibited decision, and each was green against
+		// an earlier version of this gate.
+		"const ADMIN = \"admin\";\nif (role === ADMIN) {",
+		"switch (role) {\n      case \"management\":",
+		"role == \"admin\"",
+		"role === `admin`",
+		`roles.indexOf("admin") >= 0`,
+		`["admin", "manager"].includes(role)`,
+		// A callback parameter is an ordinary name, so naming it after a
+		// discriminator must not buy an exemption.
+		`session.roles.some((kind) => kind === "admin")`,
 	}
 	for _, sample := range mustMatch {
 		if len(roleKeyComparisons(sample, keys)) == 0 {
-			t.Errorf("the scan does not recognize %q as a role comparison, so it would pass a screen that decides from one", sample)
+			t.Errorf("the scan does not recognize %q as a role decision, so it would pass a screen that makes one", sample)
 		}
 	}
 	mustNotMatch := []string{
-		`group: "admin"`, // settings navigation, not a role
-		`const ROLES: readonly Role[] = ["admin", "ops"]`, // the typed picker vocabulary
-		`t("role.admin")`,          // an i18n key
-		`seat.role === "champion"`, // a buying-committee role, a different vocabulary
+		// The settings navigation group: the one real collision in this tree.
+		`group: "admin"`,
+		`entry?.group === "admin"`,
+		`entry.group !== "admin" || adminTabVisible[entry.id]`,
+		// A key rendered rather than decided on. The picker vocabulary in
+		// users-admin.tsx is this shape, and it is type-checked against the
+		// contract enum, so a retired key there is a compile error already.
+		`const ROLES: readonly Role[] = ["admin", "ops"]`,
+		`t("role.admin")`,
+		// A URL segment that happens to be spelled like a role, bound and then
+		// compared against a ROUTE. settingsrouting.ts is exactly this.
+		"const LEGACY_ADMIN_SEGMENT = \"admin\";\nif (route.id === LEGACY_ADMIN_SEGMENT) {",
 	}
 	for _, sample := range mustNotMatch {
 		if hits := roleKeyComparisons(sample, keys); len(hits) > 0 {
-			t.Errorf("the scan reads %q as a role comparison (%v), which would fail a screen that decides nothing", sample, hits)
+			t.Errorf("the scan reads %q as a role decision (%v), which would fail a screen that decides nothing", sample, hits)
 		}
 	}
 
@@ -171,8 +251,10 @@ func TestNoScreenDecidesAuthorizationFromARoleKey(t *testing.T) {
 	}
 	// A scan that read nothing reports PASS, which is the one way this gate
 	// could fail silently: the tree moved and nobody was told.
-	if scanned < 200 {
-		t.Fatalf("scanned only %d frontend sources — the tree has moved and this gate is reading the wrong place", scanned)
+	if scanned < 600 {
+		t.Fatalf("scanned only %d frontend sources, of roughly 690 eligible — the tree has moved and this gate "+
+			"is reading part of it. The floor is close to the real count on purpose: losing one directory "+
+			"has to fail here rather than pass quietly", scanned)
 	}
 }
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (93)
+## Parity (94)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -67,6 +67,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendoauthoutcomes_test.go` | H3 | The OAuth landing outcome is one vocabulary spelled on both sides of a redirect: the api puts it in the URL the provider sends a human back to, and the SPA turns it into the sentence that human reads. |
 | `frontendprimaryemail_test.go` | H3 | The browser and the server pick the SAME address to write to, or the address a composer prefills and the address a draft is written to differ on a record where the reader can see both. |
 | `frontendprofilevocabulary_test.go` | H3 | The browser spells the company-profile vocabulary five more times, and every one of them fails SILENTLY when it falls short. |
+| `frontendrolekeys_test.go` | H2 | The screens ask what a seat MAY DO, not which role it holds. |
 | `frontendrowtagcap_test.go` | H3 | The browser and the server must agree on how many tags one LIST ROW carries, or the chip strip's "+N" counts a number nobody has. |
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -197,14 +197,17 @@ export function LeadsScreen() {
         {(session) => (
           <LeadsWorkbench
             viewerId={session.user.id}
-            // A seat that reads beyond its own records opens on every lead —
-            // they run the queue; a seat scoped to its own opens on those.
+            // A seat scoped past its own records opens on every lead — they run
+            // the queue; a seat scoped to its own opens on those.
             //
-            // The ROW SCOPE the server computed, not the role keys it came
-            // from. Those keys were a second reading of the same policy, and a
-            // custom role — or a seeded one whose scope an operator edits, which
-            // the role editor allows — would open the wrong view while the
-            // server answered correctly.
+            // The opening FILTER, not a permission: every seat holding the lead
+            // grant may read any lead (auth/tableclass.go), so this decides
+            // which view the queue starts in and nothing about what it may
+            // fetch. The row scope the server computed, though, rather than the
+            // role keys it came from — those were a second reading of the same
+            // policy, and a custom role, or a seeded role whose grants an
+            // operator edits, opens the wrong view while the server answers
+            // correctly.
             //
             // Written as the POSITIVE test, so an absent authorization block
             // opens on "mine". `!== "own"` would read a missing answer as

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -197,12 +197,23 @@ export function LeadsScreen() {
         {(session) => (
           <LeadsWorkbench
             viewerId={session.user.id}
-            // An admin or manager opens on every lead — they run the queue; a
-            // rep opens on their own.
-            opensOnAll={session.roles.some(
-              (role) =>
-                role === "admin" || role === "manager" || role === "management",
-            )}
+            // A seat that reads beyond its own records opens on every lead —
+            // they run the queue; a seat scoped to its own opens on those.
+            //
+            // The ROW SCOPE the server computed, not the role keys it came
+            // from. Those keys were a second reading of the same policy, and a
+            // custom role — or a seeded one whose scope an operator edits, which
+            // the role editor allows — would open the wrong view while the
+            // server answered correctly.
+            //
+            // Written as the POSITIVE test, so an absent authorization block
+            // opens on "mine". `!== "own"` would read a missing answer as
+            // permission to open on everything, which is the wrong direction to
+            // be wrong in — and the block is optional on this response.
+            opensOnAll={
+              session.authorization?.row_scope === "team" ||
+              session.authorization?.row_scope === "all"
+            }
           />
         )}
       </QueryGate>

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -194,8 +194,9 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
           if (request.url.endsWith("/v1/me")) {
             return jsonResponse({
               user: { id: "u-9", display_name: "Me" },
-              // Deliberately the role that USED to decide this, set opposite to
-              // the row scope under test wherever the two could disagree.
+              // Deliberately the role that USED to decide this. It says "open
+              // wide" in every case below, so the two narrow arms fail if
+              // anything still reads the role instead of the scope.
               roles: ["admin"],
               teams: [],
               ...(authorization ? { authorization } : {}),
@@ -229,6 +230,15 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
       const url = await leadRequestFor({
         seat_type: "full",
         row_scope: "team",
+        objects,
+      });
+      expect(url).not.toContain("owner_id=");
+    });
+
+    it("a seat scoped to the whole installation asks for every lead", async () => {
+      const url = await leadRequestFor({
+        seat_type: "full",
+        row_scope: "all",
         objects,
       });
       expect(url).not.toContain("owner_id=");

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -174,6 +174,75 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     expect(screen.queryByText(/typed by a person/i)).toBeNull();
   });
 
+  // The queue opens on the seat's OWN leads or on every lead, and which one is
+  // the server's row scope rather than the caller's role keys. The screen used
+  // to read `roles` for this, which is a second reading of the same policy: a
+  // custom role, or a seeded role whose scope an operator edits, opened the
+  // wrong view while the server answered correctly.
+  //
+  // The assertion is the request the list actually makes, because that is where
+  // the filter lands — a rendered row count would pass for a screen that asked
+  // for everything and happened to be handed one lead.
+  describe("the queue's opening view follows the row scope, not the role", () => {
+    const leadRequestFor = async (
+      authorization: Record<string, unknown> | undefined,
+    ) => {
+      const asked: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (request: Request) => {
+          if (request.url.endsWith("/v1/me")) {
+            return jsonResponse({
+              user: { id: "u-9", display_name: "Me" },
+              // Deliberately the role that USED to decide this, set opposite to
+              // the row scope under test wherever the two could disagree.
+              roles: ["admin"],
+              teams: [],
+              ...(authorization ? { authorization } : {}),
+            });
+          }
+          // The LIST query specifically: the screen also asks /leads/settings,
+          // which carries no filter and would satisfy the assertions vacuously.
+          if (/\/v1\/leads\?/.test(request.url)) {
+            asked.push(request.url);
+          }
+          return jsonResponse({ data: [lead], page: { next_cursor: null } });
+        }),
+      );
+      render(<LeadsScreen />);
+      await waitFor(() => expect(asked.length).toBeGreaterThan(0));
+      return asked[0];
+    };
+
+    const objects = { lead: { read: true } };
+
+    it("a seat scoped to its own records asks for its own", async () => {
+      const url = await leadRequestFor({
+        seat_type: "full",
+        row_scope: "own",
+        objects,
+      });
+      expect(url).toContain("owner_id=u-9");
+    });
+
+    it("a seat scoped to its team asks for every lead", async () => {
+      const url = await leadRequestFor({
+        seat_type: "full",
+        row_scope: "team",
+        objects,
+      });
+      expect(url).not.toContain("owner_id=");
+    });
+
+    // Fail closed: a response carrying no authorization block at all is the
+    // narrow view, never the wide one. `row_scope !== "own"` would read a
+    // missing answer as permission to open on everything.
+    it("a response with no authorization block asks for its own", async () => {
+      const url = await leadRequestFor(undefined);
+      expect(url).toContain("owner_id=u-9");
+    });
+  });
+
   it("a lead row navigates to the LEAD detail, not the person screen", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
The lead queue decided its opening view from role keys — `admin`, `manager` or `management` opened on every lead, everyone else on their own. That is the row scope, read a second time and from the wrong place. `/me` already carries the server's own answer, so the two disagree the moment an operator edits a seeded role's scope (the role editor allows it) or an installation adds a role of its own.

## What changed

- **`leads.list.tsx`** reads `authorization.row_scope`. Written as the positive test against `"team"` and `"all"`, so a response with no authorization block opens on "mine" — a missing answer must not read as permission to open on everything.
- **A new gate**, `backend/gates/frontendrolekeys_test.go`, scans `frontend/src` for a seeded role key being *compared*. Its vocabulary comes from the roles identity seeds, not a list typed into the test.

The hard part is telling a role decision from an ordinary word. The settings navigation groups pages as `"you" | "admin"`, and a buying-committee seat can be a `"champion"`. Neither decides authorization. So the compared operand has to name the principal's roles, and an operand the scan cannot name is treated as a role decision — an under-recognizing census reports PASS with nothing to notice. Both directions are pinned with fixtures.

## Tests

Three cover the opening view, asserting the request the list makes rather than the rows it renders — a page that asked for everything and was handed one lead would pass a row count. Mutation-checked by restoring the role literal: the gate names all three keys and two of the three tests fail.

`capability.ts` keeps its two documented fixed-role helpers and is the gate's one allowed reader.

Found by a Codex audit of the access-rights model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lead queue's opening view to follow the server's row scope instead of role keys, so custom or edited roles no longer open the wrong view.

- The queue reads `authorization.row_scope` from `/me`, written as a positive test against `"team"` and `"all"` so a missing block opens on "mine".
- A new parity gate fails any screen that decides authorization from a compared role key, covering bound constants, switch cases, template literals, loose equality, and membership tests; its vocabulary comes from the seeded roles, not a hard-coded list, and only the two real collisions (`group` and `id`) are exempt.
- Three tests assert the list request the screen makes, not rendered rows, so a page that asked for everything but was handed one lead would fail.

<sup>Written for commit af408992e62d46ccb38d30adfa4af45a31c65a83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

