### PR TITLE
test(gates): two censuses derive their corpus instead of listing it

### DIFF
--- a/backend/gates/doitokenexposure_test.go
+++ b/backend/gates/doitokenexposure_test.go
@@ -21,27 +21,32 @@ package gates
 // issuance_trigger IS NOT NULL clause is what excludes them); this gate is what
 // stops the shape coming back.
 //
-// Three carriers are checked, because they are the three places a value escapes
-// a Go program without anybody deciding to publish it:
+// The check is INVERTED: rather than listing the calls a token must not reach,
+// it lists the ones it MAY, and every other use of the plaintext is a finding.
 //
-//   - an HTTP response body,
-//   - a log line,
-//   - an audit or outbox payload.
+// A deny-list of sinks is a census that can fail short. The earlier version of
+// this gate carried eleven sink names, and two probes walked past it: an
+// fmt.Fprintf to a writer, and — worse, through a sink the list DID hold — a
+// slog.InfoContext handed the bare local the token actually lives in, because
+// the value match only recognised a ".Token" field selection. Both published a
+// bearer credential over one person's record and both read green. Publishing is
+// open-ended and cannot be enumerated; the legitimate destinations are named,
+// are named in the code, and change only when somebody edits this file.
 //
-// The mail body is the one legitimate destination and is ratified by name.
+// The plaintext enters the package in two ways: it is MINTED by newConfirmToken,
+// and it arrives as a "token" parameter — on the store lookups and, before them,
+// on the unauthenticated HTTP handlers a mailed link resolves to.
 //
-// This gate reads the token's OWN package rather than sweeping the tree. The
-// plaintext exists in exactly one type, IssuedConfirm.Token, built in one
-// function and returned to two callers; a value that never leaves that package
-// cannot be logged by code that cannot name it. The scope is asserted below
-// rather than assumed, so a second minting site elsewhere fails rather than
-// escaping the walk.
-
+// It may then be laundered (hashConfirmToken, confirmLink), handed to a consumer
+// that looks it up and returns a record, or placed on the IssuedConfirm the mail
+// path reads. Everything else is a finding.
+//
 import (
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -49,59 +54,417 @@ import (
 const (
 	// consentDir is the package that mints and spends the plaintext.
 	consentDir = "internal/modules/consent"
-	// plaintextField is the only field carrying an unhashed token.
+	// plaintextField is the field of IssuedConfirm carrying an unhashed token.
 	plaintextField = "Token"
-	// mailBodyFile is the one file that may put the plaintext in a string: it
-	// composes the message the token is mailed in.
-	mailBodyFile = "confirmmail.go"
+	// carrierType is the struct that carries the plaintext to the mail path.
+	carrierType = "IssuedConfirm"
+	// tokenSource mints the plaintext. Its result is what this gate follows.
+	tokenSource = "newConfirmToken"
 )
 
-// tokenSinks are the calls that publish a value outside the process. A
-// plaintext token reaching any of them is the defect.
+// tokenParameterName is what a plaintext token is called where it arrives as a
+// parameter. Every function in this package taking one holds a bearer
+// credential — the public HTTP handlers read it straight off the URL.
 //
-// The value is what the sink IS, used to render the finding — "passes the token
-// to Audit (an audit payload)" — rather than the cost of an exemption. Nothing
-// here is waived: every entry is a destination the token must never reach.
+// DERIVED from the parameter, not from a list of functions. A first version of
+// this gate seeded three named lookups instead, and the review found the two
+// most exposed holders were not among them: GetConfirmDetails and
+// SubmitConfirmDetails, the unauthenticated handlers a mailed link resolves to.
+// A slog line in either published the credential and read green, which is the
+// same failure this gate was rewritten to fix. Naming functions was how the
+// corpus fell short the first time, and naming the value is narrower: it goes
+// stale for ONE spelling rather than for every function added afterwards.
 //
-// gatekit:fixture the destination each sink publishes to, for the finding text
-var tokenSinks = map[string]string{
-	"WriteJSON":    "an HTTP response body",
-	"Encode":       "an HTTP response body",
-	"InfoContext":  "a log line",
-	"WarnContext":  "a log line",
-	"ErrorContext": "a log line",
-	"Info":         "a log line",
-	"Warn":         "a log line",
-	"Error":        "a log line",
-	"Audit":        "an audit payload",
-	"AuditEvent":   "an audit payload",
-	"Emit":         "an outbox payload",
+// It is not immune. A parameter called credential rather than token is outside
+// the walk, and no floor notices one holder lost among several. Closing that
+// needs call-graph propagation — a function whose argument at a tainted
+// position is itself tainted becomes watched — which is a bigger change than
+// this gate. Until then the spelling is the contract, and it is stated here so
+// the next author knows it is one.
+const tokenParameterName = "token"
+
+// ratifiedDestinations are the calls a plaintext token may be handed to, each
+// named for what makes it safe. Anything else is a finding.
+//
+// Two shapes qualify. A LAUNDERER turns the credential into something safe to
+// carry onward — the digest the row holds, or the URL that goes in the mail. A
+// CONSUMER looks the token up and hands back a record; the token goes in and
+// does not come out. Every consumer here is still checked by this gate in its
+// own right, because each takes the value as a "token" parameter and is walked
+// like any other holder.
+//
+// The preference-centre token is a DIFFERENT credential with its own resolver
+// and its own storage — it is kept in plaintext, where the confirm token is
+// hashed — so ResolvePreferenceToken is ratified here as a consumer and is not
+// otherwise this gate's subject.
+//
+// gatekit:fixture why each destination may receive the plaintext
+var ratifiedDestinations = map[string]string{
+	"hashConfirmToken":        "returns only the digest, which is what the row holds",
+	"confirmLink":             "returns the URL that goes in the mail body",
+	"ResolveConfirmToken":     "looks the token up and returns a record, never the token",
+	"subjectOfConfirmTokenTx": "looks the token up and returns whose link it is",
+	"spendConfirmTokenTx":     "marks the link used and returns a record",
+	"SubmitConfirmation":      "is the store method the public handler forwards its token to",
+	"ResolvePreferenceToken":  "consumes a different credential, the preference-centre token",
+	"QueryRow":                "is the parameterised lookup: the token is a bound argument, never text in a statement",
+}
+
+// launderers are the two functions whose OWN BODY this gate does not inspect,
+// because the body is where the credential legitimately becomes something else.
+//
+// Keyed RECEIVER-QUALIFIED. calleeName drops the receiver, so a bare name would
+// let any method called confirmLink, on any type, both launder the taint at its
+// call sites and have its own body skipped — two bypasses out of one name. The
+// launderers are a package function and one store method, and that is what the
+// keys say.
+//
+// Deliberately NOT the whole ratified set. Being allowed to RECEIVE the token
+// and being exempt from inspection are different permissions, and conflating
+// them is exploitable: adding SubmitConfirmation to the ratified set — correct
+// on its own terms, it is what the handler forwards to — silently stopped its
+// body being checked, and it holds the token throughout. A planted
+// fmt.Println(token) inside it then read green. So this map names only the two
+// functions that end the credential, and receipt is decided separately above.
+var launderers = map[string]bool{
+	"hashConfirmToken":  true,
+	"Store.confirmLink": true,
 }
 
 func TestThePlaintextConfirmTokenReachesNoSinkButTheMail(t *testing.T) {
 	t.Parallel()
 
 	files := parseConsentPackage(t)
-	checked := 0
+	checked, tainted := 0, 0
 	for path, file := range files {
-		if filepath.Base(path) == mailBodyFile {
-			// The mail body is where the token is SUPPOSED to go. Everything
-			// else in this file is still checked by the sink walk below via the
-			// other files; exempting the whole file here is safe because the
-			// only sink it holds is the relay call, which is the destination.
-			continue
-		}
 		checked++
-		for _, finding := range plaintextReachesASink(file) {
-			t.Errorf("%s passes the plaintext confirm token to %s (%s): the token is a bearer "+
-				"credential over one person's record, and a copy anywhere an operator can read it "+
-				"ends the claim that a grant made through it was the subject's own",
-				path, finding.call, finding.sink)
+		for _, fn := range functionsIn(file) {
+			if launderers[receiverQualified(fn)] {
+				// A launderer's own body is where the plaintext becomes a
+				// digest or a URL. Checking it would report the hash call it
+				// exists to make.
+				continue
+			}
+			holders := taintedNamesIn(fn)
+			if len(holders) == 0 {
+				continue
+			}
+			tainted++
+			for _, finding := range unratifiedUsesOf(fn, holders) {
+				t.Errorf("%s: %s hands the plaintext confirm token to %s, which is not one of "+
+					"the destinations it may reach (%s). The token is a bearer credential "+
+					"over one person's record, and a copy anywhere an operator can read it ends "+
+					"the claim that a grant made through it was the subject's own.",
+					path, finding.holder, finding.call, ratifiedList())
+			}
 		}
 	}
 	if checked == 0 {
 		t.Fatal("no consent sources were walked: this gate is looking in the wrong place")
 	}
+	// Under-recognition is the one way this gate must not break: a walk that
+	// tracked nothing would report PASS while the token flowed anywhere.
+	if tainted < taintedFunctionFloor {
+		t.Fatalf("followed the plaintext through %d functions, fewer than the %d the package "+
+			"holds — the taint walk has stopped seeing its subject", tainted, taintedFunctionFloor)
+	}
+}
+
+// taintedFunctionFloor is how many functions the walk must still be following.
+// Set below the count the tree holds, so adding a holder does not fail the gate,
+// and far enough above zero that a walk which lost its SUBJECT does — a matcher
+// narrowed, a spelling changed, the parse pointed elsewhere. It does not notice
+// one holder lost among several, and "found at least one" would not notice a
+// walk that lost most of them.
+const taintedFunctionFloor = 6
+
+// functionsIn lists a file's function declarations.
+func functionsIn(file *ast.File) []*ast.FuncDecl {
+	var out []*ast.FuncDecl
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+			out = append(out, fn)
+		}
+	}
+	return out
+}
+
+// taintedNamesIn returns the identifiers inside one function that hold a
+// plaintext token: the parameters of the functions handed one, the result of
+// the mint, and any name assigned from another tainted name.
+//
+// Field selections of IssuedConfirm.Token count too, so a caller reading the
+// struct is followed as well as the local it was built from.
+func taintedNamesIn(fn *ast.FuncDecl) map[string]bool {
+	names := map[string]bool{}
+	if fn.Type.Params != nil {
+		for _, p := range fn.Type.Params.List {
+			if id, ok := p.Type.(*ast.Ident); !ok || id.Name != "string" {
+				continue
+			}
+			for _, n := range p.Names {
+				if n.Name == tokenParameterName {
+					names[n.Name] = true
+				}
+			}
+		}
+	}
+	// Assignments propagate the taint, and a later one can feed an earlier
+	// read, so the walk repeats until nothing new is learned.
+	for changed := true; changed; {
+		changed = false
+		ast.Inspect(fn, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			if taintAssignment(assign, names) {
+				changed = true
+			}
+			return true
+		})
+	}
+	return names
+}
+
+// taintAssignment binds the left-hand names an assignment puts a plaintext
+// token into, and reports whether it learned anything new.
+//
+// The mint returns (string, error), so a single call filling several names
+// taints only the FIRST. Binding them all was the earlier shape, and it made
+// the error variable a secret: every errors.Is beside a mint was then reported
+// as a leak, which is a gate that cries wolf until somebody deletes it.
+func taintAssignment(assign *ast.AssignStmt, names map[string]bool) bool {
+	learned := false
+	bind := func(e ast.Expr) {
+		if id, ok := e.(*ast.Ident); ok && id.Name != "_" && !names[id.Name] {
+			names[id.Name] = true
+			learned = true
+		}
+	}
+	if len(assign.Rhs) == 1 && len(assign.Lhs) > 1 {
+		if carriesPlaintext(assign.Rhs[0], names) {
+			bind(assign.Lhs[0])
+		}
+		return learned
+	}
+	for i, rhs := range assign.Rhs {
+		if i < len(assign.Lhs) && carriesPlaintext(rhs, names) {
+			bind(assign.Lhs[i])
+		}
+	}
+	return learned
+}
+
+// carriesPlaintext reports whether an expression IS a plaintext token: the
+// mint's result, a tainted name, or a read of IssuedConfirm.Token.
+//
+// A call's RESULT is never the token, even when the token went in.
+// ResolveConfirmToken(token) evaluates to a record, hashConfirmToken(token) to
+// a digest, confirmLink(token) to the URL that goes in the mail. Treating a
+// result as tainted was the first shape of this walk, and it reported the
+// handlers' own WriteJSON — which carries the resolved card — as a leak of the
+// credential. A gate that cries wolf on correct code is one somebody deletes.
+//
+// A closure is a body, not a value: descending into one makes every name it
+// reads part of the expression that merely runs it, which taints the error a
+// transaction runner hands back.
+func carriesPlaintext(e ast.Expr, names map[string]bool) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.CallExpr:
+			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == tokenSource {
+				found = true
+			}
+			return false
+		case *ast.SelectorExpr:
+			if v.Sel.Name == plaintextField {
+				found = true
+			}
+		case *ast.Ident:
+			if names[v.Name] {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+type sinkFinding struct{ holder, call string }
+
+// unratifiedUsesOf reports every call handed a plaintext token that is not one
+// of the ratified destinations.
+//
+// A composite literal is not a call and is not reported: building the
+// IssuedConfirm the mail path reads is the value's whole purpose, and the
+// struct's own field is followed by carriesPlaintext wherever it is read.
+func unratifiedUsesOf(fn *ast.FuncDecl, names map[string]bool) []sinkFinding {
+	var out []sinkFinding
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.CallExpr:
+			if finding, leaked := callLeaks(fn, v, names); leaked {
+				out = append(out, finding)
+			}
+		case *ast.ReturnStmt:
+			if returnLeaks(fn, v, names) {
+				out = append(out, sinkFinding{holder: fn.Name.Name, call: "its own return"})
+			}
+		case *ast.SendStmt:
+			if carriesPlaintext(v.Value, names) {
+				out = append(out, sinkFinding{holder: fn.Name.Name, call: "a channel"})
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// returnLeaks reports whether a return statement hands the bare plaintext back.
+//
+// A function that HANDS BACK the token puts it somewhere this walk cannot
+// follow: a caller treats a call's result as clean, so a consumer returning the
+// credential would launder it on the way out.
+//
+// Returning the IssuedConfirm is different and is allowed. That struct exists
+// to carry the plaintext to the mail path, its Token field is followed by
+// carriesPlaintext wherever a caller reads it, and refusing it here would
+// report the minting function for doing its job. What is refused is a return
+// whose value IS the token: a bare identifier or a field read of it.
+func returnLeaks(fn *ast.FuncDecl, stmt *ast.ReturnStmt, names map[string]bool) bool {
+	if declaresTheCarrier(fn) {
+		return false
+	}
+	for _, result := range stmt.Results {
+		if carriesPlaintext(result, names) {
+			return true
+		}
+	}
+	return false
+}
+
+// declaresTheCarrier reports whether a function's results include the struct
+// that legitimately carries the plaintext to the mail path.
+func declaresTheCarrier(fn *ast.FuncDecl) bool {
+	if fn.Type.Results == nil {
+		return false
+	}
+	for _, r := range fn.Type.Results.List {
+		if id, ok := r.Type.(*ast.Ident); ok && id.Name == carrierType {
+			return true
+		}
+	}
+	return false
+}
+
+// callLeaks reports whether one call publishes the plaintext.
+func callLeaks(fn *ast.FuncDecl, call *ast.CallExpr, names map[string]bool) (sinkFinding, bool) {
+	callee := calleeName(call)
+	if ratifiedCall(call, callee, names) {
+		return sinkFinding{}, false
+	}
+	for _, arg := range call.Args {
+		if _, isBody := arg.(*ast.FuncLit); isBody {
+			// A closure passed to Tx or WithInfraTx is a body the walk descends
+			// into on its own, not a value handed outward. Reading it as an
+			// argument would report the transaction runner for every leak
+			// inside the closure and name the wrong call.
+			continue
+		}
+		if carriesPlaintext(arg, names) {
+			return sinkFinding{holder: fn.Name.Name, call: callee}, true
+		}
+	}
+	return sinkFinding{}, false
+}
+
+// ratifiedCall reports whether this call is one the token may be handed to.
+//
+// A CONSUMER is ratified by name alone: it takes the credential and returns a
+// record, and its own body is still walked like any other holder, so a leak
+// inside it is still a finding. Nothing is gained by pinning its receiver.
+//
+// A LAUNDERER is ratified only when called plainly or on a receiver that holds
+// the store, because a launderer's name ALSO buys its body an exemption from
+// the walk. Keyed on the name alone, any method called confirmLink on any type
+// would both launder the credential at its call sites and hide its own body —
+// two bypasses out of one name. The probe that found it declared exactly that
+// and read green.
+func ratifiedCall(call *ast.CallExpr, callee string, names map[string]bool) bool {
+	if _, ratified := ratifiedDestinations[callee]; !ratified {
+		return false
+	}
+	if callee == boundArgumentSink {
+		// The token is a BOUND argument here, never the statement. Ratifying
+		// the call outright would admit tx.QueryRow(ctx, token), where the
+		// credential IS the SQL text — a shape this gate would otherwise
+		// describe as safe in the words it uses for a parameterised lookup.
+		return !carriesPlaintextAt(call, statementArgument, names)
+	}
+	if !laundererNames[callee] {
+		return true
+	}
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		return endsInStoreReceiver(fun.X)
+	}
+	return false
+}
+
+// laundererNames is launderers keyed by bare name, for asking whether a CALL is
+// to a launderer. launderers itself is receiver-qualified, which is the right
+// key for asking whether a DECLARATION is one.
+var laundererNames = map[string]bool{
+	"hashConfirmToken": true,
+	"confirmLink":      true,
+}
+
+// carriesPlaintextAt reports whether one positional argument is the plaintext.
+func carriesPlaintextAt(call *ast.CallExpr, pos int, names map[string]bool) bool {
+	if pos >= len(call.Args) {
+		return false
+	}
+	return carriesPlaintext(call.Args[pos], names)
+}
+
+// endsInStoreReceiver reports whether a selector base resolves to the consent
+// store: its own receiver (s) or a handler's field holding it (h.store).
+func endsInStoreReceiver(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name == consentStoreReceiver
+	case *ast.SelectorExpr:
+		return v.Sel.Name == consentStoreField
+	}
+	return false
+}
+
+const (
+	// boundArgumentSink takes the token as a bound parameter, after the
+	// statement. Its own body is outside this package.
+	boundArgumentSink = "QueryRow"
+	// statementArgument is where QueryRow's SQL text sits: after the context.
+	statementArgument = 1
+	// consentStoreReceiver is what every method on *Store names its receiver.
+	consentStoreReceiver = "s"
+	// consentStoreField is what the handlers call the store they hold.
+	consentStoreField = "store"
+)
+
+// ratifiedList renders the allowed destinations for a finding.
+func ratifiedList() string {
+	var parts []string
+	for name, why := range ratifiedDestinations {
+		parts = append(parts, name+", which "+why)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "; ")
 }
 
 // TestTheConfirmTokenIsMintedOnlyWhereThisGateWatches proves the scope claim the
@@ -116,62 +479,15 @@ func TestTheConfirmTokenIsMintedOnlyWhereThisGateWatches(t *testing.T) {
 
 	files := parseConsentPackage(t)
 	minting := 0
-	for path, file := range files {
+	for _, file := range files {
 		if constructsIssuedConfirm(file) {
 			minting++
-			_ = path
 		}
 	}
 	if minting == 0 {
 		t.Fatal("no file in the consent package constructs an IssuedConfirm: the type this gate " +
 			"follows has moved, and the census is watching nothing")
 	}
-}
-
-type sinkFinding struct{ call, sink string }
-
-// plaintextReachesASink reports every publishing call that is handed something
-// named for the plaintext token.
-func plaintextReachesASink(file *ast.File) []sinkFinding {
-	var out []sinkFinding
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		name := calleeName(call)
-		sink, isSink := tokenSinks[name]
-		if !isSink {
-			return true
-		}
-		for _, arg := range call.Args {
-			if mentionsPlaintext(arg) {
-				out = append(out, sinkFinding{call: name, sink: sink})
-				break
-			}
-		}
-		return true
-	})
-	return out
-}
-
-// mentionsPlaintext reports whether an expression reads the plaintext field, at
-// any depth — a composite literal, a map value, a concatenation.
-//
-// It matches the FIELD name rather than a variable, because the variable holding
-// an IssuedConfirm is named differently at each call site and a gate keyed on
-// those names would stop matching the moment one was renamed.
-func mentionsPlaintext(e ast.Expr) bool {
-	found := false
-	ast.Inspect(e, func(n ast.Node) bool {
-		sel, ok := n.(*ast.SelectorExpr)
-		if ok && sel.Sel.Name == plaintextField {
-			found = true
-			return false
-		}
-		return true
-	})
-	return found
 }
 
 // constructsIssuedConfirm reports whether a file builds the type that carries

--- a/backend/gates/sendcontextvalidation_test.go
+++ b/backend/gates/sendcontextvalidation_test.go
@@ -15,10 +15,11 @@ package gates
 // ApplyChannelContext — one validator, and this is what stops a third door from
 // deciding for itself.
 //
-// Derived from the input types rather than from a list of doors: a function
-// that constructs an activities.SendEmailInput or SendMessageInput IS a send
-// door, whatever it is called and wherever it lives, so one added tomorrow is
-// judged the day it is written.
+// Derived from the CHOKEPOINT rather than from a list of doors: a function that
+// calls activities.Store.SendOrSchedule or SendMessage IS a send door, whatever
+// it is called and wherever it lives, so one added tomorrow is judged the day it
+// is written. A new door is judged by the walk itself; the floor below is a
+// separate guard, against the walk losing doors it used to see.
 
 import (
 	"go/ast"
@@ -41,46 +42,258 @@ import (
 // door in cmd/, an assignment after the literal, and a method that sets the
 // field — so it defended the shape of the code that existed rather than the
 // obligation.
+// sendDoorFloor is the number of send doors the tree holds today: the three
+// activities handlers (SendEmail, SendAccountEmail, SendMessage), the two
+// commsAdapter methods the tool surface reaches them by, and one test driver.
+//
+// WHAT IT DOES AND DOES NOT CATCH. It fails when the walk stops recognising a
+// door it used to see — a renamed field, a narrowed matcher — which is the way
+// a census silently reports PASS over a corpus it no longer reads. It does NOT
+// fail when a SEVENTH door appears through a shape the walk never covered: the
+// count goes up, not down. Nothing here promises otherwise, and a door added
+// through a covered shape is judged by the walk on its own.
+//
+// "Found at least one" would be too weak to notice a derivation that lost five
+// of six, which is why this is a count and not a presence check.
+const sendDoorFloor = 6
+
 var sendChokepoints = map[string]bool{
 	"SendOrSchedule": true,
 	"SendMessage":    true,
 }
 
-// sendStoreReceivers are the expressions the chokepoint is called ON. Bound
-// because "SendMessage" is a common method name — the Telegram connector, the
-// fenced channel sender, the dispatcher's own seam and the generated HTTP
-// wrapper all have one, and none of them decodes a caller's claim. What this
-// gate is about is the ACTIVITIES store, the one object that turns a request
-// into an outbound message.
+// sendStoreType is the type whose SendOrSchedule and SendMessage this gate
+// watches. The chokepoint names alone are not enough: "SendMessage" is also a
+// method on the Telegram connector, on the fenced channel sender, on the
+// dispatcher's own seam and on the generated HTTP wrapper, and none of those
+// decodes a caller's claim. What this gate is about is the ACTIVITIES store,
+// the one object that turns a request into an outbound message.
+const sendStoreType = "activities.Store"
+
+// sendStoreDir is the store's OWN package, where the type is written *Store
+// with no qualifier. A gate matching only the qualified spelling recognises the
+// handlers in this package by accident — through the h.store field — and would
+// stop the day one of them used its receiver directly.
+const sendStoreDir = "internal/modules/activities"
+
+// sendStoreLocalType is that unqualified spelling.
+const sendStoreLocalType = "Store"
+
+// storeBindings holds every name an activities store reaches a call site under.
 //
-// Matched on the selector's base expression rather than by resolving types,
-// because a gate that needed type information would need the whole program
-// loaded. The names below are what the store is called at its call sites.
-var sendStoreReceivers = map[string]bool{
-	"store": true, "s": true, "h.store": true, "c.store": true, "t.comms": true,
+// DERIVED, not listed. An earlier version of this gate carried five hard-coded
+// receiver spellings (store, s, h.store, c.store, t.comms), so a door holding
+// the store in any other field — and the tree already names it activities,
+// files and attachments elsewhere — dropped out of the corpus silently. A
+// census that can fail short reports PASS over the door it never read, which is
+// the one way this gate must not break. Proven before it was fixed: a compose
+// door calling p.acts.SendOrSchedule and validating nothing passed the old gate.
+//
+// Three declaration shapes reach a store, and all three are read:
+//
+//   - a struct field, giving the "x.field" selections,
+//   - a function parameter, receiver or var, giving a bare identifier,
+//   - a short assignment from a function whose result is *activities.Store.
+//
+// Types are not resolved — that would need the whole program loaded — so this
+// reads the DECLARED type as written, in four shapes: a named field, an
+// EMBEDDED store (recorded under the type's own name, since it is reached as
+// x.Store), a bare identifier from a parameter, receiver or var, and a local
+// bound from a constructor's store-typed result.
+//
+// WHAT THIS STILL CANNOT SEE, stated rather than rationalised: a store held
+// behind an interface, or returned by a method rather than a package-level
+// function. sendDoorFloor does not close that gap — a floor notices a door
+// LOST, not a door added through a shape the walk never covered. Closing it
+// needs real type resolution, which needs the whole program loaded. If a send
+// door ever appears behind an interface, this is the file that has to grow a
+// types pass.
+type storeBindings struct {
+	bare      map[string]bool  // identifiers declared *activities.Store
+	fields    map[string]bool  // struct field names of type *activities.Store
+	returning map[string][]int // functions, and which of their results is a store
 }
 
-// callsTheSendStore reports whether this selector is the chokepoint called on
-// something that looks like the activities store.
-func callsTheSendStore(sel *ast.SelectorExpr) bool {
+// holdsTheSendStore reports whether a type expression, as written, is
+// *activities.Store or activities.Store.
+func holdsTheSendStore(expr ast.Expr, inStorePackage bool) bool {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if id, ok := expr.(*ast.Ident); ok {
+		return inStorePackage && id.Name == sendStoreLocalType
+	}
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name+"."+sel.Sel.Name == sendStoreType
+}
+
+// collectStoreBindings reads the declared names before any call site is judged,
+// because a store field declared in one file is called on in another and a
+// local is bound from a constructor declared in a third.
+func collectStoreBindings(files map[string]*ast.File) storeBindings {
+	b := storeBindings{
+		bare:      map[string]bool{},
+		fields:    map[string]bool{},
+		returning: map[string][]int{},
+	}
+	for path, file := range files {
+		local := strings.HasPrefix(path, sendStoreDir)
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.StructType:
+				b.readFields(v, local)
+			case *ast.FuncDecl:
+				b.readSignature(v, local)
+			case *ast.ValueSpec:
+				if v.Type != nil && holdsTheSendStore(v.Type, local) {
+					b.bindNames(v.Names)
+				}
+			}
+			return true
+		})
+	}
+	// A second pass, because a short assignment reads a constructor declared
+	// anywhere in the tree and the first pass is what learns those names.
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			if assign, ok := n.(*ast.AssignStmt); ok && assign.Tok == token.DEFINE {
+				b.readShortAssign(assign)
+			}
+			return true
+		})
+	}
+	return b
+}
+
+// readFields records the struct fields that hold a store.
+//
+// An EMBEDDED store has no field name and is reached as x.Store, so the type's
+// own name is recorded as the selector. A named field of a type that itself
+// holds a store — one level deeper, x.inner.st — is reached through that
+// field's own entry, because callsTheSendStore asks about the selector base's
+// LAST name rather than the whole path.
+func (b storeBindings) readFields(st *ast.StructType, local bool) {
+	for _, f := range st.Fields.List {
+		if !holdsTheSendStore(f.Type, local) {
+			continue
+		}
+		if len(f.Names) == 0 {
+			b.fields[sendStoreLocalType] = true
+			continue
+		}
+		for _, name := range f.Names {
+			b.fields[name.Name] = true
+		}
+	}
+}
+
+// readSignature records the receivers and parameters that carry a store, and
+// the functions that hand one back.
+func (b storeBindings) readSignature(fn *ast.FuncDecl, local bool) {
+	fields := []*ast.Field{}
+	if fn.Recv != nil {
+		fields = append(fields, fn.Recv.List...)
+	}
+	if fn.Type.Params != nil {
+		fields = append(fields, fn.Type.Params.List...)
+	}
+	for _, f := range fields {
+		if holdsTheSendStore(f.Type, local) {
+			b.bindNames(f.Names)
+		}
+	}
+	if fn.Type.Results == nil {
+		return
+	}
+	// Result POSITION, counted the way a call site unpacks them: a field with
+	// several names occupies several positions.
+	pos := 0
+	for _, r := range fn.Type.Results.List {
+		width := max(len(r.Names), 1)
+		if holdsTheSendStore(r.Type, local) {
+			for i := range width {
+				b.returning[fn.Name.Name] = append(b.returning[fn.Name.Name], pos+i)
+			}
+		}
+		pos += width
+	}
+}
+
+// readShortAssign binds "store := sendStore(...)" and its multi-value form, so
+// a local reaching the chokepoint is recognised by where it came from.
+//
+// A single call filling several names binds only the POSITIONS whose declared
+// result is a store: heldSendActors returns (*activities.Store, scheduleTimer,
+// bool), and binding all three would make the timer and the ok flag look like
+// stores. That is not a safe over-approximation — it is a gate reporting the
+// wrong receiver for a finding, and the next author would not believe it.
+func (b storeBindings) readShortAssign(assign *ast.AssignStmt) {
+	for i, rhs := range assign.Rhs {
+		call, ok := rhs.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		positions, returns := b.returning[id.Name]
+		if !returns {
+			continue
+		}
+		if len(assign.Rhs) == 1 {
+			for _, pos := range positions {
+				if pos < len(assign.Lhs) {
+					b.bindAssignedNames(assign.Lhs[pos : pos+1])
+				}
+			}
+			continue
+		}
+		if i < len(assign.Lhs) && len(positions) > 0 {
+			b.bindAssignedNames(assign.Lhs[i : i+1])
+		}
+	}
+}
+
+func (b storeBindings) bindNames(names []*ast.Ident) {
+	for _, name := range names {
+		if name.Name != "_" {
+			b.bare[name.Name] = true
+		}
+	}
+}
+
+func (b storeBindings) bindAssignedNames(exprs []ast.Expr) {
+	for _, e := range exprs {
+		if name, ok := e.(*ast.Ident); ok && name.Name != "_" {
+			b.bare[name.Name] = true
+		}
+	}
+}
+
+// callsTheSendStore reports whether this selector is a chokepoint called on
+// something declared to hold the activities store.
+func (b storeBindings) callsTheSendStore(sel *ast.SelectorExpr) bool {
 	if !sendChokepoints[sel.Sel.Name] {
 		return false
 	}
-	return sendStoreReceivers[receiverText(sel.X)]
-}
-
-// receiverText renders the expression a method was called on, for the two shapes a
-// store reaches a call site in: a bare identifier and one field selection.
-func receiverText(e ast.Expr) string {
-	switch v := e.(type) {
+	// The base's LAST name is what names the holder: "z.inner.st" is reached
+	// through st, which the nested struct declared. Reading the whole path
+	// instead would need one entry per route to the same field.
+	switch v := sel.X.(type) {
 	case *ast.Ident:
-		return v.Name
+		return b.bare[v.Name] || b.fields[v.Name]
 	case *ast.SelectorExpr:
-		if base, ok := v.X.(*ast.Ident); ok {
-			return base.Name + "." + v.Sel.Name
-		}
+		return b.fields[v.Sel.Name]
 	}
-	return ""
+	return false
 }
 
 // validators are the entry points that apply the shared refusals. A caller
@@ -103,14 +316,9 @@ var validators = map[string]bool{
 // Keyed on the exact function, so moving the call re-arms the gate rather than
 // inheriting the exemption. Each entry names why it is safe.
 var forwardsAnAlreadyValidatedInput = map[string]bool{
-	// Test-only drivers: they take the send input their caller already built,
-	// so there is no claim here to decode.
-	"internal/compose/commsscheduled_integration.go:DriveScheduledSendForTest": true,
-	"internal/compose/commsscheduled_integration.go:ScheduleAsAgentForTest":    true,
-	// The tool hands its raw arguments to commsAdapter.SendMessage, which is
-	// what runs ApplyChannelContext. Validating here too would decode the same
-	// claim twice, and the adapter is the seam every channel caller shares.
-	"internal/modules/agents/tools_comms.go:sendMessageTool.Handle": true,
+	// A test-only driver: it takes the send input its caller already built, so
+	// there is no claim here to decode.
+	"internal/compose/commsscheduled_integration.go:ScheduleAsAgentForTest": true,
 	// The store's own methods are the chokepoint, not callers of it.
 	"internal/modules/activities/sendcore.go:Store.SendOrSchedule": true,
 	"internal/modules/activities/channelsend.go:Store.SendMessage": true,
@@ -120,51 +328,58 @@ func TestEverySendDoorValidatesTheClaimedContext(t *testing.T) {
 	t.Parallel()
 
 	fset := token.NewFileSet()
-	sending := map[string]bool{}    // functions that send a message
-	validating := map[string]bool{} // functions that reach a validator
-
 	// The whole backend tree, because a send door is wherever somebody calls
 	// the chokepoint — cmd/ included, which already owns an outbound mail lane.
+	files := map[string]*ast.File{}
 	for _, root := range []string{"internal", "cmd"} {
 		for path, file := range parseTreeFiles(t, fset, root) {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok {
-					continue
-				}
-				name := path + ":" + receiverQualified(fn)
-				ast.Inspect(fn, func(n ast.Node) bool {
-					sel, ok := n.(*ast.SelectorExpr)
-					if !ok {
-						if id, ok := n.(*ast.Ident); ok && validators[id.Name] {
-							validating[name] = true
-						}
-						return true
-					}
-					if callsTheSendStore(sel) {
-						sending[name] = true
-					}
-					if validators[sel.Sel.Name] {
-						validating[name] = true
-					}
-					return true
-				})
+			files[path] = file
+		}
+	}
+
+	bindings := collectStoreBindings(files)
+	if len(bindings.fields)+len(bindings.bare) == 0 {
+		t.Fatal("no identifier in the tree is declared to hold an activities store — " +
+			"the type spelling this gate derives its corpus by has moved")
+	}
+
+	sending := map[string]bool{}    // functions that send a message
+	validating := map[string]bool{} // functions whose send carries a validated input
+	for path, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			name := path + ":" + receiverQualified(fn)
+			calls := bindings.sendCallsIn(fn)
+			if len(calls) == 0 {
+				continue
+			}
+			sending[name] = true
+			if sendsAValidatedInput(fn, calls) {
+				validating[name] = true
 			}
 		}
 	}
 
 	// Under-recognition is the one way this gate must not break: a scan that
 	// found nothing would report PASS over an empty corpus.
-	if len(sending) == 0 {
-		t.Fatal("found no send call — the scan is looking in the wrong place")
+	if len(sending) < sendDoorFloor {
+		t.Fatalf("found %d send doors, fewer than the %d the tree holds. Either a door was "+
+			"deleted — lower sendDoorFloor to match — or the derivation stopped recognising "+
+			"one, in which case an unwatched door is now sending without validating its "+
+			"caller's claim", len(sending), sendDoorFloor)
 	}
 	for door := range sending {
 		if forwardsAnAlreadyValidatedInput[door] {
 			continue
 		}
 		if !validating[door] {
-			t.Errorf("%s sends a message and never validates the claimed context — "+
-				"a door that judges its own claims can name a category reserved for controller mail", door)
+			t.Errorf("%s sends a message whose claimed context no validator produced — "+
+				"a door that judges its own claims can name a category reserved for controller "+
+				"mail. Every send in the function must carry a validated input, not just one of "+
+				"them", door)
 		}
 	}
 }
@@ -208,6 +423,101 @@ func TestTheToolSurfaceSpellsTheSendContextOnce(t *testing.T) {
 		t.Errorf("the send context is declared %d times (%s) — a second copy is how two send tools "+
 			"start advertising different categories", len(declarations), strings.Join(declarations, ", "))
 	}
+}
+
+// sendCallsIn returns the chokepoint calls one function makes.
+func (b storeBindings) sendCallsIn(fn *ast.FuncDecl) []*ast.CallExpr {
+	var out []*ast.CallExpr
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && b.callsTheSendStore(sel) {
+			out = append(out, call)
+		}
+		return true
+	})
+	return out
+}
+
+// sendsAValidatedInput reports whether the value handed to the chokepoint is
+// one a validator produced.
+//
+// Asked of the ARGUMENT, not of the function. An earlier version set the flag
+// whenever a validator's name appeared anywhere in the body, in any position —
+// so a door that named a validator inside an `if false` and then sent an
+// unvalidated input passed. Naming a validator is not calling one, and calling
+// one is not sending what it returned.
+//
+// Three shapes carry a validated input, and they are the three the tree uses:
+// the result passed straight through (`in, err := replySendInput(req)`, then
+// `in`), the validator inlined into the argument, and the result read field by
+// field into the input literal (`Context: claimed.category`), which is what the
+// channel handler does.
+func sendsAValidatedInput(fn *ast.FuncDecl, calls []*ast.CallExpr) bool {
+	validated := namesFromValidators(fn)
+	for _, call := range calls {
+		if !oneCallCarriesAValidatedInput(call, validated) {
+			return false
+		}
+	}
+	return true
+}
+
+// oneCallCarriesAValidatedInput asks the question of a SINGLE send.
+//
+// Every send in a function must carry one. Asked existentially — "does this
+// function validate anywhere" — a door could validate its first message and
+// send its second raw, and the gate would report the function as covered.
+func oneCallCarriesAValidatedInput(call *ast.CallExpr, validated map[string]bool) bool {
+	for _, arg := range call.Args {
+		if readsAValidatedValue(arg, validated) {
+			return true
+		}
+	}
+	return false
+}
+
+// readsAValidatedValue reports whether an argument is, or is built from, a
+// value a validator returned.
+func readsAValidatedValue(arg ast.Expr, validated map[string]bool) bool {
+	found := false
+	ast.Inspect(arg, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.Ident:
+			if validated[v.Name] {
+				found = true
+			}
+		case *ast.CallExpr:
+			if validators[calleeName(v)] {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// namesFromValidators collects the names a validator's result was assigned to.
+func namesFromValidators(fn *ast.FuncDecl) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok || !validators[calleeName(call)] {
+			return true
+		}
+		// The validator returns (input, error); the input is first.
+		if id, ok := assign.Lhs[0].(*ast.Ident); ok && id.Name != "_" {
+			out[id.Name] = true
+		}
+		return true
+	})
+	return out
 }
 
 // literalOf concatenates a const spec's string parts, so a schema built by


### PR DESCRIPTION
Two gates in `backend/gates/` could **fail short** — report PASS over a subject they had stopped reading. Both holes were proven with compiling probes before being fixed, and every fix below is mutation-checked.

## The send-context gate

`sendcontextvalidation_test.go` asserts every door that sends an outbound message runs the caller's claimed communication context through the shared validator. A door judging its own claim can name a category reserved for the installation's own controller mail and reach somebody who has objected to marketing.

It hard-coded five receiver spellings (`store`, `s`, `h.store`, `c.store`, `t.comms`). **Proven:** a compose door calling `p.acts.SendOrSchedule` and validating nothing passed.

Receivers are now derived from declarations of `*activities.Store`, in four shapes: a named field, an **embedded** store, a bare identifier from a parameter or receiver, and a local bound from a constructor's store-typed result. The unqualified `*Store` spelling counts inside the store's own package — the three activities handlers were previously in the corpus only *by accident*, through a field sharing a name with one in compose. Renaming `Handlers.store` would have dropped all three.

Validation is now asked of the **argument**, not the function. Two bypasses closed: naming a validator anywhere in the body used to satisfy the check (so `if false { ApplyChannelContext(...) }` passed), and one validated send used to cover a second unvalidated send in the same function.

## The token-exposure gate

`doitokenexposure_test.go` asserts the plaintext confirm token — a bearer credential over one person's record, and what makes a consent grant provably the *subject's* — reaches no publishing call.

It hard-coded eleven sink names and matched the value only as a `.Token` field selection. **Two holes proven:** `fmt.Fprintf` was unlisted, and — through a sink the list *did* hold — `slog.InfoContext` handed the bare local the token actually lives in.

It is now a taint walk seeded from the mint and from every `token string` parameter. That seeding is what brings in `GetConfirmDetails` and `SubmitConfirmDetails`, the unauthenticated handlers that read the credential straight off the URL and were outside the old corpus entirely.

**Receipt and inspection are now separate permissions.** A consumer may receive the token and is still walked; only the two launderers earn a body-skip, keyed receiver-qualified. Keyed by bare name, any method called `confirmLink` on any type both laundered the credential at its call sites *and* hid its own body — two bypasses from one name. Returns and channel sends are checked, and `QueryRow` is ratified only when the token is a bound argument rather than the statement text.

## Stated, not rationalised

Neither gate sees a store held behind an **interface**, nor a token parameter under another **spelling**. Both need type resolution or call-graph propagation. The comments say so and say what closing them would take, rather than claiming a floor covers it — a floor catches a door *lost*, not one added through an uncovered shape.

Also removed: two exemptions that no longer name anything the derivation reaches, and a dead `_ = path`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites two gates in `backend/gates/` that could report PASS over a subject they had stopped reading. Both previously censused their subjects from hard-coded name lists; both now derive the corpus from code declarations.

- The send-context gate derives store receivers from `*activities.Store` declarations (named and embedded fields, parameters, receivers, constructor results), and requires every send argument to carry a validated input — naming a validator anywhere in the body no longer satisfies it.
- The token-exposure gate replaces the eleven-name sink list with a taint walk seeded from the mint and from every `token string` parameter, which brings the unauthenticated URL handlers into the corpus.
- Receipt and inspection are separate permissions: consumers are still walked while the two launderers (`hashConfirmToken`, `Store.confirmLink`) are exempt, keyed receiver-qualified; returns, channel sends, and `QueryRow` with the token as a bound argument are all checked.
- Neither gate sees stores behind interfaces or token parameters under another spelling; the gap is stated in the comments, along with what closing it requires.

<sup>Written for commit 7c804ce9a1fe7738b32d200140c978454cf06725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened security checks to detect unintended exposure of plaintext tokens.
  - Expanded validation of token handling across calls, returns, and message passing.
  - Improved coverage of activity-store send pathways and their input validation.
  - Added safeguards to ensure security checks continue reviewing the expected breadth of application code.
  - Removed reliance on hard-coded assumptions, making these checks more resilient as the codebase evolves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->