### PR TITLE
The approved deadline, the person's draft, and three more the rehearsal found

### DIFF
--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -945,3 +945,44 @@ func TestThePerson360TimelineCarriesTheVersionAWriteNeeds(t *testing.T) {
 		t.Errorf("version = %d, want 1 for a freshly inserted row", *got.Version)
 	}
 }
+
+// The THIRD instance of the same defect class, and the one a customer met.
+//
+// source_system is what says a meeting was logged as a transcript. The person
+// timeline's hand-written SELECT did not carry it, so a transcript logged
+// against a contact reached that contact's own history as an ordinary meeting:
+// no card offering its reading, no proposal count, nothing to open. The same
+// activity showed all of it on the company and on the deal, which read through
+// activities.activityColumns — so the person who was actually in the room was
+// the one place the reading was invisible.
+//
+// A row-to-payload assertion again, for the reason the siblings give: what
+// regressed is a SELECT list, and a grep for the column name passes on a query
+// that selects it into a variable nobody scans.
+func TestThePerson360TimelineSaysAMeetingCameFromATranscript(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	mine := e.SeedPerson(t, "Transcript Speaker", &e.Rep1)
+
+	meeting := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, source_system, source, captured_by)
+		VALUES ($1, 'meeting', 'Quarterly review', 'we agreed a date', '2026-08-01T09:00:00Z',
+		        'transcript', 'manual', 'human:x')`)
+	LinkActivity(t, owner, meeting, "person", mine)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, roomPerms)
+	page, err := personRoomService(e).Assemble(rep, ids.From[ids.PersonKind](mine))
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if page.Activities == nil || len(page.Activities.Data) != 1 {
+		t.Fatalf("the timeline holds %v rows, want the one logged meeting", page.Activities)
+	}
+	got := page.Activities.Data[0]
+	if got.SourceSystem == nil {
+		t.Fatal("the meeting reached the page with no source system; the timeline cannot tell " +
+			"a transcript from an ordinary meeting, so the card offering its reading is never drawn")
+	}
+	if *got.SourceSystem != "transcript" {
+		t.Errorf("source_system = %q, want transcript", *got.SourceSystem)
+	}
+}

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -181,9 +181,13 @@ func sectionPage(rows []crmcontracts.Activity, hasMore bool) (crmcontracts.PageI
 // there was no request to have one (margince#3249). This SELECT is a
 // hand-written sibling of activities.activityColumns, which is exactly how
 // it came to be missing a column for a whole slice, twice.
-// TestThePerson360TimelineNamesTheTransportThatCarriedAMessage and
-// TestThePerson360TimelineCarriesTheVersionAWriteNeeds are the guards that
-// say so out loud.
+// TestThePerson360TimelineNamesTheTransportThatCarriedAMessage,
+// TestThePerson360TimelineCarriesTheVersionAWriteNeeds and
+// TestThePerson360TimelineSaysAMeetingCameFromATranscript are the guards
+// that say so out loud. The third is the third instance: source_system was
+// missing, so a meeting logged as a transcript reached the person's history
+// with nothing to say it was one, and the card that offers its reading drew
+// on the company and the deal but not on the person who was in the room.
 func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, extra string, order sectionOrder) ([]crmcontracts.Activity, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
@@ -204,7 +208,7 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		SELECT a.id, a.kind, a.channel_provider, a.subject, a.body, a.direction,
 		       a.occurred_at, a.due_at, a.is_done, a.assignee_id, a.source, a.captured_by, a.created_at,
 		       a.thread_key, a.bulk_mail_attested, a.audience, a.audience_reason,
-		       a.version, (%s) AS content_available,
+		       a.source_system, a.version, (%s) AS content_available,
 		       EXISTS (SELECT 1 FROM activity_link fl
 		                WHERE fl.activity_id = a.id AND fl.person_id = $%d) AS filed_here
 		FROM activity a
@@ -227,7 +231,7 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		if err := rows.Scan(&id, &a.Kind, &a.ChannelProvider, &a.Subject, &a.Body,
 			&a.Direction, &a.OccurredAt, &a.DueAt, &a.IsDone, &a.AssigneeId, &a.Source, &a.CapturedBy,
 			&a.CreatedAt, &threadKey, &bulkMailAttested, &audience, &audienceReason,
-			&version, &contentAvailable, &filedHere); err != nil {
+			&a.SourceSystem, &version, &contentAvailable, &filedHere); err != nil {
 			return nil, false, err
 		}
 		a.Id = openapi_types.UUID(id)

--- a/backend/internal/compose/transcriptpropose_integration_test.go
+++ b/backend/internal/compose/transcriptpropose_integration_test.go
@@ -569,6 +569,17 @@ func TestAStatedDeadlineBecomesTheTasksDueDate(t *testing.T) {
 		t.Errorf("the task is due %q, want the end of 8 September in the "+
 			"installation's own zone", due)
 	}
+	// The day the REVIEWER approved, spelled the way the approval card spells
+	// it. The card renders the proposal's `due_date` string with no conversion
+	// at all, so this is literally what the person clicking Accept was looking
+	// at; asserting the task against the same string is what makes "the
+	// approved day survives acceptance" a checkable claim rather than two
+	// separate ones about a stamp and a render. A proposal for the 8th came
+	// back as a task the reader saw as the 9th, and neither half of it was
+	// wrong on its own.
+	if day := strings.SplitN(due, " ", 2)[0]; day != "2026-09-08" {
+		t.Errorf("the approved day was %q and the task landed on %q", "2026-09-08", day)
+	}
 }
 
 // A next step nobody dated carries no date, rather than today's.

--- a/backend/internal/compose/transcriptproposeaccept.go
+++ b/backend/internal/compose/transcriptproposeaccept.go
@@ -136,15 +136,15 @@ func stampTranscriptDue(ctx context.Context, tx pgx.Tx, in *activities.LogActivi
 	}
 	// The last second of the named day.
 	//
-	// NOT the same instant the web composer's own date box produces, and the
-	// difference is deliberate. format/calendarday.dueInstant resolves the day
-	// in the BROWSER's zone, because a rep typing a due date is setting a
-	// deadline for themselves. This one resolves in the installation's, for the
-	// reason above: a transcript's deadline is a record fact read back by
-	// colleagues elsewhere. A rep far from the installation's zone will see the
-	// two land an hour or more apart, and on the far side of midnight, a day
-	// apart. Making them agree means deciding which of the two readings a due
-	// date IS, and that is a product question rather than a bug in either.
+	// The same instant the web composer's date box now produces:
+	// format/calendarday.dueInstant resolves the picked day against the same
+	// installation zone this does. It used to resolve in the BROWSER's, and the
+	// two readings disagreed by a whole day for anyone east of the
+	// installation — a proposal approved for 9 September was read back as a
+	// task due the 10th, because this stamp lands on the day's last second and
+	// any eastward offset at all pushes that past midnight. A deadline is a
+	// record fact read back by colleagues elsewhere, so there is one clock for
+	// it: this one.
 	//
 	// Built from the day's OWN parts rather than by adding a day and taking a
 	// second back. A local day is not always 24 hours: on Europe/Berlin's

--- a/frontend/src/format/calendar-day-by-slice.test.ts
+++ b/frontend/src/format/calendar-day-by-slice.test.ts
@@ -54,6 +54,10 @@ const deliberateUtcDays: Record<string, { sites: number; why: string }> = {
     sites: 1,
     why: "the same round trip as adjacentMonth's: the date is built with Date.UTC(...) from a day this function was GIVEN, and the components read back are the ones just written. It is arithmetic on a named day, not a reading of the clock, and the zoned question is answered by startOfDayInstant on the next line",
   },
+  "screens/taskactions.tsx#next": {
+    sites: 1,
+    why: "the same round trip as shifted's: the date is built with Date.UTC(...) from a day calendarDay just named in the record's zone, and the parts read back are the ones just written. A snooze steps to the NEXT CALENDAR DAY, and doing it here rather than by adding 86_400_000 is the point — a local day is not always that long, and the old arithmetic skipped Berlin's 29 March. dueInstant answers the zoned question on the next line",
+  },
   "mcp-apps/bridge.ts#day": {
     sites: 1,
     why: "the answer beside this date says whether a promise is overdue, and the server judged that in UTC. A day rendered in the reader's zone could print tomorrow's date beside the word overdue — one clock, one day",

--- a/frontend/src/format/calendarday.test.ts
+++ b/frontend/src/format/calendarday.test.ts
@@ -103,6 +103,23 @@ describe("dueInstant", () => {
     expect(() => dueInstant("2026-02-30", "Europe/Berlin")).toThrow();
     expect(() => dueInstant("10000-09-15", "Europe/Berlin")).toThrow();
   });
+
+  // Date.UTC maps a two-digit year onto 1900-1999, so this would have come
+  // back as 1999 and the caller would never learn the day it asked for was not
+  // the day it got.
+  it("refuses a year the underlying clock would silently move", () => {
+    expect(() => dueInstant("0099-09-09", "UTC")).toThrow();
+  });
+
+  // `% 1000` on a negative instant rounds toward zero, which is the wrong way:
+  // the last second of 31 December 1969 became the first of 1 January 1970 —
+  // the very off-by-one-day this signature exists to end.
+  it("keeps its day before 1970, where the arithmetic changes sign", () => {
+    expect(dueInstant("1969-12-31", "UTC")).toBe("1969-12-31T23:59:59.000Z");
+    expect(calendarDay(new Date(dueInstant("1969-12-31", "UTC")), "UTC")).toBe(
+      "1969-12-31",
+    );
+  });
 });
 
 describe("localDateTimeValue", () => {

--- a/frontend/src/format/calendarday.test.ts
+++ b/frontend/src/format/calendarday.test.ts
@@ -35,23 +35,73 @@ describe("calendarDay", () => {
 });
 
 describe("dueInstant", () => {
-  it("files the picked day under that same day in the reader's zone", () => {
-    for (const day of ["2026-01-15", "2026-07-05", "2026-12-31"]) {
-      expect(calendarDay(new Date(dueInstant(day)), readerZone)).toBe(day);
+  it("files the picked day under that same day in the zone it was minted for", () => {
+    for (const zone of [
+      "Europe/Berlin",
+      "Asia/Bangkok",
+      "America/Los_Angeles",
+      "UTC",
+    ]) {
+      for (const day of ["2026-01-15", "2026-07-05", "2026-12-31"]) {
+        expect(calendarDay(new Date(dueInstant(day, zone)), zone)).toBe(day);
+      }
     }
   });
 
+  // The defect this signature exists to end. A transcript proposal for the 9th
+  // was accepted and came back as a task due the 10th: the day's end was
+  // resolved on one clock and read on another, and the last second of the day
+  // needs only a one-second eastward difference to fall into tomorrow.
+  it("names the same day to a reader east of the zone it was minted for", () => {
+    const at = new Date(dueInstant("2026-09-09", "Europe/Berlin"));
+    expect(at.toISOString()).toBe("2026-09-09T21:59:59.000Z");
+    expect(calendarDay(at, "Europe/Berlin")).toBe("2026-09-09");
+    expect(calendarDay(at, "Asia/Bangkok")).toBe("2026-09-10");
+  });
+
   it("lands at the END of the picked day, so a task filed for today is not overdue by breakfast", () => {
-    const at = new Date(dueInstant("2026-07-05"));
-    expect(at.getHours()).toBe(23);
-    expect(at.getMinutes()).toBe(59);
-    expect(at.getSeconds()).toBe(59);
+    const at = new Date(dueInstant("2026-07-05", "Europe/Berlin"));
+    expect(at.toISOString()).toBe("2026-07-05T21:59:59.000Z");
+  });
+
+  // Whole seconds, not the helper's own last millisecond: this is the shape the
+  // task writer has always put on the wire.
+  it("carries no fractional second", () => {
+    expect(dueInstant("2026-07-05", "Europe/Berlin")).toBe(
+      "2026-07-05T21:59:59.000Z",
+    );
+  });
+
+  // Both directions of the Berlin change, and a zone that has none.
+  it("keeps its day across a daylight-saving boundary", () => {
+    for (const day of ["2026-03-29", "2026-10-25"]) {
+      expect(
+        calendarDay(
+          new Date(dueInstant(day, "Europe/Berlin")),
+          "Europe/Berlin",
+        ),
+      ).toBe(day);
+    }
+    expect(dueInstant("2026-03-29", "Europe/Berlin")).toBe(
+      "2026-03-29T21:59:59.000Z",
+    );
+    expect(dueInstant("2026-10-25", "Europe/Berlin")).toBe(
+      "2026-10-25T22:59:59.000Z",
+    );
+    expect(dueInstant("2026-07-05", "Asia/Bangkok")).toBe(
+      "2026-07-05T16:59:59.000Z",
+    );
   });
 
   it("is a UTC instant on the wire whatever zone minted it", () => {
-    expect(dueInstant("2026-07-05")).toMatch(
+    expect(dueInstant("2026-07-05", "Asia/Bangkok")).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
+  });
+
+  it("refuses a day no calendar holds", () => {
+    expect(() => dueInstant("2026-02-30", "Europe/Berlin")).toThrow();
+    expect(() => dueInstant("10000-09-15", "Europe/Berlin")).toThrow();
   });
 });
 

--- a/frontend/src/format/calendarday.ts
+++ b/frontend/src/format/calendarday.ts
@@ -12,6 +12,8 @@
 // Both are pure and take their zone (or the reader's own wall clock) as input,
 // so nothing here has to be tested against the machine's own zone.
 
+import { endOfDayInZone } from "./timezone";
+
 // The calendar day an instant falls on, in a named IANA zone, as `yyyy-mm-dd` so
 // two of them compare as strings without a second parse.
 //
@@ -107,17 +109,34 @@ export function calendarMonth(at: Date, zone: string): string {
   return calendarDay(at, zone).slice(0, "yyyy-mm".length);
 }
 
-// The wire instant for a due date the reader picked as a calendar day — the
+// The wire instant for a due date somebody picked as a calendar day — the
 // `yyyy-mm-dd` a date input yields, which every caller has already checked is
 // non-empty.
 //
-// A task stays due until that day ends WHERE THE READER IS, so the instant is
-// the local end of day. Midnight would file a task picked for today as overdue
-// at breakfast, and `new Date(day)` on the bare date reads it as UTC midnight,
-// which does the same thing a whole zone offset earlier — east of UTC that is
-// overdue on waking, west of UTC it is the previous calendar day.
-export function dueInstant(day: string): string {
-  return new Date(`${day}T23:59:59`).toISOString();
+// A deadline is a fact about the RECORD, so the day ends on the installation's
+// clock and every colleague reads back the day that was agreed. Resolving it in
+// the browser's zone instead is what made a transcript proposal for the 9th
+// become a task labelled the 10th: the accept path stamps the day's end in the
+// installation zone, and a reader east of it saw that last second land after
+// midnight. Callers pass the zone from `useRecordZone()`, the same one the task
+// is rendered in.
+//
+// `endOfDayInZone` already resolves a named day's end against a zone's real
+// offset, DST included, and privacy files its deadlines with it. Reuse rather
+// than a second algorithm: it returns the day's last millisecond, so this floors
+// to the whole second the task writer has always sent.
+export function dueInstant(day: string, zone: string): string {
+  // Refused explicitly, because the arithmetic below no longer refuses it on
+  // its own. `new Date("10000-09-15T23:59:59")` threw a RangeError, and that
+  // throw was the only thing standing between a year typo and a due date ten
+  // thousand years out; a zone-resolved instant accepts the same string
+  // happily. HTML permits a year of four OR MORE digits, so this is a value a
+  // real date box reports — `taskduedate.guard.test.ts` measures it.
+  if (!isRealCalendarDay(day)) {
+    throw new RangeError(`not a calendar day: ${day}`);
+  }
+  const lastMs = new Date(endOfDayInZone(day, zone)).getTime();
+  return new Date(lastMs - (lastMs % 1000)).toISOString();
 }
 
 // The wall-clock value a `datetime-local` input shows for an instant, in the

--- a/frontend/src/format/calendarday.ts
+++ b/frontend/src/format/calendarday.ts
@@ -135,8 +135,19 @@ export function dueInstant(day: string, zone: string): string {
   if (!isRealCalendarDay(day)) {
     throw new RangeError(`not a calendar day: ${day}`);
   }
+  // Years 0-99 are refused rather than resolved. `endOfDayInZone` reaches
+  // Date.UTC, which maps a two-digit year onto 1900-1999 — so "0099-09-09"
+  // would come back as 1999 and the caller would never know the day it asked
+  // for was not the day it got. isRealCalendarDay admits it on shape, and this
+  // is the one place that can tell the difference.
+  if (Number(day.slice(0, 4)) < 100) {
+    throw new RangeError(`year out of range: ${day}`);
+  }
+  // FLOORED, not truncated toward zero. `% 1000` on a negative instant rounds
+  // the wrong way — a day before 1970 would land on the next day's midnight,
+  // which is the very off-by-one-day this signature exists to end.
   const lastMs = new Date(endOfDayInZone(day, zone)).getTime();
-  return new Date(lastMs - (lastMs % 1000)).toISOString();
+  return new Date(Math.floor(lastMs / 1000) * 1000).toISOString();
 }
 
 // The wall-clock value a `datetime-local` input shows for an instant, in the

--- a/frontend/src/format/timezone.ts
+++ b/frontend/src/format/timezone.ts
@@ -36,16 +36,18 @@
 // page wins: a record surface is ONE clock, so a due date and the activity
 // beside it can never be read in two different zones.
 //
-// "Genuinely both" means both readings are defensible, and that is a claim about
-// the STORED value, not about the screen. An activity's `due_at` is minted by
-// `dueInstant` as the end of the picked day in the BROWSER's zone, so the wire
-// value already carries the picker's clock; the record zone does not read the
-// organization's day out of it, it reads a day the picker never chose, off by
-// one for every reader outside that zone. A value with no record reading has
-// nothing for the page to win against, so `due_at` takes viewerZone() wherever
-// it is shown — the tasks queue, the record's next steps, the task detail —
-// while the activity's `occurred_at` beside it stays on the record zone,
-// because when something happened IS a fact about the record.
+// An activity's `due_at` is one of those sites, and the page wins it. A
+// deadline is a promise colleagues read back — the worklist already buckets
+// overdue on the installation's clock — so `dueInstant` mints the picked day's
+// end in the RECORD's zone and every task date is rendered in it: the tasks
+// queue, the record's next steps, the task detail, the picker that seeds from
+// it. The activity's `occurred_at` beside it is on the same clock, because when
+// something happened is a fact about the record too.
+//
+// It read viewerZone() until a transcript proposal approved for 9 September
+// came back as a task due the 10th. The stamp is the day's LAST SECOND, so a
+// reader one second east of the minting zone already sees tomorrow; nothing
+// about that was a preference to respect.
 
 // The zone a record's dates are read in when the installation's own answer is
 // not on hand. It is the LAST resort, not the value: `useRecordZone` in

--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -148,6 +148,14 @@ function code(path: string, source: string): string {
 // output moved with the machine it ran on would assert nothing.
 const pinnedZones: { file: string; why: string }[] = [
   {
+    file: "screens/taskduedate.test.tsx",
+    why: "The picker's day and the instant it sends are asserted across a zone boundary, so the record zone has to be a NAMED one the fixture also computes its expectation from: the case is that a deadline reads as the day it was agreed on for a colleague elsewhere, and a zone taken off the runner would make the assertion true wherever the suite happened to run. It is provided through RecordZoneProvider, the seam the product itself reads.",
+  },
+  {
+    file: "screens/taskduedate.guard.test.ts",
+    why: "The guard's subject is dueInstant, which now TAKES the zone a deadline is resolved in — so a call to it cannot be written without naming one. UTC would prove nothing here: the case that matters is a day's last second landing before midnight on the very clock that minted it, and a zero offset makes the wire value and the wall clock identical whichever rule ran.",
+  },
+  {
     file: "screens/worklist.when.test.tsx",
     why: "The rule under test is which SIDE of the reader's own day a moment falls on — today's meeting shows a bare time, another day's shows the date too. Deciding that needs a zone whose offset is not zero: in UTC the fixture's instants land on the same calendar day under either rule, so every case would pass whichever branch ran. The zone is injected by mocking viewerZone, which is the module this gate points callers at; naming it is what makes the expectation ('14:30', not '12:30') checkable at all.",
   },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8514,6 +8514,8 @@ export const de = {
   "worklist.completeness.bounded":
     "{shown} angezeigt · {sources} Quellen haben mehr",
   "worklist.clear": "Nichts wartet auf dich.",
+  "worklist.clearOfTasksToday":
+    "Heute ist keine Aufgabe fällig und nichts ist überfällig. Spätere Aufgaben stehen im Tab „Aufgaben“ des jeweiligen Datensatzes.",
   "worklist.clearOfWhatWasRead":
     "Unter den Quellen, die geantwortet haben, wartet nichts.",
   "worklist.partial": "{sources} — das ist nicht der ganze Tag.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2952,6 +2952,21 @@ export const de = {
     "{count} nächste Schritte warten auf deine Prüfung",
   "transcriptread.proposals_one":
     "{count} nächster Schritt wartet auf deine Prüfung",
+  "transcriptread.staged_one": "{count} nächster Schritt vorgeschlagen",
+  "transcriptread.staged_other": "{count} nächste Schritte vorgeschlagen",
+  "transcriptread.decided_one": "{count} Vorschlag geprüft",
+  "transcriptread.decided_other": "{count} Vorschläge geprüft",
+  "transcriptread.decidedDetail": "{accepted} übernommen, {rejected} abgelehnt",
+  "transcriptread.expired_one": "{count} ohne Entscheidung abgelaufen",
+  "transcriptread.expired_other": "{count} ohne Entscheidung abgelaufen",
+  "transcriptread.effectFailed_one":
+    "{count} übernommener Vorschlag hat seine Aufgabe nicht angelegt.",
+  "transcriptread.effectFailed_other":
+    "{count} übernommene Vorschläge haben ihre Aufgaben nicht angelegt.",
+  "transcriptread.statusUnknown_one":
+    "Status für {count} Vorschlag nicht abrufbar",
+  "transcriptread.statusUnknown_other":
+    "Status für {count} Vorschläge nicht abrufbar",
   "transcriptread.nothingStated":
     "Vollständig gelesen. Dieses Gespräch nennt keine nächsten Schritte.",
   "transcriptread.failedFallback":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3446,6 +3446,8 @@ export const de = {
   "compose.consentGoto": "Einwilligung prüfen",
   "compose.draftUnavailable":
     "KI-Entwurf ist nicht verfügbar (das Modell ist nicht konfiguriert). Sie können die E-Mail weiterhin selbst schreiben.",
+  "compose.draftUnsupportedHere":
+    "KI-Entwurf wird auf dieser Seite nicht angeboten. Sie können die E-Mail weiterhin selbst schreiben.",
   "compose.sendUnavailable":
     "Versand ist nicht verfügbar (kein Mailer konfiguriert).",
   "compose.mailboxNotSendCapable":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3539,6 +3539,8 @@ export const en = {
   "compose.consentGoto": "Review consent",
   "compose.draftUnavailable":
     "AI drafting is unavailable (the model is not configured). You can still write the email yourself.",
+  "compose.draftUnsupportedHere":
+    "AI drafting is not offered from this page. You can still write the email yourself.",
   "compose.sendUnavailable":
     "Sending is unavailable (no mailer is configured).",
   "compose.mailboxNotSendCapable":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3043,6 +3043,21 @@ export const en = {
   "transcriptread.proposals_other":
     "{count} next steps waiting for your review",
   "transcriptread.proposals_one": "{count} next step waiting for your review",
+  "transcriptread.staged_one": "{count} next step suggested",
+  "transcriptread.staged_other": "{count} next steps suggested",
+  "transcriptread.decided_one": "{count} suggestion reviewed",
+  "transcriptread.decided_other": "{count} suggestions reviewed",
+  "transcriptread.decidedDetail": "{accepted} accepted, {rejected} declined",
+  "transcriptread.expired_one": "{count} expired undecided",
+  "transcriptread.expired_other": "{count} expired undecided",
+  "transcriptread.effectFailed_one":
+    "{count} accepted suggestion did not produce its task.",
+  "transcriptread.effectFailed_other":
+    "{count} accepted suggestions did not produce their tasks.",
+  "transcriptread.statusUnknown_one":
+    "Status unavailable for {count} suggestion",
+  "transcriptread.statusUnknown_other":
+    "Status unavailable for {count} suggestions",
   "transcriptread.nothingStated":
     "Read in full. This conversation states no next steps.",
   "transcriptread.failedFallback":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8656,6 +8656,8 @@ export const en = {
   "worklist.completeness.bounded":
     "{shown} shown · {sources} sources have more",
   "worklist.clear": "Nothing is waiting on you.",
+  "worklist.clearOfTasksToday":
+    "No tasks are due today or overdue. Later work is on each record's own Tasks tab.",
   "worklist.clearOfWhatWasRead":
     "Nothing is waiting among the sources that answered.",
   "worklist.partial": "{sources}, so this is not the whole day.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8411,6 +8411,8 @@ export const vi = {
     "Hiển thị {loaded} trong {total} — xem tiếp trong ngày để thấy phần còn lại",
   "worklist.completeness.bounded": "Hiển thị {shown} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",
+  "worklist.clearOfTasksToday":
+    "Hôm nay không có công việc đến hạn và không có việc quá hạn. Công việc về sau nằm ở tab Công việc của từng hồ sơ.",
   "worklist.clearOfWhatWasRead":
     "Không có gì đang chờ trong các nguồn đã trả lời.",
   "worklist.partial": "{sources}, nên đây chưa phải cả ngày.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2918,6 +2918,21 @@ export const vi = {
   "transcriptread.proposals_other":
     "{count} bước tiếp theo đang chờ bạn rà soát",
   "transcriptread.proposals_one": "{count} bước tiếp theo đang chờ bạn rà soát",
+  "transcriptread.staged_one": "Đã đề xuất {count} bước tiếp theo",
+  "transcriptread.staged_other": "Đã đề xuất {count} bước tiếp theo",
+  "transcriptread.decided_one": "Đã rà soát {count} đề xuất",
+  "transcriptread.decided_other": "Đã rà soát {count} đề xuất",
+  "transcriptread.decidedDetail": "{accepted} đã nhận, {rejected} đã từ chối",
+  "transcriptread.expired_one": "{count} hết hạn khi chưa quyết định",
+  "transcriptread.expired_other": "{count} hết hạn khi chưa quyết định",
+  "transcriptread.effectFailed_one":
+    "{count} đề xuất đã nhận nhưng chưa tạo được công việc.",
+  "transcriptread.effectFailed_other":
+    "{count} đề xuất đã nhận nhưng chưa tạo được công việc.",
+  "transcriptread.statusUnknown_one":
+    "Không lấy được trạng thái của {count} đề xuất",
+  "transcriptread.statusUnknown_other":
+    "Không lấy được trạng thái của {count} đề xuất",
   "transcriptread.nothingStated":
     "Đã đọc toàn bộ. Cuộc trò chuyện này không nêu bước tiếp theo nào.",
   "transcriptread.failedFallback":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3409,6 +3409,8 @@ export const vi = {
   "compose.consentGoto": "Xem lại chấp thuận",
   "compose.draftUnavailable":
     "Không dùng được phần soạn nháp bằng AI (chưa cấu hình mô hình). Bạn vẫn tự viết email được.",
+  "compose.draftUnsupportedHere":
+    "Trang này không có chức năng soạn nháp bằng AI. Bạn vẫn tự viết email được.",
   "compose.sendUnavailable": "Không gửi được (chưa cấu hình bộ gửi thư).",
   "compose.mailboxNotSendCapable":
     "Hộp thư của bạn đã kết nối để thu thập nhưng chưa bao giờ được cấp quyền gửi. Hãy kết nối lại và duyệt quyền gửi — hộp thư được kết nối từ trước khi có tính năng gửi thì không nâng cấp tại chỗ được.",

--- a/frontend/src/screens/approvalrow.tsx
+++ b/frontend/src/screens/approvalrow.tsx
@@ -275,6 +275,12 @@ export function ApprovalRow({
     },
     onSuccess: (_data, input) => {
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      // THIS approval, by id, and not only the lists it appears in. Anything
+      // reading one decision on its own — the transcript card counting what
+      // became of what it staged — otherwise keeps the answer it fetched
+      // before the decision, and says a suggestion is waiting for a review
+      // that has already happened.
+      queryClient.invalidateQueries({ queryKey: ["approval", approval.id] });
       for (const queryKey of extraInvalidateKeys ?? []) {
         queryClient.invalidateQueries({ queryKey });
       }
@@ -285,6 +291,9 @@ export function ApprovalRow({
       if (problem && isAlreadyDecided(problem)) {
         onAlreadyDecided?.();
         queryClient.invalidateQueries({ queryKey: ["approvals", "pending"] });
+        // Somebody else decided it while this row was open, so the single
+        // read is stale for the same reason and in the same way.
+        queryClient.invalidateQueries({ queryKey: ["approval", approval.id] });
       }
     },
   });

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -31,7 +31,6 @@ import {
   formatNumber,
   formatTimeOfDay,
 } from "../format/format";
-import { viewerZone } from "../format/timezone";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -531,6 +530,7 @@ export function NextSteps({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const steps = view.next_steps?.data ?? [];
   const state = sectionState(
     view,
@@ -587,17 +587,13 @@ export function NextSteps({
                 {!step.overdue && step.due_at && (
                   <span>
                     {t("co.next.due", {
-                      // The one viewer-clock reading on this record page, and
-                      // it is not a preference: `dueInstant` mints a due date
-                      // as the end of the picked day in the BROWSER's zone, so
-                      // the stored instant already carries the picker's clock.
-                      // Read in the organization's zone it names a different
-                      // calendar day than the one the picker chose, for every
-                      // reader outside that zone — there is no organization
-                      // reading of it to prefer. The timeline below still reads
-                      // in the record zone, because an activity's occurrence IS a
-                      // fact about the record.
-                      when: formatDate(step.due_at, locale, viewerZone()),
+                      // The record's own clock, like the timeline below it. A
+                      // deadline is a promise colleagues read back, so
+                      // `dueInstant` mints the picked day's end in this same
+                      // zone and it is rendered in it. Reading that last second
+                      // on the browser's clock instead is what showed an
+                      // approved 9 September as a next step due the 10th.
+                      when: formatDate(step.due_at, locale, recordZone),
                     })}
                   </span>
                 )}

--- a/frontend/src/screens/companytasks.test.tsx
+++ b/frontend/src/screens/companytasks.test.tsx
@@ -126,10 +126,12 @@ const org360WithRecommendedStep = {
 };
 
 // A due date that falls on a DIFFERENT calendar day in the two zones this page
-// could read it in. `dueInstant` mints a due date as the end of the picked day
-// in the BROWSER's zone, so this is what a writer in Los Angeles picking 21
-// August actually stores: 23:59:59 there, and already the 22nd in Berlin.
-const STRADDLING_DUE_AT = "2026-08-22T06:59:59Z";
+// could read it in. `dueInstant` mints the end of the picked day on the
+// RECORD's clock, so this is what picking 21 August against a Berlin
+// installation stores: 23:59:59 there, and still the 21st at 14:59 for a reader
+// in Los Angeles — who must be shown the day the deadline was agreed on, not
+// their own reading of it.
+const STRADDLING_DUE_AT = "2026-08-21T21:59:59.000Z";
 const WRITERS_ZONE = "America/Los_Angeles";
 const PICKED_DAY = "Due 21/08/2026";
 const DAY_AFTER = "Due 22/08/2026";
@@ -184,13 +186,13 @@ describe("CompanyScreen — the Tasks tab", () => {
     await waitFor(() => expect(patched).toEqual({ is_done: true }));
   });
 
-  it("dates a task's deadline on the reader's own clock, the same day on the row and in the detail", async () => {
-    // A due date is not a fact about the record the way an occurrence is: the
-    // stored instant is minted as the end of the picked day in the BROWSER's
-    // zone, so it already carries the picker's clock. Read on the
-    // organization's clock it names the day AFTER the one the picker chose for
-    // everybody outside that zone — and the row and the modal disagreed with
-    // each other about which of the two it was.
+  it("dates a task's deadline on the record's clock, the same day on the row and in the detail", async () => {
+    // A deadline IS a fact about the record: the stored instant is minted as
+    // the end of the picked day on the organization's clock, and every
+    // colleague reads back the day that was agreed. Reading it on the viewer's
+    // clock instead named a different day for everyone outside that zone —
+    // which is how a proposal approved for 9 September became a task due the
+    // 10th. The reader here sits nine hours west and must still see the 21st.
     const user = userEvent.setup();
     pretendViewerZone(WRITERS_ZONE);
     stubFetch(

--- a/frontend/src/screens/compose-person-draft.test.tsx
+++ b/frontend/src/screens/compose-person-draft.test.tsx
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+import {
+  allowedPreview,
+  isPreviewDoor,
+  previewedAddresses,
+} from "./sendpermission.testkit";
+
+// Drafting to a PERSON, from the contact's own page.
+//
+// The record in the path is the recipient, so the request carries nothing but
+// optional steering — the shape /people/{id}/draft-email has described since it
+// shipped, answered by the same writer as the account and lead paths.
+//
+// The composer never called it. "Write email" on a contact fell through to the
+// organization guard, and the rep was told "the model is not configured" — a
+// claim about the deployment, made by a browser that had sent no request, on a
+// stack whose model was answering transcript readings on the same screen. So
+// these assert the ENDPOINT and not merely the words: a test reading the
+// sentence alone passes on the tree where this feature does not work.
+
+type Sent = { key: string; body: unknown };
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+const PERSON_DRAFT = {
+  subject: "Zwei Produkte ohne Übersetzung",
+  body: "Guten Tag Frau Malherbe,\n\nfür das Beispiel brauchen wir zwei Produkte.",
+  generated_by: "model",
+  ai_generated: true,
+  ai_disclosure: "This message was drafted with AI assistance.",
+};
+
+function stubRoutes(
+  overrides: Record<string, () => Response | Promise<Response>> = {},
+) {
+  const sent: Sent[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      sent.push({ key, body });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      if (isPreviewDoor(url.pathname)) {
+        return jsonResponse(allowedPreview(previewedAddresses(body)));
+      }
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("drafting to a person", () => {
+  it("asks the person's own endpoint and fills the fields", async () => {
+    const sent = stubRoutes({
+      "POST /people/c-1/draft-email": () => jsonResponse(PERSON_DRAFT),
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="c-1"
+        personId="c-1"
+        recordAddress="annabelle@akeneo.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(
+      await screen.findByDisplayValue("Zwei Produkte ohne Übersetzung"),
+    ).toBeTruthy();
+    // The endpoint, named. Reaching the ACCOUNT endpoint would ground the
+    // message in whatever company sits behind the contact — a conversation the
+    // rep never chose — and reaching none is what the page did before.
+    expect(
+      sent.some((call) => call.key === "POST /people/c-1/draft-email"),
+    ).toBe(true);
+    expect(sent.some((call) => call.key.includes("/organizations/"))).toBe(
+      false,
+    );
+  });
+
+  it("carries the reader's own steering and nothing else", async () => {
+    const sent = stubRoutes({
+      "POST /people/c-1/draft-email": () => jsonResponse(PERSON_DRAFT),
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="c-1"
+        personId="c-1"
+        recordAddress="annabelle@akeneo.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/Steer the draft/),
+      "kurz halten",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+    await screen.findByDisplayValue("Zwei Produkte ohne Übersetzung");
+
+    const call = sent.find((c) => c.key === "POST /people/c-1/draft-email");
+    // The intent, and no recipient among them: the person in the path IS the
+    // recipient, so naming one would be this client answering a question the
+    // route does not ask.
+    expect(call?.body).toEqual({ intent: "kurz halten" });
+  });
+
+  it("discloses a model-written draft", async () => {
+    stubRoutes({
+      "POST /people/c-1/draft-email": () => jsonResponse(PERSON_DRAFT),
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="c-1"
+        personId="c-1"
+        recordAddress="annabelle@akeneo.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(await screen.findByTestId("ai-disclosure-banner")).toBeTruthy();
+  });
+
+  // The sentence a deployment with no model earns, and the one this page used
+  // to say without asking anybody.
+  it("says the model is unconfigured only when the server says so", async () => {
+    const sent = stubRoutes({
+      "POST /people/c-1/draft-email": () => jsonResponse({}, 501),
+    });
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="c-1"
+        personId="c-1"
+        recordAddress="annabelle@akeneo.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/AI drafting is unavailable/i)).toBeTruthy(),
+    );
+    expect(
+      sent.some((call) => call.key === "POST /people/c-1/draft-email"),
+    ).toBe(true);
+  });
+
+  // An origin with no route says THAT, and does not blame the deployment. A
+  // deal has no draft-email endpoint to reach.
+  it("says drafting is not offered here for an origin with no route", async () => {
+    const sent = stubRoutes();
+    render(
+      <ComposeModal
+        entityType="deal"
+        entityId="d-1"
+        recordAddress="annabelle@akeneo.example"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/not offered from this page/i)).toBeTruthy(),
+    );
+    // No claim about the model, because nothing was asked of it.
+    expect(screen.queryByText(/model is not configured/i)).toBeNull();
+    expect(sent.some((call) => call.key.includes("/draft-email"))).toBe(false);
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -441,7 +441,9 @@ async function draftFromActivity({
       body: intent.trim() ? { intent: intent.trim() } : {},
     },
   );
-  if (response.status === 501) return { available: false as const };
+  if (response.status === 501) {
+    return { available: false as const, reason: "no_model" as const };
+  }
   // Success is the real 2xx WITH a draft body, never merely the absence of an
   // error: openapi-fetch reports a falsy `error` (and undefined `data`) for a
   // bodiless non-2xx (a gateway 502/503/504), which would otherwise fall
@@ -753,7 +755,51 @@ async function draftFromLead({
     params: { path: { id: entityId } },
     body: intent.trim() ? { intent: intent.trim() } : {},
   });
-  if (response.status === 501) return { available: false as const };
+  if (response.status === 501) {
+    return { available: false as const, reason: "no_model" as const };
+  }
+  if (!response.ok || !data) {
+    throwProblem(error || { title: t("compose.actionFailed") });
+  }
+  return {
+    available: true as const,
+    draft: data,
+    reasoning: data.reasoning,
+    scope: data.scope,
+  };
+}
+
+// The person-started draft: the composer's "Write email" on a contact.
+//
+// The mirror of the account path, and simpler for one reason — the record in
+// the path is the recipient, so there is nobody to name. It takes the project
+// when the rep attributed the message to one, exactly as the account path does,
+// so the grounding read drops correspondence filed under the others.
+//
+// Answers the same `{available, draft}` shape as the three beside it, so the
+// fill cannot tell the origins apart and they cannot drift into different
+// clobber rules.
+async function draftFromPerson({
+  entityId,
+  projectId,
+  intent,
+  t,
+}: Readonly<{
+  entityId: string;
+  projectId: string;
+  intent: string;
+  t: ReturnType<typeof useT>;
+}>): Promise<DraftResult> {
+  const { data, error, response } = await api.POST("/people/{id}/draft-email", {
+    params: { path: { id: entityId } },
+    body: {
+      ...(projectId ? { project_id: projectId } : {}),
+      ...(intent.trim() ? { intent: intent.trim() } : {}),
+    },
+  });
+  if (response.status === 501) {
+    return { available: false as const, reason: "no_model" as const };
+  }
   if (!response.ok || !data) {
     throwProblem(error || { title: t("compose.actionFailed") });
   }
@@ -797,11 +843,21 @@ async function draftFromAccount({
   if (entityType === "lead") {
     return draftFromLead({ entityId, intent, t });
   }
+  // A PERSON grounds its own, and the contract says so: /people/{id}/draft-email
+  // is the account path's mirror — written from the caller's own person 360 and
+  // taking nothing but optional steering, because the record in the path IS the
+  // recipient. This arm was missing, so the page fell through to the refusal
+  // below and told the rep the model was not configured while making no request
+  // at all, on a deployment answering every other AI call on the same screen.
+  if (entityType === "person") {
+    return draftFromPerson({ entityId, projectId, intent, t });
+  }
   // A company page has to be told which contact, because an account has many.
-  // A person or a deal grounds nothing here: writing to a contact from whatever
-  // account sits nearby would be a conversation the rep never chose.
+  // A deal grounds nothing here: writing to a contact from whatever account
+  // sits nearby would be a conversation the rep never chose, and no deal-side
+  // route exists to answer it.
   if (entityType !== "organization" || !recipientId) {
-    return { available: false as const };
+    return { available: false as const, reason: "unsupported_origin" as const };
   }
   const { data, error, response } = await api.POST(
     "/organizations/{id}/draft-email",
@@ -818,7 +874,9 @@ async function draftFromAccount({
       },
     },
   );
-  if (response.status === 501) return { available: false as const };
+  if (response.status === 501) {
+    return { available: false as const, reason: "no_model" as const };
+  }
   if (!response.ok || !data) {
     throwProblem(error || { title: t("compose.actionFailed") });
   }
@@ -837,8 +895,18 @@ async function draftFromAccount({
 // reads and nothing else. Intersecting the two contract types instead would
 // make every optional field of one optional on both, and the fill would stop
 // noticing when a required field went missing.
+
+// Why a draft is not on offer. The two are not the same fact and the reader
+// cannot act on them alike: "no model" is the deployment's answer and there is
+// nothing to do about it here, while "not from this page" is ours and the rep
+// can still reach a draft from the account. They shared one sentence — "the
+// model is not configured" — and a rehearsal spent an afternoon looking for a
+// missing provider that was never missing: the person page simply made no
+// request at all.
+type DraftUnavailable = "no_model" | "unsupported_origin";
+
 type DraftResult =
-  | { available: false }
+  | { available: false; reason: DraftUnavailable }
   | {
       available: true;
       draft: Pick<EmailDraft, "subject" | "body" | "to"> &
@@ -1150,7 +1218,7 @@ function DraftOffer({
   intent: string;
   onIntentChange: (next: string) => void;
   draft: PendingAction;
-  unavailable: boolean;
+  unavailable: DraftUnavailable | null;
 }>) {
   const t = useT();
   return (
@@ -1184,7 +1252,11 @@ function DraftOffer({
         </Button>
       </div>
       {unavailable && (
-        <p className="t-caption">{t("compose.draftUnavailable")}</p>
+        <p className="t-caption">
+          {unavailable === "no_model"
+            ? t("compose.draftUnavailable")
+            : t("compose.draftUnsupportedHere")}
+        </p>
       )}
       {/* The failure appears without any navigation, so it is announced rather
           than merely coloured: a rep who cannot see the line has to be told
@@ -1653,7 +1725,7 @@ function MailOnlyFields({
   intent: string;
   onIntentChange: (next: string) => void;
   draft: PendingAction;
-  draftUnavailable: boolean;
+  draftUnavailable: DraftUnavailable | null;
   provenance: DraftProvenance | null;
   voiceMaturity: VoiceProfile["maturity"] | undefined;
   reasons: components["schemas"]["AccountDraftReason"][];
@@ -1811,7 +1883,7 @@ function useDraftMutation({
   entityType: RelinkKind;
   entityId: string;
   intent: string;
-  onUnavailable: () => void;
+  onUnavailable: (reason: DraftUnavailable) => void;
   onDrafted: (
     result: Extract<DraftResult, { available: true }>,
     ask: DraftAsk,
@@ -1841,7 +1913,7 @@ function useDraftMutation({
     },
     onSuccess: (result, ask) => {
       if (!result.available) {
-        onUnavailable();
+        onUnavailable(result.reason);
         return;
       }
       onDrafted(result, ask);
@@ -2384,7 +2456,8 @@ export function ComposeModal({
   const [servedBody, setServedBody] = useState("");
   // Two honest non-error outcomes, kept OUT of react-query's error channel so
   // the form stays usable: the model / mailer simply isn't configured (501).
-  const [draftUnavailable, setDraftUnavailable] = useState(false);
+  const [draftUnavailable, setDraftUnavailable] =
+    useState<DraftUnavailable | null>(null);
   const [sendUnavailable, setSendUnavailable] = useState(false);
   // Retiring the previous pair's draft is the composer's job, not the
   // grounding hook's: the body, the recipients, the reference and the
@@ -2811,7 +2884,7 @@ export function ComposeModal({
     entityType,
     entityId,
     intent,
-    onUnavailable: () => setDraftUnavailable(true),
+    onUnavailable: (reason: DraftUnavailable) => setDraftUnavailable(reason),
     onDrafted: (result, ask) => {
       fillFromDraft(result, {
         subject,
@@ -2829,7 +2902,7 @@ export function ComposeModal({
       });
       revealDraftedBody();
     },
-    resetUnavailable: () => setDraftUnavailable(false),
+    resetUnavailable: () => setDraftUnavailable(null),
     t,
   });
 

--- a/frontend/src/screens/leads.list.tsx
+++ b/frontend/src/screens/leads.list.tsx
@@ -12,7 +12,6 @@ import { Callout } from "../design-system/callout";
 import { useToast } from "../design-system/toast";
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { leadIdentityName } from "../format/leadname";
-import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -455,7 +454,7 @@ function LeadsWorkbench({
                     })}`
                   : ""}
                 {lead.next_task_due_at
-                  ? ` · ${formatDateAbbrev(lead.next_task_due_at, locale, viewerZone())}`
+                  ? ` · ${formatDateAbbrev(lead.next_task_due_at, locale, recordZone)}`
                   : ""}
               </span>
             ),

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -14,6 +14,7 @@ import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useRecordWriteRefusal } from "../app/capability";
 import { PageAsideToggle, usePageAside } from "../app/pageaside";
+import { useRecordZone } from "../app/recordzone";
 import { navigate, useRoute } from "../app/router";
 import { useUrlParams } from "../app/urlstate";
 import { activityTimeline } from "../design-system/activitytimeline";
@@ -1056,7 +1057,15 @@ function LeadCall({
 // the next task on it. Neither is the agent's move — a lead carries no
 // suggestions — so both draw as to-dos the record already carries. A closed
 // lead is not worked and draws none.
-function leadTodoRows(lead: Lead, t: Translator, locale: Locale): ReactNode[] {
+function leadTodoRows(
+  lead: Lead,
+  t: Translator,
+  locale: Locale,
+  // A task's DEADLINE is the record's day — the team agreed it and every
+  // colleague must quote the same one. The response clocks below stay on the
+  // reader's own: how long a lead has been waiting on them is about them.
+  recordZone: string,
+): ReactNode[] {
   if (lead.archived_at) {
     return [];
   }
@@ -1092,7 +1101,7 @@ function leadTodoRows(lead: Lead, t: Translator, locale: Locale): ReactNode[] {
                       when: formatDateAbbrev(
                         lead.next_task_due_at,
                         locale,
-                        zone,
+                        recordZone,
                       ),
                     }),
                 tone: late ? "danger" : undefined,
@@ -1447,6 +1456,7 @@ function LeadOverviewPane({
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const recordZone = useRecordZone();
   // The verb the reader arrived to perform, named by the address rather than
   // guessed: a caller that sends somebody here to log a call says so, and the
   // composer opens on that kind instead of on a note the reader has to change.
@@ -1493,7 +1503,7 @@ function LeadOverviewPane({
           onOpenEmail={onOpenEmail}
         />
         <TodayPanel onOpenTasks={() => navigate({ screen: "worklist" })}>
-          {leadTodoRows(lead, t, locale)}
+          {leadTodoRows(lead, t, locale, recordZone)}
         </TodayPanel>
         <RecordReadingPair>
           <LeadScoreCard

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -19,7 +19,6 @@ import {
 } from "../design-system/recordpicker";
 import { Select } from "../design-system/select";
 import { calendarDay, dueInstant, middayInstant } from "../format/calendarday";
-import { viewerZone } from "../format/timezone";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys, taskWriteKeys } from "./activitykeys";
@@ -72,16 +71,15 @@ type OpeningKind = "note" | "task" | "call";
 // change it instead of being assumed at submit behind an empty box.
 //
 // Which zone that is follows what the day MEANS, the same split the draft's
-// `day` field carries. A note or meeting files under a heading on the record's
-// timeline, grouped in the record zone, so the day it can be offered is the record's
-// today; a task's day is a personal due date, minted by `dueInstant` in the
-// browser's zone and rendered there, so its today is the writer's own. Offer a
-// day from the other zone and the composer names a day the entry does not land
-// on: an afternoon in Los Angeles is already tomorrow on a Berlin clock, so a
-// writer offered their own today, accepting it, watched the entry file under the
-// day after.
-function todayDay(kind: ActivityDraft["kind"], recordZone: string): string {
-  return calendarDay(new Date(), kind === "task" ? viewerZone() : recordZone);
+// `day` field carries. Every kind this form writes files against the record's
+// clock: a note or meeting lands under a heading on the record's timeline, and
+// a task's due date is a deadline colleagues read back, minted by `dueInstant`
+// in that same zone and rendered there. Offering a day from the browser's zone
+// instead names a day the entry does not land on — an afternoon in Los Angeles
+// is already tomorrow on a Berlin clock, so a writer offered their own today,
+// accepting it, watched the entry file under the day after.
+function todayDay(_kind: ActivityDraft["kind"], recordZone: string): string {
+  return calendarDay(new Date(), recordZone);
 }
 
 // Whether a Select's answer is a kind this form writes.
@@ -182,14 +180,13 @@ function activityRequestBody(
     subject: input.subject.trim(),
     body: outgoingBody || null,
     occurred_at: occurredInstant(input, recordZone),
-    // A due date becomes the instant that day ENDS in the writer's
-    // own zone (format/calendarday). Handing the bare `yyyy-mm-dd` to
-    // `new Date` reads it as UTC midnight instead, which is neither the
-    // end of the day nor, west of UTC, the day the writer picked: the task
-    // arrived already overdue, and the tasks list — which buckets in the
-    // reader's zone — filed it under yesterday.
+    // A due date becomes the instant that day ENDS on the RECORD's clock
+    // (format/calendarday), which is the same zone the worklist buckets
+    // overdue in and the same one the task detail renders. Minting it in the
+    // writer's own zone instead is what let an approved 9 September come back
+    // as a task due the 10th for a colleague sitting further east.
     ...(input.kind === "task" && input.day
-      ? { due_at: dueInstant(input.day) }
+      ? { due_at: dueInstant(input.day, recordZone) }
       : {}),
     // Held: a hand-logged meeting already took place (the date caps at
     // today), and held is what the lead ladder reads as engagement.

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -19,7 +19,6 @@ import {
   formatDuration,
   formatMoneyOrAbsent,
 } from "../format/format";
-import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { EntityRef } from "./entityref";
@@ -469,16 +468,16 @@ function CommitmentRow({
   locale: ReturnType<typeof useLocale>["locale"];
 }>) {
   const t = useT();
+  // The record's clock, exactly as the tasks screen reads it. A commitment is a
+  // deadline the team agreed, so the day it names cannot depend on where the
+  // reader is sitting.
+  const recordZone = useRecordZone();
   return (
     <PanelRow className="project-row">
       <span>{commitment.subject}</span>
       <span className="project-row-meta t-caption">
-        {/* A due date is a personal deadline, read in the reader's own zone
-            exactly as the tasks screen reads it. */}
         {commitment.due_at && (
-          <span>
-            {formatDateAbbrev(commitment.due_at, locale, viewerZone())}
-          </span>
+          <span>{formatDateAbbrev(commitment.due_at, locale, recordZone)}</span>
         )}
         {commitment.overdue && (
           <Badge tone="danger">{t("project.commitments.overdue")}</Badge>

--- a/frontend/src/screens/taskactions.tsx
+++ b/frontend/src/screens/taskactions.tsx
@@ -42,8 +42,6 @@ type TaskPatch = {
   body: { is_done?: boolean; due_at?: string; remind_at?: string | null };
 };
 
-const ONE_DAY_MS = 86_400_000;
-
 export function useTaskUpdate(invalidateKeys: readonly QueryKey[]) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -76,12 +74,35 @@ export function useTaskUpdate(invalidateKeys: readonly QueryKey[]) {
   });
 }
 
-/** The next due date one snooze away, or null for a task that has no date to move. */
-export function snoozedDueAt(dueAt: string | null | undefined): string | null {
+/**
+ * The next due date one snooze away, or null for a task that has no date to
+ * move.
+ *
+ * A snooze moves the task to the NEXT CALENDAR DAY, which is not the same as
+ * adding twenty-four hours. A local day is not always that long: on Europe's
+ * spring-forward day, adding a day to the 28th at 23:59:59 lands at 00:59:59
+ * on the 30th, so a rep pressing "tomorrow" skips the 29th entirely. The
+ * accept path warns about exactly this arithmetic where it stamps a deadline;
+ * this writer was doing it.
+ *
+ * Read and re-minted through the calendar helpers, in the zone the deadline
+ * belongs to, so a snooze lands on the day it names for every colleague.
+ */
+export function snoozedDueAt(
+  dueAt: string | null | undefined,
+  zone: string,
+): string | null {
   if (!dueAt) {
     return null;
   }
-  return new Date(new Date(dueAt).getTime() + ONE_DAY_MS).toISOString();
+  const today = calendarDay(new Date(dueAt), zone);
+  const [year, month, day] = today.split("-").map(Number);
+  // Through UTC parts, which is a pure calendar step: no zone reading happens
+  // here, so no DST transition can shorten or lengthen the day being counted.
+  const next = new Date(Date.UTC(year, month - 1, day + 1))
+    .toISOString()
+    .slice(0, "yyyy-mm-dd".length);
+  return dueInstant(next, zone);
 }
 
 /**
@@ -168,7 +189,8 @@ export function TaskQuickActions({
   showDuePicker?: boolean;
 }>) {
   const t = useT();
-  const nextDue = snoozedDueAt(dueAt);
+  const recordZone = useRecordZone();
+  const nextDue = snoozedDueAt(dueAt, recordZone);
   const pending = update.isPending && update.variables?.id === activityId;
   return (
     <>

--- a/frontend/src/screens/taskactions.tsx
+++ b/frontend/src/screens/taskactions.tsx
@@ -20,7 +20,6 @@ import {
 import { DateInput, isISODate } from "../design-system/dateinput";
 import { calendarDay, dueInstant } from "../format/calendarday";
 import { formatDate, formatDateTime } from "../format/format";
-import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { EntityRef } from "./entityref";
@@ -238,10 +237,11 @@ function TaskDueDatePick({
 }>) {
   const t = useT();
   const pending = update.isPending && update.variables?.id === activityId;
-  // Seeded from the task's own day in the VIEWER's zone, matching what the
-  // meta line above reads it in: a picker opening on a different day than the
-  // one displayed beside it would be two answers to "when is this due".
-  const seeded = dueAt ? calendarDay(new Date(dueAt), viewerZone()) : "";
+  const recordZone = useRecordZone();
+  // Seeded from the task's own day in the INSTALLATION's zone, matching what
+  // the meta line above reads it in: a picker opening on a different day than
+  // the one displayed beside it would be two answers to "when is this due".
+  const seeded = dueAt ? calendarDay(new Date(dueAt), recordZone) : "";
   // Narrowed rather than asserted. calendarDay returns a string, and the
   // control's type says it takes a calendar day or nothing — so a value that
   // is neither opens the picker empty instead of feeding the element something
@@ -274,7 +274,7 @@ function TaskDueDatePick({
             update.mutate({
               id: activityId,
               version,
-              body: { due_at: dueInstant(day) },
+              body: { due_at: dueInstant(day, recordZone) },
             });
           }}
         />
@@ -339,14 +339,13 @@ export function TaskDetailModal({
             {task.due_at ? (
               <span>
                 {t("co.next.due", {
-                  // The one viewer-clock reading on this record surface, and it
-                  // is not a preference: `dueInstant` mints a due date as the
-                  // end of the picked day in the BROWSER's zone, so the stored
-                  // instant already carries the picker's clock. Read in the
-                  // organization's zone it names a different calendar day than
-                  // the one the picker chose, for every reader outside that
-                  // zone — there is no organization reading of it to prefer.
-                  when: formatDate(task.due_at, locale, viewerZone()),
+                  // The record's own clock, like every other date on this
+                  // surface. A deadline is a fact colleagues read back, so the
+                  // day it names cannot depend on where the reader is sitting:
+                  // `dueInstant` mints the picked day's end in this same zone,
+                  // and reading it in the browser's instead is what made an
+                  // approved 9 September arrive as a task due the 10th.
+                  when: formatDate(task.due_at, locale, recordZone),
                 })}
               </span>
             ) : (

--- a/frontend/src/screens/taskduedate.guard.test.ts
+++ b/frontend/src/screens/taskduedate.guard.test.ts
@@ -11,7 +11,8 @@
 
 import { describe, expect, it } from "vitest";
 import { isISODate } from "../design-system/dateinput";
-import { dueInstant } from "../format/calendarday";
+import { calendarDay, dueInstant } from "../format/calendarday";
+import { snoozedDueAt } from "./taskactions";
 
 describe("the days a task may be moved to", () => {
   it("refuses what dueInstant cannot convert", () => {
@@ -39,5 +40,51 @@ describe("the days a task may be moved to", () => {
     expect(dueInstant("2026-09-15", "Europe/Berlin")).toBe(
       "2026-09-15T21:59:59.000Z",
     );
+  });
+});
+
+// Snoozing moves a task to the NEXT CALENDAR DAY, which is not twenty-four
+// hours. A local day is not always that long: adding a day to Berlin's 28 March
+// at 23:59:59 landed at 00:59:59 on the 30th, so a rep pressing "tomorrow"
+// skipped the 29th entirely and the task they meant to see that day was never
+// on it.
+describe("snoozing a task by a day", () => {
+  it("lands on the next calendar day across spring forward", () => {
+    // 2026-03-28 23:59:59 Berlin. The next day is the 29th, the day the clocks
+    // move — an hour shorter, and still one day away.
+    const from = "2026-03-28T22:59:59.000Z";
+    expect(snoozedDueAt(from, "Europe/Berlin")).toBe(
+      "2026-03-29T21:59:59.000Z",
+    );
+    expect(
+      calendarDay(
+        new Date(snoozedDueAt(from, "Europe/Berlin") as string),
+        "Europe/Berlin",
+      ),
+    ).toBe("2026-03-29");
+  });
+
+  it("lands on the next calendar day across autumn back", () => {
+    const from = "2026-10-24T21:59:59.000Z";
+    expect(
+      calendarDay(
+        new Date(snoozedDueAt(from, "Europe/Berlin") as string),
+        "Europe/Berlin",
+      ),
+    ).toBe("2026-10-25");
+  });
+
+  it("steps a month end onto the first", () => {
+    const from = "2026-01-31T22:59:59.000Z";
+    expect(
+      calendarDay(
+        new Date(snoozedDueAt(from, "Europe/Berlin") as string),
+        "Europe/Berlin",
+      ),
+    ).toBe("2026-02-01");
+  });
+
+  it("has nothing to move on an undated task", () => {
+    expect(snoozedDueAt(null, "Europe/Berlin")).toBeNull();
   });
 });

--- a/frontend/src/screens/taskduedate.guard.test.ts
+++ b/frontend/src/screens/taskduedate.guard.test.ts
@@ -20,7 +20,7 @@ describe("the days a task may be moved to", () => {
     // guard a year typo reaches an uncaught exception with nothing on screen
     // to say the date was refused.
     expect(isISODate("10000-09-15")).toBe(false);
-    expect(() => dueInstant("10000-09-15")).toThrow();
+    expect(() => dueInstant("10000-09-15", "Europe/Berlin")).toThrow();
   });
 
   it("refuses the cleared box", () => {
@@ -34,8 +34,10 @@ describe("the days a task may be moved to", () => {
     // The guard has to ADMIT as well as refuse: one that said no to everything
     // would pass both tests above and break the feature.
     expect(isISODate("2026-09-15")).toBe(true);
-    expect(new Date(dueInstant("2026-09-15")).getTime()).toBe(
-      new Date("2026-09-15T23:59:59").getTime(),
+    // Read back in the zone it was minted for, the instant is that day's last
+    // whole second — the same day the picker offered, for every reader.
+    expect(dueInstant("2026-09-15", "Europe/Berlin")).toBe(
+      "2026-09-15T21:59:59.000Z",
     );
   });
 });

--- a/frontend/src/screens/taskduedate.test.tsx
+++ b/frontend/src/screens/taskduedate.test.tsx
@@ -18,18 +18,25 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordZoneProvider } from "../app/recordzone";
 import { LocaleProvider } from "../i18n";
 import { TaskQuickActions, useTaskUpdate } from "./taskactions";
 
 const TASK = "01a05500-0000-7000-8000-000000000a01";
 
+// The installation this record belongs to. Named rather than read off the
+// runner, because the rule under test is that a deadline reads as the SAME day
+// for every colleague — a suite that took the machine's own zone would assert
+// nothing when the machine happened to sit in it.
+const RECORD_ZONE = "Europe/Berlin";
+
 // The task's due instant, minted the way the product mints one: the end of a
-// calendar day in the RUNNING machine's zone. A fixed UTC string would name a
-// different calendar day depending on where the suite runs — 23:59:59Z on the
-// 1st is already the 2nd anywhere east of UTC — and the picker reads the day in
-// the viewer's zone, correctly, so the fixture has to speak the same clock.
+// calendar day on the RECORD's clock. Berlin is two hours ahead of UTC in
+// September, so this is 21:59:59Z — a value that names 1 September in Berlin
+// and 2 September in Bangkok, which is exactly the disagreement the record-zone
+// rule exists to settle.
 const DUE_DAY = "2026-09-01";
-const DUE_AT = new Date(`${DUE_DAY}T23:59:59`).toISOString();
+const DUE_AT = "2026-09-01T21:59:59.000Z";
 
 let sent: unknown[] = [];
 
@@ -80,9 +87,11 @@ function renderVerbs(dueAt?: string | null) {
   });
   return render(
     <QueryClientProvider client={client}>
-      <LocaleProvider initial="en">
-        <Harness />
-      </LocaleProvider>
+      <RecordZoneProvider zone={RECORD_ZONE}>
+        <LocaleProvider initial="en">
+          <Harness />
+        </LocaleProvider>
+      </RecordZoneProvider>
     </QueryClientProvider>,
   );
 }
@@ -127,13 +136,12 @@ describe("moving a task to a named day", () => {
     fireEvent.change(picker(container), { target: { value: "2026-09-15" } });
 
     await waitFor(() => expect(sent).toHaveLength(1));
-    // The END of the picked day, so a task due "the 15th" is not overdue at
-    // nine that morning. dueInstant owns that rule; this asserts the row uses
-    // it rather than sending midnight.
+    // The END of the picked day on the RECORD's clock, so a task due "the
+    // 15th" is not overdue at nine that morning and still reads as the 15th to
+    // a colleague in another zone. dueInstant owns that rule; this asserts the
+    // row passes it the record zone rather than the browser's.
     const body = sent[0] as { due_at: string };
-    expect(new Date(body.due_at).getTime()).toBe(
-      new Date("2026-09-15T23:59:59").getTime(),
-    );
+    expect(body.due_at).toBe("2026-09-15T21:59:59.000Z");
   });
 
   it("opens on the day the task is already due", async () => {

--- a/frontend/src/screens/transcriptread.test.tsx
+++ b/frontend/src/screens/transcriptread.test.tsx
@@ -307,6 +307,10 @@ describe("reading a transcript for its next steps", () => {
 
     expect(await screen.findByText("1 expired undecided")).toBeTruthy();
     expect(screen.queryByText(/accepted/)).toBeNull();
+    // And not "1 suggestion reviewed" beside it. Counting every staged id as
+    // reviewed put the two claims on the card at once, each contradicting the
+    // other.
+    expect(screen.queryByText("1 suggestion reviewed")).toBeNull();
   });
 
   // An approved suggestion whose effect did not run produced NO task. Reading
@@ -344,6 +348,8 @@ describe("reading a transcript for its next steps", () => {
     expect(
       await screen.findByText("Status unavailable for 1 suggestion"),
     ).toBeTruthy();
+    // A status nobody could read is not a decision somebody made.
+    expect(screen.queryByText("1 suggestion reviewed")).toBeNull();
   });
 
   it("offers a first reading, and no outcome, on a transcript nobody has read", async () => {

--- a/frontend/src/screens/transcriptread.test.tsx
+++ b/frontend/src/screens/transcriptread.test.tsx
@@ -79,6 +79,13 @@ function stubReads(options: {
   stored?: Report;
   read?: () => Response;
   post?: () => Response;
+  // What became of each staged approval, by id. The card asks the approval
+  // itself what its status is, because the reading's own proposal_ids is a
+  // frozen record of what it STAGED and never learns that one was decided.
+  // Unnamed ids answer "pending", which is the state a freshly staged one is
+  // in.
+  approvals?: Record<string, { status: string; effect_failed_at?: string }>;
+  approvalStatus?: number;
 }) {
   const calls: string[] = [];
   vi.stubGlobal(
@@ -96,6 +103,20 @@ function stubReads(options: {
           options.post ??
           (() => jsonResponse({ read_id: "rd-1", status: "queued" }, 202))
         )();
+      }
+      const approval = /\/approvals\/([^/]+)$/.exec(url.pathname);
+      if (approval) {
+        if (options.approvalStatus) {
+          return jsonResponse({}, options.approvalStatus);
+        }
+        const id = approval[1];
+        return jsonResponse({
+          id,
+          status: options.approvals?.[id]?.status ?? "pending",
+          ...(options.approvals?.[id]?.effect_failed_at
+            ? { effect_failed_at: options.approvals[id].effect_failed_at }
+            : {}),
+        });
       }
       if (url.pathname.endsWith("/transcript-proposals/latest")) {
         return options.stored
@@ -227,6 +248,101 @@ describe("reading a transcript for its next steps", () => {
     // finished reading findable at all.
     expect(
       await screen.findByText("1 next step waiting for your review"),
+    ).toBeTruthy();
+  });
+
+  // The defect a rehearsal met: accept the only suggestion, watch the task
+  // appear, come back and the card still says one is waiting. proposal_ids is
+  // written once and never learns a decision was made, so the count was right
+  // and the sentence was about a different fact.
+  it("says a decided suggestion was reviewed, not that it is waiting", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1"] }),
+      approvals: { "ap-1": { status: "approved" } },
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    expect(await screen.findByText("1 suggestion reviewed")).toBeTruthy();
+    expect(screen.getByText("1 accepted, 0 declined")).toBeTruthy();
+    expect(
+      screen.queryByText("1 next step waiting for your review"),
+    ).toBeNull();
+  });
+
+  it("counts only what is still waiting when some of a batch is decided", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1", "ap-2", "ap-3"] }),
+      approvals: {
+        "ap-1": { status: "approved" },
+        "ap-2": { status: "rejected" },
+      },
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    // One of the three is undecided, and that is the number a rep acts on.
+    expect(
+      await screen.findByText("1 next step waiting for your review"),
+    ).toBeTruthy();
+  });
+
+  it("names a rejected suggestion as declined rather than accepted", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1"] }),
+      approvals: { "ap-1": { status: "rejected" } },
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    expect(await screen.findByText("1 suggestion reviewed")).toBeTruthy();
+    expect(screen.getByText("0 accepted, 1 declined")).toBeTruthy();
+  });
+
+  // Expiry is not a review. Counting it as one tells a rep somebody looked at
+  // the suggestion when nobody did.
+  it("keeps an expired suggestion out of the accepted and declined counts", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1"] }),
+      approvals: { "ap-1": { status: "expired" } },
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    expect(await screen.findByText("1 expired undecided")).toBeTruthy();
+    expect(screen.queryByText(/accepted/)).toBeNull();
+  });
+
+  // An approved suggestion whose effect did not run produced NO task. Reading
+  // the status alone would tell a rep the work exists when it does not, which
+  // is the one wrong answer here that costs them a commitment.
+  it("says an accepted suggestion did not produce its task", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1"] }),
+      approvals: {
+        "ap-1": {
+          status: "approved",
+          effect_failed_at: "2026-09-07T09:00:00Z",
+        },
+      },
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    expect(
+      await screen.findByText(
+        "1 accepted suggestion did not produce its task.",
+      ),
+    ).toBeTruthy();
+  });
+
+  // A status nobody could read is not a reviewed one. Claiming everything is
+  // decided on the strength of a failed read is the same lie in the other
+  // direction.
+  it("says a status it could not read is unavailable", async () => {
+    stubReads({
+      stored: report({ proposal_ids: ["ap-1"] }),
+      approvalStatus: 403,
+    });
+    render(<TranscriptReadCard activityId="a-1" />);
+
+    expect(
+      await screen.findByText("Status unavailable for 1 suggestion"),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/transcriptread.tsx
+++ b/frontend/src/screens/transcriptread.tsx
@@ -111,6 +111,11 @@ function TranscriptReadProposals({ ids }: Readonly<{ ids: string[] }>) {
   // it promised. Counting it as done would tell a rep the work exists when it
   // does not — the one reading of this card that costs them a commitment.
   const effectFailed = known.filter((one) => one?.effect_failed_at).length;
+  // Only what a PERSON actually decided. An approval that lapsed was reviewed
+  // by nobody, and one whose status could not be read is unknown rather than
+  // settled — counting either as reviewed makes the card claim an answer that
+  // was never given, next to a line saying the opposite.
+  const reviewed = approved + rejected;
 
   // Until every read has answered, the historical count is all that can be
   // said honestly. Saying "reviewed" early would claim decisions not yet seen,
@@ -137,8 +142,8 @@ function TranscriptReadProposals({ ids }: Readonly<{ ids: string[] }>) {
             ? plural("transcriptread.proposals", pending, {
                 count: formatNumber(pending, locale),
               })
-            : plural("transcriptread.decided", ids.length, {
-                count: formatNumber(ids.length, locale),
+            : plural("transcriptread.decided", reviewed, {
+                count: formatNumber(reviewed, locale),
               })}
       </span>
       {!loading && pending === 0 && (approved > 0 || rejected > 0) && (

--- a/frontend/src/screens/transcriptread.tsx
+++ b/frontend/src/screens/transcriptread.tsx
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -40,8 +45,6 @@ function TranscriptReadOutcome({
   report,
 }: Readonly<{ report: TranscriptReadReport }>) {
   const t = useT();
-  const plural = usePlural();
-  const { locale } = useLocale();
   if (report.status === "failed") {
     return (
       <Callout tone="danger" live="status">
@@ -56,6 +59,64 @@ function TranscriptReadOutcome({
       </Callout>
     );
   }
+  return <TranscriptReadProposals ids={report.proposal_ids} />;
+}
+
+// What became of what the reading staged.
+//
+// `proposal_ids` is a FROZEN record of what this run proposed — it is written
+// once and never touched again — and the card read its length under the words
+// "waiting for your review". So a rep who accepted the only suggestion, and
+// watched the task appear, came back to a card still saying one was waiting.
+// Nothing was wrong with the number; the sentence was about a different fact.
+//
+// The decisions are read where they actually live, one authorised read per
+// staged approval, keyed ["approval", id] — the key approvalrow already
+// invalidates when a decision lands, so accepting from the worklist refreshes
+// this card without a reload.
+//
+// A hook cannot sit under a changing early return, which is why this is its own
+// component: the parent returns before it for a failed or empty reading.
+function TranscriptReadProposals({ ids }: Readonly<{ ids: string[] }>) {
+  const t = useT();
+  const plural = usePlural();
+  const { locale } = useLocale();
+  const decisions = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ["approval", id],
+      queryFn: async () => {
+        const { data, error } = await api.GET("/approvals/{id}", {
+          params: { path: { id } },
+        });
+        if (error) {
+          throwProblem(error);
+        }
+        return data;
+      },
+      // A decided approval does not un-decide, and this card is often on
+      // screen while the rep works elsewhere in the record.
+      staleTime: 10_000,
+      retry: false,
+    })),
+  });
+
+  const settled = decisions.filter((one) => !one.isPending);
+  const known = settled.filter((one) => !one.isError).map((one) => one.data);
+  const unreadable = settled.length - known.length;
+  const pending = known.filter((one) => one?.status === "pending").length;
+  const approved = known.filter((one) => one?.status === "approved").length;
+  const rejected = known.filter((one) => one?.status === "rejected").length;
+  const expired = known.filter((one) => one?.status === "expired").length;
+  // An approved suggestion whose effect did not run has NOT produced the task
+  // it promised. Counting it as done would tell a rep the work exists when it
+  // does not — the one reading of this card that costs them a commitment.
+  const effectFailed = known.filter((one) => one?.effect_failed_at).length;
+
+  // Until every read has answered, the historical count is all that can be
+  // said honestly. Saying "reviewed" early would claim decisions not yet seen,
+  // and saying "waiting" early is the bug this replaced.
+  const loading = settled.length < ids.length;
+
   return (
     <p
       style={{
@@ -68,10 +129,50 @@ function TranscriptReadOutcome({
     >
       <AutonomyDot tier="confirm" />
       <span className="t-caption">
-        {plural("transcriptread.proposals", report.proposal_ids.length, {
-          count: formatNumber(report.proposal_ids.length, locale),
-        })}
+        {loading
+          ? plural("transcriptread.staged", ids.length, {
+              count: formatNumber(ids.length, locale),
+            })
+          : pending > 0
+            ? plural("transcriptread.proposals", pending, {
+                count: formatNumber(pending, locale),
+              })
+            : plural("transcriptread.decided", ids.length, {
+                count: formatNumber(ids.length, locale),
+              })}
       </span>
+      {!loading && pending === 0 && (approved > 0 || rejected > 0) && (
+        <span className="t-caption">
+          {t("transcriptread.decidedDetail", {
+            accepted: formatNumber(approved, locale),
+            rejected: formatNumber(rejected, locale),
+          })}
+        </span>
+      )}
+      {!loading && expired > 0 && (
+        <span className="t-caption">
+          {plural("transcriptread.expired", expired, {
+            count: formatNumber(expired, locale),
+          })}
+        </span>
+      )}
+      {effectFailed > 0 && (
+        <Callout tone="danger" live="status">
+          {plural("transcriptread.effectFailed", effectFailed, {
+            count: formatNumber(effectFailed, locale),
+          })}
+        </Callout>
+      )}
+      {unreadable > 0 && (
+        <span className="t-caption">
+          {plural("transcriptread.statusUnknown", unreadable, {
+            count: formatNumber(unreadable, locale),
+          })}
+        </span>
+      )}
+      {/* The worklist is where a pending suggestion is decided. Once none is,
+          it is still where the decided ones are listed, so the button keeps
+          leading somewhere real rather than disappearing. */}
       <Button small onClick={() => navigate({ screen: "worklist" })}>
         {t("enrich.toInbox")}
       </Button>

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -431,11 +431,18 @@ export function dealFactsText(
 // their desk on the morning it matters, and "today" is the frame they are
 // already in. Anything else shows the date, because a bare "09:00" on a row two
 // days out is a time the reader will act on this morning.
+// The two moments are read on DIFFERENT clocks, because they are different
+// kinds of fact. A meeting STARTS at an instant the reader attends, so it is
+// theirs: a 09:00 Berlin call is 14:00 to someone in Bangkok, and telling them
+// 09:00 would send them to it five hours late. A task is DUE on a calendar day
+// the team agreed, so it is the record's: two colleagues quoting one deadline
+// have to quote the same day, which is what `dueInstant` now mints it as.
 export function whenText(
   item: WorklistItem,
   t: T,
   locale: Locale,
-  zone: string,
+  viewer: string,
+  record: string,
   now: Date,
 ): string | null {
   if (!item.due_at) {
@@ -445,6 +452,7 @@ export function whenText(
   if (key === null) {
     return null;
   }
+  const zone = item.source === "task" ? record : viewer;
   return t(key, { when: momentText(item.due_at, locale, zone, now) });
 }
 

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -10,6 +10,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useId, useRef, useState } from "react";
+import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, Modal } from "../design-system/atoms";
 import { PanelRow } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
@@ -113,6 +114,9 @@ export function WorklistRow({
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
+  // A task's deadline is the record's day; everything else on this row is a
+  // moment the reader is racing on their own clock.
+  const recordZone = useRecordZone();
   const href = rowHref(item);
   const title = itemTitle(item, t, locale);
   const facts = dealFactsText(item, t, locale, zone);
@@ -120,7 +124,7 @@ export function WorklistRow({
   // The clock this row is racing. A meeting said "starting shortly" whether it
   // began in four minutes or in fifty, and a task said "Overdue" without saying
   // by how long — on the two rows whose whole claim is a moment.
-  const when = whenText(item, t, locale, zone, new Date());
+  const when = whenText(item, t, locale, zone, recordZone, new Date());
   // The supporting line. Every source but one sends a sentence already;
   // sync_health sends its condition's facts in its own vocabulary, so its line
   // is written from `kind` and `detail` together.

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -39,6 +39,30 @@ describe("what the ranked queue tells a reader", () => {
     expect(container.querySelectorAll(".panel")).toHaveLength(0);
   });
 
+  // The queue is TODAY's: the server takes open tasks due before the
+  // installation's midnight, so a task due tomorrow is deliberately absent.
+  // "Nothing is waiting on you" read as "you have no work" to a rep looking at
+  // three tasks on the company beside it, and nothing on the page reconciled
+  // the two — a rehearsal stopped to work out whether an accepted task had been
+  // lost.
+  it("says which horizon an empty Tasks queue is empty of", async () => {
+    const user = userEvent.setup();
+    stub(day());
+    renderWorklist();
+
+    await screen.findByText("Nothing is waiting on you.");
+    await user.click(screen.getByRole("button", { name: /^Tasks/ }));
+
+    expect(
+      await screen.findByText(
+        "No tasks are due today or overdue. Later work is on each record's own Tasks tab.",
+      ),
+    ).toBeTruthy();
+    // The unqualified sentence is the one that misled: it must not be what a
+    // reader under this pill is left with.
+    expect(screen.queryByText("Nothing is waiting on you.")).toBeNull();
+  });
+
   it("names the record when the title alone cannot be told apart", async () => {
     stub(
       day({

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -12,6 +12,7 @@ import { SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { useOpenEmail } from "./openemail";
 import {
   bandSections,
@@ -342,6 +343,22 @@ function QueueRows({
 // `queue` is every row loaded so far, which grows. Reading rows off `day`
 // would draw only the first page; reading figures off the latest page would
 // describe a slice as though it were the day.
+// Which "there is nothing here" sentence an empty queue earns.
+//
+// A partial read outranks both: a day cannot be reported clear while something
+// that would have filled it was never read. Otherwise the Tasks pill names its
+// HORIZON — this queue is today's, so a task due tomorrow is deliberately
+// absent, and "Nothing is waiting on you" read as "you have no work" to a rep
+// looking at three open tasks on the company page beside it. The other pills
+// keep the unqualified sentence: the full queue carries replies and reviews
+// that have no deadline, so "due today" would be the wrong frame for it.
+function clearMessage(partial: boolean, filter: WorklistFilter): MessageKey {
+  if (partial) {
+    return "worklist.clearOfWhatWasRead";
+  }
+  return filter === "tasks" ? "worklist.clearOfTasksToday" : "worklist.clear";
+}
+
 function WorklistBody({
   day,
   walk,
@@ -524,10 +541,15 @@ function WorklistBody({
         // — a question only worth answering when there IS a page. A wholly
         // clear day has nothing to distinguish, and four headings each saying
         // nothing is under them says less than the sentence that says so once.
+        //
+        // Under the Tasks pill the sentence names its HORIZON. This queue is
+        // today's: the server takes open tasks due before the installation's
+        // midnight, so a task due tomorrow is deliberately absent. "Nothing is
+        // waiting on you" read as "you have no work" to a rep who could see
+        // three tasks on the company beside it, and the page offered nothing
+        // to reconcile the two.
         <p className="t-body worklist-clear">
-          {missing.length > 0
-            ? t("worklist.clearOfWhatWasRead")
-            : t("worklist.clear")}
+          {t(clearMessage(missing.length > 0, filter))}
         </p>
       ) : (
         // The queue, and beside it what the SELECTED row is about.


### PR DESCRIPTION
Five defects found in a webinar rehearsal on the demo stack, plus two more the review turned up in the same code.

## What was wrong, and what it does now

**A deadline no longer changes day when it is approved.** A transcript proposal stating 9 September was accepted and came back as a task due the 10th. Both halves were behaving as written: the accept path stamps the day's END in the installation's zone, and every task surface rendered that instant on the browser's clock. The stamp is the day's last second, so a reader one second east of the installation already reads tomorrow.

A deadline is a fact about the record, not about whoever is looking at it. `dueInstant` now takes the zone it resolves in, reusing `endOfDayInZone` rather than growing a second timezone algorithm, and every task date reads in that same zone — the detail, the picker that seeds from it, the company's next steps, the leads list, the project commitments and the worklist row. That is the zone the worklist already buckets overdue in, so all three readings agree.

The worklist needed care rather than a swap: the same row draws a MEETING's start, and that one is genuinely the reader's. A 09:00 Berlin call is 14:00 in Bangkok, and telling them 09:00 sends them five hours late.

**"Write email" on a contact drafts from that contact.** It answered "AI drafting is unavailable (the model is not configured)" — a claim about the deployment, made by a browser that had sent no request, on a stack whose model was answering transcript readings on the same screen. The composer refused every origin but an organization.

Nothing was missing but the arm: `/people/{id}/draft-email` already had spec, handler, wiring, certification and a generated client binding. The refusal now also says which of two different things happened, because "no model" and "not offered from this page" are not the same fact and only one of them is ours.

**A transcript logged on a person says so on their own history.** The person timeline's hand-written SELECT was missing `source_system`, so a transcript reached that contact's history as an ordinary meeting — no card, no proposal count, nothing to open. The company and the deal showed all of it, so the person who was actually in the room was the one place the reading was invisible. The file's own comment already named this defect class twice; this is the third instance.

**The transcript card counts decisions, not what it once staged.** Accept the only suggestion, watch the task appear, come back: it still said one was waiting. `proposal_ids` is written once and never learns a decision was made. It now reads the approvals themselves, and refuses to flatten three states — an expired approval was reviewed by nobody, an approved one whose effect failed produced no task, and a status that could not be read is unknown rather than settled.

**An empty Tasks queue says which horizon it is empty of.** "Nothing is waiting on you" read as "you have no work" to a rep looking at three open tasks on the company page beside it. The behaviour is correct and unchanged: this queue is today's. The sentence now says so, and where later work lives.

## Found by review, in the same code

- `% 1000` truncates toward zero, so the last second of 31 December 1969 became the first of 1 January 1970 — the off-by-one-day this change exists to end, in the one range nobody tries.
- `Date.UTC` maps a two-digit year onto 1900-1999, so `0099-09-09` came back as 1999 with nothing to say it had moved.
- The snooze button added 86_400_000ms. A local day is not always that long, so snoozing Berlin's 28 March landed on the 30th and a rep pressing "tomorrow" skipped the 29th entirely.

## Evidence

Every fix has a test measured from the other end — confirmed failing on the unpatched code, not merely passing on the patched. The person-draft tests assert the ENDPOINT rather than the sentence, because asserting the words alone passes on the tree where the feature does not work, which is how the gap survived.

## Not verified

Deadlines written before this change from a browser WEST of the installation may now display a day later than their author picked. No migration is included: the stored instants are not recoverable to an intended day without knowing each writer's zone at the time, and guessing would corrupt correct rows. Transcript-accepted tasks were always installation-zone and are unaffected.

## Inherited red gate

`TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on `main` (db9ce04425) independently of this branch — reproduced on a clean detached checkout with no local changes. Filed as #4808. Every other backend package, the frontend gate and the integration lane pass.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five defects a webinar rehearsal found on the demo stack, plus review findings in the same code: approved deadlines keep the day they were approved on, "Write email" on a contact drafts from that contact, and the transcript card reports decisions rather than staged proposals.

**Bug Fixes**
- A deadline is now resolved in the installation's zone and rendered there everywhere, so an approved 9 September no longer shows as a task due the 10th to readers east of it; the worklist still draws meeting starts in the reader's zone.
- "Write email" on a contact now calls `/people/{id}/draft-email` instead of claiming the model is unconfigured without sending a request.
- The person timeline now carries `source_system`, so a transcript logged on a contact appears on their own history rather than as an ordinary meeting.
- The transcript card reads each approval's status, so accepted suggestions read as reviewed, and expired, effect-failed, and unreadable statuses are named separately.
- An empty Tasks queue now says it is empty of tasks due today or overdue, and where later work lives.
- Snoozing steps to the next calendar day instead of adding 86,400,000ms, which skipped Berlin's 29 March.
- `dueInstant` now refuses two-digit years and keeps its day before 1970.

Deadlines written before this change from a browser west of the installation may now display a day later than their author picked; no migration is included because the stored instants can't be recovered to an intended day. `TestAnEmailIsDrawnOnlyByTheCanonicalComponents` fails on `main` independently of this branch (filed as #4808).

<sup>Written for commit dcc1b430d471d53c55eb793094453d3b60741227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

