### PR TITLE
A partial spend total says how much of it is missing

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23618,7 +23618,7 @@ components:
 
     AiUsage:
       type: object
-      description: 'AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace''s ai_model_rate price sheet as of each call''s day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line''s window carries no priced call.'
+      description: 'AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace''s ai_model_rate price sheet as of each call''s day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line''s window carries no priced call, and accompanied by unpriced_calls when it is a partial total.'
       required: [days, budget]
       properties:
         days:
@@ -23641,6 +23641,15 @@ components:
                     tokens_in: { type: integer }
                     tokens_out: { type: integer }
                     cost_est_minor: { type: integer, description: 'USD minor units (cents), estimated on read from ai_model_rate at each call''s day (ADR-0067). Omitted, not 0, when none of this line''s calls priced.' }
+                    unpriced_calls:
+                      type: integer
+                      minimum: 0
+                      description: >-
+                        Calls on this line that carried usage and no effective rate, so their spend is
+                        in the token columns and NOT in cost_est_minor. Present so a reader can tell a
+                        partial dollar figure from a whole one: a line with some priced calls reports a
+                        real total that is missing this many calls'' worth, and a money number that is
+                        short without saying so is worse than one that is absent.
         budget:
           type: object
           required: [monthly_tokens, spent_tokens, band]

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17566,7 +17566,7 @@ type AiTierBinding struct {
 	Provider string `json:"provider"`
 }
 
-// AiUsage AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace's ai_model_rate price sheet as of each call's day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line's window carries no priced call.
+// AiUsage AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace's ai_model_rate price sheet as of each call's day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line's window carries no priced call, and accompanied by unpriced_calls when it is a partial total.
 type AiUsage struct {
 	Budget struct {
 		// Band < 80% / 80–100% soft-degrade / ≥ 100% non-interactive queued (AIRT-PARAM-9..11).
@@ -17598,6 +17598,9 @@ type AiUsage struct {
 			Tier      string `json:"tier"`
 			TokensIn  int    `json:"tokens_in"`
 			TokensOut int    `json:"tokens_out"`
+
+			// UnpricedCalls Calls on this line that carried usage and no effective rate, so their spend is in the token columns and NOT in cost_est_minor. Present so a reader can tell a partial dollar figure from a whole one: a line with some priced calls reports a real total that is missing this many calls'' worth, and a money number that is short without saying so is worse than one that is absent.
+			UnpricedCalls *int `json:"unpriced_calls,omitempty"`
 		} `json:"tasks"`
 	} `json:"days"`
 }

--- a/backend/internal/modules/ai/handlers_usage.go
+++ b/backend/internal/modules/ai/handlers_usage.go
@@ -73,9 +73,10 @@ type aiUsageTask = struct {
 	Task string `json:"task"`
 
 	// Tier local_small, cheap_cloud, premium, frontier, local_large.
-	Tier      string `json:"tier"`
-	TokensIn  int    `json:"tokens_in"`
-	TokensOut int    `json:"tokens_out"`
+	Tier          string `json:"tier"`
+	TokensIn      int    `json:"tokens_in"`
+	TokensOut     int    `json:"tokens_out"`
+	UnpricedCalls *int   `json:"unpriced_calls,omitempty"`
 }
 
 // microUSDPerMinor converts ADR-0067's micro-USD price grain to wire
@@ -110,6 +111,15 @@ func wireAiUsage(days []DayUsage, budget BudgetStatus) crmcontracts.AiUsage {
 			if task.CostEstMicroUSD > 0 || task.UnpricedCalls == 0 {
 				minor := int(task.CostEstMicroUSD / microUSDPerMinor)
 				wireTask.CostEstMinor = &minor
+			}
+			// The count travels with the figure it qualifies. Without it a
+			// reader cannot tell a whole dollar total from one that is short
+			// by some number of calls, and the two look identical: both are a
+			// number, and the partial one is always the smaller. Under-reported
+			// spend is the direction nobody investigates.
+			if task.UnpricedCalls > 0 {
+				unpriced := int(task.UnpricedCalls)
+				wireTask.UnpricedCalls = &unpriced
 			}
 			wireDay.Tasks = append(wireDay.Tasks, wireTask)
 		}

--- a/backend/internal/modules/ai/usage_test.go
+++ b/backend/internal/modules/ai/usage_test.go
@@ -140,6 +140,56 @@ func TestWireAiUsageReportsPartialCostWhenSomeCallsAreUnpriced(t *testing.T) {
 	if got == nil || *got != 5 {
 		t.Fatalf("cost_est_minor = %v, want 5 (50_000 microUSD / 10_000) despite 1 unpriced call in the same line", got)
 	}
+	// And the count travels with it. A partial figure that does not say it is
+	// partial is the one a reader acts on: it is always the SMALLER number, so
+	// nobody investigates it until a provider bill disagrees.
+	unpriced := wire.Days[0].Tasks[0].UnpricedCalls
+	if unpriced == nil || *unpriced != 1 {
+		t.Fatalf("unpriced_calls = %v, want 1 — the total is short by that many calls' spend and "+
+			"nothing else on the line says so", unpriced)
+	}
+}
+
+// A whole figure carries no qualifier. Without this the case above passes
+// against a wire that stamps every line as partial, which would teach a reader
+// to ignore the sentence.
+func TestWireAiUsageOmitsTheUnpricedCountWhenEveryCallPriced(t *testing.T) {
+	days := []DayUsage{{
+		Day: time.Date(2026, time.July, 16, 0, 0, 0, 0, time.UTC),
+		Tasks: []TaskUsage{
+			{
+				Task: "summarize", Tier: "premium", Calls: 3, TokensIn: 500, TokensOut: 100,
+				CostEstMicroUSD: 50_000, UnpricedCalls: 0,
+			},
+		},
+	}}
+	wire := wireAiUsage(days, BudgetStatus{})
+	if got := wire.Days[0].Tasks[0].UnpricedCalls; got != nil {
+		t.Fatalf("unpriced_calls = %d on a fully priced line, want omitted", *got)
+	}
+}
+
+// An entirely unpriced line reports the count even though it reports no cost.
+// It is the case where the count matters most: the line contributes nothing to
+// the total, and only this says how much is missing from it.
+func TestWireAiUsageCountsTheUnpricedCallsOfALineItDoesNotPrice(t *testing.T) {
+	days := []DayUsage{{
+		Day: time.Date(2026, time.July, 16, 0, 0, 0, 0, time.UTC),
+		Tasks: []TaskUsage{
+			{
+				Task: "summarize", Tier: "premium", Calls: 3, TokensIn: 500, TokensOut: 100,
+				CostEstMicroUSD: 0, UnpricedCalls: 3,
+			},
+		},
+	}}
+	wire := wireAiUsage(days, BudgetStatus{})
+	line := wire.Days[0].Tasks[0]
+	if line.CostEstMinor != nil {
+		t.Fatalf("cost_est_minor = %d, want omitted", *line.CostEstMinor)
+	}
+	if line.UnpricedCalls == nil || *line.UnpricedCalls != 3 {
+		t.Fatalf("unpriced_calls = %v, want 3", line.UnpricedCalls)
+	}
 }
 
 // TestAttachDayCostAttachesPerTierNotBroadcastAcrossTiers proves the

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16335,7 +16335,7 @@ export interface components {
             /** @description The window's middle latency, which tells a slow lane from a dead one. */
             median_latency_ms: number;
         };
-        /** @description AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace's ai_model_rate price sheet as of each call's day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line's window carries no priced call. */
+        /** @description AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace's ai_model_rate price sheet as of each call's day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line's window carries no priced call, and accompanied by unpriced_calls when it is a partial total. */
         AiUsage: {
             days: {
                 /** Format: date */
@@ -16351,6 +16351,8 @@ export interface components {
                     tokens_out: number;
                     /** @description USD minor units (cents), estimated on read from ai_model_rate at each call's day (ADR-0067). Omitted, not 0, when none of this line's calls priced. */
                     cost_est_minor?: number;
+                    /** @description Calls on this line that carried usage and no effective rate, so their spend is in the token columns and NOT in cost_est_minor. Present so a reader can tell a partial dollar figure from a whole one: a line with some priced calls reports a real total that is missing this many calls'' worth, and a money number that is short without saying so is worse than one that is absent. */
+                    unpriced_calls?: number;
                 }[];
             }[];
             budget: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7059,6 +7059,8 @@ export const de = {
   "aiusage.col.tokensOut": "Tokens aus",
   "aiusage.col.cost": "Geschätzte Kosten",
   "aiusage.costNote": "Kosten sind Schätzungen zu den konfigurierten Tarifen.",
+  "aiusage.costPartial":
+    "Diese Summe deckt nur die berechneten Aufrufe ab: {calls} weitere hatten keinen konfigurierten Tarif, ihr Verbrauch steht in den Token-Zahlen.",
   "aiusage.monthLabel": "Monat",
   "aiusage.spendLabel": "Verbrauch nach Aufgabe",
   "aiusage.days.show": "Tage anzeigen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7168,6 +7168,8 @@ export const en = {
   "aiusage.col.tokensOut": "Tokens out",
   "aiusage.col.cost": "Est. cost",
   "aiusage.costNote": "Costs are estimates at configured rates.",
+  "aiusage.costPartial":
+    "This total covers the priced calls only: {calls} more had no configured rate, and their spend is in the token counts.",
   "aiusage.monthLabel": "Month",
   "aiusage.spendLabel": "Spend by task",
   "aiusage.days.show": "Show days",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6985,6 +6985,8 @@ export const vi = {
   "aiusage.col.tokensOut": "Token ra",
   "aiusage.col.cost": "Chi phí ước tính",
   "aiusage.costNote": "Chi phí là ước tính theo mức giá đã cấu hình.",
+  "aiusage.costPartial":
+    "Tổng này chỉ gồm các lượt gọi có giá: {calls} lượt khác không có mức giá cấu hình, phần chi tiêu của chúng nằm ở số token.",
   "aiusage.monthLabel": "Tháng",
   "aiusage.spendLabel": "Chi phí theo nhiệm vụ",
   "aiusage.days.show": "Hiện theo ngày",

--- a/frontend/src/screens/aiusage.test.tsx
+++ b/frontend/src/screens/aiusage.test.tsx
@@ -121,6 +121,67 @@ it("renders queued and lights up estimated cost only when present", async () => 
   expect(note.textContent).toContain("€1.23");
 });
 
+// A total that is SHORT says so, and one that is whole does not.
+//
+// A call with usage and no configured rate spends real money that lands in the
+// token counts and not in the dollar figure beside them. The two totals look
+// identical — both are a number — and the partial one is always the smaller,
+// which is the direction nobody investigates: an admin budgets from it and an
+// operator reconciling against a provider bill finds a gap the product never
+// mentioned.
+it("says when the cost total covers only the priced calls", async () => {
+  mount({
+    budget: { ...budget, currency: "EUR" },
+    days: [
+      {
+        date: "2026-07-20",
+        tasks: [
+          {
+            task: "enrich",
+            tier: "premium",
+            calls: 4,
+            tokens_in: 10,
+            tokens_out: 2,
+            cost_est_minor: 123,
+            unpriced_calls: 3,
+          },
+        ],
+      },
+    ],
+  });
+  const note = await screen.findByText(/Costs are estimates/);
+  expect(note.textContent).toContain("€1.23");
+  // The count, not merely a caveat: "some calls are unpriced" leaves a reader
+  // unable to tell one stray call from most of the window.
+  expect(note.textContent).toContain("3 more had no configured rate");
+});
+
+// The mirror. Without it the case above passes against a card that stamps every
+// window as partial, which teaches a reader to skip the sentence — and the one
+// window where it is true reads exactly like the rest.
+it("says nothing about unpriced calls when every call was priced", async () => {
+  mount({
+    budget: { ...budget, currency: "EUR" },
+    days: [
+      {
+        date: "2026-07-20",
+        tasks: [
+          {
+            task: "enrich",
+            tier: "premium",
+            calls: 1,
+            tokens_in: 10,
+            tokens_out: 2,
+            cost_est_minor: 123,
+          },
+        ],
+      },
+    ],
+  });
+  const note = await screen.findByText(/Costs are estimates/);
+  expect(note.textContent).not.toContain("no configured rate");
+});
+
 // An empty window and a refused read are different answers, and the card owes
 // each its own: "nothing was spent" is a fact about the month, while a 403 is a
 // fact about the reader. The refusal reads as catalog copy because that is all a

--- a/frontend/src/screens/aiusage.tsx
+++ b/frontend/src/screens/aiusage.tsx
@@ -102,6 +102,8 @@ function aggregate(days: AiUsage["days"]): UsageTask[] {
         (current.cached_hits ?? 0) + (task.cached_hits ?? 0);
       current.tokens_in += task.tokens_in;
       current.tokens_out += task.tokens_out;
+      current.unpriced_calls =
+        (current.unpriced_calls ?? 0) + (task.unpriced_calls ?? 0);
       if (task.cost_est_minor !== undefined) {
         current.cost_est_minor =
           (current.cost_est_minor ?? 0) + task.cost_est_minor;
@@ -205,6 +207,15 @@ function AiUsageBody({
     () => rows.reduce((sum, row) => sum + (row.cost_est_minor ?? 0), 0),
     [rows],
   );
+  // Calls that carried usage and no rate. Their spend is in the token columns
+  // and not in the total beside them, so the total is SHORT — and a money
+  // number that is short without saying so is the one a reader acts on: it is
+  // always the smaller figure, and nobody investigates a bill that looks
+  // cheaper than expected until it does not.
+  const unpricedCalls = useMemo(
+    () => rows.reduce((sum, row) => sum + (row.unpriced_calls ?? 0), 0),
+    [rows],
+  );
 
   return (
     <SettingList>
@@ -267,6 +278,14 @@ function AiUsageBody({
           showCost ? (
             <>
               {t("aiusage.costNote")} {formatMoney(totalCost, currency, locale)}
+              {unpricedCalls > 0 ? (
+                <>
+                  {" "}
+                  {t("aiusage.costPartial", {
+                    calls: formatNumber(unpricedCalls, locale),
+                  })}
+                </>
+              ) : null}
             </>
           ) : undefined
         }


### PR DESCRIPTION
Closes #1855 — but **not the way the ticket asks**, because the diagnosis in it
does not hold against the tree. The concern behind it is real and is fixed here.

## What the ticket says, and why each part is not true

> only three tasks declare a cost unit … the total an admin reads is lower than
> what the installation actually spends

`cost_unit` does not feed the spend total. It names the unit rule that prices
the **connect-time backfill estimate** — `costestimate/rules.go` maps the three
rule names to volume, denominator and work-shape floor functions. The workspace
spend an admin reads is `Meter.MonthTokens`, which sums `ai_usage` over the
calendar month: **every metered call, whatever task it belongs to.** It is not
short by a missing declaration.

> The fix. Extend the declaration … so every task that spends money names its
> cost unit

That would make the estimator quote a mailbox import for work that does not run
at the backfill. `owed_verdict` already documents the decision in its own `doc`:
*"cost_unit names a task the connect-time backfill prices, and this pass
deliberately does not run at backfill."*

> Worth adding at the same time: a check that a task declaring a model
> invocation also declares a cost unit

It would force `owed_verdict` to contradict that reasoning. And the obligation
that IS owed — the contract's priced set and `backfillTasks` matching exactly —
is already held both ways by `TestEveryBackfillTaskHasAUnitRule` and
`TestEveryContractCostUnitHasARule`.

## What is actually wrong, and it is the ticket's own sentence

> A wrong money number is worse than a missing one.

The AI usage card sums the priced calls and shows the figure under *"Costs are
estimates at configured rates."* A call with usage and no configured rate spends
money that lands in the token columns and **not** in that total. The total is
short, and nothing on the wire or the screen said so.

The two totals look identical — both are a number — and the partial one is
always the **smaller**. That is the direction nobody investigates, which is the
ticket's own point about under-reporting.

## The fix

The count already existed and the wire dropped it. `RateStore.CostReport`
computes `unpriced_calls` per day × task × tier, `attachDayCost` puts it on the
line, and `AiUsage` had no field for it. It travels now, and the card says how
many calls the total is missing.

**Nothing changes when every call is priced**: no field, no sentence. A card that
stamped every window as partial would teach a reader to skip the line, and the
one window where it is true would read exactly like the rest — which is why the
mirror case is a test on both sides rather than an afterthought.

`cost_est_minor`'s own rule is untouched: an entirely unpriced line still omits
it rather than reporting a fabricated 0, and a partly-priced line still reports
its real, partial total. What changes is that the partial one now says which it
is.

## Checks

- `make check-backend` green; `craft static --strict` clean.
- `make check-fe` green apart from `worklist.today`'s known flake (#4858).
- Contract change is additive — no breaking-change ratification needed.
- Mutation-checked on both sides: dropping the wire field turns two backend
  cases red, and disabling the sentence turns the card's case red.