### PR TITLE
A file at the line ceiling is not one line over it

### DIFF
--- a/cli/craft/static/runner.go
+++ b/cli/craft/static/runner.go
@@ -311,12 +311,28 @@ func (fc *fileContext) waiverHygiene() []Finding {
 	return out
 }
 
+// countLines answers the line count `wc -l` answers: a terminating newline ENDS
+// the last line rather than opening another, and an unterminated tail is still a
+// line. That is how the rubric states its ceilings and how a reader measures the
+// file in front of them, so a gate counting any other way fails files the rubric
+// admits.
+//
+// scripts/check-go-file-length.sh holds the same 500-line cap over the same Go
+// files and counts with `wc -l` itself. The two cannot share a helper across bash
+// and Go, so each names the other: a file at exactly the cap must pass both, and
+// that is only true while both count alike.
 func countLines(src []byte) int {
-	n := 1
+	if len(src) == 0 {
+		return 0
+	}
+	n := 0
 	for _, b := range src {
 		if b == '\n' {
 			n++
 		}
+	}
+	if src[len(src)-1] != '\n' {
+		n++
 	}
 	return n
 }

--- a/cli/craft/static/static_test.go
+++ b/cli/craft/static/static_test.go
@@ -334,3 +334,24 @@ func TestGeneratedFilesSkipped(t *testing.T) {
 		t.Fatal("generated file should be skipped")
 	}
 }
+
+// The ceiling is a line count, and a file's last line is the one before its
+// terminating newline — not a phantom line after it. Measuring the boundary
+// from both sides is the point: a gate that reads 500 as 501 fails a file the
+// rubric admits, and one that reads 501 as 500 admits a file it should fail.
+func TestLargeFile_theCeilingIsCountedTheWayTheTreeCountsLines(t *testing.T) {
+	// 1 package line + 499 filler = 500 lines, newline-terminated.
+	at := "package p\n" + strings.Repeat("// filler\n", 499)
+	if got := counts(lintSource(t, "p.go", at), "large-file"); got != 0 {
+		t.Fatalf("file at the 500-line ceiling: large-file = %d, want 0", got)
+	}
+	over := "package p\n" + strings.Repeat("// filler\n", 500)
+	if got := counts(lintSource(t, "p.go", over), "large-file"); got != 1 {
+		t.Fatalf("file one line over the ceiling: large-file = %d, want 1", got)
+	}
+	// No terminating newline: the last line still counts, and only once.
+	unterminated := "package p\n" + strings.Repeat("// filler\n", 498) + "// last"
+	if got := counts(lintSource(t, "p.go", unterminated), "large-file"); got != 0 {
+		t.Fatalf("unterminated file at the ceiling: large-file = %d, want 0", got)
+	}
+}

--- a/scripts/check-go-file-length.sh
+++ b/scripts/check-go-file-length.sh
@@ -8,6 +8,12 @@
 # offender with its frozen line count. A waived file may shrink but never
 # grow past its recorded count; once it drops to the cap or below, its entry
 # must be REMOVED so the file is back under the hard cap for good.
+#
+# THE COUNT IS `wc -l`. craft static's large-file check holds this same cap over
+# these same files, and countLines in cli/craft/static/runner.go is written to
+# answer the number this awk reads. Two gates over one cap that cannot share a
+# helper across bash and Go, so each names the other: a file at exactly the cap
+# must pass BOTH, which holds only while both count alike.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
## What

`craft static` counted a file's lines as newlines plus one. A terminating
newline was read as opening a further line, so every well-formed file measured
one longer than it is, and a file sitting exactly on the 500-line ceiling
reported 501 and blocked.

`countLines` now answers what `wc -l` answers: newlines, plus one only for an
unterminated tail, and zero for an empty file.

## Why this is the invariant and not the call site

`scripts/check-go-file-length.sh` holds the **same 500-line cap over the same
Go files** and counts with `wc -l` itself. So two gates disagreed about one
invariant, and the disagreement was silent in the worst direction: the tree's
own script reported

```
OK: go-file-length — no hand-written Go file exceeds 500 LOC (waivers: 0)
```

for the very file `craftsmanship` was failing at 501. That is how a 500-line
`catalog.go` took down `ci` on every open pull request while the script beside
it said the cap was met — and `craft static --strict` runs in the pre-push hook,
so it blocked pushes that had nothing to do with the file.

Closes the second half of https://github.com/margince/margince/issues/4755,
which asked for the off-by-one to be checked alongside the split. The split
landed in https://github.com/margince/margince/pull/4748 and took `catalog.go`
to 355 lines; this is the reason it will not happen again at the next boundary.

Neither holder can share a helper across bash and Go, so each now names the
other as the sibling over this cap — stated as the invariant that must hold,
in the code beside each one.

## The change can only ever lower a count

By exactly one, and only for a newline-terminated file. So nothing the gate
previously admitted becomes a finding, and no file becomes newly waivable: a
genuinely 501-line file still reports 501 and still blocks. The `large-file`
ceiling is the only consumer of `countLines`.

## How verified

- `go test ./cli/craft/static/ -run TestLargeFile` — the new test **fails on
  unmodified `main`** (`file at the 500-line ceiling: large-file = 1, want 0`)
  and passes with the fix. It measures the boundary from both sides plus the
  unterminated case, so a counter that drifts either way fails here rather than
  in somebody's unrelated push.
- `make craft-test` — all 8 packages green, including the `golden` suite.
- `make craft-static` — `PASS — 0 blocker, 0 major, 0 minor` across all four
  roots (`backend`, `extensions`, `fixtures`, `desktop`).
- `./scripts/check-go-file-length.sh` — OK, still 0 waivers.
- `make check-craft-doc` — OK.

- [x] `make check` — no frontend files touched; the Go touched is `cli/craft`,
      whose suite is `craft-test` in `ROOT_SCRIPT_GATES` and is green
- [x] `make test-integration` — this change does not touch tenant data, RLS or
      the write shape
- [x] `make craft-static` — green on all four roots
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-generated in full under the reporter's direction: the diagnosis, the counter,
the boundary test and this description. A human is accountable for merging.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
