### PR TITLE
The row-scope census answers for the table it names

### DIFF
--- a/backend/gates/composerowscope_test.go
+++ b/backend/gates/composerowscope_test.go
@@ -88,6 +88,19 @@ var unscopedReferenceReads = gatekit.Waive(map[string]string{
 	"internal/compose:scanQuietProjects":  "the quiet-project rule's scan, under the same sweep and the same system principal: the organization it names is the account the project's signal is attributed to, handed to signals.RecordDerived and never to a reader",
 	"internal/compose:dueThreads":         "the signal extractor's settled-conversation backlog, under the same sweep and the same system principal: the single organization a thread resolves to is what the extraction is filed against, and the rows go to the model lane rather than to a caller",
 
+	// The organization rollup's tree walk, found by the aliased-column pass:
+	// `parent_org_id` is an FK to organization named for its role, so the
+	// name-derived extractor could not see it at all.
+	//
+	// The reference IS scoped, one call up rather than inside this one. OrgRollup
+	// takes auth.EnsureVisible on the root in the same transaction, and every
+	// node this walk returns then passes through orgReadablePredicate's
+	// auth.ScopeClauseFor over organization — a node the caller cannot read is
+	// pruned before a figure is summed, and a root that fails it answers
+	// ErrNotFound. Scoping the walk itself would ask the same question twice and
+	// lose the tree's shape, which the pruning needs whole.
+	"internal/compose:loadOrgTree": "the rollup's recursive tree walk, whose parent_org_id reference is bounded by the caller: EnsureVisible on the root in this transaction, then orgReadablePredicate's ScopeClauseFor over every node before any figure is summed",
+
 	// The weekly retrospective's frozen deal lines. The id is served beside a
 	// label written when the review was, and NOTHING live is read: the query
 	// joins no deal, no stage and no organization, so there is no current row
@@ -196,14 +209,18 @@ func TestEveryComposeReadOfARecordReferenceAppliesItsRowScope(t *testing.T) {
 	defer unscopedReferenceReads.AssertAllMatched(t)
 
 	tables := rowScopedTables(t)
-	pkgs, sites := referenceSites(t, tables)
+	pkgs, sites := referenceSites(t, referenceVocabulary{
+		tables:  tables,
+		columns: referenceColumns(t, tables),
+		edge:    relationshipEndpointTables(t),
+	})
 	if len(sites) < wantMinimumScopedSites {
 		t.Fatalf("only %d record-reference reads found in %s, want at least %d — the SQL extractor lost its source",
 			len(sites), composeTier, wantMinimumScopedSites)
 	}
 
 	for _, site := range sites {
-		if reachesRowScope(pkgs[site.dir].visibleTo(site.recv), site.fn, map[string]bool{}) {
+		if reachesRowScope(pkgs[site.dir].visibleTo(site.recv), site.fn, site.table, map[string]bool{}) {
 			continue
 		}
 		if unscopedReferenceReads.Waived(t, site.dir+":"+site.fn) {
@@ -330,7 +347,12 @@ func stringConst(expr ast.Expr) (string, bool) {
 // rowScopeFnInfo is what this gate needs about one function: whether its body
 // applies a row scope, and the names it mentions (the resolution edges).
 type rowScopeFnInfo struct {
-	scoped bool
+	// scopes are the tables this function bounds directly, anyTable among them
+	// when a spelling names none. A SET rather than a flag: a function that
+	// probes a deal has not bounded the organization it also projects, and
+	// counting probes instead of matching them is what would have read green
+	// over #1876.
+	scopes map[string]bool
 	calls  map[string]bool
 }
 
@@ -351,7 +373,13 @@ func (p rowScopePkg) visibleTo(recv string) map[string]*rowScopeFnInfo {
 			// Two same-named functions the index cannot tell apart at a call
 			// site: union them into a third value rather than folding one into
 			// the other, which would leak this receiver's edges into the next.
-			merged := &rowScopeFnInfo{scoped: pkgLevel.scoped || info.scoped, calls: map[string]bool{}}
+			merged := &rowScopeFnInfo{scopes: map[string]bool{}, calls: map[string]bool{}}
+			for table := range pkgLevel.scopes {
+				merged.scopes[table] = true
+			}
+			for table := range info.scopes {
+				merged.scopes[table] = true
+			}
 			for _, src := range []*rowScopeFnInfo{pkgLevel, info} {
 				for call := range src.calls {
 					merged.calls[call] = true
@@ -367,7 +395,13 @@ func (p rowScopePkg) visibleTo(recv string) map[string]*rowScopeFnInfo {
 
 // reachesRowScope resolves the obligation transitively over same-package calls;
 // seen breaks recursion cycles.
-func reachesRowScope(fns map[string]*rowScopeFnInfo, name string, seen map[string]bool) bool {
+//
+// The obligation is PER TABLE. A read that projects an organization satisfies
+// nothing by probing a deal — that is #1876 exactly, and a gate that counted
+// probes would have gone green over it and then certified it, because the
+// obvious way to quiet such a gate is to add a probe over whatever table the
+// function already had in hand.
+func reachesRowScope(fns map[string]*rowScopeFnInfo, name, table string, seen map[string]bool) bool {
 	if seen[name] {
 		return false
 	}
@@ -376,11 +410,11 @@ func reachesRowScope(fns map[string]*rowScopeFnInfo, name string, seen map[strin
 	if !indexed {
 		return false
 	}
-	if info.scoped {
+	if info.scopes[table] || info.scopes[anyTable] {
 		return true
 	}
 	for call := range info.calls {
-		if _, indexed := fns[call]; indexed && reachesRowScope(fns, call, seen) {
+		if _, indexed := fns[call]; indexed && reachesRowScope(fns, call, table, seen) {
 			return true
 		}
 	}
@@ -397,7 +431,13 @@ func reachesRowScope(fns map[string]*rowScopeFnInfo, name string, seen map[strin
 // declarations unread would let any query walk out of this census by being
 // promoted, which is the quiet narrowing the extractor floor below exists to
 // refuse.
-func referenceSites(t *testing.T, tables map[string]bool) (map[string]rowScopePkg, []referenceSite) {
+func referenceSites(t *testing.T, vocab referenceVocabulary) (map[string]rowScopePkg, []referenceSite) {
+	return referenceSitesIn(t, composeTier, vocab)
+}
+
+// referenceSitesIn is referenceSites over one named tier, so a second tier can
+// be judged by the same index rather than by a copy of it.
+func referenceSitesIn(t *testing.T, tier string, vocab referenceVocabulary) (map[string]rowScopePkg, []referenceSite) {
 	t.Helper()
 	pkgs := map[string]rowScopePkg{}
 	queryVars := map[string]map[string][]referenceSite{}
@@ -407,14 +447,14 @@ func referenceSites(t *testing.T, tables map[string]bool) (map[string]rowScopePk
 	}
 	var uses []funcUse
 	var sites []referenceSite
-	for _, src := range tierFiles(t, composeTier) {
+	for _, src := range tierFiles(t, tier) {
 		dir := filepath.ToSlash(filepath.Dir(src.Path))
 		if pkgs[dir] == nil {
 			pkgs[dir] = rowScopePkg{}
 		}
 		for _, decl := range src.File.Decls {
 			if gen, ok := decl.(*ast.GenDecl); ok {
-				collectQueryVars(gen, tables, dir, src, queryVars)
+				collectQueryVars(gen, vocab, dir, src, queryVars)
 				continue
 			}
 			fn, ok := decl.(*ast.FuncDecl)
@@ -427,14 +467,14 @@ func referenceSites(t *testing.T, tables map[string]bool) (map[string]rowScopePk
 			}
 			info := pkgs[dir][recv][fn.Name.Name]
 			if info == nil {
-				info = &rowScopeFnInfo{calls: map[string]bool{}}
+				info = &rowScopeFnInfo{scopes: map[string]bool{}, calls: map[string]bool{}}
 				pkgs[dir][recv][fn.Name.Name] = info
 			}
 			// Seeded without a line: every site reports the line of the SQL that
 			// holds the reference, which is what a reader has to go and look at.
 			at := referenceSite{dir: dir, recv: recv, fn: fn.Name.Name}
 			idents := map[string]bool{}
-			sites = append(sites, indexFuncBody(fn, info, tables, at, src, idents)...)
+			sites = append(sites, indexFuncBody(fn, info, vocab, at, src, idents)...)
 			uses = append(uses, funcUse{at: at, idents: idents})
 		}
 	}
@@ -455,7 +495,7 @@ func referenceSites(t *testing.T, tables map[string]bool) (map[string]rowScopePk
 // collectQueryVars records the reference sites held by a package-level string
 // declaration — a query var or const, including one assembled by `+`. The line
 // points into the declaration itself, where the SQL is.
-func collectQueryVars(gen *ast.GenDecl, tables map[string]bool, dir string, src tierFile, into map[string]map[string][]referenceSite) {
+func collectQueryVars(gen *ast.GenDecl, vocab referenceVocabulary, dir string, src tierFile, into map[string]map[string][]referenceSite) {
 	if gen.Tok != token.VAR && gen.Tok != token.CONST {
 		return
 	}
@@ -468,7 +508,7 @@ func collectQueryVars(gen *ast.GenDecl, tables map[string]bool, dir string, src 
 		if !holdsLiteral {
 			continue
 		}
-		for _, ref := range referencedTables(sql, tables) {
+		for _, ref := range referencedTables(sql, vocab) {
 			if into[dir] == nil {
 				into[dir] = map[string][]referenceSite{}
 			}
@@ -481,7 +521,7 @@ func collectQueryVars(gen *ast.GenDecl, tables map[string]bool, dir string, src 
 
 // indexFuncBody records one function's row-scope calls and edges, and returns
 // the reference sites its SQL holds.
-func indexFuncBody(fn *ast.FuncDecl, info *rowScopeFnInfo, tables map[string]bool, at referenceSite, src tierFile, idents map[string]bool) []referenceSite {
+func indexFuncBody(fn *ast.FuncDecl, info *rowScopeFnInfo, vocab referenceVocabulary, at referenceSite, src tierFile, idents map[string]bool) []referenceSite {
 	var sites []referenceSite
 	// A statement assembled by `+` is read as ONE query, and its parts are not
 	// read again on their own. Half a statement is the shape that reads green
@@ -489,7 +529,7 @@ func indexFuncBody(fn *ast.FuncDecl, info *rowScopeFnInfo, tables map[string]boo
 	// predicate that bounds it in the last, so each half alone looks unbounded.
 	joined := map[ast.Node]bool{}
 	record := func(sql string, pos token.Pos) {
-		for _, ref := range referencedTables(sql, tables) {
+		for _, ref := range referencedTables(sql, vocab) {
 			site := at
 			site.table, site.line = ref.table, src.Line(pos)+ref.lineOffset
 			sites = append(sites, site)
@@ -510,7 +550,9 @@ func indexFuncBody(fn *ast.FuncDecl, info *rowScopeFnInfo, tables map[string]boo
 			case *ast.SelectorExpr:
 				if pkg, isPkg := fun.X.(*ast.Ident); isPkg && pkg.Name == "auth" {
 					if rowScopeSpellings[fun.Sel.Name] {
-						info.scoped = true
+						for _, table := range vocab.scopedBy(fun.Sel.Name, node.Args) {
+							info.scopes[table] = true
+						}
 					}
 					return true
 				}
@@ -580,19 +622,116 @@ var fkColumn = regexp.MustCompile(`\b(?:[A-Za-z_][\w]*\.)?([a-z_]+)_id\b`)
 // LISTS hand back. The list, not the whole statement: a `<table>_id` in a WHERE
 // or a JOIN condition is how a query NARROWS, and reading those as disclosures
 // would flag the row-scope clauses themselves.
-func referencedTables(sql string, tables map[string]bool) []tableReference {
+// referenceVocabulary is what a reference IS: the row-scoped tables, and the
+// columns that point at one. The two travel together because neither answers
+// the question alone — a column is a reference because of the table it names,
+// and a table is reachable through columns that do not carry its name.
+type referenceVocabulary struct {
+	tables  map[string]bool
+	columns map[string]string
+	// edge is what the endpoint conjunction bounds — the relationship and every
+	// endpoint table it names — read out of platform/auth rather than restated.
+	edge map[string]bool
+}
+
+// scopedBy is the tables one row-scope call bounds.
+func (v referenceVocabulary) scopedBy(spelling string, args []ast.Expr) []string {
+	table := scopedTable(spelling, args)
+	if table != edgeEndpoints {
+		return []string{table}
+	}
+	tables := make([]string, 0, len(v.edge))
+	for endpoint := range v.edge {
+		tables = append(tables, endpoint)
+	}
+	return tables
+}
+
+func referencedTables(sql string, vocab referenceVocabulary) []tableReference {
 	projected := projectedBytes(sql)
 	var found []tableReference
 	seen := map[string]bool{}
-	for _, at := range fkColumn.FindAllStringSubmatchIndex(sql, -1) {
-		table := sql[at[2]:at[3]]
-		if !projected[at[0]] || !tables[table] || seen[table] || boundToCallerArgument(sql, table) {
-			continue
+	add := func(table string, at int) {
+		if seen[table] {
+			return
 		}
 		seen[table] = true
-		found = append(found, tableReference{table: table, lineOffset: strings.Count(sql[:at[0]], "\n")})
+		found = append(found, tableReference{table: table, lineOffset: strings.Count(sql[:at], "\n")})
+	}
+	counted := countedBytes(sql)
+	for _, at := range fkColumn.FindAllStringSubmatchIndex(sql, -1) {
+		table := sql[at[2]:at[3]]
+		if !projected[at[0]] || counted[at[0]] || !vocab.tables[table] || boundToCallerArgument(sql, table+"_id") {
+			continue
+		}
+		add(table, at[0])
+	}
+	// The columns the name-derived pass above cannot see: an FK named for its
+	// ROLE. The schema says which table each one points at, so a reference is
+	// found by what it REFERS TO rather than by what it is called.
+	for column, table := range vocab.columns {
+		if column == table+"_id" || !vocab.tables[table] || boundToCallerArgument(sql, column) {
+			continue
+		}
+		at := namedColumn(column).FindStringIndex(sql)
+		if at == nil || !projected[at[0]] || counted[at[0]] {
+			continue
+		}
+		add(table, at[0])
 	}
 	return found
+}
+
+// namedColumn matches one column by name, optionally qualified by an alias.
+// Compiled per call rather than cached: the map is small, this runs once per
+// statement, and a cache keyed by column is a second place for the pattern to
+// be wrong.
+func namedColumn(column string) *regexp.Regexp {
+	return regexp.MustCompile(`\b(?:[A-Za-z_][\w]*\.)?` + column + `\b`)
+}
+
+// countedBytes marks the bytes inside a count(), which hands back a NUMBER.
+//
+// count is the whole list, and one entry is the honest length of it. sum and
+// avg over an id are nonsense nobody writes, while min and max over a uuid
+// return an id — so widening this to "aggregates" would start dropping real
+// references. array_agg and json_agg are the case that proves the rule: they
+// wrap ids and hand every one of them back, so they must stay visible here.
+//
+// It exists because an account's stakeholder TOTAL is deliberately counted past
+// the caller's person scope — the difference between that total and the visible
+// set is what "contacts you cannot see" means on the coverage card, and a scope
+// clause there would collapse it to zero and report every account complete.
+func countedBytes(sql string) []bool {
+	counted := make([]bool, len(sql)+1)
+	// Both spellings: the tree writes count() lower-case today, and a mask that
+	// saw one of them would report the other's references and be argued with
+	// rather than read.
+	starts := append(keywordOffsets(sql, "count"), keywordOffsets(sql, "COUNT")...)
+	for _, start := range starts {
+		depth, from := 0, -1
+		for i := start; i < len(sql); i++ {
+			switch sql[i] {
+			case '(':
+				if depth == 0 {
+					from = i
+				}
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					for j := from; j <= i; j++ {
+						counted[j] = true
+					}
+					i = len(sql)
+				}
+			}
+			if depth == 0 && from >= 0 {
+				break
+			}
+		}
+	}
+	return counted
 }
 
 // projectedBytes marks which bytes of a statement sit in a SELECT's projection.
@@ -633,9 +772,9 @@ func projectedBytes(sql string) []bool {
 // CALLER to have scoped the ids it passes down. What it still catches is what
 // both halves of #632 were — a query that DISCOVERS references, keyed on
 // something other than the referenced record itself.
-func boundToCallerArgument(sql, table string) bool {
+func boundToCallerArgument(sql, column string) bool {
 	return regexp.MustCompile(
-		`\b(?:[A-Za-z_][\w]*\.)?` + table + `_id\s*(?:=|IN)\s*(?:ANY\s*\(\s*)?\$\d+`).MatchString(sql)
+		`\b(?:[A-Za-z_][\w]*\.)?` + column + `\s*(?:=|IN)\s*(?:ANY\s*\(\s*)?\$\d+`).MatchString(sql)
 }
 
 // selectSpan locates one SELECT: [from, to) is its projection, and [to, stop)

--- a/backend/gates/rowscopeplanted_test.go
+++ b/backend/gates/rowscopeplanted_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind falsification H2
+
+package gates
+
+// The defect this census is for, planted and run.
+//
+// #1876 was a read that projected an organization id and probed a deal. A gate
+// that counted probes rather than matching them to the table would have gone
+// green over it — and worse, would then have CERTIFIED it, because the obvious
+// way to quiet such a gate is to add a probe over whatever the function already
+// had in hand.
+//
+// So each obstacle is planted here as source and run through the same index the
+// tier walk uses. A gate that has never been run against the bug it describes
+// has not been shown to work.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// judgePlanted indexes one synthetic file and answers, per reference site,
+// whether the enclosing function satisfies the obligation for the table it
+// names. The keys are `<function>:<table>`, so a case can assert on the pair
+// rather than on a count.
+func judgePlanted(t *testing.T, source string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "planted.go", source, 0)
+	if err != nil {
+		t.Fatalf("parsing the planted source: %v", err)
+	}
+	vocab := referenceVocabulary{
+		tables:  rowScopedTables(t),
+		columns: referenceColumns(t, rowScopedTables(t)),
+		edge:    relationshipEndpointTables(t),
+	}
+	src := tierFile{Path: "planted.go", File: parsed, fset: fset}
+	fns := map[string]*rowScopeFnInfo{}
+	var sites []referenceSite
+	for _, decl := range parsed.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil {
+			continue
+		}
+		info := &rowScopeFnInfo{scopes: map[string]bool{}, calls: map[string]bool{}}
+		fns[fn.Name.Name] = info
+		at := referenceSite{dir: "planted", fn: fn.Name.Name}
+		sites = append(sites, indexFuncBody(fn, info, vocab, at, src, map[string]bool{})...)
+	}
+	judged := map[string]bool{}
+	for _, site := range sites {
+		judged[site.fn+":"+site.table] = reachesRowScope(fns, site.fn, site.table, map[string]bool{})
+	}
+	return judged
+}
+
+// Obstacle 1: the obligation is per table, so a deal probe does not answer for
+// an organization the same read hands back.
+func TestAProbeOverAnotherTableDoesNotAnswerForTheOneServed(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func readDeal(ctx C, tx T, id U) error {
+	if err := auth.EnsureVisible(ctx, tx, "deal", id); err != nil {
+		return err
+	}
+	rows, err := tx.Query(ctx, "SELECT d.id, d.organization_id FROM deal d WHERE d.id = $1", id)
+	_, _ = rows, err
+	return nil
+}
+`)
+	satisfied, judgedAtAll := judged["readDeal:organization"]
+	if !judgedAtAll {
+		t.Fatal("the organization reference was not judged at all, so nothing below is about the defect")
+	}
+	if satisfied {
+		t.Error("a deal probe answered for an organization this read hands back — which is #1876, and " +
+			"a gate that accepts it certifies the defect the next author would 'fix' by adding one more probe")
+	}
+}
+
+// The mirror of the case above, so it is not satisfied by a gate that refuses
+// everything: the SAME probe answers for the table it names.
+func TestAProbeAnswersForTheTableItNames(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func readLink(ctx C, tx T, id U) error {
+	if err := auth.EnsureVisible(ctx, tx, "deal", id); err != nil {
+		return err
+	}
+	rows, err := tx.Query(ctx, "SELECT l.id, l.deal_id FROM activity_link l WHERE l.activity_id = $1", id)
+	_, _ = rows, err
+	return nil
+}
+`)
+	if satisfied, judgedAtAll := judged["readLink:deal"]; !judgedAtAll || !satisfied {
+		t.Errorf("a deal reference bounded by a deal probe was reported unscoped (judged=%v satisfied=%v)",
+			judgedAtAll, satisfied)
+	}
+}
+
+// Obstacle 2: an FK named for its ROLE is a reference. `partner_org_id` was one
+// of the three #1876 fixed, and the name-derived extractor could not see it.
+func TestARoleNamedForeignKeyIsStillAReference(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func readPartners(ctx C, tx T) error {
+	rows, err := tx.Query(ctx, "SELECT p.id, p.partner_org_id FROM partner p")
+	_, _ = rows, err
+	return nil
+}
+`)
+	satisfied, judgedAtAll := judged["readPartners:organization"]
+	if !judgedAtAll {
+		t.Fatal("partner_org_id was not read as an organization reference — the extractor is back to " +
+			"deriving the table from the column's own words, and drops every role-named FK silently")
+	}
+	if satisfied {
+		t.Error("a read that probes nothing reported as scoped")
+	}
+}
+
+// And the mirror, so the case above is not satisfied by a gate that reports
+// everything: the same reference, bounded, passes.
+func TestARoleNamedForeignKeyPassesWhenItsOwnTableIsScoped(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func readPartners(ctx C, tx T, arg A) error {
+	clause, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
+	if err != nil {
+		return err
+	}
+	rows, err := tx.Query(ctx, "SELECT p.id, p.partner_org_id FROM partner p JOIN organization o ON o.id = p.partner_org_id WHERE "+clause)
+	_, _ = rows, err
+	return nil
+}
+`)
+	if satisfied, judgedAtAll := judged["readPartners:organization"]; !judgedAtAll || !satisfied {
+		t.Errorf("a role-named reference bounded by its own table's scope was reported unscoped "+
+			"(judged=%v satisfied=%v) — a census that refuses correct code is one people turn off",
+			judgedAtAll, satisfied)
+	}
+}
+
+// The edge conjunction bounds its endpoints, so a person id projected from a
+// relationship that passed it is bounded — reading it as "relationship only"
+// would send the next author to add a clause over a column already covered.
+func TestTheEdgeConjunctionAnswersForItsEndpoints(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func readStakeholders(ctx C, tx T, arg A) error {
+	clause, err := auth.EdgeReadScope(ctx, "r", arg)
+	if err != nil {
+		return err
+	}
+	rows, err := tx.Query(ctx, "SELECT r.person_id FROM relationship r WHERE "+clause)
+	_, _ = rows, err
+	return nil
+}
+`)
+	if satisfied, judgedAtAll := judged["readStakeholders:person"]; !judgedAtAll || !satisfied {
+		t.Errorf("a person projected from an edge bounded by the endpoint conjunction was reported "+
+			"unscoped (judged=%v satisfied=%v)", judgedAtAll, satisfied)
+	}
+}
+
+// A count hands back a number. The account-coverage total is deliberately taken
+// past the caller's person scope, because the difference between it and the
+// visible set is what "contacts you cannot see" means.
+func TestACountOfAReferenceIsNotAReference(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func countStakeholders(ctx C, tx T) error {
+	row := tx.QueryRow(ctx, "SELECT count(DISTINCT r.person_id) FROM relationship r")
+	_ = row
+	return nil
+}
+`)
+	if _, judgedAtAll := judged["countStakeholders:person"]; judgedAtAll {
+		t.Error("a count() over a person id was read as handing one back — the total is a number, and " +
+			"scoping it would collapse the difference the coverage card is about")
+	}
+}
+
+// And the mirror: an aggregate that hands the ids back is still a reference.
+func TestAnAggregateThatReturnsTheIdsIsStillAReference(t *testing.T) {
+	t.Parallel()
+	judged := judgePlanted(t, `package planted
+
+func listStakeholders(ctx C, tx T) error {
+	row := tx.QueryRow(ctx, "SELECT array_agg(r.person_id) FROM relationship r")
+	_ = row
+	return nil
+}
+`)
+	if _, judgedAtAll := judged["listStakeholders:person"]; !judgedAtAll {
+		t.Error("array_agg over a person id was dropped as though it were a count — it hands every one " +
+			"of those ids back, which is the reference this census is about")
+	}
+}

--- a/backend/gates/rowscopetables_test.go
+++ b/backend/gates/rowscopetables_test.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// WHICH table a row-scope call bounds, and which column names a reference to
+// one.
+//
+// The obligation used to be table-agnostic: a function that projected an
+// `organization_id` satisfied it by reaching a probe over `deal`. That is not a
+// weaker check, it is a different one — #1876's read named an organization and
+// scoped a deal, and a gate counting probes rather than matching them would
+// have gone green over it and then certified it.
+//
+// And the columns it looked for were named after their table. An FK named for
+// its ROLE — `partner_org_id` was one of the three references #1876 fixed —
+// escaped entirely: the extractor read the column's own words as a table name,
+// found no such table, and dropped the site with no census entry and no waiver.
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// anyTable is the scope a spelling applies when it cannot be attributed to one
+// table. It satisfies a reference to any of them, which is the honest reading:
+// ScopeClause and OwnerPredicate render over whatever alias the caller gives
+// them, so the table is the caller's and this gate cannot see it.
+const anyTable = "*"
+
+// scopeSpellingTable says which table each row-scope spelling bounds.
+//
+// Three shapes, and the difference is in platform/auth's own signatures:
+//
+//   - a table NAMED BY ARGUMENT — EnsureVisible(ctx, tx, table, id) — where the
+//     value is the string literal at that index, and a non-literal means a
+//     caller allowlisting at its own seam, which this gate reads as any table;
+//   - a table IMPLIED BY THE NAME — EnsureActivityVisible bounds activities and
+//     nothing else, so the name is the answer;
+//   - no table at all, which is anyTable above.
+//
+// TestEveryRowScopeSpellingSaysWhichTableItBounds holds this map against
+// rowScopeSpellings in both directions, so a spelling added to one and not the
+// other fails rather than defaulting to a silent wildcard.
+var scopeSpellingTable = map[string]scopeSpelling{
+	"ScopeClause":      {table: anyTable},
+	"ScopeClauseFor":   {argument: 1},
+	"OwnerPredicate":   {table: anyTable},
+	"VisiblePredicate": {argument: 1},
+
+	"EnsureVisible":                 {argument: 2},
+	"EnsureVisibleLive":             {argument: 2},
+	"EnsureVisibleForSubjectRights": {argument: 2},
+	"EnsureLinkTarget":              {argument: 2},
+	"VisibleTo":                     {argument: 2},
+	// The link target's table is the caller's to name in its own allowlist;
+	// this clause renders over the alias it is given.
+	"LinkTargetVisibleClause": {table: anyTable},
+
+	"ActivityDiscoverClause":           {table: "activity"},
+	"ActivityContentClause":            {table: "activity"},
+	"EnsureActivityVisible":            {table: "activity"},
+	"EnsureActivityVisibleLive":        {table: "activity"},
+	"EnsureActivityContentVisible":     {table: "activity"},
+	"EnsureActivityContentVisibleLive": {table: "activity"},
+
+	"SignalScopeClause":       {table: "signal"},
+	"EnsureSignalVisible":     {table: "signal"},
+	"EnsureSignalVisibleLive": {table: "signal"},
+
+	// The edge conjunction bounds the relationship by its ENDPOINTS: each
+	// endpoint column is tested with VisiblePredicate over its own table, so a
+	// person or organization id projected from an edge that passed it is
+	// bounded as surely as one from a direct scope clause. Reading it as
+	// "relationship only" would report those projections unscoped and send the
+	// next author to add a second clause over a column the conjunction covers.
+	"RelationshipEndpointScope": {endpoints: true},
+	"EnsureRelationshipVisible": {endpoints: true},
+	"EdgeReadScope":             {endpoints: true},
+}
+
+// scopeSpelling is one spelling's table: fixed, read off an argument, or the
+// edge conjunction's — which bounds the relationship AND every endpoint it
+// names, so its tables are read out of platform/auth's own endpoint list.
+type scopeSpelling struct {
+	table string
+	// argument is the 0-based index of the parameter naming the table, used
+	// when table is empty and endpoints is false.
+	argument int
+	// endpoints marks the spellings whose clause is the endpoint conjunction:
+	// every endpoint column is bounded by VisiblePredicate over its own table,
+	// so a person id projected from an edge that passed it IS bounded.
+	endpoints bool
+}
+
+func TestEveryRowScopeSpellingSaysWhichTableItBounds(t *testing.T) {
+	t.Parallel()
+	for spelling := range rowScopeSpellings {
+		if _, classified := scopeSpellingTable[spelling]; !classified {
+			t.Errorf("%s applies a row scope and this gate cannot say which table it bounds, so every "+
+				"reference would count it — classify it in scopeSpellingTable, with anyTable only when "+
+				"platform/auth's signature genuinely names no table", spelling)
+		}
+	}
+	for spelling := range scopeSpellingTable {
+		if !rowScopeSpellings[spelling] {
+			t.Errorf("scopeSpellingTable classifies %s, which is not a row-scope spelling any more — "+
+				"a classification outliving its subject is a standing answer to a question nobody asks", spelling)
+		}
+	}
+}
+
+// referenceColumn is a column name that holds a reference to a row-scoped
+// record, mapped to the table it points at.
+//
+// DERIVED FROM THE SCHEMA's own FOREIGN KEY declarations rather than from the
+// column's spelling, which is what makes a role-named FK visible: the catalog
+// says `partner_org_id` references `organization`, where the name says
+// `partner_org` and no such table exists.
+func referenceColumns(t *testing.T, tables map[string]bool) map[string]string {
+	t.Helper()
+	catalog, err := os.ReadFile(filepath.Join(repoRoot, headCatalogPath))
+	if err != nil {
+		t.Fatalf("reading the schema catalog this census derives its columns from: %v", err)
+	}
+	columns := map[string]string{}
+	for _, at := range foreignKeyDeclaration.FindAllStringSubmatch(string(catalog), -1) {
+		column, table := at[1], at[2]
+		// Composite keys carry a comma and reference a pair; no reference this
+		// census is about is one, and half of a composite is not a reference.
+		if strings.Contains(column, ",") || !tables[table] {
+			continue
+		}
+		columns[column] = table
+	}
+	return columns
+}
+
+const headCatalogPath = "backend/migrations/testdata/head_catalog.txt"
+
+// foreignKeyDeclaration reads one single-column FK out of the catalog line that
+// declares it.
+var foreignKeyDeclaration = regexp.MustCompile(`FOREIGN KEY \(([a-z_, ]+)\) REFERENCES ([a-z_]+)\(`)
+
+// The extractor's floor, in the ticket's own words: a regex that silently
+// matches nothing reads exactly like a tree with nothing to find.
+func TestTheReferenceColumnMapIsDerivedAndReachesTheAliasedNames(t *testing.T) {
+	t.Parallel()
+	tables := rowScopedTables(t)
+	columns := referenceColumns(t, tables)
+	if len(columns) < wantMinimumReferenceColumns {
+		t.Fatalf("the schema yielded %d reference columns, want at least %d — the catalog's shape moved "+
+			"and this census is now reading almost none of it", len(columns), wantMinimumReferenceColumns)
+	}
+	// The half the old extractor could not see: a column whose own name is not
+	// its table's. Without one of these the map is only an expensive spelling
+	// of the `<table>_id` regex it replaces.
+	aliased := 0
+	for column, table := range columns {
+		if column != table+"_id" {
+			aliased++
+		}
+	}
+	if aliased == 0 {
+		t.Error("every reference column is named for its own table, so nothing here covers the case " +
+			"this map exists for — an FK named for its ROLE, which the name-derived regex drops silently")
+	}
+}
+
+// wantMinimumReferenceColumns is far below the real count: it catches a parser
+// that has stopped reading the catalog, not a schema that has changed.
+const wantMinimumReferenceColumns = 20
+
+// scopedTable resolves which table one row-scope call bounds, from the spelling
+// and the arguments it was given.
+//
+// A table argument that is not a string literal reads as anyTable, and that is
+// deliberate: those callers forward a name they allowlist at their own seam
+// (link entity types, grant record types, search anchors), and platform/auth
+// refuses an unknown one itself. Refusing them here would fail correct code for
+// being written the only way it can be.
+func scopedTable(spelling string, args []ast.Expr) string {
+	classified, known := scopeSpellingTable[spelling]
+	if !known {
+		// Unclassified is anyTable rather than nothing, so a spelling added to
+		// rowScopeSpellings alone weakens this gate instead of breaking the
+		// tree — TestEveryRowScopeSpellingSaysWhichTableItBounds is what makes
+		// that state fail, and it names the omission where a reader can fix it.
+		return anyTable
+	}
+	if classified.table != "" {
+		return classified.table
+	}
+	if classified.endpoints {
+		// One name for the whole conjunction; the caller expands it, because
+		// the tables it covers are read from source rather than written here.
+		return edgeEndpoints
+	}
+	if classified.argument >= len(args) {
+		return anyTable
+	}
+	literal, isLiteral := args[classified.argument].(*ast.BasicLit)
+	if !isLiteral {
+		return anyTable
+	}
+	table, unquoted := stringConst(literal)
+	if !unquoted {
+		return anyTable
+	}
+	return table
+}
+
+// edgeEndpoints stands for "the relationship and every endpoint table it
+// names". scopedTable returns it as one token and the census expands it, so the
+// set stays derived from platform/auth rather than restated here.
+const edgeEndpoints = "@edge-endpoints"
+
+// relationshipEndpointTables reads the endpoint tables out of platform/auth's
+// own relationshipEndpointColumns, so an endpoint added there widens this
+// census without anyone remembering to.
+func relationshipEndpointTables(t *testing.T) map[string]bool {
+	t.Helper()
+	consts := map[string]string{}
+	var endpoints []string
+	for _, src := range tierFiles(t, rowScopeVocabularyPkg) {
+		for _, decl := range src.File.Decls {
+			gen, isGen := decl.(*ast.GenDecl)
+			if !isGen {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, isValue := spec.(*ast.ValueSpec)
+				if !isValue || len(value.Names) != 1 || len(value.Values) != 1 {
+					continue
+				}
+				if gen.Tok == token.CONST {
+					if text, isString := stringConst(value.Values[0]); isString {
+						consts[value.Names[0].Name] = text
+					}
+					continue
+				}
+				if value.Names[0].Name == "relationshipEndpointColumns" {
+					endpoints = endpointTableNames(value.Values[0])
+				}
+			}
+		}
+	}
+	if len(endpoints) == 0 {
+		t.Fatalf("%s declares no relationshipEndpointColumns — teach this gate where the edge's endpoint "+
+			"list moved, because reading it as the empty set would report every edge projection unscoped",
+			rowScopeVocabularyPkg)
+	}
+	tables := map[string]bool{"relationship": true}
+	for _, name := range endpoints {
+		if text, isConst := consts[name]; isConst {
+			tables[text] = true
+			continue
+		}
+		tables[name] = true
+	}
+	return tables
+}
+
+// endpointTableNames reads the table of each {column, table} pair as WRITTEN —
+// a const by its identifier, a literal by its text.
+func endpointTableNames(expr ast.Expr) []string {
+	lit, isLit := expr.(*ast.CompositeLit)
+	if !isLit {
+		return nil
+	}
+	var names []string
+	for _, element := range lit.Elts {
+		pair, isPair := element.(*ast.CompositeLit)
+		if !isPair || len(pair.Elts) != 2 {
+			continue
+		}
+		switch table := pair.Elts[1].(type) {
+		case *ast.Ident:
+			names = append(names, table.Name)
+		case *ast.BasicLit:
+			if text, isString := stringConst(table); isString {
+				names = append(names, text)
+			}
+		}
+	}
+	return names
+}
+
+// The modules tier, measured rather than guessed at.
+//
+// Extending the census over internal/modules is the change #1984 was filed to
+// unblock, and its own header says that tier "holds several times as many
+// statements of this shape". This is that number, standing where a reader can
+// see it without breaking a gate to find it — and it may only FALL.
+//
+// It is not the widening. Ninety-five sites is not a waiver list anybody should
+// write in one sitting, and a widening that shipped with one would be the green
+// check over the same defect this ticket exists to refuse. What it does is stop
+// the number growing quietly while the widening waits, and give whoever takes
+// it a floor to work against.
+func TestTheModulesTierIsMeasuredForTheWideningItIsOwed(t *testing.T) {
+	t.Parallel()
+	tables := rowScopedTables(t)
+	vocab := referenceVocabulary{
+		tables:  tables,
+		columns: referenceColumns(t, tables),
+		edge:    relationshipEndpointTables(t),
+	}
+	pkgs, sites := referenceSitesIn(t, modulesTier, vocab)
+	if len(sites) < wantMinimumModuleSites {
+		t.Fatalf("only %d record-reference reads found in %s, want at least %d — the extractor lost its "+
+			"source, and a census that reads a smaller tree reports PASS with nothing to notice",
+			len(sites), modulesTier, wantMinimumModuleSites)
+	}
+	unscoped := 0
+	for _, site := range sites {
+		if !reachesRowScope(pkgs[site.dir].visibleTo(site.recv), site.fn, site.table, map[string]bool{}) {
+			unscoped++
+		}
+	}
+	if unscoped > modulesTierUnscopedCeiling {
+		t.Errorf("%d of %d record references in %s reach no row scope for the table they name, above the "+
+			"recorded %d. A new one is a read handing back a reference it never bounded: bound it, or lower "+
+			"nothing and explain here why this tier grew one",
+			unscoped, len(sites), modulesTier, modulesTierUnscopedCeiling)
+	}
+}
+
+const (
+	modulesTier = "internal/modules"
+	// The floor that catches an extractor which has stopped reading, far below
+	// the real count.
+	wantMinimumModuleSites = 60
+	// What the tier holds today. A ratchet: it may only fall.
+	modulesTierUnscopedCeiling = 95
+)

--- a/backend/internal/compose/person360/nextmeeting.go
+++ b/backend/internal/compose/person360/nextmeeting.go
@@ -59,6 +59,19 @@ func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID id
 	if participantScope == "" {
 		participantScope = scopeAll
 	}
+	// The linked deal is a REFERENCE, and it is served as a link the reader is
+	// invited to open — so it carries the deal's own scope, exactly as the
+	// participants beside it carry the person's. Without it a rep who may see
+	// the meeting is handed the id of a deal whose own read refuses them: a
+	// well-formed answer naming a record they cannot open, which is the whole
+	// failure this pairing exists to prevent.
+	dealScope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	if err != nil {
+		return err
+	}
+	if dealScope == "" {
+		dealScope = scopeAll
+	}
 
 	var meeting crmcontracts.Person360NextMeeting
 	var activityID ids.UUID
@@ -68,7 +81,8 @@ func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID id
 	err = tx.QueryRow(ctx, fmt.Sprintf(`
 		SELECT a.id, a.occurred_at, a.subject,
 		       (SELECT dl.deal_id FROM activity_link dl
-		         WHERE dl.activity_id = a.id AND dl.deal_id IS NOT NULL LIMIT 1),
+		          JOIN deal d ON d.id = dl.deal_id AND d.archived_at IS NULL
+		         WHERE dl.activity_id = a.id AND (%s) LIMIT 1),
 		       COALESCE((
 		         SELECT json_agg(json_build_object('person_id', p.id, 'full_name', p.full_name)
 		                         ORDER BY p.full_name, p.id)
@@ -87,7 +101,7 @@ func (s *Service) nextMeetingSection(ctx context.Context, tx pgx.Tx, personID id
 		  AND `+fmt.Sprintf(personReachesActivity, linkPos)+`
 		  AND (%s)%s
 		ORDER BY a.occurred_at, a.id
-		LIMIT 1`, participantScope, nowPos, scope, projectScope(opts, arg)), args...).
+		LIMIT 1`, dealScope, participantScope, nowPos, scope, projectScope(opts, arg)), args...).
 		Scan(&activityID, &meeting.StartsAt, &subject, &dealID, &participants)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Nothing booked. That IS the answer, and the strip renders "None".

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (96)
+## Parity (97)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -104,6 +104,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |
 | `reopenconditionparity_test.go` | H3 | What a snooze may wait for is spelled in four places, and all four must agree. |
+| `rowscopetables_test.go` | H2 | WHICH table a row-scope call bounds, and which column names a reference to one. |
 | `runneractivityparity_test.go` | H3 | The runner's own status vocabulary must be TOTAL over the column it reads. |
 | `seeddemoargonparity_test.go` | H3 | seed-demo writes password hashes a REAL person then logs in against, and it cannot import the hashing package: that package sits behind a nested `internal`, and seed-demo is its own module besides. |
 | `seedemploymentpredicate_test.go` | H2 | The dev seeder and the boot proof ask "is this person currently employed?" the way the PRODUCT asks it, and they ask it in the same words. |
@@ -370,7 +371,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooklength_test.go` | H3 | A rulebook is read in full by every session and, for its Craftsmanship section, by every gate prompt — so its length is a running cost rather than a matter of taste. |
 | `workflowtimeouts_test.go` | H3 | Every workflow job carries a wall-clock ceiling. |
 
-## Falsification (12)
+## Falsification (13)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -381,6 +382,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `piisqlreader_test.go` | H2 | Reading the SQL the PII census judges: where one statement ends and the next begins, which table a write lands on, which columns its SET clause names, and which of those the reader could not read at all. |
 | `rbacbaselineerafixture_test.go` | H3 | The pre-state the RBAC composition gate replays over must not be hand-editable. |
 | `retainedcolumncases_test.go` | H1 | The retention sweep's two SQL claims, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
+| `rowscopeplanted_test.go` | H2 | The defect this census is for, planted and run. |
 | `triggerwrittencolumncases_test.go` | H2 | The trigger-written-column reader driven with SYNTHETIC statements, for the reason retainedcolumncases\_test.go gives for its own: the tree is supposed to pass, so a reader proven only by "nothing in the tree trips it" is one that keeps passing after it stops working. |
 | `txseamreach_test.go` | H2 | Following a call one hop further than the name it is spelled with. |
 | `updateguardcases_test.go` | H2 | What the concurrency-guard census judges a function on, driven with SYNTHETIC source rather than the tree — the same reason retainedcolumncases\_test.go gives for its own cases. |


### PR DESCRIPTION
Closes #1984.

## Why

`TestEveryComposeReadOfARecordReferenceAppliesItsRowScope` asked whether a read
reached **a** row scope, not whether it reached the one for the table it hands
back. #1876 was a read that scoped `deal` and returned an `organization_id`,
and the gate said PASS. The ticket's point is that widening that answer over
`internal/modules` would multiply it, not correct it.

## The three obstacles, fixed

**1. The obligation was table-agnostic.** `reachesRowScope` now carries the
table. `scopeSpellingTable` classifies all 22 row-scope spellings in
`platform/auth` — a fixed table, an argument index, or the edge conjunction —
and `TestEveryRowScopeSpellingSaysWhichTableItBounds` fails in both directions,
so a new spelling cannot arrive unclassified and a retired one cannot linger.
`EdgeReadScope` / `RelationshipEndpointScope` expand to the endpoint tables
derived from the vocabulary's own `relationshipEndpointColumns`, rather than a
second copy of that list living in the gate.

**2. An aliased foreign key was invisible.** The old extractor derived
reference columns from table names, so `partner_org_id` was not one.
`referenceColumns` reads column→table out of the foreign-key declarations in
`migrations/testdata/head_catalog.txt`: 27 columns, 19 of them role-named. A
floor (`wantMinimumReferenceColumns`) and an explicit aliased-name assertion
fail if the derivation ever stops reaching them, because a census that reads a
smaller tree reports PASS with nothing to notice.

**3. Nothing proved the judgement was more than shape accident.**
`rowscopeplanted_test.go` runs the real judgement over six planted sources: a
probe over another table, a probe over the right one, a role-named key both
ways, the edge conjunction, a `count()` of a reference, and an aggregate that
returns the ids.

## What the widened extractor found

Five sites the old one could not see:

- three were the edge conjunction, and are modelled correctly now rather than
  waived;
- `loadOrgTree`'s recursive tree walk is waived with the bound that actually
  holds it — `EnsureVisible` on the root in the same transaction, then
  `orgReadablePredicate` over every node before any figure is summed;
- **one is a real disclosure.** `nextMeetingSection` served `LinkedDealId` off
  `activity_link` with no deal scope, so a person's next meeting named a deal
  the reader may not be allowed to see. It now carries
  `ScopeClauseFor(ctx, "deal", …)` and joins through the deal's own
  `archived_at`.

## `internal/modules` is measured, not widened

144 record-reference reads, 95 of which reach no row scope for the table they
name. That is not a waiver list anybody should write in one sitting, and one
written in a hurry would be the green check over the defect this ticket exists
to refuse. `TestTheModulesTierIsMeasuredForTheWideningItIsOwed` records the
number as a ratchet — it may only fall — with a floor underneath it so an
extractor that stops reading fails loudly instead of reporting a clean tier.

## Checks

- `make check-backend` green.
- `make test-it DIR=backend/internal/compose/integration` green (503s), which
  is the lane the `nextmeeting.go` fix sits in.
- `craft static --strict` clean on all four changed files.
- Mutation-checked: `&& false` on the reference-column role test and replacing
  the per-table check with "reaches any scope" each turn the new assertions red.

Note: `main` is red on `TestAnEmailIsDrawnOnlyByTheCanonicalComponents`
(#4790 / #4792, already owned), so the backend lanes here will inherit that
failure until it lands.