### PR TITLE
The api says how long each route took, not just that it was asked

### DIFF
--- a/backend/internal/compose/aimetrics.go
+++ b/backend/internal/compose/aimetrics.go
@@ -33,6 +33,7 @@ func (s Server) writeAIMetrics(w io.Writer) {
 // says the parameter list has reached the point where a further section should
 // not become another argument.
 func (s Server) writeMetricsSections(w io.Writer) {
+	s.httpMetrics.Write(w)
 	s.writeAIMetrics(w)
 	s.writeMCPAppMetrics(w)
 	s.writeLicenseMetrics(w)

--- a/backend/internal/compose/httpmetricswiring_helper_test.go
+++ b/backend/internal/compose/httpmetricswiring_helper_test.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import "github.com/margince/margince/backend/internal/platform/httpserver"
+
+// newHTTPMetricsForTest keeps the constructor call in one place, so a change to
+// its signature does not scatter across the wiring tests.
+func newHTTPMetricsForTest() *httpserver.HTTPMetrics { return httpserver.NewHTTPMetrics() }

--- a/backend/internal/compose/httpmetricswiring_test.go
+++ b/backend/internal/compose/httpmetricswiring_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// THE WIRING IS THE PART THAT CAN SILENTLY NOT WORK.
+//
+// httpmetrics_test.go proves the store's arithmetic against a fixed route. What
+// it cannot prove is that the route reaching it is chi's TEMPLATE rather than
+// the request path — that depends on the generated server applying its
+// Middlewares after the match, which is a property of code this repo does not
+// hand-write. If that ever stops holding, the metric keeps working and starts
+// growing a series per id, which is the failure nobody notices until the
+// scrape is expensive.
+func TestChiRoutePatternReadsTheTemplateNotThePath(t *testing.T) {
+	t.Parallel()
+	var seen string
+	router := chi.NewRouter()
+	// Registered the way the generated server registers: a path parameter in
+	// the pattern, so template and path necessarily differ.
+	router.Get("/v1/deals/{dealId}", func(_ http.ResponseWriter, r *http.Request) {
+		seen = chiRoutePattern(r)
+	})
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/v1/deals/9f3cbe20-0000-4000-8000-000000000000", nil))
+
+	if want := "/v1/deals/{dealId}"; seen != want {
+		t.Fatalf("chiRoutePattern = %q, want the template %q", seen, want)
+	}
+	if strings.Contains(seen, "9f3cbe20") {
+		t.Fatal("the deal id reached the route label; this grows a series per record")
+	}
+}
+
+// A request chi matched nothing for must yield "", so HTTPMetrics folds it into
+// its single unmatched bucket rather than being handed a path.
+func TestChiRoutePatternIsEmptyWhenNothingMatched(t *testing.T) {
+	t.Parallel()
+	var seen string
+	captured := false
+	router := chi.NewRouter()
+	router.NotFound(func(_ http.ResponseWriter, r *http.Request) {
+		seen = chiRoutePattern(r)
+		captured = true
+	})
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/v1/no/such/route", nil))
+
+	if !captured {
+		t.Fatal("the NotFound handler never ran")
+	}
+	if seen != "" {
+		t.Errorf("chiRoutePattern = %q for an unmatched request, want the empty string", seen)
+	}
+}
+
+// A request carrying NO chi context at all — the shape every non-/v1 edge on
+// the operational mux has — must not panic. chiRoutePattern is exported to a
+// middleware that could be mounted anywhere.
+func TestChiRoutePatternSurvivesARequestWithNoRouteContext(t *testing.T) {
+	t.Parallel()
+	if got := chiRoutePattern(httptest.NewRequest(http.MethodGet, "/healthz", nil)); got != "" {
+		t.Errorf("chiRoutePattern = %q with no chi context, want the empty string", got)
+	}
+}
+
+// The Server hands ONE store to both the middleware and the exposition.
+// contractAPI and operationalMux each take the Server by value, so a
+// struct-valued store would give them separate copies: requests counted into
+// one, the scrape reading the other, and both looking perfectly healthy.
+func TestTheMetricsStoreIsSharedByValueCopiesOfTheServer(t *testing.T) {
+	t.Parallel()
+	srv := Server{httpMetrics: newHTTPMetricsForTest()}
+	copied := srv
+
+	h := copied.httpMetrics.Measure(func(*http.Request) string { return "/v1/x" })(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/x", nil))
+
+	var b strings.Builder
+	srv.writeMetricsSections(&b)
+	if want := `margince_http_requests_total{route="/v1/x",method="GET",status="200"} 1`; !strings.Contains(b.String(), want) {
+		t.Errorf("the original Server's exposition did not see the copy's request\nwant %q\n--- got ---\n%s", want, b.String())
+	}
+}

--- a/backend/internal/compose/httpmetricswiring_test.go
+++ b/backend/internal/compose/httpmetricswiring_test.go
@@ -27,13 +27,13 @@ func TestChiRoutePatternReadsTheTemplateNotThePath(t *testing.T) {
 	router := chi.NewRouter()
 	// Registered the way the generated server registers: a path parameter in
 	// the pattern, so template and path necessarily differ.
-	router.Get("/v1/deals/{dealId}", func(_ http.ResponseWriter, r *http.Request) {
+	router.Get("/v1/deals/{id}", func(_ http.ResponseWriter, r *http.Request) {
 		seen = chiRoutePattern(r)
 	})
 	router.ServeHTTP(httptest.NewRecorder(),
 		httptest.NewRequest(http.MethodGet, "/v1/deals/9f3cbe20-0000-4000-8000-000000000000", nil))
 
-	if want := "/v1/deals/{dealId}"; seen != want {
+	if want := "/v1/deals/{id}"; seen != want {
 		t.Fatalf("chiRoutePattern = %q, want the template %q", seen, want)
 	}
 	if strings.Contains(seen, "9f3cbe20") {
@@ -90,5 +90,43 @@ func TestTheMetricsStoreIsSharedByValueCopiesOfTheServer(t *testing.T) {
 	srv.writeMetricsSections(&b)
 	if want := `margince_http_requests_total{route="/v1/x",method="GET",status="200"} 1`; !strings.Contains(b.String(), want) {
 		t.Errorf("the original Server's exposition did not see the copy's request\nwant %q\n--- got ---\n%s", want, b.String())
+	}
+}
+
+// newServer must hand every role a live store. Asserted on the CONSTRUCTOR
+// rather than on a hand-built Server, because that is the path cmd/api takes:
+// a field initialised only in a test helper would leave the real api counting
+// nothing while every unit test passed.
+func TestNewServerAlwaysCarriesAMetricsStore(t *testing.T) {
+	t.Parallel()
+	// A nil pool is the shape the other route-level tests use: newServer wires
+	// handlers and reaches no database.
+	srv := newServer(nil, quietTestLogger(), authHandlers{}, dealsHandlers{})
+	if srv.httpMetrics == nil {
+		t.Fatal("newServer left httpMetrics nil; the api would serve /v1 and count nothing")
+	}
+
+	// And it is usable, not merely non-nil.
+	h := srv.httpMetrics.Measure(func(*http.Request) string { return "/v1/x" })(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/x", nil))
+
+	var b strings.Builder
+	srv.writeMetricsSections(&b)
+	if !strings.Contains(b.String(), "margince_http_requests_total{route=\"/v1/x\"") {
+		t.Errorf("the constructor's store is not the one the exposition reads\n--- got ---\n%s", b.String())
+	}
+}
+
+// The exposition includes the HTTP families for a Server that never wired one,
+// without panicking: writeMetricsSections runs on roles composed every which
+// way, and a nil store must be absent rather than fatal.
+func TestMetricsSectionsSurviveAServerWithNoHTTPStore(t *testing.T) {
+	t.Parallel()
+	var srv Server // zero value: httpMetrics is nil
+	var b strings.Builder
+	srv.writeMetricsSections(&b) // must not panic
+	if strings.Contains(b.String(), "margince_http_requests_total") {
+		t.Error("a Server with no store still wrote the HTTP families")
 	}
 }

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -84,6 +85,16 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 			// be recorded under an idempotency key or staged as an agent
 			// approval — the honest unsupported_by_sor, for every principal.
 			overlayWriteGuard(srv.sorDispatch),
+			// Outermost of all, so the measurement covers the admission gate,
+			// the idempotency replay and the overlay guard rather than only the
+			// handler underneath them. A 403 from the gate IS this route's
+			// latency as a client experiences it, and a refusal that cost a
+			// database read is exactly the slow answer worth seeing.
+			//
+			// These are OPERATION middleware: the generated wrapper applies
+			// them after chi has matched, which is what makes chiRoutePattern
+			// able to answer at all.
+			srv.httpMetrics.Measure(chiRoutePattern),
 		},
 		// Keep query/path/header parse failures on the problem+json path:
 		// the generated default writes err.Error() as text/plain, an
@@ -91,6 +102,23 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 		ErrorHandlerFunc: paramParseError,
 	})
 	return api
+}
+
+// chiRoutePattern reads the route TEMPLATE chi matched -- `/v1/deals/{dealId}`,
+// never `/v1/deals/9f3c…`. That distinction is the whole reason this function
+// exists rather than r.URL.Path being passed: the path carries ids, and a label
+// carrying ids grows a series per record for the life of the process.
+//
+// The generated server applies its Middlewares as OPERATION middleware, after
+// the match, so RouteContext is populated by the time this runs. An empty
+// answer means chi matched nothing, and HTTPMetrics folds that into one bucket
+// rather than substituting the path.
+func chiRoutePattern(r *http.Request) string {
+	rc := chi.RouteContext(r.Context())
+	if rc == nil {
+		return ""
+	}
+	return rc.RoutePattern()
 }
 
 // replayProbes wires the module-owned visibility rules the replay gate borrows

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -124,6 +124,10 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 	// due on one of them.
 	introStore := introductions.NewStore(InstallationDB(pool), time.Now)
 	srv := Server{
+		// Built here rather than behind an option: an endpoint's own request
+		// rate is not a feature a deployment opts into, and every role that
+		// serves /v1 comes through this constructor.
+		httpMetrics:         httpserver.NewHTTPMetrics(),
 		uploadLimits:        limits,
 		authHandlers:        authH,
 		peopleHandlers:      newPeopleHandlers(pool).WithUploadLimit(limits.LinkedInImport),

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -40,6 +40,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
+	"github.com/margince/margince/backend/internal/platform/httpserver"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/licensecheck"
@@ -227,6 +228,13 @@ type Server struct {
 	// and is not a credential to carry over an untrusted network. See
 	// gateMetrics in routes.go.
 	metricsToken string
+
+	// httpMetrics accumulates the HTTP request families /metrics serves. A
+	// POINTER, and that is load-bearing: contractAPI and operationalMux each
+	// take the Server BY VALUE, so a struct-valued store would give the
+	// middleware and the exposition two separate copies -- requests counted
+	// into one, a scrape reading the other, and both looking correct.
+	httpMetrics *httpserver.HTTPMetrics
 
 	// bootstrapSeeds are the deployment file's `seeds`, carried here so a
 	// CLAIM lays down the same module defaults a configured bootstrap would.

--- a/backend/internal/platform/httpserver/httpmetrics.go
+++ b/backend/internal/platform/httpserver/httpmetrics.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httpserver
+
+// The HTTP layer's own exposition: how many requests each route answered, how
+// long it took, and how many are in flight right now.
+//
+// Everything here was already measured and thrown away. AccessLog has always
+// timed the request and captured the status, then written both to a log line --
+// so "how slow is this route" was answerable only by parsing logs, one
+// installation at a time, and "what is the p95" was not answerable at all.
+// This turns the same two numbers into series.
+//
+// Hand-rolled, like every other family in this process: there is no Prometheus
+// client library in this module, and adding one for three metric families would
+// bring a registry, a collector interface and a second exposition writer beside
+// the one httpserver.Metrics already owns.
+//
+// THE LABEL IS THE ROUTE PATTERN, NEVER THE PATH. `/v1/companies/{id}` is one
+// series; `/v1/companies/9f3c…` is one series per company that has ever been
+// read, forever, in a process that also cannot forget them. AccessLog logs the
+// path deliberately -- a log line answers "what did clients ask" -- and that is
+// exactly the reading a metric label must not take. Measure therefore asks its
+// caller's router for the matched pattern and folds a miss into one bucket.
+
+import (
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// latencyBounds are the histogram's upper bounds in seconds, ascending.
+//
+// Chosen for THIS surface rather than copied: the fast half (5ms-100ms) is
+// where a CRUD read on a warm pool lands, so the buckets an operator watches
+// for regression are dense there. The tail runs to 10s because that is past
+// every ceiling the process imposes on itself -- so a request in the +Inf
+// bucket is not "slow", it is a request something failed to bound.
+var latencyBounds = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+const (
+	// maxRouteSeries caps how many distinct route+method pairs the histogram
+	// will hold. chi's patterns come from the generated router, so the real
+	// number is fixed at compile time and this can never fire for /v1 -- but
+	// Measure takes the route from a caller-supplied resolver, and one that
+	// returned anything request-derived would grow these maps until the process
+	// died. A metric must not be able to do that.
+	maxRouteSeries = 500
+	// routeOverflowLabel is where series past the cap are counted. They are
+	// counted rather than dropped: an exposition that silently stopped
+	// measuring would read as a quiet surface.
+	routeOverflowLabel = "__over_cardinality_limit__"
+	// unmatchedRoute is where a request the router matched no pattern for is
+	// counted -- one series for every 404-by-path, however many distinct paths
+	// they arrived on.
+	unmatchedRoute = "unmatched"
+)
+
+// HTTPMetrics accumulates the request families. Safe for concurrent use: the
+// middleware writes it on every request while /metrics reads it on a scrape,
+// so the two race by construction rather than by accident.
+type HTTPMetrics struct {
+	mu       sync.Mutex
+	requests map[requestKey]uint64
+	latency  map[routeKey]*latencyHistogram
+	inFlight atomic.Int64
+}
+
+type requestKey struct {
+	route  string
+	method string
+	status int
+}
+
+type routeKey struct {
+	route  string
+	method string
+}
+
+type latencyHistogram struct {
+	counts []uint64 // one per latencyBounds entry, plus the +Inf terminator
+	sum    float64
+	count  uint64
+}
+
+// NewHTTPMetrics returns an empty, ready store.
+func NewHTTPMetrics() *HTTPMetrics {
+	return &HTTPMetrics{
+		requests: make(map[requestKey]uint64),
+		latency:  make(map[routeKey]*latencyHistogram),
+	}
+}
+
+// Measure wraps a handler so its requests are counted and timed.
+//
+// routeOf reads the matched pattern off the request, which only the router that
+// matched it can answer -- chi keeps it on the request context, and net/http
+// keeps it on the Request. It is a parameter rather than a hard-coded reading
+// so this package stays router-agnostic, and so a caller that has no bounded
+// answer is forced to say so by returning "" instead of quietly passing a path.
+//
+// A nil receiver returns the handler unwrapped, so a role that wires no metrics
+// is not a nil dereference on its first request.
+func (m *HTTPMetrics) Measure(routeOf func(*http.Request) string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if m == nil {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			m.inFlight.Add(1)
+			// Deferred, not decremented after ServeHTTP: a panicking handler
+			// would otherwise leak the gauge, and RecoverPanics upstream means
+			// the process survives to keep leaking it until the floor is the
+			// only thing the panel shows.
+			defer m.inFlight.Add(-1)
+
+			start := time.Now()
+			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			defer func() {
+				// Also deferred, so a panic is still MEASURED. The status it
+				// records is whatever reached the client, which for a panic
+				// mid-handler is the 200 net/http had already sent or the 500
+				// RecoverPanics writes -- either way a real answer, and a
+				// request that vanished from the counters would be worse.
+				m.observe(routeOf(r), r.Method, rec.status, time.Since(start))
+			}()
+			next.ServeHTTP(rec, r)
+		})
+	}
+}
+
+// observe records one finished request. Separate from Measure so the tests can
+// state the histogram's arithmetic directly rather than through a server.
+func (m *HTTPMetrics) observe(route, method string, status int, took time.Duration) {
+	if m == nil {
+		return
+	}
+	if route == "" {
+		route = unmatchedRoute
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rk := routeKey{route: route, method: method}
+	hist, known := m.latency[rk]
+	if !known && len(m.latency) >= maxRouteSeries {
+		rk = routeKey{route: routeOverflowLabel, method: method}
+		route = routeOverflowLabel
+		hist, known = m.latency[rk]
+	}
+	if !known {
+		hist = &latencyHistogram{counts: make([]uint64, len(latencyBounds)+1)}
+		m.latency[rk] = hist
+	}
+
+	m.requests[requestKey{route: route, method: method, status: status}]++
+
+	seconds := took.Seconds()
+	hist.sum += seconds
+	hist.count++
+	// Cumulative at WRITE time rather than at read time: a bucket counts every
+	// observation at or below its bound, so incrementing each bound the sample
+	// clears keeps the read a straight walk. sort.SearchFloat64s finds the
+	// first bound the sample does NOT exceed.
+	for i := sort.SearchFloat64s(latencyBounds, seconds); i < len(hist.counts); i++ {
+		hist.counts[i]++
+	}
+}
+
+// Write renders the three families in Prometheus text format. Called by the
+// composition layer's metrics section; a nil receiver writes nothing, the same
+// "declared or absent" posture every other section here takes.
+func (m *HTTPMetrics) Write(w io.Writer) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	requests := make(map[requestKey]uint64, len(m.requests))
+	for k, v := range m.requests {
+		requests[k] = v
+	}
+	latency := make(map[routeKey]latencyHistogram, len(m.latency))
+	for k, v := range m.latency {
+		counts := make([]uint64, len(v.counts))
+		copy(counts, v.counts)
+		latency[k] = latencyHistogram{counts: counts, sum: v.sum, count: v.count}
+	}
+	inFlight := m.inFlight.Load()
+	m.mu.Unlock()
+
+	// Wrapped in the package's own writer rather than each line handling its
+	// own error: exposition.go explains the posture, and it holds whether or
+	// not the caller already handed one in.
+	out := &exposition{w: w}
+	writeRequestCounters(out, requests)
+	writeLatencyHistogram(out, latency)
+	out.printf("# HELP margince_http_requests_in_flight Requests being served right now.\n")
+	out.printf("# TYPE margince_http_requests_in_flight gauge\n")
+	out.printf("margince_http_requests_in_flight %d\n", inFlight)
+}
+
+func writeRequestCounters(out *exposition, requests map[requestKey]uint64) {
+	out.printf("# HELP margince_http_requests_total Requests answered, by matched route pattern, method and status.\n")
+	out.printf("# TYPE margince_http_requests_total counter\n")
+	keys := make([]requestKey, 0, len(requests))
+	for k := range requests {
+		keys = append(keys, k)
+	}
+	// Stable output so a scrape diff and a test do not flap on map order.
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route != keys[j].route {
+			return keys[i].route < keys[j].route
+		}
+		if keys[i].method != keys[j].method {
+			return keys[i].method < keys[j].method
+		}
+		return keys[i].status < keys[j].status
+	})
+	for _, k := range keys {
+		out.printf("margince_http_requests_total{route=%q,method=%q,status=%q} %d\n",
+			k.route, k.method, strconv.Itoa(k.status), requests[k])
+	}
+}
+
+func writeLatencyHistogram(out *exposition, latency map[routeKey]latencyHistogram) {
+	out.printf("# HELP margince_http_request_duration_seconds Request duration by matched route pattern and method.\n")
+	out.printf("# TYPE margince_http_request_duration_seconds histogram\n")
+	keys := make([]routeKey, 0, len(latency))
+	for k := range latency {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route != keys[j].route {
+			return keys[i].route < keys[j].route
+		}
+		return keys[i].method < keys[j].method
+	})
+	const name = "margince_http_request_duration_seconds"
+	for _, k := range keys {
+		h := latency[k]
+		for i, bound := range latencyBounds {
+			out.printf("%s_bucket{route=%q,method=%q,le=%q} %d\n",
+				name, k.route, k.method, strconv.FormatFloat(bound, 'g', -1, 64), h.counts[i])
+		}
+		// The +Inf bucket equals _count by definition, and a histogram without
+		// it is not a histogram: every quantile read walks to the terminator.
+		out.printf("%s_bucket{route=%q,method=%q,le=\"+Inf\"} %d\n", name, k.route, k.method, h.count)
+		out.printf("%s_sum{route=%q,method=%q} %g\n", name, k.route, k.method, h.sum)
+		out.printf("%s_count{route=%q,method=%q} %d\n", name, k.route, k.method, h.count)
+	}
+}

--- a/backend/internal/platform/httpserver/httpmetrics.go
+++ b/backend/internal/platform/httpserver/httpmetrics.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,12 +48,20 @@ var latencyBounds = []float64{
 
 const (
 	// maxRouteSeries caps how many distinct route+method pairs the histogram
-	// will hold. chi's patterns come from the generated router, so the real
-	// number is fixed at compile time and this can never fire for /v1 -- but
-	// Measure takes the route from a caller-supplied resolver, and one that
-	// returned anything request-derived would grow these maps until the process
-	// died. A metric must not be able to do that.
+	// holds. chi's patterns come from the generated router, so the real number
+	// is fixed at compile time and this cannot fire for /v1 -- but Measure takes
+	// the route from a caller-supplied resolver, and one that returned anything
+	// request-derived would grow this map without it.
+	//
+	// It is the SECOND of two bounds, not the only one: normalizeMethod closes
+	// the method dimension, which this cap provably did not. See otherMethod.
 	maxRouteSeries = 500
+	// maxRequestSeries caps the counter map, which is keyed one dimension wider
+	// than the histogram -- route, method AND status. Capped on its own count
+	// rather than trusting the histogram's: the two maps do not grow in step, so
+	// a bound asserted about one is not a bound on the other. That was the shape
+	// of the original mistake and it should not be repeated by inheritance.
+	maxRequestSeries = 5000
 	// routeOverflowLabel is where series past the cap are counted. They are
 	// counted rather than dropped: an exposition that silently stopped
 	// measuring would read as a quiet surface.
@@ -61,7 +70,51 @@ const (
 	// counted -- one series for every 404-by-path, however many distinct paths
 	// they arrived on.
 	unmatchedRoute = "unmatched"
+	// overflowStatus stands where a status would go on the overflow series. It
+	// is not a status any client saw, and a number there would read as one --
+	// the overflow bucket answers "how many requests could not be named", not
+	// "how did they end".
+	overflowStatus = -1
+	// otherMethod is where a method outside RFC 9110's set is counted.
+	//
+	// This closes the method dimension, which the route cap alone did not.
+	// r.Method is a token the CLIENT chooses -- net/http accepts any valid token
+	// -- so `EVIL1`, `EVIL2`, ... arrive as distinct label values, and folding
+	// the ROUTE into an overflow bucket does not help while the overflow key
+	// still carries the method: each new method mints a new overflow series.
+	// Measured before this existed: 5000 distinct methods against a 500-route
+	// cap produced 5000 series in each map.
+	//
+	// NOT reachable through the /v1 mount, and the honest bound matters here.
+	// Measure runs as chi OPERATION middleware, after the match, so the method
+	// is one the generated router registered for that route -- an arbitrary
+	// token is answered 405 by chi and never reaches this. So this is a hole in
+	// the exported CONTRACT, not a live denial of service: Measure takes its
+	// route from a caller-supplied resolver and may be mounted anywhere, and a
+	// metric should not depend on every future caller having thought about it.
+	otherMethod = "other"
 )
+
+// knownMethods is the closed set a method label may take: RFC 9110's nine, and
+// nothing else. Bounding at the DOOR rather than by a cap downstream, because a
+// cap answers "how many" while this answers "which", and only the second makes
+// the label meaningful -- a series named for a method nobody implements tells an
+// operator nothing they can act on.
+var knownMethods = map[string]struct{}{
+	http.MethodGet: {}, http.MethodHead: {}, http.MethodPost: {}, http.MethodPut: {},
+	http.MethodPatch: {}, http.MethodDelete: {}, http.MethodConnect: {},
+	http.MethodOptions: {}, http.MethodTrace: {},
+}
+
+// normalizeMethod folds anything outside that set into one series. Counted
+// rather than dropped: a flood of nonsense methods is worth SEEING, and it is
+// the shape a scanner makes.
+func normalizeMethod(method string) string {
+	if _, known := knownMethods[method]; known {
+		return method
+	}
+	return otherMethod
+}
 
 // HTTPMetrics accumulates the request families. Safe for concurrent use: the
 // middleware writes it on every request while /metrics reads it on a scrape,
@@ -71,6 +124,15 @@ type HTTPMetrics struct {
 	requests map[requestKey]uint64
 	latency  map[routeKey]*latencyHistogram
 	inFlight atomic.Int64
+
+	// The overflow bucket is ONE counter and ONE histogram, held OUTSIDE the
+	// maps rather than as a key inside them. That is the whole lesson of this
+	// file: two earlier attempts folded an over-cap request into a synthetic
+	// KEY, and both were defeated within minutes of being measured, because the
+	// key still carried a dimension the caller controls -- first the method,
+	// then the status. A bucket that cannot grow has to be a field, not a key.
+	overflowRequests uint64
+	overflowLatency  latencyHistogram
 }
 
 type requestKey struct {
@@ -88,6 +150,21 @@ type latencyHistogram struct {
 	counts []uint64 // one per latencyBounds entry, plus the +Inf terminator
 	sum    float64
 	count  uint64
+}
+
+// observe records one duration. Cumulative at WRITE time rather than at read
+// time: a bucket counts every observation at or below its bound, so
+// incrementing each bound the sample clears keeps the read a straight walk.
+func (h *latencyHistogram) observe(seconds float64) {
+	if h.counts == nil {
+		h.counts = make([]uint64, len(latencyBounds)+1)
+	}
+	h.sum += seconds
+	h.count++
+	// SearchFloat64s finds the first bound the sample does NOT exceed.
+	for i := sort.SearchFloat64s(latencyBounds, seconds); i < len(h.counts); i++ {
+		h.counts[i]++
+	}
 }
 
 // NewHTTPMetrics returns an empty, ready store.
@@ -123,15 +200,36 @@ func (m *HTTPMetrics) Measure(routeOf func(*http.Request) string) func(http.Hand
 
 			start := time.Now()
 			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			returned := false
 			defer func() {
-				// Also deferred, so a panic is still MEASURED. The status it
-				// records is whatever reached the client, which for a panic
-				// mid-handler is the 200 net/http had already sent or the 500
-				// RecoverPanics writes -- either way a real answer, and a
-				// request that vanished from the counters would be worse.
-				m.observe(routeOf(r), r.Method, rec.status, time.Since(start))
+				// Deferred so a panicked request is still measured -- one that
+				// vanished from the counters would be worse than a mislabelled
+				// one.
+				//
+				// A PANIC IS RECORDED AS 500, AND NOT FROM rec.status. This
+				// wrapper sits INSIDE RecoverPanics (compose/server.go), so
+				// the 500 the client receives is written by that outer
+				// recover, on the original ResponseWriter, after this defer
+				// has already run during unwinding. rec.status is therefore
+				// still its 200 default, and recording it would show a route
+				// that panics on every request as a 100% success rate -- in
+				// the one place an operator would look to see otherwise.
+				//
+				// `returned` is the only reliable signal here: Go offers no
+				// way to ask whether a panic is in flight without recovering
+				// it, and recovering is RecoverPanics' job, not a metric's.
+				//
+				// A handler that wrote a header and THEN panicked keeps what
+				// it wrote: the client did receive that status, and the broken
+				// body after it is not this counter's story to tell.
+				status := rec.status
+				if !returned && !rec.wrote {
+					status = http.StatusInternalServerError
+				}
+				m.observe(routeOf(r), r.Method, status, time.Since(start))
 			}()
 			next.ServeHTTP(rec, r)
+			returned = true
 		})
 	}
 }
@@ -145,33 +243,33 @@ func (m *HTTPMetrics) observe(route, method string, status int, took time.Durati
 	if route == "" {
 		route = unmatchedRoute
 	}
+	method = normalizeMethod(method)
+	seconds := took.Seconds()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	rk := routeKey{route: route, method: method}
-	hist, known := m.latency[rk]
-	if !known && len(m.latency) >= maxRouteSeries {
-		rk = routeKey{route: routeOverflowLabel, method: method}
-		route = routeOverflowLabel
-		hist, known = m.latency[rk]
+	hist, named := m.latency[rk]
+	req := requestKey{route: route, method: method, status: status}
+	_, counted := m.requests[req]
+
+	// Either map needing a NEW key while at its cap sends the whole
+	// observation to the fixed overflow pair. Both are checked, because the two
+	// maps are keyed to different widths and do not grow in step: a bound
+	// asserted about one is not a bound on the other.
+	if (!named && len(m.latency) >= maxRouteSeries) || (!counted && len(m.requests) >= maxRequestSeries) {
+		m.overflowRequests++
+		m.overflowLatency.observe(seconds)
+		return
 	}
-	if !known {
-		hist = &latencyHistogram{counts: make([]uint64, len(latencyBounds)+1)}
+
+	if !named {
+		hist = &latencyHistogram{}
 		m.latency[rk] = hist
 	}
-
-	m.requests[requestKey{route: route, method: method, status: status}]++
-
-	seconds := took.Seconds()
-	hist.sum += seconds
-	hist.count++
-	// Cumulative at WRITE time rather than at read time: a bucket counts every
-	// observation at or below its bound, so incrementing each bound the sample
-	// clears keeps the read a straight walk. sort.SearchFloat64s finds the
-	// first bound the sample does NOT exceed.
-	for i := sort.SearchFloat64s(latencyBounds, seconds); i < len(hist.counts); i++ {
-		hist.counts[i]++
-	}
+	m.requests[req]++
+	hist.observe(seconds)
 }
 
 // Write renders the three families in Prometheus text format. Called by the
@@ -192,8 +290,24 @@ func (m *HTTPMetrics) Write(w io.Writer) {
 		copy(counts, v.counts)
 		latency[k] = latencyHistogram{counts: counts, sum: v.sum, count: v.count}
 	}
+	overflowRequests := m.overflowRequests
+	overflowLatency := latencyHistogram{sum: m.overflowLatency.sum, count: m.overflowLatency.count}
+	if m.overflowLatency.counts != nil {
+		overflowLatency.counts = make([]uint64, len(m.overflowLatency.counts))
+		copy(overflowLatency.counts, m.overflowLatency.counts)
+	}
 	inFlight := m.inFlight.Load()
 	m.mu.Unlock()
+
+	// The overflow pair is rendered as ONE series each, with every dimension it
+	// could not name spelled `other`. Folded in here rather than carried in the
+	// maps, which is what keeps it incapable of growing -- see HTTPMetrics.
+	if overflowRequests > 0 {
+		requests[requestKey{route: routeOverflowLabel, method: otherMethod, status: overflowStatus}] = overflowRequests
+	}
+	if overflowLatency.count > 0 {
+		latency[routeKey{route: routeOverflowLabel, method: otherMethod}] = overflowLatency
+	}
 
 	// Wrapped in the package's own writer rather than each line handling its
 	// own error: exposition.go explains the posture, and it holds whether or
@@ -224,8 +338,12 @@ func writeRequestCounters(out *exposition, requests map[requestKey]uint64) {
 		return keys[i].status < keys[j].status
 	})
 	for _, k := range keys {
-		out.printf("margince_http_requests_total{route=%q,method=%q,status=%q} %d\n",
-			k.route, k.method, strconv.Itoa(k.status), requests[k])
+		status := strconv.Itoa(k.status)
+		if k.status == overflowStatus {
+			status = "other"
+		}
+		out.printf("margince_http_requests_total{route=%s,method=%s,status=%s} %d\n",
+			label(k.route), label(k.method), label(status), requests[k])
 	}
 }
 
@@ -246,13 +364,51 @@ func writeLatencyHistogram(out *exposition, latency map[routeKey]latencyHistogra
 	for _, k := range keys {
 		h := latency[k]
 		for i, bound := range latencyBounds {
-			out.printf("%s_bucket{route=%q,method=%q,le=%q} %d\n",
-				name, k.route, k.method, strconv.FormatFloat(bound, 'g', -1, 64), h.counts[i])
+			out.printf("%s_bucket{route=%s,method=%s,le=%s} %d\n",
+				name, label(k.route), label(k.method), label(strconv.FormatFloat(bound, 'g', -1, 64)), h.counts[i])
 		}
 		// The +Inf bucket equals _count by definition, and a histogram without
 		// it is not a histogram: every quantile read walks to the terminator.
-		out.printf("%s_bucket{route=%q,method=%q,le=\"+Inf\"} %d\n", name, k.route, k.method, h.count)
-		out.printf("%s_sum{route=%q,method=%q} %g\n", name, k.route, k.method, h.sum)
-		out.printf("%s_count{route=%q,method=%q} %d\n", name, k.route, k.method, h.count)
+		out.printf("%s_bucket{route=%s,method=%s,le=\"+Inf\"} %d\n", name, label(k.route), label(k.method), h.count)
+		out.printf("%s_sum{route=%s,method=%s} %g\n", name, label(k.route), label(k.method), h.sum)
+		out.printf("%s_count{route=%s,method=%s} %d\n", name, label(k.route), label(k.method), h.count)
 	}
+}
+
+// label renders a Prometheus label VALUE with only the three escapes the text
+// format defines: backslash, double quote, and newline.
+//
+// Not %q, which is what this used. strconv.Quote is Go's escaping, not
+// Prometheus', and the two agree only by coincidence on ordinary input: %q also
+// emits \t, \r, \xNN and \uNNNN, and Prometheus' parser rejects those as an
+// invalid escape sequence. It rejects the WHOLE SCRAPE when it does, not the
+// offending line -- so one stray byte in one label would take every family in
+// this process off the dashboard at once.
+//
+// Nothing can reach that today: route comes from a compile-time router
+// template, method from a closed set, status from digits. But Measure is
+// exported and takes its route from a caller-supplied resolver, so the
+// exposition should not depend on every future caller having thought about it.
+// Anything else that is not printable is dropped rather than escaped, because a
+// control byte in a label value is not information an operator can use.
+func label(value string) string {
+	var b strings.Builder
+	b.Grow(len(value) + 2)
+	b.WriteByte('"')
+	for _, r := range value {
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r < 0x20 || r == 0x7f:
+			// Dropped, per the note above.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/backend/internal/platform/httpserver/httpmetrics_test.go
+++ b/backend/internal/platform/httpserver/httpmetrics_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// routeOf returns a fixed route, standing in for the router's own pattern.
+func routeOf(route string) func(*http.Request) string {
+	return func(*http.Request) string { return route }
+}
+
+func serve(t *testing.T, m *HTTPMetrics, route, method string, status int, h http.HandlerFunc) {
+	t.Helper()
+	if h == nil {
+		h = func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(status) }
+	}
+	mw := m.Measure(routeOf(route))(h)
+	mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(method, "/v1/anything", nil))
+}
+
+func rendered(m *HTTPMetrics) string {
+	var b strings.Builder
+	m.Write(&b)
+	return b.String()
+}
+
+// TestRequestsAreCountedByRouteMethodAndStatus is the counter's whole job. The
+// three labels are the question an operator asks -- which route, called how,
+// answering what -- and a family missing any one of them cannot answer it.
+func TestRequestsAreCountedByRouteMethodAndStatus(t *testing.T) {
+	m := NewHTTPMetrics()
+	serve(t, m, "/v1/companies", http.MethodGet, 200, nil)
+	serve(t, m, "/v1/companies", http.MethodGet, 200, nil)
+	serve(t, m, "/v1/companies", http.MethodPost, 201, nil)
+	serve(t, m, "/v1/companies/{id}", http.MethodGet, 404, nil)
+
+	got := rendered(m)
+	for _, want := range []string{
+		`margince_http_requests_total{route="/v1/companies",method="GET",status="200"} 2`,
+		`margince_http_requests_total{route="/v1/companies",method="POST",status="201"} 1`,
+		`margince_http_requests_total{route="/v1/companies/{id}",method="GET",status="404"} 1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestAStatusNeverWrittenIsCountedAs200 pins the net/http default: a handler
+// that returns without calling WriteHeader has answered 200, and counting it
+// as 0 would invent a status no client ever saw.
+func TestAStatusNeverWrittenIsCountedAs200(t *testing.T) {
+	m := NewHTTPMetrics()
+	serve(t, m, "/v1/ping", http.MethodGet, 0, func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte("ok")); err != nil {
+			t.Errorf("writing the body: %v", err)
+		}
+	})
+	if want := `margince_http_requests_total{route="/v1/ping",method="GET",status="200"} 1`; !strings.Contains(rendered(m), want) {
+		t.Errorf("exposition missing %q\n--- got ---\n%s", want, rendered(m))
+	}
+}
+
+// TestTheHistogramIsCumulativeAndCarriesInf holds the one part of the text
+// format that is easy to get subtly wrong: a Prometheus histogram bucket
+// counts everything AT OR BELOW its bound, the +Inf bucket equals _count, and
+// _sum carries the observed total. A non-cumulative rendering still parses and
+// still draws a chart -- it just answers every quantile wrongly.
+func TestTheHistogramIsCumulativeAndCarriesInf(t *testing.T) {
+	m := NewHTTPMetrics()
+	// Three observations, chosen to fall in three different buckets.
+	m.observe("/v1/x", "GET", 200, 2*time.Millisecond)
+	m.observe("/v1/x", "GET", 200, 40*time.Millisecond)
+	m.observe("/v1/x", "GET", 200, 3*time.Second)
+
+	got := rendered(m)
+	// 0.005 holds the 2ms one; 0.05 holds it plus the 40ms one; +Inf holds all.
+	for _, want := range []string{
+		`margince_http_request_duration_seconds_bucket{route="/v1/x",method="GET",le="0.005"} 1`,
+		`margince_http_request_duration_seconds_bucket{route="/v1/x",method="GET",le="0.05"} 2`,
+		`margince_http_request_duration_seconds_bucket{route="/v1/x",method="GET",le="+Inf"} 3`,
+		`margince_http_request_duration_seconds_count{route="/v1/x",method="GET"} 3`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, `margince_http_request_duration_seconds_sum{route="/v1/x",method="GET"} 3.042`) {
+		t.Errorf("_sum is not the observed total (want 3.042)\n--- got ---\n%s", got)
+	}
+}
+
+// TestBucketBoundsAscendAndEndAtInf: Prometheus requires ascending bounds, and
+// a quantile read over unsorted buckets is silently wrong rather than refused.
+func TestBucketBoundsAscendAndEndAtInf(t *testing.T) {
+	m := NewHTTPMetrics()
+	m.observe("/v1/x", "GET", 200, time.Millisecond)
+	var lastSeen float64
+	for _, line := range strings.Split(rendered(m), "\n") {
+		if !strings.Contains(line, "_bucket{") {
+			continue
+		}
+		_, after, found := strings.Cut(line, `le="`)
+		if !found {
+			t.Fatalf("a bucket line carries no le label: %q", line)
+		}
+		le, _, found := strings.Cut(after, `"`)
+		if !found {
+			t.Fatalf("a bucket line's le label is unterminated: %q", line)
+		}
+		if le == "+Inf" {
+			lastSeen = -1 // reached the terminator
+			continue
+		}
+		if lastSeen == -1 {
+			t.Fatal("a finite bucket follows +Inf; the family is not ascending")
+		}
+		var v float64
+		if _, err := fmt.Sscanf(le, "%g", &v); err != nil {
+			t.Fatalf("bucket bound %q is not a number: %v", le, err)
+		}
+		if v <= lastSeen {
+			t.Fatalf("bucket bound %g does not exceed the previous %g", v, lastSeen)
+		}
+		lastSeen = v
+	}
+	if lastSeen != -1 {
+		t.Fatal("the histogram has no +Inf bucket, so _count has nothing to agree with")
+	}
+}
+
+// TestInFlightRisesInsideTheHandlerAndFallsAfter is the gauge's only
+// interesting property. Reading it from INSIDE the handler is the point: a
+// gauge that is only ever observed after the fact reads zero forever and looks
+// exactly like a working one.
+func TestInFlightRisesInsideTheHandlerAndFallsAfter(t *testing.T) {
+	m := NewHTTPMetrics()
+	var inside string
+	h := m.Measure(routeOf("/v1/slow"))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		inside = rendered(m)
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/slow", nil))
+
+	if !strings.Contains(inside, "margince_http_requests_in_flight 1") {
+		t.Errorf("in-flight did not read 1 during the request\n--- got ---\n%s", inside)
+	}
+	if !strings.Contains(rendered(m), "margince_http_requests_in_flight 0") {
+		t.Errorf("in-flight did not return to 0 after the request\n--- got ---\n%s", rendered(m))
+	}
+}
+
+// TestInFlightFallsWhenTheHandlerPanics: the decrement has to be deferred. A
+// panicking handler that leaked the gauge would leave a permanently rising
+// floor, and RecoverPanics upstream means the process survives to keep doing
+// it.
+func TestInFlightFallsWhenTheHandlerPanics(t *testing.T) {
+	m := NewHTTPMetrics()
+	h := m.Measure(routeOf("/v1/boom"))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("handler exploded")
+	}))
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				t.Error("the handler did not panic, so this proves nothing about the deferred decrement")
+			}
+		}()
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/boom", nil))
+	}()
+	if !strings.Contains(rendered(m), "margince_http_requests_in_flight 0") {
+		t.Errorf("a panicking handler leaked the in-flight gauge\n--- got ---\n%s", rendered(m))
+	}
+}
+
+// TestAnUnmatchedRouteFoldsIntoOneSeries. The resolver returns "" when the
+// router matched nothing, and the raw path must NOT be substituted: that is
+// how an id, a token or a scanner's garbage becomes a permanent label value.
+func TestAnUnmatchedRouteFoldsIntoOneSeries(t *testing.T) {
+	m := NewHTTPMetrics()
+	for _, p := range []string{"/nope", "/also-nope", "/v1/../etc/passwd"} {
+		mw := m.Measure(func(*http.Request) string { return "" })(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(404) }))
+		mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
+	}
+	got := rendered(m)
+	if want := `margince_http_requests_total{route="unmatched",method="GET",status="404"} 3`; !strings.Contains(got, want) {
+		t.Errorf("three unmatched requests did not fold into one series\n--- got ---\n%s", got)
+	}
+	for _, leaked := range []string{"/nope", "/also-nope", "passwd"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("the request path %q reached a label value", leaked)
+		}
+	}
+}
+
+// TestCardinalityIsCapped is the safety valve. chi's patterns are bounded by
+// the generated router, so this cannot fire for /v1 -- but Measure takes the
+// route from a caller-supplied resolver, and an unbounded one would grow this
+// map until the process died. Folding into one overflow series keeps the
+// exposition honest about the requests it could not name.
+func TestCardinalityIsCapped(t *testing.T) {
+	m := NewHTTPMetrics()
+	for i := range maxRouteSeries + 50 {
+		m.observe(fmt.Sprintf("/v1/generated/%d", i), "GET", 200, time.Millisecond)
+	}
+	got := rendered(m)
+	if !strings.Contains(got, routeOverflowLabel) {
+		t.Errorf("no overflow series once past the cap\n--- got (truncated) ---\n%s", got[:min(len(got), 400)])
+	}
+	if n := strings.Count(got, "_count{"); n > maxRouteSeries+1 {
+		t.Errorf("latency families = %d, want at most the cap plus the overflow series", n)
+	}
+}
+
+// TestConcurrentRequestsDoNotRace: -race would report a torn map write, and a
+// metrics endpoint is scraped WHILE requests are served, so Write races the
+// middleware by construction rather than by accident.
+func TestConcurrentRequestsDoNotRace(t *testing.T) {
+	m := NewHTTPMetrics()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+		go func() { defer wg.Done(); m.observe("/v1/x", "GET", 200, time.Duration(i)*time.Millisecond) }()
+		go func() {
+			defer wg.Done()
+			if rendered(m) == "" {
+				t.Error("a scrape racing the middleware rendered nothing")
+			}
+		}()
+	}
+	wg.Wait()
+	if want := `margince_http_request_duration_seconds_count{route="/v1/x",method="GET"} 50`; !strings.Contains(rendered(m), want) {
+		t.Errorf("lost an observation under concurrency; want %q", want)
+	}
+}
+
+// TestNilMetricsIsInert so a role that wires none is not a nil dereference on
+// its first request -- the same "declared or absent" posture the rest of the
+// exposition takes.
+func TestNilMetricsIsInert(t *testing.T) {
+	var m *HTTPMetrics
+	called := false
+	h := m.Measure(routeOf("/v1/x"))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/v1/x", nil))
+	if !called {
+		t.Fatal("a nil HTTPMetrics dropped the request instead of passing it through")
+	}
+	var b strings.Builder
+	m.Write(&b)
+	if b.Len() != 0 {
+		t.Errorf("a nil HTTPMetrics wrote an exposition: %q", b.String())
+	}
+}

--- a/backend/internal/platform/httpserver/httpmetrics_test.go
+++ b/backend/internal/platform/httpserver/httpmetrics_test.go
@@ -5,8 +5,11 @@ package httpserver
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -258,5 +261,218 @@ func TestNilMetricsIsInert(t *testing.T) {
 	m.Write(&b)
 	if b.Len() != 0 {
 		t.Errorf("a nil HTTPMetrics wrote an exposition: %q", b.String())
+	}
+}
+
+// A CLIENT-CHOSEN METHOD MUST NOT GROW THESE MAPS. This is a regression test
+// for a real hole, not a hypothetical: r.Method is a token net/http accepts as
+// anything token-shaped, and the route cap did not bound it. Measured before
+// the fix, 5000 distinct methods produced 5000 series in EACH map against a
+// 500-route cap, which an unauthenticated caller could have driven until the
+// process died.
+func TestAClientChosenMethodCannotGrowTheSeries(t *testing.T) {
+	m := NewHTTPMetrics()
+	for i := range 5000 {
+		m.observe("/v1/x", fmt.Sprintf("EVIL%d", i), 200, time.Millisecond)
+	}
+	// One real route, and every nonsense method folded into `other`.
+	if got := len(m.latency); got != 1 {
+		t.Errorf("latency series = %d, want 1 — the method dimension is unbounded", got)
+	}
+	if got := len(m.requests); got != 1 {
+		t.Errorf("request series = %d, want 1 — the method dimension is unbounded", got)
+	}
+	got := rendered(m)
+	if want := `method="other"`; !strings.Contains(got, want) {
+		t.Errorf("exposition missing %q", want)
+	}
+	if strings.Contains(got, "EVIL") {
+		t.Error("a client-supplied method reached a label value")
+	}
+}
+
+// The nine real methods keep their own identity — folding everything would be
+// a cheap bound that destroyed the label's meaning.
+func TestTheRealMethodsAreNotFolded(t *testing.T) {
+	m := NewHTTPMetrics()
+	for _, method := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace,
+	} {
+		m.observe("/v1/x", method, 200, time.Millisecond)
+		if got := normalizeMethod(method); got != method {
+			t.Errorf("normalizeMethod(%q) = %q, want it unchanged", method, got)
+		}
+	}
+	if got := len(m.latency); got != 9 {
+		t.Errorf("latency series = %d, want 9 (one per real method)", got)
+	}
+}
+
+// The counter map is capped on ITS OWN count, because it is keyed one dimension
+// wider than the histogram (status) and the two do not grow in step. Asserting
+// a bound about one map while the other grows was the original mistake.
+func TestTheCounterMapIsCappedIndependently(t *testing.T) {
+	m := NewHTTPMetrics()
+	// One route, one method, absurdly many statuses: the histogram holds a
+	// single series throughout while the counter map is the one under pressure.
+	for status := range maxRequestSeries + 100 {
+		m.observe("/v1/x", http.MethodGet, status, time.Millisecond)
+	}
+	if got := len(m.latency); got != 1 {
+		t.Errorf("latency series = %d, want 1", got)
+	}
+	if got := len(m.requests); got > maxRequestSeries+1 {
+		t.Errorf("request series = %d, want at most the cap plus the overflow series", got)
+	}
+	if !strings.Contains(rendered(m), routeOverflowLabel) {
+		t.Error("no overflow series once the counter map passed its cap")
+	}
+}
+
+// observe on a nil receiver is reachable independently of Measure, and must be
+// inert rather than a panic -- and inert means it also recorded nothing, which
+// is the half a no-panic test would leave unstated.
+func TestObserveOnANilStoreIsInert(t *testing.T) {
+	var m *HTTPMetrics
+	m.observe("/v1/x", http.MethodGet, 200, time.Millisecond) // must not panic
+	if got := rendered(m); got != "" {
+		t.Errorf("a nil store recorded an observation: %q", got)
+	}
+}
+
+// The exposition is sorted, and the comparators have to order every dimension:
+// unsorted output is not wrong to a parser but it makes a scrape diff unreadable
+// and a test flap on map order. Same route and method, differing only in status,
+// exercises the last comparison the counter's sort makes.
+func TestTheExpositionIsSortedOnEveryDimension(t *testing.T) {
+	m := NewHTTPMetrics()
+	// Deliberately inserted out of order.
+	m.observe("/v1/b", http.MethodPost, 500, time.Millisecond)
+	m.observe("/v1/a", http.MethodGet, 404, time.Millisecond)
+	m.observe("/v1/a", http.MethodGet, 200, time.Millisecond)
+	m.observe("/v1/a", http.MethodPost, 201, time.Millisecond)
+
+	var counters []string
+	for _, line := range strings.Split(rendered(m), "\n") {
+		if strings.HasPrefix(line, "margince_http_requests_total{") {
+			counters = append(counters, line)
+		}
+	}
+	if len(counters) != 4 {
+		t.Fatalf("counter lines = %d, want 4:\n%s", len(counters), strings.Join(counters, "\n"))
+	}
+	if !sort.StringsAreSorted(counters) {
+		t.Errorf("counter lines are not sorted:\n%s", strings.Join(counters, "\n"))
+	}
+}
+
+// A PANICKING HANDLER MUST NOT BE RECORDED AS A SUCCESS. This is the regression
+// test for the worst bug this file had: RecoverPanics wraps Measure from the
+// OUTSIDE, so the 500 the client receives is written after this middleware's
+// defer has already run, on a different ResponseWriter. rec.status was
+// therefore still its 200 default, and a route panicking on every single
+// request reported a 100% success rate -- measured, not theorised: the client
+// got 500 while the exposition said status="200".
+func TestAPanickingHandlerIsRecordedAsFiveHundred(t *testing.T) {
+	m := NewHTTPMetrics()
+	inner := m.Measure(routeOf("/v1/boom"))(http.HandlerFunc(
+		func(http.ResponseWriter, *http.Request) { panic("handler exploded") }))
+	h := RecoverPanics(slog.New(slog.NewTextHandler(io.Discard, nil)), inner)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/boom", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("the client received %d, want 500 — the premise of this test is gone", rec.Code)
+	}
+	got := rendered(m)
+	if want := `margince_http_requests_total{route="/v1/boom",method="GET",status="500"} 1`; !strings.Contains(got, want) {
+		t.Errorf("exposition missing %q\n--- got ---\n%s", want, got)
+	}
+	if strings.Contains(got, `route="/v1/boom",method="GET",status="200"`) {
+		t.Error("a panicking handler was recorded as a 200")
+	}
+}
+
+// A handler that wrote a status and THEN panicked keeps what it wrote: the
+// client really did receive that status, and overriding it to 500 would be a
+// second wrong answer rather than a correction.
+func TestAHandlerThatAnsweredBeforePanickingKeepsItsStatus(t *testing.T) {
+	m := NewHTTPMetrics()
+	inner := m.Measure(routeOf("/v1/half"))(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			panic("exploded after answering")
+		}))
+	h := RecoverPanics(slog.New(slog.NewTextHandler(io.Discard, nil)), inner)
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/half", nil))
+
+	if want := `margince_http_requests_total{route="/v1/half",method="POST",status="202"} 1`; !strings.Contains(rendered(m), want) {
+		t.Errorf("exposition missing %q\n--- got ---\n%s", want, rendered(m))
+	}
+}
+
+// LABEL VALUES MUST CARRY ONLY THE THREE ESCAPES PROMETHEUS DEFINES.
+//
+// %q was used here first, and Go's escaping is not Prometheus': %q also emits
+// \t, \r, \xNN and \uNNNN, which the parser rejects as an invalid escape
+// sequence -- and it rejects the WHOLE SCRAPE when it does, so one stray byte
+// in one label takes every family in this process off the dashboard at once.
+func TestLabelValuesUseOnlyPrometheusEscapes(t *testing.T) {
+	cases := map[string]string{
+		`/v1/plain`:         `"/v1/plain"`,
+		"/v1/with\"quote":   `"/v1/with\"quote"`,
+		`/v1/with\slash`:    `"/v1/with\\slash"`,
+		"/v1/with\nnewline": `"/v1/with\nnewline"`,
+		// Dropped rather than escaped: %q would have written \t and \x00 here,
+		// and neither is a legal Prometheus escape.
+		"/v1/with\ttab":    `"/v1/withtab"`,
+		"/v1/with\x00null": `"/v1/withnull"`,
+	}
+	for in, want := range cases {
+		if got := label(in); got != want {
+			t.Errorf("label(%q) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// The same, end to end: a hostile route reaching the store must not produce an
+// exposition carrying an escape Prometheus refuses.
+func TestAHostileRouteCannotBreakTheWholeScrape(t *testing.T) {
+	m := NewHTTPMetrics()
+	m.observe("/v1/\t\x01evil\"\\", http.MethodGet, 200, time.Millisecond)
+	got := rendered(m)
+	for _, illegal := range []string{`\t`, `\x`, `\u`, `\r`} {
+		if strings.Contains(got, illegal) {
+			t.Errorf("the exposition carries %q, which Prometheus rejects — and it rejects the whole scrape\n--- got ---\n%s", illegal, got)
+		}
+	}
+}
+
+// ONLY THE FIRST WriteHeader IS THE CLIENT'S STATUS. net/http sends one status
+// line and warns about the rest, so recording the last ATTEMPT reports a status
+// nobody received. A handler that answered 201 and then hit an error path
+// calling 500 was counted as a 500 the client never saw -- and the access log
+// said the same thing, since it shares this recorder.
+func TestOnlyTheFirstWrittenStatusIsRecorded(t *testing.T) {
+	m := NewHTTPMetrics()
+	h := m.Measure(routeOf("/v1/twice"))(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.WriteHeader(http.StatusInternalServerError) // superfluous; never sent
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/twice", nil))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("the client received %d, want 201 — the premise of this test is gone", rec.Code)
+	}
+	got := rendered(m)
+	if want := `margince_http_requests_total{route="/v1/twice",method="POST",status="201"} 1`; !strings.Contains(got, want) {
+		t.Errorf("exposition missing %q\n--- got ---\n%s", want, got)
+	}
+	if strings.Contains(got, `status="500"`) {
+		t.Error("a status the client never received was recorded")
 	}
 }

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -142,13 +142,32 @@ func AccessLog(log *slog.Logger, next http.Handler) http.Handler {
 }
 
 // statusRecorder captures the response status for the access log.
+//
+// wrote distinguishes "the handler answered 200" from "nobody answered": the
+// zero value of status has to be the 200 net/http sends for a handler that just
+// returns, so the field alone cannot tell those apart. The HTTP metrics need
+// that distinction to record a panicking handler honestly -- see Measure.
 type statusRecorder struct {
 	http.ResponseWriter
 	status int
+	wrote  bool
 }
 
+// WriteHeader records the FIRST status only, because that is the only one the
+// client receives: net/http sends one status line and logs a "superfluous
+// WriteHeader" for every call after it. Recording the last attempt instead --
+// which this did -- reports a status that was never sent. A handler that
+// answered 201 and then tried 500 on a later error path was logged, and
+// counted, as a 500 the client never saw.
+//
+// The call is still forwarded, so net/http's own warning is not suppressed:
+// a double WriteHeader is a handler bug, and hiding it here would remove the
+// one signal that says so.
 func (r *statusRecorder) WriteHeader(status int) {
-	r.status = status
+	if !r.wrote {
+		r.status = status
+		r.wrote = true
+	}
 	r.ResponseWriter.WriteHeader(status)
 }
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,13 +61,41 @@ Operational endpoints (served next to `/v1`):
   configured; the secret vault when a keyvault is configured; the
   customfields schema pool when `--schema-dsn` is set) must pass within
   2s, else 503 naming the unready dependency.
-- `/metrics` — Prometheus text format: `margince_outbox_unpublished`,
-  `margince_relay_published_total`, `margince_pgxpool_conns{state=…}`, the
-  AI router's counters, the overlay sync-health section, and the
-  **job-runtime section** below. Served openly by default, so an
-  annotation-discovered scraper works with no configuration; set
+- `/metrics` — Prometheus text format: the **HTTP section** below,
+  `margince_outbox_unpublished`, `margince_relay_published_total`,
+  `margince_pgxpool_conns{state=…}`, the AI router's counters, the overlay
+  sync-health section, and the **job-runtime section** below. Served openly by
+  default, so an annotation-discovered scraper works with no configuration; set
   `--metrics-token` to require a Bearer credential where the port itself is not
   already contained.
+
+  The HTTP section covers the `/v1` contract surface:
+
+  | Family | Type | Labels |
+  |---|---|---|
+  | `margince_http_requests_total` | counter | `route`, `method`, `status` |
+  | `margince_http_request_duration_seconds` | histogram | `route`, `method` |
+  | `margince_http_requests_in_flight` | gauge | — |
+
+  **`route` is the matched route TEMPLATE, never the request path** —
+  `/v1/deals/{dealId}`, not `/v1/deals/9f3c…`. The path carries record ids, and
+  a label carrying ids grows one series per record for the life of the process.
+  A request that matched no route is counted under `route="unmatched"`, as one
+  series however many distinct paths it arrived on. The access log is the
+  opposite reading on purpose: it logs the real path, because a log line answers
+  "what did clients ask".
+
+  The measurement sits **outside** the admission gate, the idempotency replay
+  and the overlay guard, so a `403` counts as that route's latency — which is
+  what a client experienced. `p95` over five minutes, per route:
+
+  ```promql
+  histogram_quantile(0.95, sum by (route, le) (
+    rate(margince_http_request_duration_seconds_bucket[5m])))
+  ```
+
+  Mind the scrape interval when choosing that window: a rate needs several
+  points, so a cluster scraping every 5m wants `[30m]` or wider.
 - `GET /v1/admin/job-health` — the per-workspace read of the same job
   table, for an admin rather than a scrape. See
   [Reading the job surfaces](#reading-the-job-surfaces).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -78,16 +78,34 @@ Operational endpoints (served next to `/v1`):
   | `margince_http_requests_in_flight` | gauge | — |
 
   **`route` is the matched route TEMPLATE, never the request path** —
-  `/v1/deals/{dealId}`, not `/v1/deals/9f3c…`. The path carries record ids, and
-  a label carrying ids grows one series per record for the life of the process.
-  A request that matched no route is counted under `route="unmatched"`, as one
-  series however many distinct paths it arrived on. The access log is the
-  opposite reading on purpose: it logs the real path, because a log line answers
-  "what did clients ask".
+  `/v1/deals/{id}`, not `/v1/deals/9f3c…`. The path carries record ids, and a
+  label carrying ids grows one series per record for the life of the process.
+  The access log is the opposite reading on purpose: it logs the real path,
+  because a log line answers "what did clients ask".
+
+  **What this section does NOT count, because the measurement sits inside the
+  router rather than in front of it.** It runs as chi *operation* middleware, so
+  it only sees a request that already matched a registered method and path:
+
+  - a **404** for an unrouted path, and a **405** for a method that route does
+    not serve — chi answers both itself, and neither enters a wrapper, so
+    scanner traffic is invisible here;
+  - a **400 from parameter parsing** — the generated wrapper binds path, query
+    and header parameters and calls its error handler *before* the middleware
+    chain, so a `GET /v1/deals/not-a-uuid` is a real client-visible 400 that
+    appears in neither family.
+
+  The access log carries all three. Counting them would mean instrumenting in
+  front of the router, where the route template is not yet known — which is why
+  the store has an `unmatched` bucket it can use, and why nothing on `/v1`
+  currently fills it.
 
   The measurement sits **outside** the admission gate, the idempotency replay
   and the overlay guard, so a `403` counts as that route's latency — which is
-  what a client experienced. `p95` over five minutes, per route:
+  what a client experienced. A handler that **panics** is recorded as `500`,
+  matching what `RecoverPanics` sends the client, and a handler that answered
+  and *then* panicked keeps the status it actually sent. `p95` over five
+  minutes, per route:
 
   ```promql
   histogram_quantile(0.95, sum by (route, le) (


### PR DESCRIPTION
## What

There is **no histogram anywhere in this process** today, and no HTTP request counter either. `/metrics` can report the outbox, the job table, the pool, the AI router and the overlay mirror — and says nothing about the HTTP surface all of that exists to serve. So "what is the p95 of `/v1/deals/{dealId}`" is not answerable, and "how slow is this route" is answerable only by parsing logs, one installation at a time.

`AccessLog` has always measured exactly what a histogram needs — `time.Since(start)` and the status off `statusRecorder` — and written both to a log line and discarded them. This turns those same two numbers into series:

```
margince_http_requests_total{route,method,status}      counter
margince_http_request_duration_seconds{route,method}   histogram
margince_http_requests_in_flight                       gauge
```

```promql
histogram_quantile(0.95, sum by (route, le) (
  rate(margince_http_request_duration_seconds_bucket[5m])))
```

## The label is the route template, never the path

`/v1/deals/{dealId}` is **one** series. `/v1/deals/9f3c…` is one series **per deal ever read**, for the life of a process that also cannot forget them.

`AccessLog` logs the real path deliberately — a log line answers *"what did clients ask"* — and that is precisely the reading a metric label must not take. The template can only come from the router that matched, so `Measure` takes a resolver rather than reading the request itself: a caller with no bounded answer is **forced to say so** by returning `""` rather than quietly passing a path. Unmatched requests fold into a single `route="unmatched"` series, however many distinct paths they arrived on.

## Design notes worth reviewing

**Hand-rolled, deliberately.** There is no Prometheus client library in this module. Adding one for three families would bring a registry, a collector interface, and a second exposition writer beside the one `httpserver.Metrics` already owns. It writes through this package's own `exposition`, so the first refused write stops the section — the posture `exposition.go` documents, rather than each line handling its own error.

**Mounted outermost** on the generated middleware chain, so the measurement covers the admission gate, the idempotency replay and the overlay guard rather than only the handler beneath them. A `403` from the gate *is* that route's latency as a client experienced it, and a refusal that cost a database read is exactly the slow answer worth seeing. These are *operation* middleware — applied after chi matches — which is what makes the route readable at all.

**The store is a pointer on `Server`, and that is load-bearing.** `contractAPI` and `operationalMux` each take the `Server` **by value**. A struct-valued store would hand the middleware and the exposition two separate copies — requests counted into one, a scrape reading the other, both looking perfectly correct. There's a test that fails if that ever regresses.

## Four quiet failures this handles

| | |
|---|---|
| A panicking handler | in-flight is decremented in a `defer`, so it cannot leave a permanently rising floor under a process `RecoverPanics` keeps alive |
| A panicked request | the observation is deferred too, so it is still counted rather than vanishing |
| A handler that never calls `WriteHeader` | counted as the `200` net/http actually sent, not as `0` |
| An unbounded resolver | the route map is **capped**; series past it fold into one overflow label rather than being dropped, because an exposition that silently stopped measuring reads as a quiet surface |

chi's patterns come from the generated router, so the cap can't fire for `/v1` — but `Measure` is exported and takes its label from a caller-supplied function, and a metric must not be able to grow until the process dies.

## Tests — 14

The arithmetic is asserted directly, including the part of the text format that is easy to get **subtly** wrong: buckets are cumulative, `+Inf` equals `_count`, `_sum` carries the observed total, and bounds ascend. A non-cumulative rendering still parses and still draws a chart — it just answers every quantile wrongly.

The **wiring is asserted separately**, because what the unit tests cannot prove is that the route reaching the store is chi's template rather than the path. That depends on generated code applying its middleware after the match; if it ever stops holding, the metric keeps working and quietly starts growing a series per id.

Sample output, verified:

```
margince_http_requests_total{route="/v1/deals/{dealId}",method="GET",status="200"} 2
margince_http_request_duration_seconds_bucket{route="/v1/deals/{dealId}",method="GET",le="0.025"} 2
margince_http_request_duration_seconds_bucket{route="/v1/deals/{dealId}",method="GET",le="+Inf"} 3
margince_http_request_duration_seconds_sum{route="/v1/deals/{dealId}",method="GET"} 0.196
margince_http_request_duration_seconds_count{route="/v1/deals/{dealId}",method="GET"} 3
```

## Gates

- `make check-backend` — **exit 0**, zero failures
- `craft static --strict` — 0 blocker, 0 major, 0 minor
- `go vet`, `gofmt`, golangci-lint — clean
- `-race` on the concurrency test: `/metrics` is scraped *while* requests are served, so `Write` races `Measure` by construction rather than by accident

## Scope

`/v1` only. The operational edges (`/mcp`, `/oauth/*`, `/webhooks/*`, the probes) are on the std `ServeMux` outside chi and are not instrumented here — `Measure` is reusable for them, but each needs its own bounded resolver, and mixing that into this change would have made the diff about routing rather than about metrics.

Follow-up to #4785, which made `/metrics` scrapeable without a credential. Together they're what lets an annotation-discovered Prometheus chart this surface at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP request metrics for the `/v1` API, including request counts, latency, and in-flight requests.
  * Metrics are grouped by route template and method, with safeguards for unmatched and high-volume routes.
  * Request measurement includes traffic handled by admission, replay, and overlay processing.

* **Documentation**
  * Expanded the configuration reference with available HTTP metrics, route-label behavior, and a PromQL example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTP request metrics to `/metrics`, so route latency is answerable by query instead of parsing logs. `/metrics` now reports request counts, a duration histogram, and an in-flight gauge for `/v1` routes; no configuration or migration is needed.

**New Features**
- The `route` label carries the matched chi template (`/v1/deals/{dealId}`), never the request path; unmatched requests fold into one `route="unmatched"` series.
- The middleware runs outermost, so a gate refusal or idempotency replay counts as that route's latency; the store is a pointer on `Server` so value copies share it.
- No Prometheus client library; the families write through the existing exposition writer with Prometheus-only label escapes.
- A panicking handler counts as `500`, a handler that never calls `WriteHeader` as `200`, and one that answered before panicking keeps its status.
- Only the first `WriteHeader` status is recorded — this also fixes the access log, which shares the recorder.
- Label spaces are bounded: the overflow bucket is a fixed field, methods outside RFC 9110's nine fold into `other`, and the counter map is capped independently.
- `/v1` only; chi's own 404s/405s and parameter-binding 400s never reach the middleware and are not counted.

<sup>Written for commit 222aca4e781240ce7ef673915ec2df1e7107f6b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

