### PR TITLE
fix(contracts): a write locks the row before it reads what it decides

### DIFF
--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -265,6 +265,16 @@ func TestAnInvisibleContractIsAbsentRatherThanRefused(t *testing.T) {
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("a contract outside the caller's scope: err = %v, want ErrNotFound (existence stays hidden)", err)
 	}
+
+	// And a WRITE says the same. The write path now locks the row before it
+	// reads what it decides, and the lock carries no visibility clause of its
+	// own — so this is the assertion that the read under it still refuses, and
+	// a caller who cannot see the contract cannot learn it exists by trying to
+	// change it.
+	if _, err := e.Contracts.ChangeStatus(rep3, contractID, contracts.StatusActive, nil); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("changing a contract outside the caller's scope: err = %v, want ErrNotFound — a "+
+			"denial would confirm the agreement exists", err)
+	}
 }
 
 // A renewal names its OWN deal, and the successor keeps it.

--- a/backend/internal/compose/integration/contract_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/contract_lifecycle_integration_test.go
@@ -15,9 +15,14 @@ package integration
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/contracts"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -341,5 +346,76 @@ func TestARenewalCannotNameAnotherCompanysDeal(t *testing.T) {
 	}
 	if predecessor.Status == nil || string(*predecessor.Status) != contracts.StatusActive {
 		t.Errorf("predecessor status = %v after a refused renewal, want it still active", predecessor.Status)
+	}
+}
+
+// Two renewals of one agreement, at the same time, and only one may land.
+//
+// The read that decides — is this predecessor still renewable — used to happen
+// before any lock, and the lock arrived only when the patch was applied. So
+// both calls read `active`, both minted a successor, and then they serialised:
+// the second overwrote `superseded_by_id`, both successors committed, and the
+// chain this module calls single-headed had two heads with one orphaned. No
+// caller saw an error, and nothing downstream can tell which successor is the
+// agreement.
+//
+// The verdict is the same whichever goroutine wins, which is what makes this a
+// test rather than a coin toss: exactly one renewal succeeds, the other is
+// refused as a transition out of `superseded`, and the predecessor points at
+// one successor.
+func TestTwoConcurrentRenewalsLeaveOneSuccessor(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Acme", nil)
+	predecessorID := anActiveContract(t, e, org, "MSA 2026")
+
+	const racers = 2
+	results := make([]crmcontracts.Contract, racers)
+	errs := make([]error, racers)
+	var wg sync.WaitGroup
+	for i := range racers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = e.Contracts.Renew(e.Admin(), predecessorID, contracts.CreateContractInput{
+				Title: fmt.Sprintf("MSA 2027 (%d)", i), ValueBasis: contracts.BasisTotal, Source: "manual",
+			}, nil)
+		}()
+	}
+	wg.Wait()
+
+	won := 0
+	for i, err := range errs {
+		var transition *contracts.InvalidStatusTransitionError
+		switch {
+		case err == nil:
+			won++
+		case errors.As(err, &transition), errors.Is(err, apperrors.ErrConflict):
+		default:
+			t.Errorf("renewal %d answered an unexpected error class: %v", i, err)
+		}
+	}
+	if won != 1 {
+		t.Fatalf("%d renewals landed, want exactly 1 — the loser must be refused rather than "+
+			"minting a second head: %v", won, errs)
+	}
+
+	// The chain, read from the database rather than from either caller: a
+	// successor nobody points at is the orphan this guards against.
+	successors := e.WsCount(t, `SELECT count(*) FROM contract WHERE title LIKE 'MSA 2027%'`)
+	if successors != 1 {
+		t.Errorf("%d successors exist, want 1 — the losing renewal committed one nothing points at",
+			successors)
+	}
+	pointed := e.WsCount(t, `
+		SELECT count(*) FROM contract predecessor
+		JOIN contract successor ON successor.id = predecessor.superseded_by_id
+		WHERE predecessor.id = $1 AND successor.title LIKE 'MSA 2027%'`, predecessorID)
+	if pointed != 1 {
+		t.Errorf("the predecessor points at %d successors, want 1", pointed)
+	}
+	for i, res := range results {
+		if errs[i] == nil && res.Id == (openapi_types.UUID{}) {
+			t.Errorf("renewal %d succeeded with no successor id", i)
+		}
 	}
 }

--- a/backend/internal/modules/contracts/writability.go
+++ b/backend/internal/modules/contracts/writability.go
@@ -56,10 +56,13 @@ import (
 // here would refuse a write this module admits today, which is a different
 // change from the ordering one.
 //
-// The first read still guards existence. LockRow carries no visibility clause,
-// so a caller who cannot see the row takes the lock and is then answered 404 by
-// the read under it — the same answer, for the transaction's lifetime, which is
-// what LockPair's own note says about resolving ids before locking them.
+// The visibility read stays FIRST, and what it buys is not the 404 — the read
+// UNDER the lock answers that either way, since LockRow carries no visibility
+// clause and the row is refused the moment it is read. What it buys is that an
+// authenticated caller who cannot see a contract does not get to take a lock on
+// it: without it, a caller outside the row scope would queue every writer of an
+// agreement they may not even know exists, for the length of their own
+// transaction.
 func writableContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time) (crmcontracts.Contract, error) {
 	if _, err := readContract(ctx, tx, id, asOf); err != nil {
 		return crmcontracts.Contract{}, err

--- a/backend/internal/modules/contracts/writability.go
+++ b/backend/internal/modules/contracts/writability.go
@@ -29,6 +29,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -39,7 +40,33 @@ import (
 // The read comes first and keeps its 404, so a caller who cannot see the
 // contract still cannot learn it exists by trying to change it; only a caller
 // who has been shown the row is answered ErrPermissionDenied.
+//
+// It then LOCKS and reads AGAIN, and the second read is the one the write uses.
+// Every caller here decides something from what it read — a renewal refuses a
+// predecessor that is already superseded, a transition validates against the
+// status it saw, and every patch takes its audit "before" image from it — while
+// the row lock arrived only at ApplyGuarded, after all of that. So two
+// concurrent renewals both read `active`, both minted a successor and then
+// serialised on the late lock: the second overwrote superseded_by_id, both
+// successors committed, and the chain this module calls single-headed had two
+// heads with one orphaned.
+//
+// The lock includes ARCHIVED rows on purpose. readContract does not filter the
+// contract's own archived_at — its clause is about the ANCHOR's — so LiveOnly
+// here would refuse a write this module admits today, which is a different
+// change from the ordering one.
+//
+// The first read still guards existence. LockRow carries no visibility clause,
+// so a caller who cannot see the row takes the lock and is then answered 404 by
+// the read under it — the same answer, for the transaction's lifetime, which is
+// what LockPair's own note says about resolving ids before locking them.
 func writableContract(ctx context.Context, tx pgx.Tx, id ids.ContractID, asOf time.Time) (crmcontracts.Contract, error) {
+	if _, err := readContract(ctx, tx, id, asOf); err != nil {
+		return crmcontracts.Contract{}, err
+	}
+	if _, err := storekit.LockRow(ctx, tx, contractTable, id.UUID, storekit.IncludeArchived); err != nil {
+		return crmcontracts.Contract{}, err
+	}
 	existing, err := readContract(ctx, tx, id, asOf)
 	if err != nil {
 		return crmcontracts.Contract{}, err


### PR DESCRIPTION
Closes #1393.

## The defect

Every write path in this module reads its pre-image through `writableContract` and then **decides** from it:

- `Renew` refuses a predecessor that is already `superseded`;
- `ChangeStatus` validates the transition against the status it read;
- every patch takes its audit **before** image from it.

The row lock arrived only at `ApplyGuarded`, after all of that.

So two concurrent renewals both read `active`, both minted a successor, and then serialised on the late lock. The second overwrote `superseded_by_id`; **both successors committed**, and the chain this module calls single-headed had two heads with one orphaned. Neither caller saw an error, and nothing downstream can say which successor is the agreement.

## The fix, where the invariant lives

In `writableContract`, not in `Renew`. It is the one door every write reads through, and the ticket names two other symptoms of the same ordering — a stale status validation and a stale audit image — that a fix in `Renew` alone would leave.

The read now happens **under** the lock, and the lock is taken for **every** write rather than only for one without `If-Match`. A version check refuses a write against a version that moved; it says nothing about a read that decided before it.

Two properties kept deliberately, and both are stated in the code:

- **The visibility read still comes first**, so a caller who cannot see a contract still cannot learn it exists by trying to change it. `LockRow` carries no visibility clause, so an invisible row is locked and then answered 404 by the read under it — the same answer, for the transaction's lifetime, which is what `LockPair`'s own note says about resolving ids before locking them.
- **The lock includes archived rows.** `readContract` does not filter the contract's own `archived_at` — its clause is about the *anchor's* — so `LiveOnly` here would refuse a write this module admits today. That is a different change from the ordering one.

## The test the ticket asked for

`TestTwoConcurrentRenewalsLeaveOneSuccessor`: two goroutines renewing one agreement against real Postgres, no mocked clock.

**The verdict is the same whichever goroutine wins**, which is what makes it a test rather than a coin toss — exactly one renewal lands, the other is refused as a transition out of `superseded`, and the assertions on the chain are read from the database rather than from either caller: one successor exists, and the predecessor points at it.

Mutation-checked in both directions, five runs each: with the lock it passes 5/5; with the read moved back before it, it fails 5/5.

## Checks

`make check-backend` green; the `compose/integration` contract lane green.