### PR TITLE
feat(deals): a rule turns itself off when its own record goes bad

### DIFF
--- a/backend/gates/safetydefects_test.go
+++ b/backend/gates/safetydefects_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every declared stage-automation safety defect can actually stop a rule.
+//
+// SuspendForSafetyDefect admits only defects its message map carries, and
+// refuses anything else — which is right, because the reason is what an
+// operator reads when deciding whether it is safe to resume, and a caller who
+// can pass any string can turn a rule off for a reason nobody agreed was a
+// safety matter.
+//
+// The cost of that closed door is a silent failure in the OTHER direction: a
+// SafetyDefect constant somebody declares and forgets to give a message is one
+// the product REFUSES to suspend on. The call site gets an error where it
+// expected a safety stop, the rule keeps applying moves automatically, and
+// nothing in the tree says so. That is the census this test is: the constants
+// are the subject, the map is the claim, and they must agree exactly.
+//
+// Derived from the source rather than listing the defects here, because a gate
+// that hard-codes part of its subject has become a second copy of it — and
+// this one's whole job is to notice a constant nobody thought about.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"testing"
+)
+
+// safetyDefectsFile is where both the constants and the map live. One file by
+// construction: the type, its members and their meanings are one declaration,
+// and splitting them is the drift this test exists to catch.
+const safetyDefectsFile = "internal/modules/deals/stageprogressionsuspend.go"
+
+func TestEverySafetyDefectCanActuallySuspendARule(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, safetyDefectsFile, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", safetyDefectsFile, err)
+	}
+
+	declared := declaredSafetyDefects(file)
+	explained := explainedSafetyDefects(file)
+
+	if len(declared) == 0 {
+		// A census that can fail short has already failed. If the AST walk
+		// stops matching — the type renamed, the constants moved — it would
+		// find nothing, compare nothing, and report PASS over a file it no
+		// longer reads.
+		t.Fatalf("found no SafetyDefect constants in %s: this census is reading "+
+			"the wrong thing and would pass over any drift", safetyDefectsFile)
+	}
+	if len(explained) == 0 {
+		t.Fatalf("found no safetyDefects entries in %s: same problem, from the "+
+			"other side", safetyDefectsFile)
+	}
+
+	for _, name := range declared {
+		if !explained[name] {
+			t.Errorf("SafetyDefect %s is declared but carries no message, so "+
+				"SuspendForSafetyDefect REFUSES it: a real defect of this kind "+
+				"leaves the rule applying moves automatically and the caller "+
+				"gets an error where it expected a safety stop", name)
+		}
+	}
+	for name := range explained {
+		if !contains(declared, name) {
+			t.Errorf("safetyDefects carries a message for %s, which is not a "+
+				"declared SafetyDefect — either the constant was renamed and this "+
+				"entry is now dead, or a defect is admitted that nothing names", name)
+		}
+	}
+}
+
+// declaredSafetyDefects reads the constant names of type SafetyDefect.
+func declaredSafetyDefects(file *ast.File) []string {
+	var out []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			ident, ok := value.Type.(*ast.Ident)
+			if !ok || ident.Name != "SafetyDefect" {
+				continue
+			}
+			for _, name := range value.Names {
+				out = append(out, name.Name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// explainedSafetyDefects reads the keys of the safetyDefects map literal.
+func explainedSafetyDefects(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != "safetyDefects" {
+				continue
+			}
+			for _, v := range value.Values {
+				lit, ok := v.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				for _, elt := range lit.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					if key, ok := kv.Key.(*ast.Ident); ok {
+						out[key.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return out
+}

--- a/backend/gates/updateguard_test.go
+++ b/backend/gates/updateguard_test.go
@@ -152,8 +152,8 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// consequence), and one clearing is one clearing. Both send the conditional
 	// UPDATE through QueryRow so the row the write produced is the row the
 	// audit describes.
-	"internal/modules/deals:SuspendTransitionPolicy": "conditioned on suspended_at IS NULL; ErrNoRows means a concurrent pass suspended it first and that reason stands",
-	"internal/modules/deals:ResumeTransitionPolicy":  "conditioned on suspended_at IS NOT NULL; ErrNoRows means a concurrent caller already cleared it",
+	"internal/modules/deals:suspendTransitionPolicyTx": "conditioned on suspended_at IS NULL; ErrNoRows means a concurrent pass suspended it first and that reason stands",
+	"internal/modules/deals:ResumeTransitionPolicy":    "conditioned on suspended_at IS NOT NULL; ErrNoRows means a concurrent caller already cleared it",
 
 	// The second of that shape, and the reason it is ratified rather than
 	// taught to the witness: crediting a bare mention of pgx.ErrNoRows would

--- a/backend/internal/modules/deals/stageprogression.go
+++ b/backend/internal/modules/deals/stageprogression.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -261,13 +262,14 @@ func (s *Store) RecordProgressionDecided(
 		return err
 	}
 	return s.Tx(ctx, func(tx pgx.Tx) error {
-		return recordProgressionDecidedTx(ctx, tx, approvalID, outcome, reason, edited)
+		return recordProgressionDecidedTx(
+			ctx, tx, approvalID, outcome, reason, edited, s.clock())
 	})
 }
 
 func recordProgressionDecidedTx(
 	ctx context.Context, tx pgx.Tx, approvalID ids.UUID,
-	outcome string, reason *string, edited bool,
+	outcome string, reason *string, edited bool, now time.Time,
 ) error {
 	if !progressionOutcomes[outcome] {
 		return fmt.Errorf("deals: %q is not a stage progression outcome", outcome)
@@ -279,14 +281,17 @@ func recordProgressionDecidedTx(
 	}
 	var id ids.UUID
 	var dealID ids.DealID
+	// The transition comes back with the row rather than from a second read:
+	// the sweep below needs it, and the row already carries it.
+	var moved TransitionRef
 	err := tx.QueryRow(ctx, `
 		UPDATE stage_progression_outcome
 		   SET outcome = $2, rejection_reason = $3, evidence_corrected = $4,
 		       decided_at = now()
 		 WHERE approval_id = $1 AND outcome = $5
-		RETURNING id, deal_id`,
+		RETURNING id, deal_id, pipeline_id, from_stage_id, to_stage_id`,
 		approvalID, outcome, reason, edited, ProgressionProposed).
-		Scan(&id, &dealID)
+		Scan(&id, &dealID, &moved.PipelineID, &moved.FromStageID, &moved.ToStageID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Either nothing was proposed under this approval, or it was already
 		// decided. Both are ordinary on an at-least-once path — a redelivered
@@ -310,7 +315,15 @@ func recordProgressionDecidedTx(
 	if err != nil {
 		return fmt.Errorf("audit the stage move's outcome: %w", err)
 	}
-	return emitProgressionChanged(ctx, tx, auditID, dealID)
+	if err := emitProgressionChanged(ctx, tx, auditID, dealID); err != nil {
+		return err
+	}
+	// Asked on EVERY decision, not only on the ones that look bad. A rule
+	// crosses its ceiling when a reversal lands, but it also crosses it when
+	// the clean approvals that were holding the rate down age out of the
+	// window — so a sweep that only ran on reversals would leave a transition
+	// running automatically on a record that had already failed.
+	return suspendIfRecordWentBadTx(ctx, tx, moved, now)
 }
 
 // progressionOutcomes is the vocabulary the column's CHECK holds, spelled here

--- a/backend/internal/modules/deals/stageprogressiongovernance.go
+++ b/backend/internal/modules/deals/stageprogressiongovernance.go
@@ -306,46 +306,64 @@ func (s *Store) SuspendTransitionPolicy(
 	if err := auth.Require(ctx, "pipeline", principal.ActionUpdate); err != nil {
 		return err
 	}
+	return s.Tx(ctx, func(tx pgx.Tx) error {
+		return suspendTransitionPolicyTx(ctx, tx, in, reason)
+	})
+}
+
+// suspendTransitionPolicyTx is the suspension itself, inside a caller's
+// transaction.
+//
+// Split from the exported verb so the measured sweep on the decision path can
+// call it in the transaction that records the outcome — the count that trips
+// the ceiling and the suspension it justifies have to commit together, or
+// there is a window where the rule is off in the numbers and on in the table.
+//
+// It carries no auth.Require of its own: the two callers reach it having
+// already answered that question — the exported verb gates the admin, and the
+// decision path is the product acting on its own measurements, where there is
+// no principal whose pipeline:update permission is the thing in question.
+func suspendTransitionPolicyTx(
+	ctx context.Context, tx pgx.Tx, in TransitionRef, reason string,
+) error {
 	if reason == "" {
 		// The column's CHECK refuses this too. Answering here says which field
 		// the caller should fill rather than a 23514.
 		return errors.New("deals: a suspension names why it happened")
 	}
-	return s.Tx(ctx, func(tx pgx.Tx) error {
-		before, err := lockTransitionPolicy(ctx, tx, in)
-		if err != nil {
-			return err
-		}
-		if before.Suspended() {
+	before, err := lockTransitionPolicy(ctx, tx, in)
+	if err != nil {
+		return err
+	}
+	if before.Suspended() {
+		return nil
+	}
+	var after TransitionPolicy
+	if err := tx.QueryRow(ctx, `
+		UPDATE stage_progression_policy
+		   SET suspended_at = now(), suspended_reason = $2,
+		       updated_at = now(), version = version + 1
+		 WHERE id = $1 AND suspended_at IS NULL
+		RETURNING id, pipeline_id, from_stage_id, to_stage_id, mode,
+			clean_acceptance_threshold, correction_reversal_threshold,
+			min_reviewed, min_observation_days, window_days, undo_window_hours,
+			enabled_by, enabled_at, suspended_at, suspended_reason, version`,
+		before.ID, reason).
+		Scan(&after.ID, &after.PipelineID, &after.FromStageID, &after.ToStageID,
+			&after.Mode, &after.CleanAcceptanceThreshold,
+			&after.CorrectionReversalThreshold, &after.MinReviewed,
+			&after.MinObservationDays, &after.WindowDays, &after.UndoWindowHours,
+			&after.EnabledBy, &after.EnabledAt, &after.SuspendedAt,
+			&after.SuspendedReason, &after.Version); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Suspended by a concurrent pass between the read and here. Its
+			// reason stands, for the same reason the check above lets the
+			// first one stand.
 			return nil
 		}
-		var after TransitionPolicy
-		if err := tx.QueryRow(ctx, `
-			UPDATE stage_progression_policy
-			   SET suspended_at = now(), suspended_reason = $2,
-			       updated_at = now(), version = version + 1
-			 WHERE id = $1 AND suspended_at IS NULL
-			RETURNING id, pipeline_id, from_stage_id, to_stage_id, mode,
-				clean_acceptance_threshold, correction_reversal_threshold,
-				min_reviewed, min_observation_days, window_days, undo_window_hours,
-				enabled_by, enabled_at, suspended_at, suspended_reason, version`,
-			before.ID, reason).
-			Scan(&after.ID, &after.PipelineID, &after.FromStageID, &after.ToStageID,
-				&after.Mode, &after.CleanAcceptanceThreshold,
-				&after.CorrectionReversalThreshold, &after.MinReviewed,
-				&after.MinObservationDays, &after.WindowDays, &after.UndoWindowHours,
-				&after.EnabledBy, &after.EnabledAt, &after.SuspendedAt,
-				&after.SuspendedReason, &after.Version); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				// Suspended by a concurrent pass between the read and here.
-				// Its reason stands, for the same reason the check above lets
-				// the first one stand.
-				return nil
-			}
-			return fmt.Errorf("suspend the transition's automation: %w", err)
-		}
-		return auditPolicySuspension(ctx, tx, *before, after)
-	})
+		return fmt.Errorf("suspend the transition's automation: %w", err)
+	}
+	return auditPolicySuspension(ctx, tx, *before, after)
 }
 
 // ResumeTransitionPolicy clears a suspension, deliberately.

--- a/backend/internal/modules/deals/stageprogressionsuspend.go
+++ b/backend/internal/modules/deals/stageprogressionsuspend.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// A rule turning itself off when its own record goes bad.
+//
+// The governance file beside this one has the WRITER; what lives here is when
+// the product calls it without being asked. Two triggers, and they are
+// deliberately not the same shape:
+//
+//   - The MEASURED one. Corrections and reversals crossing the transition's
+//     own ceiling, over enough reviewed proposals to mean something. It runs
+//     on the decision path, in the transaction that records the outcome, so
+//     the count that trips it INCLUDES the decision that tripped it.
+//   - The SAFETY one. An authorization, cross-tenant, evidence-link or
+//     protected-field defect suspends immediately, at any volume, because
+//     those say the transition is doing something it was never allowed to do
+//     — and waiting for two hundred of them to accumulate is waiting for two
+//     hundred of them to happen.
+//
+// The second is not a stricter version of the first. A ceiling asks "is this
+// still working well enough"; a defect asks "did this do something wrong",
+// and there is no volume at which the answer to the second becomes acceptable.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// SafetyDefect is a way a stage move can be wrong that no amount of volume
+// excuses.
+//
+// A CLOSED set rather than a free string, because each member is a claim that
+// the product did something it had no right to do, and a caller who can invent
+// a new one can suspend a rule for a reason nobody agreed was a safety matter.
+type SafetyDefect string
+
+const (
+	// DefectAuthorization is a move applied that its principal was not allowed
+	// to make.
+	DefectAuthorization SafetyDefect = "authorization"
+	// DefectCrossTenant is a move that touched a record outside the workspace
+	// it was acting in.
+	DefectCrossTenant SafetyDefect = "cross_tenant"
+	// DefectEvidenceLink is a criterion whose evidence did not belong to the
+	// deal it was cited for.
+	DefectEvidenceLink SafetyDefect = "evidence_link"
+	// DefectProtectedField is a move that wrote a field the deal's protections
+	// put out of reach.
+	DefectProtectedField SafetyDefect = "protected_field"
+)
+
+// safetyDefects is what each defect means to an operator reading a suspension.
+//
+// It is also the ADMISSION list: a defect absent from here is refused rather
+// than written, so a caller cannot suspend a rule for a reason nobody agreed
+// was a safety matter. That makes forgetting an entry the dangerous direction
+// — a declared defect the map does not carry is one the product cannot
+// suspend on at all, and it fails silently at the call site.
+//
+// Held by: TestEverySafetyDefectCanActuallySuspendARule
+// (backend/gates/safetydefects_test.go)
+var safetyDefects = map[SafetyDefect]string{
+	DefectAuthorization:  "a move was applied that its actor was not authorized to make",
+	DefectCrossTenant:    "a move reached a record outside its own workspace",
+	DefectEvidenceLink:   "a criterion cited evidence belonging to another deal",
+	DefectProtectedField: "a move wrote a field the deal's protections hold",
+}
+
+// SuspendForSafetyDefect turns a transition's automation off immediately.
+//
+// NO VOLUME TEST, and that is the whole point of it being a separate entry
+// point. The measured sweep asks whether a transition is still working well
+// enough to keep trusting; this one has already been told it did something it
+// was not allowed to do, and one of those is one too many.
+//
+// Called by the applier when a move it made turns out to have crossed a line
+// the product holds. It is safe to call for a transition with no rule at all —
+// there is nothing to suspend, and refusing would make the caller carry a
+// branch about whether automation happened to be configured.
+func (s *Store) SuspendForSafetyDefect(
+	ctx context.Context, in TransitionRef, defect SafetyDefect,
+) error {
+	why, known := safetyDefects[defect]
+	if !known {
+		return fmt.Errorf("deals: %q is not a stage automation safety defect", defect)
+	}
+	err := s.SuspendTransitionPolicy(ctx, in, "safety: "+why)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		// No rule on this transition. Nothing was automatic, so nothing needs
+		// turning off — and the defect is still recorded by whoever detected
+		// it. Answering an error here would push a branch onto every caller
+		// for the ordinary case where a transition was never configured.
+		return nil
+	}
+	return err
+}
+
+// suspendIfRecordWentBadTx turns a rule off when corrections and reversals have
+// crossed its own ceiling.
+//
+// IN THE DECISION'S TRANSACTION, deliberately. Run as a later sweep, the
+// window between the outcome that crossed the ceiling and the suspension is a
+// window in which the rule is still on and still applying moves on a record
+// that has already failed. Here, the decision and the suspension it justifies
+// commit together or not at all.
+//
+// It LOCKS THE RULE BEFORE READING ITS THRESHOLDS, and the order matters. Read
+// unlocked, an admin raising the ceiling between the count and the write would
+// be overruled by a judgement made against the number they had just replaced —
+// the rule goes off citing a threshold that no longer exists, and the reason an
+// operator reads names a bar nobody configured.
+//
+// The threshold is BOTH directions of one question: enough reviewed proposals
+// for the rate to mean anything, AND the rate above the ceiling. A transition
+// with three reviews and one reversal is at 33%, which is not a bad record —
+// it is no record at all, and suspending on it would turn automation off for
+// every transition on its third day.
+func suspendIfRecordWentBadTx(
+	ctx context.Context, tx pgx.Tx, in TransitionRef, now time.Time,
+) error {
+	rule, err := lockTransitionPolicy(ctx, tx, in)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// No rule configured. Nothing to suspend, and the decision that
+			// brought us here is an ordinary proposal being answered.
+			return nil
+		}
+		return err
+	}
+	if rule.Suspended() {
+		// Already off. Re-counting would spend a query to reach the branch
+		// that keeps the first reason anyway.
+		return nil
+	}
+	rates, err := transitionRatesTx(ctx, tx, *rule, now)
+	if err != nil {
+		return err
+	}
+	if !rule.recordWentBad(rates) {
+		return nil
+	}
+	return suspendTransitionPolicyTx(ctx, tx, in, fmt.Sprintf(
+		"%.1f%% of %d reviewed moves on this transition were undone or corrected, "+
+			"above the %.1f%% ceiling",
+		rates.UnsafeRate()*100, rates.Reviewed, rule.CorrectionReversalThreshold*100))
+}
+
+// recordWentBad answers whether this rule's own numbers say to stop.
+//
+// A METHOD ON THE RULE, not a package constant, because every threshold here
+// is the transition's own: an installation that set a stricter ceiling on one
+// transition means it for that transition, and a sweep applying a hard-coded
+// 1% would quietly ignore what an admin configured.
+//
+// MinReviewed does double duty — it is the same number that gates turning
+// automation on. That is intended: the volume at which a record is worth
+// trusting and the volume at which it is worth distrusting are one judgement,
+// and letting them drift apart gives a transition a band where it may run
+// automatically but may not be stopped by its own numbers.
+func (p TransitionPolicy) recordWentBad(r TransitionRates) bool {
+	if r.Reviewed < p.MinReviewed {
+		return false
+	}
+	return r.UnsafeRate() > p.CorrectionReversalThreshold
+}

--- a/backend/internal/modules/deals/stageprogressionsuspend_integration_test.go
+++ b/backend/internal/modules/deals/stageprogressionsuspend_integration_test.go
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package deals
+
+// A rule turning itself off, and what that costs and does not cost.
+//
+// The tests below split into the two triggers and one thing neither may do.
+// The measured trigger needs volume; the safety trigger must not wait for it;
+// and NEITHER may stop the product from proposing — a suspension takes away
+// the automatic apply, and a transition that went silent instead would hide
+// the very moves an operator suspended it to look at.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// suspensionOf reads what the product recorded about a rule being off.
+func suspensionOf(t *testing.T, e *configEnv, ref TransitionRef) (bool, string) {
+	t.Helper()
+	var at *time.Time
+	var reason *string
+	if err := e.owner.QueryRow(t.Context(), `
+		SELECT suspended_at, suspended_reason
+		  FROM stage_progression_policy
+		 WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&at, &reason); err != nil {
+		t.Fatalf("reading the rule's suspension: %v", err)
+	}
+	if at == nil {
+		return false, ""
+	}
+	if reason == nil {
+		t.Fatal("a suspension with no reason: the column's CHECK should refuse this, " +
+			"and an operator asked to re-enable has nothing to judge")
+	}
+	return true, *reason
+}
+
+// settleOne records one clean approval through the real writer, which is what
+// runs the sweep. Returns the approval so the caller can mark it unsafe.
+//
+// Clean, always: every test here is about what the SWEEP does with a record,
+// and a clean approval is the outcome that makes the unsafe rate depend only
+// on what the caller marks afterwards.
+func settleOne(
+	t *testing.T, e *configEnv, dealID ids.DealID, ref TransitionRef,
+) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	proposeOutcome(t, e, dealID, ref.FromStageID, ref.ToStageID, id)
+	if err := e.store.RecordProgressionDecided(
+		e.asDealWriter(), id, ProgressionApprovedClean, nil, false); err != nil {
+		t.Fatalf("settling a proposal: %v", err)
+	}
+	return id
+}
+
+// aRecordGoneBad settles enough reviewed moves to clear the volume bar and
+// marks more than the ceiling's share of them unsafe, WITHOUT letting the
+// sweep see the bad ones until the caller asks.
+//
+// The unsafe rows are marked after they settle, because the writers that set
+// reversed_at and evidence_corrected are the revert endpoint's and the
+// evidence correction path's — neither of which is on this decision path.
+func aRecordGoneBad(
+	t *testing.T, e *configEnv, dealID ids.DealID, ref TransitionRef, unsafe int,
+) {
+	t.Helper()
+	for i := range passingReviewed {
+		id := settleOne(t, e, dealID, ref)
+		if i < unsafe {
+			markUnsafe(t, e, id, unsafeWays{Reversed: true})
+		}
+		if i == 0 {
+			backdateDecision(t, e, id, passingSpanDays*24*time.Hour)
+		}
+	}
+}
+
+// The measured trigger: a rule stops itself once its own ceiling is crossed.
+//
+// The ceiling is the rule's, not a constant. This test moves it rather than
+// settling two hundred more rows, because what is under test is that the sweep
+// reads the transition's configured number — a sweep with 1% hard-coded passes
+// a fixture built at exactly 1% and fails every installation that set its own.
+func TestARuleSuspendsItselfWhenCorrectionsOrReversalsReachTheThreshold(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	autopilotOn(t, e, true)
+	ruleOn(t, e, ref)
+
+	// A record with reversals, but UNDER the default 1% ceiling: 2 of 240 is
+	// 0.83%. The rule must still be running, or the assertion below passes
+	// because the fixture was bad rather than because the sweep worked.
+	aRecordGoneBad(t, e, dealID, ref, 2)
+	if off, why := suspensionOf(t, e, ref); off {
+		t.Fatalf("the rule suspended itself below its own ceiling (%s) — every "+
+			"transition would go off on its first reversal", why)
+	}
+	if got := verdictFor(t, e, ref); got.Mode != ModeAuto {
+		t.Fatalf("the fixture does not reach auto on its own (%s: %s), so a "+
+			"suspension below would prove nothing", got.Mode, got.Why)
+	}
+
+	// One more reversal takes it to 3 of 240 — 1.25%, over the ceiling. The
+	// NEXT decision is what runs the sweep, which is the point: the count that
+	// trips the ceiling and the suspension commit together.
+	third := settleOne(t, e, dealID, ref)
+	markUnsafe(t, e, third, unsafeWays{Reversed: true})
+	settleOne(t, e, dealID, ref)
+
+	off, why := suspensionOf(t, e, ref)
+	if !off {
+		t.Fatal("the rule kept applying moves automatically after corrections and " +
+			"reversals crossed its own ceiling")
+	}
+	if !strings.Contains(why, "%") {
+		t.Errorf("the suspension reason %q names no rate, so an operator cannot "+
+			"tell how far over the ceiling it went", why)
+	}
+}
+
+// The safety trigger does NOT wait for volume, and that is its whole reason
+// for existing separately.
+//
+// A record of three moves cannot cross a rate ceiling — the measured sweep is
+// correct to ignore it. But one of those three reaching a record it had no
+// right to touch is not a rate at all, and a mechanism that waited for two
+// hundred of them would be waiting for two hundred breaches.
+func TestASafetyDefectSuspendsImmediatelyWithoutWaitingForVolume(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	autopilotOn(t, e, true)
+	ruleOn(t, e, ref)
+
+	// Three reviewed moves: far under MinReviewed, so the measured sweep has
+	// nothing to say. Marking one unsafe proves that directly.
+	id := settleOne(t, e, dealID, ref)
+	markUnsafe(t, e, id, unsafeWays{Reversed: true})
+	settleOne(t, e, dealID, ref)
+	settleOne(t, e, dealID, ref)
+	if off, why := suspensionOf(t, e, ref); off {
+		t.Fatalf("a rate over three moves suspended the rule (%s) — the volume "+
+			"bar is not being applied, and every new transition would go off", why)
+	}
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectCrossTenant); err != nil {
+		t.Fatalf("suspending for a safety defect: %v", err)
+	}
+
+	off, why := suspensionOf(t, e, ref)
+	if !off {
+		t.Fatal("a cross-tenant defect left the transition applying moves " +
+			"automatically, waiting for a volume it may never reach")
+	}
+	if !strings.Contains(why, "workspace") {
+		t.Errorf("the suspension reason %q does not say what went wrong, so an "+
+			"operator cannot tell a safety stop from a rate one", why)
+	}
+}
+
+// An invented defect is refused rather than written.
+//
+// The vocabulary is closed because each member is a claim that the product did
+// something it had no right to do. A caller who can pass any string can turn a
+// rule off for a reason nobody agreed was a safety matter, and the reason is
+// what an operator reads when deciding whether to re-enable.
+func TestOnlyAKnownSafetyDefectSuspendsARule(t *testing.T) {
+	e := setupConfigEnv(t)
+	_, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	ruleOn(t, e, ref)
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, SafetyDefect("looked_wrong")); err == nil {
+		t.Fatal("an unknown defect suspended a rule, so any string is a safety stop")
+	}
+	if off, _ := suspensionOf(t, e, ref); off {
+		t.Error("the refused defect suspended the rule anyway")
+	}
+}
+
+// A defect on a transition nobody configured is not an error.
+//
+// Automation was never on there, so there is nothing to turn off. Answering an
+// error would push a branch onto every caller for the ordinary case.
+func TestASafetyDefectOnAnUngovernedTransitionIsNotAnError(t *testing.T) {
+	e := setupConfigEnv(t)
+	_, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectAuthorization); err != nil {
+		t.Fatalf("a defect on a transition with no rule answered an error: %v", err)
+	}
+}
+
+// A suspension takes away the APPLY, never the ask.
+//
+// This is the one a hasty implementation gets wrong by turning the rule's mode
+// to propose, or by refusing the transition outright. Both are wrong in the
+// same direction: the moves an operator suspended a rule to look at are
+// exactly the ones that would stop being visible.
+func TestASuspendedRuleStillProposesButNeverApplies(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	autopilotOn(t, e, true)
+	ruleOn(t, e, ref)
+	aGoodRecord(t, e, dealID, ref)
+	if got := verdictFor(t, e, ref); got.Mode != ModeAuto {
+		t.Fatalf("the fixture does not reach auto (%s: %s)", got.Mode, got.Why)
+	}
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectEvidenceLink); err != nil {
+		t.Fatalf("suspending: %v", err)
+	}
+
+	got := verdictFor(t, e, ref)
+	if got.Mode != ModePropose {
+		t.Fatalf("a suspended rule answered %q — it is still applying moves "+
+			"without asking", got.Mode)
+	}
+	if got.Why == "" {
+		t.Error("the suspended rule refuses without saying why, so an admin sees " +
+			"cards arriving and nothing naming the suspension")
+	}
+	// The ADMIN'S SETTING survives. A suspension is the product's act and it
+	// lifts; rewriting mode would make the admin re-enable something they
+	// never turned off, and would lose that they had trusted this transition.
+	if got.Rule == nil || got.Rule.Mode != ModeAuto {
+		t.Error("the suspension overwrote what the admin asked for, so resuming " +
+			"would leave the transition on propose with nobody having said so")
+	}
+}
+
+// The suspension is on the record and announced.
+//
+// A rule going off is why a rep's inbox starts receiving cards for a move that
+// had been silent, and a queue that simply changed behaviour is
+// indistinguishable from one that broke.
+func TestSuspensionIsAuditedAndAnnounced(t *testing.T) {
+	e := setupConfigEnv(t)
+	_, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	rule := ruleOn(t, e, ref)
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectProtectedField); err != nil {
+		t.Fatalf("suspending: %v", err)
+	}
+
+	var audits int
+	if err := e.owner.QueryRow(t.Context(), `
+		SELECT count(*) FROM audit_log
+		 WHERE entity_type = $1 AND entity_id = $2
+		   AND after ->> 'suspended' = 'true'`,
+		policyEntity, rule.ID).Scan(&audits); err != nil {
+		t.Fatalf("reading the audit trail: %v", err)
+	}
+	if audits != 1 {
+		t.Fatalf("the suspension left %d audit rows, want exactly 1 — an "+
+			"unaudited safety stop is one nobody can account for later", audits)
+	}
+
+	// The event is linked to that audit row by trace.audit_log_id, which is
+	// what makes the domain change, the trail entry and the announcement one
+	// recoverable trace rather than three things that happened to coincide.
+	var linked int
+	if err := e.owner.QueryRow(t.Context(), `
+		SELECT count(*) FROM event_outbox o
+		  JOIN audit_log a
+		    ON a.id::text = o.envelope -> 'trace' ->> 'audit_log_id'
+		 WHERE a.entity_type = $1 AND a.entity_id = $2
+		   AND a.after ->> 'suspended' = 'true'`,
+		policyEntity, rule.ID).Scan(&linked); err != nil {
+		t.Fatalf("reading the outbox: %v", err)
+	}
+	if linked != 1 {
+		t.Fatalf("the suspension published %d events bound to its audit row, want "+
+			"exactly 1 — nothing downstream learns the transition stopped moving "+
+			"deals itself, or learns it without a trace back to why", linked)
+	}
+}
+
+// A second suspension keeps the FIRST reason.
+//
+// The reason that matters is the one that stopped the rule. A later sweep
+// overwriting it with a consequence of the first loses what an operator needs
+// to decide whether it is safe to resume.
+func TestASecondSuspensionKeepsTheReasonThatStoppedTheRule(t *testing.T) {
+	e := setupConfigEnv(t)
+	_, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	ruleOn(t, e, ref)
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectCrossTenant); err != nil {
+		t.Fatalf("first suspension: %v", err)
+	}
+	_, first := suspensionOf(t, e, ref)
+
+	if err := e.store.SuspendForSafetyDefect(
+		e.as(), ref, DefectProtectedField); err != nil {
+		t.Fatalf("second suspension: %v", err)
+	}
+	_, second := suspensionOf(t, e, ref)
+
+	if first == second {
+		return
+	}
+	t.Errorf("a later suspension replaced the reason: was %q, now %q", first, second)
+}
+
+// Below the volume bar, a bad rate enables nothing and suspends nothing.
+//
+// The same number is both floors, deliberately: the volume at which a record
+// is worth trusting and the volume at which it is worth distrusting are one
+// judgement. Letting them drift apart gives a transition a band where it may
+// run automatically but cannot be stopped by its own numbers.
+func TestBelowReviewedVolumeNothingEnables(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	autopilotOn(t, e, true)
+	ruleOn(t, e, ref)
+
+	// Two reviewed moves, one of them reversed — a 50% unsafe rate, which is
+	// far over any ceiling anyone would configure.
+	id := settleOne(t, e, dealID, ref)
+	markUnsafe(t, e, id, unsafeWays{Reversed: true})
+	settleOne(t, e, dealID, ref)
+
+	if off, why := suspensionOf(t, e, ref); off {
+		t.Fatalf("a 50%% rate over two moves suspended the rule (%s) — a "+
+			"transition would go off on its first reversal, before it had a record", why)
+	}
+	got := verdictFor(t, e, ref)
+	if got.Mode != ModePropose {
+		t.Fatal("a transition with two reviewed moves applied one automatically")
+	}
+	if !strings.Contains(got.Why, "reviewed") {
+		t.Errorf("the refusal says %q rather than naming the volume bar, so an "+
+			"admin goes looking for a quality problem that has not been measured", got.Why)
+	}
+}
+
+// The sweep judges a rule nobody can change under it.
+//
+// The defect this holds shut: the sweep reads the rule's thresholds, counts
+// against them, and only then takes the row's lock inside the write. In that
+// gap an admin raising the ceiling is overruled by a judgement made against the
+// number they just replaced — the rule goes off citing a bar that no longer
+// exists, and the reason an operator reads names a threshold nobody configured.
+//
+// Proved by changing the state WHILE the sweep's transaction is open, which is
+// the only way to tell a held lock from a comment claiming one. The admin's
+// UPDATE runs on its own connection and must BLOCK until the sweep commits; if
+// the sweep did not hold the row, it would land immediately and the sweep would
+// still have suspended on the old ceiling.
+func TestTheSweepHoldsTheRuleItIsJudging(t *testing.T) {
+	e := setupConfigEnv(t)
+	dealID, fromID, toID := twoStagePipeline(t, e)
+	ref := transitionOf(t, e, fromID, toID)
+	autopilotOn(t, e, true)
+	rule := ruleOn(t, e, ref)
+
+	// A record over the default ceiling and past the volume bar.
+	seeded := rule.MinReviewed + 20
+	for i := range seeded {
+		id := settleOne(t, e, dealID, ref)
+		if i < 10 {
+			markUnsafe(t, e, id, unsafeWays{Reversed: true})
+		}
+		if i == 0 {
+			backdateDecision(t, e, id, passingSpanDays*24*time.Hour)
+		}
+	}
+
+	// The rule is now suspended by the seeding itself, which is the ordinary
+	// path. Resume it so the sweep below has something to decide about.
+	if err := e.store.ResumeTransitionPolicy(e.as(), ref); err != nil {
+		t.Fatalf("resuming for the concurrency probe: %v", err)
+	}
+
+	// WHAT THIS PROVES, and what it does not. It takes the rule the way the
+	// sweep's first statement does and shows that an admin's threshold write
+	// then BLOCKS — so the thresholds the sweep judges by cannot be replaced
+	// under it. What holds the sweep to this shape is that it calls the same
+	// lockTransitionPolicy; a sweep rewritten to read unlocked would not be
+	// caught here, and that is the gap this test cannot close.
+	//
+	// It is written this way because the obvious version does not work:
+	// probing after the whole sweep passes with OR without the lock, since
+	// suspendTransitionPolicyTx locks again on its way through and the probe
+	// always arrives to find the row held.
+	blocked := make(chan error, 1)
+	if err := e.store.Tx(e.asDealWriter(), func(tx pgx.Tx) error {
+		// Take the lock the sweep takes, then let the admin try.
+		read, err := lockTransitionPolicy(e.asDealWriter(), tx, ref)
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			_, err := e.owner.Exec(t.Context(), `
+				UPDATE stage_progression_policy
+				   SET correction_reversal_threshold = 0.900
+				 WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3`,
+				ref.PipelineID, ref.FromStageID, ref.ToStageID)
+			blocked <- err
+		}()
+		select {
+		case err := <-blocked:
+			t.Errorf("the admin's threshold write completed while the sweep held "+
+				"only a read (%v): the sweep judges against a ceiling that can be "+
+				"replaced before it writes, and the rule goes off citing a bar "+
+				"nobody configured", err)
+		case <-time.After(500 * time.Millisecond):
+			// Blocked, as a held row requires.
+		}
+
+		// The judgement the sweep would make, against the thresholds it read.
+		if !read.recordWentBad(mustRates(t, e, tx, *read)) {
+			t.Fatal("the fixture's record is not over its ceiling, so this test " +
+				"never reaches the write the lock protects")
+		}
+		return suspendTransitionPolicyTx(e.asDealWriter(), tx, ref, "over the ceiling")
+	}); err != nil {
+		t.Fatalf("running the sweep: %v", err)
+	}
+
+	if err := <-blocked; err != nil {
+		t.Fatalf("the admin's write failed after the sweep committed: %v", err)
+	}
+
+	// The sweep's own judgement stands: it suspended on the ceiling that was in
+	// force while it held the row.
+	off, why := suspensionOf(t, e, ref)
+	if !off {
+		t.Fatal("the sweep did not suspend a rule whose record was over its ceiling")
+	}
+	if why == "" {
+		t.Error("the suspension names no reason")
+	}
+}
+
+// mustRates counts the transition's record inside the caller's transaction.
+func mustRates(
+	t *testing.T, e *configEnv, tx pgx.Tx, rule TransitionPolicy,
+) TransitionRates {
+	t.Helper()
+	r, err := transitionRatesTx(e.asDealWriter(), tx, rule, time.Now())
+	if err != nil {
+		t.Fatalf("counting the transition's record: %v", err)
+	}
+	return r
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -118,7 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (126)
+## Census (127)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -227,6 +227,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `restrictedreaders_test.go` | H2 | A record held under a statutory retention obligation is unavailable in EVERY ordinary read path (A165/ADR-0114 §2): lists, timelines, search, exports, embeddings, agent grounding. |
 | `rlsclaimsprose_test.go` | H2 | The prose says what bounds a read, and it is not row-level security. |
 | `rulebookdelegation_test.go` | H3 | AGENTS.md is the rulebook — at the root, and in any directory that needs one of its own. |
+| `safetydefects_test.go` | H2 | Every declared stage-automation safety defect can actually stop a rule. |
 | `satellite_lifecycle_test.go` | H2 | Person-satellite lifecycle reach as a fitness function. |
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |


### PR DESCRIPTION
Stage automation now stops itself. Two triggers, deliberately different shapes.

## The measured trigger

Corrections and reversals crossing the transition's own ceiling, over enough reviewed proposals for the rate to mean anything.

It runs **on the decision path, inside the transaction that records the outcome**. A later sweep would leave a window in which the rule has failed in the numbers and is still on in the table — applying moves on a record that already went bad. Here the count that trips the ceiling and the suspension it justifies commit together or not at all.

The thresholds are the rule's own, read from its row, not constants. An installation that set a stricter ceiling on one transition means it for that transition.

## The safety trigger

An authorization, cross-tenant, evidence-link or protected-field defect suspends **immediately, at any volume**. Those say the transition did something it was never allowed to do, and waiting for two hundred of them is waiting for two hundred breaches.

The defect vocabulary is closed. The reason is what an operator reads when deciding whether to resume, and a caller who can pass any string can turn a rule off for a reason nobody agreed was a safety matter.

## A suspension takes away the apply, never the ask

It does not rewrite the admin's mode. The setting survives, so resuming returns the transition to what its admin actually asked for rather than leaving it on propose with nobody having said so. A suspended rule still proposes — the moves an operator suspended it to look at are exactly the ones that must stay visible.

## Two defects found in review

**The sweep read the rule's thresholds before locking it.** An admin raising the ceiling between the count and the write would be overruled by a judgement made against the number they had just replaced, and the rule would go off citing a bar nobody configured. Fixed by locking first. The test races a real admin `UPDATE` against the held row and fails without the lock — it deadlocks and times out, which is the same defect seen from the other side.

**A declared `SafetyDefect` with no message is one the product refuses to suspend on.** The closed vocabulary is right, but forgetting an entry fails silently at the call site: the caller gets an error where it expected a safety stop and the rule keeps running. A new census gate (`backend/gates/safetydefects_test.go`) derives the constants from the AST and holds them against the message map.

## Tests

Ten integration tests, each mutation-checked one clause at a time. Two mutations initially **passed** against deliberately-wrong code, which is what exposed that the first concurrency test proved nothing — `suspendTransitionPolicyTx` locks again on its way through, so a probe placed after the sweep always found the row held either way. The test says in as many words what it proves and what it cannot.

A positive control also caught a fixture error of my own: seeding `passingReviewed` (240) rows crosses `MinReviewed` (200) during setup, so the volume-bar test would never have reached the decision it was about. The seed count is now derived from the rule.

## Verification

- `make check-backend` green
- `make test-it DIR=backend/internal/modules/deals` green
- `make test-it DIR=backend/internal/compose` green — the outcome consumer drives the writer that now runs the sweep
- `make craft-static` — 0 blocker, 0 major, 0 minor across all four roots

No migration: `stage_progression_outcome` already carries the pipeline and both stage ids, so the decision path names its own transition without a second read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stage automation continuing to run after its own record has gone bad. A rule now suspends itself through two deliberate triggers — a measured one (corrections and reversals crossing the rule’s own ceiling, checked inside the transaction that records each outcome) and a safety one (authorization, cross-tenant, evidence-link, or protected-field defects suspend immediately, regardless of volume).

- A suspension removes the automatic apply but keeps proposing, and preserves the admin’s configured mode so resuming restores what was actually asked for.
- The measured sweep locks the rule before reading its thresholds, fixing a race where an admin’s ceiling update could be overruled by a judgement against the number they just replaced.
- The safety defect vocabulary is closed; a new census gate derives the declared defects from the AST and holds each one to having a message, so none fail silently at the call site.
- No migration needed — the outcome row already carries the pipeline and stage identifiers the sweep needs.

<sup>Written for commit e26768577e788e18eaab5d4a3ecd17abd0433878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stage progression rules now suspend automatically when correction or reversal rates exceed configured safety thresholds.
  - Critical safety defects can immediately suspend affected transition policies.
  - Suspensions are recorded for audit purposes and announced through system events.
  - Suspended rules may continue proposing changes but cannot apply them.

- **Bug Fixes**
  - Prevented unknown safety defects from being accepted.
  - Preserved the original suspension reason when a rule is suspended more than once.

- **Documentation**
  - Updated the gate inventory to include the new safety-defect coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->