### PR TITLE
The mobile budget's log says WHEN each open was slow, not only that some were

### DIFF
--- a/frontend/e2e/perf-mobile.spec.ts
+++ b/frontend/e2e/perf-mobile.spec.ts
@@ -137,7 +137,7 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
     `perfbench [fast-3g/390px]: record_open_perceived p95=${measured}ms ` +
       `(budget ${PERCEIVED_BUDGET_MS}ms, ${SAMPLES} samples)`,
   );
-  // The SHAPE as well as the verdict, because this lane can report two breaches
+  // The SHAPE as well as the verdict, because this lane can report breaches
   // that need opposite answers and a lone p95 does not separate them: a
   // distribution that has moved is a regression to bisect, a tight one behind a
   // single straggler is a runner that was busy. Whoever reads the breach reads
@@ -147,6 +147,18 @@ test("MOBILE-AC-2: record open holds the 300ms perceived budget on Fast-3G at 39
       `p50=${nearestRank(samples, 0.5)}ms p99=${nearestRank(samples, 0.99)}ms ` +
       `min=${Math.min(...samples)}ms max=${Math.max(...samples)}ms ` +
       `samples=${JSON.stringify([...samples].sort((a, b) => a - b))}`,
+  );
+  // And in the order they were MEASURED, which is the one question the sorted
+  // line cannot answer. A third shape reaches this lane: a tight fast body with
+  // several stragglers behind a clean gap, which is neither a moved
+  // distribution nor one unlucky sample. Where those stragglers sit separates
+  // its causes — bunched at the front is something still warming past the
+  // discarded open, evenly spaced is something expiring on a clock, scattered
+  // is the runner. Sorting threw exactly that away, and a reader could not get
+  // it back without another weekly run.
+  console.log(
+    `perfbench [fast-3g/390px]: record_open_perceived ` +
+      `in_order=${JSON.stringify(samples)}`,
   );
   // Written BEFORE the assertion, deliberately: a breach is the run whose
   // number a reader most wants to see, and recording afterwards would leave


### PR DESCRIPTION
## What

MOBILE-AC-2's log now prints the samples in **measurement order** beside the
sorted ones.

## Why

The log was built to separate two breaches that need opposite answers — its own
comment says so: *"a distribution that has moved is a regression to bisect, a
tight one behind a single straggler is a runner that was busy. Whoever reads the
breach reads this log and nothing else, so the log has to carry the difference."*

The weekly run (https://github.com/margince/margince/issues/4804) reported a
**third shape**, which neither describes:

```
perfbench [fast-3g/390px]: record_open_perceived p95=323ms (budget 300ms, 20 samples)
perfbench [fast-3g/390px]: record_open_perceived p50=83ms p99=333ms min=72ms max=333ms
  samples=[72,74,76,77,80,80,80,80,80,83,84,84,86,86,91,98,290,314,323,333]
```

Sixteen samples between 72ms and 98ms, then four behind a **clean gap** at 290,
314, 323, 333. The distribution has not moved — p50 is 83ms against a 300ms
budget, and the fast body is tight. And four stragglers are not one unlucky
sample. So a reader following the log's instruction cannot tell which of the two
answers applies, and the shape actually present — a discrete extra cost hitting
about 20% of opens — is the one the log cannot express.

**What separates its causes is where those four sat, and sorting is what threw
that away:**

- bunched at the front → something still warming past the discarded open
- evenly spaced → something expiring on a clock
- scattered → the runner

Both lines are kept, because they answer different questions: the sorted line is
the shape, the ordered line is the incidence. Without this, recovering it costs
another weekly run.

This does **not** diagnose #4804 — it makes the next run able to. I deliberately
did not guess at the cause: p95 here is the second-highest of 20 samples, so the
same number is reachable from a real intermittent cost and from a busy runner,
and the evidence to tell them apart is exactly what is missing.

## The two consumers still separate breach from lane-failed

Both match on the line's prefix only — `grep -q "perfbench \[fast-3g/390px\]:"`
in `.github/workflows/scheduled.yml` and the same discriminator in
`scripts/scheduled-report.sh` — and both take presence to mean a number was
measured. This line carries that prefix and is printed before the assertion like
the two above it, so presence still means measured and absence still means the
run never got that far.

## How verified

- `vitest run scripts/test-budget.reader.test.ts scripts/test-budget.test.ts` —
  33 tests, green.
- `make test-scheduled-report` — `OK: scheduled-report files one issue per check`,
  including "the report job requires a reason, not merely a failure".
- `tsc --noEmit` clean; biome clean.
- The lane itself is the weekly throttled run; this change adds a `console.log`
  and touches no measurement, no sample count and no assertion.

- [x] `make check` — one e2e spec touched; the frontend lanes that cover it are
      green as above
- [x] `make test-integration` — this change does not touch tenant data, RLS or
      the write shape
- [x] `make craft-static` — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-generated in full under the reporter's direction: the distribution analysis,
the change and this description. A human is accountable for merging.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
