### PR TITLE
A mailbox owner keeps a label or folder out of the CRM

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23003,7 +23003,19 @@ components:
       description: Whose rule it is — the installation's, or the caller's own for the mailbox they connected.
     CaptureExclusionKind:
       type: string
-      enum: [address, domain]
+      enum: [address, domain, container]
+      description: >-
+        What the rule names. `address` and `domain` match the parties a message names; `container`
+        matches where the provider FILED it — a Gmail label, a Graph folder, an IMAP mailbox.
+
+        A container value is `<provider>:<id>`, where the id is the provider's own token and is
+        stored exactly as given: `gmail:Label_12` (a system label is its name, `gmail:CATEGORY_PROMOTIONS`),
+        `graph:<folderId>`, `imap:INBOX/Family`. Qualified because an id means nothing without the
+        namespace it belongs to, and unfolded because a Graph folder id is base64url and an IMAP
+        mailbox name is case-sensitive — folding either would merge two containers into one rule.
+
+        A container rule is `user` scope only: the list belongs to the mailbox's owner, and a
+        workspace rule would bind every colleague's connection to a place that does not exist there.
     CaptureExclusionListResponse:
       type: object
       required: [data]
@@ -23018,12 +23030,19 @@ components:
         scope: { $ref: '#/components/schemas/CaptureExclusionScope' }
         kind: { $ref: '#/components/schemas/CaptureExclusionKind' }
         value: { type: string, maxLength: 320, description: 'An email address, or a bare domain.' }
+    CaptureOwnerIdentityKind:
+      type: string
+      enum: [address, domain]
+      description: >-
+        What the identity names. Its own schema rather than the exclusion's, which the two shared
+        while they happened to hold the same two values: an exclusion can now also name a CONTAINER,
+        and a container is not something a mailbox owner can BE.
     CaptureOwnerIdentity:
       type: object
       required: [id, kind, value, source, created_at]
       properties:
         id: { type: string, format: uuid }
-        kind: { $ref: '#/components/schemas/CaptureExclusionKind' }
+        kind: { $ref: '#/components/schemas/CaptureOwnerIdentityKind' }
         value: { type: string, description: 'The folded address or domain.' }
         source: { $ref: '#/components/schemas/CaptureOwnerIdentitySource' }
         created_at: { type: string, format: date-time }
@@ -23097,7 +23116,7 @@ components:
       type: object
       required: [kind, value]
       properties:
-        kind: { $ref: '#/components/schemas/CaptureExclusionKind' }
+        kind: { $ref: '#/components/schemas/CaptureOwnerIdentityKind' }
         value: { type: string, maxLength: 320, description: 'An email address, or a bare domain.' }
     WorkspaceEmailDomainListResponse:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -22995,7 +22995,11 @@ components:
         id: { type: string, format: uuid }
         scope: { $ref: '#/components/schemas/CaptureExclusionScope' }
         kind: { $ref: '#/components/schemas/CaptureExclusionKind' }
-        value: { type: string, description: 'The folded address or domain.' }
+        value:
+          type: string
+          description: >-
+            The folded address or domain, or a provider-qualified container (`gmail:Label_12`,
+            `graph:<folderId>`, `imap:INBOX/Family`) kept exactly as the provider spells it.
         created_at: { type: string, format: date-time }
     CaptureExclusionScope:
       type: string

--- a/backend/gates/capturecontainers_test.go
+++ b/backend/gates/capturecontainers_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every mail connector tells the sink where the provider FILED a message.
+//
+// A capture exclusion may name a container — a Gmail label, a Graph folder, an
+// IMAP mailbox — and the rule is matched against NormalizedRecord.Containers on
+// the pre-store path. A connector that does not fill it does not fail: it
+// captures exactly as before, and the owner's rule quietly matches nothing.
+// That is the shape this census exists for, because the person who set the rule
+// sees mail keep arriving and has no way to tell a rule that did not match from
+// a connector that never asked.
+//
+// The corpus is derived from the tree rather than listed: a mail connector is a
+// package that parses RFC822 through mailmap and writes through a Sink, so a
+// fourth one is judged the day it lands. The obligation is that its capture
+// path assigns Containers on the record it upserts.
+//
+// What this cannot see, stated so the next reader does not assume otherwise: it
+// does not check that the value is RIGHT — that Gmail's label ids and not its
+// display names reach the field, or that the provider prefix matches the
+// connector. Those are each connector's own tests. What it holds is that the
+// field is filled at all, which is the half that fails silently.
+
+import (
+	"go/ast"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	// mailParser is what makes a package a MAIL connector: it turns RFC822
+	// bytes into the shared message model. A connector with no mail to parse —
+	// a chat, a calendar — has no container notion and is not judged.
+	mailParser = "mailmap"
+	// containersField is the record member a connector fills.
+	containersField = "Containers"
+)
+
+// connectorsWithoutContainers ratifies a mail connector that fills nothing.
+// Each entry says why the provider offers no container, not merely that the
+// work is unfinished.
+var connectorsWithoutContainers = gatekit.Waive(map[string]string{})
+
+func TestEveryMailConnectorReportsWhereTheProviderFiledTheMessage(t *testing.T) {
+	t.Parallel()
+	defer connectorsWithoutContainers.AssertAllMatched(t)
+
+	byDir := map[string]bool{}
+	fills := map[string]bool{}
+	for _, src := range tierFiles(t, filepath.Join("internal", "modules", "capture")) {
+		dir := filepath.ToSlash(filepath.Dir(src.Path))
+		if !importsMailParser(src) {
+			continue
+		}
+		byDir[dir] = true
+		if assignsField(src, containersField) {
+			fills[dir] = true
+		}
+	}
+	// A census that can fail short has already failed: three mail connectors
+	// ship today, and a corpus that found none would report a clean tree.
+	if len(byDir) < wantMinimumMailConnectors {
+		t.Fatalf("only %d mail connector package(s) found under internal/modules/capture, want at "+
+			"least %d — the parser moved or was renamed, and this census is judging nothing",
+			len(byDir), wantMinimumMailConnectors)
+	}
+	for dir := range byDir {
+		if fills[dir] || connectorsWithoutContainers.Waived(t, dir) {
+			continue
+		}
+		t.Errorf("%s parses mail and never sets NormalizedRecord.%s, so a capture exclusion naming "+
+			"one of this provider's containers matches nothing. Fill it on the capture path from "+
+			"the provider's own metadata (connector.Container qualifies it), or ratify the package "+
+			"in connectorsWithoutContainers with the reason this provider has no container to name",
+			dir, containersField)
+	}
+}
+
+// wantMinimumMailConnectors is the anti-vacuity floor: gmail, graph and imap.
+const wantMinimumMailConnectors = 3
+
+// importsMailParser answers whether this file reaches the shared RFC822 model.
+func importsMailParser(src tierFile) bool {
+	for _, spec := range src.File.Imports {
+		if strings.HasSuffix(strings.Trim(spec.Path.Value, `"`), "/"+mailParser) {
+			return true
+		}
+	}
+	return false
+}
+
+// assignsField answers whether any statement in the file assigns the named
+// field, by any receiver — `rec.Containers = …`. The receiver is deliberately
+// not matched: a connector may call its record anything, and a census that
+// insisted on one name would report the others as missing.
+func assignsField(src tierFile, field string) bool {
+	found := false
+	ast.Inspect(src.File, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		for _, target := range assign.Lhs {
+			sel, isSel := target.(*ast.SelectorExpr)
+			if isSel && sel.Sel.Name == field {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -62,6 +62,10 @@ var waivedEnvelopeFields = gatekit.Waive(map[string]string{
 		"shape no unit has exercised",
 	"PartDrops": "the breadcrumb for refused attachments, held with Parts for the same reason " +
 		"and landing in the same PR — a drop cannot exist while what it accounts for does not",
+	"Containers": "where the PROVIDER filed a message — a Gmail label, a Graph folder, an IMAP mailbox — which a capture exclusion can name. " +
+		"Held rather than closed: the value is provider-qualified, and the qualifier is an allowlist of the providers whose namespaces the exclusion validator knows (containerProviders in the capture module). " +
+		"A unit's own provider is not on it, so a published field would let a unit state a container no rule can name — a value that travels the whole pre-store path and matches nothing, which reads to its author like a rule that does not work. " +
+		"It lands with the first unit that has containers AND a provider on that list, in the same PR, for the reason Parts is held: a frozen field with no caller freezes a shape no unit has exercised",
 	"Fields": "the envelope's `any`. The published surface is typed instead — Record.Activity — so a unit cannot hand the sink a shape it does not switch on",
 	"DeliveredTo": "the receiving server's own delivery header, and it is a CORE judgement rather than a field to publish: the value is trusted only from a header position a sender could not have authored, which mailmap.TopDeliveredTo decides once. " +
 		"A unit supplying it would be supplying the conclusion instead of the evidence — and the conclusion adds an address to a seat's own self-set, which is the one thing a unit must not be able to assert. Empty from a unit means what it means everywhere: no trustworthy claim, so no alias is learned",

--- a/backend/internal/compose/handlers_captureowneridentities.go
+++ b/backend/internal/compose/handlers_captureowneridentities.go
@@ -61,7 +61,7 @@ func (h captureOwnerIdentityHandlers) DeleteCaptureOwnerIdentity(w http.Response
 func toContractOwnerIdentity(identity capture.OwnerIdentity) crmcontracts.CaptureOwnerIdentity {
 	return crmcontracts.CaptureOwnerIdentity{
 		Id:        openapi_types.UUID(identity.ID),
-		Kind:      crmcontracts.CaptureExclusionKind(identity.Kind),
+		Kind:      crmcontracts.CaptureOwnerIdentityKind(identity.Kind),
 		Value:     identity.Value,
 		Source:    crmcontracts.CaptureOwnerIdentitySource(identity.Source),
 		CreatedAt: identity.CreatedAt,

--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -67,6 +67,12 @@ type mailBatchConnector struct {
 	// namespace across all of them, so a suite proving that a rule matches
 	// within ONE medium needs two media sharing a key.
 	kinds map[string]string
+	// containers are the provider's own filing places for a message, by
+	// Message-ID, already provider-qualified. A real connector reads them off
+	// the provider's message resource — Gmail's labelIds, Graph's
+	// parentFolderId, the IMAP mailbox a pull selected — so a fixture that
+	// wants an exclusion to match one has to arrive the same way.
+	containers map[string][]string
 }
 
 func (m *mailBatchConnector) Descriptor() connector.Descriptor {
@@ -104,6 +110,7 @@ func (m *mailBatchConnector) Sync(ctx context.Context, _ connector.Auth, _ conne
 		for _, dealID := range m.deals[msg.ID()] {
 			rec.Links = append(rec.Links, datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID})
 		}
+		rec.Containers = m.containers[msg.ID()]
 		if kind, overridden := m.kinds[msg.ID()]; overridden {
 			fields, ok := rec.Fields.(capturemod.ActivityFields)
 			if !ok {
@@ -293,6 +300,10 @@ type captureEnv struct {
 	// syncAsKind is the same pull with the listed Message-IDs landing as another
 	// activity kind, the way a non-mail connector's records do.
 	syncAsKind func(t *testing.T, kinds map[string]string, raws ...[]byte)
+	// syncInContainer is the same pull with the connector reporting where the
+	// provider filed each listed Message-ID — a Gmail label, a Graph folder, an
+	// IMAP mailbox — already provider-qualified.
+	syncInContainer func(t *testing.T, containers map[string][]string, raws ...[]byte)
 	// registry is the SAME registry the syncs above drive, so a test that
 	// configures a connection and then syncs it is configuring the connection
 	// that sync uses. A second registry would have its own connector set and no
@@ -325,6 +336,7 @@ func newCaptureEnv(t *testing.T) captureEnv {
 	pull := func(t *testing.T, sent map[string]bool, filed map[string][]ids.UUID, kinds map[string]string, raws ...[]byte) {
 		t.Helper()
 		conn.raws, conn.sent, conn.deals, conn.kinds = raws, sent, filed, kinds
+		conn.containers = nil
 		if err := registry.SyncOnce(wsCtx, connID); err != nil {
 			t.Fatalf("SyncOnce: %v", err)
 		}
@@ -346,6 +358,14 @@ func newCaptureEnv(t *testing.T) captureEnv {
 	syncAsKind := func(t *testing.T, kinds map[string]string, raws ...[]byte) {
 		t.Helper()
 		pull(t, nil, nil, kinds, raws...)
+	}
+	syncInContainer := func(t *testing.T, containers map[string][]string, raws ...[]byte) {
+		t.Helper()
+		conn.raws, conn.sent, conn.deals, conn.kinds = raws, nil, nil, nil
+		conn.containers = containers
+		if err := registry.SyncOnce(wsCtx, connID); err != nil {
+			t.Fatalf("SyncOnce: %v", err)
+		}
 	}
 
 	// The installation's own company, as cold start leaves it: a human confirmed
@@ -386,7 +406,7 @@ func newCaptureEnv(t *testing.T) captureEnv {
 	if verified {
 		t.Fatal("a mailbox must not verify its own domain — the company's claim does that")
 	}
-	return captureEnv{e: e, sync: sync, syncSent: syncSent, registry: registry, conn: conn, syncFiledUnderDeal: syncFiledUnderDeal, syncAsKind: syncAsKind}
+	return captureEnv{e: e, sync: sync, syncSent: syncSent, registry: registry, conn: conn, syncFiledUnderDeal: syncFiledUnderDeal, syncAsKind: syncAsKind, syncInContainer: syncInContainer}
 }
 
 // emailCC builds a message that copies a third party — the introduction shape:

--- a/backend/internal/compose/integration/capture/capture_exclusion_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_exclusion_integration_test.go
@@ -7,6 +7,7 @@ package capture
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/capture"
@@ -109,5 +110,85 @@ func TestAnExclusionKeepsAMessageOutBeforeAnythingIsStored(t *testing.T) {
 	}
 	if _, err := store.Add(owner, capture.ExclusionScopeWorkspace, capture.ExclusionKindDomain, "x.example"); err == nil {
 		t.Error("a rep without the capture-settings grant added a workspace rule")
+	}
+}
+
+// A container rule keeps out the mail a provider FILED somewhere the owner
+// rules out — a Gmail label, a Graph folder, an IMAP mailbox — and does it on
+// the same pre-store path an address rule does.
+//
+// The case it exists for is the one an address rule cannot reach: mail that has
+// nothing in common but where it was put. A "Family" label holds messages from
+// a dozen senders on a dozen domains, and naming them one at a time is a list
+// nobody finishes.
+func TestAContainerRuleKeepsOutMailFiledWhereTheOwnerRulesOut(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, syncInContainer := env.e, env.syncInContainer
+	store := capture.NewExclusionStore(e.DB())
+	owner := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead, principal.ScopeWrite})
+
+	if _, err := store.Add(owner, capture.ExclusionScopeUser, capture.ExclusionKindContainer, "gmail:Label_7"); err != nil {
+		t.Fatalf("container rule: %v", err)
+	}
+
+	syncInContainer(t, map[string][]string{
+		"c-1@mid.example": {"gmail:INBOX", "gmail:Label_7"},
+		"c-2@mid.example": {"gmail:INBOX", "gmail:Label_9"},
+	},
+		email("aunt@family.example", "Aunt", captureOwner, "c-1@mid.example", ""),
+		email("dana@acme.example", "Dana Buyer", captureOwner, "c-2@mid.example", ""),
+	)
+
+	if n := countRows(t, e, `SELECT count(*) FROM activity WHERE source_id = 'c-1@mid.example'`); n != 0 {
+		t.Errorf("%d activity rows for a message filed under the excluded label, want 0", n)
+	}
+	if n := countRows(t, e, `SELECT count(*) FROM raw_capture WHERE source_id = 'c-1@mid.example'`); n != 0 {
+		t.Errorf("%d raw_capture rows for the excluded message, want 0 — a container rule drops before the raw store, like every other rule", n)
+	}
+	// A message carrying OTHER labels is untouched. Without this the assertion
+	// above would pass against a rule that excluded everything.
+	if n := countRows(t, e, `SELECT count(*) FROM activity WHERE source_id = 'c-2@mid.example'`); n != 1 {
+		t.Errorf("the message in another label did not land (%d rows)", n)
+	}
+	if n := countRows(t, e, `SELECT count(*) FROM capture_trace WHERE reason = 'excluded_container'`); n != 1 {
+		t.Errorf("%d container-exclusion trace rows, want 1", n)
+	}
+	// The label is what the rule keeps out, so it does not travel into the
+	// trace or the breadcrumb as the evidence for its own suppression.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM capture_trace WHERE reason = 'excluded_container'
+		   AND (counterparty IS NOT NULL OR subject IS NOT NULL)`); n != 0 {
+		t.Error("the container-exclusion trace carries the counterparty or subject")
+	}
+	if n := countRows(t, e, `SELECT count(*) FROM system_log WHERE action = 'capture_excluded' AND detail::text ILIKE '%Label_7%'`); n != 0 {
+		t.Error("the exclusion breadcrumb names the container it matched")
+	}
+}
+
+// A container belongs to one mailbox, so a container rule is one person's.
+// The database refuses a workspace one too; this is the refusal a human gets,
+// which names the field and says why rather than answering 500.
+func TestAContainerRuleIsTheMailboxOwnersAlone(t *testing.T) {
+	env := newCaptureEnv(t)
+	e := env.e
+	store := capture.NewExclusionStore(e.DB())
+	admin := principal.WithActor(principal.WithWorkspaceID(context.Background(), e.WS), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.Rep3.String(), UserID: e.Rep3,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"capture_settings": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	_, err := store.Add(admin, capture.ExclusionScopeWorkspace, capture.ExclusionKindContainer, "gmail:Label_7")
+	var invalid *capture.InvalidExclusionError
+	if !errors.As(err, &invalid) || invalid.Field != "scope" {
+		t.Fatalf("a workspace container rule = %v, want a refusal naming the scope — a label id means "+
+			"nothing in a colleague's mailbox, so the rule would bind their connections to a place "+
+			"that does not exist there", err)
+	}
+	// The same admin may still set a workspace ADDRESS rule, so the refusal is
+	// about the kind rather than about this caller.
+	if _, err := store.Add(admin, capture.ExclusionScopeWorkspace, capture.ExclusionKindDomain, "payroll.example"); err != nil {
+		t.Errorf("the same caller setting a workspace domain rule: %v", err)
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19667,7 +19667,7 @@ type CaptureExclusion struct {
 	// Scope Whose rule it is — the installation's, or the caller's own for the mailbox they connected.
 	Scope CaptureExclusionScope `json:"scope"`
 
-	// Value The folded address or domain.
+	// Value The folded address or domain, or a provider-qualified container (`gmail:Label_12`, `graph:<folderId>`, `imap:INBOX/Family`) kept exactly as the provider spells it.
 	Value string `json:"value"`
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -2394,14 +2394,17 @@ func (e CaptureCounterpartyHoldKind) Valid() bool {
 
 // Defines values for CaptureExclusionKind.
 const (
-	CaptureExclusionKindAddress CaptureExclusionKind = "address"
-	CaptureExclusionKindDomain  CaptureExclusionKind = "domain"
+	CaptureExclusionKindAddress   CaptureExclusionKind = "address"
+	CaptureExclusionKindContainer CaptureExclusionKind = "container"
+	CaptureExclusionKindDomain    CaptureExclusionKind = "domain"
 )
 
 // Valid indicates whether the value is a known member of the CaptureExclusionKind enum.
 func (e CaptureExclusionKind) Valid() bool {
 	switch e {
 	case CaptureExclusionKindAddress:
+		return true
+	case CaptureExclusionKindContainer:
 		return true
 	case CaptureExclusionKindDomain:
 		return true
@@ -2422,6 +2425,24 @@ func (e CaptureExclusionScope) Valid() bool {
 	case CaptureExclusionScopeUser:
 		return true
 	case CaptureExclusionScopeWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CaptureOwnerIdentityKind.
+const (
+	CaptureOwnerIdentityKindAddress CaptureOwnerIdentityKind = "address"
+	CaptureOwnerIdentityKindDomain  CaptureOwnerIdentityKind = "domain"
+)
+
+// Valid indicates whether the value is a known member of the CaptureOwnerIdentityKind enum.
+func (e CaptureOwnerIdentityKind) Valid() bool {
+	switch e {
+	case CaptureOwnerIdentityKindAddress:
+		return true
+	case CaptureOwnerIdentityKindDomain:
 		return true
 	default:
 		return false
@@ -19635,9 +19656,13 @@ type CaptureCounterpartyHoldListResponse struct {
 
 // CaptureExclusion defines model for CaptureExclusion.
 type CaptureExclusion struct {
-	CreatedAt time.Time            `json:"created_at"`
-	Id        openapi_types.UUID   `json:"id"`
-	Kind      CaptureExclusionKind `json:"kind"`
+	CreatedAt time.Time          `json:"created_at"`
+	Id        openapi_types.UUID `json:"id"`
+
+	// Kind What the rule names. `address` and `domain` match the parties a message names; `container` matches where the provider FILED it — a Gmail label, a Graph folder, an IMAP mailbox.
+	// A container value is `<provider>:<id>`, where the id is the provider's own token and is stored exactly as given: `gmail:Label_12` (a system label is its name, `gmail:CATEGORY_PROMOTIONS`), `graph:<folderId>`, `imap:INBOX/Family`. Qualified because an id means nothing without the namespace it belongs to, and unfolded because a Graph folder id is base64url and an IMAP mailbox name is case-sensitive — folding either would merge two containers into one rule.
+	// A container rule is `user` scope only: the list belongs to the mailbox's owner, and a workspace rule would bind every colleague's connection to a place that does not exist there.
+	Kind CaptureExclusionKind `json:"kind"`
 
 	// Scope Whose rule it is — the installation's, or the caller's own for the mailbox they connected.
 	Scope CaptureExclusionScope `json:"scope"`
@@ -19646,7 +19671,9 @@ type CaptureExclusion struct {
 	Value string `json:"value"`
 }
 
-// CaptureExclusionKind defines model for CaptureExclusionKind.
+// CaptureExclusionKind What the rule names. `address` and `domain` match the parties a message names; `container` matches where the provider FILED it — a Gmail label, a Graph folder, an IMAP mailbox.
+// A container value is `<provider>:<id>`, where the id is the provider's own token and is stored exactly as given: `gmail:Label_12` (a system label is its name, `gmail:CATEGORY_PROMOTIONS`), `graph:<folderId>`, `imap:INBOX/Family`. Qualified because an id means nothing without the namespace it belongs to, and unfolded because a Graph folder id is base64url and an IMAP mailbox name is case-sensitive — folding either would merge two containers into one rule.
+// A container rule is `user` scope only: the list belongs to the mailbox's owner, and a workspace rule would bind every colleague's connection to a place that does not exist there.
 type CaptureExclusionKind string
 
 // CaptureExclusionListResponse defines model for CaptureExclusionListResponse.
@@ -19698,9 +19725,11 @@ type CaptureMailboxHealth struct {
 
 // CaptureOwnerIdentity defines model for CaptureOwnerIdentity.
 type CaptureOwnerIdentity struct {
-	CreatedAt time.Time            `json:"created_at"`
-	Id        openapi_types.UUID   `json:"id"`
-	Kind      CaptureExclusionKind `json:"kind"`
+	CreatedAt time.Time          `json:"created_at"`
+	Id        openapi_types.UUID `json:"id"`
+
+	// Kind What the identity names. Its own schema rather than the exclusion's, which the two shared while they happened to hold the same two values: an exclusion can now also name a CONTAINER, and a container is not something a mailbox owner can BE.
+	Kind CaptureOwnerIdentityKind `json:"kind"`
 
 	// Source Where the claim came from. `user` is the seat typing it in. `provider` is an address a mail
 	// provider attests; nothing writes it yet, because reading a provider's send-as list needs a
@@ -19719,6 +19748,9 @@ type CaptureOwnerIdentity struct {
 	// Value The folded address or domain.
 	Value string `json:"value"`
 }
+
+// CaptureOwnerIdentityKind What the identity names. Its own schema rather than the exclusion's, which the two shared while they happened to hold the same two values: an exclusion can now also name a CONTAINER, and a container is not something a mailbox owner can BE.
+type CaptureOwnerIdentityKind string
 
 // CaptureOwnerIdentityListResponse defines model for CaptureOwnerIdentityListResponse.
 type CaptureOwnerIdentityListResponse struct {
@@ -21449,6 +21481,9 @@ type CreateCaptureCounterpartyHoldRequestKind string
 
 // CreateCaptureExclusionRequest defines model for CreateCaptureExclusionRequest.
 type CreateCaptureExclusionRequest struct {
+	// Kind What the rule names. `address` and `domain` match the parties a message names; `container` matches where the provider FILED it — a Gmail label, a Graph folder, an IMAP mailbox.
+	// A container value is `<provider>:<id>`, where the id is the provider's own token and is stored exactly as given: `gmail:Label_12` (a system label is its name, `gmail:CATEGORY_PROMOTIONS`), `graph:<folderId>`, `imap:INBOX/Family`. Qualified because an id means nothing without the namespace it belongs to, and unfolded because a Graph folder id is base64url and an IMAP mailbox name is case-sensitive — folding either would merge two containers into one rule.
+	// A container rule is `user` scope only: the list belongs to the mailbox's owner, and a workspace rule would bind every colleague's connection to a place that does not exist there.
 	Kind CaptureExclusionKind `json:"kind"`
 
 	// Scope Whose rule it is — the installation's, or the caller's own for the mailbox they connected.
@@ -21460,7 +21495,8 @@ type CreateCaptureExclusionRequest struct {
 
 // CreateCaptureOwnerIdentityRequest defines model for CreateCaptureOwnerIdentityRequest.
 type CreateCaptureOwnerIdentityRequest struct {
-	Kind CaptureExclusionKind `json:"kind"`
+	// Kind What the identity names. Its own schema rather than the exclusion's, which the two shared while they happened to hold the same two values: an exclusion can now also name a CONTAINER, and a container is not something a mailbox owner can BE.
+	Kind CaptureOwnerIdentityKind `json:"kind"`
 
 	// Value An email address, or a bare domain.
 	Value string `json:"value"`

--- a/backend/internal/modules/capture/exclusioncontainer_test.go
+++ b/backend/internal/modules/capture/exclusioncontainer_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// A container rule names a provider and a place inside it, and the value is
+// stored as the provider gave it.
+//
+// The two arms beside it fold their values, because an address and a domain are
+// case-insensitive by their own specifications. A container id is not: a Graph
+// folder id is base64url, where two distinct folders can differ only in case,
+// and an IMAP mailbox name is case-sensitive except for INBOX. Folding one
+// would merge two containers into a single rule and keep out mail the owner
+// never asked to keep out — silently, because the rule would look right.
+
+import "testing"
+
+func TestAContainerRuleKeepsTheProvidersOwnSpelling(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, raw, want string
+	}{
+		{"a Gmail label id keeps its case", "gmail:Label_7", "gmail:Label_7"},
+		{"a Graph folder id keeps its case", "graph:AAMkAGI2Tg", "graph:AAMkAGI2Tg"},
+		{"an IMAP path keeps its separators and its case", "imap:INBOX/Family", "imap:INBOX/Family"},
+		{"the PROVIDER folds, because that half is ours", "GMAIL:Label_7", "gmail:Label_7"},
+		{"surrounding space is not part of either half", "  imap:INBOX  ", "imap:INBOX"},
+		{"a container may itself contain a colon", "graph:AAMk:Tg", "graph:AAMk:Tg"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidExclusionValue(ExclusionKindContainer, tc.raw)
+			if err != nil {
+				t.Fatalf("ValidExclusionValue(%q) = %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("ValidExclusionValue(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// A rule that can never match is worse than a refusal: mail keeps arriving and
+// nothing says why the rule the owner wrote does nothing.
+func TestAContainerRuleThatCouldNeverMatchIsRefused(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ name, raw string }{
+		{"no provider at all", "Private"},
+		{"a provider nothing here speaks", "outlook:Private"},
+		{"a provider with nothing after it", "gmail:"},
+		{"a container with no provider before it", ":Label_7"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidExclusionValue(ExclusionKindContainer, tc.raw)
+			var invalid *InvalidExclusionError
+			if !asInvalid(err, &invalid) || invalid.Field != "value" {
+				t.Fatalf("ValidExclusionValue(%q) = %q, %v — want a refusal naming the value", tc.raw, got, err)
+			}
+		})
+	}
+}
+
+// asInvalid is errors.As pinned to this package's own refusal, so the two cases
+// above read as one question rather than carrying the plumbing twice.
+func asInvalid(err error, target **InvalidExclusionError) bool {
+	invalid, ok := err.(*InvalidExclusionError) //nolint:errorlint // the refusal is returned directly, never wrapped
+	if ok {
+		*target = invalid
+	}
+	return ok
+}

--- a/backend/internal/modules/capture/exclusionstore.go
+++ b/backend/internal/modules/capture/exclusionstore.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"net/mail"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
 // The exclusion vocabulary, the Go spelling of the table's CHECKs.
@@ -35,7 +37,14 @@ const (
 	ExclusionScopeUser      = "user"
 	ExclusionKindAddress    = "address"
 	ExclusionKindDomain     = "domain"
+	ExclusionKindContainer  = "container"
 )
+
+// containerProviders are the provider prefixes a container rule may carry, and
+// the namespaces its value belongs to. Named rather than open-ended: an
+// unrecognised prefix is a rule that can never match anything, and a person who
+// typed one would see mail keep arriving with nothing saying why.
+var containerProviders = []string{"gmail", "graph", "imap"}
 
 // auditKeyExclusion is the audit-image key naming which rule a change was
 // about; the value is the folded address or domain, which is what the trail
@@ -117,6 +126,16 @@ func (s *ExclusionStore) Add(ctx context.Context, scope, kind, raw string) (Excl
 		userID = &me
 	default:
 		return Exclusion{}, &InvalidExclusionError{Field: "scope", Reason: "scope is workspace or user"}
+	}
+	// The database refuses this too, and a constraint violation is a 500. A
+	// container lives in ONE person's mailbox: a workspace rule naming a label
+	// id would bind every colleague's connection to a place that does not exist
+	// there, and silently match nothing forever.
+	if kind == ExclusionKindContainer && scope != ExclusionScopeUser {
+		return Exclusion{}, &InvalidExclusionError{
+			Field:  "scope",
+			Reason: "a label or folder rule is your own: only the mailbox's owner has that list",
+		}
 	}
 	value, err := ValidExclusionValue(kind, raw)
 	if err != nil {
@@ -212,8 +231,27 @@ func ValidExclusionValue(kind, raw string) (string, error) {
 			return "", &InvalidExclusionError{Field: "value", Reason: err.Error()}
 		}
 		return domain, nil
+	case ExclusionKindContainer:
+		return validContainer(raw)
 	}
-	return "", &InvalidExclusionError{Field: "kind", Reason: "kind is address or domain"}
+	return "", &InvalidExclusionError{Field: "kind", Reason: "kind is address, domain or container"}
+}
+
+// validContainer vets a provider-qualified container and returns its stored
+// form. The prefix is folded and checked; what follows is kept exactly as
+// given, because it is the provider's own token and not ours to normalize — a
+// Graph folder id differs by case, and an IMAP mailbox name is case-sensitive
+// except for INBOX.
+func validContainer(raw string) (string, error) {
+	provider, container, qualified := strings.Cut(strings.TrimSpace(raw), ":")
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if !qualified || container == "" || !slices.Contains(containerProviders, provider) {
+		return "", &InvalidExclusionError{
+			Field:  "value",
+			Reason: "name the provider and the container it belongs to, for example gmail:Private (" + strings.Join(containerProviders, ", ") + ")",
+		}
+	}
+	return connector.Container(provider, container), nil
 }
 
 // InvalidExclusionError is a malformed rule; it answers 422 naming the field.

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -97,6 +97,11 @@ type Message struct {
 	// wrote it — mailmap composes it with the message's authorship before any
 	// attestation is claimed.
 	FiledAsSent bool
+	// Labels are Gmail's own label IDS for this message, not their display
+	// names: a system label is its name (INBOX, SENT, CATEGORY_PROMOTIONS) and
+	// a user label is an opaque "Label_<n>". They ride the same messages.get
+	// response FiledAsSent is read from, so they cost no extra call.
+	Labels []string
 }
 
 // API is the read-only Gmail surface the connector uses. All calls take a
@@ -298,7 +303,7 @@ func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) (Messag
 	if err != nil {
 		return Message{}, fmt.Errorf("gmail: decoding raw message %s: %w", msgID, ErrUnreachable)
 	}
-	return Message{RFC822: decoded, FiledAsSent: hasSentLabel(out.LabelIDs)}, nil
+	return Message{RFC822: decoded, FiledAsSent: hasSentLabel(out.LabelIDs), Labels: out.LabelIDs}, nil
 }
 
 // hasSentLabel reports whether Gmail filed this message under SENT — the

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -262,7 +262,14 @@ func captureOne(ctx context.Context, fetched Message, sink connector.Sink, bounc
 		return false, mailmap.RecordIfBounce(ctx, fetched.RFC822, bounces)
 	}
 	msg = msg.AttestSentByOwner(fetched.FiledAsSent)
-	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, fetched.RFC822)); err != nil {
+	rec := msg.ToRecord(connectorName, fetched.RFC822)
+	// Where Gmail filed it, so an owner who keeps a label out of the CRM is
+	// answered before the message is stored. Set here rather than in
+	// mailmap.ToRecord because a label is provider metadata off the
+	// messages.get response and not in the RFC822 bytes — which is also why
+	// Normalize, the pure re-parse of those bytes, carries none.
+	rec.Containers = labelContainers(fetched.Labels)
+	if _, err := sink.Upsert(ctx, rec); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			return false, nil
 		}
@@ -371,6 +378,18 @@ func scopeStrings(scopes []principal.Scope) []string {
 	out := make([]string, 0, len(scopes))
 	for _, s := range scopes {
 		out = append(out, string(s))
+	}
+	return out
+}
+
+// labelContainers qualifies Gmail's label ids for the exclusion match.
+func labelContainers(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, connector.Container(connectorName, label))
 	}
 	return out
 }

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -110,5 +110,5 @@ func (c *Connector) backfillOne(ctx context.Context, access string, msg MessageR
 		// provider is waited out, anything else ends the run.
 		return false, err
 	}
-	return captureOne(ctx, raw, sink, c.bounces, owner, msg.ParentFolderID == sentFolder)
+	return captureOne(ctx, raw, sink, c.bounces, owner, msg.ParentFolderID, msg.ParentFolderID == sentFolder)
 }

--- a/backend/internal/modules/capture/graph/graph.go
+++ b/backend/internal/modules/capture/graph/graph.go
@@ -276,7 +276,7 @@ func (c *Connector) pullFolder(
 			// cursor so the next cycle retries from the same watermark.
 			return "", err
 		}
-		if _, err := captureOne(ctx, raw, sink, c.bounces, owner, sentByOwner); err != nil {
+		if _, err := captureOne(ctx, raw, sink, c.bounces, owner, folder, sentByOwner); err != nil {
 			return "", err
 		}
 	}
@@ -308,7 +308,7 @@ func (c *Connector) selectMessages(ctx context.Context, access, folder, start st
 // a no-op; only a real Sink write fault returns a non-nil error (which stops
 // the pull). It is a package function (no receiver) so a pull holds no shared
 // state.
-func captureOne(ctx context.Context, raw []byte, sink connector.Sink, bounces connector.BounceSink, owner string, sentByOwner bool) (captured bool, err error) {
+func captureOne(ctx context.Context, raw []byte, sink connector.Sink, bounces connector.BounceSink, owner, folderID string, sentByOwner bool) (captured bool, err error) {
 	msg, err := mailmap.Parse(raw, owner)
 	if err != nil {
 		return false, nil //nolint:nilerr // a single unparseable message is a skip, not a fatal pull error (mirrors the Gmail connector)
@@ -317,7 +317,17 @@ func captureOne(ctx context.Context, raw []byte, sink connector.Sink, bounces co
 		return false, mailmap.RecordIfBounce(ctx, raw, bounces)
 	}
 	msg = msg.AttestSentByOwner(sentByOwner)
-	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, raw)); err != nil {
+	rec := msg.ToRecord(connectorName, raw)
+	// Which folder Graph filed it in, so an owner who keeps one out of the CRM
+	// is answered before the message is stored. Set here rather than in
+	// mailmap.ToRecord because the folder is provider metadata off the message
+	// resource and not in the MIME bytes — which is also why Normalize, the
+	// pure re-parse of those bytes, carries none. Empty on a delta round that
+	// did not name a folder, which simply matches no rule.
+	if folderID != "" {
+		rec.Containers = []string{connector.Container(connectorName, folderID)}
+	}
+	if _, err := sink.Upsert(ctx, rec); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			return false, nil
 		}

--- a/backend/internal/modules/capture/imap/imap.go
+++ b/backend/internal/modules/capture/imap/imap.go
@@ -129,7 +129,12 @@ type syncState struct {
 	// authenticated owner sent — the T1 correspondence evidence (ADR-0072 §1).
 	// A pull selects exactly one mailbox, so the attestation is per-pull.
 	sentMailbox bool
-	contacts    map[string]struct{}
+	// mailbox is the one this pull selected, kept because it is the only
+	// container an IMAP message has — the server tells us nothing about where
+	// else a copy might live. A pull selects exactly one, so it is per-pull like
+	// the attestation above.
+	mailbox  string
+	contacts map[string]struct{}
 }
 
 // Stats is one pull's outcome tally — internal bookkeeping accumulated on
@@ -221,7 +226,16 @@ func (c *Connector) capture(ctx context.Context, raw []byte, sink connector.Sink
 		return nil
 	}
 	parsed = parsed.AttestSentByOwner(st.sentMailbox)
-	if _, err := sink.Upsert(ctx, parsed.ToRecord(connectorName, raw)); err != nil {
+	rec := parsed.ToRecord(connectorName, raw)
+	// The mailbox this pull selected, so an owner who keeps a container out of
+	// the CRM is answered before the message is stored. Set here rather than in
+	// mailmap.ToRecord because the mailbox is a property of the SESSION and not
+	// of the RFC822 bytes — which is also why Normalize, the pure re-parse of
+	// those bytes, carries none.
+	if st.mailbox != "" {
+		rec.Containers = []string{connector.Container(connectorName, st.mailbox)}
+	}
+	if _, err := sink.Upsert(ctx, rec); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			// The Sink dropped it (e.g. an erased subject's suppression list) —
 			// a deliberate skip, counted like any other.

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -208,7 +208,7 @@ func (c *Connector) syncStanding(ctx context.Context, auth connector.Auth, curso
 	// The standing connector is a registry singleton serving every IMAP
 	// connection, so all per-pull state lives on this local, never on c —
 	// concurrent syncs of different mailboxes must not see each other.
-	st := &syncState{owner: creds.Email, contacts: map[string]struct{}{}}
+	st := &syncState{owner: creds.Email, mailbox: creds.Mailbox, contacts: map[string]struct{}{}}
 	if err := netConn.SetDeadline(time.Now().Add(pullDeadline)); err != nil {
 		// Armed for the exchanges before v2 takes the deadline over — see
 		// pullDeadline, which says how much of the phase this really bounds.

--- a/backend/internal/modules/capture/sinkexclusion.go
+++ b/backend/internal/modules/capture/sinkexclusion.go
@@ -19,9 +19,10 @@ import (
 // address or domain that matched is exactly what the rule exists to keep out
 // of the CRM, and a trace that repeated it would store it after all.
 const (
-	reasonExcludedAddress = "excluded_address"
-	reasonExcludedDomain  = "excluded_domain"
-	actionCaptureExcluded = "capture_excluded"
+	reasonExcludedAddress   = "excluded_address"
+	reasonExcludedDomain    = "excluded_domain"
+	reasonExcludedContainer = "excluded_container"
+	actionCaptureExcluded   = "capture_excluded"
 )
 
 // dropBeforeStoreTx runs the gates that keep a message out of the CRM
@@ -74,7 +75,10 @@ func (s *Sink) dropBeforeStoreTx(ctx context.Context, tx pgx.Tx, rec connector.N
 // that reaches the raw store has been kept whatever happens next. The answer
 // is the reason to trace, or "" when nothing matched.
 func excludedTx(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord) (string, error) {
-	if len(rec.Addresses) == 0 {
+	// A message with no addresses may still have been FILED somewhere the
+	// owner keeps out, so the container arm is asked on its own. The address
+	// arms need the lists below and answer nothing without them.
+	if len(rec.Addresses) == 0 && len(rec.Containers) == 0 {
 		return "", nil
 	}
 	addresses := make([]string, 0, len(rec.Addresses))
@@ -87,6 +91,10 @@ func excludedTx(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord) 
 	}
 	// A domain rule covers its subdomains: an exclusion of acme.com keeps out
 	// mail.acme.com, the way the own-domain matcher reads a domain.
+	//
+	// The container arm compares EXACTLY, where the two address arms fold: a
+	// container value is the provider's own token, and folding it would merge
+	// two Graph folders whose base64url ids differ only in case.
 	var kind string
 	err := tx.QueryRow(ctx, `
 		SELECT kind FROM capture_exclusion e
@@ -94,17 +102,21 @@ func excludedTx(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord) 
 		   AND ((e.kind = 'address' AND e.value = ANY($1::text[]))
 		     OR (e.kind = 'domain' AND EXISTS (
 		           SELECT 1 FROM unnest($2::text[]) d
-		            WHERE d = e.value OR d LIKE '%.' || e.value)))
+		            WHERE d = e.value OR d LIKE '%.' || e.value))
+		     OR (e.kind = 'container' AND e.value = ANY($4::text[])))
 		 ORDER BY e.kind LIMIT 1`,
-		addresses, domains, nilToNull(actorUserID(ctx))).Scan(&kind)
+		addresses, domains, nilToNull(actorUserID(ctx)), rec.Containers).Scan(&kind)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return "", nil
 		}
 		return "", err
 	}
-	if kind == ExclusionKindAddress {
+	switch kind {
+	case ExclusionKindAddress:
 		return reasonExcludedAddress, nil
+	case ExclusionKindContainer:
+		return reasonExcludedContainer, nil
 	}
 	return reasonExcludedDomain, nil
 }
@@ -126,5 +138,9 @@ func withoutParties(rec connector.NormalizedRecord) connector.NormalizedRecord {
 	rec.Participants = nil
 	rec.Addresses = nil
 	rec.Fields = nil
+	// A label's NAME is what a container rule keeps out — "Family", "Private" —
+	// so it goes with the addresses rather than travelling into a trace as the
+	// evidence for its own suppression.
+	rec.Containers = nil
 	return rec
 }

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -13,6 +13,7 @@ package connector
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -189,6 +190,23 @@ type NormalizedRecord struct {
 	// empty value is the safe answer and the common one; a connector that
 	// cannot make the judgement leaves it empty rather than guessing.
 	DeliveredTo string
+
+	// Containers are the provider's own filing places for this message, each
+	// qualified by the provider whose namespace it belongs to:
+	// "gmail:<labelId>", "graph:<folderId>", "imap:<mailbox>". A message can
+	// sit in several (Gmail applies many labels to one message), and a
+	// connector that has no such notion leaves this empty.
+	//
+	// Qualified rather than bare because a label id means nothing without the
+	// provider it came from, and one person may have connected two mailboxes on
+	// different providers — an unqualified "inbox" would then be one rule
+	// matching two unrelated places.
+	//
+	// The values are NOT folded to lower case. A Graph folder id is base64url,
+	// where two distinct folders can differ only in case, and an IMAP mailbox
+	// name is case-sensitive except for INBOX. Only the provider prefix is
+	// fixed, and it is written lower case by every connector.
+	Containers []string
 
 	// Counterparty is the human on the other side of a captured message —
 	// the auto-create pipeline's input (ADR-0063). Zero for records that
@@ -442,4 +460,17 @@ func (r BackfillReporter) Observed(ctx context.Context, scanned, captured, skipp
 func BackfillProgressFrom(ctx context.Context) BackfillReporter {
 	p, _ := ctx.Value(backfillProgressKey{}).(BackfillProgress)
 	return BackfillReporter{to: p}
+}
+
+// Container qualifies one provider container for NormalizedRecord.Containers
+// and for a capture exclusion's stored value. Both sides call it, because a
+// rule and the record it is matched against have to agree on the spelling
+// character for character — the match is an equality.
+//
+// The provider is folded and the container is not: the prefix is ours and
+// fixed, and what follows is the provider's own token — a Graph folder id is
+// base64url, where two distinct folders can differ only in case, and an IMAP
+// mailbox name is case-sensitive except for INBOX.
+func Container(provider, container string) string {
+	return strings.ToLower(provider) + ":" + container
 }

--- a/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.down.sql
+++ b/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.down.sql
@@ -1,0 +1,16 @@
+-- Bounded because every statement below takes an ACCESS EXCLUSIVE lock on
+-- capture_exclusion, which blocks the sink's own reads: a migration that waited
+-- behind a long transaction would stall capture rather than fail.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_container_is_personal;
+
+DELETE FROM capture_exclusion WHERE kind = 'container';
+
+ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_value_check;
+ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_value_check
+    CHECK (value = lower(value) AND value <> '');
+
+ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_kind_check;
+ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_kind_check
+    CHECK (kind IN ('address', 'domain'));

--- a/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.down.sql
+++ b/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.down.sql
@@ -5,7 +5,25 @@ SET LOCAL lock_timeout = '3s';
 
 ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_container_is_personal;
 
-DELETE FROM capture_exclusion WHERE kind = 'container';
+-- REFUSE rather than delete. A container rule is a person's standing instruction
+-- that a whole label's mail never enters the CRM, and the schema this rolls back
+-- to cannot hold one — so a silent DELETE would resume capturing mail somebody
+-- had ruled out, with nothing on any surface saying it had happened.
+--
+-- The operator's remedy is on the surface that owns the rules: lift them, then
+-- roll back. That is a decision a person makes about their own mailbox, and it
+-- is not this migration's to make for them.
+DO $$
+DECLARE rules int;
+BEGIN
+  SELECT count(*) INTO rules FROM capture_exclusion WHERE kind = 'container';
+  IF rules > 0 THEN
+    RAISE EXCEPTION 'refusing to roll back: % capture exclusion(s) name a container, and the '
+      'earlier schema cannot hold one. Rolling back would silently resume capturing mail their '
+      'owners ruled out. Lift them first (Settings -> Capture -> Exclusions), then roll back.',
+      rules;
+  END IF;
+END $$;
 
 ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_value_check;
 ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_value_check

--- a/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.up.sql
+++ b/backend/migrations/core/1788784928_a_label_is_a_thing_a_mailbox_owner_keeps_out.up.sql
@@ -1,0 +1,34 @@
+-- Bounded because every statement below takes an ACCESS EXCLUSIVE lock on
+-- capture_exclusion, which blocks the sink's own reads: a migration that waited
+-- behind a long transaction would stall capture rather than fail.
+SET LOCAL lock_timeout = '3s';
+
+-- A capture exclusion may name a CONTAINER — a Gmail label, a Graph folder, an
+-- IMAP mailbox — and not only an address or a domain.
+--
+-- The value is provider-qualified ("gmail:private", "graph:<folderId>",
+-- "imap:INBOX/Family") because a label id means nothing without the provider
+-- whose namespace it belongs to, and one person may have connected two.
+ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_kind_check;
+ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_kind_check
+    CHECK (kind IN ('address', 'domain', 'container'));
+
+-- The lowercase rule stops applying to a container, and that is the point
+-- rather than a relaxation.
+--
+-- An address and a domain are case-insensitive by their own specifications, so
+-- folding them is lossless and makes the uniqueness index answer the question a
+-- reader means. A provider's container id is an OPAQUE token in that provider's
+-- namespace: a Graph folder id is base64url, where two distinct folders can
+-- differ only in case, and an IMAP mailbox name is case-sensitive except for
+-- INBOX. Folding those would silently merge two containers into one rule and
+-- exclude mail the owner never asked to exclude.
+ALTER TABLE capture_exclusion DROP CONSTRAINT capture_exclusion_value_check;
+ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_value_check
+    CHECK (value <> '' AND (kind = 'container' OR value = lower(value)));
+
+-- Only the mailbox's owner has a label list, so a container rule is theirs.
+-- A workspace-wide one would name a container in one person's mailbox and bind
+-- everybody else's connections to an id that means nothing there.
+ALTER TABLE capture_exclusion ADD CONSTRAINT capture_exclusion_container_is_personal
+    CHECK (kind <> 'container' OR scope = 'user');

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1273,12 +1273,13 @@ public.capture_digest.user_id uuid NOT NULL gen=- def=-
 public.capture_digest_pkey CREATE UNIQUE INDEX capture_digest_pkey ON public.capture_digest USING btree (id)
 public.capture_digest_user_id_digest_date_key CREATE UNIQUE INDEX capture_digest_user_id_digest_date_key ON public.capture_digest USING btree (user_id, digest_date)
 public.capture_exclusion acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
-public.capture_exclusion.capture_exclusion_kind_check CHECK ((kind = ANY (ARRAY['address'::text, 'domain'::text])))
+public.capture_exclusion.capture_exclusion_container_is_personal CHECK (((kind <> 'container'::text) OR (scope = 'user'::text)))
+public.capture_exclusion.capture_exclusion_kind_check CHECK ((kind = ANY (ARRAY['address'::text, 'domain'::text, 'container'::text])))
 public.capture_exclusion.capture_exclusion_pkey PRIMARY KEY (id)
 public.capture_exclusion.capture_exclusion_scope_check CHECK ((scope = ANY (ARRAY['workspace'::text, 'user'::text])))
 public.capture_exclusion.capture_exclusion_scope_user CHECK (((scope = 'user'::text) = (user_id IS NOT NULL)))
 public.capture_exclusion.capture_exclusion_user_id_fkey FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
-public.capture_exclusion.capture_exclusion_value_check CHECK (((value = lower(value)) AND (value <> ''::text)))
+public.capture_exclusion.capture_exclusion_value_check CHECK (((value <> ''::text) AND ((kind = 'container'::text) OR (value = lower(value)))))
 public.capture_exclusion.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.capture_exclusion.created_by text NOT NULL gen=- def=-
 public.capture_exclusion.id uuid NOT NULL gen=- def=uuidv7()

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -117,7 +117,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (124)
+## Census (125)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -141,6 +141,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `basecurrencyguard_test.go` | H2 | The base-currency lock as a fitness function. |
 | `bootcomposition_test.go` | H2 | The fitness gate on the boot sequence: a process role that composes extensions also records what it composed. |
 | `briefsectioncensus_test.go` | H2 | Every worklist category reaches a section of the morning. |
+| `capturecontainers_test.go` | H2 | Every mail connector tells the sink where the provider FILED a message. |
 | `catalogoptionsreaders_test.go` | H2 | Who may read a custom field's OPTIONS. |
 | `claimedspelling_test.go` | H3 | A constant whose doc comment says it is spelled once is making a checkable statement, and until now nothing checked it. |
 | `clearablefields_test.go` | H2 | The fields a restore says it can clear are the fields the stores clear. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15755,8 +15755,13 @@ export interface components {
          * @enum {string}
          */
         CaptureExclusionScope: "workspace" | "user";
-        /** @enum {string} */
-        CaptureExclusionKind: "address" | "domain";
+        /**
+         * @description What the rule names. `address` and `domain` match the parties a message names; `container` matches where the provider FILED it — a Gmail label, a Graph folder, an IMAP mailbox.
+         *     A container value is `<provider>:<id>`, where the id is the provider's own token and is stored exactly as given: `gmail:Label_12` (a system label is its name, `gmail:CATEGORY_PROMOTIONS`), `graph:<folderId>`, `imap:INBOX/Family`. Qualified because an id means nothing without the namespace it belongs to, and unfolded because a Graph folder id is base64url and an IMAP mailbox name is case-sensitive — folding either would merge two containers into one rule.
+         *     A container rule is `user` scope only: the list belongs to the mailbox's owner, and a workspace rule would bind every colleague's connection to a place that does not exist there.
+         * @enum {string}
+         */
+        CaptureExclusionKind: "address" | "domain" | "container";
         CaptureExclusionListResponse: {
             data: components["schemas"]["CaptureExclusion"][];
         };
@@ -15766,10 +15771,15 @@ export interface components {
             /** @description An email address, or a bare domain. */
             value: string;
         };
+        /**
+         * @description What the identity names. Its own schema rather than the exclusion's, which the two shared while they happened to hold the same two values: an exclusion can now also name a CONTAINER, and a container is not something a mailbox owner can BE.
+         * @enum {string}
+         */
+        CaptureOwnerIdentityKind: "address" | "domain";
         CaptureOwnerIdentity: {
             /** Format: uuid */
             id: string;
-            kind: components["schemas"]["CaptureExclusionKind"];
+            kind: components["schemas"]["CaptureOwnerIdentityKind"];
             /** @description The folded address or domain. */
             value: string;
             source: components["schemas"]["CaptureOwnerIdentitySource"];
@@ -15833,7 +15843,7 @@ export interface components {
             data: components["schemas"]["CaptureOwnerIdentity"][];
         };
         CreateCaptureOwnerIdentityRequest: {
-            kind: components["schemas"]["CaptureExclusionKind"];
+            kind: components["schemas"]["CaptureOwnerIdentityKind"];
             /** @description An email address, or a bare domain. */
             value: string;
         };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15745,7 +15745,7 @@ export interface components {
             id: string;
             scope: components["schemas"]["CaptureExclusionScope"];
             kind: components["schemas"]["CaptureExclusionKind"];
-            /** @description The folded address or domain. */
+            /** @description The folded address or domain, or a provider-qualified container (`gmail:Label_12`, `graph:<folderId>`, `imap:INBOX/Family`) kept exactly as the provider spells it. */
             value: string;
             /** Format: date-time */
             created_at: string;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7421,6 +7421,7 @@ export const de = {
   "captureExclusions.scope.workspace": "Ganze Organisation",
   "captureExclusions.kind.address": "Adresse",
   "captureExclusions.kind.domain": "Domain",
+  "captureExclusions.kind.container": "Label oder Ordner",
   "captureExclusions.scopeLabel": "Gilt für",
   "captureExclusions.kindLabel": "Art",
   "captureExclusions.addLabel": "Adresse oder Domain ausschließen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7421,7 +7421,7 @@ export const de = {
   "captureExclusions.scope.workspace": "Ganze Organisation",
   "captureExclusions.kind.address": "Adresse",
   "captureExclusions.kind.domain": "Domain",
-  "captureExclusions.kind.container": "Label oder Ordner",
+  "captureExclusions.kind.container": "Label, Ordner oder Postfach",
   "captureExclusions.scopeLabel": "Gilt für",
   "captureExclusions.kindLabel": "Art",
   "captureExclusions.addLabel": "Adresse oder Domain ausschließen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7527,7 +7527,7 @@ export const en = {
   "captureExclusions.scope.workspace": "Whole organization",
   "captureExclusions.kind.address": "Address",
   "captureExclusions.kind.domain": "Domain",
-  "captureExclusions.kind.container": "Label or folder",
+  "captureExclusions.kind.container": "Label, folder or mailbox",
   "captureExclusions.scopeLabel": "Applies to",
   "captureExclusions.kindLabel": "Kind",
   "captureExclusions.addLabel": "Exclude an address or a domain",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7527,6 +7527,7 @@ export const en = {
   "captureExclusions.scope.workspace": "Whole organization",
   "captureExclusions.kind.address": "Address",
   "captureExclusions.kind.domain": "Domain",
+  "captureExclusions.kind.container": "Label or folder",
   "captureExclusions.scopeLabel": "Applies to",
   "captureExclusions.kindLabel": "Kind",
   "captureExclusions.addLabel": "Exclude an address or a domain",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7344,6 +7344,7 @@ export const vi = {
   "captureExclusions.scope.workspace": "Toàn tổ chức",
   "captureExclusions.kind.address": "Địa chỉ",
   "captureExclusions.kind.domain": "Tên miền",
+  "captureExclusions.kind.container": "Nhãn hoặc thư mục",
   "captureExclusions.scopeLabel": "Áp dụng cho",
   "captureExclusions.kindLabel": "Loại",
   "captureExclusions.addLabel": "Loại trừ một địa chỉ hoặc tên miền",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7344,7 +7344,7 @@ export const vi = {
   "captureExclusions.scope.workspace": "Toàn tổ chức",
   "captureExclusions.kind.address": "Địa chỉ",
   "captureExclusions.kind.domain": "Tên miền",
-  "captureExclusions.kind.container": "Nhãn hoặc thư mục",
+  "captureExclusions.kind.container": "Nhãn, thư mục hoặc hộp thư",
   "captureExclusions.scopeLabel": "Áp dụng cho",
   "captureExclusions.kindLabel": "Loại",
   "captureExclusions.addLabel": "Loại trừ một địa chỉ hoặc tên miền",

--- a/frontend/src/screens/capture-exclusions.tsx
+++ b/frontend/src/screens/capture-exclusions.tsx
@@ -28,6 +28,12 @@ type Scope = components["schemas"]["CaptureExclusionScope"];
 type Kind = components["schemas"]["CaptureExclusionKind"];
 
 const SCOPES: readonly Scope[] = ["user", "workspace"];
+// The kinds this card OFFERS, which is not every kind a rule can have.
+// `container` is missing on purpose: a container rule names a provider's own
+// token — a Gmail label id, a Graph folder id — and asking somebody to type one
+// would be asking them to look it up. It arrives here as a picker once a
+// connector can hand over the list of names to choose from. A container rule
+// that already exists still renders, labelled like any other.
 const KINDS: readonly Kind[] = ["address", "domain"];
 
 /** The organization-wide rules, which are the ones a plain seat may not touch. */
@@ -98,6 +104,7 @@ function useRuleWords() {
   const kind: Record<Kind, string> = {
     address: t("captureExclusions.kind.address"),
     domain: t("captureExclusions.kind.domain"),
+    container: t("captureExclusions.kind.container"),
   };
   return { scope, kind };
 }

--- a/frontend/src/screens/capture-owner-identities.tsx
+++ b/frontend/src/screens/capture-owner-identities.tsx
@@ -31,7 +31,7 @@ import { problemMessageOf, QueryGate, throwProblem } from "./common";
 // list exists to protect.
 
 type OwnerIdentity = components["schemas"]["CaptureOwnerIdentity"];
-type Kind = components["schemas"]["CaptureExclusionKind"];
+type Kind = components["schemas"]["CaptureOwnerIdentityKind"];
 
 const KINDS: readonly Kind[] = ["address", "domain"];
 


### PR DESCRIPTION
Closes #1899.

## Why an address rule was not enough

An exclusion could name an address or a domain, and neither reaches the case a
mailbox owner actually has. A "Private" or "Family" label holds messages from a
dozen senders on a dozen domains; naming them one at a time is a list nobody
finishes, and each new sender arrives in the CRM before the owner can add it.

A container rule names the place instead, and is matched on the same pre-store
path — the message drops before the raw store, leaving the same breadcrumb and
trace, which name the KIND of rule and never what it matched.

## The value

`<provider>:<id>` — `gmail:Label_7`, `graph:<folderId>`, `imap:INBOX/Family`.

- **Qualified**, because an id means nothing without the namespace it belongs
  to, and one person may have connected two providers: an unqualified `inbox`
  would be one rule matching two unrelated places.
- **Unfolded**, and this is the part worth reading twice. A Graph folder id is
  base64url, where two distinct folders can differ only in case, and an IMAP
  mailbox name is case-sensitive except for `INBOX`. The existing
  `value = lower(value)` CHECK would have merged two containers into one rule
  and kept out mail the owner never asked to keep out — silently, because the
  rule would look right. So the migration **scopes** that CHECK to the two
  kinds it is true for rather than relaxing it away.

## A container rule is the owner's alone

A workspace rule would bind every colleague's connection to a place that does
not exist in their mailbox, and match nothing forever. Held by a CHECK, and by
a refusal in the store that names the field — a human gets an answer instead of
a 500 from a constraint.

## The connectors report where the provider filed the message

From metadata they already hold, at no extra call:

| connector | source |
|---|---|
| gmail | `labelIds`, off the same `messages.get` the SENT attestation is read from |
| graph | `parentFolderId`, on the delta path and the backfill path |
| imap | the mailbox the pull selected |

Set on the capture path rather than in `mailmap.ToRecord`, because none of it is
in the RFC822 bytes — which is also why `Normalize`, the pure re-parse of those
bytes, carries none.

`TestEveryMailConnectorReportsWhereTheProviderFiledTheMessage` is the gate that
matters here: a connector which does not fill the field captures exactly as
before and the owner's rule quietly matches nothing, so the failure is invisible
from the outside. Its corpus is derived — a mail connector is a package that
parses through `mailmap` — so a fourth one is judged the day it lands. It says
in its own header what it cannot see: that the value is *right*, which is each
connector's own tests.

## Two things the ticket did not name

**`CaptureOwnerIdentity` was borrowing `CaptureExclusionKind`**, because the two
happened to hold the same two values. Growing the exclusion's enum would have
told owner-identity clients that a container is a kind of identity, which it is
not — a container is not something a mailbox owner can *be*. The identity now
has its own schema with the same two values, so the two can diverge without
either lying about the other.

**The settings card labels a container rule but does not offer the kind.**
Asking somebody to type `Label_7` is asking them to look it up. It arrives as a
picker once a connector can hand over the list of names, which is what the
ticket already says — and a rule created through the API renders correctly in
the meantime rather than showing a blank kind.

## Checks

- `make check-backend`, `make check-fe` green.
- `make test-it` green for `internal/compose/integration/capture` (101s) and
  `internal/modules/capture`.
- `craft static --strict` clean on every changed Go file.
- Mutation-checked: dropping the container arm from the sink's predicate turns
  the drop test red; blanking the IMAP assignment turns the connector census
  red; renaming the parser turns its anti-vacuity floor red.
- The migration bounds its lock wait (`SET LOCAL lock_timeout`), is stamped
  above main's head, and the catalog is regenerated with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added container-based capture exclusions for Gmail labels, Microsoft Graph folders, and IMAP mailboxes.
  - Container exclusions are limited to individual mailbox owners and preserve provider-specific naming.
  - Captured messages now retain their filing location for more precise filtering and exclusions.
  - Updated translated labels to include mailboxes alongside labels and folders.

- **Bug Fixes**
  - Prevented excluded messages from being stored or exposing container details in suppression records.
  - Corrected capture-owner identity type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->