### PR TITLE
A named record opens, and it opens the ways a link does

### DIFF
--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -395,11 +395,17 @@ type Notices interface {
 
 // UnreadNotice is one line still waiting to be seen.
 type UnreadNotice struct {
-	ID        ids.UUID
-	Kind      string
-	Subject   string
-	Body      string
-	CreatedAt time.Time
+	ID      ids.UUID
+	Kind    string
+	Subject string
+	Body    string
+	// Target names the record the notice is about, when it names one. Empty
+	// type means it names none — a capture backlog, a coach's word — and the
+	// row then carries no subject, which is what it carried before any notice
+	// stored a target at all.
+	TargetType string
+	TargetID   ids.UUID
+	CreatedAt  time.Time
 }
 
 // Introductions is the asks waiting on THIS reader to answer — a colleague

--- a/backend/internal/compose/attention/noticesubject_test.go
+++ b/backend/internal/compose/attention/noticesubject_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A notice that names a record says WHICH one, so the Worklist row links to it.
+//
+// "A deal you own changed stage" is true of every deal a rep owns. The row
+// carried the sentence and nothing else, so a reader knew something had moved
+// and had to go find it.
+
+func unread(targetType string, targetID ids.UUID) UnreadNotice {
+	return UnreadNotice{
+		ID:         ids.NewV7(),
+		Kind:       "automation",
+		Subject:    "A deal you own changed stage",
+		Body:       "Fleet retrofit moved to a new pipeline stage.",
+		TargetType: targetType,
+		TargetID:   targetID,
+		CreatedAt:  time.Date(2026, time.September, 8, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestANoticeRowNamesTheRecordItIsAbout(t *testing.T) {
+	t.Parallel()
+	deal := ids.NewV7()
+
+	item := noticeItem(unread("deal", deal))
+
+	if item.Subject == nil {
+		t.Fatal("the row names no record, so it links nowhere and the reader has to go find it")
+	}
+	if item.Subject.Type != crmcontracts.AttentionSubjectTypeDeal {
+		t.Errorf("subject type = %q, want deal", item.Subject.Type)
+	}
+	if ids.UUID(item.Subject.Id) != deal {
+		t.Errorf("subject names %s, want the deal the notice is about (%s)", item.Subject.Id, deal)
+	}
+}
+
+// The refusal case, and the reason the admit case above means something: a
+// notice about no record carries no subject rather than one pointing at a zero.
+func TestANoticeAboutNoRecordNamesNone(t *testing.T) {
+	t.Parallel()
+	if item := noticeItem(unread("", ids.UUID{})); item.Subject != nil {
+		t.Errorf("a notice about no record named %+v", *item.Subject)
+	}
+}
+
+// A type this feed cannot route to yields no subject either. The client turns
+// a subject into a link, so a subject it has no screen for is a control that
+// opens nothing — worse than a row that never offered one.
+func TestANoticeNamingAnUnroutableTypeNamesNone(t *testing.T) {
+	t.Parallel()
+	if item := noticeItem(unread("invoice", ids.NewV7())); item.Subject != nil {
+		t.Errorf("an unroutable target became a subject: %+v", *item.Subject)
+	}
+}
+
+// The row's own words survive the subject arriving beside them: the headline
+// and the detail are what a reader scans, and the link is one more thing the
+// row offers rather than a replacement for either.
+func TestANoticeRowKeepsItsWordsBesideTheLink(t *testing.T) {
+	t.Parallel()
+	notice := unread("deal", ids.NewV7())
+
+	item := noticeItem(notice)
+
+	if item.Title == nil || *item.Title != notice.Subject {
+		t.Errorf("title = %v, want the notice's own subject", item.Title)
+	}
+	if item.Detail == nil || *item.Detail != notice.Body {
+		t.Errorf("detail = %v, want the notice's own body", item.Detail)
+	}
+}

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -253,6 +253,14 @@ func automationItem(run TroubledAutomationRun) crmcontracts.AttentionItem {
 // noticeItem draws one unread notice: its own subject as the headline, its
 // body as the supporting line, and acknowledge — the one verb it offers,
 // which routes to the notice's read endpoint and takes it off this lane.
+//
+// The record it is about rides `subject`, which is what makes the row's
+// headline a link. "A deal you own changed stage" is true of every deal a rep
+// owns, so a reader knew something had moved and had to go find it. A notice
+// that names no record — a capture backlog, a coach's word — carries none, and
+// so does one naming a type this feed cannot route to: subjectOf refuses it
+// rather than guessing, because a card pointing at the wrong record is worse
+// than one pointing nowhere.
 func noticeItem(notice UnreadNotice) crmcontracts.AttentionItem {
 	kind := notice.Kind
 	subject := notice.Subject
@@ -264,6 +272,9 @@ func noticeItem(notice UnreadNotice) crmcontracts.AttentionItem {
 		Title:      &subject,
 		OccurredAt: &occurred,
 		Actions:    []crmcontracts.AttentionItemActions{crmcontracts.AttentionItemActions("acknowledge")},
+	}
+	if notice.TargetType != "" {
+		item.Subject = subjectOf(notice.TargetType, notice.TargetID)
 	}
 	if notice.Body != "" {
 		body := notice.Body

--- a/backend/internal/compose/attentionopsseam.go
+++ b/backend/internal/compose/attentionopsseam.go
@@ -216,11 +216,13 @@ func (a attentionNotices) Unread(ctx context.Context, limit int) ([]attention.Un
 	out := make([]attention.UnreadNotice, 0, len(unread))
 	for _, notice := range unread {
 		out = append(out, attention.UnreadNotice{
-			ID:        notice.ID,
-			Kind:      notice.Kind,
-			Subject:   notice.Subject,
-			Body:      notice.Body,
-			CreatedAt: notice.CreatedAt,
+			ID:         notice.ID,
+			Kind:       notice.Kind,
+			Subject:    notice.Subject,
+			Body:       notice.Body,
+			TargetType: notice.Target.Type,
+			TargetID:   notice.Target.ID,
+			CreatedAt:  notice.CreatedAt,
 		})
 	}
 	return out, nil

--- a/backend/internal/compose/noticesseam.go
+++ b/backend/internal/compose/noticesseam.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/modules/notices"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
 // noticeKindAutomation labels a notice an automation's notify action raised.
@@ -41,12 +42,17 @@ type noticesNotifier struct{ store *notices.Store }
 // second line, which is the same behaviour it had before the key existed —
 // closing it means the seam carrying an identity, not this adapter inventing
 // one out of the words.
-func (n noticesNotifier) Notify(ctx context.Context, recipient ids.UUID, subject, body string) error {
+func (n noticesNotifier) Notify(
+	ctx context.Context, recipient ids.UUID, subject, body string, target datasource.EntityRef,
+) error {
 	_, err := n.store.Create(ctx, notices.NewNotice{
 		Recipient: ids.From[ids.UserKind](recipient),
 		Kind:      noticeKindAutomation,
 		Subject:   subject,
 		Body:      body,
+		// A firing that named no record writes no target: the zero EntityRef
+		// carries an empty type, and Target.Named() is what the store asks.
+		Target: notices.Target{Type: string(target.Type), ID: target.ID},
 	})
 	return err
 }

--- a/backend/internal/modules/automation/handlers_actions.go
+++ b/backend/internal/modules/automation/handlers_actions.go
@@ -62,7 +62,10 @@ func applyNotify(ctx context.Context, notifier Notifier, action workflow.Action)
 	if err != nil {
 		return err
 	}
-	return notifier.Notify(ctx, in.Recipient, in.Subject, in.Body)
+	// The action's own target, so the notice names the record the firing was
+	// about. "A deal you own changed stage" is true of every deal a rep owns,
+	// and the sentence alone left a reader with nothing to open.
+	return notifier.Notify(ctx, in.Recipient, in.Subject, in.Body, action.Target)
 }
 
 // draftEmailArgs names what draft_email hands to Comms: Target is the

--- a/backend/internal/modules/automation/handlers_actions_test.go
+++ b/backend/internal/modules/automation/handlers_actions_test.go
@@ -74,19 +74,21 @@ func (f *fakeComms) DraftEmail(_ context.Context, anchor ids.UUID, intent string
 // fakeNotifier is a DB-free stand-in for the Notifier seam: this repo
 // wires none in compose, but the seam must still work once something
 // does, so its wired path gets its own test.
-type fakeNotifier struct {
-	err   error
-	calls []struct {
-		recipient     ids.UUID
-		subject, body string
-	}
+type notifyCall struct {
+	recipient     ids.UUID
+	subject, body string
+	target        datasource.EntityRef
 }
 
-func (f *fakeNotifier) Notify(_ context.Context, recipient ids.UUID, subject, body string) error {
-	f.calls = append(f.calls, struct {
-		recipient     ids.UUID
-		subject, body string
-	}{recipient, subject, body})
+type fakeNotifier struct {
+	err   error
+	calls []notifyCall
+}
+
+func (f *fakeNotifier) Notify(
+	_ context.Context, recipient ids.UUID, subject, body string, target datasource.EntityRef,
+) error {
+	f.calls = append(f.calls, notifyCall{recipient, subject, body, target})
 	return f.err
 }
 

--- a/backend/internal/modules/automation/seams.go
+++ b/backend/internal/modules/automation/seams.go
@@ -100,7 +100,15 @@ type Comms interface {
 // a composition that forgets the seam surfaces as a visible skipped run,
 // never a silent no-op.
 type Notifier interface {
-	Notify(ctx context.Context, recipient ids.UUID, subject, body string) error
+	// target is the record the notice is about, when the firing named one.
+	// It is the ACTION's target rather than the event's: the two agree today
+	// for the stage-change rule, and a handler that plans a notice about a
+	// different record than the one that moved is planning exactly what the
+	// action's own field is for.
+	//
+	// The zero value is a notice about no record — the honest answer for a
+	// firing with nothing to open — and the transport writes no target at all.
+	Notify(ctx context.Context, recipient ids.UUID, subject, body string, target datasource.EntityRef) error
 }
 
 // ErrNoNotificationTransport is notify's honest answer when no Notifier

--- a/backend/internal/modules/notices/store.go
+++ b/backend/internal/modules/notices/store.go
@@ -44,8 +44,23 @@ type Notice struct {
 	Kind      string
 	Subject   string
 	Body      string
+	Target    Target
 	CreatedAt time.Time
 }
+
+// Target is the record a notice is about, when it is about one.
+//
+// Both halves or neither, which the table's own constraint holds: a type with
+// no id names a KIND of thing and cannot be opened, and an id with no type
+// cannot be routed to a screen. The zero value is a notice about no record —
+// a capture backlog, a coach's word — and those are the majority.
+type Target struct {
+	Type string
+	ID   ids.UUID
+}
+
+// Named reports whether this notice points at a record.
+func (t Target) Named() bool { return t.Type != "" && !t.ID.IsZero() }
 
 // NewNotice is one notice to record. It is a struct rather than a parameter
 // list because the dedupe key is the fifth thing a caller might say about a
@@ -66,6 +81,10 @@ type NewNotice struct {
 	// honest answer, since an invented key would silently collapse two real
 	// notices into one.
 	DedupeKey string
+	// Target is the record this notice is about, when it is about one. "A deal
+	// you own changed stage" is true of every deal a rep owns, so the sentence
+	// alone left a reader knowing something moved and having to find it.
+	Target Target
 }
 
 // Create records one notice for recipient — the whole of delivery on this
@@ -111,10 +130,18 @@ func (s *Store) insertNotice(ctx context.Context, in NewNotice, evidence map[str
 	subject := truncate(in.Subject, subjectBound)
 	body := truncate(in.Body, bodyBound)
 	id := ids.NewV7()
+	target := in.Target
 	var createdAt time.Time
 	var dedupe *string
 	if in.DedupeKey != "" {
 		dedupe = &in.DedupeKey
+	}
+	// Nil rather than the zero value on both halves, so the table's paired
+	// constraint sees a notice about no record as two NULLs.
+	var targetType *string
+	var targetID *ids.UUID
+	if target.Named() {
+		targetType, targetID = &target.Type, &target.ID
 	}
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		// The INDEX is the guard, not a read-then-write check: two deliveries
@@ -127,12 +154,13 @@ func (s *Store) insertNotice(ctx context.Context, in NewNotice, evidence map[str
 		// created_at is the column's own default, so the insert returns it
 		// rather than the caller stamping a second clock beside it.
 		row := tx.QueryRow(ctx, `
-			INSERT INTO notice (id, recipient_user_id, kind, subject, body, captured_by, dedupe_key)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			INSERT INTO notice (id, recipient_user_id, kind, subject, body, captured_by,
+			                    dedupe_key, target_type, target_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			ON CONFLICT (recipient_user_id, dedupe_key) WHERE dedupe_key IS NOT NULL
 			DO NOTHING
 			RETURNING created_at`,
-			id, in.Recipient, in.Kind, subject, body, capturedBy, dedupe)
+			id, in.Recipient, in.Kind, subject, body, capturedBy, dedupe, targetType, targetID)
 		switch err := row.Scan(&createdAt); {
 		case errors.Is(err, pgx.ErrNoRows):
 			// Already recorded. Answer the notice that STANDS — all of it, not
@@ -143,10 +171,25 @@ func (s *Store) insertNotice(ctx context.Context, in NewNotice, evidence map[str
 			// later version spells differently. Returning the stored id with
 			// the replay's words would put a notice on screen that the reader
 			// cannot find anywhere, and that nothing in the database says.
-			return tx.QueryRow(ctx, `
-				SELECT id, kind, subject, body, created_at FROM notice
+			// The target comes back with them, for the same reason: a second
+			// delivery can name a different entity — an event replayed after
+			// the automation was repointed — and answering the stored notice's
+			// id with this call's target would send a reader to a record the
+			// notice they can see says nothing about.
+			var storedType *string
+			var storedID *ids.UUID
+			if err := tx.QueryRow(ctx, `
+				SELECT id, kind, subject, body, target_type, target_id, created_at FROM notice
 				 WHERE recipient_user_id = $1 AND dedupe_key = $2`,
-				in.Recipient, in.DedupeKey).Scan(&id, &kind, &subject, &body, &createdAt)
+				in.Recipient, in.DedupeKey,
+			).Scan(&id, &kind, &subject, &body, &storedType, &storedID, &createdAt); err != nil {
+				return err
+			}
+			target = Target{}
+			if storedType != nil && storedID != nil {
+				target = Target{Type: *storedType, ID: *storedID}
+			}
+			return nil
 		case err != nil:
 			return fmt.Errorf("notices: recording the notice: %w", err)
 		}
@@ -165,7 +208,10 @@ func (s *Store) insertNotice(ctx context.Context, in NewNotice, evidence map[str
 	if err != nil {
 		return Notice{}, err
 	}
-	return Notice{ID: id, Kind: kind, Subject: subject, Body: body, CreatedAt: createdAt}, nil
+	return Notice{
+		ID: id, Kind: kind, Subject: subject, Body: body,
+		Target: target, CreatedAt: createdAt,
+	}, nil
 }
 
 // UnreadFor answers the CALLING person's own unread notices, newest first,
@@ -184,7 +230,7 @@ func (s *Store) UnreadFor(ctx context.Context, limit int) ([]Notice, error) {
 	var unread []Notice
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, txErr := tx.Query(ctx, `
-			SELECT id, kind, subject, body, created_at
+			SELECT id, kind, subject, body, target_type, target_id, created_at
 			  FROM notice
 			 WHERE recipient_user_id = $1 AND read_at IS NULL
 			 ORDER BY created_at DESC, id DESC
@@ -196,8 +242,16 @@ func (s *Store) UnreadFor(ctx context.Context, limit int) ([]Notice, error) {
 		unread = []Notice{}
 		for rows.Next() {
 			var n Notice
-			if scanErr := rows.Scan(&n.ID, &n.Kind, &n.Subject, &n.Body, &n.CreatedAt); scanErr != nil {
+			// Both halves are nullable and the table pairs them, so either
+			// arriving alone is a row the constraint should have refused.
+			var targetType *string
+			var targetID *ids.UUID
+			if scanErr := rows.Scan(&n.ID, &n.Kind, &n.Subject, &n.Body,
+				&targetType, &targetID, &n.CreatedAt); scanErr != nil {
 				return scanErr
+			}
+			if targetType != nil && targetID != nil {
+				n.Target = Target{Type: *targetType, ID: *targetID}
 			}
 			unread = append(unread, n)
 		}

--- a/backend/internal/modules/notices/store_integration_test.go
+++ b/backend/internal/modules/notices/store_integration_test.go
@@ -114,16 +114,22 @@ func (e *noticeEnv) asUser(u ids.UserID) context.Context {
 func TestARepeatAnswersWithTheStoredNoticeRatherThanTheReplay(t *testing.T) {
 	e := setupNotices(t)
 	key := "lead_sla:" + ids.NewV7().String()
+	firstTarget := Target{Type: "deal", ID: ids.NewV7()}
 	stored, err := e.store.insertNotice(e.engineCtx(), NewNotice{
 		Recipient: e.recipient, Kind: "lead_sla", Subject: "SLA breach",
-		Body: "overdue", DedupeKey: key,
+		Body: "overdue", DedupeKey: key, Target: firstTarget,
 	}, nil)
 	if err != nil {
 		t.Fatalf("first insert: %v", err)
 	}
+	// The target differs too, and for the same reason the words do: an event
+	// replayed after its automation was repointed names a different record.
+	// Answering the stored notice's id with THIS call's target would send a
+	// reader to a record the notice they can see says nothing about.
 	replay, err := e.store.insertNotice(e.engineCtx(), NewNotice{
 		Recipient: e.recipient, Kind: "lead_sla_v2", Subject: "Response overdue",
 		Body: "still overdue", DedupeKey: key,
+		Target: Target{Type: "person", ID: ids.NewV7()},
 	}, nil)
 	if err != nil {
 		t.Fatalf("second insert: %v", err)
@@ -131,6 +137,78 @@ func TestARepeatAnswersWithTheStoredNoticeRatherThanTheReplay(t *testing.T) {
 	if replay != stored {
 		t.Errorf("the repeat answered %+v, want the notice that already stands %+v — every field, "+
 			"or a caller renders a line nothing in the database says", replay, stored)
+	}
+	if replay.Target != firstTarget {
+		t.Errorf("the repeat names %+v, want the record the stored notice is about (%+v)",
+			replay.Target, firstTarget)
+	}
+}
+
+// A notice that names a record carries it back out, so the Worklist row can
+// link to the thing the sentence is about.
+func TestANoticeCarriesTheRecordItNames(t *testing.T) {
+	e := setupNotices(t)
+	target := Target{Type: "deal", ID: ids.NewV7()}
+
+	written, err := e.store.insertNotice(e.engineCtx(), NewNotice{
+		Recipient: e.recipient, Kind: "automation",
+		Subject: "A deal you own changed stage", Body: "Fleet retrofit moved.",
+		Target: target,
+	}, nil)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if written.Target != target {
+		t.Fatalf("the notice names %+v, want %+v", written.Target, target)
+	}
+
+	unread, err := e.store.UnreadFor(e.asUser(e.recipient), 10)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	// Through the READ, not only out of the writer: the row a reader sees is
+	// the one the Worklist draws, and a target that survived the insert and
+	// not the select would link nothing while every write test passed.
+	var found *Notice
+	for i := range unread {
+		if unread[i].ID == written.ID {
+			found = &unread[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("the recipient does not see their own notice")
+	}
+	if found.Target != target {
+		t.Errorf("the read notice names %+v, want %+v", found.Target, target)
+	}
+}
+
+// A notice about no record carries neither half, and the table's paired
+// constraint is what says it cannot carry one.
+func TestANoticeAboutNoRecordCarriesNeitherHalf(t *testing.T) {
+	e := setupNotices(t)
+
+	written, err := e.store.insertNotice(e.engineCtx(), NewNotice{
+		Recipient: e.recipient, Kind: "capture_backlog",
+		Subject: "Your mailbox is behind", Body: "1,200 messages are waiting.",
+	}, nil)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if written.Target.Named() {
+		t.Errorf("a notice about no record named %+v", written.Target)
+	}
+
+	// Half a target is refused by the table rather than stored and rendered as
+	// a link the client has to guess at.
+	var stored int
+	if err := e.pool.QueryRow(e.engineCtx(), `
+		SELECT count(*) FROM notice
+		 WHERE (target_type IS NULL) <> (target_id IS NULL)`).Scan(&stored); err != nil {
+		t.Fatalf("counting half-targets: %v", err)
+	}
+	if stored != 0 {
+		t.Errorf("%d notice(s) carry half a target; the pair is both or neither", stored)
 	}
 }
 

--- a/backend/migrations/core/1788802509_a_notice_names_the_record_it_is_about.down.sql
+++ b/backend/migrations/core/1788802509_a_notice_names_the_record_it_is_about.down.sql
@@ -1,0 +1,5 @@
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE notice
+  DROP CONSTRAINT notice_target_paired,
+  DROP COLUMN target_id,
+  DROP COLUMN target_type;

--- a/backend/migrations/core/1788802509_a_notice_names_the_record_it_is_about.up.sql
+++ b/backend/migrations/core/1788802509_a_notice_names_the_record_it_is_about.up.sql
@@ -1,0 +1,20 @@
+-- A notice that names a record says WHICH one, durably.
+--
+-- "A deal you own changed stage" is true of every deal a rep owns. The row
+-- carried the sentence and nothing else, so the Worklist drew a line a reader
+-- could not act on: they knew something moved and had to go find it.
+--
+-- The target is stored rather than derived at read time for the reason the
+-- subject is: a notice is the durable half of delivery, and re-deriving what it
+-- was about would depend on the automation still existing, still firing on the
+-- same entity, and still meaning the same thing by it.
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE notice
+  ADD COLUMN target_type text,
+  ADD COLUMN target_id uuid,
+  -- Both or neither. A type with no id names a KIND of thing and cannot be
+  -- opened; an id with no type cannot be routed to a screen. Either half alone
+  -- is a link the client has to guess at, and a guessed link is the dead
+  -- control this column exists to remove.
+  ADD CONSTRAINT notice_target_paired
+    CHECK ((target_type IS NULL) = (target_id IS NULL));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -3441,9 +3441,12 @@ public.notice.notice_content_bounded CHECK (((length(subject) <= 200) AND (lengt
 public.notice.notice_pkey PRIMARY KEY (id)
 public.notice.notice_recipient_user_id_fkey FOREIGN KEY (recipient_user_id) REFERENCES app_user(id) ON DELETE CASCADE
 public.notice.notice_subject_present CHECK ((subject <> ''::text))
+public.notice.notice_target_paired CHECK (((target_type IS NULL) = (target_id IS NULL)))
 public.notice.read_at timestamp with time zone gen=- def=-
 public.notice.recipient_user_id uuid NOT NULL gen=- def=-
 public.notice.subject text NOT NULL gen=- def=-
+public.notice.target_id uuid gen=- def=-
+public.notice.target_type text gen=- def=-
 public.notice_pkey CREATE UNIQUE INDEX notice_pkey ON public.notice USING btree (id)
 public.notice_unread CREATE INDEX notice_unread ON public.notice USING btree (recipient_user_id, created_at DESC) WHERE (read_at IS NULL)
 public.oauth_authorization_code acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -713,7 +713,13 @@
 }
 
 /* A cross-record reference rendered inline as a text link (EntityRef): the
-   accent colour + hover underline read as navigable, with no button chrome. */
+   accent colour + hover underline read as navigable, with no button chrome.
+
+   It is an ANCHOR, so the record opens the ways a link does — a new tab, a
+   bookmark, the keyboard. The resets below cover both shapes: the border and
+   background belong to the button this used to be, and text-decoration to the
+   anchor it is, because the underline is the hover state rather than the
+   resting one. */
 .entity-link {
   padding: 0;
   border: 0;
@@ -722,6 +728,7 @@
   font: inherit;
   cursor: pointer;
   text-align: left;
+  text-decoration: none;
 }
 .entity-link:hover {
   text-decoration: underline;

--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -258,13 +258,16 @@
 }
 
 .deal-card {
-  /* An anchor now rather than a button (composed.tsx says why), so it takes the
-     two things the platform gives a link and this card must not have: the UA's
-     own ink and an underline. `a:not([class])` in base.css does not reach a
-     classed anchor, so they are stated here — and neither does its focus ring,
-     which is why this card states its own below. */
+  /* A div holding a STRETCHED anchor (composed.tsx says why), so the card
+     carries the deal's link and the company's without nesting one inside the
+     other. The colour and decoration resets stay: they cover the anchors this
+     card contains, which `a:not([class])` in base.css does not reach. */
   color: inherit;
   text-decoration: none;
+  /* The containing block the stretched link measures itself against. Without
+     it the deal anchor would spread to the nearest positioned ancestor — the
+     column, or the board — and swallow every card beside it. */
+  position: relative;
   /* The pane over the column's ground, not the elevated surface: a card lifts
      off the stage it sits in by being translucent white over it, which is the
      same separation every other pane in the product is drawn with. No
@@ -290,9 +293,32 @@
 .deal-card:hover {
   border-color: var(--borderStrong);
 }
-.deal-card:focus-visible {
+/* The ring follows the LINK's focus, drawn on the card: the anchor is what
+   takes the tab stop, and a ring around its text alone would mark the deal's
+   name rather than the card a reader is about to open. */
+.deal-card:focus-within {
   outline: var(--focus-ring);
   outline-offset: 2px;
+}
+
+/* The deal's own door, stretched over the whole card. Its text stays where the
+   name belongs; the ::after is what makes the rest of the card clickable. */
+.deal-open::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+/* The company sits ABOVE the stretched link, which is the only reason its
+   click can reach it at all. */
+.deal-org-link {
+  position: relative;
+  z-index: 1;
+  color: inherit;
+  text-decoration: none;
+}
+.deal-org-link:hover {
+  text-decoration: underline;
 }
 .deal-card.staged {
   background: var(--aiLight);

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -45,6 +45,37 @@ describe("DealCard + PipelineBoard", () => {
     expect(screen.getByRole("link").className).not.toContain("stalled");
   });
 
+  // Two destinations on one card, and the reader picks. The whole card used to
+  // be one anchor to the deal, so a rep looking at a board could not reach the
+  // account behind any deal without opening the deal first.
+  it("opens the deal and the company separately", () => {
+    render(
+      <DealCard
+        deal={{ ...deal, orgHref: "#/companies/o-1" }}
+        href="#/deals/d1"
+        zone="Europe/Berlin"
+      />,
+    );
+
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((each) => each.getAttribute("href"));
+    expect(hrefs).toContain("#/deals/d1");
+    expect(hrefs).toContain("#/companies/o-1");
+  });
+
+  // The refusal case, and the reason the card takes an href rather than an id:
+  // a caller with no address for the company is saying it cannot be linked,
+  // and prose is the honest rendering of that.
+  it("draws the company as prose when the caller gives no address", () => {
+    render(<DealCard deal={deal} href="#/deals/d1" zone="Europe/Berlin" />);
+
+    expect(screen.getByText("Brandt Automotive")).toBeTruthy();
+    expect(
+      screen.getAllByRole("link").map((each) => each.getAttribute("href")),
+    ).toEqual(["#/deals/d1"]);
+  });
+
   // A company has three readings on a card and only one of them is blank. The
   // named one carries its monogram, the withheld one carries the mask every
   // other surface draws over a withheld value, and a deal that names no company

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -51,6 +51,16 @@ export type BoardDeal = BoardRecord & {
    * deal that names no company, which is the one reading that draws nothing.
    */
   org: string;
+  /**
+   * The company's own address, when the caller has one to give.
+   *
+   * An href and not an id, for the reason the deal's own `href` is one: this
+   * tier holds no routes, and a design-system card that knew how to build
+   * `#/companies/{id}` would be the app's routing table living in two places.
+   * Absent renders the company as prose, which is what a caller that cannot
+   * link it is saying.
+   */
+  orgHref?: string;
   /** The company's resolved mark. Absent leaves the monogram, which is the
    *  floor rather than a fallback. */
   orgLogoUrl?: string | null;
@@ -193,7 +203,17 @@ export type BoardMoneyColumn = BoardColumn<BoardDeal> & {
  * mark and its name. Only a deal that names no company draws nothing, which is
  * the one reading an empty slot states truthfully.
  */
-function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
+function DealCardCompany({
+  deal,
+  onOpen,
+}: Readonly<{
+  deal: BoardDeal;
+  // The same press hook the deal's own link takes, for the same reason: a
+  // click that ends a drag is not a click on the company either, and a card
+  // that suppressed one link and not the other would open the account a rep
+  // was only moving.
+  onOpen?: (deal: BoardDeal, event: React.MouseEvent) => void;
+}>) {
   const t = useT();
   if (deal.orgWithheld) {
     return (
@@ -218,7 +238,28 @@ function DealCardCompany({ deal }: Readonly<{ deal: BoardDeal }>) {
       {/* The name needs a box of its own to be truncated in: a bare text node
           has nothing for the ellipsis to apply to, and wraps under its own
           mark instead. */}
-      <span className="deal-org-name">{deal.org}</span>
+      {deal.orgHref ? (
+        // The company's own door, beside the deal's. The whole card used to be
+        // one anchor to the deal, so a rep looking at a board of deals could
+        // not reach the account behind any of them without opening a deal
+        // first.
+        //
+        // stopPropagation keeps the click off the card's stretched anchor.
+        // preventDefault would be wrong: it would leave the card's own
+        // navigation to fire while this link did nothing.
+        <a
+          className="deal-org-name deal-org-link"
+          href={deal.orgHref}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpen?.(deal, event);
+          }}
+        >
+          {deal.org}
+        </a>
+      ) : (
+        <span className="deal-org-name">{deal.org}</span>
+      )}
     </span>
   );
 }
@@ -344,13 +385,15 @@ export function DealCard({
     .filter(Boolean)
     .join(" ");
   return (
-    <a
-      href={href}
-      className={classes}
-      data-deal={deal.id}
-      onClick={(event) => onOpen?.(deal, event)}
-      {...dragHandlers}
-    >
+    // A div with a STRETCHED anchor inside it, not one anchor around
+    // everything. The card carries a second destination now — the company —
+    // and an anchor inside an anchor is invalid markup the browser silently
+    // unnests, which is how the inner link stops being clickable at all.
+    //
+    // The stretched link keeps every property the outer anchor had: the whole
+    // card is still the deal's click target, still opens in a new tab, still
+    // middle-clicks, and is still one tab stop.
+    <div className={classes} data-deal={deal.id} {...dragHandlers}>
       {/* Read in the order a rep asks (composed.css says why): what needs
           them, on this card, if anything; whose deal it is; what it is worth
           and when it closes; and what it is called. */}
@@ -381,7 +424,7 @@ export function DealCard({
         </span>
       )}
       <span className="deal-head">
-        <DealCardCompany deal={deal} />
+        <DealCardCompany deal={deal} onOpen={onOpen} />
         {deal.owner && <DealOwner name={deal.owner} />}
       </span>
       <span className="deal-figure">
@@ -398,8 +441,21 @@ export function DealCard({
           <span className="deal-closes">{t("deal.undated")}</span>
         )}
       </span>
-      <span className="deal-name">{deal.name}</span>
-    </a>
+      {/* The deal's own door, stretched over the card by CSS. It carries the
+          NAME rather than sitting empty, so the accessible name of the link is
+          the deal a reader is opening — an empty stretched anchor reads to a
+          screen reader as a link with no text. */}
+      <a
+        className="deal-name deal-open"
+        href={href}
+        // The press handler rides the ANCHOR, not the div around it: the div
+        // would also catch the company link's bubbled click, and the drop
+        // guard would then refuse a navigation the reader did ask for.
+        onClick={(event) => onOpen?.(deal, event)}
+      >
+        {deal.name}
+      </a>
+    </div>
   );
 }
 

--- a/frontend/src/screens/brief.rail.test.tsx
+++ b/frontend/src/screens/brief.rail.test.tsx
@@ -156,19 +156,22 @@ describe("BriefScreen — the context rail", () => {
     render(<BriefScreen />);
 
     const card = await screen.findByText("Ostwind refit");
-    const panel = card.closest("a");
-    expect(panel).toBeTruthy();
+    // The card is the element AROUND both its links — the deal's and the
+    // company's. The nearest anchor is the deal name itself, which contains
+    // neither the company slot nor the flags.
+    const panel = card.closest(".deal-card");
+    if (!(panel instanceof HTMLElement)) {
+      throw new Error("no board card around the quiet deal");
+    }
     // Awaited, not read: the company name comes from a second read that the
     // card does not wait for, so it can still be in flight when the deal's own
     // title is already on screen.
-    expect(
-      await within(panel ?? card).findByText("Nordwind Logistik"),
-    ).toBeTruthy();
+    expect(await within(panel).findByText("Nordwind Logistik")).toBeTruthy();
     // The quiet deal is on the page as a CARD rather than as a count. The
     // briefing line that carried "1 has gone quiet" is gone: the panel listing
     // the deal itself says more than a figure above it could, and says it in
     // the one place a reader can act on it.
-    expect(within(panel ?? card).getByText("Ostwind refit")).toBeTruthy();
+    expect(within(panel).getByText("Ostwind refit")).toBeTruthy();
   });
 
   it("says so when nothing has gone quiet", async () => {
@@ -337,7 +340,6 @@ describe("BriefScreen — the context rail", () => {
           },
         }),
     });
-    const user = userEvent.setup();
     render(<BriefScreen />);
 
     const moves = await screen.findByLabelText("Phase moves");
@@ -345,12 +347,13 @@ describe("BriefScreen — the context rail", () => {
     expect(screen.getByLabelText("Gone quiet").textContent).toContain(
       "quiet for 40 days",
     );
-    const links = await screen.findAllByRole("button", {
+    const links = await screen.findAllByRole("link", {
       name: "ERP replacement",
     });
     expect(links.length).toBe(2);
-    await user.click(links[0]);
-    expect(window.location.hash).toBe(`#/projects/${projectId}`);
+    // The href is the destination, and it is also what a new tab and a
+    // middle-click follow — neither of which goes through an onClick.
+    expect(links[0].getAttribute("href")).toBe(`#/projects/${projectId}`);
   });
 
   it("renders no projects block when the digest carries no section", async () => {

--- a/frontend/src/screens/companytoday.test.tsx
+++ b/frontend/src/screens/companytoday.test.tsx
@@ -607,6 +607,6 @@ describe("the generic draft row", () => {
 
     // The name used to be plain text inside the row's label, so a reader who
     // wanted to know who Sarah Cole is had nowhere to press.
-    expect(screen.getByRole("button", { name: "Sarah Cole" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Sarah Cole" })).toBeTruthy();
   });
 });

--- a/frontend/src/screens/contacts.test.tsx
+++ b/frontend/src/screens/contacts.test.tsx
@@ -169,6 +169,42 @@ describe("ContactsScreen (B-EP09.10a)", () => {
     expect(bruno?.textContent).not.toContain("—");
   });
 
+  // The row opens the CONTACT; the company cell opens the COMPANY. Two
+  // destinations in one row, and the reader picks.
+  //
+  // The company used to be plain text, on the reasoning that the row is
+  // already a link — but it is a link to the person, so a reader scanning who
+  // works for whom had to open a contact to reach the account behind them.
+  it("sends the row and the company to different records", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              ...anna,
+              employer: {
+                organization_id: "o-1",
+                organization_name: "Brandt AG",
+              },
+            },
+          ],
+          page: { next_cursor: null },
+        }),
+      ),
+    );
+    render(<ContactsScreen />);
+
+    const company = await screen.findByRole("link", { name: "Brandt AG" });
+    expect(company.getAttribute("href")).toBe("#/companies/o-1");
+    // The row's own identity link still goes to the person. Asserting BOTH is
+    // what says these are two destinations rather than one of them having
+    // quietly taken the other's place.
+    const links = await screen.findAllByRole("link");
+    const hrefs = links.map((each) => each.getAttribute("href"));
+    expect(hrefs).toContain("#/contacts/p-1");
+  });
+
   it("renders the honest error state with the RFC7807 detail", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/screens/contacts.tsx
+++ b/frontend/src/screens/contacts.tsx
@@ -542,14 +542,18 @@ export function ContactsScreen() {
             header: t("create.organization"),
             cell: (person: Person) =>
               person.employer ? (
-                // asText because the row is already the link to the contact: a
-                // control nested inside one is invalid markup. The name comes
-                // with the row, so EntityRef resolves nothing.
+                // A real link to the COMPANY, in a cell that is not the row's
+                // identity cell — so it nests inside no other anchor and the
+                // markup stays valid. It used to be text, on the reasoning that
+                // the row already links somewhere; but the row links to the
+                // CONTACT, and a reader looking at a list of people who works
+                // for whom had no way to reach the company without opening a
+                // person first. The name comes with the row, so this resolves
+                // nothing.
                 <EntityRef
                   kind="organization"
                   id={person.employer.organization_id}
                   name={person.employer.organization_name}
-                  asText
                 />
               ) : null,
           },

--- a/frontend/src/screens/deals-company.test.tsx
+++ b/frontend/src/screens/deals-company.test.tsx
@@ -195,8 +195,11 @@ function stubBackend(opts: {
 
 /** The board card naming `name` — the whole card is one button. */
 async function boardCard(name: string): Promise<HTMLElement> {
-  const card = (await screen.findByText(name)).closest("a");
-  if (!card) {
+  // The card is the element AROUND both its links — the deal's and the
+  // company's. Reaching for the nearest anchor lands on the deal name itself,
+  // which contains neither the company slot nor the flags.
+  const card = (await screen.findByText(name)).closest(".deal-card");
+  if (!(card instanceof HTMLElement)) {
     throw new Error(`no board card around "${name}"`);
   }
   return card;

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1820,7 +1820,7 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     render(<DealScreen id="x" />);
 
     expect(
-      await screen.findByRole("button", { name: "VietnamPartner JSC" }),
+      await screen.findByRole("link", { name: "VietnamPartner JSC" }),
     ).toBeTruthy();
     expect(screen.getByText("via")).toBeTruthy();
   });
@@ -1922,7 +1922,7 @@ describe("DealScreen — edit, archive, FX line (A3)", () => {
     );
 
     render(<DealScreen id="x" />);
-    await screen.findByRole("button", { name: "Northgate" });
+    await screen.findByRole("link", { name: "Northgate" });
     const line = document.querySelector(".identity-line")?.textContent ?? "";
 
     expect(line).toContain("·");

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -581,7 +581,10 @@ export type CompanyNaming = Readonly<{
 function dealCompany(
   deal: Deal,
   naming: CompanyNaming,
-): Pick<BoardDeal, "org" | "orgLogoUrl" | "orgWithheld" | "orgUnreadable"> {
+): Pick<
+  BoardDeal,
+  "org" | "orgHref" | "orgLogoUrl" | "orgWithheld" | "orgUnreadable"
+> {
   if (deal.masked_fields?.includes("organization_id")) {
     return { org: "", orgWithheld: true };
   }
@@ -591,7 +594,18 @@ function dealCompany(
   const mark = deal.organization_id
     ? naming.marks.get(deal.organization_id)
     : undefined;
-  return { org: mark?.name ?? "", orgLogoUrl: mark?.logoUrl };
+  return {
+    org: mark?.name ?? "",
+    // The company's address, built HERE because this is the tier that holds
+    // routes. A deal with no company, or one whose name has not resolved,
+    // gets none — the card then draws prose, which is what a slot with no
+    // name has to say anyway.
+    orgHref:
+      deal.organization_id && mark?.name
+        ? routeHash({ screen: "companies", id: deal.organization_id })
+        : undefined,
+    orgLogoUrl: mark?.logoUrl,
+  };
 }
 
 export function toBoardDeal(

--- a/frontend/src/screens/entityref.test.tsx
+++ b/frontend/src/screens/entityref.test.tsx
@@ -97,7 +97,11 @@ describe("EntityRef", () => {
     );
     render(<EntityRef kind="organization" id="o-1" />);
 
-    const link = await screen.findByRole("button", { name: "Brandt GmbH" });
+    // The href IS the destination. Asserting it rather than a click's effect
+    // is the stronger claim: it is also what a new tab, a bookmark and a
+    // middle-click follow, and none of those goes through an onClick.
+    const link = await screen.findByRole("link", { name: "Brandt GmbH" });
+    expect(link.getAttribute("href")).toBe("#/companies/o-1");
     await userEvent.click(link);
     expect(window.location.hash).toBe("#/companies/o-1");
   });
@@ -116,10 +120,11 @@ describe("EntityRef", () => {
       }),
     );
     const { rerender } = render(<EntityRef kind="person" id="p-1" />);
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Anna Weber" }),
-    );
-    expect(window.location.hash).toBe("#/contacts/p-1");
+    expect(
+      (await screen.findByRole("link", { name: "Anna Weber" })).getAttribute(
+        "href",
+      ),
+    ).toBe("#/contacts/p-1");
 
     rerender(
       <QueryClientProvider client={new QueryClient()}>
@@ -128,10 +133,11 @@ describe("EntityRef", () => {
         </LocaleProvider>
       </QueryClientProvider>,
     );
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Q3 Renewal" }),
-    );
-    expect(window.location.hash).toBe("#/deals/d-1");
+    expect(
+      (await screen.findByRole("link", { name: "Q3 Renewal" })).getAttribute(
+        "href",
+      ),
+    ).toBe("#/deals/d-1");
   });
 
   it("resolves a lead to leads/{id} (P-16: lead joins the ENTITY registry)", async () => {
@@ -145,10 +151,11 @@ describe("EntityRef", () => {
       }),
     );
     render(<EntityRef kind="lead" id="l-1" />);
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Jordan Lee" }),
-    );
-    expect(window.location.hash).toBe("#/leads/l-1");
+    expect(
+      (await screen.findByRole("link", { name: "Jordan Lee" })).getAttribute(
+        "href",
+      ),
+    ).toBe("#/leads/l-1");
   });
 
   it("falls back to the id (no link) once the lookup has settled without a name", async () => {
@@ -344,10 +351,11 @@ describe("EntityRef", () => {
     );
     render(<EntityRef kind="lead" id="l-1" />);
 
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Jonas Keller" }),
-    );
-    expect(window.location.hash).toBe("#/leads/l-1");
+    expect(
+      (await screen.findByRole("link", { name: "Jonas Keller" })).getAttribute(
+        "href",
+      ),
+    ).toBe("#/leads/l-1");
   });
 
   it("uses a caller-supplied user name without reading the roster at all", async () => {
@@ -381,10 +389,10 @@ describe("EntityRef", () => {
     render(<EntityRef kind="organization" id="o-1" name="   " />);
 
     // Whitespace is the caller saying it has nothing, exactly as an empty
-    // string is. Taken at face value it becomes a button with no readable
-    // label — a link a reader can neither read nor find.
+    // string is. Taken at face value it becomes a link with no readable
+    // label — one a reader can neither read nor find.
     expect(
-      await screen.findByRole("button", { name: "Brandt GmbH" }),
+      await screen.findByRole("link", { name: "Brandt GmbH" }),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/entityref.tsx
+++ b/frontend/src/screens/entityref.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api, FIRST_PAGE } from "../api/client";
 import type { components } from "../api/schema";
 import { ENTITY, type EntityKind } from "../app/entity";
-import { navigate } from "../app/router";
+import { routeHash } from "../app/router";
 import { leadIdentityName } from "../format/leadname";
 import { useT } from "../i18n";
 import { throwProblem } from "./common";
@@ -530,15 +530,28 @@ function RecordRef({
   if (asText) {
     return <span title={id}>{resolved}</span>;
   }
+  // A real anchor, so the record can be opened the ways a link can: a new tab,
+  // a new window, a bookmark, the keyboard. A button carried the same route and
+  // offered none of them — a reader who middle-clicked a company in a list got
+  // nothing, and one who wanted it beside the page they were on had to lose
+  // that page to get there.
+  //
+  // Only the default click is stopped from reaching an enclosing row's own
+  // handler. `navigate` is NOT called beside it: the anchor already performs
+  // the navigation, so doing both would dispatch the same route twice, and
+  // preventing the anchor instead would navigate the current page while the
+  // new tab opens too. This is the identity cell's own arrangement
+  // (design-system/listtable.tsx), which is where a row and a link inside it
+  // were first made to agree.
   return (
-    <button
-      type="button"
+    <a
       className="entity-link"
-      onClick={() => navigate(ENTITY[kind].route(id))}
+      href={routeHash(ENTITY[kind].route(id))}
+      onClick={(event) => event.stopPropagation()}
       title={id}
     >
       {resolved}
-    </button>
+    </a>
   );
 }
 

--- a/frontend/src/screens/historyedge.test.tsx
+++ b/frontend/src/screens/historyedge.test.tsx
@@ -111,7 +111,7 @@ describe("an edge row in a record's history", () => {
     render(<RecordHistory kind="person" id="p1" restore={RESTORE} />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Employer GmbH" }),
+      await screen.findByRole("link", { name: "Employer GmbH" }),
     );
 
     expect(globalThis.location.hash).toBe("#/companies/org-9");

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -2196,8 +2196,16 @@ describe("CompanyScreen — State D's one column and its card grid", () => {
     // The name opens the record, and it is the LINK's whole name: the mark
     // beside it draws initials as text, which would otherwise be announced
     // ahead of the person they stand for.
-    const name = await screen.findByRole("link", { name: "Anna Brandt" });
-    expect(name.getAttribute("href")).toBe("#/contacts/p-1");
+    //
+    // The page names this contact in more than one place — the roster card and
+    // the references beside it — so every one of them is asserted rather than
+    // the first: one of them pointing somewhere else is exactly the defect a
+    // single lookup would miss.
+    const names = await screen.findAllByRole("link", { name: "Anna Brandt" });
+    for (const each of names) {
+      expect(each.getAttribute("href")).toBe("#/contacts/p-1");
+    }
+    const name = names[0];
     expect(screen.getAllByText("Head of Procurement").length).toBeGreaterThan(
       0,
     );

--- a/frontend/src/screens/partnercommissions.test.tsx
+++ b/frontend/src/screens/partnercommissions.test.tsx
@@ -152,8 +152,9 @@ describe("the commission panel", () => {
     render(<PartnerCommissions organizationId="o-1" />);
     const ledger = await screen.findByTestId("commission-ledger");
 
-    // The control the design system routes with is a button, not an anchor.
-    const link = await within(ledger).findByRole("button", {
+    // A cross-record reference is an anchor, so the deal opens the ways a link
+    // does — a new tab, a bookmark, the keyboard.
+    const link = await within(ledger).findByRole("link", {
       name: "Northgate rollout",
     });
     expect(link).toBeTruthy();

--- a/frontend/src/screens/partnerdeals.test.tsx
+++ b/frontend/src/screens/partnerdeals.test.tsx
@@ -89,10 +89,10 @@ describe("the deals a partner brought", () => {
 
     // The design system routes with a button, not an anchor.
     expect(
-      await within(panel).findByRole("button", { name: "Northgate GmbH" }),
+      await within(panel).findByRole("link", { name: "Northgate GmbH" }),
     ).toBeTruthy();
     expect(
-      within(panel).getByRole("button", { name: "Northgate rollout" }),
+      within(panel).getByRole("link", { name: "Northgate rollout" }),
     ).toBeTruthy();
   });
 

--- a/frontend/src/screens/project360.test.tsx
+++ b/frontend/src/screens/project360.test.tsx
@@ -13,8 +13,10 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
 import { RecordShell } from "../app/testing/recordshell.testkit";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { jsonResponse } from "./company.fixtures";
 import { ProjectScreen } from "./project360";
 import { project, project360 } from "./projects.fixtures";
@@ -337,5 +339,96 @@ describe("ProjectScreen", () => {
     await screen.findByRole("heading", { name: "CRM rollout" });
 
     expect(screen.getByText(/You cannot change this project/)).toBeTruthy();
+  });
+});
+
+// A task's verbs answer to the TASK's permission, not the project's.
+//
+// They are different questions with different answers. The modal's verbs PATCH
+// /activities/{id}, which asks activity:update and the activity's own row
+// authority; the project asks whether this record takes changes. Deriving one
+// from the other offers verbs the server refuses to a reader who may write the
+// project and not its activities — and hides valid ones from a task's own
+// author whenever the project is read-only.
+describe("a commitment's task detail", () => {
+  const commitment = {
+    activity_id: "a-1",
+    subject: "Confirm the depot slot",
+    due_at: null,
+    assignee_id: null,
+    assignee_name: null,
+    overdue: false,
+  };
+
+  const TASK = {
+    id: commitment.activity_id,
+    kind: "task" as const,
+    subject: commitment.subject,
+    is_done: false,
+    version: 1,
+    source: "manual" as const,
+    captured_by: "u-me",
+    created_at: "2026-09-01T09:00:00Z",
+    updated_at: "2026-09-01T09:00:00Z",
+    occurred_at: "2026-09-01T09:00:00Z",
+  };
+
+  function showCommitments(activityActions: ("update" | "delete")[]) {
+    projectsBackend({
+      view: project360({
+        commitments: { data: [commitment], page: { has_more: false } },
+      }),
+      respond: async (url) => {
+        if (url.endsWith("/v1/me")) {
+          return jsonResponse(
+            meFixture({
+              allow: {
+                // Writable PROJECT throughout, so the only thing that moves
+                // between the two cases is the activity grant.
+                project: ["read", "create", "update", "delete"],
+                activity: ["read", ...activityActions],
+              },
+            }),
+          );
+        }
+        return url.includes(`/v1/activities/${commitment.activity_id}`)
+          ? jsonResponse(TASK)
+          : null;
+      },
+    });
+  }
+
+  it("offers no task verbs to a reader who may write the project but not its activities", async () => {
+    showCommitments([]);
+    render(<ProjectScreen id={project().id} />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: commitment.subject }),
+    );
+
+    // The task opened — the refusal below is about the VERBS, not about the
+    // reader being unable to look. The subject appears twice by design: the
+    // row it was opened from, and the modal's own heading.
+    expect(
+      await screen.findByRole("heading", { name: commitment.subject }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: en["tasks.complete"] }),
+    ).toBeNull();
+  });
+
+  // The admit case. Without it the refusal above passes against a modal that
+  // shows no verbs to anyone — including the reader who may use them.
+  it("offers them to a reader who may write activities", async () => {
+    showCommitments(["update"]);
+    render(<ProjectScreen id={project().id} />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: commitment.subject }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: en["tasks.complete"] }),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -21,6 +21,7 @@ import { SurfaceState, sectionState } from "../design-system/surfacestate";
 import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { formatDate } from "../format/format";
 import { useLocale, useT } from "../i18n";
+import { taskWriteKeys } from "./activitykeys";
 import { ArchiveAction } from "./archive";
 import { QueryGate, throwProblem, useMe, useSorMode } from "./common";
 import { NewDealAction } from "./companyactions";
@@ -61,6 +62,7 @@ import {
 } from "./recordchronology";
 import { RecordEmailVerb } from "./recordemail";
 import { ShareAction } from "./share";
+import { TaskDetailModal, useTaskUpdate } from "./taskactions";
 import { TimelineActions } from "./timelineactions";
 import { groupChronology } from "./timelinegroups";
 import "./projects.css";
@@ -120,6 +122,11 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
   // describes itself by pointing at the same explanation.
   const readOnlyReason = useProjectVerbRefusal(project);
   const readOnly = Boolean(readOnlyReason);
+  // The commitments card's task detail, owned HERE rather than by the card:
+  // one modal per page, so two cards cannot both put a dialog on the screen.
+  // The same arrangement the account page uses for its own step rows.
+  const [openTask, setOpenTask] = useState<string | null>(null);
+  const taskUpdate = useTaskUpdate(taskWriteKeys("project", project.id));
   return (
     <RecordView
       // WHO is on this work comes first, then the paperwork. The column used
@@ -228,7 +235,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
           />
         </div>
         <div id={PROJECT_COMMITMENTS_ANCHOR}>
-          <CommitmentsCard view={view} />
+          <CommitmentsCard view={view} onOpenTask={setOpenTask} />
         </div>
       </div>
       <AdvanceProjectModal
@@ -237,6 +244,14 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
         to={moveTo}
         onClose={() => setMoveTo(null)}
       />
+      {openTask && (
+        <TaskDetailModal
+          activityId={openTask}
+          readOnly={readOnly}
+          onClose={() => setOpenTask(null)}
+          update={taskUpdate}
+        />
+      )}
     </RecordView>
   );
 }

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type ReactNode, useId, useState } from "react";
 import { api } from "../api/client";
 import { ifMatch, requireVersion } from "../api/version";
-import { useRecordWriteRefusal } from "../app/capability";
+import { useCan, useRecordWriteRefusal } from "../app/capability";
 import { PageAsideToggle, usePageAside } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
@@ -127,6 +127,14 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
   // The same arrangement the account page uses for its own step rows.
   const [openTask, setOpenTask] = useState<string | null>(null);
   const taskUpdate = useTaskUpdate(taskWriteKeys("project", project.id));
+  // The TASK's own permission, not the project's. They are different questions
+  // with different answers: the modal's verbs PATCH /activities/{id}, which
+  // asks activity:update and the activity's own row authority — author,
+  // assignee, host, or a writable linked record. Deriving this from the
+  // project's writability would offer verbs the server refuses to a reader who
+  // may write the project and not its activities, and hide valid ones from a
+  // task's own author whenever the project is read-only.
+  const canUpdateTask = useCan("activity", "update");
   return (
     <RecordView
       // WHO is on this work comes first, then the paperwork. The column used
@@ -247,7 +255,7 @@ function ProjectPage({ view }: Readonly<{ view: Project360 }>) {
       {openTask && (
         <TaskDetailModal
           activityId={openTask}
-          readOnly={readOnly}
+          readOnly={!canUpdateTask}
           onClose={() => setOpenTask(null)}
           update={taskUpdate}
         />

--- a/frontend/src/screens/projectcommitments.test.tsx
+++ b/frontend/src/screens/projectcommitments.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
+import { project360 } from "./projects.fixtures";
+import { CommitmentsCard } from "./projectsections";
+
+// The one card that names what a project owes, and its rows opened nothing.
+// A reader who wanted the description, the assignee or the verbs behind a
+// commitment had to find the same task on another screen to reach them.
+
+const COMMITMENT = {
+  activity_id: "a-1",
+  subject: "Confirm the depot slot",
+  due_at: "2026-09-11T09:00:00Z",
+  assignee_id: null,
+  assignee_name: null,
+  overdue: false,
+} satisfies components["schemas"]["Project360Commitment"];
+
+// The shared builder, so the fixture is a COMPLETE Project360 rather than one
+// asserted into the type: a cast fixture can drop a required field and still
+// compile, and the test would go on passing after the wire shape moved.
+function view(
+  commitments: components["schemas"]["Project360Commitment"][],
+) {
+  return project360({
+    commitments: { data: commitments, page: { has_more: false } },
+  });
+}
+
+function draw(onOpenTask?: (activityId: string) => void) {
+  render(
+    <LocaleProvider initial="en">
+      <CommitmentsCard view={view([COMMITMENT])} onOpenTask={onOpenTask} />
+    </LocaleProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("a project's commitments", () => {
+  it("opens the task the row stands for", async () => {
+    const opened: string[] = [];
+    draw((activityId) => opened.push(activityId));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Confirm the depot slot" }),
+    );
+
+    // The exact id, not merely that something was pressed: a row that opened
+    // the wrong task would pass an assertion about the click alone.
+    expect(opened).toEqual(["a-1"]);
+  });
+
+  it("stays flat where the screen mounts no task detail", () => {
+    // The refusal case, and the one that says the button above is the
+    // handler's doing rather than something the row draws regardless.
+    draw();
+
+    expect(screen.getByText("Confirm the depot slot")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("still says when a commitment is overdue", () => {
+    // The row's other facts survive the subject becoming a control. A button
+    // wrapping the whole row would have swallowed them.
+    render(
+      <LocaleProvider initial="en">
+        <CommitmentsCard
+          view={view([{ ...COMMITMENT, overdue: true }])}
+          onOpenTask={vi.fn()}
+        />
+      </LocaleProvider>,
+    );
+
+    expect(
+      screen.getByText(en["project.commitments.overdue"]),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/projectcommitments.test.tsx
+++ b/frontend/src/screens/projectcommitments.test.tsx
@@ -28,9 +28,7 @@ const COMMITMENT = {
 // The shared builder, so the fixture is a COMPLETE Project360 rather than one
 // asserted into the type: a cast fixture can drop a required field and still
 // compile, and the test would go on passing after the wire shape moved.
-function view(
-  commitments: components["schemas"]["Project360Commitment"][],
-) {
+function view(commitments: components["schemas"]["Project360Commitment"][]) {
   return project360({
     commitments: { data: commitments, page: { has_more: false } },
   });
@@ -81,8 +79,6 @@ describe("a project's commitments", () => {
       </LocaleProvider>,
     );
 
-    expect(
-      screen.getByText(en["project.commitments.overdue"]),
-    ).toBeTruthy();
+    expect(screen.getByText(en["project.commitments.overdue"])).toBeTruthy();
   });
 });

--- a/frontend/src/screens/projects.tsx
+++ b/frontend/src/screens/projects.tsx
@@ -240,12 +240,11 @@ export function ProjectsScreen() {
           {
             key: "company",
             header: t("project.company"),
+            // A real link to the customer. The row opens the PROJECT, so a
+            // reader who wanted the account behind it had to open the project
+            // first and come back out.
             cell: (project: Project) => (
-              <EntityRef
-                kind="organization"
-                id={project.organization_id}
-                asText
-              />
+              <EntityRef kind="organization" id={project.organization_id} />
             ),
           },
           {

--- a/frontend/src/screens/projectsections.tsx
+++ b/frontend/src/screens/projectsections.tsx
@@ -433,7 +433,15 @@ function DocumentRow({
 /** The open tasks filed under the project, soonest due first. */
 export function CommitmentsCard({
   view,
-}: Readonly<{ view: Project360 | undefined }>) {
+  onOpenTask,
+}: Readonly<{
+  view: Project360 | undefined;
+  // Opens one commitment's task detail. Owned by the screen rather than by
+  // this card, because the modal is one per page: a card that mounted its own
+  // would put a second dialog on a screen that already has one whenever both
+  // are open.
+  onOpenTask?: (activityId: string) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const commitments = view?.commitments?.data ?? [];
@@ -454,6 +462,7 @@ export function CommitmentsCard({
           key={commitment.activity_id}
           commitment={commitment}
           locale={locale}
+          onOpenTask={onOpenTask}
         />
       ))}
     </SectionPanel>
@@ -463,9 +472,11 @@ export function CommitmentsCard({
 function CommitmentRow({
   commitment,
   locale,
+  onOpenTask,
 }: Readonly<{
   commitment: Commitment;
   locale: ReturnType<typeof useLocale>["locale"];
+  onOpenTask?: (activityId: string) => void;
 }>) {
   const t = useT();
   // The record's clock, exactly as the tasks screen reads it. A commitment is a
@@ -474,7 +485,21 @@ function CommitmentRow({
   const recordZone = useRecordZone();
   return (
     <PanelRow className="project-row">
-      <span>{commitment.subject}</span>
+      {/* The subject opens the task, the way this file's other two rows open
+          theirs. It was flat text here, so a reader who wanted the description,
+          the assignee or the verbs behind a commitment had nowhere to press —
+          on the one card that names what the project owes. */}
+      {onOpenTask ? (
+        <button
+          type="button"
+          className="project-rowlink"
+          onClick={() => onOpenTask(commitment.activity_id)}
+        >
+          {commitment.subject}
+        </button>
+      ) : (
+        <span>{commitment.subject}</span>
+      )}
       <span className="project-row-meta t-caption">
         {commitment.due_at && (
           <span>{formatDateAbbrev(commitment.due_at, locale, recordZone)}</span>


### PR DESCRIPTION
Five places where Margince named a record and the reader could not get to it. They are independent fixes with one shape: a thing with a name and an id, drawn as text or as a control that went nowhere.

## A cross-record reference is a link

`EntityRef` rendered a `<button>` that called `navigate`. A reader who middle-clicked a company got nothing, and one who wanted it beside the page they were on had to lose that page to reach it. It is an anchor now, with `href` and only `stopPropagation` — not `navigate` beside it, which would dispatch the same route twice and break the modifier clicks the anchor exists to restore.

The company cell in the contacts and projects lists drops `asText`. The reasoning for it was that the row is already a link — but the row links to the CONTACT and to the PROJECT, so a reader scanning who works for whom, or which account a delivery belongs to, had to open one record to reach the other.

## A deal card opens the deal and the account behind it

The whole card was one anchor to the deal, on the one surface where three deals side by side is the point. It is a div holding a stretched anchor now, keeping every property the outer anchor had — whole-card click target, new tab, middle-click, one tab stop — with the company as a second anchor above it. `BoardDeal` takes an `orgHref` rather than an organization id: this tier holds no routes, and a design-system card that knew how to build `#/companies/{id}` would be the app's routing table in two places.

## A notice says which record it is about

"A deal you own changed stage" is true of every deal a rep owns. The row carried the sentence and nothing else.

`notice` gains a nullable `target_type`/`target_id` pair with a both-or-neither constraint. The automation `Notifier` seam carries the action's own Target through, and the worklist projection turns it into an `AttentionSubject`, which the client already renders as a link. `subjectOf` refuses a type this feed cannot route to rather than guessing.

The replay path returns the STORED target, for the same reason it already returns the stored subject: an event replayed after its automation was repointed names a different record.

## A project commitment opens its task

The one card that names what a project owes drew flat text. The subject is a control now, opening the shared `TaskDetailModal` — owned by the screen, one per page.

## Checks

`make check-backend` and `make check-fe` green, `make craft-static` clean, the migrations integration lane green including reverse-and-reapply. The head catalog gained exactly the three lines this migration adds.

Every guard is mutation-checked: reverting the anchor, the company link, the stored-target replay, the unroutable-subject refusal and the commitment opener each fails a test that names what broke.

Nine test assertions across seven files moved from `role="button"` to `role="link"` — and where a destination was asserted through a click, they now assert the `href`, which is the stronger claim: it is also what a new tab and a middle-click follow. Two helpers reached a board card with `closest("a")` and now ask for the card itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes named records open the ways a link does: cross-record references, deal cards, unread notices, and project commitments now link to the record they name instead of drawing flat text or a button that only navigates on a plain click.

**Behavior changes**
- `EntityRef` is a real anchor now, so records open in new tabs and from middle-clicks; the contacts and projects company cells link to the company.
- A deal card is a div holding a stretched deal link plus a separate company link, and callers pass `orgHref` instead of an id.
- Unread notices store the record they are about, and the worklist row links to it; notices naming an unroutable type carry no link.
- A project commitment's subject opens its task detail modal, whose verbs answer to the task's own permission rather than the project's writability.
- Tests now assert `href` instead of click effects.

**Migration**
- `notice` gains nullable `target_type`/`target_id` columns with a both-or-neither check constraint; run the new migration before deploying.

<sup>Written for commit 3a6421256c3b8eb88ae6ea6172003c597e9de864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notifications can now link directly to the record they reference, including deals, people, and companies.
  - Deal cards and list views provide direct links to related companies and records.
  - Project commitments can open task details directly from the project page.

- **Improvements**
  - Record references now use standard links for more reliable navigation and accessibility.
  - Deal cards support separate navigation for deals and companies.
  - Link styling and focus behavior have been refined for clearer interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->