### PR TITLE
fix(identity): a record grant's expiry must be in the future

### DIFF
--- a/backend/internal/modules/identity/grantexpiry_test.go
+++ b/backend/internal/modules/identity/grantexpiry_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// A grant whose expiry has already passed is refused, not stored.
+//
+// Both predicates that read the column test `expires_at IS NULL OR expires_at >
+// now()`, so a back-dated grant is inert from the instant it is written. Inert
+// is not harmless, because the ROW IS THERE: the share list names somebody who
+// in fact has no access, and a human scanning who can see a record is told the
+// opposite of the truth. Nothing sweeps the table either, so the mistake
+// accumulates permanently (#2139).
+//
+// No database and no actor, for the reason requiredids_test.go gives: the guard
+// is a request-shape refusal and runs before any authority check or query, so a
+// store over a nil pool reaches it. That is also the assertion — a check that
+// had drifted below the auth gate would fail here rather than pass quietly.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// grantNoon is a fixed clock, so "already past" is a property of the input rather
+// than of how long the test took to run.
+var grantNoon = time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+
+func grantAt(t *testing.T, expiresAt *time.Time) error {
+	t.Helper()
+	svc := NewService(nil)
+	svc.now = func() time.Time { return grantNoon }
+	_, err := svc.CreateRecordGrant(context.Background(), CreateGrantInput{
+		RecordType: "person", SubjectType: "user", Access: "read",
+		RecordID: ids.NewV7(), SubjectID: ids.NewV7(), ExpiresAt: expiresAt,
+	})
+	return err
+}
+
+func expiringAt(offset time.Duration) *time.Time {
+	moment := grantNoon.Add(offset)
+	return &moment
+}
+
+func TestAGrantExpiringInThePastIsRefused(t *testing.T) {
+	for name, expiresAt := range map[string]*time.Time{
+		"an hour ago":      expiringAt(-time.Hour),
+		"a second ago":     expiringAt(-time.Second),
+		"this very moment": expiringAt(0),
+	} {
+		err := grantAt(t, expiresAt)
+		var detailed *httperr.DetailedError
+		if !errors.As(err, &detailed) {
+			t.Errorf("%s: err = %v, want a field refusal", name, err)
+			continue
+		}
+		// The FIELD, because a caller fixes what they are pointed at: a bare
+		// 422 tells them the request was wrong and not which date to change.
+		if len(detailed.Fields) != 1 || detailed.Fields[0].Field != "expires_at" {
+			t.Errorf("%s: refusal names %v, want expires_at", name, detailed.Fields)
+		}
+	}
+}
+
+// Equal to now goes with the past, and that is not a rounding preference: the
+// predicates are strict (`>`), so an expiry landing exactly on the instant it is
+// written is already spent. It is covered above with the other two.
+
+func TestAGrantExpiringInTheFutureOrNeverIsAdmitted(t *testing.T) {
+	// A nil pool means the write itself cannot run, so this asserts the shape
+	// refusal is not reached — anything that IS returned came from further down.
+	for name, expiresAt := range map[string]*time.Time{
+		"a second from now": expiringAt(time.Second),
+		"next year":         expiringAt(365 * 24 * time.Hour),
+		"never":             nil,
+	} {
+		err := grantAt(t, expiresAt)
+		var detailed *httperr.DetailedError
+		if errors.As(err, &detailed) && len(detailed.Fields) == 1 && detailed.Fields[0].Field == "expires_at" {
+			t.Errorf("%s was refused as an expiry already past: %v", name, err)
+		}
+	}
+}

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -128,6 +128,36 @@ type CreateGrantInput struct {
 	ExpiresAt   *time.Time
 }
 
+// refuseAnExpiryAlreadyPast refuses a grant that would be dead on arrival.
+//
+// Both predicates that read this column test `expires_at IS NULL OR expires_at
+// > now()`, so a back-dated grant is inert from the instant it is written. Inert
+// is not harmless, because the ROW IS THERE: the share list names somebody who
+// in fact has no access, and a human scanning who can see a record is told the
+// opposite of the truth. Nothing sweeps the table either — expiry is evaluated
+// live and no writer deletes an expired row — so the mistake accumulates.
+//
+// And it looked like success. No refusal, no field error, nothing to tell the
+// caller their date was wrong, which is what makes this a validation gap rather
+// than a quirk (#2139).
+//
+// The same refusal covers the RE-ASSERT, which shares this function: shortening
+// a live grant's expiry to a past instant is a revoke wearing an expiry's
+// clothes, and the product has an explicit revoke for that. A caller who means
+// to end access now says so, and the audit records what they meant.
+//
+// Equal to now is refused with the past. The predicates are strict — `>` — so
+// an expiry landing exactly on the instant it is written is already spent.
+func refuseAnExpiryAlreadyPast(expiresAt *time.Time, now time.Time) error {
+	if expiresAt == nil || expiresAt.After(now) {
+		return nil
+	}
+	return httperr.Validation("expires_at", "not_in_future",
+		"expires_at must be in the future: a grant that has already expired is stored and "+
+			"immediately inert, and it lists as an active share while granting nothing. "+
+			"To end an existing share now, revoke it")
+}
+
 func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (grantRow, error) {
 	// Both ids, and both before anything else: a grant is a triple of record,
 	// subject and access, and each id is required by the contract — a claim only
@@ -143,6 +173,9 @@ func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (g
 	}
 	if !shareableRecordTypes[in.RecordType] {
 		return grantRow{}, &InvalidScopeError{Scope: "record_type " + in.RecordType}
+	}
+	if err := refuseAnExpiryAlreadyPast(in.ExpiresAt, s.now()); err != nil {
+		return grantRow{}, err
 	}
 	// Sharing widens who sees the record — the grantor needs the
 	// record's own write grant (the spec's manage_sharing permission,


### PR DESCRIPTION
Closes #2139

Both predicates that read the column test `expires_at IS NULL OR expires_at > now()`, so a back-dated grant is **inert from the instant it is written**. Inert is not harmless, because the row is *there*: the share list names somebody who in fact has no access, and a human scanning who can see a record is told the opposite of the truth. Nothing sweeps the table either — expiry is evaluated live and no writer deletes an expired row — so the mistake accumulates permanently.

And it looked like success. No refusal, no field error, nothing to tell the caller their date was wrong.

## The refusal

A 422 naming `expires_at`, raised with the other request-shape refusals rather than in the store, and reached **before** any authority check or query.

That placement is also what the test asserts: it runs over a **nil pool**, so a guard that ever drifted below the auth gate would fail here rather than pass quietly. Removing the guard proves it — the probe then gets `auth: no actor bound to context` instead of a field refusal.

**Equal to now is refused with the past**, and that is not a rounding preference: the predicates are strict (`>`), so an expiry landing exactly on the instant it is written is already spent.

## The question the issue leaves open

*"Worth deciding at the same time whether a re-assert may SHORTEN an existing expiry to a past instant."*

It may not, and it needs no separate answer: create and re-assert are **one function**, so the same refusal covers both. Shortening to the past is a revoke wearing an expiry's clothes — the product has an explicit revoke, and a caller who means to end access now should say so where the audit records what they meant.

## Surface

`INSERT INTO record_grant` appears **once** in the tree, so one guard is the whole surface.

## Verification

- Three refused shapes (an hour ago, a second ago, this very moment) each naming `expires_at`, because a caller fixes what they are pointed at.
- Three admitted (a second from now, next year, never).
- A fixed clock, so "already past" is a property of the input rather than of how long the test took to run.
- `make check-backend` exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grants with an expiration time in the past or exactly at the current time are now rejected with a clear `expires_at` validation error.
  * Future-dated and non-expiring grants continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->