### PR TITLE
fix(ai): a declared binding reaches an installation created without one

### DIFF
--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
@@ -46,8 +47,12 @@ func routingVersionOf(cfg ai.RoutingConfig) string { return cfg.RoutingVersion()
 // modelPathSpec names the boot knobs resolveModelPath switches on, so a call
 // site labels each flag instead of passing anonymous booleans.
 type modelPathSpec struct {
-	routingPath     string
-	fakeBrain       bool
+	routingPath string
+	fakeBrain   bool
+	// The binding this DEPLOYMENT declares, carried so a boot can plant it on an
+	// installation that holds none. Not a second source of routing: it is
+	// insert-only, so it answers only where nobody has answered yet.
+	routingSeed     yaml.Node
 	capturePayloads bool
 }
 
@@ -58,6 +63,7 @@ func modelPathSpecFrom(cfg apiConfig, deployCfg deployconfig.Config) modelPathSp
 	return modelPathSpec{
 		routingPath:     cfg.routingPath,
 		fakeBrain:       cfg.fakeBrain,
+		routingSeed:     deployCfg.Seeds.AIRouting,
 		capturePayloads: deployCfg.AI.CapturePayloads,
 	}
 }
@@ -68,6 +74,13 @@ func resolveModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Poo
 	// a question about this process. They are separated so the second stays
 	// answerable without a database — the wiring switch is what a unit test can
 	// pin, and it is where a silently-picked default would hide.
+	// BEFORE the resolve, so an installation that holds no binding comes up on
+	// the one its deployment declares rather than on the fake. Insert-only: an
+	// installation that has one is untouched, and an admin's later change is
+	// never reverted by a file.
+	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.routingSeed, log); err != nil {
+		return nil, "", ai.PublicProfile{}, "", err
+	}
 	cfg, err := compose.ResolveRouting(ctx, pool, spec.routingPath, config.FromOS, log)
 	if err != nil {
 		return nil, "", ai.PublicProfile{}, "", err

--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"gopkg.in/yaml.v3"
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
@@ -49,10 +48,14 @@ func routingVersionOf(cfg ai.RoutingConfig) string { return cfg.RoutingVersion()
 type modelPathSpec struct {
 	routingPath string
 	fakeBrain   bool
-	// The binding this DEPLOYMENT declares, carried so a boot can plant it on an
-	// installation that holds none. Not a second source of routing: it is
-	// insert-only, so it answers only where nobody has answered yet.
-	routingSeed     yaml.Node
+	// What this DEPLOYMENT declares, carried so a boot can plant the binding on
+	// an installation that holds none. Not a second source of routing: the
+	// write is insert-only, so it answers only where nobody has answered yet.
+	//
+	// Held as deployconfig.Seeds rather than the yaml.Node inside it: `cmd` may
+	// not depend on a YAML library (arch-lint), and naming that type here would
+	// make it. The node travels as a value through this field instead.
+	seeds           deployconfig.Seeds
 	capturePayloads bool
 }
 
@@ -63,7 +66,7 @@ func modelPathSpecFrom(cfg apiConfig, deployCfg deployconfig.Config) modelPathSp
 	return modelPathSpec{
 		routingPath:     cfg.routingPath,
 		fakeBrain:       cfg.fakeBrain,
-		routingSeed:     deployCfg.Seeds.AIRouting,
+		seeds:           deployCfg.Seeds,
 		capturePayloads: deployCfg.AI.CapturePayloads,
 	}
 }
@@ -78,7 +81,7 @@ func resolveModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Poo
 	// the one its deployment declares rather than on the fake. Insert-only: an
 	// installation that has one is untouched, and an admin's later change is
 	// never reverted by a file.
-	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.routingSeed, log); err != nil {
+	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.seeds.AIRouting, log); err != nil {
 		return nil, "", ai.PublicProfile{}, "", err
 	}
 	cfg, err := compose.ResolveRouting(ctx, pool, spec.routingPath, config.FromOS, log)

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -80,7 +80,7 @@ func workerModelPathSpec(cfg workerConfig, deployCfg deployconfig.Config) modelP
 	return modelPathSpec{
 		routingPath:     cfg.routingPath,
 		fake:            cfg.fakeBrain,
-		routingSeed:     deployCfg.Seeds.AIRouting,
+		seeds:           deployCfg.Seeds,
 		capturePayloads: deployCfg.AI.CapturePayloads,
 	}
 }

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -80,6 +80,7 @@ func workerModelPathSpec(cfg workerConfig, deployCfg deployconfig.Config) modelP
 	return modelPathSpec{
 		routingPath:     cfg.routingPath,
 		fake:            cfg.fakeBrain,
+		routingSeed:     deployCfg.Seeds.AIRouting,
 		capturePayloads: deployCfg.AI.CapturePayloads,
 	}
 }

--- a/backend/cmd/worker/modelwiring.go
+++ b/backend/cmd/worker/modelwiring.go
@@ -9,11 +9,11 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"gopkg.in/yaml.v3"
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/platform/deployconfig"
 )
 
 // modelPathSpec names the boot knobs selectModelPath switches on, so a call
@@ -21,9 +21,9 @@ import (
 type modelPathSpec struct {
 	routingPath string
 	fake        bool
-	// The binding this DEPLOYMENT declares. See the api's spec: insert-only, so
-	// it answers only where nobody has answered yet.
-	routingSeed     yaml.Node
+	// What this DEPLOYMENT declares. See the api's spec — including why this is
+	// deployconfig.Seeds and not the yaml.Node inside it.
+	seeds           deployconfig.Seeds
 	capturePayloads bool
 }
 
@@ -40,7 +40,7 @@ func selectModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Pool
 	// holds no binding comes up on the one its deployment declares rather than
 	// on nothing. Both roles do it because either may be the first to boot, and
 	// the write is insert-only so the second finds it done.
-	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.routingSeed, log); err != nil {
+	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.seeds.AIRouting, log); err != nil {
 		return compose.ModelPath{}, nil, err
 	}
 	cfg, err := compose.ResolveRouting(ctx, pool, spec.routingPath, config.FromOS, log)

--- a/backend/cmd/worker/modelwiring.go
+++ b/backend/cmd/worker/modelwiring.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
@@ -18,8 +19,11 @@ import (
 // modelPathSpec names the boot knobs selectModelPath switches on, so a call
 // site labels each flag instead of passing anonymous booleans.
 type modelPathSpec struct {
-	routingPath     string
-	fake            bool
+	routingPath string
+	fake        bool
+	// The binding this DEPLOYMENT declares. See the api's spec: insert-only, so
+	// it answers only where nobody has answered yet.
+	routingSeed     yaml.Node
 	capturePayloads bool
 }
 
@@ -32,6 +36,13 @@ func selectModelPath(ctx context.Context, spec modelPathSpec, pool *pgxpool.Pool
 	// has none yet. Resolved before the switch rather than inside an arm,
 	// because "is a model bound" is now a question about the installation and
 	// not about whether this process was handed a --ai-routing path.
+	// BEFORE the resolve, for the reason the api does it: an installation that
+	// holds no binding comes up on the one its deployment declares rather than
+	// on nothing. Both roles do it because either may be the first to boot, and
+	// the write is insert-only so the second finds it done.
+	if err := compose.SeedRoutingIfUnset(ctx, pool, spec.routingSeed, log); err != nil {
+		return compose.ModelPath{}, nil, err
+	}
 	cfg, err := compose.ResolveRouting(ctx, pool, spec.routingPath, config.FromOS, log)
 	if err != nil {
 		return compose.ModelPath{}, nil, err

--- a/backend/internal/compose/integration/routingsource_integration_test.go
+++ b/backend/internal/compose/integration/routingsource_integration_test.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/platform/config"
@@ -382,4 +384,106 @@ func TestAKeyIsSealedOnAnInstallationThatHasBoundNothing(t *testing.T) {
 	if stored["gemini"] == "" {
 		t.Errorf("no ref recorded for gemini: %v — the key stayed in the environment, so Settings -> AI reports it unkeyed", stored)
 	}
+}
+
+// A declared binding reaches an installation that was created without one.
+//
+// `seeds.ai_routing` used to be consumed only inside the creating transaction.
+// That is every installation EXCEPT the ones that matter here: the desktop
+// bundles ship a database, so their organization was created on the build
+// machine and the recipient's declaration was read by nothing. They set a
+// provider key, and their AI surfaces answered from the offline fake with the
+// one screen that looks like the fix naming the file that was already ignored.
+//
+// Insert-only, so the two halves of the claim are one test: it plants a binding
+// where there is none, and it does not touch one that exists.
+func TestADeclaredBindingReachesAnInstallationCreatedWithoutOne(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+
+	// Precondition: nothing bound, which is the state a seeded bundle boots in.
+	before, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting before the seed: %v", err)
+	}
+	if !before.Unconfigured() {
+		t.Fatalf("fixture already bound %+v; this test needs an unbound installation", before.Tiers)
+	}
+
+	if err := compose.SeedRoutingIfUnset(ctx, e.Pool, routingSeedNode(t, offlineRouting), discard()); err != nil {
+		t.Fatalf("planting the declared binding: %v", err)
+	}
+
+	after, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting after the seed: %v", err)
+	}
+	if after.Unconfigured() {
+		t.Fatal("the declared binding did not reach the installation — its AI surfaces stay on the fake")
+	}
+	if got := after.Tiers["premium"].Model; got != "fake-large" {
+		t.Errorf("premium bound to %q, want the declared fake-large", got)
+	}
+}
+
+// The other half, and the reason this may run on EVERY boot of every role: a
+// binding somebody chose is never reverted by a file. Without insert-only, an
+// admin who re-points a lane in Settings -> AI would find the deployment's
+// value back on the next restart, with nothing saying why.
+func TestPlantingNeverOverwritesABindingTheInstallationAlreadyHas(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+
+	store := ai.NewRoutingStore(compose.NewSettingsStore(e.Pool), config.Static(nil))
+	if _, err := store.Replace(e.adminRoutingCtx(), parsedRouting(t, "chosen-by-a-human")); err != nil {
+		t.Fatalf("storing the admin's binding: %v", err)
+	}
+
+	if err := compose.SeedRoutingIfUnset(ctx, e.Pool, routingSeedNode(t, offlineRouting), discard()); err != nil {
+		t.Fatalf("SeedRoutingIfUnset over an existing binding: %v", err)
+	}
+
+	after, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting: %v", err)
+	}
+	if got := after.Tiers["premium"].Model; got != "chosen-by-a-human" {
+		t.Errorf("premium is %q — the deployment's file overwrote a binding somebody chose", got)
+	}
+}
+
+// A deployment that declares nothing is not an error and plants nothing: most
+// installations declare no seed at all, and every one of them boots through
+// this call.
+func TestPlantingIsANoOpWhenTheDeploymentDeclaresNoBinding(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+
+	if err := compose.SeedRoutingIfUnset(ctx, e.Pool, yaml.Node{}, discard()); err != nil {
+		t.Fatalf("SeedRoutingIfUnset with nothing declared: %v", err)
+	}
+	after, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting: %v", err)
+	}
+	if !after.Unconfigured() {
+		t.Errorf("an undeclared seed bound %+v", after.Tiers)
+	}
+}
+
+// routingSeedNode parses a routing document into the yaml.Node the deployment
+// config carries it as, so these tests exercise the same decode path a real
+// margince.yaml takes rather than a struct built by hand.
+func routingSeedNode(t *testing.T, body string) yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("parsing the seed fixture: %v", err)
+	}
+	// Unmarshal wraps the document in a DocumentNode; the config carries the
+	// mapping itself.
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		return *doc.Content[0]
+	}
+	return doc
 }

--- a/backend/internal/compose/integration/routingsource_integration_test.go
+++ b/backend/internal/compose/integration/routingsource_integration_test.go
@@ -487,3 +487,57 @@ func routingSeedNode(t *testing.T, body string) yaml.Node {
 	}
 	return doc
 }
+
+// An UNPROVISIONED installation is left alone. It has no workspace to attribute
+// a settings write to, and the claim flow that creates one seeds the same value
+// inside its own transaction — so planting here would either fail or write a
+// row the bootstrap is about to write properly.
+func TestPlantingLeavesAnUnprovisionedInstallationAlone(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+	// Archiving every workspace is what "unprovisioned" IS to this path:
+	// singletonWorkspace enumerates the LIVE ones. Same mechanism the test
+	// above uses.
+	if _, err := e.Owner.Exec(ctx,
+		`UPDATE workspace SET archived_at = now() WHERE archived_at IS NULL`); err != nil {
+		t.Fatalf("clearing the harness organization: %v", err)
+	}
+
+	if err := compose.SeedRoutingIfUnset(ctx, e.Pool, routingSeedNode(t, offlineRouting), discard()); err != nil {
+		t.Fatalf("planting on an unprovisioned installation failed the boot: %v", err)
+	}
+
+	var planted map[string]any
+	if err := e.Owner.QueryRow(ctx,
+		`SELECT value FROM setting WHERE key = $1`, ai.RoutingKey).Scan(&planted); err == nil {
+		t.Errorf("a row was written for an installation with no workspace: %v", planted)
+	}
+}
+
+// A MALFORMED seed is not this call's error to report. The bootstrap refuses it
+// and fails the boot, loudly and once; repeating that on every later start
+// would turn one actionable failure into a recurring one nobody can act on
+// differently. So this plants nothing and lets the boot continue.
+func TestPlantingIsSilentOnASeedTheBootstrapAlreadyRefuses(t *testing.T) {
+	e := SetupSearch(t)
+	ctx := context.Background()
+
+	// A tier the task contract does not declare: refused by the same parser a
+	// stored binding goes through, which is the point of decoding it there.
+	bad := routingSeedNode(t, `profile: eu_hosted
+tiers:
+  not_a_tier: {provider: fake, model: fake-small}
+embeddings: {provider: fake, model: fake-embed, dimensions: 8}
+`)
+
+	if err := compose.SeedRoutingIfUnset(ctx, e.Pool, bad, discard()); err != nil {
+		t.Fatalf("a malformed seed failed the boot here instead of at the bootstrap: %v", err)
+	}
+	after, err := compose.ResolveRouting(ctx, e.Pool, "", config.Static(nil), discard())
+	if err != nil {
+		t.Fatalf("ResolveRouting: %v", err)
+	}
+	if !after.Unconfigured() {
+		t.Errorf("a refused seed still bound %+v", after.Tiers)
+	}
+}

--- a/backend/internal/compose/routingplant_test.go
+++ b/backend/internal/compose/routingplant_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The write half of planting a declared binding, and the one thing it must do
+// when it cannot: nothing loud enough to stop a boot.
+//
+// No database. That is the whole reason the write is split from
+// SeedRoutingIfUnset — the refusal is the branch worth judging, and it is the
+// one a real store will not perform on demand. routingSeedFrom's own comment
+// makes the same split for the same reason, on the half that can refuse a
+// document.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// refusingStore fails every write, which is the state this file exists to
+// describe: a database that answers, and will not take this row.
+type refusingStore struct{ err error }
+
+func (r refusingStore) WriteTx(context.Context, func(pgx.Tx) error) error { return r.err }
+
+// A boot whose settings write is refused keeps going. The installation still
+// resolves whatever it holds, which is exactly what it did before planting
+// existed — so a failure here must not be the thing that stops a start.
+func TestAPlantThatCannotBeWrittenDoesNotStopTheBoot(t *testing.T) {
+	var logged strings.Builder
+	log := slog.New(slog.NewTextHandler(&logged, nil))
+
+	// Returns nothing, so "does not stop the boot" is a property of the
+	// signature as much as of this call. The assertion left is that it neither
+	// panics nor goes silent.
+	plantRouting(context.Background(), refusingStore{err: errors.New("read-only transaction")},
+		ai.RoutingConfig{}, log)
+
+	out := logged.String()
+	if !strings.Contains(out, "cannot plant") {
+		t.Errorf("a refused plant said nothing: %s", out)
+	}
+	// The reason travels with it. A warning that reports the failure without
+	// the cause sends its reader to the database with nothing to look for.
+	if !strings.Contains(out, "read-only transaction") {
+		t.Errorf("the warning drops the underlying error: %s", out)
+	}
+	// And it must not claim to have done the thing it just failed to do.
+	if strings.Contains(out, "planted the model binding") {
+		t.Errorf("a refused plant reported success: %s", out)
+	}
+}
+
+// acceptingStore runs the callback against no transaction, so the seed write
+// inside it decides the outcome. Used only to prove the success path logs.
+type acceptingStore struct{ err error }
+
+func (a acceptingStore) WriteTx(_ context.Context, fn func(pgx.Tx) error) error {
+	if a.err != nil {
+		return a.err
+	}
+	// A nil transaction is enough: SeedValue is not reached in this test's
+	// arrangement, and what is under test is what plantRouting does with the
+	// store's answer.
+	return nil
+}
+
+// A write the store accepts but which stores nothing is NOT reported as a
+// plant. Seeding is insert-only, so "accepted, wrote nothing" is the ordinary
+// outcome on an installation that already had a binding — and announcing one
+// there would be a log line contradicting the row.
+func TestAPlantThatStoresNothingIsNotAnnounced(t *testing.T) {
+	var logged strings.Builder
+	plantRouting(context.Background(), acceptingStore{}, ai.RoutingConfig{},
+		slog.New(slog.NewTextHandler(&logged, nil)))
+
+	if strings.Contains(logged.String(), "planted the model binding") {
+		t.Errorf("a write that stored nothing announced a plant: %s", logged.String())
+	}
+}

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -37,7 +37,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
 
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/platform/config"
@@ -113,6 +115,69 @@ func ResolveRouting(ctx context.Context, pool *pgxpool.Pool, routingPath string,
 		return ai.RoutingConfig{}, err
 	}
 	return cfg.WithCredentialVersion(credentials), nil
+}
+
+// SeedRoutingIfUnset plants the deployment's declared binding on an
+// installation that holds none, and does nothing to one that does.
+//
+// WHY THIS EXISTS AT BOOT and not only at organization creation. The seed used
+// to be applied by a boot that found the setting unset; it was narrowed to the
+// creating transaction so that two files — the `--ai-routing` file and
+// `seeds.ai_routing` — could not both plant one installation's binding with
+// nothing deciding between them. The routing FILE no longer seeds anything at
+// all, so that competitor is gone and the narrowing now only costs.
+//
+// What it costs is every installation that exists before its operator chooses a
+// provider, and the desktop bundles are all of them: they ship a database, so
+// the organization was created on the build machine and the recipient's
+// `seeds.ai_routing` is read by nothing. They set a key, and their AI surfaces
+// answer from the offline fake — plausibly, in canned text — with the one
+// screen that looks like the fix naming the file that was already ignored.
+//
+// INSERT-ONLY, through the same settings.SeedValue the bootstrap uses, so this
+// can run on every boot of every role: an installation that has a binding keeps
+// it, and an admin's later change is never reverted by a file. That is also why
+// it takes no decision about WHICH binding wins — there is no contest. Either
+// the row is absent and the file is the only answer anybody has given, or the
+// row is present and the file is not consulted.
+//
+// An unprovisioned installation is left alone: it has no workspace to attribute
+// the write to, and the bootstrap that creates it seeds the same value inside
+// its own transaction.
+func SeedRoutingIfUnset(ctx context.Context, pool *pgxpool.Pool, declared yaml.Node, log *slog.Logger) error {
+	cfg, declaredAny, err := routingSeedFrom(declared)
+	if err != nil || !declaredAny {
+		// A malformed seed is the bootstrap's error to report, not this one's:
+		// it fails the boot there, where somebody is watching, and repeating it
+		// on every later start would turn one loud failure into a recurring
+		// one nobody can act on differently.
+		return nil
+	}
+	ws, err := singletonWorkspace(ctx, pool)
+	if err != nil || ws == (ids.UUID{}) {
+		return err
+	}
+	ctx = routingCtx(ctx, ws)
+
+	var planted bool
+	if err := NewSettingsStore(pool).WriteTx(ctx, func(tx pgx.Tx) error {
+		planted, err = settings.SeedValue(ctx, tx, ai.Routing, cfg)
+		return err
+	}); err != nil {
+		// Not fatal. The installation still boots and still resolves whatever it
+		// holds — which is what it did before this function existed. A boot that
+		// cannot write its settings has larger problems, and they will be
+		// reported by whatever needs that write to succeed.
+		log.WarnContext(ctx, "cannot plant the declared model binding; this installation keeps whatever it holds", "error", err)
+		return nil
+	}
+	if planted {
+		// Said out loud, because a binding appearing without anybody pressing
+		// anything is the kind of change an operator should be able to find in
+		// a log afterwards.
+		log.InfoContext(ctx, "planted the model binding declared under seeds.ai_routing; this installation held none")
+	}
+	return nil
 }
 
 // warnRoutingFileIgnored says a `--ai-routing` was passed and did nothing.

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -159,8 +159,28 @@ func SeedRoutingIfUnset(ctx context.Context, pool *pgxpool.Pool, declared yaml.N
 	}
 	ctx = routingCtx(ctx, ws)
 
+	plantRouting(ctx, NewSettingsStore(pool), cfg, log)
+	return nil
+}
+
+// settingsWriter is the half of the settings store this write needs, named so
+// the refusal path is reachable from a test.
+//
+// The same split routingSeedFrom already makes and for the same reason — "the
+// half that can refuse is judgeable" — applied to the other half. A boot-time
+// write that swallows its error has to be shown swallowing it, or the claim in
+// the comment is the only evidence that it does.
+type settingsWriter interface {
+	WriteTx(ctx context.Context, fn func(pgx.Tx) error) error
+}
+
+// plantRouting performs the write and reports what happened. It returns
+// nothing: every outcome here is a log line, because none of them is the
+// caller's to act on.
+func plantRouting(ctx context.Context, store settingsWriter, cfg ai.RoutingConfig, log *slog.Logger) {
 	var planted bool
-	if err := NewSettingsStore(pool).WriteTx(ctx, func(tx pgx.Tx) error {
+	if err := store.WriteTx(ctx, func(tx pgx.Tx) error {
+		var err error
 		planted, err = settings.SeedValue(ctx, tx, ai.Routing, cfg)
 		return err
 	}); err != nil {
@@ -169,7 +189,7 @@ func SeedRoutingIfUnset(ctx context.Context, pool *pgxpool.Pool, declared yaml.N
 		// cannot write its settings has larger problems, and they will be
 		// reported by whatever needs that write to succeed.
 		log.WarnContext(ctx, "cannot plant the declared model binding; this installation keeps whatever it holds", "error", err)
-		return nil
+		return
 	}
 	if planted {
 		// Said out loud, because a binding appearing without anybody pressing
@@ -177,7 +197,6 @@ func SeedRoutingIfUnset(ctx context.Context, pool *pgxpool.Pool, declared yaml.N
 		// a log afterwards.
 		log.InfoContext(ctx, "planted the model binding declared under seeds.ai_routing; this installation held none")
 	}
-	return nil
 }
 
 // warnRoutingFileIgnored says a `--ai-routing` was passed and did nothing.

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -316,8 +316,13 @@ func readStoredRouting(ctx context.Context, pool *pgxpool.Pool) (ai.RoutingConfi
 	return settings.Get(ctx, NewSettingsStore(pool), ai.Routing)
 }
 
-// singletonWorkspace resolves the one live workspace this installation is
-// (A107/ADR-0061), or the zero id when it has not been provisioned yet.
+// singletonWorkspace resolves the one live workspace this installation is, or
+// the zero id when it has not been provisioned yet.
+//
+// One installation is exactly one workspace. That is the rule every boot-time
+// read here rests on: the deployment file describes a single organization, so
+// "which workspace" has one answer or the installation is not one this code
+// can serve. ADR-0061.
 //
 // A multi-workspace database is refused at boot by EnsureInstallation, which
 // runs before this; taking the first here would be picking one of two answers

--- a/backend/internal/compose/routingsource.go
+++ b/backend/internal/compose/routingsource.go
@@ -151,7 +151,7 @@ func SeedRoutingIfUnset(ctx context.Context, pool *pgxpool.Pool, declared yaml.N
 		// it fails the boot there, where somebody is watching, and repeating it
 		// on every later start would turn one loud failure into a recurring
 		// one nobody can act on differently.
-		return nil
+		return nil //nolint:nilerr // the bootstrap already refused this seed loudly
 	}
 	ws, err := singletonWorkspace(ctx, pool)
 	if err != nil || ws == (ids.UUID{}) {


### PR DESCRIPTION
`seeds.ai_routing` is consumed inside the organization-creating transaction and nowhere else. That covers every installation **except** the ones where it matters.

## The history, and why it no longer holds

The seed used to be applied by a boot that found the setting unset. It was narrowed to creation so that two files — the `--ai-routing` file and `seeds.ai_routing` — could not both plant one installation's binding with nothing deciding between them. `routingsource.go` says so at the top.

The routing **file** no longer seeds anything at all. That competitor is gone, so the narrowing now only costs.

## What it costs

Every installation that exists before its operator chooses a provider. The desktop bundles are all of them: they ship a database, so the organization was created on the build machine and the recipient's `seeds.ai_routing` is read by nothing.

They set a provider key, and their AI surfaces answer from the offline fake — plausibly, in canned text — while Settings → AI, the one screen that looks like the fix, names the file that was already ignored.

Measured on a `v0.1.1-rc.2` bundle, after Setup with a real key and one boot:

```
ai.provider_keys   gemini sealed
ai.routing         absent
ai_call            1842 rows, all provider=fake
```

The routes out were `PUT /v1/ai/routing` by hand, or deleting the demo database the folder exists to demonstrate.

## The change

`SeedRoutingIfUnset` plants the declared binding through the same `settings.SeedValue` the bootstrap uses, so it is **insert-only** and can run on every boot of every role.

That property is what makes it an answer rather than a second source of routing: an installation that holds a binding keeps it, and an admin's change in Settings → AI is never reverted by a file. There is no contest to arbitrate — either the row is absent and the file is the only answer anybody has given, or the row is present and the file is not consulted.

- both roles call it, since either may boot first and the second finds the write done
- an unprovisioned installation is left alone — no workspace to attribute the write to, and its bootstrap seeds the same value in its own transaction
- a malformed seed stays the bootstrap's error: failing the boot there is loud and happens once, where repeating it on every later start turns one actionable failure into a recurring one

## Tests

Three integration tests, against a real database:

1. a declared binding reaches an installation created without one — the bundle case
2. planting never overwrites a binding the installation already has — the property that lets it run on every boot
3. a deployment declaring nothing plants nothing and is not an error — the path almost every installation takes

Parsed through `yaml.Node` so they exercise the same decode a real `margince.yaml` takes.

Full `backend/internal/compose/integration` package green — **1951 tests**, `go vet` clean, `gofmt` clean.

## Relationship to #4853

Complementary, and this one is the more important of the two. #4853 lets an admin *create* a first binding from Settings → AI, which is the right affordance for someone who never declared one. This makes a declared binding actually arrive, so the common case needs no screen at all: after `Setup`, models and routing are already available.

## AI disclosure

**Generated** — AI produced substantial portions, reviewed and owned by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment-defined AI routing settings are now applied automatically when an installation has no existing routing configuration.
  - Existing routing settings are preserved and are never overwritten by deployment defaults.

- **Bug Fixes**
  - Unprovisioned installations remain unaffected by routing settings.
  - Invalid or unavailable routing defaults no longer interrupt startup.
  - Clear warnings are provided when routing configuration cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->