### PR TITLE
test(integrations): a sweep assertion reads the predicate, not the tick budget

### DIFF
--- a/backend/internal/modules/integrations/backfill_integration_test.go
+++ b/backend/internal/modules/integrations/backfill_integration_test.go
@@ -136,13 +136,26 @@ func TestTheSweepSpendsNoMoreThanTheDayAllows(t *testing.T) {
 	}
 }
 
-// sweepSelects runs the predicate and returns who it chose.
+// sweepSelects runs the coverage predicate and returns who it chose.
+//
+// The ceiling it passes is the whole person table and not sweepTickBudget,
+// which is the difference between asking what the predicate covers and asking
+// what one tick can afford. Every test in this package plants into ONE
+// database and nothing truncates `person`, so the uncovered set only grows as
+// the package runs; under a tick-sized ceiling `ORDER BY p.created_at` answers
+// "is this contact among the 25 longest-waiting", and a test's own freshly
+// planted subject is the last one that could be. What a tick may afford is
+// TestTheSweepSpendsNoMoreThanTheDayAllows' subject.
 func (e *runsEnv) sweepSelects(t *testing.T) map[ids.PersonID]bool {
 	t.Helper()
+	var everyone int
+	if err := e.owner.QueryRow(e.ctx, `SELECT count(*) FROM person`).Scan(&everyone); err != nil {
+		t.Fatal(err)
+	}
 	var chosen []string
 	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
 		var err error
-		chosen, err = e.store.uncoveredSubjects(e.ctx, tx, e.provider, sweepTickBudget)
+		chosen, err = e.store.uncoveredSubjects(e.ctx, tx, e.provider, everyone)
 		return err
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Unblocks `make test-integration`, which is red on `main`. One package of 52
fails:

```
--- FAIL: TestAnEmployerLinkedAfterNoIdentifiersIsPickedUpAtOnce (0.04s)
    backfill_integration_test.go:379: a contact whose employer was linked after
    the no-identifiers skip was NOT re-selected: the page told the reader to add
    the company and then ignored the relationship row it landed in
```

Reproduced in a dedicated worktree at pristine `origin/main` (ad199bad2), no
branch applied. Fixes https://github.com/margince/margince/issues/4811 and
https://github.com/margince/margince/issues/4775 (the same defect, filed twice).

## Why no pull request could see it

The test PASSES alone and fails in the whole package, and the integration lane
shards per test — so no CI job ever runs `modules/integrations` whole. `make
test-integration` locally is the only lane that sees it, which is the lane
fewest people run. That is the shape that hides a real defect indefinitely, and
it is why this landed on `main` green.

## The cause is the ceiling, not the predicate

Every test in the package plants people into ONE database and nothing truncates
`person` — `setupRuns` alone adds three per call, across 67 tests — so the set
of contacts still owed a lookup only grows as the package runs.

`sweepSelects` asked `uncoveredSubjects` with `sweepTickBudget`, and that query
is `ORDER BY p.created_at LIMIT $2`. Past twenty-five accumulated waiters the
helper stops answering "is this contact still owed a lookup" and starts
answering "is this contact among the twenty-five longest-waiting" — which is
the BUDGET's question. Every assertion in the file asks the coverage question,
and the subject each one plants is by construction the last contact a
tick-sized ceiling can reach: the newest row under `ORDER BY created_at`.

So the failure message sends a reader hunting a relationship-row bug that is
not there. The sweep is behaving exactly as designed; a tick has a budget and
takes the longest-waiting contacts first.

## The fix

`sweepSelects` now asks with the `person` table's own row count as the ceiling,
derived rather than a constant, so the answer is the predicate's and not the
ordering's. One helper, shared by every assertion in the file — the three tests
below it were surviving on nothing more than their position in the run order,
and they stop depending on it too.

**Nothing stops being proved.** What a tick may afford keeps its own test in
`TestTheSweepSpendsNoMoreThanTheDayAllows`, which reads `sweepBudget` directly.
The removed ceiling was never the subject of an assertion here.

I did not raise `sweepTickBudget`, plant older `created_at` values, or clean
`person` between tests — the first changes production to suit a test, and the
other two leave the helper still answering the wrong question for the next test
somebody writes.

## Found along the way, filed rather than fixed

https://github.com/margince/margince/issues/4842 — the `no_identifiers` arm
lifts a fixed contact's COOLDOWN but not its place in the oldest-first queue,
so under a `daily_run_limit` the page's "add a company and we will look again"
can go unanswered for months. Filed rather than fixed because oldest-first is
deliberate and the trade-off is a product call.

## Verification

- `make test-it DIR=backend/internal/modules/integrations` — the whole package,
  which is the run that fails on `main`
- `make check-all` (`check` + the integration lane) on this branch, rebased on
  current `main`
