### PR TITLE
test(sbom): the signing test's assertions use the conditional the rest of scripts/ does

### DIFF
--- a/scripts/test-sbom-sign.sh
+++ b/scripts/test-sbom-sign.sh
@@ -58,12 +58,12 @@ done
 log="$work/first.log"
 if ! run_sign "$log"; then fail "the first sbom-sign run did not succeed"; fi
 signed=$(grep -c . "$log" || true)
-[ "$signed" -eq 3 ] || fail "the first run signed $signed file(s), want 3 — an unsigned SBOM is the failure this target exists to prevent"
+[[ "$signed" -eq 3 ]] || fail "the first run signed $signed file(s), want 3 — an unsigned SBOM is the failure this target exists to prevent"
 
 log="$work/second.log"
 if ! run_sign "$log"; then fail "the re-run did not succeed"; fi
 signed=$(grep -c . "$log" || true)
-[ "$signed" -eq 0 ] || fail "the re-run signed $signed file(s) that already carry a current bundle — every one of those is a second permanent Rekor entry, and the first is left corroborating nothing"
+[[ "$signed" -eq 0 ]] || fail "the re-run signed $signed file(s) that already carry a current bundle — every one of those is a second permanent Rekor entry, and the first is left corroborating nothing"
 
 # An SBOM regenerated under its bundle IS signed again: the old bundle covers
 # bytes that are gone, and skipping there would publish a signature that
@@ -73,7 +73,7 @@ printf '{"changed":true}\n' >"$sboms/margince.cdx.json"
 log="$work/third.log"
 if ! run_sign "$log"; then fail "the run over a regenerated SBOM did not succeed"; fi
 signed=$(grep -c . "$log" || true)
-[ "$signed" -eq 1 ] || fail "a regenerated SBOM under an older bundle was signed $signed time(s), want 1 — its bundle covers bytes that no longer exist"
+[[ "$signed" -eq 1 ]] || fail "a regenerated SBOM under an older bundle was signed $signed time(s), want 1 — its bundle covers bytes that no longer exist"
 grep -q 'margince.cdx.json$' "$log" || fail "the run signed something other than the SBOM that changed"
 
 # An empty bundle is not a signature. A cancelled write can leave one.


### PR DESCRIPTION
Clears the three `shelldre:S7688` findings that are the only issues left open on the SonarCloud project — they arrived with #4837 and are not in anything I authored, but the project's issue list is the thing being cleared.

`[` is the external test command; `[[` is the bash conditional, and `scripts/test-sbom-sign.sh` declares `#!/usr/bin/env bash`. Every other numeric assertion under `scripts/` already reads `[[ "$x" -eq N ]]` (`check-ci-doc-parity.sh`, `check-host-ports.sh`, `check-image-pins.sh`, `ci-verdict.sh`, …), so these three were outliers rather than a second convention.

**The two single-bracket tests further up the file are left alone on purpose.** Lines 31 and 35 are the cosign stub's own source, inside a quoted `<<'STUB'` heredoc — text the analyzer never parses as shell and this script never runs as its own code. Sonar flagged exactly the three real ones; the same is true of the two in `test-api-entrypoint.sh`, which are also heredoc content. So there is no sibling case hiding behind this fix.

## Verification

- `make test-sbom-sign` — green: *"OK: sbom-sign signs what is unsigned and does not mint a second Rekor entry for what is not"*.
- `bash -n` clean.
- **Mutation-checked**, because a converted conditional that always succeeds would also look green: with the first assertion's expected count changed to 99 the target fails with its own message (`exit 2`). The assertions still fire.
- `make check-gates` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)