### PR TITLE
The screen-acceptance lane gates the merge, and runs beside the frontend lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,7 +1077,7 @@ jobs:
   #   sonarcloud                 — advisory, for merge speed during heavy
   #                                development. Listing it here would make it
   #                                blocking by the back door.
-  #   vuln, live-boot, uat       — advisory today, and deliberately still
+  #   vuln, live-boot            — advisory today, and deliberately still
   #                                advisory here. See below.
   #
   # WHAT THE REPOSITORY ACTUALLY REQUIRES, said once and only here so the file
@@ -1095,21 +1095,19 @@ jobs:
   # part of it. It is not: #2543's keyserver hang cancelled that job and the pull
   # request stayed mergeable, because this aggregate alone decides.
   #
-  # This list is EXACTLY the contexts the ruleset required before the
-  # aggregate replaced them, and that equality is the point: this change moves
-  # where the verdict is computed, not what the verdict covers. Adding a lane and
-  # collapsing the contexts in one step would mean a red merge queue with two
-  # candidate explanations, during the week we are establishing whether the queue
-  # itself works.
+  # This list began as EXACTLY the contexts the ruleset required before the
+  # aggregate replaced them, because that change moved where the verdict is
+  # computed, not what the verdict covers. A lane joins it as its own change, so
+  # a red aggregate has one candidate explanation. `uat`, `license-gate` and
+  # `images` joined that way, each on its own evidence.
   #
-  # vuln, live-boot and uat are the tempting additions — they run on every
-  # qualifying change and a red one does not stop a merge, which is not a state
-  # worth keeping. The reason to wait is the batching: a flaky job under a merge
-  # queue does not cost one re-run, it fails the whole group it was checked in and
+  # vuln and live-boot are the tempting additions — they run on every qualifying
+  # change and a red one does not stop a merge, which is not a state worth
+  # keeping. The reason to wait is the batching: a flaky job under a merge queue
+  # does not cost one re-run, it fails the whole group it was checked in and
   # every entry in that group is re-queued, and nothing has ever exercised these
-  # three under a gate that blocks.
-  # Promote them once the queue has a measured baseline, as their own change, so a
-  # regression has one explanation.
+  # two under a gate that blocks. Promote them once the queue has a measured
+  # baseline, as their own change, so a regression has one explanation.
   # The role images BUILD on a PR that changes what they are.
   #
   # Nothing built them between two correct changes. ci.yml's old

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,17 +1015,22 @@ jobs:
 
   # The UAT lane: the AC-<screen>-N screen-acceptance criteria as named
   # Playwright tests, plus the axe WCAG 2.2 AA gate, the 390px
-  # no-horizontal-scroll sweep, and the PERF-1 record-open budget. The suite
-  # mocks the API at the network edge (the coherent seed fixture), so it is
-  # self-contained — no backend needed — and a UI regression that breaks a
-  # named acceptance criterion fails the merge instead of shipping.
+  # no-horizontal-scroll sweep, and PERF-1's held-read claim for a record open.
+  # The suite mocks the API at the network edge (the coherent seed fixture), so
+  # it is self-contained — no backend needed — and it is in the `ci` aggregate
+  # below: a UI regression that breaks a named acceptance criterion fails the
+  # merge instead of shipping. Nothing in it reads a clock — the record-open
+  # BUDGET belongs to `make bench-mobile` — so a slow runner cannot redden it.
   uat:
     name: uat (AC screens + axe WCAG 2.2 AA + 390px, mocked)
     timeout-minutes: 20
-    # Fail fast: the Playwright UAT lane only starts once the cheaper frontend
-    # gate (biome + vitest + tsc + build) is green; both are frontend-gated, so
-    # they skip together on non-frontend PRs.
-    needs: [changes, frontend]
+    # BESIDE the frontend lane, not behind it. This job builds the SPA itself
+    # (`pnpm e2e` is a build and then the run) and shares no artefact with
+    # `frontend`, so an order between them buys nothing but latency — and since
+    # both gate the merge, the sequence would be the aggregate's wall clock on
+    # every frontend change. What the order saved was this job's runner minutes
+    # on a change biome would have refused, which is cheaper than the wait.
+    needs: [changes]
     if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
@@ -1163,6 +1168,13 @@ jobs:
       - extension-reference
       - integration
       - frontend
+      # The screen-acceptance lane gates the merge. It was advisory on the
+      # argument that a flaky job under a merge queue re-queues every entry in
+      # its group; the queue is not in use, and an advisory lane is one a red
+      # verdict never stops anybody on. Its classifier skip is admissible here
+      # for the same reason `frontend`'s is: on a pull request a skip means out
+      # of scope, and on the merge queue every scope is true so it cannot skip.
+      - uat
       - license-gate
       - images
     runs-on: ubuntu-latest

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -327,13 +327,13 @@ and the queue lane covers the remainder.
 upstream job reports a **green** required check, which is the same failure wearing
 a different hat.
 
-**`needs` is exactly the nine contexts the ruleset required before the aggregate
-replaced them**, and that equality is the point: this change moved where the
-verdict is computed, not what it covers. Widening the gate in the same step would
-mean a red merge queue with two candidate explanations, during the week the queue
-itself is on trial.
+**`needs` began as exactly the nine contexts the ruleset required before the
+aggregate replaced them**, because that change moved where the verdict is
+computed, not what it covers. A lane joins the list as its own change, so a red
+aggregate has one candidate explanation; `license-gate`, `images` and `uat` each
+joined that way, on their own evidence.
 
-Ten jobs are deliberately **not** in `needs`:
+Nine jobs are deliberately **not** in `needs`:
 
 - `changes` — the classifier produces no verdict.
 - `fe-quality`, `fe-unit`, `fe-bundle` — absorbed by the `frontend` fan-in.
@@ -349,14 +349,15 @@ Ten jobs are deliberately **not** in `needs`:
   re-queued, and nothing has ever exercised these two under a gate that blocks.
   Promote them once the queue has a measured baseline, as their own change, so a
   regression has exactly one explanation.
-- `uat` was on that list and is in the aggregate now. The queue argument assumed
-  a queue, and none has run since 2026-08-20; meanwhile the lane's record over
-  fifty-two pull-request runs was no flake at all — every red was one of three
-  deterministic screen regressions that had already landed on `main`, seen by
-  eleven pull requests in a row and stopping none of them. It reads no clock
-  (PERF-1 holds a request and asserts the heading did not wait on it; the
-  record-open budget is `make bench-mobile`'s), so a busy runner cannot redden
-  it, which is the one property a blocking Playwright lane has to have.
+
+`uat` was on that list and is in the aggregate now. The queue argument assumed a
+queue, and none has run since 2026-08-20; meanwhile the lane's record over
+fifty-two pull-request runs was no flake at all — every red was one of three
+deterministic screen regressions that had already landed on `main`, seen by
+eleven pull requests in a row and stopping none of them. It reads no clock
+(PERF-1 holds a request and asserts the heading did not wait on it; the
+record-open budget is `make bench-mobile`'s), so a busy runner cannot redden it,
+which is the one property a blocking Playwright lane has to have.
 
 Six rather than twelve because the per-test slice is the cheap half of a shard.
 Measured on a green run, one shard spent ~146s restoring the build cache and

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -16,10 +16,12 @@ the merge instead of shipping.
 Two lanes run but deliberately do **not** block: `vuln` and the SonarCloud scan.
 Both were traded off the required set for merge speed during heavy development,
 and both are re-checked daily on `main` by `scheduled.yml` — see below for why a
-non-blocking gate needs that backstop to stay honest. `uat` and `live-boot` are
-likewise advisory. Promoting the three of them is deliberate future work rather
-than an oversight; the reason it is not bundled with the merge queue is in
-[The `ci` aggregate](#the-ci-aggregate-is-the-only-required-context).
+non-blocking gate needs that backstop to stay honest. `live-boot` is likewise
+advisory. Promoting the two of them is deliberate future work rather than an
+oversight; the reason it is not bundled with the merge queue is in
+[The `ci` aggregate](#the-ci-aggregate-is-the-only-required-context). `uat` was
+advisory on the same argument until it let two screen regressions onto `main`
+under a red lane nobody was stopped by; it gates the merge now.
 
 ## Triggers
 
@@ -228,10 +230,11 @@ changes ──┬─> deterministic-gates ──> craftsmanship
           ├─> extension-reference ──────────────────────────────┐   │
           ├─> vuln                                              │   │
           ├─> license gate  (`deps` scope)                      │   │
-          ├─> frontend  →  _lane-frontend.yml ──> uat           │   │
+          ├─> frontend  →  _lane-frontend.yml                  │   │
           │                  fe-quality ┐                       │   │
           │                  fe-unit    ├─> fan-in              │   │
           │                  fe-bundle  ┘                       │   │
+          ├─> uat  (`frontend` scope, beside the lane)          │   │
           ├─> live-boot                                         │   │
           v                                                     v   v
  deterministic-gates + integration + extension-reference + frontend ──> sonarcloud
@@ -240,8 +243,8 @@ changes ──┬─> deterministic-gates ──> craftsmanship
 
   ci  ── the ONE required context. needs: deterministic-gates,
          craftsmanship, craft-residue, secret-scan, extension-reference,
-         integration, frontend, license-gate   (eight — vuln, live-boot and uat
-         stay advisory and are NOT in the fan-in)
+         integration, frontend, uat, license-gate, images   (ten — vuln and
+         live-boot stay advisory and are NOT in the fan-in)
 ```
 
 ### Two lanes are called, not inlined
@@ -281,12 +284,18 @@ events gate differently. That is the "two hand-maintained copies of one list"
 shape this repository refuses everywhere else, and it would be guarding the one
 check everything depends on.
 
-Two deliberate shapes here. The Playwright `uat` lane is **fail-fast**: it
-starts only after the cheaper `frontend` gate (biome + vitest + tsc + build)
-passes. The real-Postgres integration lane is the opposite — it runs **beside**
-`deterministic-gates`, not behind it: it is the longest lane in the pipeline,
-so serializing the two slowest jobs dominated PR wall-clock, and a broken
-build is still caught by `deterministic-gates` itself. And the lane is
+Two deliberate shapes here. The Playwright `uat` lane runs **beside**
+`frontend`, not behind it. It builds the SPA itself and shares no artefact with
+the lane, so the old fail-fast order (start only once biome, vitest and tsc were
+green) bought nothing but latency: nine minutes queued behind a seventeen-minute
+unit job, a broken screen reported twenty-six minutes after the push, and once
+it gates the merge that sequence would have been the aggregate's wall clock on
+every frontend change. What the order saved was this lane's runner minutes on a
+change `fe-quality` would have refused — one frontend run in seven — which is
+cheaper than the wait. The real-Postgres integration lane runs **beside**
+`deterministic-gates` for the same reason: it is the longest lane in the
+pipeline, so serializing the two slowest jobs dominated PR wall-clock, and a
+broken build is still caught by `deterministic-gates` itself. And the lane is
 **sharded**: six matrix runners each execute a deterministic per-test slice
 (package-level splitting would floor at the heaviest package,
 `compose/integration`), and the `integration` fan-in reassembles them into the
@@ -332,15 +341,22 @@ Ten jobs are deliberately **not** in `needs`:
   `integration` fan-in, which already asserts on their results.
 - `sonarcloud` — non-blocking by decision; listing it here would make it required
   by the back door.
-- `vuln`, `live-boot`, `uat` — advisory, and left that way **on purpose**. They
-  are the obvious additions: each runs on every qualifying change and a red one
-  does not stop a merge, which is not a state worth keeping. What argues for
-  waiting is the batching. A flaky job under a merge queue does not cost one
-  re-run; it fails the whole group it was checked in and every entry in that group
-  is re-queued, and nothing has ever exercised these three under a gate that
-  blocks. Promote them once the queue
-  has a measured baseline, as their own change, so a regression has exactly one
-  explanation.
+- `vuln`, `live-boot` — advisory, and left that way **on purpose**. They are
+  the obvious additions: each runs on every qualifying change and a red one does
+  not stop a merge, which is not a state worth keeping. What argues for waiting
+  is the batching. A flaky job under a merge queue does not cost one re-run; it
+  fails the whole group it was checked in and every entry in that group is
+  re-queued, and nothing has ever exercised these two under a gate that blocks.
+  Promote them once the queue has a measured baseline, as their own change, so a
+  regression has exactly one explanation.
+- `uat` was on that list and is in the aggregate now. The queue argument assumed
+  a queue, and none has run since 2026-08-20; meanwhile the lane's record over
+  fifty-two pull-request runs was no flake at all — every red was one of three
+  deterministic screen regressions that had already landed on `main`, seen by
+  eleven pull requests in a row and stopping none of them. It reads no clock
+  (PERF-1 holds a request and asserts the heading did not wait on it; the
+  record-open budget is `make bench-mobile`'s), so a busy runner cannot redden
+  it, which is the one property a blocking Playwright lane has to have.
 
 Six rather than twelve because the per-test slice is the cheap half of a shard.
 Measured on a green run, one shard spent ~146s restoring the build cache and


### PR DESCRIPTION
## What

- `uat` joins the `ci` aggregate's `needs:`. A broken named acceptance criterion, an axe WCAG 2.2 AA violation, or a 390px overflow now fails the merge.
- `uat` drops `needs: frontend`. It builds the SPA itself (`pnpm e2e` = build + run), so the fail-fast order shared nothing and only added latency. Signal lands ~10 min after push instead of ~26.
- `infra/ci-pipeline.md` updated: diagram, aggregate list (was stale at "eight", is ten), fail-fast paragraph, advisory list.

## Why now

The doc deferred promotion until the merge queue had a baseline. No `merge_group` run since 2026-08-20. Meanwhile, today, two deterministic screen regressions (`target-size` on `.lt-frow-more` at `#/leads`; the mailbox opt-in toggle moved) sat red on 11 consecutive PRs and merged. Over the last 52 PR runs the lane had zero flakes: 22 pass, 15 fail on those same three tests, 15 cancelled by superseding pushes.

Checked before gating: PERF-1 is a held-read claim (`readStarted && !readAnswered`), not a wall-clock budget, so a slow runner cannot redden it.

## Implications

- A red `uat` on main now blocks frontend merges until fixed, same as `deterministic-gates` today.
- Frontend PRs pay no extra `ci` wall time: `uat` (~9 min) runs in parallel with `fe-unit` (~11 min after #4771/#4786).
- Runner cost: `uat` now runs on PRs where `fe-quality` fails (8 of 54 in the sample).
- `aggregategatereach_test.go` green: `uat`'s `if:` is the same shape as `frontend`'s, so it cannot be skipped on the merge queue.
- Classifier: this PR touches only `ci.yml` and `infra/*.md`, so `frontend` and `uat` skip on this run itself; the aggregate admits the skip on a pull request as it does for `frontend`. First proof of the gate is the next frontend PR.

`make check-gates` and `cli/craft` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the `uat` screen-acceptance lane from advisory to a merge gate and runs it beside the frontend lane instead of behind it. The lane was advisory and let three deterministic screen regressions land on `main`; it now blocks the merge on failure.

- `uat` joins the `ci` aggregate's `needs`; a red verdict stops the merge.
- `uat` no longer waits on `frontend`; it builds the SPA itself, so the fail-fast order only added latency.
- The lane reads no wall-clock budget, so a slow runner cannot redden it.
- `infra/ci-pipeline.md` and the `ci.yml` aggregate comments updated: diagram, aggregate list, fail-fast paragraph, and `uat` dropped from the advisory lists.

<sup>Written for commit c6fa5f117ca2ef2fac2e7a55dfb086ba24ebcc4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * User acceptance testing now runs in parallel with frontend checks, reducing unnecessary wait time.
  * User acceptance testing is now a required merge gate, helping ensure changes meet screen-acceptance criteria before integration.

* **Documentation**
  * Updated CI pipeline documentation to reflect the revised job flow and required checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->