### PR TITLE
The docs describe the engine that ships

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -154,7 +154,7 @@ budget rather than keeping its own list of which pages are generated.
 - [channel-capture-parity.md](explanation/channel-capture-parity.md) — whose correspondence a captured chat is: the rule that a member-bound credential puts it on the mailbox path while a shared one keeps it workspace business, which rungs of the birth ladder each faces, what makes the import row's delivery evidence sound, and a capability-by-capability table of what each side gets.
 - [outbound-messaging.md](explanation/outbound-messaging.md) — the egress twin of capture: the staging row, the transmit-time gates, receipt-before-bookkeeping, and the channel reply.
 - [outbound-webhooks.md](explanation/outbound-webhooks.md) — the governed egress surface: subscription config vs. delivery engine, secret sealing, the contract-first payload pipeline (`api/public-events.yaml` + `gen-payloads` + the typed `EmitEvent` seam) and its additive-only versioning, the retry/dead-letter state machine, the owner-scope fan-out gate (incl. the ratified deferred-delivery exceptions), and the Settings → Integrations UI.
-- [privacy-and-consent.md](explanation/privacy-and-consent.md) — the consent gate and the GDPR engines (erasure / SAR / retention).
+- [privacy-and-consent.md](explanation/privacy-and-consent.md) — the authorization engine that decides whether each message may go, and the GDPR engines (erasure / SAR / retention).
 
 **AI, retrieval and automation**
 

--- a/docs/explanation/outbound-messaging.md
+++ b/docs/explanation/outbound-messaging.md
@@ -180,12 +180,30 @@ retries, so an identity-store outage does not destroy every send in flight. The 
 the channel: the credential lookup moves off the human's account (a bot is bound once for the whole
 workspace), but the seat check does not move at all.
 
-### Consent — default-deny, per purpose, over every subject
+### Authorization — per recipient, per phase, on evidence
 
-`ConsentGate.RequireGrantedForRecipients` is asked about **every subject the delivery reaches**, not
-just the To line: a Cc'd person is owed the same suppression, and this call is the only one that runs
-after they could have withdrawn. One-click unsubscribe writes a per-purpose consent withdrawal, so this
-gate *is* the suppression mechanism.
+The engine is asked about **every subject the delivery reaches**, not just the To line: a Cc'd
+person is owed the same answer, and a recipient list that only counted the visible ones would leave
+a blind copy unasked.
+
+It is asked **twice**, and the second time is the one that matters here. `AuthorizeStagingTx` runs
+in the transaction that writes the delivery row, so a message that may not go is never queued.
+`AuthorizeTransmit` runs immediately before the provider is handed anything — after the message has
+sat in the queue, which is where a withdrawal, an objection, a hard bounce or an edit to the wording
+lands. Both write a row per recipient into `communication_decision`.
+
+One-click unsubscribe writes a per-purpose consent **withdrawal**, which the engine reads **by
+class** rather than by the caller's purpose key — in BOTH phases. The evidence arms resolve a
+category from the record and may carry no purpose key at all, and unsubscribe-all withdraws every
+unlocked purpose rather than one, so the question asked is "did they stop the kind of message this
+is". That is what somebody pressing unsubscribe believes they answered.
+
+`communication_suppression` records the other stops: an Art. 21 objection, a statutory restriction,
+a subject's request to stop, a hard bounce. Neither a withdrawal nor a suppression expires on its
+own, and no rollout mode softens either. A restriction is not total, though — `security_notice`,
+`privacy_notice` and `optout_confirmation` still reach a restricted subject through a registered
+template, because a person is not better off for being unable to hear that their account was
+breached. A hard bounce stops even those.
 
 ### The three destinations one message offers
 
@@ -216,10 +234,20 @@ transports: a channel recipient has no address, so a gate that could only be han
 handed an empty list for every channel delivery — and a default-deny gate asked about nobody refuses
 nobody, so the whole channel would pass a check that never ran.
 
-Default-deny is literal. An unknown purpose, a grant for a *different* purpose, `unknown`, and
-`withdrawn` all block; a purpose declaring `requires_double_opt_in` additionally needs a confirmed
-`consent_event`. The gate must distinguish an **answer** (`apperrors.ErrConsentNotGranted` — park) from
-a **fault** (anything else — retry): getting that backwards silently kills legitimate mail.
+Default-deny is literal, and it is now answered on EVIDENCE rather than on a purpose key the
+caller supplied. The engine resolves a category from what the send actually is — the thread it
+answers, the invoice it concerns, the template it rides — and checks what that category requires. A
+reply is authorized by this recipient being on the thread the subject opened; an invoice by a live
+invoice reaching them through a current employment relationship; marketing is the case that still
+needs consent, and there a `requires_double_opt_in` purpose needs a confirmed
+`consent_event`. A send whose category nothing supports is `review`, not a silent allow.
+
+The engine must distinguish an **answer** (park — a human can act on it) from a **fault** (retry —
+the question could not be asked): getting that backwards silently kills legitimate mail. Every
+category ships **enforcing**; `consent.authorization_modes` can move one to `observe` or `warn`, an
+operator's rollback lever rather than the shipped posture. It buys less than it looks: the older
+purpose-key gate decides only where **no** recipient's category is enforced, and eight reason codes
+deny in every mode whatever the setting says.
 
 ### Confirm-first for agents; a human's own action is its own approval
 
@@ -328,10 +356,10 @@ What differs is only the vocabulary of the transport:
   and the reply transmits through the provider of that same name. `IsChannelKind` lists only what this
   installation can actually transmit through — `whatsapp` is a kind the contract reserves with no
   connector behind it, and admitting it would accept a reply that could only park.
-- **The recipient is resolved, never named by the caller.** `SendMessageRequest` carries `body` and
-  `consent_purpose` and nothing else. A channel identity is an opaque third-party account id, so a
-  caller able to name one could message a human this conversation is not with — and the reply surface
-  has no legitimate use for that. The server reads the anchor's `activity_link` rows, asks the people
+- **The recipient is resolved, never named by the caller.** `SendMessageRequest` carries the body, the
+  attachments and the context the engine is asked about — and no recipient at all. A channel identity is an opaque
+  third-party account id, so a caller able to name one could message a human this conversation is
+  not with, and the reply surface has no legitimate use for that. The server reads the anchor's `activity_link` rows, asks the people
   module which of those people are **reachable** on the provider, and refuses unless the answer is
   exactly one.
 - **Reachability replaces address validity.** `ReachableChannelIdentities` returns live identities with
@@ -441,7 +469,7 @@ Comms depends on interfaces and never on a provider:
 | `ConnectionResolver.Resolve` | Resolves **one human's** mailbox: the send seam, its unsealed credential, and the scopes the provider says the grant holds. |
 | `ConnectionResolver.ResolveChannel` | Resolves the **workspace's** channel binding: seam + credential, no user id (a bot is bound once for the whole workspace) and no scope list (there is nothing to intersect). |
 | `MessageIdentityReconciler` | Re-keys the timeline row when the provider stamped a different identity. A required constructor parameter, because a role that transmits without one files every sent message under an identity that exists nowhere on the wire. |
-| `SeatAuthority` / `ConsentGate` | The two authority answers, each obliged to distinguish an answer from a fault. |
+| `SeatAuthority` / `ConsentGate` | The two authority answers, each obliged to distinguish an answer from a fault. The consent seam is the authorization engine: it answers per recipient, on evidence, and writes the decision it took. |
 | `SendPolicy` (+ optional `SendRecorder`) | The ordered pacing chain; adding a policy is a registration, not a change to the dispatch sequence. |
 
 Three deployment facts are the **only** errors a resolver may report that park a delivery —
@@ -460,7 +488,12 @@ looking live and never sending.
 - **Authority refuses before consent answers.** A caller with no rights learns nothing about a person's
   consent state.
 - **The staging human's seat is re-read at transmit time**, on both transports.
-- **Consent is default-deny, per purpose, over every subject the delivery reaches** — including Cc.
+- **Authorization is default-deny, per recipient, over every subject the delivery reaches** —
+  including Cc, and answered on the evidence the resolved category requires rather than on a purpose
+  key the caller chose.
+- **It is decided twice and recorded both times.** Staging refuses what may never go; transmit
+  catches what changed while the message waited — a withdrawal, a suppression, a hard bounce, an
+  edit to the wording.
 - **Receipt before bookkeeping.** A message the provider accepted may never end up recorded as unsent.
 - **Park only on an answer, never on a failure to get one.**
 - **A seam that cannot detect a prior send marks in-flight first and never retries an unknown outcome.**

--- a/docs/explanation/privacy-and-consent.md
+++ b/docs/explanation/privacy-and-consent.md
@@ -1,31 +1,72 @@
 # Privacy, consent & the GDPR engines
 
-How Margince meets data-subject obligations: the **consent suppression gate** that guards every
-outbound send, and the **privacy engines** (erasure, subject-access, retention) that a fulfilled
-request executes. The product refuses scraping-based enrichment in the first place; the legal
+How Margince meets data-subject obligations: the **authorization engine** that decides — and
+records — whether each outbound message may go, and the **privacy engines** (erasure,
+subject-access, retention) that a fulfilled request executes. The product refuses scraping-based enrichment in the first place; the legal
 position behind that, for the EU and Vietnam, is a whitepaper kept with the company's business
-material rather than in this tree. Two modules cooperate — `consent` owns the gate and the case queue, `privacy` owns
+material rather than in this tree. Two modules cooperate — `consent` owns the engine and the case queue, `privacy` owns
 the machinery — and they are stitched together at the composition root, never by a sibling import.
 
-## The default-deny suppression gate (`consent`)
+## The authorization engine (`consent`)
 
-`consent` owns per-purpose consent: the purpose catalog, each person's current state, and an
-**append-only proof log**. The load-bearing piece is the **Gate** — the default-deny check every
-outbound surface consults *before anything leaves the workspace*:
+`consent` owns two things that are easy to confuse. **Consent** is a subject's answer to a question
+about a purpose — the catalog, each person's current state, an **append-only proof log**.
+**Authorization** is whether one particular message may go, which is a different question and usually
+has a different answer: most legitimate mail is not sent on consent at all, but on a contract, a
+reply the subject started, or a legal duty.
 
-- The question is always **per purpose**: a `marketing` grant never authorizes a `profiling` use.
-- **Default-deny in every direction** — an unknown purpose, an address that resolves to no subject,
-  state `unknown`, and state `withdrawn` all block. A double-opt-in purpose additionally requires the
-  confirmed round-trip on the proof log (a granted-but-unconfirmed row does not send). That round
-  trip is completed **only by the data subject**, by spending a single-use link mailed to their own
-  live primary address — there is no operator-held token, because a token an operator can read and
-  hand back proves nothing about the mailbox it was supposed to reach.
-- A refusal answers `ErrConsentNotGranted` and names only the address — it discloses nothing new.
+The engine answers the second. It resolves a **category** from what the send actually is, checks the
+**evidence** that category requires, and records a per-recipient **decision** saying why:
 
-The gate is spelled once (`consent.NewGate`) and **injected into the send path** (activities) at the
-composition root, so consent never becomes an import edge between siblings. Every consent *state* write
-also appends a proof row (Art. 7(1) demonstrability) — a fitness test (`consentproof_test.go`) fails any
-state write that skips its proof.
+- **The category is server-resolved**, not caller-named. A closed vocabulary
+  (`reply_to_inbound`, `invoice_or_payment`, `marketing`, `security_notice`, … in
+  `internal/shared/ports/commsauthz`) is derived from the message's own origin — its anchor thread,
+  the records it links, the template it rides. A caller can propose one; it cannot invent one, and
+  the send doors refuse a claim to any of the five **subject-serving** categories — a security or
+  privacy notice, an opt-out, consent or record confirmation — so only the installation itself
+  writes to somebody on its own behalf.
+- **Basis is evidence, not consent.** A reply is authorized by the thread the subject opened — this
+  recipient on that thread, not merely the message being a reply. An invoice is authorized by a live
+  invoice reaching this recipient through a current employment relationship, which is a real bar:
+  a finance contact nobody linked to the customer record is `review`, not a refusal. Marketing is
+  the case that needs consent, and it stays purpose-specific.
+- **The decision is taken twice and recorded before any provider I/O** — once as the message is
+  staged, once immediately before the provider is handed anything — into `communication_decision`,
+  one row per distinct recipient. The row says the category, the verdict, the reason, the basis and
+  a fingerprint of the wording, so "why did this message go" is a query rather than a
+  reconstruction. (The evidence itself lands in `communication_basis`, not on the decision row.)
+  A message that reaches a provider always has both rows; the second is what catches a withdrawal,
+  a bounce or an edit to the wording landing between the two.
+- **A withdrawal and a suppression are different records, and both bind hard.** Unsubscribing
+  withdraws consent, which the engine reads **by class** — "did they stop this kind of message" —
+  because a category resolved from evidence may carry no purpose key to match.
+  `communication_suppression` records the other stops: an Art. 21 objection, a statutory
+  restriction, a subject's request to stop, a hard bounce. Neither expires on its own, and no
+  rollout mode softens either.
+- **A restriction is not total, and that is deliberate.** Three categories still reach a restricted
+  subject through a registered template — `security_notice`, `privacy_notice` and
+  `optout_confirmation` — because a person is not better off for being unable to hear that their
+  account was breached or that their opt-out was recorded. A hard bounce stops even those: no
+  template makes a dead address deliverable.
+- **Every category ships enforcing.** `consent.authorization_modes` can move one to `observe` or
+  `warn`, which records the engine's answer without binding — an operator's rollback lever, not the
+  shipped posture. The older purpose-key gate decides only where **no** recipient's category is
+  enforced, so flipping one category buys less than it looks. Eight reason codes are absolute
+  (`absoluteDenials` in `commsauthz`) and deny in every mode whatever the setting says: the four
+  above, an unconfirmed double opt-in, a recipient that resolves to no single subject, a consent
+  withdrawal, and a jurisdiction's advertising frequency cap.
+
+Marketing consent still works the way it always did, and the round trip is what proves it: a
+double-opt-in purpose needs a confirmed `consent_event`, completed **only by the data subject**, by
+spending a single-use link mailed to their own live primary address. There is no operator-held
+token, because a token an operator can read and hand back proves nothing about the mailbox it was
+supposed to reach.
+
+A refusal names only the address — it discloses nothing new. The engine is spelled once
+(`consent.NewGate`) and **injected into the send path** (activities) at the composition root, so
+consent never becomes an import edge between siblings. Every consent *state* write also appends a
+proof row (Art. 7(1) demonstrability) — a fitness test (`consentproof_test.go`) fails any state write
+that skips its proof.
 
 ## The privacy engines (`privacy`)
 
@@ -108,7 +149,9 @@ have with a supervisory authority, and destruction is irreversible.
 
 | | |
 |---|---|
-| The suppression gate | `internal/modules/consent/gate.go` (`NewGate`) |
+| The authorization engine | `internal/modules/consent/authorize*.go` (`AuthorizeStagingTx`, `AuthorizeTransmit`) |
+| The shared vocabulary | `internal/shared/ports/commsauthz/` (category, basis, phase, verdict, mode) |
+| Per-recipient decisions | `communication_decision`, `communication_basis`, `communication_suppression` |
 | Consent state + proof log | `internal/modules/consent/` (`consent_purpose`, `person_consent`, `consent_event`) |
 | Art. 17 erasure | `internal/modules/privacy/erasure.go` (`NewEraser`, `ErasePerson`) |
 | Art. 15 SAR | `internal/modules/privacy/sar.go` (`AssembleSAR`) |


### PR DESCRIPTION
Both explanation docs described the product before the authorization engine:
one caller-supplied consent-purpose key, checked once. 620 lines between them
and zero mentions of communication_decision, AuthorizeTransmit, resolved
categories, evidence-based basis or the rollout modes. One sentence was
actively false — "this call is the only one that runs after they could have
withdrawn" — because AuthorizeTransmit runs at the same point and reads records
the legacy gate never looks at.

The rewrite says what the code does: a server-resolved category, evidence
rather than a purpose key, a decision per recipient recorded in both phases,
and every category shipping ENFORCING — which was the most consequential thing
missing for anyone operating this.

I FACT-CHECKED MY OWN REWRITE AGAINST THE CODE AND FOUND FIVE FALSE CLAIMS IN
IT. Writing them down so the next person to touch these pages does not repeat
them:

- Unsubscribe does NOT write a communication_suppression row. It writes a
  consent withdrawal, and the engine reads that by CLASS (withdrawalCovers).
- The withdrawal check runs in BOTH phases, not only at transmit.
- absoluteDenials has EIGHT members, not the four or five I listed. A consent
  withdrawal is one of them and binds exactly as hard as an objection, so my
  "suppression is the stronger record" framing was wrong.
- "No category or template reaches past a suppression" is backwards: three
  categories deliberately DO reach a restricted subject through a registered
  template, because somebody is not better off for being unable to hear that
  their account was breached. A hard bounce stops even those.
- Moving one category to observe does not hand the decision back to the legacy
  gate. That gate decides only where NO recipient's category is enforced.

Two more were imprecise and are now exact: an invoice does not authorize on
itself but on a live invoice reaching this recipient through a current
employment relationship, and the system-category refusal is a door invariant in
sendcontext.go rather than an engine one.

Nothing gates these pages, which is why they drifted this far. That is worth a
fitness function and is not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the outbound-messaging and privacy-and-consent explanation docs to describe the authorization engine that actually ships: a server-resolved category, evidence-based basis, and a per-recipient decision recorded in both staging and transmit phases. The old pages described a caller-supplied consent-purpose key checked once, and one sentence was actively false.

- The engine is asked twice, per recipient, writing rows to `communication_decision`; the transmit-time check catches withdrawals, objections, hard bounces, and wording edits that land while a message waits in the queue.
- Unsubscribing writes a consent withdrawal that the engine reads by class, in both phases, not a `communication_suppression` row.
- `communication_suppression` covers the other stops; three categories deliberately still reach a restricted subject through a registered template, and a hard bounce stops even those.
- Every category ships enforcing; `consent.authorization_modes` is the operator's rollback lever, and the legacy purpose-key gate decides only where no recipient's category is enforced.
- Eight absolute denial reason codes deny in every mode, including consent withdrawal.
- Corrected the README index line for `privacy-and-consent.md`.

<sup>Written for commit 27699e03549581d3692d6aa69613e0392a93f35b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy and consent guidance to describe evidence-based authorization rather than a consent-only gate.
  * Clarified that authorization is evaluated per recipient during staging and immediately before transmission.
  * Documented category-specific evidence, withdrawal and suppression handling, restricted-subject exceptions, and enforcement modes.
  * Updated outbound messaging guidance to reflect authorization decisions and the information included with send requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->