### PR TITLE
Every answer on a credential path is uncacheable

### DIFF
--- a/backend/gates/publictokencachecensus_test.go
+++ b/backend/gates/publictokencachecensus_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H3
+
+package gates
+
+// The no-store census covers every route the contract publishes on the two
+// anonymous token prefixes.
+//
+// publictokencache_integration_test.go asserts that /v1/public/preferences/*
+// and /v1/public/confirm/* answer every request with Cache-Control: no-store,
+// because each of their answers is derived from a bearer token sitting in
+// somebody's mailbox. That test drives a fixed list of verb+route pairs, and a
+// fixed list is exactly the thing that goes stale: publish a sixth pair and the
+// census keeps passing while silently covering less of its subject than it
+// claims. Under-recognition leaves no failing assertion behind, which is why
+// this gate derives the subject from the contract instead of restating it.
+//
+// This gate proves COVERAGE, not the header. The header is proven by the
+// integration test, against the running stack, where it is actually set.
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
+)
+
+// tokenPrefixes are the anonymous surfaces whose every answer must be
+// uncacheable, read from the package that decides which paths carry a
+// credential rather than restated here — a second list would drift the first
+// time a prefix is added there.
+//
+// The contract spells paths without the /v1 mount, so the prefixes are trimmed
+// to match what crm.yaml actually declares.
+func tokenPrefixes() []string {
+	var prefixes []string
+	for _, p := range capabilitypath.CredentialPrefixes() {
+		// The booking page's slug is in capabilitypath because it must not be
+		// logged — it is the only admission check on a route that WRITES. But
+		// it is a public identifier the host hands out, not a mailed token, so
+		// its answers disclose the host's availability rather than a named
+		// person's record, and no case in the census drives them.
+		//
+		// noStoreOnCredentialPaths does stamp them, and compose's own
+		// TestEveryCredentialPathAnswersUncacheable asserts that for every
+		// prefix in the list, this one included. What is deliberately not
+		// claimed here is a per-route census over live booking state.
+		if strings.Contains(p, "/booking/") {
+			continue
+		}
+		prefixes = append(prefixes, strings.TrimPrefix(p, "/v1"))
+	}
+	return prefixes
+}
+
+// httpVerbs is the set a path item may declare. Anything outside it (parameters,
+// summary) is not an operation and is not part of the census.
+// The full OpenAPI 3.1 set, trace included: a verb missing from this map is a
+// published operation the census silently stops seeing, which is the shape of
+// under-recognition this gate exists to prevent.
+var httpVerbs = map[string]bool{
+	"get": true, "put": true, "post": true, "patch": true,
+	"delete": true, "head": true, "options": true, "trace": true,
+}
+
+func TestTheNoStoreCensusCoversEveryPublicTokenRoute(t *testing.T) {
+	t.Parallel()
+
+	published := publishedTokenOperations(t)
+	if len(published) == 0 {
+		t.Fatal("the contract publishes no route under the anonymous token prefixes, so this " +
+			"gate is reading the wrong subject and would pass however little the census covered")
+	}
+
+	covered := coveredTokenOperations(t)
+	for _, op := range published {
+		if !covered[op] {
+			t.Errorf("%s is published on an anonymous token prefix but no case in "+
+				"publictokencache_integration_test.go drives it, so nothing proves its answer "+
+				"carries Cache-Control: no-store. Add a case naming the token state it answers in.",
+				op)
+		}
+	}
+
+	// The reverse direction: a case naming a route the contract no longer
+	// publishes is dead weight that makes the census look larger than it is.
+	for op := range covered {
+		if !slicesContains(published, op) {
+			t.Errorf("publictokencache_integration_test.go drives %s, which the contract no "+
+				"longer publishes on an anonymous token prefix. Remove the case or restore the route.",
+				op)
+		}
+	}
+}
+
+// publishedTokenOperations reads every verb+path the contract declares under the
+// token prefixes, as "METHOD /path".
+func publishedTokenOperations(t *testing.T) []string {
+	t.Helper()
+	var doc struct {
+		Paths map[string]map[string]yaml.Node `yaml:"paths"`
+	}
+	raw, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing the contract: %v", err)
+	}
+
+	var ops []string
+	for path, item := range doc.Paths {
+		if !hasAnyPrefix(path, tokenPrefixes()) {
+			continue
+		}
+		for verb := range item {
+			if httpVerbs[strings.ToLower(verb)] {
+				ops = append(ops, strings.ToUpper(verb)+" "+path)
+			}
+		}
+	}
+	sort.Strings(ops)
+	return ops
+}
+
+// coveredTokenOperations reads the census file's own declaration of what it
+// drives. The list is a comment block rather than the case table, because the
+// table's paths carry live tokens and query strings that no static reader can
+// resolve back to a contract path — a match on those would be a match on
+// spelling, and the first case whose URL was built differently would read as a
+// missing route.
+//
+// The declaration is therefore the claim, and the integration test is what makes
+// it true. Both fail loudly on their own terms: this gate when the claim stops
+// matching the contract, the integration test when a claimed answer loses its
+// header.
+func coveredTokenOperations(t *testing.T) map[string]bool {
+	t.Helper()
+	const census = "internal/compose/integration/publictokencache_integration_test.go"
+	raw, err := os.ReadFile(census)
+	if err != nil {
+		t.Fatalf("reading the census: %v", err)
+	}
+
+	// Each declared pair is written as "//   COVERS: GET /public/confirm/{token}".
+	declared := regexp.MustCompile(`(?m)^//\s+COVERS:\s+([A-Z]+)\s+(\S+)\s*$`)
+	matches := declared.FindAllStringSubmatch(string(raw), -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s declares no COVERS line, so this gate has nothing to compare against the "+
+			"contract and would pass while covering nothing", census)
+	}
+
+	covered := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		covered[m[1]+" "+m[2]] = true
+	}
+	return covered
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func slicesContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/credentialpathcache.go
+++ b/backend/internal/compose/credentialpathcache.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every answer on a credential-bearing public path is uncacheable, whichever
+// layer produces it.
+//
+// A path that carries a credential in a URL segment answers from a bearer token
+// sitting in somebody's mailbox for weeks. A shared cache holding any of those
+// answers — the record itself, a consent state, or merely the fact that a token
+// is expired — hands the next reader through that cache somebody else's data.
+//
+// This runs OUTSIDE the session middleware for a reason that was a live bug: the
+// per-edge middlewares set the header themselves, but identity.Handlers.Middleware
+// wraps them and answers first when the installation is not bootstrapped or its
+// workspace cannot be resolved. Those two answers left with no Cache-Control at
+// all, and a census that only drove the routed paths could not see it. Setting
+// the header above everything that can answer is what makes "every answer"
+// true rather than "every answer we thought of".
+//
+// The prefixes come from shared/kernel/capabilitypath rather than being named
+// here: that package already decides which routes carry a credential, for the
+// neighbouring reason that such a path must not be written to a log. One
+// decision, two consequences.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
+)
+
+func noStoreOnCredentialPaths(next http.Handler) http.Handler {
+	prefixes := capabilitypath.CredentialPrefixes()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(r.URL.Path, prefix) {
+				w.Header().Set("Cache-Control", "no-store")
+				break
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/compose/credentialpathcache_test.go
+++ b/backend/internal/compose/credentialpathcache_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every credential-bearing public path answers with Cache-Control: no-store,
+// and the header is set before anything downstream can decide otherwise.
+//
+// The bug this pins is an ordering one, and it shipped: the two public token
+// edges each set the header themselves, but the session middleware wraps them
+// and answers first when the installation is not bootstrapped. That answer left
+// with no Cache-Control while the per-edge lines made the surface look covered,
+// and no test could see it because none drove a layer above the edges.
+//
+// So these cases drive the wrapper with a stand-in for everything below it,
+// including a stand-in that answers WITHOUT calling through — the shape of the
+// middleware that used to leak. The companion census in compose/integration
+// proves the same header survives the real handlers over live tokens.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
+)
+
+// answersWithout stands in for a middleware that answers on its own instead of
+// calling through — the session middleware's not-bootstrapped branch. If the
+// header were set below this, its answer would carry none.
+func answersWithout(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	})
+}
+
+func TestEveryCredentialPathAnswersUncacheable(t *testing.T) {
+	prefixes := capabilitypath.CredentialPrefixes()
+	if len(prefixes) == 0 {
+		t.Fatal("capabilitypath names no credential-bearing prefix, so this test has no subject " +
+			"and would pass however many uncacheable answers leaked")
+	}
+
+	// Driven for EVERY prefix the tree calls credential-bearing, not for a
+	// chosen few: adding one to capabilitypath brings it under this assertion
+	// automatically, which is the point of reading the list rather than
+	// restating it.
+	for _, prefix := range prefixes {
+		for _, tc := range []struct {
+			name   string
+			path   string
+			status int
+		}{
+			{"a live token's answer", prefix + "sometoken", http.StatusOK},
+			{"an answer from above the edges", prefix + "sometoken", http.StatusServiceUnavailable},
+			{"a refusal", prefix + "sometoken", http.StatusNotFound},
+			{"the bare prefix", prefix, http.StatusNotFound},
+			{"a deeper path", prefix + "sometoken/unsubscribe", http.StatusOK},
+		} {
+			rec := httptest.NewRecorder()
+			noStoreOnCredentialPaths(answersWithout(tc.status)).
+				ServeHTTP(rec, httptest.NewRequest("GET", tc.path, nil))
+
+			if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+				t.Errorf("%s: %s → %d carried Cache-Control %q, want %q — this path carries a "+
+					"credential in a segment and a shared cache holding its answer is a leak",
+					tc.name, capabilitypath.Redact(tc.path), tc.status, got, "no-store")
+			}
+		}
+	}
+}
+
+// ServeMux answers a path needing canonicalization with its own 307 BEFORE any
+// registered handler runs, and that redirect echoes the cleaned path — the
+// credential segment included — into a Location header. Mounted under the /v1
+// pattern rather than around the mux, this middleware never saw those answers,
+// and no case here would have said so.
+func TestTheMuxsOwnRedirectIsUncacheable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/v1/", answersWithout(http.StatusOK))
+	handler := noStoreOnCredentialPaths(mux)
+
+	for _, path := range []string{
+		"/v1/public/confirm//sometoken",
+		"/v1/public/confirm/a/../sometoken",
+		"/v1/public/preferences//sometoken",
+	} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+
+		if rec.Code != http.StatusTemporaryRedirect {
+			t.Fatalf("%s → %d, want a 307 — this case no longer drives the mux's own redirect, "+
+				"so it proves nothing about it", capabilitypath.Redact(path), rec.Code)
+		}
+		if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: the mux's redirect carried Cache-Control %q, want %q — its Location "+
+				"header echoes the cleaned path, credential segment and all",
+				capabilitypath.Redact(path), got, "no-store")
+		}
+	}
+}
+
+// The wiring itself, not a hand-built copy of it.
+//
+// Every other case in this file constructs noStoreOnCredentialPaths directly,
+// which assumes the very placement it claims to check: nest the wrapper back
+// UNDER the session middleware and they all still pass, while the
+// not-bootstrapped answer leaks again exactly as it did before. So this reads
+// the composed handler and asserts the order of the two names in the source
+// that wires them.
+//
+// A source assertion rather than a driven request because the alternative needs
+// an installation that is NOT bootstrapped, and every harness in the tree
+// bootstraps one — the state that leaked is the state no test environment
+// produces, which is why it survived.
+func TestTheHeaderIsWiredAboveTheSessionMiddleware(t *testing.T) {
+	raw, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("reading the wiring: %v", err)
+	}
+	wiring := string(raw)
+
+	wrapper := strings.Index(wiring, "noStoreOnCredentialPaths(mux)")
+	if wrapper < 0 {
+		t.Fatal("server.go no longer wraps the mux in noStoreOnCredentialPaths. If the header " +
+			"moved, it must still sit above every layer that can answer on a credential path — " +
+			"the session middleware and the mux's own canonicalization redirect included")
+	}
+
+	// The mux holds the session middleware, so wrapping the mux is what puts
+	// the header above it. Wrapping anything the mux mounts does not.
+	if strings.Contains(wiring, "authH.Middleware(noStoreOnCredentialPaths") {
+		t.Error("noStoreOnCredentialPaths is nested UNDER the session middleware, which answers " +
+			"a not-bootstrapped installation before reaching it — the leak this middleware exists " +
+			"to close")
+	}
+}
+
+// A path that carries no credential must not be stamped. A no-store on an
+// authenticated API answer would be harmless, but on a cacheable one it is a
+// regression nobody would attribute to this middleware.
+func TestAPathWithNoCredentialIsLeftAlone(t *testing.T) {
+	for _, path := range []string{
+		"/v1/people",
+		"/v1/public/rooms/peek",
+		"/v1/public",
+		"/healthz",
+	} {
+		rec := httptest.NewRecorder()
+		noStoreOnCredentialPaths(answersWithout(http.StatusOK)).
+			ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+
+		if got := rec.Header().Get("Cache-Control"); got != "" {
+			t.Errorf("%s was stamped Cache-Control %q, but it carries no credential segment",
+				path, got)
+		}
+	}
+}
+
+// The header must be set BEFORE the handler starts writing, and a recorder will
+// not show that on its own: httptest.ResponseRecorder happily accepts a header
+// written after WriteHeader, where a real connection has already flushed it. So
+// this drives a real server over a real socket, which is the only place the
+// ordering is observable — moving the Set below next.ServeHTTP passes every
+// recorder-based case in this file and fails here.
+func TestTheHeaderIsSetBeforeTheBodyStarts(t *testing.T) {
+	srv := httptest.NewServer(noStoreOnCredentialPaths(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write([]byte(`{"title":"not found"}`)); err != nil {
+				t.Errorf("writing the stand-in body: %v", err)
+			}
+		})))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/v1/public/confirm/sometoken")
+	if err != nil {
+		t.Fatalf("driving the credential path: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing the body: %v", err)
+		}
+	}()
+
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q over a real connection, want no-store — the header was set "+
+			"after the response began, where it no longer reaches the client", got)
+	}
+}
+
+// The header must reach the response even when the handler writes its own,
+// which is the case for every answer the API actually gives.
+func TestTheHeaderSurvivesAHandlerThatWritesItsOwn(t *testing.T) {
+	rec := httptest.NewRecorder()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := w.Write([]byte(`{"title":"not found"}`)); err != nil {
+			t.Errorf("writing the stand-in body: %v", err)
+		}
+	})
+	noStoreOnCredentialPaths(inner).
+		ServeHTTP(rec, httptest.NewRequest("GET", "/v1/public/confirm/sometoken", nil))
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("the wrapper displaced the handler's own header: Content-Type = %q", got)
+	}
+}

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
 )
 
 // publicCall hits the API with NO cookie jar and NO workspace header —
@@ -29,6 +30,20 @@ import (
 //
 //craft:ignore naked-any generic JSON test helper: body and out are each call's own shape
 func publicCall(t *testing.T, e *apptest.AppEnv, method, path string, body any, headers map[string]string, out any) int {
+	t.Helper()
+	status, _ := publicCallWithHeaders(t, e, method, path, body, headers, out)
+	return status
+}
+
+// publicCallWithHeaders is the one place that knows how an anonymous request is
+// shaped. publicCall drops the response headers because almost every caller only
+// asks about the status; publictokencache_integration_test.go asks about the
+// headers, and that question went unasked for as long as there was no way to
+// pose it. One builder, so a change to how these requests are made — a timeout,
+// a redirect policy, a header — cannot reach one caller and miss the other.
+//
+//craft:ignore naked-any generic JSON test helper: body and out are each call's own shape
+func publicCallWithHeaders(t *testing.T, e *apptest.AppEnv, method, path string, body any, headers map[string]string, out any) (int, http.Header) {
 	t.Helper()
 	var reqBody io.Reader
 	if body != nil {
@@ -48,7 +63,7 @@ func publicCall(t *testing.T, e *apptest.AppEnv, method, path string, body any, 
 	}
 	resp, err := e.TS.Client().Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
-		t.Fatalf("%s %s: %v", method, path, err)
+		t.Fatalf("%s %s: %v", method, capabilitypath.Redact(path), err)
 	}
 	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
@@ -57,10 +72,10 @@ func publicCall(t *testing.T, e *apptest.AppEnv, method, path string, body any, 
 	}
 	if out != nil && len(raw) > 0 {
 		if err := json.Unmarshal(raw, out); err != nil {
-			t.Fatalf("%s %s: decoding %q: %v", method, path, raw, err)
+			t.Fatalf("%s %s: decoding %q: %v", method, capabilitypath.Redact(path), raw, err)
 		}
 	}
-	return resp.StatusCode
+	return resp.StatusCode, resp.Header
 }
 
 // bookingSlug reads the bootstrap-seeded page slug through the owner

--- a/backend/internal/compose/integration/publictokencache_integration_test.go
+++ b/backend/internal/compose/integration/publictokencache_integration_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Every answer on the two anonymous token prefixes is uncacheable.
+//
+// /v1/public/preferences/* and /v1/public/confirm/* derive their whole
+// response from a bearer token that lives in somebody's mailbox for weeks. A
+// shared cache holding ANY of those answers hands the next reader through that
+// cache somebody else's consent state or somebody else's record. Both edges set
+// Cache-Control: no-store before their first refusal for that reason, and until
+// this file nothing asserted it: deleting either line left the suite green.
+//
+// So the assertion is a census, not a spot check. Each case below drives a real
+// request through the real stack and every one of them is checked, because the
+// header's whole value is that it holds on the answers nobody thought about —
+// the rate-limited one, the not-found one, the wrong-verb one. A test that
+// checked only the happy path would pass while the refusals leaked.
+//
+// This file covers the answers the ROUTER produces, over live tokens in every
+// state one can be in. The answers produced ABOVE the router — the session
+// middleware's, which reply before any of this is reached — are covered by
+// compose/credentialpathcache_test.go, against the single middleware that now
+// sets the header for both. Splitting them that way is deliberate: one claim is
+// about real token states and needs a database, the other is about ordering and
+// must not.
+//
+// The routes this file claims to cover are declared below, one COVERS line each.
+// gates/publictokencachecensus_test.go reads those lines and compares them with
+// what backend/api/crm.yaml actually publishes under the two prefixes, in both
+// directions. Publish a sixth route without a case here and that gate fails, so
+// the census cannot quietly shrink to cover less than it says it does.
+//
+//   COVERS: GET /public/preferences/{token}
+//   COVERS: PUT /public/preferences/{token}
+//   COVERS: POST /public/preferences/{token}/unsubscribe
+//   COVERS: GET /public/confirm/{token}
+//   COVERS: POST /public/confirm/{token}
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/capabilitypath"
+)
+
+// tokenCase is one answer the surface can give, named for the state that
+// produces it so a failure says which answer leaked rather than which line did.
+type tokenCase struct {
+	name   string
+	method string
+	path   string
+	body   any
+}
+
+// assertNoStore drives every case and reports EVERY failure, not the first.
+// A partial answer here would send somebody back for a second run to discover
+// the next uncacheable response they also lost.
+// It returns the contract operations the cases actually drove, so a test can
+// prove its COVERS claim against its own table rather than beside it.
+func assertNoStore(t *testing.T, e *apptest.AppEnv, cases []tokenCase) map[string]bool {
+	t.Helper()
+	driven := make(map[string]bool, len(cases))
+	for _, tc := range cases {
+		driven[tc.method+" "+strings.TrimPrefix(redactToken(tc.path), "/v1")] = true
+		status, headers := publicCallWithHeaders(t, e, tc.method, tc.path, tc.body, nil, nil)
+		if got := headers.Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: %s %s → %d carried Cache-Control %q, want %q — this answer is "+
+				"derived from a mailed bearer token and a shared cache holding it is a leak",
+				tc.name, tc.method, redactToken(tc.path), status, got, "no-store")
+		}
+	}
+	return driven
+}
+
+// assertClaimed proves this file's COVERS declarations are true of its own case
+// tables. The gate compares those declarations with the contract; this compares
+// them with what the tests really drive. Without it the declarations could drift
+// into a claim no request backs, and the gate would keep passing on the strength
+// of a comment.
+//
+// The claims are READ from the COVERS lines rather than restated as an argument.
+// A hand-passed list would be a third copy: add a route, a COVERS line and no
+// case, and a restated list would keep checking the old set while both the gate
+// and this assertion reported success.
+func assertClaimed(t *testing.T, driven map[string]bool, prefix string) {
+	t.Helper()
+	claimed := declaredCovers(t, prefix)
+	if len(claimed) == 0 {
+		t.Fatalf("no COVERS line names %s, so this assertion has no subject and would pass "+
+			"however little the cases drove", prefix)
+	}
+	for _, op := range claimed {
+		if !driven[op] {
+			t.Errorf("this file declares COVERS %s but no case drove it — the declaration the "+
+				"census gate reads is not backed by a request", op)
+		}
+	}
+}
+
+// declaredCovers reads this file's own COVERS lines, keeping those naming the
+// given path prefix. Reading the source is what makes the declaration and the
+// cases one claim rather than two that can disagree.
+func declaredCovers(t *testing.T, prefix string) []string {
+	t.Helper()
+	raw, err := os.ReadFile("publictokencache_integration_test.go")
+	if err != nil {
+		t.Fatalf("reading this file's own COVERS declarations: %v", err)
+	}
+	var claimed []string
+	for _, m := range regexp.MustCompile(`(?m)^//\s+COVERS:\s+([A-Z]+)\s+(\S+)\s*$`).
+		FindAllStringSubmatch(string(raw), -1) {
+		if strings.HasPrefix(m[2], prefix) {
+			claimed = append(claimed, m[1]+" "+m[2])
+		}
+	}
+	return claimed
+}
+
+// redactToken keeps a live token out of the test log and, in doing so, turns a
+// driven URL back into the contract path it exercised, which is what lets a test
+// check its own COVERS claim against what it really drives.
+//
+// The prefix list and the replacement both come from capabilitypath, which
+// already decides which segments are credentials. A second copy here would drift
+// the first time a prefix is added there — and the placeholder is normalized to
+// the contract's own {token} spelling rather than re-deciding anything.
+func redactToken(path string) string {
+	withoutQuery := strings.SplitN(path, "?", 2)[0]
+	return strings.Replace(capabilitypath.Redact(withoutQuery), "[redacted]", "{token}", 1)
+}
+
+// The preference edge, across every state its token can be in.
+func TestEveryPreferenceAnswerIsUncacheable(t *testing.T) {
+	c := setupConsent(t)
+	grantPurpose(t, c, createNewsletterPurpose(t, c))
+	live := sendAndAssertUnsubscribeLink(t, c)
+
+	driven := assertNoStore(t, c.AppEnv, []tokenCase{
+		{"a live token's view", "GET", "/v1/public/preferences/" + live, nil},
+		{
+			"a live token's one-click withdrawal", "POST",
+			"/v1/public/preferences/" + live + "/unsubscribe?purpose=newsletter", nil,
+		},
+		{
+			"a live token's saved choices", "PUT", "/v1/public/preferences/" + live,
+			AnyMap{"choices": []AnyMap{{
+				"purpose_key": "newsletter", "state": "granted",
+				"wording": "Yes, you may contact me about this.",
+			}}},
+		},
+		{
+			"a refused save", "PUT", "/v1/public/preferences/" + live,
+			AnyMap{"choices": []AnyMap{}},
+		},
+		{"an unknown token", "GET", "/v1/public/preferences/pref_does_not_exist", nil},
+		{
+			"an unknown token's withdrawal", "POST",
+			"/v1/public/preferences/pref_does_not_exist/unsubscribe?purpose=newsletter", nil,
+		},
+		{"an empty token", "GET", "/v1/public/preferences/", nil},
+		{"a GET on the one-click verb", "GET", "/v1/public/preferences/" + live + "/unsubscribe", nil},
+	})
+	assertClaimed(t, driven, "/public/preferences/")
+
+	// A revoked token answers as absent, and that answer is a fact about
+	// somebody too: it says a token that once existed no longer does.
+	revokePreferenceTokens(t, c)
+	assertNoStore(t, c.AppEnv, []tokenCase{
+		{"a revoked token", "GET", "/v1/public/preferences/" + live, nil},
+		{
+			"a revoked token's withdrawal", "POST",
+			"/v1/public/preferences/" + live + "/unsubscribe?purpose=newsletter", nil,
+		},
+	})
+}
+
+// The confirm edge, across every state its token can be in.
+//
+// Its GET discloses the person's stored record rather than a list of switches,
+// so a cached answer here is a larger disclosure than on the preference edge.
+func TestEveryConfirmAnswerIsUncacheable(t *testing.T) {
+	c := setupConsent(t)
+
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
+	}
+	live := confirmLinkToken(t, c.AppEnv)
+
+	driven := assertNoStore(t, c.AppEnv, []tokenCase{
+		{"a live link's record view", "GET", "/v1/public/confirm/" + live, nil},
+		{"an unknown token", "GET", "/v1/public/confirm/confirm_does_not_exist", nil},
+		{
+			"an unknown token's answer", "POST", "/v1/public/confirm/confirm_does_not_exist",
+			AnyMap{"marketing_choice": "granted", "marketing_wording": "Yes."},
+		},
+		{"an empty token", "GET", "/v1/public/confirm/", nil},
+	})
+	assertClaimed(t, driven, "/public/confirm/")
+
+	// Spending the link is the one answer the subject actually acts on, and
+	// the spent link's refusal that follows it.
+	assertNoStore(t, c.AppEnv, []tokenCase{
+		{
+			"the subject spending their link", "POST", "/v1/public/confirm/" + live,
+			AnyMap{"marketing_choice": "granted", "marketing_wording": "Yes, send me product news."},
+		},
+		{"a consumed link", "GET", "/v1/public/confirm/" + live, nil},
+		{
+			"a consumed link replayed", "POST", "/v1/public/confirm/" + live,
+			AnyMap{"marketing_choice": "granted", "marketing_wording": "Yes, send me product news."},
+		},
+	})
+
+	// An expired link is aged in the database rather than waited for: the TTL
+	// is days, and a real-clock test would be a flake by construction.
+	expired := freshExpiredConfirmToken(t, c)
+	assertNoStore(t, c.AppEnv, []tokenCase{
+		{"an expired link", "GET", "/v1/public/confirm/" + expired, nil},
+		{
+			"an expired link answered", "POST", "/v1/public/confirm/" + expired,
+			AnyMap{"marketing_choice": "granted", "marketing_wording": "Yes."},
+		},
+	})
+}
+
+// The answer the session middleware gives before either edge is reached.
+//
+// This is the leak that shipped: identity.Handlers.Middleware wraps the public
+// edges and answers a not-bootstrapped installation with a 503 of its own, so
+// while each edge set the header itself, that answer carried none. No test could
+// see it, because every harness in the tree bootstraps a workspace first — the
+// state that leaked is the one no test environment produces.
+//
+// So this one deliberately does not bootstrap. It is also the case that proves
+// the header is wired ABOVE the session middleware rather than below it: nest
+// the wrapper back under and this fails while every hand-built unit case in
+// compose/credentialpathcache_test.go still passes.
+func TestANotBootstrappedInstallationAnswersUncacheable(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t)
+	// No BootstrapWorkspaceSession: the installation has no active
+	// organization, which is what makes the session middleware answer first.
+
+	for _, path := range []string{
+		"/v1/public/confirm/sometoken",
+		"/v1/public/preferences/sometoken",
+	} {
+		status, headers := publicCallWithHeaders(t, e, "GET", path, nil, nil, nil)
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("%s → %d, want 503 — this case did not reach the answer the session "+
+				"middleware gives, so its header assertion proves nothing",
+				capabilitypath.Redact(path), status)
+		}
+		if got := headers.Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: the not-bootstrapped answer carried Cache-Control %q, want %q — it is "+
+				"given above both public edges, so a header either edge sets never reaches it",
+				capabilitypath.Redact(path), got, "no-store")
+		}
+	}
+}
+
+// Both edges refuse a flood before they reach any handler, and that refusal is
+// the answer most likely to be served from a cache in front of the API — it is
+// cheap, repeated, and identical. It is also the one a reviewer would not think
+// to check, which is exactly why it is here.
+func TestARateLimitedAnswerIsUncacheable(t *testing.T) {
+	c := setupConsent(t)
+
+	for _, edge := range []struct{ name, path string }{
+		{"the preference edge", "/v1/public/preferences/pref_flood/unsubscribe?purpose=newsletter"},
+		{"the confirm edge", "/v1/public/confirm/confirm_flood"},
+	} {
+		var status int
+		var headers http.Header
+		// The per-token brake is 20 a minute on both edges; this outruns it.
+		for i := 0; i < 40 && status != http.StatusTooManyRequests; i++ {
+			status, headers = publicCallWithHeaders(t, c.AppEnv, "POST", edge.path,
+				AnyMap{"marketing_choice": "granted", "marketing_wording": "Yes."}, nil, nil)
+		}
+		if status != http.StatusTooManyRequests {
+			t.Fatalf("%s never throttled (last %d), so this test asserts nothing about a "+
+				"throttled answer", edge.name, status)
+		}
+		if got := headers.Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: the throttled answer carried Cache-Control %q, want %q",
+				edge.name, got, "no-store")
+		}
+	}
+}
+
+// revokePreferenceTokens retires every live preference token the way a real
+// revocation does, through the column the resolver reads.
+func revokePreferenceTokens(t *testing.T, c *consentEnv) {
+	t.Helper()
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE preference_token SET revoked_at = now() WHERE revoked_at IS NULL`); err != nil {
+		t.Fatalf("revoking the preference tokens: %v", err)
+	}
+}
+
+// freshExpiredConfirmToken mints a link and ages it past its TTL in place. The
+// token itself is real and server-issued; only its clock is moved.
+func freshExpiredConfirmToken(t *testing.T, c *consentEnv) string {
+	t.Helper()
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("minting a link to expire → %d", status)
+	}
+	token := confirmLinkToken(t, c.AppEnv)
+	if _, err := c.Owner.Exec(context.Background(),
+		`UPDATE confirm_token SET expires_at = now() - interval '1 day' WHERE consumed_at IS NULL`); err != nil {
+		t.Fatalf("ageing the confirm link past its TTL: %v", err)
+	}
+	return token
+}

--- a/backend/internal/compose/publicconfirm.go
+++ b/backend/internal/compose/publicconfirm.go
@@ -53,14 +53,11 @@ func publicConfirm(limits publicConfirmLimiters) func(http.Handler) http.Handler
 				next.ServeHTTP(w, r)
 				return
 			}
-			// Set before any refusal below, for the preference edge's reason
-			// and with more at stake: every response on this prefix is derived
-			// from a bearer token that lives in somebody's mailbox, and a GET
-			// here discloses that person's record rather than a list of
-			// switches. A shared cache holding any of them is a leak, so the
-			// rate-limited and not-found answers are as uncacheable as the
-			// successful one.
-			w.Header().Set("Cache-Control", "no-store")
+			// Cache-Control: no-store is NOT set here. It is set by
+			// noStoreOnCredentialPaths, which runs above the session
+			// middleware — the layer that answers first, and that used to
+			// answer a not-bootstrapped installation with no header at all
+			// while this line made the surface look covered.
 			token := strings.SplitN(strings.TrimPrefix(r.URL.Path, publicConfirmPrefix), "/", 2)[0]
 			if token == "" {
 				httperr.Write(w, r, apperrors.ErrNotFound)

--- a/backend/internal/compose/publicpreferences.go
+++ b/backend/internal/compose/publicpreferences.go
@@ -50,12 +50,9 @@ func publicPreferences(store *consent.Store, limits publicPreferenceLimiters) fu
 				next.ServeHTTP(w, r)
 				return
 			}
-			// Set before any refusal below, so a rate-limit or
-			// not-found answer is no more cacheable than a successful
-			// one: every response on this prefix is derived from a
-			// bearer token that lives in somebody's mailbox for thirty
-			// days, and a shared cache holding any of them is a leak.
-			w.Header().Set("Cache-Control", "no-store")
+			// Cache-Control: no-store is NOT set here — see the same note
+			// on the confirm edge. One writer, above everything that can
+			// answer on these prefixes.
 			token := strings.SplitN(strings.TrimPrefix(r.URL.Path, publicPreferencesPrefix), "/", 2)[0]
 			if token == "" {
 				httperr.Write(w, r, apperrors.ErrNotFound)

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -100,9 +100,14 @@ func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	// they share its singleton cache and its clock.
 	mux := operationalMux(srv, pool, log, identitySvc, api)
 
+	// noStoreOnCredentialPaths wraps the MUX, not the /v1 mount inside it.
+	// ServeMux answers a path needing canonicalization ("//token", "a/../b")
+	// with its own 307 before any registered handler runs, and that redirect
+	// echoes the cleaned path — credential segment and all — into a Location
+	// header. Mounted deeper, the middleware never saw those answers.
 	return httpserver.RecoverPanics(log,
 		httpserver.LimitBodies(bodyCeilingFor(uploadCeilings(srv.uploadLimits)),
-			httpserver.SecureHeaders(mux)))
+			httpserver.SecureHeaders(noStoreOnCredentialPaths(mux))))
 }
 
 // newServer assembles the module handler sets. Every cross-module edge is

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -116,7 +116,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (121)
+## Census (122)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -212,6 +212,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `projectionedgereaders_test.go` | H2 | The projection tier's read census. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |
 | `promptvoice_test.go` | H1 | Every prompt either speaks in Margince's one voice or says why it does not. |
+| `publictokencachecensus_test.go` | H3 | The no-store census covers every route the contract publishes on the two anonymous token prefixes. |
 | `recencyorigins_test.go` | H2 | Every reading of "when was this record last touched" excludes the origins the system wrote itself. |
 | `registrarparity_test.go` | H2 | A registry that claims to be complete must be. |
 | `remediationnotbuyeractivity_test.go` | H2 | Remediation work must never read as buyer engagement. |


### PR DESCRIPTION
The two anonymous token surfaces — `/v1/public/preferences/*` and `/v1/public/confirm/*` — each set `Cache-Control: no-store` in their own middleware, and nothing asserted it. Deleting either line left the whole suite green, on a surface whose every response is derived from a bearer token that sits in somebody's mailbox for weeks.

Writing the test found the header was not in fact set on every answer.

**Two layers answer before the public edges are reached.** `identity.Handlers.Middleware` wraps both edges and replies first when the installation is not bootstrapped or its workspace cannot be resolved — those replies carried no `Cache-Control` at all. `http.ServeMux` answers earlier still: a path needing canonicalization (`//token`, `a/../b`) gets a 307 whose `Location` header echoes the cleaned path with the credential segment in it.

**One writer, above everything that can answer.** The two per-edge `Set` calls are replaced by `noStoreOnCredentialPaths`, wrapping the mux in `compose/server.go`. It takes its prefix list from `capabilitypath` — the package that already decides which paths carry a credential, for the neighbouring reason that such a path must not be written to a log. One decision, two consequences.

## Three tests, each proving what the others cannot

- **`compose/credentialpathcache_test.go`** drives the wrapper for every prefix `capabilitypath` names, including the mux's own redirect and one case over a real socket. A `httptest.ResponseRecorder` accepts a header written after `WriteHeader`; a real connection has already flushed it, so the socket is the only place the ordering is observable.
- **`compose/integration/publictokencache_integration_test.go`** drives live tokens through the booted stack in every state one can be in — valid, unknown, revoked, consumed, expired, throttled — plus a deliberately un-bootstrapped installation. That last is the state that leaked, and the one no harness in the tree produces, which is why it survived.
- **`gates/publictokencachecensus_test.go`** derives the route list from `crm.yaml` and fails in both directions, so the census cannot quietly shrink to cover less than it claims.

Every guard was mutation-checked one clause at a time, including re-nesting the wrapper back under the session middleware: the integration census still passes, and the two tests written for that leak both fail.

`publicCall` gains a header-returning sibling rather than a second copy of itself, and both now redact the credential segment before naming a path in a failure message.

## Note on main

`TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on clean `origin/main` (`design-system/composed.tsx` reads `EmailSummary` and draws its own markup). It is unrelated to this diff, reproduces on a detached checkout of `origin/main`, and no open PR covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every answer on the anonymous token surfaces (`/v1/public/preferences/*` and `/v1/public/confirm/*`) is now uncacheable. Previously each edge set `Cache-Control: no-store` in its own middleware, but the session middleware and `http.ServeMux` could answer first with no header; now a single `noStoreOnCredentialPaths` wrapper sits above everything that can answer and takes its prefix list from `capabilitypath`.

**Tests**
- `compose/credentialpathcache_test.go` drives the wrapper for every `capabilitypath` prefix, including the mux's own 307 and a real socket, where the header-before-body ordering is observable.
- `compose/integration/publictokencache_integration_test.go` drives live tokens in every state — valid, unknown, revoked, consumed, expired, throttled — plus a deliberately un-bootstrapped installation.
- `gates/publictokencachecensus_test.go` derives the route list from `crm.yaml` and fails in both directions, so the census can't quietly shrink.

`publicCall` gains a header-returning sibling, and both redact the credential segment before naming a path in failure messages. Booking slug paths also get the header now, since they share `capabilitypath`'s credential list. Note: `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on clean `origin/main`, unrelated to this diff.

<sup>Written for commit 6a1323445d51472e1cd2fe71275772159f91b622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

