### PR TITLE
fix(frontend): the subject scan reads the line once, and an ARIA menu is focusable

### DIFF
--- a/frontend/src/app/account.tsx
+++ b/frontend/src/app/account.tsx
@@ -296,6 +296,12 @@ function ThemeSubmenu({
       className="accountsub"
       role="menu"
       aria-label={t("shell.theme")}
+      // -1, not 0: the tab stop belongs to the roving rows below, and a menu
+      // that took one of its own would stand in front of the choices it exists
+      // to offer. What a `menu` role owes the keyboard is to be focusable AT
+      // ALL — it promises somewhere to stand, and a div carrying no tabindex
+      // cannot be focused even programmatically.
+      tabIndex={-1}
       ref={panel}
       onKeyDown={onKeyDown}
     >
@@ -437,6 +443,10 @@ function AccountPanel({
           ? `${t("shell.accountAria")} — ${identity.spoken}`
           : t("shell.accountAria")
       }
+      // Focusable, and only programmatically: the roving tabstop lives on the
+      // rows, and the effect above lands the reader on one of them the moment
+      // this opens. See ThemeSubmenu for why the value is -1 rather than 0.
+      tabIndex={-1}
       ref={panel}
       onKeyDown={onKeyDown}
     >

--- a/frontend/src/screens/projectrecord.test.ts
+++ b/frontend/src/screens/projectrecord.test.ts
@@ -119,6 +119,54 @@ describe("the project tag a subject carries", () => {
     );
   });
 
+  it("clears a key carrying the underscore the CHECK admits", () => {
+    // project_key_shape is `^[A-Za-z][A-Za-z0-9_-]{1,23}$`, so `alpha_two` is a
+    // key the capture matcher reads. Left standing it is a SECOND live key
+    // beside the one written here — and a subject naming two files under
+    // neither, which is the exact outcome this function exists to prevent.
+    expect(withSubjectTag("[alpha_two] Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Hallo",
+    );
+  });
+
+  it("takes no separator from the tag beside it, because that one is gone", () => {
+    expect(withSubjectTag("[OTHER-9] [THIRD-2] Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] Hallo",
+    );
+  });
+
+  it("takes the leading space of a key tag that ends the subject", () => {
+    expect(withSubjectTag("Hallo [OTHER-9]", "[N2P-1]")).toBe("[N2P-1] Hallo");
+  });
+
+  it("leaves a bracket that never closes, as the capture side does", () => {
+    // A subject trailing off mid-marker names no key. Reading the rest of the
+    // line as one would turn a stray `[` into a match.
+    expect(withSubjectTag("[N2P-1 Hallo", "[N2P-1]")).toBe(
+      "[N2P-1] [N2P-1 Hallo",
+    );
+  });
+
+  it("reads a group from its bracket to the NEXT close, as capture does", () => {
+    // `a[N2P-1` is what the matcher sees inside this group, and it is not a
+    // key — so neither side reads one here, and the rep's line stands. A
+    // frontend that instead started the group at the INNER `[` would strip a
+    // tag the matcher never saw, and leave the `[a` in front of it behind.
+    expect(withSubjectTag("[a[N2P-1] Hallo", "[OTHER-9]")).toBe(
+      "[OTHER-9] [a[N2P-1] Hallo",
+    );
+  });
+
+  it("reads a run of brackets after the last close without rewriting it", () => {
+    // Every `[` here opens a group that never closes, which is the shape a
+    // backtracking bracket matcher re-reads the tail of the line for, once per
+    // bracket. A subject is attacker-supplied text, and none of these is a key:
+    // the line comes back whole.
+    expect(withSubjectTag("Re: ] [[[[[[[[", "[N2P-1]")).toBe(
+      "[N2P-1] Re: ] [[[[[[[[",
+    );
+  });
+
   it("takes its own tag back off, and nobody else's", () => {
     expect(stripSubjectTag("[N2P-1] Re: Hallo", "[N2P-1]")).toBe("Re: Hallo");
     // One separator comes off with the tag, not every space behind it.

--- a/frontend/src/screens/projectrecord.ts
+++ b/frontend/src/screens/projectrecord.ts
@@ -98,22 +98,75 @@ export function withSubjectTag(subject: string, tag: string): string {
  * Only key-SHAPED groups go. `[FYI]` is prose to the matcher and prose here.
  */
 export function stripEveryKeyTag(subject: string): string {
-  // A removed tag takes ONE of the spaces that surrounded it with it, so
-  // "Re: [KEY] Hallo" becomes "Re: Hallo" rather than "Re:  Hallo". The rest of
-  // the line is returned byte for byte: this runs over a subject the rep is
-  // typing, and a global whitespace collapse would rewrite their spacing —
-  // eating the second space of "Re:  Kurzer" that they put there on purpose.
-  // Exactly ONE space on each side is eligible to go with the tag — the
-  // separator this module writes. A second space is the rep's own and stays.
-  return subject.replace(/ ?\[[^\]]*\] ?/g, (group) => {
-    const inner = group.trim().slice(1, -1);
-    if (!keyShaped(inner)) {
-      return group;
+  let out = "";
+  let cursor = 0;
+  for (const group of bracketedGroups(subject)) {
+    // A removed tag takes ONE of the spaces that surrounded it with it, so
+    // "Re: [KEY] Hallo" becomes "Re: Hallo" rather than "Re:  Hallo". The rest
+    // of the line is returned byte for byte: this runs over a subject the rep
+    // is typing, and a global whitespace collapse would rewrite their spacing —
+    // eating the second space of "Re:  Kurzer" that they put there on purpose.
+    // Exactly ONE space on each side is eligible — the separator this module
+    // writes. A second space is the rep's own and stays, and a separator the
+    // group before this one already took is gone: two adjacent tags do not
+    // share one.
+    const leading = group.start > cursor && subject[group.start - 1] === " ";
+    const trailing = subject[group.end] === " ";
+    const from = leading ? group.start - 1 : group.start;
+    out += subject.slice(cursor, from);
+    cursor = trailing ? group.end + 1 : group.end;
+    if (!keyShaped(group.inner)) {
+      out += subject.slice(from, cursor);
+      continue;
     }
     // Keep one separator when the tag sat BETWEEN two things; keep none when it
     // sat at either end.
-    return group.startsWith(" ") && group.endsWith(" ") ? " " : "";
-  });
+    if (leading && trailing) {
+      out += " ";
+    }
+  }
+  return out + subject.slice(cursor);
+}
+
+/** One `[...]` group: where it sits in the subject, and what it holds. */
+type BracketGroup = Readonly<{
+  /** Index of the `[`. */
+  start: number;
+  /** Index just past the `]`. */
+  end: number;
+  /** The text between the brackets, untrimmed. */
+  inner: string;
+}>;
+
+/**
+ * Every `[...]` group in `subject`, read the way the capture side's own
+ * tokenizer reads it: from each `[` to the NEXT `]`, non-overlapping, and an
+ * unclosed `[` ends the scan — a subject trailing off mid-marker names no key,
+ * and treating the rest of the line as one would turn a stray `[` into a match.
+ *
+ * A single pass rather than a regular expression, and that is the property to
+ * keep. A bracket matcher of the form ` ?\[[^\]]*\] ?` re-reads the tail of the
+ * line at every `[` it then fails to close, so a subject whose brackets all sit
+ * after its last `]` costs time quadratic in the subject's length — and a
+ * subject is attacker-supplied text, reaching this composer through the reply it
+ * seeds. Two `indexOf` walks reach the end of the line once.
+ */
+function bracketedGroups(subject: string): BracketGroup[] {
+  const groups: BracketGroup[] = [];
+  let open = subject.indexOf("[");
+  while (open >= 0) {
+    const shut = subject.indexOf("]", open + 1);
+    if (shut < 0) {
+      return groups;
+    }
+    groups.push({
+      start: open,
+      end: shut + 1,
+      inner: subject.slice(open + 1, shut),
+    });
+    open = subject.indexOf("[", shut + 1);
+  }
+  return groups;
 }
 
 /**
@@ -146,11 +199,16 @@ function prefixed(body: string, tag: string): string {
 /**
  * Whether one bracketed token could be a project key — the frontend reading of
  * the rule the capture side applies (`project_key_shape`): letter-led, then
- * letters, digits and hyphens, bounded in length. A bare number is deliberately
- * excluded, so `[2026]` and `[4711]` stay prose.
+ * letters, digits, underscores and hyphens, bounded in length. A bare number is
+ * deliberately excluded, so `[2026]` and `[4711]` stay prose.
+ *
+ * The UNDERSCORE is part of that constraint, and a shape narrower here than the
+ * CHECK is what this whole class of divergence costs: a project keyed
+ * `alpha_two` is a key the matcher reads, so leaving its tag standing while ours
+ * goes in beside it hands the message two live keys, and it files under neither.
  */
 function keyShaped(token: string): boolean {
-  return /^[a-z][a-z0-9-]{1,23}$/i.test(token.trim());
+  return /^[a-z][a-z0-9_-]{1,23}$/i.test(token.trim());
 }
 
 /** Where a send files, and what the composer should say about it. */

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -258,7 +258,7 @@ sonar.coverage.exclusions=\
   frontend/src/**/*.stories.tsx
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
@@ -472,3 +472,109 @@ sonar.issue.ignore.multicriteria.e15.resourceKey=.github/actions/install-claude-
 # thrown away.
 sonar.issue.ignore.multicriteria.e16.ruleKey=text:S8566
 sonar.issue.ignore.multicriteria.e16.resourceKey=extensions/*/go.mod
+# godre:S8188 wants `defer cancel()` in the function that calls
+# context.WithCancel. laneLifetime cannot have it, and the reason is the whole
+# point of the helper: it RETURNS the end of the lanes' context to its caller,
+# so that run() can defer it BEFORE anything has started reading the bus and the
+# pool. Deferring inside laneLifetime would cancel the lanes' context as the
+# helper returned — every lane dead before its first read, which is not a leak
+# but a worker that does nothing.
+#
+# What the rule is protecting is held instead by a fitness function at the site
+# that can be wrong:
+# TestALaneCannotStartBeforeItsShutdownIsRegistered in
+# backend/cmd/worker/lanelifetime_test.go parses run() and fails when the defer
+# does not precede the call that starts the lanes. So the obligation is enforced
+# more strictly than S8188 states it — the cancel must not merely be deferred,
+# it must be deferred first — and this waiver cannot become cover for dropping
+# it. lanes.go calls context.WithCancel exactly once, so the file scope hides
+# nothing else.
+sonar.issue.ignore.multicriteria.e17.ruleKey=godre:S8188
+sonar.issue.ignore.multicriteria.e17.resourceKey=backend/cmd/worker/lanes.go
+# typescript:S6843 and typescript:S6825 on the list table's `<td>` elements, and
+# both arms come from one thing the rule cannot see: which element the cells sit
+# inside.
+#
+# A `<td>` resolves to `cell` under a table and to `gridcell` under a grid. The
+# analyzer reads one JSX element at a time, cannot see the `<table role="table">`
+# ancestor, and so takes the interactive reading — `gridcell`. From there
+# `role="cell"` looks like an interactive element being demoted to a
+# non-interactive role (S6843), and `aria-hidden` on a spacer cell looks like
+# aria-hidden on something focusable (S6825). Under a table neither is true: a
+# `<td>` IS a cell, and a `<td>` carrying no tabindex is not focusable at all.
+# The `<th role="columnheader">` cells in the same table are not flagged, which
+# is the same rule agreeing with itself once the implicit role it picks happens
+# to be the non-interactive one.
+#
+# The explicit roles are load-bearing rather than redundant. Under 720px the
+# stylesheet lays the rows out as cards — `display: block`/`flex` on the table,
+# thead, tbody, tr, th and td — and changing a table element's display is what
+# drops its implicit table semantics in every browser. Re-declaring
+# table/rowgroup/row/columnheader/cell is the sanctioned repair, and
+# listtable.css says so where it makes the switch: "The table element keeps its
+# markup and its explicit roles, so what changes here is the layout, not the
+# semantics." Removing them to satisfy the analyzer would hand a phone reader a
+# stack of unrelated divs.
+#
+# Scoped to the one file that re-declares the roles. Every other table in the
+# tree keeps the implicit ones and stays enforced.
+sonar.issue.ignore.multicriteria.e18.ruleKey=typescript:S6843
+sonar.issue.ignore.multicriteria.e18.resourceKey=frontend/src/design-system/listtable.tsx
+sonar.issue.ignore.multicriteria.e19.ruleKey=typescript:S6825
+sonar.issue.ignore.multicriteria.e19.resourceKey=frontend/src/design-system/listtable.tsx
+# typescript:S6845 forbids `tabindex` on a non-interactive element. WCAG 2.1.1
+# requires the opposite of a scrollable region: content that scrolls out of view
+# must be reachable by keyboard, and `tabindex="0"` on the scroller is the
+# technique the guideline itself prescribes — which is why axe raises
+# scrollable-region-focusable for exactly the elements this rule wants left
+# alone. The two cannot both be satisfied, and the reader who cannot use a
+# pointer is the one who loses if the analyzer wins.
+#
+# Each site is a scroller or an arrow-key surface that no descendant can stand
+# in for, each already carries the biome waiver for the same rule under its
+# other name, and each states its own reasoning in the code beside it:
+#
+#   trust.tsx        — a long field diff scrolls its own box. A `section` was
+#                      rejected on purpose: a named one is a landmark, and one
+#                      record's history holds dozens.
+#   composed.tsx     — a board column scrolls its cards. A card's own link makes
+#                      a FULL column reachable and says nothing about an empty
+#                      one, so the scroller takes the stop itself.
+#   decisiondeck.tsx — the four arrow-key verdicts. A swipe surface with no
+#                      keyboard equivalent is a surface only a pointer can
+#                      answer.
+#
+# One entry per file rather than a directory wildcard: the design system has no
+# standing exemption from this rule, and a fourth site should have to argue for
+# itself here.
+sonar.issue.ignore.multicriteria.e20.ruleKey=typescript:S6845
+sonar.issue.ignore.multicriteria.e20.resourceKey=frontend/src/design-system/trust.tsx
+sonar.issue.ignore.multicriteria.e21.ruleKey=typescript:S6845
+sonar.issue.ignore.multicriteria.e21.resourceKey=frontend/src/design-system/composed.tsx
+sonar.issue.ignore.multicriteria.e22.ruleKey=typescript:S6845
+sonar.issue.ignore.multicriteria.e22.resourceKey=frontend/src/design-system/decisiondeck.tsx
+# typescript:S6848 forbids an interaction handler on a non-interactive element.
+# At both of these sites the interactive element is a real control INSIDE the
+# element carrying the handler, and the handler exists only because of where the
+# events it wants arrive:
+#
+#   inlinechoice.tsx — the keydown catches an Escape that the Select inside has
+#                      already declined to claim, which is the one case a picker
+#                      left open on a failed save has no other way out of. The
+#                      control is that Select's own trigger.
+#   agentrail.tsx    — the click widens the rail button's pointer target to the
+#                      words beside it. The button is the control: it carries the
+#                      accessible name and the expanded state, and the keyboard
+#                      reaches this handler only as that button's own Enter and
+#                      Space. A CSS overlay — the usual way to widen a hit area
+#                      without a handler — is not available here, because the
+#                      words include a link it would cover, so the handler does
+#                      that job instead.
+#
+# Neither is a control a keyboard reader can be stranded on, which is what the
+# rule is for. Both already carry the biome waiver for the same rule under its
+# other name. Scoped per file for the same reason as e20-e22.
+sonar.issue.ignore.multicriteria.e23.ruleKey=typescript:S6848
+sonar.issue.ignore.multicriteria.e23.resourceKey=frontend/src/design-system/inlinechoice.tsx
+sonar.issue.ignore.multicriteria.e24.ruleKey=typescript:S6848
+sonar.issue.ignore.multicriteria.e24.resourceKey=frontend/src/app/agentrail.tsx


### PR DESCRIPTION
Clears the sixteen open findings on the SonarCloud project. Three were defects; the other thirteen are the analyzer resolving a JSX element without the ancestor that decides its role, and each now carries its reasoning in `sonar-project.properties` beside the sixteen waivers already there.

## The defects

**A bracket matcher that re-reads the line** (`typescript:S8786`, `frontend/src/screens/projectrecord.ts`). `stripEveryKeyTag` found groups with `` / ?\[[^\]]*\] ?/g ``, which re-scans the tail of the line at every `[` it then fails to close — so a subject whose brackets all sit after its last `]` costs time quadratic in its length. A subject is attacker-supplied text: it reaches this composer through the reply it seeds.

It now walks the line the way the capture side's own `bracketedGroups` walks it — each `[` to the NEXT `]`, non-overlapping, an unclosed `[` ending the scan. That was already the semantics the regex had, so **the existing spec passes unchanged**; narrowing the character class instead (`[^\][]*`) would have been the tempting one-character fix and would have broken the mirror, because the capture side's inner group *may* contain a `[`. Six cases were added for the shapes the two sides have to agree on, including that one.

**A key shape narrower than the constraint it reads** (found alongside). `keyShaped` was `^[a-z][a-z0-9-]{1,23}$`; `project_key_shape` is `^[A-Za-z][A-Za-z0-9_-]{1,23}$`. So a project keyed `alpha_two` is a key the inbound matcher reads and this side left standing — and writing ours in beside it hands the message two live keys, which files it under neither. That is the exact outcome `stripEveryKeyTag` exists to prevent, missed on one character of the shape.

**Two ARIA menus that could not take focus** (`typescript:S6852` ×2, `frontend/src/app/account.tsx`). Both `role="menu"` panels carried `onKeyDown` and no `tabindex`, so neither could be focused at all — not even programmatically. Both now take `tabIndex={-1}`: the tab stop stays on the roving rows, which is where each panel's own mount effect already lands the reader.

## The waivers

| Rule | File(s) | Why the rule cannot be satisfied here |
| --- | --- | --- |
| `typescript:S6843` ×4, `typescript:S6825` ×3 | `design-system/listtable.tsx` | A `<td>` resolves to `cell` under a table and `gridcell` under a grid. The analyzer sees one element, not the `<table role="table">` around it, so it takes the interactive reading — and then `role="cell"` looks like a demotion and `aria-hidden` on a spacer cell looks like hiding something focusable. Under a table neither is true. The roles are load-bearing: below 720px the stylesheet lays rows out as cards, and changing a table element's `display` is what drops its implicit semantics — `listtable.css` says so where it makes the switch. Removing them hands a phone reader a stack of unrelated divs. |
| `typescript:S6845` ×3 | `design-system/{trust,composed,decisiondeck}.tsx` | WCAG 2.1.1 requires the opposite for a scrollable region: `tabindex="0"` on the scroller is the technique the guideline prescribes, which is why axe raises `scrollable-region-focusable` for the very elements this rule wants left alone. Each site is a scroller or arrow-key surface no descendant can stand in for, and each already carries the biome waiver for the same rule under its other name. |
| `typescript:S6848` ×2 | `design-system/inlinechoice.tsx`, `app/agentrail.tsx` | At both sites the control is a real element *inside* the one carrying the handler. The rail's click widens the button's pointer target to the words beside it — a CSS overlay, the usual way to do that without a handler, would cover a link those words contain. |
| `godre:S8188` ×1 | `cmd/worker/lanes.go` | `laneLifetime` *returns* the cancel so `run()` can defer it before anything starts reading the bus and the pool. Deferring it inside would kill every lane as the helper returned. What the rule protects is held more strictly at the site that can be wrong: `TestALaneCannotStartBeforeItsShutdownIsRegistered` fails when the defer does not *precede* the call that starts the lanes. |

Every waiver names one exact file rather than a directory wildcard, so a fourth scrollable region or a second table re-declaring its roles has to argue for itself here. `lanes.go` calls `context.WithCancel` once, so that file scope hides nothing else.

## Verification

- `make fe-typecheck-composed`, `fe-ds-gates`, `fe-drift`, `fe-lint`, `fe-build` — green.
- `make fe-unit` — 626 files, 8263 passed (a first run flaked on an untouched `leads.test.tsx`; it passes 75/75 alone and the re-run is clean).
- `make check-gates` — green. No Go changed.
- No open security hotspots on the project; the quality gate reads OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)