### PR TITLE
feat(ai): Settings -> AI can give an installation its first binding

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7298,8 +7298,11 @@ export const de = {
     "Die Modelllisten stammen aus der Preisliste, die Sie nicht einsehen dürfen. Jede ID, die Ihr Anbieter bedient, funktioniert — einfach eintippen.",
   "aiRouting.sub":
     "Welches Modell welche Stufe bedient. Änderungen wirken ohne Neustart; jeder Prozess übernimmt sie innerhalb einer Minute.",
-  "aiRouting.unbound":
-    "Diese Installation hat keine Modelle gebunden, daher sind ihre KI-Funktionen aus. Die erste Bindung deklariert eine Bereitstellung unter seeds.ai_routing in margince.yaml.",
+  "aiRouting.unboundUnkeyed":
+    "Diese Installation hat keine Modelle gebunden, daher sind ihre KI-Funktionen aus. Hinterlegen Sie unten einen Modellanbieter-Schlüssel und binden Sie die Stufen anschließend hier. Eine Bereitstellung kann die erste Bindung auch unter seeds.ai_routing in margince.yaml deklarieren; diese wird einmalig beim Anlegen der Organisation gelesen.",
+  "aiRouting.unboundKeyed":
+    "Diese Installation hat keine Modelle gebunden, daher sind ihre KI-Funktionen aus. Beginnen Sie mit den Vorgaben eines hinterlegten Anbieters, passen Sie sie an und speichern Sie.",
+  "aiRouting.unboundStart": "Mit {provider} beginnen",
   "aiRouting.profile.card": "Bereitstellungsprofil",
   "aiRouting.profile.label": "Standort",
   "aiRouting.profile.help":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7406,8 +7406,11 @@ export const en = {
     "Model lists come from the price sheet, which is not yours to read. Any id your provider serves works — type it.",
   "aiRouting.sub":
     "Which model serves each tier. Changes take effect without a restart, and every process picks them up within a minute.",
-  "aiRouting.unbound":
-    "This installation has no models bound, so its AI features are off. A deployment declares its first binding under seeds.ai_routing in margince.yaml.",
+  "aiRouting.unboundUnkeyed":
+    "This installation has no models bound, so its AI features are off. Add a model provider key below, then bind the tiers here. A deployment can also declare its first binding under seeds.ai_routing in margince.yaml, which is read once when the organization is created.",
+  "aiRouting.unboundKeyed":
+    "This installation has no models bound, so its AI features are off. Start from a keyed provider's defaults, adjust anything you like, then save.",
+  "aiRouting.unboundStart": "Start from {provider}",
   "aiRouting.profile.card": "Deployment profile",
   "aiRouting.profile.label": "Location",
   "aiRouting.profile.help":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7221,8 +7221,11 @@ export const vi = {
     "Danh sách mô hình lấy từ bảng giá, mà bạn không có quyền đọc. Mọi ID nhà cung cấp của bạn phục vụ đều dùng được — cứ gõ vào.",
   "aiRouting.sub":
     "Mô hình nào phục vụ từng bậc. Thay đổi có hiệu lực mà không cần khởi động lại; mọi tiến trình sẽ nhận trong vòng một phút.",
-  "aiRouting.unbound":
-    "Cài đặt này chưa ràng buộc mô hình nào nên các tính năng AI đang tắt. Bản triển khai khai báo ràng buộc đầu tiên tại seeds.ai_routing trong margince.yaml.",
+  "aiRouting.unboundUnkeyed":
+    "Cài đặt này chưa ràng buộc mô hình nào nên các tính năng AI đang tắt. Hãy thêm khóa nhà cung cấp mô hình bên dưới, rồi ràng buộc các tầng tại đây. Bản triển khai cũng có thể khai báo ràng buộc đầu tiên tại seeds.ai_routing trong margince.yaml; mục này chỉ được đọc một lần khi tạo tổ chức.",
+  "aiRouting.unboundKeyed":
+    "Cài đặt này chưa ràng buộc mô hình nào nên các tính năng AI đang tắt. Hãy bắt đầu với mặc định của nhà cung cấp đã có khóa, chỉnh sửa tùy ý rồi lưu.",
+  "aiRouting.unboundStart": "Bắt đầu với {provider}",
   "aiRouting.profile.card": "Hồ sơ triển khai",
   "aiRouting.profile.label": "Vị trí",
   "aiRouting.profile.help":

--- a/frontend/src/screens/ai-routing.test.tsx
+++ b/frontend/src/screens/ai-routing.test.tsx
@@ -92,6 +92,14 @@ const BOUND = {
   embeddings: { provider: "gemini", model: "gemini-embedding-001" },
 };
 
+// What an installation that has bound nothing answers: an empty tier map, not
+// null — the contract is explicit that it says so with `{}`.
+const UNBOUND = {
+  profile: "",
+  tiers: {},
+  embeddings: { provider: "", model: "" },
+};
+
 const VENDOR_MODELS: Record<string, unknown> = {
   gemini: {
     provider: "gemini",
@@ -116,7 +124,17 @@ const VENDOR_MODELS: Record<string, unknown> = {
 function backendFor(
   allow: GrantSpec,
   routing: unknown = BOUND,
-  { sheetStatus = 200 }: { sheetStatus?: number } = {},
+  {
+    sheetStatus = 200,
+    providerKeys = PROVIDER_KEYS,
+  }: {
+    sheetStatus?: number;
+    providerKeys?: readonly {
+      provider: string;
+      configured: boolean;
+      env_var: string;
+    }[];
+  } = {},
 ) {
   let stored = routing;
   // Typed as the document this endpoint takes, so an assertion can read a field
@@ -142,7 +160,7 @@ function backendFor(
         );
       }
       if (req.url.includes("/ai/provider-keys")) {
-        return jsonResponse({ providers: PROVIDER_KEYS });
+        return jsonResponse({ providers: providerKeys });
       }
       if (req.url.includes("/ai-model-rates")) {
         return sheetStatus === 200
@@ -192,6 +210,88 @@ afterEach(() => {
 });
 
 describe("AiRoutingCard", () => {
+  // ── the FIRST binding ──────────────────────────────────────────────────
+  //
+  // An installation with no tiers used to get a sentence and nothing else: "a
+  // deployment declares its first binding under seeds.ai_routing". True of a
+  // deployment and false for everyone else — that seed is consumed once, at
+  // organization creation, so an installation that ALREADY EXISTS can never
+  // take one. The desktop bundles ship a database, so their organization was
+  // created on the build machine, and their recipient reached this screen with
+  // no way forward but curl or deleting the demo data they were given.
+  it("offers a first binding from a keyed provider when nothing is bound", async () => {
+    const backend = backendFor(ROUTING_EDITOR, UNBOUND);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+
+    const start = await screen.findByRole("button", {
+      name: /start from google gemini/i,
+    });
+    // Only the vendor that HOLDS a key. Binding a lane at a vendor with no
+    // credential fails closed at the first call, which is a state this screen
+    // exists to make visible rather than to create.
+    expect(
+      screen.queryByRole("button", { name: /start from.*anthropic/i }),
+    ).toBeNull();
+
+    await userEvent.click(start);
+
+    // The form arrives complete: every tier the contract declares plus the
+    // embeddings binding, because a document missing either is refused and the
+    // reader would be exactly where they started.
+    await userEvent.click(
+      await screen.findByRole("button", { name: /save routing/i }),
+    );
+    await waitFor(() => expect(backend.getCapturedPut()).not.toBeNull());
+    const sent = backend.getCapturedPut() as CapturedRouting;
+    expect(Object.keys(sent.tiers).sort()).toEqual([
+      "cheap_cloud",
+      "frontier",
+      "local_large",
+      "local_small",
+      "premium",
+    ]);
+    expect(sent.embeddings.model).toBe("gemini-embedding-001");
+    expect(sent.tiers.premium.provider).toBe("gemini");
+  });
+
+  // Nothing to bind TO. The seed sentence is still right for a deployment, and
+  // the half a reader of THIS screen can act on is "add a key first" — so the
+  // callout says that and offers no button that could only fail.
+  it("asks for a key first when no provider has one", async () => {
+    const backend = backendFor(ROUTING_EDITOR, UNBOUND, {
+      providerKeys: [
+        { provider: "gemini", configured: false, env_var: "GEMINI_API_KEY" },
+        {
+          provider: "anthropic",
+          configured: false,
+          env_var: "ANTHROPIC_API_KEY",
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+
+    expect(await screen.findByText(/add a model provider key/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /start from/i })).toBeNull();
+  });
+
+  // A reader who may not change the binding still SEES why it is absent — the
+  // same rule the save button follows here: disabled, never hidden.
+  it("shows the first-binding offer disabled to a reader who cannot save", async () => {
+    const backend = backendFor(ROUTING_READER, UNBOUND);
+    vi.stubGlobal("fetch", backend.fetchMock);
+    render(<AiRoutingCard />);
+
+    expect(
+      (
+        (await screen.findByRole("button", {
+          name: /start from google gemini/i,
+        })) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
   it("shows the bound model for each tier", async () => {
     vi.stubGlobal("fetch", backendFor(ROUTING_EDITOR).fetchMock);
     render(<AiRoutingCard />);

--- a/frontend/src/screens/ai-routing.tsx
+++ b/frontend/src/screens/ai-routing.tsx
@@ -31,6 +31,7 @@ import {
 import { useProviderKeys } from "./ai-provider-keys";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import { RefreshFromSources } from "./rate-refresh";
+import { SETUP_PROVIDERS } from "./setup-providers";
 import "./ai-settings.css";
 
 // Which vendor this installation's text is sent to (ai-operational-spec §1.4).
@@ -234,11 +235,51 @@ function RoutingForm({
   // dies on is the one an error path or an older server produces.
   const tiers = orderedTiers(draft.tiers);
   if (tiers.length === 0) {
-    // Not an error and not an empty form: this installation binds nothing, and
-    // the way to give it a first binding is the deployment file's seed, which
-    // is where a deployment declares one. Saying so beats a form whose every
-    // field is blank and whose Save cannot produce a valid document.
-    return <Callout tone="info">{t("aiRouting.unbound")}</Callout>;
+    // An installation that binds nothing needs a FIRST binding, and for a long
+    // time this said only that a deployment declares one under
+    // `seeds.ai_routing`. True of a deployment, false for everybody else: the
+    // seed is consumed once, at organization creation, so an installation that
+    // ALREADY EXISTS can never take one. The desktop bundles make it concrete —
+    // they ship a database, so their organization was created on the build
+    // machine, and their recipient met this callout with no way forward but
+    // curl or deleting the demo data they were given.
+    //
+    // The old reasoning was "a form whose every field is blank has a Save that
+    // cannot produce a valid document". Right about the blank form, wrong about
+    // the conclusion: the defaults are not unknown. A keyed provider names the
+    // preset the app's own onboarding would have offered, so the form can open
+    // on a document that is already valid and the reader adjusts it.
+    //
+    // Nothing is written until Save — this seeds the DRAFT, so the binding
+    // stays their decision and goes through the same validation as every later
+    // change.
+    const startable = startableProviders(keys.data?.providers);
+    if (startable.length === 0) {
+      // No key, so nothing to bind TO. The seed sentence is still right for a
+      // deployment; the other half — add a key first — is the part a reader of
+      // THIS screen can act on.
+      return <Callout tone="info">{t("aiRouting.unboundUnkeyed")}</Callout>;
+    }
+    return (
+      <Callout tone="info">
+        {t("aiRouting.unboundKeyed")}
+        <div className="ai-routing-start">
+          {startable.map(({ id, label }) => (
+            <Button
+              key={id}
+              // `dirty` is derived — draft against the document it was seeded
+              // from — so replacing the draft is what marks it unsaved. There
+              // is no setter to call, and the re-seed effect above leaves a
+              // dirty form alone, so this survives another role's save.
+              onClick={() => setDraft(firstBinding(id))}
+              disabled={!canManage}
+            >
+              {t("aiRouting.unboundStart", { provider: label })}
+            </Button>
+          ))}
+        </div>
+      </Callout>
+    );
   }
 
   const setTier = (tier: string, next: TierBinding) =>
@@ -715,6 +756,52 @@ function EmbeddingWidthField({
 // Null is not "none". A list that has not arrived, or one a reader may not have,
 // must not draw a row as keyed: a lane that fails closed at call time and reads
 // as fine here is the exact thing the pill exists to prevent.
+// The providers this installation could bind RIGHT NOW: keyed, and named by a
+// preset so the binding opens on real model ids rather than blank fields.
+//
+// Deliberately the onboarding list rather than every keyed vendor. Those two
+// are the vendors that serve chat AND embeddings from one key, and a routing
+// document REQUIRES an embeddings binding — offering a third here would open a
+// form its reader cannot complete, which is the failure this branch exists to
+// end rather than repeat.
+function startableProviders(
+  providers: readonly { provider: string; configured: boolean }[] | undefined,
+): readonly { id: keyof typeof SETUP_PROVIDERS; label: string }[] {
+  const keyed = new Set(
+    (providers ?? []).filter((p) => p.configured).map((p) => p.provider),
+  );
+  return (
+    Object.keys(SETUP_PROVIDERS) as (keyof typeof SETUP_PROVIDERS)[]
+  ).flatMap((id) => {
+    const preset = SETUP_PROVIDERS[id];
+    return keyed.has(preset.provider) ? [{ id, label: preset.label }] : [];
+  });
+}
+
+// A complete, valid document on one provider's presets: every tier the contract
+// declares, plus the embeddings binding without which the document is refused.
+//
+// TIER_ORDER is the tier list for the same reason the form reads it — a tier
+// added to the contract has to appear here too, or a first binding silently
+// omits the lane and its tasks keep answering from the fake.
+function firstBinding(id: keyof typeof SETUP_PROVIDERS): Routing {
+  const p = SETUP_PROVIDERS[id];
+  const lane = {
+    provider: p.provider,
+    model: p.chatModel,
+    ...(p.baseUrl ? { base_url: p.baseUrl } : {}),
+  };
+  return {
+    profile: "cloud_frontier",
+    tiers: Object.fromEntries(TIER_ORDER.map((t) => [t, { ...lane }])),
+    embeddings: {
+      provider: p.provider,
+      model: p.embedModel,
+      ...(p.baseUrl ? { base_url: p.baseUrl } : {}),
+    },
+  } as Routing;
+}
+
 function unkeyedProviders(
   providers: readonly { provider: string; configured: boolean }[] | undefined,
 ): ReadonlySet<string> | null {

--- a/frontend/src/screens/ai-settings.css
+++ b/frontend/src/screens/ai-settings.css
@@ -181,3 +181,13 @@
   gap: var(--space-3);
   flex-wrap: wrap;
 }
+
+/* The first-binding affordance, inside the callout that explains why the form
+ * is not here yet. A row because there may be two providers keyed, and the
+ * choice between them is one decision rather than a list to work down. */
+.ai-routing-start {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-3);
+}


### PR DESCRIPTION
## The dead end

An installation with no tiers bound gets a sentence and nothing else:

> This installation has no models bound, so its AI features are off. A deployment declares its first binding under `seeds.ai_routing` in `margince.yaml`.

True of a deployment, false for everyone else. `seeds.ai_routing` is consumed **once, at organization creation**, so an installation that already exists can never take one. The screen that is the only place to bind a model tells its reader to use a file that will not be read.

`ai-routing.tsx` returned a bare `Callout` when `tiers.length === 0` — no form, no Save.

## Where it bites

The desktop bundles ship a database, so their organization was created on the build machine. A recipient sets a provider key, opens Settings → AI to bind a tier, and has nowhere to go. The only routes out are `PUT /v1/ai/routing` by hand, or deleting the demo data they were given — which nothing in the folder can fetch again.

Measured on a `v0.1.1-rc.2` bundle after Setup with a real key and one boot:

```
ai.provider_keys   gemini sealed
ai.routing         absent
ai_call            1842 rows, all provider=fake
```

## The change

The old reasoning was *"a form whose every field is blank has a Save that cannot produce a valid document."* Right about the blank form, wrong about the conclusion — the defaults are not unknown. A **keyed** provider names the preset the app's own onboarding would have offered, so the form can open on a document that is already valid and the reader adjusts it.

Nothing is written until Save: this seeds the **draft**, so the binding stays the reader's decision and goes through the same validation as every later change.

- offered only for the onboarding vendors (`SETUP_PROVIDERS`), and only where a key is actually held — those two serve chat *and* embeddings from one key, and a routing document requires an embeddings binding, so a third would open a form its reader cannot complete
- with no key held at all, the callout says **add a key first** and offers no button that could only fail
- the seed sentence stays, for the reader it was always right for
- disabled rather than hidden for a reader without `ai_routing:update`, matching the save button on this card

`firstBinding` builds from `TIER_ORDER` for the same reason the form reads it: a tier added to the contract must appear here too, or a first binding silently omits the lane and its tasks keep answering from the fake.

## Tests

Three added to `ai-routing.test.tsx`, and the provider-keys fixture is parameterised so an unkeyed installation can be tested:

1. a keyed provider offers a start button, an unkeyed one does not, and saving sends **all five tiers plus embeddings**
2. with no key held, the callout asks for a key and offers no button
3. a reader who cannot save sees the offer disabled, not hidden

Two of the three fail against the old callout; all 18 in the file pass with the change.

`tsc --noEmit` clean, `biome check` clean, i18n suites green (55 tests) — copy added to `en`, `de` and `vi` together.

Found while shipping a desktop release; the companion change in our installation stops its `Setup` claiming a binding it cannot apply.

## AI disclosure

**Generated** — AI produced substantial portions, reviewed and owned by me.
