### PR TITLE
The frontend gates share one parser, and the suite runs on worker threads

### DIFF
--- a/docs/principles/one-source-of-truth.md
+++ b/docs/principles/one-source-of-truth.md
@@ -317,7 +317,11 @@ invisible to the other for no reason either author chose. A walk is the worst
 place for a second answer: the gate with the narrower walk reads a smaller tree
 and reports the same word for it, PASS, and there is no failing assertion to
 notice. The one answer is now `frontend/scripts/lib/source-tree.ts`, with its
-test beside it rather than inside either caller.
+test beside it rather than inside either caller. The parse went the same way
+once there were two dozen of them: each gate called the compiler itself and the
+calls disagreed about the dialect, so one read a `.ts` file as TSX and walked
+parse recovery for the rest of it. `parseSource` and `sourceFileAt` in the same
+file are the one parser now, and its test fails a second call site by name.
 
 ## What this does not ask for
 

--- a/frontend/scripts/ext-imports.test.ts
+++ b/frontend/scripts/ext-imports.test.ts
@@ -82,7 +82,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { extensionLayers, filesUnder, scriptKindFor } from "./lib/source-tree";
+import { extensionLayers, filesUnder, parseSource } from "./lib/source-tree";
 
 const frontendRoot = resolve(__dirname, "..");
 const repoRoot = resolve(frontendRoot, "..");
@@ -217,13 +217,7 @@ function specifiersIn(path: string, text: string): Specifier[] {
 // they each built their own, which is a second parse of identical text and,
 // worse, two trees a later edit could make disagree.
 function parse(path: string, text: string): ts.SourceFile {
-  return ts.createSourceFile(
-    path,
-    text,
-    ts.ScriptTarget.ES2022,
-    true,
-    scriptKindFor(path),
-  );
+  return parseSource(path, text);
 }
 
 // astSpecifiers is this gate's ONE reading of "what does this source import" —

--- a/frontend/scripts/lib/source-tree.test.ts
+++ b/frontend/scripts/lib/source-tree.test.ts
@@ -13,15 +13,24 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { extensionLayers, filesUnder, scriptKindFor } from "./source-tree";
+import {
+  extensionFrontendFiles,
+  extensionLayers,
+  filesUnder,
+  parseSource,
+  scriptKindFor,
+  sourceFileAt,
+} from "./source-tree";
 
 describe("the walk the source-wide gates share", () => {
   let dir = "";
@@ -192,13 +201,7 @@ describe("the walk the source-wide gates share", () => {
     expect(scriptKindFor("a.cts")).toBe(ts.ScriptKind.TS);
     // The property the .ts arm exists for, rather than the enum value: a
     // generic call in a .ts file parses, and would be a syntax error as TSX.
-    const generic = ts.createSourceFile(
-      "a.ts",
-      "const x = f<T>();",
-      ts.ScriptTarget.ES2022,
-      true,
-      scriptKindFor("a.ts"),
-    );
+    const generic = parseSource("a.ts", "const x = f<T>();");
     expect(generic.statements.length).toBe(1);
   });
 
@@ -236,5 +239,79 @@ describe("the walk the source-wide gates share", () => {
       recursive: true,
     });
     expect(extensionLayers(dir)).toEqual([]);
+  });
+});
+
+describe("the one parser the source-wide gates share", () => {
+  let dir = "";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "source-parse-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads a module in its own dialect, with parents set", () => {
+    // JSX is only syntax in a .tsx file; a .ts generic is only a generic there.
+    const jsx = parseSource("a.tsx", "const x = <div />;");
+    const [jsxStatement] = jsx.statements;
+    if (!ts.isVariableStatement(jsxStatement))
+      throw new Error("not a statement");
+    const jsxInit = jsxStatement.declarationList.declarations[0].initializer;
+    expect(jsxInit && ts.isJsxSelfClosingElement(jsxInit)).toBe(true);
+    const generic = parseSource("a.ts", "const x = f<T>();");
+    const [genericStatement] = generic.statements;
+    if (!ts.isVariableStatement(genericStatement))
+      throw new Error("not a statement");
+    const call = genericStatement.declarationList.declarations[0].initializer;
+    expect(
+      call && ts.isCallExpression(call) && call.typeArguments?.length,
+    ).toBe(1);
+    // A walk that asks a node for its parent must get one: every gate that
+    // reads `node.parent` would otherwise compare against undefined and
+    // quietly match nothing.
+    expect(genericStatement.parent).toBe(generic);
+  });
+
+  it("parses a file once for the run and hands every reader the same tree", () => {
+    const file = join(dir, "once.ts");
+    writeFileSync(file, "export const a = 1;");
+    const first = sourceFileAt(file);
+    writeFileSync(file, "export const a = 2;");
+    // The second read is the FIRST tree, not a re-parse of the edited file:
+    // the tree under test does not change during a run, and a reader that
+    // re-parsed would pay the whole corpus again for every pass that asks.
+    expect(sourceFileAt(file)).toBe(first);
+    expect(first.text).toBe("export const a = 1;");
+  });
+
+  // The gates used to call the compiler themselves, and disagreed about the
+  // dialect — one read a `.ts` file as TSX and walked parse recovery for the
+  // rest of the file, reporting PASS over what it had not seen. A single parse
+  // site is what keeps them reading the same tree, and this is what holds it:
+  // a second `ts.createSourceFile` anywhere in the frontend, core or extension
+  // tier, fails here and names itself.
+  it("is the only place the frontend calls the compiler's parser", () => {
+    const frontendRoot = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "..",
+    );
+    const corpus = [
+      ...filesUnder(join(frontendRoot, "src")),
+      ...filesUnder(join(frontendRoot, "scripts")),
+      ...filesUnder(join(frontendRoot, "e2e")),
+      ...extensionFrontendFiles(join(frontendRoot, "..", "extensions")),
+    ];
+    // The census must have read something, or an emptied corpus passes vacuously.
+    expect(corpus.length).toBeGreaterThan(100);
+    // Spelled in two halves so this file does not name itself a parser.
+    const call = ["ts.createSourceFile", "("].join("");
+    const parsers = corpus
+      .filter((file) => readFileSync(file, "utf8").includes(call))
+      .map((file) => file.slice(frontendRoot.length + 1))
+      .sort();
+    expect(parsers).toEqual(["scripts/lib/source-tree.ts"]);
   });
 });

--- a/frontend/scripts/lib/source-tree.ts
+++ b/frontend/scripts/lib/source-tree.ts
@@ -19,7 +19,13 @@
 // There is ONE set here, and it is the wide one.
 
 import type { Dirent } from "node:fs";
-import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 import ts from "typescript";
 
@@ -144,4 +150,47 @@ export function extensionFrontendFiles(extensionsDir: string): string[] {
   // with `1` where a Set belongs. The compiler catches it; the shape is worth
   // naming because the point-free version is the one that looks tidier.
   return extensionLayers(extensionsDir).flatMap((layer) => filesUnder(layer));
+}
+
+// parseSource is the ONE way this tree turns source text into a syntax tree.
+//
+// Every source-wide gate used to call `ts.createSourceFile` itself, and the
+// calls disagreed in the two arguments that change what a walk sees: the
+// language target and the script kind. One gate read a `.ts` file as TSX, where
+// a generic arrow is an unclosed element and everything after it is parse
+// recovery; another read it as TS. Both reported PASS over trees they had read
+// differently. The dialect comes from `scriptKindFor`, the target is the newest
+// the compiler knows, and parent pointers are always set, because a walk that
+// asks a node for its parent gets `undefined` and a silent non-match otherwise.
+//
+// `path` names the file for diagnostics and the dialect; `text` is what is
+// parsed, so a fixture or a prefiltered read can be handed in directly.
+export function parseSource(path: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(path),
+  );
+}
+
+// sourceFileAt reads and parses the module at `path` ONCE for the run, and
+// hands every later caller the same tree.
+//
+// A gate that walks the corpus several times — one pass per rule — re-parsed
+// every file on every pass, and a gate that walks the import graph from many
+// entry points re-parsed the shared subgraph once per entry. The tree does not
+// change while a suite runs, so the second parse can only agree with the first;
+// what it costs is the whole runner for the tail of the run. The cache is per
+// worker: vitest isolates test files from one another, so one file's reads are
+// never another's stale view.
+const parsedSources = new Map<string, ts.SourceFile>();
+
+export function sourceFileAt(path: string): ts.SourceFile {
+  const known = parsedSources.get(path);
+  if (known) return known;
+  const parsed = parseSource(path, readFileSync(path, "utf8"));
+  parsedSources.set(path, parsed);
+  return parsed;
 }

--- a/frontend/scripts/lib/story-title.ts
+++ b/frontend/scripts/lib/story-title.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import ts from "typescript";
+import { parseSource } from "./source-tree";
 
 /**
  * The Storybook sidebar path a story file claims, or null.
@@ -19,13 +20,7 @@ import ts from "typescript";
  * which stories exist.
  */
 export function storyTitle(path: string, text: string): string | null {
-  const source = ts.createSourceFile(
-    path,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(path, text);
   const exported = source.statements.find(ts.isExportAssignment);
   if (!exported) return null;
   const named = unwrap(exported.expression);

--- a/frontend/scripts/test-budget.ts
+++ b/frontend/scripts/test-budget.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import ts from "typescript";
 import { ASYNC_UTIL_TIMEOUT_MS } from "../vitest.budget";
+import { parseSource } from "./lib/source-tree";
 
 // Reads a test file and works out, for every test in it, how long that test is
 // ALLOWED to spend waiting — the sum of the budgets of the waiters it runs in
@@ -141,12 +142,7 @@ function declaredConsts(
 }
 
 function parse(file: string): ts.SourceFile {
-  return ts.createSourceFile(
-    file,
-    readFileSync(file, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-  );
+  return parseSource(file, readFileSync(file, "utf8"));
 }
 
 /**

--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { sourceFileAt } from "../../scripts/lib/source-tree";
 
 // Fitness function for the lost update: a write to an endpoint that takes an
 // `If-Match` precondition, sent without one.
@@ -72,13 +73,7 @@ const HTTP_METHODS: readonly string[] = [
   "delete",
 ];
 
-const schemaSource = ts.createSourceFile(
-  "schema.d.ts",
-  readFileSync(join(apiDir, "schema.d.ts"), "utf8"),
-  ts.ScriptTarget.Latest,
-  true,
-  ts.ScriptKind.TS,
-);
+const schemaSource = sourceFileAt(join(apiDir, "schema.d.ts"));
 
 function declaration(name: string): ts.InterfaceDeclaration {
   let found: ts.InterfaceDeclaration | undefined;
@@ -245,13 +240,7 @@ function callsIfMatch(node: ts.Node): boolean {
 
 /** `<file> METHOD /path` for every call in one file that sends no precondition. */
 function unpinnedIn(file: string, conditional: ReadonlySet<string>): string[] {
-  const source = ts.createSourceFile(
-    file,
-    readFileSync(file, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = sourceFileAt(file);
   const found: string[] = [];
   const visit = (node: ts.Node) => {
     const endpoint = calledEndpoint(node);

--- a/frontend/src/app/reach.test.ts
+++ b/frontend/src/app/reach.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   extensionFrontendFiles,
   filesUnder,
-  scriptKindFor,
+  parseSource,
 } from "../../scripts/lib/source-tree";
 import { NAV } from "./nav";
 import { SCREENS, type Screen } from "./router";
@@ -62,13 +62,7 @@ function shippedSources(): string[] {
 }
 
 function parse(path: string, source: string): ts.SourceFile {
-  return ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(path),
-  );
+  return parseSource(path, source);
 }
 
 /**

--- a/frontend/src/design-system/actionrow.test.ts
+++ b/frontend/src/design-system/actionrow.test.ts
@@ -47,7 +47,7 @@ import {
   extensionLayers,
   filesMatching,
   filesUnder,
-  scriptKindFor,
+  parseSource,
 } from "../../scripts/lib/source-tree";
 
 const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -232,13 +232,7 @@ function actionRows(
   text: string,
   gaps: Map<string, Set<string>>,
 ): readonly Row[] {
-  const source = ts.createSourceFile(
-    file,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(file),
-  );
+  const source = parseSource(file, text);
   const rows: Row[] = [];
 
   const visit = (node: ts.Node): void => {

--- a/frontend/src/design-system/catalog.test.ts
+++ b/frontend/src/design-system/catalog.test.ts
@@ -58,7 +58,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { filesUnder, scriptKindFor } from "../../scripts/lib/source-tree";
+import { filesUnder, parseSource } from "../../scripts/lib/source-tree";
 import { storyTitle } from "../../scripts/lib/story-title";
 
 const frontendRoot = resolve(__dirname, "..", "..");
@@ -121,13 +121,7 @@ function tableRows(section: string): string[][] {
 // The PUBLIC name is the one the catalog has to carry, because it is what a
 // caller imports and therefore what a reader greps for.
 function componentsIn(path: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    path,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(path),
-  );
+  const source = parseSource(path, text);
   const declarations = new Map<string, ts.Node>();
   const published: [string, string][] = [];
   for (const statement of source.statements) {

--- a/frontend/src/design-system/conformance.test.ts
+++ b/frontend/src/design-system/conformance.test.ts
@@ -8,6 +8,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource, sourceFileAt } from "../../scripts/lib/source-tree";
 
 // The two source-wide design gates from B-EP09.1, derived from the tree so a
 // new file is enrolled the moment it exists:
@@ -136,14 +137,7 @@ function scannableSource(file: string, text: string): string {
       file.endsWith(".css") ? /\/\*[\s\S]*?\*\//g : /<!--[\s\S]*?-->/g,
     );
   }
-  const parsed = ts.createSourceFile(
-    file,
-    text,
-    ts.ScriptTarget.Latest,
-    // Parent pointers, so the walk below can ask a node for its child tokens.
-    true,
-    file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
+  const parsed = parseSource(file, text);
   const chars = text.split("");
   const blank = ({ pos, end }: ts.CommentRange): void => {
     for (let index = pos; index < end; index++) {
@@ -299,13 +293,7 @@ describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
       ) {
         continue;
       }
-      const source = ts.createSourceFile(
-        file,
-        readFileSync(file, "utf8"),
-        ts.ScriptTarget.ES2022,
-        true,
-        ts.ScriptKind.TSX,
-      );
+      const source = sourceFileAt(file);
       const visit = (node: ts.Node) => {
         if (ts.isJsxText(node) && hasWords(node.text)) {
           const { line } = source.getLineAndCharacterOfPosition(
@@ -351,13 +339,7 @@ describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
       ) {
         continue;
       }
-      const source = ts.createSourceFile(
-        file,
-        readFileSync(file, "utf8"),
-        ts.ScriptTarget.ES2022,
-        true,
-        file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-      );
+      const source = sourceFileAt(file);
       const visit = (node: ts.Node) => {
         const isText =
           ts.isStringLiteral(node) ||
@@ -461,13 +443,7 @@ describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
       if (!file.endsWith(".tsx") || file.endsWith("design-system/atoms.tsx")) {
         continue;
       }
-      const source = ts.createSourceFile(
-        file,
-        readFileSync(file, "utf8"),
-        ts.ScriptTarget.ES2022,
-        true,
-        ts.ScriptKind.TSX,
-      );
+      const source = sourceFileAt(file);
       const visit = (node: ts.Node) => {
         if (ts.isJsxAttribute(node) && node.name.getText() === "className") {
           const element = node.parent.parent;
@@ -536,13 +512,7 @@ describe("design-system conformance gates (B-EP09.1)", scanBudget, () => {
       if (!file.endsWith(".tsx") || file.endsWith("design-system/atoms.tsx")) {
         continue;
       }
-      const source = ts.createSourceFile(
-        file,
-        readFileSync(file, "utf8"),
-        ts.ScriptTarget.ES2022,
-        true,
-        ts.ScriptKind.TSX,
-      );
+      const source = sourceFileAt(file);
       const visit = (node: ts.Node) => {
         if (ts.isJsxAttribute(node) && node.name.getText() === "className") {
           const element = node.parent.parent;

--- a/frontend/src/design-system/native-controls.test.ts
+++ b/frontend/src/design-system/native-controls.test.ts
@@ -66,6 +66,7 @@ import { describe, expect, it } from "vitest";
 import {
   extensionFrontendFiles,
   filesUnder,
+  parseSource,
   scriptKindFor,
 } from "../../scripts/lib/source-tree";
 
@@ -135,13 +136,7 @@ function findNativeControls(path: string, text: string): string[] {
   // escape, and every escape begins with a backslash — so a file with neither a
   // name nor a backslash cannot spell one, and skipping it costs no coverage.
   if (!prefilter.test(text)) return [];
-  const source = ts.createSourceFile(
-    path,
-    text,
-    ts.ScriptTarget.ES2022,
-    true,
-    scriptKindFor(path),
-  );
+  const source = parseSource(path, text);
   const found: string[] = [];
   // Anything not already TSX is read a SECOND time as TSX, and the findings
   // unioned. This is ONE mechanism rather than a per-extension rule, and it

--- a/frontend/src/design-system/table-scroll-coverage.test.ts
+++ b/frontend/src/design-system/table-scroll-coverage.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // Fitness function for a table that runs past its box with no way to reach the
 // rest of it.
@@ -90,13 +91,7 @@ function srOnly(
 
 /** `<file>:<line>` for every `<table>` in one file with no TableScroll above it. */
 function unwrappedIn(fileName: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(fileName, text);
   const found: string[] = [];
   const visit = (node: ts.Node) => {
     const opening = ts.isJsxElement(node)

--- a/frontend/src/format/calendar-day-by-slice.test.ts
+++ b/frontend/src/format/calendar-day-by-slice.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // A calendar day cut out of an ISO string is UTC's day, whoever is reading.
 //
@@ -137,13 +138,7 @@ function isIsoSlice(node: ts.Node): node is ts.CallExpression {
 }
 
 function isoSliceSites(path: string, source: string): Finding[] {
-  const parsed = ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
+  const parsed = parseSource(path, source);
   const found: Finding[] = [];
   const visit = (node: ts.Node): void => {
     if (isIsoSlice(node)) {

--- a/frontend/src/format/currency-table-coverage.test.ts
+++ b/frontend/src/format/currency-table-coverage.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // Fitness function for a screen that decides for itself what a currency is.
 //
@@ -133,13 +134,7 @@ function isFunctionScope(node: ts.Node): node is FunctionScope {
 
 /** `<kind> <file>:<line>` for every per-currency table in one file. */
 function tablesIn(fileName: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(fileName, text);
   const found: string[] = [];
   const at = (node: ts.Node) =>
     `${fileName}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`;

--- a/frontend/src/format/jsx-magnitude.test.ts
+++ b/frontend/src/format/jsx-magnitude.test.ts
@@ -16,6 +16,8 @@ import { describe, expect, it } from "vitest";
 import {
   extensionFrontendFiles,
   filesUnder,
+  parseSource,
+  sourceFileAt,
 } from "../../scripts/lib/source-tree";
 
 // A number reaching a reader has been written in SOME notation, and the only
@@ -129,13 +131,7 @@ function blindStringifiers(): Set<string> {
     if (!/^lib\..*\.d\.ts$/.test(file)) {
       continue;
     }
-    const parsed = ts.createSourceFile(
-      file,
-      ts.sys.readFile(join(libDir, file)) ?? "",
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TS,
-    );
+    const parsed = sourceFileAt(join(libDir, file));
     const walk = (node: ts.Node): void => {
       if (ts.isInterfaceDeclaration(node) && node.name.text === "Number") {
         for (const member of node.members) {
@@ -186,13 +182,7 @@ function svgGeometry(): Set<string> {
     "react",
     "index.d.ts",
   );
-  const parsed = ts.createSourceFile(
-    declarations,
-    ts.sys.readFile(declarations) ?? "",
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
+  const parsed = sourceFileAt(declarations);
   const found = new Set<string>();
   const walk = (node: ts.Node): void => {
     if (ts.isInterfaceDeclaration(node) && node.name.text === "SVGAttributes") {
@@ -756,7 +746,7 @@ function plant(
   const readReal = host.getSourceFile.bind(host);
   host.getSourceFile = (name, version, onError, shouldCreate) =>
     name === fixtureName
-      ? ts.createSourceFile(name, source, version, true, ts.ScriptKind.TSX)
+      ? parseSource(name, source)
       : readReal(name, version, onError, shouldCreate);
   host.fileExists = (name) => name === fixtureName || ts.sys.fileExists(name);
   host.readFile = (name) =>

--- a/frontend/src/format/leadname-coverage.test.ts
+++ b/frontend/src/format/leadname-coverage.test.ts
@@ -6,7 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { filesUnder, scriptKindFor } from "../../scripts/lib/source-tree";
+import { filesUnder, parseSource } from "../../scripts/lib/source-tree";
 
 // Fitness function for a screen that works out for itself what a lead is
 // called.
@@ -118,19 +118,7 @@ function fieldRead(expression: ts.Expression): FieldRead | null {
 
 /** `<file>:<line>` for every hand-spelled lead name in one file. */
 function fallbacksIn(fileName: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    // The file's OWN kind, from the one place this tree decides that. Under
-    // `TSX` a plain `.ts` generic arrow — `<T>(value: T) => value` — parses as
-    // an unclosed JSX element, and everything after it is parse recovery
-    // rather than the tree this scan means to walk. A census that reads a
-    // smaller tree reports PASS and nothing fails, which is the one way a gate
-    // must not break.
-    scriptKindFor(fileName),
-  );
+  const source = parseSource(fileName, text);
   const found: string[] = [];
   const visit = (node: ts.Node) => {
     if (

--- a/frontend/src/format/money-scale.test.ts
+++ b/frontend/src/format/money-scale.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // The TypeScript half of the money-scale census: an amount already in minor
 // units, scaled by a hard-coded power of ten.
@@ -65,13 +66,7 @@ function scaleFindings(
   path: string,
   source: string,
 ): { findings: Finding[]; unreadable: boolean } {
-  const file = ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKind(path),
-  );
+  const file = parseSource(path, source);
   if (unfinished(file)) return { findings: [], unreadable: true };
   const waived = waivedLines(source, file);
   const findings: Finding[] = [];
@@ -93,10 +88,6 @@ function scaleFindings(
   };
   ts.forEachChild(file, visit);
   return { findings, unreadable: false };
-}
-
-function scriptKind(path: string): ts.ScriptKind {
-  return path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
 }
 
 // unfinished reports a file the scanner could not finish reading, which is a

--- a/frontend/src/format/one-locale.test.ts
+++ b/frontend/src/format/one-locale.test.ts
@@ -9,7 +9,8 @@ import { describe, expect, it } from "vitest";
 import {
   extensionFrontendFiles,
   filesUnder,
-  scriptKindFor,
+  parseSource,
+  sourceFileAt,
 } from "../../scripts/lib/source-tree";
 import { INTL_LOCALE } from "./format";
 
@@ -143,13 +144,7 @@ function localeMethods(): Map<string, number> {
     if (!/^lib\..*\.d\.ts$/.test(file)) {
       continue;
     }
-    const parsed = ts.createSourceFile(
-      file,
-      readFileSync(join(libDir, file), "utf8"),
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TS,
-    );
+    const parsed = sourceFileAt(join(libDir, file));
     const walk = (node: ts.Node): void => {
       if (
         ts.isInterfaceDeclaration(node) &&
@@ -443,13 +438,7 @@ function findingsIn(
   formatters: readonly string[],
   methods: ReadonlyMap<string, number>,
 ): Finding[] {
-  const parsed = ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(path),
-  );
+  const parsed = parseSource(path, source);
   const rel = relative(srcRoot, path).split("\\").join("/");
   const imported = importsTheMapping(parsed);
   const aliases = intlAliases(parsed, formatters);

--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 import { FALLBACK_RECORD_ZONE } from "./timezone";
 
 // A screen that names a zone has decided something, and the decision is the
@@ -110,14 +111,7 @@ function sourceFiles(dir: string): string[] {
 // under it at the wrong place — a gate that names the wrong line sends the next
 // reader to innocent code.
 function code(path: string, source: string): string {
-  const parsed = ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    // Parent pointers, so the walk below can ask a node for its child tokens.
-    true,
-    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
+  const parsed = parseSource(path, source);
   const chars = source.split("");
   const blank = ({ pos, end }: ts.CommentRange): void => {
     for (let index = pos; index < end; index++) {

--- a/frontend/src/i18n/one-plural-rule.test.ts
+++ b/frontend/src/i18n/one-plural-rule.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   extensionFrontendFiles,
   filesUnder,
-  scriptKindFor,
+  parseSource,
 } from "../../scripts/lib/source-tree";
 import { en } from "./en";
 
@@ -174,13 +174,7 @@ function waivedAt(source: string, node: ts.Node): boolean {
 }
 
 function findingsIn(path: string, source: string): Finding[] {
-  const parsed = ts.createSourceFile(
-    path,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindFor(path),
-  );
+  const parsed = parseSource(path, source);
   const rel = relative(srcRoot, path).split("\\").join("/");
   const found: Finding[] = [];
   const walk = (node: ts.Node): void => {

--- a/frontend/src/screens/caught-error-coverage.test.ts
+++ b/frontend/src/screens/caught-error-coverage.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // Fitness function for a caught failure reaching the screen in the SERVER's
 // words instead of the reader's.
@@ -88,13 +89,7 @@ function unwrap(node: ts.Expression): ts.Expression {
 
 /** A rendered read of one caught binding: `<arm> <file>:<line>`. */
 function disclosuresIn(fileName: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(fileName, text);
   const found: string[] = [];
 
   const visitCatch = (clause: ts.CatchClause) => {

--- a/frontend/src/screens/historyfieldlabels.test.ts
+++ b/frontend/src/screens/historyfieldlabels.test.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { sourceFileAt } from "../../scripts/lib/source-tree";
 import { en } from "../i18n/en";
 import {
   historyFieldLabel,
@@ -33,13 +33,7 @@ const schemaPath = join(
 );
 
 function schemaSource(): ts.SourceFile {
-  return ts.createSourceFile(
-    "schema.d.ts",
-    readFileSync(schemaPath, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
+  return sourceFileAt(schemaPath);
 }
 
 // The property of one named type in the contract, wherever it is declared.

--- a/frontend/src/screens/historyundo.test.ts
+++ b/frontend/src/screens/historyundo.test.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { sourceFileAt } from "../../scripts/lib/source-tree";
 import { en } from "../i18n/en";
 import { undoRefusalKey, undoRefusalsNamed } from "./historyundo";
 
@@ -22,13 +22,7 @@ const schemaPath = join(
 // The `reason` members `Undoability` declares. Read off the generated types,
 // which openapi-typescript writes as a union of string literals plus null.
 function refusalsInContract(): string[] {
-  const source = ts.createSourceFile(
-    "schema.d.ts",
-    readFileSync(schemaPath, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
+  const source = sourceFileAt(schemaPath);
   let members: string[] = [];
   const walk = (node: ts.Node) => {
     if (

--- a/frontend/src/screens/leadkeys.test.ts
+++ b/frontend/src/screens/leadkeys.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 import {
   LEAD_LIST_KEY,
   leadKey,
@@ -114,13 +115,7 @@ function isQueryKeyPosition(node: ts.ArrayLiteralExpression): boolean {
 
 /** `<file>:<line> <literal>` for every hand-spelled lead query key in one file. */
 function spelledIn(fileName: string, text: string): string[] {
-  const source = ts.createSourceFile(
-    fileName,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(fileName, text);
   const found: string[] = [];
   const visit = (node: ts.Node) => {
     if (ts.isArrayLiteralExpression(node) && node.elements.length > 0) {

--- a/frontend/src/screens/mutation-variable-coverage.test.ts
+++ b/frontend/src/screens/mutation-variable-coverage.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 
 // Fitness function for the one way a mutation can refuse work the screen was
 // plainly offering: a `mutationFn` that reads the value it needs out of its
@@ -117,13 +118,7 @@ function refuses(statement: ts.Node): boolean {
 
 function findingsIn(file: string): string[] {
   const text = readFileSync(file, "utf8");
-  const source = ts.createSourceFile(
-    file,
-    text,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+  const source = parseSource(file, text);
   const findings: string[] = [];
 
   const visit = (node: ts.Node) => {

--- a/frontend/src/screens/page-gutter-coverage.test.ts
+++ b/frontend/src/screens/page-gutter-coverage.test.ts
@@ -62,6 +62,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { sourceFileAt } from "../../scripts/lib/source-tree";
 
 const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const ROUTER = join(srcRoot, "app/router.tsx");
@@ -87,24 +88,6 @@ const NOT_OURS_TO_INSET: ReadonlyMap<string, string> = new Map([
 // ---------------------------------------------------------------------------
 // Reading source
 // ---------------------------------------------------------------------------
-
-const parsed = new Map<string, ts.SourceFile>();
-
-function sourceOf(path: string): ts.SourceFile {
-  const hit = parsed.get(path);
-  if (hit) {
-    return hit;
-  }
-  const file = ts.createSourceFile(
-    path,
-    readFileSync(path, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
-  parsed.set(path, file);
-  return file;
-}
 
 function declarationNamed(
   file: ts.SourceFile,
@@ -349,7 +332,11 @@ function componentSource(
   if (!binding?.file.startsWith(srcRoot) || hops >= 8) {
     return undefined;
   }
-  return componentSource(sourceOf(binding.file), binding.exported, hops + 1);
+  return componentSource(
+    sourceFileAt(binding.file),
+    binding.exported,
+    hops + 1,
+  );
 }
 
 /** `export const EXTENSION_SCREEN = "ext"`, followed through the import. */
@@ -360,7 +347,7 @@ function constantString(file: ts.SourceFile, name: string): string | undefined {
   }
   const binding = bindingsOf(file).get(name);
   return binding
-    ? constantString(sourceOf(binding.file), binding.exported)
+    ? constantString(sourceFileAt(binding.file), binding.exported)
     : undefined;
 }
 
@@ -661,19 +648,21 @@ function componentVerdict(
 
 /** Every address this build answers, from the union that owns them. */
 function screenNames(): string[] {
-  return stringsIn(declarationNamed(sourceOf(ROUTER), "SCREENS")?.initializer);
+  return stringsIn(
+    declarationNamed(sourceFileAt(ROUTER), "SCREENS")?.initializer,
+  );
 }
 
 /** The documented rail-less family, from the set that owns it. */
 function railLessNames(): string[] {
   return stringsIn(
-    declarationNamed(sourceOf(NAV), "RAIL_LESS_SCREENS")?.initializer,
+    declarationNamed(sourceFileAt(NAV), "RAIL_LESS_SCREENS")?.initializer,
   );
 }
 
 /** Screen → the expression that renders it, from the dispatch that owns it. */
 function dispatch(): ReadonlyMap<string, ts.Expression> {
-  const file = sourceOf(APP);
+  const file = sourceFileAt(APP);
   const literal = declarationNamed(file, "SCREEN_VIEWS")?.initializer;
   const out = new Map<string, ts.Expression>();
   if (!literal || !ts.isObjectLiteralExpression(literal)) {
@@ -725,7 +714,7 @@ function raillessComponents(): ReadonlySet<string> {
     }
     ts.forEachChild(node, visit);
   };
-  visit(sourceOf(APP));
+  visit(sourceFileAt(APP));
   return out;
 }
 
@@ -770,7 +759,7 @@ describe("page gutter", () => {
     const insetting = selfInsettingClasses();
     const railless = raillessComponents();
     expect(railless.size).toBeGreaterThan(0);
-    const app = sourceOf(APP);
+    const app = sourceFileAt(APP);
     const judged: string[] = [];
     const flush: string[] = [];
     for (const screen of screens) {

--- a/frontend/src/screens/recordwritekeys.test.ts
+++ b/frontend/src/screens/recordwritekeys.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { parseSource } from "../../scripts/lib/source-tree";
 import { ENTITY_KINDS } from "../app/entity";
 import { recordWriteKeys } from "./recordwritekeys";
 
@@ -48,12 +49,7 @@ describe("every restore callback goes through the helper", scanBudget, () => {
     const offenders: string[] = [];
     for (const file of sourceFiles()) {
       const text = readFileSync(file, "utf8");
-      const parsed = ts.createSourceFile(
-        file,
-        text,
-        ts.ScriptTarget.Latest,
-        true,
-      );
+      const parsed = parseSource(file, text);
       const visit = (node: ts.Node): void => {
         if (
           ts.isPropertyAssignment(node) &&

--- a/frontend/src/screens/settings-imports.test.ts
+++ b/frontend/src/screens/settings-imports.test.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { sourceFileAt } from "../../scripts/lib/source-tree";
 
 // The settings catalog is split in two so the shell can ask where a settings
 // entry lives without paying to draw it. `settingsnav.tsx` answers the address
@@ -62,12 +63,7 @@ function resolveSpecifier(fromFile: string, specifier: string): string | null {
  * same edge would not show up as a new dependency in review.
  */
 function importsOf(file: string): string[] {
-  const source = ts.createSourceFile(
-    file,
-    readFileSync(file, "utf8"),
-    ts.ScriptTarget.Latest,
-    true,
-  );
+  const source = sourceFileAt(file);
   const out: string[] = [];
   const visit = (node: ts.Node) => {
     if (

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -227,6 +227,13 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Worker threads rather than child processes. Every test file still gets
+    // its own module graph and its own jsdom (isolation is unchanged — the
+    // suite has module-level state that a shared graph breaks, measured at 28
+    // failures with `isolate: false`); what a thread saves is the process spawn
+    // and the IPC per file, across six hundred files. Measured on the whole
+    // suite: 123s to 108s, same verdict on every test.
+    pool: "threads",
     // Derived in vitest.budget.ts, which carries the measurement and the
     // arithmetic. The short version: a test of N sequential waits may spend N
     // seconds without a single wait failing, and the longest chain here is six —


### PR DESCRIPTION
## What

Two of the follow-ups from #4771, in one change:

1. **One parser.** Every source-wide gate under `frontend/` called `ts.createSourceFile` itself: 27 files, 36 sites, disagreeing on script kind and language target. Six read every file as TSX (a `.ts` generic arrow becomes an unclosed element and the rest of the file is parse recovery). `parseSource(path, text)` and `sourceFileAt(path)` in `scripts/lib/source-tree.ts` are the only parser now; `sourceFileAt` parses a module once per run, which removes the per-rule re-parse in `conformance.test.ts` (4× the corpus) and the private memo `page-gutter-coverage.test.ts` had grown. A test in `source-tree.test.ts` fails a second `ts.createSourceFile` anywhere in `src/`, `scripts/`, `e2e/` or an extension's frontend layer, by name.
2. **`pool: "threads"`** in `vite.config.ts`. Isolation unchanged (`isolate: false` measured at 28 failures from module-level state). Threads save the process spawn and IPC per file.

`scripts/test-budget.ts` deliberately keeps parsing from text: its reader tests rewrite one fixture path in place, the one shape a run-long memo cannot serve (the memo was tried there first and failed those six tests).

## Proof

- Gate fails on a planted `src/zz-parser.ts` calling `ts.createSourceFile`, and passes on the tree.
- `sourceFileAt` returns the first tree after the file is rewritten (test).
- Whole suite, same machine, quiet: forks 123s → threads 108s, same verdict. Inside `make check-fe` the unit leg went 321s → 127s wall, though that run also had less load.
- `make check-fe` green. Typecheck (`tsc -b`) clean.

## Along the way

- `docs/principles/one-source-of-truth.md` records the parser as the second extraction into `source-tree.ts`.
- Not touched: `native-controls.test.ts`'s prefilter still reads text before deciding to parse, so it goes through `parseSource` rather than the memo; same for the fixture-parsing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies all frontend source-wide gates on one TypeScript parser and moves the test suite to worker threads.

- All 36 `ts.createSourceFile` call sites now go through `parseSource` and `sourceFileAt` in `scripts/lib/source-tree.ts`, which pick script kind from the file's extension, set the newest language target, and always set parent pointers.
- Six gates previously forced TSX on every file, so a `.ts` generic arrow turned into parse recovery and the rest of the file went unread but still reported PASS.
- `sourceFileAt` parses each module once per run and reuses the tree, dropping the per-rule reparse in `conformance.test.ts` and the private memo in `page-gutter-coverage.test.ts`.
- A new test fails if any other `ts.createSourceFile` appears in `src/`, `scripts/`, `e2e/`, or an extension's frontend layer.
- `vite.config.ts` sets `pool: "threads"`, saving the per-file process spawn and IPC; isolation is unchanged and the whole suite drops from 123s to 108s locally.
- `test-budget.ts` and `native-controls.test.ts` still parse from text because they rewrite or prefilter fixture paths that a run-long memo cannot serve.

<sup>Written for commit ff777fc409cf6372cb15a74e5c166534a358927b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized source parsing across frontend checks, preserving the correct TypeScript and TSX syntax handling.
  - Reused parsed source files during repeated analysis, improving consistency and reducing redundant work.

- **Tests**
  - Added coverage for syntax dialects, parent links, parser caching, and centralized parsing enforcement.
  - Improved test execution performance by running tests with worker threads.

- **Documentation**
  - Expanded guidance on maintaining a single source of truth for parsing and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->