### PR TITLE
Five patterns that hang a tab on a long enough string, and the accept sets stay identical

### DIFF
--- a/docs/reference/sonarcloud-deviations.md
+++ b/docs/reference/sonarcloud-deviations.md
@@ -40,3 +40,75 @@ the same call that produced the closure. A caller that discards the closure is
 still a caller with no shutdown, and the tests are what say otherwise —
 `TestJoinCancelsTheLanesAndWaitsForThem` covers the cancel and the wait,
 `TestJoinReportsALaneThatDoesNotStop` the bounded overrun.
+
+## The accessibility rules, on a table and two menus that are already correct
+
+Thirteen findings across `frontend/src/design-system/` and
+`frontend/src/app/account.tsx` — `typescript:S6825`, `S6843`, `S6845`, `S6848`
+and `S6852`. They stay open together because they are one mistake made five
+ways: each rule states a default posture that the code deliberately departs
+from, for a reason WCAG itself gives, and applying the rule would take
+accessibility away rather than add it. Six of the sites already carry a
+`biome-ignore` naming the reason, written before SonarCloud ever ran.
+
+**`ListTable`'s explicit roles are load-bearing (`S6843`, four sites).** The
+rule reads `role="cell"` on a `<td>` as an interactive element given a
+non-interactive role. A `<td>` is not interactive, and the role is not
+redundant: at 720px and below, `listtable.css` sets `display: block` and
+`display: flex` on `.lt-table`, `thead`, `tbody`, `tr`, `th` and `td`, which is
+exactly what strips a table of its implicit ARIA semantics. The explicit roles
+are what keep a phone list a table for a screen reader — the CSS says so where
+it does it, and `listtable.test.tsx` reads the rows and cells back by role.
+Removing them would break the phone table silently, with every test still green
+only if the roles were removed from the tests too.
+
+**The slack cell is a spacer, not a control (`S6825`, three sites).** The rule
+forbids `aria-hidden` on a focusable element. `<td className="lt-slack">` has no
+`tabindex` and is not an interactive element, so it is not focusable; hiding a
+layout spacer is what `aria-hidden` is for. The header row, every body row and
+the empty-state row's `colSpan` all account for the same extra column, so the
+table's geometry stays consistent with it hidden.
+
+**A scrollable region must be reachable (`S6845`, three sites).** The rule
+forbids `tabIndex` on a non-interactive element. WCAG 2.1.1 requires a
+scrollable region to be operable by keyboard, and axe's
+`scrollable-region-focusable` fails a scroller that is not — which is why
+`composed.tsx` and `trust.tsx` take the stop on the scroller itself. In
+`decisiondeck.tsx` the stop is what makes the four arrow-key verdicts reachable
+at all. Removing any of the three replaces a lint finding with a real
+accessibility failure, one the `uat` lane's axe pass would catch.
+
+**The Escape catcher is not a control (`S6848`).** The `<span>` in
+`inlinechoice.tsx` carries a `keydown` that only ever sees an Escape the `Select`
+inside it declined to claim. Giving it a role and a tab stop, which is what the
+rule asks for, would announce a control that does not exist and put a stop in
+the tab order that leads nowhere.
+
+**The menus use a roving tabindex (`S6852`, two sites).** The rule wants the
+`role="menu"` container focusable. In both menus focus lives on the items —
+each `menuitem` carries `tabIndex={active ? 0 : -1}` — which is the WAI-ARIA
+authoring practice for a menu. The container is never focused: its ref is read
+only for `contains(document.activeElement)`, and the menu focuses a row on open.
+A `tabIndex` on the container would be either a second tab stop in front of the
+item that already has one, or an attribute nothing uses.
+
+## typescript:S8786 — `stripEveryKeyTag` in `frontend/src/screens/projectrecord.ts`
+
+**What the rule wants.** ` ?\[[^\]]*\] ?` backtracks super-linearly. It does:
+a subject of 20 000 unclosed `[` takes 592 ms, and four times that for each
+doubling. The rule is right about the shape.
+
+**Why this one is not rewritten with the others.** Five sibling findings were
+fixed in the same change, each by a rewrite proven identical on every string up
+to length five. This one has no such rewrite. The tempting fix — excluding `[`
+from the inner class, ` ?\[[^\][]*\] ?` — is linear and silently changes which
+tags are stripped: on `Fix [old[PROJ-1] thing` the current pattern reads the tag
+as `old[PROJ-1`, is not key-shaped, and leaves the subject byte for byte, while
+the "fixed" one finds `[PROJ-1]` inside it and strips a tag this module never
+wrote. The function's contract is that the rep's own text comes back unchanged.
+
+**What bounds it instead.** The input is a mail subject, which RFC 5322 lines
+cap near 1 000 bytes; at that length the pattern costs microseconds. If a
+subject ever arrives unbounded, the fix is a forward scan with `indexOf` — the
+first `]` after a `[` is what the pattern means — and not the one-character
+class change.

--- a/e2e/llm/check.py
+++ b/e2e/llm/check.py
@@ -81,7 +81,9 @@ def parse_scenario(path):
             continue
         seq = None
 
-        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        # No \s* after the colon: the value is stripped two lines down, so it
+        # only made the pattern ambiguous about which of the two ate the spaces.
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*):(.*)$", line)
         if not m:
             continue
         key, value = m.group(1), m.group(2).strip()

--- a/frontend/src/format/emailtext.ts
+++ b/frontend/src/format/emailtext.ts
@@ -120,7 +120,10 @@ function isSignOff(line: string): boolean {
   const normalized = line
     .trim()
     .toLowerCase()
-    .replace(/[,.!]+$/, "");
+    // The lookbehind is what keeps this linear. Without it the engine retries
+    // the trailing run from every position in the line, which is quadratic on a
+    // line that is all punctuation — and an inbound mail body is not ours.
+    .replace(/(?<![,.!])[,.!]+$/, "");
   if (!normalized) {
     return false;
   }

--- a/frontend/src/screens/aiexport.tsx
+++ b/frontend/src/screens/aiexport.tsx
@@ -62,10 +62,14 @@ function blockScalar(text: string): string {
 }
 
 function scenarioSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, "_")
-    .replaceAll(/^_+|_+$/g, "");
+  return (
+    name
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, "_")
+      // The lookbehind keeps the trailing run from being retried from every
+      // underscore in it, which is quadratic on a name that is mostly separators.
+      .replaceAll(/^_+|(?<!_)_+$/g, "")
+  );
 }
 
 export function scenarioYaml(call: AiCallDetail, name: string): string {

--- a/frontend/src/screens/historyvalues.ts
+++ b/frontend/src/screens/historyvalues.ts
@@ -47,7 +47,11 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // A path or URI: at least one "/" separating two non-blank segments. Checked
 // after the timestamp rule (its offset can carry digits and colons but never
 // a slash) so a value never matches both.
-const PATH_LIKE = /^\S*\/\S+$/;
+// The head excludes "/" so the slash this matches is the FIRST one. That is
+// the same accept set — the tail may still hold slashes of its own — reached
+// without the head and the tail competing for every slash in between, which is
+// quadratic on a long path-shaped value.
+const PATH_LIKE = /^[^\s/]*\/\S+$/;
 
 /** A JSON array, or `undefined` when the value does not parse as one. */
 function asJsonArray(value: string): unknown[] | undefined {

--- a/frontend/src/screens/leads.list.stories.tsx
+++ b/frontend/src/screens/leads.list.stories.tsx
@@ -59,11 +59,16 @@ const ROSTER = {
 // the roster, the custom fields, the SoR posture — falls through to the stub's
 // own empty page, which is a legitimate answer for each of them and keeps the
 // story about the queue rather than about its chrome.
+// Hoisted rather than written inline as a default: a literal in the parameter
+// list is a fresh object on every call, and the stories that pass nothing would
+// each get one of their own.
+const MANAGER: { roles?: string[]; seat?: "full" | "read" } = {
+  roles: ["manager"],
+};
+
 function leads(
   rows: Lead[],
-  identity: { roles?: string[]; seat?: "full" | "read" } = {
-    roles: ["manager"],
-  },
+  identity: { roles?: string[]; seat?: "full" | "read" } = MANAGER,
 ) {
   return () => {
     installFetchStub({

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -356,7 +356,9 @@ export function normalizeUrl(raw: string): {
   s = s
     .replace(/^https?:\/\//i, "")
     .replace(/^www\./i, "")
-    .replace(/\/+$/, "");
+    // Lookbehind: without it a URL ending in a long run of slashes is matched
+    // from every one of them in turn.
+    .replace(/(?<!\/)\/+$/, "");
   const host = s.split("/")[0] ?? "";
   // NOSONAR: rewriting this host check to a linear pattern changes its accept/reject
   // set (dotted-label edge cases); input is a bounded hostname, so backtracking is not a risk.

--- a/frontend/src/screens/personnetwork/personnetwork.stories.tsx
+++ b/frontend/src/screens/personnetwork/personnetwork.stories.tsx
@@ -173,13 +173,18 @@ function graph(over: Partial<PersonGraph> = {}): PersonGraph {
 
 // The tab reads two endpoints, and a story that routed only one would render
 // the other's loading state under a name claiming something else.
+// Hoisted rather than written inline as a default: a literal in the parameter
+// list is a fresh object on every call, and every story that takes the default
+// would get one of its own.
+const READS_AND_ASKS: Parameters<typeof meRoute>[0] = {
+  person: ["read"],
+  introduction: ["read", "create"],
+};
+
 function stub(
   payload: PersonGraph,
   asks: IntroRequest[] = [],
-  allow: Parameters<typeof meRoute>[0] = {
-    person: ["read"],
-    introduction: ["read", "create"],
-  },
+  allow: Parameters<typeof meRoute>[0] = READS_AND_ASKS,
 ) {
   installFetchStub({
     "GET /me": meRoute(allow),

--- a/frontend/src/screens/rates.tsx
+++ b/frontend/src/screens/rates.tsx
@@ -37,7 +37,9 @@ function trimDecimal(value: string): string {
   if (!value.includes(".")) {
     return value;
   }
-  return value.replace(/0+$/, "").replace(/\.$/, "");
+  // Lookbehind: the run of zeros is found once, not retried from each zero in
+  // it. numeric(20,10) is short, but the shape is the one that hangs a tab.
+  return value.replace(/(?<!0)0+$/, "").replace(/\.$/, "");
 }
 
 // Withheld, not absent (design-system README, "Absent, disabled, or withheld"):


### PR DESCRIPTION
The frontend half of SonarCloud's reliability list: 22 findings, 8 fixed and 14 written down as findings that stay open on purpose. With https://github.com/margince/margince/pull/4734 (the Go half) and https://github.com/margince/margince/pull/4729 (the last of the shell rule), this closes the list.

## The regexes really do backtrack — measured, not assumed

`typescript:S8786` flags six patterns as super-linear. On V8 they are. Each row quadruples for every doubling of the input:

| site | 80 000-character adversarial input | after |
|---|---|---|
| `format/emailtext.ts` `isSignOff` | **10 655 ms** | 0.6 ms |
| `screens/aiexport.tsx` `scenarioSlug` | **9 402 ms** | 0.6 ms |
| `screens/onboarding.tsx` host strip | **9 306 ms** | 0.6 ms |
| `screens/rates.tsx` `trimDecimal` | **9 490 ms** | 0.6 ms |
| `screens/historyvalues.ts` `PATH_LIKE` | **21 253 ms** | 0.7 ms |

Two of those read text nobody in this repository wrote — an inbound mail body, and a field-history value. A browser tab that stops answering for ten seconds is the reliability failure the rule is about.

Four are one shape: a trailing run that the engine retries from every character in it. Each takes the same one-token fix — a lookbehind pinning the run to its start (`/0+$/` → `/(?<!0)0+$/`). Lookbehind is ES2018, the app targets ES2022, and `voice-excerpts.ts` already ships one.

`PATH_LIKE` is the other kind: `^\S*\/\S+$` had a head and a tail competing for every slash between them. The head no longer accepts slashes, so the **first** slash is the match. Same accept set — the tail still holds slashes of its own, which is why `//` stays true. My first attempt at this one was wrong in exactly that way, which is why:

**Identical is checked, not claimed.** Every one of the five new patterns was run against its predecessor over all **161 051** strings up to length five, drawn from an alphabet of the characters each pattern cares about (letters, digits, `.` `,` `!` `_` `/`, space, tab). Zero differences.

## Two smaller ones

`e2e/llm/check.py` loses a `\s*` rather than gaining anything: the value it matched is `.strip()`ped two lines below, so the only thing it contributed was an ambiguity about which of the two ate the spaces.

`typescript:S7737` — two Storybook helpers took an object literal as a parameter default, which builds a fresh object on every call. Hoisted to a `const` each.

## Fourteen findings stay open, and the page says why

`docs/reference/sonarcloud-deviations.md` gains an entry per group. In short:

**The thirteen accessibility findings are one mistake made five ways.** Six of the sites already carried a `biome-ignore` naming the reason before SonarCloud ever ran. Applying the rules would remove accessibility, not add it:

- **`ListTable`'s `role="cell"`/`role="row"` are load-bearing.** At ≤720px `listtable.css` sets `display: block`/`flex` on `.lt-table`, `thead`, `tbody`, `tr`, `th` and `td` — which is exactly what strips a table of its implicit ARIA semantics. The explicit roles are what keep a phone list a table for a screen reader, and `listtable.test.tsx` reads rows and cells back by role.
- **`aria-hidden` on the slack cell** is on a `<td>` with no `tabindex` — not focusable, so not a violation. It is a layout spacer, and the header row, the body rows and the empty state's `colSpan` all account for the same extra column.
- **The three `tabIndex={0}`** are on scrollable regions and the decision deck's swipe surface. WCAG 2.1.1 requires a scrollable region to be keyboard-operable; axe's `scrollable-region-focusable` fails one that is not. Removing them would trade a lint finding for a real failure the `uat` lane's axe pass would catch.
- **The two `role="menu"` containers use a roving tabindex** — focus lives on the items, which is the WAI-ARIA authoring practice. The container is never focused; its ref is read only for `contains(document.activeElement)`.

**The sixth regex, `stripEveryKeyTag`, is real but is not rewritten here.** The tempting one-character fix (excluding `[` from the inner class) is linear and silently changes which tags are stripped: on `Fix [old[PROJ-1] thing` the current pattern leaves the subject byte for byte, while the "fixed" one finds `[PROJ-1]` inside it and strips a tag this module never wrote. The input is a mail subject, RFC 5322-bounded near 1 000 bytes, where the pattern costs microseconds. The page records what the right fix would be if that bound ever goes away.

## Verification

- `make check-fe` — green, 4m42s. **On Node 24**, which CI pins: on Node 22 eleven Intl/CLDR tests fail on unmodified `main` too.
- `make fe-unit` — 621 files, 8 114 passed, 1 expected fail.
- `make fe-lint` — clean.
- `make test-e2e-llm-check` — green, covering the `check.py` change.
- Docs-reachability gate green. `TestPublicTreeCitesNoDocumentGitIgnores` fails identically on a clean `origin/main` in this checkout — it reads `git check-ignore`, and `.superpowers/` is excluded through `.git/info/exclude` on this machine only.