### PR TITLE
A domain leaf folds its operand, so both surfaces answer the same

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33568,10 +33568,18 @@ components:
             since the catalog owns labels and this vocabulary does not.
         type:
           type: string
-          enum: [text, number, date, currency, picklist, boolean, id]
+          enum: [text, number, date, currency, picklist, boolean, id, domain]
           description: |
-            The six custom-field types plus `id` for a reference to another
-            record. The type decides the operators, which is why it is here.
+            The six custom-field types, plus `id` for a reference to another record and
+            `domain` for a host column. The type decides the operators, which is why it is here.
+
+            `domain` also decides what happens to the VALUE, and it is the only type that does:
+            the operand is folded to the host the column stores, so
+            `https://www.acme.example/careers`, `WWW.Acme.Example` and `acme.example` are one
+            filter. A builder can offer a plain text box for it — the server reads the domain out
+            of whatever the reader pastes, and refuses a value no domain can be read from rather
+            than matching nothing. `contains` is absent from its operators for the same reason:
+            a folded value has no fragment to match against.
         operators:
           type: array
           description: |

--- a/backend/gates/filtervocabularyparity_test.go
+++ b/backend/gates/filtervocabularyparity_test.go
@@ -70,6 +70,12 @@ var correspondingTypes = map[string]string{
 	"FieldBoolean":  "KindBoolean",
 	"FieldPicklist": "KindText",
 	"FieldCurrency": "KindNumber",
+	// A domain column is text as far as search's structured where is
+	// concerned: it compares the stored string. What storekit adds is the
+	// FOLDING of the operand before it binds, which is a normalization rather
+	// than a different question — so the two surfaces are comparable, and the
+	// operator difference below is the real one.
+	"FieldDomain": "KindText",
 }
 
 // declaredDifferences ratifies each operator one surface offers and the other
@@ -83,6 +89,7 @@ var declaredDifferences = gatekit.Waive(map[string]string{
 	"FieldDate/exists":     exists,
 	"FieldBoolean/exists":  exists,
 	"FieldPicklist/exists": exists,
+	"FieldDomain/exists":   exists,
 	"FieldCurrency/exists": exists,
 	"FieldText/contains":   "search declares no `contains` operator. Its structured `where` answers exact and ordering comparisons; approximate text is the free-text half of the same request, not a structured operator. storekit has no free-text half, so `contains` is the only way to ask there. The split is real, but nothing states it as a decision — it is how the two surfaces were built.",
 	"FieldBoolean/neq":     "search offers `eq` alone on a boolean, its vocabulary saying `neq true` is `eq false`. THAT REASONING NO LONGER HOLDS: with neq NULL-safe, `neq true` selects false AND unset, which `eq false` does not. storekit's boolean neq now answers a question search cannot express. Waived because closing it is a product decision about search's vocabulary, not a repair.",

--- a/backend/internal/compose/filtervocabularyenums_test.go
+++ b/backend/internal/compose/filtervocabularyenums_test.go
@@ -105,11 +105,25 @@ func TestTheVocabularysReferenceEnumIsExactlyWhatTheEngineDeclares(t *testing.T)
 		"the contract advertises it and no id field points at it, so no field can ever report it")
 }
 
-// everyFilterableFieldType is the six custom-field types plus id, which only a
-// core field carries. Derived from fieldcatalog.Types() so a seventh custom type
-// joins these gates by existing rather than by somebody remembering them.
+// everyFilterableFieldType is the six custom-field types plus the two only a
+// CORE field carries. The custom half is derived from fieldcatalog.Types(), so a
+// seventh custom type joins these gates by existing rather than by somebody
+// remembering them.
+//
+// The core-only half is listed, because there is nowhere to derive it from: a
+// custom field cannot be an id or a domain — the catalogue offers neither — so
+// no catalogue read would ever report them. Listing them is what makes this
+// helper's set the same set the contract enum must carry, and adding a third
+// core-only type here is the deliberate act of widening a public enum.
+var coreOnlyFieldTypes = []storekit.FieldType{
+	// A reference to another record.
+	storekit.FieldID,
+	// A host column, whose operand is folded to the host the column stores.
+	storekit.FieldDomain,
+}
+
 func everyFilterableFieldType() []storekit.FieldType {
-	types := []storekit.FieldType{storekit.FieldID}
+	types := append([]storekit.FieldType{}, coreOnlyFieldTypes...)
 	for _, declared := range fieldcatalog.Types() {
 		types = append(types, storekit.FieldType(declared))
 	}

--- a/backend/internal/compose/integration/domainleafparity_integration_test.go
+++ b/backend/internal/compose/integration/domainleafparity_integration_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A pasted URL and a bare host select the same account on BOTH surfaces that
+// filter organizations by domain.
+//
+// The list parameter has folded its value all along — a caller who pasted
+// `https://www.acme.example/careers` out of an email signature is asking about
+// `acme.example`, which is what the column holds. A segment leaf did not, so
+// one product fact answered two different questions depending on which surface
+// asked: the list found the account and the saved view found nothing.
+//
+// ONE test over both, because "the same answer" is the claim. Two tests would
+// each keep passing while the surfaces drifted apart, which is the state this
+// was filed about.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/collections"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestADomainFilterAnswersTheSameAccountOnBothSurfaces(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+	lists := collections.NewStore(e.DB())
+
+	acme := seedOrgWithDomain(t, e, "Acme", "acme.example")
+	seedOrgWithDomain(t, e, "Other", "other.example")
+
+	// The three spellings of one question: what the column holds, the same
+	// with a subdomain and a path, and a difference of case alone.
+	for _, asked := range []string{
+		"acme.example",
+		"https://www.acme.example/careers",
+		"ACME.Example",
+	} {
+		t.Run(asked, func(t *testing.T) {
+			listed, _, err := e.People.ListOrganizations(admin, people.ListOrganizationsInput{Domain: &asked})
+			if err != nil {
+				t.Fatalf("the list parameter refused %q: %v", asked, err)
+			}
+			if len(listed) != 1 || ids.UUID(listed[0].Id) != acme {
+				t.Fatalf("the list answered %d account(s) for %q, want only Acme", len(listed), asked)
+			}
+
+			segment, err := lists.CreateList(admin, collections.CreateListInput{
+				Name: "by domain " + asked, EntityType: "organization", ListType: "dynamic",
+				Definition: map[string]any{"field": "domain", "op": "eq", "value": asked},
+			})
+			if err != nil {
+				t.Fatalf("storing a segment on %q: %v — the leaf refuses a value the list accepts, "+
+					"so a reader can filter by domain on one surface and not the other", asked, err)
+			}
+			members, _, err := lists.ListMembers(admin, segment.ID, 50, "")
+			if err != nil {
+				t.Fatalf("evaluating the segment: %v", err)
+			}
+			if len(members) != 1 || members[0].EntityID != acme {
+				t.Fatalf("the segment answered %d member(s) for %q, want the same one account the "+
+					"list answered", len(members), asked)
+			}
+		})
+	}
+}
+
+// A value no domain can be read from is REFUSED rather than folded to empty.
+// Empty would bind and match nothing, which reads to a caller exactly like a
+// domain nobody uses — and in a saved view the mistake would stay invisible.
+func TestASegmentRefusesAValueThatIsNotADomain(t *testing.T) {
+	e := Setup(t)
+	lists := collections.NewStore(e.DB())
+
+	_, err := lists.CreateList(e.Admin(), collections.CreateListInput{
+		Name: "not a domain", EntityType: "organization", ListType: "dynamic",
+		Definition: map[string]any{"field": "domain", "op": "eq", "value": "not a domain at all"},
+	})
+	if err == nil {
+		t.Fatal("a segment stored a domain leaf whose value is not a domain; it would match nothing " +
+			"and read as an account nobody has")
+	}
+}
+
+// seedOrgWithDomain creates an account carrying one domain, through the real
+// writer — the column the leaf reads is written by CreateOrganization's own
+// domain path, and a fixture inserting the row itself would prove nothing about
+// the form that path stores.
+func seedOrgWithDomain(t *testing.T, e *Env, name, domain string) ids.UUID {
+	t.Helper()
+	org, err := e.People.CreateOrganization(e.Admin(), people.CreateOrganizationInput{
+		DisplayName: name,
+		Domains:     []people.OrgDomainInput{{Domain: domain, IsPrimary: true}},
+		Source:      "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding %s: %v", name, err)
+	}
+	return ids.UUID(org.Id)
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -5658,6 +5658,7 @@ const (
 	FilterVocabularyFieldTypeBoolean  FilterVocabularyFieldType = "boolean"
 	FilterVocabularyFieldTypeCurrency FilterVocabularyFieldType = "currency"
 	FilterVocabularyFieldTypeDate     FilterVocabularyFieldType = "date"
+	FilterVocabularyFieldTypeDomain   FilterVocabularyFieldType = "domain"
 	FilterVocabularyFieldTypeId       FilterVocabularyFieldType = "id"
 	FilterVocabularyFieldTypeNumber   FilterVocabularyFieldType = "number"
 	FilterVocabularyFieldTypePicklist FilterVocabularyFieldType = "picklist"
@@ -5672,6 +5673,8 @@ func (e FilterVocabularyFieldType) Valid() bool {
 	case FilterVocabularyFieldTypeCurrency:
 		return true
 	case FilterVocabularyFieldTypeDate:
+		return true
+	case FilterVocabularyFieldTypeDomain:
 		return true
 	case FilterVocabularyFieldTypeId:
 		return true
@@ -23624,8 +23627,16 @@ type FilterVocabularyField struct {
 	// `id`, so only a core field can carry a reference.
 	References *FilterVocabularyFieldReferences `json:"references,omitempty"`
 
-	// Type The six custom-field types plus `id` for a reference to another
-	// record. The type decides the operators, which is why it is here.
+	// Type The six custom-field types, plus `id` for a reference to another record and
+	// `domain` for a host column. The type decides the operators, which is why it is here.
+	//
+	// `domain` also decides what happens to the VALUE, and it is the only type that does:
+	// the operand is folded to the host the column stores, so
+	// `https://www.acme.example/careers`, `WWW.Acme.Example` and `acme.example` are one
+	// filter. A builder can offer a plain text box for it — the server reads the domain out
+	// of whatever the reader pastes, and refuses a value no domain can be read from rather
+	// than matching nothing. `contains` is absent from its operators for the same reason:
+	// a folded value has no fragment to match against.
 	Type FilterVocabularyFieldType `json:"type"`
 }
 
@@ -23643,8 +23654,16 @@ type FilterVocabularyFieldOperators string
 // `id`, so only a core field can carry a reference.
 type FilterVocabularyFieldReferences string
 
-// FilterVocabularyFieldType The six custom-field types plus `id` for a reference to another
-// record. The type decides the operators, which is why it is here.
+// FilterVocabularyFieldType The six custom-field types, plus `id` for a reference to another record and
+// `domain` for a host column. The type decides the operators, which is why it is here.
+//
+// `domain` also decides what happens to the VALUE, and it is the only type that does:
+// the operand is folded to the host the column stores, so
+// `https://www.acme.example/careers`, `WWW.Acme.Example` and `acme.example` are one
+// filter. A builder can offer a plain text box for it — the server reads the domain out
+// of whatever the reader pastes, and refuses a value no domain can be read from rather
+// than matching nothing. `contains` is absent from its operators for the same reason:
+// a folded value has no fragment to match against.
 type FilterVocabularyFieldType string
 
 // FilteredExportRequest A filtered export request. Supply exactly ONE source: an inline `object` (with a required `filter`) or a `view_id` (a saved view whose filter state is exported). The slice is always row-scoped to the caller through the one filter engine.

--- a/backend/internal/modules/collections/vocab_test.go
+++ b/backend/internal/modules/collections/vocab_test.go
@@ -314,10 +314,13 @@ func TestTheDomainLeafExcludesRemovedRows(t *testing.T) {
 	if !strings.Contains(field.Link, "od.organization_id = t.id") {
 		t.Errorf("the domain leaf does not correlate to the account: %q", field.Link)
 	}
-	// Text, not a picklist: there is no enum of domains to compare against, and
-	// a picklist leaf with no Options would refuse every value a caller sent.
-	if field.Type != storekit.FieldText {
-		t.Errorf("the domain leaf is typed %v, want text", field.Type)
+	// Domain, not text: the column stores a host, and the type is what folds a
+	// caller's pasted URL to it. Typed text, this leaf accepted
+	// `https://www.acme.example/careers` and matched nothing, while the list
+	// parameter for the same fact answered the account — one product fact
+	// giving two answers depending on which surface asked.
+	if field.Type != storekit.FieldDomain {
+		t.Errorf("the domain leaf is typed %v, want domain", field.Type)
 	}
 }
 

--- a/backend/internal/modules/collections/vocabaccountleaves.go
+++ b/backend/internal/modules/collections/vocabaccountleaves.go
@@ -53,13 +53,26 @@ var relationshipTypeField = storekit.Field{
 // naming it would otherwise keep selecting on a fact somebody deliberately
 // removed.
 //
-// FieldText rather than a picklist: a domain is free text with no enum to
-// compare against, and the column is stored lower-cased (org_domain_norm), so a
-// caller's value matches the stored form only when they spell it the same way.
-// That is the same contract every other text leaf here offers.
+// FieldDomain rather than text, and that is the difference between this leaf
+// answering the question and merely accepting it. The column stores a host, and
+// a caller pasting `https://www.acme.example/careers` out of an email signature
+// is asking about `acme.example` — the organization LIST has folded its own
+// `domain` parameter that way all along, so a text leaf here made one product
+// fact answer two different questions depending on which surface asked.
+//
+// It also settles the operators: `contains` is not offered, because folding a
+// fragment to a host and then substring-matching it would answer something
+// nobody asked. Equality, membership and presence are what a normalized value
+// can honestly support.
+//
+// One difference from the list parameter, stated because it is real rather than
+// an oversight: liveness. The list's domain clause follows the caller's
+// `include_archived`; this engine's BaseWhere pins `archived_at IS NULL`
+// unconditionally, so the leaf answers over live accounts. That is consistent
+// with every other leaf on this engine, which is the property worth keeping.
 var domainField = storekit.Field{
 	Expr: "od.domain",
-	Type: storekit.FieldText,
+	Type: storekit.FieldDomain,
 	Link: "EXISTS (SELECT 1 FROM organization_domain od" +
 		" WHERE od.organization_id = t.id AND od.archived_at IS NULL AND %s)",
 }

--- a/backend/internal/platform/database/storekit/predicate.go
+++ b/backend/internal/platform/database/storekit/predicate.go
@@ -47,104 +47,6 @@ const (
 	PredicateRowLimit = 1000
 )
 
-// FieldType types a filterable field (features/10 §3: typed operators
-// per field type). It decides which operators apply and how a leaf's
-// value is validated before it may become a bind parameter.
-type FieldType string
-
-const (
-	FieldText     FieldType = "text"
-	FieldNumber   FieldType = "number"
-	FieldDate     FieldType = "date"
-	FieldCurrency FieldType = "currency"
-	FieldPicklist FieldType = "picklist"
-	FieldBoolean  FieldType = "boolean"
-	// FieldID covers the allow-list's UUID reference columns (owner_id,
-	// stage_id, …): equality/membership only, value must parse as a UUID
-	// so a malformed id fails validation (422), never query execution.
-	FieldID FieldType = "id"
-)
-
-// Field is one entry of a resource's closed filter vocabulary: the API
-// name maps to a fixed SQL expression (table alias included, e.g.
-// "t.owner_id") plus its type. Only expressions from this map ever
-// reach the query text.
-type Field struct {
-	Expr string
-	Type FieldType
-	// Link makes this a correlated-subquery leaf rather than a base-table
-	// one: Expr names the column INSIDE the subquery, and Link is the
-	// EXISTS template — exactly one %s — the compiled comparison is
-	// substituted into. It exists because some filterable facts are link
-	// rows rather than columns (a tag lives in the polymorphic taggable
-	// join), and a link row is present or absent where a column is null
-	// or not. Empty for every base-table field.
-	Link string
-	// References names the record type this field's ids point at, for a
-	// surface that has to offer the record rather than ask for its uuid.
-	//
-	// The compiler has no use for it — an id compares as an id whatever it
-	// refers to — so it sits here for one reason: this is where a field is
-	// declared, and a lookup table keyed by field name elsewhere would be a
-	// second list of the engine's fields for a new leaf to fall out of.
-	//
-	// It is required of every id field in a vocabulary that is PUBLISHED to a
-	// client — the collections segment engines, gated by
-	// TestEveryIDFieldDeclaresWhatItReferences — and left empty everywhere
-	// else. An engine built to answer a count nobody reads a field list from
-	// (automation's preview vocabularies) owes no target, because nothing can
-	// offer a picker for it.
-	References Reference
-	// Options is a picklist field's allowed values, for a surface that has to
-	// OFFER them. Empty for every other type, and empty for a picklist whose
-	// values this engine does not know.
-	//
-	// ADVERTISEMENT only: compileLeaf does not refuse a value outside the set, and
-	// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt holds that
-	// so the behaviour is gated rather than assumed. Refusing would be a live-API
-	// change — a saved segment holding a value since removed from its set would
-	// begin failing at read time — which is why the set travels first and the
-	// refusal is a separate call to make.
-	//
-	// What this fixes meanwhile is the surface: a builder that knows the values
-	// offers them instead of asking a reader to type one, which is how a typo
-	// became a filter that matched nothing and read as a settled answer.
-	Options []string
-}
-
-// Reference is a record type an id field's values point at. Named rather than a
-// bare string so an unlisted target cannot be assigned, the same way FieldType
-// closes the type column above it.
-type Reference string
-
-// The record types a FieldID field may reference. The values are the contract's
-// own record-type words (`app_user`, not `user`), so a client keying a picker on
-// them needs no translation table.
-const (
-	RefTag          Reference = "tag"
-	RefAppUser      Reference = "app_user"
-	RefTeam         Reference = "team"
-	RefOrganization Reference = "organization"
-	RefPipeline     Reference = "pipeline"
-	RefStage        Reference = "stage"
-	RefProject      Reference = "project"
-)
-
-// ReferenceTargets is every target the engine admits, and the ONE list of them.
-//
-// A function beside the constants rather than a slice restated in each test that
-// needs it — the shape fieldcatalog.Types() already uses for the same reason. The
-// point is which drift stays catchable: a constant absent here fails the sweep
-// over the engines, and an entry here absent from the contract's enum fails the
-// parity gate in compose. Restating this set in either test would make both gates
-// pass on a stale copy of it, which is the one failure they exist to catch.
-func ReferenceTargets() []Reference {
-	return []Reference{
-		RefTag, RefAppUser, RefTeam, RefOrganization,
-		RefPipeline, RefStage, RefProject,
-	}
-}
-
 // Predicate is the canonical filter tree (the representation
 // saved_view.query and dynamic-list definitions carry). Exactly one of
 // And, Or, or the leaf triple (Field+Op) is set per node; anything else
@@ -181,6 +83,11 @@ const (
 var operatorsByType = map[FieldType]map[string]bool{
 	FieldText:     {OpEq: true, OpNeq: true, OpIn: true, OpContains: true, OpExists: true},
 	FieldPicklist: {OpEq: true, OpNeq: true, OpIn: true, OpExists: true},
+	// No `contains`, and the omission is the type's whole point: folding
+	// `acme` yields a host and then substring-matching it would answer a
+	// question nobody asked. The equality family is what a normalized value
+	// can honestly support.
+	FieldDomain:   {OpEq: true, OpNeq: true, OpIn: true, OpExists: true},
 	FieldID:       {OpEq: true, OpNeq: true, OpIn: true, OpExists: true},
 	FieldNumber:   {OpEq: true, OpNeq: true, OpGt: true, OpGte: true, OpLt: true, OpLte: true, OpIn: true, OpExists: true},
 	FieldCurrency: {OpEq: true, OpNeq: true, OpGt: true, OpGte: true, OpLt: true, OpLte: true, OpIn: true, OpExists: true},

--- a/backend/internal/platform/database/storekit/predicate_test.go
+++ b/backend/internal/platform/database/storekit/predicate_test.go
@@ -442,6 +442,7 @@ func operandFor(t FieldType, op string) any { //craft:ignore naked-any mirrors P
 		FieldCurrency: float64(1000),
 		FieldDate:     "2026-08-19",
 		FieldBoolean:  true,
+		FieldDomain:   "acme.example",
 	}[t]
 	if op == OpIn {
 		return []any{scalar}
@@ -496,4 +497,79 @@ func TestALinkedFieldAdvertisesExactlyWhatItCanCompile(t *testing.T) {
 func isOpNotAllowed(err error) bool {
 	var predicateErr *PredicateError
 	return errors.As(err, &predicateErr) && predicateErr.Code == CodeFilterOpNotAllowed
+}
+
+// A domain field does not advertise `contains`, and the reason is the folding
+// rather than a preference.
+//
+// Its operand is normalized to a host before it binds, so `contains: "acme"`
+// would fold a fragment to a domain and then substring-match the result — a
+// question nobody asked, answered confidently. The equality family is what a
+// value the engine rewrote can honestly support.
+//
+// Asserted here rather than left to the operator matrix's shape, because the
+// matrix is a table anybody can add a line to and this is the one entry whose
+// absence carries an argument.
+func TestADomainFieldDoesNotOfferContainsBecauseItsOperandIsFolded(t *testing.T) {
+	t.Parallel()
+	field := Field{Expr: "od.domain", Type: FieldDomain}
+	for _, op := range OperatorsFor(field) {
+		if op == OpContains {
+			t.Fatalf("a domain field offers %q: folding a fragment to a host and matching it as a "+
+				"substring answers a question nobody asked", OpContains)
+		}
+	}
+	// The equality family IS offered, so the assertion above is about
+	// `contains` rather than about the type being unusable.
+	offered := map[string]bool{}
+	for _, op := range OperatorsFor(field) {
+		offered[op] = true
+	}
+	for _, want := range []string{OpEq, OpNeq, OpIn, OpExists} {
+		if !offered[want] {
+			t.Errorf("a domain field does not offer %q", want)
+		}
+	}
+}
+
+// The folding itself, at the seam: what binds is the host, whatever the caller
+// pasted — and a value no domain can be read from is refused rather than folded
+// to empty, which would bind and match nothing while reading like a domain
+// nobody uses.
+func TestADomainOperandBindsTheHostTheColumnHolds(t *testing.T) {
+	t.Parallel()
+	fields := map[string]Field{"domain": {Expr: "t.domain", Type: FieldDomain}}
+	cases := []struct {
+		name, sent, bound string
+	}{
+		{"the bare host", "acme.example", "acme.example"},
+		{"a pasted URL", "https://www.acme.example/careers", "acme.example"},
+		{"case alone", "ACME.Example", "acme.example"},
+		{"a www prefix", "www.acme.example", "acme.example"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var args []any
+			arg := func(v any) int { args = append(args, v); return len(args) }
+			if _, err := CompilePredicate(leaf("domain", OpEq, tc.sent), fields, arg); err != nil {
+				t.Fatalf("compiling %q: %v", tc.sent, err)
+			}
+			if len(args) != 1 || args[0] != tc.bound {
+				t.Errorf("%q bound %#v, want %q — the column stores the host", tc.sent, args, tc.bound)
+			}
+		})
+	}
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	_, err := CompilePredicate(leaf("domain", OpEq, "not a domain at all"), fields, arg)
+	var refusal *PredicateError
+	if !errors.As(err, &refusal) || refusal.Code != CodeFilterValueInvalid {
+		t.Fatalf("a value that is not a domain = %v, want a filter_value_invalid refusal", err)
+	}
+	if len(args) != 0 {
+		t.Errorf("the unusable value still bound %#v — an empty bind matches nothing and reads "+
+			"exactly like a domain nobody has", args)
+	}
 }

--- a/backend/internal/platform/database/storekit/predicatefields.go
+++ b/backend/internal/platform/database/storekit/predicatefields.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+// The filter VOCABULARY: what a field is, what it may point at, and the types
+// that decide both. Split from the compiler beside it because they are two
+// subjects with different readers — this one is what every surface that
+// OFFERS a filter reads (the vocabulary endpoint, the builders behind it),
+// while the compiler is read by nobody but the engine.
+
+// FieldType types a filterable field (features/10 §3: typed operators
+// per field type). It decides which operators apply and how a leaf's
+// value is validated before it may become a bind parameter.
+type FieldType string
+
+// The filterable field types. Six of them are what a custom field may be; the
+// last two are core-only, because the catalogue offers neither.
+const (
+	FieldText     FieldType = "text"
+	FieldNumber   FieldType = "number"
+	FieldDate     FieldType = "date"
+	FieldCurrency FieldType = "currency"
+	FieldPicklist FieldType = "picklist"
+	FieldBoolean  FieldType = "boolean"
+	// FieldID covers the allow-list's UUID reference columns (owner_id,
+	// stage_id, …): equality/membership only, value must parse as a UUID
+	// so a malformed id fails validation (422), never query execution.
+	FieldID FieldType = "id"
+	// FieldDomain is a host column, and it is a type rather than text because
+	// the operand is NORMALIZED before it binds: a caller who pasted
+	// `https://www.acme.example/careers` out of an email signature is asking
+	// about `acme.example`, which is what the column holds.
+	//
+	// The organization LIST already folds its `domain` parameter that way, so
+	// without a type here one product fact would answer two different questions
+	// depending on which surface asked — a saved view returning nothing for the
+	// URL the list matches.
+	//
+	// Folding is the one place this engine touches an operand, and the type is
+	// what keeps that bounded: every other value still reaches SQL exactly as it
+	// arrived. A per-field transform would have bought the same behaviour by
+	// making arbitrary rewriting possible everywhere, which is the guarantee
+	// that makes "selects nothing" safe rather than merely unhelpful.
+	FieldDomain FieldType = "domain"
+)
+
+// Field is one entry of a resource's closed filter vocabulary: the API
+// name maps to a fixed SQL expression (table alias included, e.g.
+// "t.owner_id") plus its type. Only expressions from this map ever
+// reach the query text.
+type Field struct {
+	Expr string
+	Type FieldType
+	// Link makes this a correlated-subquery leaf rather than a base-table
+	// one: Expr names the column INSIDE the subquery, and Link is the
+	// EXISTS template — exactly one %s — the compiled comparison is
+	// substituted into. It exists because some filterable facts are link
+	// rows rather than columns (a tag lives in the polymorphic taggable
+	// join), and a link row is present or absent where a column is null
+	// or not. Empty for every base-table field.
+	Link string
+	// References names the record type this field's ids point at, for a
+	// surface that has to offer the record rather than ask for its uuid.
+	//
+	// The compiler has no use for it — an id compares as an id whatever it
+	// refers to — so it sits here for one reason: this is where a field is
+	// declared, and a lookup table keyed by field name elsewhere would be a
+	// second list of the engine's fields for a new leaf to fall out of.
+	//
+	// It is required of every id field in a vocabulary that is PUBLISHED to a
+	// client — the collections segment engines, gated by
+	// TestEveryIDFieldDeclaresWhatItReferences — and left empty everywhere
+	// else. An engine built to answer a count nobody reads a field list from
+	// (automation's preview vocabularies) owes no target, because nothing can
+	// offer a picker for it.
+	References Reference
+	// Options is a picklist field's allowed values, for a surface that has to
+	// OFFER them. Empty for every other type, and empty for a picklist whose
+	// values this engine does not know.
+	//
+	// ADVERTISEMENT only: compileLeaf does not refuse a value outside the set, and
+	// TestAPicklistLeafComparesAnUnrecognisedValueRatherThanRefusingIt holds that
+	// so the behaviour is gated rather than assumed. Refusing would be a live-API
+	// change — a saved segment holding a value since removed from its set would
+	// begin failing at read time — which is why the set travels first and the
+	// refusal is a separate call to make.
+	//
+	// What this fixes meanwhile is the surface: a builder that knows the values
+	// offers them instead of asking a reader to type one, which is how a typo
+	// became a filter that matched nothing and read as a settled answer.
+	Options []string
+}
+
+// Reference is a record type an id field's values point at. Named rather than a
+// bare string so an unlisted target cannot be assigned, the same way FieldType
+// closes the type column above it.
+type Reference string
+
+// The record types a FieldID field may reference. The values are the contract's
+// own record-type words (`app_user`, not `user`), so a client keying a picker on
+// them needs no translation table.
+const (
+	RefTag          Reference = "tag"
+	RefAppUser      Reference = "app_user"
+	RefTeam         Reference = "team"
+	RefOrganization Reference = "organization"
+	RefPipeline     Reference = "pipeline"
+	RefStage        Reference = "stage"
+	RefProject      Reference = "project"
+)
+
+// ReferenceTargets is every target the engine admits, and the ONE list of them.
+//
+// A function beside the constants rather than a slice restated in each test that
+// needs it — the shape fieldcatalog.Types() already uses for the same reason. The
+// point is which drift stays catchable: a constant absent here fails the sweep
+// over the engines, and an entry here absent from the contract's enum fails the
+// parity gate in compose. Restating this set in either test would make both gates
+// pass on a stale copy of it, which is the one failure they exist to catch.
+func ReferenceTargets() []Reference {
+	return []Reference{
+		RefTag, RefAppUser, RefTeam, RefOrganization,
+		RefPipeline, RefStage, RefProject,
+	}
+}

--- a/backend/internal/platform/database/storekit/predicateoperand.go
+++ b/backend/internal/platform/database/storekit/predicateoperand.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // comparisonSQL is closed over the operator constants above; compileLeaf
@@ -65,6 +66,8 @@ func inOperand(p Predicate, field Field) (any, error) {
 		return inNumberOperand(raw, field, p.Field)
 	case FieldCurrency:
 		return inCurrencyOperand(raw, field, p.Field)
+	case FieldDomain:
+		return inDomainOperand(raw, p.Field)
 	default: // text, picklist, id — string-valued types (dates take no `in`).
 		return inStringOperand(raw, field, p.Field)
 	}
@@ -144,6 +147,8 @@ func scalarOperand(value any, field Field, name, op string) (any, error) {
 	switch field.Type {
 	case FieldText, FieldPicklist:
 		return scalarStringOperand(value, invalid, "a string")
+	case FieldDomain:
+		return scalarDomainOperand(value, invalid)
 	case FieldID:
 		return scalarUUIDOperand(value, invalid)
 	case FieldNumber:
@@ -286,3 +291,55 @@ func scalarBoolOperand(value any, invalid func(string) error) (any, error) {
 // % and _ and the escape character itself must match themselves, and Postgres'
 // default LIKE escape is backslash, so the compiled predicate needs no ESCAPE
 // clause of its own.
+
+// scalarDomainOperand folds a domain operand to the host the column stores.
+//
+// `https://www.acme.example/careers`, `WWW.Acme.Example` and `acme.example` are
+// one question, and values.ParseDomain is the answer the organization list
+// already gives it — the same function on both surfaces, so the two answer the
+// same rows.
+//
+// Held by: TestADomainFilterAnswersTheSameAccountOnBothSurfaces
+// (backend/internal/compose/integration/domainleafparity_integration_test.go)
+//
+// A value that is not a domain at all is refused rather than folded to empty.
+// Empty would bind and match nothing, which reads to a caller exactly like a
+// domain nobody uses, and the mistake would stay invisible in a saved view.
+//
+//craft:ignore naked-any value is a decoded JSON filter operand and the return a bind parameter — scalarOperand's own span across the SQL scalar types
+func scalarDomainOperand(value any, invalid func(string) error) (any, error) {
+	text, ok := value.(string)
+	if !ok {
+		return nil, invalid("a domain")
+	}
+	parsed, err := values.ParseDomain(text)
+	if err != nil {
+		return nil, invalid("a domain, or a URL one can be read from")
+	}
+	return parsed.String(), nil
+}
+
+// inDomainOperand folds every member of an `in` list, refusing the first that
+// is not a domain — the same rule as the scalar arm, applied per member so one
+// bad entry is named rather than silently matching nothing.
+func inDomainOperand(raw []any, name string) ([]string, error) {
+	out := make([]string, 0, len(raw))
+	for _, member := range raw {
+		text, ok := member.(string)
+		if !ok {
+			return nil, &PredicateError{
+				Field: name, Code: CodeFilterValueInvalid,
+				Message: "in on a domain field takes strings",
+			}
+		}
+		parsed, err := values.ParseDomain(text)
+		if err != nil {
+			return nil, &PredicateError{
+				Field: name, Code: CodeFilterValueInvalid,
+				Message: fmt.Sprintf("%q is not a domain, or a URL one can be read from", text),
+			}
+		}
+		out = append(out, parsed.String())
+	}
+	return out, nil
+}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -571,7 +571,7 @@ internal/platform/database/statementbudget.go#func BoundStatement
 internal/platform/database/storekit/claim.go#func ClaimOwnership
 internal/platform/database/storekit/customcolumns.go#func quoteColumnIdentifier
 internal/platform/database/storekit/patch.go#func PlainDate
-internal/platform/database/storekit/predicate.go#func ReferenceTargets
+internal/platform/database/storekit/predicatefields.go#func ReferenceTargets
 internal/platform/database/storekit/query.go#method Query.CountMatching
 internal/platform/database/storekit/sqlstate.go#const block at const pgUniqueViolation
 internal/platform/database/storekit/sqlstate.go#func pgViolation

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24689,11 +24689,19 @@ export interface components {
              */
             name: string;
             /**
-             * @description The six custom-field types plus `id` for a reference to another
-             *     record. The type decides the operators, which is why it is here.
+             * @description The six custom-field types, plus `id` for a reference to another record and
+             *     `domain` for a host column. The type decides the operators, which is why it is here.
+             *
+             *     `domain` also decides what happens to the VALUE, and it is the only type that does:
+             *     the operand is folded to the host the column stores, so
+             *     `https://www.acme.example/careers`, `WWW.Acme.Example` and `acme.example` are one
+             *     filter. A builder can offer a plain text box for it — the server reads the domain out
+             *     of whatever the reader pastes, and refuses a value no domain can be read from rather
+             *     than matching nothing. `contains` is absent from its operators for the same reason:
+             *     a folded value has no fragment to match against.
              * @enum {string}
              */
-            type: "text" | "number" | "date" | "currency" | "picklist" | "boolean" | "id";
+            type: "text" | "number" | "date" | "currency" | "picklist" | "boolean" | "id" | "domain";
             /**
              * @description The operator subset this field's type admits (LVS-PARAM-1), in one
              *     stable order. An operator absent here is one the engine refuses for


### PR DESCRIPTION
Closes #1848, on the ruling: **option 1, a normalizing `storekit.FieldDomain`.**

## The defect, reproduced

The organization list has folded its `domain` parameter all along — a caller who
pasted `https://www.acme.example/careers` out of an email signature is asking
about `acme.example`, which is what the column holds. A segment leaf typed it as
text and did not.

So one product fact answered two different questions depending on which surface
asked: the list found the account, the saved view found nothing and said so
confidently. Reverting the type in this branch reproduces it exactly — the
parity test reports `0 member(s)` for the URL and for the difference of case,
while the list answers the account for both.

## Why a type rather than a per-field transform

Folding is the one place this engine touches an operand, and the **type** is
what keeps that bounded: every other value still reaches SQL exactly as it
arrived. A transform hook buys the same behaviour by making arbitrary rewriting
possible everywhere, and that guarantee is what makes "selects nothing" safe
rather than merely unhelpful.

A value no domain can be read from is **refused**, not folded to empty. Empty
would bind and match nothing — indistinguishable from a domain nobody uses, and
in a stored filter the mistake would never surface.

## The two semantics the ruling asked to be stated

- **Operators.** No `contains`: folding a fragment to a host and then
  substring-matching the result answers a question nobody asked. Asserted with
  the reason in the test name, rather than left to the shape of the operator
  matrix — that matrix is a table anybody can add a line to, and this is the one
  entry whose absence carries an argument.
- **Liveness.** The list's domain clause follows the caller's `include_archived`;
  this engine's `BaseWhere` pins `archived_at IS NULL` unconditionally, so the
  leaf answers over live accounts. Consistent with every other leaf on the
  engine, which is the property worth keeping — and written in the leaf's own
  comment, because it is a real difference from the list parameter.

## The acceptance list

- ✅ a segment, saved view and export can filter organizations by domain
- ✅ **a pasted URL and the bare host answer the same rows on both surfaces —
  one test**, over three spellings (the host, a URL with subdomain and path, a
  difference of case), each asserted through `ListOrganizations` *and* through a
  stored segment's members
- ✅ the vocabulary advertises `domain`, and the type-enum gate passes because
  the contract carries it
- ✅ `contains` is not advertised, with the reason in the test name

## What the widening touched

The contract enum is public, so all three regenerations ran: `make gen`,
`pnpm gen:api`, and the MCP snapshot.

Two gates had to learn about a **core-only** field type, and that is the shape
they were missing rather than a special case for this change: a custom field can
be neither an `id` nor a `domain`, so neither is derivable from the catalogue.
They are now listed together with that reason, so a third one is a deliberate
act rather than a surprise. The cross-surface parity gate maps `FieldDomain` to
search's text kind — search compares the stored string, and the folding is a
normalization rather than a different question — which makes the comparison real
instead of leaving the type uncompared.

`predicate.go` crossed the 500-line ceiling, so the filter **vocabulary** moved
to its own file: what every surface that offers a filter reads, split from the
compiler that nothing but the engine reads.

## Checks

- `make check-backend`, `make check-fe` green; `craft static --strict` clean.
- `make test-it DIR=backend/internal/compose/integration` green for the new
  suite.
- Mutation-checked: reverting the leaf to `FieldText` turns the parity test red
  on exactly the two spellings the ticket names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added domain-based filtering for host fields.
  - Domain filters normalize URLs, hostnames, case, and common prefixes to a canonical host.
  - Supported operators include equality, inequality, membership, and existence; substring matching is unavailable.
  - Invalid domain values are rejected.
  - Organization filters and dynamic segment conditions now produce consistent results for equivalent domain formats.

- **Bug Fixes**
  - Domain-based conditions consistently exclude archived records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->