### PR TITLE
fix(reports): an unowned row is a caller's population too

### DIFF
--- a/backend/internal/compose/analyticscontext.go
+++ b/backend/internal/compose/analyticscontext.go
@@ -86,7 +86,8 @@ func analyticsContextFor(ctx context.Context, tx pgx.Tx, now time.Time) (crmcont
 		return crmcontracts.AnalyticsContext{}, errors.New("compose: no actor bound to context")
 	}
 
-	def, defClause, err := AnalyticsPopulationClause(ctx, tx, RequestedScope{}, "", func(any) int { return 0 })
+	def, defClause, err := AnalyticsPopulationClause(
+		ctx, tx, RequestedScope{}, "", func(any) int { return 0 }, unownedIsPartOfDefault)
 	if err != nil {
 		return crmcontracts.AnalyticsContext{}, err
 	}

--- a/backend/internal/compose/analyticsmcpquestions_manager_integration_test.go
+++ b/backend/internal/compose/analyticsmcpquestions_manager_integration_test.go
@@ -19,12 +19,10 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// seedClosedOwnedDeal writes one won or lost deal OWNED by somebody.
-//
-// seedPricedDeal leaves owner_id NULL, which is right for the currency cases it
-// serves and wrong here: every report in this file measures the caller's own
-// population by default, so an unowned deal is invisible to the manager asking
-// about their team and the fixture would prove nothing.
+// seedClosedOwnedDeal writes one won or lost deal OWNED by somebody, with a
+// chosen `source` — seedPricedDeal takes neither, and every case here is
+// management reading a specific rep's real, attributed contribution, not an
+// unclaimed one.
 func seedClosedOwnedDeal(
 	t *testing.T, e *forecastEnv, name string, amountMinor int64, status, source string, owner ids.UUID,
 ) {

--- a/backend/internal/compose/analyticsquery_integration_test.go
+++ b/backend/internal/compose/analyticsquery_integration_test.go
@@ -493,6 +493,40 @@ func TestATypedQueryRefusesAPopulationTheAskerCannotMeasure(t *testing.T) {
 	}
 }
 
+// Naming a colleague explicitly is a different ask than measuring your own
+// default population, and an unowned row must not count toward it: this is a
+// standing forecast asking what a NAMED person specifically committed to,
+// and an unclaimed deal is nobody's commitment. Only the caller's own
+// default (self, or a team manager's own managed-teams default) admits an
+// unowned row — never an explicitly named owner or team.
+func TestATypedQueryNamingAColleagueExcludesAnUnownedRow(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	// Five of Rep3's own, clearing analyticsquery.DefaultFloor, plus one
+	// unowned deal that must not be counted as Rep3's.
+	for i := 0; i < 5; i++ {
+		e.seedOpenDeal(t, "Rep3's own", 20, &e.Rep3, &amount, nil)
+	}
+	e.seedOpenDeal(t, "Unowned", 20, nil, &amount, nil)
+
+	answer, err := e.askAnalytics(e.wideLensCtx(e.Rep1), t, analyticsquery.Query{
+		Entity:    "open-deals-per-company",
+		ScopeKind: ScopeKindOwner,
+		ScopeID:   e.Rep3.String(),
+		Measures:  []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "deals"}},
+	})
+	if err != nil {
+		t.Fatalf("naming a colleague by id was refused: %v", err)
+	}
+	if len(answer.Rows) != 1 {
+		t.Fatalf("an ungrouped query answered %d rows: %+v", len(answer.Rows), answer.Rows)
+	}
+	if got := answer.Rows[0]["deals"]; got != float64(5) && got != int64(5) {
+		t.Errorf("Rep3's named count is %v, want exactly their own 5 — the unowned "+
+			"deal must not be counted as a named colleague's commitment", got)
+	}
+}
+
 // wideLensCtx is a REAL seat that may measure the whole workspace.
 //
 // A real one because saving a run records who asked, and report_run carries a

--- a/backend/internal/compose/analyticsquery_integration_test.go
+++ b/backend/internal/compose/analyticsquery_integration_test.go
@@ -527,6 +527,37 @@ func TestATypedQueryNamingAColleagueExcludesAnUnownedRow(t *testing.T) {
 	}
 }
 
+// The same exclusion holds for an explicitly named TEAM (ScopeKindTeam),
+// never the caller's own managed-teams default: an unowned deal must not
+// count toward a specific team's named commitment either.
+func TestATypedQueryNamingATeamExcludesAnUnownedRow(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	// Five of Team1's own (Rep1), clearing analyticsquery.DefaultFloor, plus
+	// one unowned deal that must not be counted as Team1's.
+	for i := 0; i < 5; i++ {
+		e.seedOpenDeal(t, "Rep1's own", 20, &e.Rep1, &amount, nil)
+	}
+	e.seedOpenDeal(t, "Unowned", 20, nil, &amount, nil)
+
+	answer, err := e.askAnalytics(e.wideLensCtx(e.Rep3), t, analyticsquery.Query{
+		Entity:    "open-deals-per-company",
+		ScopeKind: ScopeKindTeam,
+		ScopeID:   e.Team1.String(),
+		Measures:  []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "deals"}},
+	})
+	if err != nil {
+		t.Fatalf("naming a team by id was refused: %v", err)
+	}
+	if len(answer.Rows) != 1 {
+		t.Fatalf("an ungrouped query answered %d rows: %+v", len(answer.Rows), answer.Rows)
+	}
+	if got := answer.Rows[0]["deals"]; got != float64(5) && got != int64(5) {
+		t.Errorf("Team1's named count is %v, want exactly its own 5 — the unowned "+
+			"deal must not be counted as a named team's commitment", got)
+	}
+}
+
 // wideLensCtx is a REAL seat that may measure the whole workspace.
 //
 // A real one because saving a run records who asked, and report_run carries a

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -117,8 +117,26 @@ func AnalyticsPopulationClause(
 
 	switch resolved.Kind {
 	case ScopeKindOwner:
-		return resolved, fmt.Sprintf("%s = $%d", col, arg(*resolved.ID)), nil
+		clause := fmt.Sprintf("%s = $%d", col, arg(*resolved.ID))
+		if *resolved.ID == p.UserID {
+			// Measuring MYSELF — whether I asked for that by name or asked for
+			// nothing — is the one case `platform/auth.OwnerPredicate` already
+			// answers for reads: "a row nobody owns is the workspace's to see"
+			// (rowscope.go's unownedIsShared). A population predicate narrows
+			// what a READ already permitted, so an unowned row that is on my
+			// worklist has to be on my population too, or a rep's own board
+			// disagrees with a rep's own list about a lead sitting in both.
+			//
+			// Naming somebody ELSE by id does not get this arm: that is a
+			// standing forecast asking what a NAMED colleague specifically
+			// committed to, and an unclaimed deal is nobody's commitment yet.
+			clause = ownedOrUnowned(col, clause)
+		}
+		return resolved, clause, nil
 	case ScopeKindTeam:
+		// An EXPLICITLY named team (never the default — see ScopeKindManagedTeams
+		// below) is the same "somebody specific" accountability ask ScopeKindOwner
+		// makes for a named colleague, so it stays exact for the same reason.
 		return resolved, fmt.Sprintf(
 			"%s IN (%s)", col, liveTeamMembersSQL(arg(*resolved.ID), "= $%d")), nil
 	case ScopeKindManagedTeams:
@@ -129,12 +147,32 @@ func AnalyticsPopulationClause(
 		// from their own default answer reads as data loss.
 		me := arg(p.UserID)
 		teams := arg(p.TeamIDs)
-		return resolved, fmt.Sprintf(
+		clause := fmt.Sprintf(
 			"(%s = $%d OR %s IN (%s))",
-			col, me, col, liveTeamMembersSQL(teams, "= ANY($%d)")), nil
+			col, me, col, liveTeamMembersSQL(teams, "= ANY($%d)"))
+		// Always the caller's own default population (never requestable by
+		// name, see ScopeKindManagedTeams's own doc), so the same unowned-is-
+		// shared arm as the self-named ScopeKindOwner case above applies.
+		return resolved, ownedOrUnowned(col, clause), nil
 	default:
 		return resolved, "", nil
 	}
+}
+
+// ownedOrUnowned widens an owner/team population clause to also admit a row
+// nobody owns yet.
+//
+// Mirrors platform/auth.OwnerPredicate's unownedIsShared arm for row scope,
+// for the same reason: an owner_id IS NULL row matches neither `= $n` nor
+// `IN (...)` under ordinary SQL null semantics, so without this a fresh,
+// unrouted lead or an unassigned deal silently drops out of every report a
+// non-admin seat runs, though the SAME row is on their ordinary, unscoped
+// list. The two clauses cannot share one function — this one narrows to an
+// ARBITRARY resolved population, that one always narrows to the caller's own
+// — so the invariant is kept in one place in each file's own doc instead: a
+// reader changing what "unowned" means to a read has to find this one too.
+func ownedOrUnowned(col, clause string) string {
+	return fmt.Sprintf("(%s IS NULL OR %s)", col, clause)
 }
 
 // liveTeamMembersSQL selects the members of a team, as the installation stands

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -92,6 +92,28 @@ func ResolveAnalyticsScope(
 // AnalyticsPopulationClause resolves a requested scope against the caller's
 // lens and renders the SQL that narrows to it.
 //
+// unownedPopulation says whether an owner/team CALLER's default population
+// (never an explicitly named one — see the ScopeKindOwner/ScopeKindTeam
+// split in AnalyticsPopulationClause) admits a row nobody owns yet.
+//
+// A REPORT and a STANDING FORECAST answer this differently for the same
+// reason they answer row-scope's identical question differently
+// (platform/auth/rowscope.go's unownedRows, unownedIsShared/unownedIsNobodys):
+// a report reads what is on a caller's radar, and an unrouted lead sitting in
+// their worklist belongs on their board too. A forecast is a commitment
+// number, and nobody has committed to a deal nobody has claimed — widening it
+// would make a manager's team total stop reconciling with the sum of naming
+// each member by id, the one thing a standing forecast promises never to do.
+type unownedPopulation bool
+
+const (
+	unownedIsPartOfDefault unownedPopulation = true
+	unownedIsExcluded      unownedPopulation = false
+)
+
+// AnalyticsPopulationClause resolves a requested scope against the caller's
+// lens and renders the SQL that narrows to it.
+//
 // The returned clause is a bare predicate WITHOUT a leading AND, so a caller
 // composes it the way they compose any other; an empty string means the
 // population is the whole workspace and nothing needs adding.
@@ -100,6 +122,7 @@ func ResolveAnalyticsScope(
 // calling spec, never a name off a request.
 func AnalyticsPopulationClause(
 	ctx context.Context, tx pgx.Tx, requested RequestedScope, alias string, arg func(any) int,
+	unowned unownedPopulation,
 ) (ResolvedScope, string, error) {
 	resolved, err := ResolveAnalyticsScope(ctx, tx, requested)
 	if err != nil {
@@ -118,25 +141,28 @@ func AnalyticsPopulationClause(
 	switch resolved.Kind {
 	case ScopeKindOwner:
 		clause := fmt.Sprintf("%s = $%d", col, arg(*resolved.ID))
-		if *resolved.ID == p.UserID {
+		if unowned == unownedIsPartOfDefault && *resolved.ID == p.UserID {
 			// Measuring MYSELF — whether I asked for that by name or asked for
 			// nothing — is the one case `platform/auth.OwnerPredicate` already
-			// answers for reads: "a row nobody owns is the workspace's to see"
-			// (rowscope.go's unownedIsShared). A population predicate narrows
-			// what a READ already permitted, so an unowned row that is on my
-			// worklist has to be on my population too, or a rep's own board
-			// disagrees with a rep's own list about a lead sitting in both.
+			// answers for reads: "a row nobody owns is the workspace's to see."
+			// A population predicate narrows what a READ already permitted, so
+			// an unowned row that is on my worklist has to be on my population
+			// too, or a rep's own board disagrees with a rep's own list about a
+			// lead sitting in both.
 			//
-			// Naming somebody ELSE by id does not get this arm: that is a
-			// standing forecast asking what a NAMED colleague specifically
-			// committed to, and an unclaimed deal is nobody's commitment yet.
+			// Naming somebody ELSE by id does not get this arm even when the
+			// caller admits unowned rows for their own default: that is a
+			// standing forecast or report asking what a NAMED colleague
+			// specifically committed to, and an unclaimed deal is nobody's
+			// commitment yet.
 			clause = ownedOrUnowned(col, clause)
 		}
 		return resolved, clause, nil
 	case ScopeKindTeam:
 		// An EXPLICITLY named team (never the default — see ScopeKindManagedTeams
 		// below) is the same "somebody specific" accountability ask ScopeKindOwner
-		// makes for a named colleague, so it stays exact for the same reason.
+		// makes for a named colleague, so it stays exact for the same reason,
+		// regardless of unowned.
 		return resolved, fmt.Sprintf(
 			"%s IN (%s)", col, liveTeamMembersSQL(arg(*resolved.ID), "= $%d")), nil
 	case ScopeKindManagedTeams:
@@ -150,10 +176,14 @@ func AnalyticsPopulationClause(
 		clause := fmt.Sprintf(
 			"(%s = $%d OR %s IN (%s))",
 			col, me, col, liveTeamMembersSQL(teams, "= ANY($%d)"))
-		// Always the caller's own default population (never requestable by
-		// name, see ScopeKindManagedTeams's own doc), so the same unowned-is-
-		// shared arm as the self-named ScopeKindOwner case above applies.
-		return resolved, ownedOrUnowned(col, clause), nil
+		if unowned == unownedIsPartOfDefault {
+			// Always the caller's own default population (never requestable by
+			// name, see ScopeKindManagedTeams's own doc), so the same
+			// unowned-is-shared arm as the self-named ScopeKindOwner case above
+			// applies.
+			clause = ownedOrUnowned(col, clause)
+		}
+		return resolved, clause, nil
 	default:
 		return resolved, "", nil
 	}

--- a/backend/internal/compose/analyticsscope_test.go
+++ b/backend/internal/compose/analyticsscope_test.go
@@ -18,6 +18,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/modules/forecasting"
@@ -199,6 +200,34 @@ func TestNamingYourselfIsAlwaysWithinYourOwnLens(t *testing.T) {
 	}
 	if got.Kind != ScopeKindOwner || got.ID == nil || *got.ID != me {
 		t.Fatalf("naming yourself resolved to %q/%v", got.Kind, got.ID)
+	}
+}
+
+// A manager's default population clause must also admit a row nobody owns
+// yet: an unrouted lead or an unassigned deal is on the SAME worklist row
+// scope already hands a team manager, so a population clause that excludes it
+// would disagree with the manager's own list about a row that is in both.
+//
+// arg is a no-op collector here — the assertion is on the RENDERED SQL shape,
+// not on a live query — because this is the ManagedTeams path, the one kind
+// labelScope never touches a database for (analyticsUserLabel/analyticsTeamLabel
+// both need one), so this stays a pure policy test like its neighbours.
+func TestManagedTeamsPopulationTreatsAnUnownedRowAsShared(t *testing.T) {
+	team := ids.NewV7()
+	actor := actorWithScope(principal.RowScopeTeam, team)
+	ctx := principal.WithActor(context.Background(), actor)
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	resolved, clause, err := AnalyticsPopulationClause(ctx, nil, RequestedScope{}, "t", arg)
+	if err != nil {
+		t.Fatalf("rendering a manager's default population clause: %v", err)
+	}
+	if resolved.Kind != ScopeKindManagedTeams {
+		t.Fatalf("resolved to %q, want %q", resolved.Kind, ScopeKindManagedTeams)
+	}
+	if !strings.Contains(clause, "t.owner_id IS NULL") {
+		t.Errorf("clause %q does not admit an unowned row", clause)
 	}
 }
 

--- a/backend/internal/compose/analyticsscope_test.go
+++ b/backend/internal/compose/analyticsscope_test.go
@@ -217,9 +217,9 @@ func TestManagedTeamsPopulationTreatsAnUnownedRowAsShared(t *testing.T) {
 	actor := actorWithScope(principal.RowScopeTeam, team)
 	ctx := principal.WithActor(context.Background(), actor)
 
-	var args []any
-	arg := func(v any) int { args = append(args, v); return len(args) }
-	resolved, clause, err := AnalyticsPopulationClause(ctx, nil, RequestedScope{}, "t", arg)
+	n := 0
+	arg := func(any) int { n++; return n }
+	resolved, clause, err := AnalyticsPopulationClause(ctx, nil, RequestedScope{}, "t", arg, unownedIsPartOfDefault)
 	if err != nil {
 		t.Fatalf("rendering a manager's default population clause: %v", err)
 	}

--- a/backend/internal/compose/analyticssharesnapshot.go
+++ b/backend/internal/compose/analyticssharesnapshot.go
@@ -142,7 +142,10 @@ func sharedVisibilityClause(ctx context.Context, tx pgx.Tx, arg func(any) int) (
 	//
 	// Requested is deliberately EMPTY: the recipient asked for nothing, so this
 	// resolves to their own default, which is the most they may see.
-	_, population, err := AnalyticsPopulationClause(ctx, tx, RequestedScope{}, "d", arg)
+	// Excludes unowned rows even from the recipient's own default — a shared
+	// snapshot is a forecast commitment number, the same reasoning
+	// forecastseam.go's ForecastDeals carries.
+	_, population, err := AnalyticsPopulationClause(ctx, tx, RequestedScope{}, "d", arg, unownedIsExcluded)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/compose/forecastconversionseam.go
+++ b/backend/internal/compose/forecastconversionseam.go
@@ -194,8 +194,10 @@ func forecastHistoryClauses(
 	if scopeClause == "" {
 		scopeClause = sqlUnnarrowed
 	}
+	// Excludes unowned rows even from the caller's own default — the same
+	// forecast-is-a-commitment reasoning ForecastDeals carries (forecastseam.go).
 	_, populationClause, err := AnalyticsPopulationClause(
-		ctx, tx, requestedFromForecastScope(scope), "d", arg)
+		ctx, tx, requestedFromForecastScope(scope), "d", arg, unownedIsExcluded)
 	if err != nil {
 		return "", "", err
 	}

--- a/backend/internal/compose/forecastseam.go
+++ b/backend/internal/compose/forecastseam.go
@@ -51,8 +51,13 @@ func ForecastDeals(
 	// unset scope means they named nothing, which is a rep's own records and a
 	// manager's teams — never the installation, which is what this read
 	// answered before and why a rep's forecast was somebody else's.
+	//
+	// Excludes unowned rows even from the caller's own default: a forecast is
+	// a commitment number, and nobody has committed to a deal nobody has
+	// claimed. Widening it would make a manager's team total stop reconciling
+	// with the sum of naming each member by id.
 	resolved, populationClause, err := AnalyticsPopulationClause(
-		ctx, tx, requestedFromForecastScope(scope), "d", arg)
+		ctx, tx, requestedFromForecastScope(scope), "d", arg, unownedIsExcluded)
 	if err != nil {
 		return nil, forecasting.Scope{}, false, err
 	}

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -136,10 +136,10 @@ func TestDealsByStageMeasuresTheReadersOwnPopulation(t *testing.T) {
 
 // An unowned deal — the ordinary shape of one nobody has claimed yet — must
 // count toward a rep's own population the same way it counts toward their
-// ordinary, unscoped deal list. Before this fix, `owner_id = $me` matched
-// nothing against a NULL owner_id under ordinary SQL null semantics, so the
-// deal silently vanished from the rep's own board while still sitting on
-// their worklist one click away (margince#4206's own reproduction shape).
+// ordinary, unscoped deal list: `owner_id = $me` matches nothing against a
+// NULL owner_id under ordinary SQL null semantics, so without an explicit
+// unowned-is-shared arm the deal would silently vanish from the rep's own
+// board while still sitting on their worklist one click away.
 func TestDealsByStageCountsAnUnownedDealForARep(t *testing.T) {
 	e := setupForecast(t)
 	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))
@@ -453,45 +453,5 @@ func TestDealsByStageNarrowsToOnePartner(t *testing.T) {
 	}
 	if total != 40000 {
 		t.Errorf("total = %d, want 40000 — the filter did not narrow to the partner asked for", total)
-	}
-}
-
-// stage-age (margince#4210) and open-deals-per-company (margince#4209) are
-// both install-wide analysis questions, reachable only through the generic
-// run_report/Analytics doors with no personal-work framing — a team manager
-// must see them for the whole installation, not narrowed to their own teams.
-func TestStageAgeIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
-	e := setupForecast(t)
-	e.seedOpenDeal(t, "Cross-team", 60, &e.Rep3, int64p(10000), stringp("commit"))
-
-	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
-	result := e.runReport(manager, t, "stage-age",
-		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"}]}`)
-	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no stage-age rows, want Rep3's Team2 " +
-			"deal to still count — stage-age answers for the whole installation")
-	}
-}
-
-// open-deals-per-company keeps the caller's own/team lens — proved by
-// TestATypedQueryAnswersTheAskersOwnPopulation and
-// TestADealOutsideThePopulationIsNotAPermissionExclusion, which both require
-// this report to narrow to the caller's own population, not the whole
-// installation. What margince#4209 actually needed was the same unowned-row
-// fix as every other report here: an unrouted deal must still count toward a
-// team manager's own company rollup.
-func TestOpenDealsPerCompanyCountsAnUnownedDealForATeamManager(t *testing.T) {
-	e := setupForecast(t)
-	orgID := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Unowned Co', 'manual', 'human:x')`)
-	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
-		VALUES ($1, 'Unowned', $2, $3, $4, 10000, 'EUR', 'manual', 'human:x')`,
-		e.pipeline, e.stages[60], orgID)
-
-	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
-	result := e.runReport(manager, t, "open-deals-per-company",
-		`{"group_by":["organization_id"],"aggregates":[{"fn":"count","as":"open_deals"}]}`)
-	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no open-deals-per-company rows, want the " +
-			"unowned deal to still count toward their own managed-teams population")
 	}
 }

--- a/backend/internal/compose/report_dealsbystage_integration_test.go
+++ b/backend/internal/compose/report_dealsbystage_integration_test.go
@@ -134,6 +134,59 @@ func TestDealsByStageMeasuresTheReadersOwnPopulation(t *testing.T) {
 	}
 }
 
+// An unowned deal — the ordinary shape of one nobody has claimed yet — must
+// count toward a rep's own population the same way it counts toward their
+// ordinary, unscoped deal list. Before this fix, `owner_id = $me` matched
+// nothing against a NULL owner_id under ordinary SQL null semantics, so the
+// deal silently vanished from the rep's own board while still sitting on
+// their worklist one click away (margince#4206's own reproduction shape).
+func TestDealsByStageCountsAnUnownedDealForARep(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))
+	e.seedOpenDeal(t, "Mine", 60, &e.Rep1, int64p(5000), stringp("commit"))
+
+	rep := e.dealReadCtx(e.Rep1, nil, principal.RowScopeOwn)
+	result := e.runReport(rep, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
+	if got := wireInt(t, row, "deals"); got != 2 {
+		t.Fatalf("deals = %d, want 2 (the rep's own deal AND the unowned one) — "+
+			"an unowned deal must not silently drop out of a rep's own population", got)
+	}
+}
+
+// The same unowned deal must count toward a TEAM manager's default
+// (ScopeKindManagedTeams) population too, for the identical reason.
+func TestDealsByStageCountsAnUnownedDealForATeamManager(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	row := dealsByStageRow(t, result, e.stages[60].String())
+	if got := wireInt(t, row, "deals"); got != 1 {
+		t.Fatalf("deals = %d, want 1 (the unowned deal) — a team manager's "+
+			"managed-teams population must also admit an unowned row", got)
+	}
+}
+
+// A deal owned by a real seat who shares none of the caller's teams stays
+// OUT of a team manager's population — the fix above widens for UNOWNED rows
+// only, never for somebody else's specifically-claimed work.
+func TestDealsByStageStillExcludesAnUnrelatedSeatsDealForATeamManager(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Theirs", 60, &e.Rep3, int64p(20000), stringp("commit"))
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "deals-by-stage",
+		`{"group_by":["stage_id","currency"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	if len(result.Rows) != 0 {
+		t.Fatalf("Team1 manager saw %d rows, want 0 — Rep3's Team2 deal must stay "+
+			"outside Team1's population", len(result.Rows))
+	}
+}
+
 // The board's per-column totals need deals-by-stage to accept
 // every filter dial the board itself exposes, and to split a stage's total
 // by currency so a mixed-currency column can still decline to sum (the same
@@ -400,5 +453,45 @@ func TestDealsByStageNarrowsToOnePartner(t *testing.T) {
 	}
 	if total != 40000 {
 		t.Errorf("total = %d, want 40000 — the filter did not narrow to the partner asked for", total)
+	}
+}
+
+// stage-age (margince#4210) and open-deals-per-company (margince#4209) are
+// both install-wide analysis questions, reachable only through the generic
+// run_report/Analytics doors with no personal-work framing — a team manager
+// must see them for the whole installation, not narrowed to their own teams.
+func TestStageAgeIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Cross-team", 60, &e.Rep3, int64p(10000), stringp("commit"))
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "stage-age",
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no stage-age rows, want Rep3's Team2 " +
+			"deal to still count — stage-age answers for the whole installation")
+	}
+}
+
+// open-deals-per-company keeps the caller's own/team lens — proved by
+// TestATypedQueryAnswersTheAskersOwnPopulation and
+// TestADealOutsideThePopulationIsNotAPermissionExclusion, which both require
+// this report to narrow to the caller's own population, not the whole
+// installation. What margince#4209 actually needed was the same unowned-row
+// fix as every other report here: an unrouted deal must still count toward a
+// team manager's own company rollup.
+func TestOpenDealsPerCompanyCountsAnUnownedDealForATeamManager(t *testing.T) {
+	e := setupForecast(t)
+	orgID := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Unowned Co', 'manual', 'human:x')`)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Unowned', $2, $3, $4, 10000, 'EUR', 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], orgID)
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "open-deals-per-company",
+		`{"group_by":["organization_id"],"aggregates":[{"fn":"count","as":"open_deals"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no open-deals-per-company rows, want the " +
+			"unowned deal to still count toward their own managed-teams population")
 	}
 }

--- a/backend/internal/compose/report_leadsbystatus_integration_test.go
+++ b/backend/internal/compose/report_leadsbystatus_integration_test.go
@@ -71,12 +71,12 @@ func TestLeadsByStatusCountsTheTerminalLeadsEveryOtherReadHides(t *testing.T) {
 	}
 }
 
-// An unowned lead is the ordinary shape of a fresh, unrouted one — and it
-// must count on a rep's own board the same way it counts on their unscoped
-// list. This is margince#4205's own literal reproduction: before the fix,
-// `owner_id = $me` matched nothing against a NULL owner_id, and the Leads
-// board's terminal-status columns silently dropped a lead the panel's own
-// list still showed one click below.
+// An unowned lead is the ordinary shape of a fresh, unrouted one, and it must
+// count on a rep's own board the same way it counts on their unscoped list:
+// `owner_id = $me` matches nothing against a NULL owner_id under ordinary SQL
+// null semantics, so the Leads board's terminal-status columns would
+// otherwise silently drop a lead the panel's own list still shows one click
+// below.
 func TestLeadsByStatusCountsAnUnownedLeadForARep(t *testing.T) {
 	e := integration.Setup(t)
 	seedLeadAt(t, e, "new", false)
@@ -99,7 +99,11 @@ func TestLeadsByStatusCountsAnUnownedLeadForARep(t *testing.T) {
 	decodeWire(t, rec, http.StatusOK, &result)
 	counts := map[string]int64{}
 	for _, row := range result.Rows {
-		counts[row["status"].(string)] = wireInt(t, row, "leads")
+		status, ok := row["status"].(string)
+		if !ok {
+			t.Fatalf("row %v has no status", row)
+		}
+		counts[status] = wireInt(t, row, "leads")
 	}
 	if counts["new"] != 1 {
 		t.Errorf(`a rep's own population counted %d "new" leads, want 1 — `+

--- a/backend/internal/compose/report_leadsbystatus_integration_test.go
+++ b/backend/internal/compose/report_leadsbystatus_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // Terminal leads are counted, and counted under their own status.
@@ -67,6 +68,46 @@ func TestLeadsByStatusCountsTheTerminalLeadsEveryOtherReadHides(t *testing.T) {
 			t.Errorf("leads-by-status counted %d %s, want %d — the two terminal statuses are the ones this report exists for",
 				counts[status], status, want)
 		}
+	}
+}
+
+// An unowned lead is the ordinary shape of a fresh, unrouted one — and it
+// must count on a rep's own board the same way it counts on their unscoped
+// list. This is margince#4205's own literal reproduction: before the fix,
+// `owner_id = $me` matched nothing against a NULL owner_id, and the Leads
+// board's terminal-status columns silently dropped a lead the panel's own
+// list still showed one click below.
+func TestLeadsByStatusCountsAnUnownedLeadForARep(t *testing.T) {
+	e := integration.Setup(t)
+	seedLeadAt(t, e, "new", false)
+	e.WsExec(t, `INSERT INTO lead (id, full_name, status, source, captured_by, owner_id, archived_at)
+		VALUES ($1, 'Owned Fixture', 'disqualified', 'inbound', 'human:x', $2, now())`, ids.NewV7(), e.Rep1)
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		Objects: map[string]principal.ObjectGrant{
+			"lead":                  {Read: true},
+			"installation_settings": {Read: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/leads-by-status",
+		strings.NewReader(`{}`)).WithContext(rep)
+	rec := httptest.NewRecorder()
+	reportHandlers{engine: newReportEngine(e.Pool)}.RunReport(rec, req, "leads-by-status")
+
+	var result reportResultWire
+	decodeWire(t, rec, http.StatusOK, &result)
+	counts := map[string]int64{}
+	for _, row := range result.Rows {
+		counts[row["status"].(string)] = wireInt(t, row, "leads")
+	}
+	if counts["new"] != 1 {
+		t.Errorf(`a rep's own population counted %d "new" leads, want 1 — `+
+			"an unowned lead must not silently drop out", counts["new"])
+	}
+	if counts["disqualified"] != 1 {
+		t.Errorf(`a rep's own population counted %d "disqualified" leads, want 1 (their own)`,
+			counts["disqualified"])
 	}
 }
 

--- a/backend/internal/compose/report_opendealspercompany_integration_test.go
+++ b/backend/internal/compose/report_opendealspercompany_integration_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// open-deals-per-company keeps the caller's own/team lens: TestATypedQueryAnswersTheAskersOwnPopulation
+// and TestADealOutsideThePopulationIsNotAPermissionExclusion (both in this
+// package) require it to narrow to the caller's own population, the same
+// door prebuilt reports and typed queries share — so an unrouted deal has to
+// reach a team manager's own company rollup through the same unowned-row
+// arm every other own-lens report in this package takes, not through a wider
+// population declaration.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestOpenDealsPerCompanyCountsAnUnownedDealForATeamManager(t *testing.T) {
+	e := setupForecast(t)
+	orgID := e.seedID(t, `INSERT INTO organization (id, display_name, source, captured_by) VALUES ($1, 'Unowned Co', 'manual', 'human:x')`)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+		VALUES ($1, 'Unowned', $2, $3, $4, 10000, 'EUR', 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], orgID)
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "open-deals-per-company",
+		`{"group_by":["organization_id"],"aggregates":[{"fn":"count","as":"open_deals"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no open-deals-per-company rows, want the " +
+			"unowned deal to still count toward their own managed-teams population")
+	}
+}

--- a/backend/internal/compose/report_pipelinecurrent_integration_test.go
+++ b/backend/internal/compose/report_pipelinecurrent_integration_test.go
@@ -28,12 +28,13 @@ import (
 )
 
 // pipeline-current keeps the caller's own/team lens (a team manager's own
-// pipeline composition, the same shape deals-by-stage answers — proved by
-// TestATypedQueryAnswersTheAskersOwnPopulation-adjacent cases in
-// analyticsmcpquestions_integration_test.go's G01/G02/M04). What margince#4207
-// actually needed was the unowned-row fix: an unrouted, unassigned deal must
-// still count toward a manager's own pipeline, the same way it counts toward
-// deals-by-stage (report_dealsbystage_integration_test.go).
+// pipeline composition, the same shape deals-by-stage answers) — proved by
+// analyticsmcpquestions_integration_test.go's G01 (an omitted scope is the
+// rep's own deals) and M04 (one row per stage, the caller's own open deals
+// only). What this report needs instead is the unowned-row fix: an unrouted,
+// unassigned deal must still count toward a manager's own pipeline, the same
+// way it counts toward deals-by-stage
+// (report_dealsbystage_integration_test.go).
 func TestPipelineCurrentCountsAnUnownedDealForATeamManager(t *testing.T) {
 	e := setupForecast(t)
 	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))

--- a/backend/internal/compose/report_pipelinecurrent_integration_test.go
+++ b/backend/internal/compose/report_pipelinecurrent_integration_test.go
@@ -22,7 +22,29 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
+
+// pipeline-current keeps the caller's own/team lens (a team manager's own
+// pipeline composition, the same shape deals-by-stage answers — proved by
+// TestATypedQueryAnswersTheAskersOwnPopulation-adjacent cases in
+// analyticsmcpquestions_integration_test.go's G01/G02/M04). What margince#4207
+// actually needed was the unowned-row fix: an unrouted, unassigned deal must
+// still count toward a manager's own pipeline, the same way it counts toward
+// deals-by-stage (report_dealsbystage_integration_test.go).
+func TestPipelineCurrentCountsAnUnownedDealForATeamManager(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "pipeline-current", pipelineCurrentPlan)
+	if result.TotalRows == 0 {
+		t.Fatal("a Team1 manager read an empty pipeline-current, want the " +
+			"unowned deal to still count toward their own managed-teams population")
+	}
+}
 
 const pipelineCurrentPlan = `{"group_by":["stage_id"],"aggregates":[` +
 	`{"fn":"count","as":"deals"},` +

--- a/backend/internal/compose/report_projectpopulation_integration_test.go
+++ b/backend/internal/compose/report_projectpopulation_integration_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// projects-by-phase, project-commitments and projects-gone-quiet
+// (margince#4225/#4226/#4227) are the exact case reportpopulation.go's own
+// comment names as the motivating example for measureEveryReadableRow: "how
+// many projects are in delivery" is a question about the installation, not
+// about the asker. A team manager must see a project owned by a seat on a
+// different team, not a silently narrowed slice of their own team's work.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedCrossTeamProject plants one live project owned by Rep3 (Team2), the
+// same fixture every case in this file measures a Team1 manager against.
+func seedCrossTeamProject(t *testing.T, e *integration.Env) ids.UUID {
+	t.Helper()
+	orgID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Cross-team Co', 'manual', 'human:x')`, orgID)
+	projectID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO project (id, name, organization_id, owner_id, phase, source, captured_by)
+		VALUES ($1, 'Cross-team Delivery', $2, $3, 'delivering', 'manual', 'human:x')`,
+		projectID, orgID, e.Rep3)
+	return projectID
+}
+
+// managerScopedTo binds a RowScopeTeam context for a synthetic manager on the
+// given teams, granted exactly the "project" (and, for the commitments key,
+// "activity") reads the three project reports need.
+func managerScopedTo(e *integration.Env, teams []ids.UUID, extra ...string) context.Context {
+	objects := map[string]principal.ObjectGrant{
+		"project":               {Read: true},
+		"installation_settings": {Read: true},
+	}
+	for _, obj := range extra {
+		objects[obj] = principal.ObjectGrant{Read: true}
+	}
+	return e.As(ids.NewV7(), teams, principal.Permissions{Objects: objects, RowScope: principal.RowScopeTeam})
+}
+
+func runProjectReport(ctx context.Context, t *testing.T, e *integration.Env, report, body string) reportResultWire {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/"+report, strings.NewReader(body)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	reportHandlers{engine: newReportEngine(e.Pool)}.RunReport(rec, req, report)
+	var result reportResultWire
+	decodeWire(t, rec, http.StatusOK, &result)
+	return result
+}
+
+func TestProjectsByPhaseIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := integration.Setup(t)
+	seedCrossTeamProject(t, e)
+
+	manager := managerScopedTo(e, []ids.UUID{e.Team1})
+	result := runProjectReport(manager, t, e, "projects-by-phase",
+		`{"group_by":["phase"],"aggregates":[{"fn":"count","as":"projects"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no projects-by-phase rows, want Rep3's " +
+			"Team2 project to still count — this is the installation's own delivery question")
+	}
+}
+
+func TestProjectCommitmentsIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := integration.Setup(t)
+	seedCrossTeamProject(t, e)
+
+	manager := managerScopedTo(e, []ids.UUID{e.Team1}, "activity")
+	result := runProjectReport(manager, t, e, "project-commitments", `{}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no project-commitments rows, want Rep3's " +
+			"Team2 project to still count")
+	}
+}
+
+func TestProjectsGoneQuietIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := integration.Setup(t)
+	projectID := seedCrossTeamProject(t, e)
+	// Backdated well past the default 30-day quiet threshold, with no activity
+	// at all, so the report's own "measured from creation" fallback applies.
+	e.WsExec(t, `UPDATE project SET created_at = now() - interval '90 days' WHERE id = $1`, projectID)
+
+	manager := managerScopedTo(e, []ids.UUID{e.Team1})
+	result := runProjectReport(manager, t, e, "projects-gone-quiet", `{}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no projects-gone-quiet rows, want Rep3's " +
+			"quiet Team2 project to still count")
+	}
+}

--- a/backend/internal/compose/report_projectpopulation_integration_test.go
+++ b/backend/internal/compose/report_projectpopulation_integration_test.go
@@ -5,12 +5,15 @@
 
 package compose
 
-// projects-by-phase, project-commitments and projects-gone-quiet are the
-// exact case reportpopulation.go's own comment names as the motivating
-// example for measureEveryReadableRow: "how many projects are in delivery"
-// is a question about the installation, not about the asker. A team manager
-// must see a project owned by a seat on a different team, not a silently
-// narrowed slice of their own team's work.
+// projects-by-phase, project-commitments and projects-gone-quiet keep the
+// caller's own/team lens: owner_id is a dimension (projects-by-phase) or
+// part of defaultBy (the other two) over `project`, an identity table with
+// no other narrowing — a wider population would let a rep read a named
+// colleague's exact delivery figures (projects-by-phase's aggregates are
+// money) or workload (the other two) by filtering or grouping on their id.
+// An unowned project — one nobody has claimed — must still count toward a
+// team manager's own managed-teams population, the same unowned-row fix
+// every report in this cluster takes.
 
 import (
 	"context"
@@ -24,17 +27,17 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// seedCrossTeamProject plants one live project owned by Rep3 (Team2), the
-// same fixture every case in this file measures a Team1 manager against.
-func seedCrossTeamProject(t *testing.T, e *integration.Env) ids.UUID {
+// seedUnownedProject plants one live, unowned project — the same fixture
+// every case in this file measures a Team1 manager against.
+func seedUnownedProject(t *testing.T, e *integration.Env) ids.UUID {
 	t.Helper()
 	orgID := ids.NewV7()
 	e.WsExec(t, `INSERT INTO organization (id, display_name, source, captured_by)
-		VALUES ($1, 'Cross-team Co', 'manual', 'human:x')`, orgID)
+		VALUES ($1, 'Unowned Co', 'manual', 'human:x')`, orgID)
 	projectID := ids.NewV7()
-	e.WsExec(t, `INSERT INTO project (id, name, organization_id, owner_id, phase, source, captured_by)
-		VALUES ($1, 'Cross-team Delivery', $2, $3, 'delivering', 'manual', 'human:x')`,
-		projectID, orgID, e.Rep3)
+	e.WsExec(t, `INSERT INTO project (id, name, organization_id, phase, source, captured_by)
+		VALUES ($1, 'Unowned Delivery', $2, 'delivering', 'manual', 'human:x')`,
+		projectID, orgID)
 	return projectID
 }
 
@@ -62,34 +65,34 @@ func runProjectReport(ctx context.Context, t *testing.T, e *integration.Env, rep
 	return result
 }
 
-func TestProjectsByPhaseIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+func TestProjectsByPhaseCountsAnUnownedProjectForATeamManager(t *testing.T) {
 	e := integration.Setup(t)
-	seedCrossTeamProject(t, e)
+	seedUnownedProject(t, e)
 
 	manager := managerScopedTo(e, []ids.UUID{e.Team1})
 	result := runProjectReport(manager, t, e, "projects-by-phase",
 		`{"group_by":["phase"],"aggregates":[{"fn":"count","as":"projects"}]}`)
 	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no projects-by-phase rows, want Rep3's " +
-			"Team2 project to still count — this is the installation's own delivery question")
+		t.Fatal("a Team1 manager read no projects-by-phase rows, want the " +
+			"unowned project to still count toward their own managed-teams population")
 	}
 }
 
-func TestProjectCommitmentsIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+func TestProjectCommitmentsCountsAnUnownedProjectForATeamManager(t *testing.T) {
 	e := integration.Setup(t)
-	seedCrossTeamProject(t, e)
+	seedUnownedProject(t, e)
 
 	manager := managerScopedTo(e, []ids.UUID{e.Team1}, "activity")
 	result := runProjectReport(manager, t, e, "project-commitments", `{}`)
 	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no project-commitments rows, want Rep3's " +
-			"Team2 project to still count")
+		t.Fatal("a Team1 manager read no project-commitments rows, want the " +
+			"unowned project to still count")
 	}
 }
 
-func TestProjectsGoneQuietIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+func TestProjectsGoneQuietCountsAnUnownedProjectForATeamManager(t *testing.T) {
 	e := integration.Setup(t)
-	projectID := seedCrossTeamProject(t, e)
+	projectID := seedUnownedProject(t, e)
 	// Backdated well past the default 30-day quiet threshold, with no activity
 	// at all, so the report's own "measured from creation" fallback applies.
 	e.WsExec(t, `UPDATE project SET created_at = now() - interval '90 days' WHERE id = $1`, projectID)
@@ -97,7 +100,7 @@ func TestProjectsGoneQuietIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
 	manager := managerScopedTo(e, []ids.UUID{e.Team1})
 	result := runProjectReport(manager, t, e, "projects-gone-quiet", `{}`)
 	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no projects-gone-quiet rows, want Rep3's " +
-			"quiet Team2 project to still count")
+		t.Fatal("a Team1 manager read no projects-gone-quiet rows, want the " +
+			"quiet, unowned project to still count")
 	}
 }

--- a/backend/internal/compose/report_projectpopulation_integration_test.go
+++ b/backend/internal/compose/report_projectpopulation_integration_test.go
@@ -5,12 +5,12 @@
 
 package compose
 
-// projects-by-phase, project-commitments and projects-gone-quiet
-// (margince#4225/#4226/#4227) are the exact case reportpopulation.go's own
-// comment names as the motivating example for measureEveryReadableRow: "how
-// many projects are in delivery" is a question about the installation, not
-// about the asker. A team manager must see a project owned by a seat on a
-// different team, not a silently narrowed slice of their own team's work.
+// projects-by-phase, project-commitments and projects-gone-quiet are the
+// exact case reportpopulation.go's own comment names as the motivating
+// example for measureEveryReadableRow: "how many projects are in delivery"
+// is a question about the installation, not about the asker. A team manager
+// must see a project owned by a seat on a different team, not a silently
+// narrowed slice of their own team's work.
 
 import (
 	"context"

--- a/backend/internal/compose/report_stageage_integration_test.go
+++ b/backend/internal/compose/report_stageage_integration_test.go
@@ -5,9 +5,12 @@
 
 package compose
 
-// stage-age is reachable only through the generic run_report/Analytics door,
-// with no personal-work screen framing "how long has MY stage been sitting"
-// — an aging-analysis question about the installation, not about the caller.
+// stage-age keeps the caller's own/team lens (owner_id is both a dimension
+// and a filter here, over an identity table with no other narrowing — a
+// wider population would let a rep pull a named colleague's exact
+// stage-aging figures by filtering to their id). An unowned deal — one
+// nobody has claimed — must still count toward a team manager's own
+// managed-teams population.
 
 import (
 	"testing"
@@ -16,18 +19,15 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// A deal owned by a seat on a different team must still count toward a team
-// manager's stage-age reading: this report answers for the whole
-// installation and must not narrow to the caller's own teams.
-func TestStageAgeIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+func TestStageAgeCountsAnUnownedDealForATeamManager(t *testing.T) {
 	e := setupForecast(t)
-	e.seedOpenDeal(t, "Cross-team", 60, &e.Rep3, int64p(10000), stringp("commit"))
+	e.seedOpenDeal(t, "Unowned", 60, nil, int64p(10000), stringp("commit"))
 
 	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
 	result := e.runReport(manager, t, "stage-age",
 		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"}]}`)
 	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no stage-age rows, want Rep3's Team2 " +
-			"deal to still count — stage-age answers for the whole installation")
+		t.Fatal("a Team1 manager read no stage-age rows, want the unowned " +
+			"deal to still count toward their own managed-teams population")
 	}
 }

--- a/backend/internal/compose/report_stageage_integration_test.go
+++ b/backend/internal/compose/report_stageage_integration_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// stage-age is reachable only through the generic run_report/Analytics door,
+// with no personal-work screen framing "how long has MY stage been sitting"
+// — an aging-analysis question about the installation, not about the caller.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// A deal owned by a seat on a different team must still count toward a team
+// manager's stage-age reading: this report answers for the whole
+// installation and must not narrow to the caller's own teams.
+func TestStageAgeIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := setupForecast(t)
+	e.seedOpenDeal(t, "Cross-team", 60, &e.Rep3, int64p(10000), stringp("commit"))
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "stage-age",
+		`{"group_by":["stage_id"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no stage-age rows, want Rep3's Team2 " +
+			"deal to still count — stage-age answers for the whole installation")
+	}
+}

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -19,6 +19,7 @@ package compose
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -728,21 +729,45 @@ func TestWinLossFiltersToOneLostReason(t *testing.T) {
 	}
 }
 
-// win-loss is an install-wide analysis question — a cross-team comparison is
-// exactly what a win-rate report is FOR, so a team manager must see a
-// won/lost deal closed by a seat on a different team, not just their own
-// team's outcomes.
-func TestWinLossIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+// win-loss keeps the caller's own/team lens (owner_id is both a dimension
+// and a filter here, over an identity table with no other narrowing — a
+// wider population would let a rep pull a named colleague's exact win/loss
+// revenue by filtering to their id). An unowned won deal — one nobody has
+// claimed — must still count toward a team manager's own managed-teams
+// population, the same unowned-row fix every report in this cluster takes.
+func TestWinLossCountsAnUnownedWonDealForATeamManager(t *testing.T) {
 	e := setupForecast(t)
-	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
-		VALUES ($1, 'Cross-team win', $2, $3, $4, 50000, 'EUR', 'won', '2026-01-15T10:00:00Z'::timestamptz, NULL, 1.0, 'manual', 'human:x')`,
-		e.pipeline, e.stages[60], e.Rep3)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
+		VALUES ($1, 'Unowned win', $2, $3, 50000, 'EUR', 'won', '2026-01-15T10:00:00Z'::timestamptz, NULL, 1.0, 'manual', 'human:x')`,
+		e.pipeline, e.stages[60])
 
 	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
 	result := e.runReport(manager, t, "win-loss",
 		`{"group_by":["status"],"aggregates":[{"fn":"count","as":"deals"}]}`)
 	if len(result.Rows) == 0 {
-		t.Fatal("a Team1 manager read no won/lost deals, want Rep3's Team2 " +
-			"win to still count — win-loss answers a cross-team question")
+		t.Fatal("a Team1 manager read no won/lost deals, want the unowned win " +
+			"to still count toward their own managed-teams population")
+	}
+}
+
+// A rep must not be able to pull a NAMED colleague's exact win/loss revenue
+// by filtering win-loss to their owner_id — `deal` is an identity table
+// (row scope renders unconditionally TRUE), so the population clause is the
+// ONLY thing standing between "my own closed deals" and "anyone's, on
+// request." Filtering to a colleague's id must answer empty, the same as
+// filtering deals-by-stage does.
+func TestWinLossFilteredToAColleaguesOwnerIDAnswersEmptyForARep(t *testing.T) {
+	e := setupForecast(t)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
+		VALUES ($1, 'Colleague win', $2, $3, $4, 90000, 'EUR', 'won', '2026-01-15T10:00:00Z'::timestamptz, NULL, 1.0, 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], e.Rep3)
+
+	rep := e.dealReadCtx(e.Rep1, nil, principal.RowScopeOwn)
+	result := e.runReport(rep, t, "win-loss",
+		fmt.Sprintf(`{"filters":{"owner_id":%q},"aggregates":[{"fn":"count","as":"deals"},{"fn":"sum","field":"amount_minor","as":"amount_minor_sum"}]}`,
+			e.Rep3.String()))
+	if len(result.Rows) != 0 {
+		t.Fatalf("a rep filtering to a named colleague's owner_id answered %+v, "+
+			"want no rows — this is the exact revenue leak the population narrowing must block", result.Rows)
 	}
 }

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -728,10 +728,10 @@ func TestWinLossFiltersToOneLostReason(t *testing.T) {
 	}
 }
 
-// win-loss is an install-wide analysis question (margince#4224) — a
-// cross-team comparison is exactly what a win-rate report is FOR, so a team
-// manager must see a won/lost deal closed by a seat on a different team, not
-// just their own team's outcomes.
+// win-loss is an install-wide analysis question — a cross-team comparison is
+// exactly what a win-rate report is FOR, so a team manager must see a
+// won/lost deal closed by a seat on a different team, not just their own
+// team's outcomes.
 func TestWinLossIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
 	e := setupForecast(t)
 	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)

--- a/backend/internal/compose/report_winloss_integration_test.go
+++ b/backend/internal/compose/report_winloss_integration_test.go
@@ -20,6 +20,9 @@ package compose
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // wireFloat reads a cell that is legitimately fractional. A percentile
@@ -722,5 +725,24 @@ func TestWinLossFiltersToOneLostReason(t *testing.T) {
 	}
 	if got := wireInt(t, row, "amount_minor_sum"); got != 50000 {
 		t.Errorf("amount = %d, want 50000 — a filtered-out deal reached the sum", got)
+	}
+}
+
+// win-loss is an install-wide analysis question (margince#4224) — a
+// cross-team comparison is exactly what a win-rate report is FOR, so a team
+// manager must see a won/lost deal closed by a seat on a different team, not
+// just their own team's outcomes.
+func TestWinLossIsNotNarrowedToATeamManagersOwnTeams(t *testing.T) {
+	e := setupForecast(t)
+	e.seedID(t, `INSERT INTO deal (id, name, pipeline_id, stage_id, owner_id, amount_minor, currency, status, closed_at, lost_reason, fx_rate_to_base, source, captured_by)
+		VALUES ($1, 'Cross-team win', $2, $3, $4, 50000, 'EUR', 'won', '2026-01-15T10:00:00Z'::timestamptz, NULL, 1.0, 'manual', 'human:x')`,
+		e.pipeline, e.stages[60], e.Rep3)
+
+	manager := e.dealReadCtx(ids.NewV7(), []ids.UUID{e.Team1}, principal.RowScopeTeam)
+	result := e.runReport(manager, t, "win-loss",
+		`{"group_by":["status"],"aggregates":[{"fn":"count","as":"deals"}]}`)
+	if len(result.Rows) == 0 {
+		t.Fatal("a Team1 manager read no won/lost deals, want Rep3's Team2 " +
+			"win to still count — win-loss answers a cross-team question")
 	}
 }

--- a/backend/internal/compose/reportperiod.go
+++ b/backend/internal/compose/reportperiod.go
@@ -285,11 +285,15 @@ func winLossSpec() reportSpec {
 		baseWhere: "t.archived_at IS NULL AND t.status IN ('won','lost')",
 		basePlain: "live (unarchived) deals that have been won or lost, bucketed by when they closed " +
 			"in the installation's reporting timezone (an open deal is absent from this report, not a zero in it)",
-		// Reachable only through the generic run_report/analysis door — a win
-		// rate scoped to one team is systematically incomplete for the
-		// cross-team comparison the question asks, and a won or lost deal
-		// stays a fact about the business regardless of who carried it.
-		population: measureEveryReadableRow,
+		// Stays on the caller's own/team default (measureCallersOwn, the zero
+		// value): owner_id is both a dimension and a filter here, and `deal`
+		// is an identity table (row scope renders unconditionally TRUE), so a
+		// declared measureEveryReadableRow would remove the ONLY narrowing
+		// standing between a rep and a named colleague's exact closed-deal
+		// revenue — filtering to one owner_id, or grouping by it, would answer
+		// a question this door refuses everywhere else it is asked. The
+		// unowned-row arm (analyticsscope.go) still reaches this report's own
+		// default population.
 		dimensions: dimensions,
 		// Money in both denominations, and how long the deal took.
 		//

--- a/backend/internal/compose/reportperiod.go
+++ b/backend/internal/compose/reportperiod.go
@@ -285,6 +285,11 @@ func winLossSpec() reportSpec {
 		baseWhere: "t.archived_at IS NULL AND t.status IN ('won','lost')",
 		basePlain: "live (unarchived) deals that have been won or lost, bucketed by when they closed " +
 			"in the installation's reporting timezone (an open deal is absent from this report, not a zero in it)",
+		// Reachable only through the generic run_report/analysis door — a win
+		// rate scoped to one team is systematically incomplete for the
+		// cross-team comparison the question asks, and a won or lost deal
+		// stays a fact about the business regardless of who carried it.
+		population: measureEveryReadableRow,
 		dimensions: dimensions,
 		// Money in both denominations, and how long the deal took.
 		//

--- a/backend/internal/compose/reportpopulation.go
+++ b/backend/internal/compose/reportpopulation.go
@@ -31,13 +31,12 @@ const (
 	// measureEveryReadableRow measures every row the caller may READ, with no
 	// narrowing of its own.
 	//
-	// The ad-hoc datasource plan is the one surface that takes it. A tool
-	// asking "how many projects are in delivery" is asking about the
-	// installation, not about the asker: a project is read by every seat
-	// holding the object grant, and an aggregate that narrowed it to the
-	// caller's team would tell a delivery lead their department has no
-	// projects running. Row scope still applies — this widens the POPULATION,
-	// never the reader's authority.
+	// For a surface with no "my work" framing: a tool asking "how many
+	// projects are in delivery" is asking about the installation, not about
+	// the asker, and an aggregate that narrowed it to the caller's team would
+	// tell a delivery lead their department has no projects running. Row
+	// scope still applies — this widens the POPULATION, never the reader's
+	// authority.
 	measureEveryReadableRow
 )
 

--- a/backend/internal/compose/reportpopulation.go
+++ b/backend/internal/compose/reportpopulation.go
@@ -64,6 +64,6 @@ func callersOwnPopulation() RequestedScope { return RequestedScope{} }
 func reportPopulationClause(
 	ctx context.Context, tx pgx.Tx, requested RequestedScope, arg func(any) int,
 ) (string, error) {
-	_, clause, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg)
+	_, clause, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg, unownedIsPartOfDefault)
 	return clause, err
 }

--- a/backend/internal/compose/reportprojects.go
+++ b/backend/internal/compose/reportprojects.go
@@ -107,10 +107,14 @@ func projectsByPhaseSpec() reportSpec {
 		table:     tableProject,
 		baseWhere: whereArchivedNull,
 		basePlain: "live (unarchived) projects, with each project's open and won deal value in the installation's base currency",
-		// The motivating case reportpopulation.go's own measureEveryReadableRow
-		// doc names: "how many projects are in delivery" is asking about the
-		// installation, not about the asker.
-		population: measureEveryReadableRow,
+		// Stays on the caller's own/team default: owner_id is both a
+		// dimension and a filter here, the aggregates are money
+		// (open/won deal value), and `project` is an identity table (row
+		// scope renders unconditionally TRUE) — declaring
+		// measureEveryReadableRow would remove the only narrowing between a
+		// rep and a named colleague's exact delivery-value figures. The
+		// unowned-row arm (analyticsscope.go) still reaches this report's own
+		// default population.
 		dimensions: map[string]string{
 			fieldPhase:          colPhase,
 			fieldOrganizationID: colProjectCustomer,
@@ -149,8 +153,9 @@ func projectCommitmentsSpec() reportSpec {
 		table:     tableProject,
 		baseWhere: whereArchivedNull,
 		basePlain: "live (unarchived) projects, each with the open tasks filed under it (overdue: due date already past)",
-		// Same install-wide question as projectsByPhaseSpec, same precedent.
-		population: measureEveryReadableRow,
+		// Stays on the caller's own/team default, same reason as
+		// projectsByPhaseSpec: owner_id is in defaultBy, and `project` is an
+		// identity table with no other narrowing on it.
 		dimensions: projectRowDimensions(),
 		measures: map[string]string{
 			measureOpenCommitments: openCommitmentsExpr,
@@ -188,10 +193,8 @@ func projectsGoneQuietSpec() reportSpec {
 		table:     tableProject,
 		baseWhere: whereArchivedNull + " AND " + projects.ProjectInFlightSQL("t"),
 		basePlain: "live projects being pursued or delivered that nothing has been filed against for at least `days` days (a project with no activity at all is measured from its creation)",
-		// Same install-wide question as projectsByPhaseSpec, same precedent —
-		// and this signal is meant to surface every quiet project, not just
-		// the ones a caller's own lens happens to cover.
-		population: measureEveryReadableRow,
+		// Stays on the caller's own/team default, same reason as
+		// projectsByPhaseSpec.
 		dimensions: dimensions,
 		measures:   map[string]string{},
 		filters: map[string]string{

--- a/backend/internal/compose/reportprojects.go
+++ b/backend/internal/compose/reportprojects.go
@@ -107,6 +107,10 @@ func projectsByPhaseSpec() reportSpec {
 		table:     tableProject,
 		baseWhere: whereArchivedNull,
 		basePlain: "live (unarchived) projects, with each project's open and won deal value in the installation's base currency",
+		// The motivating case reportpopulation.go's own measureEveryReadableRow
+		// doc names: "how many projects are in delivery" is asking about the
+		// installation, not about the asker.
+		population: measureEveryReadableRow,
 		dimensions: map[string]string{
 			fieldPhase:          colPhase,
 			fieldOrganizationID: colProjectCustomer,
@@ -141,10 +145,12 @@ func projectsByPhaseSpec() reportSpec {
 // on which body of work.
 func projectCommitmentsSpec() reportSpec {
 	return reportSpec{
-		entity:     datasource.EntityProject,
-		table:      tableProject,
-		baseWhere:  whereArchivedNull,
-		basePlain:  "live (unarchived) projects, each with the open tasks filed under it (overdue: due date already past)",
+		entity:    datasource.EntityProject,
+		table:     tableProject,
+		baseWhere: whereArchivedNull,
+		basePlain: "live (unarchived) projects, each with the open tasks filed under it (overdue: due date already past)",
+		// Same install-wide question as projectsByPhaseSpec, same precedent.
+		population: measureEveryReadableRow,
 		dimensions: projectRowDimensions(),
 		measures: map[string]string{
 			measureOpenCommitments: openCommitmentsExpr,
@@ -178,10 +184,14 @@ func projectsGoneQuietSpec() reportSpec {
 	dimensions[fieldLastActivityAt] = colLastActivity
 	dimensions[fieldQuietSince] = projects.ProjectQuietAnchorSQL("t")
 	return reportSpec{
-		entity:     datasource.EntityProject,
-		table:      tableProject,
-		baseWhere:  whereArchivedNull + " AND " + projects.ProjectInFlightSQL("t"),
-		basePlain:  "live projects being pursued or delivered that nothing has been filed against for at least `days` days (a project with no activity at all is measured from its creation)",
+		entity:    datasource.EntityProject,
+		table:     tableProject,
+		baseWhere: whereArchivedNull + " AND " + projects.ProjectInFlightSQL("t"),
+		basePlain: "live projects being pursued or delivered that nothing has been filed against for at least `days` days (a project with no activity at all is measured from its creation)",
+		// Same install-wide question as projectsByPhaseSpec, same precedent —
+		// and this signal is meant to surface every quiet project, not just
+		// the ones a caller's own lens happens to cover.
+		population: measureEveryReadableRow,
 		dimensions: dimensions,
 		measures:   map[string]string{},
 		filters: map[string]string{

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -122,11 +122,13 @@ var prebuiltReports = map[string]reportSpec{
 		},
 		baseWhere: whereArchivedNull + " AND t.status = 'open'",
 		basePlain: "live (unarchived) open deals, aged from the last time each entered its current stage",
-		// Reachable only through the generic run_report/analysis door — no
-		// personal screen frames "how long has MY stage been sitting" as a
-		// question — so this is an install-wide aging analysis, same shape as
-		// reportpopulation.go's "how many projects are in delivery" precedent.
-		population: measureEveryReadableRow,
+		// Stays on the caller's own/team default: owner_id is both a
+		// dimension and a filter here, and `deal` is an identity table (row
+		// scope renders unconditionally TRUE), so declaring
+		// measureEveryReadableRow would remove the only narrowing between a
+		// rep and a named colleague's exact stage-aging figures. The
+		// unowned-row arm (analyticsscope.go) still reaches this report's own
+		// default population.
 		dimensions: map[string]string{
 			fieldStageID:    colStageID,
 			fieldPipelineID: colPipelineID,

--- a/backend/internal/compose/reportspecs.go
+++ b/backend/internal/compose/reportspecs.go
@@ -122,6 +122,11 @@ var prebuiltReports = map[string]reportSpec{
 		},
 		baseWhere: whereArchivedNull + " AND t.status = 'open'",
 		basePlain: "live (unarchived) open deals, aged from the last time each entered its current stage",
+		// Reachable only through the generic run_report/analysis door — no
+		// personal screen frames "how long has MY stage been sitting" as a
+		// question — so this is an install-wide aging analysis, same shape as
+		// reportpopulation.go's "how many projects are in delivery" precedent.
+		population: measureEveryReadableRow,
 		dimensions: map[string]string{
 			fieldStageID:    colStageID,
 			fieldPipelineID: colPipelineID,

--- a/backend/internal/compose/reportwhere.go
+++ b/backend/internal/compose/reportwhere.go
@@ -86,10 +86,11 @@ func buildReportWhere(
 	// WHICH population, as against which rows the caller may read at all.
 	//
 	// Row scope does not answer it: a deal is an identity table read by every
-	// seat, so the clause above renders TRUE and a rep's Pipeline showed the
-	// whole installation while their Forecast — narrowed by this same resolver
-	// since #4077 — showed their own. Two Analytics tabs disagreeing about
-	// which records they cover, with nothing on screen saying so.
+	// seat, so the clause above renders TRUE, and without a population
+	// narrowing a rep's Pipeline would show the whole installation while
+	// their Forecast — narrowed by this same resolver — shows their own. Two
+	// Analytics tabs disagreeing about which records they cover, with nothing
+	// on screen saying so.
 	if spec.population == measureCallersOwn {
 		population, err := reportPopulationClause(ctx, tx, requested, arg)
 		if err != nil {
@@ -176,7 +177,7 @@ func specNarrowings(
 	// with no owner_id column (activities-by-kind) resolving this
 	// unconditionally is not a narrower answer, it is a crash.
 	if spec.population == measureCallersOwn {
-		_, population, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg)
+		_, population, err := AnalyticsPopulationClause(ctx, tx, requested, "t", arg, unownedIsPartOfDefault)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/platform/auth/rowscope.go
+++ b/backend/internal/platform/auth/rowscope.go
@@ -55,6 +55,13 @@ func OwnerPredicate(p principal.Principal, arg func(any) int) func(alias string)
 // workspace's to see. A WRITE does not: a row nobody owns is nobody's to
 // change until somebody claims it — an ownerless customer record that every
 // seat could rewrite is how two teams edit one company past each other.
+//
+// compose.unownedPopulation (analyticsscope.go) mirrors this same split one
+// layer up, for a POPULATION rather than a row-scope predicate: a report
+// reads what is on a caller's radar, so it takes the READ answer; a standing
+// forecast is a commitment number, so it takes the WRITE answer instead
+// (nobody has committed to a deal nobody has claimed). A reader changing
+// what "unowned" means on either side should check the other.
 type unownedRows bool
 
 const (


### PR DESCRIPTION
## Summary

Fixes the unowned-row defect from `.tmp/qc-issues/PLAN.md` Wave A across all
nine report-population issues (margince#4205, #4206, #4207, #4209, #4210,
#4224, #4225, #4226, #4227). **Scope note up front**: this PR fully closes
four of the nine; the other five need a follow-up before their own-lens
narrowing can be safely widened — see "What this PR does NOT do" below. That
follow-up decision is not this PR's to make alone.

## The confirmed, safe fix (all nine reports get this)

`AnalyticsPopulationClause` (`backend/internal/compose/analyticsscope.go`)
renders `owner_id = $me` / `owner_id IN (team subquery)` for a caller's
default population. SQL null semantics mean that never matches a row with
`owner_id IS NULL` — an unrouted lead, an unassigned deal — so it silently
dropped out of every report for every non-admin caller, even though the same
row is fully visible on an ordinary unscoped list. This is margince#4205's
own literal reproduction.

`platform/auth/rowscope.go` already treats an unowned row as shared for
ordinary row-scope reads (`unownedIsShared`). `AnalyticsPopulationClause` now
carries the same rule for a caller's own default population (self, or a team
manager's own "managed teams" default) — **never** when a caller explicitly
names a different colleague or team, since that path is a standing forecast
or named-lookup asking what a specific person committed to, and an unclaimed
row is nobody's commitment. Confirmed to resolve deals-by-stage (#4206),
leads-by-status (#4205), pipeline-current (#4207) and open-deals-per-company
(#4209) with no change to their population scope.

## What this PR does NOT do, and why

The plan proposed declaring `population: measureEveryReadableRow` on five
more reports (stage-age #4210, win-loss #4224, projects-by-phase #4225,
project-commitments #4226, projects-gone-quiet #4227) to make them
install-wide. **I implemented that, then reverted it after an adversarial
security review caught a real regression**: `deal` and `project` are identity
tables — row scope renders unconditionally TRUE for every seat — so on these
five reports the population clause was the *only* thing narrowing anything.
Declaring `measureEveryReadableRow` removes it, and three of the five expose
`owner_id` as both a dimension and a filter with two carrying money
aggregates. The result: a rep filtering win-loss to `owner_id: <colleague>`
would get that colleague's exact closed-deal revenue — the same question the
report's own declared scope check already refuses.

These five stay on the caller's own/team default for now (still getting the
unowned-row fix above, which was the part of each report's original QC
finding actually confirmed live). Closing #4210/#4224/#4225/#4226/#4227 the
way the plan intended needs an owner-filter authority gate — checking that a
caller may "measure" a specific named owner even when the report's overall
population is unnarrowed — which is its own design decision and its own
diff, not a one-line addition to this one.

## Also in this diff

- `AnalyticsPopulationClause`'s unowned-row admission is gated by an explicit
  `unownedPopulation` parameter now, not applied unconditionally: a second
  review round found the shared function also feeds Forecast and its
  share/conversion seams, where widening a manager's own default would make
  their team total stop reconciling with the sum of naming each member by
  id — a money-integrity defect on a standing commitment number. Forecast and
  its seams now pass `unownedIsExcluded`, unchanged from before this PR;
  only the report engine passes `unownedIsPartOfDefault`.
- A named-team negative test (the `ScopeKindTeam` twin of the named-colleague
  one already added), both mutation-tested by temporarily bypassing their
  guard and confirming the test catches it.

## Test plan

- [x] `make check-go` / `make check-all` — clean (0 lint issues, 0 craft
      findings); the one local `backend/gates` failure
      (`TestPublicTreeCitesNoDocumentGitIgnores`) is a pre-existing,
      machine-local artifact from this machine's `.git/info/exclude` — CI's
      fresh clone doesn't have it, confirmed by comparing against `origin/main`'s
      own green CI run independent of this branch.
- [x] New/changed lines: 100% covered, verified with `go test -coverprofile`
- [x] Regression test per issue, each confirmed to fail without its half of
      the fix; the security-relevant ones (named-colleague, named-team,
      colleague-filter-answers-empty) mutation-tested against the guard they
      pin
- [x] UAT: seeded a real unowned, disqualified lead on a live dev stack and
      confirmed via `rep@demo.test`'s own Leads board that the terminal
      column now reads "Disqualified 1" instead of 0 — video attached below
- [x] `make craft-static --strict` — 0 blocker/major/minor
- [x] No `crm.yaml` contract change; no AI prompt touched, so no aicert
      re-run needed
- [x] Fable + Codex craftsmanship review, then a separate craft-reviewer +
      security-redteam round — every confirmed finding from both rounds
      applied (see commit messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
