### PR TITLE
A task's due hour is read on the record's clock, as the writer now stamps it

### DIFF
--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -14,6 +14,7 @@ import { meFixture } from "../app/mefixture";
 import { RecordZoneProvider } from "../app/recordzone";
 import { pickOption } from "../design-system/select-testing";
 import { calendarDay } from "../format/calendarday";
+import { hourInZone } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { LogActivity } from "./logactivity";
 import { PersonScreen } from "./people";
@@ -562,7 +563,7 @@ describe("log activity from a 360", () => {
     expect(screen.getByLabelText<HTMLInputElement>("Due date").max).toBe("");
   });
 
-  it("posts a task's due_at as the END of the picked day in the writer's own zone", async () => {
+  it("posts a task's due_at as the END of the picked day on the record's clock", async () => {
     const captured: Captured[] = [];
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="organization" entityId="o1" />);
@@ -586,12 +587,15 @@ describe("log activity from a 360", () => {
     });
     if (!post) throw new Error("expected a POST /activities to be captured");
     const dueAt = new Date(postedDueAt(post.body));
-    // The instant has to fall on the day the writer picked, read where the
-    // writer is — the bare `yyyy-mm-dd` handed to `new Date` is UTC midnight,
-    // which is the previous calendar day for every writer west of UTC.
-    expect(calendarDay(dueAt, READER_ZONE)).toBe(PICKED_DAY);
+    // The instant has to fall on the day the writer picked, read on the
+    // RECORD's clock: a deadline is a fact about the record, and two
+    // colleagues quoting one task must quote the same day whichever zone each
+    // sits in. Read on the browser's clock instead, the same instant is a
+    // different hour on every machine that runs this suite.
+    expect(calendarDay(dueAt, INSTALLATION_ZONE)).toBe(PICKED_DAY);
     // And at that day's END, because a task picked for today is due all day.
-    expect(dueAt.getHours()).toBe(23);
+    // The minute needs no zone: the installation's offset is a whole hour.
+    expect(hourInZone(dueAt, INSTALLATION_ZONE)).toBe(23);
     expect(dueAt.getMinutes()).toBe(59);
   });
 


### PR DESCRIPTION
## What

`frontend / fe-unit` is red on `main`: `logactivity.test.tsx › posts a task's due_at as the END of the picked day…` fails with `expected 16 to be 23`. This makes the one assertion read the hour in the installation's zone, the zone the writer stamps it in, and renames the test to say so. One test file, no product code.

## Why

#4812 made `dueInstant` stamp a task's due date at the end of the picked day on the **record's** clock, and every task surface renders it there — a deadline is a fact about the record, not about whoever is looking. The test still read the hour off the **browser's** clock, so it agreed with the writer only on a machine whose zone matched the installation's. CI runs UTC against this suite's `Asia/Ho_Chi_Minh` installation, where 23:59 reads as 16:59; the same failure reproduces locally under both the local zone and `TZ=UTC`.

The invariant the test now states is the one #4812 introduced: the day is the picked day and the hour is 23 *in the record's zone*, asked through `hourInZone`, the formatter the tree already has for that question. The minute is asserted directly because the installation's offset is a whole hour, and the test says so.

## How verified

- `pnpm vitest run src/screens/logactivity.test.tsx` → 22 passed, on the local zone and under `TZ=America/Los_Angeles`.
- `pnpm tsc --noEmit` and `pnpm biome check` on the file → clean.
- The gates package (`go test ./gates`) does not read this file; no backend change.

- [x] `make check` is green (frontend lane run for the touched file; nothing else changed)
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — test-only frontend change
- [x] `make craft-static` reports no new blockers — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

## AI involvement

Entirely AI-assisted: the failure was diagnosed from a red `fe-unit` lane on #4787, which does not touch this screen; that PR carries this commit ported until it merges here.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U53h75jRk6s1azE1wrKai

---
_Generated by [Claude Code](https://claude.ai/code/session_013U53h75jRk6s1azE1wrKai)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `logactivity.test.tsx` assertion for a task's due hour by reading it on the record's clock instead of the browser's clock.

- The test now uses `hourInZone` with the installation's zone, matching how the writer stamps `due_at`.
- This aligns the test with the invariant that a deadline is a fact about the record, not the viewer's timezone.

<sup>Written for commit 0044333fb18cfc71f1c974a23789c52ca0be8d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

