### PR TITLE
The board card holds a link rather than being one

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -511,10 +511,16 @@ test("AC-pipeline-7: board↔table swaps views preserving the deal set", async (
   // card for this deal is on the board", not "this text is the card".
   const boardCard = page.locator('[data-deal="d-fleet"]');
   await expect(boardCard).toBeVisible();
-  // The card IS the link — `data-deal` sits on the anchor — and the role is
-  // asserted rather than assumed, because that is the behaviour the change
-  // bought: a middle-click and an open-in-new-tab on a deal card.
-  await expect(boardCard).toHaveRole("link");
+  // The card HOLDS the link rather than being one. It carries two
+  // destinations now — the deal and the company behind it — and an anchor
+  // inside an anchor is invalid markup the browser unnests, so the deal's link
+  // is stretched over the card instead of wrapped around it.
+  //
+  // The link is still asserted, because it is the behaviour worth having: a
+  // middle-click and an open-in-new-tab on a deal card. It is asserted on the
+  // anchor that carries it, which is what a reader actually presses.
+  const boardLink = boardCard.getByRole("link", { name: /Fleet retrofit/ });
+  await expect(boardLink).toHaveAttribute("href", /#\/deals\/d-fleet/);
   await expect(boardCard).toContainText("Fleet retrofit");
   await page.getByRole("button", { name: "Tabelle" }).click();
   // The board is gone, so its card locator is the proof the view swapped
@@ -2314,10 +2320,11 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe)", () => {
     // and reaching it STOPS the withdrawal — a control that walks out from
     // under the focus ring three and a half seconds after a reader tabbed to it
     // is a control they cannot use (WCAG 2.2.1).
-    // A BUTTON, not a link: `EntityRef` opens the record through the app's own
-    // hash router rather than by navigating, so what the message carries is a
-    // control. Which is the point — it is focusable either way.
-    const carried = said.getByRole("button").first();
+    // A LINK: `EntityRef` is an anchor over the app's own hash route, so the
+    // record opens the ways a link does — a new tab, a bookmark, the keyboard.
+    // Which is the point here — it is focusable either way, and this test is
+    // about whether a keyboard reader can reach it and keep it.
+    const carried = said.getByRole("link").first();
     await carried.focus();
     await expect(carried).toBeFocused();
     await page.waitForTimeout(4000);


### PR DESCRIPTION
Main is red on `uat`. Two e2e assertions describe the markup as it was before a deal card carried two destinations.

`make check-fe` does not run Playwright, so neither local gate could see this — the lane that catches it is `make frontend-e2e`.

## What changed under them

**AC-pipeline-7** asserted `role="link"` on the element carrying `data-deal`. That element is the card, and the card is a div now: it holds the deal's stretched anchor and the company's beside it, because an anchor inside an anchor is invalid markup the browser silently unnests. The link is still asserted — it is the behaviour worth having, a middle-click and an open-in-new-tab on a deal card — on the anchor that actually carries it, together with its href.

**The WCAG confirmation test** looked for a button, on the stated reasoning that `EntityRef` opened records through the hash router rather than by navigating. It is a real anchor now. The test is about whether a keyboard reader can reach the control and keep it under the focus ring, which is true either way.

## Checks

`make frontend-e2e`: 344 passed, 0 failed. `make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates two e2e assertions to match the new card markup, where the card is a div holding stretched anchors rather than being a link itself. This fixes failing checks on `uat`.

- The deal card assertion now checks the anchor's role and href instead of the card's role.
- The WCAG test now looks for a link instead of a button, since `EntityRef` is now an anchor.

<sup>Written for commit 48fe66ac8ae28e4ab82c1bef9c2c1ec95ab799c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

