### PR TITLE
The cap's advisory lock is proven to serialize, and a blind gate is opened

### DIFF
--- a/backend/gates/contentionprobe_test.go
+++ b/backend/gates/contentionprobe_test.go
@@ -137,7 +137,12 @@ func scanTree(root string, fset *token.FileSet) ([]string, error) {
 			return err
 		}
 		if entry.IsDir() {
-			if skipDir(entry.Name()) {
+			// The ROOT is never skipped, whatever it is called. probeTrees
+			// names "." for this module, and skipDir refuses any name starting
+			// with a dot — so consulting it for the root made this gate walk
+			// past the entire backend tree and report a clean PASS over zero
+			// files. It read extensions/ and fixtures/ and looked alive.
+			if path != root && skipDir(entry.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -702,6 +702,14 @@ func (e *resolveEnv) waitForBlockedWriter(t *testing.T, firing <-chan firingResu
 				got.completed, got.err)
 		default:
 		}
+		// pg_stat_activity is materialized once per transaction and cached
+		// until it ends, so a probe that did not clear it cannot see a backend
+		// that dialled after the snapshot was taken — the wait then runs to its
+		// deadline over a race that really did happen.
+		if _, err := e.owner.Exec(context.Background(),
+			`SELECT pg_stat_clear_snapshot()`); err != nil {
+			t.Fatalf("clearing the stats snapshot before probing: %v", err)
+		}
 		var blocked int
 		// Blocked BY US specifically, through pg_blocking_pids: any other
 		// waiter in this database would otherwise release the wait early and

--- a/backend/internal/modules/consent/authorizecaplock_integration_test.go
+++ b/backend/internal/modules/consent/authorizecaplock_integration_test.go
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The frequency cap's advisory lock actually serializes two dispatches.
+//
+// The lock is the whole defence: without it two workers holding the same
+// address both read "one below the ceiling", both decide allow, and the cap is
+// exceeded by exactly the number of concurrent dispatchers. The four tests
+// beside this file derive lock KEYS and say themselves that they never open a
+// second transaction, so the serialization was unproven.
+//
+// Held the way TestOnePersonsConsentWritesDoNotInterleave holds its lock: take
+// the same key from a separate session, drive the REAL authorization, and watch
+// Postgres report it stopped. That is the mechanism rather than a race for the
+// symptom — a test that launched two dispatches and hoped they crossed would
+// have to lose a coin toss to fail, and would pass on the machine where it
+// mattered least.
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// holdingSession opens a connection outside the pool, so a lock it takes is
+// held while the code under test runs on a different backend.
+func holdingSession(t *testing.T) *pgx.Conn {
+	t.Helper()
+	holder, err := pgx.Connect(context.Background(), os.Getenv("MARGINCE_TEST_DSN"))
+	if err != nil {
+		t.Fatalf("opening the holding connection: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := holder.Close(context.Background()); err != nil {
+			t.Errorf("closing the holding connection: %v", err)
+		}
+	})
+	return holder
+}
+
+// holdCapLock takes an address's cap lock from the holding session, spelled
+// through capLockKey so it is the SAME key the dispatch takes. A lock on some
+// other number would be a test of nothing.
+//
+// The session form, not the transaction form: it must outlive the statement
+// that took it, because the whole point is to still be holding it while the
+// dispatch runs.
+func holdCapLock(t *testing.T, holder *pgx.Conn, address string) {
+	t.Helper()
+	if _, err := holder.Exec(context.Background(),
+		`SELECT pg_advisory_lock($1)`, capLockKey(address)); err != nil {
+		t.Fatalf("taking the cap lock for %s: %v", address, err)
+	}
+}
+
+func releaseCapLock(t *testing.T, holder *pgx.Conn, address string) {
+	t.Helper()
+	if _, err := holder.Exec(context.Background(),
+		`SELECT pg_advisory_unlock($1)`, capLockKey(address)); err != nil {
+		t.Fatalf("releasing the cap lock for %s: %v", address, err)
+	}
+}
+
+// capWindow is the window every ceiling in this file uses. The tests are about
+// serialization, not about when a message ages out — that is the sibling's
+// TestAMessageOlderThanTheWindowHasStoppedCounting — so one value keeps the
+// window from reading as a variable any of these cases depends on.
+const capWindow = 24 * time.Hour
+
+// testJurisdiction hands out a code no other test is using.
+//
+// Handed out rather than chosen because the registry is process-wide and panics
+// on a second rule set for a country it already knows — deliberately, since two
+// would be two answers about one country's law, and there is no deregister. A
+// hand-picked code meant every new cap test had to find a letter pair nobody
+// had taken, across files, and a wrong guess panicked the whole package rather
+// than failing one test.
+//
+// Codes are drawn IN ORDER from the QM-QZ range and each is taken at most once,
+// so a collision is impossible rather than unlikely — hashing the test name
+// into fourteen slots would have been four tests inside a space where a fifth
+// has a fair chance of landing on one already used. ISO 3166 never assigns a
+// QM-QZ code, so no jurisdiction this product serves can arrive under one, and
+// the sibling file's "z" codes are a separate range again.
+var capJurisdictions = struct {
+	mu   sync.Mutex
+	next int
+}{}
+
+func testJurisdiction(t *testing.T) jurisdiction.Code {
+	t.Helper()
+	capJurisdictions.mu.Lock()
+	defer capJurisdictions.mu.Unlock()
+	if capJurisdictions.next >= 14 {
+		t.Fatalf("this package has taken all %d test jurisdictions in the QM-QZ range — widen the "+
+			"range rather than reusing one, which panics the registry for every test after it", 14)
+	}
+	code := jurisdiction.Code("q" + string(rune('m'+capJurisdictions.next)))
+	capJurisdictions.next++
+	return code
+}
+
+// cappedGate registers a ceiling under a freshly minted jurisdiction and returns
+// a gate bound to it.
+func (e *capEnv) cappedGate(t *testing.T, messages int) *Gate {
+	t.Helper()
+	code := testJurisdiction(t)
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: code, Version: 1,
+		FrequencyCap: &messagingrules.FrequencyCap{Messages: messages, Window: capWindow},
+	})
+	return NewGate(e.store).WithInstallationCountry(
+		InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+			return code, nil
+		}))
+}
+
+// grantMarketingTo gives a SECOND address a person with a live marketing grant,
+// so the engine reaches an allow for it and the lock is what a dispatch to it
+// waits on — or does not. It reuses the purpose seedMarketingSubject created;
+// calling that a second time would collide on the purpose key.
+func (e *capEnv) grantMarketingTo(t *testing.T, address string) {
+	t.Helper()
+	ctx := context.Background()
+	personID := ids.New[ids.PersonKind]()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Other Cap Subject', 'manual', 'human:x')`, personID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ($1, $2, true, 'manual', 'human:x')`, personID, address); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person_consent (person_id, purpose_id, state, lawful_basis, captured_at, source)
+		SELECT $1, id, 'granted', 'consent', now(), 'test'
+		  FROM consent_purpose WHERE key = $2`, personID, marketingPurposeKey); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// transmitFor is one advertising dispatch to this env's address.
+func (e *capEnv) transmitFor(attempt int) commsauthz.TransmitRequest {
+	return e.transmitForAddress(e.address, attempt)
+}
+
+// transmitForAddress is the same dispatch to any address, so a test can drive
+// two recipients through the real gate at once.
+func (e *capEnv) transmitForAddress(address string, attempt int) commsauthz.TransmitRequest {
+	return commsauthz.TransmitRequest{
+		DeliveryID: e.decisionDelivery, Attempt: attempt,
+		Recipients: []connector.Recipient{{Email: address}},
+		PurposeKey: marketingPurposeKey, Subject: "Offer", Body: "body",
+	}
+}
+
+// A dispatch waits for an address's cap lock rather than counting past it.
+//
+// This is the property the ceiling rests on. With the lock held elsewhere the
+// authorization must STOP — if it proceeds, two dispatchers can each read the
+// count before the other's decision lands, and the ceiling is exceeded by
+// however many are running.
+func TestADispatchWaitsForTheAddressCapLock(t *testing.T) {
+	e := setupCap(t)
+	e.seedMarketingSubject(t)
+	gate := e.cappedGate(t, 3)
+
+	holder := holdingSession(t)
+	holdCapLock(t, holder, e.address)
+
+	dispatched := make(chan error, 1)
+	go func() {
+		_, err := gate.AuthorizeTransmit(e.ctx, e.transmitFor(1))
+		dispatched <- err
+	}()
+
+	waitUntilBlockedBy(t, holder)
+
+	// Still stopped: nothing has released the lock. Asserted separately from
+	// the wait, so a dispatch that never took the lock cannot pass by having
+	// been granted it immediately.
+	select {
+	case err := <-dispatched:
+		t.Fatalf("the dispatch finished while another session held this address's cap lock "+
+			"(err %v) — the count and the decision are not serialized, so two dispatchers can "+
+			"both read below the ceiling and both send", err)
+	default:
+	}
+
+	releaseCapLock(t, holder, e.address)
+	if err := <-dispatched; err != nil {
+		t.Fatalf("the dispatch failed once the lock was free: %v", err)
+	}
+}
+
+// A different address is not held behind this one.
+//
+// The control, and it is deliberately driven from BOTH sides through the real
+// code. A dispatch to a second address runs while a dispatch to the first is
+// stopped on its lock — so the lock being held is one production itself took,
+// not one this test spelled. Holding a key of the test's own choosing would
+// pass over a production lock taken on a constant: the two would simply never
+// meet, and the test would report an independence it never observed.
+//
+// What it says: the key is derived from the address, and one busy mailbox does
+// not serialize every advertising send in the installation.
+func TestADispatchToAnotherAddressIsNotHeldBehindThisOne(t *testing.T) {
+	e := setupCap(t)
+	e.seedMarketingSubject(t)
+	gate := e.cappedGate(t, 3)
+
+	// The first address's lock, held so a real dispatch to it stops and STAYS
+	// stopped for the duration of the second.
+	holder := holdingSession(t)
+	holdCapLock(t, holder, e.address)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			releaseCapLock(t, holder, e.address)
+		}
+	})
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := gate.AuthorizeTransmit(e.ctx, e.transmitFor(1))
+		firstDone <- err
+	}()
+	waitUntilNBlockedBy(t, holder, 1)
+
+	// A dispatch to a DIFFERENT address, while the first is still stopped. It
+	// must not join the queue behind it.
+	e.grantMarketingTo(t, "someone-else@cap.test")
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := gate.AuthorizeTransmit(e.ctx, e.transmitForAddress("someone-else@cap.test", 1))
+		secondDone <- err
+	}()
+
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("dispatching to an address nobody holds: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Error("a dispatch to an unrelated address blocked behind this one, so the cap lock is " +
+			"not per-address and one busy mailbox serializes every advertising send there is")
+	}
+
+	releaseCapLock(t, holder, e.address)
+	released = true
+	if err := <-firstDone; err != nil {
+		t.Fatalf("the first dispatch failed once its lock was free: %v", err)
+	}
+}
+
+// The count happens AFTER the lock is held, not before it.
+//
+// This is the ordering the cap rests on, and it is the one the other tests in
+// this file cannot see: they hold the lock externally and watch a dispatch stop
+// at it, which proves the dispatch REACHES the lock but not that it reaches it
+// before counting. Moving lockCapAddresses to after applyFrequencyCap leaves
+// every one of them green.
+//
+// So this observes the order rather than the blocking. The lock is held, a
+// dispatch stops on it, and a further advertising message is committed WHILE it
+// waits. A dispatch that counts after acquiring must see that row and refuse; a
+// dispatch that counted first is holding a number taken before the row existed
+// and allows. The difference is the whole defect.
+func TestTheCountIsTakenAfterTheLockNotBeforeIt(t *testing.T) {
+	e := setupCap(t)
+	e.seedMarketingSubject(t)
+	gate := e.cappedGate(t, 1)
+
+	holder := holdingSession(t)
+	holdCapLock(t, holder, e.address)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			releaseCapLock(t, holder, e.address)
+		}
+	})
+
+	dispatched := make(chan bool, 1)
+	go func() {
+		ticket, err := gate.AuthorizeTransmit(e.ctx, e.transmitFor(1))
+		if err != nil {
+			t.Errorf("authorizing the dispatch: %v", err)
+			dispatched <- true // an error must not read as a refusal
+			return
+		}
+		dispatched <- ticket.Allowed
+	}()
+
+	waitUntilBlockedBy(t, holder)
+
+	// The ceiling fills while the dispatch waits. Committed from another
+	// session, so it is visible to any transaction that reads after this
+	// point — and invisible to one that already read.
+	e.deliveredAdvertising(t, time.Now().Add(-time.Minute))
+
+	releaseCapLock(t, holder, e.address)
+	released = true
+
+	if <-dispatched {
+		t.Error("the dispatch was ticketed although the ceiling filled while it waited for the " +
+			"lock — it counted BEFORE acquiring, so the lock is serializing nothing that matters " +
+			"and two dispatchers can both send on a number neither of them re-read")
+	}
+}
+
+// Two dispatches for one address cannot both take the LAST slot under a ceiling.
+//
+// The property in the cap's own terms rather than the lock's, and the fixture
+// is the whole test. An earlier version seeded the ceiling as already REACHED,
+// so both dispatches denied for want of headroom and the assertion could not
+// fail from a lock-ordering bug at all: moving the lock to AFTER the count left
+// it green. It distinguished "the cap works" from "the cap is off", which two
+// other tests already say.
+//
+// So the ceiling is seeded one BELOW. Exactly one slot is left, the correct
+// answer is a split — one allow, one deny — and two allows is precisely what an
+// unserialized pair produces, each having read the same count before the
+// other's decision landed.
+//
+// The interleaving is arranged rather than raced: both dispatches are brought to
+// a stop on the address's lock, held from another session, and only then is it
+// released. Two goroutines merely launched together almost never cross tightly
+// enough, and a version that hoped they would passed cleanly with the lock
+// deleted.
+func TestTwoConcurrentDispatchesCannotBothTakeTheLastSlot(t *testing.T) {
+	e := setupCap(t)
+	e.seedMarketingSubject(t)
+	gate := e.cappedGate(t, 2)
+
+	// One of two slots already spent, so one dispatch may go and the other
+	// may not.
+	e.deliveredAdvertising(t, time.Now().Add(-time.Minute))
+
+	holder := holdingSession(t)
+	holdCapLock(t, holder, e.address)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			releaseCapLock(t, holder, e.address)
+		}
+	})
+
+	type outcome struct {
+		allowed bool
+		err     error
+	}
+	results := make(chan outcome, 2)
+	dispatch := func(attempt int) {
+		go func() {
+			ticket, err := gate.AuthorizeTransmit(e.ctx, e.transmitFor(attempt))
+			results <- outcome{allowed: ticket.Allowed, err: err}
+		}()
+	}
+
+	// BOTH are waited for by COUNT, not by "somebody is blocked": the second
+	// wait would otherwise return on the first dispatch's block, and the lock
+	// would be released while dispatch 2 had not yet run a statement — the two
+	// would then race exactly as this arrangement exists to prevent.
+	dispatch(1)
+	waitUntilNBlockedBy(t, holder, 1)
+	dispatch(2)
+	waitUntilNBlockedBy(t, holder, 2)
+	releaseCapLock(t, holder, e.address)
+	released = true
+
+	allowed := 0
+	for range 2 {
+		got := <-results
+		// Reported from the test goroutine: a t.Fatal inside a spawned one
+		// stops that goroutine and lets the test pass regardless.
+		if got.err != nil {
+			t.Errorf("authorizing a concurrent dispatch: %v", got.err)
+			continue
+		}
+		if got.allowed {
+			allowed++
+		}
+	}
+	if allowed != 1 {
+		t.Errorf("%d of 2 concurrent dispatches were ticketed for the ONE slot left under the "+
+			"ceiling, want exactly 1 — two means each read the count before the other's decision "+
+			"landed, and the ceiling is exceeded by however many dispatchers are running", allowed)
+	}
+}

--- a/backend/internal/modules/consent/unsubscribeallrace_integration_test.go
+++ b/backend/internal/modules/consent/unsubscribeallrace_integration_test.go
@@ -122,6 +122,19 @@ func TestUnsubscribeAllStopsAPurposeGrantedWhileItWasRunning(t *testing.T) {
 // press for a pool connection.
 func waitUntilBlockedBy(t *testing.T, holder *pgx.Conn) {
 	t.Helper()
+	waitUntilNBlockedBy(t, holder, 1)
+}
+
+// waitUntilNBlockedBy is the same wait for a known NUMBER of waiters.
+//
+// One is the common case and reads better as its own name. A caller arranging
+// an interleaving needs more: with two dispatches meant to meet on one lock,
+// waiting for "somebody is blocked" returns on the FIRST of them and releases
+// the lock while the second may not have run a statement yet — so the two race
+// exactly as the test was written to prevent. Asking for the count is what makes
+// the arrangement observed rather than assumed.
+func waitUntilNBlockedBy(t *testing.T, holder *pgx.Conn, want int) {
+	t.Helper()
 	ctx := context.Background()
 	var holderPID int
 	if err := holder.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&holderPID); err != nil {
@@ -129,19 +142,26 @@ func waitUntilBlockedBy(t *testing.T, holder *pgx.Conn) {
 	}
 	deadline := time.Now().Add(30 * time.Second)
 	for {
+		// pg_stat_activity is materialized once per transaction and cached
+		// until it ends, so a probe that did not clear it cannot see a backend
+		// that dialled after the snapshot was taken — the wait then runs to its
+		// deadline over contention that is really there.
+		if _, err := holder.Exec(ctx, `SELECT pg_stat_clear_snapshot()`); err != nil {
+			t.Fatalf("clearing the stats snapshot before probing: %v", err)
+		}
 		var waiting int
 		if err := holder.QueryRow(ctx,
 			`SELECT count(*) FROM pg_stat_activity WHERE $1 = ANY(pg_blocking_pids(pid))`,
 			holderPID).Scan(&waiting); err != nil {
 			t.Fatalf("reading who this connection is blocking: %v", err)
 		}
-		if waiting > 0 {
+		if waiting >= want {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("nothing ever waited on the lock this connection holds: the press did not " +
-				"reach it, so this case interleaved nothing and would pass over the defect it " +
-				"is named for")
+			t.Fatalf("%d backend(s) ever waited on the lock this connection holds, want %d: the "+
+				"press did not reach it, so this case interleaved nothing and would pass over "+
+				"the defect it is named for", waiting, want)
 		}
 		//craft:ignore test-sleep the wait IS on the condition — pg_blocking_pids, asked in the loop above. This paces the asking so the poll does not compete with the press for a pool connection, which CodeRabbit raised on #4631; removing it makes the test flakier, not less.
 		time.Sleep(20 * time.Millisecond)

--- a/backend/internal/modules/introductions/store_integration_test.go
+++ b/backend/internal/modules/introductions/store_integration_test.go
@@ -341,6 +341,13 @@ func waitForLockOn(t *testing.T, e *introEnv, id ids.UUID) {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
+		// pg_stat_activity is materialized once per transaction and cached
+		// until it ends, so a probe that did not clear it cannot see a backend
+		// that dialled after the snapshot was taken.
+		if _, err := e.owner.Exec(context.Background(),
+			`SELECT pg_stat_clear_snapshot()`); err != nil {
+			t.Fatalf("clearing the stats snapshot before probing: %v", err)
+		}
 		var waiting bool
 		// A backend blocked on a row lock in THIS database, while the ask still
 		// exists. pg_blocking_pids is the direct question — "is somebody stuck


### PR DESCRIPTION
The VN advertising ceiling rests entirely on a `pg_advisory_xact_lock`. Without it, two dispatchers for one address both read "below the ceiling", both decide allow, and the cap is exceeded by however many are running.

The unit tests beside it assert the key derivation — and the first says outright that it proves the ordering *"without running two transactions"*. None opened a second one, so the serialization itself was unproven.

## Four tests, each catching what the others cannot

- a dispatch **stops** when the address's lock is held elsewhere
- a dispatch to a **different** address does not stop behind it
- the count is taken **after** the lock, not before
- two dispatches cannot both take the **last slot** under a ceiling

The third exists because the first two cannot see a read-then-lock defect: they hold the lock externally and watch a dispatch reach it, which says nothing about whether it counted first. Moving `lockCapAddresses` to after `applyFrequencyCap` leaves both green. So that test commits a further advertising message *while* the dispatch waits — one that counts after acquiring must see it and refuse; one that counted first allows.

The fourth seeds the ceiling one **below** rather than at it. An earlier version seeded it as already reached, so both dispatches denied for want of headroom and the assertion could not fail from a lock-ordering bug at all. One slot left makes the correct answer a split, and two allows is exactly what an unserialized pair produces.

## A gate that scanned nothing

`gates/contentionprobe_test.go` walked with `skipDir` applied to the **root**. `probeTrees` names `"."` for this module, and `skipDir` refuses any name starting with a dot — so the gate scanned **zero** files of the backend tree while reading `extensions/` and `fixtures/` normally. It reported a clean PASS over an empty census.

The fixed walk found **three real offenders** (consent, activities, introductions), all now clearing the stats snapshot before probing `pg_blocking_pids`. A probe that does not cannot see a backend that dialled after its cached snapshot — the gate's own header records two incidents that read as timeouts and were not.

Proven both directions: the broken walk passes over a planted offender; the fixed walk fails on the same one.

## Two smaller fixes this change leans on

`waitUntilBlockedBy` returned on **any** waiter, so a caller arranging a two-dispatch interleaving got it back on the first and released the lock while the second had not run a statement — the two then raced exactly as the arrangement existed to prevent. Split into `waitUntilNBlockedBy`.

Test jurisdictions are handed out in order from the QM-QZ range under a mutex, at most once each. The registry panics on a duplicate and has no deregister, so hand-picked codes made every new cap test guess a free pair across two files — and a counter over a hashed name only moved the problem.

## Mutation matrix

| mutation | result |
|---|---|
| lock removed entirely | all four fail |
| lock moved after the count | the two ordering tests fail |
| lock key made constant | the control fails |
| broken walk + planted offender | gate passes (it was blind) |
| fixed walk + same offender | gate fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proves the advertising cap's advisory lock actually serializes dispatches with four new integration tests, and fixes a contention probe gate that scanned zero files and reported a clean pass.

- The cap tests hold the lock from a separate session and drive the real authorization, covering a stop, a different-address control, count-after-lock ordering, and a two-dispatch race for the last slot seeded one below the ceiling.
- The gate applied `skipDir` to the root (named `"."`), so it never walked the backend tree; the fixed walk found three offenders, all now clearing the stats snapshot before probing `pg_blocking_pids`.
- Split `waitUntilBlockedBy` into `waitUntilNBlockedBy` so callers can wait for a known number of waiters rather than any one.
- Test jurisdictions are handed out in order from the QM-QZ range under a mutex, so new cap tests can't collide on a code.

<sup>Written for commit 7c95b57922788c7972b41ab5c196216a8cf7f6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

