### PR TITLE
The export says what became of every link it mailed

### DIFF
--- a/backend/gates/piicoverage_test.go
+++ b/backend/gates/piicoverage_test.go
@@ -75,6 +75,29 @@ type piiHandling struct {
 	// it wherever the row holds something an Art. 15 package must not carry —
 	// a live credential, say — and the gate fails the moment SAR touches it.
 	sarForbidden bool
+	// sarWithholds: SAR reads this table, but these COLUMNS must never appear
+	// in the export statement. The middle case sarRead and sarForbidden cannot
+	// express between them, and the one confirm_token needs: the row's timing
+	// and outcome are the subject's own history and belong in the package,
+	// while the token that opens their record and the address it was sent to
+	// do not.
+	//
+	// Table-level flags forced that row to be all-or-nothing, so protecting
+	// two columns meant withholding the whole lifecycle — and a later author
+	// wanting the lifecycle would have had to drop the protection on the
+	// credential to get it. Naming the columns keeps both true at once, and
+	// keeps the reason attached to the thing it is about.
+	//
+	// THIS CHECK IS THE CHEAP HALF, and it is a name deny-list: it fails a
+	// statement that SELECTs the column by name. Four ordinary spellings walk
+	// past it — `t.*`, `to_jsonb(t)`, `row_to_json(t)` and `t::text` all carry
+	// the withheld columns without naming them. privacy's
+	// TestNoWithheldColumnReachesTheAssembledExport is the half that closes
+	// them: it PREPAREs each assembled section against the real schema and
+	// reads the result columns, which is what the export actually returns.
+	// Registering a column here without that runtime check in place would be a
+	// withholding an author could bypass by accident.
+	sarWithholds []string
 }
 
 // piiTables is the registry of every table holding data about a subject.
@@ -348,13 +371,29 @@ var piiTables = map[string]piiHandling{
 	"preference_token": {erasureWrite: true, sarForbidden: true},
 
 	// The confirm-details link: a live bearer credential that opens the
-	// subject's own record. Registered for the same two reasons preference_token
-	// is. Erasure must retire it explicitly, because anonymize-in-place leaves
-	// the person row standing so the schema's ON DELETE CASCADE never fires. The
-	// export side is sarFORBIDDEN because the row holds a working credential and
-	// the address it went to, and an Art. 15 package assembled by an admin must
-	// carry neither — the subject already has their own copy, in the mail.
-	"confirm_token": {erasureWrite: true, sarForbidden: true},
+	// subject's own record. Erasure must retire it explicitly, because
+	// anonymize-in-place leaves the person row standing so the schema's
+	// ON DELETE CASCADE never fires.
+	//
+	// The export side is read WITH TWO COLUMNS WITHHELD, where it used to be
+	// forbidden outright. The row holds two things an Art. 15 package must not
+	// carry — a working credential, and the address the workspace chose to send
+	// it to — but it also holds when the subject was asked and what became of
+	// the asking, which is their own history and exactly what Art. 15 is for.
+	// Forbidding the table protected the first pair by withholding the second,
+	// so a subject could be told a marketing consent was held for them without
+	// being able to see the round trip it rests on.
+	//
+	// token_hash: not exported even hashed. The package is assembled by an
+	// admin and handed on through a channel they choose, and a credential that
+	// widens with every copy has no business in it.
+	// delivered_to: the subject's own addresses are already exported in full in
+	// their own section, so repeating the chosen one here adds nothing they do
+	// not know while putting a live address in a second place in the package.
+	"confirm_token": {
+		erasureWrite: true, sarRead: true,
+		sarWithholds: []string{"token_hash", "delivered_to"},
+	},
 	// And what came back through it: a correction the subject typed, or their
 	// request to be removed. sarREAD rather than forbidden, and it is the one
 	// part of the package the subject authored — an export that handed back
@@ -366,11 +405,18 @@ var piiTables = map[string]piiHandling{
 // sarAssemblyFiles are the files whose SQL literals make up the Art. 15
 // package. Listed rather than globbed: the gate asks what the EXPORT reads, and
 // a glob over the package would read erasure's DELETE statements as disclosures.
-// A new file carrying SAR sections joins this list; the section-count assertion
-// below is what fails if one is forgotten.
+// A new file carrying SAR sections joins this list, and a forgotten one reads
+// here as a table the export never touches.
+//
+// What this list CANNOT see is whether a written section is an ASSEMBLED one:
+// it reads the literals, so deleting the append that adds a chapter to
+// sarSections leaves the text in place and every table in it still counted.
+// privacy's own TestEveryPromisedTableIsActuallyAssembled asks that half, from
+// the only package that can call sarSections.
 var sarAssemblyFiles = []string{
 	"internal/modules/privacy/sar.go",
 	"internal/modules/privacy/sarsections.go",
+	"internal/modules/privacy/sarconsentlinks.go",
 	"internal/modules/privacy/sarmessages.go",
 }
 
@@ -437,10 +483,12 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 	// the whole package sweeps in erasure's own DELETE ... FROM statements,
 	// which fromJoinRe cannot tell from a SELECT.
 	reads := map[string]bool{}
+	sarStatements := map[string][]string{}
 	for _, path := range sarAssemblyFiles {
 		for _, lit := range sqlLiterals(t, path) {
 			for _, m := range fromJoinRe.FindAllStringSubmatch(lit, -1) {
 				reads[m[1]] = true
+				sarStatements[m[1]] = append(sarStatements[m[1]], lit)
 			}
 		}
 	}
@@ -524,6 +572,27 @@ func TestErasureAndSARReachEveryPIITable(t *testing.T) {
 		if h.sarRead && h.sarForbidden {
 			missing = append(missing, "PII table "+table+
 				" is registered both sarRead and sarForbidden — the export cannot both require and refuse it")
+		}
+		if h.sarForbidden && len(h.sarWithholds) > 0 {
+			missing = append(missing, "PII table "+table+
+				" is registered sarForbidden AND names withheld columns — a table SAR must not read at all"+
+				" has no columns to withhold; drop one of the two")
+		}
+		for _, column := range h.sarWithholds {
+			if !reads[table] {
+				missing = append(missing, "PII table "+table+" names `"+column+
+					"` as withheld from the Art. 15 export, but SAR does not read the table at all —"+
+					" a withholding nothing enforces is a claim, not a control. Add the section or"+
+					" register the table sarForbidden")
+				break
+			}
+			if where := sarStatementNaming(sarStatements[table], table, column); where != "" {
+				missing = append(missing, "the Art. 15 export now selects `"+column+"` from PII table "+
+					table+" (`"+where+"`), which is registered as deliberately WITHHELD. Read the reason"+
+					" beside the registration before changing it: these columns are withheld because the"+
+					" package is assembled by an admin and handed on, not because the subject may not"+
+					" know them")
+			}
 		}
 	}
 	sort.Strings(missing)

--- a/backend/gates/piisqlreader_test.go
+++ b/backend/gates/piisqlreader_test.go
@@ -686,3 +686,52 @@ func TestTheSQLReaderStepsOverWhatIsNotSQL(t *testing.T) {
 		})
 	}
 }
+
+// sarStatementNaming reports the SAR statement that selects a withheld column
+// from the given table, or "" when none does.
+//
+// It reads the SELECT list only. A withheld column is free to appear in a WHERE
+// or a JOIN — `WHERE person_id = $1` is how the section finds the subject's own
+// rows, and `expires_at <= now()` is how the outcome is derived — because
+// neither puts a value in the package. What must never happen is the column
+// reaching the output, so the question is what is being returned.
+//
+// The column is matched as a whole identifier, optionally qualified by a table
+// alias, so `token_hash` and `ct.token_hash` both count while a longer name
+// merely containing it does not.
+func sarStatementNaming(statements []string, table, column string) string {
+	needle := regexp.MustCompile(`(?i)(?:^|[\s,(])(?:[a-z_][a-z0-9_]*\.)?` +
+		regexp.QuoteMeta(strings.ToLower(column)) + `\b`)
+	for _, stmt := range statements {
+		// The statement has to read THIS table, for the reason its sibling
+		// above re-checks its own: a helper that is only correct because the
+		// caller grouped first is one the next caller gets wrong.
+		readsTable := false
+		for _, m := range fromJoinRe.FindAllStringSubmatch(stmt, -1) {
+			readsTable = readsTable || m[1] == table
+		}
+		if !readsTable {
+			continue
+		}
+		if needle.MatchString(selectList(stmt)) {
+			return stmt
+		}
+	}
+	return ""
+}
+
+// selectList returns what a statement RETURNS — the text between its first
+// SELECT and the FROM that closes it. Everything after that FROM is how the
+// rows were found, which is not what a withholding is about.
+func selectList(stmt string) string {
+	lower := strings.ToLower(stmt)
+	start := strings.Index(lower, "select")
+	if start < 0 {
+		return ""
+	}
+	rest := stmt[start+len("select"):]
+	if end := regexp.MustCompile(`(?is)\bfrom\b`).FindStringIndex(rest); end != nil {
+		return rest[:end[0]]
+	}
+	return rest
+}

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -57,6 +57,15 @@ type SARPackage struct {
 	// Why this contact exists: the answer to Art. 15(1)(g).
 	AcquisitionEvidence []map[string]any `json:"acquisition_evidence"`
 	NoticeCases         []map[string]any `json:"notice_cases"`
+	// Every confirm link the workspace mailed this subject, and what became of
+	// it: issued, opened, answered, or left to expire. The mail carrying the
+	// link is already in Activities; this says what the link itself did, which
+	// is the half that decides whether a grant on file is one the subject
+	// actually completed.
+	//
+	// Neither the token nor the address it went to appears here — see
+	// sarConsentLinkSections for why each is withheld.
+	ConsentLinks []map[string]any `json:"consent_links"`
 	// What the subject themselves sent through their confirm link — a
 	// correction they typed, or a request to be removed. The one part of this
 	// package the subject authored rather than the workspace, which is exactly

--- a/backend/internal/modules/privacy/sarconsentlinks.go
+++ b/backend/internal/modules/privacy/sarconsentlinks.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+// The Art. 15 chapter covering the confirm links the workspace mailed a subject.
+//
+// Its own file because sarsections.go reached the 500-line ceiling, and this is
+// the chapter that comes off cleanly: one section, one table, and a withholding
+// rule that needs its reasons stated at length beside it rather than buried in a
+// file about every other chapter.
+
+// sarConsentLinkSections report what became of every confirm link the
+// workspace mailed this subject.
+//
+// A grant on file says the subject agreed. It does not say whether they were
+// ever asked, when, or whether the link they were sent was one they actually
+// answered — and that is the difference between a completed double opt-in and a
+// row somebody typed. The mail itself is already in the Activities section; what
+// was missing is the link's own lifecycle, so a subject reading their export
+// could see "you hold a marketing consent for me" without seeing the round trip
+// it rests on.
+//
+// TWO COLUMNS ARE WITHHELD, for different reasons:
+//
+// token_hash, because the row is a live bearer credential that opens this
+// subject's own record. Even hashed it is not exported: an Art. 15 package is
+// assembled by an admin and handed over through whatever channel they choose,
+// and a credential that widens with every copy has no business in it. The
+// subject was already sent it, in the mail that carried the link.
+//
+// delivered_to, because it is the address the workspace CHOSE at issuance, and
+// the subject's addresses are already exported in full in their own section.
+// Repeating one here would add nothing they do not know while putting a live
+// address into a second place in the package.
+//
+// What remains is timing, outcome and — for a consent link — the purpose it
+// asked about, which is the answer Art. 15 asks for and carries no credential at
+// all. The purpose join is LEFT because a record-confirmation link names none:
+// an inner join would drop every one of them, and a subject asked only to check
+// their details would read an empty section as never having been written to.
+//
+// `outcome` is derived rather than exported as three nullable timestamps,
+// because "expired unanswered" is a fact about the subject's own history that a
+// reader should not have to compute by comparing dates.
+//
+// Supersession is tested BEFORE expiry, and that ordering is the point. Issuing
+// a fresh link retires the pending one by setting its expires_at to the new
+// link's issue time (consent's confirmtoken.go), so a superseded row is
+// bit-identical to one the subject let lapse. Reporting it as
+// "expired_unanswered" would tell a subject they ignored a link the workspace
+// itself withdrew — a statement about their conduct that is not true. The
+// matching clauses mirror the writer's: same person, same kind, same purpose,
+// which is exactly the scope it supersedes within.
+func sarConsentLinkSections(pkg *SARPackage) []sarSection {
+	return []sarSection{
+		{&pkg.ConsentLinks, `SELECT ct.kind, cp.key AS purpose, ct.issued_at, ct.expires_at,
+		          ct.opened_at, ct.consumed_at,
+		          CASE WHEN ct.consumed_at IS NOT NULL THEN 'answered'
+		               WHEN EXISTS (
+		                   SELECT 1 FROM confirm_token later
+		                    WHERE later.person_id = ct.person_id
+		                      AND later.kind = ct.kind
+		                      AND later.purpose_id IS NOT DISTINCT FROM ct.purpose_id
+		                      AND later.issued_at > ct.issued_at
+		               ) THEN 'superseded_by_a_newer_link'
+		               WHEN ct.expires_at <= now() THEN 'expired_unanswered'
+		               WHEN ct.opened_at IS NOT NULL THEN 'opened_not_answered'
+		               ELSE 'awaiting_answer'
+		          END AS outcome
+		   FROM confirm_token ct
+		   LEFT JOIN consent_purpose cp ON cp.id = ct.purpose_id
+		   WHERE ct.person_id = $1`, nil},
+	}
+}

--- a/backend/internal/modules/privacy/sarconsentlinks_integration_test.go
+++ b/backend/internal/modules/privacy/sarconsentlinks_integration_test.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// What the Art. 15 export says about the links the workspace mailed a subject.
+//
+// A grant on file says the subject agreed. It does not say whether they were
+// ever asked, when, or whether the link they were sent is one they actually
+// answered — and that gap is the difference between a completed double opt-in
+// and a row somebody typed. Until this section the export carried the grant and
+// not the round trip behind it.
+//
+// The four outcomes are asserted against rows in each state rather than through
+// the minting API: the writer lives in the consent module, which privacy may not
+// import (a module never imports a sibling). The full round trip — mint, mail,
+// open, answer — is driven over the real HTTP stack in
+// compose/integration/consent_integration_test.go, which is where the writer and
+// this reader meet. What is proven HERE is the projection: given a row in a
+// given state, what does the subject's package say about it.
+//
+// The seeded columns are exactly the ones the writer sets, so a change to which
+// timestamps it records fails the schema check beside this rather than passing
+// silently against a shape production never produces.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedConfirmLink writes one link in a named state. delivered_to and token_hash
+// are set because the writer sets them and both are NOT NULL — this fixture
+// carries the columns the export must NOT return, so a test asserting their
+// absence is asking a real question rather than reading an empty row.
+func seedConfirmLink(ctx context.Context, t *testing.T, owner *pgx.Conn, person ids.PersonID,
+	kind string, issued, expires time.Time, opened, consumed *time.Time,
+) {
+	t.Helper()
+	// A consent link names the purpose it confirms and a record link never
+	// does — confirm_token_purpose_is_consents. Honoured rather than worked
+	// around: a fixture that broke it would be modelling a row the minting path
+	// cannot produce.
+	var purpose *ids.UUID
+	if kind == "consent_confirmation" {
+		purpose = seedConsentPurpose(ctx, t, owner)
+	}
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO confirm_token
+		    (person_id, token_hash, delivered_to, issued_at, expires_at, opened_at, consumed_at,
+		     kind, purpose_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		person, "hash-"+kind+"-"+issued.Format(time.RFC3339Nano),
+		"sara@sar.test", issued, expires, opened, consumed, kind, purpose); err != nil {
+		t.Fatalf("seeding a %s confirm link: %v", kind, err)
+	}
+}
+
+// seedConsentPurpose mints one purpose for a consent link to name. Each call
+// makes its own, so two links in one fixture are never accidentally the same
+// question asked twice.
+func seedConsentPurpose(ctx context.Context, t *testing.T, owner *pgx.Conn) *ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO consent_purpose (id, key, label, requires_double_opt_in)
+		 VALUES ($1, $2, 'Newsletter', true)`, id, "newsletter-"+id.String()); err != nil {
+		t.Fatalf("seeding a consent purpose: %v", err)
+	}
+	return &id
+}
+
+func TestTheExportSaysWhatBecameOfEveryLinkItMailed(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	now := time.Now()
+
+	answered := now.Add(-2 * time.Hour)
+	opened := now.Add(-3 * time.Hour)
+	// One link per outcome, each in its own supersession scope.
+	//
+	// The writer supersedes per kind and per purpose, and so does the export, so
+	// two links of one kind for one person would make the older one superseded
+	// rather than whatever this fixture meant it to be. Each row below therefore
+	// gets its own kind, or its own purpose within a kind — which is also how
+	// production produces four live links for one subject at once.
+	//
+	// The answered link is deliberately ALSO opened: a projection that tested
+	// opened_at before consumed_at would call it merely opened, and this notices.
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "record_confirmation",
+		now.Add(-4*time.Hour), now.Add(24*time.Hour), &opened, &answered)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "consent_confirmation",
+		now.Add(-30*24*time.Hour), now.Add(-20*24*time.Hour), nil, nil)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "consent_confirmation",
+		now.Add(-5*time.Hour), now.Add(48*time.Hour), &opened, nil)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "consent_confirmation",
+		now.Add(-time.Hour), now.Add(72*time.Hour), nil, nil)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	if len(pkg.ConsentLinks) != 4 {
+		t.Fatalf("the export carries %d confirm link(s), want 4 — a subject cannot see a round "+
+			"trip the package omits", len(pkg.ConsentLinks))
+	}
+
+	outcomes := map[string]int{}
+	for _, link := range pkg.ConsentLinks {
+		outcome, ok := link["outcome"].(string)
+		if !ok {
+			t.Fatalf("a confirm link reports no outcome: %v", link)
+		}
+		outcomes[outcome]++
+
+		// The two columns the registration withholds must not be in the
+		// package, whatever the outcome. Asserted on the ASSEMBLED row rather
+		// than on the query text, which is the gate's question.
+		for _, withheld := range []string{"token_hash", "delivered_to"} {
+			if _, present := link[withheld]; present {
+				t.Errorf("the export handed back %s (%v) — it is a live bearer credential, or the "+
+					"address it was sent to, and an Art. 15 package assembled by an admin carries "+
+					"neither", withheld, link[withheld])
+			}
+		}
+	}
+
+	for outcome, want := range map[string]int{
+		"answered":            1,
+		"expired_unanswered":  1,
+		"opened_not_answered": 1,
+		"awaiting_answer":     1,
+	} {
+		if outcomes[outcome] != want {
+			t.Errorf("outcome %q appears %d time(s), want %d — the export is describing a link's "+
+				"fate as something other than what happened to it", outcome, outcomes[outcome], want)
+		}
+	}
+}
+
+// A link the workspace itself retired is not one the subject ignored.
+//
+// Issuing a fresh link supersedes the pending one by setting its expires_at to
+// the new link's issue time, so on the row it is indistinguishable from a lapse.
+// Reporting that as "expired_unanswered" tells a subject they let something
+// expire when the workspace withdrew it, which is a claim about their conduct
+// and not true.
+func TestASupersededLinkIsNotReportedAsIgnored(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	now := time.Now()
+
+	// Seeded exactly as the writer leaves them: the older row's expires_at IS
+	// the newer row's issued_at, which is what makes the two cases identical
+	// on the row and the reason this test exists.
+	superseded := now.Add(-2 * time.Hour)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "record_confirmation",
+		now.Add(-4*time.Hour), superseded, nil, nil)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "record_confirmation",
+		superseded, now.Add(48*time.Hour), nil, nil)
+
+	// A link of a DIFFERENT kind, expired on its own, is the control: the
+	// writer supersedes per kind and per purpose, so this one must still read
+	// as a genuine lapse. Without it a query that called everything superseded
+	// would pass.
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "consent_confirmation",
+		now.Add(-30*24*time.Hour), now.Add(-20*24*time.Hour), nil, nil)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	outcomes := map[string]int{}
+	for _, link := range pkg.ConsentLinks {
+		outcome, _ := link["outcome"].(string)
+		outcomes[outcome]++
+	}
+	if outcomes["superseded_by_a_newer_link"] != 1 {
+		t.Errorf("the retired link reads as superseded %d time(s), want 1 — the export is telling "+
+			"the subject they ignored a link the workspace withdrew", outcomes["superseded_by_a_newer_link"])
+	}
+	if outcomes["expired_unanswered"] != 1 {
+		t.Errorf("a genuinely lapsed link of another kind reads as expired %d time(s), want 1 — "+
+			"supersession is per kind and per purpose, and this says the query lost that scope",
+			outcomes["expired_unanswered"])
+	}
+	if outcomes["awaiting_answer"] != 1 {
+		t.Errorf("the live replacement reads as awaiting %d time(s), want 1", outcomes["awaiting_answer"])
+	}
+}
+
+// A subject who was never asked gets an empty section, not a missing one.
+//
+// The distinction matters to the reader: an absent key reads as "we have no
+// idea", while an empty list says "we mailed you no links", which is a fact
+// about their record and one they may well be checking.
+func TestASubjectNeverAskedCarriesAnEmptyLinkSection(t *testing.T) {
+	e := setupSARIdentifiers(t)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+	if len(pkg.ConsentLinks) != 0 {
+		t.Fatalf("a subject who was mailed no link carries %d — the section is reading somebody "+
+			"else's rows", len(pkg.ConsentLinks))
+	}
+
+	// Serialized, because len(nil) is also 0: the check above passes just as
+	// well when the section was never assembled, which is the case this test
+	// exists to tell apart. An absent key reads to the subject as "we have no
+	// idea"; an empty list says "we mailed you none", and only one of those is
+	// a fact about their record.
+	body, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("serializing the package: %v", err)
+	}
+	if !strings.Contains(string(body), `"consent_links":[]`) {
+		t.Error(`the package carries no "consent_links":[] — the section is missing rather than ` +
+			"empty, so a subject who was never written to cannot tell that from an export that " +
+			"forgot to ask")
+	}
+}
+
+// One subject's links never appear in another's package.
+func TestTheLinkSectionNeverCarriesAnotherSubjectsRoundTrip(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	now := time.Now()
+
+	stranger := ids.New[ids.PersonKind]()
+	if _, err := e.owner.Exec(e.ctx,
+		`INSERT INTO person (id, full_name, source, captured_by)
+		 VALUES ($1, 'Other Person', 'manual', 'user:'||$2::text)`,
+		stranger, ids.NewV7()); err != nil {
+		t.Fatalf("seeding the stranger: %v", err)
+	}
+	seedConfirmLink(e.ctx, t, e.owner, stranger, "consent_confirmation",
+		now.Add(-time.Hour), now.Add(72*time.Hour), nil, nil)
+	seedConfirmLink(e.ctx, t, e.owner, e.person, "record_confirmation",
+		now.Add(-time.Hour), now.Add(72*time.Hour), nil, nil)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+	if len(pkg.ConsentLinks) != 1 {
+		t.Fatalf("the export carries %d link(s) for a subject who was mailed one — the section is "+
+			"not scoped to its subject", len(pkg.ConsentLinks))
+	}
+	if kind, _ := pkg.ConsentLinks[0]["kind"].(string); kind != "record_confirmation" {
+		t.Errorf("the exported link is %q, want record_confirmation — this is the stranger's row", kind)
+	}
+}

--- a/backend/internal/modules/privacy/sarreachable_test.go
+++ b/backend/internal/modules/privacy/sarreachable_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+// A section present in the file is not a section in the package.
+//
+// gates/piicoverage_test.go decides whether the Art. 15 export reaches a PII
+// table by reading the SQL literals in the assembly files. That answers "is the
+// query written", not "is it assembled": delete the one `append` line that adds
+// a chapter to sarSections and the query text stays where it is, so the gate
+// goes on reporting the tables as covered while the export stops carrying them.
+//
+// Proven, not assumed — removing the append for sarCommunicationSections leaves
+// that gate green while three registered tables silently leave the package.
+//
+// This closes the gap from the side that can see it. sarSections is unexported,
+// so no gate can call it; the privacy package can, and the assembled list is the
+// only thing that knows what the export will actually run.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// fromJoin names the table a FROM or JOIN clause reads. SAR sections are
+// SELECTs, so the write-target readers used elsewhere cannot see them.
+//
+// A character-identical copy of fromJoinRe in gates/piicoverage_test.go, and
+// deliberately so rather than shared: backend/gates carries no non-test file, so
+// it is not an importable package, and there is no test helper package in the
+// tree to move it to. The two ask the same question of different halves — that
+// one of the assembly files' text, this one of the assembled list — and a change
+// to what counts as a read belongs in both.
+var fromJoin = regexp.MustCompile(`(?is)\b(?:from|join)\s+([a-z_][a-z0-9_]*)`)
+
+// tablesTheExportReaches assembles the real gather list and reports every table
+// its statements read.
+func tablesTheExportReaches(t *testing.T) map[string]bool {
+	t.Helper()
+	var pkg SARPackage
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+
+	// A floor, for the reason the schema check beside this one carries one: an
+	// empty gather list reads exactly like a complete one, and every assertion
+	// below would pass over it having examined nothing.
+	const atLeast = 20
+	if len(sections) < atLeast {
+		t.Fatalf("the gather list has %d section(s), fewer than the %d this check assumes — "+
+			"it was about to pass having read almost nothing", len(sections), atLeast)
+	}
+
+	reached := map[string]bool{}
+	for _, section := range sections {
+		for _, m := range fromJoin.FindAllStringSubmatch(section.query, -1) {
+			reached[m[1]] = true
+		}
+	}
+	return reached
+}
+
+// registeredForExport reads the tables the PII registry marks sarRead — the
+// declaration that says the Art. 15 package must carry them.
+//
+// Read from the gate's source rather than restated here. A hand-kept list was
+// the first shape of this test and it covered nine tables against the registry's
+// twenty-eight, so dropping any chapter outside those nine went unnoticed —
+// which is the same under-recognition the test was written to catch, reproduced
+// in the test itself.
+func registeredForExport(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile("../../../gates/piicoverage_test.go")
+	if err != nil {
+		t.Fatalf("reading the PII registry: %v", err)
+	}
+
+	// Entries read `"table": {… sarRead: true …}`, spanning lines.
+	entry := regexp.MustCompile(`(?s)"([a-z_]+)":\s*\{([^}]*?)\}`)
+	var tables []string
+	for _, m := range entry.FindAllStringSubmatch(string(raw), -1) {
+		if strings.Contains(m[2], "sarRead: true") {
+			tables = append(tables, m[1])
+		}
+	}
+	if len(tables) < 20 {
+		t.Fatalf("the registry reports %d table(s) as sarRead, fewer than this check assumes — "+
+			"it was about to pass having examined almost nothing", len(tables))
+	}
+	return tables
+}
+
+func TestEveryPromisedTableIsActuallyAssembled(t *testing.T) {
+	reached := tablesTheExportReaches(t)
+	for _, table := range registeredForExport(t) {
+		if !reached[table] {
+			t.Errorf("no ASSEMBLED section reads %s. Its query may still be written in the file — "+
+				"which is all gates/piicoverage_test.go can see — but sarSections no longer returns "+
+				"it, so the subject's package leaves without it", table)
+		}
+	}
+}
+
+// The credential columns stay out of the assembled statements, not merely out
+// of the ones somebody remembered to look at.
+//
+// The coverage gate holds this too, from the file. Held here as well because the
+// two questions differ: that one asks whether the withheld column is written
+// anywhere in the assembly files, this one asks whether it reaches a statement
+// the export will run. A section built by string concatenation would pass the
+// first and could fail this.
+func TestTheConfirmLinkSectionCarriesNoCredential(t *testing.T) {
+	var pkg SARPackage
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+
+	var probed int
+	for _, section := range sections {
+		if !strings.Contains(section.query, "confirm_token") {
+			continue
+		}
+		probed++
+		// The SELECT list only: `expires_at` in a CASE is how the outcome is
+		// derived, and a column in a WHERE is how the subject's own rows are
+		// found. Neither puts a value in the package.
+		selected := section.query
+		if from := regexp.MustCompile(`(?is)\bfrom\b`).FindStringIndex(selected); from != nil {
+			selected = selected[:from[0]]
+		}
+		for _, withheld := range []string{"token_hash", "delivered_to"} {
+			if regexp.MustCompile(`(?i)(?:^|[\s,(])(?:[a-z_][a-z0-9_]*\.)?` + withheld + `\b`).
+				MatchString(selected) {
+				t.Errorf("the assembled confirm-link section selects %s. It is a live bearer "+
+					"credential (or the address it went to) and an Art. 15 package assembled by an "+
+					"admin must carry neither:\n%s", withheld, strings.TrimSpace(section.query))
+			}
+		}
+	}
+	if probed == 0 {
+		t.Fatal("no assembled section reads confirm_token, so this check examined nothing — " +
+			"either the section was dropped or it was renamed out of reach")
+	}
+}

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -23,6 +23,7 @@ func sarSections(pkg *SARPackage, personID ids.PersonID, emails []string, leads 
 	sections = append(sections, sarRecordSections(pkg)...)
 	sections = append(sections, sarMessagingSections(pkg, personID, emails, leads)...)
 	sections = append(sections, sarConsentSections(pkg)...)
+	sections = append(sections, sarConsentLinkSections(pkg)...)
 	sections = append(sections, sarCommunicationSections(pkg, personID, leads)...)
 	return append(sections, sarProvenanceSections(pkg)...)
 }
@@ -235,10 +236,6 @@ func sarConsentSections(pkg *SARPackage) []sarSection {
 		{&pkg.ConsentQualifyingEvents, `SELECT kind, occurred_at, source_entity_type, created_at AS captured_at
 		   FROM consent_qualifying_event
 		   WHERE person_id = $1`, nil},
-		// The token row itself is deliberately NOT read: it is a live
-		// credential, and the subject already holds their own copy in the mail
-		// that delivered it. Registered sarForbidden so a future section over
-		// it fails the coverage gate rather than shipping.
 		{&pkg.ConfirmSubmissions, `SELECT kind, field, proposed_value, submitted_at, resolution, resolved_at
 		   FROM person_confirm_submission
 		   WHERE person_id = $1`, nil},

--- a/backend/internal/modules/privacy/sarwithheld_integration_test.go
+++ b/backend/internal/modules/privacy/sarwithheld_integration_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// No withheld column reaches the Art. 15 package, whatever the SQL spelling.
+//
+// This asks Postgres what each assembled section RETURNS, rather than asking a
+// regexp what its text says. The distinction is not academic: the export's keys
+// come straight from pgx's FieldDescriptions (sar.go's rowMaps), so the result
+// columns ARE the package, and a name-matching check answers a different
+// question than the one that matters.
+//
+// It was a real gap, not a hypothetical. The first version of this withholding
+// searched the SELECT list for the literal `token_hash`, and four ordinary
+// spellings walked straight past it — `SELECT ct.*`, `to_jsonb(ct)`,
+// `row_to_json(ct)`, and a `/* from */` comment that made the text-splitter cut
+// the SELECT list short. Every one of them ships the credential. Asking the
+// database removes the whole class: a star expands to real column names before
+// this ever sees them, and a whole-row constructor returns one composite column
+// whose type is the table, which is checked for separately below.
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// withheldFromTheExport names, per table, the columns an Art. 15 package must
+// never carry. It mirrors sarWithholds in gates/piicoverage_test.go, which is
+// the registration a reader is pointed at; this is the runtime half that
+// actually holds the line.
+//
+// Two copies because backend/gates carries no non-test file and so is not an
+// importable package. TestTheTwoWithholdingRegistriesAgree reads the gate's
+// source and fails when they diverge — without it, registering a column there
+// and forgetting it here would leave the airtight half not looking.
+var withheldFromTheExport = map[string][]string{
+	"confirm_token": {"token_hash", "delivered_to"},
+}
+
+// The gate's registration and this one describe the same rule, so they must name
+// the same tables and columns.
+//
+// Read from the gate's SOURCE rather than restated, because a hand-kept mirror
+// is what this test exists to catch. The direction that matters most is a
+// column registered in the gate and missing here: the gate's own check is a name
+// deny-list four SQL spellings walk past, so a column only IT knows about is one
+// nothing effectively guards.
+func TestTheTwoWithholdingRegistriesAgree(t *testing.T) {
+	raw, err := os.ReadFile("../../../gates/piicoverage_test.go")
+	if err != nil {
+		t.Fatalf("reading the withholding registration: %v", err)
+	}
+
+	// Each entry reads `sarWithholds: []string{"a", "b"}` inside the piiTables
+	// literal for a table, so the table name is the nearest preceding key.
+	entry := regexp.MustCompile(`(?s)"([a-z_]+)":\s*\{[^}]*?sarWithholds:\s*\[\]string\{([^}]*)\}`)
+	matches := entry.FindAllStringSubmatch(string(raw), -1)
+	if len(matches) == 0 {
+		t.Fatal("no sarWithholds registration found in the gate, so this comparison has no " +
+			"subject and would pass however far the two had drifted")
+	}
+
+	registered := map[string][]string{}
+	for _, m := range matches {
+		var columns []string
+		for _, c := range regexp.MustCompile(`"([a-z_]+)"`).FindAllStringSubmatch(m[2], -1) {
+			columns = append(columns, c[1])
+		}
+		registered[m[1]] = columns
+	}
+
+	for table, columns := range registered {
+		for _, column := range columns {
+			if !slices.Contains(withheldFromTheExport[table], column) {
+				t.Errorf("the gate registers %s.%s as withheld from the Art. 15 export, but "+
+					"withheldFromTheExport does not name it — the gate's own check is a name "+
+					"deny-list that several SQL spellings walk past, so this column is currently "+
+					"guarded by nothing that holds", table, column)
+			}
+		}
+	}
+	for table, columns := range withheldFromTheExport {
+		for _, column := range columns {
+			if !slices.Contains(registered[table], column) {
+				t.Errorf("this check probes %s.%s, which the gate no longer registers as withheld. "+
+					"Either the withholding was lifted — and this probe should go with it — or the "+
+					"registration was dropped by accident", table, column)
+			}
+		}
+	}
+}
+
+func TestNoWithheldColumnReachesTheAssembledExport(t *testing.T) {
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	if ownerDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+
+	var pkg SARPackage
+	sections := sarSections(&pkg, ids.New[ids.PersonKind](), []string{"subject@sar.test"}, []ids.UUID{ids.NewV7()})
+
+	var probed int
+	for _, section := range sections {
+		table, columns := withheldTableIn(section.query)
+		if table == "" {
+			continue
+		}
+		probed++
+
+		// What the top plan node RETURNS, which is the only complete answer.
+		//
+		// Reading the SQL text cannot settle this: `ct.token_hash AS outcome`
+		// hides the column behind a harmless alias, `format('%%s', ct)`
+		// serializes the whole row into ordinary text, and a `/* from */`
+		// comment cuts a text-splitter short. Reading the result TYPES misses
+		// all three too, because each returns a plain scalar.
+		//
+		// The planner has already resolved every alias, expanded every star and
+		// looked inside every function argument, and it reports what the node
+		// emits. Asking it removes the whole class rather than the four
+		// spellings somebody thought of.
+		for _, referenced := range topLevelOutput(ctx, t, owner, section.query) {
+			for _, withheld := range columns {
+				if !referencesColumn(referenced, withheld) {
+					continue
+				}
+				t.Errorf("the assembled export returns %s from %s, however it is spelled or "+
+					"aliased. It is a live bearer credential, or the address it was mailed to, "+
+					"and an Art. 15 package assembled by an admin carries neither:\n%s",
+					referenced, table, strings.TrimSpace(section.query))
+			}
+		}
+	}
+
+	if probed == 0 {
+		t.Fatal("no assembled section reads a table with withheld columns, so this check examined " +
+			"nothing — either the section was dropped or withheldFromTheExport names a table the " +
+			"export no longer touches")
+	}
+}
+
+// topLevelOutput asks the planner what the statement's OUTERMOST node emits.
+//
+// The top node only: an inner scan lists every column it reads, including ones
+// the projection discards, so reading the whole plan would refuse a statement
+// that merely joins the table. What the outermost node outputs is what reaches
+// pgx, and what reaches pgx is the package.
+//
+// Explained rather than executed, for the reason the schema check beside this
+// prepares rather than executing: this is a question about the statement, and
+// answering it must not depend on rows existing.
+func topLevelOutput(ctx context.Context, t *testing.T, owner *pgx.Conn, query string) []string {
+	t.Helper()
+
+	var plan []map[string]any
+	if err := owner.QueryRow(ctx,
+		"EXPLAIN (VERBOSE, COSTS OFF, FORMAT JSON) "+withPlaceholdersBound(query)).Scan(&plan); err != nil {
+		t.Fatalf("explaining a section: %v — this check cannot tell what the statement returns "+
+			"without a plan, so it must not pass by default:\n%s", err, strings.TrimSpace(query))
+	}
+	if len(plan) == 0 {
+		t.Fatalf("the planner returned no plan for:\n%s", strings.TrimSpace(query))
+	}
+
+	node, ok := plan[0]["Plan"].(map[string]any)
+	if !ok {
+		t.Fatalf("the plan carries no top node for:\n%s", strings.TrimSpace(query))
+	}
+	output, ok := node["Output"].([]any)
+	if !ok {
+		t.Fatalf("the top plan node reports no Output for:\n%s", strings.TrimSpace(query))
+	}
+
+	var referenced []string
+	for _, item := range output {
+		if text, ok := item.(string); ok {
+			referenced = append(referenced, text)
+		}
+	}
+	return referenced
+}
+
+// withPlaceholdersBound replaces $N with a typed NULL so EXPLAIN can plan the
+// statement without a PREPARE round trip. The values never matter — the question
+// is what the projection names, which no argument changes.
+func withPlaceholdersBound(query string) string {
+	return regexp.MustCompile(`\$\d+`).ReplaceAllString(query, "NULL")
+}
+
+// referencesColumn reports whether a plan output item carries the given column —
+// as `alias.column`, as a bare `column`, or inside a whole-row reference, which
+// carries every column including this one.
+//
+// The table is not a parameter: the caller has already established that this
+// statement reads the withholding table, and a plan node's output is not
+// qualified consistently enough to re-derive it here. Asking about the column
+// alone is what makes the whole-row case answerable at all — that spelling names
+// no column, and no table either.
+func referencesColumn(output, column string) bool {
+	if regexp.MustCompile(`(?i)(?:^|[^a-z0-9_.])(?:[a-z_][a-z0-9_]*\.)?` +
+		regexp.QuoteMeta(column) + `\b`).MatchString(output) {
+		return true
+	}
+	// A whole-row reference names no column at all and carries every one of
+	// them. The planner spells it `ct.*` when an alias survives into the plan
+	// and a bare `*` when it does not — a single-relation plan drops the
+	// qualifier, so matching only the qualified form let `format('%s', ct)`
+	// through. Both spellings are refused, and a bare `*` is never a legitimate
+	// projection in a section over this table: every column the subject is owed
+	// here is named.
+	return regexp.MustCompile(`(?i)(?:^|[^a-z0-9_.])(?:[a-z_][a-z0-9_]*\.)?\*`).
+		MatchString(output)
+}
+
+// withheldTableIn reports the withheld-column table a statement reads, if any.
+func withheldTableIn(query string) (string, []string) {
+	for _, m := range fromJoin.FindAllStringSubmatch(query, -1) {
+		if columns, ok := withheldFromTheExport[m[1]]; ok {
+			return m[1], columns
+		}
+	}
+	return "", nil
+}


### PR DESCRIPTION
A grant on file says the subject agreed. It did not say whether they were ever asked, when, or whether the link they were sent is one they actually answered — and that gap is the difference between a completed double opt-in and a row somebody typed.

The Art. 15 package now carries the round trip: one entry per confirm link, with its purpose and what became of it — `answered`, `opened_not_answered`, `expired_unanswered`, `superseded_by_a_newer_link`, or `awaiting_answer`.

## The table was forbidden, for two good reasons that still hold

`confirm_token` was registered `sarForbidden`, meaning SAR must never read it: the row holds a live bearer credential that opens the subject's own record, and the address the workspace chose to mail it to. Neither belongs in a package an admin assembles and hands on.

But a table-level flag made the row all-or-nothing, so protecting those two columns meant withholding the whole lifecycle — and a later author wanting the lifecycle would have had to drop the protection to get it. The registration becomes `sarRead` + `sarWithholds` naming the two columns, so both stay true at once.

## The withholding is enforced by asking Postgres, not a regexp

The static gate check is a name deny-list, and eight ordinary spellings walk straight past it — `ct.*`, `to_jsonb(ct)`, `row_to_json(ct)`, `ct::text`, a bare alias, an alias-hidden `ct.token_hash AS outcome`, `format('%s', ct)`, and a `/* from */` comment that cuts a text splitter short. Every one of them ships the credential.

So `privacy` EXPLAINs each assembled section and reads what the **top plan node outputs**. The planner has already resolved every alias, expanded every star and looked inside every function argument, so one question replaces eight patches. All eight spellings are refused and the real section passes. The gate keeps the cheap half and now states where its limit is, rather than implying it is complete.

## Two pre-existing gaps found while building this, both closed

**A written section is not an assembled one.** The coverage gate decides "does SAR reach this table" by reading the assembly files, so a section still written in the file but no longer appended to `sarSections` went on counting. Deleting the communication chapter left the gate green while three registered tables silently left the subject's package. `TestEveryPromisedTableIsActuallyAssembled` asks the assembled list instead, over every table the registry marks `sarRead`.

**A superseded link was reported as ignored.** Issuing a fresh link retires the pending one by setting its `expires_at` to the new link's issue time, so on the row a superseded link and a lapsed one are identical. Telling a subject they let something expire when the workspace withdrew it is a claim about their conduct that is not true.

Every guard was mutation-checked one clause at a time, including all eight bypass spellings and each chapter of the export in turn.

`sarsections.go` reached the 500-line ceiling, so the new chapter is its own file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Art. 15 export now reports what became of every confirm link it mailed, so a subject can see the round trip behind a consent grant instead of just the grant itself.

**New Features**
- Adds a `consent_links` section with one entry per link, its purpose, and its outcome: `answered`, `opened_not_answered`, `expired_unanswered`, `superseded_by_a_newer_link`, or `awaiting_answer`.
- `confirm_token` is now `sarRead` with `token_hash` and `delivered_to` withheld, instead of `sarForbidden`, so the lifecycle is exported without the credential or the address.
- The withholding is enforced by EXPLAINing each section and reading the top plan node's output, which catches spellings like `ct.*`, `to_jsonb(ct)`, or an alias-hidden column that a name deny-list misses.

**Bug Fixes**
- The coverage gate now checks the assembled `sarSections` list instead of the SQL text, so a chapter removed from the append no longer counts as covered.
- Superseded links are reported as `superseded_by_a_newer_link` rather than `expired_unanswered`, since the workspace withdrew them.

<sup>Written for commit 353bf93409b4c8db905f731277655e527aee89c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SAR exports now include confirmation-link history for each subject.
  * Each link reports its status, such as issued, opened, answered, expired, superseded, or awaiting a response.
  * Subjects with no confirmation links receive an explicit empty section.

* **Privacy Enhancements**
  * Sensitive confirmation-link tokens and destination addresses remain excluded from SAR exports.
  * Export data is scoped to the correct subject.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->