### PR TITLE
fix(dbmigrate): Down reads the digest Up records

### DIFF
--- a/backend/internal/platform/dbmigrate/dbmigrate.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate.go
@@ -241,6 +241,12 @@ func Down(ctx context.Context, conn *pgx.Conn, ns Namespace, n int) (reverted in
 		if _, isDone := done[m.Version]; !isDone {
 			continue
 		}
+		// After the not-applied skip: a version this database never ran has no
+		// content to disagree about, and reporting one would refuse a rollback
+		// over a migration that is not there.
+		if err := assertContentMatches(ns.Name, done, m); err != nil {
+			return reverted, err
+		}
 		if err := inTx(ctx, conn, func(tx pgx.Tx) error {
 			if _, err := tx.Exec(ctx, m.DownSQL); err != nil {
 				return err
@@ -325,22 +331,36 @@ func trackingTable(ctx context.Context, conn *pgx.Conn, namespace string) (strin
 // database that applied some other migration in that slot — and matching on
 // the version alone makes the two indistinguishable, so the migration actually
 // sitting there is skipped silently and forever.
-func appliedVersions(ctx context.Context, conn *pgx.Conn, table string) (map[string]string, error) {
-	rows, err := conn.Query(ctx, fmt.Sprintf(`SELECT version, name FROM %s`, table))
+func appliedVersions(ctx context.Context, conn *pgx.Conn, table string) (map[string]appliedRow, error) {
+	rows, err := conn.Query(ctx, fmt.Sprintf(`SELECT version, name, content_digest FROM %s`, table))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	done := map[string]string{}
+	done := map[string]appliedRow{}
 	for rows.Next() {
-		var version, name string
-		if err := rows.Scan(&version, &name); err != nil {
+		var version string
+		var applied appliedRow
+		if err := rows.Scan(&version, &applied.name, &applied.digest); err != nil {
 			return nil, err
 		}
-		done[version] = name
+		done[version] = applied
 	}
 	return done, rows.Err()
+}
+
+// appliedRow is what the ledger recorded for one version: the name it was
+// applied under, and the digest of the content that was applied.
+//
+// The digest is a POINTER because NULL is a real and permanent answer — a row
+// written before the column existed records no fingerprint, and back-filling
+// one would stamp a fingerprint over content nobody can recover, which is the
+// divergence the column exists to expose. Unverifiable is not the same as
+// matching, and the two must never collapse into one another.
+type appliedRow struct {
+	name   string
+	digest *string
 }
 
 // assertLedgerMatches refuses when a version was applied under a different
@@ -353,16 +373,50 @@ func appliedVersions(ctx context.Context, conn *pgx.Conn, table string) (map[str
 // permanently missing whatever the skipped migration created, with no failure
 // to point at it. A renumbered migration cannot be reconciled forward: the
 // database has to be rebuilt (make dev-fresh).
-func assertLedgerMatches(namespace string, done map[string]string, m Migration) error {
+func assertLedgerMatches(namespace string, done map[string]appliedRow, m Migration) error {
 	recorded, ok := done[m.Version]
-	if !ok || recorded == m.Name {
+	if !ok || recorded.name == m.Name {
 		return nil
 	}
 	return fmt.Errorf(
 		"pgmigrate: %s %s: applied as %q, but the source at that version is %q — this database "+
 			"applied a migration that has since been renumbered, so %q would be skipped as done. "+
 			"It cannot be repaired forward; rebuild the database (make dev-fresh)",
-		namespace, m.Version, recorded, m.Name, m.Name)
+		namespace, m.Version, recorded.name, m.Name, m.Name)
+}
+
+// assertContentMatches refuses to REVERT a version whose recorded digest is not
+// the content this binary holds.
+//
+// The down half is the sharper one, which is why it is answered first. Up
+// skipping an edited migration leaves a database missing whatever the edit
+// added — bad, and visible later as an absent object. Down running the CURRENT
+// rollback against a schema the OLD up-migration built is a schema CHANGE made
+// on a false premise: it drops what this version's down names, which is not
+// what that database has, and then deletes the row that was the only record of
+// what it did have. There is nothing left to compare afterwards.
+//
+// A NULL digest is admitted, permanently. It means the row predates the column,
+// so there is no fingerprint to disagree with — refusing there would strand
+// every installation that migrated before #2135 with no way forward, and
+// back-filling one would invent the evidence. Unverifiable is its own answer.
+//
+// Up is deliberately NOT held to this. Whether a live installation should stop
+// migrating at boot over an edited migration — even in whitespace, even in a
+// comment — decides how a deployment fails, which is a product call and is
+// #2141's open half.
+func assertContentMatches(namespace string, done map[string]appliedRow, m Migration) error {
+	recorded, ok := done[m.Version]
+	if !ok || recorded.digest == nil || *recorded.digest == Digest(m) {
+		return nil
+	}
+	return fmt.Errorf(
+		"pgmigrate: %s %s_%s: applied content does not match the source — this database ran a "+
+			"different version of this migration, so its rollback would drop what the source names "+
+			"rather than what the database has, and would then delete the only record of what it "+
+			"applied. Applied core migrations are never edited (CLAUDE.md); rebuild the database "+
+			"(make dev-fresh), or revert the edit to the migration's committed content",
+		namespace, m.Version, m.Name)
 }
 
 func inTx(ctx context.Context, conn *pgx.Conn, fn func(pgx.Tx) error) error {

--- a/backend/internal/platform/dbmigrate/dbmigrate_test.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate_test.go
@@ -142,7 +142,7 @@ func TestTrackingTableRefusesUnspellableNamespaces(t *testing.T) {
 // relation at runtime, long after the deploy that caused it.
 func TestALedgerRowNamingADifferentMigrationStopsTheRun(t *testing.T) {
 	t.Parallel()
-	applied := map[string]string{"0209": "drop_workspace_identity_columns"}
+	applied := map[string]appliedRow{"0209": {name: "drop_workspace_identity_columns"}}
 
 	err := assertLedgerMatches("core", applied, Migration{Version: "0209", Name: "person_record_page_v2"})
 	if err == nil {
@@ -160,12 +160,81 @@ func TestALedgerRowNamingADifferentMigrationStopsTheRun(t *testing.T) {
 // trip the guard, or every run would refuse.
 func TestALedgerRowMatchingItsMigrationIsNotARenumber(t *testing.T) {
 	t.Parallel()
-	applied := map[string]string{"0209": "person_record_page_v2"}
+	applied := map[string]appliedRow{"0209": {name: "person_record_page_v2"}}
 
 	if err := assertLedgerMatches("core", applied, Migration{Version: "0209", Name: "person_record_page_v2"}); err != nil {
 		t.Errorf("an exact match refused: %v", err)
 	}
 	if err := assertLedgerMatches("core", applied, Migration{Version: "0210", Name: "consumer_mail_create_grant"}); err != nil {
+		t.Errorf("an unapplied version refused: %v", err)
+	}
+}
+
+// Down reads the digest Up records, which nothing did before: the column held
+// the evidence and no code acted on it (#2141).
+//
+// The down half is the sharper one. Up skipping an edited migration leaves a
+// database missing whatever the edit added — bad, and visible later as an
+// absent object. Down running the CURRENT rollback against a schema the OLD
+// up-migration built is a schema CHANGE made on a false premise: it drops what
+// this version's down names, which is not what that database has, and then
+// deletes the row that was the only record of what it did have.
+func TestARevertRefusesContentTheDatabaseNeverApplied(t *testing.T) {
+	t.Parallel()
+	was := Migration{Version: "0209", Name: "add_thing", UpSQL: "CREATE TABLE thing ()", DownSQL: "DROP TABLE thing"}
+	stamped := Digest(was)
+	applied := map[string]appliedRow{"0209": {name: was.Name, digest: &stamped}}
+
+	// The same content is an ordinary revert.
+	if err := assertContentMatches("core", applied, was); err != nil {
+		t.Errorf("a revert of the content that was applied refused: %v", err)
+	}
+
+	// An edited DOWN is the case with teeth: the up half is identical, so the
+	// database looks current by every other measure, and this rollback would
+	// drop a different object from the one that exists.
+	edited := was
+	edited.DownSQL = "DROP TABLE thing CASCADE"
+	if err := assertContentMatches("core", applied, edited); err == nil {
+		t.Error("a revert whose down SQL was edited after it was applied was admitted — it would drop " +
+			"what the source names rather than what the database has")
+	}
+
+	// An edited UP counts too. The digest covers both halves because a binary
+	// whose up differs built a different schema, whatever its down says.
+	edited = was
+	edited.UpSQL = "CREATE TABLE thing (id int)"
+	if err := assertContentMatches("core", applied, edited); err == nil {
+		t.Error("a revert whose up SQL was edited after it was applied was admitted")
+	}
+}
+
+// A row written before the digest column existed records no fingerprint, and
+// that is a permanent answer rather than a gap to fill.
+//
+// Refusing on NULL would strand every installation that migrated before the
+// column landed, with no way forward. Back-filling one would stamp a
+// fingerprint over content nobody can recover — the exact divergence the column
+// exists to expose.
+func TestARevertOfAnUnverifiableRowIsAdmitted(t *testing.T) {
+	t.Parallel()
+	m := Migration{Version: "0209", Name: "add_thing", UpSQL: "CREATE TABLE thing ()", DownSQL: "DROP TABLE thing"}
+	applied := map[string]appliedRow{"0209": {name: m.Name, digest: nil}}
+
+	edited := m
+	edited.DownSQL = "DROP TABLE thing CASCADE"
+	if err := assertContentMatches("core", applied, edited); err != nil {
+		t.Errorf("a revert of a row with no recorded digest refused: %v — unverifiable is not "+
+			"the same as mismatched, and treating it as one strands every database that migrated "+
+			"before the column existed", err)
+	}
+}
+
+// A version this database never applied has no content to disagree about.
+func TestARevertOfAnUnappliedVersionHasNothingToCompare(t *testing.T) {
+	t.Parallel()
+	m := Migration{Version: "0210", Name: "other", UpSQL: "SELECT 1", DownSQL: "SELECT 1"}
+	if err := assertContentMatches("core", map[string]appliedRow{}, m); err != nil {
 		t.Errorf("an unapplied version refused: %v", err)
 	}
 }

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -292,5 +293,57 @@ func seedLedgerRowsForReversal(t *testing.T, conn *pgx.Conn) {
 		INSERT INTO system_log (actor_type, actor_id, action)
 		VALUES ('system', 'system:reversal-fixture', 'reversal_fixture')`); err != nil {
 		t.Fatalf("seeding the system_log row this reversal must survive: %v", err)
+	}
+}
+
+// Down REFUSES a version whose applied content is not the content this binary
+// holds — driven through dbmigrate.Down rather than against the predicate, so
+// it proves the production revert path actually consults the digest.
+//
+// Up records a content_digest and, before this, nothing read it: the column
+// held the evidence and no code acted on it (#2141). The down half is the
+// sharper one. Running the CURRENT rollback against a schema the OLD
+// up-migration built is a schema CHANGE made on a false premise — it drops
+// what the source names rather than what the database has, then deletes the row
+// that was the only record of what it did apply.
+func TestMigrations_downRefusesAnEditedMigration(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	conn := connect(t, ownerDSN)
+	resetSchema(t, conn)
+	ctx := context.Background()
+
+	core, err := migrations.Core()
+	if err != nil {
+		t.Fatalf("loading core: %v", err)
+	}
+	if _, err := dbmigrate.Up(ctx, conn, core); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+
+	// The edit a contributor would make: the newest migration's rollback,
+	// changed after this database applied it. Its UP is untouched, so the
+	// database looks current by every other measure the ledger keeps.
+	edited := core
+	edited.Migrations = append([]dbmigrate.Migration(nil), core.Migrations...)
+	last := len(edited.Migrations) - 1
+	edited.Migrations[last].DownSQL += "\n-- an edit made after this was applied\n"
+
+	reverted, err := dbmigrate.Down(ctx, conn, edited, 1)
+	if err == nil {
+		t.Fatal("the revert ran against a database that applied different content — it would drop " +
+			"what the source names rather than what the database has, and then delete the only " +
+			"record of what it applied")
+	}
+	if reverted != 0 {
+		t.Errorf("reverted %d migration(s) before refusing, want 0", reverted)
+	}
+	if !strings.Contains(err.Error(), "applied content does not match the source") {
+		t.Errorf("the revert was refused by something else: %v", err)
+	}
+
+	// And the UNEDITED revert still runs, so the guard refuses an edit rather
+	// than refusing rollbacks.
+	if _, err := dbmigrate.Down(ctx, conn, core, 1); err != nil {
+		t.Errorf("the revert of the content that was applied refused: %v", err)
 	}
 }


### PR DESCRIPTION
Addresses #2141 — item 3. **Items 1 and 2 stay open**, deliberately.

#2135 gave every ledger row a `content_digest`, written in the same transaction as the row. **Nothing read it**: the column recorded the evidence and no code acted on it.

## Down first, because it is the sharper half

| | what goes wrong |
|---|---|
| **Up** skipping an edited migration | the database is missing whatever the edit added — bad, and visible later as an absent object |
| **Down** running the current rollback | a schema **change** on a false premise: it drops what the source names, which is not what the database has, then deletes the row that was the only record of what it did have. Nothing is left to compare afterwards |

The issue says this itself — *"Down is the sharper half: running the wrong rollback is a schema change, not a refusal"* — and unlike items 1 and 2 it is not a decision about how a live installation fails at boot.

## A NULL digest is admitted, permanently

A row written before the column existed records no fingerprint, so there is nothing to disagree with. Refusing there would strand every installation that migrated before #2135 with no way forward, and back-filling one would stamp a fingerprint over content nobody can recover — the exact divergence the column exists to expose. **Unverifiable is its own answer**, and it must never collapse into "matches".

## Items 1 and 2 stay open

Whether `Up` should **refuse** or **warn** on a digest mismatch decides how a deployment fails — a live installation whose migration was edited, even in whitespace, even in a comment, would stop migrating at boot. That is a product call. The source already carried a note saying so; it now points at what was answered and what was not.

## Verification

- Driven through `dbmigrate.Down` against a real database, not against the predicate: **removing the call makes the revert run**, which is the wiring this issue is about.
- The edit planted is to the **down** SQL, with the up half untouched — so the database looks current by every other measure the ledger keeps.
- An edited **up** is caught too: the digest covers both halves, because a binary whose up differs built a different schema whatever its down says.
- The unedited revert still runs, so the guard refuses an edit rather than refusing rollbacks.
- `TestMigrations_applyReverseReapply` — the full up/down/up cycle — still passes.
- `make check-backend` exit 0.
