### PR TITLE
The authorization gate counts a decision, not a mention of the package

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 45
+	wantFixtureAnnotations = 46
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 44
+	wantFixtureAnnotations = 45
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/rbacgate_test.go
+++ b/backend/gates/rbacgate_test.go
@@ -47,6 +47,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -69,7 +70,15 @@ import (
 // So an entry added here is a security decision, and the reason has to survive
 // being read on its own: "a sweep runs it" is not one, "no row leaves this
 // call" is.
-var ungatedEntryPoints = gatekit.Waive(map[string]string{ // #nosec G101 -- waiver rationales for the fitness gate, not credentials
+var ungatedEntryPoints = gatekit.Waive(map[string]string{
+	"internal/modules/activities:LabeledCaptureCountSince": "a COUNT and nothing else: it answers how many captured activities carry a label since a date, for the AI-cost arithmetic on the backfill preview. No row, no id and no text leaves it, so there is nothing for a row gate to withhold — and the number is the installation's, not one caller's. Reached from a signed-in human's preview request rather than a worker, which is why the bound is stated as the shape of the answer rather than the principal",
+
+	"internal/modules/capture:CorrespondsWith": "a bool the verdict engine asks itself while deciding whether an address corresponds with us, under the system principal on the capture path. It returns no row and reaches no caller: the answer goes into a verdict that is itself audited, and a human never invokes it",
+
+	"internal/modules/capture:ListMine": "the caller's OWN traffic, and the predicate is the caller: it reads the actor off the context and refuses an invocation naming no member, then selects on that user id. There is no id from the request to gate — a caller can only ever ask about themselves",
+
+	"internal/modules/capture:SweepOlderThan": "a retention sweep that deletes traces past their window and returns a count. Run by the worker under the system principal, on a clock rather than a request; no caller names a row and nothing is disclosed",
+	// #nosec G101 -- waiver rationales for the fitness gate, not credentials
 	"internal/modules/knowledge:ReconcileHandbook":          "brings the shipped handbook corpus in line with the pages THIS BINARY carries, reached from nothing but the api boot step, which runs under a system principal holding no object grants at all \u2014 so there is no human grant a gate here could consult, and adding one would refuse the only caller rather than protect anything. Nothing about its subject is caller-chosen: the pages come from the embedded filesystem compiled into the binary, and every row it touches is found by `managed_source = 'handbook'`, so a corpus or document a person created is unreachable from here by construction \u2014 TestTheReconciliationLeavesAWorkspacesOwnCorpusAlone holds that. The tenant is bound the way every boot write is: bootLedgerScope resolves the installation's workspace and binds the transaction to it, and the boot cannot pick another. It returns a COUNT of pages written, never a row and never any prose",
 	"internal/modules/knowledge:EmbedDocument":              "gives one document's passages their vectors, reached from the ingest worker and from the drift sweep, both of which run under a system principal holding no object grants. There is no human grant to consult and no row a caller chose: it takes a document id the calling job already read from a row, reads only that document's passages, and writes only vectors back onto them. It exposes NOTHING — no text leaves, no row is returned, and the count it answers is a number of rows touched. A gate here would refuse the only two callers and protect no one. Reading what a passage says is the ask's business, and the ask is gated",
 	"internal/modules/knowledge:SweepAbandonedIngests":      "closes the ingests that stopped without saying so \u2014 a document left `running` by a process that died on its LAST attempt, which River cannot rescue because there is no attempt left to run. Reached only from the periodic drift sweep, under the same system principal and the same workspace binding as SweepCorpusDrift beside it, and bounded the same way: the sweep's args declare one workspace and workspaceJobCtx binds the transaction to it. It takes no id and no caller-chosen value \u2014 its subject is derived entirely from the database's own clock against ingest_started_at \u2014 and it returns a count, never a row. A gate here would refuse the only caller and protect nothing; what it protects AGAINST is a corpus permanently unaskable because one upload's worker was killed",
@@ -634,7 +643,7 @@ func packageFunctionIndex(t *testing.T) map[string]gatePkg {
 				}
 				ast.Inspect(fn.Body, func(n ast.Node) bool {
 					if sel, ok := n.(*ast.SelectorExpr); ok {
-						if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "auth" {
+						if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "auth" && isAuthDecision(sel.Sel.Name) {
 							info.auth = true
 						}
 						info.calls[sel.Sel.Name] = true
@@ -652,6 +661,140 @@ func packageFunctionIndex(t *testing.T) map[string]gatePkg {
 		}
 	}
 	return pkgs
+}
+
+// isAuthDecision says whether this name in the auth package REFUSES a caller.
+//
+// The gate used to count any selector on the package, which meant auth.Actor —
+// a read of who is calling — satisfied it, and so did every clause builder. A
+// clause builder is not a gate: auth.ScopeClauseFor renders a row predicate for
+// a caller already admitted, and a method that composes one while asking nobody
+// whether the caller may be there at all is exactly the shape this test claims
+// to catch. Two such reads were found the day this changed.
+//
+// The set is DERIVED from the verb the function's name starts with, not typed
+// out: Require, Ensure, Admit, Hold and Lock are the package's refusal verbs,
+// and a new one inherits the rule by being named like its neighbours. The
+// census below proves the convention still describes the package.
+func isAuthDecision(name string) bool {
+	for _, verb := range authDecisionVerbs {
+		if strings.HasPrefix(name, verb) {
+			return true
+		}
+	}
+	return authDecisionsByRatification[name] != ""
+}
+
+var authDecisionVerbs = []string{"Require", "Ensure", "Admit", "Hold", "Lock"}
+
+// gatekit:fixture the decisions whose names do not carry a refusal verb, each
+// with the reason it refuses — expected data about the auth package, not costs
+// this gate is paying.
+//
+// authDecisionsByRatification are the decisions whose names do not carry a
+// refusal verb. Each entry says why it refuses, because a name that reads like
+// a query and behaves like a gate is the thing a reader gets wrong.
+var authDecisionsByRatification = map[string]string{
+	"EdgeReadAdmitted": "the relationship-edge admission itself: it answers whether this caller may read an edge, and the readers that compose a clause call it first",
+	"EdgeReadScope":    "calls EdgeReadAdmitted before composing, so a caller it refuses gets an error rather than a predicate",
+	"VisibleTo":        "per-record read admission — it answers about ONE row and its callers act on the refusal",
+	"WritableBy":       "the write half of the same question",
+	"VisibleSubset":    "the batched form of VisibleTo: the rows it omits are the rows it refused",
+	"WritableSubset":   "the batched form of WritableBy",
+	"StampWritable":    "resolves writability per row and stamps the answer the client acts on",
+	"MasksAnyRowOf":    "refuses a sort or filter over a column the caller's role withholds, which is a refusal and not a projection",
+}
+
+// TestTheAuthDecisionVerbsStillDescribeThePackage holds the convention the gate
+// derives from. A refusal added under a SIXTH verb would be invisible to
+// isAuthDecision, and the gate would go on passing — under-recognition, which
+// reports PASS with nothing to notice.
+func TestTheAuthDecisionVerbsStillDescribeThePackage(t *testing.T) {
+	t.Parallel()
+
+	decisions := 0
+	err := filepath.WalkDir(filepath.Join("internal", "platform", "auth"), func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !fn.Name.IsExported() {
+				continue
+			}
+			if isAuthDecision(fn.Name.Name) {
+				decisions++
+				continue
+			}
+			// A function that is NOT counted must not look like a refusal. The
+			// tell is the sentinel: a gate returns ErrPermissionDenied, and a
+			// clause builder returns SQL.
+			if returnsPermissionDenied(fn) {
+				t.Errorf("auth.%s refuses a caller with ErrPermissionDenied but is not counted as a gate: "+
+					"name it with one of %v, or ratify it in authDecisionsByRatification with the reason it refuses",
+					fn.Name.Name, authDecisionVerbs)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading the auth package: %v", err)
+	}
+	// A parser regression that read no declarations would report a clean
+	// package. The floor is near the real count.
+	if decisions < 25 {
+		t.Fatalf("found only %d decisions in platform/auth — the walk has lost the package "+
+			"and every entry point would now count as ungated", decisions)
+	}
+	for name := range authDecisionsByRatification {
+		if !authPackageDeclares(t, name) {
+			t.Errorf("authDecisionsByRatification names auth.%s, which the package no longer exports: "+
+				"a stale entry silently keeps a renamed gate counted", name)
+		}
+	}
+}
+
+// returnsPermissionDenied reports whether the body ever names the refusal
+// sentinel. It is the cheapest tell that a function decides rather than
+// composes, and it is a heuristic in one direction only: a gate that refuses
+// through a helper is missed, which is why the ratification map exists.
+func returnsPermissionDenied(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "ErrPermissionDenied" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func authPackageDeclares(t *testing.T, name string) bool {
+	t.Helper()
+	declared := false
+	err := filepath.WalkDir(filepath.Join("internal", "platform", "auth"), func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == name {
+				declared = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading the auth package: %v", err)
+	}
+	return declared
 }
 
 // reachesAuthGate resolves gatedness transitively over the calls a name can

--- a/backend/gates/rbacgate_test.go
+++ b/backend/gates/rbacgate_test.go
@@ -71,6 +71,8 @@ import (
 // being read on its own: "a sweep runs it" is not one, "no row leaves this
 // call" is.
 var ungatedEntryPoints = gatekit.Waive(map[string]string{
+	"internal/modules/people:DecidableForMerge": "answers WHICH of the given rows this caller could merge — a permission map, not data. It deliberately requires no object grant, because a reader whose role lacks the update verb is a legitimate caller whose answer is \"no verb for you\", and refusing the read would cost them the merge card they are entitled to see. WritableSubset omits every row they cannot see, so the map never names a record the caller could not have listed",
+
 	"internal/modules/activities:LabeledCaptureCountSince": "a COUNT and nothing else: it answers how many captured activities carry a label since a date, for the AI-cost arithmetic on the backfill preview. No row, no id and no text leaves it, so there is nothing for a row gate to withhold — and the number is the installation's, not one caller's. Reached from a signed-in human's preview request rather than a worker, which is why the bound is stated as the shape of the answer rather than the principal",
 
 	"internal/modules/capture:CorrespondsWith": "a bool the verdict engine asks itself while deciding whether an address corresponds with us, under the system principal on the capture path. It returns no row and reaches no caller: the answer goes into a verdict that is itself audited, and a human never invokes it",
@@ -685,7 +687,24 @@ func isAuthDecision(name string) bool {
 	return authDecisionsByRatification[name] != ""
 }
 
-var authDecisionVerbs = []string{"Require", "Ensure", "Admit", "Hold", "Lock"}
+var authDecisionVerbs = []string{"Require", "Ensure", "Admit", "Hold"}
+
+// gatekit:fixture the exported auth names that read like a refusal and are not
+// one, each with what it actually does — a classification of the package, not a
+// cost this gate is paying.
+//
+// authNotDecisions are exported names that READ like a refusal and are not one.
+// Stated rather than left implicit, because the census below cannot tell them
+// apart: each returns ErrNotFound or ErrPermissionDenied for a reason that is
+// about the ROW rather than about the caller, so the sentinel heuristic would
+// keep proposing them.
+var authNotDecisions = map[string]string{
+	"MasksAnyRowOf":   "answers a BOOLEAN about the caller's role and returns no error of its own. The refusal is the caller's: deals turns it into a parse error on a sort over a withheld column",
+	"VisibleSubset":   "OMITS the rows the caller may not see rather than refusing, and answers an empty map for a caller holding no read at all. Its callers use the set to withhold a reference, which is a projection decision made above it",
+	"WritableSubset":  "the write half of the same shape: an empty map for a caller with no update verb, and omission rather than refusal for the rest",
+	"LockSubjectLive": "takes a row lock and refuses a table outside the closed set or a row already archived. It never reads the principal: the authority probe is a separate call the caller makes first, and its own comment says so",
+	"StampWritable":   "stamps a per-row boolean the CLIENT reads to decide what to offer. It removes no row and refuses no caller — its comment separates what the client is told from what the server enforces",
+}
 
 // gatekit:fixture the decisions whose names do not carry a refusal verb, each
 // with the reason it refuses — expected data about the auth package, not costs
@@ -699,10 +718,6 @@ var authDecisionsByRatification = map[string]string{
 	"EdgeReadScope":    "calls EdgeReadAdmitted before composing, so a caller it refuses gets an error rather than a predicate",
 	"VisibleTo":        "per-record read admission — it answers about ONE row and its callers act on the refusal",
 	"WritableBy":       "the write half of the same question",
-	"VisibleSubset":    "the batched form of VisibleTo: the rows it omits are the rows it refused",
-	"WritableSubset":   "the batched form of WritableBy",
-	"StampWritable":    "resolves writability per row and stamps the answer the client acts on",
-	"MasksAnyRowOf":    "refuses a sort or filter over a column the caller's role withholds, which is a refusal and not a projection",
 }
 
 // TestTheAuthDecisionVerbsStillDescribeThePackage holds the convention the gate
@@ -726,16 +741,32 @@ func TestTheAuthDecisionVerbsStillDescribeThePackage(t *testing.T) {
 			if !ok || fn.Recv != nil || !fn.Name.IsExported() {
 				continue
 			}
+			if reason, named := authNotDecisions[fn.Name.Name]; named {
+				if isAuthDecision(fn.Name.Name) {
+					t.Errorf("auth.%s is named a non-decision (%s) but the classifier counts it: "+
+						"one of the two is wrong, and the classifier is what the gate believes", fn.Name.Name, reason)
+				}
+				continue
+			}
 			if isAuthDecision(fn.Name.Name) {
 				decisions++
+				// A counted name that no longer refuses is the regression this
+				// census exists for: it keeps every entry point reaching it
+				// passing. Checked for the counted names too, which is the half
+				// an earlier version of this test skipped.
+				if !refusesSomehow(fn) {
+					t.Errorf("auth.%s is counted as a gate but its body neither refuses nor delegates to something that does: "+
+						"if it stopped refusing, every entry point that reaches it is now ungated and passing", fn.Name.Name)
+				}
 				continue
 			}
 			// A function that is NOT counted must not look like a refusal. The
-			// tell is the sentinel: a gate returns ErrPermissionDenied, and a
-			// clause builder returns SQL.
+			// tell is the sentinel: a gate returns a refusal, a clause builder
+			// returns SQL.
 			if returnsPermissionDenied(fn) {
 				t.Errorf("auth.%s refuses a caller with ErrPermissionDenied but is not counted as a gate: "+
-					"name it with one of %v, or ratify it in authDecisionsByRatification with the reason it refuses",
+					"name it with one of %v, ratify it in authDecisionsByRatification with the reason it refuses, "+
+					"or name it in authNotDecisions if the refusal is about the row rather than the caller",
 					fn.Name.Name, authDecisionVerbs)
 			}
 		}
@@ -756,6 +787,39 @@ func TestTheAuthDecisionVerbsStillDescribeThePackage(t *testing.T) {
 				"a stale entry silently keeps a renamed gate counted", name)
 		}
 	}
+}
+
+// refusesSomehow reports whether the body can refuse at all — by naming a
+// refusal sentinel itself, or by calling something that does.
+//
+// Deliberately loose. Most gates in this package refuse through an unexported
+// helper (ensureWriteAuthority, refuseBuyer, probeExistsLive) or by returning
+// ErrNotFound so existence stays hidden, so a sentinel-only test would report
+// two thirds of the package as broken. What it catches is the case that matters:
+// a counted name whose body stopped being able to refuse anything.
+func refusesSomehow(fn *ast.FuncDecl) bool {
+	if returnsPermissionDenied(fn) {
+		return true
+	}
+	refuses := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			switch node.Sel.Name {
+			case "ErrNotFound", "ErrPermissionDenied", "ErrConflict":
+				refuses = true
+			}
+		case *ast.Ident:
+			// A call to a sibling gate, exported or not: the unexported
+			// helpers are named for what they do to a caller.
+			if isAuthDecision(node.Name) || strings.HasPrefix(node.Name, "ensure") ||
+				strings.HasPrefix(node.Name, "refuse") || strings.HasPrefix(node.Name, "probe") {
+				refuses = true
+			}
+		}
+		return !refuses
+	})
+	return refuses
 }
 
 // returnsPermissionDenied reports whether the body ever names the refusal

--- a/backend/internal/modules/capture/traceresolution_integration_test.go
+++ b/backend/internal/modules/capture/traceresolution_integration_test.go
@@ -283,3 +283,48 @@ func entriesByConnector(ctx context.Context, t *testing.T, store *capture.TraceS
 	}
 	return out
 }
+
+// A disposition belongs to the member who raised it, and the join says so.
+//
+// The ledger keeps one question per ADDRESS, and two colleagues corresponding
+// with the same person each raise their own. Joined on the address alone, one
+// member's trace answers with whichever verdict was settled last — including
+// another member's. What the ledger settled about a sender is a fact about that
+// member's own correspondence, which is the one boundary this product does not
+// cross: everyone reads everything EXCEPT mail.
+//
+// The comment on the join used to credit a workspace predicate for keeping
+// these apart. There is no workspace column on either table, so nothing did.
+func TestOneMembersDispositionDoesNotAnswerAnothersTrace(t *testing.T) {
+	ctx, ws, db, store := traceReadWorkspace(t)
+	me, colleague := ids.NewV7(), ids.NewV7()
+	const sender = "shared.sender@client.io"
+
+	// The colleague raises the LATER disposition and settles it DIFFERENTLY, so
+	// an address-only join answers the caller with theirs. Two distinguishable
+	// verdicts are what make this fail rather than pass by luck.
+	seedRecord(memberContext(ctx, ws, me), t, db, me, seededRecord{
+		SourceID: "mine-1", Sender: sender,
+		Outcome: capture.TraceDeferred, Ledger: true, Verdict: "real",
+	})
+	seedRecord(memberContext(ctx, ws, colleague), t, db, colleague, seededRecord{
+		SourceID: "theirs-1", Sender: sender,
+		Outcome: capture.TraceDeferred, Ledger: true, Verdict: "noise",
+	})
+
+	window, err := store.ListMine(memberContext(ctx, ws, me), nil, nil)
+	if err != nil {
+		t.Fatalf("ListMine: %v", err)
+	}
+	if len(window.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1 — the caller seeded one message", len(window.Entries))
+	}
+	got := window.Entries[0].Resolution
+	if got == nil {
+		t.Fatal("the caller's own disposition is absent, so this test would pass for a join that answers nothing")
+	}
+	if got.Status != "real" {
+		t.Errorf("resolution status = %q, want \"real\" — the trace carries a colleague's verdict about the same sender",
+			got.Status)
+	}
+}

--- a/backend/internal/modules/capture/tracestore.go
+++ b/backend/internal/modules/capture/tracestore.go
@@ -293,10 +293,18 @@ const traceRowColumns = `t.id, t.stage, t.connector, t.outcome, coalesce(t.reaso
 // the outcome. Mail is unguarded, so a `captured` row carrying noise_prior or
 // decided_prior still reports the settled PRIOR verdict that explains it.
 //
-// BOTH joins carry the workspace, and that is not belt-and-braces: there is no
-// RLS on these tables since 0217, an address is not unique across tenants, and
-// an unscoped `d.email = a.counterparty_email` would answer with ANOTHER
-// workspace's verdict about the same person.
+// The join carries the trace's OWNER, and that is the isolation rather than a
+// belt on one: the ledger row records who raised the disposition, an address is
+// not unique across members, and `d.email = a.counterparty_email` alone answers
+// with ANOTHER member's verdict about the same person. A disposition can say
+// `personal` or `advisor` about a sender, which is a statement about that
+// member's own correspondence.
+//
+// A workspace-owned trace has no member to match, so it joins the row the
+// workspace itself raised — `t.user_id IS NULL AND d.owner_id IS NULL` — and
+// never a member's. There is nothing behind this: the tables carry no policy
+// and no workspace column, so a predicate this query does not write is a
+// predicate nothing writes.
 //
 // The widened arm additionally requires a MEMBER, which keeps it on the
 // personal side of the read. `a.channel_provider IS NULL` used to make that
@@ -320,6 +328,7 @@ const resolutionJoin = `
 		         SELECT status, kind, resolved_at
 		           FROM capture_pending_counterparty
 		          WHERE email = a.counterparty_email
+		            AND owner_id IS NOT DISTINCT FROM t.user_id
 		            AND (a.channel_provider IS NULL
 		                 OR (t.user_id IS NOT NULL
 		                     AND t.outcome IN ('deferred', 'suppressed')))

--- a/backend/internal/modules/people/conversationclaim.go
+++ b/backend/internal/modules/people/conversationclaim.go
@@ -216,6 +216,15 @@ func (s *Store) readClaims(
 	ctx context.Context, tx pgx.Tx, personID ids.PersonID, within *ids.ProjectID,
 	extra, order string, limit int,
 ) ([]crmcontracts.ConversationClaim, error) {
+	// The object grant first, then the audience clause. The clause narrows rows
+	// for a caller already admitted; it asks nobody whether the caller may read
+	// an activity at all, so composing one on its own admits a principal holding
+	// no activity grant to every claim whose source they happen to be in the
+	// audience of. Both callers require this today — the object read is the gate
+	// they document — and this is the check that survives the third one.
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	personPos := arg(personID)

--- a/backend/internal/modules/people/geocodecity.go
+++ b/backend/internal/modules/people/geocodecity.go
@@ -31,6 +31,9 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // LookupCity answers a point for a city NAME, derived from the located
@@ -63,6 +66,14 @@ func (s *Store) LookupCity(ctx context.Context, city string) (CachedPlace, bool,
 	// GROUP BY always returns exactly one row, and scanning that NULL into a
 	// float64 is an error rather than the not-found this function means. Found
 	// by the test for a city nobody is in.
+	// The object grant, before the row scope below composes anything. The scope
+	// clause narrows to the companies this caller could list; it does not ask
+	// whether they may list companies at all, and scopeOrAllRows answers ALL
+	// ROWS for an unbounded principal — so a caller holding no organization
+	// grant would learn a city's centroid from every company in it.
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		return CachedPlace{}, false, err
+	}
 	var lat, lon, latSpread, lonSpread *float64
 	var located int
 	err := s.tx(ctx, func(tx pgx.Tx) error {


### PR DESCRIPTION
`TestEveryStoreEntryPointIsAuthGated` marked a method gated when its body named **any** selector on the `auth` package. `auth.Actor` satisfied it — a read of who is calling. So did every clause builder, which is the shape that matters: `auth.ScopeClauseFor` renders a row predicate for a caller *already admitted*, and a method that composes one while asking nobody whether the caller may be there at all is exactly what this gate claims to catch.

## The new rule

It counts refusals. The set is **derived** from the verb the name starts with — `Require`, `Ensure`, `Admit`, `Hold`, `Lock` — so a gate added later inherits the rule by being named like its neighbours, plus eight ratified names that refuse without carrying one, each stating what it refuses.

A census holds the convention: an exported function that names `ErrPermissionDenied` and is not counted fails the build. A sixth refusal verb would otherwise be invisible, and the gate would go on passing.

## Fallout: seven entry points, three real

- **`readClaims`** (behind `ClaimsForPerson` / `OpenCommitmentsForPerson`) composed the activity *audience* clause and no activity grant. A principal holding none read every claim whose source they were in the audience of.
- **`LookupCity`** composed the organization row scope through `scopeOrAllRows`, which answers **all rows** for an unbounded principal — so a caller holding no organization grant learned a city's centroid from every company in it.

Both callers of each already require the object read, so this is defence for the third caller rather than a live hole.

Four are waived, with reasons naming the real bound: a count returning no row, a verdict-engine bool under the system principal, a read whose predicate is the caller's own id, and a worker sweep.

## Why this is load-bearing

Reverting the one-line rule change and removing `LookupCity`'s gate: the old rule reports **nothing**, and all four honest waivers read as stale.

`craft-static` already fails on `main` over `events/catalog.go`, untouched here — filed as #4755.

Found by a Codex audit of the access-rights model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the authorization gate so it counts actual refusals, not any mention of the `auth` package, and fixes the entry points the old rule missed.

The gate previously marked a method gated if its body named any selector on `auth` — including `auth.Actor` (a read of who is calling) and clause builders like `auth.ScopeClauseFor`, which compose row predicates for callers already admitted. Now it counts only names that refuse a caller: verbs `Require`, `Ensure`, `Admit`, `Hold`, plus four ratified names that refuse without a verb (`EdgeReadAdmitted`, `EdgeReadScope`, `VisibleTo`, `WritableBy`). A census fails if an exported `auth` function names `ErrPermissionDenied` without being counted, or if a counted name stops refusing; names that read like refusals but only omit rows or stamp booleans (`LockSubjectLive`, `MasksAnyRowOf`, `VisibleSubset`, `WritableSubset`, `StampWritable`) are recorded in `authNotDecisions`.

Five entry points are explicitly waived with reasons naming what bounds them (a permission map, a count returning no row, a verdict bool under the system principal, a read scoped to the caller's own id, a worker sweep).

**Bug Fixes**
- `readClaims` and `LookupCity` composed row scopes without object grants, letting a caller with no grant read claims they were in the audience of, or city centroids from every company; both now call `auth.Require` first.
- Trace dispositions now join on the trace's owner: an address-only join answered a member's trace with a colleague's later verdict about the same sender, and a workspace-owned trace never matched a member's ledger row.

<sup>Written for commit 0f1a9920c4a3d2dc11b00f018e468a66e2960cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

