### PR TITLE
The settings-import walk parses each module once, not once per entry point

### DIFF
--- a/frontend/src/screens/settings-imports.test.ts
+++ b/frontend/src/screens/settings-imports.test.ts
@@ -92,6 +92,32 @@ function importsOf(file: string): string[] {
 }
 
 /**
+ * The source files `file` imports, parsed ONCE per file and kept for the run.
+ *
+ * Every entry point below walks the same shared subgraph — the design system,
+ * the api client, i18n — so a module's parse is paid once for the run, not once
+ * per entry that reaches it. Per entry, the walks re-parse that subgraph as many
+ * times as there are entries, and the file's cost grows with the product of the
+ * two rather than their sum.
+ *
+ * The tree does not change while the suite runs, so a parsed edge list is as
+ * true on the last walk as on the first.
+ */
+const resolvedImports = new Map<string, string[]>();
+
+function edgesOf(file: string): string[] {
+  const known = resolvedImports.get(file);
+  if (known) {
+    return known;
+  }
+  const edges = importsOf(file)
+    .map((specifier) => resolveSpecifier(file, specifier))
+    .filter((next): next is string => next !== null);
+  resolvedImports.set(file, edges);
+  return edges;
+}
+
+/**
  * The shortest import path from `entry` to `target`, or null when unreachable.
  * Returning the path rather than a boolean is what makes a failure actionable:
  * the offending edge is usually three hops in and invisible from the entry.
@@ -102,9 +128,8 @@ function pathTo(entry: string, target: string): string[] | null {
   while (queue.length > 0) {
     const trail = queue.shift() as string[];
     const head = trail[trail.length - 1];
-    for (const specifier of importsOf(head)) {
-      const next = resolveSpecifier(head, specifier);
-      if (next === null || seen.has(next)) {
+    for (const next of edgesOf(head)) {
+      if (seen.has(next)) {
         continue;
       }
       if (next === target) {


### PR DESCRIPTION
## What

`frontend/src/screens/settings-imports.test.ts` walks the import graph from every module under `src/app/**` and `src/screens/**` to prove none reaches `settings.tsx`. Each walk re-parsed every module it reached, so the file's cost was entries × reachable modules. This change parses each module's resolved edges once and keeps them for the run.

## Why

Measured over the last 80 `ci` runs, `fe-unit` is the longest required lane (median ~17 min per job, 10–18 min for the `make fe-unit` step alone on a 4-vCPU runner). In a representative successful run this one file took **269s** of the suite's 877s of test time, five times the next-longest file, and it finished ~100s after every other file while the remaining workers sat idle. Since this file was widened to `src/screens/**` two days ago it has been the suite's tail.

## Proof

- File alone: 182s → 5s (529 cases, unchanged).
- Full suite locally (12 cores): 145s → 123s; the gain is larger on the 4-vCPU runner where the tail was serial.
- The gate still fails: a planted `src/app/zz-probe.ts` importing `../screens/settings` is reported with its import path.
- `make check-fe` green.

## Along the way

Findings from the same analysis that are not in this diff (each is its own change or decision):

- The `uat` lane is advisory: the `ci` aggregate does not list it and the ruleset requires only `ci`. It has been red on every frontend PR since ~03:00 UTC today on two deterministic regressions (`target-size` on `.lt-frow-more` at `#/leads`, and `mailboxprivacy.spec.ts` AC-mailbox-3 after the toggle moved). The merge queue the promotion was waiting on has not run since 2026-08-20.
- `conformance.test.ts` (47s) parses the same corpus four times; the same memo shape would apply.
- The two observed `fe-unit` flakes in this window were a whole-tree census hitting the 10.4s per-test ceiling under load and one real regression; `App.test.tsx` (#4428) did not recur in the sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `settings-imports.test.ts` by parsing each module's import edges once instead of once per entry point, cutting the file's runtime from ~269s to ~5s on the CI runner.

- The walk previously re-parsed every reachable module for each of ~500 entry points; resolved edges are now cached per file for the run.
- Import-graph behavior is unchanged: the test still fails on a planted import path to `settings.tsx`, and the known-path sanity case still passes.

<sup>Written for commit 96ce887e1a1a686d5a17ad3084bcd29b429d3be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dependency graph traversal by reusing resolved import information, reducing repeated processing during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->