### PR TITLE
fix(ai): seal a provider key on an installation that has bound nothing

### DIFF
--- a/backend/internal/compose/integration/routingsource_integration_test.go
+++ b/backend/internal/compose/integration/routingsource_integration_test.go
@@ -23,7 +23,9 @@ package integration
 //     than failing the boot.
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -33,6 +35,8 @@ import (
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -338,5 +342,44 @@ func TestAnIgnoredRoutingPathIsAnnouncedAndSaysWhichSituation(t *testing.T) {
 	}
 	if strings.Contains(bound.String(), "NO stored model binding") {
 		t.Errorf("a bound installation was told its AI lanes are absent: %s", bound.String())
+	}
+}
+
+// A key in the environment is sealed on a boot that has NO binding yet.
+//
+// The regression this closes was silent and self-defeating. Sealing lived
+// BELOW the unconfigured early return, so a fresh installation — the only kind
+// that has no binding — never reached it. `ai.provider_keys` stayed empty,
+// which is the row /ai/provider-keys reports `configured` from, so Settings ->
+// AI told an admin their vendor was unkeyed on the very screen they had opened
+// to bind a tier to it. The key was in the environment the whole time and the
+// api process had it.
+//
+// Sealing does not depend on a binding and never did: one is a credential
+// moving out of the process environment, the other is which vendor answers
+// which tier. Whoever binds first has to be able to see that the credential
+// for it has arrived.
+func TestAKeyIsSealedOnAnInstallationThatHasBoundNothing(t *testing.T) {
+	e := SetupSearch(t)
+	env := config.Static(map[string]string{
+		keyvault.EnvRootKey: base64.StdEncoding.EncodeToString(bytes.Repeat([]byte("k"), 32)),
+		"GEMINI_API_KEY":    "a-gemini-key",
+	})
+
+	cfg, err := compose.ResolveRouting(context.Background(), e.Pool, "", env, discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting on an unbound installation: %v", err)
+	}
+	// Unchanged: nothing here binds anything. The lanes stay absent.
+	if !cfg.Unconfigured() {
+		t.Errorf("resolved %+v, want unconfigured", cfg.Tiers)
+	}
+
+	stored, err := settings.Get(e.adminRoutingCtx(), compose.NewSettingsStore(e.Pool), ai.ProviderKeys)
+	if err != nil {
+		t.Fatalf("reading the recorded refs: %v", err)
+	}
+	if stored["gemini"] == "" {
+		t.Errorf("no ref recorded for gemini: %v — the key stayed in the environment, so Settings -> AI reports it unkeyed", stored)
 	}
 }

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -95,10 +95,19 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 	if routingPath != "" {
 		warnRoutingFileIgnored(ctx, routingPath, stored.Unconfigured(), log)
 	}
+	// Sealing runs BEFORE the unconfigured return, and the order is the whole
+	// point. A credential moving out of the process environment and into the
+	// vault has nothing to do with which vendor answers which tier: below the
+	// return, the only installation that never sealed was the fresh one, whose
+	// admin then opened Settings -> AI to bind a tier and was told the vendor
+	// they were about to bind was unkeyed. The key was in the environment the
+	// whole time. `configured` on /ai/provider-keys reads the sealed ref, so an
+	// unsealed key is indistinguishable from an absent one on the one screen
+	// that could have fixed it.
+	lookup, credentials := sealedKeys(ctx, pool, ws, keys, log)
 	if stored.Unconfigured() {
 		return ai.RoutingConfig{}, nil
 	}
-	lookup, credentials := sealedKeys(ctx, pool, ws, keys, log)
 	cfg, err := ai.FromStored(stored, lookup)
 	if err != nil {
 		return ai.RoutingConfig{}, err


### PR DESCRIPTION
## What

`ResolveRouting` returned at the `stored.Unconfigured()` check before it reached `sealedKeys`, so the only installation that never sealed a BYOK key was the fresh one — the only kind that has no binding yet.

```go
if stored.Unconfigured() {
    return ai.RoutingConfig{}, nil     // fresh install returns here
}
lookup, credentials := sealedKeys(ctx, pool, ws, keys, log)   // never reached
```

## Why it matters

`configured` on `GET /ai/provider-keys` is computed from the sealed ref (`ProviderKeyStore.List`), not from the environment. So an unsealed key is indistinguishable from an absent one.

An operator who exported `GEMINI_API_KEY` and opened Settings → AI to bind a tier was told, on that same screen, that the vendor they were about to bind had no credential. The key was in the environment the whole time and the process had it.

The failure mode is worse than a plain wrong report, because it is self-correcting in a way that hides the cause: binding a tier for any other reason reaches `sealedKeys` and seals the key retroactively, so the state reads as a credential that "started working" on its own.

Found on a desktop bundle, where `Setup.command` writes the key into `margince.env` and the launcher passes it through — verified with `ps eww` that the api process held `GEMINI_API_KEY` while `/ai/provider-keys` reported `gemini: configured=false` and no `ai.provider_keys` setting row existed. Saving any binding sealed it immediately.

## The change

Two lines moved. Sealing and binding answer different questions — one moves a credential out of the process environment, the other says which vendor answers which tier — so the seal now runs before the return. An unconfigured installation still resolves unconfigured; nothing here binds anything.

## Test

`TestAKeyIsSealedOnAnInstallationThatHasBoundNothing` in `backend/internal/compose/integration/routingsource_integration_test.go`: an installation with a root key and `GEMINI_API_KEY` in the environment and **no** binding must record a gemini ref, and must still resolve unconfigured.

Fails on `main` with `no ref recorded for gemini: map[]`; passes with the change.

- Full `backend/internal/compose/integration` package green (534s)
- `go vet ./...` clean, `gofmt` clean

## AI disclosure

**Generated** — AI produced substantial portions, reviewed and owned by me.
