### PR TITLE
An extension unit has no lock file to be missing

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -258,7 +258,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -457,3 +457,18 @@ sonar.issue.ignore.multicriteria.e14.resourceKey=e2e/llm/check.py
 # against a global install at all).
 sonar.issue.ignore.multicriteria.e15.ruleKey=githubactions:S6505
 sonar.issue.ignore.multicriteria.e15.resourceKey=.github/actions/install-claude-cli/action.yml
+# text:S8566 wants a lock file beside a go.mod that declares a dependency, and
+# every extension unit declares exactly one: the backend IN THIS TREE, redirected
+# by the `replace` directive its own go.mod explains at length. Go computes no
+# checksum for a filesystem replacement — the target is a directory in this
+# repository, already covered by this repository's own history — so there is
+# nothing a lock file could pin. `go mod tidy` in any of these modules succeeds
+# and writes no go.sum; a hand-written one would be a file the toolchain ignores.
+#
+# Scoped to `extensions/*/go.mod` and no wider. backend/go.mod and
+# backend/tools/go.mod declare 63 and 48 network dependencies and DO carry a
+# go.sum, so a missing lock file there is a real finding and stays enforced —
+# which is the whole value of this rule and exactly what `**/go.mod` would have
+# thrown away.
+sonar.issue.ignore.multicriteria.e16.ruleKey=text:S8566
+sonar.issue.ignore.multicriteria.e16.resourceKey=extensions/*/go.mod


### PR DESCRIPTION
## What

SonarCloud's quality gate on `main` reads `ERROR`, which the scheduled reader
files as https://github.com/margince/margince/issues/4774:

```
quality gate on main: ERROR
  failing: new_reliability_rating GT 1 (actual 3)
  failing: new_security_rating   GT 1 (actual 3)
```

Two conditions, four findings, and only one of them needs a change here.

## The security rating: three findings that ask for an impossible file

`new_security_rating` is three `text:S8566` vulnerabilities, one per extension
unit — `extensions/de`, `extensions/openchannel`, `extensions/vn` — each saying
*"Dependency versions are not predictable if the lock file (go.sum) is missing."*

Each of those modules declares **exactly one** dependency: the backend in this
tree, redirected by the `replace` directive its own go.mod already explains at
length. Go computes no checksum for a filesystem replacement — the target is a
directory this repository versions itself — so there is nothing a lock file
could pin.

Verified rather than reasoned about:

```
$ cd extensions/de && go mod tidy
$ ls go.sum
ls: go.sum: No such file or directory
$ git status --short extensions/
(clean)
```

`go mod tidy` succeeds and writes no go.sum. A hand-written one would be a file
the toolchain ignores.

**Scoped to `extensions/*/go.mod` and no wider.** `backend/go.mod` and
`backend/tools/go.mod` declare 63 and 48 network dependencies and both carry a
go.sum, so a missing lock file *there* is a real finding and stays enforced.
`**/go.mod` would have hidden it, which is the whole value of the rule — the same
trade this file already makes explicit at `e12`.

Waived per rule and per path rather than by excluding the files, so the three
go.mod files stay analyzed for every other rule.

## The reliability rating: already fixed, stale analysis

`new_reliability_rating` is one `go:S3923` bug —
`consent.AuthorizeTransmit`, a three-branch `switch` in which every branch was
empty. https://github.com/margince/margince/pull/4734 removed it, and it is on
`main`:

```
-	switch {
-	case legacyErr == nil:
-	case errors.Is(legacyErr, apperrors.ErrConsentNotGranted):
-	default:
-		// NOT an answer. ...
-	}
```

The gate read an analysis attached to revision `01628b2ae` (2026-09-07T03:12Z),
which predates that merge. Nothing to do but let `main` be scanned again — so
this PR deliberately does not touch it.

## How verified

- The failing conditions come from the `sonarcloud quality gate (main)` job of
  https://github.com/margince/margince/actions/runs/34086509641, not inferred.
- The four underlying findings were read from the SonarCloud issues API for
  `branch=main&inNewCodePeriod=true` — 43 issues, of which exactly one is a
  `BUG` and exactly three are `VULNERABILITY`. The other 39 are maintainability
  findings and drive neither failing condition.
- `go mod tidy` run in `extensions/de` as shown above; tree left clean.
- Surveyed every go.mod in the tree for `go.sum` presence before choosing the
  scope: only `backend`, `backend/tools` and `composition` have one, and each of
  those has real network requires.

- [x] `make check` — no Go, TypeScript or shell changed; this is one properties
      file
- [x] `make test-integration` — this change does not touch tenant data, RLS or
      the write shape
- [x] `make craft-static` — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-generated in full under the reporter's direction: the diagnosis, the waiver,
its scope and this description. A human is accountable for merging.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code-quality checks to avoid reporting missing lock files for extension modules where lock files are not generated.
  - Lock-file validation remains enabled for backend modules that use network dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->