### PR TITLE
A contract does not name a record its reader cannot open

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -30055,18 +30055,39 @@ components:
         An agreement between the installation and one organization. Mirrors the
         `contract` table. Carries no owner: visibility is inherited from the linked
         deal, falling back to the organization (ADR-0109 §8).
-      required: [id, organization_id, title, status, value_basis, under_contract, source, captured_by, version, created_at, updated_at]
+      required: [id, title, status, value_basis, under_contract, source, captured_by, version, created_at, updated_at]
       properties:
         id: { type: string, format: uuid }
+        masked_fields:
+          type: array
+          readOnly: true
+          items: { type: string }
+          description: >-
+            The fields of THIS row the caller may not read (a field mask). A named field is null
+            because it is withheld, not because it is empty; absent or empty means nothing is
+            withheld.
         organization_id:
-          type: string
+          type: [string, 'null']
           format: uuid
-          description: The counterparty. An organization holds many contracts.
+          description: >-
+            The counterparty. An organization holds many contracts. Every contract has one, so
+            null here always means withheld — a reader admitted through the DEAL may not be able
+            to open the company, and handing the id back would make the agreement an existence
+            oracle over a row their own organization read refuses. `masked_fields` names it.
         deal_id:
           type: [string, 'null']
           format: uuid
-          description: 'The deal this agreement came from, when there was one. Absent on an import or a renewal that never ran through the pipeline.'
-        project_id: { type: [string, 'null'], format: uuid }
+          description: >-
+            The deal this agreement came from, when there was one. Absent on an import or a
+            renewal that never ran through the pipeline, and null ALSO when the reader may not
+            open that deal — the two are told apart by `masked_fields`, which names it only in
+            the second case.
+        project_id:
+          type: [string, 'null']
+          format: uuid
+          description: >-
+            The delivery this agreement funds, when one is attached. Null for no project and for
+            a project the reader may not open; `masked_fields` names it only in the second case.
         contract_number:
           type: [string, 'null']
           description: 'Free text — an imported agreement carries whatever number the counterparty''s own system gave it. Duplicates within an account are permitted: two systems reusing a number is their business, not a reason to refuse the row.'

--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -159,7 +159,7 @@ func TestRenewalChainsRatherThanOverwrites(t *testing.T) {
 	// The successor inherits the counterparty rather than taking one from the
 	// request: a renewal that changed companies would be a different agreement
 	// wearing this one's history.
-	if ids.UUID(successor.OrganizationId) != org {
+	if successor.OrganizationId == nil || ids.UUID(*successor.OrganizationId) != org {
 		t.Error("the successor names a different company than the agreement it renews")
 	}
 }
@@ -304,7 +304,7 @@ func TestARenewalSuccessorKeepsTheDealItNames(t *testing.T) {
 	}
 	// The counterparty is still the predecessor's, which is the one thing a
 	// renewal does inherit.
-	if ids.UUID(successor.OrganizationId) != org {
+	if successor.OrganizationId == nil || ids.UUID(*successor.OrganizationId) != org {
 		t.Errorf("successor organization = %v, want the predecessor's (%v)", successor.OrganizationId, org)
 	}
 }

--- a/backend/internal/compose/integration/contractreferences_integration_test.go
+++ b/backend/internal/compose/integration/contractreferences_integration_test.go
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A contract is admitted by its deal OR its organization, and that disjunction
+// is about ADMISSION. A reader let in through the deal may not be able to open
+// the company, the delivery or even the deal itself as a KIND of record — so
+// the three references the projection carries are withheld from a reader who
+// could not open them, and named in masked_fields.
+//
+// The sibling of dealreferences_integration_test.go, and the half that closes a
+// hole that one left: `deal_project_same_org` forces a deal's project and its
+// organization to name one company, so a caller who reads the project and not
+// the company recovered in one hop, through the contract, the id the deal read
+// had just withheld.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// contractReferenceFixture is one agreement per reference under test, each
+// reached through an anchor the reader CAN see so the mask is the only thing
+// standing between them and the id.
+type contractReferenceFixture struct {
+	// onPrivateOrg is anchored on a capture-private company, admitted through
+	// its deal.
+	onPrivateOrg ids.ContractID
+	// onOtherTeamsProject names a delivery, on a company the reader can open.
+	onOtherTeamsProject ids.ContractID
+	openOrg             ids.UUID
+	privateOrg          ids.UUID
+	project             ids.ProjectID
+}
+
+func seedContractReferenceFixture(t *testing.T, e *Env) contractReferenceFixture {
+	t.Helper()
+	admin := e.Admin()
+	pipeline, open, _ := DealFixture(t, e)
+
+	// Seeded workspace-visible so the admin's writes pass their own
+	// EnsureLinkTarget gate; capture privacy lands afterwards, which is the
+	// order a connector-captured company reaches this state in anyway.
+	privateOrg := e.SeedOrg(t, "Meridian Labs", &e.Rep3)
+	openOrg := e.SeedOrg(t, "Kestrel Foods", nil)
+
+	privateDeal := e.SeedDeal(t, "Meridian renewal", pipeline, open, &e.Rep1)
+	anchorOnOrg(t, e, privateDeal, privateOrg)
+	onPrivateOrg := seedContract(t, e, contracts.CreateContractInput{
+		OrganizationID: orgIDOf(privateOrg),
+		DealID:         dealIDPtr(privateDeal),
+		Title:          "An agreement with a company the reader cannot open",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	e.MakeCapturePrivate(t, "organization", privateOrg, e.Rep3)
+
+	project := seedProject(admin, t, e, "Kestrel rollout", openOrg, &e.Rep3)
+	openDeal := e.SeedDeal(t, "Kestrel expansion", pipeline, open, &e.Rep1)
+	anchorOnOrg(t, e, openDeal, openOrg)
+	onOtherTeamsProject := seedContract(t, e, contracts.CreateContractInput{
+		OrganizationID: orgIDOf(openOrg),
+		DealID:         dealIDPtr(openDeal),
+		ProjectID:      &project.ID,
+		Title:          "An agreement funding a delivery",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	return contractReferenceFixture{
+		onPrivateOrg:        onPrivateOrg,
+		onOtherTeamsProject: onOtherTeamsProject,
+		openOrg:             openOrg,
+		privateOrg:          privateOrg,
+		project:             project.ID,
+	}
+}
+
+func seedContract(t *testing.T, e *Env, in contracts.CreateContractInput) ids.ContractID {
+	t.Helper()
+	created, err := e.Contracts.CreateContract(e.Admin(), in)
+	if err != nil {
+		t.Fatalf("create contract %q: %v", in.Title, err)
+	}
+	return ids.From[ids.ContractKind](ids.UUID(created.Id))
+}
+
+func dealIDPtr(deal ids.UUID) *ids.DealID {
+	id := ids.From[ids.DealKind](deal)
+	return &id
+}
+
+// contractReaderPerms is a rep who reads agreements: the object grid
+// AccountRepPerms carries, plus `contract`, minus whatever the case removes.
+func contractReaderPerms(without ...string) principal.Permissions {
+	perms := AccountRepPerms
+	perms.Objects = make(map[string]principal.ObjectGrant, len(AccountRepPerms.Objects)+1)
+	for object, grant := range AccountRepPerms.Objects {
+		perms.Objects[object] = grant
+	}
+	perms.Objects["contract"] = principal.ObjectGrant{Create: true, Read: true, Update: true, Delete: true}
+	for _, object := range without {
+		delete(perms.Objects, object)
+	}
+	return perms
+}
+
+func TestAContractDoesNotNameRecordsItsReaderCannotRead(t *testing.T) {
+	e := Setup(t)
+	fx := seedContractReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, contractReaderPerms())
+
+	// Admitted through the deal, which every seat reads. The company it names
+	// is capture-private to a colleague, so the id does not travel with it.
+	got, err := e.Contracts.GetContract(rep, fx.onPrivateOrg)
+	if err != nil {
+		t.Fatalf("a rep reading a contract whose company is capture-private: %v", err)
+	}
+	if got.OrganizationId != nil {
+		t.Errorf("organization_id = %v, want withheld: the reader was admitted through the deal "+
+			"and cannot open the company", got.OrganizationId)
+	}
+	assertContractMaskNames(t, got, "organization_id")
+
+	// A project is read by every seat HOLDING THE OBJECT GRANT, and this rep
+	// holds no project grant at all. Row scope is not the only gate on a
+	// reference: object RBAC answers whether the caller may read that KIND of
+	// record, and a contract must not become the door to an id from a table
+	// its reader may not open.
+	delivery, err := e.Contracts.GetContract(rep, fx.onOtherTeamsProject)
+	if err != nil {
+		t.Fatalf("a rep reading a contract that funds another team's delivery: %v", err)
+	}
+	if delivery.ProjectId != nil {
+		t.Errorf("project_id = %v, want withheld: this rep holds no project.read grant", delivery.ProjectId)
+	}
+	if delivery.OrganizationId == nil || ids.UUID(*delivery.OrganizationId) != fx.openOrg {
+		t.Errorf("organization_id = %v, want the workspace-visible company the reader CAN open",
+			delivery.OrganizationId)
+	}
+	assertContractMaskNames(t, delivery, "project_id")
+
+	// Add the project grant and the SAME contract names its delivery. Without
+	// this half the assertion above would pass against a mask that withheld
+	// every project from everybody.
+	withProject := contractReaderPerms()
+	withProject.Objects["project"] = principal.ObjectGrant{Read: true}
+	granted, err := e.Contracts.GetContract(e.As(e.Rep1, []ids.UUID{e.Team1}, withProject), fx.onOtherTeamsProject)
+	if err != nil {
+		t.Fatalf("a rep holding project.read reading the same contract: %v", err)
+	}
+	if granted.ProjectId == nil {
+		t.Error("project_id is withheld from a rep who holds project.read; a project carries " +
+			"no owner scope and no capture privacy")
+	}
+
+	// The deal arm is the one that ADMITTED this row, and it still says nothing
+	// about whether the reader may read deals as a kind.
+	noDeals := e.As(e.Rep1, []ids.UUID{e.Team1}, contractReaderPerms("deal"))
+	withoutDeal, err := e.Contracts.GetContract(noDeals, fx.onOtherTeamsProject)
+	if err != nil {
+		t.Fatalf("a rep holding no deal.read reading a contract admitted through its deal: %v", err)
+	}
+	if withoutDeal.DealId != nil {
+		t.Errorf("deal_id = %v, want withheld: this rep holds no deal.read grant", withoutDeal.DealId)
+	}
+
+	// A reader who can see all three still receives all three, or the fix
+	// closed the oracle by breaking the feature.
+	full, err := e.Contracts.GetContract(e.Admin(), fx.onOtherTeamsProject)
+	if err != nil || full.OrganizationId == nil || full.DealId == nil ||
+		full.ProjectId == nil || full.MaskedFields != nil {
+		t.Errorf("the admin's read = org %v deal %v project %v masked %v (%v), want every reference",
+			full.OrganizationId, full.DealId, full.ProjectId, full.MaskedFields, err)
+	}
+}
+
+// The one-hop recovery this ticket exists to close: `deal_project_same_org`
+// forces a deal's project and its organization to name one company, so a caller
+// who reads the PROJECT and not the company must not be handed that company's
+// id by the paper hanging off it.
+func TestAContractIsNotTheWayBackToACompanyTheProjectAlreadyWithholds(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	pipeline, open, _ := DealFixture(t, e)
+
+	org := e.SeedOrg(t, "Halden Industries", &e.Rep3)
+	project := seedProject(admin, t, e, "Halden migration", org, &e.Rep3)
+	deal := e.SeedDeal(t, "Halden platform", pipeline, open, &e.Rep1)
+	anchorOnOrg(t, e, deal, org)
+	contract := seedContract(t, e, contracts.CreateContractInput{
+		OrganizationID: orgIDOf(org),
+		DealID:         dealIDPtr(deal),
+		ProjectID:      &project.ID,
+		Title:          "The paper on a company the reader cannot open",
+		ValueBasis:     contracts.BasisTotal,
+		Source:         "manual",
+	})
+	e.MakeCapturePrivate(t, "organization", org, e.Rep3)
+
+	perms := contractReaderPerms()
+	perms.Objects["project"] = principal.ObjectGrant{Read: true}
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	seen, err := e.Projects.GetProject(reader, project.ID, 0)
+	if err != nil {
+		t.Fatalf("a rep reading the project itself: %v", err)
+	}
+	if seen.OrganizationId != nil {
+		t.Fatalf("the project already hands back organization_id = %v; this test's premise is that "+
+			"it does not, so the contract is the only remaining hop", seen.OrganizationId)
+	}
+
+	got, err := e.Contracts.GetContract(reader, contract)
+	if err != nil {
+		t.Fatalf("the same rep reading the contract: %v", err)
+	}
+	if got.OrganizationId != nil {
+		t.Errorf("organization_id = %v from the contract, want withheld — the project read just "+
+			"refused it, and one hop through the paper recovers it", got.OrganizationId)
+	}
+	if got.ProjectId == nil || ids.UUID(*got.ProjectId) != project.ID.UUID {
+		t.Errorf("project_id = %v, want the delivery this reader CAN open", got.ProjectId)
+	}
+	assertContractMaskNames(t, got, "organization_id")
+}
+
+// The page path, not only the single-row one: a list is where an existence
+// oracle is cheapest, so it must not be the looser door.
+func TestTheContractListWithholdsTheSameReferencesAsTheGet(t *testing.T) {
+	e := Setup(t)
+	fx := seedContractReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, contractReaderPerms())
+
+	page, err := e.Contracts.ListOrganizationContracts(rep, contracts.ListContractsInput{
+		OrganizationID: orgIDOf(fx.openOrg),
+	})
+	if err != nil {
+		t.Fatalf("listing a readable company's contracts: %v", err)
+	}
+	var found bool
+	for _, c := range page.Data {
+		if ids.UUID(c.Id) != fx.onOtherTeamsProject.UUID {
+			continue
+		}
+		found = true
+		if c.ProjectId != nil {
+			t.Errorf("the list handed out a project id to a rep holding no project grant: %v", c.ProjectId)
+		}
+		assertContractMaskNames(t, c, "project_id")
+	}
+	if !found {
+		t.Error("the list does not show the contract at all — withholding a reference must not drop the row")
+	}
+}
+
+// A mutation RESPONSE is a read. Every entry point that hands a contract back
+// must withhold the same references the GET does, or a no-op PATCH becomes the
+// second door onto the id the GET just refused. Being allowed to change the
+// CONTRACT says nothing about being allowed to read the company it names.
+//
+// A table over the entry points rather than one case each, so a further
+// contract mutation is a compile-time addition to this list rather than a
+// silent omission.
+func TestEveryContractMutationResponseWithholdsTheSameReferences(t *testing.T) {
+	e := Setup(t)
+	fx := seedContractReferenceFixture(t, e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, contractReaderPerms())
+
+	retitled := "Meridian renewal, retitled"
+	cases := []struct {
+		name string
+		call func() (crmcontracts.Contract, error)
+	}{
+		{"a patch that changes nothing still echoes the row", func() (crmcontracts.Contract, error) {
+			return e.Contracts.UpdateContract(rep, fx.onPrivateOrg, crmcontracts.UpdateContractRequest{}, nil)
+		}},
+		{"a patch that changes something", func() (crmcontracts.Contract, error) {
+			return e.Contracts.UpdateContract(rep, fx.onPrivateOrg,
+				crmcontracts.UpdateContractRequest{Title: &retitled}, nil)
+		}},
+		{"activating the agreement", func() (crmcontracts.Contract, error) {
+			return e.Contracts.ChangeStatus(rep, fx.onPrivateOrg, contracts.StatusActive, nil)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.call()
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if got.OrganizationId != nil {
+				t.Errorf("%s handed back organization_id %v, want it withheld", tc.name, got.OrganizationId)
+			}
+			assertContractMaskNames(t, got, "organization_id")
+		})
+	}
+}
+
+// assertContractMaskNames checks masked_fields carries exactly the given names:
+// a null a reader cannot distinguish from an empty field is the half-fix this
+// whole seam exists to avoid.
+func assertContractMaskNames(t *testing.T, c crmcontracts.Contract, want ...string) {
+	t.Helper()
+	if c.MaskedFields == nil {
+		if len(want) > 0 {
+			t.Errorf("masked_fields is absent, want %v named — a withheld null must say it was withheld", want)
+		}
+		return
+	}
+	got := map[string]bool{}
+	for _, field := range *c.MaskedFields {
+		got[field] = true
+	}
+	for _, field := range want {
+		if !got[field] {
+			t.Errorf("masked_fields = %v, want it to name %s", *c.MaskedFields, field)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("masked_fields = %v, want exactly %v", *c.MaskedFields, want)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21205,7 +21205,7 @@ type Contract struct {
 	CreatedAt      *time.Time `json:"created_at,omitempty"`
 	Currency       *string    `json:"currency,omitempty"`
 
-	// DealId The deal this agreement came from, when there was one. Absent on an import or a renewal that never ran through the pipeline.
+	// DealId The deal this agreement came from, when there was one. Absent on an import or a renewal that never ran through the pipeline, and null ALSO when the reader may not open that deal — the two are told apart by `masked_fields`, which names it only in the second case.
 	DealId *openapi_types.UUID `json:"deal_id,omitempty"`
 
 	// EndsOn Absent means open-ended.
@@ -21216,13 +21216,18 @@ type Contract struct {
 	FxRateToBase *string            `json:"fx_rate_to_base,omitempty"`
 	Id           openapi_types.UUID `json:"id"`
 
+	// MaskedFields The fields of THIS row the caller may not read (a field mask). A named field is null because it is withheld, not because it is empty; absent or empty means nothing is withheld.
+	MaskedFields *[]string `json:"masked_fields,omitempty"`
+
 	// NoticePeriodDays Drives the renewal warning, which fires against the notice deadline rather than the renewal date (CONTRACT-FORM-3).
 	NoticePeriodDays *int `json:"notice_period_days,omitempty"`
 
-	// OrganizationId The counterparty. An organization holds many contracts.
-	OrganizationId openapi_types.UUID  `json:"organization_id"`
-	ProjectId      *openapi_types.UUID `json:"project_id,omitempty"`
-	RenewalOn      *openapi_types.Date `json:"renewal_on,omitempty"`
+	// OrganizationId The counterparty. An organization holds many contracts. Every contract has one, so null here always means withheld — a reader admitted through the DEAL may not be able to open the company, and handing the id back would make the agreement an existence oracle over a row their own organization read refuses. `masked_fields` names it.
+	OrganizationId *openapi_types.UUID `json:"organization_id,omitempty"`
+
+	// ProjectId The delivery this agreement funds, when one is attached. Null for no project and for a project the reader may not open; `masked_fields` names it only in the second case.
+	ProjectId *openapi_types.UUID `json:"project_id,omitempty"`
+	RenewalOn *openapi_types.Date `json:"renewal_on,omitempty"`
 
 	// SignedOn When a human asserts it was signed. Never derived from a deal close time, and never a signing ceremony — in-product e-signature stays removed (A94).
 	SignedOn *openapi_types.Date `json:"signed_on,omitempty"`

--- a/backend/internal/modules/contracts/contract_lifecycle.go
+++ b/backend/internal/modules/contracts/contract_lifecycle.go
@@ -160,7 +160,7 @@ func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing c
 	changed := crmcontracts.PublicEventContractStatusChanged{
 		FromStatus:     statusOf(existing),
 		ToStatus:       to,
-		OrganizationId: &existing.OrganizationId,
+		OrganizationId: existing.OrganizationId,
 	}
 	if supersededBy != nil {
 		successor := openapi_types.UUID(supersededBy.UUID)
@@ -169,7 +169,7 @@ func applyStatusTx(ctx context.Context, tx pgx.Tx, id ids.ContractID, existing c
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, changed); err != nil {
 		return crmcontracts.Contract{}, fmt.Errorf("emit contract.status_changed: %w", err)
 	}
-	return readContract(ctx, tx, id, asOf)
+	return readContractForCaller(ctx, tx, id, asOf)
 }
 
 // frozenRate is what activation stamps: the conversion and the day it is the
@@ -242,7 +242,7 @@ func (s *Store) Cancel(ctx context.Context, id ids.ContractID, noticeOn, effecti
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract cancellation"); err != nil {
 			return err
 		}
-		out, err = readContract(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today())
 		return err
 	})
 	return out, err
@@ -276,7 +276,11 @@ func (s *Store) Renew(ctx context.Context, id ids.ContractID, successor CreateCo
 		// The successor inherits the predecessor's counterparty rather than
 		// taking one from the request: a renewal that changed companies would
 		// be a different agreement wearing this one's history.
-		successor.OrganizationID = ids.OrganizationID{UUID: ids.UUID(predecessor.OrganizationId)}
+		anchor, err := anchorOf(predecessor)
+		if err != nil {
+			return err
+		}
+		successor.OrganizationID = ids.OrganizationID{UUID: anchor}
 
 		created, err := createContractTx(ctx, tx, successor, by, s.today())
 		if err != nil {

--- a/backend/internal/modules/contracts/contract_list.go
+++ b/backend/internal/modules/contracts/contract_list.go
@@ -44,7 +44,7 @@ func (s *Store) ListOrganizationContracts(ctx context.Context, in ListContractsI
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		// Naming the account is a read of it: a caller who cannot see the
 		// company does not learn how many agreements it holds.
-		if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
+		if err := auth.EnsureLinkTarget(ctx, tx, organizationTable, in.OrganizationID.UUID); err != nil {
 			return err
 		}
 		var err error
@@ -104,6 +104,9 @@ func listContractsTx(ctx context.Context, tx pgx.Tx, in ListContractsInput, asOf
 	if err := rows.Err(); err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("read contract page: %w", err)
 	}
+	if err := maskContracts(ctx, tx, contracts); err != nil {
+		return crmcontracts.ContractListResponse{}, err
+	}
 
 	page := crmcontracts.PageInfo{}
 	// One row beyond the page proves another page exists without a second
@@ -139,7 +142,7 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	if err := auth.Require(ctx, contractObject, principal.ActionRead); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
-	if err := auth.EnsureLinkTarget(ctx, tx, "project", projectID.UUID); err != nil {
+	if err := auth.EnsureLinkTarget(ctx, tx, projectTable, projectID.UUID); err != nil {
 		return crmcontracts.ContractListResponse{}, err
 	}
 	var args []any
@@ -171,6 +174,9 @@ func (s *Store) ListProjectContractsTx(ctx context.Context, tx pgx.Tx, projectID
 	}
 	if err := rows.Err(); err != nil {
 		return crmcontracts.ContractListResponse{}, fmt.Errorf("read contract page: %w", err)
+	}
+	if err := maskContracts(ctx, tx, contracts); err != nil {
+		return crmcontracts.ContractListResponse{}, err
 	}
 	page := crmcontracts.PageInfo{}
 	if len(contracts) > lim {

--- a/backend/internal/modules/contracts/contract_write.go
+++ b/backend/internal/modules/contracts/contract_write.go
@@ -67,7 +67,7 @@ func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by
 	// Naming the counterparty is a read of it, and naming a deal is a read of
 	// that deal — both are client-supplied references to row-scoped records, so
 	// a caller may not hang an agreement off something it cannot see.
-	if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
+	if err := auth.EnsureLinkTarget(ctx, tx, organizationTable, in.OrganizationID.UUID); err != nil {
 		return crmcontracts.Contract{}, err
 	}
 	if err := ensureLinksVisible(ctx, tx, dealRef(in.DealID), projectRef(in.ProjectID)); err != nil {
@@ -116,7 +116,7 @@ func createContractTx(ctx context.Context, tx pgx.Tx, in CreateContractInput, by
 	if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, created); err != nil {
 		return crmcontracts.Contract{}, fmt.Errorf("emit contract.created: %w", err)
 	}
-	return readContract(ctx, tx, id, asOf)
+	return readContractForCaller(ctx, tx, id, asOf)
 }
 
 // UpdateContract applies a partial patch. Status is absent by design: it moves
@@ -140,22 +140,28 @@ func (s *Store) UpdateContract(ctx context.Context, id ids.ContractID, in crmcon
 		// cannot see — and because the organization arm of the visibility
 		// predicate enforces capture privacy while the deal arm does not,
 		// moving the anchor would strip that boundary from the row for good.
-		if err := ensureLinksVisible(ctx, tx, uuidRef("deal", in.DealId), uuidRef("project", in.ProjectId)); err != nil {
+		if err := ensureLinksVisible(ctx, tx, uuidRef(dealTable, in.DealId), uuidRef(projectTable, in.ProjectId)); err != nil {
 			return err
 		}
-		if err := ensureLinksShareOrganization(ctx, tx, ids.UUID(existing.OrganizationId),
-			uuidRef("deal", in.DealId), uuidRef("project", in.ProjectId)); err != nil {
+		anchor, err := anchorOf(existing)
+		if err != nil {
+			return err
+		}
+		if err := ensureLinksShareOrganization(ctx, tx, anchor,
+			uuidRef(dealTable, in.DealId), uuidRef(projectTable, in.ProjectId)); err != nil {
 			return err
 		}
 		patch := contractPatch(existing, in)
 		if patch.Empty() {
-			out = existing
-			return nil
+			// The unchanged row still leaves the store, so it is masked like
+			// any other answer — `existing` is the write path's pre-image.
+			out, err = maskContractForCaller(ctx, tx, existing)
+			return err
 		}
 		if err := applyContractUpdate(ctx, tx, id, patch, ifVersion, "contract update"); err != nil {
 			return err
 		}
-		out, err = readContract(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today())
 		return err
 	})
 	return out, err
@@ -226,8 +232,12 @@ func (s *Store) ArchiveContract(ctx context.Context, id ids.ContractID) error {
 		if err != nil {
 			return fmt.Errorf("audit contract archive: %w", err)
 		}
+		anchor, err := anchorOf(existing)
+		if err != nil {
+			return err
+		}
 		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
-			crmcontracts.PublicEventContractArchived{OrganizationId: existing.OrganizationId}); err != nil {
+			crmcontracts.PublicEventContractArchived{OrganizationId: openapi_types.UUID(anchor)}); err != nil {
 			return fmt.Errorf("emit contract.archived: %w", err)
 		}
 		return nil
@@ -291,16 +301,16 @@ type linkRef struct {
 
 func dealRef(id *ids.DealID) linkRef {
 	if id == nil {
-		return linkRef{table: "deal"}
+		return linkRef{table: dealTable}
 	}
-	return linkRef{table: "deal", id: &id.UUID}
+	return linkRef{table: dealTable, id: &id.UUID}
 }
 
 func projectRef(id *ids.ProjectID) linkRef {
 	if id == nil {
-		return linkRef{table: "project"}
+		return linkRef{table: projectTable}
 	}
-	return linkRef{table: "project", id: &id.UUID}
+	return linkRef{table: projectTable, id: &id.UUID}
 }
 
 // uuidRef names a link the patch body carried. An absent field is not a

--- a/backend/internal/modules/contracts/fieldmask.go
+++ b/backend/internal/modules/contracts/fieldmask.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contracts
+
+// The contract read mask, the sibling of the deal's and the project's and for
+// the same reason: a projection carrying a reference to ANOTHER record must
+// withhold the one its reader could not open, or the record becomes an
+// existence oracle over rows that reader's own reads would refuse.
+//
+// A contract is admitted by its deal OR its organization (visibility.go), and
+// that disjunction is about ADMISSION — it says nothing about disclosure. A
+// contract admitted through its deal still hands back an organization_id whose
+// company may be capture-private to the colleague who captured it, and a
+// project_id whose delivery keeps its own own/team row scope.
+//
+// The deal reference is masked on the same footing. It is the anchor the
+// admission arm tested, so a contract admitted through its ORGANIZATION was
+// never asked anything about the deal it names.
+//
+// Why this closes a hole the deal mask left open: `deal_project_same_org`
+// forces a deal's project and its organization to name one company, so a caller
+// who reads the project and not the company recovered, in one hop through the
+// contract, the id the deal read had just withheld.
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The masked_fields names for the three references. They are the wire members'
+// own names, which is what a client reads the mask against.
+const (
+	filterOrganizationID = "organization_id"
+	filterDealID         = "deal_id"
+	filterProjectID      = "project_id"
+)
+
+// maskedReference is one reference of one row: where to read it, what to call
+// it when it is withheld, and how to withhold it.
+//
+// Held as data rather than as three copies of the same if-statement, because
+// the three differ only in which table answers for them — and a fourth
+// reference added to the projection is then one line here instead of a fourth
+// place to forget.
+type maskedReference struct {
+	table string
+	field string
+	ref   func(*crmcontracts.Contract) **openapi_types.UUID
+}
+
+var maskedReferences = []maskedReference{
+	{
+		table: organizationTable, field: filterOrganizationID,
+		ref: func(c *crmcontracts.Contract) **openapi_types.UUID { return &c.OrganizationId },
+	},
+	{
+		table: dealTable, field: filterDealID,
+		ref: func(c *crmcontracts.Contract) **openapi_types.UUID { return &c.DealId },
+	},
+	{
+		table: projectTable, field: filterProjectID,
+		ref: func(c *crmcontracts.Contract) **openapi_types.UUID { return &c.ProjectId },
+	},
+}
+
+// readContractForCaller is readContract with the reader's own sight applied to
+// what the row POINTS AT.
+//
+// The two are separate deliberately. `readContract` answers what the row is,
+// and the write paths take their pre-image, their anchor and their audit images
+// from it — a masked pre-image would authorize a patch against a withheld
+// company. This is the one that leaves the store, and every outward answer
+// comes through it.
+func readContractForCaller(
+	ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time,
+) (crmcontracts.Contract, error) {
+	out, err := readContract(ctx, tx, id, asOf)
+	if err != nil {
+		return crmcontracts.Contract{}, err
+	}
+	return maskContractForCaller(ctx, tx, out)
+}
+
+// maskContractForCaller applies the read mask to ONE row about to leave the
+// store.
+func maskContractForCaller(
+	ctx context.Context, tx pgx.Tx, c crmcontracts.Contract,
+) (crmcontracts.Contract, error) {
+	one := []crmcontracts.Contract{c}
+	if err := maskContracts(ctx, tx, one); err != nil {
+		return crmcontracts.Contract{}, err
+	}
+	return one[0], nil
+}
+
+// maskContracts withholds, per row, the references naming a record this reader
+// could not open. ONE statement per referenced table for the whole page, never
+// a probe per row.
+func maskContracts(ctx context.Context, tx pgx.Tx, page []crmcontracts.Contract) error {
+	withheld := make([][]string, len(page))
+	for _, reference := range maskedReferences {
+		named := make([]ids.UUID, 0, len(page))
+		for i := range page {
+			if id := *reference.ref(&page[i]); id != nil {
+				named = append(named, ids.UUID(*id))
+			}
+		}
+		// VisibleSubset answers an empty list without a round trip, so a page
+		// naming none of a table pays nothing for it. It checks the object
+		// grant as well as the row scope: a seat holding no `project.read`
+		// learns no project id from a contract either.
+		visible, err := auth.VisibleSubset(ctx, tx, reference.table, named)
+		if err != nil {
+			return err
+		}
+		for i := range page {
+			held := reference.ref(&page[i])
+			if *held == nil || visible[ids.UUID(**held)] {
+				continue
+			}
+			*held = nil
+			withheld[i] = append(withheld[i], reference.field)
+		}
+	}
+	for i := range page {
+		if len(withheld[i]) > 0 {
+			page[i].MaskedFields = &withheld[i]
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/contracts/readpathmask_test.go
+++ b/backend/internal/modules/contracts/readpathmask_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package contracts
+
+import (
+	"go/ast"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// A contract leaves this package through ONE reader, and it is the masked one.
+//
+// `readContract` answers what the row IS: the write paths take their pre-image,
+// their anchor and their audit before-image from it, and a masked pre-image
+// would authorize a patch against a company the caller was merely not shown.
+// `readContractForCaller` is the same read with the reader's own sight applied
+// to what the row points at, and it is the one whose answer reaches the wire.
+//
+// The distinction lives in two function names, and a name is not an obligation.
+// A sixth store method added next year reaches for the shorter name — it is the
+// one that reads like "read the contract" — and ships an unmasked
+// organization_id to a caller admitted through the deal. That is #1876's defect
+// arriving through the door #1983 closed, so it is held here rather than
+// explained in a comment nobody greps.
+func TestTheUnmaskedContractReadIsForWritesOnly(t *testing.T) {
+	t.Parallel()
+	callers := functionsWhere(t, func(_ *ast.File, fn *ast.FuncDecl) bool {
+		return callsFunction(fn, unmaskedRead)
+	})
+	// A census that can fail short has already failed: a rename would leave
+	// this walking an empty set and reporting PASS over every read at once.
+	if len(callers) == 0 {
+		t.Fatalf("nothing in this package calls %s — it was renamed or removed, and this gate "+
+			"is now judging nothing", unmaskedRead)
+	}
+	for _, caller := range callers {
+		if slices.Contains(unmaskedReadCallers, caller) {
+			continue
+		}
+		t.Errorf("%s calls %s, which does not withhold the references its reader may not open.\n\n"+
+			"A contract is admitted by its deal OR its organization, and that disjunction is about "+
+			"admission — a reader admitted through the deal may still not open the company. If this "+
+			"answer reaches a caller, go through %s. If it is a write's pre-image, its anchor or its "+
+			"audit image, add it to unmaskedReadCallers with what it does with the row.",
+			caller, unmaskedRead, maskedRead)
+	}
+}
+
+const (
+	unmaskedRead = "readContract"
+	maskedRead   = "readContractForCaller"
+)
+
+// unmaskedReadCallers are the two functions entitled to the unmasked row, each
+// a sentence somebody wrote rather than an omission nobody noticed.
+var unmaskedReadCallers = []string{
+	// The write path's pre-image: it needs the anchor to authorize against and
+	// the before image to audit, neither of which is a disclosure to anybody.
+	"writableContract",
+	// The masked read itself, which is this rule's one sanctioned wrapper.
+	maskedRead,
+}
+
+// callsFunction answers whether the function calls the named one directly, by
+// its bare name.
+//
+// Bare because both names are this package's own: a selector spelling
+// (`x.readContract`) would be a method on some other type and a different
+// function entirely, and matching it would report a stranger.
+func callsFunction(fn *ast.FuncDecl, name string) bool {
+	if fn.Body == nil || fn.Name.Name == name {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		if ident, isIdent := call.Fun.(*ast.Ident); isIdent && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// Every reference the contract projection carries is masked, or the mask is a
+// subset of the projection and the next column added to the select list travels
+// unbounded.
+//
+// The projection is the census's own subject rather than a list restated here:
+// a fourth reference added to contractColumns fails this until it is either
+// masked or named as something other than a reference.
+func TestEveryReferenceInTheProjectionIsMasked(t *testing.T) {
+	t.Parallel()
+	masked := map[string]bool{}
+	for _, reference := range maskedReferences {
+		masked[reference.field] = true
+	}
+	if len(masked) == 0 {
+		t.Fatal("maskedReferences is empty, so this gate compares the projection against nothing")
+	}
+	var unmaskedColumns []string
+	for _, column := range strings.Split(contractColumns, ",") {
+		column = strings.TrimSpace(strings.ReplaceAll(column, "\n", ""))
+		column = strings.TrimSpace(strings.Trim(column, "\t"))
+		if !strings.HasSuffix(column, "_id") || masked[column] || slices.Contains(notAReference, column) {
+			continue
+		}
+		unmaskedColumns = append(unmaskedColumns, column)
+	}
+	if len(unmaskedColumns) > 0 {
+		t.Errorf("the contract projection carries %s, which name a record and are not withheld.\n\n"+
+			"Handing back the id of a row the reader's own read would refuse makes the contract an "+
+			"existence oracle over it. Add each to maskedReferences with the table that answers for "+
+			"it, or to notAReference with why it points at nothing row-scoped.",
+			strings.Join(unmaskedColumns, ", "))
+	}
+}
+
+// notAReference are the projection's `_id` columns that do not name a
+// row-scoped record, so nothing about the reader bounds them.
+var notAReference = []string{
+	// The row's own identity, which the caller was already admitted to.
+	"id",
+	// The successor in the renewal chain: another CONTRACT, admitted by the
+	// same clause this row was, so a reader holding this one holds that one.
+	"superseded_by_id",
+}

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -41,6 +41,15 @@ const (
 	contractTable  = "contract"
 )
 
+// The tables a contract POINTS AT. The same three spellings bound the write's
+// link check, the read's visibility clause and the read mask, and a table name
+// spelled at each of those is three places for one rename to miss.
+const (
+	organizationTable = "organization"
+	dealTable         = "deal"
+	projectTable      = "project"
+)
+
 // Status values. Asserted by a human or an approved proposal — never derived
 // from a date, here or anywhere (ADR-0109 §2).
 const (
@@ -158,7 +167,7 @@ func scanContract(row pgx.Row) (crmcontracts.Contract, error) {
 		return crmcontracts.Contract{}, err
 	}
 	c.Id = openapi_types.UUID(id)
-	c.OrganizationId = openapi_types.UUID(orgID)
+	c.OrganizationId = uuidPtr(&orgID)
 	c.DealId = uuidPtr(dealID)
 	c.ProjectId = uuidPtr(projectID)
 	c.SupersededById = uuidPtr(supersededBy)
@@ -185,6 +194,20 @@ func datePtr(t *time.Time) *openapi_types.Date {
 	return &openapi_types.Date{Time: *t}
 }
 
+// anchorOf is the counterparty of a contract that a WRITE is about to act on.
+//
+// organization_id left the wire's required set so a reader admitted through the
+// DEAL can be told nothing about a company they may not open. Every write path
+// takes its pre-image from readContract, which does not mask — so a nil anchor
+// here is a masked row that reached a write, not an agreement without a
+// company, and it stops rather than authorizing against a zero uuid.
+func anchorOf(c crmcontracts.Contract) (ids.UUID, error) {
+	if c.OrganizationId == nil {
+		return ids.UUID{}, fmt.Errorf("contracts: a write reached contract %s with its counterparty withheld", ids.UUID(c.Id))
+	}
+	return ids.UUID(*c.OrganizationId), nil
+}
+
 func uuidPtr(id *ids.UUID) *openapi_types.UUID {
 	if id == nil {
 		return nil
@@ -201,7 +224,7 @@ func (s *Store) GetContract(ctx context.Context, id ids.ContractID) (crmcontract
 	var out crmcontracts.Contract
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		var err error
-		out, err = readContract(ctx, tx, id, s.today())
+		out, err = readContractForCaller(ctx, tx, id, s.today())
 		return err
 	})
 	return out, err

--- a/backend/internal/modules/contracts/visibility.go
+++ b/backend/internal/modules/contracts/visibility.go
@@ -58,11 +58,11 @@ import (
 // widening to the company would hand a caller agreements attached to deals
 // they cannot see.
 func VisibleClause(ctx context.Context, alias string, arg func(any) int) (string, error) {
-	dealScope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	dealScope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
 	if err != nil {
 		return "", err
 	}
-	orgScope, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
+	orgScope, err := auth.ScopeClauseFor(ctx, organizationTable, "o", arg)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/modules/contracts/writability.go
+++ b/backend/internal/modules/contracts/writability.go
@@ -67,7 +67,11 @@ func writableContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf ti
 // authoritative.
 func ensureAnchorWritable(ctx context.Context, tx pgx.Tx, contract crmcontracts.Contract) error {
 	if contract.DealId != nil {
-		return auth.EnsureWritable(ctx, tx, "deal", ids.UUID(*contract.DealId))
+		return auth.EnsureWritable(ctx, tx, dealTable, ids.UUID(*contract.DealId))
 	}
-	return auth.EnsureWritable(ctx, tx, "organization", ids.UUID(contract.OrganizationId))
+	anchor, err := anchorOf(contract)
+	if err != nil {
+		return err
+	}
+	return auth.EnsureWritable(ctx, tx, organizationTable, anchor)
 }

--- a/backend/internal/modules/identity/rbacmatrix_test.go
+++ b/backend/internal/modules/identity/rbacmatrix_test.go
@@ -232,8 +232,17 @@ sees the record but not the amount on it". The last seeded mask, a rep's
 withheld deal amount, was dropped in a later migration; the machinery stayed,
 because an operator may still author a mask on a custom role.
 
-The project read also reports masked_fields, and it is a DIFFERENT mechanism:
-it withholds a reference to a company the reader may not see, which follows
-from that company's own visibility rather than from anything a role document
-says. A mask authored on a custom role does not reach it.
+The deal, project and contract reads also report masked_fields, and it is a
+DIFFERENT mechanism: each withholds a REFERENCE to another record the reader
+may not open — a deal's company, partner and delivery; a project's company; a
+contract's company, deal and delivery. That follows from the referenced
+record's own visibility rather than from anything a role document says, so a
+mask authored on a custom role does not reach it.
+
+Nor is it lifted by write authority, the way a role mask conditioned on
+outside_write_authority is: being allowed to change a contract says nothing
+about being allowed to read the company it names. A contract is admitted by
+its deal OR its organization, and that disjunction decides ADMISSION only — a
+reader let in through the deal is still asked, per reference, whether they
+could open what it points at.
 `

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -173,7 +173,16 @@ sees the record but not the amount on it". The last seeded mask, a rep's
 withheld deal amount, was dropped in a later migration; the machinery stayed,
 because an operator may still author a mask on a custom role.
 
-The project read also reports masked_fields, and it is a DIFFERENT mechanism:
-it withholds a reference to a company the reader may not see, which follows
-from that company's own visibility rather than from anything a role document
-says. A mask authored on a custom role does not reach it.
+The deal, project and contract reads also report masked_fields, and it is a
+DIFFERENT mechanism: each withholds a REFERENCE to another record the reader
+may not open — a deal's company, partner and delivery; a project's company; a
+contract's company, deal and delivery. That follows from the referenced
+record's own visibility rather than from anything a role document says, so a
+mask authored on a custom role does not reach it.
+
+Nor is it lifted by write authority, the way a role mask conditioned on
+outside_write_authority is: being allowed to change a contract says nothing
+about being allowed to read the company it names. A contract is admitted by
+its deal OR its organization, and that disjunction decides ADMISSION only — a
+reader let in through the deal is still asked, per reference, whether they
+could open what it points at.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21486,17 +21486,22 @@ export interface components {
         Contract: {
             /** Format: uuid */
             id: string;
+            /** @description The fields of THIS row the caller may not read (a field mask). A named field is null because it is withheld, not because it is empty; absent or empty means nothing is withheld. */
+            readonly masked_fields?: string[];
             /**
              * Format: uuid
-             * @description The counterparty. An organization holds many contracts.
+             * @description The counterparty. An organization holds many contracts. Every contract has one, so null here always means withheld — a reader admitted through the DEAL may not be able to open the company, and handing the id back would make the agreement an existence oracle over a row their own organization read refuses. `masked_fields` names it.
              */
-            organization_id: string;
+            organization_id?: string | null;
             /**
              * Format: uuid
-             * @description The deal this agreement came from, when there was one. Absent on an import or a renewal that never ran through the pipeline.
+             * @description The deal this agreement came from, when there was one. Absent on an import or a renewal that never ran through the pipeline, and null ALSO when the reader may not open that deal — the two are told apart by `masked_fields`, which names it only in the second case.
              */
             deal_id?: string | null;
-            /** Format: uuid */
+            /**
+             * Format: uuid
+             * @description The delivery this agreement funds, when one is attached. Null for no project and for a project the reader may not open; `masked_fields` names it only in the second case.
+             */
             project_id?: string | null;
             /** @description Free text — an imported agreement carries whatever number the counterparty's own system gave it. Duplicates within an account are permitted: two systems reusing a number is their business, not a reason to refuse the row. */
             contract_number?: string | null;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1221,6 +1221,8 @@ export const de = {
   "contracts.renew.dealHint":
     "Der Deal, der diese Laufzeit gewonnen hat, falls es einen gab — nie der des Vorgängers.",
   "contracts.renew.dealNone": "Kein Deal",
+  "contracts.renew.dealWithheldCompany":
+    "Du kannst das Unternehmen dieser Vereinbarung nicht öffnen, deshalb lassen sich seine Deals nicht auflisten. Die Verlängerung behält denselben Vertragspartner und hält keinen Deal fest.",
   "contracts.renew.submit": "Verlängern",
   "contracts.deal": "Deal",
   "contracts.statusChange.title": "Status ändern",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1298,6 +1298,8 @@ export const en = {
   "contracts.renew.dealHint":
     "The opportunity that won this term, if there was one — never the predecessor's own.",
   "contracts.renew.dealNone": "No deal",
+  "contracts.renew.dealWithheldCompany":
+    "You cannot open this agreement's company, so its deals cannot be listed. The renewal keeps the same counterparty and records no deal.",
   "contracts.renew.submit": "Renew",
   "contracts.deal": "Deal",
   "contracts.statusChange.title": "Change status",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1211,6 +1211,8 @@ export const vi = {
   "contracts.renew.dealHint":
     "Deal \u0111\u00e3 gi\u00e0nh \u0111\u01b0\u1ee3c k\u1ef3 h\u1ea1n n\u00e0y, n\u1ebfu c\u00f3 \u2014 kh\u00f4ng bao gi\u1edd l\u00e0 deal c\u1ee7a h\u1ee3p \u0111\u1ed3ng tr\u01b0\u1edbc.",
   "contracts.renew.dealNone": "Kh\u00f4ng c\u00f3 deal",
+  "contracts.renew.dealWithheldCompany":
+    "Bạn không mở được công ty của thỏa thuận này nên không thể liệt kê các deal của họ. Lần gia hạn vẫn giữ nguyên đối tác và không ghi nhận deal nào.",
   "contracts.renew.submit": "Gia h\u1ea1n",
   "contracts.deal": "Deal",
   "contracts.statusChange.title": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -80,6 +80,42 @@ function stubRenewalFetch(onRenewal: (request: Request) => Promise<Response>) {
 }
 
 describe("ContractRenewModal", () => {
+  // A reader admitted through the DEAL may not be able to open the company
+  // (#1983): organization_id comes back null and masked_fields names it. They
+  // may still renew, so the modal keeps working — but the deal picker is filled
+  // by listing that company's deals, and an empty picker would read as "this
+  // company has no deals" rather than "you cannot see them".
+  it("says why the deal picker is missing when the counterparty is withheld", async () => {
+    const listed = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        listed(new URL(request.url).pathname);
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    show(
+      <ContractRenewModal
+        contract={{
+          ...PREDECESSOR,
+          organization_id: null,
+          masked_fields: ["organization_id"],
+        }}
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/company, so its deals cannot be listed/),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Deal/)).not.toBeInTheDocument();
+    // And no request went out for a company the reader cannot open.
+    expect(listed).not.toHaveBeenCalledWith("/v1/deals");
+  });
+
   it("posts the successor's own title, basis and the predecessor's version as If-Match, with no deal picked", async () => {
     let posted: { body: unknown; ifMatch: string | null; path: string } | null =
       null;

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -8,6 +8,7 @@ import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useInstallationSettings } from "../app/uploadlimit";
 import { Button, Field, Modal, TextInput } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -166,9 +167,15 @@ export function ContractRenewModal({
   const [dealId, setDealId] = useState("");
   const baseCurrency = useInstallationSettings().data?.base_currency;
   const contractCurrency = draft.currency || baseCurrency || "";
+  // The counterparty is withheld from a reader admitted through the DEAL who
+  // cannot open the company (masked_fields names it). They may still renew —
+  // write authority follows the deal — so the modal keeps working and the deal
+  // picker, which can only be filled by listing that company's deals, says why
+  // it is not there rather than showing an empty list that reads as "no deals".
+  const anchor = contract.organization_id;
   const deals = useQuery({
-    ...dealsForOrg(contract.organization_id),
-    enabled: open,
+    ...dealsForOrg(anchor ?? ""),
+    enabled: open && anchor != null,
   });
 
   // Re-seed on open, and when a different row's renewal is what just opened:
@@ -220,26 +227,32 @@ export function ContractRenewModal({
       {/* Never required: the API path this mirrors has always accepted a
           renewal with no deal, and a picker that refused to submit without
           one would refuse an agreement the server has always allowed. */}
-      <Field
-        label={t("contracts.renew.deal")}
-        hint={t("contracts.renew.dealHint")}
-      >
-        {(props) => (
-          <Select
-            {...props}
-            value={dealId}
-            onChange={setDealId}
-            disabled={deals.isPending}
-            options={[
-              { value: "", label: t("contracts.renew.dealNone") },
-              ...(deals.data ?? []).map((deal) => ({
-                value: deal.id,
-                label: deal.name,
-              })),
-            ]}
-          />
-        )}
-      </Field>
+      {anchor == null ? (
+        <Callout tone="info">
+          {t("contracts.renew.dealWithheldCompany")}
+        </Callout>
+      ) : (
+        <Field
+          label={t("contracts.renew.deal")}
+          hint={t("contracts.renew.dealHint")}
+        >
+          {(props) => (
+            <Select
+              {...props}
+              value={dealId}
+              onChange={setDealId}
+              disabled={deals.isPending}
+              options={[
+                { value: "", label: t("contracts.renew.dealNone") },
+                ...(deals.data ?? []).map((deal) => ({
+                  value: deal.id,
+                  label: deal.name,
+                })),
+              ]}
+            />
+          )}
+        </Field>
+      )}
 
       {renew.error && (
         <p className="t-caption" role="alert">

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -34,3 +34,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 6a7b29a268183069393c39b1931648a5894b6abe 91cc59b5c3855fed8bf8ba020d95894ed60822e4 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them
 0e10662bd2e43fb3018888323893dd1f3a44fc08 bb87bde2d4a8e3507be239b8d6af8783d0e3f870 ratified-the-installation-writes-through-the-durable-lane-a-confirm-link-is-queued-not-handed-to-a-relay
 7155d6a82570fa939eb5c52afb3a42d3d6071127 f49f227303664d0ddcbab0c55e339c5200998553 ratified-a-deal-room-invitation-is-queued-not-delivered
+82f676997776c2b77cd04767490824812b59953a a150a2ec34f28b3daf86467a27c8c896be52a23f ratified-1983-a-contract-masks-the-references-its-reader-cannot-open


### PR DESCRIPTION
Closes #1983.

The sibling of #1876's deal fix, and the half that makes it hold.

## The defect

`contractColumns` projects `organization_id, deal_id, project_id`, and none of
the three was checked against the reader's own sight of the referenced row.

A contract is admitted by its deal **OR** its organization, and that
disjunction decides ADMISSION. It says nothing about disclosure. A reader let
in through the deal still received:

- an `organization_id` whose company may be capture-private to the colleague
  who captured it,
- a `project_id` whose delivery keeps its own own/team row scope,
- a `deal_id` from a table they may hold no object grant on at all.

It is reachable in a routine configuration. The `deal_project_same_org` CHECK
forces a deal's project and its organization to name one company, so a caller
who reads the **project** and not the company recovered, in one hop through the
paper, the id the deal read had just withheld. Until this lands, #1876 is only
as strong as its weakest sibling — which is the case
`TestAContractIsNotTheWayBackToACompanyTheProjectAlreadyWithholds` pins.

## The contract change

`Contract.organization_id` leaves the required set and becomes nullable, which
is what makes the deal remedy available here: withhold the reference, null on
the wire, named in `masked_fields`. There is no live client, so relaxing it
costs nothing today and is a breaking change after go-live. Ratified in
`scripts/contract-breaking-allowlist.txt`, which returns to the stable gate on
the next contract edit.

**Withheld and absent stay distinguishable.** `organization_id` is `NOT NULL`
in the schema, so a null there always means withheld; `deal_id` and
`project_id` are genuinely optional, and `masked_fields` names them only when
they were withheld.

## Where it is applied, and what holds it there

`readContract` answers what the row IS — the write paths take their pre-image,
their anchor and their audit images from it, and a masked pre-image would
authorize a patch against a company the caller was merely not shown.
`readContractForCaller` is the same read with the reader's sight applied to
what the row points at, and every outward answer comes through it.

Two function names are not an obligation, so two in-package censuses hold it:

- `TestTheUnmaskedContractReadIsForWritesOnly` — a sixth store method reaching
  for the shorter name fails until it is either routed through the masked read
  or ratified with what it does with the row.
- `TestEveryReferenceInTheProjectionIsMasked` — derives its subject from
  `contractColumns` itself, so a fourth reference added to the select list
  fails until it is masked or named as pointing at nothing row-scoped.

`anchorOf` replaces five blind dereferences of the now-optional anchor: a nil
there is a masked row that reached a write, and it stops rather than
authorizing against a zero uuid.

## The frontend half

The renew modal filled its deal picker by listing the contract's company's
deals. A reader admitted through the deal may not be able to open that company
and can still renew, so the modal keeps working and says why the picker is not
there — an empty picker reads as "this company has no deals" rather than "you
cannot see them".

## Checks

- `make check-backend` green apart from
  `TestAnEmailIsDrawnOnlyByTheCanonicalComponents`, which fails on pristine
  `main` too (#4790 / #4792) and is nothing this branch touches.
- `make check-fe` green.
- `make test-it DIR=backend/internal/compose/integration` green (559s with the
  timeout raised; the 600s default is #1950's known problem, not this change).
- `make test-it` green for `internal/modules/{contracts,deals,projects}` and
  `internal/compose`.
- `craft static --strict` clean on every changed Go file.
- Mutation-checked: forcing every reference visible turns all four assertions
  red; both in-package censuses go red on a call site moved back to the
  unmasked read and on a reference dropped from the mask; the frontend guard
  goes red with its branch disabled.