### PR TITLE
A forecast finding names the deal it is about

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -34553,6 +34553,19 @@ components:
             this.
         subject_kind: { type: string, enum: [deal, signal, offer, contract] }
         subject_id: { type: string, format: uuid }
+        subject:
+          allOf: [{ $ref: '#/components/schemas/AttentionSubject' }]
+          readOnly: true
+          nullable: true
+          description: >-
+            The record this finding is about, named and addressed — the same shape the
+            Worklist carries, so a client routes it through the one registry rather
+            than mapping `subject_kind` onto a screen a second time.
+
+            `subject_kind` and `subject_id` stay: they are the durable fields, and a
+            client that has them and not this still draws today's label. Null when the
+            read that found this exception could not name the record — which today
+            means it is not a deal, since only a deal's findings are returned at all.
         severity: { type: string, enum: [low, medium, high] }
         affected_minor:
           type: integer

--- a/backend/internal/compose/assurancelist.go
+++ b/backend/internal/compose/assurancelist.go
@@ -55,7 +55,7 @@ func AssuranceExceptions(ctx context.Context, tx pgx.Tx) ([]assurance.Exception,
 	// visibility decision having been made about it. A LEFT join would let
 	// exactly the rows nobody can gate through.
 	sql := fmt.Sprintf(`
-		SELECT `+exceptionColumns+`
+		SELECT `+exceptionColumns+`, d.name
 		FROM assurance_exception e
 		JOIN deal d ON d.id = e.subject_id
 		WHERE e.status = 'open'
@@ -76,7 +76,7 @@ func AssuranceExceptions(ctx context.Context, tx pgx.Tx) ([]assurance.Exception,
 	}
 	defer rows.Close()
 
-	return pgx.CollectRows(rows, scanException)
+	return pgx.CollectRows(rows, scanLabelledException)
 }
 
 // exceptionColumns is the select list every read of a finding shares, aliased
@@ -88,6 +88,17 @@ const exceptionColumns = `e.id, e.type, e.subject_kind, e.subject_id, e.severity
 	       e.affected_minor, e.currency, e.owner_id, e.status,
 	       e.claim, e.observed, e.first_seen_at, e.last_seen_at`
 
+// scanLabelledException reads one row of exceptionColumns plus the subject's
+// own name, which only this reader selects.
+//
+// The name is appended rather than added to exceptionColumns because that list
+// is shared with bundleableFindings and bound POSITIONALLY: a column inserted
+// there would be read into a neighbouring field by the other scanner, silently.
+func scanLabelledException(row pgx.CollectableRow) (assurance.Exception, error) {
+	out, err := scanExceptionInto(row, true)
+	return out, err
+}
+
 // scanException reads one row of exceptionColumns.
 //
 // The nullable columns are read through pointers and folded in afterwards
@@ -95,14 +106,26 @@ const exceptionColumns = `e.id, e.type, e.subject_kind, e.subject_id, e.severity
 // there is "no money was named", which is a different fact from the empty
 // string only in that nothing may print it as a currency.
 func scanException(row pgx.CollectableRow) (assurance.Exception, error) {
+	return scanExceptionInto(row, false)
+}
+
+// scanExceptionInto is both scanners' body; labelled says whether the row
+// carries the trailing subject name.
+func scanExceptionInto(row pgx.CollectableRow, labelled bool) (assurance.Exception, error) {
 	var out assurance.Exception
 	var id, subjectID ids.UUID
 	var owner *ids.UUID
 	var currency *string
 	var firstSeen, lastSeen time.Time
-	err := row.Scan(&id, &out.Type, &out.SubjectKind, &subjectID, &out.Severity,
+	targets := []any{
+		&id, &out.Type, &out.SubjectKind, &subjectID, &out.Severity,
 		&out.AffectedMinor, &currency, &owner, &out.Status,
-		&out.Claim, &out.Observed, &firstSeen, &lastSeen)
+		&out.Claim, &out.Observed, &firstSeen, &lastSeen,
+	}
+	if labelled {
+		targets = append(targets, &out.SubjectLabel)
+	}
+	err := row.Scan(targets...)
 	out.ID = id
 	out.SubjectID = subjectID
 	out.FirstSeenAt = firstSeen

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24635,12 +24635,16 @@ type InputCheck struct {
 	LastSeenAt time.Time `json:"last_seen_at"`
 
 	// Observed What the check found, as structured values only.
-	Observed    *map[string]interface{} `json:"observed,omitempty"`
-	OwnerId     *openapi_types.UUID     `json:"owner_id,omitempty"`
-	Severity    InputCheckSeverity      `json:"severity"`
-	Status      InputCheckStatus        `json:"status"`
-	SubjectId   openapi_types.UUID      `json:"subject_id"`
-	SubjectKind InputCheckSubjectKind   `json:"subject_kind"`
+	Observed *map[string]interface{} `json:"observed,omitempty"`
+	OwnerId  *openapi_types.UUID     `json:"owner_id,omitempty"`
+	Severity InputCheckSeverity      `json:"severity"`
+	Status   InputCheckStatus        `json:"status"`
+
+	// Subject The record this finding is about, named and addressed — the same shape the Worklist carries, so a client routes it through the one registry rather than mapping `subject_kind` onto a screen a second time.
+	// `subject_kind` and `subject_id` stay: they are the durable fields, and a client that has them and not this still draws today's label. Null when the read that found this exception could not name the record — which today means it is not a deal, since only a deal's findings are returned at all.
+	Subject     *AttentionSubject     `json:"subject,omitempty"`
+	SubjectId   openapi_types.UUID    `json:"subject_id"`
+	SubjectKind InputCheckSubjectKind `json:"subject_kind"`
 
 	// Type Which question noticed it. The key set in `claim` and `observed` depends on this.
 	Type string `json:"type"`

--- a/backend/internal/modules/assurance/handlers.go
+++ b/backend/internal/modules/assurance/handlers.go
@@ -57,6 +57,36 @@ func (h Handlers) ListInputChecks(w http.ResponseWriter, r *http.Request) {
 	}{Data: exceptionsToWire(found)})
 }
 
+// subjectOf names the record a finding is about, so the row can open it.
+//
+// Only a NAMED subject becomes one: the label comes from the surface read's own
+// join, under the caller's own deal scope, so an empty one means the reader was
+// never shown the name and a row carrying the id alone is the honest answer.
+//
+// The kind is mapped rather than cast. `subject_kind` and AttentionSubject's
+// vocabulary overlap on `deal` and nowhere else — an offer, a contract and a
+// signal are not screens a subject routes to — so a kind this map does not know
+// yields no subject rather than a link that opens nothing.
+func subjectOf(e Exception) *crmcontracts.AttentionSubject {
+	kind, ok := subjectKinds[e.SubjectKind]
+	if !ok || e.SubjectLabel == "" {
+		return nil
+	}
+	label := e.SubjectLabel
+	return &crmcontracts.AttentionSubject{
+		Type:  kind,
+		Id:    openapi_types.UUID(e.SubjectID),
+		Label: &label,
+	}
+}
+
+// subjectKinds maps a finding's subject onto the contract's subject vocabulary.
+// Today the surface read returns deal findings only; the map is what makes a
+// second kind arriving later a deliberate act rather than a silent link.
+var subjectKinds = map[string]crmcontracts.AttentionSubjectType{
+	"deal": crmcontracts.AttentionSubjectTypeDeal,
+}
+
 func exceptionsToWire(in []Exception) []crmcontracts.InputCheck {
 	// Empty, never nil. "Nothing to check" is a real answer and arrives shaped
 	// like the array it is; null reads as "unknown", which on this surface
@@ -82,6 +112,7 @@ func exceptionsToWire(in []Exception) []crmcontracts.InputCheck {
 			owner := openapi_types.UUID(*e.OwnerID)
 			wire.OwnerId = &owner
 		}
+		wire.Subject = subjectOf(e)
 		// The structured values travel as they were stored. Decoding and
 		// re-encoding them here would make this the second place that knows
 		// what each exception type's keys are.

--- a/backend/internal/modules/assurance/store.go
+++ b/backend/internal/modules/assurance/store.go
@@ -450,4 +450,13 @@ type Exception struct {
 	Observed      []byte
 	FirstSeenAt   time.Time
 	LastSeenAt    time.Time
+	// SubjectLabel is the subject's own display name, when the read that found
+	// this exception could see it. The surface read joins the deal already, so
+	// the name arrives under the caller's own scope rather than through a
+	// second, differently-gated lookup.
+	//
+	// Empty where a reader did not ask for it — the bundling pass does not,
+	// because it decides what to group and never draws a row — and the wire
+	// then names the subject by id alone, which is what it did before.
+	SubjectLabel string
 }

--- a/backend/internal/modules/assurance/subject_test.go
+++ b/backend/internal/modules/assurance/subject_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package assurance
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A forecast finding names the deal it is about, so a manager reading the
+// review can open it. The row carried a subject_kind and a uuid, which named
+// the record to the database and to nobody else.
+
+func exception(kind, label string) Exception {
+	return Exception{
+		ID: ids.NewV7(), Type: "amount_disagrees", SubjectKind: kind,
+		SubjectID: ids.NewV7(), Severity: "high", Status: "open",
+		SubjectLabel: label,
+	}
+}
+
+func TestAFindingNamesTheDealItIsAbout(t *testing.T) {
+	t.Parallel()
+	in := exception("deal", "Fleet retrofit")
+
+	wire := exceptionsToWire([]Exception{in})
+
+	if len(wire) != 1 {
+		t.Fatalf("got %d rows, want one", len(wire))
+	}
+	subject := wire[0].Subject
+	if subject == nil {
+		t.Fatal("the finding names no record, so the review row opens nothing")
+	}
+	if subject.Type != crmcontracts.AttentionSubjectTypeDeal {
+		t.Errorf("subject type = %q, want deal", subject.Type)
+	}
+	if ids.UUID(subject.Id) != in.SubjectID {
+		t.Errorf("subject names %s, want the finding's own subject %s", subject.Id, in.SubjectID)
+	}
+	if subject.Label == nil || *subject.Label != "Fleet retrofit" {
+		t.Errorf("subject label = %v, want the deal's own name", subject.Label)
+	}
+	// The durable fields stay, so a client that has them and not the subject
+	// still draws today's row.
+	if wire[0].SubjectId != subject.Id {
+		t.Errorf("subject_id = %s, want the same record the subject names", wire[0].SubjectId)
+	}
+}
+
+// A finding whose name this reader never saw carries the id alone. The label
+// comes from the surface read's own join under the caller's deal scope, so an
+// empty one is a record they were not shown rather than a record with no name.
+func TestAFindingWithNoNameCarriesNoSubject(t *testing.T) {
+	t.Parallel()
+	wire := exceptionsToWire([]Exception{exception("deal", "")})
+
+	if wire[0].Subject != nil {
+		t.Errorf("an unnamed finding produced a subject: %+v", *wire[0].Subject)
+	}
+	if wire[0].SubjectId == (crmcontracts.InputCheck{}).SubjectId {
+		t.Error("the durable subject_id went missing too; the row can still say WHICH id")
+	}
+}
+
+// A kind the subject vocabulary has no screen for yields no subject. An offer,
+// a contract and a signal are not records a client routes to, and a link that
+// opens nothing teaches a reader that the row's links do not work.
+func TestAFindingOnAKindWithNoScreenNamesNoSubject(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"offer", "contract", "signal"} {
+		wire := exceptionsToWire([]Exception{exception(kind, "Named anyway")})
+		if wire[0].Subject != nil {
+			t.Errorf("a %s finding produced a subject: %+v", kind, *wire[0].Subject)
+		}
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -25388,6 +25388,11 @@ export interface components {
             subject_kind: "deal" | "signal" | "offer" | "contract";
             /** Format: uuid */
             subject_id: string;
+            /**
+             * @description The record this finding is about, named and addressed — the same shape the Worklist carries, so a client routes it through the one registry rather than mapping `subject_kind` onto a screen a second time.
+             *     `subject_kind` and `subject_id` stay: they are the durable fields, and a client that has them and not this still draws today's label. Null when the read that found this exception could not name the record — which today means it is not a deal, since only a deal's findings are returned at all.
+             */
+            readonly subject?: components["schemas"]["AttentionSubject"] | null;
             /** @enum {string} */
             severity: "low" | "medium" | "high";
             /**

--- a/frontend/src/screens/analytics.forecast.review.tsx
+++ b/frontend/src/screens/analytics.forecast.review.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { isEntityKind } from "../app/entity";
 import { Badge, Button } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import {
@@ -12,6 +13,7 @@ import {
 import { formatMoneyOrAbsent } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { QueryGate, throwProblem } from "./common";
+import { EntityRef } from "./entityref";
 
 type InputCheck = components["schemas"]["InputCheck"];
 type Assurance = components["schemas"]["ForecastAssurance"];
@@ -236,6 +238,19 @@ function CheckRow({
     <>
       <PanelRow>
         <span>{t(checkLabel(check.type))}</span>
+        {/* WHICH deal. The row named the check and the money and left the
+            record to a uuid on the wire, so a manager reading the review
+            before a call knew something was wrong and not what it was wrong
+            about. An older server sends no subject and the row reads as it
+            did, and so does a subject kind the registry has no screen for —
+            the same guard the Worklist's own rows apply. */}
+        {check.subject && isEntityKind(check.subject.type) && (
+          <EntityRef
+            kind={check.subject.type}
+            id={check.subject.id}
+            name={check.subject.label}
+          />
+        )}
         <span className="num">
           {formatMoneyOrAbsent(
             check.affected_minor ?? null,

--- a/frontend/src/screens/analytics.forecast.subject.test.tsx
+++ b/frontend/src/screens/analytics.forecast.subject.test.tsx
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { ForecastReview } from "./analytics.forecast.review";
+import { jsonResponse } from "./company.fixtures";
+
+// A finding in the forecast review says WHICH deal it is about.
+//
+// The row named the check and the money and left the record to a uuid on the
+// wire, so a manager reading the review before a call knew something was wrong
+// and not what it was wrong about.
+
+type InputCheck = components["schemas"]["InputCheck"];
+
+const CHECK = {
+  id: "e-1",
+  type: "close_past",
+  subject_kind: "deal",
+  subject_id: "d-1",
+  severity: "high",
+  status: "open",
+  first_seen_at: "2026-09-01T09:00:00Z",
+  last_seen_at: "2026-09-07T09:00:00Z",
+} satisfies InputCheck;
+
+function show(check: InputCheck) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/forecast/assurance/exceptions")) {
+        return jsonResponse({ data: [check] });
+      }
+      if (url.includes("/forecast/assurance")) {
+        return jsonResponse({
+          ran_at: "2026-09-07T03:00:00Z",
+          coverage: { deals_checked: 10, deals_total: 10 },
+        });
+      }
+      return jsonResponse({}, 404);
+    }),
+  );
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">
+        <ForecastReview />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("a forecast finding", () => {
+  it("names the deal and links to it", async () => {
+    show({
+      ...CHECK,
+      subject: { type: "deal", id: "d-1", label: "Fleet retrofit" },
+    });
+
+    const link = await screen.findByRole("link", { name: "Fleet retrofit" });
+    // The href, not a click: it is also what a new tab and a middle-click
+    // follow, and a manager triaging a review opens several deals at once.
+    expect(link.getAttribute("href")).toBe("#/deals/d-1");
+  });
+
+  it("still draws the row when the server names no subject", async () => {
+    // Version skew, and the reader who may not see the deal's name. The row
+    // said what was wrong before any of this and still does.
+    show(CHECK);
+
+    expect(await screen.findByText(/close date/i)).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Fleet retrofit" })).toBeNull();
+  });
+});


### PR DESCRIPTION
The forecast review's rows said which check failed and how much money was in question, and left the record to a uuid on the wire. A manager reading the review before a call knew something was wrong and not what it was wrong about.

## Where the name comes from

The surface read already INNER JOINs `deal` under the caller's own row-scope clause — that join is what decides whether the finding is visible at all. So the name is one column away, and it arrives having passed the same gate the row did rather than through a second, differently-gated lookup.

It is selected only in that query and **appended after** the shared `exceptionColumns` list rather than inserted into it. That list is bound positionally and is also read by the bundling pass, so a column added in the middle would be scanned into a neighbouring field, silently. `scanException` splits into a labelled and an unlabelled scanner over one body; the bundling pass keeps the unlabelled one and the unchanged list.

## What the client gets

`InputCheck` gains an optional `subject` — the same `AttentionSubject` shape the Worklist carries, so a client routes it through the one entity registry instead of mapping `subject_kind` onto a screen a second time. `subject_kind` and `subject_id` stay: they are the durable fields, and a client that has them and not this still draws today's row.

A kind with no screen yields no subject on both sides. The wire maps `deal` and nothing else; the row applies `isEntityKind`, the same guard the Worklist's own rows use. Today only deal findings are returned at all, so the map is what makes a second kind arriving later a deliberate act rather than a silent link.

## Checks

`make check-backend` and `make check-fe` green, `make craft-static` clean.

Both halves are mutation-checked: removing the wire's `subject` fails a backend test that says the row opens nothing, and suppressing the render fails a frontend test that asserts the `href`. The href is asserted rather than a click, because it is also what a new tab and a middle-click follow — and a manager triaging a review opens several deals at once.

Version skew has its own test: a server that names no subject still draws the row it drew before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the deal a forecast finding is about, so a manager reading the review can open it instead of decoding a UUID.

- Adds an optional `subject` to `InputCheck`, the same `AttentionSubject` shape the Worklist carries, so a client routes it through the one entity registry.
- Takes the name from the surface read's existing deal join, under the caller's own row-scope clause.
- Keeps `subject_kind` and `subject_id` as the durable fields; clients with only those still draw today's row.
- Kinds with no screen produce no subject on both sides: the wire maps only `deal`, and the row applies the same `isEntityKind` guard the Worklist uses.
- Servers that send no `subject` still render rows as before.

<sup>Written for commit aac68d29087300e6c8feffe535b1c9b5c48c9f0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

