### PR TITLE
fix(capture): the subject-key rung reads on the caller's transaction

### DIFF
--- a/backend/internal/compose/projectkeytx_integration_test.go
+++ b/backend/internal/compose/projectkeytx_integration_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The subject-key rung reads on the CALLER'S transaction, and the proof is a
+// pool with one connection in it.
+//
+// The project-attribution ladder runs inside a transaction. Its third rung asks
+// which project a subject's tokens name, through a seam the projects module
+// implements — and that implementation opened a connection of its OWN while the
+// ladder's transaction was still held. Each caller then holds one connection and
+// waits for another: with a small pool, or whenever concurrent captures occupy
+// every connection, they deadlock until the context is cancelled, and a path
+// documented as never failing the capture stalls the sync instead (#2107).
+//
+// One connection is the whole fixture. Before the fix this test hangs to its
+// deadline; after it, the read is on the transaction already in hand and there
+// is no second connection to wait for. The two rungs beside it always read this
+// way — this was the one that did not.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/projects"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestTheSubjectKeyRungNeedsNoSecondConnection(t *testing.T) {
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` " +
+			"(integration tests fail loudly, they never skip)")
+	}
+	owner, err := pgx.Connect(context.Background(), ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(context.Background(), owner); err != nil {
+		t.Fatal(err)
+	}
+	ws := ids.New[ids.WorkspaceKind]()
+	if _, err := owner.Exec(context.Background(), `INSERT INTO workspace (id) VALUES ($1)`, ws.UUID); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := pgxpool.ParseConfig(appDSN)
+	if err != nil {
+		t.Fatalf("parsing the app DSN: %v", err)
+	}
+	// MaxConns alone, for the reason keyvault's own single-connection fixture
+	// gives: MinConns is the owner constructor's to set.
+	cfg.MaxConns = 1
+	pool, err := testdb.OwnPoolFromConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("opening the single-connection pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	store := projects.NewStore(database.BindTo(pool, ws))
+
+	// A deadline rather than waiting for the suite's: a deadlock here is the
+	// FINDING, and a test that reports it as "the package timed out" sends the
+	// reader to the wrong place.
+	reader := principal.WithActor(principal.WithWorkspaceID(context.Background(), ws.UUID),
+		principal.Principal{
+			Type: principal.PrincipalHuman, ID: "human:probe", UserID: ids.NewV7(),
+			Permissions: principal.Permissions{
+				Objects:  map[string]principal.ObjectGrant{"project": {Read: true}},
+				RowScope: principal.RowScopeAll,
+			},
+		})
+	ctx, cancel := context.WithTimeout(reader, 20*time.Second)
+	defer cancel()
+
+	var matched ids.UUID
+	err = store.Tx(ctx, func(tx pgx.Tx) error {
+		// The rung, called the way the ladder calls it: inside a transaction
+		// this pool's only connection is already serving.
+		var inner error
+		matched, inner = store.MatchProjectKey(ctx, tx, []string{"no-such-key"})
+		return inner
+	})
+	if err != nil {
+		t.Fatalf("the subject-key rung could not run inside the caller's transaction: %v — with one "+
+			"connection in the pool, an implementation reaching for a second waits for the one it is "+
+			"already inside", err)
+	}
+	if !matched.IsZero() {
+		t.Errorf("a key no project carries matched %v", matched)
+	}
+}

--- a/backend/internal/modules/capture/sinkproject.go
+++ b/backend/internal/modules/capture/sinkproject.go
@@ -43,8 +43,17 @@ import (
 // Ambiguity is the matcher's to report, not the caller's to reconstruct: two
 // distinct projects named in one subject means the message says nothing
 // reliable, so the matcher answers with no project rather than picking one.
+//
+// It takes the caller's TRANSACTION, the way StampProjectCorrespondence below
+// does and for a sharper reason. An implementation opening its own connection
+// does so while this ladder's transaction is still held, so each caller holds
+// one connection and waits for another: with a small pool, or whenever
+// concurrent captures occupy every connection, they deadlock until the context
+// is cancelled — and a path documented as never failing the capture stalls the
+// sync instead (#2107). The two rungs beside this one already read on the
+// caller's tx; this is the one that did not.
 type ProjectKeyMatcher interface {
-	MatchProjectKey(ctx context.Context, tokens []string) (ids.UUID, error)
+	MatchProjectKey(ctx context.Context, tx pgx.Tx, tokens []string) (ids.UUID, error)
 }
 
 // StampProjectCorrespondence marks the activity just filed under a project as
@@ -176,7 +185,7 @@ func (s *Sink) decideProject(ctx context.Context, tx pgx.Tx, rec connector.Norma
 	for _, rung := range []func() (ids.UUID, error){
 		func() (ids.UUID, error) { return threadProject(ctx, tx, rec, fields, activityID) },
 		func() (ids.UUID, error) { return dealProject(ctx, tx, activityID) },
-		func() (ids.UUID, error) { return s.subjectProject(ctx, fields) },
+		func() (ids.UUID, error) { return s.subjectProject(ctx, tx, fields) },
 	} {
 		projectID, err := rung()
 		if err != nil || !projectID.IsZero() {
@@ -190,12 +199,12 @@ func (s *Sink) decideProject(ctx context.Context, tx pgx.Tx, rec connector.Norma
 // subject carrying none never reaches the seam: the bracket rule rules out
 // almost every message, and asking anyway would be one query per captured
 // message to learn what the tokenizer already knows.
-func (s *Sink) subjectProject(ctx context.Context, fields ActivityFields) (ids.UUID, error) {
+func (s *Sink) subjectProject(ctx context.Context, tx pgx.Tx, fields ActivityFields) (ids.UUID, error) {
 	tokens := projectKeyCandidates(fields.Subject)
 	if len(tokens) == 0 {
 		return ids.Nil, nil
 	}
-	return s.projectKeys.MatchProjectKey(ctx, tokens)
+	return s.projectKeys.MatchProjectKey(ctx, tx, tokens)
 }
 
 // threadProject is the stickiness rung: a conversation is about one body of

--- a/backend/internal/modules/projects/keymatch.go
+++ b/backend/internal/modules/projects/keymatch.go
@@ -32,7 +32,7 @@ import (
 // Archived projects are excluded because a key is unique among LIVE rows only
 // (uq_project_key): once a project is archived its key can be reused, so
 // matching an archived row could file today's mail under last year's work.
-func (s *Store) MatchProjectKey(ctx context.Context, tokens []string) (ids.UUID, error) {
+func (s *Store) MatchProjectKey(ctx context.Context, tx pgx.Tx, tokens []string) (ids.UUID, error) {
 	if len(tokens) == 0 {
 		return ids.Nil, nil
 	}
@@ -54,18 +54,20 @@ func (s *Store) MatchProjectKey(ctx context.Context, tokens []string) (ids.UUID,
 	if scope != "" {
 		where += " AND " + scope
 	}
-	var matched []ids.UUID
-	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		// LIMIT 2 because the query answers a yes/no/ambiguous question, not a
-		// list: one row is the match, two is enough to know it is ambiguous,
-		// and a third would only be read to be discarded.
-		rows, err := tx.Query(ctx, `SELECT id FROM project WHERE `+where+` LIMIT 2`, args...)
-		if err != nil {
-			return fmt.Errorf("deals: matching a subject's project keys: %w", err)
-		}
-		matched, err = pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
-		return err
-	})
+	// The CALLER'S transaction, not one of this store's own. Opening a second
+	// connection here happens while the attribution ladder's transaction is
+	// still held, so each caller holds one and waits for another — a deadlock
+	// under a small pool, on a path documented as never failing the capture
+	// (#2107).
+	//
+	// LIMIT 2 because the query answers a yes/no/ambiguous question, not a
+	// list: one row is the match, two is enough to know it is ambiguous, and a
+	// third would only be read to be discarded.
+	rows, err := tx.Query(ctx, `SELECT id FROM project WHERE `+where+` LIMIT 2`, args...)
+	if err != nil {
+		return ids.Nil, fmt.Errorf("deals: matching a subject's project keys: %w", err)
+	}
+	matched, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
 	if err != nil {
 		return ids.Nil, err
 	}


### PR DESCRIPTION
Closes #2107

The project-attribution ladder runs inside a transaction. Its third rung asks which project a subject's tokens name, through a seam the projects module implements — and that implementation opened a connection of its **own** while the ladder's transaction was still held.

Each caller then holds one connection and waits for another. With a small pool, or whenever concurrent captures occupy every connection, they deadlock until the context is cancelled — and a path documented as *never failing the capture* stalls the sync instead.

## The fix the issue prescribes

> Thread the caller's `pgx.Tx` through the `ProjectKeyMatcher` seam rather than letting the implementation take its own connection.

Which is also the shape already in use on both sides of it: `StampProjectCorrespondence`, declared ten lines below in the same file, takes a `tx`; and the ladder's other two rungs (`threadProject`, `dealProject`) already read on the caller's. **This was the one that did not.**

No compose wiring changed — the store satisfies the widened interface directly.

## Proven, not read

The issue's own reproduction: the rung is called inside a transaction on a pool with **one connection** in it.

Restoring the second connection fails that test in 28 seconds:

```
the subject-key rung could not run inside the caller's transaction:
pg: begin: context deadline exceeded — with one connection in the pool,
an implementation reaching for a second waits for the one it is already inside
```

The test carries its own 20-second deadline rather than waiting for the suite's, because a deadlock here **is** the finding — a run that reported it as "the package timed out" would send the reader to the wrong place.

## Verification

- One-connection pool, rung called inside a transaction: passes.
- Second connection restored: deadlock, named.
- `make check-backend` exit 0; `projects`, `capture` and `compose` unit lanes green.
