### PR TITLE
fix(frontend): a thread member draws scalars, not the email carrier

### DIFF
--- a/frontend/src/design-system/activitytimeline.tsx
+++ b/frontend/src/design-system/activitytimeline.tsx
@@ -129,6 +129,14 @@ export function activityTimeline(
       // exactly when kind=email, so the row branches on the field and every
       // other kind keeps the reading it had.
       emailSummary: activity.email_summary ?? undefined,
+      // The preview as a scalar beside the carrier, for the thread member that
+      // draws its words inline. Present exactly when the row is a message, so
+      // the branch that used to read the carrier reads this instead and the
+      // contract type stays with the canonical components.
+      messagePreview: activity.email_summary
+        ? (activity.email_summary.preview ?? "")
+        : undefined,
+      messageVisibility: activity.email_summary?.display_status,
       audience: activity.audience,
       withheld: activity.content_state === "withheld",
       threadKey: activity.thread_key,

--- a/frontend/src/design-system/composed.thread.test.tsx
+++ b/frontend/src/design-system/composed.thread.test.tsx
@@ -20,13 +20,19 @@ afterEach(cleanup);
 const render = (ui: ReactNode) =>
   rtlRender(<LocaleProvider initial="en">{ui}</LocaleProvider>);
 
+// entry stands in for activitytimeline's mapper, and derives the message
+// scalars from the carrier the way it does. A test that set the carrier alone
+// would build a row production never builds, and then assert on it.
 function entry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+  const summary = overrides.emailSummary;
   return {
     id: overrides.id ?? "m1",
     kind: "email",
     title: "Re: Renewal",
     atIso: "2026-07-03T10:00:00Z",
     provenance: { kind: "connector", connector: "gmail" },
+    messagePreview: summary ? (summary.preview ?? "") : undefined,
+    messageVisibility: summary?.display_status,
     ...overrides,
   };
 }

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -723,6 +723,23 @@ export type TimelineEntry = {
    */
   emailSummary?: EmailSummary;
   /**
+   * What a THREAD MEMBER draws, as scalars: its preview text, and who may read
+   * it. `messagePreview` is present exactly when the row is a message, and
+   * empty when that message has no preview to show — so it answers "is this a
+   * message?" as well as "what does it say?".
+   *
+   * Duplicates of fields inside `emailSummary` on purpose. A thread member
+   * draws its words inline rather than mounting the canonical row
+   * (ThreadMessage below says why), and a sub-part of this file reaching into
+   * the contract type to draw it is how the canonical components stop being
+   * the one place a message is drawn — a company timeline once showed
+   * old-style rows beside canonical ones on the same page while the census
+   * read clean. EmailReference takes scalars for the same reason: what cannot
+   * hold the type cannot grow a second rendering of it.
+   */
+  messagePreview?: string;
+  messageVisibility?: EmailSummary["display_status"];
+  /**
    * Opens the canonical detail for this message. The caller's, because the
    * drawer is mounted by the screen rather than by the list — absent leaves
    * the row readable and not openable, which is what a surface with nowhere to
@@ -1585,7 +1602,7 @@ function messageVisibility(entry: TimelineEntry): ReactNode {
   if (entry.withheld) {
     return <VisibilityBadge state="withheld" />;
   }
-  const status = entry.emailSummary?.display_status;
+  const status = entry.messageVisibility;
   if (status && status !== "team") {
     return <VisibilityBadge state={status} />;
   }
@@ -1637,9 +1654,9 @@ function MessageWords({
   if (entry.withheld) {
     return <span className="tl-withheld">{t("timeline.withheld")}</span>;
   }
-  if (entry.emailSummary) {
-    return entry.emailSummary.preview ? (
-      <span className="tl-msg-text">{entry.emailSummary.preview}</span>
+  if (entry.messagePreview !== undefined) {
+    return entry.messagePreview ? (
+      <span className="tl-msg-text">{entry.messagePreview}</span>
     ) : null;
   }
   return entry.body ? (
@@ -1686,7 +1703,9 @@ function ThreadMessage({
       </span>
     </>
   );
-  const onOpen = entry.emailSummary ? entry.onOpenEmail : undefined;
+  // A message opens; a note does not. The scalar is what says which, for the
+  // reason messagePreview gives.
+  const onOpen = entry.messagePreview !== undefined ? entry.onOpenEmail : undefined;
   if (!onOpen) {
     return <div className="tl-msg">{content}</div>;
   }


### PR DESCRIPTION
Fixes #4799 — **main is red**, and the `gates` package runs in three CI jobs, so every open PR inherits three red checks from it (`deterministic-gates`, `extension-reference`, `integration / integration unit coverage`).

`MessageWords` and `ThreadMessage` read the email carrier and return markup without mounting a canonical component. `rendersCanonically` judges **per function** — deliberately, per the gate's own comment: an earlier file-level rule let `TimelineRow`'s mount discharge the whole file while `TimelineGroupRow` beside it went on writing its own subject-and-preview markup, and a company timeline showed old-style rows next to canonical ones on the same page while the census read clean.

## Option 1 from the issue

The carrier stops at the canonical components, and the thread member takes what it draws as **scalars**:

| scalar | says |
|---|---|
| `messagePreview` | the words — present exactly when the row is a message, empty when that message has no preview |
| `messageVisibility` | who may read it |

`EmailReference` has taken scalars for the same reason all along: *"no contract type at all, which is what stops a citation from ever growing a preview."*

`messagePreview`'s presence also answers *"is this a message?"*, which is what the two branches on the carrier were really asking — so `ThreadMessage`'s opener reads it too.

## Why the mapper derives them

Deriving the scalars in a local helper here would have satisfied the census — a function that reads the carrier and returns a *value* is not a renderer — while leaving exactly the reach the gate exists to remove. They come from `activitytimeline.tsx`'s mapper instead, which is already a ratified passthrough.

The thread test's factory derives them the same way rather than each case setting them: a test that set the carrier alone would build a row production never builds, and then assert on it.

## Verification

- The gate passes; reverting either scalar makes it fail again.
- 1064 design-system tests pass. No behaviour change — same preview, same badge, same opener.
- `make check-backend` exit 0, `tsc` and `biome` clean.

## Not taken

- **A file-level `emailPassthroughs` entry** — the issue explains why: the map is file-keyed, so it re-opens the shipped bug the gate was tightened to catch, and the sentence would be untrue since the file does render.
- **Mounting a canonical row in `MessageWords`** — contradicts `ThreadMessage`'s stated design: a member of a conversation has no date gutter, no rail and no kind of its own.
