### PR TITLE
docs(contract): the relationship PATCH states the rule it enforces

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8002,7 +8002,8 @@ paths:
         per person; `is_current_primary` is decided here only when you OMIT it — an
         employment for somebody with no other current one then becomes their primary
         — and an employment that has already ended never takes the flag. Send the
-        field to decide it yourself; a later PATCH always wins over both.
+        field to decide it yourself. A later PATCH can change it on the same terms,
+        the ended-employment rule included: see `updateRelationship`.
       requestBody:
         required: true
         content:
@@ -8042,6 +8043,19 @@ paths:
       operationId: updateRelationship
       x-mcp-tool: { verb: update_record, record_type: relationship, tier: auto_execute, scope: write }
       summary: Update a relationship (role, primary flag, dates).
+      description: |
+        Only the fields you send change. An employment somebody has LEFT is not
+        their current primary one, whichever half of the patch makes it so: an
+        `ended_at` that has already arrived clears `is_current_primary`, and
+        sending `is_current_primary: true` for an employment that is already over
+        does NOT take. Neither is an error — the response is 200 carrying the row
+        as it stands, with the flag false, so read the response rather than
+        retrying.
+
+        A notice period is not a departure: an `ended_at` still in the future
+        leaves the flag alone. Granting it to an employment that is still current
+        demotes the person's existing primary one in the same transaction, so the
+        one-primary-per-person rule holds without a 409.
       parameters:
         - $ref: '#/components/parameters/IfMatch'
       requestBody:

--- a/backend/internal/compose/integration/employment_dedupe_integration_test.go
+++ b/backend/internal/compose/integration/employment_dedupe_integration_test.go
@@ -430,3 +430,48 @@ func (e *relEnv) isPrimary(t *testing.T, edgeID string) bool {
 	t.Fatalf("employment %s is not in the person's own list of %d", edgeID, len(listed.Data))
 	return false
 }
+
+// The half of the PATCH rule no test held: ending an employment through the
+// patch itself clears the flag, in the same statement, rather than leaving a
+// stale true for every reader to derive around.
+//
+// Both directions, because the boundary is where a predicate written with the
+// wrong comparison passes one of them and still gets the other backwards — and
+// because the contract now states both, which is what makes them one item.
+func TestEndingAnEmploymentThroughAPatchClearsThePrimaryFlag(t *testing.T) {
+	e := setupRelationships(t)
+
+	status, edge, primary, _ := e.employment(t, e.orgID, AnyMap{"role": "cto"})
+	if status != http.StatusCreated || !primary {
+		t.Fatalf("the job they hold → %d primary=%t, want 201 and primary", status, primary)
+	}
+
+	// A last day still ahead is a notice period. They still work there.
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
+		AnyMap{"ended_at": e.dbDate(t, 30)}, nil, nil); status != http.StatusOK {
+		t.Fatalf("patching a notice period → %d", status)
+	}
+	if !e.isPrimary(t, edge) {
+		t.Error("a last day 30 days out took the flag off a job they are still doing")
+	}
+
+	// The last day arrives. The patch that says so is the departure.
+	var patched struct {
+		IsCurrentPrimary bool `json:"is_current_primary"`
+	}
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
+		AnyMap{"ended_at": e.dbDate(t, 0)}, nil, &patched); status != http.StatusOK {
+		t.Fatalf("patching the departure → %d", status)
+	}
+	if patched.IsCurrentPrimary {
+		t.Error("the patch that ended the employment answered with the flag still set")
+	}
+	var stored bool
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT is_current_primary FROM relationship WHERE id = $1`, edge).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored {
+		t.Error("the stored flag survived the departure, so every reader of the column has to derive around it")
+	}
+}

--- a/backend/internal/compose/integration/employment_dedupe_integration_test.go
+++ b/backend/internal/compose/integration/employment_dedupe_integration_test.go
@@ -118,6 +118,9 @@ func TestAnEndedEmploymentCannotBeMadeTheCurrentPrimaryOne(t *testing.T) {
 	if patched.IsCurrentPrimary {
 		t.Error("an employment that ended in 2021 now reads as the person's current primary employer")
 	}
+	if e.storedPrimary(t, edge) {
+		t.Error("the column took the flag the response refused, so the two answer differently")
+	}
 }
 
 func TestAPersonsOnlyCurrentEmploymentIsTheirPrimaryOne(t *testing.T) {
@@ -446,19 +449,24 @@ func TestEndingAnEmploymentThroughAPatchClearsThePrimaryFlag(t *testing.T) {
 		t.Fatalf("the job they hold → %d primary=%t, want 201 and primary", status, primary)
 	}
 
-	// A last day still ahead is a notice period. They still work there.
+	// A last day still ahead is a notice period. They still work there — in
+	// the patch's own answer, in the list, and in the column, because the
+	// contract promises the response is what to read.
+	var patched struct {
+		IsCurrentPrimary bool `json:"is_current_primary"`
+	}
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
-		AnyMap{"ended_at": e.dbDate(t, 30)}, nil, nil); status != http.StatusOK {
+		AnyMap{"ended_at": e.dbDate(t, 30)}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patching a notice period → %d", status)
 	}
-	if !e.isPrimary(t, edge) {
+	if !patched.IsCurrentPrimary {
+		t.Error("the patch that filed a notice period answered as though they had already left")
+	}
+	if !e.isPrimary(t, edge) || !e.storedPrimary(t, edge) {
 		t.Error("a last day 30 days out took the flag off a job they are still doing")
 	}
 
 	// The last day arrives. The patch that says so is the departure.
-	var patched struct {
-		IsCurrentPrimary bool `json:"is_current_primary"`
-	}
 	if status := e.Call(t, "PATCH", "/v1/relationships/"+edge,
 		AnyMap{"ended_at": e.dbDate(t, 0)}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patching the departure → %d", status)
@@ -466,12 +474,21 @@ func TestEndingAnEmploymentThroughAPatchClearsThePrimaryFlag(t *testing.T) {
 	if patched.IsCurrentPrimary {
 		t.Error("the patch that ended the employment answered with the flag still set")
 	}
-	var stored bool
-	if err := e.Owner.QueryRow(t.Context(),
-		`SELECT is_current_primary FROM relationship WHERE id = $1`, edge).Scan(&stored); err != nil {
-		t.Fatal(err)
-	}
-	if stored {
+	if e.storedPrimary(t, edge) {
 		t.Error("the stored flag survived the departure, so every reader of the column has to derive around it")
 	}
+}
+
+// storedPrimary reads the column itself. The list read beside it goes through
+// the API's own derivation, so a stale flag can hide behind a reader that
+// corrects for it — which is exactly what this rule exists to stop being
+// necessary.
+func (e *relEnv) storedPrimary(t *testing.T, edgeID string) bool {
+	t.Helper()
+	var stored bool
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT is_current_primary FROM relationship WHERE id = $1`, edgeID).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	return stored
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5327,7 +5327,8 @@ export interface paths {
          *     per person; `is_current_primary` is decided here only when you OMIT it — an
          *     employment for somebody with no other current one then becomes their primary
          *     — and an employment that has already ended never takes the flag. Send the
-         *     field to decide it yourself; a later PATCH always wins over both.
+         *     field to decide it yourself. A later PATCH can change it on the same terms,
+         *     the ended-employment rule included: see `updateRelationship`.
          */
         post: operations["createRelationship"];
         delete?: never;
@@ -5353,7 +5354,21 @@ export interface paths {
         delete: operations["archiveRelationship"];
         options?: never;
         head?: never;
-        /** Update a relationship (role, primary flag, dates). */
+        /**
+         * Update a relationship (role, primary flag, dates).
+         * @description Only the fields you send change. An employment somebody has LEFT is not
+         *     their current primary one, whichever half of the patch makes it so: an
+         *     `ended_at` that has already arrived clears `is_current_primary`, and
+         *     sending `is_current_primary: true` for an employment that is already over
+         *     does NOT take. Neither is an error — the response is 200 carrying the row
+         *     as it stands, with the flag false, so read the response rather than
+         *     retrying.
+         *
+         *     A notice period is not a departure: an `ended_at` still in the future
+         *     leaves the flag alone. Granting it to an employment that is still current
+         *     demotes the person's existing primary one in the same transaction, so the
+         *     one-primary-per-person rule holds without a 409.
+         */
         patch: operations["updateRelationship"];
         trace?: never;
     };


### PR DESCRIPTION
Closes #1808.

## The contradiction

`createRelationship` promised callers *"a later PATCH always wins over both."* It does not. `UpdateRelationship` forces `is_current_primary` false whenever the row is or becomes ended, and `TestAnEndedEmploymentCannotBeMadeTheCurrentPrimaryOne` — shipped in the same PR as the sentence — asserts exactly that. The contract was the half that was wrong.

`updateRelationship` carried **no description at all**, so the only place a caller could learn the update-time rule was the create operation's description, which misstated it.

## What the contract says now

- **create**: "Send the field to decide it yourself. A later PATCH can change it on the same terms, the ended-employment rule included: see `updateRelationship`."
- **update**: both halves, and the boundary between them — an `ended_at` that has **already arrived** clears the flag; sending `is_current_primary: true` for an employment that is already over does not take; **neither is an error**, the response is 200 with the flag false, so read the response rather than retrying; and a notice period is not a departure, so an `ended_at` still in the future leaves the flag alone.

That last clause matters: my first draft said "setting `ended_at` clears the flag", which is the same kind of over-absolute claim this ticket is about. `employment.IsCurrentSQL` decides on LEFT, not on "has a date", and `TestTheBoundaryBetweenNoticeAndDepartureIsTodayItself` pins it.

## The test that was missing

The clearing half had no test. The existing coverage moves `ended_at` with raw SQL **on purpose**, to prove the readers derive rather than trusting the column — so nothing exercised the patch actually clearing it.

`TestEndingAnEmploymentThroughAPatchClearsThePrimaryFlag` now does, in both directions: a last day 30 days out leaves the flag alone; a last day that has arrived clears it, in the response and in the stored column. Mutation-checked — dropping the `AND (kind <> 'employment' OR IsCurrentSQL(…))` clause fails both assertions.

## The two open questions in the ticket

**Does an operation description feed a tool description?** No. `update_record`'s MCP description is `updateRecordCopy.render()` in `tools_update.go`, and the field vocabulary a model reads is the `margince://` record-fields document, built by reflection over the contract *types* plus hand-written notes. `make gen` after this edit produced no diff outside the OpenAPI artifacts, and the frontend `schema.d.ts` regeneration is the only generated change here. So this is OpenAPI-facing copy and needs no aicert re-run — which matches #1789 not triggering one.

**Do other descriptions make claims their tests refute?** The suggested grep does not narrow it: `always|never|cannot|every` matches **753 of the 1361** block descriptions in `crm.yaml`, and the ones I read are load-bearing and true ("Always returns 202 regardless of whether the address exists", "Never re-discloses a token"). A word list is not a defect detector here, and I am not going to claim an audit of 753 descriptions I did not do.

What I did scan is the *shape* that produced this defect — a store that takes a sent field and then narrows it, so the write answers 200 having ignored the caller. Across `internal/modules` there are two `coalesce($n, col)` assignments immediately narrowed by a following clause: this one, and `consent/dsr.go:406`, where the narrowing is a `WHERE` guard on row selection rather than a value override — a mismatch there is a refusal, not a silent no-op. So this was the only instance of the class.

## Checks

`make check-backend` green; `make test-it DIR=backend/internal/compose/integration` green on the employment lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified relationship update behavior when an employment’s end date affects its primary status.
  - Documented how current and future end dates interact with the primary flag, including automatic demotion of an existing primary employment.

- **Tests**
  - Added coverage confirming that ending a current primary employment clears its primary status, while a future end date preserves it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->