### PR TITLE
fix(sitecensus): a name against two registrations is two entities

### DIFF
--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -56,9 +56,10 @@ type corpusLegalEntity struct {
 // count, so a winner-takes-all rule kept whichever came first and dropped
 // the other's number entirely.
 func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
+	contested := contestedLegalNames(entities)
 	var out []corpusLegalEntity
 	for _, entity := range entities {
-		at := matchingLegalEntity(out, entity)
+		at := matchingLegalEntity(out, entity, contested)
 		if at < 0 {
 			out = append(out, entity)
 			continue
@@ -71,6 +72,49 @@ func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 		out[at] = fillLegalDetailsFrom(out[at], entity)
 	}
 	return removeBrandOnlyLegalAliases(out)
+}
+
+// contestedLegalNames names the companies this census cannot tell apart by
+// name alone: one printed name against more than one registry or tax identity.
+//
+// It has to be answered over the WHOLE census before any folding, because the
+// contradiction is invisible pairwise. A sighting that printed only an address
+// contradicts nothing on its own, so it accepts the first registration that
+// comes along and then stands as the fold target for the second — and two
+// registry identities become one row carrying neither number.
+// A register number and a VAT ID are counted APART. One company prints both,
+// and a locale that printed only the tax identifier beside one that printed
+// only the register entry is that company twice — not two of them.
+func contestedLegalNames(entities []corpusLegalEntity) map[string]bool {
+	registers := map[string]map[string]bool{}
+	vats := map[string]map[string]bool{}
+	for _, entity := range entities {
+		name := legalEntityNameKey(entity.Name)
+		if name == "" {
+			continue
+		}
+		noteLegalIdentity(registers, name, normalizeEvidence(entity.RegisterNumber))
+		noteLegalIdentity(vats, name, normalizeEvidence(entity.VatNumber))
+	}
+	contested := map[string]bool{}
+	for _, byName := range []map[string]map[string]bool{registers, vats} {
+		for name, seen := range byName {
+			if len(seen) > 1 {
+				contested[name] = true
+			}
+		}
+	}
+	return contested
+}
+
+func noteLegalIdentity(seen map[string]map[string]bool, name, identity string) {
+	if identity == "" {
+		return
+	}
+	if seen[name] == nil {
+		seen[name] = map[string]bool{}
+	}
+	seen[name][identity] = true
 }
 
 // fillLegalDetailsFrom completes one sighting of an entity from another of
@@ -113,24 +157,52 @@ func fillLegalDetailsFrom(kept, other corpusLegalEntity) corpusLegalEntity {
 // of one entity split under their locale names and could trip the
 // multi-entity abstention, and two different companies printed under one
 // name merged into whichever was seen first.
-func matchingLegalEntity(existing []corpusLegalEntity, candidate corpusLegalEntity) int {
-	candidateName := legalEntityNameKey(candidate.Name)
-	candidateRegister := normalizeEvidence(candidate.RegisterNumber)
-	candidateVat := normalizeEvidence(candidate.VatNumber)
+func matchingLegalEntity(existing []corpusLegalEntity, candidate corpusLegalEntity, contested map[string]bool) int {
 	for i, entity := range existing {
-		name := legalEntityNameKey(entity.Name)
-		register := normalizeEvidence(entity.RegisterNumber)
-		vat := normalizeEvidence(entity.VatNumber)
-		sameRegister := candidateRegister != "" && register != "" && candidateRegister == register
-		sameVat := candidateVat != "" && vat != "" && candidateVat == vat
-		compatibleName := candidateName != "" && candidateName == name &&
-			bothOrEitherEmpty(candidateRegister, register) &&
-			bothOrEitherEmpty(candidateVat, vat)
-		if sameRegister || sameVat || compatibleName {
+		if sameLegalEntity(entity, candidate, contested) {
 			return i
 		}
 	}
 	return -1
+}
+
+// sameLegalEntity answers the pair. A shared identifier is decisive whatever
+// the names say; otherwise the printed name decides, and only while that name
+// stands for ONE identity.
+func sameLegalEntity(entity, candidate corpusLegalEntity, contested map[string]bool) bool {
+	register, candidateRegister := normalizeEvidence(entity.RegisterNumber), normalizeEvidence(candidate.RegisterNumber)
+	vat, candidateVat := normalizeEvidence(entity.VatNumber), normalizeEvidence(candidate.VatNumber)
+	if sameLegalIdentifier(register, candidateRegister) || sameLegalIdentifier(vat, candidateVat) {
+		return true
+	}
+	name := legalEntityNameKey(candidate.Name)
+	if name == "" || name != legalEntityNameKey(entity.Name) {
+		return false
+	}
+	if !bothOrEitherEmpty(register, candidateRegister) || !bothOrEitherEmpty(vat, candidateVat) {
+		return false
+	}
+	// The name is the only evidence left, and under a CONTESTED name it is
+	// not evidence: the site prints that name against more than one identity,
+	// so a sighting carrying one of them could belong to either company.
+	// Attaching it to whichever was seen first is the guess the multi-entity
+	// abstention exists to refuse — and folding it hides the second
+	// registration from that abstention entirely.
+	//
+	// Two sightings that printed NO identifier at all still fold: they carry
+	// nothing to tell apart, and splitting them would invent a company out of
+	// a repeated market heading.
+	if !contested[name] {
+		return true
+	}
+	return register == "" && candidateRegister == "" && vat == "" && candidateVat == ""
+}
+
+// sameLegalIdentifier reports whether two sightings agree on one authority's
+// identifier. An absent one agrees with nothing — it is a page that did not
+// print it, not a company that has none.
+func sameLegalIdentifier(left, right string) bool {
+	return left != "" && left == right
 }
 
 // bothOrEitherEmpty reports whether two identifiers can belong to one
@@ -332,13 +404,13 @@ const (
 // distinct entities is answered first: that holds whether or not another
 // legal page also failed, while an incomplete census says only that this
 // run cannot trust its count.
+// The count is of ENTITIES, not of names. Two rows reach here only when
+// nothing folded them, and two registrations printed under one name is the
+// very case this abstention is for — counting names answers "one company" to
+// the census that most needs a human.
 func legalAbstentionOf(entities []corpusLegalEntity, censusIncomplete bool) legalAbstention {
-	distinct := map[string]bool{}
-	for _, e := range entities {
-		distinct[legalEntityNameKey(e.Name)] = true
-	}
 	switch {
-	case len(distinct) > 1:
+	case len(entities) > 1:
 		return legalAbstentionMultipleEntities
 	case censusIncomplete:
 		return legalAbstentionCensusIncomplete

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -444,3 +444,124 @@ func TestCensusFillIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// The census the abstention exists for: one printed name against two
+// registrations, stated across the locales of one site.
+//
+// A sighting that printed only an address contradicts nothing, so it accepted
+// the first registration to come along and then stood as the fold target for
+// the second. Two registry identities became one row carrying NEITHER number,
+// and the settled census that followed offered a human a company whose
+// registered identity was assembled from two.
+//
+// Across LOCALES, because within one page the sightings complete each other
+// (fillLegalDetailsFrom) and the anchor stops being numberless after the
+// first fold. Nothing completes a sighting across pages — an entity cites one
+// snippet, and a number borrowed from another page would be published quoting
+// a passage that never printed it.
+func TestOneNameAgainstTwoRegistrationsStaysTwoEntities(t *testing.T) {
+	entities := []corpusLegalEntity{
+		{Name: "Acme GmbH", RegisteredAddress: "Weg 1 11111 Ort", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 111", SourceURL: seedURL + "/de/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 222", SourceURL: seedURL + "/en/imprint"},
+	}
+	got := dedupeLegalEntities(entities)
+	if len(got) < 2 {
+		t.Fatalf("two registry identities folded into one company: %+v", got)
+	}
+	registers := map[string]bool{}
+	for _, entity := range got {
+		registers[entity.RegisterNumber] = true
+	}
+	for _, want := range []string{"HRB 111", "HRB 222"} {
+		if !registers[want] {
+			t.Errorf("%s is gone from the census; the abstention can only refuse what it can see: %+v", want, got)
+		}
+	}
+	if abstention := legalAbstentionOf(got, false); abstention != legalAbstentionMultipleEntities {
+		t.Errorf("abstention = %q, want %q — this is the census that must not be answered without a human",
+			abstention, legalAbstentionMultipleEntities)
+	}
+}
+
+// The same shape one authority weaker. A page that prints tax identifiers and
+// no register entries has to reach the same verdict, or the guard is about the
+// column it was written against rather than about the identity.
+func TestOneNameAgainstTwoVatIdentifiersStaysTwoEntities(t *testing.T) {
+	entities := []corpusLegalEntity{
+		{Name: "Acme GmbH", RegisteredAddress: "Weg 1 11111 Ort", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme GmbH", VatNumber: "DE111111111", SourceURL: seedURL + "/de/impressum"},
+		{Name: "Acme GmbH", VatNumber: "DE222222222", SourceURL: seedURL + "/en/imprint"},
+	}
+	got := dedupeLegalEntities(entities)
+	if len(got) < 2 {
+		t.Fatalf("two tax identities folded into one company: %+v", got)
+	}
+	if abstention := legalAbstentionOf(got, false); abstention != legalAbstentionMultipleEntities {
+		t.Errorf("abstention = %q, want %q", abstention, legalAbstentionMultipleEntities)
+	}
+}
+
+// The abstention counts entities. Two rows that survived dedupe under one
+// name are the case it is for, and counting names answered "one company" to
+// exactly that census.
+func TestTheAbstentionCountsEntitiesRatherThanNames(t *testing.T) {
+	sameName := []corpusLegalEntity{
+		{Name: "Acme GmbH", RegisterNumber: "HRB 111", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 222", SourceURL: seedURL + "/impressum"},
+	}
+	if got := legalAbstentionOf(sameName, false); got != legalAbstentionMultipleEntities {
+		t.Errorf("two registrations printed under one name gave %q, want %q", got, legalAbstentionMultipleEntities)
+	}
+}
+
+// And the whole path, because the abstention is only worth having if the trio
+// it guards is actually withheld: applyLegalGate must strip the legal fields
+// on this census rather than publish one company's address as the other's.
+func TestTheLegalTrioIsWithheldWhenOneNameCarriesTwoRegistrations(t *testing.T) {
+	entities := dedupeLegalEntities([]corpusLegalEntity{
+		{Name: "Acme GmbH", RegisteredAddress: "Weg 1 11111 Ort", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 111", SourceURL: seedURL + "/de/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 222", SourceURL: seedURL + "/en/imprint"},
+	})
+	fields := []evidencedField{
+		{Field: fieldRegisteredAddress, Value: "Weg 1 11111 Ort", SourceURL: seedURL + "/impressum"},
+	}
+	kinds := map[string]crmcontracts.SiteReadPageKind{
+		seedURL + "/impressum": crmcontracts.SiteReadPageKindImpressum,
+	}
+	kept, abstained, dropped := applyLegalGate(fields, entities, kinds, false)
+	if !abstained {
+		t.Fatalf("the gate answered a contested census without abstaining: %+v", entities)
+	}
+	if len(kept) != 0 {
+		t.Errorf("a legal field survived a contested census: %+v", kept)
+	}
+	if len(dropped) == 0 || dropped[0].Reason != string(legalAbstentionMultipleEntities) {
+		t.Errorf("the withheld field must name the cause that fired: %+v", dropped)
+	}
+}
+
+// The guard must not split a company that simply appears twice. Over-
+// correction here returns a census of duplicates and abstains on every
+// multi-locale imprint, which is the shape of guard that gets turned off.
+func TestARepeatedSightingWithNoIdentifierStillFolds(t *testing.T) {
+	entities := []corpusLegalEntity{
+		{Name: "Acme GmbH", RegisterNumber: "HRB 111", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme GmbH", RegisterNumber: "HRB 222", SourceURL: seedURL + "/en/imprint"},
+		// A market heading repeated under both blocks, printing no identity.
+		{Name: "Acme Deutschland", SourceURL: seedURL + "/impressum"},
+		{Name: "Acme Deutschland", SourceURL: seedURL + "/de/impressum"},
+	}
+	got := dedupeLegalEntities(entities)
+	headings := 0
+	for _, entity := range got {
+		if legalEntityNameKey(entity.Name) == legalEntityNameKey("Acme Deutschland") {
+			headings++
+		}
+	}
+	if headings != 1 {
+		t.Errorf("a repeated heading became %d entities; sightings carrying nothing to tell apart fold: %+v",
+			headings, got)
+	}
+}


### PR DESCRIPTION
Closes #1822.

## The defect

`dedupeLegalEntities` folded by name whenever *either* sighting lacked a register number. So an address-only sighting anchored a row, the first registration folded into it, and the second folded into it too — one entity carrying **neither** number. `legalAbstentionOf` then saw a settled census and did not abstain, and the company's legal identity was taken from whichever sighting was richest.

The multi-entity abstention exists precisely to refuse a domain that hosts two companies with similar names. In this shape it did not fire, and it reaches the auto-enrichment and domain-triage paths without human confirmation.

## The ticket's literal repro no longer reproduces — the defect does

The three sightings in the ticket are all on **one page**, and `fillLegalDetailsFrom` (added since it was filed) completes a kept sighting from another on the same page. The anchor stops being numberless after the first fold, so the second registration now conflicts and stays separate.

Across **locales** it still holds, and that is the realistic shape: nothing completes a sighting across pages, on purpose — an entity cites one snippet, and a number borrowed from another page would be published quoting a passage that never printed it. Same three sightings under `/impressum`, `/de/impressum`, `/en/imprint`:

| | before | after |
|---|---|---|
| rows | 1, `reg=""` | 3 |
| abstention | none | `legal_conflict_no_override` |

## The change

**Folding by name requires the name to stand for one identity.** `contestedLegalNames` reads the whole census first — the contradiction is invisible pairwise — and marks a name printed against more than one register number, or more than one VAT ID. Under a contested name, a sighting carrying an identifier no longer folds on the name alone.

Register numbers and VAT IDs are counted **apart**: one company prints both, and a locale printing only the tax identifier beside one printing only the register entry is that company twice, not two of them. (`TestOneEntitySeenTwiceKeepsBothItsNumbers` fails when they are counted together — I checked.)

Sightings that printed **no identifier at all** still fold. They carry nothing to tell apart, and splitting them would invent a company out of a repeated market heading — the over-correction that would abstain on every multi-locale imprint.

**The abstention counts entities, not names.** Two rows reach it only when nothing folded them, and two registrations under one name is the case it is for.

`matchingLegalEntity` is now a loop over `sameLegalEntity`, which answers the pair — the combined form was over `cyclop`'s ceiling and the pair decision is the part worth reading on its own.

## Tests

Five, in `sitecorpuslegal_test.go`: the cross-locale register shape end to end (rows kept, both numbers still visible, abstention fires); the same one authority weaker with VAT IDs; the abstention counting entities under one name; `applyLegalGate` actually withholding the trio and naming the cause; and a repeated identifier-less heading still folding to one.

Mutation-checked: disabling the contested guard fails three of them, with the failure output showing the ticket's exact defect — one row, no register number, no abstention. Restoring the name count fails the abstention test. Counting register numbers and VAT IDs together fails the two pre-existing same-entity tests.

## Checks

`make check-backend` green.

The attribution half found in the same review is #1823 (PR #4884).