### PR TITLE
fix(launcher): one launcher at a time per installation folder

### DIFF
--- a/backend/gates/lintbuildtagreach_test.go
+++ b/backend/gates/lintbuildtagreach_test.go
@@ -180,12 +180,13 @@ var unreadFiles = gatekit.Waive(map[string]string{
 	"backend/internal/platform/ownedfile/owned_windows.go":   "the windows half of the owned-file primitive, cross-compiled and unlinted for the reason its blobstore sibling above states — the cost is that a permissions or error-handling defect here is caught only by review",
 
 	// The desktop launcher is its own module, released by its own lanes.
-	"desktop/launcher/platform_windows.go":  "desktop launcher platform layer: built by the windows release lane (desktop-windows.yml), not by the merge gate, which neither cross-compiles this module nor lints at a foreign GOOS. A break here surfaces at release rather than at merge",
-	"desktop/launcher/process_windows.go":   "desktop launcher process control, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"desktop/launcher/postgres_windows.go":  "desktop launcher Postgres supervision, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"desktop/launcher/runerror_windows.go":  "desktop launcher error rendering, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
-	"desktop/launcher/browser_darwin.go":    "desktop launcher browser handoff for macOS: compiled by the macOS release lane (desktop-macos.yml) and by a maintainer's own machine, and by nothing at all in the merge gate — GOOS is not a tag, so no config entry could change that",
-	"desktop/launcher/quarantine_darwin.go": "desktop launcher quarantine-attribute handling, macOS-only and reached only by the macOS release lane. This one carries the most risk of the set: it is the code that decides what a downloaded bundle is allowed to do, and no linter in this repository has read it",
+	"desktop/launcher/platform_windows.go":     "desktop launcher platform layer: built by the windows release lane (desktop-windows.yml), not by the merge gate, which neither cross-compiles this module nor lints at a foreign GOOS. A break here surfaces at release rather than at merge",
+	"desktop/launcher/process_windows.go":      "desktop launcher process control, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/postgres_windows.go":     "desktop launcher Postgres supervision, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/runerror_windows.go":     "desktop launcher error rendering, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it",
+	"desktop/launcher/processalive_windows.go": "desktop launcher liveness probe for the start lock, built by the windows release lane alone — see platform_windows.go above for why no merge-gate pass reaches it. The cost here is that the OpenProcess/GetExitCodeProcess pair decides whether a lock is abandoned, and an inverted answer either reclaims a folder another launcher is starting in or refuses one nobody holds",
+	"desktop/launcher/browser_darwin.go":       "desktop launcher browser handoff for macOS: compiled by the macOS release lane (desktop-macos.yml) and by a maintainer's own machine, and by nothing at all in the merge gate — GOOS is not a tag, so no config entry could change that",
+	"desktop/launcher/quarantine_darwin.go":    "desktop launcher quarantine-attribute handling, macOS-only and reached only by the macOS release lane. This one carries the most risk of the set: it is the code that decides what a downloaded bundle is allowed to do, and no linter in this repository has read it",
 })
 
 func TestEveryGoFileIsCompiledAndAnalysedBySomePass(t *testing.T) {

--- a/desktop/launcher/main.go
+++ b/desktop/launcher/main.go
@@ -58,6 +58,26 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// BEFORE ANYTHING IS CREATED, and held until the stack has stopped. Two
+	// launchers on a fresh installation otherwise both decide the database
+	// needs creating and both build it in the same staging directory, which
+	// leaves a half-initialised cluster where a finished one belongs — and
+	// double-clicking the start script twice is enough to do it.
+	//
+	// Around the whole run rather than around initdb: a second launcher that
+	// waited for the cluster and then bound ports and ran migrations against it
+	// is the same collision arriving later.
+	lock, err := lockInstallation(layout)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := lock.release(); err != nil {
+			// Reported, never fatal: the run is over, and the next start reads
+			// an unreleased lock as stale and reclaims it.
+			say("\n%v\n", err)
+		}
+	}()
 	// Before anything is spawned: on macOS a downloaded bundle otherwise puts a
 	// Gatekeeper dialog in front of every one of the six programs below.
 	clearQuarantine(layout)

--- a/desktop/launcher/processalive_unix.go
+++ b/desktop/launcher/processalive_unix.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processAlive reports whether a process with this id exists.
+//
+// Signal 0 is the POSIX question rather than an action: the kernel runs its
+// permission and existence checks and delivers nothing. That is what makes it
+// safe to ask about a process this launcher does not own.
+//
+// EPERM means ALIVE, and getting that backwards is the bug worth naming. It is
+// the answer when the process exists and belongs to another user — which is
+// exactly the shared-machine case the lock matters most on — so reading it as
+// "gone" would let a second user's launcher reclaim a folder the first is
+// initialising.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return !errors.Is(err, syscall.ESRCH)
+}

--- a/desktop/launcher/processalive_windows.go
+++ b/desktop/launcher/processalive_windows.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import "syscall"
+
+// processAlive reports whether a process with this id exists.
+//
+// Windows has no signal 0, and os.FindProcess succeeds for any id there, so it
+// answers nothing. Opening a handle is the question: OpenProcess fails when no
+// process carries the id.
+//
+// PROCESS_QUERY_LIMITED_INFORMATION rather than PROCESS_QUERY_INFORMATION,
+// because the shared-machine case is the one the lock is for: the wider right
+// is refused across a user boundary, and a refusal read as "gone" would let a
+// second user's launcher reclaim a folder the first is initialising. The
+// limited right answers existence across that boundary, which is all this asks.
+//
+// A handle that opens is CLOSED immediately — leaking one would hold the
+// process's exit code alive in the kernel for as long as the launcher runs.
+//
+// A still-running process and one that has exited but whose id nothing has
+// reused are told apart by the exit code: STILL_ACTIVE means running. That
+// distinction matters because a handle can outlive its process here, unlike a
+// pid on unix.
+func processAlive(pid int) bool {
+	const (
+		processQueryLimitedInformation = 0x1000
+		// STILL_ACTIVE, spelled here because the standard library's windows
+		// syscall package does not export it. It is 259 (STATUS_PENDING) and
+		// has been since NT — the value a process's exit code carries while it
+		// is running.
+		stillActive = 259
+	)
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() {
+		//craft:ignore swallowed-errors closing a query handle cannot change the answer already read, and reporting it would replace a liveness answer with a housekeeping one
+		_ = syscall.CloseHandle(handle)
+	}()
+	var code uint32
+	if err := syscall.GetExitCodeProcess(handle, &code); err != nil {
+		// The handle opened, so something carries this id. Reporting it alive
+		// is the safe direction: the cost is a readable refusal, and the cost
+		// of the other answer is a corrupted cluster.
+		return true
+	}
+	return code == stillActive
+}

--- a/desktop/launcher/startlock.go
+++ b/desktop/launcher/startlock.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// One launcher per installation folder.
+//
+// Two launchers started at once on a FRESH installation both decide the
+// database needs creating, and then both create it in the same staging
+// directory: one process's RemoveAll deletes what the other is midway through
+// writing, and the rename that follows can land a half-built cluster where the
+// finished one belongs. Double-clicking the start script twice is enough.
+//
+// It is first-boot only — on a later launch the postmaster's own lock file and
+// the fixed UI port refuse the second process, for reasons a user can read — so
+// what is missing is not a general mutex but an answer to "is another launcher
+// working on this folder", asked before anything is created.
+//
+// HELD FOR THE WHOLE RUN rather than around initdb alone. A second launcher
+// that waited for the cluster and then bound ports and ran migrations against
+// it is the same collision arriving later, so the lock is taken before the
+// stack starts and released after it stops.
+//
+// WHY A PID FILE AND NOT flock. `flock` is the better primitive and this module
+// cannot reach it: it is deliberately stdlib-only and outside the workspace,
+// and Windows's LockFileEx lives in golang.org/x/sys. A PID file with a
+// liveness check is what both platforms can answer from the standard library,
+// and its weakness is stated where it bites — see staleLock.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// startLockName sits in data/ beside the other per-installation state rather
+// than in the installation root, so a user browsing the folder they installed
+// into sees the program and their own settings, not a lock file.
+const startLockName = "starting.lock"
+
+func (l layout) startLockPath() string { return filepath.Join(l.data(), startLockName) }
+
+// startLock is a held installation lock. Release is the only way it ends.
+type startLock struct{ path string }
+
+// lockInstallation claims this folder for this launcher.
+//
+// THE CREATE IS THE CHECK, the shape the rest of this launcher uses for a
+// single-writer question: O_EXCL answers "does it exist" and "claim it" in one
+// syscall, so two launchers racing cannot both be told the folder is free.
+func lockInstallation(l layout) (*startLock, error) {
+	if err := os.MkdirAll(l.data(), 0o700); err != nil {
+		return nil, fmt.Errorf("create the data directory: %w", err)
+	}
+	path := l.startLockPath()
+	if err := writeStartLock(path); err == nil {
+		return &startLock{path: path}, nil
+	} else if !errors.Is(err, os.ErrExist) {
+		return nil, err
+	}
+
+	// It exists. Either another launcher is running, or one died holding it.
+	stale, holder := staleLock(path)
+	if !stale {
+		// The capital is the product name, and this error is printed verbatim to
+		// the person who just double-clicked the second icon.
+		return nil, fmt.Errorf( //nolint:staticcheck // ST1005: leading word is a proper noun
+			"Margince is already starting in this folder (process %s) — wait for it to finish, "+
+				"or close that one and start again", holder)
+	}
+	// The holder is gone. Removing and re-claiming is safe because the lock
+	// grants nothing on its own: whatever that run left half-done is cleaned by
+	// the step that owns it — initCluster clears its own staging directory, and
+	// nothing was ever moved into place from one.
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("clear the abandoned start lock %s: %w", path, err)
+	}
+	// Once, not in a loop. A second failure here means a launcher claimed the
+	// folder between the remove and this write, which is the answer this
+	// function exists to give.
+	if err := writeStartLock(path); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, errors.New("another Margince launcher claimed this folder while this one was starting")
+		}
+		return nil, err
+	}
+	return &startLock{path: path}, nil
+}
+
+// release drops the claim. A launcher that exits without reaching this leaves a
+// lock the next start reads as stale, which is why the staleness check is not
+// optional.
+func (s *startLock) release() error {
+	if s == nil {
+		return nil
+	}
+	if err := os.Remove(s.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("release the start lock %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// writeStartLock records this process's id, and refuses an existing file.
+func writeStartLock(path string) error {
+	// #nosec G304 -- path is layout.data()'s lock file, derived from the installation directory and never from input
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|openNoFollow, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return fmt.Errorf("write %s: %w (and closing it failed: %v)", path, err, closeErr)
+		}
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return nil
+}
+
+// staleLock reports whether the recorded holder is gone, and names it either
+// way so the refusal can say who has the folder.
+//
+// WHAT THIS CANNOT ANSWER, said here because it decides what a user sees. A
+// process id is reused, so a lock left by a crashed launcher whose id has since
+// been taken by something unrelated reads as live. The installation then
+// refuses to start with a message naming a process that is not Margince — which
+// is why that message says what to do about it rather than only what is wrong.
+// The alternative, treating an unreadable or doubtful lock as stale, trades a
+// readable refusal for the corrupted cluster this whole file exists to prevent.
+//
+// An unreadable or malformed lock is treated as HELD for the same reason: it
+// was written by something, and guessing otherwise is the guess that costs a
+// database.
+func staleLock(path string) (stale bool, holder string) {
+	// #nosec G304 -- see writeStartLock
+	recorded, err := os.ReadFile(path)
+	if err != nil {
+		return false, "unknown"
+	}
+	text := strings.TrimSpace(string(recorded))
+	pid, err := strconv.Atoi(text)
+	if err != nil || pid <= 0 {
+		return false, "unknown"
+	}
+	if pid == os.Getpid() {
+		// This process wrote it and did not release it — a crash inside one
+		// run, or a lock file left in a copied installation folder. Reclaiming
+		// is correct: there is no other launcher to collide with.
+		return true, text
+	}
+	return !processAlive(pid), text
+}

--- a/desktop/launcher/startlock_test.go
+++ b/desktop/launcher/startlock_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The single-writer question this launcher could not answer: is another one
+// already working on this folder?
+//
+// Without it two launchers on a fresh installation both decide the database
+// needs creating and both build it in the same staging directory — one's
+// RemoveAll deleting what the other is writing, and the rename that follows
+// landing a half-built cluster where the finished one belongs.
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A launcher holding the folder refuses the next one, and says what to do
+// rather than letting it fail later on a symptom — an initdb error, or a
+// cluster that will not start.
+//
+// The holder is the PARENT process rather than this one: a real second
+// launcher is a different process, and lockInstallation reclaims its own id on
+// purpose (a crash inside one run, or a lock copied with the folder). Writing
+// this process's id would exercise that branch instead of the one under test.
+func TestASecondLauncherIsRefusedWhileAnotherHoldsTheFolder(t *testing.T) {
+	l := newTestLayout(t)
+	holder := os.Getppid()
+	if !processAlive(holder) {
+		t.Skip("the parent process is gone, so it cannot stand in for a live launcher")
+	}
+	if err := os.WriteFile(l.startLockPath(), []byte(strconv.Itoa(holder)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := lockInstallation(l)
+	if err == nil {
+		t.Fatal("a second launcher claimed a folder another is starting in; both would create the " +
+			"database in the same staging directory")
+	}
+	if !strings.Contains(err.Error(), "already starting") {
+		t.Errorf("the refusal reads %q, want it to say the folder is already starting", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(holder)) {
+		t.Errorf("the refusal reads %q, want it to name the holder — a user with two windows open "+
+			"needs to know which one to close", err)
+	}
+}
+
+// Claiming and releasing leaves the folder free. A lock nothing can drop would
+// brick the installation on its second run.
+func TestClaimingAndReleasingFreesTheFolder(t *testing.T) {
+	l := newTestLayout(t)
+
+	held, err := lockInstallation(l)
+	if err != nil {
+		t.Fatalf("the first launcher could not claim the folder: %v", err)
+	}
+	if _, err := os.Stat(l.startLockPath()); err != nil {
+		t.Fatalf("the claim wrote no lock: %v", err)
+	}
+	if err := held.release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if _, err := os.Stat(l.startLockPath()); !os.IsNotExist(err) {
+		t.Fatalf("the lock survived release: %v", err)
+	}
+	next, err := lockInstallation(l)
+	if err != nil {
+		t.Fatalf("the folder stayed locked after release: %v", err)
+	}
+	if err := next.release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A launcher killed mid-start leaves its lock behind. The next one must reclaim
+// it: a lock only a graceful exit can drop turns one crash into an
+// installation nobody can start.
+func TestAnAbandonedLockIsReclaimed(t *testing.T) {
+	l := newTestLayout(t)
+
+	// A pid that is certainly not running. 0 and negatives are refused by the
+	// parse; this is a live-looking id with nothing behind it.
+	if err := os.WriteFile(l.startLockPath(), []byte(strconv.Itoa(deadPID(t))+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := lockInstallation(l)
+	if err != nil {
+		t.Fatalf("a lock left by a dead launcher was not reclaimed: %v — one crash would brick the "+
+			"installation", err)
+	}
+	// The file is this process's now, not the corpse's.
+	recorded, err := os.ReadFile(l.startLockPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(recorded)) != strconv.Itoa(os.Getpid()) {
+		t.Errorf("the reclaimed lock records %q, want this process", strings.TrimSpace(string(recorded)))
+	}
+	if err := lock.release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A lock whose contents cannot be read as a process id is treated as HELD.
+//
+// The safe direction is the one that refuses: the cost of refusing a folder
+// nobody holds is a message a user can act on, and the cost of the other answer
+// is the corrupted cluster this lock exists to prevent.
+func TestAnUnreadableLockIsTreatedAsHeld(t *testing.T) {
+	l := newTestLayout(t)
+	for _, contents := range []string{"", "   ", "not a pid", "-1", "0"} {
+		if err := os.WriteFile(l.startLockPath(), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := lockInstallation(l); err == nil {
+			t.Errorf("a lock containing %q was reclaimed; an unreadable lock was written by "+
+				"something, and guessing otherwise is the guess that costs a database", contents)
+		}
+	}
+}
+
+// This process's own id in the lock means a crash inside one run, or a lock
+// copied along with an installation folder. There is no other launcher to
+// collide with, so reclaiming is correct.
+func TestALockThisProcessLeftIsReclaimed(t *testing.T) {
+	l := newTestLayout(t)
+	if err := os.WriteFile(l.startLockPath(), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := lockInstallation(l)
+	if err != nil {
+		t.Fatalf("a lock this process itself left was not reclaimed: %v", err)
+	}
+	if err := lock.release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Releasing a lock somebody already removed is not an error: the run is over
+// either way, and reporting it would replace the outcome of the launch with a
+// housekeeping complaint.
+func TestReleasingAnAlreadyRemovedLockIsQuiet(t *testing.T) {
+	l := newTestLayout(t)
+	lock, err := lockInstallation(l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(l.startLockPath()); err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.release(); err != nil {
+		t.Errorf("release complained about a lock that was already gone: %v", err)
+	}
+}
+
+// This process is alive and pid 1 exists on every unix; the liveness check has
+// to agree with both, or every lock reads stale and the whole file is inert.
+func TestProcessAliveAnswersForARunningProcess(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("this process reads as gone, so every lock would be reclaimed and nothing serialised")
+	}
+}
+
+// deadPID finds an id nothing is using, so the stale-lock case is about a dead
+// holder rather than about a parse failure.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	// Downward from a high id: a freshly booted machine has few processes, and
+	// the top of the range is where the gaps are.
+	for pid := 4_000_000; pid > 100_000; pid -= 7919 {
+		if !processAlive(pid) {
+			return pid
+		}
+	}
+	t.Skip("no unused process id could be found on this machine")
+	return 0
+}


### PR DESCRIPTION
Closes #1841.

## The race

`needsInitdb` answers from the filesystem, so two launchers started on the same fresh installation both get `true`. `initCluster` then does `os.RemoveAll(staging)` → `initdb` → `os.Rename(staging, pgData())`. Interleaved, one process deletes what the other is populating, and the rename lands a half-built cluster where the finished one belongs. Nothing downstream can tell that apart from a corrupt install.

## The lock

One installation-scoped lock, acquired right after `resolveLayout()` and held through shutdown by a `defer`. A PID file rather than `flock`/`LockFileEx`: this module is deliberately stdlib-only and outside `go.work`, and a PID file is the shape the ticket named first.

- `O_CREATE|O_EXCL` (plus the no-follow flag this module already uses) claims it and records the holder's process id.
- A lock that already exists goes to a liveness probe: `kill(pid, 0)` on unix, `OpenProcess` + `GetExitCodeProcess` on windows. A live holder is refused with *"Margince is already starting in this folder (process N) — wait for it to finish, or close that one and start again"*. A dead one is removed and re-claimed.
- Releasing is never fatal: a failure to remove the lock is reported after the run rather than replacing the run's own outcome.

**Every answer the probe cannot give reads as HELD** — an empty, malformed or unreadable lock file, and `EPERM` from `kill`, which means a process this user may not signal rather than an absent one. Refusing a folder nobody holds costs a message the user can act on; the other answer costs the database the lock exists to protect. The one exception is this process's own id, which reads as stale: that is a crash inside a single run, or a lock copied along with the installation folder, and there is no second launcher to collide with.

Re-claiming is safe because the lock grants nothing on its own — whatever an abandoned run left half-done is cleaned by the step that owns it, and `initCluster` clears its own staging directory before it writes.

## Tests

`desktop/launcher/startlock_test.go`, six cases: a live holder is refused and named; claim/release frees the folder; a lock naming a dead pid is reclaimed and re-stamped with this process; five unreadable spellings each stay held; this process's own id is reclaimed; release is quiet when the file is already gone. The "second launcher" is the parent process, not this one — a real second launcher is a different process, and using this one's id would exercise the self-reclaim branch instead of the branch under test.

Mutation-checked: forcing the held branch off (`if !stale && false`) fails the refusal and the unreadable-lock cases; inverting the liveness answer fails the refusal.

## Also in this diff

`processalive_windows.go` is ratified in `unreadFiles` in `backend/gates/lintbuildtagreach_test.go` — the merge gate neither cross-compiles this module nor lints at a foreign GOOS, as it already does not for the six launcher files beside it. The entry states the specific cost: an inverted answer from this pair either reclaims a folder another launcher is starting in, or refuses one nobody holds.

## Checks

`make check-backend` green; `make test-desktop-launcher` green; `GOWORK=off go build` green for host, `GOOS=windows` and `GOOS=linux`; `make craft-static` clean.