### PR TITLE
An agent can name the record its send stands on

### DIFF
--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -291,6 +291,11 @@ func sendContextOf(in agents.SendContextArgs) activities.SendContextInput {
 		Context:          in.CommunicationContext,
 		MarketingPurpose: in.MarketingPurpose,
 		OperatorReason:   in.OperatorReason,
+		Evidence: activities.SendEvidenceInput{
+			InvoiceID:  in.Evidence.InvoiceID,
+			ContractID: in.Evidence.ContractID,
+			DealID:     in.Evidence.DealID,
+		},
 	}
 }
 

--- a/backend/internal/compose/heldrelease.go
+++ b/backend/internal/compose/heldrelease.go
@@ -246,6 +246,25 @@ func heldDraftPrecheck(
 // The CONTEXT, which the engine actually decides on. Same violation, quieter
 // shape: a purpose reads as a permission and a context reads as a description,
 // so an edit to it looks like a correction to the words.
+//
+// EVIDENCE IS NOT PINNED HERE BECAUSE THE PROPOSAL CARRIES NONE, and that is
+// the honest state rather than a gap — but the reason is an ORDERING, not an
+// absence. An operator CAN configure invoice_or_payment on a draft_email
+// action (draftEmailArgs.CommunicationContext), so a claim needing a named
+// record does reach this path.
+//
+// It cannot outrank the anchor. Both producers set AnchorActivityID, and
+// resolveCategory checks the thread arm before any claim: on a live thread the
+// send resolves to reply_to_inbound whatever was configured, and off one it
+// falls to the claim, finds no invoice, and parks as review. Carrying evidence
+// on the proposal would change neither outcome.
+//
+// If a producer ever stages a draft whose category needs an explicit record,
+// the field has to arrive on the proposal AND be pinned here. Note that the
+// approvals edit scope would already cover it: entityRefs walks the payload at
+// any depth and pins every uuid-shaped string, which is exactly what an
+// evidence id is. The pin below exists for the two fields that are shaped like
+// prose and therefore invisible to that walk.
 // The refusal is approvals' OWN RetargetedEditError, not a new error beside it.
 // This is the same violation the edit scope refuses for entity references, in a
 // field whose shape that check cannot see — so it should read identically to the

--- a/backend/internal/compose/sendcontextseam_test.go
+++ b/backend/internal/compose/sendcontextseam_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The seam between the tool surface's send arguments and the module's.
+//
+// It is one mapping function, and it silently dropped evidence: the tool
+// surface offered no evidence field, so the seam had nothing to carry and the
+// module's own field sat unfilled. An agent claiming invoice_or_payment,
+// contract_notice or active_deal_followup — three categories this surface
+// admits and whose validators read the named record — resolved to `review` and
+// parked, which reads to a rep as the tool being broken.
+//
+// Nothing tested this mapping, which is how the drop survived. A field added to
+// either side and forgotten here is invisible in exactly the same way, so the
+// census below asks the question structurally rather than field by field.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+)
+
+func TestTheSendContextSeamCarriesEveryEvidenceField(t *testing.T) {
+	t.Parallel()
+
+	args := agents.SendContextArgs{
+		CommunicationContext: "invoice_or_payment",
+		MarketingPurpose:     "newsletter",
+		OperatorReason:       "they asked",
+		Evidence: agents.SendEvidenceArgs{
+			InvoiceID:  "01a05500-0000-7000-8000-000000000001",
+			ContractID: "01a05500-0000-7000-8000-000000000002",
+			DealID:     "01a05500-0000-7000-8000-000000000003",
+		},
+	}
+	got := sendContextOf(args)
+
+	if got.Context != args.CommunicationContext ||
+		got.MarketingPurpose != args.MarketingPurpose ||
+		got.OperatorReason != args.OperatorReason {
+		t.Errorf("the seam dropped a context field: %+v", got)
+	}
+	if got.Evidence.InvoiceID != args.Evidence.InvoiceID ||
+		got.Evidence.ContractID != args.Evidence.ContractID ||
+		got.Evidence.DealID != args.Evidence.DealID {
+		t.Errorf("the seam dropped an evidence field: %+v", got.Evidence)
+	}
+
+	// EVERY field, not the four named above. A fifth added to the tool surface
+	// and forgotten in the seam is the defect this test exists for, and naming
+	// them one by one would leave it exactly as invisible as it was.
+	//
+	// Both sides are flat structs of strings, so a non-empty input mapping to a
+	// non-empty output is the whole question: a field the seam never assigns
+	// stays at its zero value.
+	in := reflect.ValueOf(args.Evidence)
+	out := reflect.ValueOf(got.Evidence)
+	if in.NumField() != out.NumField() {
+		t.Fatalf("the two evidence shapes carry %d and %d fields: the seam cannot map "+
+			"one onto the other and this census has stopped meaning anything",
+			in.NumField(), out.NumField())
+	}
+	// PAIRED BY NAME, not by index. Matching on position would pass a seam that
+	// mapped InvoiceID onto ContractID — the two are both non-empty strings, so
+	// every value would arrive and none would arrive where it belonged.
+	for i := range in.NumField() {
+		name := in.Type().Field(i).Name
+		if in.Field(i).String() == "" {
+			t.Fatalf("%s is empty in the fixture, so this census does not read it", name)
+		}
+		paired := out.FieldByName(name)
+		if !paired.IsValid() {
+			t.Errorf("%s has no field of that name on the module's shape: the seam "+
+				"cannot be carrying it", name)
+			continue
+		}
+		if paired.String() != in.Field(i).String() {
+			t.Errorf("%s reached the module as %q, want %q: the seam drops or mis-wires it",
+				name, paired.String(), in.Field(i).String())
+		}
+	}
+}

--- a/backend/internal/modules/activities/sendcontext.go
+++ b/backend/internal/modules/activities/sendcontext.go
@@ -185,7 +185,20 @@ type SendContextInput struct {
 	Context          string
 	MarketingPurpose string
 	OperatorReason   string
-	Evidence         commsauthz.Evidence
+	Evidence         SendEvidenceInput
+}
+
+// SendEvidenceInput is a non-HTTP caller's evidence, as STRINGS.
+//
+// Unparsed on purpose: the HTTP door hands the shared validator typed uuids
+// that its own decoder already refused a malformed one for, and a tool caller
+// has had no such pass. Parsing here means one spelling of "that is not a
+// record id" for both doors instead of a tool surface that accepts a
+// nonsense id and a validator that later cannot find it.
+type SendEvidenceInput struct {
+	InvoiceID  string
+	ContractID string
+	DealID     string
 }
 
 // ApplyContext validates a non-HTTP caller's claim and puts it on the send
@@ -226,11 +239,50 @@ func decodeSendContext(claim SendContextInput) (sendContext, error) {
 	if err != nil {
 		return sendContext{}, err
 	}
-	// Evidence arrives already typed on this path, so it is carried rather than
-	// re-flattened. Nothing about it is trusted here either: the engine reads
-	// each named record and asks whether it supports the category.
-	decoded.evidence = claim.Evidence
+	// Parsed HERE, so a malformed id is refused at the door rather than
+	// resolving to the zero uuid and failing later as "no such record". The
+	// HTTP door's decoder has already done this for its own callers; this is
+	// the same refusal for the ones that never passed through it.
+	//
+	// Nothing about the evidence is TRUSTED by parsing it. The engine still
+	// reads each named record and asks whether it supports the category —
+	// naming one widens nothing.
+	evidence, err := decodeSendEvidence(claim.Evidence)
+	if err != nil {
+		return sendContext{}, err
+	}
+	decoded.evidence = evidence
 	return decoded, nil
+}
+
+// decodeSendEvidence parses a non-HTTP caller's record ids.
+func decodeSendEvidence(in SendEvidenceInput) (commsauthz.Evidence, error) {
+	var out commsauthz.Evidence
+	for _, field := range []struct {
+		name string
+		raw  string
+		onto *ids.UUID
+	}{
+		{"invoice_id", in.InvoiceID, &out.InvoiceID},
+		{"contract_id", in.ContractID, &out.ContractID},
+		{"deal_id", in.DealID, &out.DealID},
+	} {
+		if field.raw == "" {
+			continue
+		}
+		parsed, err := ids.Parse(field.raw)
+		if err != nil {
+			return commsauthz.Evidence{}, &CommunicationContextError{
+				// The FIELD too, not only the sentence. FieldFault defaults to
+				// communication_context, so a caller who mistyped an evidence id
+				// would be pointed at a field they got right.
+				field:  "evidence." + field.name,
+				Reason: "evidence." + field.name + " is not a record id",
+			}
+		}
+		*field.onto = parsed
+	}
+	return out, nil
 }
 
 // legacyPurposeOf reads the deprecated purpose key a caller may still send.

--- a/backend/internal/modules/activities/sendcontext_test.go
+++ b/backend/internal/modules/activities/sendcontext_test.go
@@ -236,11 +236,12 @@ func TestANonHTTPCallerCannotClaimAnUnknownCategory(t *testing.T) {
 // An ordinary claim reaches the input on both doors, or the refusals above
 // would be indistinguishable from a surface that drops everything.
 func TestANonHTTPClaimReachesBothInputs(t *testing.T) {
+	deal := ids.NewV7()
 	claim := SendContextInput{
 		Context:          string(commsauthz.CategoryActiveDealFollowup),
 		MarketingPurpose: "newsletter",
 		OperatorReason:   "they asked at the fair",
-		Evidence:         commsauthz.Evidence{DealID: ids.NewV7()},
+		Evidence:         SendEvidenceInput{DealID: deal.String()},
 	}
 	mail, err := ApplyContext(SendEmailInput{Subject: "Hello"}, claim)
 	if err != nil {
@@ -249,7 +250,7 @@ func TestANonHTTPClaimReachesBothInputs(t *testing.T) {
 	if mail.Context != commsauthz.CategoryActiveDealFollowup || mail.MarketingPurpose != "newsletter" {
 		t.Errorf("the claim did not reach the mail input: %+v", mail)
 	}
-	if mail.Evidence.DealID != claim.Evidence.DealID {
+	if mail.Evidence.DealID != deal {
 		t.Error("named evidence did not reach the mail input")
 	}
 	if mail.Subject != "Hello" {
@@ -263,7 +264,7 @@ func TestANonHTTPClaimReachesBothInputs(t *testing.T) {
 	if channel.Context != commsauthz.CategoryActiveDealFollowup {
 		t.Errorf("the claim did not reach the channel input: %+v", channel)
 	}
-	if channel.Evidence.DealID != claim.Evidence.DealID {
+	if channel.Evidence.DealID != deal {
 		t.Error("named evidence did not reach the channel input")
 	}
 	if channel.Body != "Hi" {
@@ -280,5 +281,42 @@ func TestANonHTTPOperatorReasonIsBounded(t *testing.T) {
 	}
 	if _, err := ApplyChannelContext(SendMessageInput{}, claim); err == nil {
 		t.Error("the channel tool accepted an unbounded operator reason")
+	}
+}
+
+// TestAMalformedEvidenceIdIsRefusedAtTheDoor holds what parsing here buys.
+//
+// A tool caller's ids arrive as strings and have passed no decoder. Left
+// unparsed they would resolve to the zero uuid, match no record, and fail much
+// later as "this category is not supported" — which reads as the engine
+// refusing a legitimate send rather than as the caller having typed nonsense.
+func TestAMalformedEvidenceIdIsRefusedAtTheDoor(t *testing.T) {
+	claim := SendContextInput{
+		Context:  string(commsauthz.CategoryActiveDealFollowup),
+		Evidence: SendEvidenceInput{DealID: "not-a-uuid"},
+	}
+	if _, err := ApplyContext(SendEmailInput{}, claim); err == nil {
+		t.Error("the mail door accepted an evidence id that is not a record id")
+	}
+	// The channel door shares the validator, so a claim refused on one
+	// transport must not become makeable by choosing the other.
+	if _, err := ApplyChannelContext(SendMessageInput{}, claim); err == nil {
+		t.Error("the channel door accepted an evidence id that is not a record id")
+	}
+}
+
+// TestEvidenceOmittedEntirelyIsNotAnError is the other arm.
+//
+// Every evidence field is optional: a caller that can name nothing says
+// nothing, and the engine resolves the send from its origin instead. Refusing
+// an empty claim would make evidence mandatory on every agent send.
+func TestEvidenceOmittedEntirelyIsNotAnError(t *testing.T) {
+	claim := SendContextInput{Context: string(commsauthz.CategoryReplyToInbound)}
+	mail, err := ApplyContext(SendEmailInput{}, claim)
+	if err != nil {
+		t.Fatalf("a claim naming no evidence was refused: %v", err)
+	}
+	if mail.Evidence != (commsauthz.Evidence{}) {
+		t.Errorf("an empty claim invented evidence: %+v", mail.Evidence)
 	}
 }

--- a/backend/internal/modules/agents/toollinks.go
+++ b/backend/internal/modules/agents/toollinks.go
@@ -41,6 +41,35 @@ func requireAddressee(to []string) error {
 		"`to` is empty; a send with no addressee reaches nobody and would be refused after approval")}
 }
 
+// requireParsableEvidence refuses an evidence id that is not a record id,
+// BEFORE the call is staged.
+//
+// Same reason as requireAddressee above: a send floored to confirm-first is
+// staged, put in front of a human, and redeemed — and redemption consumes the
+// one-shot approval before the send door parses anything. A malformed id would
+// therefore burn an approval a person granted and fail afterwards, which reads
+// as the system losing their decision.
+//
+// It only asks whether the string IS an id. Whether the record exists, supports
+// the category, or may be read by this caller are the engine's questions, asked
+// where the answer can be recorded.
+func requireParsableEvidence(e SendEvidenceArgs) error {
+	for _, named := range []struct{ field, raw string }{
+		{"invoice_id", e.InvoiceID},
+		{"contract_id", e.ContractID},
+		{"deal_id", e.DealID},
+	} {
+		if named.raw == "" {
+			continue
+		}
+		if _, err := ids.Parse(named.raw); err != nil {
+			return &BadArgsError{Cause: fmt.Errorf(
+				"`evidence.%s` is not a record id; it would be refused after approval", named.field)}
+		}
+	}
+	return nil
+}
+
 // maxRecordLinks bounds how many records one call may attach to.
 //
 // This is a REQUEST BOUND, not a modelling opinion. Each link costs its own

--- a/backend/internal/modules/agents/toollinks_test.go
+++ b/backend/internal/modules/agents/toollinks_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The refusals a send tool makes before anything is staged.
+//
+// They share one hazard: a send floored to confirm-first is staged, decided by
+// a human, and redeemed — and redemption consumes the one-shot approval before
+// the send door validates anything. An argument that could never work would
+// burn a decision somebody made, which reads as the system losing it.
+
+import "testing"
+
+// TestAMalformedEvidenceIdIsRefusedBeforeStaging holds the evidence half.
+func TestAMalformedEvidenceIdIsRefusedBeforeStaging(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []SendEvidenceArgs{
+		{InvoiceID: "not-a-uuid"},
+		{ContractID: "12345"},
+		{DealID: "01a05500-0000-7000-8000"},
+	} {
+		if err := requireParsableEvidence(bad); err == nil {
+			t.Errorf("%+v was accepted: it would be refused after approval", bad)
+		}
+	}
+
+	// Every field empty is the ordinary case — evidence is optional, and a
+	// caller that names nothing says nothing.
+	if err := requireParsableEvidence(SendEvidenceArgs{}); err != nil {
+		t.Errorf("naming no evidence was refused: %v", err)
+	}
+	// A well-formed id passes, or the refusals above would be
+	// indistinguishable from a check that refuses everything.
+	if err := requireParsableEvidence(SendEvidenceArgs{
+		InvoiceID: "01a05500-0000-7000-8000-000000000001",
+	}); err != nil {
+		t.Errorf("a well-formed evidence id was refused: %v", err)
+	}
+}
+
+// TestASendWithNoAddresseeIsRefusedBeforeStaging holds the sibling this was
+// modelled on, which had no test of its own.
+func TestASendWithNoAddresseeIsRefusedBeforeStaging(t *testing.T) {
+	t.Parallel()
+
+	if err := requireAddressee(nil); err == nil {
+		t.Error("a send with no addressee was accepted: it reaches nobody")
+	}
+	if err := requireAddressee([]string{}); err == nil {
+		t.Error("a send with an empty addressee list was accepted")
+	}
+	if err := requireAddressee([]string{"dana@buyer.test"}); err != nil {
+		t.Errorf("a send with one addressee was refused: %v", err)
+	}
+}

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -121,6 +121,12 @@ func (t sendAccountEmailTool) Handle(ctx context.Context, in json.RawMessage) (j
 	if _, err := readStageableLinks(ctx, t.p, links); err != nil {
 		return nil, err
 	}
+	// And the evidence ids, for the reason stated above applied to argument
+	// shape: a malformed one staged and approved would fail at redemption,
+	// after the approval it consumed.
+	if err := requireParsableEvidence(args.Evidence); err != nil {
+		return nil, err
+	}
 	for _, link := range links {
 		noteEvidence(ctx, datasource.EntityType(link.EntityType), link.EntityID)
 	}

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -93,6 +93,26 @@ type SendContextArgs struct {
 	CommunicationContext string `json:"communication_context,omitempty"`
 	MarketingPurpose     string `json:"marketing_purpose,omitempty"`
 	OperatorReason       string `json:"operator_reason,omitempty"`
+	// Evidence names the record that bears the category out. A claim without
+	// it is not refused — the engine decides that — but three of the categories
+	// this surface admits cannot be allowed without one.
+	Evidence SendEvidenceArgs `json:"evidence,omitempty"`
+}
+
+// SendEvidenceArgs is the record a category is borne out by, in the tool
+// surface's own shape. It mirrors the HTTP contract's CommunicationEvidence
+// field for field: an agent proposing a send and a human posting one name the
+// same records, or the two doors would answer differently about one message.
+// THE THREE THE ENGINE READS, and no more. commsauthz.Evidence also carries an
+// ActivityID, a ConsentEventID and a BasisID; no validator reads any of them,
+// and the thread a reply answers reaches the engine as Request.AnchorActivityID
+// — derived from the send's own origin, never named by a caller. Offering them
+// here would spend the catalog budget on fields that do nothing and teach a
+// model that naming one buys something.
+type SendEvidenceArgs struct {
+	InvoiceID  string `json:"invoice_id,omitempty"`
+	ContractID string `json:"contract_id,omitempty"`
+	DealID     string `json:"deal_id,omitempty"`
 }
 
 // SendMessageArgs is one channel reply. It carries no subject and no
@@ -255,14 +275,24 @@ type sendEmailTool struct {
 // sendContextProperties is the context arguments, spelled once for the three
 // send tools. One question asked one way, and one place to change it.
 //
-// There is deliberately no `evidence` here. The HTTP contract has one, and
-// nothing in the engine reads it yet — the validators that will resolve a
-// category FROM the named records land with the jurisdiction packs. A tool
-// description is text a model reads and reasons about, so advertising a check
-// the system does not perform teaches it something false, and the next author
-// to wire evidence up would read it and skip writing the validation. It also
-// costs the catalog budget on every step of every run that carries one of
-// these tools.
+// `evidence` IS here, and the reason it was once absent is worth keeping: this
+// text is written into the system prompt of every step of every run, so
+// advertising a check the system does not perform teaches a model something
+// false. That was the honest answer while nothing read the field.
+//
+// It is no longer. validateInvoice, validateContract and validateQuote resolve a
+// category FROM the named record (authorizevalidators.go), and three of the
+// categories this tool may claim — invoice_or_payment, contract_notice,
+// precontract_quote — cannot be borne out without one. An agent claiming one
+// with no evidence to offer resolved to `review` and parked, which reads to a
+// rep as the tool being broken rather than as the model having named a
+// category it could not support.
+//
+// NOT active_deal_followup, though a deal id is offered. That category has no
+// validator: it is supported by arm 2 of resolveCategory, which reads a live
+// deal from the message's own LINKS, and evidence never reaches Links. The deal
+// id here is read only by validateQuote. Saying otherwise in the description
+// below would teach a model that naming one buys something it does not.
 //
 // Held by: TestTheToolSurfaceSpellsTheSendContextOnce
 // (backend/gates/sendcontextvalidation_test.go)
@@ -278,7 +308,11 @@ const sendContextProperties = `,
 	`"contract_notice","invoice_or_payment","marketing"],` +
 	`"description":"What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing."},
 	"marketing_purpose":{"type":"string","description":"For marketing, the purpose key naming the topic"},
-	"operator_reason":{"type":"string","maxLength":500,"description":"Why this first message is being sent. Recorded; grants nothing."}`
+	"operator_reason":{"type":"string","maxLength":500,"description":"Why this first message is being sent. Recorded; grants nothing."},
+	"evidence":{"type":"object","description":"The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one","properties":{
+		"invoice_id":{"type":"string","format":"uuid"},
+		"contract_id":{"type":"string","format":"uuid"},
+		"deal_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`
 
 func (t sendEmailTool) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
@@ -345,6 +379,9 @@ func (t sendEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 	if err := requireAddressee(args.To); err != nil {
 		return nil, err
 	}
+	if err := requireParsableEvidence(args.Evidence); err != nil {
+		return nil, err
+	}
 	if err := (&anchoredRecord{records: t.p, entityType: datasource.EntityActivity}).refuse(ctx, args.ActivityID); err != nil {
 		return nil, err
 	}
@@ -407,6 +444,9 @@ func (t sendMessageTool) Handle(ctx context.Context, in json.RawMessage) (json.R
 	// Same reason as its mail twin above: the anchor's authority is checked on
 	// the door that sends, not only on the one that staged.
 	if err := (&anchoredRecord{records: t.p, entityType: datasource.EntityActivity}).refuse(ctx, args.ActivityID); err != nil {
+		return nil, err
+	}
+	if err := requireParsableEvidence(args.Evidence); err != nil {
 		return nil, err
 	}
 	// NOT carried over from the resolver's Guards: CanSendOnProvider, which

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 73,
     "system_frame_tokens": 353,
-    "tokens": 21707,
+    "tokens": 21967,
     "median_tool_tokens": 263,
-    "mean_tool_tokens": 297
+    "mean_tool_tokens": 300
   },
   "agents": [
     {
@@ -75,24 +75,28 @@
       "tokens": 939
     },
     {
+      "name": "send_account_email",
+      "tokens": 742
+    },
+    {
       "name": "preview_import",
       "tokens": 677
     },
     {
-      "name": "send_account_email",
-      "tokens": 655
+      "name": "send_email",
+      "tokens": 675
     },
     {
       "name": "log_activity",
       "tokens": 635
     },
     {
-      "name": "send_email",
-      "tokens": 588
-    },
-    {
       "name": "update_record",
       "tokens": 572
+    },
+    {
+      "name": "send_message",
+      "tokens": 518
     },
     {
       "name": "list_records",
@@ -121,10 +125,6 @@
     {
       "name": "advance_deal",
       "tokens": 443
-    },
-    {
-      "name": "send_message",
-      "tokens": 431
     },
     {
       "name": "annotate_brief",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 4% | 21576 | 6 | 6 |
 | `overnight_at_risk_sweep` | 7 | 2467 | 7% | 20743 | 15 | 10 |
-| _whole served catalog, for scale_ | 73 | 21707 | 66% | — | — | — |
+| _whole served catalog, for scale_ | 73 | 21967 | 67% | — | — | — |
 
 ### `morning_brief`
 
@@ -126,7 +126,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 263 tokens, mean 297, across 73 served tools.
+Median 263 tokens, mean 300, across 73 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -136,11 +136,12 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 939 | 3 scenarios |
+| `send_account_email` | 742 | — |
 | `preview_import` | 677 | — |
-| `send_account_email` | 655 | — |
+| `send_email` | 675 | 1 scenario |
 | `log_activity` | 635 | 1 scenario |
-| `send_email` | 588 | 1 scenario |
 | `update_record` | 572 | 4 scenarios |
+| `send_message` | 518 | — |
 | `list_records` | 508 | — |
 | `progress_deal` | 501 | 3 scenarios |
 | `resolve_entities` | 498 | — |
@@ -148,7 +149,6 @@ a term in an addition.
 | `create_record` | 473 | 1 scenario |
 | `run_analytics_query` | 465 | — |
 | `advance_deal` | 443 | 1 scenario |
-| `send_message` | 431 | — |
 | `annotate_brief` | 418 | — |
 | `review_commitments` | 401 | 1 scenario |
 | `book_meeting` | 393 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 73,
     "resources": 12,
-    "tool_catalog_bytes": 209251,
+    "tool_catalog_bytes": 210379,
     "resource_catalog_bytes": 4584,
-    "approx_wire_tokens_total": 53458,
+    "approx_wire_tokens_total": 53740,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 51079,
-      "input_schema_bytes": 43519,
+      "input_schema_bytes": 44647,
       "output_schema_bytes": 98901,
-      "description_plus_input_schema_bytes": 94598
+      "description_plus_input_schema_bytes": 95726
     }
   },
   "tools": {
@@ -12287,6 +12287,25 @@
               "description": "Purpose key the recipients must have granted",
               "type": "string"
             },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+              "properties": {
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
               "maxLength": 255,
@@ -12514,6 +12533,25 @@
               "description": "Purpose key the recipients must have granted",
               "type": "string"
             },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+              "properties": {
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
               "maxLength": 255,
@@ -12705,6 +12743,25 @@
             "consent_purpose": {
               "description": "Purpose key the recipient must have granted",
               "type": "string"
+            },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+              "properties": {
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
             },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 73 |
 | Resources | 12 |
-| Tool catalog | 204.3 KB |
+| Tool catalog | 205.4 KB |
 | Resource catalog | 4.5 KB |
-| Approx. wire tokens | 53458 |
+| Approx. wire tokens | 53740 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,9 +31,9 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 96.6 KB | 47% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 49.9 KB | 24% | Yes, every step |
-| Input schemas | 42.5 KB | 20% | Yes, every step |
+| Input schemas | 43.6 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.4 KB | 7% | Partly |
-| **Description + input schema** | **92.4 KB** | **45%** | **the recurring cost** |
+| **Description + input schema** | **93.5 KB** | **45%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -129,9 +129,9 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`run_report`](#run_report) | Run a report | yes |  | 5.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.9 KB |
-| [`send_email`](#send_email) | Send an email |  |  | 3.6 KB |
-| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.9 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.2 KB |
+| [`send_email`](#send_email) | Send an email |  |  | 3.9 KB |
+| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.3 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`update_tag`](#update_tag) | Rename or recolour a tag |  |  | 2.0 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
@@ -13232,6 +13232,25 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
       "description": "Purpose key the recipients must have granted",
       "type": "string"
     },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+      "properties": {
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
       "maxLength": 255,
@@ -13469,6 +13488,25 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
       "description": "Purpose key the recipients must have granted",
       "type": "string"
     },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+      "properties": {
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
       "maxLength": 255,
@@ -13670,6 +13708,25 @@ Reply on a captured chat conversation — the channels this workspace has connec
     "consent_purpose": {
       "description": "Purpose key the recipient must have granted",
       "type": "string"
+    },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "The record that bears out the category: required for invoice_or_payment, contract_notice and precontract_quote, which cannot be allowed without one",
+      "properties": {
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",

--- a/docs/reference/mcp-tool-coverage.json
+++ b/docs/reference/mcp-tool-coverage.json
@@ -5,7 +5,7 @@
     "driven": 7,
     "never_driven": 66,
     "permitted_but_never_required": 13,
-    "tokens_served_but_never_driven": 17745,
+    "tokens_served_but_never_driven": 18006,
     "use_case_cases": 7,
     "cases_with_a_committed_run": 7,
     "acceptance_criteria_named": 6,
@@ -222,7 +222,7 @@
   "tools": [
     {
       "name": "send_account_email",
-      "tokens": 655,
+      "tokens": 742,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -231,7 +231,7 @@
     },
     {
       "name": "send_email",
-      "tokens": 588,
+      "tokens": 675,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -241,6 +241,15 @@
     {
       "name": "update_record",
       "tokens": 572,
+      "agents": [],
+      "required_by_cases": [],
+      "permitted_in_cases": [],
+      "driven": false,
+      "measured": null
+    },
+    {
+      "name": "send_message",
+      "tokens": 518,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],
@@ -292,15 +301,6 @@
     {
       "name": "advance_deal",
       "tokens": 443,
-      "agents": [],
-      "required_by_cases": [],
-      "permitted_in_cases": [],
-      "driven": false,
-      "measured": null
-    },
-    {
-      "name": "send_message",
-      "tokens": 431,
       "agents": [],
       "required_by_cases": [],
       "permitted_in_cases": [],

--- a/docs/reference/mcp-tool-coverage.md
+++ b/docs/reference/mcp-tool-coverage.md
@@ -29,7 +29,7 @@ This page does not grade single steps or name a best model per site — that is
 | … some case requires | 7 |
 | … **no case requires** | 66 |
 | … of those, permitted somewhere but never required | 13 |
-| Prompt tokens spent on tools no case requires | 17745 |
+| Prompt tokens spent on tools no case requires | 18006 |
 | Use cases | 7 |
 | … with a committed run | 7 |
 | Acceptance criteria the cases declare | 15 |
@@ -99,15 +99,15 @@ stopped being able to call it. A tool in the `permitted` column is worse than on
 
 | Tool | Tokens | Permitted in | Attached to |
 |---|---:|---|---|
-| `send_account_email` | 655 | — | — |
-| `send_email` | 588 | — | — |
+| `send_account_email` | 742 | — | — |
+| `send_email` | 675 | — | — |
 | `update_record` | 572 | — | — |
+| `send_message` | 518 | — | — |
 | `list_records` | 508 | — | `morning_brief`, `overnight_at_risk_sweep` |
 | `progress_deal` | 501 | — | — |
 | `resolve_entities` | 498 | `case1_log_it`, `case2_business_card` | — |
 | `run_analytics_query` | 465 | — | — |
 | `advance_deal` | 443 | — | — |
-| `send_message` | 431 | — | — |
 | `annotate_brief` | 418 | — | `morning_brief` |
 | `review_commitments` | 401 | — | `overnight_at_risk_sweep` |
 | `book_meeting` | 393 | — | — |


### PR DESCRIPTION
An MCP agent could name a communication_context but had no way to name the
EVIDENCE that bears it out. Three categories it may claim have validators that
read exactly that — invoice_or_payment, contract_notice, precontract_quote —
so an agent claiming one always resolved to `review` and parked. To a rep that
reads as the tool being broken.

The tool comment said "nothing in the engine reads it yet" and that was true
when written. validateInvoice, validateContract and validateQuote read it now.

NAMING EVIDENCE WIDENS NOTHING, which the security review tried four ways to
break: refuseUnreadableEvidence gates every field before any validator runs and
turns a grant refusal into a not-found, so a guessed id discloses nothing; the
document validators require the RECIPIENT to be reachable from the named record
through a current employment or stakeholder edge; and the reserved-category
refusal runs before evidence is parsed at all.

Three things I got wrong and fixed:

I nearly shipped a dead field. `activity_id` is in the HTTP contract, so I
mirrored it — but no validator reads Evidence.ActivityID, and the thread a
reply answers reaches the engine as Request.AnchorActivityID, derived from the
send origin and never named by a caller. It was also the one evidence field
refuseUnreadableEvidence does not cover. Dropped.

I advertised `active_deal_followup` as needing evidence, in a string written
into every system prompt of every run. It does not: that category has no
validator and is supported by a live deal in the message's LINKS, which
evidence never reaches. My comment also named a validateDeal that does not
exist. Both corrected — this is the exact failure the comment I replaced was
written to prevent.

Codex found a malformed id would burn a human's approval: a send floored to
confirm-first is staged, decided, and redeemed, and redemption consumes the
one-shot approval before the send door parses anything. requireParsableEvidence
now refuses at the door, beside requireAddressee, which exists for that reason
and had no test of its own until now.

NOT DONE, and verified rather than assumed: evidence is not added to
HeldDraftProposal. An operator can configure invoice_or_payment on a
draft_email action, but it cannot outrank the anchor — resolveCategory checks
the thread arm before any claim, so a live thread resolves to reply_to_inbound
whatever was configured and anything else parks as review. Carrying evidence
there would change neither outcome. The ordering is now stated in heldrelease.go.

The seam that dropped the field had no test at all. It has one now, pairing
fields BY NAME so a mis-wire is caught as well as a drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agents can now name the record that bears out a send category — `invoice_id`, `contract_id`, or `deal_id` — so claims of `invoice_or_payment`, `contract_notice`, and `precontract_quote` no longer always resolve to `review` and park. Naming evidence widens nothing: `refuseUnreadableEvidence` gates every field before any validator runs.

- A malformed evidence ID is refused at the send door before staging, so it cannot consume a human's one-shot approval.
- The seam between the tool surface and the send module now carries every evidence field, with a structural test that pairs fields by name.
- `active_deal_followup` no longer advertises evidence as required; that category has no validator and is supported by a live deal in the message's links.
- Evidence is not added to `HeldDraftProposal`; carrying it there would change neither the live-thread nor the parked outcome.

<sup>Written for commit a365004de32f9dd13eb85349e2e45a3afdd77ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

