### PR TITLE
Two readers of one ledger ask the same question of the account

### DIFF
--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -325,5 +326,56 @@ func TestSuggestionsAreOmittedWhenNeitherInputReachesTheCaller(t *testing.T) {
 	}
 	if !named {
 		t.Errorf("sections_omitted = %v, want it to name suggestions", view.SectionsOmitted)
+	}
+}
+
+// The two readers of the dismissal ledger ask the same question of the account.
+//
+// UndismissedAdvice and KeepUndismissed both read one table, both key it on an
+// organization id the caller supplies, and both answer whether this reader has
+// judged advice about that account. Only the first checked that the caller may
+// see the account; the second was reached behind two other checks, so the
+// protection belonged to its call site rather than to the read — and a second
+// call site would not have inherited it.
+//
+// The rep holds the object grant and cannot see THIS row: the account is
+// capture-private to a colleague, which is the one narrowing that survives on
+// an organization (every seat otherwise reads them all). The refusal therefore
+// comes from visibility rather than from holding no organization read at all,
+// which a test refusing everybody would also produce.
+func TestBothReadersOfTheDismissalLedgerGateOnTheAccount(t *testing.T) {
+	e := integration.Setup(t)
+	svc := org360Service(e)
+	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Someone Else's Account", &e.Rep2))
+	// Capture privacy: a connector-minted account answers to its owner alone
+	// until it is promoted, whatever the reader's row scope.
+	e.WsExec(t, `UPDATE organization SET visibility = 'owner', owner_id = $2 WHERE id = $1`,
+		org.UUID, e.Rep2)
+
+	stranger := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"organization": {Read: true}, "installation_settings": {Read: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	})
+
+	// The premise: this seat holds organization:read and still cannot see THIS
+	// account. Without it the assertions below prove only that a caller holding
+	// nothing is refused.
+	if _, err := svc.UndismissedAdvice(stranger, org); err == nil {
+		t.Fatal("the reader can see the account, so neither arm below is a test of the gate")
+	}
+
+	// One suggestion in hand, as a caller would pass it. Its content does not
+	// matter: what is under test is whether the ACCOUNT is checked before the
+	// ledger is read about it.
+	found := []crmcontracts.Organization360Suggestion{{
+		Kind:        "stalled_deal",
+		Fingerprint: "stalled_deal:" + org.String(),
+	}}
+	if _, err := svc.KeepUndismissed(stranger, org, found); err == nil {
+		t.Error("KeepUndismissed answered about an account the caller cannot see, " +
+			"while UndismissedAdvice beside it refused the same reader")
 	}
 }

--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -19,12 +19,14 @@ package org360
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -363,8 +365,14 @@ func TestBothReadersOfTheDismissalLedgerGateOnTheAccount(t *testing.T) {
 	// The premise: this seat holds organization:read and still cannot see THIS
 	// account. Without it the assertions below prove only that a caller holding
 	// nothing is refused.
-	if _, err := svc.UndismissedAdvice(stranger, org); err == nil {
-		t.Fatal("the reader can see the account, so neither arm below is a test of the gate")
+	//
+	// NOT-FOUND specifically, in both arms. An account the caller may not see
+	// must not answer "denied" — that tells them it exists — and asserting only
+	// that SOME error came back would pass for a transaction that failed, a
+	// grant checked with the wrong verb, or a gate that refuses everybody.
+	if _, err := svc.UndismissedAdvice(stranger, org); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("UndismissedAdvice = %v, want not-found — the reader can see the account, "+
+			"so neither arm below is a test of the gate", err)
 	}
 
 	// One suggestion in hand, as a caller would pass it. Its content does not
@@ -374,8 +382,24 @@ func TestBothReadersOfTheDismissalLedgerGateOnTheAccount(t *testing.T) {
 		Kind:        "stalled_deal",
 		Fingerprint: "stalled_deal:" + org.String(),
 	}}
-	if _, err := svc.KeepUndismissed(stranger, org, found); err == nil {
-		t.Error("KeepUndismissed answered about an account the caller cannot see, " +
-			"while UndismissedAdvice beside it refused the same reader")
+	if _, err := svc.KeepUndismissed(stranger, org, found); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("KeepUndismissed = %v, want not-found — it answered about an account the caller "+
+			"cannot see, while UndismissedAdvice beside it refused the same reader", err)
+	}
+
+	// The positive control. The SAME reader, once the account is no longer
+	// private, gets an answer from both — so the refusal above is about
+	// visibility and not a gate that turns everyone away.
+	e.WsExec(t, `UPDATE organization SET visibility = 'workspace' WHERE id = $1`, org.UUID)
+	if _, err := svc.UndismissedAdvice(stranger, org); err != nil {
+		t.Fatalf("UndismissedAdvice on a visible account: %v", err)
+	}
+	kept, err := svc.KeepUndismissed(stranger, org, found)
+	if err != nil {
+		t.Fatalf("KeepUndismissed on a visible account: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Errorf("kept %d of 1 suggestions on a visible account — nothing was dismissed, "+
+			"so the filter must return what it was given", len(kept))
 	}
 }

--- a/backend/internal/compose/org360/advice.go
+++ b/backend/internal/compose/org360/advice.go
@@ -82,6 +82,14 @@ func (s *Service) UndismissedAdvice(
 // KeepUndismissed drops from found whatever this caller has already judged,
 // for advice another writer raised. The fingerprints asked about are the ones
 // in hand, never the caller's whole history.
+//
+// The SAME account gate UndismissedAdvice above opens with, for the same
+// reason. Both read one ledger, both key it on an organization id the caller
+// supplies, and both answer whether this reader has judged advice about that
+// account — so an account the caller cannot see must answer not-found to both.
+// This one is reached only behind two of those checks today, which is why the
+// gap was invisible: the protection was the call site's rather than the read's,
+// and a second call site would not have inherited it.
 func (s *Service) KeepUndismissed(
 	ctx context.Context, orgID ids.OrganizationID, found []crmcontracts.Organization360Suggestion,
 ) ([]crmcontracts.Organization360Suggestion, error) {
@@ -90,6 +98,9 @@ func (s *Service) KeepUndismissed(
 	}
 	var kept []crmcontracts.Organization360Suggestion
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+			return err
+		}
 		var err error
 		kept, err = s.withoutDismissed(ctx, tx, orgID, found)
 		return err


### PR DESCRIPTION
`UndismissedAdvice` and `KeepUndismissed` sit twelve lines apart in `org360/advice.go`. Both read the dismissal ledger, both key it on an organization id the caller supplies, and both answer whether this reader has already judged advice about that account. Only the first checked that the caller may see the account.

**Nothing is exposed today.** `KeepUndismissed` is reached from one place, behind `auth.RequireHuman` and two `auth.EnsureVisible` calls, and it filters rows the caller passed in rather than fetching any. But that makes the protection the *call site's* rather than the read's, and a second call site would not inherit it.

It now opens with the same gate its sibling does.

## The test

The reader holds `organization:read` and cannot see the row, because the account is capture-private to a colleague — the one narrowing that survives on an organization, since every seat otherwise reads them all. So the refusal comes from visibility rather than from a caller holding nothing.

The test asserts its own premise first: if the reader can see the account, it fails rather than passing vacuously. Mutation-checked by removing the gate.

Found while tracing the fourteen `internal/compose` entry points for #4761. All fourteen turned out to be protected; this was the thinnest, and the only one worth changing on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the same visibility gate to `KeepUndismissed` that its sibling `UndismissedAdvice` already had, so the dismissal ledger is never read about an account the caller cannot see.

- No behavior changes today: the only call site already ran the same checks, but the protection now lives on the read itself rather than the call site.
- The integration test asserts not-found specifically, since an invisible account must not answer "denied" (that would reveal it exists), and includes a positive control where the same reader gets answers once the account is visible.

<sup>Written for commit 904d03fdb0dc178ba8761d7aeda2f2f9568f65b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

