### PR TITLE
The seeder's version guards go where the server reads them

### DIFF
--- a/backend/tools/seed-demo/ownership.go
+++ b/backend/tools/seed-demo/ownership.go
@@ -148,8 +148,8 @@ func setOrganizationOwner(c *client, orgID, ownerID string) (bool, error) {
 	if current.OwnerID == ownerID {
 		return false, nil
 	}
-	body := jsonBody{"owner_id": ownerID, "if_version": current.Version}
-	if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
+	body := jsonBody{"owner_id": ownerID}
+	if err := c.patchGuarded("/v1/organizations/"+orgID, current.Version, body, nil); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -183,8 +183,8 @@ func setStaffOwner(c *client, orgID, ownerID string, mode runMode) (int, error) 
 		if current.OwnerID == ownerID {
 			continue
 		}
-		body := jsonBody{"owner_id": ownerID, "if_version": current.Version}
-		if err := c.patch("/v1/people/"+personID, body, nil); err != nil {
+		body := jsonBody{"owner_id": ownerID}
+		if err := c.patchGuarded("/v1/people/"+personID, current.Version, body, nil); err != nil {
 			return changed, fmt.Errorf("owning person %s: %w", personID, err)
 		}
 		changed++

--- a/backend/tools/seed-demo/relationships.go
+++ b/backend/tools/seed-demo/relationships.go
@@ -87,8 +87,8 @@ func seedRelationshipTypes(c *client, cfg demoConfig, refs pipelineRefs, mode ru
 		if sameTypes(current.Types, want) {
 			continue
 		}
-		body := jsonBody{"relationship_types": want, "if_version": current.Version}
-		if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
+		body := jsonBody{"relationship_types": want}
+		if err := c.patchGuarded("/v1/organizations/"+orgID, current.Version, body, nil); err != nil {
 			return changed, fmt.Errorf("typing %s as %s: %w", domain, strings.Join(want, "+"), err)
 		}
 		changed++

--- a/backend/tools/seed-demo/standing.go
+++ b/backend/tools/seed-demo/standing.go
@@ -73,10 +73,12 @@ func seedLifecycle(c *client, cfg demoConfig, refs pipelineRefs, plan map[string
 			if current == stage {
 				continue
 			}
-			// The write is version-checked, so a concurrent edit loses rather
-			// than being silently overwritten.
-			body := jsonBody{"lifecycle": stage, "if_version": version}
-			if err := c.patch("/v1/organizations/"+orgID, body, nil); err != nil {
+			// The version guard goes in the If-Match HEADER, which is the only
+			// place these endpoints read it: an `if_version` in the body is
+			// accepted and ignored, so a guard spelled that way answers 200 and
+			// writes anyway.
+			body := jsonBody{"lifecycle": stage}
+			if err := c.patchGuarded("/v1/organizations/"+orgID, version, body, nil); err != nil {
 				return changed, fmt.Errorf("setting %s to %s: %w", domain, stage, err)
 			}
 			changed++

--- a/backend/tools/seed-demo/versionguard_test.go
+++ b/backend/tools/seed-demo/versionguard_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// A version guard that is not read is worse than none: the code says the write
+// is protected, and it is not.
+//
+// These endpoints read optimistic concurrency from the `If-Match` HEADER only.
+// An `if_version` in the JSON body is accepted and IGNORED — a PATCH carrying a
+// version that cannot exist answers 200 and writes anyway — so a guard spelled
+// that way is decorative, and the seeder's writes were last-write-wins while
+// reading as though they were not.
+//
+// Nothing failed when they were: the seeder ran, the rows were written, and the
+// symptom is an owner or a lifecycle stage that reverts for no visible reason
+// on the run where two writers overlap. So the rule is held here rather than
+// left to the next reviewer noticing the same thing a second time.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bodyVersionKey is the spelling the wire accepts and the server ignores.
+const bodyVersionKey = "if_version"
+
+// guardedWriters are the client methods that put a version where the server
+// reads it. A write needing a guard goes through one of these.
+var guardedWriters = []string{"patchGuarded", "postGuarded"}
+
+func TestNoSeederWriteSpellsItsVersionGuardInTheBody(t *testing.T) {
+	t.Parallel()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	files := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files++
+		file, parseErr := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		for _, at := range bodyVersionKeys(file) {
+			t.Errorf("%s:%d puts %q in a request body, where the server does not read it — the "+
+				"write is unguarded and reads as though it is not. Pass the version to %s instead, "+
+				"which sends the If-Match header",
+				filepath.Join("backend/tools/seed-demo", name), fset.Position(at).Line,
+				bodyVersionKey, strings.Join(guardedWriters, " or "))
+		}
+	}
+	// A census that read no files certifies nothing, and this one walks a
+	// directory: a package move would leave it green over a tree it never saw.
+	if files == 0 {
+		t.Fatal("no seeder source files were read — this census is judging nothing")
+	}
+}
+
+// bodyVersionKeys reports every position where the version key appears as a
+// STRING LITERAL, which is how it enters a request body.
+//
+// Literals rather than comments: this package explains the trap in prose beside
+// the guarded writers, and a census that flagged the explanation would push the
+// next author to delete the sentence that stops them repeating it.
+func bodyVersionKeys(file *ast.File) []token.Pos {
+	var found []token.Pos
+	ast.Inspect(file, func(node ast.Node) bool {
+		lit, isLit := node.(*ast.BasicLit)
+		if !isLit || lit.Kind != token.STRING {
+			return true
+		}
+		text, err := strconv.Unquote(lit.Value)
+		if err == nil && text == bodyVersionKey {
+			found = append(found, lit.Pos())
+		}
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
Closes #1867.

## The defect

Four seeder PATCH writes spelled their optimistic-concurrency guard as
`if_version` in the JSON body. These endpoints read it from the **`If-Match`
header only**, so the field was accepted and ignored — the ticket's own
verification says it plainly:

```
PATCH /v1/organizations/{id}  body {"if_version": 999999, ...}  -> HTTP 200, written
PATCH /v1/organizations/{id}  header If-Match: 999999           -> HTTP 422
```

The writes were last-write-wins while the code read as though they were not.
Nothing failed: the seeder ran, the rows were written, and the symptom is an
owner or a lifecycle stage that reverts for no visible reason on the run where
two writers overlap — exactly what the guard was written to prevent.

All four now go through `patchGuarded`, which sends the header.

## Four, not the three filed

`ownership.go` (two sites) and `standing.go`'s lifecycle write are the ones the
ticket names. `relationships.go` retypes a company the same way and had the same
bug — found by grepping the key rather than the call sites, which is the
difference between fixing the invariant and fixing what was reported.

## Why it needs a gate rather than four edits

A fifth site would arrive exactly as this one did: a reviewer noticing, on an
unrelated change, that a guard is decorative. Nothing else fails.

`TestNoSeederWriteSpellsItsVersionGuardInTheBody` matches the key as a string
**literal** rather than anywhere in the source. That distinction is deliberate:
this package explains the trap in prose beside `patchGuarded` and `postGuarded`,
and a census that flagged the explanation would teach the next author to delete
the sentence that stops them repeating it. It also carries a floor — it walks a
directory, so a package move would otherwise leave it green over a tree it never
read.

Mutation-checked: putting one site back turns it red, naming the file, the line
and the writer to use instead.

## Checks

- `make check-backend` green; `craft static --strict` clean on all four files.