### PR TITLE
What the evidence entitles the product to do about a stage

### DIFF
--- a/backend/internal/modules/deals/doc.go
+++ b/backend/internal/modules/deals/doc.go
@@ -10,7 +10,7 @@
 // the deals slice of the datasource provider, flat per ADR-0054 §3.
 //
 // Tables owned: deal, deal_stage_history, deal_forecast_history, pipeline,
-// stage, stage_exit_criterion, fx_rate,
+// stage, stage_exit_criterion, deal_stage_evidence, fx_rate,
 // product, offer, offer_line_item, offer_template (the E03.16-.20 offer
 // engine: rate-card products, versioned deal-bound offers with derived money
 // totals).

--- a/backend/internal/modules/deals/stagepolicy.go
+++ b/backend/internal/modules/deals/stagepolicy.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// What a deal's evidence entitles the product to DO about its stage.
+//
+// A pure function over facts the caller already read, for the reason
+// AuthorSideOf is one: every row of the decision table below can then be
+// written as a test, including the rows that must refuse. A policy that needed
+// a database to answer would be a policy nobody could enumerate.
+//
+// THE FOUR OUTCOMES ARE A LADDER OF WHO DECIDES. Observe means the product
+// says nothing and the deal stays where it is. Propose puts a card in front of
+// a human. ProposeConfirmFirst puts the same card up but says out loud that
+// this one needs a person's judgement rather than their assent. AutoApply
+// moves the deal. Nothing in this file can reach AutoApply on its own — the
+// caller has to have measured the transition first, which is what
+// FactsAutopilot carries.
+
+import "time"
+
+// StageMoveOutcome is what the policy entitles the caller to do.
+type StageMoveOutcome string
+
+const (
+	// OutcomeObserve records what is known and proposes nothing.
+	OutcomeObserve StageMoveOutcome = "observe"
+	// OutcomePropose stages a card for a human to accept or reject.
+	OutcomePropose StageMoveOutcome = "propose"
+	// OutcomeProposeConfirmFirst stages the same card, marked as needing a
+	// judgement rather than an assent. It is what every move a mistake would
+	// be expensive to undo gets, whatever the evidence says.
+	OutcomeProposeConfirmFirst StageMoveOutcome = "propose_confirm_first"
+	// OutcomeAutoApply moves the deal without asking. Reachable only where the
+	// caller has measured this transition and the autopilot is on for it.
+	OutcomeAutoApply StageMoveOutcome = "auto_apply"
+)
+
+// StageMoveDecision is the outcome and why, in words that go on the card.
+type StageMoveDecision struct {
+	Outcome StageMoveOutcome
+	// Reason is the product's own sentence about this decision. It names the
+	// fact that decided it, so a rep reading the card learns why this is being
+	// asked rather than that something was computed.
+	Reason string
+	// Exception is set where the facts are not merely insufficient but
+	// WRONG-LOOKING — a contradiction, an unhealthy source, a link nobody can
+	// vouch for. Observing quietly would leave a rep with a stage that never
+	// moves and no way to find out why.
+	Exception string
+}
+
+// CriterionFact is one exit criterion and what the ledger says about it.
+type CriterionFact struct {
+	Key      string
+	Required bool
+	Kind     CriterionKind
+	// Met is whether the standing evidence says the criterion is settled. A
+	// criterion with no evidence at all is not met.
+	Met bool
+	// AuthorSide is who authored the evidence that settled it. Only meaningful
+	// where Met; a criterion settled by no evidence has no author.
+	AuthorSide AuthorSide
+	// Commitment tells an agreement from a proposal. A criterion met on a
+	// proposal is met on something nobody agreed to.
+	Commitment string
+	// Confidence is the model's, or nil where a record settled it outright. A
+	// deterministic claim is not uncertain, so nil reads as certain.
+	Confidence *float64
+	// Contradicted marks evidence another claim disagrees with.
+	Contradicted bool
+}
+
+// StageMoveFacts is everything the decision reads. Assembled in one
+// transaction by the caller, so the policy sees one consistent picture.
+type StageMoveFacts struct {
+	Criteria []CriterionFact
+	// FromTerminal and ToTerminal say whether either end of the move is a won
+	// or lost stage.
+	FromTerminal bool
+	ToTerminal   bool
+	// SingleStep is whether the target is the very next open stage. Anything
+	// else is a skip or a regression.
+	SingleStep bool
+	// SamePipeline is false where the move would cross pipelines.
+	SamePipeline bool
+	// Protected marks a deal a human has recently steered: a stage move by a
+	// person in the protection window, a reversal on the record, or a proposal
+	// for this same target already rejected with no newer evidence since.
+	Protected bool
+	// ProtectedReason names which of those it was, so the Reason can say so.
+	ProtectedReason string
+	// SourceUnhealthy marks evidence read from a source that was not working
+	// properly — a mailbox behind on sync, a failed reading.
+	SourceUnhealthy bool
+	// LinkageUncertain marks a deal whose activities may not all belong to it.
+	LinkageUncertain bool
+	// Autopilot carries the caller's measurement of this transition.
+	Autopilot AutopilotFacts
+}
+
+// AutopilotFacts is what the caller has measured about letting this transition
+// move itself. Every field must hold for AutoApply, and the zero value is a
+// transition nobody has measured — which is the honest default.
+type AutopilotFacts struct {
+	// Enabled is the installation kill switch AND the per-transition mode
+	// together: the caller reads both in the apply transaction and hands one
+	// answer, because a policy that read them separately could be told yes by
+	// a stale one.
+	Enabled bool
+	// Suspended marks a transition that suspended itself on its own error rate.
+	Suspended bool
+	// ThresholdsMet is whether the measured rates clear the bar: reviewed
+	// volume, observation days, clean acceptance, correction and reversal.
+	ThresholdsMet bool
+}
+
+// ambiguousConfidence is where a model's reading stops being objective enough
+// to move a deal without a person looking.
+//
+// HIGHER than the extraction floor (0.7) on purpose. That floor answers "is
+// this worth recording at all"; this one answers "is this worth acting on
+// unasked", and the second question deserves the stricter answer. A claim
+// between the two is recorded, shown, and confirmed by a human.
+const ambiguousConfidence = 0.85
+
+// DecideStageMove answers what this deal's evidence entitles the product to do.
+//
+// The order of the checks IS the policy, and it is deliberately
+// refusal-first: every reason to say no is asked before any reason to say yes,
+// so a deal that is both protected and fully evidenced observes. A policy that
+// asked the permissive questions first would answer AutoApply for a deal a
+// human had just steered by hand.
+func DecideStageMove(facts StageMoveFacts) StageMoveDecision {
+	if decision, refused := refuseOnTheFacts(facts); refused {
+		return decision
+	}
+	// Everything below here has met evidence for every required criterion,
+	// authored by whoever had to author it, uncontradicted, on a deal nobody
+	// has recently steered.
+	if reason := needsAJudgement(facts); reason != "" {
+		return StageMoveDecision{Outcome: OutcomeProposeConfirmFirst, Reason: reason}
+	}
+	if facts.Autopilot.Enabled && !facts.Autopilot.Suspended && facts.Autopilot.ThresholdsMet {
+		return StageMoveDecision{
+			Outcome: OutcomeAutoApply,
+			Reason:  "every exit criterion is settled by the other side's own words, and this transition has been measured long enough to move itself",
+		}
+	}
+	return StageMoveDecision{
+		Outcome: OutcomePropose,
+		Reason:  "every exit criterion for this stage is settled",
+	}
+}
+
+// refuseOnTheFacts asks every question whose answer is Observe.
+func refuseOnTheFacts(facts StageMoveFacts) (StageMoveDecision, bool) {
+	// The exception arm FIRST among the refusals, because these three are the
+	// facts a rep needs told rather than merely acted on: a contradiction, a
+	// source that was not working, a link nobody can vouch for. Observing them
+	// silently leaves a stage that never moves and no way to find out why.
+	if exception := surfacedException(facts); exception != "" {
+		return StageMoveDecision{
+			Outcome:   OutcomeObserve,
+			Reason:    "the evidence for this stage cannot be relied on as it stands",
+			Exception: exception,
+		}, true
+	}
+	if facts.Protected {
+		return StageMoveDecision{
+			Outcome: OutcomeObserve,
+			Reason:  facts.ProtectedReason,
+		}, true
+	}
+	// A STAGE THAT ASKS FOR NOTHING SETTLES NOTHING. Every check below is a
+	// loop over the criteria, so an empty list passes all of them vacuously —
+	// and an unconfigured stage is the DEFAULT state of every stage in the
+	// product, which would make this the common case rather than an edge one.
+	// The reason would have read "settled by the other side's own words" about
+	// a deal nobody had said anything about.
+	if len(facts.Criteria) == 0 {
+		return StageMoveDecision{
+			Outcome: OutcomeObserve,
+			Reason:  "this stage does not say what it takes to leave it, so nothing here can settle it",
+		}, true
+	}
+	for _, c := range facts.Criteria {
+		if c.Required && !c.Met {
+			return StageMoveDecision{
+				Outcome: OutcomeObserve,
+				Reason:  "the stage still asks for " + c.Key + ", and nothing says it is settled",
+			}, true
+		}
+		// The rule the whole ledger rests on, asked again HERE because the
+		// ledger refuses such a row at the write and this reads rows already
+		// written: a criterion naming something the buyer did, settled by our
+		// own side's word, settles nothing. A row that predates the write-time
+		// refusal, or one whose criterion kind changed after it was recorded,
+		// reaches this function and must not move a deal.
+		if c.Met && !SettlesBuyerMilestone(c.Kind, c.AuthorSide) {
+			return StageMoveDecision{
+				Outcome: OutcomeObserve,
+				Reason:  c.Key + " names something the buyer does, and only our own side has said it",
+			}, true
+		}
+	}
+	return StageMoveDecision{}, false
+}
+
+// surfacedException names a fact that is wrong rather than missing.
+func surfacedException(facts StageMoveFacts) string {
+	for _, c := range facts.Criteria {
+		if c.Contradicted {
+			return "another claim disagrees with the evidence for " + c.Key
+		}
+	}
+	if facts.SourceUnhealthy {
+		return "some of this deal's evidence was read from a source that was not working properly"
+	}
+	if facts.LinkageUncertain {
+		return "some of this deal's activity may belong to another record"
+	}
+	return ""
+}
+
+// needsAJudgement names why a move a human should look at is one, or "" where
+// the move is ordinary.
+//
+// Each of these is a move whose MISTAKE is expensive, independently of how
+// good the evidence is. Winning a deal that is not won, skipping a stage the
+// pipeline exists to enforce, or acting on a date somebody floated are all
+// errors a rep would rather catch on a card than find later in a forecast.
+func needsAJudgement(facts StageMoveFacts) string {
+	if facts.FromTerminal || facts.ToTerminal {
+		return "this move enters or leaves a closing stage, which is always a person's call"
+	}
+	if !facts.SamePipeline {
+		return "this move would cross into another pipeline"
+	}
+	if !facts.SingleStep {
+		return "this move skips or goes back a stage rather than advancing by one"
+	}
+	for _, c := range facts.Criteria {
+		if !c.Met {
+			// An unmet OPTIONAL criterion does not block the move — the stage
+			// said it was optional — but it is not nothing either: a stage
+			// carrying an unsettled criterion of any kind is one a person
+			// should glance at before the deal moves itself.
+			return c.Key + " is not settled, and the stage lists it"
+		}
+		// Anything but an explicit agreement. CommitmentNone is a criterion
+		// settled by a record rather than by anybody's undertaking — a
+		// signature, a meeting that happened — and that is objective. An EMPTY
+		// commitment is a row that never said, and a policy treating silence
+		// as agreement would act on the one value nobody chose.
+		if c.Commitment != CommitmentAgreed && c.Commitment != CommitmentNone {
+			return c.Key + " does not rest on anything the other side agreed to"
+		}
+		if c.Confidence != nil && *c.Confidence < ambiguousConfidence {
+			return "the reading of " + c.Key + " is not certain enough to act on unasked"
+		}
+	}
+	return ""
+}
+
+// ProtectionWindow is how long a human's own stage move keeps the product from
+// proposing another.
+//
+// A fortnight, because a rep who moved a deal by hand has said where they
+// think it is, and a proposal contradicting them a day later is the product
+// arguing with the person it works for. Long enough to cover a sales cycle's
+// natural pause; short enough that a deal does not go unread for a quarter.
+const ProtectionWindow = 14 * 24 * time.Hour

--- a/backend/internal/modules/deals/stagepolicy_test.go
+++ b/backend/internal/modules/deals/stagepolicy_test.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// One test per row of the decision table, plus the census that proves the
+// table is the whole table.
+//
+// The refusals are the subject. A policy that proposes a move it should have
+// observed puts a wrong card in front of a rep; one that AUTO-APPLIES a move
+// it should have proposed moves a deal nobody agreed to move, and the rep
+// finds out from a forecast.
+
+import "testing"
+
+// settledFacts is the fully-evidenced single-step move every test below varies
+// ONE fact of. Written as the permissive case on purpose: a test that started
+// from a refusing fixture would pass whether or not its own clause worked.
+func settledFacts() StageMoveFacts {
+	return StageMoveFacts{
+		Criteria: []CriterionFact{
+			{
+				Key: "problem_confirmed", Required: true, Kind: CriterionBuyerConfirmed,
+				Met: true, AuthorSide: AuthorBuyer, Commitment: CommitmentAgreed,
+			},
+			{
+				Key: "demo_held", Required: true, Kind: CriterionEventHeld,
+				Met: true, AuthorSide: AuthorUnknown, Commitment: CommitmentAgreed,
+			},
+		},
+		SingleStep:   true,
+		SamePipeline: true,
+	}
+}
+
+// The control: without it every refusal below could be passing because the
+// fixture refuses everything.
+func TestASingleStepMoveWithObjectiveEvidenceProposes(t *testing.T) {
+	got := DecideStageMove(settledFacts())
+	if got.Outcome != OutcomePropose {
+		t.Fatalf("a fully evidenced single-step move decided %q (%s)", got.Outcome, got.Reason)
+	}
+	if got.Exception != "" {
+		t.Errorf("an ordinary move surfaced the exception %q", got.Exception)
+	}
+}
+
+func TestAnUnmetRequiredCriterionOnlyObserves(t *testing.T) {
+	facts := settledFacts()
+	facts.Criteria[0].Met = false
+	got := DecideStageMove(facts)
+	if got.Outcome != OutcomeObserve {
+		t.Fatalf("an unmet required criterion decided %q", got.Outcome)
+	}
+	if got.Reason == "" {
+		t.Error("the refusal says nothing about which criterion is missing")
+	}
+}
+
+// An OPTIONAL criterion left unmet does not REFUSE the move — the stage said
+// it was optional, and treating it as required would make the flag mean
+// nothing — but it does cost the move its automatic pass. A stage carrying an
+// unsettled criterion of any kind is one a person should glance at before the
+// deal moves itself.
+func TestAnUnmetOptionalCriterionDoesNotRefuseButAsksForAGlance(t *testing.T) {
+	facts := settledFacts()
+	facts.Criteria = append(facts.Criteria, CriterionFact{
+		Key: "nice_to_have", Required: false, Kind: CriterionCustom,
+	})
+	got := DecideStageMove(facts)
+	if got.Outcome == OutcomeObserve {
+		t.Fatalf("an unmet OPTIONAL criterion refused the move; the required "+
+			"flag then means nothing (%s)", got.Reason)
+	}
+	if got.Outcome != OutcomeProposeConfirmFirst {
+		t.Errorf("an unmet optional criterion decided %q, want a card a person looks at", got.Outcome)
+	}
+
+	// And it must outrank a measured autopilot: an unsettled criterion is
+	// exactly what a person should see before the deal moves itself.
+	facts.Autopilot = AutopilotFacts{Enabled: true, ThresholdsMet: true}
+	if got := DecideStageMove(facts); got.Outcome == OutcomeAutoApply {
+		t.Error("an unmet optional criterion auto-applied under a measured autopilot")
+	}
+}
+
+// A stage that says nothing about what it takes to leave it settles nothing.
+//
+// Every other check is a loop over the criteria, so an empty list passes all
+// of them vacuously — and an unconfigured stage is the DEFAULT state of every
+// stage in the product. Left unhandled this was not an edge case: it
+// auto-applied every deal on every stage nobody had configured, with a reason
+// claiming the buyer's own words had settled it.
+func TestAStageWithNoCriteriaSettlesNothing(t *testing.T) {
+	bare := StageMoveFacts{
+		SingleStep: true, SamePipeline: true,
+		Autopilot: AutopilotFacts{Enabled: true, ThresholdsMet: true},
+	}
+	got := DecideStageMove(bare)
+	if got.Outcome != OutcomeObserve {
+		t.Fatalf("a stage with no exit criteria decided %q (%s)", got.Outcome, got.Reason)
+	}
+}
+
+// Silence is not agreement. A row that never said what it rests on is the one
+// value nobody chose, and treating it as objective would act on it.
+func TestACriterionRestingOnNothingNamedIsNotObjective(t *testing.T) {
+	facts := settledFacts()
+	facts.Criteria[0].Commitment = ""
+	if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+		t.Fatalf("a criterion with no stated commitment decided %q", got.Outcome)
+	}
+
+	// CommitmentNone is different and IS objective: it is a criterion settled
+	// by a record rather than by anybody's undertaking — a signature, a
+	// meeting that happened.
+	facts.Criteria[0].Commitment = CommitmentNone
+	if got := DecideStageMove(facts); got.Outcome != OutcomePropose {
+		t.Errorf("a criterion settled by a record decided %q", got.Outcome)
+	}
+}
+
+// The rule the whole ledger rests on, asked again at the policy: the store
+// refuses such a row at the write, and this reads rows already written — one
+// recorded before that refusal existed, or whose criterion kind changed after
+// the fact, reaches here and must not move a deal.
+func TestSellerAuthoredEvidenceForABuyerMilestoneOnlyObserves(t *testing.T) {
+	for _, side := range []AuthorSide{AuthorSeller, AuthorUnknown} {
+		facts := settledFacts()
+		facts.Criteria[0].AuthorSide = side
+		got := DecideStageMove(facts)
+		if got.Outcome != OutcomeObserve {
+			t.Errorf("%s-authored evidence for a buyer milestone decided %q", side, got.Outcome)
+		}
+	}
+	// The positive control: the buyer's own word still proposes, so the
+	// refusals above are about authorship and not about a fixture that refuses
+	// everything.
+	if got := DecideStageMove(settledFacts()); got.Outcome != OutcomePropose {
+		t.Fatalf("buyer-authored evidence decided %q", got.Outcome)
+	}
+}
+
+func TestContradictedEvidenceObservesAndSurfacesAnException(t *testing.T) {
+	facts := settledFacts()
+	facts.Criteria[1].Contradicted = true
+	got := DecideStageMove(facts)
+	if got.Outcome != OutcomeObserve {
+		t.Fatalf("contradicted evidence decided %q", got.Outcome)
+	}
+	if got.Exception == "" {
+		t.Error("a contradiction was observed silently; the rep is left with a " +
+			"stage that never moves and no way to find out why")
+	}
+}
+
+// The other two exception facts take the same arm, and each must surface.
+func TestAnUnhealthySourceOrUncertainLinkageSurfacesAnException(t *testing.T) {
+	for name, mutate := range map[string]func(*StageMoveFacts){
+		"an unhealthy source": func(f *StageMoveFacts) { f.SourceUnhealthy = true },
+		"uncertain linkage":   func(f *StageMoveFacts) { f.LinkageUncertain = true },
+	} {
+		facts := settledFacts()
+		mutate(&facts)
+		got := DecideStageMove(facts)
+		if got.Outcome != OutcomeObserve {
+			t.Errorf("%s decided %q", name, got.Outcome)
+		}
+		if got.Exception == "" {
+			t.Errorf("%s was observed without surfacing anything", name)
+		}
+	}
+}
+
+// A deal a human has recently steered is theirs. The reason must be the
+// PROTECTION's, not a generic refusal, because the rep is owed the difference
+// between "we are not sure" and "you moved this yourself".
+func TestAProtectedDealIsNeverProposed(t *testing.T) {
+	facts := settledFacts()
+	facts.Protected = true
+	facts.ProtectedReason = "you moved this deal by hand last week"
+	got := DecideStageMove(facts)
+	if got.Outcome != OutcomeObserve {
+		t.Fatalf("a protected deal decided %q", got.Outcome)
+	}
+	if got.Reason != facts.ProtectedReason {
+		t.Errorf("the refusal reads %q, not the protection's own reason", got.Reason)
+	}
+}
+
+// Protection outranks a perfect case, INCLUDING a measured autopilot: a
+// product that moved a deal the rep had just steered would be arguing with the
+// person it works for, and doing it silently.
+func TestProtectionOutranksAMeasuredAutopilot(t *testing.T) {
+	facts := settledFacts()
+	facts.Protected = true
+	facts.ProtectedReason = "you moved this deal by hand last week"
+	facts.Autopilot = AutopilotFacts{Enabled: true, ThresholdsMet: true}
+	if got := DecideStageMove(facts); got.Outcome != OutcomeObserve {
+		t.Fatalf("a protected deal with the autopilot on decided %q", got.Outcome)
+	}
+}
+
+func TestEnteringOrLeavingWonOrLostIsAlwaysConfirmFirst(t *testing.T) {
+	for name, mutate := range map[string]func(*StageMoveFacts){
+		"leaving a closing stage": func(f *StageMoveFacts) { f.FromTerminal = true },
+		"entering one":            func(f *StageMoveFacts) { f.ToTerminal = true },
+	} {
+		facts := settledFacts()
+		mutate(&facts)
+		if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+			t.Errorf("%s decided %q, want confirm-first", name, got.Outcome)
+		}
+	}
+}
+
+// A terminal move stays a person's call however well measured the transition
+// is. This is the row a future autopilot must not be able to reach.
+func TestNoFactCombinationYieldsAutoApplyOntoATerminalStage(t *testing.T) {
+	facts := settledFacts()
+	facts.ToTerminal = true
+	facts.Autopilot = AutopilotFacts{Enabled: true, ThresholdsMet: true}
+	got := DecideStageMove(facts)
+	if got.Outcome == OutcomeAutoApply {
+		t.Fatal("a measured autopilot auto-applied a move onto a closing stage")
+	}
+	// The exact outcome, not merely "not auto-apply": a terminal move that
+	// resolved to an ordinary Propose would pass a not-equal assertion while
+	// dropping the confirm-first the row demands.
+	if got.Outcome != OutcomeProposeConfirmFirst {
+		t.Errorf("a terminal move under a measured autopilot decided %q, want confirm-first", got.Outcome)
+	}
+}
+
+func TestSkippingOrRegressingIsConfirmFirst(t *testing.T) {
+	facts := settledFacts()
+	facts.SingleStep = false
+	if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+		t.Fatalf("a skip or regression decided %q", got.Outcome)
+	}
+}
+
+func TestCrossingPipelinesIsConfirmFirst(t *testing.T) {
+	facts := settledFacts()
+	facts.SamePipeline = false
+	if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+		t.Fatalf("a cross-pipeline move decided %q", got.Outcome)
+	}
+}
+
+// "We could meet Thursday" is not "Thursday works". A criterion met on a
+// proposal is met on something nobody agreed to.
+func TestAProposedNextStepIsAmbiguousAndConfirmFirst(t *testing.T) {
+	facts := settledFacts()
+	facts.Criteria[0].Commitment = CommitmentProposed
+	if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+		t.Fatalf("a criterion resting on a proposal decided %q", got.Outcome)
+	}
+}
+
+// The confidence bar for ACTING is higher than the bar for recording. A claim
+// between the two is recorded, shown, and confirmed by a human.
+func TestAnUncertainReadingIsConfirmFirst(t *testing.T) {
+	facts := settledFacts()
+	// LITERALS, not arithmetic on the production constant: deriving the input
+	// from the value under test makes the test agree with any threshold,
+	// including one that silently drifted down to 0.5.
+	low := 0.84
+	facts.Criteria[0].Confidence = &low
+	if got := DecideStageMove(facts); got.Outcome != OutcomeProposeConfirmFirst {
+		t.Fatalf("a reading below the acting bar decided %q", got.Outcome)
+	}
+
+	// At the bar it is objective, and a deterministic claim carries no
+	// confidence at all — nil must read as certain rather than as zero.
+	at := 0.85
+	facts.Criteria[0].Confidence = &at
+	if got := DecideStageMove(facts); got.Outcome != OutcomePropose {
+		t.Errorf("a reading AT the bar decided %q", got.Outcome)
+	}
+	facts.Criteria[0].Confidence = nil
+	if got := DecideStageMove(facts); got.Outcome != OutcomePropose {
+		t.Errorf("a deterministic claim carrying no confidence decided %q", got.Outcome)
+	}
+}
+
+// Every one of the three autopilot facts is necessary, checked one at a time
+// so a policy that dropped one from the condition fails here rather than
+// passing on the other two.
+func TestAutopilotAppliesOnlyWhenEnabledUnsuspendedAndMeasured(t *testing.T) {
+	full := AutopilotFacts{Enabled: true, Suspended: false, ThresholdsMet: true}
+	facts := settledFacts()
+	facts.Autopilot = full
+	if got := DecideStageMove(facts); got.Outcome != OutcomeAutoApply {
+		t.Fatalf("a measured, enabled, unsuspended transition decided %q", got.Outcome)
+	}
+
+	for name, broken := range map[string]AutopilotFacts{
+		"the kill switch off":      {Enabled: false, ThresholdsMet: true},
+		"the transition suspended": {Enabled: true, Suspended: true, ThresholdsMet: true},
+		"nothing measured yet":     {Enabled: true},
+	} {
+		facts := settledFacts()
+		facts.Autopilot = broken
+		if got := DecideStageMove(facts); got.Outcome != OutcomePropose {
+			t.Errorf("with %s the policy decided %q, want a proposal", name, got.Outcome)
+		}
+	}
+}
+
+// The zero value is a transition nobody has measured, and it must propose
+// rather than apply. A policy whose default was permissive would auto-apply
+// every transition on an installation that had never configured one.
+func TestAnUnmeasuredTransitionProposes(t *testing.T) {
+	if got := DecideStageMove(settledFacts()); got.Outcome != OutcomePropose {
+		t.Fatalf("the zero autopilot decided %q", got.Outcome)
+	}
+}
+
+// Every decision carries a sentence. A card that says a move is proposed
+// without saying why is a card a rep cannot act on.
+func TestEveryDecisionSaysWhy(t *testing.T) {
+	for name, facts := range map[string]StageMoveFacts{
+		"proposed":      settledFacts(),
+		"observed":      unmetFacts(),
+		"confirm-first": terminalFacts(),
+		"auto-applied":  autopilotFacts(),
+	} {
+		if got := DecideStageMove(facts); got.Reason == "" {
+			t.Errorf("the %s decision carries no reason", name)
+		}
+	}
+}
+
+func unmetFacts() StageMoveFacts {
+	f := settledFacts()
+	f.Criteria[0].Met = false
+	return f
+}
+
+func terminalFacts() StageMoveFacts {
+	f := settledFacts()
+	f.ToTerminal = true
+	return f
+}
+
+func autopilotFacts() StageMoveFacts {
+	f := settledFacts()
+	f.Autopilot = AutopilotFacts{Enabled: true, ThresholdsMet: true}
+	return f
+}

--- a/backend/internal/modules/deals/stageprogression_integration_test.go
+++ b/backend/internal/modules/deals/stageprogression_integration_test.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package deals
+
+// Reading a real deal into the facts the policy judges.
+//
+// The policy itself is unit-tested per decision row; what these prove is that
+// the SQL under it answers what those rows assume — which criterion counts as
+// met, which evidence wins when two disagree, and which of the three
+// protections fired.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// twoStagePipeline seeds a pipeline with two open stages and a deal on the
+// first, and answers the deal plus both stage ids.
+func twoStagePipeline(t *testing.T, e *configEnv) (ids.DealID, ids.StageID, ids.StageID) {
+	t.Helper()
+	ctx := e.as()
+	pipeline, err := e.store.CreatePipeline(ctx, CreatePipelineInput{Name: "Sales " + ids.NewV7().String()})
+	if err != nil {
+		t.Fatalf("seeding a pipeline: %v", err)
+	}
+	pipelineID := ids.From[ids.PipelineKind](ids.UUID(pipeline.Id))
+	open := 0
+	first, err := e.store.CreateStage(ctx, CreateStageInput{
+		PipelineID: pipelineID, Name: "Discovery", Position: 0,
+		Semantic: string(SemanticOpen), WinProbability: &open,
+	})
+	if err != nil {
+		t.Fatalf("seeding the first stage: %v", err)
+	}
+	second, err := e.store.CreateStage(ctx, CreateStageInput{
+		PipelineID: pipelineID, Name: "Negotiation", Position: 1,
+		Semantic: string(SemanticOpen), WinProbability: &open,
+	})
+	if err != nil {
+		t.Fatalf("seeding the second stage: %v", err)
+	}
+	fromID := ids.From[ids.StageKind](ids.UUID(first.Id))
+	owner := ids.From[ids.UserKind](e.admin)
+	deal, err := e.store.CreateDeal(e.asDealWriter(), CreateDealInput{
+		Name: "Warehouse rollout", PipelineID: pipelineID, StageID: fromID,
+		OwnerID: &owner, OwnerExact: true,
+	})
+	if err != nil {
+		t.Fatalf("seeding a deal: %v", err)
+	}
+	return ids.From[ids.DealKind](ids.UUID(deal.Id)), fromID,
+		ids.From[ids.StageKind](ids.UUID(second.Id))
+}
+
+// facts reads the deal through the real assembler.
+//
+// The autopilot is the ZERO value throughout: a transition nobody has measured
+// is what every deal starts as, and the autopilot's own arms are unit-tested
+// per row. What these prove is the SQL beneath the decision.
+func facts(t *testing.T, e *configEnv, dealID ids.DealID) StageProgressionFacts {
+	t.Helper()
+	var out StageProgressionFacts
+	if err := e.store.Tx(e.asDealWriter(), func(tx pgx.Tx) error {
+		var err error
+		out, err = ReadStageProgressionFacts(e.asDealWriter(), tx, dealID, AutopilotFacts{}, time.Now())
+		return err
+	}); err != nil {
+		t.Fatalf("reading the deal's progression facts: %v", err)
+	}
+	return out
+}
+
+// The target is the pipeline's next open stage, computed rather than supplied:
+// a proposer that could be told where to move a deal is one whose target a bug
+// could choose.
+func TestTheTargetIsTheNextOpenStageOfTheDealsOwnPipeline(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+
+	got := facts(t, e, dealID)
+	if got.FromStageID != fromID {
+		t.Errorf("the move starts at %v, want the deal's own stage %v", got.FromStageID, fromID)
+	}
+	if got.ToStageID != toID {
+		t.Errorf("the move targets %v, want the next open stage %v", got.ToStageID, toID)
+	}
+	if got.ToName != "Negotiation" {
+		t.Errorf("the target is named %q", got.ToName)
+	}
+}
+
+// A deal on the last stage has nowhere to go, and that is an ordinary outcome
+// rather than a failure.
+func TestADealOnTheLastStageHasNothingToPropose(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, _, toID := twoStagePipeline(t, e)
+	if _, err := e.store.AdvanceDeal(e.asDealWriter(), dealID,
+		AdvanceDealInput{ToStageID: toID}); err != nil {
+		t.Fatalf("advancing the deal to the last stage: %v", err)
+	}
+
+	err := e.store.Tx(e.asDealWriter(), func(tx pgx.Tx) error {
+		_, err := ReadStageProgressionFacts(e.asDealWriter(), tx, dealID, AutopilotFacts{}, time.Now())
+		return err
+	})
+	if !errors.Is(err, ErrNoNextStage) {
+		t.Fatalf("a deal on the last stage answered %v, want the no-next-stage outcome", err)
+	}
+}
+
+// A criterion with no evidence at all is not met, and the stage's own required
+// flag is what decides whether that blocks the move.
+func TestACriterionWithNoEvidenceIsNotMet(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, _ := twoStagePipeline(t, e)
+	addCriterion(t, e, fromID, "problem_confirmed")
+
+	got := facts(t, e, dealID)
+	if len(got.Criteria) != 1 {
+		t.Fatalf("read %d criteria, want the one the stage carries", len(got.Criteria))
+	}
+	if got.Criteria[0].Met {
+		t.Error("a criterion nothing has said anything about reads as met")
+	}
+	if got.Decision.Outcome != OutcomeObserve {
+		t.Errorf("an unmet required criterion decided %q", got.Decision.Outcome)
+	}
+}
+
+// REFUTED evidence does not count. A claim a human struck out is one they said
+// was wrong, and counting it would make the correction do nothing.
+func TestRefutedEvidenceDoesNotSettleACriterion(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, _ := twoStagePipeline(t, e)
+	criterion := addCriterion(t, e, fromID, "problem_confirmed")
+	criterionID := ids.From[ids.ExitCriterionKind](ids.UUID(criterion.Id))
+
+	recorded, err := e.store.RecordStageEvidence(e.asDealWriter(),
+		claim(dealID, criterionID, AuthorBuyer))
+	if err != nil {
+		t.Fatalf("recording evidence: %v", err)
+	}
+	if got := facts(t, e, dealID); !got.Criteria[0].Met {
+		t.Fatal("precondition: the criterion is not met before the refutation, " +
+			"so this test would pass without one")
+	}
+
+	if _, err := e.store.RefuteStageEvidence(e.asDealWriter(), dealID,
+		ids.UUID(recorded.Id)); err != nil {
+		t.Fatalf("refuting: %v", err)
+	}
+	got := facts(t, e, dealID)
+	if got.Criteria[0].Met {
+		t.Error("refuted evidence still settles the criterion, so striking a " +
+			"claim out changes nothing")
+	}
+}
+
+// The BUYER's own word wins where two claims settle one criterion. The
+// authorship rule is the bar, so a seller-authored row sitting beside a
+// buyer's must not be the one the policy judges.
+func TestTheBuyersOwnWordWinsAmongClaimsForOneCriterion(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, _ := twoStagePipeline(t, e)
+	// A CUSTOM criterion, because the ranking is what is under test: a
+	// buyer-milestone kind refuses the seller's claim at the write, and the
+	// test would then be about that refusal instead.
+	criterion, err := e.store.CreateStageExitCriterion(e.as(), CreateCriterionInput{
+		StageID: fromID, Key: "internal_review", Label: "Internal review done",
+		Kind: string(CriterionCustom),
+	})
+	if err != nil {
+		t.Fatalf("adding a custom criterion: %v", err)
+	}
+	criterionID := ids.From[ids.ExitCriterionKind](ids.UUID(criterion.Id))
+
+	// THE BUYER'S CLAIM IS THE OLDER ONE, which is what makes this test load-
+	// bearing: written first and observed a week earlier, so a query that
+	// simply took the most recent row would pick the seller's and this would
+	// fail. Authorship priority is the only rule that answers buyer here.
+	buyer := claim(dealID, criterionID, AuthorBuyer)
+	buyer.SourceID = ids.NewV7()
+	buyer.ObservedAt = time.Now().UTC().Add(-7 * 24 * time.Hour)
+	if _, err := e.store.RecordStageEvidence(e.asDealWriter(), buyer); err != nil {
+		t.Fatalf("recording the buyer's claim: %v", err)
+	}
+	seller := claim(dealID, criterionID, AuthorSeller)
+	seller.SourceID = ids.NewV7()
+	seller.ExtractedBy = "stage_evidence_extract"
+	confidence := 0.9
+	seller.Confidence = &confidence
+	if _, err := e.store.RecordStageEvidence(e.asDealWriter(), seller); err != nil {
+		t.Fatalf("recording the seller's claim: %v", err)
+	}
+
+	got := facts(t, e, dealID)
+	if got.Criteria[0].AuthorSide != AuthorBuyer {
+		t.Errorf("the criterion reads as %s-authored with a buyer's claim on it",
+			got.Criteria[0].AuthorSide)
+	}
+	if len(got.Criteria[0].EvidenceIDs) != 2 {
+		t.Errorf("the card cites %d rows, want both claims so a reader can see "+
+			"what the criterion rests on", len(got.Criteria[0].EvidenceIDs))
+	}
+}
+
+// A human's own stage move in the window protects the deal: a proposal the day
+// after is the product arguing with the person it works for.
+func TestAHumanStageMoveInTheLastFortnightBlocksAProposal(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	settleEveryCriterion(t, e, dealID, fromID)
+
+	if got := facts(t, e, dealID); got.Decision.Outcome != OutcomePropose {
+		t.Fatalf("precondition: a settled deal decided %q, so the protection "+
+			"below would not be what this test measures", got.Decision.Outcome)
+	}
+	// The rep moves it back by hand, which writes a human stage-history row.
+	if _, err := e.store.AdvanceDeal(e.asDealWriter(), dealID,
+		AdvanceDealInput{ToStageID: toID}); err != nil {
+		t.Fatalf("the human stage move: %v", err)
+	}
+	if _, err := e.store.AdvanceDeal(e.asDealWriter(), dealID,
+		AdvanceDealInput{ToStageID: fromID}); err != nil {
+		t.Fatalf("moving back: %v", err)
+	}
+
+	got := facts(t, e, dealID)
+	if got.Decision.Outcome != OutcomeObserve {
+		t.Fatalf("a deal a human just moved decided %q", got.Decision.Outcome)
+	}
+	if got.Decision.Reason == "" {
+		t.Error("the protection does not say why, so the rep cannot tell it " +
+			"from an ordinary refusal")
+	}
+}
+
+// settleEveryCriterion gives the deal's current stage one criterion and
+// settles it with the buyer's own word.
+func settleEveryCriterion(t *testing.T, e *configEnv, dealID ids.DealID, stageID ids.StageID) {
+	t.Helper()
+	criterion := addCriterion(t, e, stageID, "problem_confirmed")
+	if _, err := e.store.RecordStageEvidence(e.asDealWriter(), claim(dealID,
+		ids.From[ids.ExitCriterionKind](ids.UUID(criterion.Id)), AuthorBuyer)); err != nil {
+		t.Fatalf("settling the criterion: %v", err)
+	}
+}
+
+// Creating a deal is not steering it.
+//
+// A deal's creation writes a stage-history row like any move, and counting it
+// as a human's would protect EVERY new deal for a fortnight — precisely the
+// window in which its first criteria get settled. The feature would have
+// looked like it simply never fired.
+func TestCreatingADealIsNotAHumanStageMove(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, _ := twoStagePipeline(t, e)
+	settleEveryCriterion(t, e, dealID, fromID)
+
+	got := facts(t, e, dealID)
+	if got.Decision.Outcome != OutcomePropose {
+		t.Fatalf("a freshly created, fully settled deal decided %q (%s)",
+			got.Decision.Outcome, got.Decision.Reason)
+	}
+}

--- a/backend/internal/modules/deals/stageprogressionfacts.go
+++ b/backend/internal/modules/deals/stageprogressionfacts.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Reading one deal into the facts DecideStageMove judges.
+//
+// ONE TRANSACTION, because the policy is a judgement about a consistent
+// picture: criteria read at one moment and evidence at another can disagree
+// with each other, and the decision would then be about a deal that never
+// existed in that state.
+//
+// The target stage is computed HERE and never taken from a caller. A proposer
+// that could be told where to move a deal would be a proposer whose target a
+// bug — or a request body — could choose.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// StageProgressionFacts is the whole picture one decision rests on: what the
+// policy judges, plus the identities the proposal needs to name.
+type StageProgressionFacts struct {
+	Decision StageMoveDecision
+	DealID   ids.DealID
+	// FromStageID and ToStageID name the move. ToStageID is the next open
+	// stage in the pipeline's own order, computed here.
+	FromStageID ids.StageID
+	ToStageID   ids.StageID
+	FromName    string
+	ToName      string
+	PipelineID  ids.PipelineID
+	// Criteria carries the evidence ids behind each met criterion, so the card
+	// can cite what it rests on and a reviewer can open it.
+	Criteria []ProgressionCriterion
+}
+
+// ProgressionCriterion is one criterion as the card shows it: the fact the
+// policy judged, plus the rows a reader can click through to.
+type ProgressionCriterion struct {
+	CriterionFact
+	CriterionID ids.ExitCriterionID
+	Label       string
+	EvidenceIDs []ids.UUID
+}
+
+// ErrNoNextStage is the ordinary outcome for a deal already on its pipeline's
+// last open stage: there is nowhere to propose, and that is not a failure.
+var ErrNoNextStage = errors.New("deals: this deal is on the last open stage of its pipeline")
+
+// ReadStageProgressionFacts assembles one deal's picture and decides on it.
+//
+// The autopilot facts are the CALLER's to supply: they are read from the
+// installation setting, the per-transition policy row and the measured rates,
+// and the caller reads all three in the transaction that will apply the move.
+// Passing them in keeps this function's answer a function of what it read.
+func ReadStageProgressionFacts(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID, autopilot AutopilotFacts, now time.Time,
+) (StageProgressionFacts, error) {
+	var out StageProgressionFacts
+	out.DealID = dealID
+
+	where, err := readDealStanding(ctx, tx, dealID)
+	if err != nil {
+		return out, err
+	}
+	out.FromStageID, out.PipelineID, out.FromName = where.stageID, where.pipelineID, where.stageName
+
+	next, err := nextOpenStage(ctx, tx, where)
+	if err != nil {
+		return out, err
+	}
+	out.ToStageID, out.ToName = next.id, next.name
+
+	criteria, err := readProgressionCriteria(ctx, tx, where.stageID, dealID)
+	if err != nil {
+		return out, err
+	}
+	out.Criteria = criteria
+
+	protected, reason, err := readProtection(ctx, tx, dealID, now)
+	if err != nil {
+		return out, err
+	}
+
+	facts := StageMoveFacts{
+		Criteria:        make([]CriterionFact, 0, len(criteria)),
+		FromTerminal:    where.semantic.Terminal(),
+		ToTerminal:      next.semantic.Terminal(),
+		SingleStep:      true,
+		SamePipeline:    true,
+		Protected:       protected,
+		ProtectedReason: reason,
+		Autopilot:       autopilot,
+	}
+	for _, c := range criteria {
+		facts.Criteria = append(facts.Criteria, c.CriterionFact)
+	}
+	// SingleStep and SamePipeline are true by construction: nextOpenStage
+	// answers the very next open stage of THIS deal's pipeline and nothing
+	// else. They are still fields on the facts rather than assumptions inside
+	// the policy, because a later caller — the human proposing a specific
+	// target — reaches the same decision table with them false.
+	out.Decision = DecideStageMove(facts)
+	return out, nil
+}
+
+// dealStanding is where a deal sits right now.
+type dealStanding struct {
+	stageID    ids.StageID
+	pipelineID ids.PipelineID
+	stageName  string
+	position   int
+	semantic   StageSemantic
+}
+
+func readDealStanding(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (dealStanding, error) {
+	var out dealStanding
+	var semantic string
+	err := tx.QueryRow(ctx, `
+		SELECT s.id, s.pipeline_id, s.name, s.position, s.semantic
+		  FROM deal d JOIN stage s ON s.id = d.stage_id
+		 WHERE d.id = $1 AND d.archived_at IS NULL`, dealID).
+		Scan(&out.stageID, &out.pipelineID, &out.stageName, &out.position, &semantic)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return out, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return out, fmt.Errorf("read the deal's standing: %w", err)
+	}
+	out.semantic = StageSemantic(semantic)
+	return out, nil
+}
+
+// stageRef is the target of a proposed move.
+type stageRef struct {
+	id       ids.StageID
+	name     string
+	semantic StageSemantic
+}
+
+// nextOpenStage answers the stage after this one in the pipeline's own order.
+//
+// The pipeline's ORDER decides, not a caller: a proposer that could be told
+// where to move a deal is one whose target a bug could choose. A deal already
+// on the last stage answers ErrNoNextStage, which the caller treats as an
+// ordinary outcome.
+func nextOpenStage(ctx context.Context, tx pgx.Tx, from dealStanding) (stageRef, error) {
+	var out stageRef
+	var semantic string
+	err := tx.QueryRow(ctx, `
+		SELECT id, name, semantic
+		  FROM stage
+		 WHERE pipeline_id = $1 AND archived_at IS NULL
+		   AND (position, id) > ($2, $3)
+		 ORDER BY position, id
+		 LIMIT 1`, from.pipelineID, from.position, from.stageID).
+		Scan(&out.id, &out.name, &semantic)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return out, ErrNoNextStage
+	}
+	if err != nil {
+		return out, fmt.Errorf("read the next stage: %w", err)
+	}
+	out.semantic = StageSemantic(semantic)
+	return out, nil
+}
+
+// readProgressionCriteria answers the stage's live criteria and what the
+// ledger says about each.
+//
+// A criterion with no standing evidence is NOT met, which is the default the
+// row shape gives it. Refuted evidence does not count: a claim a human struck
+// out is a claim they said was wrong, and counting it would make the
+// correction do nothing.
+//
+// Where more than one row settles one criterion the strongest wins — the
+// authorship rule is the bar, so a buyer-authored claim beats a seller's, and
+// among equals the most recent observation. A criterion settled by one good
+// claim is settled whatever weaker claims sit beside it.
+func readProgressionCriteria(
+	ctx context.Context, tx pgx.Tx, stageID ids.StageID, dealID ids.DealID,
+) ([]ProgressionCriterion, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT c.id, c.key, c.label, c.required, c.kind,
+		       coalesce(e.met, false), coalesce(e.author_side, ''),
+		       coalesce(e.commitment, ''), e.confidence,
+		       coalesce(e.contradicted, false), coalesce(e.ids, '{}')
+		  FROM stage_exit_criterion c
+		  LEFT JOIN LATERAL (
+		      SELECT bool_or(v.met) AS met,
+		             (array_agg(v.author_side ORDER BY v.rank, v.observed_at DESC))[1] AS author_side,
+		             (array_agg(v.commitment ORDER BY v.rank, v.observed_at DESC))[1] AS commitment,
+		             (array_agg(v.confidence ORDER BY v.rank, v.observed_at DESC))[1] AS confidence,
+		             -- ANY row's contradiction, not the winner's. A newer
+		             -- uncontradicted claim can out-rank an older contradicted
+		             -- one on the same criterion, and picking only the winner
+		             -- would drop the disagreement exactly when a reader most
+		             -- needs telling that one exists.
+		             bool_or(v.contradicted_by IS NOT NULL) AS contradicted,
+		             array_agg(v.id) AS ids
+		        FROM (
+		            SELECT ev.*,
+		                   CASE WHEN ev.author_side = 'buyer' THEN 0 ELSE 1 END AS rank
+		              FROM deal_stage_evidence ev
+		             WHERE ev.criterion_id = c.id AND ev.deal_id = $2
+		               AND ev.refuted_at IS NULL AND ev.met
+		        ) v
+		  ) e ON true
+		 WHERE c.stage_id = $1 AND c.archived_at IS NULL
+		 ORDER BY c."position"`, stageID, dealID)
+	if err != nil {
+		return nil, fmt.Errorf("read the stage's criteria and their evidence: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ProgressionCriterion
+	for rows.Next() {
+		var c ProgressionCriterion
+		var kind, authorSide, commitment string
+		if err := rows.Scan(&c.CriterionID, &c.Key, &c.Label, &c.Required, &kind,
+			&c.Met, &authorSide, &commitment, &c.Confidence,
+			&c.Contradicted, &c.EvidenceIDs); err != nil {
+			return nil, fmt.Errorf("scan a criterion's standing: %w", err)
+		}
+		c.Kind = CriterionKind(kind)
+		c.AuthorSide = AuthorSide(authorSide)
+		c.Commitment = commitment
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read the stage's criteria: %w", err)
+	}
+	return out, nil
+}
+
+// readProtection answers whether a human has recently steered this deal, and
+// in which of the three ways.
+//
+// Each arm is a different sentence to a rep, which is why the reason travels
+// with the boolean rather than being composed at the card: "you moved this
+// yourself" and "this move was undone before" are different things to be told.
+//
+// A THIRD arm belongs here and is not built yet: a proposal for this same
+// target already rejected, with no newer evidence since. It reads
+// stage_progression_outcome, which arrives with the writer that fills it —
+// a table nothing writes is a migration shipping dead weight.
+func readProtection(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID, now time.Time,
+) (bool, string, error) {
+	var humanMove, reversal bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		    -- A HUMAN's own move, named positively. captured_by carries the
+		    -- principal's prefix, and "not system" would read an agent's move
+		    -- as a person's — the opposite of what protection is for, since an
+		    -- agent moving a deal is precisely what a human has not done.
+		    --
+		    -- from_stage_id IS NOT NULL excludes the row a deal's CREATION
+		    -- writes. Creating a deal is not steering it, and counting it as a
+		    -- human stage move would protect every new deal for a fortnight —
+		    -- exactly the window in which its first criteria are met.
+		    --
+		    -- approval_id IS NULL keeps a move a human made THROUGH a card out
+		    -- of it: accepting a proposal is agreeing with the product, not
+		    -- overruling it, and protecting on it would make one accepted card
+		    -- silence the next fortnight of them.
+		    SELECT 1 FROM deal_stage_history
+		     WHERE deal_id = $1 AND changed_at >= $2
+		       AND from_stage_id IS NOT NULL
+		       AND changed_by LIKE 'human:%'
+		       AND approval_id IS NULL
+		),
+		EXISTS (
+		    SELECT 1 FROM deal_stage_history WHERE deal_id = $1 AND reversal_of IS NOT NULL
+		)`, dealID, now.Add(-ProtectionWindow)).
+		Scan(&humanMove, &reversal); err != nil {
+		return false, "", fmt.Errorf("read the deal's recent stage history: %w", err)
+	}
+	switch {
+	case humanMove:
+		return true, "you moved this deal yourself in the last fortnight", nil
+	case reversal:
+		// A move that was undone once is a move this deal has already had the
+		// argument about. Proposing it again is the product not listening.
+		return true, "a stage move on this deal was undone before", nil
+	}
+	return false, "", nil
+}


### PR DESCRIPTION
`DecideStageMove` is a pure function over facts the caller already read, and it answers one of four things: **observe**, **propose**, **propose-and-say-this-needs-a-judgement**, or **apply**. Pure for the reason `AuthorSideOf` is — every row of the decision table can then be written as a test, including the rows that must refuse. A policy that needed a database to answer would be one nobody could enumerate.

## The order of the checks is the policy

Refusal-first. Every reason to say no is asked before any reason to say yes, so a deal that is both protected and fully evidenced observes. Asking the permissive questions first would answer auto-apply for a deal a human had just steered by hand.

| facts | outcome |
|---|---|
| the stage lists no criteria at all | Observe |
| any required criterion unmet | Observe |
| a met buyer-milestone criterion not buyer-authored | Observe |
| contradicted, source unhealthy, or linkage uncertain | Observe + exception surfaced |
| protected | Observe |
| from or to terminal (won/lost) | ProposeConfirmFirst |
| skip / regress / cross-pipeline | ProposeConfirmFirst |
| an unmet optional criterion, or one resting on a proposal, or a reading under 0.85 | ProposeConfirmFirst |
| single-step open→open, objective, autopilot off/suspended/unmeasured | Propose |
| same + autopilot enabled, unsuspended, thresholds met | AutoApply |

## A stage that asks for nothing settles nothing

Every check is a loop over the criteria, so an empty list passed all of them **vacuously** — and an unconfigured stage is the default state of every stage in the product. Left unhandled this was not an edge case: it auto-applied every deal on every unconfigured stage, with a reason claiming the buyer's own words had settled it. Codex found this one.

## The facts assembler

One deal, one transaction: the decision is a judgement about a consistent picture, and criteria read at one moment with evidence read at another can disagree — the decision would then be about a deal that never existed in that state.

The target stage is **computed** from the pipeline's own order and never taken from a caller. A proposer that could be told where to move a deal is one whose target a bug could choose.

Three rules the SQL holds, each with a test that fails without it:

- **Refuted evidence does not count.** A claim a human struck out is one they said was wrong, and counting it would make the correction do nothing.
- **The buyer's own word wins** among claims on one criterion, on *authorship* rather than recency. The test writes the buyer's claim a week earlier than the seller's, so a query taking the newest row fails it.
- **A contradiction on any claim surfaces**, not just the winning one. A newer uncontradicted claim can out-rank an older contradicted one, and picking only the winner would drop the disagreement exactly when a reader most needs telling one exists.

## Protection

Named positively — `changed_by LIKE 'human:%'` — because "not system" reads an agent's move as a person's, which is the opposite of what protection is for.

It excludes the row a deal's **creation** writes. Creating a deal is not steering it, and counting it would protect every new deal for a fortnight — exactly the window in which its first criteria get settled. The feature would have looked like it simply never fired.

It also excludes a move a human made *through a card*: accepting a proposal is agreeing with the product, not overruling it, and protecting on it would make one accepted card silence the next fortnight of them.

## Scope

The plan's WP4 also carries the approval kind, the compose adapter and the frontend card. This is the decidable core — the policy and what feeds it.

The `stage_progression_outcome` ledger and its third protection arm (a target already rejected with nothing learned since) go with the writer that fills them. A migration shipping a table nothing writes is dead weight, so it was cut from this PR rather than landed empty.

## Review

Codex found two P1s and four P2s, all fixed: the empty-criteria hole above; a contradiction on a losing row being silently dropped; an empty `commitment` string treated as agreement; an unmet *optional* criterion not costing the move its automatic pass; the agent-as-human misclassification; and three tests that could not fail — the terminal test asserted only "not auto-apply", the confidence test derived its input from the constant it checked, and the buyer-wins test made the buyer both higher-ranked and newer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the stage-move decision policy as a pure function over facts the caller reads, answering observe, propose, propose-confirm-first, or auto-apply, plus the SQL assembler that reads a real deal into those facts in one transaction.

**Policy semantics**

- Refusal-first: every reason to say no is checked before any reason to say yes, so a protected deal observes even with full evidence.
- An empty criteria list observes — an unconfigured stage would otherwise pass every check vacuously and auto-apply.
- Buyer-milestone criteria need buyer-authored evidence; any other side only observes.
- A contradiction, an unhealthy source, or uncertain linkage observes and surfaces an exception.
- Terminal moves, skips, regressions, cross-pipeline moves, unmet optional criteria, proposal-level commitments, and readings below 0.85 get propose-confirm-first.
- Auto-apply needs the caller's measured autopilot facts: enabled, unsuspended, thresholds met.

**Facts assembler**

- Criteria and evidence are read in one transaction; the target stage is computed from the pipeline's order, never taken from a caller.
- Refuted evidence does not count; the buyer's word wins by authorship, not recency; a contradiction on any claim surfaces.
- Protection covers human moves in the last fortnight (`changed_by LIKE 'human:%'`), excluding the creation row and card-approval moves.
- The `stage_progression_outcome` ledger and its third protection arm (rejected target, nothing learned since) ship later with the writer that fills the table.

<sup>Written for commit 315ccd6fe0b43d70280a7f779911a86a7318e6f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

