### PR TITLE
The due-date tests read the zone the deadline is anchored to

### DIFF
--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -13,7 +13,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { meFixture } from "../app/mefixture";
 import { RecordZoneProvider } from "../app/recordzone";
 import { pickOption } from "../design-system/select-testing";
-import { calendarDay } from "../format/calendarday";
+import { calendarDay, middayInstant } from "../format/calendarday";
+import { formatTimeOfDay } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { LogActivity } from "./logactivity";
 import { PersonScreen } from "./people";
@@ -91,7 +92,24 @@ type Captured = { key: string; body: unknown };
 // is the day the reader reads", which has to hold on every laptop rather than
 // only on one that runs UTC.
 const PICKED_DAY = "2026-07-10";
-const READER_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+// Two readers, NAMED — never this machine's own zone.
+//
+// Every instant these tests assert on is anchored to the RECORD zone, so
+// reading one back through `Intl.DateTimeFormat().resolvedOptions().timeZone`
+// asks what the runner's clock says and passes only where the runner happens to
+// sit. This file passed in Asia/Ho_Chi_Minh and failed in UTC, Berlin, Tokyo,
+// Auckland, São Paulo and Los Angeles — one zone green out of seven, and the
+// green one is where it was written.
+//
+// FAR_WEST_READER is exactly twelve hours from the record zone, which is the
+// span `middayInstant` promises a backdated day survives across. It is the edge
+// of that promise rather than a comfortable middle, and Bogotá keeps −05 all
+// year so no DST switch moves it.
+const FAR_WEST_READER = "America/Bogota";
+// And the far east. +14 is the largest offset any zone has, seven hours from
+// the record zone, so the eastern side of the promise is not close to its edge
+// — asserted anyway, because the two directions fail separately.
+const FAR_EAST_READER = "Pacific/Kiritimati";
 
 // The task the form has just logged, as the tasks list receives it — everything
 // but the due date, which is the field under test.
@@ -367,13 +385,14 @@ describe("log activity from a 360", () => {
     );
     const post = captured.find((entry) => entry.key === "POST /activities");
     if (!post) throw new Error("expected a POST /activities to be captured");
-    // The instant lands on the day the writer picked in BOTH zones that
-    // matter: the record pages render timelines in the record zone, and the
-    // writer reads their own wall clock — and a note never carries a due
-    // date, backdated or not.
+    // The instant lands on the day the writer picked in the record zone, where
+    // the record pages render timelines — and still on it for a reader at
+    // either edge of the twelve hours `middayInstant` promises. A note never
+    // carries a due date, backdated or not.
     const occurred = new Date(postedOccurredAt(post.body));
     expect(calendarDay(occurred, INSTALLATION_ZONE)).toBe(PICKED_DAY);
-    expect(calendarDay(occurred, READER_ZONE)).toBe(PICKED_DAY);
+    expect(calendarDay(occurred, FAR_WEST_READER)).toBe(PICKED_DAY);
+    expect(calendarDay(occurred, FAR_EAST_READER)).toBe(PICKED_DAY);
     expect(post.body).not.toHaveProperty("due_at");
   });
 
@@ -562,7 +581,7 @@ describe("log activity from a 360", () => {
     expect(screen.getByLabelText<HTMLInputElement>("Due date").max).toBe("");
   });
 
-  it("posts a task's due_at as the END of the picked day in the writer's own zone", async () => {
+  it("posts a task's due_at as the END of the picked day in the record's zone", async () => {
     const captured: Captured[] = [];
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="organization" entityId="o1" />);
@@ -586,13 +605,18 @@ describe("log activity from a 360", () => {
     });
     if (!post) throw new Error("expected a POST /activities to be captured");
     const dueAt = new Date(postedDueAt(post.body));
-    // The instant has to fall on the day the writer picked, read where the
-    // writer is — the bare `yyyy-mm-dd` handed to `new Date` is UTC midnight,
-    // which is the previous calendar day for every writer west of UTC.
-    expect(calendarDay(dueAt, READER_ZONE)).toBe(PICKED_DAY);
+    // The instant has to fall on the day the writer picked, read in the zone
+    // the deadline is ANCHORED to — the bare `yyyy-mm-dd` handed to `new Date`
+    // is UTC midnight, which is the previous calendar day for every writer west
+    // of UTC.
+    expect(calendarDay(dueAt, INSTALLATION_ZONE)).toBe(PICKED_DAY);
     // And at that day's END, because a task picked for today is due all day.
-    expect(dueAt.getHours()).toBe(23);
-    expect(dueAt.getMinutes()).toBe(59);
+    // Read as a wall clock in that same zone: `getHours()` answers for the
+    // machine running the test, so it agreed only where the record zone and the
+    // runner's zone happened to be the same one.
+    expect(
+      formatTimeOfDay(postedDueAt(post.body), "en", INSTALLATION_ZONE),
+    ).toBe("23:59");
   });
 
   it("posts a due date the tasks list then buckets as today, not as overdue", async () => {
@@ -617,12 +641,19 @@ describe("log activity from a 360", () => {
     // for today at midday must find it under Today — with the day sent as UTC
     // midnight it read as already overdue, which is the state the screen puts
     // in red at the top of the list.
-    const middayOnThePickedDay = new Date(`${PICKED_DAY}T12:00:00`);
+    // Midday of the picked day IN THE RECORD ZONE, and grouped in that zone.
+    // A bare `${PICKED_DAY}T12:00:00` is parsed as the runner's local time, so
+    // the "now" this compares against moved with the machine while the deadline
+    // did not — which read as `upcoming` east of the record zone and `overdue`
+    // west of it.
+    const middayOnThePickedDay = new Date(
+      middayInstant(PICKED_DAY, INSTALLATION_ZONE),
+    );
     expect(
       groupTask(
         { ...LOGGED_TASK, due_at: postedDueAt(post.body) },
         middayOnThePickedDay,
-        READER_ZONE,
+        INSTALLATION_ZONE,
       ),
     ).toBe("today");
   });


### PR DESCRIPTION
## What

`main` fails `frontend / fe-unit` and `frontend / frontend` — the required `ci`
aggregate needs both — on one assertion:

```
FAIL src/screens/logactivity.test.tsx > posts a task's due_at as the END of the picked day
AssertionError: expected 16 to be 23
  ❯ logactivity.test.tsx:594  expect(dueAt.getHours()).toBe(23);
```

Filed as https://github.com/margince/margince/issues/4816, from
https://github.com/margince/margince/pull/4812.

**The production code is right.** `due_at` is minted by
`dueInstant(day, recordZone)` — 23:59:59 in the RECORD zone, which the fixture
sets to `Asia/Ho_Chi_Minh`. The posted instant is therefore 16:59:59Z, and
`dueAt.getHours()` answers for the machine running the test. It read 23 only
where the runner's zone and the record zone happened to be the same one.

## It was four assertions, not one

`READER_ZONE` was `Intl.DateTimeFormat().resolvedOptions().timeZone` — the
runner's own zone — and three further assertions read record-zone instants
through it. Measured across timezones before touching anything:

| TZ | result |
|---|---|
| `Asia/Ho_Chi_Minh` | **22 passed** ← where it was written |
| `UTC` | 1 failed |
| `Europe/Berlin` | 1 failed |
| `America/Sao_Paulo` | 1 failed |
| `Asia/Tokyo` | 2 failed |
| `Pacific/Auckland` | 2 failed |
| `America/Los_Angeles` | 3 failed |

One zone green out of seven, and it is the author's. CI's UTC caught the least
of it: Tokyo and Auckland fail a *different* assertion (line 592), Los Angeles a
*third* (line 376). Fixing the reported line alone would have left two
landmines for whoever next changes a runner image — which is why this is one
change rather than a one-line patch.

## Each assertion now names the zone its value is anchored to

- **The deadline's day and wall clock**, in the record zone — the clock through
  `formatTimeOfDay` rather than `getHours()`/`getMinutes()`, so it is read where
  the deadline lives. (`hourInZone` and `formatTimeOfDay` already existed in
  `format/`; no new helper.)
- **A backdated note's day at both edges of the twelve hours `middayInstant`
  documents** it survives: *"keeps it on the picked day both there and in the
  wall clock of any writer within twelve hours of that zone."* `America/Bogota`
  is exactly twelve hours from the record zone and keeps −05 all year;
  `Pacific/Kiritimati` at +14 is the furthest east any zone goes. The old
  host-zone assertion claimed more than the function promises — Los Angeles is
  *fourteen* hours away — which is precisely why it failed there.
- **The bucketing "now"** as midday in the record zone, grouped in that zone. A
  bare `` `${PICKED_DAY}T12:00:00` `` is parsed as the runner's local time, so
  the moment moved with the machine while the deadline did not: `upcoming` east
  of the record zone, `overdue` west of it.

## How verified

Nine timezones, all **22 passed**: UTC, Los Angeles, São Paulo, Berlin,
Ho Chi Minh, Tokyo, Auckland, Kiritimati, Bogotá.

- `make check-fe` — green: **625 test files, 8233 tests** (+1 expected fail),
  plus the ds gates, the custom-property check and biome.
- `tsc --noEmit` clean.
- No production file touched — this is one test file.

Worth noting for whoever owns the lane: nothing in CI would have caught the
other two. `make fe-clock-drift` moves the calendar by +200 days, not the zone,
so a host-zone assertion is invisible to it. This diff does not add that
coverage; it removes the file's dependence on the host.

- [x] `make check` — `check-fe` green as above; no Go changed
- [x] `make test-integration` — this change does not touch tenant data, RLS or
      the write shape
- [x] `make craft-static` — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local
      machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-generated in full under the reporter's direction: the diagnosis, the
cross-timezone measurement, the re-anchoring and this description. A human is
accountable for merging.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).
