### PR TITLE
feat(runner): the estate refuses a settled run that cannot say when

### DIFF
--- a/backend/migrations/core/1788767819_a_settled_run_says_when_it_settled.down.sql
+++ b/backend/migrations/core/1788767819_a_settled_run_says_when_it_settled.down.sql
@@ -1,0 +1,11 @@
+-- Bounded: dropping a CHECK takes a lock that blocks writers on a table this
+-- migration did not create, and an open transaction holding a conflicting lock
+-- would otherwise stall every write to it indefinitely.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE agent_run DROP CONSTRAINT IF EXISTS agent_run_settled_shape;
+
+-- The backfilled stamps are NOT undone. A rollback restores what the schema
+-- REFUSES, never what it recorded: an approximate finish is still the truest
+-- thing known about a run that had stopped, and clearing it would put the rows
+-- back into the invisible state this migration exists to end.

--- a/backend/migrations/core/1788767819_a_settled_run_says_when_it_settled.up.sql
+++ b/backend/migrations/core/1788767819_a_settled_run_says_when_it_settled.up.sql
@@ -1,0 +1,39 @@
+-- A run that has stopped says WHEN it stopped, or it is invisible.
+--
+-- agent_run.finished_at is load-bearing: the personal activity read bounds
+-- settled work with `finished_at >= <local midnight>` and orders by it, because
+-- "settled today" is a fact about when a run FINISHED and not when it started.
+-- A terminal run whose finished_at is NULL has left the in-flight statuses and
+-- cannot match the settled predicate, so it does not arrive late or out of
+-- order — it disappears from the feed entirely.
+--
+-- Nothing enforced the pairing. status and finished_at are independent columns
+-- and every writer was trusted to set them together; one of them
+-- (privacy/erasure_approvals.go) did not, and the only symptom was a run
+-- silently missing from a reader's day. Fixing that writer corrected today's
+-- tree and did nothing about the next one, which is what this constraint is
+-- for.
+--
+-- Stated as an implication rather than as NOT NULL on the column: an in-flight
+-- run genuinely has no finish, and a default would invent one.
+--
+-- The backfill takes updated_at, which is the honest approximation and worth
+-- naming as one. Every terminal writer stamps updated_at in the same statement
+-- it sets the status, so for a row that reached a terminal state the two are
+-- the same instant; for a row that did not, updated_at is the last time
+-- anything touched it, which is the closest thing the record holds. No row is
+-- expected here — the writers were fixed before this landed — and the backfill
+-- exists so an installation that ran the old code still validates.
+-- Bounded: adding a validated CHECK takes a lock that blocks writers on a table
+-- this migration did not create, and an open transaction holding a conflicting
+-- lock would otherwise stall every write to it indefinitely.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE agent_run
+   SET finished_at = updated_at
+ WHERE status IN ('completed', 'degraded', 'failed')
+   AND finished_at IS NULL;
+
+ALTER TABLE agent_run
+    ADD CONSTRAINT agent_run_settled_shape
+    CHECK (status NOT IN ('completed', 'degraded', 'failed') OR finished_at IS NOT NULL);

--- a/backend/migrations/settledrunstamped_integration_test.go
+++ b/backend/migrations/settledrunstamped_integration_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package migrations_test
+
+// A run that has stopped says WHEN it stopped, and the database is what makes
+// that so.
+//
+// agent_run.finished_at is load-bearing: the personal activity read bounds
+// settled work with `finished_at >= <local midnight>` and orders by it, because
+// "settled today" is a fact about when a run FINISHED. A terminal run whose
+// finished_at is NULL has left the in-flight statuses and cannot match that
+// predicate, so it does not arrive late or out of order — it disappears from
+// the feed.
+//
+// status and finished_at were independent columns and every writer was trusted
+// to set them together. One did not, and the only symptom was a run silently
+// missing from a reader's day (#2187). Asked of the estate rather than of the
+// writers, because a census of writers is a list somebody has to keep and this
+// answers for the one that has not been written yet.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// seedRun writes one run in the given state and answers whether the estate
+// accepted it. The columns are the table's own minimum: everything else has a
+// default or is nullable.
+func seedRun(t *testing.T, conn *pgx.Conn, status string, stamped bool) error {
+	t.Helper()
+	finished := "NULL"
+	if stamped {
+		finished = "now()"
+	}
+	_, err := conn.Exec(context.Background(), `
+		INSERT INTO agent_run (agent_spec, goal, trigger_ref, status, finished_at)
+		VALUES ('probe_spec', 'a probe', $1, $2, `+finished+`)`,
+		t.Name()+status+finished, status)
+	return err
+}
+
+func TestATerminalRunWithoutAFinishIsRefused(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	owner := connect(t, ownerDSN)
+	headSchema(t, owner)
+
+	// Every terminal status, not the one that happened to have the bug: the
+	// constraint names three and a test that checked one would pass while two
+	// of them stayed open.
+	for _, status := range []string{"completed", "degraded", "failed"} {
+		if err := seedRun(t, owner, status, false); err == nil {
+			t.Errorf("the estate accepted a %s run with no finished_at — such a run has left the "+
+				"in-flight statuses and cannot match the settled predicate, so it vanishes from the "+
+				"feed rather than arriving late", status)
+			continue
+		} else if !strings.Contains(err.Error(), "agent_run_settled_shape") {
+			t.Errorf("a %s run with no finished_at was refused by something else: %v", status, err)
+		}
+		// And the same status WITH a stamp is ordinary.
+		if err := seedRun(t, owner, status, true); err != nil {
+			t.Errorf("a settled %s run carrying its finish was refused: %v", status, err)
+		}
+	}
+
+	// The in-flight half, which is the reason this is an implication and not
+	// NOT NULL on the column: a run that has not stopped has no finish, and a
+	// default would invent one.
+	for _, status := range []string{"running", "awaiting_approval"} {
+		err := seedRun(t, owner, status, false)
+		if status == "awaiting_approval" {
+			// agent_run_awaiting_shape wants an approval and a pending call,
+			// which this probe does not seed — a different rule, and refusing
+			// here would say nothing about the one under test.
+			if err != nil && !strings.Contains(err.Error(), "agent_run_awaiting_shape") {
+				t.Errorf("an %s run was refused by the settled rule: %v", status, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("a %s run with no finished_at was refused, and an unfinished run has no finish to give: %v", status, err)
+		}
+	}
+}
+
+// The backfill leaves no row the constraint would refuse, and stamps it with
+// the truest instant the record holds.
+//
+// No row is expected on a tree whose writers are already fixed — the point is
+// an installation that ran the old code. Driven by putting the estate back into
+// that state on purpose, because a migration whose backfill was never run
+// against the shape it exists for is a migration that fails on the one
+// installation that needed it.
+func TestTheBackfillStampsARunThatStoppedWithoutSayingWhen(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	owner := connect(t, ownerDSN)
+	headSchema(t, owner)
+	ctx := context.Background()
+
+	// The pre-migration estate: the rule gone, and a row that could only exist
+	// while it was.
+	if _, err := owner.Exec(ctx, `ALTER TABLE agent_run DROP CONSTRAINT agent_run_settled_shape`); err != nil {
+		t.Fatalf("removing the rule to reproduce the old estate: %v", err)
+	}
+	var stranded string
+	if err := owner.QueryRow(ctx, `
+		INSERT INTO agent_run (agent_spec, goal, trigger_ref, status, finished_at, updated_at)
+		VALUES ('probe_spec', 'stopped without saying when', $1, 'failed', NULL, now() - interval '2 hours')
+		RETURNING id::text`, t.Name()).Scan(&stranded); err != nil {
+		t.Fatalf("seeding the stranded run: %v", err)
+	}
+
+	// The migration's own backfill, verbatim.
+	if _, err := owner.Exec(ctx, `
+		UPDATE agent_run
+		   SET finished_at = updated_at
+		 WHERE status IN ('completed', 'degraded', 'failed')
+		   AND finished_at IS NULL`); err != nil {
+		t.Fatalf("the backfill: %v", err)
+	}
+
+	var matchesUpdated bool
+	if err := owner.QueryRow(ctx,
+		`SELECT finished_at IS NOT NULL AND finished_at = updated_at FROM agent_run WHERE id::text = $1`,
+		stranded).Scan(&matchesUpdated); err != nil {
+		t.Fatalf("reading the backfilled run: %v", err)
+	}
+	if !matchesUpdated {
+		t.Error("the stranded run did not take updated_at as its finish — every terminal writer stamps " +
+			"updated_at in the same statement it sets the status, so for a row that reached a terminal " +
+			"state the two are the same instant")
+	}
+
+	// And the rule goes back on, which is what the backfill is FOR: without it
+	// this statement fails and the migration takes the installation with it.
+	if _, err := owner.Exec(ctx, `
+		ALTER TABLE agent_run
+		    ADD CONSTRAINT agent_run_settled_shape
+		    CHECK (status NOT IN ('completed', 'degraded', 'failed') OR finished_at IS NOT NULL)`); err != nil {
+		t.Fatalf("the rule could not be added after the backfill, so the migration would fail on an "+
+			"installation that ran the old code: %v", err)
+	}
+}

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -435,6 +435,7 @@ public.agent_run.agent_run_attempt_check CHECK ((attempt >= 1))
 public.agent_run.agent_run_awaiting_shape CHECK (((status <> 'awaiting_approval'::text) OR ((approval_id IS NOT NULL) AND (pending IS NOT NULL))))
 public.agent_run.agent_run_passport_fkey FOREIGN KEY (passport_id) REFERENCES passport(id) ON DELETE SET NULL (passport_id)
 public.agent_run.agent_run_pkey PRIMARY KEY (id)
+public.agent_run.agent_run_settled_shape CHECK (((status <> ALL (ARRAY['completed'::text, 'degraded'::text, 'failed'::text])) OR (finished_at IS NOT NULL)))
 public.agent_run.agent_run_status_check CHECK ((status = ANY (ARRAY['running'::text, 'awaiting_approval'::text, 'completed'::text, 'degraded'::text, 'failed'::text])))
 public.agent_run.agent_run_trigger_unique UNIQUE (trigger_ref)
 public.agent_run.agent_spec text NOT NULL gen=- def=-


### PR DESCRIPTION
Closes #2187

`agent_run.finished_at` is load-bearing: the personal activity read bounds settled work with `finished_at >= <local midnight>` and orders by it, because *"settled today"* is a fact about when a run **finished**. A terminal run whose `finished_at` is NULL has left the in-flight statuses and cannot match that predicate — so it does not arrive late or out of order, it **disappears from the feed**.

Nothing enforced the pairing. `status` and `finished_at` were independent columns and every writer was trusted to set them together; one of them did not, and the only symptom was a run silently missing from a reader's day. Fixing that writer corrected today's tree and did nothing about the next one.

## Option 1 from the issue

A `CHECK`, stated as an **implication** rather than as NOT NULL on the column: an in-flight run genuinely has no finish, and a default would invent one. It sits beside `agent_run_awaiting_shape`, which says the same kind of thing about the same column set.

```sql
CHECK (status NOT IN ('completed', 'degraded', 'failed') OR finished_at IS NOT NULL)
```

## The backfill

It takes `updated_at`, and the migration says why that is the honest approximation: every terminal writer stamps `updated_at` in the same statement it sets the status, so for a row that reached a terminal state the two are the same instant.

No row is expected on a tree whose writers are already fixed — it is there so an installation that ran the old code still validates. It is **tested by putting the estate back into that state on purpose**, because a backfill never run against the shape it exists for is one that fails on the only installation that needed it: the test drops the rule, seeds a stranded run, runs the backfill verbatim, and re-adds the rule.

## The 4xx obligation, and why it does not apply

The issue notes that a new CHECK carries an obligation to map its violation to a 4xx rather than a 500. **This one should stay a 500.** No caller input reaches `agent_run.status` — the column is written only by the runner's own store and the erasure path, never from a request body — so a violation is a code defect, not a bad request. Telling a caller to fix their input would name something they cannot change. That is why this PR adds no mapping, and the reasoning is here rather than left to be inferred.

## Verification

- All three terminal statuses are refused without a stamp, and accepted with one. A test that checked only the status that had the bug would pass while two stayed open.
- Both in-flight statuses are still accepted with no stamp.
- Removing the constraint from the migration → the test reports all three.
- `make check-backend` exit 0, head catalog regenerated.
- The migration sorts above main's highest; I will re-check that before merge, since several sessions are working against the same version gate.
