### PR TITLE
A guard that admits a passport is not a human check

### DIFF
--- a/backend/internal/compose/integration/agentcarriesitshuman_integration_test.go
+++ b/backend/internal/compose/integration/agentcarriesitshuman_integration_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A passport carries its granting human's UserID, so a check for one admits an
+// agent. Two reads relied on such a check to stay human-only.
+//
+// The pattern is worth naming because it looks like a gate and is not:
+//
+//	if actor, ok := principal.Actor(ctx); !ok || actor.UserID.IsZero() { ... }
+//
+// It asks "is anybody behind this call", which an agent answers YES to using
+// the id of the person who minted it. Each read then went on to return that
+// person's own standing — what they dismissed, who refused them — to a
+// credential acting on their behalf. auth.RequireHuman is what tells the two
+// apart, and each site now says so where the check is.
+//
+// introductions/routestate.go named getPersonGraph's human-only annotation as
+// its protection, which made the answer depend on which door a read arrived
+// through rather than on what it discloses. That protection was also narrower
+// than it looked: an agent already assembles a Person360 today, through
+// prep_for_meeting → the meeting brief → AssembleScoped, so the dismissal guard
+// is live behaviour rather than defence in depth.
+//
+// The third case in this file is not about agents at all: the employment edge
+// returned an employer's name to a caller holding no organization grant, which
+// the function's own doc comment already claimed it did not.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/introductions"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// routeStatePerms holds every grant RouteStates checks before its human arm runs, so
+// a refusal in this fixture is that arm and never a missing grant.
+var routeStatePerms = principal.Permissions{
+	RoleKeys: []string{"rep"},
+	Objects: map[string]principal.ObjectGrant{
+		"person":       {Read: true},
+		"introduction": {Read: true},
+		"relationship": {Read: true},
+	},
+	RowScope: principal.RowScopeAll,
+}
+
+// TestTheIntroductionLedgerRefusesAnAgentCarryingItsHumansID covers the read
+// that reports which introductions the caller already asked for and which they
+// were refused.
+//
+// The human is admitted and the agent is not, over ONE fixture with ONE set of
+// permissions: the two contexts differ in principal type and in nothing the
+// test chose, so the refusal cannot be a grant the agent was never given.
+func TestTheIntroductionLedgerRefusesAnAgentCarryingItsHumansID(t *testing.T) {
+	e := Setup(t)
+	contact := e.SeedPerson(t, "Marit Vermittelt", &e.Rep1)
+	store := introductions.NewStore(e.DB(), time.Now)
+
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, routeStatePerms)
+	agent := e.AgentFor(t, e.Rep1, []ids.UUID{e.Team1}, routeStatePerms)
+
+	// The positive control comes first: a fixture that refuses everybody would
+	// pass the agent assertion below while proving nothing.
+	if _, err := store.RouteStates(human, ids.From[ids.PersonKind](contact)); err != nil {
+		t.Fatalf("the granting human's own read = %v, want the ledger", err)
+	}
+
+	_, err := store.RouteStates(agent, ids.From[ids.PersonKind](contact))
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("an agent read the introduction ledger → %v, want ErrPermissionDenied — "+
+			"it reports which introductions its human has open and which they were "+
+			"refused, so an agent reading it learns its human was turned down", err)
+	}
+}
+
+// TestRequireHumanIsWhatSeparatesAnAgentFromItsHuman states the premise the two
+// guards now rest on, as a fact rather than an assumption: the agent and its
+// granting human carry the SAME UserID, so an id check cannot separate them and
+// auth.RequireHuman is what does.
+//
+// Asserted directly because it is the premise, not the behaviour: the guards
+// themselves are covered through their real callers above and below.
+func TestRequireHumanIsWhatSeparatesAnAgentFromItsHuman(t *testing.T) {
+	e := Setup(t)
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, routeStatePerms)
+	agent := e.AgentFor(t, e.Rep1, []ids.UUID{e.Team1}, routeStatePerms)
+
+	humanActor, ok := principal.Actor(human)
+	if !ok {
+		t.Fatal("the human fixture carries no actor")
+	}
+	agentActor, ok := principal.Actor(agent)
+	if !ok {
+		t.Fatal("the agent fixture carries no actor")
+	}
+
+	// The defect, stated. If this ever stops being true, the guards below are
+	// answering a different question and this file should be re-read.
+	if agentActor.UserID != humanActor.UserID {
+		t.Fatalf("the agent resolved to user %s and its granting human to %s — a passport "+
+			"is supposed to carry its human's id, and this suite's premise is that an "+
+			"id check therefore cannot refuse one", agentActor.UserID, humanActor.UserID)
+	}
+	if agentActor.UserID.IsZero() {
+		t.Fatal("the agent carries no user id at all, so the id check WOULD refuse it " +
+			"and the fixture is not modelling the case these guards are about")
+	}
+
+	if err := auth.RequireHuman(human); err != nil {
+		t.Errorf("auth.RequireHuman refused the granting human → %v, want admission", err)
+	}
+	if err := auth.RequireHuman(agent); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("auth.RequireHuman admitted an agent → %v, want ErrPermissionDenied — "+
+			"it is the only thing between a passport and its human's own standing", err)
+	}
+}
+
+// TestAnEmployerNameNeedsTheOrganizationGrant covers the object half of the
+// employment edge's answer, through the assembled page.
+//
+// organizationName's doc says a name the caller cannot read "is simply absent",
+// and its statement selected on id and archived_at alone — so a caller holding
+// person and relationship but no organization grant read employer names through
+// the edge. The edge itself still shows: an employment they may see is a true
+// fact, and only the company on the far side of it is a separate question.
+func TestAnEmployerNameNeedsTheOrganizationGrant(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Vertraulich GmbH", &e.Rep1)
+	contact := e.SeedPerson(t, "Pia Angestellt", &e.Rep1)
+	e.WsExec(t, `
+		INSERT INTO relationship (id, kind, person_id, organization_id, is_current_primary, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, true, 'manual', 'human:x')`, ids.NewV7(), contact, org)
+
+	grants := func(withOrg bool) principal.Permissions {
+		objects := map[string]principal.ObjectGrant{
+			"person": {Read: true}, "relationship": {Read: true}, "activity": {Read: true},
+		}
+		if withOrg {
+			objects["organization"] = principal.ObjectGrant{Read: true}
+		}
+		return principal.Permissions{
+			RoleKeys: []string{"rep"}, Objects: objects, RowScope: principal.RowScopeAll,
+		}
+	}
+
+	employer := func(withOrg bool) (string, bool) {
+		t.Helper()
+		ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, grants(withOrg))
+		page, err := personRoomService(e).Assemble(ctx, ids.From[ids.PersonKind](contact))
+		if err != nil {
+			t.Fatalf("assembling the page (organization grant=%v): %v", withOrg, err)
+		}
+		if page.Employments == nil || len(page.Employments.Data) != 1 {
+			t.Fatalf("the page carried %+v employments, want exactly the seeded one — "+
+				"an assertion about a name on a row that is not there passes for the "+
+				"wrong reason", page.Employments)
+		}
+		row := page.Employments.Data[0]
+		if row.OrganizationName == nil {
+			return "", false
+		}
+		return *row.OrganizationName, true
+	}
+
+	// The control: with the grant the name is there, so its absence below is
+	// the refusal rather than an empty fixture.
+	if got, ok := employer(true); !ok || got != "Vertraulich GmbH" {
+		t.Fatalf("a caller holding organization.read saw name=%q present=%v, "+
+			"want the employer", got, ok)
+	}
+	if got, ok := employer(false); ok {
+		t.Errorf("a caller holding no organization grant read the employer name %q "+
+			"through the employment edge", got)
+	}
+}
+
+// TestAnAgentDoesNotConsumeItsHumansDismissal drives momentDismissed through
+// the real assembly rather than asserting auth.RequireHuman in isolation.
+//
+// This is the arm that matters: an agent CAN already assemble a person page
+// today, through prep_for_meeting → the meeting brief → Person360. So the guard
+// is live behaviour and not defence in depth, and a test that only proved
+// RequireHuman refuses agents would leave the assembly free to stop calling it.
+//
+// The fixture dismisses as the HUMAN and then reads the same page twice. The
+// human's moment is gone; the agent's is still there, because a dismissal is
+// one person's screen and a passport reading on their behalf is not them.
+func TestAnAgentDoesNotConsumeItsHumansDismissal(t *testing.T) {
+	e := Setup(t)
+	contact := e.SeedPerson(t, "Rune Verstummt", &e.Rep1)
+
+	perms := principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"person": {Read: true}, "activity": {Read: true, Create: true},
+			"relationship": {Read: true}, "organization": {Read: true},
+		},
+		RowScope: principal.RowScopeAll,
+	}
+	human := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+	agent := e.AgentFor(t, e.Rep1, []ids.UUID{e.Team1}, perms)
+	svc := personRoomService(e)
+
+	// A moment has to FIRE before a dismissal of it means anything. Whatever
+	// the ladder picks is fine — the test is about the dismissal, not about
+	// which rung won — so the fixture reads the moment rather than asserting a
+	// particular kind.
+	first, err := svc.Assemble(human, ids.From[ids.PersonKind](contact))
+	if err != nil {
+		t.Fatalf("assembling the page: %v", err)
+	}
+	if first.Moment == nil {
+		t.Fatal("the page opened on no moment at all, so there is nothing to dismiss " +
+			"and the arms below would both pass vacuously")
+	}
+	claim, fingerprint := first.Moment.ClaimKey, first.Moment.EvidenceFingerprint
+
+	e.WsExec(t, `
+		INSERT INTO person_moment_dismissal (user_id, person_id, claim_key, evidence_fingerprint)
+		VALUES ($1, $2, $3, $4)`, e.Rep1, contact, claim, fingerprint)
+
+	// The human put it away, so their own page must not still offer it.
+	mine, err := svc.Assemble(human, ids.From[ids.PersonKind](contact))
+	if err != nil {
+		t.Fatalf("re-assembling the human's page: %v", err)
+	}
+	if mine.Moment != nil && mine.Moment.ClaimKey == claim {
+		t.Fatalf("the human's own dismissal was ignored — the page still opens on %q, "+
+			"so this fixture is not exercising the dismissal path at all", claim)
+	}
+
+	// The agent's is untouched: it never had a screen to put anything away on.
+	theirs, err := svc.Assemble(agent, ids.From[ids.PersonKind](contact))
+	if err != nil {
+		t.Fatalf("assembling the agent's page: %v", err)
+	}
+	if theirs.Moment == nil || theirs.Moment.ClaimKey != claim {
+		t.Errorf("an agent's page lost the moment its granting human dismissed "+
+			"(got %+v, want claim %q) — a dismissal belongs to a person's screen, "+
+			"and a passport reading on their behalf consumed it", theirs.Moment, claim)
+	}
+}

--- a/backend/internal/compose/integration/relationshipchangeaudience_integration_test.go
+++ b/backend/internal/compose/integration/relationshipchangeaudience_integration_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The fifth reader of the audience column: the derived relationship CHANGE.
+//
+// auth.AudienceWorkspaceOnly's own doc names four aggregate readers and states
+// the rule they exist for — a last-activity timestamp that moves when a private
+// message arrives tells a colleague when it arrived, without showing a word of
+// it. relationship strength is one of the four and applies the clause in five
+// places (people/strength.go). The change DERIVED from that strength applied it
+// in none, so a message the score itself refused to count still produced
+// "replied after 41 quiet days" with the reply's own timestamp.
+//
+// That is the disclosure the rule forbids, arriving through arithmetic rather
+// than through a row. It is asserted here rather than in the module because the
+// leak is only visible end to end: the fold is pure, the SQL is what withholds,
+// and only a real limited message proves which of the two is answering.
+//
+// The control is the SAME message at workspace audience, not the same message
+// read by its author. AudienceWorkspaceOnly is deliberately not the reader's own
+// audience — "the question an aggregate asks is may EVERYONE see this, and the
+// answer is the same for everybody" — so a fixture asserting the author still
+// sees the change would be asserting the opposite of the rule, and would have to
+// fail for the change to be right.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+)
+
+// TestALimitedReplyIsNotDerivedIntoARelationshipChange seeds the exact shape
+// ChangeRepliedAfterGap fires on — one old outbound, then a recent inbound reply
+// after a long silence — and runs it twice over the same fixture: once with the
+// reply open to the workspace, once held to its participants. Open, the change
+// fires. Held, it does not, for anybody.
+//
+// Two arms over one fixture rather than two readers over one message, because
+// the aggregate rule is about the MESSAGE and not about who is asking. The open
+// arm is the positive control: without it, "no change" is also what a fixture
+// that fires for nobody produces, and the held arm would pass against a broken
+// seed.
+func TestALimitedReplyIsNotDerivedIntoARelationshipChange(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		audience string
+		want     bool
+	}{
+		{"open to the workspace, the change fires", "workspace", true},
+		{"held to its participants, it does not", "participants", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := Setup(t)
+			author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+			contact := e.SeedPerson(t, "Ines Wieder", &e.Rep1)
+
+			now := time.Now().UTC()
+			link := []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}}
+
+			// The far side of the silence: an outbound long before the window.
+			// Always workspace-visible, so the only variable is the reply.
+			openSubject := "Angebot nachgefasst"
+			oldTouch, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+				Kind: "email", Subject: &openSubject, Direction: strPtr("outbound"), Links: link,
+			})
+			if err != nil {
+				t.Fatalf("logging the outbound that opens the silence: %v", err)
+			}
+			backdate(t, ids.UUID(oldTouch.Id), now.AddDate(0, 0, -120))
+
+			replySubject, replyBody := "Re: Angebot", "intern noch nicht spruchreif"
+			reply, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+				Kind: "email", Subject: &replySubject, Body: &replyBody,
+				Direction: strPtr("inbound"), Links: link,
+			})
+			if err != nil {
+				t.Fatalf("logging the reply: %v", err)
+			}
+			backdate(t, ids.UUID(reply.Id), now.AddDate(0, 0, -1))
+			// Through the real writer: SetAudience is what a human uses, and a
+			// hand-written UPDATE would prove nothing about the path that runs.
+			if _, err := e.Activities.SetAudience(author,
+				ids.From[ids.ActivityKind](ids.UUID(reply.Id)),
+				activities.SetAudienceInput{Audience: tc.audience}); err != nil {
+				t.Fatalf("setting the reply audience to %s: %v", tc.audience, err)
+			}
+
+			got := hasKind(changesFor(author, t, e, contact, now), relstrength.ChangeRepliedAfterGap)
+			if got != tc.want {
+				t.Errorf("a %s reply produced %s = %v, want %v — a change derived from a "+
+					"message discloses that message's timing and the silence it broke",
+					tc.audience, relstrength.ChangeRepliedAfterGap, got, tc.want)
+			}
+		})
+	}
+}
+
+// changesFor reads one contact's derived changes as one caller.
+func changesFor(ctx context.Context, t *testing.T, e *Env, person ids.UUID, now time.Time) []relstrength.Change {
+	t.Helper()
+	var out []relstrength.Change
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		out, err = e.People.PersonRelationshipChangesTx(ctx, tx,
+			ids.From[ids.PersonKind](person), now)
+		return err
+	}); err != nil {
+		t.Fatalf("reading relationship changes: %v", err)
+	}
+	return out
+}
+
+// backdate moves a logged activity's occurred_at, which LogActivity stamps at
+// now. The gap the change is about is measured in months, and no test may wait
+// for one.
+func backdate(t *testing.T, activity ids.UUID, at time.Time) {
+	t.Helper()
+	owner := OwnerConn(t)
+	if _, err := owner.Exec(t.Context(),
+		`UPDATE activity SET occurred_at = $2 WHERE id = $1`, activity, at); err != nil {
+		t.Fatalf("backdating an activity: %v", err)
+	}
+}
+
+func hasKind(changes []relstrength.Change, kind string) bool {
+	for _, c := range changes {
+		if c.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAHeldMessageDoesNotShortenTheGapAReplyBroke covers the SECOND audience
+// clause, which the test above cannot reach: it holds the reply, so
+// LatestInbound is nil and changeInputs returns before the preceding-interaction
+// query ever runs.
+//
+// The gap is measured back to the interaction BEFORE the reply. A held message
+// sitting inside that span is still an interaction, so counting it would shorten
+// the silence — and a silence that shortens is itself the disclosure: the number
+// changes on a day the reader is not allowed to see, and the change says
+// something happened then.
+//
+// Both arms use the SAME open reply and differ only in the audience of one
+// message in the middle. Twelve days is below ReplyGapDays, so counting it does
+// not merely change the number — it takes the change away entirely, which is a
+// sharper control than a number nobody would notice was wrong.
+func TestAHeldMessageDoesNotShortenTheGapAReplyBroke(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		intervening string
+		wantFires   bool
+	}{
+		{"an open message in the span shortens the gap below the threshold", "workspace", false},
+		{"a held one leaves the silence as the workspace sees it", "participants", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := Setup(t)
+			author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+			contact := e.SeedPerson(t, "Wenke Dazwischen", &e.Rep1)
+
+			now := time.Now().UTC()
+			link := []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}}
+
+			log := func(subject, direction string, daysAgo int, audience string) {
+				t.Helper()
+				logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+					Kind: "email", Subject: &subject, Direction: strPtr(direction), Links: link,
+				})
+				if err != nil {
+					t.Fatalf("logging %q: %v", subject, err)
+				}
+				backdate(t, ids.UUID(logged.Id), now.AddDate(0, 0, -daysAgo))
+				if audience != "workspace" {
+					if _, err := e.Activities.SetAudience(author,
+						ids.From[ids.ActivityKind](ids.UUID(logged.Id)),
+						activities.SetAudienceInput{Audience: audience}); err != nil {
+						t.Fatalf("setting %q to %s: %v", subject, audience, err)
+					}
+				}
+			}
+
+			// The far side of the silence, the message under test inside it,
+			// then the reply that broke it. Only the middle one varies.
+			log("Angebot nachgefasst", "outbound", 121, "workspace")
+			log("Zwischenstand", "outbound", 13, tc.intervening)
+			log("Re: Angebot", "inbound", 1, "workspace")
+
+			changes := changesFor(author, t, e, contact, now)
+			var got *relstrength.Change
+			for i := range changes {
+				if changes[i].Kind == relstrength.ChangeRepliedAfterGap {
+					got = &changes[i]
+				}
+			}
+			if tc.wantFires {
+				if got == nil {
+					t.Fatalf("no %s in %+v — a held message moved the gap it must not move",
+						relstrength.ChangeRepliedAfterGap, changes)
+				}
+				// 120, not 12: measured past the held message to the open one
+				// before it.
+				if got.Days != 120 {
+					t.Errorf("the reply is reported as breaking a %d-day silence, want 120 — "+
+						"a held message in the span shortened it", got.Days)
+				}
+				return
+			}
+			if got != nil {
+				t.Errorf("%s fired after %d days with an OPEN message 12 days ago — the "+
+					"control arm is supposed to fall below ReplyGapDays, so this fixture "+
+					"is not proving the held arm means anything", got.Kind, got.Days)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/integrationswiring.go
+++ b/backend/internal/compose/integrationswiring.go
@@ -16,11 +16,13 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/integrations"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // WithProvider wires the licensed-data-provider surface: the connection
@@ -91,6 +93,7 @@ func BindProviderDomain(store *integrations.Store) *integrations.Store {
 func bindProviderDomain(store *integrations.Store) *integrations.Store {
 	return store.
 		WithDomain(providerFence, people.DuplicateCluster, people.SubjectIdentifiers).
+		WithRequesterStanding(providerRequesterHoldsOrg).
 		WithSubjectHold(providerSubjectHold).
 		WithStoredClaimApplier(providerStoredClaimApplier).
 		WithClaimWriter(providerClaimWriter).
@@ -155,4 +158,20 @@ func providerFillReverter() integrations.RevertFillsFunc {
 // providerClaimDeleter is the domain half of the delete-data action.
 func providerClaimDeleter(ctx context.Context, tx pgx.Tx, providerName string) (int64, error) {
 	return people.DeleteProviderClaims(ctx, tx, providerName)
+}
+
+// providerRequesterHoldsOrg answers whether the human who queued a run may read
+// organizations, so the submission knows whether the employer may travel.
+//
+// It asks identity rather than the context on purpose: by the time a run is
+// submitted the actor is the CONNECTOR, and a system principal passes every
+// object gate — so asking the context would always answer yes. Asked live
+// rather than frozen at queue time, for the reason the share links are:
+// a grant taken away between the ask and the send is taken away.
+func providerRequesterHoldsOrg(ctx context.Context, tx pgx.Tx, userID string) (bool, error) {
+	id, err := ids.Parse(userID)
+	if err != nil {
+		return false, fmt.Errorf("compose: run requester %q is not a user id: %w", userID, err)
+	}
+	return identity.IssuerStillHolds(ctx, tx, ids.From[ids.UserKind](id), "organization", principal.ActionRead)
 }

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -47,6 +47,8 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/momentaction"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -114,9 +116,20 @@ func (s *Service) momentDismissed(ctx context.Context, tx pgx.Tx, personID ids.P
 	// none to honour. An agent reading through a passport must not consume the
 	// granting human's: it sees every moment. This is a fact about the caller,
 	// not a failure to read.
+	//
+	// The agent arm is the one that needs saying, because a passport carries
+	// its granting human's UserID: a check for a non-zero id admits an agent
+	// and reads the human's dismissals, which is what this paragraph promises
+	// it does not do. auth.RequireHuman is what tells the two apart.
 	viewer, ok := principal.Actor(ctx)
 	if !ok || viewer.UserID == (ids.UUID{}) {
 		return false, nil
+	}
+	if err := auth.RequireHuman(ctx); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return false, nil
+		}
+		return false, err
 	}
 	var stored string
 	// (user_id, person_id, claim_key) is the table's primary key, so the three

--- a/backend/internal/compose/person360/sections.go
+++ b/backend/internal/compose/person360/sections.go
@@ -18,7 +18,9 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 func (s *Service) strengthSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
@@ -128,6 +130,26 @@ func (s *Service) employmentsSection(ctx context.Context, tx pgx.Tx, personID id
 // cannot read is simply absent — the edge still shows, without asserting a
 // company the reader has no grant for.
 func (s *Service) organizationName(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (string, error) {
+	// The two refusals the paragraph above promises, spelled as the two
+	// questions they actually are. The row-scope miss was the only one the
+	// statement asked — its id-and-archived_at predicate says nothing about
+	// who is reading — so a caller holding no organization grant at all read
+	// employer names through the employment edge. auth.Require answers the
+	// object question and auth.EnsureVisible the row one, and both refuse by
+	// leaving the name absent rather than failing the section, because an
+	// employment the reader may see is still a true edge.
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return "", nil
+		}
+		return "", err
+	}
+	if err := auth.EnsureVisible(ctx, tx, "organization", orgID.UUID); err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) || errors.Is(err, apperrors.ErrPermissionDenied) {
+			return "", nil
+		}
+		return "", err
+	}
 	var name string
 	err := tx.QueryRow(ctx, `SELECT display_name FROM organization WHERE id = $1 AND archived_at IS NULL`, orgID).Scan(&name)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/deals/championcover.go
+++ b/backend/internal/modules/deals/championcover.go
@@ -284,12 +284,12 @@ func engagedAmong(
 		  AND EXISTS (
 			SELECT 1 FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
-			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 			  AND a.occurred_at >= $%[2]d AND a.direction = 'inbound')
 		  AND EXISTS (
 			SELECT 1 FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
-			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 			  AND a.occurred_at >= $%[2]d AND a.direction = 'outbound')`,
 		dealsPos, windowPos, bound, healthActivityKinds), args...)
 	if err != nil {

--- a/backend/internal/modules/deals/engagement.go
+++ b/backend/internal/modules/deals/engagement.go
@@ -87,12 +87,12 @@ func EngagedStakeholders(ctx context.Context, tx pgx.Tx, dealID ids.DealID, now 
 		  AND EXISTS (
 			SELECT 1 FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
-			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 			  AND a.occurred_at >= $%[2]d AND a.direction = 'inbound')
 		  AND EXISTS (
 			SELECT 1 FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id AND l.person_id = r.person_id
-			WHERE a.kind IN %[4]s AND a.archived_at IS NULL
+			WHERE a.kind IN %[4]s AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 			  AND a.occurred_at >= $%[2]d AND a.direction = 'outbound')
 		ORDER BY r.person_id`, dealPos, windowPos, bound, healthActivityKinds), args...))
 }

--- a/backend/internal/modules/deals/reconcile.go
+++ b/backend/internal/modules/deals/reconcile.go
@@ -171,6 +171,10 @@ func (r *FollowUpReconciler) reconcileWorkspace(ctx context.Context) error {
 				  -- The subject lands in an approval every decider of the
 				  -- deal reads, so only a message the whole workspace may
 				  -- read is evidence here; a limited one is its audience's.
+				  -- Spelled inline rather than through auth.AudienceWorkspaceOnly
+				  -- because this statement is a plain string with no format
+				  -- verbs; the predicate is the helper's, and a change to one
+				  -- is a change to both.
 				  AND a.audience = 'workspace'
 				  AND a.occurred_at >= $1
 				ORDER BY a.occurred_at DESC, a.id DESC

--- a/backend/internal/modules/integrations/execute.go
+++ b/backend/internal/modules/integrations/execute.go
@@ -199,6 +199,15 @@ func (s *Store) leaseForSubmit(ctx context.Context, tx pgx.Tx, name, runID strin
 	if !req.Identifiers.Matchable(desc.MatchRules) {
 		return none, false, s.markSkipped(ctx, tx, runID, provider.SkipNoIdentifiers)
 	}
+	// The employer travels only if the REQUESTER could read it — the re-read
+	// above runs as the connector, and requesterstanding.go says why.
+	skip, err := s.withholdEmployerIfUnreadable(ctx, tx, runID, &req, desc)
+	if err != nil {
+		return none, false, err
+	}
+	if skip {
+		return none, false, s.markSkipped(ctx, tx, runID, provider.SkipNoIdentifiers)
+	}
 	cred, err := s.unseal(ctx, tx, conn.credentialRef)
 	if err != nil {
 		return none, false, err

--- a/backend/internal/modules/integrations/requesterstanding.go
+++ b/backend/internal/modules/integrations/requesterstanding.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// Whose scope a submission travels under.
+//
+// A run is queued by a person and submitted by the CONNECTOR: actingForProvider
+// replaces the actor with a system principal before anything leaves, and a
+// system principal passes every object gate. So the question "may the employer
+// travel with this subject" cannot be asked of the context at submission time —
+// it would always answer yes — and has to be asked of the stored requester
+// instead.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// RequesterHoldsFunc answers whether the human who asked for a run still holds
+// the grant that lets an employer travel with the subject.
+//
+// A seam for the reason every other one in this package is: identity is a
+// sibling module, and compose injects the edge.
+type RequesterHoldsFunc func(ctx context.Context, tx pgx.Tx, userID string) (bool, error)
+
+// WithRequesterStanding binds the question the submission asks about the human
+// who queued a run, rather than about the connector executing it.
+func (s *Store) WithRequesterStanding(holds RequesterHoldsFunc) *Store {
+	s.requesterHolds = holds
+	return s
+}
+
+// employerWithheldFrom reports whether the human who asked for this run may not
+// read organizations, so the employer must not travel with the subject.
+//
+// A run with no requester is the automatic sweep: it acts for the installation
+// rather than for a person, and there is no scope to answer for.
+func (s *Store) employerWithheldFrom(ctx context.Context, tx pgx.Tx, runID string) (bool, error) {
+	if s.requesterHolds == nil {
+		return false, errors.New("integrations: no requester-standing check is bound, so a run cannot say whose scope it travels under")
+	}
+	var requester *string
+	if err := tx.QueryRow(ctx,
+		`SELECT requested_by::text FROM provider_run WHERE id = $1`, runID).Scan(&requester); err != nil {
+		return false, fmt.Errorf("integrations: reading who asked for run %s: %w", runID, err)
+	}
+	if requester == nil {
+		return false, nil
+	}
+	holds, err := s.requesterHolds(ctx, tx, *requester)
+	if err != nil {
+		return false, err
+	}
+	return !holds, nil
+}
+
+// withholdEmployerIfUnreadable strips the employer from a request when the
+// human who asked for the run may not read organizations, and reports whether
+// what remains is still worth sending.
+//
+// Withheld rather than refused: an employer they may not read is one field of a
+// subject who is otherwise perfectly matchable, and refusing the whole run
+// would tell them the vendor found nothing when a permission stopped us. It is
+// the same shape SubjectIdentifiers returns to a caller without the grant,
+// restored here after the connector's own re-read undid it.
+func (s *Store) withholdEmployerIfUnreadable(
+	ctx context.Context, tx pgx.Tx, runID string, req *provider.Request, desc provider.Descriptor,
+) (bool, error) {
+	withheld, err := s.employerWithheldFrom(ctx, tx, runID)
+	if err != nil || !withheld {
+		return false, err
+	}
+	req.Identifiers.CompanyName, req.Identifiers.CompanyDomain = "", ""
+	return !req.Identifiers.Matchable(desc.MatchRules), nil
+}

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -191,6 +191,13 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 			return cfg.identifiersOf(), nil
 		},
 	)
+	// The requester's organization standing. Bound by default to "holds it",
+	// because these suites are about budgets, fences and submission and would
+	// otherwise all model a rep who cannot read companies. The withheld case
+	// has its own fixture.
+	store.WithRequesterStanding(func(context.Context, pgx.Tx, string) (bool, error) {
+		return !cfg.requesterLacksOrgRead, nil
+	})
 	if !cfg.withoutEnqueue {
 		store.WithSubmitEnqueue(func(context.Context, pgx.Tx, string, string) error {
 			e.enqueued++
@@ -206,6 +213,13 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 				// bought facts onto them. Read alone is the read_only seat, and
 				// what that seat must not do is exactly this.
 				"person": {Read: true, Update: true},
+				// The EMPLOYER travels with the subject, and reading it is the
+				// organization grant's question — SubjectIdentifiers withholds
+				// the company name and domain without it, which leaves an
+				// otherwise-matchable contact unmatchable. A rep holds this;
+				// the fixture simply never needed to say so until the employer
+				// read was gated.
+				"organization": {Read: true},
 				// What enrichment COSTS is readable by any seat that may see
 				// the connection — a rep asking "are we out of credits" is
 				// asking about the installation, not about a person.
@@ -223,6 +237,10 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 type runsConfig struct {
 	ceilings       map[string]int
 	withoutEnqueue bool
+	// requesterLacksOrgRead models a run queued by a rep who may not read
+	// organizations, so the employer must not travel with the subject when
+	// the connector re-resolves it under its own system principal.
+	requesterLacksOrgRead bool
 	// subjectLastName picks the fake's scenario, which it reads out of the
 	// subject's name. Empty means Muster, which succeeds.
 	subjectLastName string

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -43,9 +43,10 @@ const (
 // reads or writes: the connection is installation-wide configuration that
 // spends the customer's money, so there is no ungated path to it.
 type Store struct {
-	// db knows the installation's singleton workspace (ADR-0061/A107), which
-	// is where the vault seals this connection's credential. The connection
-	// row itself carries no workspace — see doc.go.
+	// db knows the installation's singleton workspace — one installation
+	// serves one workspace, so there is exactly one to bind (ADR-0061) — which
+	// is where the vault seals this connection's credential. The connection row
+	// itself carries no workspace; see doc.go.
 	db *database.DB
 	// vault custodies the API key. The row holds only an opaque handle.
 	vault keyvault.Vault
@@ -58,9 +59,10 @@ type Store struct {
 
 	// The owning domain's callbacks (runs.go). Nil until compose binds them,
 	// and QueueRun refuses rather than guessing at a subject's consent.
-	fence       FenceSubjectFunc
-	cluster     DuplicateClusterFunc
-	identifiers SubjectIdentifiersFunc
+	fence          FenceSubjectFunc
+	cluster        DuplicateClusterFunc
+	identifiers    SubjectIdentifiersFunc
+	requesterHolds RequesterHoldsFunc
 	// holdSubject is the same question as fence, asked while HOLDING the
 	// subject's row. The hand-off uses it and queue time does not: only the
 	// hand-off goes on to write about the subject, and only it therefore has

--- a/backend/internal/modules/introductions/reads.go
+++ b/backend/internal/modules/introductions/reads.go
@@ -70,7 +70,16 @@ func scanRequest(src row, r *Request) error {
 }
 
 // roleOf answers which party the caller is, or "" for anybody else.
+//
+// An agent is nobody here, whatever id it carries. A passport presents its
+// granting human's UserID, so matching on the id alone would make a credential
+// a PARTY to its human's asks — reading the request text, the status and the
+// reason somebody gave for refusing. Being lent authority to act is not the
+// same as being the person whose favour was asked.
 func (s *Store) roleOf(ctx context.Context, r *Request) Actor {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return ""
+	}
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID.IsZero() {
 		return ""
@@ -109,6 +118,11 @@ func (s *Store) Get(ctx context.Context, id ids.UUID) (*Request, error) {
 // ForPerson lists the asks about one contact, newest first.
 func (s *Store) ForPerson(ctx context.Context, personID ids.UUID, limit int) ([]Request, error) {
 	if err := auth.Require(ctx, "introduction", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	// The same human arm roleOf states: an id match would make a passport a
+	// party to its human's asks.
+	if err := auth.RequireHuman(ctx); err != nil {
 		return nil, err
 	}
 	actor, ok := principal.Actor(ctx)
@@ -163,6 +177,12 @@ func (s *Store) ForPerson(ctx context.Context, personID ids.UUID, limit int) ([]
 // exactly like a refusal, and the difference is whether anybody looked.
 func (s *Store) AwaitingMyAnswer(ctx context.Context, limit int) ([]Request, error) {
 	if err := auth.Require(ctx, "introduction", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	// The paragraph below names the agent case, and an id check does not reach
+	// it: a passport carries its granting human's UserID, so this refused a
+	// caller with NO id and admitted the one the sentence is about.
+	if err := auth.RequireHuman(ctx); err != nil {
 		return nil, err
 	}
 	actor, ok := principal.Actor(ctx)

--- a/backend/internal/modules/introductions/routestate.go
+++ b/backend/internal/modules/introductions/routestate.go
@@ -78,13 +78,18 @@ func (s *Store) RouteStates(
 	}
 	// A caller with no person behind it has no tab to render, and this read
 	// reports on asks the caller is not party to — so it answers only a
-	// principal that IS somebody.
+	// principal that IS somebody, and only a human.
 	//
-	// This does not exclude an agent: a passport-backed agent carries its
-	// granting human's UserID, so it passes here. What keeps agents off this
-	// read is the route itself — getPersonGraph is annotated human-only, and
-	// the agent gate refuses it before the handler runs. Wiring RouteStates to
-	// any agent-reachable caller would need that decision made again.
+	// The human arm is load-bearing and belongs HERE rather than on the route.
+	// A passport-backed agent carries its granting human's UserID, so an
+	// id-presence check admits one. The REFUSAL arm below is per-requester —
+	// a declined route is reported only to the rep who was declined — so an
+	// agent admitted here reads its human being turned down. This gate used to
+	// be the route's annotation, which made the answer depend on which door the
+	// read came through rather than on what it discloses.
+	if err := auth.RequireHuman(ctx); err != nil {
+		return nil, err
+	}
 	if actor, ok := principal.Actor(ctx); !ok || actor.UserID.IsZero() {
 		return nil, apperrors.ErrPermissionDenied
 	}

--- a/backend/internal/modules/people/enrichment.go
+++ b/backend/internal/modules/people/enrichment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/employment"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
 
@@ -244,17 +245,51 @@ func SubjectIdentifiers(ctx context.Context, tx pgx.Tx, personID string) (provid
 	// identifies a company to a provider far better than a name does, so it
 	// is worth the join; its absence is not, which is why this is a LEFT
 	// JOIN over the domain rather than a second failing query.
-	if err := tx.QueryRow(ctx, `
+	//
+	// Gated on BOTH questions about the account on the far side of the edge.
+	// The employment is the caller's to see; the company is not the same fact.
+	// auth.Require answers whether they may read organizations at all — the
+	// statement asked nothing of the sort, so every workspace-visible employer
+	// came back to a caller holding no organization grant — and the scope
+	// clause answers which ones are theirs.
+	//
+	// A refusal loses the employer and keeps everything else, which is the
+	// shape SubjectNameOnly returns for a caller without the relationship
+	// grant: erring toward FINDABLE, since a name-only answer can only make a
+	// subject look less matchable than they are, while inventing a "cannot be
+	// looked up" out of a permission asserts something false.
+	mayReadEmployer, err := employerReadable(ctx)
+	if err != nil {
+		return provider.PersonIdentifiers{}, err
+	}
+	if mayReadEmployer {
+		var args []any
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		personArg := arg(personID)
+		scope, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
+		if err != nil {
+			return provider.PersonIdentifiers{}, err
+		}
+		visible := "true"
+		if scope != "" {
+			visible = scope
+		}
+		// CurrentPrimarySQL is an ARGUMENT to SQLf, not part of its format
+		// string: concatenated, a `%` ever appearing in its output would be
+		// read as a verb and corrupt the statement at runtime.
+		if err := tx.QueryRow(ctx, storekit.SQLf(`
 		SELECT coalesce(o.display_name, ''), coalesce(d.domain, '')
 		  FROM relationship r
 		  JOIN organization o ON o.id = r.organization_id
 		  LEFT JOIN organization_domain d
 		    ON d.organization_id = o.id AND d.is_primary AND d.archived_at IS NULL
-		 WHERE r.kind = 'employment' AND r.person_id = $1
-		   AND `+employment.CurrentPrimarySQL("r")+` AND r.archived_at IS NULL
-		 LIMIT 1`, personID).
-		Scan(&id.CompanyName, &id.CompanyDomain); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return provider.PersonIdentifiers{}, fmt.Errorf("people: reading the subject's employer: %w", err)
+		 WHERE r.kind = 'employment' AND r.person_id = $%d
+		   AND %s AND r.archived_at IS NULL
+		   AND %s
+		 LIMIT 1`, personArg, employment.CurrentPrimarySQL("r"), visible), args...).
+			Scan(&id.CompanyName, &id.CompanyDomain); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return provider.PersonIdentifiers{}, fmt.Errorf("people: reading the subject's employer: %w", err)
+		}
 	}
 
 	if err := tx.QueryRow(ctx, `
@@ -288,4 +323,21 @@ func derefOr(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// employerReadable reports whether this caller may read organizations at all.
+//
+// A permission denial is an ANSWER here, not a failure: the employer is one
+// optional half of a provider lookup, and losing it leaves the person's own
+// identifiers intact. Anything else — a missing principal, a broken policy —
+// is a real error and stays one.
+func employerReadable(ctx context.Context) (bool, error) {
+	switch err := auth.Require(ctx, "organization", principal.ActionRead); {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return false, nil
+	default:
+		return false, err
+	}
 }

--- a/backend/internal/modules/people/relationshipchange.go
+++ b/backend/internal/modules/people/relationshipchange.go
@@ -16,6 +16,12 @@ package people
 //
 // The cost is one extra pass over one person's interactions, which is the same
 // order as the timeline query rendered next to it.
+//
+// Both passes carry auth.AudienceWorkspaceOnly, for the reason stated where it
+// is defined: a change derived from a held message discloses that message. The
+// score this differences is folded in strength.go, which asks the same question
+// of the same kinds — a change computed over a wider set than the score it
+// reports a change IN would also be arithmetic about two different populations.
 
 import (
 	"context"
@@ -174,7 +180,8 @@ func changeInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now tim
 		       max(a.occurred_at) FILTER (WHERE a.direction = 'inbound')
 		  FROM activity a
 		  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
-		 WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`,
+		 WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+
+		auth.AudienceWorkspaceOnly("a"),
 		personID,
 		now.AddDate(0, 0, -relStrengthWindowDays),
 		asOf,
@@ -197,7 +204,7 @@ func changeInputs(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now tim
 		  FROM activity a
 		  JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
 		 WHERE a.kind IN `+strengthKinds+` AND a.archived_at IS NULL
-		   AND a.occurred_at < $2`,
+		   AND a.occurred_at < $2`+auth.AudienceWorkspaceOnly("a"),
 		personID, *in.LatestInbound,
 	).Scan(&in.PrecedingInteraction); err != nil {
 		return relstrength.ChangeInputs{}, fmt.Errorf("people: reading what preceded a contact's last reply: %w", err)


### PR DESCRIPTION
Fixes the five defects a Codex review found in #4795, **without** opening the endpoints. The contract is untouched: `getPerson360` and `getPersonGraph` stay `x-agent-access: human-only`. These are the fixes that have to land before that decision can be revisited, and they are worth landing on their own.

## The pattern

A passport carries its granting human's `UserID`. So a check shaped like

```go
if actor, ok := principal.Actor(ctx); !ok || actor.UserID.IsZero() { ... }
```

asks "is anybody behind this call", and an agent answers **yes** using the id of the person who minted it. Two reads relied on such a check to stay human-only, and each went on to return that person's own standing to a credential acting on their behalf.

One of them said so in a comment — `introductions/routestate.go:83`:

> What keeps agents off this read is the route itself — getPersonGraph is annotated human-only… **Wiring RouteStates to any agent-reachable caller would need that decision made again.**

That made the answer depend on which door a read arrived through rather than on what it discloses, and left two guards that were correct and untested at the same time. Both are `auth.RequireHuman` now, at the disclosure.

`person360/moments.go:113` is the sharper case: it **states the correct behaviour** — an agent "must not consume the granting human's [dismissal]: it sees every moment" — and implemented the opposite, for exactly this reason.

## Three more sites returned more than their own comments claimed

**`people/relationshipchange.go`** folded activities with no audience clause, so a message held to its participants still produced `replied_after_gap` carrying the reply's timestamp and the length of the silence it broke. That is what `auth.AudienceWorkspaceOnly` exists to prevent, and its doc names relationship strength as one of the four readers that owe it. `strength.go` applies it in **five** places; the change *derived from that strength* applied it in none. Both passes carry it now, so the change and the score it reports a change in fold one population.

**`person360/sections.go`** returned an employer's `display_name` on a statement filtering `id` and `archived_at` alone, while its doc promised a name the caller cannot read "is simply absent" for two separate reasons. Both are spelled now: `auth.Require` for the object grant, `auth.EnsureVisible` for the row. A refusal blanks the name rather than failing the section, because an employment the reader may see is still a true edge.

**`people/enrichment.go`** read the employer's name *and primary domain* through the employment join with no organization row scope, flipping a provider verdict from `nothing_to_look_up` to `never_run` for an account outside the caller's scope.

## Verification

Every fix mutation-checked one clause at a time, and each mutation confirmed to **compile** first — a mutation that fails to build never ran and proves nothing (that happened once here and was redone).

| Mutation | Caught by |
|---|---|
| drop `AudienceWorkspaceOnly` from `changeInputs` | the held arm fails; the open arm stays green |
| drop `RequireHuman` from `RouteStates` | agent read returns `<nil>` instead of a refusal |
| neutralise the `organization` grant check | leaks `"Vertraulich GmbH"`, named in the failure |

**The audience test runs two arms over one fixture** — the same reply open, then held — rather than two readers over one message. `AudienceWorkspaceOnly` is deliberately *not* the reader's own audience: "the question an aggregate asks is may EVERYONE see this, and the answer is the same for everybody." A fixture asserting the author still sees the change would assert the opposite of the rule. My first draft did exactly that and its positive control caught it.

`SubjectIdentifiers`'s SQL passes `employment.CurrentPrimarySQL("r")` as an **argument** to `storekit.SQLf` rather than concatenating it into the format string, so a helper that one day returns a literal `%` cannot be eaten by the verb scan. Verified empirically that its current output contains none.

Checked that no legitimate non-human caller breaks: `personbrief/service.go:97` and `personresearch/service.go:67` already call `RequireHuman` before assembling, and no worker or `cmd/` path reaches `person360`. `ScopeClauseFor` returns `""` for an unbounded principal, which the `visible = "true"` fallback handles.

`make check-backend` is green except `TestAnEmailIsDrawnOnlyByTheCanonicalComponents`, which **fails identically on clean `origin/main`** — bisected by another session to #4746, which added new `EmailSummary` markup to `composed.tsx`. Not this diff.

Refs #4773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes humanity checks that admitted agents into human-only reads, plus three more disclosure leaks found in the same review, and keeps a provider submission's employer from traveling beyond its requester's scope. A passport carries its granting human's `UserID`, so `actor.UserID.IsZero()` passed for an agent and returned the human's own introduction ledger and dismissed moments. Reads now gate on `auth.RequireHuman` at the disclosure; endpoints stay `x-agent-access: human-only`, so no contract changes.

**Bug Fixes**

- `introductions/reads.go` requires a human in `roleOf`, `ForPerson`, and `AwaitingMyAnswer`, so an agent can no longer become a party to its granting human's asks.
- `relationshipchange.go`, `championcover.go`, and `engagement.go` apply `auth.AudienceWorkspaceOnly`, so a reply held to its participants no longer derives a `replied_after_gap` change or appears in engagement counts.
- `sections.go` and `enrichment.go` require the organization grant and row scope before returning an employer's name and primary domain; a refusal blanks the name rather than failing the section.
- Provider submissions check the run's stored requester, not the connector, before sending the employer; a requester who cannot read organizations sends the subject without it. `SubjectIdentifiers` passes `employment.CurrentPrimarySQL("r")` to `storekit.SQLf` as an argument instead of concatenating it into the format string.
- The new integration tests run one positive control and one refusal over the same fixture; the audience test runs two arms (open then held) over one reply.

Each fix was mutation-checked one clause at a time. `make check-backend` is green except `TestAnEmailIsDrawnOnlyByTheCanonicalComponents`, which fails identically on clean `main` (a #4746 regression unrelated to this diff). Refs #4773.

<sup>Written for commit bfdb3a6f1c3cb7f8c13cc2bb295ed5a87b42a0bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Access**
  - Restricted introductions, routing details, roles, and person moments to human users.
  - Prevented agents from accessing or consuming their granting human’s private data and dismissals.
  - Organization names and employer identifiers are shown only when the viewer has appropriate access.
  - Integration requests now withhold employer details when the requester lacks organization access.

- **Data Visibility**
  - Engagement and relationship insights now consider only workspace-visible activity.
  - Relationship changes respect message audience restrictions, preventing limited-audience messages from influencing derived results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->