### PR TITLE
main is green again: the census page counts its rows, and a thread message reads its message like its neighbour

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -116,7 +116,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (120)
+## Census (121)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
Two independent gates are failing on a clean `main` (verified at `490bef626`, clean tree, after `make composition`). The `gates` package runs in three jobs, so **every open PR inherits three red checks** from them:

- `deterministic-gates`
- `extension-reference`
- `integration / integration unit coverage`

Neither is caused by any open PR. Both are fixed here, in one commit each, following the precedent of #4748.

---

## 1. `TestTheGateInventoryPageIsCurrent` — the Census heading

The page said `120` while the tree declares `121`. Regenerated with the tool the failure message names:

```
go test ./gates -run GateInventory -update-gate-inventory
```

```diff
-## Census (120)
+## Census (121)
```

No `//gate:kind` declaration changes — only the count the page reports about them, which is the whole reason it is generated rather than written.

## 2. `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` — the thread message

From `dbb95e06f` (#4746). Three functions in the `ThreadMessage` cluster read the email carrier *and* return markup:

| function | read | drew |
|---|---|---|
| `messageVisibility` | `emailSummary?.display_status` | `<VisibilityBadge>` |
| `MessageWords` | `emailSummary.preview` | `<span className="tl-msg-text">` |
| `ThreadMessage` | `emailSummary` (for the opener) | the row |

`rendersCanonically` judges **per function**, so `composed.tsx` mounting `EmailEntry` in `TimelineRow` and `TimelineGroupRow` does not discharge these.

**The fix is the shape this file already uses.** `otherSideOf` reads `entry.emailSummary?.counterparty` and hands back a `string`, and the census admits it for precisely that reason — its comment says a function that reads a message into a value, "a mapper building a row model, a function returning a title string — renders nothing." So each of the three splits the same way:

- `messageVisibilityState(entry): Visibility | undefined`
- `messageWordsOf(entry): MessageWordsSource` — which of the three sources holds the words
- `messageOpener(entry): (() => void) | undefined`

…each read by a drawing function that now draws from a scalar.

### No pixel changes

The 46 tests across `composed.test.tsx`, `composed.thread.test.tsx`, `composed.rail.test.tsx` and `visibility.test.tsx` pass **untouched** — which is what a refactor of this shape should be able to say. `tsc --noEmit` and `biome check` are clean.

### What this deliberately does *not* do

`composed.tsx` is **not** added to `emailPassthroughs`. That map is file-keyed, and the census's own comment records the bug a file-level pass shipped:

> An earlier version read the whole file: `composed.tsx` mounts EmailEntry in TimelineRow, which discharged the file, and TimelineGroupRow beside it went on writing its own subject-and-preview markup [...] A company timeline of grouped threads therefore showed old-style rows next to canonical ones on the same page while this census reported clean.

A waiver here reopens exactly that, and the ratifying sentence would be untrue besides — the file does render.

---

## Verification

- `go test ./gates -count=1` → **`ok`** (the whole package, both gates included)
- `pnpm vitest run` on the four affected design-system files → 46 passed
- `pnpm tsc --noEmit`, `pnpm biome check` → clean

Raised as #4799 before fixing, since #2 is a design call inside #4746 — cc @joshbruh-lang. The resolution taken here is the one that changes no rendered output; if you'd rather `MessageWords` mounted a canonical component instead, say so and I'll swap it.