### PR TITLE
A voice build with no AI provider says so instead of blaming the samples

### DIFF
--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -337,6 +337,13 @@ func (w *voiceBuildWorker) fail(ctx context.Context, buildID ids.UUID, claimedAt
 // missing or unbound model lane is model_unavailable, malformed or
 // unverifiable model output is invalid_output, everything else is internal.
 func failureStatusCode(err error) string {
+	// By sentinel and FIRST, because the fake's rejection is also a rejection:
+	// its text matches the invalid_output markers below, and classifying an
+	// installation with no provider as bad model output is what makes the row
+	// say "try again" to somebody whose every retry is already failing.
+	if errors.Is(err, ai.ErrUnconfiguredModel) {
+		return "model_unavailable"
+	}
 	text := err.Error()
 	for _, marker := range []string{"no model path", "no bound", "not bound", "unbound"} {
 		if strings.Contains(text, marker) {

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -767,3 +767,58 @@ func TestVoiceBuildAlwaysReachesATerminalState(t *testing.T) {
 		})
 	}
 }
+
+// An installation with no vendor bound runs the whole voice build on the
+// offline stand-in, whose one answer no validator can accept. The row it
+// leaves is the only thing its operator sees, and it used to say the model
+// "returned something we could not read as a profile … try again" — advice
+// that cannot work, because every retry buys the same stand-in. A first user
+// spent an hour on it.
+//
+// Driven through the REAL offline routing rather than a scripted brain: what
+// carries the cause is the provider name the --ai-fake config installs, so a
+// double that merely returns an error would prove nothing about production.
+func TestVoiceBuildOnAnUnconfiguredInstallationNamesTheSetting(t *testing.T) {
+	env, build := seedVoiceBuild(t, "A quote the stand-in will never cite.", 6)
+	ctx := env.workerCtx(t)
+	path, err := NewLocalModelPath(ai.FakeRoutingConfig())
+	if err != nil {
+		t.Fatalf("building the offline model path: %v", err)
+	}
+	worker := newVoiceBuildWorker(env.e.Pool, path.VoiceBuild, slog.New(slog.DiscardHandler))
+
+	input, claimed, err := env.store.ClaimBuild(ctx, env.profile.ID, build.ID, time.Minute)
+	if err != nil || !claimed {
+		t.Fatalf("claim: %v claimed=%v", err, claimed)
+	}
+	runErr := worker.run(ctx, build.ID, input)
+	if runErr == nil {
+		t.Fatal("the stand-in cannot produce a profile, so the run must fail")
+	}
+	if err := worker.fail(ctx, build.ID, *input.Build.StartedAt,
+		failureStatusCode(runErr), ai.SafeVoiceBuildFailure(runErr)); err != nil {
+		t.Fatalf("recording the failure: %v", err)
+	}
+
+	finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// model_unavailable, not invalid_output: the row's code is what tells an
+	// operator whether to retry or to open a setting.
+	if finished.StatusCode == nil {
+		t.Fatal("a failed build always records a status code")
+	}
+	if *finished.StatusCode != "model_unavailable" {
+		t.Fatalf("status code = %s, want model_unavailable", *finished.StatusCode)
+	}
+	if finished.StatusDetail == nil {
+		t.Fatal("a failed build always records the operator's guidance")
+	}
+	if !strings.Contains(*finished.StatusDetail, "Settings") {
+		t.Fatalf("the detail names where to fix it: %s", *finished.StatusDetail)
+	}
+	if strings.Contains(*finished.StatusDetail, "your samples") {
+		t.Fatalf("nothing blames the corpus for a missing setting: %s", *finished.StatusDetail)
+	}
+}

--- a/backend/internal/compose/voicebuild_test.go
+++ b/backend/internal/compose/voicebuild_test.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,6 +26,14 @@ func TestFailureStatusCodeClassifiesErrorFamilies(t *testing.T) {
 		"fabricated evidence":     {errors.New(`voice build cited unknown sample "s-9"`), "invalid_output"},
 		"non-verbatim quote":      {errors.New(`voice build signature move quote is not verbatim in sample "s-1"`), "invalid_output"},
 		"anything else is opaque": {errors.New("connection reset by peer"), "internal"},
+		// The stand-in's rejection carries the invalid_output words AND the
+		// sentinel. It is the sentinel that decides, because the row's code is
+		// what tells an operator whether to retry or to open a setting.
+		"the offline stand-in answered": {
+			fmt.Errorf("voice build model call: %w: %w: voice build returned invalid JSON: unexpected end",
+				ai.ErrUnconfiguredModel, ai.ErrOutputRejected),
+			"model_unavailable",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/modules/ai/structured.go
+++ b/backend/internal/modules/ai/structured.go
@@ -29,6 +29,20 @@ import (
 // reply this site will not act on is owed a decision.
 var ErrOutputRejected = errors.New("ai: model output rejected by the validator")
 
+// ErrUnconfiguredModel marks a rejection whose text came from the offline fake
+// provider — the stand-in an installation runs on until an operator binds a
+// real vendor. The fake answers every request with a hash string, so it fails
+// the validator on the first attempt and on every retry forever after.
+//
+// It exists because the two rejections need opposite words. A real model that
+// answered badly is worth another attempt and might be the corpus's fault; the
+// fake is neither, and telling its operator that "the model returned something
+// we could not read" sent one to audit their own writing samples while the
+// answer was a two-field settings screen. Carried alongside ErrOutputRejected
+// rather than instead of it, so every caller that classifies a terminal
+// rejection keeps classifying this one the same way.
+var ErrUnconfiguredModel = errors.New("ai: no AI provider is configured, so the offline stand-in model answered")
+
 // Validator judges one completion's text; the returned error is fed
 // back verbatim on the retry so the model sees WHY it failed.
 type Validator func(text string) error
@@ -91,11 +105,22 @@ func (r *Router) CompleteStructured(ctx context.Context, task Task, req model.Re
 	}
 	if finalErr := validate(resp.Text); finalErr != nil {
 		r.forgetCached(ctx, task, escalated)
-		return model.Response{}, info, fmt.Errorf(
-			"%w: %s after retry and escalation: %w", ErrOutputRejected, task, finalErr,
-		)
+		return model.Response{}, info, rejected(task, info, finalErr)
 	}
 	return resp, info, nil
+}
+
+// rejected names what refused the text. The offline fake cannot produce a
+// valid answer for any structured task, so a rejection it served is an
+// unconfigured installation and gets its own sentinel on top of the terminal
+// one — the caller then has the choice between "your model misbehaved" and
+// "you have no model", which is the difference between a retry and a setting.
+func rejected(task Task, info RouteInfo, finalErr error) error {
+	err := fmt.Errorf("%w: %s after retry and escalation: %w", ErrOutputRejected, task, finalErr)
+	if info.Provider == ProviderFake {
+		return fmt.Errorf("%w: %w", ErrUnconfiguredModel, err)
+	}
+	return err
 }
 
 // forgetCached evicts the cached completion for exactly this request: a

--- a/backend/internal/modules/ai/structured_test.go
+++ b/backend/internal/modules/ai/structured_test.go
@@ -100,3 +100,58 @@ func TestStructuredExhaustionIsAnHonestError(t *testing.T) {
 		t.Errorf("exhaustion error %q drops the task or the validator's reason", err)
 	}
 }
+
+// An installation with no vendor bound runs on the offline stand-in, whose
+// answer is a hash string no structured task can accept. The rejection is
+// terminal like any other, but its CAUSE is a setting rather than the model or
+// the input — so the router marks it, and a caller can say which of the two it
+// is instead of telling an operator to retry a thing that cannot succeed.
+//
+// Built through the real FakeRoutingConfig rather than a hand-supplied route
+// map, because what carries the provider name into RouteInfo is the config the
+// --ai-fake path actually installs.
+func TestStructuredMarksRejectionFromTheUnconfiguredStandIn(t *testing.T) {
+	r, err := NewLocalRouter(FakeRoutingConfig(), WithoutResultCache())
+	if err != nil {
+		t.Fatalf("building the offline router: %v", err)
+	}
+
+	_, info, err := r.CompleteStructured(wsContext(t), TaskColdStart, structuredReq(), jsonObjectValidator)
+	if err == nil {
+		t.Fatal("the stand-in cannot satisfy a structured validator, so this must fail")
+	}
+	if info.Provider != ProviderFake {
+		t.Fatalf("the route says what served it; got %q", info.Provider)
+	}
+	// Both sentinels: every caller that classifies a terminal rejection keeps
+	// classifying this one, and the one that wants the cause can now ask.
+	if !errors.Is(err, ErrOutputRejected) {
+		t.Fatalf("still a terminal rejection: %v", err)
+	}
+	if !errors.Is(err, ErrUnconfiguredModel) {
+		t.Fatalf("a rejection served by the stand-in is marked as one: %v", err)
+	}
+}
+
+// The counter-case, without which the marker above could be unconditional: a
+// REAL bound model that answers badly is not an unconfigured installation, and
+// sending its operator to a settings screen wastes the one message they get.
+func TestStructuredLeavesARealModelsBadAnswerUnmarked(t *testing.T) {
+	cheap := NewFakeClient().Script("garbage", "still garbage", "garbage again")
+	r := assembleRouter(
+		map[Tier]model.Client{TierCheapCloud: cheap, TierPremium: cheap},
+		NewFakeClient(), ProfileEUHosted, &memMeter{}, DefaultMonthlyTokens, nil,
+		map[Tier]routeMeta{
+			TierCheapCloud: {provider: "anthropic", model: "claude-x"},
+			TierPremium:    {provider: "anthropic", model: "claude-y"},
+		}, false, nil,
+	)
+
+	_, _, err := r.CompleteStructured(wsContext(t), TaskColdStart, structuredReq(), jsonObjectValidator)
+	if !errors.Is(err, ErrOutputRejected) {
+		t.Fatalf("three bad answers are a terminal rejection: %v", err)
+	}
+	if errors.Is(err, ErrUnconfiguredModel) {
+		t.Fatalf("a bound vendor that answered badly is not an unconfigured installation: %v", err)
+	}
+}

--- a/backend/internal/modules/ai/voicebuilder.go
+++ b/backend/internal/modules/ai/voicebuilder.go
@@ -48,6 +48,15 @@ func SafeVoiceBuildFailure(err error) string {
 	if errors.Is(err, ErrProviderQuota) {
 		return "Our AI provider refused the call: the account behind it is out of budget or over its quota, so the build never ran. Your previous version is unchanged. Raise the limit on the provider account, then build again."
 	}
+	// Asked before the answer-shaped default below for the same reason: the
+	// offline stand-in DID answer, but with the one string it produces for
+	// every request, so reading its reply as a bad profile blames a corpus for
+	// a missing setting. An installation that never bound a vendor reaches this
+	// on its FIRST build and on every retry after, which is exactly the case
+	// the default message cost an operator an hour of retrying.
+	if errors.Is(err, ErrUnconfiguredModel) {
+		return "Voice building is unavailable until an AI provider is configured: the offline stand-in model answered instead. Open Settings → AI, bind each tier to a vendor and add that vendor's key under Model provider keys, then build again."
+	}
 	// A burst limit, not an empty account: the same build succeeds shortly,
 	// and telling this operator to go raise a spending limit would send them
 	// to a console where nothing is wrong.

--- a/backend/internal/modules/ai/voicebuilder_test.go
+++ b/backend/internal/modules/ai/voicebuilder_test.go
@@ -430,3 +430,33 @@ func TestABrokerSentenceIsRedactedAndBoundedBeforeItIsLogged(t *testing.T) {
 		t.Fatalf("one logged vendor sentence is bounded; got %d characters", got)
 	}
 }
+
+// An installation that never bound a vendor runs on the offline stand-in, which
+// answers every request with one hash string and so fails the validator on the
+// first attempt and on every retry after. Its operator is told to try again by
+// the generic message, and does — one did, for an hour, while the answer was a
+// two-field settings screen. So this cause gets its own sentence.
+func TestSafeVoiceBuildFailureNamesAnUnconfiguredProvider(t *testing.T) {
+	rejected := fmt.Errorf("%w: voice_build after retry and escalation: voice build returned invalid JSON: invalid character 'k'", ErrOutputRejected)
+	unconfigured := fmt.Errorf("voice build model call: %w: %w", ErrUnconfiguredModel, rejected)
+
+	message := SafeVoiceBuildFailure(unconfigured)
+	if !strings.Contains(message, "Settings") {
+		t.Fatalf("the message names where to fix it: %q", message)
+	}
+	if strings.Contains(strings.ToLower(message), "your samples") {
+		t.Fatalf("nothing blames the corpus for a missing setting: %q", message)
+	}
+
+	// The same wrapped rejection WITHOUT the sentinel still reads as a bad
+	// answer — otherwise the new branch has swallowed the old cause and every
+	// genuinely unreadable reply now sends its operator to a settings screen
+	// where nothing is wrong.
+	answeredBadly := SafeVoiceBuildFailure(fmt.Errorf("voice build model call: %w", rejected))
+	if answeredBadly == message {
+		t.Fatal("an unconfigured installation and a model that answered badly are different failures and read differently")
+	}
+	if strings.Contains(answeredBadly, "Settings") {
+		t.Fatalf("a real model's bad answer is not a settings problem: %q", answeredBadly)
+	}
+}

--- a/frontend/src/screens/onboarding-conversation/conversation-correlation.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-correlation.test.ts
@@ -320,7 +320,7 @@ describe("voice build", () => {
     run(
       [
         { type: "BUILD_STAGE", buildId: "b1", stage: "snapshot" },
-        { type: "BUILD_TERMINAL", buildId: "b1", status },
+        { type: "BUILD_TERMINAL", buildId: "b1", status, detail: null },
       ],
       building(),
     );
@@ -356,7 +356,7 @@ describe("voice build", () => {
     });
     // A late failure from attempt 1 must never yank attempt 2 to vo.result.
     const stale: ConversationEvent[] = [
-      { type: "BUILD_TERMINAL", buildId: "b1", status: "failed" },
+      { type: "BUILD_TERMINAL", buildId: "b1", status: "failed", detail: null },
       { type: "BUILD_STAGE", buildId: "b1", stage: "activate" },
     ];
     for (const event of stale) {
@@ -366,6 +366,7 @@ describe("voice build", () => {
       type: "BUILD_TERMINAL",
       buildId: "b2",
       status: "succeeded",
+      detail: null,
     });
     expect(done.phase).toBe("vo.result");
   });
@@ -398,6 +399,7 @@ describe("voice build", () => {
         type: "BUILD_TERMINAL",
         buildId: "b1",
         status: "deferred",
+        detail: null,
       }),
     ).toBe(deferred);
     // Another build's events do not resume this one.
@@ -423,6 +425,7 @@ describe("voice build", () => {
       type: "BUILD_TERMINAL",
       buildId: "b1",
       status: "succeeded",
+      detail: null,
     });
     expect(done.phase).toBe("vo.result");
     expect(done.thread.at(-1)).toMatchObject({
@@ -438,6 +441,7 @@ describe("voice build", () => {
       type: "BUILD_TERMINAL",
       buildId: "b1",
       status: "succeeded",
+      detail: null,
     });
     expect(done.phase).toBe("vo.result");
     expect(done.lastBuildStatus).toBe("succeeded");

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
@@ -114,7 +114,12 @@ describe("conversationReducer happy path", () => {
         { type: "BUILD_STAGE", buildId: "b1", stage: "extract" },
         { type: "BUILD_STAGE", buildId: "b1", stage: "evaluate" },
         { type: "BUILD_STAGE", buildId: "b1", stage: "activate" },
-        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
+        {
+          type: "BUILD_TERMINAL",
+          buildId: "b1",
+          status: "succeeded",
+          detail: null,
+        },
       ],
       state,
     );
@@ -216,7 +221,12 @@ describe("conversationReducer happy path", () => {
       { type: "BASIS_DONE" },
       { type: "INVITE_ACCEPTED" },
       { type: "BUILD_STARTED", buildId: "b1" },
-      { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
+      {
+        type: "BUILD_TERMINAL",
+        buildId: "b1",
+        status: "succeeded",
+        detail: null,
+      },
     ]);
     const revised = conversationReducer(built, { type: "VOICE_REVISE" });
     expect(revised).toMatchObject({ act: "voice", phase: "vo.collecting" });
@@ -228,7 +238,12 @@ describe("conversationReducer happy path", () => {
     const failed = run(
       [
         { type: "BUILD_STARTED", buildId: "b2" },
-        { type: "BUILD_TERMINAL", buildId: "b2", status: "failed", detail: null },
+        {
+          type: "BUILD_TERMINAL",
+          buildId: "b2",
+          status: "failed",
+          detail: null,
+        },
       ],
       revised,
     );
@@ -395,7 +410,12 @@ describe("member path", () => {
     state = run(
       [
         { type: "BUILD_STARTED", buildId: "b1" },
-        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
+        {
+          type: "BUILD_TERMINAL",
+          buildId: "b1",
+          status: "succeeded",
+          detail: null,
+        },
         { type: "VOICE_DONE" },
       ],
       state,

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
@@ -114,7 +114,7 @@ describe("conversationReducer happy path", () => {
         { type: "BUILD_STAGE", buildId: "b1", stage: "extract" },
         { type: "BUILD_STAGE", buildId: "b1", stage: "evaluate" },
         { type: "BUILD_STAGE", buildId: "b1", stage: "activate" },
-        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded" },
+        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
       ],
       state,
     );
@@ -216,7 +216,7 @@ describe("conversationReducer happy path", () => {
       { type: "BASIS_DONE" },
       { type: "INVITE_ACCEPTED" },
       { type: "BUILD_STARTED", buildId: "b1" },
-      { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded" },
+      { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
     ]);
     const revised = conversationReducer(built, { type: "VOICE_REVISE" });
     expect(revised).toMatchObject({ act: "voice", phase: "vo.collecting" });
@@ -228,7 +228,7 @@ describe("conversationReducer happy path", () => {
     const failed = run(
       [
         { type: "BUILD_STARTED", buildId: "b2" },
-        { type: "BUILD_TERMINAL", buildId: "b2", status: "failed" },
+        { type: "BUILD_TERMINAL", buildId: "b2", status: "failed", detail: null },
       ],
       revised,
     );
@@ -395,7 +395,7 @@ describe("member path", () => {
     state = run(
       [
         { type: "BUILD_STARTED", buildId: "b1" },
-        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded" },
+        { type: "BUILD_TERMINAL", buildId: "b1", status: "succeeded", detail: null },
         { type: "VOICE_DONE" },
       ],
       state,

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.ts
@@ -49,6 +49,7 @@ export const initialConversationState: ConversationState = {
   activeBuildId: null,
   lastBuildStage: null,
   lastBuildStatus: null,
+  lastBuildDetail: null,
   linkedinStatus: "pending",
 };
 
@@ -399,6 +400,7 @@ function applyEvent(
         activeBuildId: event.buildId,
         lastBuildStage: null,
         lastBuildStatus: null,
+        lastBuildDetail: null,
       });
     case "BUILD_STAGE":
       // A stage from vo.result means a deferred build resumed on its own:
@@ -409,6 +411,7 @@ function applyEvent(
           phase: "vo.building",
           lastBuildStage: event.stage,
           lastBuildStatus: null,
+          lastBuildDetail: null,
         },
         [
           {
@@ -421,7 +424,11 @@ function applyEvent(
     case "BUILD_TERMINAL":
       return withEntries(
         state,
-        { phase: "vo.result", lastBuildStatus: event.status },
+        {
+          phase: "vo.result",
+          lastBuildStatus: event.status,
+          lastBuildDetail: event.detail,
+        },
         [
           {
             kind: "outcome",

--- a/frontend/src/screens/onboarding-conversation/conversation-types.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-types.ts
@@ -163,6 +163,12 @@ export type ConversationState = {
   /** How the last voice build ended: failed may be retried, deferred
    * resumes on its own and its later events re-enter vo.building. */
   lastBuildStatus: BuildTerminalStatus | null;
+  /** What the server said about that ending, in its own words (the build
+   * row's status_detail). It is the whole difference between "no provider is
+   * configured" and "the model answered badly", and dropping it left one
+   * fixed sentence standing in for every cause. Null when the server had
+   * none, and cleared whenever a new build starts. */
+  lastBuildDetail: string | null;
   /** LinkedIn's own resolution on the connect screen, independent of mail:
    * "pending" admits LINKEDIN_SAVED/LINKEDIN_SKIPPED exactly once; either
    * resolves it, and neither ever gates CONNECT_DONE. */
@@ -245,7 +251,16 @@ export type ConversationEvent =
   | { type: "SPEAKER_NEEDED"; question: ConversationQuestion }
   | { type: "BUILD_STARTED"; buildId: string }
   | { type: "BUILD_STAGE"; buildId: string; stage: BuildStage }
-  | { type: "BUILD_TERMINAL"; buildId: string; status: BuildTerminalStatus }
+  // detail is the build row's own status_detail: safe operator guidance the
+  // server composed for exactly this outcome, and the only thing that tells a
+  // broken build apart from another broken build. Null when the server had
+  // none, which every headline below reads correctly without.
+  | {
+      type: "BUILD_TERMINAL";
+      buildId: string;
+      status: BuildTerminalStatus;
+      detail: string | null;
+    }
   // Leaving the voice act, built or skipped, lands straight on connect.
   | { type: "VOICE_DONE" }
   // A succeeded build the reader does not recognise as their own: back to

--- a/frontend/src/screens/onboarding-conversation/use-voice-build.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-build.ts
@@ -164,7 +164,12 @@ export function useVoiceBuild({ dispatch, machine }: UseVoiceBuildArgs) {
     });
     // A poll that never recovered: the server's guidance is exactly what
     // this branch could not fetch, so it says nothing rather than inventing.
-    dispatch({ type: "BUILD_TERMINAL", buildId, status: "failed", detail: null });
+    dispatch({
+      type: "BUILD_TERMINAL",
+      buildId,
+      status: "failed",
+      detail: null,
+    });
   }, [poll.isError, buildId, machine, queue, dispatch]);
 
   // What the finished build produced: the just-built version carries the

--- a/frontend/src/screens/onboarding-conversation/use-voice-build.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-build.ts
@@ -128,7 +128,12 @@ export function useVoiceBuild({ dispatch, machine }: UseVoiceBuildArgs) {
     queue.push(events);
     const terminal = terminalOf(next.status);
     if (flushed && terminal !== null) {
-      dispatch({ type: "BUILD_TERMINAL", buildId: next.id, status: terminal });
+      dispatch({
+        type: "BUILD_TERMINAL",
+        buildId: next.id,
+        status: terminal,
+        detail: next.status_detail,
+      });
     }
   }, [poll.data, queue, dispatch]);
 
@@ -157,7 +162,9 @@ export function useVoiceBuild({ dispatch, machine }: UseVoiceBuildArgs) {
         i18nKey: "ob.conv.voice.buildPollFailed",
       },
     });
-    dispatch({ type: "BUILD_TERMINAL", buildId, status: "failed" });
+    // A poll that never recovered: the server's guidance is exactly what
+    // this branch could not fetch, so it says nothing rather than inventing.
+    dispatch({ type: "BUILD_TERMINAL", buildId, status: "failed", detail: null });
   }, [poll.isError, buildId, machine, queue, dispatch]);
 
   // What the finished build produced: the just-built version carries the

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -110,7 +110,21 @@ const documentStats: IngestStats = {
 
 // Build poll rows: only the fields the hook reads; the stub serves them as
 // plain JSON exactly like the server would.
-type BuildRow = { id: string; status: string; stage: string | null };
+// What the server sends when an installation has no AI provider bound: the
+// one sentence that separates "open a setting" from "try again", and the
+// reason a reader retried a build that could never succeed.
+const UNCONFIGURED_DETAIL =
+  "Voice building is unavailable until an AI provider is configured: the offline stand-in model answered instead. Open Settings → AI, bind each tier to a vendor and add that vendor's key under Model provider keys, then build again.";
+
+type BuildRow = {
+  id: string;
+  status: string;
+  stage: string | null;
+  /** The server's own words about a terminal outcome. Optional here exactly
+   * as it is on the wire — absent is what a build with nothing to add sends,
+   * and the screen must read correctly either way. */
+  status_detail?: string;
+};
 
 const candidateVersion = {
   profile_version: 3,
@@ -609,7 +623,14 @@ describe("the conversational voice act", () => {
         preview: documentPreview,
         ingests: [{ stats: documentStats, summary: summaryOf(820) }],
         builds: {
-          [BUILD_IDS[0]]: [{ id: BUILD_IDS[0], status: "failed", stage: null }],
+          [BUILD_IDS[0]]: [
+            {
+              id: BUILD_IDS[0],
+              status: "failed",
+              stage: null,
+              status_detail: UNCONFIGURED_DETAIL,
+            },
+          ],
           [BUILD_IDS[1]]: [
             { id: BUILD_IDS[1], status: "succeeded", stage: null },
           ],
@@ -631,6 +652,11 @@ describe("the conversational voice act", () => {
           },
         ),
       ).toBeTruthy();
+      // The headline is the same for every broken build, so what the reader
+      // acts on is the server's sentence under it. Without this the screen
+      // says only "the build did not finish" and the one actionable fact —
+      // that no provider is configured — never reaches them.
+      expect(await screen.findByText(UNCONFIGURED_DETAIL)).toBeTruthy();
 
       await userEvent.click(
         screen.getByRole("button", { name: /Try the build again/ }),
@@ -768,7 +794,7 @@ describe("the conversational voice act", () => {
     const retried = run(
       [
         { type: "BUILD_STARTED", buildId: BUILD_IDS[0] },
-        { type: "BUILD_TERMINAL", buildId: BUILD_IDS[0], status: "failed" },
+        { type: "BUILD_TERMINAL", buildId: BUILD_IDS[0], status: "failed", detail: null },
         { type: "BUILD_STARTED", buildId: BUILD_IDS[1] },
       ],
       collectingState(),
@@ -779,6 +805,7 @@ describe("the conversational voice act", () => {
       type: "BUILD_TERMINAL",
       buildId: BUILD_IDS[0],
       status: "succeeded",
+      detail: null,
     });
     expect(afterStale).toBe(retried);
   });

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -794,7 +794,12 @@ describe("the conversational voice act", () => {
     const retried = run(
       [
         { type: "BUILD_STARTED", buildId: BUILD_IDS[0] },
-        { type: "BUILD_TERMINAL", buildId: BUILD_IDS[0], status: "failed", detail: null },
+        {
+          type: "BUILD_TERMINAL",
+          buildId: BUILD_IDS[0],
+          status: "failed",
+          detail: null,
+        },
         { type: "BUILD_STARTED", buildId: BUILD_IDS[1] },
       ],
       collectingState(),

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -3,11 +3,13 @@ import { useRef } from "react";
 import type { components } from "../../api/schema";
 import { ordinalNumber } from "../../format/format";
 import { useT } from "../../i18n";
+import type { MessageKey } from "../../i18n/en";
 import { problemMessageOf } from "../common";
 import { useFileDrop } from "../use-file-drop";
 import { parseVoiceInsights } from "../voice-insights";
 import { VOICE_MIN_WORDS } from "../voice-intake-core";
 import type {
+  BuildTerminalStatus,
   ConversationEvent,
   ConversationState,
 } from "./conversation-machine";
@@ -131,6 +133,15 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   );
 }
 
+// The two ways a build ends without a profile. Keyed rather than branched so
+// the rule they share — the server's own detail under a fixed headline — is
+// written once and cannot drift between them. A succeeded build has its own
+// headline above and is absent here on purpose.
+const brokenBuildTitles: Partial<Record<BuildTerminalStatus, MessageKey>> = {
+  failed: "ob.conv.build.failed",
+  deferred: "ob.conv.build.deferred",
+};
+
 /**
  * What the room says this screen is, per phase. THE QUESTION IS THE TITLE
  * while the speaker decision is pending, the same rule the company act's
@@ -174,23 +185,22 @@ function boardHeading(
   // A build that did not finish, or is waiting on budget, is the room's own
   // headline: left under "teach me how you write" the reader takes the dossier
   // below for the result and never learns nothing was built.
-  // The server's own sentence rides under that headline, because the headline
-  // is the same for every broken build: "no AI provider is configured" and
-  // "the model answered badly" are one line apart on screen and a settings
-  // change apart in life, and the reader who cannot tell them apart retries
-  // forever. Absent detail leaves the headline standing alone rather than
-  // inventing a cause — it reads correctly on its own.
-  if (state.phase === "vo.result" && state.lastBuildStatus === "failed") {
+  //
+  // Both take the server's own sentence under that headline, because the
+  // headline alone is the same for every broken build: "no AI provider is
+  // configured" and "the model answered badly" are one line apart on screen
+  // and a settings change apart in life, and the reader who cannot tell them
+  // apart retries forever. Absent detail leaves the headline standing alone
+  // rather than inventing a cause — it reads correctly on its own.
+  const ending = state.lastBuildStatus;
+  const brokenTitle =
+    state.phase === "vo.result" && ending !== null
+      ? brokenBuildTitles[ending]
+      : undefined;
+  if (brokenTitle !== undefined) {
     return {
       eyebrow,
-      title: t("ob.conv.build.failed"),
-      sub: state.lastBuildDetail ?? undefined,
-    };
-  }
-  if (state.phase === "vo.result" && state.lastBuildStatus === "deferred") {
-    return {
-      eyebrow,
-      title: t("ob.conv.build.deferred"),
+      title: t(brokenTitle),
       sub: state.lastBuildDetail ?? undefined,
     };
   }

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -174,11 +174,25 @@ function boardHeading(
   // A build that did not finish, or is waiting on budget, is the room's own
   // headline: left under "teach me how you write" the reader takes the dossier
   // below for the result and never learns nothing was built.
+  // The server's own sentence rides under that headline, because the headline
+  // is the same for every broken build: "no AI provider is configured" and
+  // "the model answered badly" are one line apart on screen and a settings
+  // change apart in life, and the reader who cannot tell them apart retries
+  // forever. Absent detail leaves the headline standing alone rather than
+  // inventing a cause — it reads correctly on its own.
   if (state.phase === "vo.result" && state.lastBuildStatus === "failed") {
-    return { eyebrow, title: t("ob.conv.build.failed") };
+    return {
+      eyebrow,
+      title: t("ob.conv.build.failed"),
+      sub: state.lastBuildDetail ?? undefined,
+    };
   }
   if (state.phase === "vo.result" && state.lastBuildStatus === "deferred") {
-    return { eyebrow, title: t("ob.conv.build.deferred") };
+    return {
+      eyebrow,
+      title: t("ob.conv.build.deferred"),
+      sub: state.lastBuildDetail ?? undefined,
+    };
   }
   return {
     eyebrow,


### PR DESCRIPTION
## What this fixes

A first user retried the onboarding voice build for an hour. His install had no AI provider bound, so every model call was served by the offline stand-in, whose one hash-string answer can never satisfy a structured validator. The build row said the model *"returned something we could not read as a profile … try again"* — advice that could not work, because every retry bought the same stand-in.

His worker log is unambiguous: `ai.call task=voice_build ... provider=fake` followed by `voice build failed status_code=invalid_output`.

## The change

**The router marks the cause.** When a terminal rejection was served by the fake provider, `CompleteStructured` wraps it with a new `ErrUnconfiguredModel` sentinel — *alongside* `ErrOutputRejected`, never instead of it, so every caller that classifies a terminal rejection keeps classifying this one identically.

**The voice build reads it first**, files the row as `model_unavailable` rather than `invalid_output`, and writes a `status_detail` naming Settings → AI.

**The onboarding voice step shows that detail.** It had the headline only, and the headline is identical for every broken build, so the one actionable fact never reached the reader. Folding the failed and deferred branches into one keyed table kept `boardHeading` under the complexity limit and states the rule they share once.

## Verified

On a live `DEV_SLUG` stack with no provider key — the user's exact condition:

```
"status_code": "model_unavailable",
"status_detail": "Voice building is unavailable until an AI provider is configured: the
offline stand-in model answered instead. Open Settings → AI, bind each tier to a vendor
and add that vendor's key under Model provider keys, then build again."
```

and the same sentence renders under the headline in the browser.

Every added branch was mutation-checked: reverting it fails the test with the old message. The integration test drives the real `FakeRoutingConfig` through the worker's own run/fail path rather than a scripted brain, because what carries the cause is the provider name the `--ai-fake` config installs.

Two generated artifacts that were already stale on main ride along (the frontend contract types and the gate inventory count) — both gates regenerate them, so leaving them out keeps the gate red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Voice builds on installations with no AI provider bound now fail with `model_unavailable` and point the operator to Settings → AI, instead of blaming the samples and asking for a retry that can never succeed.

**Bug Fixes**
- The router marks terminal rejections served by the offline fake provider with a new `ErrUnconfiguredModel` sentinel, carried alongside `ErrOutputRejected` so existing callers keep classifying them the same way.
- The onboarding voice screen now renders the server's `status_detail` under the broken-build headline, since the headline alone is identical for every failure.
- Frontend `BUILD_TERMINAL` events now carry the build row's `status_detail`, null when the server has none.

<sup>Written for commit 3f61e221dec2b92c54b435e4fd91159703716845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

