### PR TITLE
A criterion belongs to its case, so the catalog says which one

### DIFF
--- a/backend/internal/compose/mcptoolcoverage_test.go
+++ b/backend/internal/compose/mcptoolcoverage_test.go
@@ -95,21 +95,26 @@ type toolMeasurement struct {
 // The statement lives in e2e/llm/criteria.yaml rather than here because it is
 // the lane's to state, not this page's to invent.
 type criterionRow struct {
-	Number    int      `json:"number"`
-	Name      string   `json:"name"`
-	Statement string   `json:"statement"`
-	Cases     []string `json:"cases"`
+	// Case is half of a criterion's identity. The numbers are PER CASE: case 1
+	// criterion 1 and case 2 criterion 1 are different criteria that share a
+	// digit, and the suites that pin them say "case 4 criterion 5" rather than a
+	// bare number for exactly that reason.
+	Case      string `json:"case"`
+	Number    int    `json:"number"`
+	Name      string `json:"name"`
+	Statement string `json:"statement"`
 }
 
 type coverageTotals struct {
-	Tools              int   `json:"tools"`
-	Driven             int   `json:"driven"`
-	NeverDriven        int   `json:"never_driven"`
-	PermittedNotDriven int   `json:"permitted_but_never_required"`
-	UndrivenCost       int   `json:"tokens_served_but_never_driven"`
-	Cases              int   `json:"use_case_cases"`
-	CasesRecorded      int   `json:"cases_with_a_committed_run"`
-	CriteriaCovered    []int `json:"acceptance_criteria_covered"`
+	Tools              int `json:"tools"`
+	Driven             int `json:"driven"`
+	NeverDriven        int `json:"never_driven"`
+	PermittedNotDriven int `json:"permitted_but_never_required"`
+	UndrivenCost       int `json:"tokens_served_but_never_driven"`
+	Cases              int `json:"use_case_cases"`
+	CasesRecorded      int `json:"cases_with_a_committed_run"`
+	CriteriaNamed      int `json:"acceptance_criteria_named"`
+	CriteriaUnnamed    int `json:"acceptance_criteria_without_a_statement"`
 }
 
 type caseRow struct {
@@ -167,37 +172,37 @@ func TestTheMCPToolCoverageIsPublished(t *testing.T) {
 
 	report := mcpToolCoverage{Note: mcpToolCoverageNote, Cases: cases}
 	report.Totals.Cases = len(cases)
-	criteria := map[int]bool{}
 	for _, c := range cases {
 		if c.Recorded {
 			report.Totals.CasesRecorded++
 		}
-		for _, n := range c.Criteria {
-			criteria[n] = true
-		}
-	}
-	for n := range criteria {
-		report.Totals.CriteriaCovered = append(report.Totals.CriteriaCovered, n)
-	}
-	sort.Ints(report.Totals.CriteriaCovered)
-	for _, n := range report.Totals.CriteriaCovered {
-		row, named := catalog[n]
-		if !named {
-			t.Errorf("scenarios declare criterion %d and %s does not name it — a grade against a "+
+		named, ok := catalog[c.Name]
+		if !ok {
+			t.Errorf("case %s declares criteria and %s names none of them — a grade against a "+
 				"number nothing in this repository explains cannot be read by the person it is for",
-				n, e2eLLMCriteriaFile)
+				c.Name, e2eLLMCriteriaFile)
 			continue
 		}
-		for _, c := range cases {
-			for _, declared := range c.Criteria {
-				if declared == n {
-					row.Cases = append(row.Cases, c.Name)
-				}
+		for _, n := range c.Criteria {
+			row, isNamed := named[n]
+			if !isNamed {
+				t.Errorf("case %s declares criterion %d and %s does not name it", c.Name, n, e2eLLMCriteriaFile)
+				continue
 			}
+			report.Criteria = append(report.Criteria, row)
+			if strings.Contains(row.Name, "NEEDS A STATEMENT") {
+				report.Totals.CriteriaUnnamed++
+				continue
+			}
+			report.Totals.CriteriaNamed++
 		}
-		row.Cases = sortedCopy(row.Cases)
-		report.Criteria = append(report.Criteria, row)
 	}
+	sort.Slice(report.Criteria, func(i, j int) bool {
+		if report.Criteria[i].Case != report.Criteria[j].Case {
+			return report.Criteria[i].Case < report.Criteria[j].Case
+		}
+		return report.Criteria[i].Number < report.Criteria[j].Number
+	})
 
 	for _, spec := range specs {
 		row := toolCoverageRow{
@@ -368,27 +373,30 @@ func readE2ELLMVerdicts(dir string) (map[verdictKey]e2eVerdict, error) {
 // Parsed with the YAML decoder this module already depends on, not by hand: a
 // bespoke reader for a folded block is how the first version of this silently
 // published the first line of every statement and dropped the rest.
-func readCriteria(path string) (map[int]criterionRow, error) {
+func readCriteria(path string) (map[string]map[int]criterionRow, error) {
 	body, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	var file struct {
-		Criteria map[int]struct {
+		Cases map[string]map[int]struct {
 			Name      string `yaml:"name"`
 			Statement string `yaml:"statement"`
-		} `yaml:"criteria"`
+		} `yaml:"cases"`
 	}
 	if err := yaml.Unmarshal(body, &file); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
-	out := make(map[int]criterionRow, len(file.Criteria))
-	for number, entry := range file.Criteria {
-		out[number] = criterionRow{
-			Number:    number,
-			Name:      entry.Name,
-			Statement: strings.TrimSpace(entry.Statement),
-			Cases:     []string{},
+	out := make(map[string]map[int]criterionRow, len(file.Cases))
+	for name, numbered := range file.Cases {
+		out[name] = make(map[int]criterionRow, len(numbered))
+		for number, entry := range numbered {
+			out[name][number] = criterionRow{
+				Case:      name,
+				Number:    number,
+				Name:      entry.Name,
+				Statement: strings.TrimSpace(entry.Statement),
+			}
 		}
 	}
 	return out, nil
@@ -579,7 +587,8 @@ func writeCoverageTotals(p *strings.Builder, r mcpToolCoverage) {
 	fmt.Fprintf(p, "| Prompt tokens spent on tools no case requires | %d |\n", r.Totals.UndrivenCost)
 	fmt.Fprintf(p, "| Use cases | %d |\n", r.Totals.Cases)
 	fmt.Fprintf(p, "| … with a committed run | %d |\n", r.Totals.CasesRecorded)
-	fmt.Fprintf(p, "| Acceptance criteria covered | %s |\n\n", criteriaList(r.Totals.CriteriaCovered))
+	fmt.Fprintf(p, "| Acceptance criteria the cases declare | %d |\n", r.Totals.CriteriaNamed+r.Totals.CriteriaUnnamed)
+	fmt.Fprintf(p, "| … with a statement in this repository | %d |\n\n", r.Totals.CriteriaNamed)
 	if r.Totals.CasesRecorded < r.Totals.Cases {
 		fmt.Fprintf(p, "> **%d of %d cases have no committed run.** Their rows below say `not run` "+
 			"rather than a rate — nobody has paid for the answer yet.\n\n",
@@ -606,7 +615,7 @@ func writeCoverageCases(p *strings.Builder, r mcpToolCoverage) {
 		}
 		fmt.Fprintf(p, "| [%s](../../e2e/llm/scenarios/%s) | %s | %s | %s | %s | %s | %s |\n",
 			c.Name, c.File, result, passed, bar, model,
-			criteriaNames(c.Criteria, r.Criteria), joinOrDash(c.Requires))
+			criteriaNames(c.Name, c.Criteria, r.Criteria), joinOrDash(c.Requires))
 	}
 	p.WriteString("\n")
 }
@@ -617,10 +626,11 @@ func writeCoverageCriteria(p *strings.Builder, r mcpToolCoverage) {
 	p.WriteString("## What the criteria ask\n\n")
 	p.WriteString("The numbers in the table above, in words. Source: " +
 		"[`e2e/llm/criteria.yaml`](../../e2e/llm/criteria.yaml).\n\n")
-	p.WriteString("| # | Criterion | What it asks | Cases |\n|---:|---|---|---|\n")
+	p.WriteString("**The numbers are per case.** Case 1 criterion 1 and case 2 criterion 1 are " +
+		"different criteria that share a digit, which is why every row below names its case.\n\n")
+	p.WriteString("| Case | # | Criterion | What it asks |\n|---|---:|---|---|\n")
 	for _, c := range r.Criteria {
-		fmt.Fprintf(p, "| %d | **%s** | %s | %s |\n",
-			c.Number, c.Name, c.Statement, joinOrDash(c.Cases))
+		fmt.Fprintf(p, "| `%s` | %d | **%s** | %s |\n", c.Case, c.Number, c.Name, c.Statement)
 	}
 	p.WriteString("\n")
 }
@@ -698,13 +708,15 @@ func writeCoverageUndriven(p *strings.Builder, r mcpToolCoverage) {
 // criteriaNames renders a case's criteria as "8 promises come back as
 // suggestions" rather than "8" — a number is only a reference, and the table it
 // referenced was not in this repository.
-func criteriaNames(numbers []int, catalog []criterionRow) string {
+func criteriaNames(caseName string, numbers []int, catalog []criterionRow) string {
 	if len(numbers) == 0 {
 		return "—"
 	}
 	named := map[int]string{}
 	for _, c := range catalog {
-		named[c.Number] = c.Name
+		if c.Case == caseName {
+			named[c.Number] = c.Name
+		}
 	}
 	out := make([]string, 0, len(numbers))
 	for _, n := range numbers {
@@ -715,19 +727,6 @@ func criteriaNames(numbers []int, catalog []criterionRow) string {
 		out = append(out, fmt.Sprintf("**%d**", n))
 	}
 	return strings.Join(out, "<br>")
-}
-
-// criteriaList renders acceptance-criteria numbers, or a dash when a case
-// declares none — an empty cell reads as a rendering bug rather than as "none".
-func criteriaList(in []int) string {
-	if len(in) == 0 {
-		return "—"
-	}
-	out := make([]string, 0, len(in))
-	for _, n := range in {
-		out = append(out, fmt.Sprintf("%d", n))
-	}
-	return strings.Join(out, ", ")
 }
 
 // joinOrDash renders a list as backticked names, or a dash when it is empty.

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -8,16 +8,8 @@
     "tokens_served_but_never_driven": 17745,
     "use_case_cases": 7,
     "cases_with_a_committed_run": 7,
-    "acceptance_criteria_covered": [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      8,
-      14
-    ]
+    "acceptance_criteria_named": 6,
+    "acceptance_criteria_without_a_statement": 9
   },
   "cases": [
     {
@@ -137,75 +129,94 @@
   ],
   "criteria": [
     {
-      "number": 1,
-      "name": "A briefing arrives without naming a record",
-      "statement": "The request identifies an account by something other than its name, and the assistant finds the record anyway rather than asking which one.",
-      "cases": [
-        "case3_spreadsheet",
-        "case4_use_the_moment",
-        "case5_before_the_meeting",
-        "case6_ask_the_company",
-        "case7_ask_for_a_number"
-      ]
-    },
-    {
-      "number": 2,
-      "name": "NEEDS A STATEMENT",
-      "statement": "Not yet written down in this repository. Declared by case5.",
-      "cases": [
-        "case5_before_the_meeting"
-      ]
-    },
-    {
-      "number": 3,
-      "name": "NEEDS A STATEMENT",
-      "statement": "Not yet written down in this repository. Declared by case6 and case7.",
-      "cases": [
-        "case6_ask_the_company",
-        "case7_ask_for_a_number"
-      ]
-    },
-    {
-      "number": 4,
-      "name": "A possible duplicate is reported, not just filed",
-      "statement": "The create's own answer carries the duplicate it queued, and the assistant reads what came back and says so — a queue nobody is told about is a queue nobody reads.",
-      "cases": [
-        "case2_business_card"
-      ]
-    },
-    {
-      "number": 5,
-      "name": "The unkept promise is noticed",
-      "statement": "Somebody said they would send something and there is no record it went. Reading across the timeline to spot the gap is the point.",
-      "cases": [
-        "case5_before_the_meeting",
-        "case6_ask_the_company"
-      ]
-    },
-    {
-      "number": 6,
-      "name": "Check with the owner before turning up",
-      "statement": "The assistant tells the rep to confirm with the account owner rather than acting on a proximity answer alone.",
-      "cases": [
-        "case3_spreadsheet",
-        "case4_use_the_moment"
-      ]
-    },
-    {
+      "case": "case1_log_it",
       "number": 8,
       "name": "Promises come back as suggestions",
-      "statement": "Only what was actually promised is reported. Listing every topic that was discussed means the reader is reciting what it saw rather than what was committed to.",
-      "cases": [
-        "case1_log_it"
-      ]
+      "statement": "Only what was actually promised is reported. Listing every topic that was discussed means the reader is reciting what it saw rather than what was committed to."
     },
     {
+      "case": "case1_log_it",
       "number": 14,
       "name": "The assistant says what is waiting",
-      "statement": "Work held for approval is reported as pending. A run whose every write was correct and whose report of them was not still fails this.",
-      "cases": [
-        "case1_log_it"
-      ]
+      "statement": "Work held for approval is reported as pending. A run whose every write was correct and whose report of them was not still fails this."
+    },
+    {
+      "case": "case2_business_card",
+      "number": 4,
+      "name": "A possible duplicate is reported, not just filed",
+      "statement": "The create's own answer carries the duplicate it queued, and the assistant reads what came back and says so — a queue nobody is told about is a queue nobody reads."
+    },
+    {
+      "case": "case3_spreadsheet",
+      "number": 1,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 3's own header describes the case (show the numbers before committing) without naming which criterion that is."
+    },
+    {
+      "case": "case3_spreadsheet",
+      "number": 6,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 3 declares it; only case 4 states what ITS criterion 6 asks, and the numbering is per case."
+    },
+    {
+      "case": "case4_use_the_moment",
+      "number": 1,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 4 declares it."
+    },
+    {
+      "case": "case4_use_the_moment",
+      "number": 6,
+      "name": "Check with the owner before turning up",
+      "statement": "The assistant tells the rep to confirm with the account owner rather than acting on a proximity answer alone."
+    },
+    {
+      "case": "case5_before_the_meeting",
+      "number": 1,
+      "name": "A briefing arrives without naming a record",
+      "statement": "The request identifies an account by something other than its name — \"Vietnam partner\" is not the account's name — and finding it is the test."
+    },
+    {
+      "case": "case5_before_the_meeting",
+      "number": 2,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 5 declares it."
+    },
+    {
+      "case": "case5_before_the_meeting",
+      "number": 5,
+      "name": "The unkept promise is noticed",
+      "statement": "Somebody said they would send something and there is no record it went. Reading across the timeline to spot the gap is the point."
+    },
+    {
+      "case": "case6_ask_the_company",
+      "number": 1,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 6 declares it."
+    },
+    {
+      "case": "case6_ask_the_company",
+      "number": 3,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 6's header describes the case (the record's date is right and the prose recalling it is wrong) without naming which criterion that is."
+    },
+    {
+      "case": "case6_ask_the_company",
+      "number": 5,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 6 declares it."
+    },
+    {
+      "case": "case7_ask_for_a_number",
+      "number": 1,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 7 declares it."
+    },
+    {
+      "case": "case7_ask_for_a_number",
+      "number": 3,
+      "name": "NEEDS A STATEMENT",
+      "statement": "Not written down in this repository. Case 7 declares it."
     }
   ],
   "tools": [

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -32,7 +32,8 @@ This page does not grade single steps or name a best model per site — that is
 | Prompt tokens spent on tools no case requires | 17745 |
 | Use cases | 7 |
 | … with a committed run | 7 |
-| Acceptance criteria covered | 1, 2, 3, 4, 5, 6, 8, 14 |
+| Acceptance criteria the cases declare | 15 |
+| … with a statement in this repository | 6 |
 
 ## The use cases
 
@@ -40,26 +41,35 @@ This page does not grade single steps or name a best model per site — that is
 |---|---|---:|---:|---|---|---|
 | [case1_log_it](../../e2e/llm/scenarios/case1-log-it.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **8** Promises come back as suggestions<br>**14** The assistant says what is waiting | `create_record`, `log_activity` |
 | [case2_business_card](../../e2e/llm/scenarios/case2-business-card.yaml) | pass | 2/3 | 2 | `claude-opus-5` | **4** A possible duplicate is reported, not just filed | `create_record` |
-| [case3_spreadsheet](../../e2e/llm/scenarios/case3-spreadsheet.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** A briefing arrives without naming a record<br>**6** Check with the owner before turning up | `preview_import` |
-| [case4_use_the_moment](../../e2e/llm/scenarios/case4-use-the-moment.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** A briefing arrives without naming a record<br>**6** Check with the owner before turning up | `query_workspace` |
+| [case3_spreadsheet](../../e2e/llm/scenarios/case3-spreadsheet.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** NEEDS A STATEMENT<br>**6** NEEDS A STATEMENT | `preview_import` |
+| [case4_use_the_moment](../../e2e/llm/scenarios/case4-use-the-moment.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** NEEDS A STATEMENT<br>**6** Check with the owner before turning up | `query_workspace` |
 | [case5_before_the_meeting](../../e2e/llm/scenarios/case5-before-the-meeting.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** A briefing arrives without naming a record<br>**2** NEEDS A STATEMENT<br>**5** The unkept promise is noticed | `search_records` |
-| [case6_ask_the_company](../../e2e/llm/scenarios/case6-ask-the-company.yaml) | **FAIL** | 0/3 | 2 | `claude-opus-5` | **1** A briefing arrives without naming a record<br>**3** NEEDS A STATEMENT<br>**5** The unkept promise is noticed | `search_context` |
-| [case7_ask_for_a_number](../../e2e/llm/scenarios/case7-ask-for-a-number.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** A briefing arrives without naming a record<br>**3** NEEDS A STATEMENT | `run_report` |
+| [case6_ask_the_company](../../e2e/llm/scenarios/case6-ask-the-company.yaml) | **FAIL** | 0/3 | 2 | `claude-opus-5` | **1** NEEDS A STATEMENT<br>**3** NEEDS A STATEMENT<br>**5** NEEDS A STATEMENT | `search_context` |
+| [case7_ask_for_a_number](../../e2e/llm/scenarios/case7-ask-for-a-number.yaml) | pass | 3/3 | 2 | `claude-opus-5` | **1** NEEDS A STATEMENT<br>**3** NEEDS A STATEMENT | `run_report` |
 
 ## What the criteria ask
 
 The numbers in the table above, in words. Source: [`e2e/llm/criteria.yaml`](../../e2e/llm/criteria.yaml).
 
-| # | Criterion | What it asks | Cases |
-|---:|---|---|---|
-| 1 | **A briefing arrives without naming a record** | The request identifies an account by something other than its name, and the assistant finds the record anyway rather than asking which one. | `case3_spreadsheet`, `case4_use_the_moment`, `case5_before_the_meeting`, `case6_ask_the_company`, `case7_ask_for_a_number` |
-| 2 | **NEEDS A STATEMENT** | Not yet written down in this repository. Declared by case5. | `case5_before_the_meeting` |
-| 3 | **NEEDS A STATEMENT** | Not yet written down in this repository. Declared by case6 and case7. | `case6_ask_the_company`, `case7_ask_for_a_number` |
-| 4 | **A possible duplicate is reported, not just filed** | The create's own answer carries the duplicate it queued, and the assistant reads what came back and says so — a queue nobody is told about is a queue nobody reads. | `case2_business_card` |
-| 5 | **The unkept promise is noticed** | Somebody said they would send something and there is no record it went. Reading across the timeline to spot the gap is the point. | `case5_before_the_meeting`, `case6_ask_the_company` |
-| 6 | **Check with the owner before turning up** | The assistant tells the rep to confirm with the account owner rather than acting on a proximity answer alone. | `case3_spreadsheet`, `case4_use_the_moment` |
-| 8 | **Promises come back as suggestions** | Only what was actually promised is reported. Listing every topic that was discussed means the reader is reciting what it saw rather than what was committed to. | `case1_log_it` |
-| 14 | **The assistant says what is waiting** | Work held for approval is reported as pending. A run whose every write was correct and whose report of them was not still fails this. | `case1_log_it` |
+**The numbers are per case.** Case 1 criterion 1 and case 2 criterion 1 are different criteria that share a digit, which is why every row below names its case.
+
+| Case | # | Criterion | What it asks |
+|---|---:|---|---|
+| `case1_log_it` | 8 | **Promises come back as suggestions** | Only what was actually promised is reported. Listing every topic that was discussed means the reader is reciting what it saw rather than what was committed to. |
+| `case1_log_it` | 14 | **The assistant says what is waiting** | Work held for approval is reported as pending. A run whose every write was correct and whose report of them was not still fails this. |
+| `case2_business_card` | 4 | **A possible duplicate is reported, not just filed** | The create's own answer carries the duplicate it queued, and the assistant reads what came back and says so — a queue nobody is told about is a queue nobody reads. |
+| `case3_spreadsheet` | 1 | **NEEDS A STATEMENT** | Not written down in this repository. Case 3's own header describes the case (show the numbers before committing) without naming which criterion that is. |
+| `case3_spreadsheet` | 6 | **NEEDS A STATEMENT** | Not written down in this repository. Case 3 declares it; only case 4 states what ITS criterion 6 asks, and the numbering is per case. |
+| `case4_use_the_moment` | 1 | **NEEDS A STATEMENT** | Not written down in this repository. Case 4 declares it. |
+| `case4_use_the_moment` | 6 | **Check with the owner before turning up** | The assistant tells the rep to confirm with the account owner rather than acting on a proximity answer alone. |
+| `case5_before_the_meeting` | 1 | **A briefing arrives without naming a record** | The request identifies an account by something other than its name — "Vietnam partner" is not the account's name — and finding it is the test. |
+| `case5_before_the_meeting` | 2 | **NEEDS A STATEMENT** | Not written down in this repository. Case 5 declares it. |
+| `case5_before_the_meeting` | 5 | **The unkept promise is noticed** | Somebody said they would send something and there is no record it went. Reading across the timeline to spot the gap is the point. |
+| `case6_ask_the_company` | 1 | **NEEDS A STATEMENT** | Not written down in this repository. Case 6 declares it. |
+| `case6_ask_the_company` | 3 | **NEEDS A STATEMENT** | Not written down in this repository. Case 6's header describes the case (the record's date is right and the prose recalling it is wrong) without naming which criterion that is. |
+| `case6_ask_the_company` | 5 | **NEEDS A STATEMENT** | Not written down in this repository. Case 6 declares it. |
+| `case7_ask_for_a_number` | 1 | **NEEDS A STATEMENT** | Not written down in this repository. Case 7 declares it. |
+| `case7_ask_for_a_number` | 3 | **NEEDS A STATEMENT** | Not written down in this repository. Case 7 declares it. |
 
 ## 1. What you can rely on
 

--- a/e2e/llm/criteria.yaml
+++ b/e2e/llm/criteria.yaml
@@ -1,57 +1,102 @@
-# The acceptance criteria the use-case lane scores against.
+# What each use case's acceptance criteria ask.
 #
-# WHY THIS FILE EXISTS: a scenario declares `criteria: [8, 14]`, and until this
-# file those numbers named nothing a reader of this repository could reach. The
-# statements were written down elsewhere, so the lane published grades against
-# criteria a public contributor could not look up — and neither could anyone
-# reading docs/reference/mcp-tool-coverage.md, which is the page a decision gets
-# made from.
+# THE NUMBERS ARE PER CASE, NOT GLOBAL. Case 1 criterion 1 and case 2 criterion 1
+# are different criteria that share a digit. The suites that pin them say so in
+# their own failures — "case 4 criterion 5", never a bare "criterion 5" — and a
+# catalog keyed on the number alone would attribute one case's statement to
+# every other case that happens to use the same digit.
 #
-# Each entry is the ONE sentence saying what the criterion asks of the
-# assistant. It is the summary, not the specification: the case that scores it
-# is the specification, and every criterion here names the cases that do.
+# WHY THIS FILE EXISTS: a scenario declares `criteria: [8, 14]`, and those
+# numbers named nothing a reader of this repository could reach. The statements
+# were written down in a working folder outside this tree, so the lane published
+# grades against criteria a public contributor could not look up — and neither
+# could anyone reading docs/reference/mcp-tool-coverage.md, which is the page a
+# decision gets made from.
 #
-# A number a scenario declares and this file does not carry fails
-# TestEveryDeclaredCriterionIsNamed. Add it here in the change that declares it.
+# Each entry is the ONE sentence saying what that case's criterion asks. It is
+# the summary, not the specification: the case is the specification.
+#
+# A criterion a scenario declares and this file does not carry fails
+# TestEveryDeclaredCriterionIsNamed. Add it in the change that declares it.
 version: 1
-criteria:
-  1:
-    name: A briefing arrives without naming a record
-    statement: >-
-      The request identifies an account by something other than its name, and
-      the assistant finds the record anyway rather than asking which one.
-  2:
-    name: NEEDS A STATEMENT
-    statement: >-
-      Not yet written down in this repository. Declared by case5.
-  3:
-    name: NEEDS A STATEMENT
-    statement: >-
-      Not yet written down in this repository. Declared by case6 and case7.
-  4:
-    name: A possible duplicate is reported, not just filed
-    statement: >-
-      The create's own answer carries the duplicate it queued, and the assistant
-      reads what came back and says so — a queue nobody is told about is a queue
-      nobody reads.
-  5:
-    name: The unkept promise is noticed
-    statement: >-
-      Somebody said they would send something and there is no record it went.
-      Reading across the timeline to spot the gap is the point.
-  6:
-    name: Check with the owner before turning up
-    statement: >-
-      The assistant tells the rep to confirm with the account owner rather than
-      acting on a proximity answer alone.
-  8:
-    name: Promises come back as suggestions
-    statement: >-
-      Only what was actually promised is reported. Listing every topic that was
-      discussed means the reader is reciting what it saw rather than what was
-      committed to.
-  14:
-    name: The assistant says what is waiting
-    statement: >-
-      Work held for approval is reported as pending. A run whose every write was
-      correct and whose report of them was not still fails this.
+cases:
+  case1_log_it:
+    8:
+      name: Promises come back as suggestions
+      statement: >-
+        Only what was actually promised is reported. Listing every topic that was
+        discussed means the reader is reciting what it saw rather than what was
+        committed to.
+    14:
+      name: The assistant says what is waiting
+      statement: >-
+        Work held for approval is reported as pending. A run whose every write
+        was correct and whose report of them was not still fails this.
+  case2_business_card:
+    4:
+      name: A possible duplicate is reported, not just filed
+      statement: >-
+        The create's own answer carries the duplicate it queued, and the
+        assistant reads what came back and says so — a queue nobody is told
+        about is a queue nobody reads.
+  case3_spreadsheet:
+    1:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 3's own header describes the
+        case (show the numbers before committing) without naming which criterion
+        that is.
+    6:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 3 declares it; only case 4
+        states what ITS criterion 6 asks, and the numbering is per case.
+  case4_use_the_moment:
+    1:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 4 declares it.
+    6:
+      name: Check with the owner before turning up
+      statement: >-
+        The assistant tells the rep to confirm with the account owner rather
+        than acting on a proximity answer alone.
+  case5_before_the_meeting:
+    1:
+      name: A briefing arrives without naming a record
+      statement: >-
+        The request identifies an account by something other than its name —
+        "Vietnam partner" is not the account's name — and finding it is the test.
+    2:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 5 declares it.
+    5:
+      name: The unkept promise is noticed
+      statement: >-
+        Somebody said they would send something and there is no record it went.
+        Reading across the timeline to spot the gap is the point.
+  case6_ask_the_company:
+    1:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 6 declares it.
+    3:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 6's header describes the case
+        (the record's date is right and the prose recalling it is wrong) without
+        naming which criterion that is.
+    5:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 6 declares it.
+  case7_ask_for_a_number:
+    1:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 7 declares it.
+    3:
+      name: NEEDS A STATEMENT
+      statement: >-
+        Not written down in this repository. Case 7 declares it.


### PR DESCRIPTION
## The defect

**The acceptance-criteria numbers are per case, and the catalog I landed last week read them as global.**

The suites that pin these criteria have always said so — they fail with `case 4 criterion 5`, never a bare `criterion 5`, and the UAT tree carries `case 1 criterion 1` through `case 1 criterion 10` alongside a separate `case 2 criterion 1`. I did not check that before building `e2e/llm/criteria.yaml`, and keyed it on the number alone.

Criterion 1 is declared by five of the seven cases. So one statement — lifted from case 5's own header, where it is correct — was published against cases 3, 4, 6 and 7, where it describes something else entirely. `docs/reference/mcp-tool-coverage.md` told a reader that case 4's criterion 1 is *"a briefing arrives without naming a record"*. Case 4's criterion 1 is about whether the vocabulary says an organization's `address` is a location the CRM can search.

**That is worse than the bare numbers it replaced.** A number that names nothing is visibly a gap. A confident sentence attached to the wrong criterion reads as an answer, and nothing on the page tells the reader it is wrong.

## The fix

`criteria.yaml` is keyed `cases → number → statement`, and the check that a declared criterion is named is keyed the same way (`case case7_ask_for_a_number declares criterion 42 and … does not name it` — watched failing).

Six statements survive with their case attached, each sourced from that case's own header:

| Case | # | |
|---|---:|---|
| `case1_log_it` | 8, 14 | promises come back as suggestions; the assistant says what is waiting |
| `case2_business_card` | 4 | a possible duplicate is reported, not just filed |
| `case4_use_the_moment` | 6 | check with the owner before turning up |
| `case5_before_the_meeting` | 1, 5 | a briefing arrives without naming a record; the unkept promise is noticed |

The other eight say `NEEDS A STATEMENT` and name what is missing. They are not invented — the statements live in a working folder outside this tree, and writing a plausible sentence for them is precisely the failure #4679 documents a model committing.

The page now leads its criteria section with **"The numbers are per case"**, and every row names its case. Totals report criteria declared and how many have a statement here, rather than a list of numbers that were never comparable across cases.

## Checks

`make check-all` — lint 0 issues, and the only failing gates are two that fail on this machine alone: `TestPublicTreeCitesNoDocumentGitIgnores` (the `superpowers` plugin writes `.superpowers/sdd/.gitignore` containing `*`) and `TestNoProseClaimsRLSStillScopesARead`, whose 631 findings all come from `.claude/worktrees/agent-*/` — nested agent worktrees inside the clone. **Zero findings from the repository tree** in either case; both walk `../` and see what CI's fresh clone does not.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the acceptance-criteria catalog so numbers are keyed per case instead of globally, preventing statements from being attached to the wrong criteria. Previously criterion 1 was published against five cases using case 5's statement, misdescribing the others. Now each case declares its own criteria, and only statements sourced from that case's header are used; the rest say "NEEDS A STATEMENT".

- Keys `criteria.yaml` by case then number, and the test that checks declared criteria are named uses the same structure.
- Updates the coverage page and JSON to name the case in every criterion row and report counts of stated vs. unstated criteria.
- Keeps six verified statements, marks the other nine as "NEEDS A STATEMENT" instead of inventing plausible sentences.

<sup>Written for commit 1ed9806478fc08d9244c572b63657186c25c861d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP tool coverage reports now show acceptance criteria separately for each use case.
  - Reports include per-case criteria counts and detailed case-specific criteria tables.
  - Criteria without available repository statements are clearly marked as needing a statement.

- **Documentation**
  - Updated the criteria catalog to organize criteria by use case.
  - Revised generated JSON and Markdown coverage references to reflect case-specific criteria and updated totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->