### PR TITLE
The carriage field is out for a reason an author cannot satisfy by accident

### DIFF
--- a/backend/internal/compose/handlers_channelproviders.go
+++ b/backend/internal/compose/handlers_channelproviders.go
@@ -155,14 +155,17 @@ func publishedChannelProviders(registered []channelProviderFacts, sending map[st
 // room besides.
 //
 // The field stays dropped anyway, and the honest reason is smaller than the
-// budget was: NO SCHEDULED AGENT ATTACHES A CHANNEL TOOL, so today nothing on
-// this surface would read the field. The parked-delivery path that teaches an
-// agent the bounds is the REST and human send path, not one either shipped
-// agent can reach.
+// budget was and firmer than "no agent is wired for it": THE CHANNEL SEND TOOL
+// CARRIES NO FILES. `send_message` takes an activity, a body and a consent
+// purpose, and there is no attachment argument on it or on any other verb this
+// surface offers — so `max_files` and `max_bytes_per_file` would state a bound
+// on something an agent cannot do.
 //
-// So this is currently a question about a capability nobody exercises. Adding
-// the field back is answerable on its own merits the moment an agent attaches a
-// channel tool — see #1985, whose budget premise this supersedes.
+// That is a stronger reason than the scheduled-agent menus, and it is stated
+// this way on purpose: an author who attached a channel tool to a scheduled
+// agent would satisfy the weaker reason and still be adding a field nothing can
+// read. The question becomes answerable when the send verb learns to carry a
+// file — see #1985, whose budget premise this supersedes.
 //
 // IT ALSO DROPS `capture_sources`, for the same reason and with the same shape
 // of consequence: a passport reading REST resolves a unit's `ext:` provenance and


### PR DESCRIPTION
Closes #1985.

The ticket asks to re-land `attachments` on `list_channel_providers`, and the
ruling recorded on it agreed — on the grounds that the token budget that forced
the revert had since been raised. **That is true and no longer the question.**

`compose/handlers_channelproviders.go` already says the budget ground is gone,
and gives a different reason for leaving the field out: *no scheduled agent
attaches a channel tool*. That reason is true and **too weak** — an author who
attached a channel tool to a scheduled agent would satisfy it and still be
adding a field nothing can read.

**The reason that actually holds: the channel send verb carries no files.**
`send_message` takes `activity_id`, `body` and `consent_purpose`; there is no
attachment argument on it, and no other verb on this surface has one either. So
`max_files` and `max_bytes_per_file` would state a bound on something an agent
cannot do. The ticket's own framing — *"an agent staging a channel message with
files can only discover the bounds by having the delivery parked"* — describes a
path that does not exist on the tool surface: an agent cannot stage a channel
message with files at all.

So this PR does not add the field. It replaces the comment's weaker reason with
the one that holds, and names the condition that makes the question live again:
the send verb learning to carry a file.

**Verification**

`make check-go` green; `craft static --strict` clean. No behaviour changes — the
diff is one comment, which is the whole content of the finding.