### PR TITLE
fix(sitecensus): a cited passage testifies only for the entity it names

### DIFF
--- a/backend/internal/compose/evidencematch.go
+++ b/backend/internal/compose/evidencematch.go
@@ -121,6 +121,13 @@ const (
 	// (±1 same-page neighbor) does not carry — the reference-evidence
 	// no-guess rule.
 	dropValueNotInSnippet = "value_not_in_snippet"
+	// dropLegalBlockNotThisEntity marks a legal detail refused because the
+	// passage it was cited from never names the entity it is being
+	// attributed to. Both halves are grounded on the page and neither is
+	// invented, which is why this needs its own reason: the defect is the
+	// ATTRIBUTION, and reporting it as an ungrounded value would send a
+	// reader looking for text that is right there.
+	dropLegalBlockNotThisEntity = "legal_block_not_this_entity"
 	// dropParaphraseLowOverlap is WARNING-class, never a refusal: a
 	// paraphrase profile field whose value shares no content word with
 	// its cited passage. Multilingual sites trip it legitimately; the

--- a/backend/internal/compose/sitepageentities.go
+++ b/backend/internal/compose/sitepageentities.go
@@ -49,7 +49,8 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 			// across passages), but a DETAIL must come from the entity's own
 			// block or it belongs to a sibling company.
 			blockNorm := ""
-			if block, ok := legalEvidenceBlock(idx, e.E, name); ok {
+			block, refusal := legalEvidenceBlock(idx, e.E, name)
+			if refusal == "" {
 				entity.EvidenceSnippet = block
 				blockNorm = normalizeEvidence(block)
 			}
@@ -71,7 +72,15 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 				fieldRegisterVat:       e.V,
 			} {
 				if strings.TrimSpace(claimed) != "" && groundedDetail(blockNorm, claimed) == "" {
-					drop(laneLegal, field, claimed, dropValueNotInSnippet)
+					// The block's own refusal when it had one: a detail
+					// printed on the page under a sibling's name is a
+					// different defect from one the page never prints, and
+					// telling them apart is what makes either actionable.
+					reason := refusal
+					if reason == "" {
+						reason = dropValueNotInSnippet
+					}
+					drop(laneLegal, field, claimed, reason)
 				}
 			}
 			out = append(out, entity)
@@ -84,14 +93,38 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 // block. Addresses and registry lines commonly follow the company name in
 // the next 300-rune passage. Adjacent text joins only while it does not look
 // like a different registered company, preserving the sibling-entity gate.
-func legalEvidenceBlock(idx snippetIndex, id, currentName string) (string, bool) {
+//
+// It answers the drop reason rather than a bare bool, because the two ways a
+// block can be unusable are not the same finding and a reader acts on each
+// differently.
+func legalEvidenceBlock(idx snippetIndex, id, currentName string) (string, string) {
 	ref, ok := idx.resolve(id)
 	if !ok {
-		return "", false
+		return "", dropSnippetIDUnknown
+	}
+	// THE CITED PASSAGE MUST NAME THE ENTITY IT IS TESTIFYING FOR.
+	//
+	// Without this, a reply may name entity A while citing entity B's block,
+	// and B's grounded address and register number attach to A. Both halves
+	// are printed on the page, so nothing downstream can tell — which is the
+	// shape a group imprint listing several subsidiaries produces, and it
+	// lands without human confirmation on the auto-enrichment path.
+	//
+	// It is the CITED passage rather than the joined block: a reply citing a
+	// sibling's block would otherwise pass on a neighbour that happens to
+	// print this entity's name, which is the ordinary layout of exactly the
+	// page this guards.
+	//
+	// A name the layout broke across this boundary therefore loses its
+	// details. That is the safe direction — the entity still stands in the
+	// census, and a human types an address — where the other one prints a
+	// register number that was never this company's.
+	if groundedDetail(ref.norm, currentName) == "" {
+		return "", dropLegalBlockNotThisEntity
 	}
 	var n int
 	if _, err := fmt.Sscanf(id, "s%d", &n); err != nil {
-		return ref.passage, true
+		return ref.passage, ""
 	}
 	parts := []string{ref.passage}
 	for _, adjacent := range []int{n - 1, n + 1} {
@@ -107,7 +140,7 @@ func legalEvidenceBlock(idx snippetIndex, id, currentName string) (string, bool)
 			parts = append(parts, idx.refs[adjacent].passage)
 		}
 	}
-	return strings.Join(parts, " "), true
+	return strings.Join(parts, " "), ""
 }
 
 func looksLikeDifferentLegalEntity(passageNorm, currentName string) bool {

--- a/backend/internal/compose/sitepageentities_test.go
+++ b/backend/internal/compose/sitepageentities_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Attribution on a group imprint: which company a grounded detail belongs to.
+//
+// The lane's other tests ask whether a value is printed on the page. These ask
+// whose it is — a distinction with no symptom, because on the page that
+// produces it both halves are printed and neither is invented.
+
+import (
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// groupImprint is the common German shape: a parent and a subsidiary, each
+// with its own registered address and register number, in blocks the passage
+// packer keeps apart.
+//
+// Both companies are named on the page, so the census — which reads the whole
+// page on purpose — counts them both. That is what makes the attribution the
+// only thing standing between a reply and a register number that belongs to
+// somebody else.
+func groupImprint(t *testing.T) (crawlPage, pageMenu, snippetIndex) {
+	t.Helper()
+	parent := "Impressum. Nordwerk Holding SE, Deliusstrasse 7, 24114 Kiel, Germany. " +
+		"Amtsgericht Kiel HRB 111222. USt-IdNr. DE111222333. " +
+		strings.Repeat("Vertreten durch den Vorstand. ", 7)
+	subsidiary := "Nordwerk Systems GmbH, Kaistrasse 40, 20359 Hamburg, Germany. " +
+		"Amtsgericht Hamburg HRB 333444. USt-IdNr. DE333444555. " +
+		strings.Repeat("Geschaeftsfuehrung nach Satzung. ", 7)
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindImpressum, seedURL+"/impressum",
+		parent+"\n"+subsidiary)
+	if len(idx.refs) < 2 {
+		t.Fatalf("the two companies must land in separate passages, got %d", len(idx.refs))
+	}
+	return page, menu, idx
+}
+
+// The defect this guards: a reply names one company and cites the other's
+// block. Nothing is hallucinated — the address and the register number are
+// printed, in full, on the page the entity was found on — so every
+// no-guess check downstream passes, and the census hands a human a company
+// whose registered identity is its sibling's.
+func TestALegalDetailCitedFromASiblingsBlockIsRefused(t *testing.T) {
+	page, menu, idx := groupImprint(t)
+
+	// s1 is the subsidiary's block; the reply attributes it to the parent.
+	reply := `{"facts":[],"entities":[{"n":"Nordwerk Holding SE",` +
+		`"a":"Kaistrasse 40, 20359 Hamburg, Germany","r":"HRB 333444","v":"DE333444555","e":"s1"}]}`
+	res, dropped := gatePageEntities2(t, reply, page, menu, idx)
+
+	// The entity itself survives: it is printed on the page, and dropping it
+	// would undercount the census, which is the failure the page-wide name
+	// check exists to prevent.
+	if len(res) != 1 || res[0].Name != "Nordwerk Holding SE" {
+		t.Fatalf("the parent is printed on this page and stays in the census: %+v", res)
+	}
+	if res[0].RegisteredAddress != "" || res[0].RegisterNumber != "" || res[0].VatNumber != "" {
+		t.Errorf("the subsidiary's registered identity attached to the parent: %+v", res[0])
+	}
+	reasons := dropReasons(dropped)
+	for _, field := range []string{fieldRegisteredAddress, fieldRegisterNumber, fieldRegisterVat} {
+		if reasons[field] != dropLegalBlockNotThisEntity {
+			t.Errorf("%s was refused as %q, want %q — the value IS on the page, and reporting it as "+
+				"ungrounded sends a reader looking for text that is right there",
+				field, reasons[field], dropLegalBlockNotThisEntity)
+		}
+	}
+}
+
+// The same page, cited correctly. The guard has to leave the ordinary answer
+// alone, or a multi-entity imprint returns two names and no details at all —
+// which is the shape of over-correction that gets a gate turned off.
+func TestEachCompanyKeepsTheDetailsPrintedInItsOwnBlock(t *testing.T) {
+	page, menu, idx := groupImprint(t)
+
+	reply := `{"facts":[],"entities":[` +
+		`{"n":"Nordwerk Holding SE","a":"Deliusstrasse 7, 24114 Kiel, Germany",` +
+		`"r":"HRB 111222","v":"DE111222333","e":"s0"},` +
+		`{"n":"Nordwerk Systems GmbH","a":"Kaistrasse 40, 20359 Hamburg, Germany",` +
+		`"r":"HRB 333444","v":"DE333444555","e":"s1"}]}`
+	res, dropped := gatePageEntities2(t, reply, page, menu, idx)
+
+	if len(res) != 2 {
+		t.Fatalf("both companies are printed and both stand: %+v", res)
+	}
+	want := map[string][3]string{
+		"Nordwerk Holding SE":   {"Deliusstrasse 7, 24114 Kiel, Germany", "HRB 111222", "DE111222333"},
+		"Nordwerk Systems GmbH": {"Kaistrasse 40, 20359 Hamburg, Germany", "HRB 333444", "DE333444555"},
+	}
+	for _, got := range res {
+		w, known := want[got.Name]
+		if !known {
+			t.Errorf("unexpected entity %q", got.Name)
+			continue
+		}
+		if got.RegisteredAddress != w[0] || got.RegisterNumber != w[1] || got.VatNumber != w[2] {
+			t.Errorf("%s kept %q/%q/%q, want %q/%q/%q — a correctly cited detail must survive",
+				got.Name, got.RegisteredAddress, got.RegisterNumber, got.VatNumber, w[0], w[1], w[2])
+		}
+	}
+	if len(dropped) != 0 {
+		t.Errorf("nothing is refused when each company cites its own block: %+v", dropped)
+	}
+}
+
+// A citation outside the numbered index yields no block, and now says so.
+// Reporting it as a value the page does not print would be false — the page
+// was never asked.
+func TestACitationOutsideTheIndexIsReportedAsUnknown(t *testing.T) {
+	page, menu, idx := groupImprint(t)
+
+	reply := `{"facts":[],"entities":[{"n":"Nordwerk Holding SE",` +
+		`"a":"Deliusstrasse 7, 24114 Kiel, Germany","r":"HRB 111222","e":"s99"}]}`
+	res, dropped := gatePageEntities2(t, reply, page, menu, idx)
+
+	if len(res) != 1 || res[0].RegisteredAddress != "" || res[0].RegisterNumber != "" {
+		t.Fatalf("a detail with no resolvable citation carries no evidence: %+v", res)
+	}
+	if got := dropReasons(dropped)[fieldRegisteredAddress]; got != dropSnippetIDUnknown {
+		t.Errorf("the unresolvable citation was reported as %q, want %q", got, dropSnippetIDUnknown)
+	}
+}


### PR DESCRIPTION
Closes #1823.

## The defect

The legal census grounds an entity **name** against the whole page, deliberately: a layout can break a name across passages, and an undercounted census applies the wrong company's legal identity.

Its **details** come from the block the model cited — but nothing required that block to name the entity the details were being attributed to. A reply could name company A while citing company B's block, and B's grounded address, register number and VAT ID attached to A.

Neither half is invented. Both are printed on the page, in full, under the entity that was found there. So every no-guess check downstream passes and nothing reports anything. On a group imprint listing several subsidiaries — the common German shape — a human is handed a company whose registered identity is its sibling's, and it reaches the auto-enrichment and domain-triage paths without confirmation.

The existing `looksLikeDifferentLegalEntity` guard does not close it: it reads the *adjacent* passage, and it returns false as soon as that passage prints the current entity's name — which on a group imprint is exactly the neighbour a block joins.

## The fix

`legalEvidenceBlock` now requires the **cited** passage to print the entity's own name, using the same whole-token rule every other grounded value gets.

The cited passage rather than the joined block: a reply citing a sibling's block would otherwise pass on a neighbour that happens to print this entity's name, which is the layout this guards.

A name the page broke across that boundary therefore loses its details. That is the safe direction — the entity still stands in the census and a human types an address — where the other one prints a register number that was never this company's. The adjacency heuristic stays, and is no longer the only thing between a reply and somebody else's register number.

## Reporting

Two drop reasons, because they are two different findings and a reader acts on each differently:

- `legal_block_not_this_entity` (new) — the value **is** on the page, under a sibling's name. Reporting it as ungrounded would send somebody looking for text that is right there.
- `snippet_id_unknown` — an unresolvable citation, which previously reported as `value_not_in_snippet`. The page was never asked, so saying it does not print the value is false.

## Tests

`backend/internal/compose/sitepageentities_test.go`, new, beside the source it covers — the multi-entity corpus the ticket asks for. A two-company group imprint whose blocks the passage packer keeps apart, with a registered address, register number and VAT ID each:

- the sibling-citation attack: the entity survives the census, all three details drop, each under the attribution reason;
- the ordinary answer: both companies cite their own blocks and keep all six values, with nothing refused — over-correction here would return two names and no details, which is the shape of guard that gets turned off;
- an out-of-index citation reports as unknown.

Mutation-checked: disabling the name requirement fails the first test, and the failure output is the ticket's exact defect — the parent SE holding the subsidiary GmbH's address, HRB and VAT. Reverting the unknown-citation reason fails the third.

## Checks

`make check-backend` green; `make test-it DIR=backend/internal/compose` green on the legal-page lane.

The dedup/abstention half found in the same review is #1822 and is not touched here.