### PR TITLE
fix(people): every employment writer waits on the person's lock

### DIFF
--- a/backend/gates/personattachlock_test.go
+++ b/backend/gates/personattachlock_test.go
@@ -95,52 +95,148 @@ type relationshipWriter struct {
 }
 
 // personRelationshipWriters finds each function whose body contains an INSERT
-// into relationship naming person_id, and whether that same function takes the
-// lock in either of its two spellings.
+// into relationship naming person_id, and whether it takes the lock in either
+// of its two spellings.
+//
+// ONE hop, and only into a helper in the same file. A writer that reads the
+// people it is about through a named helper is still locking them — the
+// candidate read and the insert are one transaction either way — and refusing
+// that would push the query back inline for no reason but this gate's reach.
+// The hop stops there: a lock two calls away is one a reader of the writer
+// cannot see, which is the same blindness the gate exists to close.
 func personRelationshipWriters(file *ast.File) []relationshipWriter {
+	locking := lockingHelpers(file)
 	var found []relationshipWriter
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		inserts, statementLock := false, false
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			lit, ok := n.(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				return true
-			}
-			sql := gatekit.TextOf(lit)
-			if strings.Contains(sql, "INSERT INTO relationship") && strings.Contains(sql, "person_id") {
-				inserts = true
-			}
-			if strings.Contains(sql, setBasedLock) {
-				statementLock = true
-			}
-			return true
-		})
-		if !inserts {
+		if !insertsPersonRelationship(fn.Body) {
 			continue
 		}
 		found = append(found, relationshipWriter{
 			name:   fn.Name.Name,
-			locked: statementLock || callsLock(fn.Body),
+			locked: takesLock(fn.Body, locking),
 		})
 	}
 	return found
 }
 
-func callsLock(body *ast.BlockStmt) bool {
-	called := false
+func insertsPersonRelationship(body *ast.BlockStmt) bool {
+	inserts := false
 	ast.Inspect(body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
 			return true
 		}
-		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == singlePersonLock {
-			called = true
+		sql := gatekit.TextOf(lit)
+		if strings.Contains(sql, "INSERT INTO relationship") && strings.Contains(sql, "person_id") {
+			inserts = true
 		}
 		return true
 	})
-	return called
+	return inserts
+}
+
+// lockingHelpers names the functions in one file that take a person lock
+// themselves, so a writer calling one is recognised as locked.
+func lockingHelpers(file *ast.File) map[string]bool {
+	helpers := map[string]bool{}
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil && takesLock(fn.Body, nil) {
+			helpers[fn.Name.Name] = true
+		}
+	}
+	return helpers
+}
+
+// takesLock reports whether a body locks the people it writes: in its own
+// statement, by calling the single-person helper, or by calling one of the
+// same file's own locking helpers.
+func takesLock(body *ast.BlockStmt, viaHelper map[string]bool) bool {
+	locked := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.BasicLit:
+			if node.Kind == token.STRING && strings.Contains(gatekit.TextOf(node), setBasedLock) {
+				locked = true
+			}
+		case *ast.CallExpr:
+			ident, ok := node.Fun.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name == singlePersonLock || viaHelper[ident.Name] {
+				locked = true
+			}
+		}
+		return true
+	})
+	return locked
+}
+
+// The reader is asserted against planted files, because the failure this gate
+// must never have is under-recognition: a walk that stopped matching reports
+// the same green as a tree where every writer locks.
+//
+// The hop is asserted in both directions — a writer whose helper locks is
+// clean, and one whose helper does not is not — since a hop that accepted any
+// call at all would pass the whole module.
+func TestTheWriterReaderSeesTheLockAndOnlyTheLock(t *testing.T) {
+	t.Parallel()
+
+	const insert = "`INSERT INTO relationship (kind, person_id) VALUES ($1, $2)`"
+	for _, tc := range []struct {
+		name       string
+		source     string
+		wantWriter bool
+		wantLocked bool
+	}{
+		{
+			name:   "no insert at all",
+			source: "package p\nfunc f() { q(`SELECT 1 FROM relationship`) }",
+		},
+		{
+			name:       "an insert with no lock",
+			source:     "package p\nfunc f() { q(" + insert + ") }",
+			wantWriter: true,
+		},
+		{
+			name:       "the single-person helper",
+			source:     "package p\nfunc f() { lockPersonForAttach(ctx, tx, id); q(" + insert + ") }",
+			wantWriter: true, wantLocked: true,
+		},
+		{
+			name:       "the lock in the statement",
+			source:     "package p\nfunc f() { q(`SELECT id FROM person p FOR UPDATE OF p`); q(" + insert + ") }",
+			wantWriter: true, wantLocked: true,
+		},
+		{
+			name: "a same-file helper that locks",
+			source: "package p\nfunc h() { q(`SELECT id FROM person p FOR UPDATE OF p`) }\n" +
+				"func f() { h(); q(" + insert + ") }",
+			wantWriter: true, wantLocked: true,
+		},
+		{
+			name: "a same-file helper that does NOT lock",
+			source: "package p\nfunc h() { q(`SELECT id FROM person`) }\n" +
+				"func f() { h(); q(" + insert + ") }",
+			wantWriter: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := parser.ParseFile(token.NewFileSet(), "planted.go", tc.source, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parsing the planted source: %v", err)
+			}
+			writers := personRelationshipWriters(file)
+			if got := len(writers) > 0; got != tc.wantWriter {
+				t.Fatalf("read %d writer(s), want a writer: %t", len(writers), tc.wantWriter)
+			}
+			if tc.wantWriter && writers[0].locked != tc.wantLocked {
+				t.Errorf("locked = %t, want %t", writers[0].locked, tc.wantLocked)
+			}
+		})
+	}
 }

--- a/backend/internal/compose/flipassoc.go
+++ b/backend/internal/compose/flipassoc.go
@@ -22,7 +22,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/migration"
 	"github.com/margince/margince/backend/internal/modules/people"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -109,7 +108,14 @@ func (w *flipWriters) Associate(ctx context.Context, a migration.Assoc) (migrati
 			// a resumed run replaying its association phase re-offers an
 			// edge that already landed, which is convergence, not a
 			// failure — every other error still stops the run.
-			if errors.Is(err, apperrors.ErrConflict) {
+			//
+			// The store is asked WHICH rule refused, because a second one
+			// answers here: the primary-employer index is keyed on the person
+			// alone, and its refusal means this edge did not land at all.
+			// Reading that as convergence reported an import as applied while
+			// silently dropping the employment it was importing.
+			var conflict *people.RelationshipConflictError
+			if errors.As(err, &conflict) && conflict.AlreadyRecorded() {
 				return migration.AssocResult{Applied: true}, nil
 			}
 			return migration.AssocResult{}, fmt.Errorf("flip import: creating employment %s→%s: %w", a.FromID, a.ToID, err)

--- a/backend/internal/compose/fliplanding_integration_test.go
+++ b/backend/internal/compose/fliplanding_integration_test.go
@@ -454,3 +454,50 @@ func TestAMappedButOpenDealIsClosedOnTheNextPass(t *testing.T) {
 		t.Errorf("deal rows = %d, want exactly the one the interrupted pass landed", n)
 	}
 }
+
+// A resumed run re-offers an association its earlier attempt already landed.
+// That is convergence, and the report must say applied — the edge IS on file.
+//
+// It is asked of the REAL writer rather than of the predicate, because the
+// question the writer has to answer is which uniqueness rule refused it: only
+// a rule keyed on the pair being inserted says the edge is already there. The
+// primary-employer index is keyed on the person alone, and reading its refusal
+// as convergence reported an import as applied while dropping the employment.
+// That refusal is reachable only under a concurrent writer, which is why this
+// case can exercise one side and TestOnlyATupleKeyedRefusalMeansTheEdgeIsAlreadyOnFile
+// holds the other.
+func TestAReplayedEmploymentAssociationConvergesRatherThanFailing(t *testing.T) {
+	f := setupLanding(t)
+
+	if _, err := f.w.Ensure(f.ctx, flipObjectPerson,
+		landingRow("hs-person-emp", map[string]any{"full_name": "Ada Lovelace"})); err != nil {
+		t.Fatalf("landing the person: %v", err)
+	}
+	if _, err := f.w.Ensure(f.ctx, flipObjectOrganization,
+		landingRow("hs-org-emp", map[string]any{"display_name": "Analytical Engines Ltd"})); err != nil {
+		t.Fatalf("landing the organization: %v", err)
+	}
+	edge := migration.Assoc{
+		FromType: flipObjectPerson, FromID: "hs-person-emp",
+		ToType: flipObjectOrganization, ToID: "hs-org-emp", Label: "primary",
+	}
+
+	first, err := f.w.Associate(f.ctx, edge)
+	if err != nil {
+		t.Fatalf("the first association: %v", err)
+	}
+	if !first.Applied {
+		t.Fatalf("the first association reported %+v, want applied", first)
+	}
+
+	second, err := f.w.Associate(f.ctx, edge)
+	if err != nil {
+		t.Fatalf("re-offering an association that already landed: %v — a resumed run must converge", err)
+	}
+	if !second.Applied {
+		t.Errorf("the replay reported %+v, want applied: the edge is on file", second)
+	}
+	if n := f.e.WsCount(t, `SELECT count(*) FROM relationship WHERE kind = 'employment'`); n != 1 {
+		t.Errorf("%d employment rows, want 1 — the replay wrote a second edge", n)
+	}
+}

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -277,36 +277,41 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 	if err != nil {
 		return 0, err
 	}
-	// The lock is IN the statement here, not beside it: this writer attaches a
-	// SET of people found by domain rather than one named person, so there is
-	// no id to lock before the select that finds it. `FOR UPDATE OF p` at the
-	// bottom locks each person this insert is about to attach, which is the
-	// same guarantee lockPersonForAttach gives the single-person writers — an
-	// archive in flight either commits first and drops the row out of this
-	// select, or waits and sweeps the edge this plants.
+	// The candidate set is read FIRST so each person's employment lock can be
+	// taken before the insert decides anything from a read of their
+	// employments. `FOR UPDATE` gives the same archive guarantee
+	// lockPersonForAttach gives the single-person writers — an archive in
+	// flight either commits first and drops the row out of this read, or waits
+	// and sweeps the edge this plants.
+	candidates, err := domainEmploymentCandidates(ctx, tx, domain)
+	if err != nil {
+		return 0, err
+	}
+	// Then the same per-person lock every other writer of this state takes.
+	// Without it this planter reads "they already have a primary", skips them,
+	// and a patch ending that employment commits beside the read: the person is
+	// left employed once, unmarked. The rows come back in id order, so two runs
+	// over overlapping domains take their locks in one order rather than each
+	// waiting on the other's.
+	for _, personID := range candidates {
+		if err := storekit.LockWriteIdentity(ctx, tx, employmentKind, personID.String()); err != nil {
+			return 0, err
+		}
+	}
+	// The NOT EXISTS is re-asked HERE, under those locks, and that is the whole
+	// point of the split: the candidate read above is a snapshot, and this is
+	// the decision.
 	rows, err := tx.Query(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)
 		SELECT 'employment', p.id, $1, true, $2, $3
 		FROM person p
-		WHERE p.archived_at IS NULL
-		  AND p.merged_into_id IS NULL
-		  AND EXISTS (
-			SELECT 1 FROM person_email pe
-			WHERE pe.person_id = p.id
-			  -- An address somebody no longer uses must not attach them to a
-			  -- new employer: a former colleague would be re-hired by a domain
-			  -- they left.
-			  AND pe.archived_at IS NULL
-			  AND (split_part(pe.email, '@', 2) = $4
-			       -- A literal suffix compare, never LIKE — see PersonsOnDomain.
-			       OR right(split_part(pe.email, '@', 2), length($4) + 1) = '.' || $4))
+		WHERE p.id = ANY($4)
 		  AND NOT EXISTS (
 			SELECT 1 FROM relationship r
 			WHERE r.person_id = p.id AND `+employment.CurrentPrimarySlotSQL("r")+`)
-		FOR UPDATE OF p
 		ON CONFLICT DO NOTHING
 		RETURNING id, person_id`,
-		orgID, domainTriageSource(domain), by, domain)
+		orgID, domainTriageSource(domain), by, candidates)
 	if err != nil {
 		return 0, fmt.Errorf("people: planting the employment edges for %s: %w", domain, err)
 	}
@@ -337,6 +342,51 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 		}
 	}
 	return len(made), nil
+}
+
+// domainEmploymentCandidates names the live people this domain's verdict is
+// about: everybody reachable at it who has no current primary employment yet.
+//
+// It exists so the planter can hold a lock per person before it decides. The
+// order is the person id, which is what keeps two runs over overlapping domains
+// from taking one pair of locks in opposite orders.
+func domainEmploymentCandidates(ctx context.Context, tx pgx.Tx, domain string) ([]ids.PersonID, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT p.id
+		FROM person p
+		WHERE p.archived_at IS NULL
+		  AND p.merged_into_id IS NULL
+		  AND EXISTS (
+			SELECT 1 FROM person_email pe
+			WHERE pe.person_id = p.id
+			  -- An address somebody no longer uses must not attach them to a
+			  -- new employer: a former colleague would be re-hired by a domain
+			  -- they left.
+			  AND pe.archived_at IS NULL
+			  AND (split_part(pe.email, '@', 2) = $1
+			       -- A literal suffix compare, never LIKE — see PersonsOnDomain.
+			       OR right(split_part(pe.email, '@', 2), length($1) + 1) = '.' || $1))
+		  AND NOT EXISTS (
+			SELECT 1 FROM relationship r
+			WHERE r.person_id = p.id AND `+employment.CurrentPrimarySlotSQL("r")+`)
+		ORDER BY p.id
+		FOR UPDATE OF p`, domain)
+	if err != nil {
+		return nil, fmt.Errorf("people: reading the people on %s: %w", domain, err)
+	}
+	defer rows.Close()
+	var out []ids.PersonID
+	for rows.Next() {
+		var one ids.PersonID
+		if err := rows.Scan(&one); err != nil {
+			return nil, fmt.Errorf("people: reading the people on %s: %w", domain, err)
+		}
+		out = append(out, one)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("people: reading the people on %s: %w", domain, err)
+	}
+	return out, nil
 }
 
 // bindTriageDossier attaches the triage read to the organization it produced.

--- a/backend/internal/modules/people/domaintriageresolve.go
+++ b/backend/internal/modules/people/domaintriageresolve.go
@@ -345,11 +345,19 @@ func plantDomainEmployment(ctx context.Context, tx pgx.Tx, domain string, orgID 
 }
 
 // domainEmploymentCandidates names the live people this domain's verdict is
-// about: everybody reachable at it who has no current primary employment yet.
+// about: everybody reachable at it, whatever employments they already hold.
 //
-// It exists so the planter can hold a lock per person before it decides. The
-// order is the person id, which is what keeps two runs over overlapping domains
-// from taking one pair of locks in opposite orders.
+// It exists so the planter can hold a lock per person before it decides, and
+// it deliberately does NOT ask who has a primary employment yet. That question
+// is the decision, and asking it here would answer it from an unlocked read: a
+// person whose only employment ends while this list is being built would be
+// excluded from it, and the insert — which can only reconsider the ids it was
+// handed — would leave them employed once and unmarked. Locking a few people
+// the insert then skips costs nothing; the other way costs the case this lock
+// exists for.
+//
+// The order is the person id, which is what keeps two runs over overlapping
+// domains from taking one pair of locks in opposite orders.
 func domainEmploymentCandidates(ctx context.Context, tx pgx.Tx, domain string) ([]ids.PersonID, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT p.id
@@ -366,9 +374,6 @@ func domainEmploymentCandidates(ctx context.Context, tx pgx.Tx, domain string) (
 			  AND (split_part(pe.email, '@', 2) = $1
 			       -- A literal suffix compare, never LIKE — see PersonsOnDomain.
 			       OR right(split_part(pe.email, '@', 2), length($1) + 1) = '.' || $1))
-		  AND NOT EXISTS (
-			SELECT 1 FROM relationship r
-			WHERE r.person_id = p.id AND `+employment.CurrentPrimarySlotSQL("r")+`)
 		ORDER BY p.id
 		FOR UPDATE OF p`, domain)
 	if err != nil {

--- a/backend/internal/modules/people/employmentedge.go
+++ b/backend/internal/modules/people/employmentedge.go
@@ -76,6 +76,19 @@ func plantEmploymentEdge(ctx context.Context, tx pgx.Tx, in EnsureCounterpartyIn
 	if err := lockPersonForAttach(ctx, tx, personID); err != nil {
 		return err
 	}
+	// And the same per-person lock every other writer of this person's
+	// current-primary employment takes. The person row lock above answers a
+	// different question — is this person still here — and the two writers that
+	// decide the flag WITHOUT one (update, archive) take only this. Without it
+	// capture reads "they already have a primary", plants nothing, and a patch
+	// ending that employment commits beside it: the person is left employed
+	// once, unmarked, which is the state the flag exists to make impossible.
+	//
+	// After the row lock, never before: create takes them in this order too, and
+	// two writers taking one pair of locks in opposite orders is a deadlock.
+	if err := storekit.LockWriteIdentity(ctx, tx, employmentKind, personID.String()); err != nil {
+		return err
+	}
 	var edgeID ids.UUID
 	err := tx.QueryRow(ctx, `
 		INSERT INTO relationship (kind, person_id, organization_id, is_current_primary, source, captured_by)

--- a/backend/internal/modules/people/employmentlock_integration_test.go
+++ b/backend/internal/modules/people/employmentlock_integration_test.go
@@ -200,3 +200,46 @@ func (e *dedupeEnv) seedUnmarkedIncumbent(ctx context.Context, t *testing.T) ids
 	}
 	return person
 }
+
+// The candidate list is everybody on the domain, and that is the point.
+//
+// Asking who already has a primary employment here would answer the decision
+// from an UNLOCKED read: a person whose only employment ends between this read
+// and the insert would be missing from the list, and the insert can only
+// reconsider the ids it was handed — leaving them employed once and unmarked,
+// which is the state this whole lock exists to prevent.
+func TestTheDomainCandidateListDoesNotPreJudgeWhoNeedsAnEmployment(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// This person's employment is at another company and IS their primary one,
+	// so a list that pre-judged would leave them out.
+	settled, _ := e.seedEmployedPerson(ctx, t,
+		"Already Employed", "settled@newemployer-race.test", "Incumbent Employer GmbH", "incumbent-race.test")
+	// And one with nothing, who is a candidate under either reading.
+	e.openTriageFirst(ctx, t, "colleague@newemployer-race.test", "A Colleague", "newemployer-race.test")
+
+	var candidates []ids.PersonID
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		candidates, err = domainEmploymentCandidates(ctx, tx, "newemployer-race.test")
+		return err
+	}); err != nil {
+		t.Fatalf("reading the candidates: %v", err)
+	}
+
+	found := false
+	for _, one := range candidates {
+		if one == settled {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the person who already has a primary employment is not in the candidate list, so "+
+			"the insert could never reconsider them: %v", candidates)
+	}
+	if len(candidates) < 2 {
+		t.Errorf("%d candidate(s) on the domain, want both people — a list this short is one that "+
+			"answered the decision instead of naming who it is about", len(candidates))
+	}
+}

--- a/backend/internal/modules/people/employmentlock_integration_test.go
+++ b/backend/internal/modules/people/employmentlock_integration_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Every writer that decides a person's current-primary employment from a read
+// of their other employments waits for whoever is already deciding.
+//
+// Asserted by BLOCKING rather than by racing goroutines. A race reproduces this
+// defect about one run in six, which is a test that reports a regression as an
+// occasional flake — and the shape it produces is
+// `uq_rel_current_primary_employer` refusing a caller that never sent the flag,
+// reachable by no ordering of the two writers at all. The caller it reaches
+// first is an inbound email nobody is watching.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/employment"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// holdEmploymentLock opens a transaction holding one person's employment write
+// identity and hands it back still open, so the test owns the moment a second
+// writer may proceed.
+//
+// Taken through the production call rather than a copy of its key: a change to
+// how the identity is spelled can never leave this transaction holding
+// something no writer waits on.
+func (e *dedupeEnv) holdEmploymentLock(ctx context.Context, t *testing.T, person ids.PersonID) (pgx.Tx, int) {
+	t.Helper()
+	tx, err := e.store.db.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("opening the lock holder's transaction: %v", err)
+	}
+	// A transaction left open on a failure path holds the lock and a pooled
+	// connection with it, and the run that meant to fail loudly would hang.
+	t.Cleanup(func() {
+		err := tx.Rollback(context.Background())
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the lock holder's transaction: %v", err)
+		}
+	})
+	var pid int
+	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+		t.Fatalf("reading the lock holder's backend pid: %v", err)
+	}
+	if err := storekit.LockWriteIdentity(ctx, tx, employmentKind, person.String()); err != nil {
+		t.Fatalf("taking the employment write identity for %s: %v", person, err)
+	}
+	return tx, pid
+}
+
+// Capture plants an employment for a person it reads as having no primary one.
+// A patch granting the flag to another of their employments is the same
+// decision from the other side, and holds this lock while it makes it — so
+// capture waiting for the lock IS capture refusing to decide from a read
+// somebody else is invalidating.
+func TestCaptureWaitsOnThePersonsEmploymentLock(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	person := e.seedUnmarkedIncumbent(ctx, t)
+	// The company that owns the person's OWN email domain, so capture has an
+	// employment to plant rather than one that already exists.
+	if _, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "New Employer GmbH", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "newemployer-race.test", IsPrimary: true}},
+	}); err != nil {
+		t.Fatalf("seeding the capture target: %v", err)
+	}
+	captureInput := e.ensureInput(ctx, t, "subject@newemployer-race.test", "Race Subject", "newemployer-race.test")
+
+	holder, pid := e.holdEmploymentLock(ctx, t, person)
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.store.EnsureCounterparty(e.as(), captureInput)
+		done <- err
+	}()
+	mustBlockOn(t, holder, pid, done)
+
+	if err := holder.Rollback(ctx); err != nil {
+		t.Fatalf("releasing the lock holder: %v", err)
+	}
+	mustFinishCleanly(t, "capture", done)
+	if got := e.currentPrimaryCount(ctx, t, person); got != 1 {
+		t.Errorf("%d current primary employments, want exactly 1", got)
+	}
+}
+
+// The domain-triage backlog is the same decision in bulk: a primary employment
+// for every person on a domain who reads as having none. It answered from a
+// snapshot taken before it had locked anybody.
+func TestTheDomainBacklogWaitsOnEachPersonsEmploymentLock(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	person := e.seedUnmarkedIncumbent(ctx, t)
+	// A second person on the same domain, so this is the bulk path it exists to
+	// be rather than a one-row special case.
+	e.openTriageFirst(ctx, t, "colleague@newemployer-race.test", "A Colleague", "newemployer-race.test")
+	readID := e.startTriageRead(ctx, t, "newemployer-race.test")
+
+	holder, pid := e.holdEmploymentLock(ctx, t, person)
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.store.ResolveDomainTriage(e.as(), ResolveDomainTriageInput{
+			Domain: "newemployer-race.test", Status: DomainCompany, Source: DomainSourceSiteRead,
+			Evidence: "the site states a legal entity", ReadID: readID,
+			DossierName: "New Employer GmbH", SeedURL: "https://newemployer-race.test",
+		})
+		done <- err
+	}()
+	mustBlockOn(t, holder, pid, done)
+
+	if err := holder.Rollback(ctx); err != nil {
+		t.Fatalf("releasing the lock holder: %v", err)
+	}
+	mustFinishCleanly(t, "the domain backlog", done)
+	if got := e.currentPrimaryCount(ctx, t, person); got != 1 {
+		t.Errorf("%d current primary employments, want exactly 1", got)
+	}
+}
+
+func mustFinishCleanly(t *testing.T, who string, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("%s failed once the lock was free: %v — no ordering of these two writers "+
+				"refuses either of them", who, err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("%s never finished after the lock was released", who)
+	}
+}
+
+// asEditor is the same rep the other fixtures use, with the relationship UPDATE
+// grant the patch half of these cases needs. The shared context grants create
+// and read only, and widening it there would quietly hand every other case in
+// this package an authority it was written without.
+func (e *dedupeEnv) asEditor() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"person":       {Create: true, Read: true, Update: true},
+				"organization": {Create: true, Read: true, Update: true},
+				"relationship": {Create: true, Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// currentPrimaryCount is asked of the database rather than of any caller's
+// return: every reader of the flag — the account's contact count, the person
+// list's employer filter, the company People tab — answers wrong for a person
+// carrying two.
+func (e *dedupeEnv) currentPrimaryCount(ctx context.Context, t *testing.T, person ids.PersonID) int {
+	t.Helper()
+	// Through the production predicates: a count that spelled the slot by hand
+	// would keep passing after the definition moved under it.
+	return e.countInWorkspace(ctx, t, `
+		SELECT count(*) FROM relationship
+		WHERE person_id = $1 AND `+employment.CurrentPrimarySlotSQL("")+`
+		  AND `+employment.IsCurrentSQL("ended_at"), person)
+}
+
+// seedUnmarkedIncumbent gives one person an employment at a company that is NOT
+// their email's domain, with the flag explicitly off — the state in which a
+// capture and a patch both have a decision to make about the same person.
+func (e *dedupeEnv) seedUnmarkedIncumbent(ctx context.Context, t *testing.T) ids.PersonID {
+	t.Helper()
+	person, _ := e.seedEmployedPerson(ctx, t,
+		"Race Subject", "subject@newemployer-race.test", "Incumbent Employer GmbH", "incumbent-race.test")
+	var incumbent ids.UUID
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT id FROM relationship WHERE kind = 'employment' AND person_id = $1`, person).Scan(&incumbent)
+	}); err != nil {
+		t.Fatalf("reading the seeded employment: %v", err)
+	}
+	no := false
+	if _, err := e.store.UpdateRelationship(e.asEditor(), incumbent,
+		UpdateRelationshipInput{IsCurrentPrimary: &no}); err != nil {
+		t.Fatalf("clearing the incumbent's flag: %v", err)
+	}
+	return person
+}

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -434,6 +434,13 @@ func (s *Store) archiveRelationshipWithEvidence(ctx context.Context, id ids.UUID
 	}
 	var out relationshipRow
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		// No per-person employment lock here, deliberately. This path frees the
+		// current-primary slot but never DECIDES anything from a read of it, so
+		// every interleaving with a writer that does lands on a state one of the
+		// two sequential orders also produces: a create that read the incumbent
+		// as live inserts an unpromoted second employment, which is the create-
+		// then-archive order. A person left with an employment and no primary
+		// one is a successor nobody promotes, not a race.
 		current, err := s.visibleRelationship(ctx, tx, id)
 		if err != nil {
 			return err

--- a/backend/internal/modules/people/relationship_conflict_test.go
+++ b/backend/internal/modules/people/relationship_conflict_test.go
@@ -105,3 +105,29 @@ func TestANonUniquenessErrorIsNotDressedAsAConflict(t *testing.T) {
 		t.Fatal("an unrelated failure was reported as a conflict")
 	}
 }
+
+// AlreadyRecorded is what an idempotent writer asks before it treats a refusal
+// as convergence, and the answer differs by which KEY refused.
+//
+// The rule keyed on the person alone is the one that must answer no: its
+// conflict is with a different company entirely, so the edge the caller offered
+// did not land. An importer reading every 409 as "already there" reported a row
+// it never wrote, and the person kept an employer nobody recorded.
+//
+// The list is derived from the mapper's own vocabulary rather than typed twice,
+// so a rule added there is answered here or names itself.
+func TestOnlyATupleKeyedRefusalMeansTheEdgeIsAlreadyOnFile(t *testing.T) {
+	personKeyed := map[string]bool{"uq_rel_current_primary_employer": true}
+	for constraint := range relationshipConflictDetails {
+		t.Run(constraint, func(t *testing.T) {
+			got := (&RelationshipConflictError{Constraint: constraint}).AlreadyRecorded()
+			if want := !personKeyed[constraint]; got != want {
+				t.Fatalf("AlreadyRecorded() = %t for %s, want %t", got, constraint, want)
+			}
+		})
+	}
+	// A rule this type has never seen is not evidence that anything landed.
+	if (&RelationshipConflictError{Constraint: "uq_something_new"}).AlreadyRecorded() {
+		t.Error("an unrecognised constraint was read as the edge already being on file")
+	}
+}

--- a/backend/internal/modules/people/relationship_conflict_test.go
+++ b/backend/internal/modules/people/relationship_conflict_test.go
@@ -126,6 +126,14 @@ func TestOnlyATupleKeyedRefusalMeansTheEdgeIsAlreadyOnFile(t *testing.T) {
 			}
 		})
 	}
+	// uq_rel_works_with is answered by AlreadyRecorded but carries no
+	// caller-facing sentence, so the loop above — which walks the sentences —
+	// never reaches it. Named here, or the classification of a rule the mapper
+	// does return has nothing holding it.
+	if !(&RelationshipConflictError{Constraint: "uq_rel_works_with"}).AlreadyRecorded() {
+		t.Error("uq_rel_works_with is keyed on the pair being inserted, so its refusal does mean the " +
+			"edge is already on file")
+	}
 	// A rule this type has never seen is not evidence that anything landed.
 	if (&RelationshipConflictError{Constraint: "uq_something_new"}).AlreadyRecorded() {
 		t.Error("an unrecognised constraint was read as the edge already being on file")

--- a/backend/internal/modules/people/relationshiperrors.go
+++ b/backend/internal/modules/people/relationshiperrors.go
@@ -136,6 +136,24 @@ func (e *RelationshipConflictError) Error() string {
 // ErrConflict to 409 keeps doing so without knowing this type exists.
 func (e *RelationshipConflictError) Is(target error) bool { return target == apperrors.ErrConflict }
 
+// AlreadyRecorded reports whether this refusal means the edge the caller
+// offered is ALREADY on file — the answer an idempotent writer needs before it
+// treats a conflict as convergence.
+//
+// Only the rules keyed on the tuple being inserted qualify. The primary-
+// employer index is keyed on the PERSON alone, so its conflict is with a
+// different company entirely and the offered edge did NOT land: an importer
+// that read every 409 as "already there" would report a row it never wrote,
+// and the person would keep an employer nobody recorded.
+func (e *RelationshipConflictError) AlreadyRecorded() bool {
+	switch e.Constraint {
+	case employmentUnique, projectStakeholderUnique, "uq_rel_deal_person_role", "uq_rel_works_with":
+		return true
+	default:
+		return false
+	}
+}
+
 // mapRelationshipConstraint turns the insert's constraint failures into
 // typed input errors: the rel_* CHECKs are the kind→endpoint shape rules
 // (migration 0007) — bad input, not a fault — and the partial unique


### PR DESCRIPTION
Closes #1805.

## What was still open

Of the three writers the ticket names, one — `UpdateRelationship` — has since taken the lock, and the create path takes it too. Two had not:

| path | held | now |
|---|---|---|
| capture's employment edge (`employmentedge.go`) | the person ROW lock, for the archive race | + the per-person employment lock |
| domain-triage backlog (`domaintriageresolve.go`) | `FOR UPDATE OF p`, same reason | + the per-person employment lock |
| update (`relationship.go`) | already took it | unchanged |
| archive | nothing | still nothing — see below |

The person row lock and the employment lock answer different questions. The first is *is this person still here*; the second is *who is deciding about their employments*. A writer holding only the first still decides from a read the second is invalidating.

## Why it matters

`uq_rel_current_primary_employer` refuses whichever of the pair commits second, and **no ordering of the two writers produces that**: capture first and the patch demotes what capture planted; the patch first and capture reads the primary it granted and plants nothing. The caller that meets the refusal first is an inbound email nobody is watching.

## The bulk path

It answered its `NOT EXISTS` from a snapshot taken before it had locked anybody. The candidate read is now its own statement — `ORDER BY p.id`, so two runs over overlapping domains queue rather than wait on each other — and the decision is re-asked under the locks it then takes. The email-domain predicate moved with it and is still spelled once.

## Archive: deliberately NOT locked

The ticket lists it, and I did add the lock before taking it back out. Archiving frees the slot but decides nothing from a read of it, so every interleaving lands where one of the two sequential orders lands — a create that read the incumbent as live inserts an unpromoted second employment, which is exactly the create-then-archive order. A person left employed once and unmarked is **#1781** (nothing promotes a successor), reachable with no concurrency at all. Locking here would buy nothing and cost a lock on the archive path; the reason is stated in the code beside it.

## The Flip importer

`flipassoc.go` mapped every `ErrConflict` to `Applied: true`. That is right for the per-pair index — a resumed run re-offering an edge that already landed is convergence — and wrong for the primary-employer index, which is keyed on the **person**: its refusal means the offered edge never landed, and the run reported an import as applied while dropping the employment.

`RelationshipConflictError` already carried the constraint for this exact purpose ("a caller racing ITSELF … can tell which rule fired"). It now answers the question — `AlreadyRecorded()` — rather than making each caller learn the index names. `TestOnlyATupleKeyedRefusalMeansTheEdgeIsAlreadyOnFile` derives its cases from the mapper's own vocabulary, so a rule added there is answered here or names itself.

## Tests: blocking, not racing

Two goroutines reproduce this **about one run in six** — I measured it: six mutation runs with the locks removed, one failure. A test that reports a regression as an occasional flake is worse than none.

So the assertion is the one this package already uses for contention (`holdDomainAdmissionLock` / `mustBlockOn`): hold the person's employment write identity in an open transaction, then prove each writer waits for it. Taken through `storekit.LockWriteIdentity` rather than a copy of the key, so a change to how the identity is spelled cannot leave the probe holding something nobody waits on.

Mutation-checked: with either lock removed, both tests fail on **every** run (3/3).

## The gate

`TestEveryRelationshipCarryingAPersonIsWrittenUnderItsLock` required the lock in the same function as the insert, so splitting the candidate read out failed it — correctly, by its own rules. It now follows **one** hop into a helper in the same file that takes a lock itself. One hop and no further: a lock two calls away is one a reader of the writer cannot see, which is the blindness the gate exists to close.

Per the census rule I added the falsification arm it lacked: `TestTheWriterReaderSeesTheLockAndOnlyTheLock` plants six sources, including a writer whose helper locks (clean) and one whose helper does not (still reported) — a hop that accepted any call at all would pass the whole module.

## Checks

`make check-backend` green; `make test-it DIR=backend/internal/modules/people` and `DIR=backend/internal/compose` both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved employment relationship processing to prevent incorrect “already recorded” results when a person already has a different primary employer.
  * Improved consistency when employment information is updated concurrently, helping ensure only one current primary employment is selected.
  * Strengthened handling of domain-based employment resolution and relationship creation under simultaneous changes.

* **Tests**
  * Added coverage for employment locking, relationship conflict handling, and writer behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->