### PR TITLE
A reconnected mailbox picks its truncated import back up

### DIFF
--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -176,6 +176,16 @@ func (r *Registry) StartBackfill(ctx context.Context, provider string, userID id
 		if err != nil {
 			return err
 		}
+		// The connection row first, before anything reads capture_backfill.
+		// uq_capture_backfill_live is what stops a second live run, and the
+		// violation it raises is answerable HERE (ErrBackfillRunning) and not on
+		// the other path that can create one: reviveTruncatedBackfillTx runs
+		// inside a successful sync's own transaction, where a failed statement
+		// takes the sync down with it. Serializing on the connection is what
+		// keeps that from being a race somebody loses.
+		if err := lockConnectionTx(ctx, tx, connID); err != nil {
+			return err
+		}
 		// Widen-only protects a mailbox from re-importing a window narrower than
 		// one it already has: the narrower run would look like a fresh import and
 		// end with less history than before. That reasoning is about the ACCOUNT,

--- a/backend/internal/modules/capture/backfilllockorder_test.go
+++ b/backend/internal/modules/capture/backfilllockorder_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// Two paths can give a connection a live backfill, and they take the connection
+// row before either of them looks at capture_backfill.
+//
+// `uq_capture_backfill_live` admits one live run per connection, and a
+// predicate alone does not hold that: a human pressing Import while a sync
+// commits passes its own NOT EXISTS at the same instant, and one of the two
+// takes the unique violation. StartBackfill can answer that — it returns
+// ErrBackfillRunning — and the revival cannot, because the statement that fails
+// is inside somebody's successful sync transaction, which then rolls back and
+// takes a working mailbox's sync down with it.
+//
+// So the obligation is an ORDER, and an order is exactly what a later edit
+// loses without anything failing: the race is rare, the tests pass, and the
+// mailbox that breaks is somebody else's. This reads the package's own source
+// and requires the lock to come first.
+//
+// Why not a contention test instead: what a running database would prove is
+// that FOR UPDATE blocks, which is Postgres's contract and not ours. What can
+// regress here is forgetting to take it, and that is a property of the text.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// liveRunWrites are the SQL fragments that give a connection a live run. Both
+// are matched as substrings of a statement literal, because the two writers
+// spell the same act differently — one inserts a queued row, the other moves an
+// errored one back to queued.
+var liveRunWrites = []string{
+	"INSERT INTO capture_backfill (",
+	"UPDATE capture_backfill SET status = 'queued'",
+}
+
+const connectionLock = "lockConnectionTx"
+
+func TestEveryWriterOfALiveBackfillLocksTheConnectionFirst(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	judged := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, name, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			writeAt, ok := firstLiveRunWrite(fn)
+			if !ok {
+				continue
+			}
+			judged++
+			lockAt, locked := firstCallTo(fn, connectionLock)
+			switch {
+			case !locked:
+				t.Errorf("%s: %s gives a connection a live backfill and never takes %s. "+
+					"uq_capture_backfill_live is the only thing stopping a second live run, and the "+
+					"violation it raises is answerable on one of these paths and not the other",
+					filepath.Join("internal/modules/capture", name), fn.Name.Name, connectionLock)
+			case lockAt > writeAt:
+				t.Errorf("%s: %s takes %s AFTER it has already read or written capture_backfill. "+
+					"A lock taken after the decision serializes nothing — both transactions have "+
+					"already seen a connection with no live run",
+					filepath.Join("internal/modules/capture", name), fn.Name.Name, connectionLock)
+			}
+		}
+	}
+	// A census that can fail short has already failed: a rewritten statement
+	// leaves this walking no subjects and reporting a clean package.
+	if judged < len(liveRunWrites) {
+		t.Fatalf("only %d writer(s) of a live backfill found, want at least %d — the statements were "+
+			"rewritten and this gate is judging nothing. Teach liveRunWrites their new spelling",
+			judged, len(liveRunWrites))
+	}
+}
+
+// firstLiveRunWrite is the position of the earliest statement in this function
+// that gives a connection a live run.
+func firstLiveRunWrite(fn *ast.FuncDecl) (token.Pos, bool) {
+	first, found := token.Pos(0), false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		// The literal's STRING, never its source text: a statement written in
+		// double quotes reaches a source-text reader as its escapes, and the
+		// fragments below would then match nothing on the very shape this is
+		// looking for.
+		expr, isExpr := node.(ast.Expr)
+		if !isExpr {
+			return true
+		}
+		text, isString := gatekit.LiteralText(expr)
+		if !isString {
+			return true
+		}
+		for _, fragment := range liveRunWrites {
+			if !strings.Contains(text, fragment) {
+				continue
+			}
+			if !found || node.Pos() < first {
+				first, found = node.Pos(), true
+			}
+		}
+		return true
+	})
+	return first, found
+}
+
+// firstCallTo is the position of the earliest call to the named function.
+func firstCallTo(fn *ast.FuncDecl, name string) (token.Pos, bool) {
+	first, found := token.Pos(0), false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		ident, isIdent := call.Fun.(*ast.Ident)
+		if !isIdent || ident.Name != name {
+			return true
+		}
+		if !found || call.Pos() < first {
+			first, found = call.Pos(), true
+		}
+		return true
+	})
+	return first, found
+}

--- a/backend/internal/modules/capture/backfilllockorder_test.go
+++ b/backend/internal/modules/capture/backfilllockorder_test.go
@@ -46,6 +46,13 @@ var liveRunWrites = []string{
 
 const connectionLock = "lockConnectionTx"
 
+// backfillTable is what the lock must come before — ANY statement naming it,
+// not only the write. StartBackfill reads capture_backfill for the widen-only
+// rule before it inserts, and that read is part of the decision: a lock taken
+// between the two would serialize the insert while both transactions had
+// already seen the same page of history.
+const backfillTable = "capture_backfill"
+
 func TestEveryWriterOfALiveBackfillLocksTheConnectionFirst(t *testing.T) {
 	t.Parallel()
 	fset := token.NewFileSet()
@@ -68,11 +75,15 @@ func TestEveryWriterOfALiveBackfillLocksTheConnectionFirst(t *testing.T) {
 			if !ok || fn.Body == nil {
 				continue
 			}
-			writeAt, ok := firstLiveRunWrite(fn)
-			if !ok {
+			if !givesALiveRun(fn) {
 				continue
 			}
 			judged++
+			touchAt, touches := firstStatementNaming(fn, backfillTable)
+			if !touches {
+				t.Fatalf("%s: %s was judged a live-run writer and yet names no %s statement — the "+
+					"two readers of this file's source disagree", filepath.Join("internal/modules/capture", name), fn.Name.Name, backfillTable)
+			}
 			lockAt, locked := firstCallTo(fn, connectionLock)
 			switch {
 			case !locked:
@@ -80,7 +91,7 @@ func TestEveryWriterOfALiveBackfillLocksTheConnectionFirst(t *testing.T) {
 					"uq_capture_backfill_live is the only thing stopping a second live run, and the "+
 					"violation it raises is answerable on one of these paths and not the other",
 					filepath.Join("internal/modules/capture", name), fn.Name.Name, connectionLock)
-			case lockAt > writeAt:
+			case lockAt > touchAt:
 				t.Errorf("%s: %s takes %s AFTER it has already read or written capture_backfill. "+
 					"A lock taken after the decision serializes nothing — both transactions have "+
 					"already seen a connection with no live run",
@@ -97,9 +108,20 @@ func TestEveryWriterOfALiveBackfillLocksTheConnectionFirst(t *testing.T) {
 	}
 }
 
-// firstLiveRunWrite is the position of the earliest statement in this function
-// that gives a connection a live run.
-func firstLiveRunWrite(fn *ast.FuncDecl) (token.Pos, bool) {
+// givesALiveRun answers whether this function is one of the two that can put a
+// connection into the state uq_capture_backfill_live admits one of.
+func givesALiveRun(fn *ast.FuncDecl) bool {
+	for _, fragment := range liveRunWrites {
+		if _, found := firstStatementNaming(fn, fragment); found {
+			return true
+		}
+	}
+	return false
+}
+
+// firstStatementNaming is the position of the earliest SQL literal in this
+// function containing the given text.
+func firstStatementNaming(fn *ast.FuncDecl, want string) (token.Pos, bool) {
 	first, found := token.Pos(0), false
 	ast.Inspect(fn.Body, func(node ast.Node) bool {
 		// The literal's STRING, never its source text: a statement written in
@@ -114,13 +136,11 @@ func firstLiveRunWrite(fn *ast.FuncDecl) (token.Pos, bool) {
 		if !isString {
 			return true
 		}
-		for _, fragment := range liveRunWrites {
-			if !strings.Contains(text, fragment) {
-				continue
-			}
-			if !found || node.Pos() < first {
-				first, found = node.Pos(), true
-			}
+		if !strings.Contains(text, want) {
+			return true
+		}
+		if !found || node.Pos() < first {
+			first, found = node.Pos(), true
 		}
 		return true
 	})

--- a/backend/internal/modules/capture/backfillresume_integration_test.go
+++ b/backend/internal/modules/capture/backfillresume_integration_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture_test
+
+// A truncated import is resumable, and a successful sync is what resumes it.
+//
+// The run that ends on a terminal fault keeps its cursor, so the mailbox never
+// has to be re-read from the top — but nothing used that cursor, and the run sat
+// at `error` forever. The commonest cause is a credential the operator then
+// fixes: rotating the connector's client app invalidates the grant mid-import,
+// the human reconnects, mail flows again, and the history import stays dead with
+// no sign that it is.
+//
+// These run on a real database because every assertion is about what a row is
+// after a write nobody mocked: the status the revival moved it to, the cap that
+// refused to move it, and the cursor it kept while doing so.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// truncatedRun leaves the fixture's connection holding a run that ended on a
+// terminal fault with its resume point intact — the state failBackfill leaves
+// behind. errClass is what ended it, which is what decides whether reconnecting
+// is the remedy.
+func truncatedRun(ctx context.Context, t *testing.T, errClass string) (connID, backfillID ids.UUID) {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("fixture context carries no actor")
+	}
+	if err := owner.QueryRow(ctx,
+		`SELECT id FROM capture_connection WHERE user_id = $1 AND provider = 'gmail'`,
+		actor.UserID).Scan(&connID); err != nil {
+		t.Fatalf("reading the fixture's connection: %v", err)
+	}
+	if err := owner.QueryRow(ctx, `
+		UPDATE capture_backfill
+		   SET status = 'error', last_error_class = $2, completed_at = now(),
+		       cursor = '{"page_token":"resume-here"}'
+		 WHERE connection_id = $1
+		 RETURNING id`, connID, errClass).Scan(&backfillID); err != nil {
+		t.Fatalf("truncating the run: %v", err)
+	}
+	return connID, backfillID
+}
+
+func runState(ctx context.Context, t *testing.T, backfillID ids.UUID) (status string, completedAt *string, cursor []byte) {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	if err := owner.QueryRow(ctx,
+		`SELECT status, completed_at::text, cursor FROM capture_backfill WHERE id = $1`,
+		backfillID).Scan(&status, &completedAt, &cursor); err != nil {
+		t.Fatalf("reading the run: %v", err)
+	}
+	return status, completedAt, cursor
+}
+
+// startFixtureBackfill puts a run on the fixture's connection. The enqueue is a
+// no-op because these tests are about the ROW's lifecycle; the reconcile pass
+// owns putting a job behind a live run, and asserting that here would be
+// asserting somebody else's contract.
+func startFixtureBackfill(ctx context.Context, t *testing.T, reg *capture.Registry) {
+	t.Helper()
+	actor, _ := principal.Actor(ctx)
+	if _, err := reg.StartBackfill(ctx, "gmail", ids.From[ids.UserKind](actor.UserID), 3, 100,
+		func(context.Context, pgx.Tx, ids.UUID) error { return nil }); err != nil {
+		t.Fatalf("StartBackfill: %v", err)
+	}
+}
+
+// The case the change exists for. The credential that ended the run has been
+// fixed — that is what a successful sync proves — so the run goes back to being
+// live and keeps the cursor it stopped on. Re-enqueueing it is the reconcile
+// pass's job, which already puts a job behind every live run.
+func TestASuccessfulSyncRevivesATruncatedImport(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	connectFixtureConnection(ctx, t, reg)
+	startFixtureBackfill(ctx, t, reg)
+	connID, backfillID := truncatedRun(ctx, t, "auth")
+
+	if err := reg.SyncOnce(ctx, connID); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	status, completedAt, cursor := runState(ctx, t, backfillID)
+	if status != "queued" {
+		t.Errorf("status = %q, want %q — a healthy connection is what makes the run live again", status, "queued")
+	}
+	if completedAt != nil {
+		t.Errorf("completed_at = %v, want NULL — a revived run has not completed", *completedAt)
+	}
+	if len(cursor) == 0 {
+		t.Error("the resume point was dropped; the mailbox would be re-read from the top and its counters inflated")
+	}
+}
+
+// Reconnecting answers a refused credential and nothing else. A run ended by our
+// own bug would be revived by every successful sync — one every couple of
+// minutes — so it is left where it is. This is the guard that keeps the revival
+// from becoming a loop, and it is why the class is the predicate rather than a
+// counter: `internal` does not become true again because a mailbox synced.
+func TestAFaultTheCredentialDidNotCauseIsNotRevived(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	connectFixtureConnection(ctx, t, reg)
+	startFixtureBackfill(ctx, t, reg)
+	connID, backfillID := truncatedRun(ctx, t, "internal")
+
+	if err := reg.SyncOnce(ctx, connID); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	if status, _, _ := runState(ctx, t, backfillID); status != "error" {
+		t.Errorf("status = %q, want %q — a sync succeeding says nothing about our own bug", status, "error")
+	}
+}
+
+// A run that never committed a page has no resume point, and reviving it would
+// re-page the window from the top — which the cursor reader refuses for the
+// reason it states: the counters would count the same messages twice. Starting
+// that mailbox over is a decision with a cost, so it stays the operator's.
+func TestARunWithNoResumePointIsNotRevived(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	connectFixtureConnection(ctx, t, reg)
+	startFixtureBackfill(ctx, t, reg)
+	connID, backfillID := truncatedRun(ctx, t, "auth")
+
+	owner, _ := setupCaptureDB(t)
+	if _, err := owner.Exec(ctx,
+		`UPDATE capture_backfill SET cursor = NULL WHERE id = $1`, backfillID); err != nil {
+		t.Fatalf("clearing the cursor: %v", err)
+	}
+
+	if err := reg.SyncOnce(ctx, connID); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	if status, _, _ := runState(ctx, t, backfillID); status != "error" {
+		t.Errorf("status = %q, want %q — with no cursor there is nothing to resume from", status, "error")
+	}
+}

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -12,6 +12,7 @@ package capture
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -79,8 +80,9 @@ func backoffDelay(consecutiveFailures int) time.Duration {
 }
 
 // recordSyncSuccess resets the ladder, paces the next sync one interval out,
-// and — the auto-recovery path — flips a degraded connection back to
-// connected. One success heals everything.
+// and — the auto-recovery path — flips a degraded connection back to connected
+// and revives an import this connection's own trouble truncated. One success
+// heals everything.
 func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID) error {
 	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		now := r.now()
@@ -100,11 +102,68 @@ func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID)
 			connectionID, r.syncInterval.Seconds(), now); err != nil {
 			return err
 		}
-		_, err := tx.Exec(ctx, `
+		if _, err := tx.Exec(ctx, `
 			UPDATE capture_connection SET status = 'connected'
-			WHERE id = $1 AND status = 'error' AND archived_at IS NULL`, connectionID)
-		return err
+			WHERE id = $1 AND status = 'error' AND archived_at IS NULL`, connectionID); err != nil {
+			return err
+		}
+		return reviveTruncatedBackfillTx(ctx, tx, connectionID)
 	})
+}
+
+// reviveTruncatedBackfillTx puts a truncated import back in the queue when the
+// connection it belongs to is working again.
+//
+// A run that ends on a terminal fault keeps its cursor, so the mailbox never has
+// to be re-read from the top — but nothing used that cursor, and the run sat at
+// `error` for good. The commonest cause is a credential the operator then fixes:
+// rotating the connector's client app invalidates the grant mid-import, the human
+// reconnects, mail flows again, and the history import stays dead with nothing
+// saying so. A successful sync is the proof that the cause is gone, which is why
+// the revival hangs off this write rather than a clock.
+//
+// It only moves the row. The reconcile pass already puts a paging job behind
+// every live run and decides nothing about which — so a revived run is a live
+// run, and that pass is what pages it. Nothing here reaches for a scheduler.
+//
+// Three guards, each of which is a way this could otherwise go wrong:
+//
+//   - Only a run the CREDENTIAL ended. `auth` is the one class whose remedy is a
+//     human reconnecting, and a sync succeeding on this connection is the proof
+//     they did — the same evidence, arriving on the same write, that flips the
+//     connection back to connected. That makes the revival self-limiting: while
+//     the grant is still refused no sync succeeds, so nothing revives. Every
+//     other class is left alone, because no reconnection answers it and retrying
+//     it on a two-minute sync interval would be a loop. The transient ladder is
+//     deliberately NOT spent here: a run ended by a revoked grant needs its
+//     human, not a retry, and that ladder measures something else.
+//   - A run with no cursor is left alone. Reviving it would re-page the window
+//     from the top and count the same messages twice, which backfillPageCursor
+//     refuses for that reason. Starting a mailbox over has a cost, so it stays
+//     the operator's decision.
+//   - Exactly one run, and only when no other is live. uq_capture_backfill_live
+//     admits one live run per connection, and this write runs inside the sync's
+//     own transaction — so a second live run would not merely fail the revival,
+//     it would fail the sync that triggered it and take a working mailbox down.
+func reviveTruncatedBackfillTx(ctx context.Context, tx pgx.Tx, connectionID ids.UUID) error {
+	_, err := tx.Exec(ctx, `
+		UPDATE capture_backfill SET status = 'queued', completed_at = NULL`+resetInflightProgress+`
+		 WHERE id = (
+		         SELECT id FROM capture_backfill
+		          WHERE connection_id = $1
+		            AND status = 'error'
+		            AND last_error_class = $2
+		            AND cursor IS NOT NULL
+		          ORDER BY started_at DESC
+		          LIMIT 1)
+		   AND NOT EXISTS (
+		         SELECT 1 FROM capture_backfill
+		          WHERE connection_id = $1 AND status IN ('queued','running'))`,
+		connectionID, string(classAuth))
+	if err != nil {
+		return fmt.Errorf("capture: reviving a truncated backfill: %w", err)
+	}
+	return nil
 }
 
 // recordSyncFailure classifies, schedules the retry, and degrades — never

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -145,7 +145,18 @@ func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID)
 //     admits one live run per connection, and this write runs inside the sync's
 //     own transaction — so a second live run would not merely fail the revival,
 //     it would fail the sync that triggered it and take a working mailbox down.
+//
+// The last guard is a predicate, and a predicate alone does not hold it. A
+// human pressing Import while this sync commits passes its own NOT EXISTS at
+// the same instant, and the loser of that race takes the unique violation —
+// which StartBackfill answers with ErrBackfillRunning and this path cannot
+// answer at all, because the statement that fails is inside somebody's
+// successful sync. So both paths take the connection row first, in that order,
+// and the race becomes a wait.
 func reviveTruncatedBackfillTx(ctx context.Context, tx pgx.Tx, connectionID ids.UUID) error {
+	if err := lockConnectionTx(ctx, tx, connectionID); err != nil {
+		return err
+	}
 	_, err := tx.Exec(ctx, `
 		UPDATE capture_backfill SET status = 'queued', completed_at = NULL`+resetInflightProgress+`
 		 WHERE id = (
@@ -162,6 +173,30 @@ func reviveTruncatedBackfillTx(ctx context.Context, tx pgx.Tx, connectionID ids.
 		connectionID, string(classAuth))
 	if err != nil {
 		return fmt.Errorf("capture: reviving a truncated backfill: %w", err)
+	}
+	return nil
+}
+
+// lockConnectionTx takes the connection row for the rest of the transaction, so
+// that two paths deciding whether this connection may have a live backfill
+// decide one at a time.
+//
+// The connection rather than the runs: there is no row to lock for a run that
+// does not exist yet, which is exactly the case the insert and the revival can
+// collide on. Both take it BEFORE reading capture_backfill, so the order is the
+// same on both paths and neither can wait on the other.
+//
+// A connection that is gone locks nothing and the caller proceeds: the writes
+// behind this are all keyed on the connection id, so they simply match no rows.
+func lockConnectionTx(ctx context.Context, tx pgx.Tx, connectionID ids.UUID) error {
+	var locked int
+	err := tx.QueryRow(ctx,
+		`SELECT 1 FROM capture_connection WHERE id = $1 FOR UPDATE`, connectionID).Scan(&locked)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("capture: locking the connection: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #4646.

A backfill that ends on a terminal fault keeps its cursor, so the mailbox never has to be re-read from the top. Nothing used that cursor. The run sat at `error` for good.

The commonest way in is a credential the operator then fixes. Rotating the connector's Google client app invalidates the grant mid-import; the human reconnects, mail flows again, and the history import stays dead with nothing anywhere saying so — the connection reads `connected` and its sync state shows a recent success, because incremental sync is unaffected.

## What changes

A successful sync is the proof the cause is gone, so the revival hangs off that write rather than a clock — beside the flip that already returns a degraded connection to `connected`. "One success heals everything" now heals one more thing.

It only moves the row. The reconcile pass already puts a paging job behind every live run and deliberately decides nothing about which, so a revived run is simply a live run again and that pass pages it. Nothing here reaches for a scheduler.

## The three guards

**Only a run `auth` ended.** That is the one class whose remedy is a human reconnecting, and a sync succeeding on the connection is the proof they did — the same evidence, on the same write, that un-degrades the connection. This makes the revival *self-limiting* rather than counter-bounded: while the grant is still refused no sync succeeds, so nothing revives. Every other class is left where it is. `internal` does not become true again because a mailbox synced, and retrying it on a two-minute sync interval would be a loop.

**A run with no cursor is left alone.** Reviving it would re-page the window from the top and count the same messages twice, which `backfillPageCursor` already refuses for exactly that reason. Starting a mailbox over has a cost, so it stays the operator's decision.

**One run, and only when no other is live.** `uq_capture_backfill_live` admits one live run per connection, and this write shares the sync's transaction — so a second live run would not merely fail the revival, it would fail the sync that triggered it and take a working mailbox down.

## An invariant this first broke

The first cut bounded revivals by spending `consecutive_failures`, and had `failBackfill` count a terminal fault onto that ladder. `TestBackfillEndsOnAFaultNoRetryCanFix` caught it: *"consecutive_failures = 1, want 0 — the ladder is for transients only"*.

That test is right, and it produced a better design. A run ended by a revoked grant needs its human, not a retry, and the transient ladder measures something else entirely. Keying on the class instead removed the counter, the ladder change and the need to export a constant — and states plainly *why* reviving is safe rather than merely how often. That path is reverted in full; the diff is one file plus its tests.

## Checks

`make check-backend` green (`BACKEND_EXIT=0`, 15m12s). `craft static --strict`: 0 blocker / 0 major / 0 minor. Integration lane green on both affected packages — `internal/modules/capture` and `internal/compose/integration/capture`, the latter being the one that caught the invariant above.

New tests fail before the change and pass after: the revival itself, a non-credential fault that must not revive, and a run with no resume point that must not revive.

## Note on the two mailboxes already stuck

One ended `auth` and will resume on its next successful sync once this ships. The other ended `internal` — the poison-record fault fixed in #4664 — and deliberately will not: its cause was our bug, not a credential, so it needs a fresh import rather than a resume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Truncated imports can now automatically resume after a connection successfully recovers from an authentication failure.
  - Imports without a saved resume point, or those affected by internal errors, remain in an error state for appropriate follow-up.
  - Existing queued or running imports are not interrupted when recovery processing occurs.
  - Concurrent import and connection-recovery actions are handled safely, preventing duplicate or conflicting import states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->