### PR TITLE
fix(deployconfig): bootstrap_admin accepts the spelling it says to prefer

### DIFF
--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -382,8 +382,16 @@ func (b BootstrapAdmin) validate() error {
 	if b.DisplayName == "" {
 		return errors.New("deployconfig: bootstrap_admin.display_name is required")
 	}
-	if b.PasswordFile == "" {
-		return errors.New("deployconfig: bootstrap_admin.password_file is required (secrets are file references, never inline values)")
+	// EITHER spelling, and the same sentence ResolvePassword gives when neither
+	// is set. Checking password_file alone refused a deployment that wrote the
+	// key this file's own doc comment says to prefer, and told the operator to
+	// use the legacy one instead — so the natural read was that the reference
+	// form is unsupported, at first boot, with nothing to correct it.
+	//
+	// It also made the validator and the resolver two different contracts for
+	// one field: Parse refused a document ResolvePassword handles perfectly.
+	if !b.Password.Configured() && b.PasswordFile == "" {
+		return errors.New("deployconfig: bootstrap_admin names no password — set bootstrap_admin.password to ${file:/run/secrets/admin-password} or ${env:MARGINCE_ADMIN_PASSWORD}")
 	}
 	return nil
 }

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -460,3 +460,36 @@ func commentedBlock(t *testing.T, doc, start, contains string) string {
 	t.Fatalf("the example no longer documents a commented %s block containing %q", start, contains)
 	return ""
 }
+
+// The reference form the field's own doc comment says to prefer is ACCEPTED.
+//
+// validate checked password_file alone, so a deployment that wrote `password`
+// was refused at first boot with a message naming the legacy spelling — the
+// natural read being that the reference form is unsupported, with nothing to
+// correct it. It also made Parse and ResolvePassword two different contracts
+// for one field: Parse refused a document the resolver handles perfectly.
+func TestParseAcceptsEitherSpellingOfTheAdminPassword(t *testing.T) {
+	both := map[string]string{
+		"the reference form": "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A, password: \"${file:/run/secrets/admin-password}\" }\n",
+		"the env reference":  "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A, password: \"${env:MARGINCE_ADMIN_PASSWORD}\" }\n",
+		"the original file":  "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A, password_file: /run/secrets/admin-password }\n",
+	}
+	for name, doc := range both {
+		if _, err := Parse([]byte(doc)); err != nil {
+			t.Errorf("%s was refused: %v", name, err)
+		}
+	}
+
+	// And the two refusals stay refusals: an INLINE value is still not a
+	// reference, and naming no password at all is still an error. A fix that
+	// widened the check into accepting anything would pass the cases above
+	// while removing what they are a relaxation of.
+	for name, doc := range map[string]string{ // #nosec G101 -- documents that must FAIL, not credentials
+		"an inline password": "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A, password: hunter2hunter2 }\n",
+		"neither spelling":   "version: 1\nbootstrap_admin: { email: a@b.co, display_name: A }\n",
+	} {
+		if _, err := Parse([]byte(doc)); err == nil {
+			t.Errorf("%s parsed without error", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2195

`BootstrapAdmin` carries two spellings of the admin password, and the field carrying the reference form says to prefer it. `ResolvePassword` honours both. `validate` checked `password_file` **alone**, so a deployment that wrote the preferred key was refused — at **first boot**, with a message naming the legacy spelling and nothing to say the reference form is valid at all. The natural read is that it is unsupported, and the operator hitting it is following the field's own documentation.

It also made the validator and the resolver two different contracts for one field: `Parse` refused a document `ResolvePassword` handles perfectly.

`validate` now accepts either and refuses when neither is set — in the **resolver's own words**, rather than a second sentence about the same condition.

## Both refusals stay refusals

An inline value is still not a reference, and naming no password at all is still an error. The test asserts those beside the three accepted shapes, because a fix that widened the check into accepting anything would pass the new cases while removing what they are a relaxation of.

## The sibling the issue asks about

`email.smtp.password` / `password_file` has the same pair but **not** the same split: `Email.validate` requires no password at all, since an unauthenticated relay is a real deployment. Nothing to fix — recorded here rather than left for the next reader to check again.

## Verification

- Three accepted shapes: `${file:…}`, `${env:…}`, and the original `password_file`.
- Two still refused: an inline value, and neither spelling set.
- Reverting the check to `password_file` alone → both reference forms are refused again.
- `make check-backend` exit 0.
