### PR TITLE
The German exception's fixture is the pack's declaration

### DIFF
--- a/backend/gates/deexceptionmirror_test.go
+++ b/backend/gates/deexceptionmirror_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The engine's test fixture for the German exception is the pack's declaration,
+// or the tests prove nothing about what ships.
+//
+// UWG §7(3) permits advertising to an existing customer only where all four of
+// its conditions hold, and extensions/de declares all four. The evaluator that
+// reads them lives in internal/modules/consent, and its unit tests hand it a
+// MarketingException built in the test file — because the schema will not store
+// the failing shape for one condition, so the only way to ask what the code does
+// with it is to pass the values directly.
+//
+// That fixture calls itself "what extensions/de declares" and nothing checked
+// it. The pack cannot be imported to remove the copy: extensions/de depends on
+// backend, so backend reading it back would be a cycle. So the copy is a
+// declared MIRROR, and this is what makes "mirror" true — it compares the two
+// literals in both directions, so a condition added to the pack and not the
+// fixture fails, and so does one relaxed in the fixture and not the pack.
+//
+// Why it matters that the fixture is right: relax a condition there and the
+// evaluator's tests go on passing while asserting a §7(3) the statute does not
+// grant. A test that models a laxer law than the one shipped is worse than no
+// test, because it reports coverage of the case it stopped checking.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+const (
+	dePackSource     = "../extensions/de/de.go"
+	consentFixture   = "internal/modules/consent/existingcustomer_test.go"
+	exceptionLiteral = "MarketingException"
+	// The function on the consent side whose literal IS the mirror. Named
+	// rather than taken by position: the fixture file exists to exercise
+	// conditions one at a time, so a relaxed variant written there as a literal
+	// is an ordinary thing for it to grow — and a gate reading whichever came
+	// first would then compare a struct nobody ships and report agreement.
+	// Today the file holds one literal and builds its relaxed case by copying
+	// it, so this changes nothing yet; it is what keeps the subject stable.
+	fixtureFunc = "germanConditions"
+	// And the function on the pack side, for the same reason. Reading the whole
+	// file merged every MarketingException literal in it into one map, last
+	// writer wins — so a relaxed shipped exception plus an honest reference
+	// literal elsewhere in the file compared as agreeing.
+	packFunc = "messagingRules"
+	// The pack's constructor, which is what compose calls.
+	packConstructor = "New"
+)
+
+func TestTheGermanExceptionFixtureMirrorsThePack(t *testing.T) {
+	t.Parallel()
+
+	// The pack side is read from the function New() wires, and that wiring is
+	// asserted here rather than assumed: this gate names a FILE and a FUNCTION,
+	// so a pack that moved its shipped declaration elsewhere would leave this
+	// comparing a literal nobody registers. extensions/de's own test reads
+	// New().Messaging and fails on exactly that move; this checks the two are
+	// still the same function, which is what makes reading the file enough.
+	if !packWires(t, packFunc) {
+		t.Fatalf("%s no longer builds its Messaging from %s, so this gate is comparing a literal "+
+			"that may not be the one compose registers. Point packFunc at whatever New() wires now",
+			dePackSource, packFunc)
+	}
+
+	declared := marketingExceptionFields(t, dePackSource, packFunc)
+	if len(declared) == 0 {
+		t.Fatalf("%s builds no %s in %s, so this gate has no subject and would pass however far "+
+			"the engine's fixture had drifted from the pack. If the pack's declaration moved, "+
+			"point packFunc at it", dePackSource, exceptionLiteral, packFunc)
+	}
+
+	fixture := marketingExceptionFields(t, consentFixture, fixtureFunc)
+	if len(fixture) == 0 {
+		t.Fatalf("%s builds no %s in %s — the evaluator's tests no longer model the pack's "+
+			"exception there, so nothing says what they are asserting about. If the fixture "+
+			"moved, point fixtureFunc at it rather than letting this gate read a different one",
+			consentFixture, exceptionLiteral, fixtureFunc)
+	}
+
+	for field, want := range declared {
+		got, named := fixture[field]
+		if !named {
+			t.Errorf("extensions/de requires %s and the engine's fixture does not set it: the "+
+				"evaluator's tests are modelling a §7(3) with one fewer condition than the pack "+
+				"grants, and would keep passing if the engine stopped reading it", field)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s is %s in extensions/de and %s in the engine's fixture — the tests are "+
+				"asserting about an exception this installation does not ship", field, want, got)
+		}
+	}
+	// A field on the type that NEITHER side states. Both would agree by
+	// omission, and the §7(3) condition it represents would be unchecked in the
+	// engine and unnoticed here — the census failing short over a field nobody
+	// wrote. Read from the type, so a field added tomorrow is covered the day
+	// it is added.
+	for _, field := range exceptionFields() {
+		if _, stated := declared[field]; !stated {
+			t.Errorf("messaging.MarketingException carries %s and extensions/de states it nowhere. "+
+				"An unstated condition is one the engine is not asked to check: set it in the "+
+				"pack, or say in the type why Germany does not require it", field)
+		}
+	}
+
+	for field := range fixture {
+		if _, declared := declared[field]; !declared {
+			t.Errorf("the engine's fixture sets %s, which extensions/de does not declare. Either "+
+				"the pack dropped a condition and the fixture kept it — so the tests assert a "+
+				"stricter rule than ships — or the fixture named a field the pack never had",
+				field)
+		}
+	}
+}
+
+// packWires reports whether the pack's New() builds its Messaging field by
+// calling the named function.
+//
+// Scoped to New itself, not to the file: a helper or dead literal elsewhere
+// carrying a Messaging key would otherwise satisfy this while New shipped
+// something else.
+//
+// What it CANNOT do is follow the value. New assigning a local slice, appending
+// to one, or calling through a wrapper all read here as unwired, and this fails
+// closed on each — loudly, naming the function to repoint, rather than passing
+// over a shape it did not understand. That is the right direction for a check
+// whose whole job is to say "the literal below is the one that ships": a false
+// alarm costs a line of this gate, and a false pass costs the §7(3) conditions
+// nobody is checking. extensions/de's own test reads New().Messaging and holds
+// the value side, which is the half source-reading cannot reach.
+func packWires(t *testing.T, fn string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, dePackSource, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", dePackSource, err)
+	}
+
+	var constructor *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == packConstructor {
+			constructor = fn
+			break
+		}
+	}
+	if constructor == nil {
+		t.Fatalf("%s declares no %s, so this gate cannot tell which rules the pack ships",
+			dePackSource, packConstructor)
+	}
+
+	wired := false
+	ast.Inspect(constructor, func(n ast.Node) bool {
+		kv, ok := n.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		if key, ok := kv.Key.(*ast.Ident); !ok || key.Name != "Messaging" {
+			return true
+		}
+		ast.Inspect(kv.Value, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if name, ok := call.Fun.(*ast.Ident); ok && name.Name == fn {
+				wired = true
+			}
+			return true
+		})
+		return true
+	})
+	return wired
+}
+
+// marketingExceptionFields reads the MarketingException composite literals in a
+// file and returns the boolean fields they set, by name.
+//
+// within scopes the read to one function when given, which is how the consent
+// side names its mirror: that file builds a second, deliberately relaxed
+// exception for a test of one condition, and comparing THAT against the pack
+// would report a disagreement the product does not have. The pack side passes
+// "" because its file declares exactly one, which the caller asserts.
+//
+// Read from the SOURCE of both sides rather than by building either: the pack
+// is a separate module this one cannot import, and the point is to compare two
+// declarations rather than to trust one of them.
+//
+// Both the boolean conditions and Kind are read. Kind is the exception's
+// identity rather than one of its conditions, but it is compared here for the
+// same reason the conditions are: the pack side is asserted by extensions/de's
+// own test and the FIXTURE side is asserted by nothing else, so leaving it out
+// would let the evaluator's tests model an exception of a different kind
+// entirely while every test in the tree stayed green.
+func marketingExceptionFields(t *testing.T, path, within string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	var root ast.Node = file
+	if within != "" {
+		root = nil
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == within {
+				root = fn
+				break
+			}
+		}
+		if root == nil {
+			t.Fatalf("%s declares no %s, so this gate cannot find the mirror it compares — "+
+				"point fixtureFunc at wherever the fixture moved", path, within)
+		}
+	}
+
+	// A field ASSIGNED after the literal is built would leave this reading the
+	// pre-mutation value — the literal says one thing and the function returns
+	// another. Refused rather than followed: this gate reads declarations, and
+	// a function that mutates its exception is no longer a declaration.
+	ast.Inspect(root, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, target := range assign.Lhs {
+			sel, ok := target.(*ast.SelectorExpr)
+			if !ok || !exceptionFieldName(sel.Sel.Name) {
+				continue
+			}
+			t.Errorf("%s assigns %s after building the exception, so the literal this gate reads "+
+				"is not what the function returns. Set the field in the literal, or this "+
+				"comparison is about a struct nobody uses", path, sel.Sel.Name)
+		}
+		return true
+	})
+
+	fields := map[string]string{}
+	ast.Inspect(root, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || !namesMarketingException(lit) {
+			return true
+		}
+		// Inside a slice of them the element type is ELIDED — the pack writes
+		// `[]messaging.MarketingException{{Kind: …}}` — so the elements carry
+		// no type of their own and are read here from the slice's.
+		elements := lit.Elts
+		if isExceptionSlice(lit) {
+			elements = nil
+			for _, element := range lit.Elts {
+				inner, ok := element.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				elements = append(elements, inner.Elts...)
+			}
+		}
+		for _, element := range elements {
+			kv, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			value, readable := literalValue(kv.Value)
+			if !readable {
+				t.Errorf("%s sets %s to something this gate cannot read as a written-out value. "+
+					"Both sides are compared as source, so a constant or an expression could "+
+					"name the same thing and mean two different ones — write the value out",
+					path, key.Name)
+				continue
+			}
+			fields[key.Name] = value
+		}
+		return true
+	})
+	return fields
+}
+
+// literalValue renders the value a field is set to, and refuses anything that is
+// not written out in full.
+//
+// This gate diffs two SOURCES, so it compares spellings: `true` against `true`,
+// `messaging.ExistingCustomer` against the same. A field set to a named constant
+// would compare by that name, and two files can define one differently — so a
+// name this gate does not recognise is refused rather than compared, and the
+// caller says so. Reading the meaning instead would mean type-checking two
+// modules, one of which this one cannot import.
+//
+// Refusing is the safe direction: an unreadable field fails the gate and costs
+// somebody a spelling, where comparing it could agree about a value neither side
+// holds.
+func literalValue(expr ast.Expr) (string, bool) {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		if value.Name == "true" || value.Name == "false" {
+			return value.Name, true
+		}
+	case *ast.SelectorExpr:
+		// A qualified constant, kept whole: `messaging.ExistingCustomer` and
+		// some other package's ExistingCustomer are different values, and the
+		// bare selector name would read them as the same.
+		if pkg, ok := value.X.(*ast.Ident); ok {
+			return pkg.Name + "." + value.Sel.Name, true
+		}
+	}
+	return "", false
+}
+
+// exceptionFields names every field on the exception type. Derived rather than
+// listed, so a field added to messaging.MarketingException is covered the day it
+// is added — which is the whole point of asking the type instead of a copy.
+func exceptionFields() []string {
+	typ := reflect.TypeOf(messaging.MarketingException{})
+	names := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		names = append(names, typ.Field(i).Name)
+	}
+	return names
+}
+
+// exceptionFieldName reports whether a name is one of the exception's own
+// fields.
+func exceptionFieldName(name string) bool {
+	return slices.Contains(exceptionFields(), name)
+}
+
+// namesMarketingException reports whether a composite literal is one, or a
+// slice of them. The fixture writes it directly; the pack writes a slice whose
+// elements elide their type.
+func namesMarketingException(lit *ast.CompositeLit) bool {
+	return exceptionTypeName(lit.Type) == exceptionLiteral || isExceptionSlice(lit)
+}
+
+func isExceptionSlice(lit *ast.CompositeLit) bool {
+	slice, ok := lit.Type.(*ast.ArrayType)
+	return ok && exceptionTypeName(slice.Elt) == exceptionLiteral
+}
+
+// exceptionTypeName names the type an expression denotes, qualified or bare.
+func exceptionTypeName(expr ast.Expr) string {
+	switch typ := expr.(type) {
+	case *ast.SelectorExpr:
+		return typ.Sel.Name
+	case *ast.Ident:
+		return typ.Name
+	}
+	return ""
+}

--- a/backend/internal/modules/consent/existingcustomer_test.go
+++ b/backend/internal/modules/consent/existingcustomer_test.go
@@ -7,12 +7,21 @@ package consent
 // the DDL will not store the failing case for one of them.
 
 import (
+	"context"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
-// germanConditions is what extensions/de declares.
+// germanConditions is what extensions/de declares — a deliberate mirror rather
+// than a second answer. It compares this literal against the pack's in both
+// directions, so a condition added to one and not the other fails.
+//
+// Held by: TestTheGermanExceptionFixtureMirrorsThePack (backend/gates/deexceptionmirror_test.go)
+//
+// Copied rather than imported because extensions/de depends on backend, so
+// reading it back here would be a cycle.
 func germanConditions() messaging.MarketingException {
 	return messaging.MarketingException{
 		Kind:                         messaging.ExistingCustomer,
@@ -61,5 +70,36 @@ func TestSaleEvidenceMustBeRecorded(t *testing.T) {
 	}
 	if !conditionsMet(all, "INV-1", true) {
 		t.Error("a recorded sale reference did not allow")
+	}
+}
+
+// The exception Germany ships today refuses before it reads anything.
+//
+// RequiresSimilarity is set, and similarity is unanswerable with the fields this
+// tree has — so existingCustomerAllows short-circuits ahead of the row read.
+//
+// Without this, the file's other tests exercise conditionsMet — a function the
+// SHIPPED German exception never reaches. This is the case that fails the day
+// somebody drops RequiresSimilarity from the pack to "make the exception work",
+// which is the one change the mirror gate cannot tell from a legitimate one.
+func TestTheShippedGermanExceptionRefusesBeforeReadingARow(t *testing.T) {
+	german := germanConditions()
+	if !german.RequiresSimilarity {
+		t.Fatal("the shipped German exception no longer requires similarity. That is the field " +
+			"that makes it refuse without reading a row, so this probe would dereference its nil " +
+			"transaction — but the change worth noticing is the product one: similarity cannot " +
+			"be answered with today's fields, so dropping it grants §7(3) on evidence nobody has")
+	}
+
+	// A NIL transaction is the assertion: a query would dereference it, so
+	// returning cleanly proves the refusal precedes the read.
+	allowed, err := existingCustomerAllows(context.Background(), nil, ids.NewV7().String(), &german)
+	if err != nil {
+		t.Fatalf("evaluating the shipped German exception: %v", err)
+	}
+	if allowed {
+		t.Error("the shipped §7(3) exception allowed a send. It requires similarity, which this " +
+			"tree cannot answer, so the only safe answer is a refusal — and an allow here would " +
+			"be one reached without reading the customer's row at all")
 	}
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (97)
+## Parity (98)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -48,6 +48,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dealmoveargument_test.go` | H2 | One rule, read on both sides of a compose seam. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
+| `deexceptionmirror_test.go` | H3 | The engine's test fixture for the German exception is the pack's declaration, or the tests prove nothing about what ships. |
 | `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |
 | `emailsplitterparity_test.go` | H3 | The server composes a row's preview and the browser folds the quoted tail in the drawer, from two copies of one vocabulary. |
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |

--- a/extensions/de/de_test.go
+++ b/extensions/de/de_test.go
@@ -58,8 +58,26 @@ func TestNewDeclaresTheGoBDFloors(t *testing.T) {
 // four conditions hold. The pack declares all four; declaring three would be an
 // exception the engine applies while checking less than the statute asks, which
 // is worse than none because it looks lawful.
+//
+// Read off New(), not off messagingRules(): what binds an installation is the
+// rule set compose registers out of the extension, and asserting the helper
+// would leave New() free to ship a different one. A pack that declared four
+// conditions in a function nobody wires and three in the one it does is a
+// §7(3) that looks lawful in its own tests.
+//
+// This asserts the DECLARATION and no more, deliberately: a pack states rules
+// and the core evaluates them, and this unit cannot reach the evaluator — it is
+// unexported in internal/modules/consent, and backend cannot import this module
+// back without a cycle. What the engine does with these four is held on the
+// other side, by consent's own tests over conditionsMet, and the two are tied
+// together by gates/deexceptionmirror_test.go.
 func TestTheExistingCustomerExceptionCarriesAllFourConditions(t *testing.T) {
-	rules := messagingRules()
+	shipped := New().Messaging
+	if len(shipped) != 1 {
+		t.Fatalf("New() ships %d messaging rule set(s), want exactly one — the engine registers "+
+			"every one of them, so a second is a second answer about German law", len(shipped))
+	}
+	rules := shipped[0]
 	if len(rules.MarketingExceptions) != 1 {
 		t.Fatalf("%d marketing exceptions declared, want exactly the §7(3) one", len(rules.MarketingExceptions))
 	}


### PR DESCRIPTION
UWG §7(3) permits advertising to an existing customer only where all four of its conditions hold. `extensions/de` declares four; the evaluator that reads them lives in `internal/modules/consent`, and its unit tests build a `MarketingException` in the test file — because the schema will not store the failing shape for one condition, so the only way to ask what the code does with it is to pass the values directly.

**That fixture called itself "what extensions/de declares" and nothing checked it.** Relax a condition there and the evaluator's tests go on passing while asserting a §7(3) the statute does not grant — a test modelling a laxer law than the one shipped, which is worse than no test because it reports coverage of the case it stopped checking.

The copy cannot be removed: `extensions/de` depends on `backend`, so reading it back would be a module cycle. So it is a declared **mirror**, and `gates/deexceptionmirror_test.go` is what makes "mirror" true — it parses both sources and compares the exception's fields in both directions.

## Three ways it could have agreed about nothing

Each found by review, each closed:

1. **It read the whole pack file**, merging every `MarketingException` literal into one map, last writer wins. A relaxed shipped exception plus an honest reference literal elsewhere compared as *agreeing*. Both sides are now scoped to the function that owns them.

2. **Neither holder read what `New()` actually ships.** Relocating the declaration to a sibling file, leaving an honest decoy in `de.go`, left the gate *and* `extensions/de`'s own test green while the installation shipped a §7(3) missing three of four conditions. The pack test now reads `New().Messaging`, and the gate asserts `New` wires the function it parses.

3. **A field set to a named constant, or assigned after the literal**, compared by a spelling that can mean two things in two files. Both are refused rather than compared. A field on the type that **neither** side states now fails too — agreement by omission is the census failing short over a condition nobody wrote.

## One test on the product side

The exception Germany ships today refuses before reading a row, because it requires similarity and similarity is unanswerable with the fields this tree has. Probed with a **nil** transaction, so a query would dereference it — returning cleanly is the proof.

That is the case that fails the day somebody drops `RequiresSimilarity` to "make the exception work", which is the one change a mirror cannot tell from a legitimate one.

## Mutation matrix

| mutation | result |
|---|---|
| fixture relaxes a condition | fail |
| fixture drops a condition | fail |
| pack drops a condition | fail |
| fixture `Kind` changed | fail |
| fixture function renamed | fail |
| decoy literal in the fixture file | correctly ignored |
| relaxed shipped literal + honest decoy in `de.go` | fail |
| shipped rules relocated to a sibling file | both holders fail |
| field set to a named constant | fail |
| field assigned after the literal | fail |
| field stated by neither side | fail |
| `RequiresSimilarity` dropped | fail, naming the product consequence |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the consent evaluator's German §7(3) test fixture so it can no longer drift from the exception `extensions/de` ships. The fixture previously called itself "what extensions/de declares" with nothing checking it; a new parity gate parses both sources and compares every exception field in both directions, so relaxing or dropping a condition on either side fails the build.

- The pack's own test now reads `New().Messaging` instead of `messagingRules()`, so a declaration relocated to a sibling file fails rather than shipping silently.
- A new consent-side probe passes a nil transaction to the shipped exception and proves it refuses before reading a row; this fails the day `RequiresSimilarity` is dropped.
- Fields set to named constants or assigned after the literal are refused rather than compared, and a condition stated by neither side fails the gate.

<sup>Written for commit fbddfab1523308525e27e486e7968faa939cda51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Germany’s marketing exception to ensure all declared conditions match the consent evaluator.
  * Confirmed the exception refuses requests before accessing customer data when required information is unavailable.

* **Documentation**
  * Updated the gate inventory to include the new German exception parity check.
  * Expanded test documentation describing the relationship between the shipped German rule and its validation fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->