### PR TITLE
A disqualified lead can be reopened

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7510,6 +7510,46 @@ paths:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }
 
+  /leads/{id}/reopen:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    post:
+      tags: [Leads]
+      operationId: reopenLead
+      # Human-only, on the same ground the disqualify it reverses is: deciding a
+      # lead is worth pursuing again is a judgement, and the governed tool would
+      # need its own registry entry and approvals authority.
+      x-agent-access: human-only
+      summary: Put a disqualified lead back on the open ladder.
+      description: |
+        The reverse of `DELETE /leads/{id}`. It clears the archive, the reason and the note,
+        and returns the lead to the status it held when it was disqualified — read from that
+        act's own audit row rather than guessed at, because the status a lead had reached is
+        a fact the trail already holds and re-deriving it would answer about today's data.
+
+        A row whose audit trail no longer names a status reopens to `engaged`, which is what a
+        lead somebody is choosing to pursue again is: `new` would claim nobody had touched it,
+        and refusing would leave a lead nothing can reopen because of a record it does not own.
+
+        Emits `lead.updated`. Reopening a lead that is not disqualified is a **409**: the verb
+        answers about a state the lead is not in, and silently succeeding would tell a caller
+        it had undone something.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The reopened lead.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Lead' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: The lead is not disqualified, so there is nothing to reopen.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
   /leads/{id}/score:
     parameters:
       - $ref: '#/components/parameters/Id'

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -502,6 +502,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/leads/{id}/demote":                                         {Op: "demoteLead", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/leads/{id}/draft-email":                                    {Op: "draftLeadEmail", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/leads/{id}/promote":                                        {Op: "promoteLead", Access: "tool", Tool: "promote_lead", RecordType: "lead", Tier: "auto_execute", Scope: "write"},
+	"POST /v1/leads/{id}/reopen":                                         {Op: "reopenLead", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/me/linkedin-connections":                                   {Op: "importLinkedInConnections", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/notices":                                                   {Op: "raiseNotice", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/notices/{id}/read":                                         {Op: "markNoticeRead", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/leadreopen_http_integration_test.go
+++ b/backend/internal/compose/integration/leadreopen_http_integration_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The reopen over HTTP: the way back from a disqualification, end to end.
+//
+// The store's own suite proves what the verb restores and where it reads that
+// from. What only this reaches is the door — the route, the handler and the
+// refusal a caller actually receives — and a 409 that arrived as a 500 would
+// tell a screen to say "something went wrong" about a state it can explain.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+type leadWire struct {
+	ID                 string  `json:"id"`
+	Status             string  `json:"status"`
+	ArchivedAt         *string `json:"archived_at"`
+	DisqualifyNote     *string `json:"disqualify_note"`
+	DisqualifyReasonID *string `json:"disqualify_reason_id"`
+}
+
+func TestReopeningADisqualifiedLeadOverHTTP(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+
+	var lead leadWire
+	if status := e.Call(t, "POST", "/v1/leads", map[string]any{
+		"full_name": "Robin Reopen", "email": "robin@reopen.test", "source": "manual",
+	}, nil, &lead); status != http.StatusCreated {
+		t.Fatalf("create lead -> %d, want 201", status)
+	}
+	base := "/v1/leads/" + lead.ID
+
+	note := "budget gone for this quarter"
+	var closed leadWire
+	if status := e.Call(t, "DELETE", base, map[string]any{"note": note}, nil, &closed); status != http.StatusOK {
+		t.Fatalf("disqualify -> %d, want 200", status)
+	}
+	if closed.Status != "disqualified" || closed.ArchivedAt == nil {
+		t.Fatalf("after disqualify = %+v, want disqualified and archived", closed)
+	}
+
+	var reopened leadWire
+	if status := e.Call(t, "POST", base+"/reopen", nil, nil, &reopened); status != http.StatusOK {
+		t.Fatalf("reopen -> %d, want 200", status)
+	}
+	// `new`, because that is where this lead was when it was closed — nothing
+	// had moved it up the ladder. The point is that the status is READ rather
+	// than assumed: a fallback would have answered `engaged` here.
+	if reopened.Status != "new" {
+		t.Errorf("reopened status = %q, want new — the status it was closed at", reopened.Status)
+	}
+	if reopened.ArchivedAt != nil {
+		t.Errorf("archived_at = %v, want cleared", reopened.ArchivedAt)
+	}
+	if reopened.DisqualifyNote != nil || reopened.DisqualifyReasonID != nil {
+		t.Errorf("the closure survived the reopen: note=%v reason=%v",
+			reopened.DisqualifyNote, reopened.DisqualifyReasonID)
+	}
+
+	// The lead is on the open ladder again, which is what every list and filter
+	// reads. A GET that still answered 404 would mean the archive had not lifted
+	// where it counts.
+	var live leadWire
+	if status := e.Call(t, "GET", base, nil, nil, &live); status != http.StatusOK {
+		t.Fatalf("read the reopened lead -> %d, want 200", status)
+	}
+	if live.Status != "new" {
+		t.Errorf("live read status = %q, want new", live.Status)
+	}
+
+	// Reopening an open lead is a 409 and not a 500: the state is one the
+	// screen can explain, and a caller told "something went wrong" cannot.
+	if status := e.Call(t, "POST", base+"/reopen", nil, nil, nil); status != http.StatusConflict {
+		t.Errorf("second reopen -> %d, want 409", status)
+	}
+}

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -197,6 +197,9 @@ var replayableOperations = map[string]replayTarget{
 		object: tableLead, table: tableLead, idPath: "lead.id",
 		companions: []companionRef{{table: tablePerson, idPath: companionPersonField}},
 	},
+	// The reopen answers the lead it put back, keyed on the same row the
+	// disqualify it reverses was keyed on.
+	"POST /v1/leads/{id}/reopen":        {object: tableLead, table: tableLead, idPath: "id"},
 	"POST /v1/activities":               {object: tableActivity, table: tableActivity, idPath: "id"},
 	"POST /v1/tasks":                    {object: tableActivity, table: tableActivity, idPath: "id"},
 	"PATCH /v1/activities/{id}":         {object: tableActivity, table: tableActivity, idPath: "id"},

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1215,6 +1215,10 @@ func (stubs) PreviewLeadPromotion(w nethttp.ResponseWriter, r *nethttp.Request, 
 	httperr.NotImplemented(w, r, "PreviewLeadPromotion")
 }
 
+func (stubs) ReopenLead(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.ReopenLeadParams) {
+	httperr.NotImplemented(w, r, "ReopenLead")
+}
+
 func (stubs) ExplainLeadScore(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.ExplainLeadScoreParams) {
 	httperr.NotImplemented(w, r, "ExplainLeadScore")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -38713,6 +38713,25 @@ type PromoteLeadParams struct {
 	XApprovalToken *ApprovalToken `json:"X-Approval-Token,omitempty"`
 }
 
+// ReopenLeadParams defines parameters for ReopenLead.
+type ReopenLeadParams struct {
+	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
+	// create (API-CC-6). **Scope:** the key is unique within
+	// `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+	// returns the original status + body. Reusing the same key with a *different* request body
+	// returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+	// **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+	// answer lost": without it the blind retry answers `409 version_skew`, because the first
+	// attempt already bumped the version.
+	// **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+	// retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+	// (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+	// what makes an operation replay-safe** — an operation that omits it ignores the header rather
+	// than half-honouring it, so read this contract, not the client, to know which calls are safe
+	// to retry blind.
+	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+}
+
 // ExplainLeadScoreParams defines parameters for ExplainLeadScore.
 type ExplainLeadScoreParams struct {
 	// History Return the retained score series instead of the current explanation.
@@ -50966,6 +50985,9 @@ type ServerInterface interface {
 	// What promoting this lead would do — merge into an existing person, or create one.
 	// (GET /leads/{id}/promote-preview)
 	PreviewLeadPromotion(w http.ResponseWriter, r *http.Request, id Id)
+	// Put a disqualified lead back on the open ladder.
+	// (POST /leads/{id}/reopen)
+	ReopenLead(w http.ResponseWriter, r *http.Request, id Id, params ReopenLeadParams)
 	// Explain This Score — the weighted-factor decomposition behind a lead's score.
 	// (GET /leads/{id}/score)
 	ExplainLeadScore(w http.ResponseWriter, r *http.Request, id Id, params ExplainLeadScoreParams)
@@ -53696,6 +53718,12 @@ func (_ Unimplemented) PromoteLead(w http.ResponseWriter, r *http.Request, id Id
 // What promoting this lead would do — merge into an existing person, or create one.
 // (GET /leads/{id}/promote-preview)
 func (_ Unimplemented) PreviewLeadPromotion(w http.ResponseWriter, r *http.Request, id Id) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Put a disqualified lead back on the open ladder.
+// (POST /leads/{id}/reopen)
+func (_ Unimplemented) ReopenLead(w http.ResponseWriter, r *http.Request, id Id, params ReopenLeadParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -67391,6 +67419,64 @@ func (siw *ServerInterfaceWrapper) PreviewLeadPromotion(w http.ResponseWriter, r
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PreviewLeadPromotion(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ReopenLead operation middleware
+func (siw *ServerInterfaceWrapper) ReopenLead(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ReopenLeadParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "Idempotency-Key" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("Idempotency-Key")]; found {
+		var IdempotencyKey IdempotencyKey
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "Idempotency-Key", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "Idempotency-Key", valueList[0], &IdempotencyKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "Idempotency-Key", Err: err})
+			return
+		}
+
+		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ReopenLead(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -82538,6 +82624,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/leads/{id}/promote-preview", wrapper.PreviewLeadPromotion)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/leads/{id}/reopen", wrapper.ReopenLead)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/leads/{id}/score", wrapper.ExplainLeadScore)

--- a/backend/internal/modules/people/handlers.go
+++ b/backend/internal/modules/people/handlers.go
@@ -191,6 +191,13 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 		})
 		return
 	}
+	var notDisqualified *NotDisqualifiedError
+	if errors.As(err, &notDisqualified) {
+		httperr.Write(w, r, &httperr.DetailedError{
+			Status: http.StatusConflict, Code: "not_disqualified", Detail: notDisqualified.Error(),
+		})
+		return
+	}
 	var alreadyMerged *AlreadyMergedError
 	if errors.As(err, &alreadyMerged) {
 		e := &httperr.DetailedError{

--- a/backend/internal/modules/people/handlers_lead.go
+++ b/backend/internal/modules/people/handlers_lead.go
@@ -197,6 +197,20 @@ func (h Handlers) DemoteLead(w http.ResponseWriter, r *http.Request, id crmcontr
 	httperr.WriteJSON(w, http.StatusOK, out)
 }
 
+// ReopenLead puts a disqualified lead back on the open ladder — POST
+// /leads/{id}/reopen, the reverse of the disqualify below.
+//
+// No body. What a reopen restores is read from the trail rather than supplied,
+// so there is nothing for a caller to say beyond which lead.
+func (h Handlers) ReopenLead(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.ReopenLeadParams) {
+	lead, err := h.store.ReopenLead(r.Context(), pathID[ids.LeadKind](id))
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, lead)
+}
+
 // DisqualifyLead: DELETE /leads/{id} — the one path where
 // "disqualified ⇒ archived" is enforced.
 // DisqualifyLead: DELETE /leads/{id}. The body is optional on the wire — an

--- a/backend/internal/modules/people/leadreopen.go
+++ b/backend/internal/modules/people/leadreopen.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Reopening a disqualified lead — the reverse of DisqualifyLead, which is the
+// one path enforcing "disqualified ⇒ archived".
+//
+// The lead page could say "Disqualified: <reason>" and could not offer the way
+// back, because there was none: demote reverses a PROMOTION and answers about a
+// lead that became a person. A judgement that somebody is not worth pursuing is
+// exactly the kind that changes, and a record with no way back makes the
+// operator re-key the lead — which loses its history and its score along with
+// its reason.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// NotDisqualifiedError maps to 409: the lead is on the open ladder already, or
+// was never taken off it, so there is nothing to reopen. Succeeding silently
+// would tell a caller their undo did something.
+type NotDisqualifiedError struct{}
+
+func (e *NotDisqualifiedError) Error() string {
+	return "lead is not disqualified; there is nothing to reopen"
+}
+
+// reopenFallbackStatus is where a lead lands when its disqualify audit row no
+// longer names the status it held.
+//
+// `engaged`, because that is what a lead somebody is choosing to pursue again
+// IS. `new` would claim nobody had ever touched it, which is false of every
+// lead that reached a disqualification. Refusing was the other option and it is
+// worse: a lead that cannot be reopened because of a record it does not own is
+// a dead row, and the audit trail is retained on its own schedule.
+const reopenFallbackStatus = string(crmcontracts.LeadStatusEngaged)
+
+// ReopenLead puts a disqualified lead back on the open ladder at the status it
+// held when it was closed.
+//
+// It takes both grants the disqualify took — update AND delete — because it is
+// that act's reverse, and a caller who may not close a lead has no business
+// deciding a closure was wrong.
+func (s *Store) ReopenLead(ctx context.Context, id ids.LeadID) (crmcontracts.Lead, error) {
+	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	if err := auth.Require(ctx, "lead", principal.ActionDelete); err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	active, err := s.activeColumns(ctx, "lead")
+	if err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	var out crmcontracts.Lead
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureWritable(ctx, tx, "lead", id.UUID); err != nil {
+			return err
+		}
+		// IncludeArchived on both the lock and the read: a disqualified lead IS
+		// archived, so the live-only forms this verb's siblings take would
+		// answer not-found for every row it exists to act on.
+		if _, err := storekit.LockRow(ctx, tx, "lead", id.UUID, storekit.IncludeArchived); err != nil {
+			return err
+		}
+		current, err := readLead(ctx, tx, id, storekit.IncludeArchived, active)
+		if err != nil {
+			return err
+		}
+		// Re-read under the lock, so a reopen racing a second reopen refuses
+		// rather than both succeeding and the later one restoring a status the
+		// earlier one had already moved on from.
+		if current.Status != crmcontracts.LeadStatusDisqualified {
+			return &NotDisqualifiedError{}
+		}
+		restored, err := statusBeforeDisqualification(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		setBy, err := statusSetByFor(ctx)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE lead
+			   SET status = $2, status_set_by = $3, archived_at = NULL,
+			       disqualify_reason_id = NULL, disqualify_note = NULL
+			 WHERE id = $1`, id, restored, setBy); err != nil {
+			return fmt.Errorf("reopen the lead: %w", err)
+		}
+		auditID, err := storekit.Audit(ctx, tx, "restore", "lead", id.UUID,
+			map[string]any{leadStatusColumn: string(crmcontracts.LeadStatusDisqualified)},
+			map[string]any{leadStatusColumn: restored})
+		if err != nil {
+			return err
+		}
+		// lead.updated rather than a verb of its own: the closed catalog carries
+		// no lead.reopened, and what a subscriber acts on is that the lead is
+		// back on the ladder at a status — which the changed fields say.
+		//
+		// The reason and the note are named as cleared rather than left out. A
+		// subscriber holding the closure has to learn that it is gone, and an
+		// absent key reads as "unchanged" in this payload's own shape.
+		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventLeadUpdated{
+			ChangedFields: map[string]any{
+				leadStatusColumn:       restored,
+				"disqualify_reason_id": nil,
+				"disqualify_note":      nil,
+			},
+		}); err != nil {
+			return err
+		}
+		out, err = readLead(ctx, tx, id, storekit.LiveOnly, active)
+		return err
+	})
+	return out, err
+}
+
+// statusBeforeDisqualification reads the status this lead held when it was
+// closed, from the disqualify's own audit row.
+//
+// READ, never re-derived. The status a lead had reached is a fact the trail
+// already holds, and recomputing it from today's activity would answer about
+// the lead as it is now rather than as it was when somebody closed it — a lead
+// disqualified at `contacted` and since emailed twice would come back
+// `engaged`, which is a claim nobody made.
+//
+// A row whose trail no longer names one falls back rather than refusing: see
+// reopenFallbackStatus. A status the ladder no longer has falls back the same
+// way, because restoring a word the enum dropped would put the lead in a state
+// no filter can name.
+func statusBeforeDisqualification(ctx context.Context, tx pgx.Tx, id ids.LeadID) (string, error) {
+	var recorded *string
+	err := tx.QueryRow(ctx, `
+		SELECT before->>$2 FROM audit_log
+		 WHERE entity_type = 'lead' AND entity_id = $1 AND action = 'archive'
+		 ORDER BY occurred_at DESC LIMIT 1`, id, leadStatusColumn).Scan(&recorded)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return reopenFallbackStatus, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read the status this lead was disqualified from: %w", err)
+	}
+	if recorded == nil || !openLadderStatus(*recorded) {
+		return reopenFallbackStatus, nil
+	}
+	return *recorded, nil
+}
+
+// openLadderStatus answers whether a status is one a reopened lead may hold.
+//
+// `disqualified` and `promoted` are excluded deliberately, and not merely
+// because they are terminal: restoring either would undo the archive while
+// leaving the lead reading as closed, which is a row the page cannot explain
+// and no filter counts correctly.
+func openLadderStatus(status string) bool {
+	switch crmcontracts.LeadStatus(status) {
+	case crmcontracts.LeadStatusNew, crmcontracts.LeadStatusContacted, crmcontracts.LeadStatusEngaged:
+		return true
+	}
+	return false
+}

--- a/backend/internal/modules/people/leadreopen.go
+++ b/backend/internal/modules/people/leadreopen.go
@@ -52,6 +52,16 @@ const reopenFallbackStatus = string(crmcontracts.LeadStatusEngaged)
 // It takes both grants the disqualify took — update AND delete — because it is
 // that act's reverse, and a caller who may not close a lead has no business
 // deciding a closure was wrong.
+//
+// The transaction reads like DisqualifyLead's and is deliberately not shared
+// with it. What the two have in common is the module's own write shape — probe,
+// lock, read, patch, audit, emit, re-read — which every store method here
+// spells and which storekit already owns the halves of. What differs is every
+// decision inside it: the liveness the lock and the reads take (this verb acts
+// only on archived rows, its sibling only on live ones), the guard, the columns,
+// and the audit action. A helper covering both would take those as parameters
+// and be a switch between two verbs wearing one name, which is harder to read
+// than the two and hides that they are opposites.
 func (s *Store) ReopenLead(ctx context.Context, id ids.LeadID) (crmcontracts.Lead, error) {
 	if err := auth.Require(ctx, "lead", principal.ActionUpdate); err != nil {
 		return crmcontracts.Lead{}, err

--- a/backend/internal/modules/people/leadreopen_integration_test.go
+++ b/backend/internal/modules/people/leadreopen_integration_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Reopening a disqualified lead against Postgres: the archive, the reason and
+// the note go, and the lead comes back at the status it held when somebody
+// closed it — read from the disqualify's own audit row rather than re-derived.
+//
+// The status is the assertion that matters. Recomputing it from today's
+// activity would answer about the lead as it is NOW, and a lead disqualified at
+// `contacted` and since emailed twice would come back `engaged` — a claim
+// nobody made about a lead nobody was working.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+func TestReopeningALeadRestoresTheStatusItWasClosedAt(t *testing.T) {
+	e := setupPromoteConsent(t)
+	now := time.Now().UTC()
+	lead := e.seedLeadCreatedAt(t, "reopen-contacted@example.test", now.Add(-time.Hour))
+
+	if _, err := e.store.AdvanceLeadStatus(e.ctx, lead, LeadStatusContacted, now); err != nil {
+		t.Fatalf("climb to contacted: %v", err)
+	}
+	note := "budget gone for this quarter"
+	closed, err := e.store.DisqualifyLead(e.ctx, lead, DisqualifyLeadInput{Note: &note})
+	if err != nil {
+		t.Fatalf("disqualify: %v", err)
+	}
+	if closed.Status != crmcontracts.LeadStatusDisqualified || closed.ArchivedAt == nil {
+		t.Fatalf("after disqualify: status=%s archived=%v, want disqualified and archived", closed.Status, closed.ArchivedAt)
+	}
+
+	reopened, err := e.store.ReopenLead(e.ctx, lead)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	// Contacted, not engaged: the lead comes back where it was left, and the
+	// fallback is only for a row whose trail no longer says.
+	if reopened.Status != crmcontracts.LeadStatusContacted {
+		t.Errorf("reopened status = %s, want contacted — the status it was closed at, read from the "+
+			"disqualify's audit row", reopened.Status)
+	}
+	if reopened.ArchivedAt != nil {
+		t.Errorf("archived_at = %v, want cleared — a reopened lead is back on the open ladder", reopened.ArchivedAt)
+	}
+	if reopened.DisqualifyReasonId != nil || reopened.DisqualifyNote != nil {
+		t.Errorf("the closure's reason and note survived the reopen: reason=%v note=%v",
+			reopened.DisqualifyReasonId, reopened.DisqualifyNote)
+	}
+	// The lead is readable through the live-only door again, which is what
+	// "back on the ladder" means to every list and filter that reads it.
+	live, err := e.store.GetLead(e.ctx, lead, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("read the reopened lead live: %v", err)
+	}
+	if live.Status != crmcontracts.LeadStatusContacted {
+		t.Errorf("live read status = %s, want contacted", live.Status)
+	}
+
+	// Reopening again refuses. Succeeding would tell a caller their undo did
+	// something, and would restore `disqualified` as this lead's "last status".
+	if _, err := e.store.ReopenLead(e.ctx, lead); err == nil {
+		t.Error("reopening an open lead succeeded, want a conflict")
+	} else {
+		var notDisqualified *NotDisqualifiedError
+		if !errors.As(err, &notDisqualified) {
+			t.Errorf("second reopen: err = %v, want NotDisqualifiedError", err)
+		}
+	}
+}
+
+// A lead whose trail no longer names a status comes back as `engaged` rather
+// than refusing: the audit log is retained on its own schedule, and a lead that
+// cannot be reopened because of a record it does not own is a dead row.
+func TestALeadWhoseClosureIsNoLongerOnTheTrailReopensAsEngaged(t *testing.T) {
+	e := setupPromoteConsent(t)
+	now := time.Now().UTC()
+	lead := e.seedLeadCreatedAt(t, "reopen-untraced@example.test", now.Add(-time.Hour))
+
+	// Closed WITHOUT going through DisqualifyLead, so no audit row names the
+	// status. That is the state a lead reaches two ways in production: a row
+	// disqualified before the trail recorded the before-image, and one whose
+	// audit rows have aged out under their own retention. It cannot be
+	// simulated by deleting the row — audit_log refuses a DELETE, which is the
+	// append-only rule doing its job.
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE lead SET status = 'disqualified', archived_at = now() WHERE id = $1`,
+		lead.UUID); err != nil {
+		t.Fatalf("closing the lead without a trail: %v", err)
+	}
+
+	reopened, err := e.store.ReopenLead(e.ctx, lead)
+	if err != nil {
+		t.Fatalf("reopen without a trail: %v — a lead nothing can reopen is a dead row", err)
+	}
+	if reopened.Status != crmcontracts.LeadStatusEngaged {
+		t.Errorf("reopened status = %s, want engaged — what a lead somebody is choosing to pursue "+
+			"again is; `new` would claim nobody had touched it", reopened.Status)
+	}
+	if reopened.ArchivedAt != nil {
+		t.Error("archived_at survived the reopen")
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4982,6 +4982,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/leads/{id}/reopen": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Put a disqualified lead back on the open ladder.
+         * @description The reverse of `DELETE /leads/{id}`. It clears the archive, the reason and the note,
+         *     and returns the lead to the status it held when it was disqualified — read from that
+         *     act's own audit row rather than guessed at, because the status a lead had reached is
+         *     a fact the trail already holds and re-deriving it would answer about today's data.
+         *
+         *     A row whose audit trail no longer names a status reopens to `engaged`, which is what a
+         *     lead somebody is choosing to pursue again is: `new` would claim nobody had touched it,
+         *     and refusing would leave a lead nothing can reopen because of a record it does not own.
+         *
+         *     Emits `lead.updated`. Reopening a lead that is not disqualified is a **409**: the verb
+         *     answers about a state the lead is not in, and silently succeeding would tell a caller
+         *     it had undone something.
+         */
+        post: operations["reopenLead"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/leads/{id}/score": {
         parameters: {
             query?: never;
@@ -41130,6 +41164,58 @@ export interface operations {
             };
             /** @description The promoted person owns a deal — the reversal is refused rather than orphaning it. */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    reopenLead: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a mutation safe to retry — an update exactly as much as a
+                 *     create (API-CC-6). **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+                 *     answer lost": without it the blind retry answers `409 version_skew`, because the first
+                 *     attempt already bumped the version.
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+                 *     what makes an operation replay-safe** — an operation that omits it ignores the header rather
+                 *     than half-honouring it, so read this contract, not the client, to know which calls are safe
+                 *     to retry blind.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The reopened lead. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Lead"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            /** @description The lead is not disqualified, so there is nothing to reopen. */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2158,6 +2158,11 @@ export const de = {
   "lead.demoteReason": "Grund (wird im Protokoll festgehalten)",
   "lead.demoteReasonRequired": "Bitte zuerst begr\u00fcnden.",
   "lead.demoteConfirm": "Rückgängig machen",
+  "lead.reopen": "Wieder öffnen",
+  "lead.reopenDialog": "Diesen Lead wieder öffnen?",
+  "lead.reopenExplain":
+    "Der Lead kommt mit dem Status zurück, den er beim Disqualifizieren hatte, und der Grund wird gelöscht. Verlauf und Score bleiben erhalten.",
+  "lead.reopenConfirm": "Lead wieder öffnen",
   "lead.promotedOutcomePending":
     "Wird gelesen, was diese Übernahme bewirkt hat …",
   "lead.promotedOutcomeUnavailable":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2236,6 +2236,11 @@ export const en = {
   "lead.demoteReason": "Reason (recorded in the audit trail)",
   "lead.demoteReasonRequired": "Say why first.",
   "lead.demoteConfirm": "Reverse",
+  "lead.reopen": "Reopen",
+  "lead.reopenDialog": "Reopen this lead?",
+  "lead.reopenExplain":
+    "The lead goes back on the open ladder at the status it had when it was disqualified, and the reason is cleared. Its history and its score are kept.",
+  "lead.reopenConfirm": "Reopen lead",
   "lead.promotedOutcomePending": "Reading what this promotion did…",
   "lead.promotedOutcomeUnavailable":
     "We cannot show whether this merged or created a person.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2146,6 +2146,11 @@ export const vi = {
   "lead.demoteReason": "Lý do (được ghi vào nhật ký)",
   "lead.demoteReasonRequired": "H\u00e3y n\u00eau l\u00fd do tr\u01b0\u1edbc.",
   "lead.demoteConfirm": "Hoàn tác",
+  "lead.reopen": "Mở lại",
+  "lead.reopenDialog": "Mở lại lead này?",
+  "lead.reopenExplain":
+    "Lead quay lại thang trạng thái mở, ở đúng trạng thái khi bị loại, và lý do được xóa. Lịch sử và điểm số được giữ nguyên.",
+  "lead.reopenConfirm": "Mở lại lead",
   "lead.promotedOutcomePending": "Đang đọc kết quả của lần chuyển này…",
   "lead.promotedOutcomeUnavailable":
     "Không thể hiển thị việc này đã gộp hay tạo hồ sơ người mới.",

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -2227,6 +2227,16 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
       // unreadable, and this is one of the reads.
       "Open leads in this status →",
     ]);
+    // The one WRITE a terminal lead offers, and it is named separately from
+    // the reads above because it is one: reopening is not a change to the
+    // record, it is the undo of the state that makes the record read-only.
+    // Disabling it would leave the page saying "Disqualified: <reason>" with
+    // no way back, which is what forces an operator to re-key the lead and
+    // lose its history and its score with it.
+    //
+    // Its own set rather than an entry in viewControls, so a future reader
+    // cannot mistake it for a control that writes nothing.
+    const closureReversals = new Set(["Reopen"]);
     // The pane's own controls are skipped structurally rather than by label:
     // what folds a disclosure in it is a view control, and "Hide" is too
     // ordinary a word to exempt everywhere it might appear.
@@ -2242,6 +2252,7 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
       // count that changes with the record.
       if (
         viewControls.has(name) ||
+        closureReversals.has(name) ||
         contextColumn?.contains(button) ||
         button.classList.contains("r360-rests-toggle")
       ) {
@@ -2252,6 +2263,46 @@ describe("LeadScreen — archived/terminal is read-only (P-3)", () => {
         `"${name}" is still live on a terminal lead`,
       ).toBe(true);
     }
+  });
+
+  // The way back, which is what a disqualified lead's page was missing: it
+  // could say "Disqualified: <reason>" and offer nothing to undo it. Nothing
+  // else in the suite fails if the button quietly stops calling the server —
+  // the read-only sweep above passes with it inert, because an exempt control
+  // is exempt whether or not it works.
+  it("offers Reopen on a disqualified lead, and it calls the reopen endpoint", async () => {
+    const calls: string[] = [];
+    stubFetchWithMe(async (url, method) => {
+      if (method !== "GET") {
+        calls.push(`${method} ${new URL(url, "http://localhost").pathname}`);
+        return jsonResponse({
+          ...lead,
+          status: "contacted",
+          archived_at: null,
+        });
+      }
+      if (url.includes("/score")) {
+        return jsonResponse({ score: 72, explained: false });
+      }
+      return jsonResponse({
+        ...lead,
+        status: "disqualified",
+        archived_at: "2026-07-13T00:00:00Z",
+      });
+    });
+    render(<LeadScreen id="l-1" />);
+
+    const reopen = await screen.findByRole("button", { name: "Reopen" });
+    expect((reopen as HTMLButtonElement).disabled).toBe(false);
+    await userEvent.click(reopen);
+    // The dialog says what reopening does before it is done: the status comes
+    // back, the reason goes, the history stays.
+    expect(screen.getByText(en["lead.reopenExplain"] as string)).toBeTruthy();
+    await userEvent.click(
+      screen.getByRole("button", { name: en["lead.reopenConfirm"] as string }),
+    );
+
+    await waitFor(() => expect(calls).toContain("POST /v1/leads/l-1/reopen"));
   });
 
   it("a disqualified lead keeps its controls DISABLED with the reason, never hidden", async () => {

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1286,6 +1286,65 @@ function DemoteAction({ id }: Readonly<{ id: string }>) {
 }
 
 /**
+ * ReopenAction puts a disqualified lead back on the open ladder.
+ *
+ * The page could say "Disqualified: <reason>" and could not offer the way
+ * back. A judgement that somebody is not worth pursuing is exactly the kind
+ * that changes — the budget arrives, the champion returns — and with no way
+ * back the operator re-keys the lead, which loses its history and its score
+ * along with its reason.
+ *
+ * No reason field, unlike the demote beside it. The demote asks for one
+ * because it unwinds a person and a reader of that trail needs to know why;
+ * reopening restores a status the trail already holds, and there is nothing a
+ * caller could say that the server does not read for itself.
+ */
+function ReopenAction({ id }: Readonly<{ id: string }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const reopen = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/leads/{id}/reopen", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error, t);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      for (const key of leadWriteKeys(id)) {
+        queryClient.invalidateQueries({ queryKey: key });
+      }
+      setOpen(false);
+    },
+  });
+  const close = () => {
+    setOpen(false);
+    reopen.reset();
+  };
+  return (
+    <>
+      <Button small onClick={() => setOpen(true)}>
+        {t("lead.reopen")}
+      </Button>
+      <ConfirmModal
+        open={open}
+        onClose={close}
+        title={t("lead.reopenDialog")}
+        confirmLabel={t("lead.reopenConfirm")}
+        onConfirm={() => reopen.mutate()}
+        pending={reopen.isPending}
+        error={reopen.isError ? problemMessageOf(reopen.error, t) : undefined}
+      >
+        <p className="t-body">{t("lead.reopenExplain")}</p>
+      </ConfirmModal>
+    </>
+  );
+}
+
+/**
  * PromotedLeadPanel is what a promoted lead's page is FOR (ADR-0119/A170).
  *
  * The page used to redirect to the person, which told the reader the lead had
@@ -1942,6 +2001,13 @@ function LeadRecord({
                 : writer.readOnlyReason}
             </p>
           )}
+          {/* The way back, beside the sentence that says the lead is closed.
+              Offered only on a disqualification a reader may WRITE: the
+              promoted closure is the demote's to reverse, and a reader who
+              cannot change this lead cannot reopen it either. */}
+          {lead.archived_at &&
+            lead.status === "disqualified" &&
+            lead.writable !== false && <ReopenAction id={id} />}
         </>
       }
       // The same strip every record in the product carries: a place a reader


### PR DESCRIPTION
Closes #1888.

## What was missing

The lead page said "Disqualified: <reason>" and could not offer the way back,
because there was no server path. `POST /leads/{id}/demote` reverses a
**promotion** — it answers about a lead that became a person — and nothing
reversed a closure.

A judgement that somebody is not worth pursuing is exactly the kind that
changes: the budget arrives, the champion comes back. With no way back the
operator re-keys the lead, and that loses its history and its score along with
its reason.

## The status is read, not guessed

`POST /leads/{id}/reopen` clears `archived_at`, `disqualify_reason_id` and
`disqualify_note`, and returns the lead to the status it held when it was
closed — read from the disqualify's own audit row.

Re-deriving it from today's activity would answer about the lead **as it is
now**: one disqualified at `contacted` and since emailed twice would come back
`engaged`, a claim nobody made about a lead nobody was working. The status a
lead had reached is a fact the trail already holds.

**The fallback, and why it is not a refusal.** A row whose trail no longer names
a status reopens to `engaged`:

- `new` would say nobody had ever touched it, which is false of every lead that
  reached a disqualification;
- refusing would leave a dead row whenever the audit log aged out under its own
  retention — a lead nothing can reopen because of a record it does not own.

A status the ladder no longer carries falls back the same way, rather than
restoring a word no filter can name. `promoted` and `disqualified` are excluded
for a sharper reason than being terminal: either would clear the archive while
leaving the lead reading as closed, which is a row the page cannot explain.

## Authority and conflict

Both grants the disqualify takes — `lead:update` **and** `lead:delete` — because
a caller who may not close a lead has no business deciding a closure was wrong.

Reopening a lead that is not disqualified is a **409**. Succeeding silently would
tell a caller their undo did something, and would leave `disqualified` as this
lead's remembered status for the next reopen.

## On the page

The button sits beside the sentence that says the lead is closed, offered only
on a disqualification the reader may write — the promoted closure is the
demote's to reverse.

`leads.test.tsx`'s read-only sweep asserts that a disqualified lead exposes **no
enabled mutation anywhere**, deliberately over every button so a control added
later is caught by construction. It now names this one as the exception, in its
own set rather than among the view controls, with the reason: reopening is not a
change to the record, it is the undo of the state that makes the record
read-only. A separate test proves the button is enabled and actually calls the
endpoint — the sweep passes with it inert, because an exempt control is exempt
whether or not it works.

## Checks

- `make check-backend`, `make check-fe` green.
- `make test-it DIR=backend/internal/modules/people` green in full (119s).
- `craft static --strict` clean.
- Mutation-checked: forcing the fallback turns the restore test red on both the
  wire and the live re-read; removing the not-disqualified guard turns the
  second-reopen case red; hiding the button turns the page test red.

One thing found and **not** fixed here: `src/screens/worklist.today.test.tsx >
"submits once however fast the reader presses"` is flaky under the parallel
suite — it failed CI on #4822 (a contracts change nowhere near it), failed once
here, and passes three-for-three in isolation. Filed rather than fixed: it is
another screen's double-submit race and diagnosing it would double this diff.