### PR TITLE
The finance mirror's audit-only posture is a decision, not a wait

### DIFF
--- a/backend/gates/writeshape_test.go
+++ b/backend/gates/writeshape_test.go
@@ -222,9 +222,21 @@ var auditOnlyWrites = gatekit.Waive(map[string]string{
 	// The audit row is the half that could not wait, because it cannot be
 	// written afterwards: an invoice mirrored without one stays permanently
 	// unaccounted for, and the erasure and retention reasoning that reads
-	// audit_log is blind to it. Which finance types the contract should carry is
-	// a product decision, tracked as its own issue; ratifying them replaces
-	// these seven entries with emits at the same call sites.
+	// audit_log is blind to it.
+	//
+	// Audit-only here is SETTLED rather than pending. No finance verb exists in
+	// the closed catalog, no consumer asks for one, and emitting would mean
+	// minting public contract surface speculatively — which is the layering
+	// working rather than a shortcut taken under it. It reads like the
+	// attachment entries above and is their opposite: those skip a type that
+	// could legitimately be declared, this has no type to skip.
+	//
+	// Said plainly because an exemption marked "waiting on a decision" is how a
+	// temporary state becomes permanent with nobody choosing it. The condition
+	// that reopens this one, so the silence has an expiry: a consumer that needs
+	// to learn an invoice arrived. Then the contract declares the type FIRST —
+	// the order a closed catalog requires — and these seven entries become emits
+	// at the same call sites.
 	"internal/modules/finance:insertInvoice":             "the mirror takes in an invoice \u2014 see the note above these seven entries",
 	"internal/modules/finance:updateInvoice":             "the source restated an invoice \u2014 same ground",
 	"internal/modules/finance:insertPayment":             "the mirror takes in a received payment \u2014 same ground",


### PR DESCRIPTION
Closes #1927.

No behaviour changes. The change is to the record, which is what the ticket
asks for.

## What was wrong with the record

The seven finance entries in `auditOnlyWrites` ended with:

> Which finance types the contract should carry is a product decision, tracked
> as its own issue; ratifying them replaces these seven entries with emits at
> the same call sites.

That reads as provisional, and it is not. The constraint decides it: the event
catalog is **closed** — a type exists because the contract declares one, and a
build may not mint one to satisfy the write-shape rule. `grep -icE
"invoice|finance|payment"` over the catalog and the published-events contract
still returns 0 and 0. No consumer asks for one. Emitting would mean minting
public contract surface speculatively.

So audit-only here is the layering working rather than a shortcut taken under
it — and it is worth saying so, because it looks superficially like the
attachment entries above it in the same map and is their opposite: those skip a
type that could legitimately be declared, this has no type to skip.

## What the note says now

The settled reason, plus the condition that reopens it: a consumer that needs
to learn an invoice arrived. At that point the contract declares the type
**first** — the order a closed catalog requires — and these seven entries become
emits at the same call sites.

An exemption marked "waiting on a decision" is how a temporary state becomes
permanent with nobody choosing it, which is exactly what had happened here for
long enough to file a ticket about.

## One thing found and deliberately not fixed here

`backend/gates/profilefieldreaders_test.go` carries a waiver that opens
`"RATIFIED PENDING A DECISION, see issue #NNNN"` — the same shape, and it also
puts a ticket number in a gate comment, which the review-loop rule against
build-process residue asks not to happen. The decision it waits on belongs to
that ticket, which is in another session's range right now, so it is left alone
rather than half-answered here.

I considered generalising this into a census that refuses a waiver reason
claiming to be provisional. It is the right shape — a fitness function rather
than a point fix — but that one entry is its only other subject in the tree
today, and landing a gate whose single finding is somebody else's open product
question would make it a gate that gets waived on arrival. Worth doing once
that entry resolves.

## Checks

- `make check-backend` green.
- `craft static --strict` clean.