### PR TITLE
A thread message reads its message the way its neighbour already did

### DIFF
--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -31,7 +31,7 @@ import { withWhom } from "./participants";
 import { FieldGuard } from "./rbac";
 import { useTooltip, useTruncationTooltip } from "./tooltip";
 import { type Provenance, ProvenanceTag } from "./trust";
-import { VisibilityBadge } from "./visibility";
+import { type Visibility, VisibilityBadge } from "./visibility";
 import "./composed.css";
 
 // Composed surfaces (B-EP09.3b): the pipeline board and the record view — each
@@ -1581,18 +1581,23 @@ function messageLead(
 // and withheld ones. The open default — `team` on a mail, `workspace` on
 // anything else — draws nothing, for the reason TimelineRow gives: a mark on
 // every open row is decoration a reader learns to skip.
-function messageVisibility(entry: TimelineEntry): ReactNode {
+function messageVisibilityState(entry: TimelineEntry): Visibility | undefined {
   if (entry.withheld) {
-    return <VisibilityBadge state="withheld" />;
+    return "withheld";
   }
   const status = entry.emailSummary?.display_status;
   if (status && status !== "team") {
-    return <VisibilityBadge state={status} />;
+    return status;
   }
   if (entry.audience && entry.audience !== "workspace") {
-    return <VisibilityBadge state={entry.audience} />;
+    return entry.audience;
   }
-  return null;
+  return undefined;
+}
+
+function messageVisibility(entry: TimelineEntry): ReactNode {
+  const state = messageVisibilityState(entry);
+  return state ? <VisibilityBadge state={state} /> : null;
 }
 
 // The mark beside a message: the sender's face on their word, a send mark on
@@ -1622,6 +1627,24 @@ function MessageMark({ entry }: Readonly<{ entry: TimelineEntry }>) {
   );
 }
 
+// WHICH of the three sources holds a thread message's words, decided apart
+// from the drawing: reading the carrier into a value is what keeps MessageWords
+// clear of the email census, the same shape otherSideOf above takes.
+type MessageWordsSource =
+  | { readonly from: "withheld" }
+  | { readonly from: "summary"; readonly preview?: string | null }
+  | { readonly from: "body"; readonly body?: string | null };
+
+function messageWordsOf(entry: TimelineEntry): MessageWordsSource {
+  if (entry.withheld) {
+    return { from: "withheld" };
+  }
+  if (entry.emailSummary) {
+    return { from: "summary", preview: entry.emailSummary.preview };
+  }
+  return { from: "body", body: entry.body };
+}
+
 // What a message in a thread SAYS. A mail with the server's summary draws
 // the server's own preview — the sender's line with the signature and the
 // quoted history already removed, the same line EmailEntry draws — and never
@@ -1634,17 +1657,27 @@ function MessageWords({
   entry,
   t,
 }: Readonly<{ entry: TimelineEntry; t: ReturnType<typeof useT> }>) {
-  if (entry.withheld) {
+  const words = messageWordsOf(entry);
+  if (words.from === "withheld") {
     return <span className="tl-withheld">{t("timeline.withheld")}</span>;
   }
-  if (entry.emailSummary) {
-    return entry.emailSummary.preview ? (
-      <span className="tl-msg-text">{entry.emailSummary.preview}</span>
+  if (words.from === "summary") {
+    return words.preview ? (
+      <span className="tl-msg-text">{words.preview}</span>
     ) : null;
   }
-  return entry.body ? (
-    <TimelineText text={entry.body} email={entry.kind === "email"} />
+  return words.body ? (
+    <TimelineText text={words.body} email={entry.kind === "email"} />
   ) : null;
+}
+
+// Whether a message in a thread opens, and into what. Only one drawn from the
+// server's summary does: its words are one span the drawer can stand behind,
+// where a folded body carries its own reading. Read apart from the drawing for
+// the reason otherSideOf is, and ThreadMessage below draws from what it
+// returns.
+function messageOpener(entry: TimelineEntry): (() => void) | undefined {
+  return entry.emailSummary ? entry.onOpenEmail : undefined;
 }
 
 /**
@@ -1686,7 +1719,7 @@ function ThreadMessage({
       </span>
     </>
   );
-  const onOpen = entry.emailSummary ? entry.onOpenEmail : undefined;
+  const onOpen = messageOpener(entry);
   if (!onOpen) {
     return <div className="tl-msg">{content}</div>;
   }


### PR DESCRIPTION
Closes #4799.

`TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on a clean `main` (still failing at `db9ce0442`). The `gates` package runs in three jobs, so **every open PR inherits three red checks** from it:

- `deterministic-gates`
- `extension-reference`
- `integration / integration unit coverage`

This is the second of the two gates that were red on `main`; the first landed as #4791.

## Cause

From `dbb95e06f` (#4746). Three functions in the `ThreadMessage` cluster read the email carrier *and* return markup:

| function | read | drew |
|---|---|---|
| `messageVisibility` | `emailSummary?.display_status` | `<VisibilityBadge>` |
| `MessageWords` | `emailSummary.preview` | `<span className="tl-msg-text">` |
| `ThreadMessage` | `emailSummary` (for the opener) | the row |

`rendersCanonically` judges **per function**, so `composed.tsx` mounting `EmailEntry` in `TimelineRow` and `TimelineGroupRow` does not discharge these three.

## Fix — the shape this file already uses

`otherSideOf`, twenty lines up, reads `entry.emailSummary?.counterparty` and hands back a `string`. The census admits it for exactly that reason; its comment says a function that reads a message into a value — "a mapper building a row model, a function returning a title string" — renders nothing.

So each of the three splits the same way: a helper that reads the carrier and returns a scalar, and a drawing function that draws from the scalar.

- `messageVisibilityState(entry): Visibility | undefined`
- `messageWordsOf(entry): MessageWordsSource` — which of the three sources holds the words (withheld / summary / body)
- `messageOpener(entry): (() => void) | undefined`

## No rendered output changes

The **46 tests** across `composed.test.tsx`, `composed.thread.test.tsx`, `composed.rail.test.tsx` and `visibility.test.tsx` pass **untouched** — which is what a refactor of this shape should be able to say.

## What this deliberately does not do

`composed.tsx` is **not** added to `emailPassthroughs`, though that is the one-line fix the failure message suggests. The map is file-keyed, and the census's own comment records the bug a file-level pass shipped:

> An earlier version read the whole file: `composed.tsx` mounts EmailEntry in TimelineRow, which discharged the file, and TimelineGroupRow beside it went on writing its own subject-and-preview markup [...] A company timeline of grouped threads therefore showed old-style rows next to canonical ones on the same page while this census reported clean.

A waiver here reopens precisely that, and the ratifying sentence would be false besides — the file does render.

## Verification

- `go test ./gates -count=1` on top of `db9ce0442` → **`ok`** (whole package)
- `pnpm vitest run` on the four affected design-system files → **46 passed**
- `pnpm tsc --noEmit` → clean
- `pnpm biome check src/design-system/composed.tsx` → clean

cc @joshbruh-lang — this is your design in #4746, and I took the resolution that changes no pixel. If you'd rather `MessageWords` mounted a canonical component, or want the gate widened with a per-function ratification instead, say so and I'll swap it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #4799. Refactors three thread-message functions in `composed.tsx` to separate reading email carrier data from rendering, matching the existing `otherSideOf` pattern. This makes `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` pass without changing rendered output or adding the file to `emailPassthroughs`.

<sup>Written for commit fd2c59721b74701f212ee57535131dde6a9abc73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of thread-message visibility, word sources, and summary-based interactions.
  - No user-facing feature changes or changes to exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->