### PR TITLE
Storing a filter refuses a picklist value the field does not have

### DIFF
--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -330,6 +330,16 @@ func compileForValidation(engine storekit.Query, tree map[string]any, field stri
 		}
 		return err
 	}
+	// Refused BEFORE the compile, and only here. A picklist leaf compares
+	// text, so a value outside the field's set compiles fine and selects
+	// nothing — an honest answer for a value no row carries, and the wrong one
+	// for the person who just typed it, whose equivalent list URL would have
+	// been told. Evaluation stays permissive on purpose: a definition stored
+	// last quarter must not begin failing because somebody removed a value
+	// from a custom field's option set since.
+	if err := storekit.RefuseUnknownPicklistValues(pred, engine.Fields); err != nil {
+		return err
+	}
 	discard := 0
 	arg := func(any) int { discard++; return discard }
 	_, err = storekit.CompilePredicate(pred, engine.Fields, arg)

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -572,3 +572,71 @@ func TestAPredicateOnAnOmittedColumnIsRefusedByName(t *testing.T) {
 		t.Errorf("field = %q, want the offending column named", perr.Field)
 	}
 }
+
+// A stored filter is refused at the WRITE for a picklist value outside the
+// field's set, and the value stays evaluable at read.
+//
+// Through validateSegmentDefinition rather than the refusal function directly:
+// the pair is what the decision is, and the two halves have to be provable on
+// one tree or nothing stops a later change arming the compiler instead. The
+// list URL for the same fact already answers 422 for the same typo, so what
+// this closes is a saved view and a URL disagreeing about the same word.
+func TestStoringASegmentRefusesAPicklistValueTheFieldDoesNotHave(t *testing.T) {
+	store := &Store{}
+	definition := func(value any) map[string]any {
+		return map[string]any{"field": "relationship_type", "op": "eq", "value": value}
+	}
+
+	err := store.validateSegmentDefinition(context.Background(), "organization", definition("custmer"))
+	var refusal *storekit.PredicateError
+	if !errors.As(err, &refusal) || refusal.Code != "filter_value_invalid" {
+		t.Fatalf("storing a mistyped picklist value = %v, want a filter_value_invalid refusal — the "+
+			"list parameter for the same fact answers 422, and a saved view must not disagree", err)
+	}
+	if refusal.Field != "relationship_type" {
+		t.Errorf("refusal names %q, want the field the caller sent", refusal.Field)
+	}
+
+	// A real value still stores, so the refusal is about the VALUE rather than
+	// about picklists having become unfilterable.
+	engine, _, err := store.SegmentEngine(context.Background(), "organization")
+	if err != nil {
+		t.Fatal(err)
+	}
+	known := engine.Fields["relationship_type"].Options
+	if len(known) == 0 {
+		t.Fatal("relationship_type offers no values, so this test cannot tell a refusal from a typo")
+	}
+	if err := store.validateSegmentDefinition(
+		context.Background(), "organization", definition(known[0])); err != nil {
+		t.Errorf("storing %q, one of the field's own values, was refused: %v", known[0], err)
+	}
+}
+
+// A CUSTOM picklist is refused on the same terms, through the real merge.
+//
+// Its values live in the catalogue and arrive per workspace, so this is the one
+// arm that cannot be proved against the static vocabulary — and it is the arm
+// where the sets actually change under a stored filter, which is why evaluation
+// stays permissive.
+func TestStoringASegmentRefusesAValueOutsideACustomPicklist(t *testing.T) {
+	store := (&Store{}).WithFieldCatalog(stubFilterable{cols: map[string][]fieldcatalog.Column{
+		"person": {{
+			Name: "cf_region", Type: fieldcatalog.TypePicklist,
+			Options: []string{"emea", "amer"},
+		}},
+	}})
+	definition := func(value any) map[string]any {
+		return map[string]any{"field": "cf_region", "op": "eq", "value": value}
+	}
+
+	err := store.validateSegmentDefinition(context.Background(), "person", definition("APAC"))
+	var refusal *storekit.PredicateError
+	if !errors.As(err, &refusal) || refusal.Code != "filter_value_invalid" {
+		t.Fatalf("storing a value outside a custom picklist = %v, want filter_value_invalid", err)
+	}
+	if err := store.validateSegmentDefinition(
+		context.Background(), "person", definition("emea")); err != nil {
+		t.Errorf("storing one of the custom field's own values was refused: %v", err)
+	}
+}

--- a/backend/internal/platform/database/storekit/picklistrefusal.go
+++ b/backend/internal/platform/database/storekit/picklistrefusal.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RefuseUnknownPicklistValues refuses a picklist leaf whose operand is not in
+// the field's own set — at the moment a filter is STORED, and nowhere else.
+//
+// A picklist leaf compares text, so a typo compiles fine and selects nothing.
+// That is an honest answer for a value no row carries, and it is the wrong
+// answer for the person who just typed it: the equivalent list PARAMETER
+// answers 422 for the same mistake, so a saved view and a URL disagreed about
+// whether "Open" is a status.
+//
+// WHY THIS IS NOT A COMPILER CHANGE, which is the whole of the decision it
+// implements. Evaluation stays permissive: a definition stored last quarter
+// keeps comparing text, so removing a value from a custom field's option set
+// cannot make an existing view start failing at read time. Validating on write
+// catches the typo at the moment somebody makes it, in the surface that made
+// it, and no stored filter's behaviour changes.
+//
+// A SEPARATE FUNCTION rather than a strict flag on CompilePredicate, and that
+// is deliberate too. The compiler has four callers — this write validator, the
+// members evaluation, the filtered export and the preview count — and a `strict
+// bool` would put the three read paths one wrong argument away from refusing a
+// stored filter at read time, which is exactly what the decision avoids. A
+// separate call cannot be armed on a read by accident, and cannot be disarmed
+// on the write without deleting a line that says what it does.
+//
+// It also leaves the operand guarantee intact: values still travel unaltered as
+// bind parameters. This refuses BEFORE compiling and rewrites nothing.
+func RefuseUnknownPicklistValues(pred Predicate, fields map[string]Field) error {
+	for _, branch := range pred.And {
+		if err := RefuseUnknownPicklistValues(branch, fields); err != nil {
+			return err
+		}
+	}
+	for _, branch := range pred.Or {
+		if err := RefuseUnknownPicklistValues(branch, fields); err != nil {
+			return err
+		}
+	}
+	if pred.Field == "" {
+		return nil
+	}
+	field, known := fields[pred.Field]
+	// An unknown field, and an operator this type does not admit, are the
+	// compiler's refusals and it makes them a moment later with its own
+	// messages. Answering here first would give one mistake two spellings.
+	if !known || field.Type != FieldPicklist || len(field.Options) == 0 {
+		return nil
+	}
+	switch pred.Op {
+	case OpEq, OpNeq:
+		return refuseStranger(pred.Field, pred.Value, field.Options)
+	case OpIn:
+		members, ok := pred.Value.([]any)
+		if !ok {
+			// The shape is the compiler's business: `in` with a scalar is its
+			// refusal to make, in its own words.
+			return nil
+		}
+		for _, member := range members {
+			if err := refuseStranger(pred.Field, member, field.Options); err != nil {
+				return err
+			}
+		}
+	}
+	// Every other operator is unreachable on a picklist — operatorsByType
+	// admits only these four plus `exists` — so there is no fallback branch to
+	// write. `exists` is skipped because its operand is the QUESTION rather
+	// than a value: "is this set at all" names no member of the set.
+	return nil
+}
+
+// refuseStranger names the first value outside the set, and the set.
+//
+// The set is in the message because a picklist's values are the whole of what a
+// caller needs to correct the mistake, and they are already published to the
+// same client through the field vocabulary — so this discloses nothing a reader
+// could not ask for, and saves them a second request to find out what they
+// should have typed.
+//
+//craft:ignore naked-any the operand is Predicate.Value, schemaless at the wire — a JSON scalar or array, typed only by the field it names
+func refuseStranger(field string, value any, options []string) error {
+	text, ok := value.(string)
+	if !ok {
+		// A non-string operand on a picklist is the type check's refusal.
+		return nil
+	}
+	for _, option := range options {
+		if text == option {
+			return nil
+		}
+	}
+	return &PredicateError{
+		Field:   field,
+		Code:    "filter_value_invalid",
+		Message: fmt.Sprintf("%q is not a value of %s (%s)", text, field, strings.Join(options, ", ")),
+	}
+}

--- a/backend/internal/platform/database/storekit/picklistrefusal_test.go
+++ b/backend/internal/platform/database/storekit/picklistrefusal_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// picklistFields is one field of each shape the refusal has a rule for.
+var picklistFields = map[string]Field{
+	"status":  {Expr: "status", Type: FieldPicklist, Options: []string{"open", "won", "lost"}},
+	"name":    {Expr: "display_name", Type: FieldText},
+	"amount":  {Expr: "amount_minor", Type: FieldNumber},
+	"retired": {Expr: "classification", Type: FieldPicklist},
+}
+
+func TestAStoredFilterRefusesAValueOutsideItsPicklist(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		pred    Predicate
+		refused bool
+	}{
+		{"eq on a stranger", Predicate{Field: "status", Op: OpEq, Value: "Open"}, true},
+		{"neq on a stranger", Predicate{Field: "status", Op: OpNeq, Value: "Open"}, true},
+		{"in with one stranger among members", Predicate{
+			Field: "status", Op: OpIn, Value: []any{"open", "Won", "lost"},
+		}, true},
+		{"eq on a member", Predicate{Field: "status", Op: OpEq, Value: "open"}, false},
+		{"in with every member known", Predicate{
+			Field: "status", Op: OpIn, Value: []any{"open", "won"},
+		}, false},
+		// The operand is the QUESTION, not a value: "is this set at all" names
+		// no member of the set.
+		{"exists on a picklist", Predicate{Field: "status", Op: OpExists, Value: true}, false},
+		// A picklist carrying no set is a picklist this engine does not know
+		// the values of — the retired field among them — so a stored filter
+		// naming one is never refused.
+		{"a picklist with no options", Predicate{Field: "retired", Op: OpEq, Value: "anything"}, false},
+		// Not this function's refusals: the compiler makes each of them a
+		// moment later, in its own words. Answering here would give one
+		// mistake two spellings.
+		{"a field this engine does not have", Predicate{Field: "nope", Op: OpEq, Value: "x"}, false},
+		{"a text field", Predicate{Field: "name", Op: OpEq, Value: "Anything At All"}, false},
+		{"a number field", Predicate{Field: "amount", Op: OpEq, Value: 12}, false},
+		{"a non-string operand", Predicate{Field: "status", Op: OpEq, Value: 12}, false},
+		{"`in` carrying a scalar", Predicate{Field: "status", Op: OpIn, Value: "open"}, false},
+		// The walk reaches every branch, at any depth: a tree refused only at
+		// its root would let the typo through one `and` down.
+		{"a stranger nested two levels deep", Predicate{And: []Predicate{{Or: []Predicate{
+			{Field: "status", Op: OpEq, Value: "open"},
+			{Field: "status", Op: OpEq, Value: "Lost"},
+		}}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := RefuseUnknownPicklistValues(tc.pred, picklistFields)
+			if tc.refused != (err != nil) {
+				t.Fatalf("err = %v, want refused=%v", err, tc.refused)
+			}
+		})
+	}
+}
+
+// The refusal says which value, which field, and what the field admits — a
+// caller correcting a typo needs the set, and it is already published to the
+// same client through the field vocabulary.
+func TestTheRefusalNamesTheStrangerAndTheSet(t *testing.T) {
+	t.Parallel()
+	err := RefuseUnknownPicklistValues(
+		Predicate{Field: "status", Op: OpIn, Value: []any{"open", "Won", "lost"}}, picklistFields)
+	var refusal *PredicateError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("err = %v, want a PredicateError the transport maps to 422", err)
+	}
+	if refusal.Field != "status" || refusal.Code != "filter_value_invalid" {
+		t.Errorf("refusal = %+v, want the field and filter_value_invalid", refusal)
+	}
+	// The FIRST stranger, not "one of these is wrong": a message that named the
+	// clause without naming the member leaves a caller to find it themselves.
+	if !strings.Contains(refusal.Message, `"Won"`) {
+		t.Errorf("message = %q, want it to name the stranger", refusal.Message)
+	}
+	if !strings.Contains(refusal.Message, "open, won, lost") {
+		t.Errorf("message = %q, want it to name what the field admits", refusal.Message)
+	}
+}
+
+// The pairing this whole shape rests on, asserted on one tree so nothing can
+// break it silently: the value a WRITE refuses is one an already-stored
+// definition still evaluates.
+//
+// That is the decision, not an implementation detail. Making the compiler
+// strict would have a saved view written last quarter begin failing the moment
+// somebody removed a value from a custom field's option set.
+func TestAValueTheWriteRefusesIsStillEvaluatedWhenAlreadyStored(t *testing.T) {
+	t.Parallel()
+	stored := Predicate{Field: "status", Op: OpEq, Value: "Open"}
+
+	if err := RefuseUnknownPicklistValues(stored, picklistFields); err == nil {
+		t.Fatal("the write accepted a value outside the set, so this test proves nothing about the pair")
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	if _, err := CompilePredicate(stored, picklistFields, arg); err != nil {
+		t.Fatalf("the compiler refused a stored value the write would refuse: %v — evaluation must "+
+			"stay permissive, or a stored filter starts failing when its field's options change", err)
+	}
+	if len(args) != 1 || args[0] != "Open" {
+		t.Errorf("the value did not travel as a bind parameter: %#v", args)
+	}
+}


### PR DESCRIPTION
Closes #1851, on the ruling recorded there: **refuse on write, stay permissive
on read.**

## The divergence

A picklist leaf compares text, so a value outside the field's set compiles fine
and selects nothing. The **list parameter** for the same fact answers 422. A
typo in a saved view or a dynamic list was silently a filter that matched
nothing; the same typo on a URL was told to the caller.

## Why the split is the decision

Making the compiler strict would have a saved view written last quarter begin
failing at read time the moment somebody removed a value from a custom field's
option set — the class of problem the retired `classification` field already had
to survive. Validating on write catches the typo where somebody makes it, in the
surface that made it, and **no stored filter's behaviour changes.**

`RefuseUnknownPicklistValues` is a separate function rather than a `strict bool`
on `CompilePredicate`, for the reason the ruling gives: the compiler has four
callers — this validator, members evaluation, filtered export, the preview count
— and a flag would put the three read paths one wrong argument away from
refusing a stored filter at read time. A separate call cannot be armed on a read
by accident, and cannot be disarmed on the write without deleting a line that
says what it does.

It refuses **before** compiling and rewrites nothing, so storekit's operand
guarantee is untouched: values still travel as bind parameters.

## What it deliberately lets through

Each of these is somebody else's refusal a moment later, and one mistake must
not have two spellings:

| let through | because |
|---|---|
| a picklist with empty `Options` | the engine does not know the set — the retired `classification` among them, so a view naming it is never refused |
| `exists` | the operand is the *question*, not a value |
| an unknown field, a mistyped type, `in` with a scalar | the compiler's own refusals, in its own words |

No fallback branch for other operators, because `operatorsByType` admits only
`eq`/`neq`/`in`/`exists` on a picklist — the type check upstream owns the rest.

## The acceptance list

- ✅ storing `{"field":"relationship_type","op":"eq","value":"custmer"}` answers
  `filter_value_invalid`, through the real `validateSegmentDefinition`
- ✅ **a definition stored before the check still evaluates — asserted on the
  same tree as the refusal**, so nothing can break the pairing silently
- ✅ `in` with one bad member among good ones is refused and names it
- ✅ `exists` on a picklist, and any clause on retired `classification`, are
  never refused
- ✅ a custom picklist refuses a value outside the catalogue's set, through the
  real merge — the arm that matters most, since those sets actually change under
  a stored filter

`TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt` is untouched.
It asserts the READ behaviour this does not change, and it is what fails if
somebody later makes the engine strict without deciding to.

## Checks

- `make check-backend` green; `craft static --strict` clean.
- `make test-it DIR=backend/internal/modules/collections` green.
- Mutation-checked: removing the call from the write path turns both end-to-end
  cases red; skipping the `in` members turns the naming case red.