### PR TITLE
An invitation is queued, not delivered — and now actually sends

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15811,10 +15811,11 @@ paths:
       operationId: inviteDealRoomParticipant
       summary: Admit a named person to the room.
       description: |
-        HUMAN-ONLY. Records the person and mints one credential for them. Whether that
-        credential is delivered depends on the installation having outbound mail
-        configured; the participant and the invitation are recorded either way, so a
-        mail failure never leaves a half-admitted person.
+        HUMAN-ONLY. Records the person and mints one credential for them. Whether a mail
+        relay took the credential is reported as `queued` — it is false when the
+        installation has no outbound mail configured and when the relay refused the
+        message. The participant and the invitation are recorded either way, so a mail
+        failure never leaves a half-admitted person.
 
         One live seat per address: inviting an address that already holds one is
         rejected (409 `deal_room_participant_already_invited`). Re-inviting an address
@@ -39009,20 +39010,26 @@ components:
         `credential` is returned ONCE and never again — only its hash is stored, so it
         cannot be recovered, only replaced by a resend. Treat it as a secret: it admits
         the bearer to everything the room has published.
-      required: [participant, credential, credential_expires_at, delivered]
+      required: [participant, credential, credential_expires_at, queued]
       properties:
         participant: { $ref: '#/components/schemas/DealRoomParticipant' }
         credential:
           type: string
           description: The raw one-time credential. Put it in the link's fragment, never its path.
         credential_expires_at: { type: string, format: date-time }
-        delivered:
+        queued:
           type: boolean
           description: |
-            Whether the invitation was handed to a mail relay. False when the
-            installation has no outbound mail configured — the participant and the
-            credential are still recorded, and the caller is expected to deliver the
-            link itself rather than being told the invitation failed.
+            Whether a mail relay accepted the invitation for sending. False when the
+            installation has no outbound mail configured, or the relay refused it — the
+            participant and the credential are recorded either way, and the caller is
+            expected to pass the link on themselves rather than being told the
+            invitation failed.
+
+            Deliberately not `delivered`: a relay accepting a message is not a mailbox
+            receiving it, and an address that hard-bounces a second later was `queued`
+            all the same. The one attempt is stamped onto the invitation, which the
+            roster reports; nothing revises it afterwards.
       additionalProperties: false
 
     DealRoomPreviewIssued:

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -390,8 +390,18 @@ func passwordResetOptions(ctx context.Context, deployCfg deployconfig.Config, po
 	}
 	_, _ = fmt.Fprintln(stdout, "api operator mail enabled (password reset, invites)")
 	// The link base rides compose.WithPublicBaseURL, assembled with the base
-	// options — this option carries the transport alone.
-	return []compose.Option{compose.WithOperatorMail(m)}, nil
+	// options — these options carry the transport alone.
+	//
+	// BOTH options, because they wire different handler sets off the same
+	// relay: WithOperatorMail reaches password reset and the controller lane,
+	// and the Deal Room invitation is its own handler set. Wiring only the
+	// first left an installation whose banner said "invites" mailing none of
+	// them — every invitation came back queued=false and every seller was told
+	// to pass the link on by hand.
+	return []compose.Option{
+		compose.WithOperatorMail(m),
+		compose.WithDealRoomInviteMail(m),
+	}, nil
 }
 
 // blobstoreOptions wires the attachment endpoints (and their /readyz probe +

--- a/backend/gates/relaywiring_test.go
+++ b/backend/gates/relaywiring_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind reachability H2
+
+package gates
+
+// Every option that wires the mail relay is wired by a role binary.
+//
+// A compose option nobody calls is dead code, and most kinds announce
+// themselves: the feature is simply absent and somebody notices. A MAILER
+// option does not. The product still answers, still records the participant,
+// still mints the credential — it just never sends, and the surface reports
+// that as an ordinary "no relay configured", which is exactly what an
+// installation without SMTP looks like.
+//
+// That shipped. WithDealRoomInviteMail had no caller in cmd/api, which wired
+// only WithOperatorMail, so every deal room invitation in every real
+// installation came back unsent while the startup banner said "password reset,
+// invites". The seller was told to pass the link on by hand and had no way to
+// know the product had not tried.
+//
+// Derived from the SIGNATURE, not a list: an option taking a mailer.Mailer is
+// one of these, whatever it is named, so a third joins this gate the day it is
+// written. What the gate does NOT check is that the relay reaches the handler
+// the option claims — a fitness function can see that main calls the option,
+// never that the option wires the right handler set. It makes an unwired one
+// visible, which is the half that was silent.
+
+import (
+	"go/ast"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEveryMailRelayOptionIsWiredByARoleBinary(t *testing.T) {
+	t.Parallel()
+
+	options := mailerOptionsIn(t, "internal/compose")
+	if len(options) == 0 {
+		t.Fatal("no compose option takes a mailer.Mailer, so this gate has no subject and would " +
+			"pass however many relays went unwired")
+	}
+
+	roles, err := os.ReadDir("cmd")
+	if err != nil {
+		t.Fatalf("reading the process roles under cmd/: %v", err)
+	}
+	// composeCallsIn is bootcomposition_test's, selector-matched on the compose
+	// package: one reader of "which options does a role call", asked here of a
+	// different set of options.
+	wired := map[string]bool{}
+	for _, role := range roles {
+		if !role.IsDir() {
+			continue
+		}
+		for name := range composeCallsIn(t, filepath.Join("cmd", role.Name())) {
+			wired[name] = true
+		}
+	}
+
+	for _, option := range options {
+		if !wired[option] {
+			t.Errorf("compose.%s wires the mail relay but no role binary under cmd/ calls it. "+
+				"An unwired mailer does not fail — the product records everything and silently "+
+				"sends nothing, which reads to an operator exactly like an installation with no "+
+				"SMTP configured. Call it where the relay is built, beside the other mail options.",
+				option)
+		}
+	}
+}
+
+// mailerOptionsIn names every exported function in the package that takes a
+// mailer.Mailer and returns an Option.
+func mailerOptionsIn(t *testing.T, dir string) []string {
+	t.Helper()
+	// parseGoFilesUnder is jobrole_test's, which every gate here reaches for:
+	// one reader of "the Go files under this directory", rather than a second
+	// walk that would drift from it over build tags.
+	_, files := parseGoFilesUnder(t, dir)
+
+	var options []string
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !fn.Name.IsExported() {
+				continue
+			}
+			if takesAMailer(fn) && returnsAnOption(fn) {
+				options = append(options, fn.Name.Name)
+			}
+		}
+	}
+	return options
+}
+
+func takesAMailer(fn *ast.FuncDecl) bool {
+	for _, param := range fn.Type.Params.List {
+		selector, ok := param.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if ok && pkg.Name == "mailer" && selector.Sel.Name == "Mailer" {
+			return true
+		}
+	}
+	return false
+}
+
+func returnsAnOption(fn *ast.FuncDecl) bool {
+	if fn.Type.Results == nil {
+		return false
+	}
+	for _, result := range fn.Type.Results.List {
+		if name, ok := result.Type.(*ast.Ident); ok && name.Name == "Option" {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/integration/dealroom_buyer_edge_integration_test.go
+++ b/backend/internal/compose/integration/dealroom_buyer_edge_integration_test.go
@@ -31,6 +31,11 @@ type buyerRoom struct {
 	roomID     string
 	credential string
 	email      string
+	// queued is what the invitation said about its own mail: whether a relay
+	// accepted it, never that a mailbox received it. Carried here so the suite
+	// asserting that distinction shares this helper rather than growing a
+	// second copy of the same three requests.
+	queued bool
 }
 
 // openRoomWithABuyer creates a room and invites one buyer into it. There is no
@@ -58,7 +63,15 @@ func openRoomWithABuyer(t *testing.T, e *apptest.AppEnv) buyerRoom {
 	if credential == "" {
 		t.Fatalf("invite returned no credential: %v", issued)
 	}
-	return buyerRoom{roomID: roomID, credential: credential, email: "laura@buyer.example"}
+	// Asserted rather than defaulted: `queued` is a required response property,
+	// and reading a missing one as false would let the two tests that expect
+	// false pass against a response that had dropped the field entirely.
+	queued, present := issued["queued"].(bool)
+	if !present {
+		t.Fatalf("the issued invitation carries no boolean `queued`, so nothing says whether the "+
+			"seller must pass the link on by hand: %v", issued)
+	}
+	return buyerRoom{roomID: roomID, credential: credential, email: "laura@buyer.example", queued: queued}
 }
 
 func bearer(token string) map[string]string {

--- a/backend/internal/compose/integration/dealroominvitequeued_integration_test.go
+++ b/backend/internal/compose/integration/dealroominvitequeued_integration_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a deal room invitation says about the mail it sent.
+//
+// It says `queued`: a relay accepted the message for sending. A mailbox
+// receiving it is a later and separate fact, and an address that hard-bounces a
+// second afterwards was queued all the same. The distinction decides what a
+// seller does next — told the invitation went, they wait; told it did not, they
+// copy the link and pass it on themselves — so a field that overstated this
+// would leave a buyer with no way into the room and a seller unaware of it.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+var errRelayRefused = errors.New("the relay refused the envelope")
+
+// refusingMailer is a relay that takes nothing. It stands for the ordinary
+// outage — configured, attempted, and the message still does not go — which is
+// the case that separates "queued" from "we have somewhere to send".
+type refusingMailer struct{}
+
+func (refusingMailer) Send(context.Context, string, string, string) error {
+	return errRelayRefused
+}
+
+// A relay that accepts the message reads as queued.
+func TestAnAcceptedInvitationReadsAsQueued(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t,
+		compose.WithDealRoomInviteMail(discardingMailer{}),
+		compose.WithPublicBaseURL("https://rooms.example.test"))
+	e.BootstrapWorkspace(t)
+
+	if !openRoomWithABuyer(t, e).queued {
+		t.Error("a relay that accepted the invitation reads as not queued, so the seller is told " +
+			"to pass on a link that is already on its way")
+	}
+}
+
+// An installation with no relay reads as not queued, and the credential is
+// still issued — the seller passes it on themselves.
+func TestAnInvitationWithNoRelayReadsAsNotQueued(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t, compose.WithPublicBaseURL("https://rooms.example.test"))
+	e.BootstrapWorkspace(t)
+
+	// openRoomWithABuyer fatals on an empty credential, which is the assertion
+	// this case most needs: sending is best-effort and must never cost the
+	// seller the link they are being asked to pass on by hand.
+	if openRoomWithABuyer(t, e).queued {
+		t.Error("an installation with no relay reads as queued, so the seller waits for mail that " +
+			"was never attempted")
+	}
+}
+
+// Resend answers the same way, because it is the same question.
+//
+// Both endpoints render through issuedBody today, which is a fact about one
+// function rather than a promise. A resend that grew its own body — the obvious
+// place for it, since it supersedes rather than creates — would ship the old
+// claim on the endpoint a seller reaches precisely when the first mail did not
+// arrive. This asks resend directly, so that change fails here.
+func TestAResentInvitationReportsQueuedTheSameWay(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t,
+		compose.WithDealRoomInviteMail(refusingMailer{}),
+		compose.WithPublicBaseURL("https://rooms.example.test"))
+	e.BootstrapWorkspace(t)
+	room := openRoomWithABuyer(t, e)
+
+	var resent AnyMap
+	if status := e.Call(t, "POST",
+		"/v1/deal-rooms/"+room.roomID+"/participants/"+participantOf(t, e, room)+"/resend",
+		AnyMap{}, nil, &resent); status != http.StatusCreated {
+		t.Fatalf("resend = %d %v", status, resent)
+	}
+
+	queued, present := resent["queued"].(bool)
+	if !present {
+		t.Fatalf("the resent invitation carries no boolean `queued`: %v", resent)
+	}
+	if queued {
+		t.Error("a resent invitation the relay refused reads as queued, so a seller retrying a " +
+			"failed send is told the second one went when it did not either")
+	}
+}
+
+// participantOf reads the one buyer's id off the room's roster.
+func participantOf(t *testing.T, e *apptest.AppEnv, room buyerRoom) string {
+	t.Helper()
+	var roster struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/deal-rooms/"+room.roomID+"/participants",
+		nil, nil, &roster); status != http.StatusOK {
+		t.Fatalf("read roster = %d", status)
+	}
+	if len(roster.Data) != 1 {
+		t.Fatalf("the room holds %d participant(s), want the one this suite invited", len(roster.Data))
+	}
+	id := roster.Data[0].ID
+	if id == "" {
+		t.Fatal("the roster entry carries no id")
+	}
+	return id
+}
+
+// A relay that REFUSES the message reads as not queued.
+//
+// The case that discriminates: the installation can send, the send was
+// attempted, and it did not happen. A field reporting the ATTEMPT rather than
+// the outcome passes both cases above and fails only this one.
+func TestARefusedInvitationReadsAsNotQueued(t *testing.T) {
+	e := apptest.SetupAppWithOptions(t,
+		compose.WithDealRoomInviteMail(refusingMailer{}),
+		compose.WithPublicBaseURL("https://rooms.example.test"))
+	e.BootstrapWorkspace(t)
+
+	if openRoomWithABuyer(t, e).queued {
+		t.Error("an invitation the relay refused reads as queued, so the seller is told it is on " +
+			"its way when nothing left")
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22552,15 +22552,21 @@ type DealRoomInvitationIssued struct {
 	Credential          string    `json:"credential"`
 	CredentialExpiresAt time.Time `json:"credential_expires_at"`
 
-	// Delivered Whether the invitation was handed to a mail relay. False when the
-	// installation has no outbound mail configured — the participant and the
-	// credential are still recorded, and the caller is expected to deliver the
-	// link itself rather than being told the invitation failed.
-	Delivered bool `json:"delivered"`
-
 	// Participant One named person admitted to one room. Not an app_user: a participant consumes
 	// no licence, holds no CRM authority, and their whole reach is this one room.
 	Participant DealRoomParticipant `json:"participant"`
+
+	// Queued Whether a mail relay accepted the invitation for sending. False when the
+	// installation has no outbound mail configured, or the relay refused it — the
+	// participant and the credential are recorded either way, and the caller is
+	// expected to pass the link on themselves rather than being told the
+	// invitation failed.
+	//
+	// Deliberately not `delivered`: a relay accepting a message is not a mailbox
+	// receiving it, and an address that hard-bounces a second later was `queued`
+	// all the same. The one attempt is stamped onto the invitation, which the
+	// roster reports; nothing revises it afterwards.
+	Queued bool `json:"queued"`
 }
 
 // DealRoomLinkRequest defines model for DealRoomLinkRequest.

--- a/backend/internal/modules/dealrooms/handlers.go
+++ b/backend/internal/modules/dealrooms/handlers.go
@@ -18,9 +18,10 @@ import (
 // Handlers is this module's transport.
 type Handlers struct {
 	store *Store
-	// inviteMailer delivers a buyer's invitation. Nil means the installation
-	// has no outbound mail configured: invitations are still recorded and their
-	// credential still returned, and the response says it was not delivered.
+	// inviteMailer carries a buyer's invitation to a relay. Nil means the
+	// installation has no outbound mail configured: invitations are still
+	// recorded and their credential still returned, and the response reports
+	// `queued` false — as it also does when a configured relay refuses.
 	inviteMailer mailer.Mailer
 	// publicBaseURL is the origin a buyer link is built on.
 	publicBaseURL string

--- a/backend/internal/modules/dealrooms/handlers_participants.go
+++ b/backend/internal/modules/dealrooms/handlers_participants.go
@@ -91,15 +91,22 @@ func (h Handlers) UpdateDealRoomParticipant(w http.ResponseWriter, r *http.Reque
 	httperr.WriteJSON(w, http.StatusOK, participant)
 }
 
-// issuedBody renders a freshly minted credential and delivers it if the
-// installation can send mail.
+// issuedBody renders a freshly minted credential and mails it if the
+// installation can send.
 //
-// Delivery is best-effort and never fails the write: the participant and the
+// Sending is best-effort and never fails the write: the participant and the
 // credential are recorded either way, so a relay outage leaves a seller with a
 // link they can pass on by hand rather than a half-admitted person and an error.
-// `delivered` says which happened, so the caller knows whether to send it.
+// `queued` says which happened, so the caller knows whether to send it.
+//
+// Queued, not delivered. All this knows is that the relay took the message; a
+// mailbox receiving it is a later and separate fact, and an address that
+// hard-bounces a second afterwards was queued all the same. recordSendOutcome
+// stamps that one attempt onto the invitation as sent_at or failed_at, which the
+// roster reads. Nothing revises it afterwards — the invitation carries a
+// delivered_at column that no writer in this tree sets.
 func (h Handlers) issuedBody(r *http.Request, issued IssuedInvitation) crmcontracts.DealRoomInvitationIssued {
-	delivered := false
+	queued := false
 	if h.canSendInvite() {
 		sendErr := h.sendInvite(r, issued)
 		if sendErr != nil {
@@ -109,7 +116,7 @@ func (h Handlers) issuedBody(r *http.Request, issued IssuedInvitation) crmcontra
 			slog.ErrorContext(r.Context(), "deal room invitation email failed",
 				"participant_id", issued.Participant.Id, "err", sendErr)
 		} else {
-			delivered = true
+			queued = true
 		}
 		// Recorded as well as reported, so the roster can answer "did it
 		// arrive?" tomorrow. Without this the delivery state a seller reads
@@ -120,7 +127,7 @@ func (h Handlers) issuedBody(r *http.Request, issued IssuedInvitation) crmcontra
 		Participant:         issued.Participant,
 		Credential:          issued.Credential,
 		CredentialExpiresAt: issued.ExpiresAt,
-		Delivered:           delivered,
+		Queued:              queued,
 	}
 }
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -243,7 +243,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistdestination_test.go` | H2 | Every source the worklist can emit has one screen it belongs on. |
 | `worklistreasonkinds_test.go` | H2 | Every reason a row gives is one the contract declares and a client can render. |
 
-## Reachability (16)
+## Reachability (17)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -257,6 +257,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `orgrenamerecheck_test.go` | H2 | A company's NAME is the axis on which two records of one company converge, so every rename has to ask whether it just created a duplicate. |
 | `personscrub_test.go` | H2 | Erasing a person and anonymizing one are the same act with one difference: the erased subject goes on a suppression list, and the anonymized subject may lawfully return. |
 | `rbacgate_test.go` | H2 | The store-entry-point admission rule as a fitness function: every exported method on a module's \*Store or \*Service — the seam both the HTTP handlers and the MCP tool surface call through — references the platform auth gate (object RBAC and/or the row-scope spellings), directly or through a same-package helper. |
+| `relaywiring_test.go` | H2 | Every option that wires the mail relay is wired by a role binary. |
 | `replayscope_test.go` | H2 | API-CC-8 as a fitness function: a replay is a read, so every operation the idempotency middleware can replay must either re-probe the row scope of the record its recorded body carries, or say in writing that the body carries no such record. |
 | `resetflushscope_test.go` | H2 | The reset's cache flush has two entry points on purpose, and the split is a security boundary rather than a style choice. |
 | `versionguard_test.go` | H2 | A version pin is only real if the pinned table's version actually moves. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10824,10 +10824,11 @@ export interface paths {
         put?: never;
         /**
          * Admit a named person to the room.
-         * @description HUMAN-ONLY. Records the person and mints one credential for them. Whether that
-         *     credential is delivered depends on the installation having outbound mail
-         *     configured; the participant and the invitation are recorded either way, so a
-         *     mail failure never leaves a half-admitted person.
+         * @description HUMAN-ONLY. Records the person and mints one credential for them. Whether a mail
+         *     relay took the credential is reported as `queued` — it is false when the
+         *     installation has no outbound mail configured and when the relay refused the
+         *     message. The participant and the invitation are recorded either way, so a mail
+         *     failure never leaves a half-admitted person.
          *
          *     One live seat per address: inviting an address that already holds one is
          *     rejected (409 `deal_room_participant_already_invited`). Re-inviting an address
@@ -29034,12 +29035,18 @@ export interface components {
             /** Format: date-time */
             credential_expires_at: string;
             /**
-             * @description Whether the invitation was handed to a mail relay. False when the
-             *     installation has no outbound mail configured — the participant and the
-             *     credential are still recorded, and the caller is expected to deliver the
-             *     link itself rather than being told the invitation failed.
+             * @description Whether a mail relay accepted the invitation for sending. False when the
+             *     installation has no outbound mail configured, or the relay refused it — the
+             *     participant and the credential are recorded either way, and the caller is
+             *     expected to pass the link on themselves rather than being told the
+             *     invitation failed.
+             *
+             *     Deliberately not `delivered`: a relay accepting a message is not a mailbox
+             *     receiving it, and an address that hard-bounces a second later was `queued`
+             *     all the same. The one attempt is stamped onto the invitation, which the
+             *     roster reports; nothing revises it afterwards.
              */
-            delivered: boolean;
+            queued: boolean;
         };
         DealRoomPreviewIssued: {
             /** @description The one-time `mdr_` credential. Shown once; the server keeps only its digest. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1079,12 +1079,12 @@ export const de = {
   "access.emailLabel": "E-Mail",
   "access.capabilityLegend": "Was darf die Person tun?",
   "access.inviteNote":
-    "Sie erhalten den Link zum Kopieren. Ist ein Mail-Relay konfiguriert, wird er zusätzlich versandt.",
+    "Sie erhalten den Link zum Kopieren. Ist ein Mail-Relay konfiguriert, versuchen wir zusätzlich, ihn zu versenden.",
   "access.issued.title": "Link für {name}",
   "access.issued.mailed":
     "An {email} gesendet. Sie können ihn unten auch kopieren.",
   "access.issued.notMailed":
-    "Es wurde keine Mail gesendet. Kopieren Sie den Link und senden Sie ihn selbst.",
+    "Der Link wurde nicht per Mail versendet. Kopieren Sie ihn und senden Sie ihn selbst.",
   "access.issued.linkLabel": "Der Link",
   "access.issued.copy": "Link kopieren",
   "access.issued.copied": "Kopiert",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1159,11 +1159,11 @@ export const en = {
   "access.emailLabel": "Email",
   "access.capabilityLegend": "What may they do?",
   "access.inviteNote":
-    "You will get the link to copy. If a mail relay is configured it is also sent to them.",
+    "You will get the link to copy. If a mail relay is configured we also try to send it to them.",
   "access.issued.title": "Link for {name}",
   "access.issued.mailed": "Sent to {email}. You can also copy it below.",
   "access.issued.notMailed":
-    "No mail was sent. Copy the link and send it yourself.",
+    "The link was not mailed. Copy it and send it yourself.",
   "access.issued.linkLabel": "Their link",
   "access.issued.copy": "Copy link",
   "access.issued.copied": "Copied",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1066,11 +1066,12 @@ export const vi = {
   "access.emailLabel": "Địa chỉ email",
   "access.capabilityLegend": "Họ được làm gì?",
   "access.inviteNote":
-    "Bạn sẽ nhận được liên kết để sao chép. Nếu đã cấu hình gửi thư, liên kết cũng được gửi cho họ.",
+    "Bạn sẽ nhận được liên kết để sao chép. Nếu đã cấu hình gửi thư, chúng tôi cũng thử gửi cho họ.",
   "access.issued.title": "Liên kết cho {name}",
   "access.issued.mailed":
     "Đã gửi tới {email}. Bạn cũng có thể sao chép bên dưới.",
-  "access.issued.notMailed": "Chưa gửi thư. Hãy sao chép liên kết và tự gửi.",
+  "access.issued.notMailed":
+    "Liên kết chưa được gửi qua thư. Hãy sao chép và tự gửi.",
   "access.issued.linkLabel": "Liên kết của họ",
   "access.issued.copy": "Sao chép liên kết",
   "access.issued.copied": "Đã sao chép",

--- a/frontend/src/screens/dealroomaccess.tsx
+++ b/frontend/src/screens/dealroomaccess.tsx
@@ -311,8 +311,8 @@ function IssuedLink({ issued }: Readonly<{ issued: Issued }>) {
   };
   return (
     <div className="access-issued">
-      <Callout tone={issued.delivered ? "success" : "info"}>
-        {issued.delivered
+      <Callout tone={issued.queued ? "success" : "info"}>
+        {issued.queued
           ? t("access.issued.mailed", { email: issued.participant.email })
           : t("access.issued.notMailed")}
       </Callout>

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -33,3 +33,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 98f26a4484760912e7cede9f57715a7be587b6c5 49728224fbaa221da787bacd7a391776d6fc85a4 ratified-worklist-move-carries-the-deal-cards-verbs
 6a7b29a268183069393c39b1931648a5894b6abe 91cc59b5c3855fed8bf8ba020d95894ed60822e4 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them
 0e10662bd2e43fb3018888323893dd1f3a44fc08 bb87bde2d4a8e3507be239b8d6af8783d0e3f870 ratified-the-installation-writes-through-the-durable-lane-a-confirm-link-is-queued-not-handed-to-a-relay
+7155d6a82570fa939eb5c52afb3a42d3d6071127 f49f227303664d0ddcbab0c55e339c5200998553 ratified-a-deal-room-invitation-is-queued-not-delivered


### PR DESCRIPTION
Two defects, found together because the second only surfaced once the first had a test.

## The field asserted something the server cannot know

`DealRoomInvitationIssued.delivered` only ever meant that a mail relay accepted the message. An address that hard-bounces a second later read as `delivered: true` all the same. That assertion is what stops a seller passing the link on by hand when the mail never lands, so it is renamed to `queued`, with a description saying what it does mean.

The confirm-details path settled this same distinction earlier and its contract says so in as many words. The deal room kept the old word.

## The invitation mailer was never wired in production

`compose.WithDealRoomInviteMail` had **no caller under `cmd/`**. `cmd/api` wired only `WithOperatorMail`, which reaches password reset and the controller lane but not the deal room handler set — so every invitation in every real installation came back unsent, while the startup banner printed `api operator mail enabled (password reset, invites)`.

An unwired mailer is the one kind of dead wiring that does not announce itself: the product records the participant, mints the credential, and reports exactly what an installation with no SMTP reports. `gates/relaywiring_test.go` now derives the mailer options from their **signature** — an option taking a `mailer.Mailer` and returning an `Option` — and fails when one has no role binary behind it, so a third joins the gate the day it is written.

## Nothing asserted the field at all before this

No test, backend or frontend, read it. Four now do, and the load-bearing one is the relay **refusal**: a field reporting the attempt rather than the outcome passes the accepted and no-relay cases and fails only that. Resend is asked directly rather than assumed — it renders through the same function today, but it is the obvious place to grow its own body, and it is the endpoint a seller reaches precisely when the first mail did not arrive.

## Copy

The three `access.issued.notMailed` strings said "no mail was sent". True while `false` meant only "no relay configured"; false once it also covers a relay that refused. `access.inviteNote` promised the link "is also sent" before anything had been attempted — it now says we try.

`buyerRoom` gains `queued`, asserted present rather than defaulted, rather than this suite growing a second copy of `openRoomWithABuyer`.

Breaking response-property rename, ratified in the contract allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deal room invitations never being sent in production: `compose.WithDealRoomInviteMail` had no caller under `cmd/`, so every invite returned unsent while the startup banner claimed invites were enabled. Renames the response field `delivered` to `queued` — a relay accepting a message is not a mailbox receiving it — and `queued: false` now also covers a relay that refused, not just a missing relay.

**Bug Fixes**
- Wires `WithDealRoomInviteMail` in `cmd/api` beside `WithOperatorMail`.
- Adds a gate (`relaywiring_test.go`) that fails when any mailer option has no role binary calling it.
- Frontend copy now says the link was not mailed rather than no mail was sent.

**Migration**
- `DealRoomInvitationIssued.delivered` is now `queued`; clients reading the old field must update. Ratified in the contract-breaking allowlist.

<sup>Written for commit ec40decaaa0fd620631b1e3b811e40ee49b7b4db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Deal Room invitations now report whether the message was accepted by the mail relay for sending, rather than implying mailbox delivery.
  - Invitation responses clearly indicate when no mail service is configured or when the relay refuses the message; credentials are still issued.
  - The access screen now shows “mailed” status only when the invitation is queued, with updated English, German, and Vietnamese wording.

- **Reliability**
  - Added coverage to verify invitation queue-status behavior and mail-relay configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->