### PR TITLE
A message edited after it was authorized does not go

### DIFF
--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -151,6 +151,10 @@ func (m outboundMessage) authorization(origin SendOrigin) commsauthz.Request {
 		Links:            linkedRecordIDs(m.links),
 		Subject:          m.in.Subject,
 		Body:             m.body,
+		// The markup alternative travels with the plain one: both are the
+		// message, and the fingerprint stamped from this request is what the
+		// transmit phase later compares the wire against.
+		HTMLBody: m.htmlBody,
 	}
 }
 

--- a/backend/internal/modules/comms/gates.go
+++ b/backend/internal/modules/comms/gates.go
@@ -262,6 +262,7 @@ func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (commsauthz.
 		PurposeKey: del.ConsentPurpose,
 		Subject:    del.Subject,
 		Body:       del.Body,
+		HTMLBody:   del.HTMLBody,
 	})
 	if terr != nil {
 		// The question could not be asked. A consent service that is merely

--- a/backend/internal/modules/consent/authorizecontent.go
+++ b/backend/internal/modules/consent/authorizecontent.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Whether the message about to go is the message that was authorized.
+//
+// A decision is taken twice: once when the message is staged, and again before
+// the provider is handed it. Both phases stamp a fingerprint of the wording, so
+// a later reader can tell the two apart — but the staging value was never read
+// back, which made the second stamp a record of what went out rather than a
+// check on it. A body edited between the two phases authorized one message and
+// sent another, and nothing said so.
+//
+// MAIL AND CHANNEL AGREE, which was worth checking rather than assuming: a
+// channel reply carries no subject at all — SendMessageInput has no such field,
+// because a chat message has no subject line — so its request leaves Subject
+// empty. WordingDigest separates the two strings with a NUL, so an empty
+// subject is unambiguous rather than colliding with a body that begins the same
+// way, and the two paths reduce identical content to the same digest.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// stagedWordingFor answers the fingerprint this delivery's staging phase
+// recorded, and whether there was one.
+//
+// FALSE is not a fault. A delivery staged before this column carried anything
+// has no fingerprint to compare, and inventing a mismatch from an absence would
+// park mail that nothing is wrong with. The caller treats "no staged wording"
+// as "nothing to disagree with", which is the honest reading of a record that
+// was never made.
+//
+// ERASURE IS NOT ONE OF THOSE CASES, though it looks like it should be. The
+// privacy paths tombstone a decision row in place — they blank the address and
+// the subject and leave the fingerprint standing — because the row is Art. 5(2)
+// accountability evidence, and migration 1788529047 revokes UPDATE on it from
+// the runtime role besides. An erased subject's delivery still has its wording
+// on record.
+//
+// Any recipient's row answers, because the fingerprint is per MESSAGE rather
+// than per addressee: the staging writer computes the digest once above its
+// recipient loop and binds the same value into every row.
+//
+// A delivery has ONE staging set today: all three production callers mint the
+// delivery id and stage it in the same transaction, and a retry produces a new
+// delivery rather than a second staging set. The ordering is what keeps that
+// from being load-bearing — if a re-stage ever lands, this names the newest set
+// deterministically instead of leaving the planner to choose.
+func stagedWordingFor(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID) ([]byte, bool, error) {
+	var sum []byte
+	// ONE staging set, named by its own id, and the newest by TIME rather than
+	// by row id. uuidv7 here is a millisecond timestamp over random low bits, so
+	// two rows written inside one millisecond do not order — the id is unique,
+	// not monotonic at that resolution. decided_at is the transaction clock, so
+	// it ties across a set and separates two sets; decision_set_id breaks the
+	// remaining tie, which is what keeps this deterministic rather than
+	// planner-dependent.
+	//
+	// Every row of one set carries the same fingerprint — the staging writer
+	// computes the digest once above its recipient loop — so which row of the
+	// chosen set answers does not matter. Which SET answers does.
+	err := tx.QueryRow(ctx, `
+		SELECT content_fingerprint
+		  FROM communication_decision
+		 WHERE delivery_id = $1 AND phase = $2
+		   AND content_fingerprint IS NOT NULL
+		 ORDER BY decided_at DESC, decision_set_id DESC
+		 LIMIT 1`, deliveryID, string(commsauthz.PhaseStaging)).Scan(&sum)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("consent: read the wording this delivery was staged with: %w", err)
+	}
+	return sum, len(sum) > 0, nil
+}
+
+// wordingChangedSinceStaging reports whether the message being transmitted
+// differs from the one that was authorized at staging.
+//
+// The comparison is over the DIGEST rather than the text, which is the whole
+// reason the column holds a hash: the decision must be able to answer "is this
+// the same message" without becoming a second copy of the mail.
+// A wrong-length stored value reads as "nothing to compare" rather than as a
+// mismatch. No writer in this tree produces one — the only staging writer binds
+// a 32-byte digest — so this guards a row that could only arrive by hand, and
+// it fails OPEN because parking real mail over a value this code cannot read
+// would be the worse mistake.
+func wordingChangedSinceStaging(staged []byte, subject, body, htmlBody string) bool {
+	if len(staged) != sha256.Size {
+		return false
+	}
+	now := SendingDigest(subject, body, htmlBody)
+	if bytes.Equal(now[:], staged) {
+		return false
+	}
+	// A delivery staged BEFORE this change carries the two-field digest, which
+	// covered subject and body and knew nothing about markup. Its wording has
+	// not changed — the shape of the question has — and refusing it would park
+	// every message in flight at the moment this deployed.
+	//
+	// Accepted only for a plain-text send. A message that HAS markup cannot
+	// have been staged under a digest that never saw it, so allowing the older
+	// shape there would be accepting a fingerprint that answers a narrower
+	// question than the one being asked.
+	if htmlBody == "" {
+		legacy := WordingDigest(subject, body)
+		if bytes.Equal(legacy[:], staged) {
+			return false
+		}
+	}
+	return true
+}
+
+// wordingDiffersFromStaging answers whether this delivery's wording changed
+// since the decision that authorized it.
+//
+// It runs on the transmit transaction, so the comparison and the ticket it
+// settles commit together: reading the staged value outside would let a
+// re-stage land between the read and the decision.
+func (g *Gate) wordingDiffersFromStaging(
+	ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest,
+) (bool, error) {
+	staged, recorded, err := stagedWordingFor(ctx, tx, req.DeliveryID)
+	if err != nil {
+		return false, err
+	}
+	if !recorded {
+		return false, nil
+	}
+	return wordingChangedSinceStaging(staged, req.Subject, req.Body, req.HTMLBody), nil
+}

--- a/backend/internal/modules/consent/authorizecontent_integration_test.go
+++ b/backend/internal/modules/consent/authorizecontent_integration_test.go
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The message that goes is the message that was authorized.
+//
+// Both phases stamp a fingerprint of the wording, and until now nothing read
+// the staging one back — so a body edited between staging and transmit was
+// authorized as one message and sent as another, with the record showing two
+// different fingerprints and nobody comparing them.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+const (
+	stagedSubject = "Your April invoice"
+	stagedBody    = "The invoice for April is attached, due on the 30th."
+	// The distinguishing fragment of the wording refusal, so a test can tell it
+	// from a refusal about the recipient.
+	wordingRefusal = "edited after it was authorized"
+)
+
+// stageThenTransmit runs BOTH real writers over one delivery: the staging
+// decision through AuthorizeStagingTx, then the transmit decision through
+// AuthorizeTransmit with whatever wording the caller says goes.
+//
+// Through the real writers on purpose. A hand-planted staging row is where this
+// defect hides — the fixtures elsewhere in this package omit
+// content_fingerprint entirely, so a test built on one would compare against a
+// NULL and pass whatever the code did.
+func stageThenTransmit(
+	t *testing.T, e *resolveEnv, delivery ids.UUID, sentSubject, sentBody string,
+) commsauthz.TransmitTicket {
+	t.Helper()
+	// A live confirm link, which is what authorizes a record-confirmation send.
+	// The category is chosen for how LITTLE it needs: the subject of these tests
+	// is the fingerprint, and an invoice or a deal would put a chain of
+	// organization, employment and document rows between the test and its point.
+	//
+	// Through the sibling's own fixture helper, which already argues why direct
+	// SQL is right here: the real writer mints a token AND stages the mail that
+	// carries it, so reaching for it would need a stager, a vault and a runner.
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	recipients := []connector.Recipient{{Email: e.address}}
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: recipients,
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the delivery: %v", err)
+	}
+	ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery,
+		Attempt:    1,
+		Recipients: recipients,
+		Subject:    sentSubject,
+		Body:       sentBody,
+	})
+	if err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+	return ticket
+}
+
+// TestTheSameWordingStillTransmits is the positive control, and it comes first
+// because without it every refusal below could be a refusal about something
+// else entirely — a category, a suppression, a missing basis.
+func TestTheSameWordingStillTransmits(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	ticket := stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+	if !ticket.Allowed {
+		t.Fatalf("an unedited message was refused: %q — the comparison is failing a send "+
+			"whose wording never changed", ticket.Reason)
+	}
+}
+
+// TestABodyEditedAfterStagingDoesNotTransmit is the defect this closes.
+func TestABodyEditedAfterStagingDoesNotTransmit(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	ticket := stageThenTransmit(t, e, delivery, stagedSubject,
+		"Actually, pay this to a different account entirely.")
+	if ticket.Allowed {
+		t.Fatal("a message edited after it was authorized still transmitted: the decision " +
+			"on record describes wording that is not what would go")
+	}
+	// The WORDING reason specifically. Asserting only that it refused would pass
+	// against a refusal about the recipient, which is how the first version of
+	// these tests proved nothing.
+	if !strings.Contains(ticket.Reason, wordingRefusal) {
+		t.Errorf("the refusal reads %q, not the wording reason: this test would pass "+
+			"against a refusal about something else entirely", ticket.Reason)
+	}
+}
+
+// TestASubjectEditedAfterStagingDoesNotTransmit holds the other half of the
+// digest. The fingerprint is over subject AND body, separated by a NUL so a
+// sentence moved between them is a different message — a subject rewritten
+// while the body stands is exactly the edit a body-only check would miss.
+func TestASubjectEditedAfterStagingDoesNotTransmit(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	ticket := stageThenTransmit(t, e, delivery, "URGENT: your account is suspended", stagedBody)
+	if ticket.Allowed {
+		t.Fatal("a message whose subject was rewritten after authorization still transmitted")
+	}
+	if !strings.Contains(ticket.Reason, wordingRefusal) {
+		t.Errorf("the refusal reads %q, not the wording reason", ticket.Reason)
+	}
+}
+
+// TestADeliveryWithNoStagedWordingIsNotTreatedAsEdited holds the absence case.
+//
+// A delivery staged before this column carried anything, or one whose staging
+// rows erasure scrubbed, has no fingerprint to compare. Inventing a mismatch
+// from an absence would park every legacy delivery in flight when this shipped.
+//
+// Asserted at the comparison rather than through AuthorizeTransmit, and that
+// distinction is the point: a delivery with NO staging row is also refused for
+// having no staged claim to resolve a category from, so a ticket-level
+// assertion would pass on that refusal and prove nothing about the wording. The
+// question here is narrow — does an absent fingerprint read as "changed"? — so
+// it is asked of the function that answers it.
+func TestADeliveryWithNoStagedWordingIsNotTreatedAsEdited(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	var recorded bool
+	var staged []byte
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		staged, recorded, err = stagedWordingFor(e.ctx, tx, delivery)
+		return err
+	}); err != nil {
+		t.Fatalf("reading the staged wording: %v", err)
+	}
+	if recorded {
+		t.Fatalf("a delivery that was never staged reports a fingerprint of %d bytes", len(staged))
+	}
+	// And the CALLER's reading of that, which is the branch that decides:
+	// wordingDiffersFromStaging must answer false on an absence rather than
+	// treating "no record" as "changed". Asked through the caller and not
+	// through the comparison alone, because the comparison never sees the
+	// absent case — the early return above is what handles it, and a test that
+	// skipped past it would leave that return unheld.
+	var differs bool
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		differs, err = e.gate.wordingDiffersFromStaging(e.ctx, tx, commsauthz.TransmitRequest{
+			DeliveryID: delivery, Attempt: 1,
+			Subject: stagedSubject, Body: stagedBody,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("asking whether the wording differs: %v", err)
+	}
+	if differs {
+		t.Error("an absent staging fingerprint reads as an edited message, which would park " +
+			"every delivery staged before this column carried anything")
+	}
+}
+
+// TestTheTransmitRowRecordsTheWordingThatWouldHaveGone holds what the record
+// says after a refusal.
+//
+// The transmit row stamps the wording it was ASKED about, not the staged one:
+// an auditor asking "what did somebody try to send" is owed the message that
+// was actually presented, and the staging row beside it holds the other.
+func TestTheTransmitRowRecordsTheWordingThatWouldHaveGone(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	edited := "Actually, pay this to a different account entirely."
+
+	stageThenTransmit(t, e, delivery, stagedSubject, edited)
+
+	var fingerprints [][]byte
+	rows, err := e.owner.Query(context.Background(), `
+		SELECT content_fingerprint FROM communication_decision
+		 WHERE delivery_id = $1 ORDER BY phase`, delivery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var sum []byte
+		if err := rows.Scan(&sum); err != nil {
+			rows.Close()
+			t.Fatal(err)
+		}
+		fingerprints = append(fingerprints, sum)
+	}
+	rows.Close()
+	if len(fingerprints) != 2 {
+		t.Fatalf("the delivery carries %d decisions, want a staging and a transmit row",
+			len(fingerprints))
+	}
+	// SendingDigest, which is what both writers stamp: the row records what a
+	// recipient can read, markup included, and this asserts the stored bytes.
+	staged := SendingDigest(stagedSubject, stagedBody, "")
+	sent := SendingDigest(stagedSubject, edited, "")
+	// Ordered by phase: 'staging' sorts before 'transmit'.
+	if string(fingerprints[0]) != string(staged[:]) {
+		t.Error("the staging row does not record the wording that was authorized")
+	}
+	if string(fingerprints[1]) != string(sent[:]) {
+		t.Error("the transmit row does not record the wording that was presented")
+	}
+}
+
+// TestARefusedSendKeepsItsOwnReason holds the ordering.
+//
+// The wording check runs LAST and only on a send the engine would otherwise
+// allow. A delivery already refused about its RECIPIENT — a suppression, a
+// missing basis — must keep that reason: replacing it with "the wording
+// changed" would tell an operator to re-approve a message somebody had
+// objected to, which is the one reading that turns a refusal into an invitation.
+func TestARefusedSendKeepsItsOwnReason(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+
+	// Staged with a live link, so the staging phase records a fingerprint...
+	recipients := []connector.Recipient{{Email: e.address}}
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: recipients,
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the delivery: %v", err)
+	}
+	// ...then the link is spent, so the recipient no longer authorizes anything.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE confirm_token SET consumed_at = now() WHERE person_id = $1`, e.person); err != nil {
+		t.Fatalf("spending the link: %v", err)
+	}
+
+	// And the body is edited too, so BOTH refusals are available and the test
+	// can tell which one the ticket reports.
+	ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery, Attempt: 1, Recipients: recipients,
+		Subject: stagedSubject, Body: "Actually, pay this to a different account entirely.",
+	})
+	if err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+	if ticket.Allowed {
+		t.Fatal("a send whose recipient no longer authorizes it still transmitted")
+	}
+	if strings.Contains(ticket.Reason, "edited after it was authorized") {
+		t.Errorf("the refusal reads %q: a recipient-level refusal was overwritten by the "+
+			"wording check, so an operator is told to re-approve rather than that the "+
+			"recipient refused", ticket.Reason)
+	}
+}
+
+// TestARetryOfAnUneditedMessageStillTransmits holds the retry ladder.
+//
+// A delivery is staged ONCE and transmitted as many times as the dispatcher
+// retries, each attempt taking a fresh decision. The comparison is against the
+// staging row, which does not move — so an unedited message must clear it on
+// every attempt. A check that parked on the second try would turn every
+// transient provider failure into a permanent one.
+func TestARetryOfAnUneditedMessageStillTransmits(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	recipients := []connector.Recipient{{Email: e.address}}
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: recipients,
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the delivery: %v", err)
+	}
+
+	// Three attempts of the same message, as a retrying dispatcher makes them.
+	for attempt := 1; attempt <= 3; attempt++ {
+		ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+			DeliveryID: delivery, Attempt: attempt, Recipients: recipients,
+			Subject: stagedSubject, Body: stagedBody,
+		})
+		if err != nil {
+			t.Fatalf("attempt %d: authorizing the transmit: %v", attempt, err)
+		}
+		if !ticket.Allowed {
+			t.Fatalf("attempt %d of an unedited message was refused: %q — a retry must not "+
+				"read as an edit, or a transient failure becomes a permanent one",
+				attempt, ticket.Reason)
+		}
+	}
+}
+
+// TestMarkupEditedAfterStagingDoesNotTransmit holds the half of the message
+// most recipients actually read.
+//
+// A mail carries two bodies. A client that renders markup shows HTMLBody and
+// never Body, so a fingerprint over the plain text alone would let the visible
+// half be rewritten between the decision and the send while the record went on
+// claiming the message was unchanged. The plain body here is IDENTICAL in both
+// phases, so nothing but the markup can account for the refusal.
+func TestMarkupEditedAfterStagingDoesNotTransmit(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	recipients := []connector.Recipient{{Email: e.address}}
+
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: recipients,
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+			HTMLBody:   "<p>The invoice for April is attached, due on the 30th.</p>",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the delivery: %v", err)
+	}
+
+	ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery, Attempt: 1, Recipients: recipients,
+		Subject: stagedSubject, Body: stagedBody,
+		HTMLBody: "<p>Pay this to a different account entirely.</p>",
+	})
+	if err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+	if ticket.Allowed {
+		t.Fatal("a message whose MARKUP was rewritten after authorization still transmitted: " +
+			"the half a rendering client shows is outside what was checked")
+	}
+	if !strings.Contains(ticket.Reason, wordingRefusal) {
+		t.Errorf("the refusal reads %q, not the wording reason", ticket.Reason)
+	}
+}
+
+// TestADeliveryStagedUnderTheOlderDigestStillTransmits holds the deploy.
+//
+// A delivery staged before this change carries the two-field digest, which
+// covered subject and body and knew nothing about markup. Its wording has not
+// changed — the shape of the question has — and refusing it would park every
+// message in flight at the moment this shipped.
+//
+// The staging row is written by hand HERE, and that is the point rather than a
+// shortcut: the current writer cannot produce the old shape, so the only way to
+// test the compatibility path is to plant what the old writer left behind.
+func TestADeliveryStagedUnderTheOlderDigestStillTransmits(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+
+	legacy := WordingDigest(stagedSubject, stagedBody)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   requested_category, resolved_category, verdict, reason_code,
+		   content_fingerprint, mode, actor)
+		VALUES ($1, 0, $2, $3, 'staging', 'record_confirmation', 'record_confirmation',
+		        'allow', 'confirmation_link_live', $4, 'enforce', 'test')`,
+		delivery, ids.NewV7(), e.address, legacy[:]); err != nil {
+		t.Fatalf("planting the pre-deploy staging row: %v", err)
+	}
+
+	ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery, Attempt: 1,
+		Recipients: []connector.Recipient{{Email: e.address}},
+		Subject:    stagedSubject, Body: stagedBody,
+	})
+	if err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+	if !ticket.Allowed {
+		t.Fatalf("a delivery staged under the older digest was refused: %q — every message "+
+			"in flight at the deploy would park", ticket.Reason)
+	}
+}
+
+// TestTheOlderDigestIsNotAcceptedForAMessageWithMarkup is the other half.
+//
+// A message that HAS markup cannot have been staged under a digest that never
+// saw markup, so accepting the older shape there would take a fingerprint that
+// answers a narrower question than the one being asked — and let the markup be
+// anything at all.
+func TestTheOlderDigestIsNotAcceptedForAMessageWithMarkup(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+
+	legacy := WordingDigest(stagedSubject, stagedBody)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   requested_category, resolved_category, verdict, reason_code,
+		   content_fingerprint, mode, actor)
+		VALUES ($1, 0, $2, $3, 'staging', 'record_confirmation', 'record_confirmation',
+		        'allow', 'confirmation_link_live', $4, 'enforce', 'test')`,
+		delivery, ids.NewV7(), e.address, legacy[:]); err != nil {
+		t.Fatalf("planting the pre-deploy staging row: %v", err)
+	}
+
+	ticket, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery, Attempt: 1,
+		Recipients: []connector.Recipient{{Email: e.address}},
+		Subject:    stagedSubject, Body: stagedBody,
+		HTMLBody: "<p>Pay this to a different account entirely.</p>",
+	})
+	if err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+	if ticket.Allowed {
+		t.Fatal("markup rode a fingerprint that never covered markup: the compatibility " +
+			"path must not admit a message the older digest could not have described")
+	}
+}

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -84,7 +84,7 @@ func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids
 // to. The fingerprint is of the message as staged, so a later reader can tell
 // whether what went out is what was authorized.
 func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID, setID ids.UUID, req commsauthz.Request, set commsauthz.DecisionSet) error {
-	sum := WordingDigest(req.Subject, req.Body)
+	sum := SendingDigest(req.Subject, req.Body, req.HTMLBody)
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
 		return err

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -115,6 +115,25 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 		}
 		ticket.Allowed = set.Effective(modeFor, legacyAllowed)
 		ticket.Reason = refusalReason(set, legacyAllowed)
+		// The message that goes must be the message that was authorized.
+		//
+		// Asked LAST, and only of a send the engine would otherwise allow: a
+		// delivery already refused is parked with a reason about the recipient,
+		// and replacing that with "the wording changed" would tell an operator
+		// to re-approve a message somebody had objected to. A changed body on
+		// an allowed send is its own refusal, and it parks rather than denying
+		// forever — the wording is a thing a human can look at and re-send.
+		if ticket.Allowed {
+			changed, err := g.wordingDiffersFromStaging(ctx, tx, req)
+			if err != nil {
+				return err
+			}
+			if changed {
+				ticket.Allowed = false
+				ticket.Reason = "this message was edited after it was authorized, so the wording that " +
+					"was checked is not the wording that would go"
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -316,7 +335,7 @@ func refusalReason(set commsauthz.DecisionSet, legacyAllowed bool) string {
 // message that was authorized, and storing the words themselves would make the
 // decision a second copy of the mail.
 func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet) error {
-	sum := WordingDigest(req.Subject, req.Body)
+	sum := SendingDigest(req.Subject, req.Body, req.HTMLBody)
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
 		return err

--- a/backend/internal/modules/consent/textversion.go
+++ b/backend/internal/modules/consent/textversion.go
@@ -51,6 +51,34 @@ func WordingDigest(subject, body string) [sha256.Size]byte {
 	return sha256.Sum256([]byte(subject + "\x00" + body))
 }
 
+// SendingDigest is the digest over everything a RECIPIENT can read: the
+// subject, the plain-text alternative, and the markup one.
+//
+// The markup is in it because a mail carries two bodies and the tree says so
+// itself — a client rendering markup can show something the plain part never
+// mentioned. A fingerprint over the plain body alone would let the half most
+// recipients actually read be rewritten between the decision and the send while
+// the record went on claiming the message was unchanged.
+//
+// NUL-separated, and three fields rather than two so a sentence moved from one
+// to another is a different digest.
+//
+// IT IS NOT WordingDigest WITH AN EMPTY THIRD ARGUMENT, and that is deliberate
+// rather than a missed simplification. Appending a separator changes the hash
+// of every plain-text message: `S\x00B` and `S\x00B\x00` are different digests.
+// Folding the two would silently invalidate every consent_text_version row
+// already published — bootstrap re-publishes the controller templates and would
+// find unchanged wording conflicting, which fails startup — and would park
+// every delivery staged before the deploy, because its stored fingerprint would
+// no longer match its own unchanged body.
+//
+// So the two-field digest keeps its exact bytes and this is a separate
+// question: what a RECIPIENT can read, which a stored wording has no markup
+// half of. The wordingdigest gate holds that neither grows a third spelling.
+func SendingDigest(subject, body, htmlBody string) [sha256.Size]byte {
+	return sha256.Sum256([]byte(subject + "\x00" + body + "\x00" + htmlBody))
+}
+
 // ContentHashOf renders the digest as the hex text consent_text_version stores.
 func ContentHashOf(subject, body string) string {
 	sum := WordingDigest(subject, body)

--- a/backend/internal/shared/ports/commsauthz/decision.go
+++ b/backend/internal/shared/ports/commsauthz/decision.go
@@ -118,6 +118,11 @@ type Request struct {
 	// Subject and Body are fingerprinted, never stored on the decision.
 	Subject string
 	Body    string
+	// HTMLBody is the markup alternative, carried for the reason
+	// TransmitRequest carries it: the fingerprint stamped here is what the
+	// transmit phase compares against, so a field missing from one side is a
+	// field neither side can notice changing.
+	HTMLBody string
 }
 
 // Decision is the engine's answer about ONE recipient at ONE phase.
@@ -186,6 +191,11 @@ type TransmitRequest struct {
 	PurposeKey string
 	Subject    string
 	Body       string
+	// HTMLBody is the markup alternative, empty for a plain-text send. It is
+	// part of the request because it is part of the MESSAGE: a client rendering
+	// markup shows this and not Body, so a fingerprint that ignored it would
+	// leave the half most recipients read outside what was authorized.
+	HTMLBody string
 }
 
 // TransmitTicket is what a dispatcher must hold before it calls a provider.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (94)
+## Parity (95)
 
 | Gate | Hardness | What it holds |
 |---|---|---|

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -52705,6 +52705,8 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };
     };


### PR DESCRIPTION
content_fingerprint was written at BOTH authorization phases and read by
nobody. The second stamp was a record of what went out, not a check on it: a
body edited between staging and transmit authorized one message and sent
another, with two different fingerprints on the record and nothing comparing
them. The transmit phase now compares, and parks when they differ.

The check runs LAST and only on a send the engine would otherwise allow. A
delivery already refused about its recipient keeps that reason — replacing it
with "the wording changed" would tell an operator to re-approve a message
somebody had objected to.

THE PLAIN BODY WAS HALF THE MESSAGE. Security review found html_body goes on
the wire and was nowhere in the digest, so the half a rendering client actually
shows could be rewritten while the record claimed the message was unchanged. It
is in the request and in the digest now, on both phases.

Extending the digest is a breaking change, which Codex caught and I had not:
`S\0B` and `S\0B\0` are different hashes, so folding WordingDigest into the
three-field one would invalidate every published consent_text_version row —
bootstrap re-publishes the controller templates and would find unchanged
wording conflicting, failing startup — and park every delivery already staged.
WordingDigest keeps its exact bytes; SendingDigest is a separate question. A
delivery staged under the older shape is accepted, but only for a plain-text
send: a message that HAS markup cannot have been staged under a digest that
never saw markup.

stagedWordingFor orders by decided_at then decision_set_id, not by row id.
uuidv7 here is a millisecond timestamp over random low bits, so two rows inside
one millisecond do not order — the id is unique, not monotonic at that
resolution.

Two comments I wrote were false and both reviews said so: erasure does NOT
scrub the fingerprint (the privacy paths tombstone the row in place, and the
column is not even in the app role's GRANT), and a delivery cannot be staged
twice (every caller mints the id and stages in one transaction). Both corrected
to what the code does.

The ledger's second claim about this item was wrong. Mail and channel do not
disagree on the digest: a channel reply has no subject field at all, and the
NUL separator makes an empty one unambiguous. Recorded rather than "fixed".

Carried, not caused: frontend/src/api/schema.d.ts and the gate-inventory page
were both stale on main — #4741 changed crm.yaml and a parity gate landed
without either being regenerated. main is red on contract-frontend-drift by
itself; these two regenerations are what let this branch gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a message edited after it was authorized from being sent. The transmit phase now compares the wording fingerprint recorded at staging against the message about to go out and refuses the send when they differ; previously both phases stamped a fingerprint but nothing read the staging one back.

**Migration**
- The fingerprint now covers the HTML body too, via a new `SendingDigest`; `WordingDigest` keeps its exact bytes so existing consent rows stay valid.
- Deliveries staged under the older digest still transmit, but only for plain-text sends.

**Bug Fixes**
- The wording check runs last and only on sends the engine would otherwise allow, so recipient-level refusals keep their reason.
- Regenerates `schema.d.ts` and the gate-inventory page, both of which were stale on main.

<sup>Written for commit 85a05a79f1238637f19c3ddff78c565c643e4d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

