### PR TITLE
A dispatched branch is filed as itself, not as main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,7 +866,43 @@ jobs:
         timeout-minutes: 8
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
-          args: ${{ github.event_name == 'merge_group' && '-Dsonar.branch.name=main' || '' }}
+          # WHICH BRANCH THIS ANALYSIS IS FILED UNDER, said for every event
+          # rather than for one.
+          #
+          # An analysis carrying no `sonar.branch.name` is filed as the
+          # project's MAIN branch. On a pull request that is right — the action
+          # sets sonar.pullrequest.* itself and the scan decorates the PR — and
+          # on merge_group the ref is the queue's ephemeral one, so `main` is
+          # named outright. Every OTHER event fell through to the same empty
+          # argument, and a workflow_dispatch has no pull-request context: a
+          # run dispatched on a feature branch published that branch's tree as
+          # main's stored verdict, which is the one every scheduled check reads.
+          #
+          # It is not hypothetical and it is not rare. `main`'s two most recent
+          # analyses were `issue-1985-agent-carriage` and
+          # `issue-2381-ast-censuses`, neither revision a commit on main, while
+          # merge_group — the one event this argument covered — has not fired
+          # since 2026-08-20. So the quality gate has been reporting on feature
+          # branches for as long as anyone has been dispatching this workflow,
+          # including a bug already fixed on main and a new-code coverage figure
+          # belonging to somebody's diff.
+          #
+          # `main` when the ref genuinely IS main, so a dispatch there refreshes
+          # the verdict that no merge_group is left to refresh; the branch's own
+          # name otherwise, so a dispatched branch is filed as itself and can
+          # only ever describe itself.
+          # The empty case is LAST on purpose. `&&` here yields its right
+          # operand, and an empty string is falsy, so `pull_request && ''`
+          # would fall straight through the `||` beside it and hand a pull
+          # request the `<number>/merge` ref as a branch name. Ordering the
+          # arms so that only a truthy argument short-circuits is what keeps
+          # the PR arm empty.
+          args: >-
+            ${{ (github.event_name == 'merge_group' || github.ref_name == 'main')
+                && '-Dsonar.branch.name=main'
+             || (github.event_name != 'pull_request'
+                && format('-Dsonar.branch.name={0}', github.ref_name))
+             || '' }}
       - name: No token yet — scan skipped
         if: ${{ env.SONAR_TOKEN == '' }}
         run: echo "SONAR_TOKEN not set; skipping CI scan (Automatic Analysis still active). Add the secret to activate."


### PR DESCRIPTION
## What

The SonarCloud scan now says which branch its analysis is for on **every**
event, not on one.

## Why: main's quality gate has been reporting on feature branches

An analysis carrying no `sonar.branch.name` is filed as the project's **main**
branch. The step named `main` outright on `merge_group` and sent nothing
otherwise:

```yaml
args: ${{ github.event_name == 'merge_group' && '-Dsonar.branch.name=main' || '' }}
```

Empty is right for a `pull_request` — the action sets `sonar.pullrequest.*`
itself and the scan decorates the PR. It is wrong for a `workflow_dispatch`,
which has no pull-request context: a run dispatched on a feature branch
published **that branch's tree as main's stored verdict**, which is what every
scheduled check reads.

This is not hypothetical, and the evidence is in the API rather than in
reasoning. `main`'s two most recent analyses:

| Analysis date | Revision | What it actually is |
|---|---|---|
| 2026-09-07T07:16Z | `eaa1d6832` | head of `issue-1985-agent-carriage` |
| 2026-09-07T03:12Z | `01628b2ae` | head of `issue-2381-ast-censuses` |

Neither revision is a commit on `main` — `git cat-file -t` does not know either
of them, because both are feature-branch heads that were dispatched and are not
in main's history.

And `merge_group`, the one event the old argument covered, **appears zero times
in the last 100 runs of this workflow**; the most recent one ever was
2026-08-20. So nothing has published an analysis of a real `main` tree in weeks,
and whichever feature branch was dispatched last has been standing in for it.

## What that explains

Every failing condition on https://github.com/margince/margince/issues/4774:

- `new_reliability_rating GT 1 (actual 3)` — one `go:S3923` bug, in a `switch`
  whose branches were all empty. **Removed from main by
  https://github.com/margince/margince/pull/4734.** The gate still reports it
  because it is reading a branch, not main.
- `new_security_rating GT 1 (actual 3)` — the three `text:S8566` go.sum
  findings, waived in https://github.com/margince/margince/pull/4793 (those
  modules' one dependency is a local `replace` to a directory in this repo, so
  `go mod tidy` writes no go.sum at all). The waiver is on main and did not
  clear the rating, for the same reason.
- `new_coverage LT 80 (actual 69.9)` — a diff's new-code coverage figure. Not
  main's, and nothing on main would move it.

I reported the stale-analysis half of this on #4774 earlier. That was
incomplete: it is not lag, it is misattribution, and lag would have healed on
its own.

## The fix

`main` when the ref genuinely **is** main — so a dispatch there refreshes the
verdict that no `merge_group` is left to refresh — and the branch's own name
otherwise, so a dispatched branch is filed as itself and can only describe
itself.

The empty arm is ordered **last** deliberately. In Actions `&&` yields its right
operand and an empty string is falsy, so written the obvious way round
(`pull_request && '' || …`) the pull-request arm falls through the `||` beside it
and hands the scan a `<number>/merge` ref as a branch name. Ordering the arms so
only a truthy argument short-circuits is what keeps the PR arm empty. I got that
wrong on the first pass and caught it by evaluating the arms rather than reading
them.

## How verified

Every event case evaluated against Actions' own `&&`/`||` semantics:

| event | `github.ref_name` | argument |
|---|---|---|
| `pull_request` | `4806/merge` | *(empty — PR mode)* |
| `merge_group` | `gh-readonly-queue/main/…` | `-Dsonar.branch.name=main` |
| `workflow_dispatch` | `main` | `-Dsonar.branch.name=main` |
| `workflow_dispatch` | `issue-1985-agent-carriage` | `-Dsonar.branch.name=issue-1985-agent-carriage` |
| `push` | `main` | `-Dsonar.branch.name=main` |

- YAML parses; the `sonarcloud` job is still present and its `needs:`/`if:` are
  untouched.
- `make ci-doc-parity`, `test-laneorder`, `check-image-pins`, `check-host-ports`,
  `test-ci-verdict`, `test-merge-verdict`, `test-scheduled-report` — all **OK**.
- No action pin, permission or `needs:` changed; this is the `args:` value only.

## What this does not do

It does not make main's gate green. It makes the gate **measure main**, after
which the two conditions already fixed should clear on the next analysis of a
real main tree and `new_coverage` will report main's own number for the first
time — which may itself need work, and that is worth knowing rather than
guessing at now.

- [x] `make check` — one workflow file; the gates that cover it are listed above
- [x] `make test-integration` — this change does not touch tenant data, RLS or
      the write shape
- [x] `make craft-static` — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-generated in full under the reporter's direction: the diagnosis, the
expression, its case analysis and this description. A human is accountable for
merging.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
