### PR TITLE
A widened hit area joins the deviation page, because the button inside it is the control

### DIFF
--- a/docs/reference/sonarcloud-deviations.md
+++ b/docs/reference/sonarcloud-deviations.md
@@ -84,6 +84,16 @@ inside it declined to claim. Giving it a role and a tab stop, which is what the
 rule asks for, would announce a control that does not exist and put a stop in
 the tab order that leads nowhere.
 
+**A widened hit area is not a second control either (`S6848`).** The same
+reading, for the `<div className="arhit">` in `app/agentrail.tsx`. The control
+is the `<button>` inside it — that is what carries the accessible name and the
+expanded state — and the div exists so a pointer can also press the words and
+the chevron beside it. The keyboard already reaches the button, whose Enter and
+Space arrive at the div as the same click. A role here would announce a control
+that is not one and put a tab stop in front of the one that is. Two
+`biome-ignore` lines beside it say the same thing; this entry is the third
+reader being told.
+
 **The menus use a roving tabindex (`S6852`, two sites).** The rule wants the
 `role="menu"` container focusable. In both menus focus lives on the items —
 each `menuitem` carries `tabIndex={active ? 0 : -1}` — which is the WAI-ARIA


### PR DESCRIPTION
Completes the SonarCloud reliability pass. A fresh scan of `main`'s own tip (`7f6a7b708`, 09:26 — the first one today that was not skipped) reads:

| | before | now |
|---|---|---|
| Reliability open | 40 | **16** |
| — of which HIGH | 16 | **1** |
| Security open | 3 | **0** |

Fifteen of the sixteen are already answered on `docs/reference/sonarcloud-deviations.md`. The sixteenth, `typescript:S6848` on `app/agentrail.tsx`, was created **today** — it arrived with the AI-activity rail, after the sweep that cleared the rest — so this adds it.

It is the reading `inlinechoice.tsx` already has an entry for, one surface over. The control is the `<button>` inside the div: that is what carries the accessible name and the `aria-expanded` state. The div exists so a pointer can press the words and the chevron beside it, and the keyboard never needed it — the button's own Enter and Space arrive at the div as the same click. Giving the div a role would announce a control that is not one, and put a tab stop in front of the one that is.

Two `biome-ignore` lines beside the code say this already. The page says it for the reader who is looking at the dashboard rather than at the file.

## Where the list now stands

Every open reliability finding is either fixed or written down:

- **272 fixed** across https://github.com/margince/margince/pull/4662 (247 shell `[` → `[[`), https://github.com/margince/margince/pull/4729 (15 more that landed mid-sweep), https://github.com/margince/margince/pull/4734 (an empty `switch`, and `WithoutCancel` for a process-lifetime lane) and https://github.com/margince/margince/pull/4740 (five measured-quadratic regexes, a redundant `\s*`, two object-literal parameter defaults).
- **16 adjudicated**, each with what would break if the rule were applied: thirteen accessibility findings where `ListTable`'s explicit roles are load-bearing below 720px, three `tabIndex` stops that WCAG 2.1.1 requires, two menus using a roving tabindex, two hit areas whose control is the button inside them, one super-linear regex bounded by RFC 5322, and one `CancelFunc` the rule cannot follow into the closure its caller defers.

## Verification

Docs-only change. `docs/reference/sonarcloud-deviations.md` is already linked from `docs/README.md`, so the reachability gate is unaffected; the pre-commit gates ran green.