### PR TITLE
The sidebar files deals with the records and calls the person list Contacts

### DIFF
--- a/docs/explanation/frontend-architecture.md
+++ b/docs/explanation/frontend-architecture.md
@@ -266,7 +266,7 @@ The older primitives survive in two places, both deliberate:
   (`screens/onboarding-conversation/confirm-card.tsx`,
   `screens/onboarding-company-form.tsx`), the Company-context settings screen,
   and the record surfaces that show a single provenance line
-  (`people.tsx`, `leads.tsx`, `consent.tsx`, `history.tsx`).
+  (`contacts.tsx`, `leads.tsx`, `consent.tsx`, `history.tsx`).
   `StagedProposal`/`FieldDiff`/`ApprovalGate` are the composed forms of the same
   vocabulary.
 

--- a/docs/explanation/relationship-graph.md
+++ b/docs/explanation/relationship-graph.md
@@ -426,7 +426,7 @@ see [authorization.md](authorization.md) and [privacy-and-consent.md](privacy-an
 | The tables | `activity_participant` (`migrations/core/0157_*`), `graph_interaction_edge` (`0158_*`), `linkedin_connection` (`0159_*`), `linkedin_account` (`0160_*`) |
 | The REST contract | `backend/api/crm.yaml` (`getPersonNetwork`, `getDealCoverage`) |
 | The job contract (cadence, fan-out, batch sizes) | `backend/api/jobs.yaml` (`graph_edge_reconcile`, `participant_backfill`, `linkedin_rematch`) |
-| The two cards | `frontend/src/screens/network.tsx` (rendered from `people.tsx` and `deals.tsx`) |
+| The two cards | `frontend/src/screens/network.tsx` (rendered from `contacts.tsx` and `deals.tsx`) |
 
 ## Where to go next
 

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -242,18 +242,18 @@ function accountTrigger(page: Page) {
 
 // The canonical ten, in order: Brief alone, then records / work / intelligence.
 // Not upstream's set: Automations is not a destination here (it is set-and-forget
-// configuration on Settings → AI). One label differs from its route id on
-// purpose — `deals` presents as Pipeline — so this asserts what a person reads,
-// not what the router matches.
+// configuration on Settings → AI). These are the TRANSLATED words a person
+// reads rather than the route ids the router matches — `home` presents as
+// Briefing, and no row here may be satisfied by its slug.
 //
 // The count and the list are both spelled out on purpose. NAV_GROUPS in
 // src/app/nav.ts is the source of the rail; deriving this from it would assert
 // only that the rail renders itself, so a destination added there is meant to
 // fail here until somebody says what a person now reads and where.
 //
-// Heute LEADS the work group and is the only door to the work that waits on a
-// person: decisions to answer, tasks to finish and duplicates to merge are lanes
-// inside it rather than rows of their own.
+// Arbeitsliste LEADS the work group and is the only door to the work that waits
+// on a person: decisions to answer, tasks to finish and duplicates to merge are
+// lanes inside it rather than rows of their own.
 test("AC-shell-1: the rail renders the canonical 10 items in order", async ({
   page,
 }) => {
@@ -271,13 +271,13 @@ test("AC-shell-1: the rail renders the canonical 10 items in order", async ({
     );
   expect(labels).toEqual([
     "Briefing",
-    "Personen",
+    "Kontakte",
     "Firmen",
     "Leads",
-    "Filter & Ansichten",
+    "Deals",
     "Arbeitsliste",
-    "Pipeline",
     "Projekte",
+    "Filter & Ansichten",
     "Analytics",
     "Margince fragen",
   ]);
@@ -290,7 +290,7 @@ test("AC-shell-2: exactly one rail item is active and tracks the route", async (
   await expect(page.locator("nav.rail a.navitem.active")).toHaveCount(1);
   await expect(page.locator("nav.rail a.navitem.active")).toHaveAttribute(
     "aria-label",
-    "Pipeline",
+    "Deals",
   );
   await page.locator('nav.rail a[aria-label="Analytics"]').click();
   await expect(page.locator("nav.rail a.navitem.active")).toHaveAttribute(
@@ -309,7 +309,7 @@ test("AC-shell-1k: one h1 per railed page, and on a record it is the record's ow
   page,
 }) => {
   await page.goto("/#/contacts");
-  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Personen");
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Kontakte");
 
   await page.goto("/#/contacts/p-anna");
   const heading = page.getByRole("heading", { level: 1 });
@@ -318,7 +318,7 @@ test("AC-shell-1k: one h1 per railed page, and on a record it is the record's ow
   await expect(page.locator(".record-head h1")).toHaveText("Anna Weber");
   // The trail that leads back to the list stands in the top bar, where it is
   // true of the page rather than part of the document the reader is reading.
-  await expect(page.locator(".topbar .crumbs a").last()).toHaveText("Personen");
+  await expect(page.locator(".topbar .crumbs a").last()).toHaveText("Kontakte");
   await expect(page.locator('.topbar [aria-current="page"]')).toHaveText(
     "Anna Weber",
   );
@@ -346,10 +346,10 @@ test("AC-shell-3/4/5: ⌘K opens focused+empty, filters, Enter navigates", async
   await page.keyboard.press("ControlOrMeta+k");
   const input = page.getByRole("searchbox", { name: "Befehlspalette" });
   await expect(input).toBeFocused();
-  // "Deals" is the route id, not the label the rail shows (Pipeline) — typing the
-  // domain word still has to land on the screen, or a relabeled destination
-  // becomes unreachable for everyone who knows it by its old name.
-  await input.fill("Deals");
+  // "Pipeline" is the word this row used to print, kept as its alias — typing it
+  // still has to land on the screen, or a relabeled destination becomes
+  // unreachable for everyone who knows it by its old name.
+  await input.fill("Pipeline");
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/#\/deals$/);
 });
@@ -412,7 +412,7 @@ test("features/10 §7: the locale switch flips the chrome DE↔EN", async ({
   page,
 }) => {
   await page.goto("/#/brief");
-  await expect(page.locator('nav.rail a[aria-label="Personen"]')).toBeVisible();
+  await expect(page.locator('nav.rail a[aria-label="Kontakte"]')).toBeVisible();
   // The language is a preference of this person rather than a destination, so it
   // lives on Settings → Account; the account block at the sidebar foot carries
   // the three places it can take you and nothing that changes a setting. Three
@@ -2865,18 +2865,17 @@ test.describe("filters and views", () => {
       objects.getByRole("button", { name: "Geschäfte", pressed: true }),
     ).toBeVisible();
 
-    // "Personen": `filters.tab.contacts` is a different KEY from the nav's,
-    // which is why it was read as out of the People ruling's reach — but the
-    // key is not the word, and the catalog moved this one too. The tab says
+    // "Kontakte": `filters.tab.contacts` is a different KEY from the nav's, and
+    // a key is not a word — the catalog moved this one with it. The tab says
     // what every other surface says.
-    await objects.getByRole("button", { name: "Personen" }).click();
+    await objects.getByRole("button", { name: "Kontakte" }).click();
     await expect(page).toHaveURL(/#\/filters\/contacts$/);
 
     // Reloaded, not just navigated: the tab is where you ARE, so a shared link
     // and a refresh have to land on the same object.
     await page.reload();
     await expect(
-      objects.getByRole("button", { name: "Personen", pressed: true }),
+      objects.getByRole("button", { name: "Kontakte", pressed: true }),
     ).toBeVisible();
   });
 });

--- a/frontend/e2e/company-record.spec.ts
+++ b/frontend/e2e/company-record.spec.ts
@@ -89,7 +89,7 @@ test.describe("company record — the glance's page shape", () => {
 
   // The readings are the overview's, under the bar that chose it (DESIGN.md
   // §7): a tab without them moves nothing above itself, and a row of account
-  // readings over the People roster would be a header for a page it is not
+  // readings over the Contacts roster would be a header for a page it is not
   // describing.
   test("the readings row sits under the tab strip, on the overview alone", async ({
     page,
@@ -98,7 +98,7 @@ test.describe("company record — the glance's page shape", () => {
     expect(await topOf(page.locator(".co-tabs"))).toBeLessThan(
       await topOf(page.locator(STRIP)),
     );
-    await page.getByRole("button", { name: "Personen" }).click();
+    await page.getByRole("button", { name: "Kontakte" }).click();
     await expect(page.locator(STRIP)).toHaveCount(0);
   });
 
@@ -138,7 +138,7 @@ test.describe("company record — the glance's page shape", () => {
     expect(sizes.size).toBe(1);
   });
 
-  // Overview · History · People · Deals · Tasks · Finance · Documents · Profile,
+  // Overview · History · Contacts · Deals · Tasks · Finance · Documents · Profile,
   // plus Partner for an account that has a partner programme (companyTabsFor
   // in organizations.tsx gates it on relationship_types, not on a fixed
   // count) — so the expectation follows the fixture's own data rather than
@@ -203,7 +203,7 @@ test.describe("company record — the glance's page shape", () => {
 
   // The needs list asks for a move on the account, so it belongs to the tab a
   // reader opens to be told what to do — not to every tab. Someone who has
-  // gone to People or Documents has already chosen what to read.
+  // gone to Contacts or Documents has already chosen what to read.
   test("the needs list leads the overview, and is not drawn on the other tabs", async ({
     page,
   }) => {
@@ -211,7 +211,7 @@ test.describe("company record — the glance's page shape", () => {
     const needs = page.getByRole("heading", { name: "Was dich jetzt braucht" });
     await expect(needs).toBeVisible();
 
-    await page.getByRole("button", { name: "Personen" }).click();
+    await page.getByRole("button", { name: "Kontakte" }).click();
     await expect(needs).toHaveCount(0);
   });
 

--- a/frontend/src/App.stories.tsx
+++ b/frontend/src/App.stories.tsx
@@ -12,9 +12,11 @@ type Story = StoryObj;
 
 function installAppStub() {
   globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
-  // Land on a screen with a known-good empty-state story rather than Brief,
-  // whose dashboard queries need richer fixtures than this shell smoke test cares about.
-  globalThis.location.hash = "#/products";
+  // Land on a list screen whose empty state needs nothing but the page-shaped
+  // fallback below, rather than the Brief, whose dashboard queries want richer
+  // fixtures than this shell smoke test cares about. A screen the router does
+  // not know would draw Not found under the name of this story.
+  globalThis.location.hash = "#/contacts";
   globalThis.fetch = (async (input: Request | string | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.endsWith("/v1/me")) {
@@ -23,6 +25,21 @@ function installAppStub() {
           user: { email: "ada@acme.test" },
           roles: ["admin"],
           teams: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    // The shell's brand block draws the installation's OWN company, read off
+    // GET /company. The list-shaped fallback below answers that read with a
+    // page envelope, which is not a 404 — so the app reads the installation as
+    // described, the block renders it, and the name it draws with is missing.
+    // A story of the authenticated app is a story of a described installation,
+    // so it says which company that is.
+    if (url.endsWith("/v1/company")) {
+      return new Response(
+        JSON.stringify({
+          organization_id: "018f3a1b-0000-7000-8000-0000000000a1",
+          display_name: "Acme Freight",
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -276,7 +276,7 @@ describe("locale switch", () => {
       </QueryClientProvider>,
     );
     // English default: once the session resolves, the rail carries English labels
-    expect(await screen.findByRole("link", { name: "People" })).toBeTruthy();
+    expect(await screen.findByRole("link", { name: "Contacts" })).toBeTruthy();
     // The language is a preference of this person rather than a destination, so
     // it lives on Settings → Account and reaching it is a navigation. Which is
     // also what makes this an app-level claim: the choice is made on one route
@@ -296,9 +296,9 @@ describe("locale switch", () => {
 
     window.location.hash = "#/brief";
     await waitFor(() =>
-      expect(screen.getByRole("link", { name: "Personen" })).toBeTruthy(),
+      expect(screen.getByRole("link", { name: "Kontakte" })).toBeTruthy(),
     );
-    expect(screen.queryByRole("link", { name: "People" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Contacts" })).toBeNull();
   });
 });
 
@@ -860,7 +860,7 @@ describe("onboarding gate", () => {
     // into the hash on arrival, so contacts settles at `#/contacts?sort=…` a
     // moment after the shell renders; an equality against the bare address
     // holds only while that write is still pending. Where the gate left the
-    // reader is this test's claim — how the list is sorted is people.tsx's.
+    // reader is this test's claim — how the list is sorted is contacts.tsx's.
     expect(routeHash(parseHash(window.location.hash))).toBe("#/contacts");
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -192,7 +192,7 @@ const PartnersScreen = lazy(
 );
 const ContactsScreen = lazy(
   routed(() =>
-    import("./screens/people").then((m) => ({ default: m.ContactsScreen })),
+    import("./screens/contacts").then((m) => ({ default: m.ContactsScreen })),
   ),
 );
 const PersonPageV2 = lazy(

--- a/frontend/src/api/if-match-coverage.test.ts
+++ b/frontend/src/api/if-match-coverage.test.ts
@@ -45,9 +45,9 @@ const UNPINNED_WRITES: readonly string[] = [
   // version through six screens is its own change with its own proof; what
   // matters here is that the class is now visible and the count can only fall.
   "screens/companyheader.tsx DELETE /organizations/{id}",
+  "screens/contacts.tsx DELETE /people/{id}",
   "screens/dealbulk.tsx DELETE /deals/{id}",
   "screens/deals.tsx DELETE /deals/{id}",
-  "screens/people.tsx DELETE /people/{id}",
   "screens/personrail.tsx DELETE /relationships/{id}",
   "screens/relationships.tsx DELETE /relationships/{id}",
   "screens/contractform.tsx PATCH /contracts/{id}",

--- a/frontend/src/app/nav.test.ts
+++ b/frontend/src/app/nav.test.ts
@@ -73,24 +73,26 @@ describe("the rail and a composed unit", () => {
 // A screen the product ships and this list does not name is reachable only by
 // typing its hash, which is the same to a reader as a screen nobody built.
 describe("the filter builder's address", () => {
-  const recordRows = () => {
+  const workRows = () => {
     const [primary] = railTrail({ screen: "filters" });
-    const records = primary.groups.find(
-      (group) => group.headingKey === "nav.group.records",
+    const work = primary.groups.find(
+      (group) => group.headingKey === "nav.group.work",
     );
-    return records?.items ?? [];
+    return work?.items ?? [];
   };
 
-  // With the record types it slices, not under Intelligence: a filter here
-  // selects records, and nothing on the screen aggregates them.
-  it("stands among the record destinations", () => {
-    expect(recordRows().map((item) => item.id)).toContain("filters");
+  // With the work, not among the record types it slices: writing a filter is
+  // an authoring surface somebody sits down at — it produces a dynamic list, a
+  // saved view or an export — rather than a kind of record the workspace keeps.
+  // Nothing on the screen aggregates either, so it is not Intelligence.
+  it("stands among the work destinations", () => {
+    expect(workRows().map((item) => item.id)).toContain("filters");
   });
 
   // The screen's own title, so the product has one name for this surface. A
   // `nav.*` key of its own would be a fourth spelling to keep in step.
   it("reuses the label the screen already prints", () => {
-    expect(recordRows().find((item) => item.id === "filters")?.labelKey).toBe(
+    expect(workRows().find((item) => item.id === "filters")?.labelKey).toBe(
       "filters.title",
     );
   });

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -56,12 +56,16 @@ export {
 // rows of their own, because three sidebar entries for one question ("what
 // needs me?") read as three separate piles.
 //
-// `screen` is the route id and never changes with a label: `deals` presents as
-// Pipeline, because it routes to the pipeline surface.
+// `screen` is the route id and never changes with a label. The id is the
+// address a reader bookmarked and the word every test and every `#/` link
+// spells, so a row is free to be renamed without moving anything.
 export type NavItem = {
   screen: Screen;
   labelKey: MessageKey;
   icon: LucideIcon;
+  // Words this destination is also known by, for the palette: a reader who
+  // learned one of them must still find the row by typing it.
+  aliases?: readonly string[];
 };
 
 export type NavGroup = {
@@ -74,21 +78,29 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   {
     headingKey: "nav.group.records",
     items: [
-      { screen: "contacts", labelKey: "nav.contacts", icon: Users },
+      {
+        screen: "contacts",
+        labelKey: "nav.contacts",
+        icon: Users,
+        aliases: ["people"],
+      },
       { screen: "companies", labelKey: "nav.companies", icon: Building2 },
       { screen: "leads", labelKey: "nav.leads", icon: UserPlus },
-      // Slicing the records above it: a filter authored here becomes a dynamic
-      // list, a saved view or an export, and each of those selects from the
-      // record types this group names. So it belongs with them rather than under
-      // Intelligence — nothing on this screen aggregates, it answers "which
-      // records", which is the question the rows above it each answer with one
-      // fixed set. It reuses the screen's own title rather than a `nav.*` label,
-      // because a surface named twice gets renamed once.
+      // A deal is one of the records this group names: it is created, owned,
+      // listed, opened and reported on exactly as the three rows above it are,
+      // and the board this route draws is a VIEW of that record type rather
+      // than a fourth kind of thing. So it closes the group it belongs to.
       //
-      // A funnel is the glyph every CRM draws a sales pipeline with, and
-      // Pipeline is already a row on this list; a filtered list says what this
-      // surface produces and cannot be read as a second door to the board.
-      { screen: "filters", labelKey: "filters.title", icon: ListFilter },
+      // The board, not a bullseye: this route opens a column per stage with the
+      // deals standing in them, and `Target` drew a goal rather than a board. A
+      // reader scanning five glyphs on a phone bar with no labels under them
+      // has only the shape to go on.
+      {
+        screen: "deals",
+        labelKey: "nav.deals",
+        icon: Kanban,
+        aliases: ["pipeline"],
+      },
     ],
   },
   {
@@ -99,15 +111,22 @@ export const NAV_GROUPS: readonly NavGroup[] = [
       // lanes inside it. It leads the group because it is what a reader opens
       // when the question is "what needs me?".
       { screen: "worklist", labelKey: "nav.today", icon: Sun },
-      // The board, not a bullseye: this route opens a column per stage with
-      // the deals standing in them, and `Target` drew a goal rather than a
-      // board. A reader scanning five glyphs on a phone bar with no labels
-      // under them has only the shape to go on.
-      { screen: "deals", labelKey: "nav.deals", icon: Kanban },
       // The body of work a deal is about. It starts during the deal and
-      // outlives close-won, so it sits beside the pipeline rather than under
-      // it: a project in delivery has no deal column to stand in.
+      // outlives close-won, so what it belongs to is the work rather than the
+      // record of the sale: a project in delivery has no deal column to stand
+      // in.
       { screen: "projects", labelKey: "nav.projects", icon: Briefcase },
+      // Closes the group as the AUTHORING surface over lists: a filter written
+      // here becomes a dynamic list, a saved view or an export, and writing one
+      // is work somebody does rather than a record they keep. Nothing on this
+      // screen aggregates, so it is not Intelligence either. It reuses the
+      // screen's own title rather than a `nav.*` label, because a surface named
+      // twice gets renamed once.
+      //
+      // A funnel is the glyph every CRM draws a sales pipeline with, and the
+      // deals board is a row on this list; a filtered list says what this
+      // surface produces and cannot be read as a second door to that board.
+      { screen: "filters", labelKey: "filters.title", icon: ListFilter },
     ],
   },
   {

--- a/frontend/src/app/palette.stories.tsx
+++ b/frontend/src/app/palette.stories.tsx
@@ -33,8 +33,8 @@ const COMMANDS: Command[] = [
   },
   {
     id: "screen:deals",
-    label: "Pipeline",
-    keywords: ["deals"],
+    label: "Deals",
+    keywords: ["pipeline"],
     type: "screen",
     route: { screen: "deals" },
   },

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -59,8 +59,8 @@ const render = (ui: ReactNode) => {
 const commands: Command[] = [
   {
     id: "screen:deals",
-    label: "Pipeline",
-    keywords: ["deals"],
+    label: "Deals",
+    keywords: ["pipeline"],
     type: "screen",
     route: { screen: "deals" },
   },
@@ -109,19 +109,20 @@ describe("CommandPalette (AC-shell-3/4/5/6)", () => {
   it("shows the default command list with type tags, focuses the input", () => {
     render(<CommandPalette open onClose={() => {}} commands={commands} />);
     expect(document.activeElement).toBe(screen.getByRole("searchbox"));
-    expect(screen.getByText("Pipeline")).toBeTruthy();
+    expect(screen.getByText("Deals")).toBeTruthy();
     expect(screen.getByText("Record")).toBeTruthy(); // type tag rendered
   });
 
-  // A nav label is a presentation choice; the domain word outlives it. Typing
-  // "deals" has to reach Pipeline, or renaming a destination quietly removes it
-  // from the palette for everyone who knows it by its older name.
+  // A nav label is a presentation choice; the word a reader already learned
+  // outlives it. Typing "pipeline" has to reach the Deals row, or relabelling a
+  // destination quietly removes it from the palette for everyone who knows it by
+  // its older name.
   it("matches a keyword the row does not display, without showing it", async () => {
     render(<CommandPalette open onClose={() => {}} commands={commands} />);
-    await userEvent.type(screen.getByRole("searchbox"), "deals");
+    await userEvent.type(screen.getByRole("searchbox"), "pipeline");
     const rows = screen.getAllByRole("button");
-    expect(rows[0].textContent).toContain("Pipeline");
-    expect(rows[0].textContent).not.toContain("deals");
+    expect(rows[0].textContent).toContain("Deals");
+    expect(rows[0].textContent).not.toContain("pipeline");
     await userEvent.keyboard("{Enter}");
     expect(window.location.hash).toBe("#/deals");
   });
@@ -186,7 +187,7 @@ describe("CommandPalette (AC-shell-3/4/5/6)", () => {
     const user = userEvent.setup();
     // Where the arrow keys put a reader — and where Escape used to do nothing,
     // because the handler belonged to the input this focus has left.
-    const row = screen.getByRole("button", { name: /Pipeline/ });
+    const row = screen.getByRole("button", { name: /Deals/ });
     row.focus();
     expect(document.activeElement).toBe(row);
     await user.keyboard("{Escape}");
@@ -283,11 +284,11 @@ describe("CommandPalette (AC-shell-3/4/5/6)", () => {
     // failed RECORD search leaves the command list working, not that it leaves
     // the previous query matching something it never matched.
     await userEvent.clear(screen.getByRole("searchbox"));
-    await userEvent.type(screen.getByRole("searchbox"), "Pipeline");
+    await userEvent.type(screen.getByRole("searchbox"), "Deals");
     expect(
       screen
         .getAllByRole("button")
-        .some((row) => row.textContent?.includes("Pipeline")),
+        .some((row) => row.textContent?.includes("Deals")),
     ).toBe(true);
   });
 
@@ -492,6 +493,26 @@ describe("useBuiltinCommands", () => {
       expect(screen.queryByText("Company profile")).toBeNull();
     });
   });
+
+  // The two destinations that carry a word the rail no longer prints. A reader
+  // who learned "People" or "Pipeline" types it, and the row it named must be
+  // what answers — against the REAL rail rows, because the alias lives on the
+  // nav item and a fixture command list would only prove the fixture.
+  it.each([
+    ["people", "Contacts", "#/contacts"],
+    ["pipeline", "Deals", "#/deals"],
+  ])(
+    "reaches %s's destination by the name it used to print",
+    async (typed, label, hash) => {
+      const user = userEvent.setup();
+      renderProbe();
+      await user.type(screen.getByRole("searchbox"), typed);
+      const rows = screen.getAllByRole("button");
+      expect(rows[0].textContent).toContain(label);
+      await user.keyboard("{Enter}");
+      expect(window.location.hash).toBe(hash);
+    },
+  );
 
   it("reaches the filter builder by the name the screen prints", async () => {
     const user = userEvent.setup();

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -99,9 +99,10 @@ export function useBuiltinCommands(): Command[] {
       id: `screen:${item.screen}`,
       label: t(item.labelKey),
       // The route id is the screen's stable English name and doubles as its
-      // alias, so a relabeled destination stays findable under both words in
-      // both locales without a hand-kept synonym list.
-      keywords: [item.screen],
+      // alias, so a destination stays findable under it in every locale. The
+      // row's own aliases (app/nav.ts) ride alongside it, which is what keeps a
+      // word a reader already learned pointing at the row that carries it.
+      keywords: [item.screen, ...(item.aliases ?? [])],
       type: "screen",
       route: { screen: item.screen },
     }));

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -88,17 +88,19 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
-// The route id never changes with a label: `deals` presents as Pipeline, which
-// names the board this row opens.
+// The words a reader sees, in the order the sidebar shows them: the four record
+// types first, then the surfaces that work over them, then what reads them back.
+// A label is not a route id — `ai` presents as Ask Margince, and no assertion
+// here may be satisfied by a route id that happens to match.
 const CANONICAL_ORDER = [
   "Brief",
-  "People",
+  "Contacts",
   "Companies",
   "Leads",
-  "Filters & views",
+  "Deals",
   "Worklist",
-  "Pipeline",
   "Projects",
+  "Filters & views",
   "Analytics",
   "Ask Margince",
 ];
@@ -207,7 +209,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
       .getAllByRole("link")
       .filter((link) => link.getAttribute("aria-current") === "page");
     expect(active).toHaveLength(1);
-    expect(active[0].getAttribute("aria-label")).toBe("Pipeline");
+    expect(active[0].getAttribute("aria-label")).toBe("Deals");
   });
 
   // Settings is not a destination and no longer has a door here, so a route the
@@ -253,17 +255,17 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
   it("keeps the accessible name when collapsed and shows a dismissible tooltip on focus", async () => {
     const user = userEvent.setup();
     render(<WorkspaceRail route={{ screen: "brief" }} collapsed />);
-    const pipeline = screen.getByRole("link", { name: "Pipeline" });
+    const deals = screen.getByRole("link", { name: "Deals" });
     expect(screen.queryByRole("tooltip")).toBeNull();
 
-    pipeline.focus();
+    deals.focus();
     const tip = await screen.findByRole("tooltip");
-    expect(tip.textContent).toBe("Pipeline");
+    expect(tip.textContent).toBe("Deals");
 
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("tooltip")).toBeNull();
     // Escape dismisses the tooltip without moving focus (WCAG 1.4.13).
-    expect(document.activeElement).toBe(pipeline);
+    expect(document.activeElement).toBe(deals);
   });
 
   // WCAG 1.4.13 also requires the tooltip be HOVERABLE: reaching for it must not
@@ -279,12 +281,12 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
   it("nests the collapsed tooltip inside its own row so hovering it cannot dismiss it", async () => {
     const user = userEvent.setup();
     render(<WorkspaceRail route={{ screen: "brief" }} collapsed />);
-    const pipeline = screen.getByRole("link", { name: "Pipeline" });
+    const deals = screen.getByRole("link", { name: "Deals" });
 
-    await user.hover(pipeline);
+    await user.hover(deals);
     const tip = await screen.findByRole("tooltip");
-    expect(pipeline.contains(tip)).toBe(true);
-    expect(tip.parentElement).toBe(pipeline);
+    expect(deals.contains(tip)).toBe(true);
+    expect(tip.parentElement).toBe(deals);
   });
 
   // On a phone the four bar tabs are the only rows rendered, so a route living
@@ -382,7 +384,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
           ? "agent"
           : "more",
     );
-    expect(cells).toEqual(["Brief", "People", "agent", "Pipeline", "more"]);
+    expect(cells).toEqual(["Brief", "Contacts", "agent", "Deals", "more"]);
   });
 
   // The Worklist is the destination the bar gave up for that cell. Off the bar
@@ -468,7 +470,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
     );
     // The destinations are GONE, not pushed below a second list: 56px cannot
     // carry two levels and 224px carrying both is a list of twenty places to go.
-    expect(screen.queryByRole("link", { name: "Pipeline" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Deals" })).toBeNull();
     expect(levelLabels()).toEqual(["Account", "Privacy & retention"]);
     expect(
       screen

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -503,7 +503,7 @@ describe("Shell", () => {
     expect(claims).toHaveLength(1);
     expect(claims[0].textContent).toBe("Anna Weber");
     const row = container.querySelector("nav.rail a.navitem.active");
-    expect(row?.textContent).toBe("People");
+    expect(row?.textContent).toBe("Contacts");
     expect(row?.getAttribute("aria-current")).toBe("true");
   });
 
@@ -518,12 +518,12 @@ describe("Shell", () => {
     );
     const claims = [...container.querySelectorAll('[aria-current="page"]')];
     expect(claims.map((claim) => claim.textContent)).toEqual([
-      "People",
-      "People",
+      "Contacts",
+      "Contacts",
     ]);
     expect(
       container.querySelector("nav.rail a.navitem.active")?.textContent,
-    ).toBe("People");
+    ).toBe("Contacts");
   });
 
   // The a11y hole this restructure closes: the page's name used to be a span in
@@ -630,7 +630,9 @@ describe("Shell", () => {
     // topbar.test.tsx; that the shell still shows one here is the shell's.
     const trail = screen.getByRole("navigation", { name: "Breadcrumb" });
     expect(
-      within(trail).getByRole("link", { name: "People" }).getAttribute("href"),
+      within(trail)
+        .getByRole("link", { name: "Contacts" })
+        .getAttribute("href"),
     ).toBe("#/contacts");
   });
 

--- a/frontend/src/app/topbar.test.tsx
+++ b/frontend/src/app/topbar.test.tsx
@@ -201,7 +201,7 @@ describe("Top bar sidebar toggle", () => {
 describe("Top bar trail", () => {
   it("names the page once on a list route, with nothing to lead back to", () => {
     renderTopBar({ screen: "deals" }, { onToggle: ignoreToggle });
-    expect(stopTexts()).toEqual(["Pipeline"]);
+    expect(stopTexts()).toEqual(["Deals"]);
     // A one-stop trail is the page and nothing else: no link, and no separator
     // leading a stop that is not there.
     expect(within(trail()).queryByRole("link")).toBeNull();
@@ -221,8 +221,8 @@ describe("Top bar trail", () => {
       />,
     );
 
-    expect(stopTexts()).toEqual(["People", "Anna Weber"]);
-    const back = within(trail()).getByRole("link", { name: "People" });
+    expect(stopTexts()).toEqual(["Contacts", "Anna Weber"]);
+    const back = within(trail()).getByRole("link", { name: "Contacts" });
     expect(back.getAttribute("href")).toBe("#/contacts");
     // The record itself is the page: not a link, and the one current claim.
     const stops = within(trail()).getAllByRole("listitem");
@@ -245,7 +245,7 @@ describe("Top bar trail", () => {
       { screen: "contacts", id: "p-anna" },
       { onToggle: ignoreToggle },
     );
-    expect(stopTexts()).toEqual(["People", "p-anna"]);
+    expect(stopTexts()).toEqual(["Contacts", "p-anna"]);
   });
 
   it("leads a section entry back to the section it belongs to", () => {

--- a/frontend/src/design-system/atoms.stories.tsx
+++ b/frontend/src/design-system/atoms.stories.tsx
@@ -874,18 +874,18 @@ function ToolbarDemo() {
         value={tab}
         onChange={setTab}
         labels={TAB_LABELS}
-        counts={{ people: 6, deals: 0 }}
+        counts={{ contacts: 6, deals: 0 }}
         label="Record section"
       />
     </div>
   );
 }
 
-const TABS = ["overview", "people", "deals"] as const;
+const TABS = ["overview", "contacts", "deals"] as const;
 type Tab = (typeof TABS)[number];
 const TAB_LABELS: Record<Tab, string> = {
   overview: "360",
-  people: "People",
+  contacts: "Contacts",
   deals: "Deals",
 };
 

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -551,7 +551,7 @@ describe("TimelineText on a mail row", () => {
   it("keeps the correspondents' addresses above the message", () => {
     // The preamble says who wrote to whom, which is part of reading a mail on
     // a record. It is the row TITLE that must not lead with it — see the
-    // timelineTitle rule in people.tsx — not the message body.
+    // timelineTitle rule in contacts.tsx — not the message body.
     render(<RecordView name="Acme" zone="UTC" timeline={mailRow(SIGNED)} />);
     const body = document.querySelector(".tl-text-clamp")?.textContent ?? "";
     expect(body).toContain("anna@kunde.de");

--- a/frontend/src/design-system/recordtabs.stories.tsx
+++ b/frontend/src/design-system/recordtabs.stories.tsx
@@ -27,11 +27,11 @@ const meta: Meta<typeof RecordTabs> = {
 export default meta;
 type Story = StoryObj<typeof RecordTabs>;
 
-type Body = "overview" | "people" | "activity" | "brief";
+type Body = "overview" | "contacts" | "activity" | "brief";
 
 const LABELS: Record<Body, string> = {
   overview: "Overview",
-  people: "People",
+  contacts: "Contacts",
   activity: "Activity",
   brief: "Brief",
 };
@@ -42,11 +42,11 @@ function Live(props: Readonly<{ initial: Body }>) {
   return (
     <RecordTabs
       label="Record"
-      options={["overview", "people", "activity", "brief"]}
+      options={["overview", "contacts", "activity", "brief"]}
       value={value}
       onChange={setValue}
       labels={LABELS}
-      counts={{ people: 10, activity: 27 }}
+      counts={{ contacts: 10, activity: 27 }}
       marks={{ brief: true }}
     />
   );
@@ -73,11 +73,11 @@ export const WithTrailingControl: Story = {
   render: () => (
     <RecordTabs
       label="Record"
-      options={["overview", "people", "activity", "brief"]}
+      options={["overview", "contacts", "activity", "brief"]}
       value="overview"
       onChange={() => undefined}
       labels={LABELS}
-      counts={{ people: 10, activity: 27 }}
+      counts={{ contacts: 10, activity: 27 }}
       trailing={
         <Button small aria-pressed={false}>
           Details

--- a/frontend/src/design-system/recordtabs.test.tsx
+++ b/frontend/src/design-system/recordtabs.test.tsx
@@ -9,14 +9,17 @@ import { RecordTabs } from "./recordtabs";
 
 afterEach(cleanup);
 
-type Body = "overview" | "people";
-const LABELS: Record<Body, string> = { overview: "Overview", people: "People" };
+type Body = "overview" | "contacts";
+const LABELS: Record<Body, string> = {
+  overview: "Overview",
+  contacts: "Contacts",
+};
 
 function strip(trailing?: React.ReactNode) {
   return render(
     <LocaleProvider initial="en">
       <RecordTabs
-        options={["overview", "people"]}
+        options={["overview", "contacts"]}
         value="overview"
         onChange={() => undefined}
         labels={LABELS}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -161,10 +161,10 @@ export const de = {
   "autonomy.confirm": "erst bestätigen",
 
   "nav.brief": "Briefing",
-  "nav.contacts": "Personen",
+  "nav.contacts": "Kontakte",
   "nav.companies": "Firmen",
   "nav.leads": "Leads",
-  "nav.deals": "Pipeline",
+  "nav.deals": "Deals",
   "nav.today": "Arbeitsliste",
   "nav.analytics": "Analytics",
   "nav.ai": "Margince fragen",
@@ -221,7 +221,7 @@ export const de = {
     "Personen, Firmen, Deals, Projekte, Produkte, Aktivitäten, Leads durchsuchen…",
   "search.prompt": "Gib ein, wonach du suchst.",
   "search.empty": "Keine Treffer für „{q}“.",
-  "search.group.person": "Personen",
+  "search.group.person": "Kontakte",
   "search.group.organization": "Organisationen",
   "search.group.deal": "Deals",
   "search.group.project": "Projekte",
@@ -601,7 +601,7 @@ export const de = {
   "table.none": "Noch keine {unit}.",
   "table.actions": "Aktionen",
   "table.rangeLoaded": "{first}–{last} von bisher {count} geladenen {unit}",
-  "unit.contacts": "Personen",
+  "unit.contacts": "Kontakte",
   "unit.companies": "Firmen",
   "unit.deals": "Deals",
   "unit.leads": "Leads",
@@ -819,7 +819,7 @@ export const de = {
   "org.name": "Firma",
   "org.description": "Was sie tun",
   "org.website": "Website",
-  "org.contactCount": "Personen",
+  "org.contactCount": "Kontakte",
   "org.openDealCount": "Offene Deals",
   // Nur dort angeboten, wo es noch kein Partnerprogramm gibt: der Tab mit dem
   // Formular erscheint erst, wenn eines besteht — so entsteht das erste.
@@ -942,7 +942,7 @@ export const de = {
   "timeline.filters.to": "Bis",
   "timeline.filters.searchOmitsLimited":
     "Unterhaltungen, deren Inhalt Sie nicht öffnen dürfen, bleiben bei einer Suche außen vor.",
-  "tab.people": "Personen",
+  "tab.contacts": "Kontakte",
   "tab.deals": "Deals",
   "tab.tasks": "Aufgaben",
   "tab.timeline": "Verlauf",
@@ -1988,7 +1988,7 @@ export const de = {
   "tagResult.gone":
     "Dieses Tag existiert nicht mehr. Es wurde möglicherweise zusammengeführt.",
   "tagResult.totalVisible": "{count} sichtbare Zuordnungen",
-  "tagResult.people": "Personen",
+  "tagResult.contacts": "Kontakte",
   "tagResult.companies": "Unternehmen",
   "tagResult.deals": "Deals",
   "tagResult.viewAll": "Alle {count} {kind} anzeigen",
@@ -2269,7 +2269,7 @@ export const de = {
   "lead.trigger.humanQualify": "Manuell qualifiziert",
   "lead.evidenceNote": "Beleg-Notiz (optional)",
   "lead.segregation":
-    "Leads bleiben von Personen getrennt. Ein Lead wird erst zur Person, wenn du ihn qualifizierst.",
+    "Leads bleiben von Kontakten getrennt. Ein Lead wird erst zum Kontakt, wenn du ihn qualifizierst.",
   "lead.segregationDismiss": "Verstanden",
   "list.emptyMine": "Dir sind keine {unit} zugewiesen.",
   "list.showAll": "Alle anzeigen",
@@ -2805,7 +2805,7 @@ export const de = {
 
   "brief.digestFor": "Digest vom {date}",
   "brief.digestSynced": "E-Mails synchronisiert",
-  "brief.digestPeople": "Personen angelegt",
+  "brief.digestContacts": "Kontakte angelegt",
   "brief.digestOrgs": "Firmen angelegt",
   "brief.digestDedupe": "Dubletten zu prüfen",
   "brief.digestClassify":
@@ -3979,7 +3979,7 @@ export const de = {
   "import.objectLabel": "Was die Zeilen sind",
   "import.object.lead": "Interessenten",
   "import.object.organization": "Firmen",
-  "import.object.person": "Personen",
+  "import.object.person": "Kontakte",
   "import.objectHint.lead":
     "Eine unbearbeitete Liste landet als Leads zur Qualifizierung, bevor sie jemand als Personen behandelt.",
   "import.objectHint.organization":
@@ -4689,7 +4689,7 @@ export const de = {
   "backfill.progressLabel": "Import-Fortschritt",
   "backfill.countScanned": "Nachrichten durchsucht",
   "backfill.statEmails": "E-Mails erfasst",
-  "backfill.statPeople": "Personen",
+  "backfill.statContacts": "Kontakte",
   "backfill.statCompanies": "Firmen zu prüfen",
   "backfill.errorNote":
     "Er versucht es selbstständig erneut; alles bisher Erfasste bleibt erhalten.",
@@ -5255,7 +5255,7 @@ export const de = {
   "ob.conv.triage.looksSolid": "Sieht belegt aus · {count}",
   "ob.conv.triage.companyWebsite": "Website",
   "ob.conv.triage.sourceCount": "{count} Quelle",
-  "ob.conv.triage.peopleLabel": "Personen",
+  "ob.conv.triage.contactsLabel": "Kontakte",
   "ob.conv.triage.peopleCount": "{count} gefunden",
   "ob.conv.triage.peopleEmpty": "Keine Personen auf deiner Website gefunden.",
   "ob.conv.triage.factsLabel": "Fakten",
@@ -6829,7 +6829,7 @@ export const de = {
   "users.access.read": "lesen",
   "users.access.write": "schreiben",
   "users.access.delete": "löschen",
-  "users.access.object.person": "Personen",
+  "users.access.object.person": "Kontakte",
   "users.access.object.organization": "Firmen",
   "users.access.object.lead": "Leads",
   "users.access.object.deal": "Deals",
@@ -8296,7 +8296,7 @@ export const de = {
   "filters.subtitle":
     "Filter erstellen, Treffer beobachten und als Ansicht speichern.",
   "filters.objectLabel": "Welche Datens\u00e4tze gefiltert werden",
-  "filters.tab.contacts": "Personen",
+  "filters.tab.contacts": "Kontakte",
   "filters.tab.companies": "Firmen",
   "filters.tab.deals": "Gesch\u00e4fte",
   "filters.builderTitle": "Filter",
@@ -8831,7 +8831,7 @@ export const de = {
     "Eine Auskunft, die diese Person zu bekommen hat",
   "worklist.untitled.sync_health":
     "Die CRM-Synchronisierung braucht Aufmerksamkeit",
-  "worklist.sync.class.contacts": "Personen",
+  "worklist.sync.class.contacts": "Kontakte",
   "worklist.sync.class.companies": "Firmen",
   "worklist.sync.class.deals": "Deals",
   "worklist.sync.class.leads": "Interessenten",
@@ -8963,7 +8963,7 @@ export const de = {
   "ob.digest.section.customer": "An wen sie verkaufen",
   "ob.digest.section.sales": "Wie sie schreiben",
   "ob.digest.facts": "Belege",
-  "ob.digest.people": "Personen",
+  "ob.digest.contacts": "Kontakte",
   "ob.digest.sources": "Quellen",
   "ob.digest.blank": "noch nicht geschrieben",
   "ob.digest.notWritten": "nicht eingetragen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -163,10 +163,10 @@ export const en = {
   "autonomy.confirm": "confirm-first",
 
   "nav.brief": "Brief",
-  "nav.contacts": "People",
+  "nav.contacts": "Contacts",
   "nav.companies": "Companies",
   "nav.leads": "Leads",
-  "nav.deals": "Pipeline",
+  "nav.deals": "Deals",
   "nav.today": "Worklist",
   // The decision lane, one at a time: how far through the reader is, and the
   // cleared plate the whole surface is built to reach.
@@ -242,7 +242,7 @@ export const en = {
     "Search people, companies, deals, projects, products, activities, leads…",
   "search.prompt": "Type what you are looking for.",
   "search.empty": "No matches for “{q}”.",
-  "search.group.person": "People",
+  "search.group.person": "Contacts",
   "search.group.organization": "Organizations",
   "search.group.deal": "Deals",
   "search.group.project": "Projects",
@@ -655,7 +655,7 @@ export const en = {
   "table.none": "No {unit} yet.",
   "table.actions": "Actions",
   "table.rangeLoaded": "{first}–{last} of {count} {unit} loaded so far",
-  "unit.contacts": "people",
+  "unit.contacts": "contacts",
   "unit.companies": "companies",
   "unit.deals": "deals",
   "unit.leads": "leads",
@@ -875,7 +875,7 @@ export const en = {
   "org.name": "Company",
   "org.description": "What they do",
   "org.website": "Website",
-  "org.contactCount": "People",
+  "org.contactCount": "Contacts",
   "org.openDealCount": "Open deals",
   // Offered only where there is no partner programme yet: the tab that holds
   // the form appears once one exists, so this is how the first one is made.
@@ -1013,7 +1013,7 @@ export const en = {
   "timeline.filters.to": "To",
   "timeline.filters.searchOmitsLimited":
     "Conversations whose content you may not open are left out of a search.",
-  "tab.people": "People",
+  "tab.contacts": "Contacts",
   "tab.deals": "Deals",
   "tab.tasks": "Tasks",
   "tab.timeline": "History",
@@ -2070,7 +2070,7 @@ export const en = {
   "tagResult.gone":
     "This tag no longer exists. It may have been merged into another.",
   "tagResult.totalVisible": "{count} visible assignments",
-  "tagResult.people": "People",
+  "tagResult.contacts": "Contacts",
   "tagResult.companies": "Companies",
   "tagResult.deals": "Deals",
   "tagResult.viewAll": "View all {count} {kind}",
@@ -2342,7 +2342,7 @@ export const en = {
   "lead.trigger.humanQualify": "Human qualified",
   "lead.evidenceNote": "Evidence note (optional)",
   "lead.segregation":
-    "Leads are kept apart from People. A lead becomes a person only when you qualify it.",
+    "Leads are kept apart from Contacts. A lead becomes a contact only when you qualify it.",
   "lead.segregationDismiss": "Got it",
   "list.emptyMine": "You own no {unit}.",
   "list.showAll": "Show all",
@@ -2896,7 +2896,7 @@ export const en = {
 
   "brief.digestFor": "digest for {date}",
   "brief.digestSynced": "Emails synced",
-  "brief.digestPeople": "People created",
+  "brief.digestContacts": "Contacts created",
   "brief.digestOrgs": "Companies created",
   "brief.digestDedupe": "Duplicates to review",
   "brief.digestClassify":
@@ -4081,7 +4081,7 @@ export const en = {
   "import.objectLabel": "What the rows are",
   "import.object.lead": "Prospects",
   "import.object.organization": "Companies",
-  "import.object.person": "People",
+  "import.object.person": "Contacts",
   "import.objectHint.lead":
     "An unworked list lands as leads for a human to qualify before anyone treats them as people.",
   "import.objectHint.organization":
@@ -4787,7 +4787,7 @@ export const en = {
   "backfill.progressLabel": "Import progress",
   "backfill.countScanned": "Messages scanned",
   "backfill.statEmails": "Emails captured",
-  "backfill.statPeople": "People",
+  "backfill.statContacts": "Contacts",
   // The count is domains this run raised a company question for, not
   // companies created — a domain becomes one only if its site says so.
   "backfill.statCompanies": "Companies to check",
@@ -5367,7 +5367,7 @@ export const en = {
   "ob.conv.triage.looksSolid": "Looks solid · {count}",
   "ob.conv.triage.companyWebsite": "Website",
   "ob.conv.triage.sourceCount": "{count} src",
-  "ob.conv.triage.peopleLabel": "People",
+  "ob.conv.triage.contactsLabel": "Contacts",
   "ob.conv.triage.peopleCount": "{count} found",
   "ob.conv.triage.peopleEmpty": "No people found on your site.",
   "ob.conv.triage.factsLabel": "Facts",
@@ -6945,7 +6945,7 @@ export const en = {
   "users.access.read": "read",
   "users.access.write": "write",
   "users.access.delete": "delete",
-  "users.access.object.person": "People",
+  "users.access.object.person": "Contacts",
   "users.access.object.organization": "Companies",
   "users.access.object.lead": "Leads",
   "users.access.object.deal": "Deals",
@@ -8421,7 +8421,7 @@ export const en = {
   "filters.subtitle":
     "Build a filter, watch what it selects, and save it as a view.",
   "filters.objectLabel": "Which records to filter",
-  "filters.tab.contacts": "People",
+  "filters.tab.contacts": "Contacts",
   "filters.tab.companies": "Companies",
   "filters.tab.deals": "Deals",
   "filters.builderTitle": "Filter",
@@ -8964,7 +8964,7 @@ export const en = {
   "worklist.untitled.dsr": "An open privacy request",
   "worklist.untitled.notice_case": "A disclosure this person is owed",
   "worklist.untitled.sync_health": "The CRM sync needs attention",
-  "worklist.sync.class.contacts": "people",
+  "worklist.sync.class.contacts": "contacts",
   "worklist.sync.class.companies": "companies",
   "worklist.sync.class.deals": "deals",
   "worklist.sync.class.leads": "prospects",
@@ -9099,7 +9099,7 @@ export const en = {
   "ob.digest.section.customer": "Who they sell to",
   "ob.digest.section.sales": "How they write",
   "ob.digest.facts": "Proof",
-  "ob.digest.people": "People",
+  "ob.digest.contacts": "Contacts",
   "ob.digest.sources": "References",
   "ob.digest.blank": "not written yet",
   "ob.digest.notWritten": "not written down",

--- a/frontend/src/i18n/record-noun.test.ts
+++ b/frontend/src/i18n/record-noun.test.ts
@@ -3,140 +3,59 @@ import { de } from "./de";
 import { en } from "./en";
 import { vi } from "./vi";
 
-// The person record is called a person — "People" in the nav, "person" in a
-// sentence — and never a contact. The older word survives only where it names
-// the ACT of reaching someone ("never contacted", "last contact yesterday"),
-// the details one reaches them by ("contact data", "contact email"), or a
-// buyer's counterpart in a room ("your contact"). Those keys are waived here by
-// name, so a new value that says "contact" for the record fails, and a waiver
-// whose value stops carrying the word fails too: a stale waiver would let the
-// next author reintroduce the record noun under a key nobody looks at.
+// The person record is NAMED a contact — "Contacts" on the nav row, and the
+// same noun on every tab, group heading, import object, counter and unit that
+// offers the record TYPE as a thing to pick, count, file under or navigate to.
+// Those keys are listed below, and this is the only place the set is written
+// down.
+//
+// It fails in both directions: a listed value that stops carrying the noun, and
+// a listed value that carries the retired one. Half a rename is what puts two
+// names for one record on one screen, and each half looks correct on its own.
+//
+// The list is hand-kept because nothing in a catalog marks which key names a
+// record type — a value is a string, and "Contacts" as a tab and "contacts" as
+// a table unit are indistinguishable to a sweep. A label that names this type
+// and is missing here is a label free to drift to a second word, so add it.
+//
+// This gate has no opinion about "person" or "people" elsewhere. Those are
+// still the right words for a human being, and the catalogs say them in
+// hundreds of sentences about PEOPLE rather than about the record type — "the
+// people on this message", "Their key people", "3 people match". Only the
+// type's own name is held here.
 type Catalog = Record<string, string>;
+
+const RECORD_TYPE_NAME_KEYS = [
+  "nav.contacts",
+  "search.group.person",
+  "filters.tab.contacts",
+  "tab.contacts",
+  "tagResult.contacts",
+  "import.object.person",
+  "org.contactCount",
+  "users.access.object.person",
+  "backfill.statContacts",
+  "ob.digest.contacts",
+  "ob.conv.triage.contactsLabel",
+  "brief.digestContacts",
+  "unit.contacts",
+  "worklist.sync.class.contacts",
+  // The one sentence that names the type rather than labelling it: it tells a
+  // reader what a lead turns into, so it drifts the way a label does and costs
+  // more when it does.
+  "lead.segregation",
+];
 
 const RECORD_NOUN: Record<string, RegExp> = {
   en: /\bcontacts?\b/i,
   de: /kontakt/i,
-  vi: /liên hệ|\bcontacts?\b/i,
+  vi: /liên hệ/i,
 };
 
-// A company website's Contact page, as the deep read and the onboarding
-// digest classify what they cited: a kind of page, not a record.
-const WEBSITE_PAGE_KIND_KEYS = [
-  "deepread.kindContact",
-  "ob.digest.pageKind.contact",
-];
-
-// Shared across the locales: the act of reaching someone, and the details one
-// reaches them by. A locale adds the keys where only its own wording says the
-// word — German says "Kontaktstand" where English says "Engagement".
-const ACT_OR_DETAIL_KEYS_SHARED = [
-  "co.routeIn.band.strong",
-  "co.routeIn.band.some",
-  "co.routeIn.band.faint",
-  "co.routeIn.band.unknown",
-  "co.factField.contact_email",
-  "deal.strip.momentum.detail",
-  "passport.scope.enrich",
-  "connectors.signatureEnrich.label",
-  "captureSettings.signatureEnrich.label",
-  "network.empty",
-  "network.neverSpoken",
-  "network.bucket.none",
-  "license.holder.contact",
-  "person.intro.evidenceLastContact",
-  "person.intro.stripWhoMix",
-  "person.intro.whenToday",
-  "person.intro.whenYesterday",
-  "person.intro.whenDays",
-  "person.intro.whenNever",
-  "person.band.none",
-  "person.research.notConnected",
-  "provider.title",
-  "provider.sub",
-  "provider.profile.title",
-  ...WEBSITE_PAGE_KIND_KEYS,
-];
-
-// The buyer room: "your contact" is the steward on the seller's side, a
-// counterpart rather than a record.
-const BUYER_COUNTERPART_KEYS = [
-  "buyer.deadAskContact",
-  "buyer.expiredBody",
-  "buyer.contact",
-  "buyer.stewardUnknown",
-  "buyer.docs.downloadFailed",
-];
-
-const ACT_OR_DETAIL_KEYS: Record<string, readonly string[]> = {
-  en: [
-    ...ACT_OR_DETAIL_KEYS_SHARED,
-    ...BUYER_COUNTERPART_KEYS,
-    // What a phone exports is called contacts by the phone.
-    "vcardImport.whichFile",
-    "coverage.quiet",
-    // "as a sponsor, a contact, or whoever else": a role on the delivery.
-    "personProjects.empty",
-  ],
-  de: [
-    ...ACT_OR_DETAIL_KEYS_SHARED,
-    "partner.stage.contacted",
-    "co.strip.lastTouch",
-    "co.strip.engagement.never_contacted",
-    "co.health.means.relationship",
-    "co.rail.people.inTouch",
-    // LinkedIn calls a connection a Kontakt in German, and these describe
-    // the import of LinkedIn's own file.
-    "linkedinImport.title",
-    "linkedinImport.connectedNote",
-    "linkedinImport.notConnectedNote",
-    "linkedinImport.importLabel",
-    "linkedinImport.noMatchesYet",
-    "linkedinImport.imported",
-    "ob.conv.linkedin.cardBody",
-    "ob.conv.linkedin.importLater",
-    "co.people.engagement",
-    "co.people.filter.status",
-    "co.people.filter.statusAll",
-    "co.people.band.untried",
-    "co.people.band.showUntried",
-    "lead.statusContacted",
-    "lead.status.contacted",
-    "lead.ladder.new",
-    "brief.readings.leads",
-    "vcardImport.whichFile",
-    "acctCoverage.noneButPartial",
-    "compose.why.requestedFollowup",
-    "confirm.marketing.title",
-    "coverage.quiet",
-    "person.thin.logFirst",
-    "person.intro.evidenceOneSided_one",
-    "person.intro.evidenceOneSided_other",
-    "person.network.twoWay",
-    "person.network.oneSided",
-    "person.rail.nobodyYet",
-    "person.rail.exchanges",
-    "person.meeting.what_changed",
-    "person.meeting.arc",
-    "deal.strip.lastTouch",
-  ],
-  vi: [
-    ...ACT_OR_DETAIL_KEYS_SHARED,
-    ...BUYER_COUNTERPART_KEYS,
-    "partner.stage.contacted",
-    "co.strip.noInboundEver",
-    "co.strip.engagement.never_contacted",
-    "signal.kind.reengagement",
-    "co.rail.people.inTouch",
-    "co.people.engagement",
-    "co.people.filter.status",
-    "lead.source.inbound",
-    "lead.statusContacted",
-    "lead.status.contacted",
-    "lead.ladder.new",
-    "compose.why.requestedFollowup",
-    "person.intro.fallbackNameDropHelp",
-    "person.intro.answerNameDropHelp",
-  ],
+const RETIRED_NOUN: Record<string, RegExp> = {
+  en: /\bpeople\b|\bpersons?\b/i,
+  de: /\bpersonen?\b/i,
+  vi: /\bngười\b/i,
 };
 
 const CATALOGS: Record<string, Catalog> = { en, de, vi };
@@ -148,25 +67,22 @@ function visibleWords(value: string): string {
 }
 
 describe.each(Object.keys(CATALOGS))(
-  "%s names the record a person",
+  "%s names the record a contact",
   (locale) => {
     const catalog = CATALOGS[locale];
-    const pattern = RECORD_NOUN[locale];
-    const waived = new Set(ACT_OR_DETAIL_KEYS[locale]);
+    const noun = RECORD_NOUN[locale];
+    const retired = RETIRED_NOUN[locale];
 
-    it("says contact only where the key is waived as the act or the details", () => {
-      const offenders = Object.entries(catalog)
-        .filter(
-          ([key, value]) =>
-            !waived.has(key) && pattern.test(visibleWords(value)),
-        )
-        .map(([key, value]) => `${key}: ${value}`);
-      expect(offenders).toEqual([]);
+    it("every key that names the record type carries the noun", () => {
+      const missing = RECORD_TYPE_NAME_KEYS.filter(
+        (key) => !(key in catalog) || !noun.test(visibleWords(catalog[key])),
+      );
+      expect(missing).toEqual([]);
     });
 
-    it("keeps every waiver pointing at a value that still says contact", () => {
-      const stale = [...waived].filter(
-        (key) => !(key in catalog) || !pattern.test(visibleWords(catalog[key])),
+    it("no key that names the record type carries the retired noun", () => {
+      const stale = RECORD_TYPE_NAME_KEYS.filter(
+        (key) => key in catalog && retired.test(visibleWords(catalog[key])),
       );
       expect(stale).toEqual([]);
     });

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -167,10 +167,10 @@ export const vi = {
   "autonomy.confirm": "xác nhận trước",
 
   "nav.brief": "Bản tóm tắt",
-  "nav.contacts": "Người",
+  "nav.contacts": "Liên hệ",
   "nav.companies": "Công ty",
   "nav.leads": "Lead",
-  "nav.deals": "Pipeline",
+  "nav.deals": "Deals",
   "nav.today": "Danh sách việc",
   "nav.analytics": "Analytics",
   "nav.ai": "Hỏi Margince",
@@ -227,7 +227,7 @@ export const vi = {
     "Tìm người, công ty, deal, dự án, sản phẩm, hoạt động, lead…",
   "search.prompt": "Nhập nội dung bạn muốn tìm.",
   "search.empty": "Không có kết quả cho “{q}”.",
-  "search.group.person": "Người",
+  "search.group.person": "Liên hệ",
   "search.group.organization": "Tổ chức",
   "search.group.deal": "Deal",
   "search.group.project": "Dự án",
@@ -594,7 +594,7 @@ export const vi = {
   "table.none": "Chưa có {unit} nào.",
   "table.actions": "Thao tác",
   "table.rangeLoaded": "{first}–{last} trong {count} {unit} đã tải",
-  "unit.contacts": "người",
+  "unit.contacts": "liên hệ",
   "unit.companies": "công ty",
   "unit.deals": "thương vụ",
   "unit.leads": "khách hàng tiềm năng",
@@ -806,7 +806,7 @@ export const vi = {
   "org.name": "Công ty",
   "org.description": "Họ làm gì",
   "org.website": "Trang web",
-  "org.contactCount": "Người",
+  "org.contactCount": "Liên hệ",
   "org.openDealCount": "Deal đang mở",
   // Offered only where there is no partner programme yet: the tab that holds
   // the form appears once one exists, so this is how the first one is made.
@@ -929,7 +929,7 @@ export const vi = {
   "timeline.filters.to": "Đến",
   "timeline.filters.searchOmitsLimited":
     "Khi tìm kiếm, những cuộc trò chuyện bạn không được mở nội dung sẽ không xuất hiện.",
-  "tab.people": "Người",
+  "tab.contacts": "Liên hệ",
   "tab.deals": "Deals",
   "tab.tasks": "Công việc",
   "tab.timeline": "Lịch sử",
@@ -1974,7 +1974,7 @@ export const vi = {
   "tagResult.gone":
     "Tag này không còn tồn tại. Có thể nó đã được gộp vào tag khác.",
   "tagResult.totalVisible": "{count} gán hiển thị",
-  "tagResult.people": "Người",
+  "tagResult.contacts": "Liên hệ",
   "tagResult.companies": "Công ty",
   "tagResult.deals": "Deal",
   "tagResult.viewAll": "Xem tất cả {count} {kind}",
@@ -2253,7 +2253,7 @@ export const vi = {
   "lead.trigger.humanQualify": "Người xác nhận đủ điều kiện",
   "lead.evidenceNote": "Ghi chú bằng chứng (không bắt buộc)",
   "lead.segregation":
-    "Khách hàng tiềm năng được giữ tách biệt với Người. Chỉ trở thành người trong CRM khi bạn xác nhận đủ điều kiện.",
+    "Khách hàng tiềm năng được giữ tách biệt với Liên hệ. Chỉ trở thành liên hệ trong CRM khi bạn xác nhận đủ điều kiện.",
   "lead.segregationDismiss": "Đã hiểu",
   "list.emptyMine": "Bạn không có {unit} nào được giao.",
   "list.showAll": "Hiện tất cả",
@@ -2777,7 +2777,7 @@ export const vi = {
 
   "brief.digestFor": "tổng hợp ngày {date}",
   "brief.digestSynced": "Email đã đồng bộ",
-  "brief.digestPeople": "Người đã tạo",
+  "brief.digestContacts": "Liên hệ đã tạo",
   "brief.digestOrgs": "Công ty đã tạo",
   "brief.digestDedupe": "Trùng lặp cần rà",
   "brief.digestClassify":
@@ -3929,7 +3929,7 @@ export const vi = {
   "import.objectLabel": "Các dòng là gì",
   "import.object.lead": "Khách hàng tiềm năng",
   "import.object.organization": "Công ty",
-  "import.object.person": "Người",
+  "import.object.person": "Liên hệ",
   "import.objectHint.lead":
     "Danh sách chưa xử lý vào dạng lead để người thẩm định trước khi được xem là người trong CRM.",
   "import.objectHint.organization":
@@ -4630,7 +4630,7 @@ export const vi = {
   "backfill.progressLabel": "Tiến độ nhập",
   "backfill.countScanned": "Số thư đã quét",
   "backfill.statEmails": "Email đã thu thập",
-  "backfill.statPeople": "Người",
+  "backfill.statContacts": "Liên hệ",
   // The count is domains this run raised a company question for, not
   // companies created — a domain becomes one only if its site says so.
   "backfill.statCompanies": "Công ty cần kiểm tra",
@@ -5194,7 +5194,7 @@ export const vi = {
   "ob.conv.triage.looksSolid": "Trông ổn · {count}",
   "ob.conv.triage.companyWebsite": "Website",
   "ob.conv.triage.sourceCount": "{count} nguồn",
-  "ob.conv.triage.peopleLabel": "Người",
+  "ob.conv.triage.contactsLabel": "Liên hệ",
   "ob.conv.triage.peopleCount": "tìm được {count}",
   "ob.conv.triage.peopleEmpty":
     "Không tìm thấy người nào trên website của bạn.",
@@ -6759,7 +6759,7 @@ export const vi = {
   "users.access.read": "đọc",
   "users.access.write": "ghi",
   "users.access.delete": "xóa",
-  "users.access.object.person": "Người",
+  "users.access.object.person": "Liên hệ",
   "users.access.object.organization": "Công ty",
   "users.access.object.lead": "Lead",
   "users.access.object.deal": "Deal",
@@ -8192,7 +8192,7 @@ export const vi = {
   "filters.subtitle":
     "T\u1ea1o b\u1ed9 l\u1ecdc, xem n\u00f3 ch\u1ecdn nh\u1eefng g\u00ec, r\u1ed3i l\u01b0u th\u00e0nh ch\u1ee7 \u0111\u1ec1.",
   "filters.objectLabel": "L\u1ecdc lo\u1ea1i b\u1ea3n ghi n\u00e0o",
-  "filters.tab.contacts": "Ng\u01b0\u1eddi",
+  "filters.tab.contacts": "Liên hệ",
   "filters.tab.companies": "C\u00f4ng ty",
   "filters.tab.deals": "Th\u01b0\u01a1ng v\u1ee5",
   "filters.builderTitle": "B\u1ed9 l\u1ecdc",
@@ -8725,7 +8725,7 @@ export const vi = {
   "worklist.untitled.dsr": "Một yêu cầu quyền riêng tư",
   "worklist.untitled.notice_case": "Một thông báo cần gửi cho người này",
   "worklist.untitled.sync_health": "Đồng bộ CRM cần chú ý",
-  "worklist.sync.class.contacts": "người",
+  "worklist.sync.class.contacts": "liên hệ",
   "worklist.sync.class.companies": "công ty",
   "worklist.sync.class.deals": "giao dịch",
   "worklist.sync.class.leads": "khách hàng tiềm năng",
@@ -8845,7 +8845,7 @@ export const vi = {
   "ob.digest.section.customer": "Họ bán cho ai",
   "ob.digest.section.sales": "Cách họ viết",
   "ob.digest.facts": "Bằng chứng",
-  "ob.digest.people": "Con người",
+  "ob.digest.contacts": "Liên hệ",
   "ob.digest.sources": "Nguồn tham khảo",
   "ob.digest.blank": "chưa ghi",
   "ob.digest.notWritten": "chưa được ghi",

--- a/frontend/src/screens/backfill.test.tsx
+++ b/frontend/src/screens/backfill.test.tsx
@@ -243,7 +243,7 @@ describe("the connect-time backfill payoff", () => {
     expect(screen.getByText("47")).toBeTruthy();
     expect(screen.getByText("12")).toBeTruthy();
     expect(screen.getByText("Emails captured")).toBeTruthy();
-    expect(screen.getByText("People")).toBeTruthy();
+    expect(screen.getByText("Contacts")).toBeTruthy();
     // "to check", not created: the count is domains this run raised a company
     // question for, and a domain becomes a company only if its site says so.
     expect(screen.getByText("Companies to check")).toBeTruthy();

--- a/frontend/src/screens/backfill.tsx
+++ b/frontend/src/screens/backfill.tsx
@@ -334,7 +334,7 @@ const CAPTURE_STATS: {
   icon: typeof Mail;
 }[] = [
   { key: "captured", label: "backfill.statEmails", icon: Mail },
-  { key: "people_created", label: "backfill.statPeople", icon: Users },
+  { key: "people_created", label: "backfill.statContacts", icon: Users },
   {
     key: "organizations_created",
     label: "backfill.statCompanies",

--- a/frontend/src/screens/brief.rail.test.tsx
+++ b/frontend/src/screens/brief.rail.test.tsx
@@ -205,7 +205,7 @@ describe("BriefScreen — the context rail", () => {
     // pending state announces now that a wait says what it is waiting for, so
     // finding it proves the panel exists rather than that the digest arrived.
     await screen.findByText("Emails synced");
-    expect(screen.getByText("People created")).toBeTruthy();
+    expect(screen.getByText("Contacts created")).toBeTruthy();
     expect(screen.getByText("Companies created")).toBeTruthy();
     expect(
       screen.getByText(

--- a/frontend/src/screens/brief.rail.tsx
+++ b/frontend/src/screens/brief.rail.tsx
@@ -206,7 +206,7 @@ export function OvernightPanel() {
                 and more besides, not fewer. The messages-synced count above
                 has no list surface at all and keeps no door. */}
             <DigestCount
-              label={t("brief.digestPeople")}
+              label={t("brief.digestContacts")}
               value={capture.people_created ?? 0}
               onOpen={() =>
                 navigate(

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -148,7 +148,7 @@ function stub(
       if (pathname.endsWith("/360")) {
         return jsonResponse(three60, status);
       }
-      // The People tab's list, served from the SAME people section the 360
+      // The Contacts tab's list, served from the SAME people section the 360
       // fixture carries: a test that seeds a contact sees it on the tab
       // without seeding it twice in two shapes that could disagree.
       if (pathname.endsWith("/contacts")) {
@@ -1204,10 +1204,10 @@ describe("company view — Partner is not a permanent tab", () => {
     renderCompany();
     await screen.findByRole("complementary", { name: "Context" });
 
-    // 360, People and History belong to every account. Partner is a form
+    // 360, Contacts and History belong to every account. Partner is a form
     // about a commercial arrangement almost none of them have.
     expect(screen.getByRole("button", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^People/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Contacts/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: "History" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Partner" })).toBeNull();
   });
@@ -1807,7 +1807,7 @@ describe("company view — where the record came from", () => {
 });
 
 describe("company view — the account's own tabs", () => {
-  it("keeps the rail summary beside the People tab", async () => {
+  it("keeps the rail summary beside the Contacts tab", async () => {
     stub(
       view({
         people: {
@@ -1840,7 +1840,7 @@ describe("company view — the account's own tabs", () => {
     renderCompany();
     await screen.findByRole("complementary", { name: "Context" });
 
-    await userEvent.click(screen.getByRole("button", { name: /^People/ }));
+    await userEvent.click(screen.getByRole("button", { name: /^Contacts/ }));
     // TWICE, deliberately: the tab is the roster in full and the rail's
     // capped summary stands beside it as the reader's anchor across tabs —
     // both checked independently, so the test still fails if either goes
@@ -1857,7 +1857,7 @@ describe("company view — the account's own tabs", () => {
 
     // An account with no partner programme still gets all four: Partner is
     // the only conditional tab.
-    for (const name of ["Overview", /^People/, "History", "Documents"]) {
+    for (const name of ["Overview", /^Contacts/, "History", "Documents"]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
     }
     expect(screen.queryByRole("button", { name: "Partner" })).toBeNull();

--- a/frontend/src/screens/companypeople/contacts.stories.tsx
+++ b/frontend/src/screens/companypeople/contacts.stories.tsx
@@ -84,7 +84,7 @@ function stub(rows: OrganizationContact[]) {
 }
 
 const meta = {
-  title: "Records/Company 360/People/Contact list",
+  title: "Records/Company 360/Contacts/Contact list",
   component: CompanyPeopleList,
   parameters: { layout: "padded" },
 } satisfies Meta<typeof CompanyPeopleList>;

--- a/frontend/src/screens/companypeople/introrequest.stories.tsx
+++ b/frontend/src/screens/companypeople/introrequest.stories.tsx
@@ -17,7 +17,7 @@ import { IntroRequestModal } from "./introrequest";
 // their time in, which is why the draft is editable rather than read-only.
 
 const meta = {
-  title: "Records/Company 360/People/Intro request",
+  title: "Records/Company 360/Contacts/Intro request",
   component: IntroRequestModal,
   parameters: { layout: "padded" },
 } satisfies Meta<typeof IntroRequestModal>;

--- a/frontend/src/screens/companypeople/summary.stories.tsx
+++ b/frontend/src/screens/companypeople/summary.stories.tsx
@@ -45,7 +45,7 @@ function stub(body: Coverage) {
 }
 
 const meta = {
-  title: "Records/Company 360/People/Coverage band",
+  title: "Records/Company 360/Contacts/Coverage band",
   component: CoverageBand,
   parameters: { layout: "padded" },
 } satisfies Meta<typeof CoverageBand>;

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -360,7 +360,7 @@ describe("ConsentSection", () => {
     });
   });
 
-  // Preserves people.test.tsx's former "shows Grant for a non-granted purpose"
+  // Preserves contacts.test.tsx's former "shows Grant for a non-granted purpose"
   // coverage: a plain (non-DOI) grant must send no token key either, and this
   // exercises the ternary badge's `granted` branch for what the fixture's p1
   // otherwise never reaches (it starts already granted).

--- a/frontend/src/screens/contacts.stories.tsx
+++ b/frontend/src/screens/contacts.stories.tsx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { components } from "../api/schema";
-import { ContactsScreen, PersonScreen } from "./people";
+import { ContactsScreen, PersonScreen } from "./contacts";
 import {
   installFetchStub,
   jsonResponse,
@@ -14,11 +14,11 @@ import {
 type Person = components["schemas"]["Person"];
 
 // ContactsScreen (list) and PersonScreen (360 Overview) both read through
-// the api client on mount — fixtures mirror people.test.tsx's `anna` +
+// the api client on mount — fixtures mirror contacts.test.tsx's `anna` +
 // dormant-strength default (the Overview tab fires the strength GET
 // unconditionally).
 const meta: Meta = {
-  title: "Records/People",
+  title: "Records/Contacts",
   parameters: { layout: "padded" },
 };
 export default meta;
@@ -154,7 +154,7 @@ export const ContactsListMorePages: Story = {
 };
 
 // A row whose archived_at is set: the warn badge next to the name
-// (people.tsx's name column) renders off the row's own field, independent
+// (contacts.tsx's name column) renders off the row's own field, independent
 // of the includeArchived toggle's checked state. The checkbox itself starts
 // unchecked every render (useListQuery seeds includeArchived: false with no
 // prop to override it) and only flips on click, so this story shows the

--- a/frontend/src/screens/contacts.test.tsx
+++ b/frontend/src/screens/contacts.test.tsx
@@ -17,7 +17,7 @@ import { meFixture } from "../app/mefixture";
 import { activityTimeline } from "../design-system/activitytimeline";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
-import { ContactsScreen, PersonScreen } from "./people";
+import { ContactsScreen, PersonScreen } from "./contacts";
 
 // B-EP09.10a acceptance: per-row provenance chips, row→360 navigation, and
 // the honest error state. Lead-specific acceptance (score thresholds,

--- a/frontend/src/screens/contacts.tsx
+++ b/frontend/src/screens/contacts.tsx
@@ -905,7 +905,7 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
             rail={view ? <IdentityRail view={view} /> : undefined}
             aside={<PersonAside view={view} overlay={overlay} />}
           >
-            <div style={{ marginBottom: 16 }}>
+            <div style={{ marginBottom: "var(--space-4)" }}>
               <SegmentedControl
                 options={PERSON_TABS}
                 value={tab}

--- a/frontend/src/screens/create.stories.tsx
+++ b/frontend/src/screens/create.stories.tsx
@@ -31,11 +31,11 @@ export default meta;
 type Story = StoryObj;
 
 // A mix of text + select + a repeatable "emails" field — the contact create
-// form's actual shape (people.tsx's contactCreateFields, trimmed to the
+// form's actual shape (contacts.tsx's contactCreateFields, trimmed to the
 // fields that show every control kind in one screen). Option labels are
 // display-ready strings, not MessageKeys — fieldControl (create.tsx) renders
 // option.label verbatim, so a real screen resolves any translated option
-// text (e.g. people.tsx's email/phone "Type" options) via useT() before
+// text (e.g. contacts.tsx's email/phone "Type" options) via useT() before
 // building its CreateField array; this story's LocaleProvider is pinned to
 // "en", so the English strings stand in for that already-resolved text.
 const contactFields: CreateField[] = [

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
+import { ContactsScreen } from "./contacts";
 import {
   type CreateField,
   CreateRecordModal,
@@ -21,7 +22,6 @@ import {
   visibleFields,
 } from "./create";
 import { DealsScreen } from "./deals";
-import { ContactsScreen } from "./people";
 
 // Create flows (the "you can actually add a record" acceptance): the list
 // screens open a create modal, the POST body carries the server's shape

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -38,7 +38,7 @@ beforeEach(() => {
 // contact graph — the ≥60/40–59/<40 score thresholds, eligibility-gated
 // promote, and a lead row navigating to the LEAD detail (never the person
 // screen). Below that: the same P-14/15/16/1 shared-block wiring as contacts
-// (people.test.tsx) and companies (organizations.test.tsx) — search/sort/
+// (contacts.test.tsx) and companies (organizations.test.tsx) — search/sort/
 // pagination + a status filter, the rich create modal (full_name/email/
 // linkedin_url/company_name), the lead-360 If-Match edit
 // (Promote + badges preserved), and the duplicate_email dedupe link.
@@ -159,8 +159,8 @@ describe("promote eligibility gate", () => {
 describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
   it("names the owner on each row, the way the people and company lists do", async () => {
     // The column this replaced rendered "typed by a person" for every
-    // human-captured row — the bug #1577 fixed on People and Companies while
-    // this list kept its own copy of the column. Same column, same test.
+    // human-captured row. The Contacts and Companies lists were corrected
+    // while this one kept its own copy of the column: same column, same test.
     vi.stubGlobal(
       "fetch",
       vi.fn(async (request: Request) => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -111,7 +111,7 @@ import "./leads.css";
 // lead-local; the ≥60 / 40–59 / <40 colour thresholds are pinned by test.
 // Search/filter/sort/pagination (P-14), the rich create modal (P-15), the
 // If-Match edit form (P-1), and the dedupe view-existing link (P-16) are
-// wired in here the same way as contacts (people.tsx) — the Promote button
+// wired in here the same way as contacts (contacts.tsx) — the Promote button
 // and score/status/company badges on the lead 360 stay exactly as they
 // were. Status-change and score-override are Phase 4, not surfaced here.
 

--- a/frontend/src/screens/list-page-size-coverage.test.ts
+++ b/frontend/src/screens/list-page-size-coverage.test.ts
@@ -47,7 +47,7 @@ describe("every list fetcher asks for the page size the reader picked", () => {
   it("finds the list screens rather than trusting a list written here", () => {
     // The census IS the directory. A hand-kept list would be the thing that
     // went stale, which is the failure this test exists to prevent.
-    expect(listScreens()).toContain("people.tsx");
+    expect(listScreens()).toContain("contacts.tsx");
     expect(listScreens()).toContain("organizations.tsx");
     expect(listScreens().length).toBeGreaterThanOrEqual(6);
   });

--- a/frontend/src/screens/list-sort-claim-coverage.test.ts
+++ b/frontend/src/screens/list-sort-claim-coverage.test.ts
@@ -80,7 +80,7 @@ describe("a list claims no ordering its endpoint cannot give", () => {
   it("finds the list screens rather than trusting a list written here", () => {
     // The census IS the directory. A hand-kept list would be the thing that
     // went stale, which is the failure this test exists to prevent.
-    expect(listScreens()).toContain("people.tsx");
+    expect(listScreens()).toContain("contacts.tsx");
     expect(listScreens()).toContain("partners.tsx");
     expect(listScreens().length).toBeGreaterThanOrEqual(6);
   });

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -566,7 +566,7 @@ describe("ListTable: pending, error and empty states", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
 
-    await screen.findByRole("cell", { name: "No People yet." });
+    await screen.findByRole("cell", { name: "No Contacts yet." });
   });
 
   it("renders the table's own empty state once the list loads with no rows", async () => {
@@ -575,7 +575,7 @@ describe("ListTable: pending, error and empty states", () => {
     );
     render(<ListTableHarness fetchPage={fetchPage} />);
 
-    await screen.findByRole("cell", { name: "No People yet." });
+    await screen.findByRole("cell", { name: "No Contacts yet." });
   });
 });
 

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -16,8 +16,8 @@ import { pickOption } from "../design-system/select-testing";
 import { calendarDay, middayInstant } from "../format/calendarday";
 import { formatTimeOfDay } from "../format/format";
 import { LocaleProvider } from "../i18n";
+import { PersonScreen } from "./contacts";
 import { LogActivity } from "./logactivity";
-import { PersonScreen } from "./people";
 import { groupTask } from "./taskgroup";
 
 // Logging from a 360 (the "you can actually add to the timeline" acceptance):

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -901,7 +901,7 @@ function PeopleGroupSection({
   return (
     <section id={groupDomId(PEOPLE_KEY)} className="ob-triage-group">
       <div className="ob-triage-group-head">
-        <h3>{t("ob.conv.triage.peopleLabel")}</h3>
+        <h3>{t("ob.conv.triage.contactsLabel")}</h3>
         {people.length > 0 && (
           <span className="t-caption">
             {t("ob.conv.triage.peopleCount", {
@@ -1361,7 +1361,7 @@ export function CompanyConfirmCard(props: CompanyConfirmCardProps) {
     if (readAtMount != null) {
       extra.push({
         key: PEOPLE_KEY,
-        labelKey: "ob.conv.triage.peopleLabel" as const,
+        labelKey: "ob.conv.triage.contactsLabel" as const,
         order: [],
         workCount: 0,
         openByDefault: new Set<CompanyFieldName>(),

--- a/frontend/src/screens/onboarding-conversation/profile-digest-article.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/profile-digest-article.stories.tsx
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Evidence } from "../../design-system/trust";
+import type { CompanyFieldName } from "../onboarding";
+import { StoryProviders } from "../story-utils";
+import type { ReviewRow, RowState } from "./company-review-state";
+import { ProfileArticle } from "./profile-digest-article";
+import {
+  type Citation,
+  citationsOf,
+  type Fact,
+  factsByCategory,
+  type LegalEntity,
+  type Page,
+  type Person,
+} from "./profile-digest-data";
+// The article draws `pdigest-*`; the sheet is a side-effect import of
+// profile-digest.tsx, which a story of this column alone never reaches.
+import "./profile-digest.css";
+
+// The whole-record document's LEFT COLUMN on its own — the record grouped into
+// the four sections a reader recognises from reading it, then what the crawl
+// found beyond those fields, then the numbered pages every line above cited.
+// The header and the sidebar beside it are Onboarding/Profile digest.
+//
+// The column takes no data of its own, so every state it can be in comes from
+// the props. The numbering and the fact grouping are derived through the
+// document's own `citationsOf` and `factsByCategory` rather than written out
+// here: a story that numbered its own references would agree with itself and
+// prove nothing about the page.
+
+const SITE = "https://acme.test";
+
+function row(
+  field: CompanyFieldName,
+  label: string,
+  value: string,
+  state: RowState,
+  evidence: Evidence | null = null,
+): ReviewRow {
+  return {
+    field,
+    label,
+    value,
+    multiline: false,
+    state,
+    evidence,
+    confidence: null,
+    emptyHintKey: "ob.conv.triage.emptyHint",
+    omissionReasonKey: null,
+  };
+}
+
+function cited(path: string, snippet: string): Evidence {
+  return { source: `${SITE}${path}`, snippet };
+}
+
+// One row per section, so all four headings draw, plus one still open — the
+// dashed line "Settle it" points at.
+const ROWS: readonly ReviewRow[] = [
+  row(
+    "display_name",
+    "Company name",
+    "Acme Freight",
+    "quoted",
+    cited("/", "Acme Freight — European road freight, planned right."),
+  ),
+  row(
+    "legal_name",
+    "Registered legal name",
+    "Acme Freight GmbH",
+    "quoted",
+    cited("/impressum", "Acme Freight GmbH, registered in Munich."),
+  ),
+  row(
+    "offer_summary",
+    "What do you sell?",
+    "Route planning software for freight forwarders.",
+    "quoted",
+    cited("/product", "Route planning software for freight forwarders."),
+  ),
+  row(
+    "icp",
+    "Ideal customer",
+    "Mid-market freight forwarders running 40-200 trucks.",
+    "typed",
+  ),
+  row("usp", "What makes you different?", "", "required"),
+  row(
+    "sales_motion",
+    "How do deals happen?",
+    "Free route audit, then a 90-day pilot on one depot.",
+    "quoted",
+    cited("/product", "We start with a free route audit."),
+  ),
+];
+
+const PAGES: readonly Page[] = [
+  { url: `${SITE}/`, status: "fetched", kind: "home" },
+  { url: `${SITE}/product`, status: "fetched", kind: "services" },
+  { url: `${SITE}/impressum`, status: "fetched", kind: "impressum" },
+  { url: `${SITE}/team`, status: "fetched", kind: "team" },
+];
+
+const LEGAL_ENTITIES: readonly LegalEntity[] = [
+  {
+    name: "Acme Freight GmbH",
+    registered_address: "Lindwurmstraße 12, 80337 Munich",
+    register_number: "HRB 123456",
+    vat_number: "DE123456789",
+    evidence_snippet: "Acme Freight GmbH, HRB 123456, Amtsgericht München.",
+    source_url: `${SITE}/impressum`,
+  },
+];
+
+const FACTS: readonly Fact[] = [
+  {
+    category: "company",
+    field: "founded_year",
+    value: "2014",
+    value_key: "founded_year:2014",
+    evidence_snippet: "Founded in 2014.",
+    evidence_url: `${SITE}/`,
+    confidence: 0.91,
+  },
+  {
+    category: "offering",
+    field: "product",
+    value: "Route optimiser",
+    value_key: "product:route-optimiser",
+    evidence_snippet: "Our route optimiser replans a depot in minutes.",
+    evidence_url: `${SITE}/product`,
+    confidence: 0.77,
+  },
+];
+
+const PEOPLE: readonly Person[] = [
+  {
+    name: "Mara Voss",
+    role: "Co-founder",
+    published_email: "mara@acme.test",
+    linkedin_url: null,
+    evidence_snippet: "Mara Voss, co-founder, leads product.",
+    evidence_url: `${SITE}/team`,
+  },
+  {
+    name: "Devrim Aksoy",
+    role: "Head of Operations",
+    published_email: null,
+    linkedin_url: "https://linkedin.com/in/devrim-aksoy",
+    evidence_snippet: "Devrim Aksoy runs day-to-day operations.",
+    evidence_url: `${SITE}/team`,
+  },
+];
+
+function Article({
+  legalEntities = [],
+  facts = [],
+  people = [],
+}: Readonly<{
+  legalEntities?: readonly LegalEntity[];
+  facts?: readonly Fact[];
+  people?: readonly Person[];
+}>) {
+  const factGroups = factsByCategory(facts);
+  // Rendering order, the same order the document hands them in, so a page
+  // first seen behind a legal entity keeps the lower number.
+  const cites: readonly Citation[] = citationsOf(ROWS, [
+    ...legalEntities.map((entity) => entity.source_url),
+    ...factGroups.flatMap((group) => group.facts.map((f) => f.evidence_url)),
+    ...people.map((person) => person.evidence_url),
+  ]);
+  return (
+    <StoryProviders>
+      <ProfileArticle
+        rows={ROWS}
+        number={new Map(cites.map((cite) => [cite.url, cite.n]))}
+        pages={PAGES}
+        legalEntities={legalEntities}
+        factGroups={factGroups}
+        people={people}
+        cites={cites}
+        onSettle={() => {}}
+        onField={() => {}}
+      />
+    </StoryProviders>
+  );
+}
+
+const meta: Meta<typeof Article> = {
+  title: "Onboarding/Profile article",
+  component: Article,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof Article>;
+
+// Everything the crawl found: the four record sections with a legal entity
+// folded into Identity, the proof it gathered, the two people it named under
+// Contacts, and a References list numbering every page cited above it.
+export const WholeRecord: Story = {
+  render: () => (
+    <Article legalEntities={LEGAL_ENTITIES} facts={FACTS} people={PEOPLE} />
+  ),
+};
+
+// A read that found nothing beyond the record's own lines: no legal entity, no
+// proof, nobody named. Those three sections are absent rather than drawn empty
+// — a heading over nothing claims the crawl looked and came back — and the
+// References list still numbers the pages the record lines themselves cite.
+export const NothingBeyondTheRecord: Story = {
+  render: () => <Article />,
+};

--- a/frontend/src/screens/onboarding-conversation/profile-digest-article.tsx
+++ b/frontend/src/screens/onboarding-conversation/profile-digest-article.tsx
@@ -123,7 +123,7 @@ export function ProfileArticle({
       {people.length === 0 ? null : (
         <section className="pdigest-section">
           <Eyebrow as="h3" className="pdigest-heading">
-            {t("ob.digest.people")}
+            {t("ob.digest.contacts")}
           </Eyebrow>
           {people.map((person) => (
             <PersonLine

--- a/frontend/src/screens/onboarding-facts.test.tsx
+++ b/frontend/src/screens/onboarding-facts.test.tsx
@@ -1043,7 +1043,7 @@ describe("CompanyConfirmCard as a triage surface", () => {
     evidence_url: "https://gradion.com/team",
   };
 
-  // People are a company fact (who to talk to), the same class of thing as
+  // Contacts are a company fact (who to talk to), the same class of thing as
   // an office or a service line — they belong on the board, in the section
   // nav and the group list, not folded into the tail below it.
   it("promotes people found on the site to their own section on the board", () => {
@@ -1051,17 +1051,17 @@ describe("CompanyConfirmCard as a triage surface", () => {
 
     const nav = screen.getByRole("navigation", { name: "Jump to a section" });
     expect(
-      within(nav).getByRole("button", { name: /^People/ }),
+      within(nav).getByRole("button", { name: /^Contacts/ }),
     ).toBeInTheDocument();
 
-    const heading = screen.getByRole("heading", { name: "People", level: 3 });
+    const heading = screen.getByRole("heading", { name: "Contacts", level: 3 });
     // The section sits in the group list, the same place every field group
     // does — not in the reference tail further down.
     expect(heading.closest(".ob-triage-groups")).not.toBeNull();
     expect(heading.closest(".ob-triage-readmore")).toBeNull();
     const section = heading.closest("section");
     if (section === null) {
-      throw new Error("expected the People section to exist");
+      throw new Error("expected the Contacts section to exist");
     }
     expect(within(section).getByText("Jamie Fox")).toBeInTheDocument();
     expect(within(section).getByText("Co-founder")).toBeInTheDocument();
@@ -1070,10 +1070,10 @@ describe("CompanyConfirmCard as a triage surface", () => {
   it("says plainly when the read found no people, rather than a zero count", () => {
     renderTriage([], readWith([]));
 
-    const heading = screen.getByRole("heading", { name: "People", level: 3 });
+    const heading = screen.getByRole("heading", { name: "Contacts", level: 3 });
     const section = heading.closest("section");
     if (section === null) {
-      throw new Error("expected the People section to exist");
+      throw new Error("expected the Contacts section to exist");
     }
     expect(
       within(section).getByText("No people found on your site."),
@@ -1083,11 +1083,11 @@ describe("CompanyConfirmCard as a triage surface", () => {
     // here is the human's to resolve.
     expect(within(section).queryByText(/^\d+$/)).not.toBeInTheDocument();
     const nav = screen.getByRole("navigation", { name: "Jump to a section" });
-    const peopleLink = within(nav).getByRole("button", { name: /^People/ });
-    expect(within(peopleLink).queryByText(/^\d+$/)).not.toBeInTheDocument();
+    const contactsLink = within(nav).getByRole("button", { name: /^Contacts/ });
+    expect(within(contactsLink).queryByText(/^\d+$/)).not.toBeInTheDocument();
   });
 
-  // The count beside People or Facts means "this is what I found", never
+  // The count beside Contacts or Facts means "this is what I found", never
   // "this needs you" — it must equal the section's own content and must
   // never be mistaken, sighted or not, for an outstanding-work count.
   it("shows how many people the read found in the nav, as a found quantity rather than outstanding work", () => {
@@ -1095,17 +1095,17 @@ describe("CompanyConfirmCard as a triage surface", () => {
     renderTriage([], { ...readWith([]), people: found });
 
     const nav = screen.getByRole("navigation", { name: "Jump to a section" });
-    const peopleLink = within(nav).getByRole("button", {
-      name: /^People.*2 found/,
+    const contactsLink = within(nav).getByRole("button", {
+      name: /^Contacts.*2 found/,
     });
-    expect(within(peopleLink).getByText("2")).toBeInTheDocument();
+    expect(within(contactsLink).getByText("2")).toBeInTheDocument();
     // Never the blocking/advisory pill's own class — a find is not a gap.
-    expect(peopleLink.querySelector(".ob-triage-nav-badge")).toBeNull();
+    expect(contactsLink.querySelector(".ob-triage-nav-badge")).toBeNull();
 
-    const heading = screen.getByRole("heading", { name: "People", level: 3 });
+    const heading = screen.getByRole("heading", { name: "Contacts", level: 3 });
     const section = heading.closest("section");
     if (section === null) {
-      throw new Error("expected the People section to exist");
+      throw new Error("expected the Contacts section to exist");
     }
     expect(within(section).getAllByRole("listitem")).toHaveLength(found.length);
   });

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -36,7 +36,7 @@ import {
 import { WriteToHost } from "./writeto";
 
 // The same P-14/15/16/1 shared-block wiring as contacts
-// (people.test.tsx) — search/sort/pagination, the rich create modal
+// (contacts.test.tsx) — search/sort/pagination, the rich create modal
 // (display_name/legal_name/industry/size_band/domains), the company-360
 // If-Match edit, and the duplicate_domain dedupe link.
 
@@ -85,7 +85,7 @@ async function openRecordMenu(testId: string): Promise<HTMLElement> {
 }
 
 // openHistory switches to the tab the account's chronology now lives on. The
-// timeline left the overview when the page gained People and History tabs, so
+// timeline left the overview when the page gained Contacts and History tabs, so
 // a test about the timeline has to go there first.
 async function openHistory() {
   await userEvent.click(await screen.findByRole("button", { name: "History" }));

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -162,7 +162,7 @@ import { invalidateRecord } from "./recordwritekeys";
 // evidence-or-omit: a field with no stored value is absent, never guessed.
 // Search/filter/sort/pagination (P-14), the rich create modal (P-15), the
 // If-Match edit form (P-1), and the dedupe view-existing link (P-16) are
-// wired in here the same way as contacts (people.tsx) — the enrich flow,
+// wired in here the same way as contacts (contacts.tsx) — the enrich flow,
 // firmographics card, and timeline stay exactly as they were.
 
 type Organization = components["schemas"]["Organization"];
@@ -225,7 +225,7 @@ function stringField(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-// Merge-target search (P-2): mirrors searchPeopleTargets (people.tsx) — the
+// Merge-target search (P-2): mirrors searchPeopleTargets (contacts.tsx) — the
 // caller filters out the source row.
 export async function searchOrgTargets(
   q: string,
@@ -1470,7 +1470,7 @@ function CompanyRecord({
             // `tab.overview`, which four other record types render and none of
             // them is this.
             overview: t("tab.overview"),
-            people: t("tab.people"),
+            people: t("tab.contacts"),
             deals: t("tab.deals"),
             tasks: t("tab.tasks"),
             timeline: t("tab.timeline"),

--- a/frontend/src/screens/overlay-refusal-coverage.test.ts
+++ b/frontend/src/screens/overlay-refusal-coverage.test.ts
@@ -150,7 +150,7 @@ describe("what counts as distance", () => {
 describe("overlay refusal copy — translator coverage", () => {
   it("create-person (POST /people)", () => {
     assertTranslatedRefusal(
-      "people.tsx",
+      "contacts.tsx",
       'api.POST("/people", {',
       "create-person",
     );
@@ -158,7 +158,7 @@ describe("overlay refusal copy — translator coverage", () => {
 
   it("merge-person (POST /people/{id}/merge)", () => {
     assertTranslatedRefusal(
-      "people.tsx",
+      "contacts.tsx",
       '"/people/{id}/merge"',
       "merge-person",
     );

--- a/frontend/src/screens/recordlist.test.tsx
+++ b/frontend/src/screens/recordlist.test.tsx
@@ -8,7 +8,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 // The record lists that share the Owner/Created columns and the standard
 // views. A fourth owner-scoped list joins this array, not the copy-paste.
-const RECORD_LISTS = ["people.tsx", "organizations.tsx", "leads.list.tsx"];
+const RECORD_LISTS = ["contacts.tsx", "organizations.tsx", "leads.list.tsx"];
 
 describe("one record list, three record types", () => {
   it("every record list takes Owner and Created from recordlist.tsx, never its own copy", () => {

--- a/frontend/src/screens/relationships.stories.tsx
+++ b/frontend/src/screens/relationships.stories.tsx
@@ -7,7 +7,7 @@ import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 
 // RelationshipsTab reads GET /relationships?person_id=… (there is no
 // GET /relationships/{id} in the contract — every row is hydrated straight
-// off the list read). The fixture mirrors people.test.tsx's employmentRel.
+// off the list read). The fixture mirrors contacts.test.tsx's employmentRel.
 const meta: Meta = {
   title: "Records/Relationships",
   parameters: { layout: "padded" },

--- a/frontend/src/screens/relationships.stories.tsx
+++ b/frontend/src/screens/relationships.stories.tsx
@@ -3,11 +3,20 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { RelationshipsTab } from "./relationships";
-import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+import { jsonResponse, StoryProviders, stubWithSession } from "./story-utils";
 
 // RelationshipsTab reads GET /relationships?person_id=… (there is no
 // GET /relationships/{id} in the contract — every row is hydrated straight
 // off the list read). The fixture mirrors contacts.test.tsx's employmentRel.
+//
+// The panel is a WORK surface: it gates Add, Edit and Remove on
+// `relationship` create/update/delete, so every story here holds all three.
+// A story that left the session unrouted would draw the same rows with no
+// verbs on them, which is the read-only panel under another name.
+const MAY_WRITE_RELATIONSHIPS = {
+  relationship: ["create", "update", "delete"],
+} as const;
+
 const meta: Meta = {
   title: "Records/Relationships",
   parameters: { layout: "padded" },
@@ -42,13 +51,16 @@ const partnerOfRel = {
 
 export const WithRelationships: Story = {
   render: () => {
-    installFetchStub({
-      "GET /relationships": () =>
-        jsonResponse({
-          data: [employmentRel, partnerOfRel],
-          page: { next_cursor: null, has_more: false },
-        }),
-    });
+    stubWithSession(
+      {
+        "GET /relationships": () =>
+          jsonResponse({
+            data: [employmentRel, partnerOfRel],
+            page: { next_cursor: null, has_more: false },
+          }),
+      },
+      MAY_WRITE_RELATIONSHIPS,
+    );
     return (
       <StoryProviders>
         <RelationshipsTab scope={{ person_id: "p-1" }} />
@@ -59,13 +71,16 @@ export const WithRelationships: Story = {
 
 export const Empty: Story = {
   render: () => {
-    installFetchStub({
-      "GET /relationships": () =>
-        jsonResponse({
-          data: [],
-          page: { next_cursor: null, has_more: false },
-        }),
-    });
+    stubWithSession(
+      {
+        "GET /relationships": () =>
+          jsonResponse({
+            data: [],
+            page: { next_cursor: null, has_more: false },
+          }),
+      },
+      MAY_WRITE_RELATIONSHIPS,
+    );
     return (
       <StoryProviders>
         <RelationshipsTab scope={{ person_id: "p-1" }} />
@@ -89,16 +104,19 @@ const stakeholderRel = {
 // with a single answer.
 export const DealStakeholders: Story = {
   render: () => {
-    installFetchStub({
-      "GET /relationships": () =>
-        jsonResponse({
-          data: [
-            stakeholderRel,
-            { ...stakeholderRel, id: "rel-4", role: "economic_buyer" },
-          ],
-          page: { next_cursor: null, has_more: false },
-        }),
-    });
+    stubWithSession(
+      {
+        "GET /relationships": () =>
+          jsonResponse({
+            data: [
+              stakeholderRel,
+              { ...stakeholderRel, id: "rel-4", role: "economic_buyer" },
+            ],
+            page: { next_cursor: null, has_more: false },
+          }),
+      },
+      MAY_WRITE_RELATIONSHIPS,
+    );
     return (
       <StoryProviders>
         <RelationshipsTab scope={{ deal_id: "d-1" }} />
@@ -109,13 +127,16 @@ export const DealStakeholders: Story = {
 
 export const DealStakeholdersEmpty: Story = {
   render: () => {
-    installFetchStub({
-      "GET /relationships": () =>
-        jsonResponse({
-          data: [],
-          page: { next_cursor: null, has_more: false },
-        }),
-    });
+    stubWithSession(
+      {
+        "GET /relationships": () =>
+          jsonResponse({
+            data: [],
+            page: { next_cursor: null, has_more: false },
+          }),
+      },
+      MAY_WRITE_RELATIONSHIPS,
+    );
     return (
       <StoryProviders>
         <RelationshipsTab scope={{ deal_id: "d-1" }} />

--- a/frontend/src/screens/relationships.test.tsx
+++ b/frontend/src/screens/relationships.test.tsx
@@ -13,7 +13,7 @@ type Relationship = components["schemas"]["Relationship"];
 // rel_*_shape CHECK constraints (migration 0007). These pure-function specs
 // pin that mapping so the UI can never offer a (scope, kind) it can't satisfy
 // — the mismatch that used to reach the server as a "endpoint shape is
-// required" 422. Interactive coverage of the picker lives in people.test.tsx
+// required" 422. Interactive coverage of the picker lives in contacts.test.tsx
 // / organizations.test.tsx; this file is the invariant itself.
 
 const personScope: RelationshipScope = { person_id: "p-1" };

--- a/frontend/src/screens/search.test.tsx
+++ b/frontend/src/screens/search.test.tsx
@@ -269,10 +269,10 @@ describe("SearchScreen", () => {
     );
     render(<SearchScreen q="acme" />);
     // By ROLE, not by text: the type filter above the results names the same
-    // groups the headings do, so a bare getByText("People") matches the pill —
+    // groups the headings do, so a bare getByText("Contacts") matches the pill —
     // which renders before the read settles, and would wait out nothing.
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "People" })).toBeTruthy(),
+      expect(screen.getByRole("heading", { name: "Contacts" })).toBeTruthy(),
     );
     expect(screen.getByRole("heading", { name: "Deals" })).toBeTruthy();
     expect(screen.getByText(/Dana at Acme/)).toBeTruthy();
@@ -459,7 +459,7 @@ describe("SearchScreen", () => {
 // this is the assertion that says so for every member of it.
 describe("SearchScreen — every hit type the contract can return", () => {
   const KINDS = [
-    { type: "person", heading: "People" },
+    { type: "person", heading: "Contacts" },
     { type: "organization", heading: "Organizations" },
     { type: "deal", heading: "Deals" },
     { type: "project", heading: "Projects" },

--- a/frontend/src/screens/strength.stories.tsx
+++ b/frontend/src/screens/strength.stories.tsx
@@ -12,7 +12,7 @@ import { StrengthCard } from "./strength";
 
 // StrengthCard fetches its own data (GET /people/{id}/strength or
 // /organizations/{id}/strength) — the shared fetch stub (story-utils.tsx)
-// mirrors the strength fixtures already exercised in people.test.tsx.
+// mirrors the strength fixtures already exercised in contacts.test.tsx.
 const meta: Meta = {
   title: "Records/Relationship strength",
   parameters: { layout: "padded" },

--- a/frontend/src/screens/tagresult.stories.tsx
+++ b/frontend/src/screens/tagresult.stories.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+import { TagResultScreen } from "./tagresult";
+
+type TagUsage = components["schemas"]["TagUsage"];
+
+// The page behind a tag pill, whose whole job is naming WHICH records carry
+// the word. The three groups are three separate reads gated on the counts the
+// tag read returned, so what a story sets those counts to is what decides the
+// shape of the page — which is why they are the axis the stories vary.
+//
+// The screen heads itself and reaches for no capability, so there is no session
+// probe here and no shell title above it; `fullscreen` because the page draws
+// its own `.wrap`.
+const meta: Meta = {
+  title: "Records/Tag page",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj;
+
+const TAG = "01a0641b-db0c-7b92-8564-6c843bf58df3";
+
+function tagRead(usage: TagUsage) {
+  return () =>
+    jsonResponse({
+      id: TAG,
+      name: "Automation World 2026",
+      color: "slate",
+      description:
+        "Everyone we met at the hall, and the deals that came of it.",
+      version: 1,
+      usage,
+    });
+}
+
+const people = [
+  { id: "p-1", full_name: "Katrin Hofmann" },
+  { id: "p-2", full_name: "Devrim Aksoy" },
+];
+const organizations = [
+  { id: "o-1", display_name: "MiTek" },
+  { id: "o-2", display_name: "Nordfracht" },
+];
+const deals = [{ id: "d-1", name: "netcare GmbH — Einführung" }];
+
+// All three record types carry the word: one group per type, each naming its
+// own rows, and none of them offering "View all" — every group here is shorter
+// than the preview, so there is nothing further to show.
+export const RecordsInEveryGroup: Story = {
+  render: () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 2, companies: 2, deals: 1 }),
+      "GET /people": () => jsonResponse({ data: people }),
+      "GET /organizations": () => jsonResponse({ data: organizations }),
+      "GET /deals": () => jsonResponse({ data: deals }),
+    });
+    return (
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>
+    );
+  },
+};
+
+// A word nothing carries: one panel saying so, rather than three cards each
+// reporting a zero. The counts come from the tag read, so no group read runs.
+export const NothingCarriesIt: Story = {
+  render: () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 0, companies: 0, deals: 0 }),
+    });
+    return (
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>
+    );
+  },
+};
+
+// The rows are still on the wire. The counts already arrived, so each group
+// has its heading and a skeleton sized to what it is about to show — the state
+// a reader on a slow connection actually sees, since the page itself renders
+// nothing at all until the tag read settles.
+export const RowsStillLoading: Story = {
+  render: () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 2, companies: 2, deals: 1 }),
+      "GET /people": () => new Promise<Response>(() => {}),
+      "GET /organizations": () => new Promise<Response>(() => {}),
+      "GET /deals": () => new Promise<Response>(() => {}),
+    });
+    return (
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/tagresult.test.tsx
+++ b/frontend/src/screens/tagresult.test.tsx
@@ -155,8 +155,8 @@ describe("the tag page names what carries the word", () => {
     );
 
     expect(await screen.findByText("Katrin Hofmann")).toBeInTheDocument();
-    expect(screen.getByText("People (1)")).toBeInTheDocument();
-    expect(screen.queryByText("People (3)")).toBeNull();
+    expect(screen.getByText("Contacts (1)")).toBeInTheDocument();
+    expect(screen.queryByText("Contacts (3)")).toBeNull();
   });
 
   // A request that FAILED is not a permission fact. Reporting one as the other

--- a/frontend/src/screens/tagresult.tsx
+++ b/frontend/src/screens/tagresult.tsx
@@ -109,7 +109,7 @@ export function TagResultScreen({ tagID }: Readonly<{ tagID?: string }>) {
         <div className="tagresult-groups">
           <ResultGroup
             kind="person"
-            title={t("tagResult.people")}
+            title={t("tagResult.contacts")}
             icon={Contact}
             count={usage.people}
             tagID={tagID}

--- a/frontend/src/screens/webhooks.tsx
+++ b/frontend/src/screens/webhooks.tsx
@@ -253,7 +253,7 @@ function updateWebhookSubscription(
 }
 
 // Archive stops all delivery (DELETE, no If-Match — mirrors products.tsx/
-// people.tsx's ArchiveAction usage: archiving isn't a concurrent-edit hazard
+// contacts.tsx's ArchiveAction usage: archiving isn't a concurrent-edit hazard
 // the way a field patch is).
 async function archiveWebhookSubscription(
   subscription: WebhookSubscription,

--- a/frontend/src/screens/worklist.detail.test.tsx
+++ b/frontend/src/screens/worklist.detail.test.tsx
@@ -219,9 +219,9 @@ describe("the supporting line each source sends", () => {
     {
       what: "stale object classes",
       kind: "objects_stale",
-      detail: "deals, contacts",
-      says: "Out of date here: deals, people.",
-      never: "deals, contacts",
+      detail: "deals, leads",
+      says: "Out of date here: deals, prospects.",
+      never: "deals, leads",
     },
   ])(
     "says $what in the reader's own words",
@@ -241,9 +241,10 @@ describe("the supporting line each source sends", () => {
       ]);
 
       expect(await screen.findByText(says)).toBeTruthy();
-      // The producer's word never reaches the page. `deals, contacts` reads
-      // almost like the sentence, which is exactly why it is asserted: a
-      // renderer that fell back to the raw field would look right at a glance.
+      // The producer's word never reaches the page. Every fixture here picks a
+      // class the reader's word RENAMES — `leads` reads as prospects — so the
+      // raw field still looks almost like the sentence, which is exactly why it
+      // is asserted: a renderer that fell back to it would pass at a glance.
       expect(screen.queryByText(never)).toBeNull();
     },
   );


### PR DESCRIPTION
## What changed

The sidebar's record group now reads **Contacts, Companies, Leads, Deals**, and its work group reads **Worklist, Projects, Filters & views**. Two views are renamed and one row moves.

**Contacts (was People).** The route id and slug were already `contacts` / `#/contacts`; only the words change. `nav.contacts` is "Contacts" / "Kontakte" / "Liên hệ", and the same noun now names the record type wherever a label offers it as a thing to pick, count, file under or navigate to: the search group, the Filters & views object tab, the company record's tab, the tag-result group, the import object, the organization count, the access object, the onboarding digest and triage labels, the backfill stat, the Brief digest ("Contacts created"), the list unit ("1–25 of 200 contacts"), the sync-health class, and the lead sentence ("Leads are kept apart from Contacts. A lead becomes a contact only when you qualify it."). Deliberately unchanged: Settings → People (team members, not contacts), the "People & companies" relationships tab, and every sentence about human beings ("the people on this message", "Their key people").

**Deals (was Pipeline).** Route id and slug were already `deals` / `#/deals`. `nav.deals` is "Deals" in all three locales ("deal" is a glossary loanword). "Pipeline" stays as the name of the board inside the Deals screen, the forecast concept and the analytics section.

**Filters & views** leaves the Records group and closes the Work group: writing a filter is an authoring surface over lists, not a record type.

**Palette aliases.** `NavItem` gains `aliases`, and the palette spreads them into a row's keywords, so typing "pipeline" still surfaces Deals and "people" still surfaces Contacts. Held by a test in `palette.test.tsx`.

**Code follows the product.** `screens/people.{tsx,test.tsx,stories.tsx}` are `contacts.*`; the i18n keys whose value became "Contacts" are renamed (`tab.contacts`, `tagResult.contacts`, `home.digestContacts`, `backfill.statContacts`, `ob.digest.contacts`, `ob.conv.triage.contactsLabel`); the RecordTabs/SegmentedControl demo fixtures and the `Records/Company 360/Contacts/…` story titles follow. Keys that name the singular entity (`search.group.person`, `import.object.person`, `cf.obj.person`) keep their names.

**`record-noun.test.ts` inverted and narrowed.** It held the opposite invariant ("the person record is called a person, never a contact") over the whole catalog. It now holds that the record-type labels listed in it carry the contact noun in every locale and never the retired one, failing in both directions. It has no opinion about "person"/"people" in prose. This is a real reduction in what the gate sweeps; see the open question below.

## Fixed along the way

- `contacts.tsx:908` carried a raw `marginBottom: 16`; the rename put it in the diff-scoped spacing gate's path, so it now reads `var(--space-4)`.
- Stale `people.tsx` paths in comments across ten test/story files and two docs pages.
- `leads.test.tsx` carried a bare ticket number in a comment; dropped.
- `tagresult.tsx` and `onboarding-conversation/profile-digest-article.tsx` had no story; `Records/Tag page` and `Onboarding/Profile article` now render the renamed labels (loaded, empty, loading).
- `relationships.stories.tsx` never routed `GET /me`, so its four stories failed under `fe-uat` on `main` too; they now carry the relationship grants the screen gates its verbs on.
- `App.stories.tsx` "Authenticated home" landed on `#/products`, a screen the router does not know, and answered `GET /company` with a list envelope, so the shell drew Not found and the brand block threw on an undefined name (`monogramOf`). It lands on `#/contacts` and names its installation. Pre-existing on `main`; entered scope through the `App.tsx` import path change.

## Gates run

| Gate | Result |
|---|---|
| `make frontend-check` | pass (625 files, 8252 tests, 1 expected fail) |
| `make fe-uat` | pass — 165 stories captured, 0 missing, receipt `.tmp/fe-uat/manifest.json` |
| `make native-controls` | pass |
| `make frontend-e2e` | pass (340 specs, axe sweep included) |
| `make check` | pass |
| `make fe-clock-drift` | not run: no touched test reads a date |

Browser spot-check against the seeded demo stack (desktop 1440, phone 390, dark): rail order and group headings, H1 and breadcrumb on `#/contacts`, `#/deals`, `#/filters`, palette "pipeline" → Deals, keyboard tab order through the rail with visible focus rings, phone bottom bar (Brief, Contacts, agent, Deals, more), no horizontal scroll at 390px. Console carried only pre-existing dev-stack noise (`EmbedReindexStatus` 501, pre-login 401 probe).

## Open question (product)

The nav and every record-type label say **Contacts**, but the singular noun in prose and on verbs is still **person**: the Contacts screen's primary button reads "New person", record pages say "this person", and the API path is `/people`. Renaming the singular is a catalog-wide change (hundreds of strings in three locales) and a different decision from this one. If the answer is "the record is a contact", that is a follow-up PR and `record-noun.test.ts` widens back to the catalog with the nouns swapped.

## Proposals deferred

- The company record's contact tab is addressed as `#/companies/<id>/people` (`companytab.ts`). It is a bookmarkable slug, so renaming it to `contacts` needs a redirect for the old address and is a route change rather than a label change. The tab's label already reads Contacts; the segment is left alone here.

- The phone bar's five cells derive from nav order, so Deals now sits in the primary five in place of nothing lost; if the bar should pin a different set, that is a `MOBILE_PRIMARY` decision, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Interface**
  - Renamed “People” to “Contacts” across navigation, tabs, search, onboarding, reports, and empty states.
  - Renamed “Pipeline” to “Deals” and reorganized navigation destinations.
  - Renamed the Home destination to “Brief” and updated related labels to “Overview.”
  - Updated German and Vietnamese translations to match the revised terminology.

- **Navigation**
  - Command palette searches now recognize previous terms such as “People” and “Pipeline” as aliases for Contacts and Deals.

- **Visual Improvements**
  - Updated contact record tab spacing for more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->