### PR TITLE
feat(consent): the installation's own mail speaks the installation's language

### DIFF
--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 46
+	wantFixtureAnnotations = 47
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gates/maillanguagereader_test.go
+++ b/backend/gates/maillanguagereader_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// One reader of the installation's base language.
+//
+// The setting decides what language a message a stranger receives is written
+// in, and two readers of it are two chances to disagree about which principal
+// may ask and what an absent row means. Before this gate the tree had exactly
+// that: identity's reset-mail path ran its own SELECT against the setting table
+// while the confirm-mail path went through settings.ApplyTx, and the two
+// spelled the fallback separately.
+//
+// The subject is the KEY, not a function name: any production statement that
+// SELECTs on installation.base_language is a reader, wherever it lives and
+// whatever it is called. LanguageOf is the one place allowed to, because it is
+// where the setting is declared.
+//
+// Reads only. A harness or a fixture that INSERTs the key is seeding a value,
+// not deciding what an absent one means, and sweeping those in would make this
+// a waiver list rather than a finding.
+//
+// A second reader does not fail anything on its own — it returns the same value
+// today. It fails the day one of them is changed and the other is not, which is
+// a defect nobody will connect back to this, so it is refused up front.
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// baseLanguageKey is the setting whose readers this gate counts.
+const baseLanguageKey = "installation.base_language"
+
+// readsTheLanguageKey reports whether a statement asks the setting table for
+// this key, as opposed to seeding it.
+func readsTheLanguageKey(statement string) bool {
+	if !strings.Contains(statement, baseLanguageKey) {
+		return false
+	}
+	upper := strings.ToUpper(statement)
+	return strings.Contains(upper, "SELECT") &&
+		!strings.Contains(upper, "INSERT") &&
+		!strings.Contains(upper, "UPDATE")
+}
+
+// languageKeyOwners are the files that may name the key: the settings entry
+// that declares it, and the contract types generated from the API description.
+//
+// gatekit:fixture why each file may name the base-language setting key
+var languageKeyOwners = map[string]string{
+	"internal/modules/identity/settingsentry.go": "declares the setting and is where LanguageOf reads it",
+	"internal/contracts/api_gen.go":              "is generated from the contract, which publishes the key",
+}
+
+func TestTheInstallationLanguageHasOneReader(t *testing.T) {
+	t.Parallel()
+
+	var found []string
+	eachGoFileInTheModule(t, func(path string, file *ast.File) {
+		if _, owns := languageKeyOwners[path]; owns || strings.HasSuffix(path, "_test.go") {
+			return
+		}
+		for _, text := range gatekit.SQLStatementsOf(file) {
+			if readsTheLanguageKey(text) {
+				found = append(found, path)
+				break
+			}
+		}
+	})
+
+	for _, path := range found {
+		t.Errorf("%s names %q itself rather than reading it through identity.LanguageOf. "+
+			"Two readers of this setting are two spellings of what an absent row means and of "+
+			"which principal may ask — and they answer the same thing today, so the disagreement "+
+			"only appears once somebody changes one of them", path, baseLanguageKey)
+	}
+}

--- a/backend/internal/compose/briefs/briefmailrender.go
+++ b/backend/internal/compose/briefs/briefmailrender.go
@@ -19,22 +19,13 @@ package briefs
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/margince/margince/backend/internal/platform/mailcopy"
 )
 
-// mailDateLayout is how a day is written, in every language.
-//
-// ISO, and that is deliberate: `2 January 2006` puts an English month name in
-// the middle of a German sentence, and a numeric order like 06/01 is read as
-// 6 January by half the world. A reader needs two things from this date — to
-// tell one morning's message from the next, and to know which day.
-const mailDateLayout = time.DateOnly
-
 // MailSubject names the day, so two mornings do not read alike in a list.
 func MailSubject(run BriefRun, words mailcopy.Copy) string {
-	return words.MorningSubject + run.LocalDay.Format(mailDateLayout)
+	return words.MorningSubject + run.LocalDay.Format(mailcopy.DateLayout)
 }
 
 // MailBody renders one run as the message a rep reads before opening the app.
@@ -44,7 +35,7 @@ func MailSubject(run BriefRun, words mailcopy.Copy) string {
 // whose only call to action it is.
 func MailBody(run BriefRun, homeURL string, words mailcopy.Copy) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s%s\n\n", words.MorningHeading, run.LocalDay.Format(mailDateLayout))
+	fmt.Fprintf(&b, "%s%s\n\n", words.MorningHeading, run.LocalDay.Format(mailcopy.DateLayout))
 
 	waiting := waitingItems(run)
 	if len(waiting) == 0 {

--- a/backend/internal/compose/integration/confirmlinkmail_integration_test.go
+++ b/backend/internal/compose/integration/confirmlinkmail_integration_test.go
@@ -30,13 +30,16 @@ package integration
 
 import (
 	"context"
+	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // confirmLinkToken returns the token from the most recently sealed confirm link.
@@ -92,3 +95,62 @@ func confirmLinkToken(t *testing.T, e *apptest.AppEnv) string {
 type discardingMailer struct{}
 
 func (discardingMailer) Send(context.Context, string, string, string) error { return nil }
+
+// TestTheConfirmMailIsWrittenInTheInstallationsLanguage is what the catalog was
+// wired in for, asserted through the REAL composition.
+//
+// It lives at this tier rather than beside the consent store because the seam
+// under test is the wiring: identity owns the setting, consent may not import
+// it, and compose is the only place the two meet. A test that injected its own
+// reader would prove the renderer takes a string and say nothing about whether
+// the setting an administrator chooses ever reaches a message.
+//
+// Both directions are asserted. That the two languages DIFFER rules out a build
+// that ignores the setting; that the German is the catalog's rules out one that
+// differs for any other reason.
+func TestTheConfirmMailIsWrittenInTheInstallationsLanguage(t *testing.T) {
+	c := setupConsent(t)
+
+	english := stagedConfirmSubject(t, c)
+	setBaseLanguage(installationContext(t, c), t, c.Pool, "de")
+	german := stagedConfirmSubject(t, c)
+
+	if english == german {
+		t.Fatalf("the subject is %q in both languages — the setting reached no message", english)
+	}
+	if want := mailcopy.For("de").ConfirmRecordSubject; german != want {
+		t.Errorf("the German subject is %q, want the catalog's %q", german, want)
+	}
+	if want := mailcopy.For(string(mailcopy.Fallback)).ConfirmRecordSubject; english != want {
+		t.Errorf("an installation that chose no language got %q, want the English fallback %q",
+			english, want)
+	}
+}
+
+// stagedConfirmSubject asks the workspace to mail a confirm link and returns
+// the subject line of the message it staged.
+func stagedConfirmSubject(t *testing.T, c *consentEnv) string {
+	t.Helper()
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
+	}
+	var subject string
+	if err := c.Pool.QueryRow(context.Background(), `
+		SELECT subject FROM comms_outbound
+		 WHERE sender_kind = 'controller'
+		 ORDER BY created_at DESC
+		 LIMIT 1`).Scan(&subject); err != nil {
+		t.Fatalf("no controller delivery was staged: %v", err)
+	}
+	return subject
+}
+
+// installationContext binds the installation's own workspace, which the setting
+// row's transaction requires. The value is not tenant data, but the write still
+// goes through WithWorkspaceTx like every other write in this tree.
+func installationContext(t *testing.T, c *consentEnv) context.Context {
+	t.Helper()
+	return principal.WithWorkspaceID(context.Background(),
+		apptest.InstallationWorkspaceUUID(context.Background(), t, c.Pool))
+}

--- a/backend/internal/compose/integration/promptlanguage_integration_test.go
+++ b/backend/internal/compose/integration/promptlanguage_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/orgdossier"
 	"github.com/margince/margince/backend/internal/compose/promptlang"
@@ -32,14 +33,18 @@ import (
 	"github.com/margince/margince/backend/internal/platform/settings"
 )
 
+// Takes the POOL rather than a harness, because two harnesses need it: the
+// prompt suite runs on Env and the confirm-mail suite on apptest.AppEnv, and
+// the setting is the same row under both.
+//
 // setBaseLanguage writes the setting through settings.SeedValue, which is the
 // writer bootstrap itself uses. It seeds rather than updates, so the existing
 // row is cleared first — SeedValue's whole contract is that it does not
 // overwrite, and a helper that ignored that would silently leave the old
 // language in place and make every assertion below pass for the wrong reason.
-func setBaseLanguage(ctx context.Context, t *testing.T, e *Env, code string) {
+func setBaseLanguage(ctx context.Context, t *testing.T, pool *pgxpool.Pool, code string) {
 	t.Helper()
-	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(context.Background(),
 			`DELETE FROM setting WHERE key = $1`, identity.BaseLanguage.Key()); err != nil {
 			return err
@@ -64,7 +69,7 @@ func TestTheBaseLanguageSetOnTheInstallationReachesThePrompt(t *testing.T) {
 	e := Setup(t)
 	ctx := e.Admin()
 
-	setBaseLanguage(ctx, t, e, "de")
+	setBaseLanguage(ctx, t, e.Pool, "de")
 
 	rule := promptlang.Rule(identity.BaseLanguageForPrompt(ctx, e.Pool))
 	if !strings.Contains(rule, "German") {
@@ -74,7 +79,7 @@ func TestTheBaseLanguageSetOnTheInstallationReachesThePrompt(t *testing.T) {
 	// The other direction, and it is the one that catches a resolver that
 	// happens to return a constant. A test asserting only "German appears"
 	// passes against code that always says German.
-	setBaseLanguage(ctx, t, e, "vi")
+	setBaseLanguage(ctx, t, e.Pool, "vi")
 
 	rule = promptlang.Rule(identity.BaseLanguageForPrompt(ctx, e.Pool))
 	if !strings.Contains(rule, "Vietnamese") {
@@ -119,7 +124,7 @@ func TestTheDossierAndGrowthFitPromptsCarryTheInstallationsLanguage(t *testing.T
 	e := Setup(t)
 	ctx := e.Admin()
 
-	setBaseLanguage(ctx, t, e, "vi")
+	setBaseLanguage(ctx, t, e.Pool, "vi")
 	lang := identity.BaseLanguageForPrompt(ctx, e.Pool)
 
 	dossier := orgdossier.DossierRequest(orgdossier.Input{}, lang)

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -361,6 +361,12 @@ func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
 // resolves the same jurisdiction windows. Without the country seam it would
 // answer on the core defaults while a pack shortened the real ones, and tell a
 // rep a send is allowed that the engine then refuses.
+//
+// The language seam is beside it because the two are the same shape: a setting
+// identity owns, read on the caller's transaction, that consent cannot import
+// its way to. Unwired, the confirm mail is written in English — which is what it
+// was before the catalog existed, and is why this is not part of the
+// confirmation lane's all-three-or-none rule.
 func newConsentHandlers(pool *pgxpool.Pool) consent.Handlers {
 	return consent.NewHandlers(InstallationDB(pool)).
 		WithEraser(privacy.NewEraser(InstallationDB(pool))).
@@ -368,5 +374,6 @@ func newConsentHandlers(pool *pgxpool.Pool) consent.Handlers {
 		WithInstallationName(consent.InstallationNameFunc(func(ctx context.Context) (string, error) {
 			return identity.InstallationNameForPublicPage(ctx, pool)
 		})).
-		WithInstallationCountry(consent.InstallationCountryFunc(identity.CountryOf))
+		WithInstallationCountry(consent.InstallationCountryFunc(identity.CountryOf)).
+		WithMailLanguage(consent.MailLanguageFunc(identity.LanguageOf))
 }

--- a/backend/internal/compose/weekly/weeklymail.go
+++ b/backend/internal/compose/weekly/weeklymail.go
@@ -54,19 +54,8 @@ const mailDealCap = 10
 // that already has last week's, and two identical subjects are two messages a
 // reader cannot tell apart in a list.
 func MailSubject(review Review, words mailcopy.Copy) string {
-	return words.WeeklySubject + review.LocalWeekStart.Format(mailDateLayout)
+	return words.WeeklySubject + review.LocalWeekStart.Format(mailcopy.DateLayout)
 }
-
-// mailDateLayout is how a week's start is written, in every language.
-//
-// ISO, and that is the point: `2 January 2006` puts an English month name in
-// the middle of a German sentence, which is the half-translated message this
-// catalog exists to stop, and a numeric order like 06/01 is read as 6 January
-// by half the world. A reader needs two things from this date — to tell one
-// week's message from the next, and to know which week — and 2026-06-01 gives
-// both in any language. The deal lines in the same message already read this
-// way.
-const mailDateLayout = time.DateOnly
 
 // MailBody renders one review as the message a rep reads on Monday.
 //
@@ -75,7 +64,7 @@ const mailDateLayout = time.DateOnly
 // whose only call to action it is.
 func MailBody(review Review, homeURL string, words mailcopy.Copy) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s%s\n\n", words.WeeklyHeading, review.LocalWeekStart.Format(mailDateLayout))
+	fmt.Fprintf(&b, "%s%s\n\n", words.WeeklyHeading, review.LocalWeekStart.Format(mailcopy.DateLayout))
 
 	// The sentence first, when a pass wrote one. It is the only part of the
 	// message that reads as a person talking, so it goes above the numbers it

--- a/backend/internal/modules/consent/confirmstage.go
+++ b/backend/internal/modules/consent/confirmstage.go
@@ -21,11 +21,13 @@ package consent
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -76,7 +78,8 @@ func (s *Store) stageConfirmMail(ctx context.Context, tx pgx.Tx, in confirmMailI
 	if s.confirmSender == nil || s.vault == nil {
 		return false, nil
 	}
-	rendered, category, err := RenderControllerTemplate(templateForLinkKind(in.kind), in.expiresAt)
+	rendered, category, err := RenderControllerTemplate(
+		templateForLinkKind(in.kind), in.expiresAt, s.mailLanguage(ctx, tx))
 	if err != nil {
 		return false, err
 	}
@@ -154,4 +157,26 @@ func (s *Store) canSendConfirm() bool {
 func (h Handlers) WithConfirmationLane(sender ConfirmationSender, vault ConfirmLinkVault, base string) Handlers {
 	h.store = h.store.WithConfirmationLane(sender, vault, base)
 	return h
+}
+
+// mailLanguage is the language this installation's controller mail is written
+// in, or the fallback when nothing is wired or nothing is set.
+//
+// An unwired reader answers the FALLBACK rather than failing. Refusing to send
+// a confirm link because a settings read failed trades the whole message for a
+// formatting preference, and for the consent link that is worse than it sounds:
+// the permission stays withheld until the person answers a mail that never
+// arrived. mailcopy.For treats an unknown answer the same way, so the two
+// agree without either having to know the other's list.
+func (s *Store) mailLanguage(ctx context.Context, tx pgx.Tx) string {
+	if s.language == nil {
+		return string(mailcopy.Fallback)
+	}
+	language, err := s.language.MailLanguageTx(ctx, tx)
+	if err != nil {
+		slog.WarnContext(ctx, "the installation's mail language could not be read; sending in the fallback",
+			"fallback", mailcopy.Fallback, "cause", err)
+		return string(mailcopy.Fallback)
+	}
+	return language
 }

--- a/backend/internal/modules/consent/controllertemplates.go
+++ b/backend/internal/modules/consent/controllertemplates.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
@@ -70,11 +71,22 @@ type ConfirmationSender interface {
 type controllerTemplate struct {
 	version  int
 	category commsauthz.Category
-	subject  string
-	// body carries the link placeholder exactly once. comms checks that against
-	// the material it is staged with and refuses a disagreement, which is what
-	// stops a message that was meant to carry a link from going out without one.
-	body string
+	// The three parts of the message, each read from the installation's own
+	// catalog rather than held as a literal here.
+	//
+	// The wording moved to platform/mailcopy because these were the last mail
+	// the product sent in hard-coded English. An installation whose screens are
+	// German asked a stranger, in English, whether it might keep writing to
+	// them — and that is the one message where being understood is the point,
+	// since an unanswered opt-in withholds the permission.
+	//
+	// The rendered body still carries the link placeholder exactly once. comms
+	// checks that against the material it is staged with and refuses a
+	// disagreement, which is what stops a message that was meant to carry a
+	// link from going out without one.
+	subject func(mailcopy.Copy) string
+	intro   func(mailcopy.Copy) string
+	closing func(mailcopy.Copy) string
 }
 
 // controllerTemplates is the closed catalog.
@@ -85,24 +97,18 @@ type controllerTemplate struct {
 // — which is both a deliverability problem and a fair reaction.
 var controllerTemplates = map[string]controllerTemplate{
 	TemplateRecordConfirmation: {
-		version:  1,
+		version:  2,
 		category: commsauthz.CategoryRecordConfirmation,
-		subject:  "Your details, and whether we may stay in touch",
-		body: "You can see what we have on file about you, correct anything that is wrong,\n" +
-			"and tell us whether you want to hear from us.\n\n" +
-			"  " + linkPlaceholder + "\n\n" +
-			"This link is personal to you.\n\n" +
-			"You do not have to do anything. Ignoring this changes nothing.\n",
+		subject:  func(w mailcopy.Copy) string { return w.ConfirmRecordSubject },
+		intro:    func(w mailcopy.Copy) string { return w.ConfirmRecordBody },
+		closing:  func(w mailcopy.Copy) string { return w.ConfirmRecordIgnore },
 	},
 	TemplateConsentConfirmation: {
-		version:  1,
+		version:  2,
 		category: commsauthz.CategoryConsentConfirmation,
-		subject:  "Please confirm you want to hear from us",
-		body: "You asked to hear from us. Confirming below is what turns that into a\n" +
-			"permission we will act on — until you do, we will not write to you about it.\n\n" +
-			"  " + linkPlaceholder + "\n\n" +
-			"This link is personal to you.\n\n" +
-			"If you did not ask for this, ignore it. Nothing happens until you confirm.\n",
+		subject:  func(w mailcopy.Copy) string { return w.ConfirmConsentSubject },
+		intro:    func(w mailcopy.Copy) string { return w.ConfirmConsentBody },
+		closing:  func(w mailcopy.Copy) string { return w.ConfirmConsentIgnore },
 	},
 }
 
@@ -135,15 +141,21 @@ func (templateRegistry) Registered(key string, version int) bool {
 // function. The body carries a placeholder, the material rides the vault, and
 // the two meet in memory at dispatch — so the link is absent from the delivery
 // row, the timeline, the audit entry and the outbox event alike.
-func RenderControllerTemplate(key string, expiresAt time.Time) (Rendered, commsauthz.Category, error) {
+func RenderControllerTemplate(key string, expiresAt time.Time, language string) (Rendered, commsauthz.Category, error) {
 	t, ok := controllerTemplates[key]
 	if !ok {
 		return Rendered{}, "", fmt.Errorf("consent: %q is not a registered controller template", key)
 	}
-	body := t.body
+	words := mailcopy.For(language)
+	var body strings.Builder
+	body.WriteString(t.intro(words) + "\n\n  " + linkPlaceholder + "\n\n" + words.ConfirmPersonal)
 	if !expiresAt.IsZero() {
-		body = strings.Replace(body, "This link is personal to you.",
-			"This link is personal to you and works until "+expiresAt.Format("2 January 2006")+".", 1)
+		// Appended to the personal-link sentence rather than substituted into
+		// it: the shipped English replaced a phrase inside its own body text,
+		// which stops working the moment a language spells that sentence
+		// differently.
+		fmt.Fprintf(&body, words.ConfirmExpiry, expiresAt.Format(mailcopy.DateLayout))
 	}
-	return Rendered{Key: key, Version: t.version, Subject: t.subject, Body: body}, t.category, nil
+	body.WriteString("\n\n" + t.closing(words) + "\n")
+	return Rendered{Key: key, Version: t.version, Subject: t.subject(words), Body: body.String()}, t.category, nil
 }

--- a/backend/internal/modules/consent/controllertemplates_test.go
+++ b/backend/internal/modules/consent/controllertemplates_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 )
 
 // TestEveryControllerTemplateCarriesExactlyOnePlaceholder holds the rendered
@@ -22,18 +24,24 @@ import (
 // its own send impossible and one with two would put the same live link in a
 // message twice. Both are silent until somebody tries to send.
 func TestEveryControllerTemplateCarriesExactlyOnePlaceholder(t *testing.T) {
+	// EVERY language, because the body is assembled per language now. A
+	// translation that dropped the placeholder, or repeated it, would make its
+	// own send impossible on exactly the installations that speak it, while
+	// English stayed green.
 	for key := range controllerTemplates {
-		rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour))
-		if err != nil {
-			t.Fatalf("rendering %q: %v", key, err)
-		}
-		if got := strings.Count(rendered.Body, linkPlaceholder); got != 1 {
-			t.Errorf("template %q carries %d link placeholder(s), want exactly 1: comms refuses "+
-				"a body whose count disagrees with its material, so this template can never be sent",
-				key, got)
-		}
-		if rendered.Subject == "" {
-			t.Errorf("template %q renders no subject line", key)
+		for _, language := range mailcopy.Languages() {
+			rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour), string(language))
+			if err != nil {
+				t.Fatalf("rendering %q in %s: %v", key, language, err)
+			}
+			if got := strings.Count(rendered.Body, linkPlaceholder); got != 1 {
+				t.Errorf("template %q in %s carries %d link placeholder(s), want exactly 1: comms "+
+					"refuses a body whose count disagrees with its material, so this template can "+
+					"never be sent", key, language, got)
+			}
+			if rendered.Subject == "" {
+				t.Errorf("template %q renders no subject line in %s", key, language)
+			}
 		}
 	}
 }
@@ -49,7 +57,7 @@ func TestEveryControllerTemplateCarriesExactlyOnePlaceholder(t *testing.T) {
 // a message that can never be sent.
 func TestEveryControllerTemplateResolvesToASubjectServingCategory(t *testing.T) {
 	for key := range controllerTemplates {
-		_, category, err := RenderControllerTemplate(key, time.Time{})
+		_, category, err := RenderControllerTemplate(key, time.Time{}, string(mailcopy.Fallback))
 		if err != nil {
 			t.Fatalf("rendering %q: %v", key, err)
 		}
@@ -88,7 +96,7 @@ func TestTheTemplatePlaceholderAgreesWithTheLane(t *testing.T) {
 // TestAnUnregisteredTemplateIsRefused — the registry is what makes the lane
 // closed. A body assembled at a call site must not reach it.
 func TestAnUnregisteredTemplateIsRefused(t *testing.T) {
-	if _, _, err := RenderControllerTemplate("marketing_blast", time.Time{}); err == nil {
+	if _, _, err := RenderControllerTemplate("marketing_blast", time.Time{}, string(mailcopy.Fallback)); err == nil {
 		t.Fatal("an unregistered template rendered, so the installation's own words are not " +
 			"fixed in code after all")
 	}
@@ -106,12 +114,14 @@ func TestAnUnregisteredTemplateIsRefused(t *testing.T) {
 // outbox event, so a link rendered into it lands in all four.
 func TestTheRenderedBodyNeverCarriesTheLink(t *testing.T) {
 	for key := range controllerTemplates {
-		rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour))
-		if err != nil {
-			t.Fatalf("rendering %q: %v", key, err)
-		}
-		if strings.Contains(rendered.Body, "http") {
-			t.Errorf("template %q renders a URL into its body:\n%s", key, rendered.Body)
+		for _, language := range mailcopy.Languages() {
+			rendered, _, err := RenderControllerTemplate(key, time.Now().Add(72*time.Hour), string(language))
+			if err != nil {
+				t.Fatalf("rendering %q in %s: %v", key, language, err)
+			}
+			if strings.Contains(rendered.Body, "http") {
+				t.Errorf("template %q in %s renders a URL into its body:\n%s", key, language, rendered.Body)
+			}
 		}
 	}
 }
@@ -142,8 +152,11 @@ func TestTheRenderedBodyNeverCarriesTheLink(t *testing.T) {
 
 // pinnedWording is the hash of each template as it is registered today.
 //
-// The key carries the version so a bump reads as a deliberate act: changing the
-// words alone fails, and the fix is to move the version and the pin together.
+// The key carries the version AND the language, so a bump reads as a deliberate
+// act and a translation cannot change quietly. Keyed by version alone, one
+// language would hold the pin and the other two would be exempt — which is the
+// half of this gate that matters most, since a German reader is the one who
+// actually reads the German.
 //
 // It is a SNAPSHOT of what this build sends, not an archive of what it once
 // sent. controllerTemplates is keyed by template key, so one version per key is
@@ -154,8 +167,12 @@ func TestTheRenderedBodyNeverCarriesTheLink(t *testing.T) {
 //
 // gatekit:fixture the sha256 of each registered template's rendered wording
 var pinnedWording = map[string]string{
-	"record_confirmation@1":  "d53b469155a1219102d50008f40fa992447915a7354fbc51755c39bb9b9aec16",
-	"consent_confirmation@1": "65bf988d3efe84768d89cace0cd7bbab93b433269b592fe6bebaa11587be8320",
+	"record_confirmation@2@en":  "ae6261f551d0f39945b720db03b9ef2f51a36516b88eeff0b1afae80808e0c28",
+	"record_confirmation@2@de":  "3ba76e0c75f2dd619ad4666d3452607b87a638ea1183e3188ace7bd7d4ac6b06",
+	"record_confirmation@2@vi":  "28894b02130d640779a9fd4550a2f987a4925c04aaf2749679d44708eae9d2a7",
+	"consent_confirmation@2@en": "05485c736c4971864938a0a4100a69b0533b7f9792e1d75820299461c043233e",
+	"consent_confirmation@2@de": "78ed420da7fa53e0cbfc5f02996520e27f8ba0fbb84b1c435b52abbe0da30054",
+	"consent_confirmation@2@vi": "e224aa3f581bf8b2fccb3468364abe52f0f6467e3dd045c9e2b056a96fd4b7b3",
 }
 
 // TestEveryControllerTemplateIsPinnedToItsWording fails when a registered
@@ -183,38 +200,13 @@ func TestEveryControllerTemplateIsPinnedToItsWording(t *testing.T) {
 
 	seen := map[string]bool{}
 	for _, key := range keys {
-		rendered, _, err := RenderControllerTemplate(key, expires)
-		if err != nil {
-			t.Errorf("rendering %s: %v", key, err)
-			continue
-		}
-
-		sum := sha256.Sum256([]byte(rendered.Subject + "\x00" + rendered.Body))
-		got := hex.EncodeToString(sum[:])
-		pin := fmt.Sprintf("%s@%d", key, rendered.Version)
-		seen[pin] = true
-
-		want, pinned := pinnedWording[pin]
-		if !pinned {
-			t.Errorf("%s is registered but not pinned here. If this is a NEW template, "+
-				"add a row with %q. If you edited an existing one, bump its version and move "+
-				"the pin with it — the version is what a consent proof names",
-				pin, got)
-			continue
-		}
-		if want == "" {
-			t.Errorf("%s has an empty pin. Fill it with %q — an empty pin matches nothing "+
-				"and silently exempts the wording it was meant to hold", pin, got)
-			continue
-		}
-		if got != want {
-			t.Errorf("%s wording changed but its version did not.\n  pinned: %s\n  now:    %s\n\n"+
-				"Bump the template's version and REPLACE this row with one for the new "+
-				"version. Do not keep the old row: this map is what THIS build sends, and the "+
-				"check below fails a pin nothing renders. What version %d actually showed a "+
-				"person is recoverable from consent_event.policy_text, which is where that "+
-				"history belongs — not here",
-				pin, want, got, rendered.Version)
+		for _, language := range mailcopy.Languages() {
+			rendered, _, err := RenderControllerTemplate(key, expires, string(language))
+			if err != nil {
+				t.Errorf("rendering %s in %s: %v", key, language, err)
+				continue
+			}
+			checkPin(t, seen, key, string(language), rendered)
 		}
 	}
 
@@ -225,6 +217,95 @@ func TestEveryControllerTemplateIsPinnedToItsWording(t *testing.T) {
 				"this map is what THIS build sends, and a pin nothing renders is a claim about "+
 				"wording that no longer exists. What that person was shown is recoverable from "+
 				"consent_event.policy_text, not from here", pin)
+		}
+	}
+}
+
+// checkPin holds one rendered wording against its row, and records that the row
+// was reached.
+//
+// Keyed key@version@locale. The wording is per language now, so a pin naming
+// only key and version would hold whichever language happened to render last
+// and silently exempt the other two — a German translation could then change
+// without anything failing, on the installations that actually read it.
+func checkPin(t *testing.T, seen map[string]bool, key, locale string, rendered Rendered) {
+	t.Helper()
+
+	sum := sha256.Sum256([]byte(rendered.Subject + "\x00" + rendered.Body))
+	got := hex.EncodeToString(sum[:])
+	pin := fmt.Sprintf("%s@%d@%s", key, rendered.Version, locale)
+	seen[pin] = true
+
+	want, pinned := pinnedWording[pin]
+	switch {
+	case !pinned:
+		t.Errorf("%s is registered but not pinned here. If this is a NEW template or a new "+
+			"language, add a row with %q. If you edited an existing one, bump its version and "+
+			"move the pin with it — the version is what a consent proof names", pin, got)
+	case want == "":
+		t.Errorf("%s has an empty pin. Fill it with %q — an empty pin matches nothing "+
+			"and silently exempts the wording it was meant to hold", pin, got)
+	case got != want:
+		t.Errorf("%s wording changed but its version did not.\n  pinned: %s\n  now:    %s\n\n"+
+			"Bump the template's version and REPLACE this row with one for the new "+
+			"version. Do not keep the old row: this map is what THIS build sends, and the "+
+			"check below fails a pin nothing renders. What version %d actually showed a "+
+			"person is recoverable from consent_event.policy_text, which is where that "+
+			"history belongs — not here",
+			pin, want, got, rendered.Version)
+	}
+}
+
+// TestTheExpiryDateReadsTheSameInEveryLanguage is the one part of a rendered
+// message that is not copy, and it was wrong first time round.
+//
+// Go's reference layouts name the month in English, so "2 January 2006" put
+// "9 March 2026" inside a German sentence — the single visible place where a
+// catalog of translations would still have shipped English. An ISO date carries
+// no month name to get wrong.
+func TestTheExpiryDateReadsTheSameInEveryLanguage(t *testing.T) {
+	expires := time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC)
+	for key := range controllerTemplates {
+		for _, language := range mailcopy.Languages() {
+			rendered, _, err := RenderControllerTemplate(key, expires, string(language))
+			if err != nil {
+				t.Fatalf("rendering %q in %s: %v", key, language, err)
+			}
+			if !strings.Contains(rendered.Body, "2026-03-09") {
+				t.Errorf("template %q in %s does not carry the ISO expiry date:\n%s",
+					key, language, rendered.Body)
+			}
+			// The month name is what an English layout leaks. Asserting the ISO
+			// date alone would pass on a body carrying both.
+			if strings.Contains(rendered.Body, "March") {
+				t.Errorf("template %q in %s spells the month in English:\n%s",
+					key, language, rendered.Body)
+			}
+		}
+	}
+}
+
+// TestTheExpiryLineTakesExactlyOneDate holds the one format string in a
+// controller mail.
+//
+// ConfirmExpiry is the only catalog line with a verb in it, and Fprintf answers
+// a mismatch with text rather than an error: two verbs render
+// "%!s(MISSING)" and a stray percent renders "%!(NOVERB)", both of which reach
+// the mailbox as-is. The pin would change, but a translator repinning their own
+// change would read "wording changed" and repin it — so the wrong thing has to
+// be named here.
+func TestTheExpiryLineTakesExactlyOneDate(t *testing.T) {
+	for _, language := range mailcopy.Languages() {
+		line := mailcopy.For(string(language)).ConfirmExpiry
+		if got := strings.Count(line, "%s"); got != 1 {
+			t.Errorf("the %s expiry line carries %d %%s verbs, want exactly 1: %q",
+				language, got, line)
+		}
+		// Every percent in the line must be that one verb. A stray one — an
+		// escaped literal, a %d left by a copy — renders as a diagnostic.
+		if got := strings.Count(line, "%"); got != 1 {
+			t.Errorf("the %s expiry line carries %d percent signs and only one verb is allowed: %q",
+				language, got, line)
 		}
 	}
 }

--- a/backend/internal/modules/consent/maillanguage.go
+++ b/backend/internal/modules/consent/maillanguage.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Which language this installation's controller mail is written in.
+//
+// The setting lives in identity, and a module never imports a sibling — so the
+// reader is injected and this file holds only the seam, exactly as
+// installationcountry.go does for where the installation is established.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// MailLanguageReader answers the installation's base language, or empty when it
+// is unstated.
+//
+// It takes the CALLER'S transaction rather than opening its own, for the reason
+// InstallationCountryReader does: the wording it selects is staged on that
+// transaction, so reading the language outside it would let the setting change
+// between the read and the write and stage a message in a language the
+// installation had already stopped speaking.
+type MailLanguageReader interface {
+	MailLanguageTx(ctx context.Context, tx pgx.Tx) (string, error)
+}
+
+// MailLanguageFunc adapts a plain function, so compose can inject identity's
+// reader without either module knowing the other.
+type MailLanguageFunc func(ctx context.Context, tx pgx.Tx) (string, error)
+
+// MailLanguageTx satisfies MailLanguageReader.
+func (f MailLanguageFunc) MailLanguageTx(ctx context.Context, tx pgx.Tx) (string, error) {
+	return f(ctx, tx)
+}
+
+// WithMailLanguage injects the reader behind the controller mail's wording.
+//
+// It lands on the STORE because that is where the mail is staged: issueLink
+// renders and queues on one transaction, and the handlers reach it through the
+// store they already hold.
+func (s *Store) WithMailLanguage(r MailLanguageReader) *Store {
+	s.language = r
+	return s
+}
+
+// WithMailLanguage is the handlers-side spelling, for the surface that mints a
+// confirm link.
+func (h Handlers) WithMailLanguage(r MailLanguageReader) Handlers {
+	h.store = h.store.WithMailLanguage(r)
+	return h
+}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -33,6 +33,9 @@ type Store struct {
 	// under. Injected by compose because the setting lives in identity
 	// (installationcountry.go).
 	country InstallationCountryReader
+	// language is which language the controller mail this store stages is
+	// written in. Nil sends in the fallback rather than refusing.
+	language MailLanguageReader
 	// confirmSender stages the installation's own mail on the durable lane, and
 	// vault holds the one-time link so the plaintext never reaches the delivery
 	// row. Both nil on an installation that has not wired the lane, which

--- a/backend/internal/modules/consent/textversion.go
+++ b/backend/internal/modules/consent/textversion.go
@@ -22,17 +22,41 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // TextVersion is one published wording.
 type TextVersion struct {
-	Key         string
-	Version     string
+	Key     string
+	Version string
+	// Locale is which language this text is, empty for a wording that applies
+	// in every language. A controller template names one: the same template at
+	// the same version has an English, a German and a Vietnamese text, and a
+	// proof row has to say which of the three a person was shown.
+	Locale      string
 	Subject     string
 	Body        string
 	PublishedAt time.Time
+}
+
+// describe names one wording for an error message: key@version, and the
+// language when it names one.
+func (in TextVersion) describe() string {
+	if in.Locale == "" {
+		return in.Key + "@" + in.Version
+	}
+	return in.Key + "@" + in.Version + " (" + in.Locale + ")"
+}
+
+// localeOrNil turns an unset locale into the NULL the column means by it: this
+// wording applies in every language.
+func localeOrNil(locale string) *string {
+	if locale == "" {
+		return nil
+	}
+	return &locale
 }
 
 // WordingDigest is the ONE way a subject line and a body are reduced to a
@@ -113,32 +137,38 @@ func PublishTextVersionTx(ctx context.Context, tx pgx.Tx, in TextVersion) (ids.U
 
 	var existingID ids.UUID
 	var existingHash string
+	// Read by locale as well as by key and version, matching the published
+	// index. Asked without it, the second language of one template would find
+	// the first, compare a German body against an English hash and refuse the
+	// boot as a wording change.
 	err := tx.QueryRow(ctx, `
 		SELECT id, content_hash FROM consent_text_version
-		 WHERE key = $1 AND version = $2 AND published_at IS NOT NULL`,
-		in.Key, in.Version).Scan(&existingID, &existingHash)
+		 WHERE key = $1 AND version = $2
+		   AND locale IS NOT DISTINCT FROM $3 AND published_at IS NOT NULL`,
+		in.Key, in.Version, localeOrNil(in.Locale)).Scan(&existingID, &existingHash)
 	switch {
 	case err == nil:
 		if existingHash != hash {
 			return ids.UUID{}, fmt.Errorf(
-				"%s@%s is published with different wording; publish a new version rather than "+
-					"changing what this one said: %w", in.Key, in.Version, apperrors.ErrConflict)
+				"%s is published with different wording; publish a new version rather than "+
+					"changing what this one said: %w", in.describe(), apperrors.ErrConflict)
 		}
 		return existingID, nil
 	case !errors.Is(err, pgx.ErrNoRows):
-		return ids.UUID{}, fmt.Errorf("read the published wording for %s@%s: %w", in.Key, in.Version, err)
+		return ids.UUID{}, fmt.Errorf("read the published wording for %s: %w", in.describe(), err)
 	}
 
 	var id ids.UUID
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO consent_text_version (key, version, subject_line, body, content_hash, published_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO consent_text_version (key, version, locale, subject_line, body, content_hash, published_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING id`,
-		in.Key, in.Version, nullableText(in.Subject), in.Body, hash, in.PublishedAt).Scan(&id); err != nil {
-		return ids.UUID{}, fmt.Errorf("publish the wording %s@%s: %w", in.Key, in.Version, err)
+		in.Key, in.Version, localeOrNil(in.Locale), nullableText(in.Subject),
+		in.Body, hash, in.PublishedAt).Scan(&id); err != nil {
+		return ids.UUID{}, fmt.Errorf("publish the wording %s: %w", in.describe(), err)
 	}
 	if _, err := storekit.Audit(ctx, tx, "create", "consent_text_version", id, nil, map[string]any{
-		fieldKey: in.Key, "version": in.Version, "content_hash": hash,
+		fieldKey: in.Key, "version": in.Version, "locale": in.Locale, "content_hash": hash,
 	}); err != nil {
 		return ids.UUID{}, fmt.Errorf("audit the published wording: %w", err)
 	}
@@ -155,19 +185,42 @@ func PublishTextVersionTx(ctx context.Context, tx pgx.Tx, in TextVersion) (ids.U
 // is worth failing a boot over: the alternative is a live version whose text no
 // longer matches the proofs that name it.
 //
-// The template's own body is published, not one render of it. RenderControllerTemplate
-// substitutes an expiry date, so a rendered copy would publish one message's
-// wording as though it were the canonical text.
+// The wording is published WITHOUT an expiry date, which is what makes it the
+// canonical text rather than one message's render: the date belongs to a
+// particular link, and publishing a rendered copy would name one send's wording
+// as though it were the template's.
+//
+// EVERY LANGUAGE THIS BUILD SPEAKS is published, not just the installation's
+// own. The installation's language can change after a link was sent, so a
+// wording published only for the setting live at boot would disappear from a
+// later boot — and the text somebody was shown in March would be gone in
+// September. Publishing all three costs two extra rows per template and keeps
+// each of them answerable.
+//
+// WHAT IT DOES NOT YET DO. consent_event.consent_text_version_id has no writer
+// anywhere in this tree, so nothing records WHICH of the three a given proof
+// was rendered from. This change makes all three resolvable; picking one is the
+// writer's job and that writer does not exist. When it lands it must take the
+// locale from the language the mail was actually staged in, not from
+// installation.base_language at read time, which is the value that can have
+// changed in between.
 func PublishControllerTemplatesTx(ctx context.Context, tx pgx.Tx, now time.Time) error {
 	for key, t := range controllerTemplates {
-		if _, err := PublishTextVersionTx(ctx, tx, TextVersion{
-			Key:         key,
-			Version:     fmt.Sprintf("v%d", t.version),
-			Subject:     t.subject,
-			Body:        t.body,
-			PublishedAt: now,
-		}); err != nil {
-			return err
+		for _, language := range mailcopy.Languages() {
+			rendered, _, err := RenderControllerTemplate(key, time.Time{}, string(language))
+			if err != nil {
+				return err
+			}
+			if _, err := PublishTextVersionTx(ctx, tx, TextVersion{
+				Key:         key,
+				Version:     fmt.Sprintf("v%d", t.version),
+				Locale:      string(language),
+				Subject:     rendered.Subject,
+				Body:        rendered.Body,
+				PublishedAt: now,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/backend/internal/modules/consent/textversion_integration_test.go
+++ b/backend/internal/modules/consent/textversion_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 )
 
 // The one wording these tests publish. Every test here asks what the database
@@ -179,12 +181,15 @@ func TestPublishingTheCatalogTwiceIsANoOp(t *testing.T) {
 		}
 	}
 
+	// Grouped by LOCALE as well: one template at one version legitimately has
+	// three rows now, one per language this build speaks. Grouped without it,
+	// the second language of every template reads as a duplicate.
 	var duplicated int
 	if err := e.owner.QueryRow(context.Background(), `
 		SELECT count(*) FROM (
-		  SELECT key, version FROM consent_text_version
+		  SELECT key, version, locale FROM consent_text_version
 		   WHERE published_at IS NOT NULL
-		   GROUP BY key, version HAVING count(*) > 1
+		   GROUP BY key, version, locale HAVING count(*) > 1
 		) d`).Scan(&duplicated); err != nil {
 		t.Fatal(err)
 	}
@@ -193,14 +198,24 @@ func TestPublishingTheCatalogTwiceIsANoOp(t *testing.T) {
 			"\"which text is this\" a question with two answers", duplicated)
 	}
 
+	// Scoped to the CONTROLLER templates. Counting every published wording
+	// would make this test fail the day a preference-centre sentence gets its
+	// own publisher — a legitimate row this test has no opinion about.
 	var published int
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT count(*) FROM consent_text_version WHERE published_at IS NOT NULL`).Scan(&published); err != nil {
+		`SELECT count(*) FROM consent_text_version
+		  WHERE published_at IS NOT NULL
+		    AND key = ANY($1)`, controllerTemplateKeys()).Scan(&published); err != nil {
 		t.Fatal(err)
 	}
-	if published < 2 {
-		t.Errorf("the catalog published %d wordings, want at least the confirm-details and "+
-			"double-opt-in templates", published)
+	// Two templates in three languages. Asked as "at least 2" this would pass a
+	// build that published one language and dropped the others, which is the
+	// failure that leaves a German installation with no German text for a proof
+	// row to point at.
+	want := len(controllerTemplates) * len(mailcopy.Languages())
+	if published != want {
+		t.Errorf("the catalog published %d wordings, want %d — %d template(s) in %d language(s)",
+			published, want, len(controllerTemplates), len(mailcopy.Languages()))
 	}
 }
 
@@ -255,4 +270,14 @@ func TestAPublishedVersionsScopeIsFrozenToo(t *testing.T) {
 				"moving it leaves no trace at all", set)
 		}
 	}
+}
+
+// controllerTemplateKeys names the catalog's own keys, so the count above asks
+// about the rows this publisher writes rather than about the table.
+func controllerTemplateKeys() []string {
+	keys := make([]string, 0, len(controllerTemplates))
+	for key := range controllerTemplates {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/backend/internal/modules/identity/maillanguage.go
+++ b/backend/internal/modules/identity/maillanguage.go
@@ -21,14 +21,21 @@ import (
 
 // mailCopy resolves what this installation's mail says.
 //
-// The setting row is read DIRECTLY rather than through platform/settings, for
-// the reason Login reads the installation's name the same way: those readers
-// take the installation_settings object gate, and this runs where there is no
-// principal for that gate to judge. `POST /auth/forgot-password` is public — it
-// answers 202 before it knows whether the address maps to an account, and
-// everything after that runs off the request path with nothing bound. Through
-// the gated reader every reset mail would be refused the setting and fall back
-// to English, on exactly the installations this catalog exists for.
+// It reads through LanguageOf, which is the one reader of this setting: the
+// query and the "which principal may ask" decision are spelled once, and a
+// second copy here would be a second place to get either wrong.
+//
+// Held by: TestTheInstallationLanguageHasOneReader
+// (backend/gates/maillanguagereader_test.go)
+//
+// LanguageOf goes through settings.ApplyTx, which skips the entry's read gate.
+// That is what this path needs: those readers take the installation_settings
+// object gate, and this runs where there is no principal for the gate to judge.
+// `POST /auth/forgot-password` is public — it answers 202 before it knows
+// whether the address maps to an account, and everything after that runs off
+// the request path with nothing bound. Through the gated reader every reset
+// mail would be refused the setting and fall back to English, on exactly the
+// installations this catalog exists for.
 //
 // Nothing is widened by it. The value is the installation's own label, chosen
 // by an administrator and shown on a settings screen; it is not tenant data,
@@ -45,10 +52,8 @@ import (
 func (h Handlers) mailCopy(ctx context.Context) mailcopy.Copy {
 	language := string(mailcopy.Fallback)
 	err := h.svc.db.Tx(ctx, func(tx pgx.Tx) error {
-		var stored string
-		if err := tx.QueryRow(ctx,
-			`SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = $1), '')`,
-			BaseLanguage.Key()).Scan(&stored); err != nil {
+		stored, err := LanguageOf(ctx, tx)
+		if err != nil {
 			return err
 		}
 		if stored != "" {

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -182,7 +182,7 @@ var BaseLanguage = settings.Define[string](
 		}
 		return nil
 	},
-).AsInstallationIdentity()
+).AsInstallationIdentity().MachineryApplied()
 
 // Country is where this installation is established, as a lower-case ISO
 // 3166-1 alpha-2 code. Empty means unstated, and unstated is the strict answer
@@ -452,4 +452,27 @@ func CountryOf(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
 		return "", err
 	}
 	return jurisdiction.Code(code), nil
+}
+
+// LanguageOf is the language this installation's controller mail is written in,
+// read on the caller's transaction.
+//
+// MachineryApplied for the reason Country is: the confirm-details and
+// double-opt-in mails are rendered inside the transaction that mints their
+// link, and through the gated reader the language would be refused to any
+// principal without the installation_settings object — a narrow seat asking a
+// contact to confirm their details would silently get English while the
+// installation's own screens are German. A language a narrow principal could
+// not read would simply not apply to what they send, which is the opposite of
+// a setting.
+//
+// Nothing is widened. The value is the installation's own label, chosen by an
+// administrator and shown on a settings screen; it is not tenant data, and the
+// language a message is written in is not a fact about its recipient.
+//
+// An absent row reads as the registered default, which is English — the same
+// answer mailcopy falls back to, so an installation that has never chosen gets
+// what it got before this existed.
+func LanguageOf(ctx context.Context, tx pgx.Tx) (string, error) {
+	return settings.ApplyTx(ctx, tx, BaseLanguage)
 }

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -37,6 +37,7 @@ func buildCatalog() map[Language]Copy {
 	inviteLines(line)
 	weeklyLines(line)
 	morningLines(line)
+	confirmLines(line)
 
 	return map[Language]Copy{English: *en, German: *de, Vietnamese: *vi}
 }
@@ -250,4 +251,62 @@ func morningLines(line writeLine) {
 		"Open your day:",
 		"Öffne deinen Tag:",
 		"Mở ngày của bạn:")
+}
+
+// confirmLines is the two links the installation sends as itself.
+//
+// The English is the wording that shipped, unchanged: it is pinned by hash and
+// recorded on every consent proof, so moving a word here is a version bump, not
+// a translation.
+//
+// The German and Vietnamese use the formal address (Sie / quý vị), unlike the
+// reset and invite copy above. Those speak to a colleague who works here; these
+// speak to a stranger the installation holds a record about, and about their
+// own rights.
+func confirmLines(line writeLine) {
+	line(func(c *Copy) *string { return &c.ConfirmRecordSubject },
+		"Your details, and whether we may stay in touch",
+		"Ihre Daten, und ob wir in Kontakt bleiben dürfen",
+		"Thông tin của quý vị, và liệu chúng tôi có thể giữ liên lạc")
+	line(func(c *Copy) *string { return &c.ConfirmRecordBody },
+		"You can see what we have on file about you, correct anything that is wrong,\n"+
+			"and tell us whether you want to hear from us.",
+		"Sie können sehen, was wir über Sie gespeichert haben, Falsches korrigieren\n"+
+			"und uns sagen, ob Sie von uns hören möchten.",
+		"Quý vị có thể xem chúng tôi lưu giữ thông tin gì về mình, sửa những gì chưa đúng,\n"+
+			"và cho chúng tôi biết quý vị có muốn nhận tin từ chúng tôi hay không.")
+	line(func(c *Copy) *string { return &c.ConfirmConsentSubject },
+		"Please confirm you want to hear from us",
+		"Bitte bestätigen Sie, dass Sie von uns hören möchten",
+		"Vui lòng xác nhận quý vị muốn nhận tin từ chúng tôi")
+	line(func(c *Copy) *string { return &c.ConfirmConsentBody },
+		"You asked to hear from us. Confirming below is what turns that into a\n"+
+			"permission we will act on — until you do, we will not write to you about it.",
+		"Sie haben darum gebeten, von uns zu hören. Erst Ihre Bestätigung unten macht\n"+
+			"daraus eine Einwilligung, auf die wir uns stützen — bis dahin schreiben wir\n"+
+			"Ihnen dazu nicht.",
+		"Quý vị đã yêu cầu nhận tin từ chúng tôi. Việc xác nhận bên dưới mới biến điều đó\n"+
+			"thành sự đồng ý mà chúng tôi dựa vào — cho đến lúc đó, chúng tôi sẽ không\n"+
+			"viết cho quý vị về việc này.")
+	line(func(c *Copy) *string { return &c.ConfirmPersonal },
+		"This link is personal to you.",
+		"Dieser Link ist persönlich für Sie.",
+		"Liên kết này dành riêng cho quý vị.")
+	// The date arrives ISO-formatted, so each language frames it rather than
+	// inflecting it: German "bis zum" would want an ordinal with a period
+	// ("bis zum 9. März"), which no formatter in this tree produces.
+	line(func(c *Copy) *string { return &c.ConfirmExpiry },
+		" It works until %s.",
+		" Er gilt bis einschließlich %s.",
+		" Liên kết có hiệu lực đến hết ngày %s.")
+	line(func(c *Copy) *string { return &c.ConfirmRecordIgnore },
+		"You do not have to do anything. Ignoring this changes nothing.",
+		"Sie müssen nichts tun. Ignorieren ändert nichts.",
+		"Quý vị không cần làm gì cả. Bỏ qua thư này thì không có gì thay đổi.")
+	line(func(c *Copy) *string { return &c.ConfirmConsentIgnore },
+		"If you did not ask for this, ignore it. Nothing happens until you confirm.",
+		"Falls Sie darum nicht gebeten haben, ignorieren Sie diese E-Mail. Ohne Ihre\n"+
+			"Bestätigung passiert nichts.",
+		"Nếu quý vị không yêu cầu điều này, hãy bỏ qua. Không có gì xảy ra cho đến khi\n"+
+			"quý vị xác nhận.")
 }

--- a/backend/internal/platform/mailcopy/mailcopy.go
+++ b/backend/internal/platform/mailcopy/mailcopy.go
@@ -27,7 +27,11 @@
 // (backend/gates/mailcopy_test.go)
 package mailcopy
 
-import "strings"
+import (
+	"slices"
+	"strings"
+	"time"
+)
 
 // Language is a base language this installation can send in. The set is the
 // contract's `base_language` enum, and English is what an installation that
@@ -51,6 +55,47 @@ const (
 // build that adds a language to the contract and not to this catalog is caught
 // by the gate, not by a rep's mailbox.
 const Fallback = English
+
+// DateLayout is how a date is written in this installation's mail, in every
+// language.
+//
+// ISO, and that is deliberate: `2 January 2006` puts an English month name in
+// the middle of a German sentence — the half-translated message this catalog
+// exists to stop — and a numeric order like 06/01 is read as 6 January by half
+// the world. Go's layouts name months in English and nothing here translates
+// one, so a formatted date is the one part of a mail a catalog cannot fix.
+//
+// It lives beside the copy rather than beside each sender. The weekly, the
+// morning brief and the confirm link all write dates a recipient reads, and
+// three constants would be three chances to decide this differently.
+const DateLayout = time.DateOnly
+
+// Languages is every language this build carries copy for, in a stable order.
+//
+// DERIVED from the catalog rather than restated. The set is already written
+// three times — the constants above, the map catalog.go builds, and
+// textlang.Shipped — and a fourth hand-written list would be the one that goes
+// stale: a language added to the catalog but forgotten here would publish two
+// wordings where three are needed and pin two hashes where three are, with
+// nothing failing to say so.
+//
+// Sorted so a caller writing one row per language writes them the same way on
+// every boot. Map iteration is random, and a bootstrap that inserted three rows
+// in a different order each time would be harder to read in an audit log than
+// it needs to be.
+//
+// Held by: TestTheMailCatalogSpeaksEveryLanguageTheContractAdmits
+// (backend/gates/mailcopy_test.go), which fails when the contract admits a
+// language the catalog has no copy for — so a set this returns short is a set
+// that gate has already refused.
+func Languages() []Language {
+	out := make([]Language, 0, len(catalog))
+	for language := range catalog {
+		out = append(out, language)
+	}
+	slices.Sort(out)
+	return out
+}
 
 // For is the copy one installation's mail is written in.
 func For(language string) Copy {
@@ -133,6 +178,34 @@ type Copy struct {
 	WeeklyOutcomeWon   string
 	WeeklyOutcomeLost  string
 	WeeklyOutcomeMoved string
+
+	// The two links the installation sends as ITSELF rather than on a rep's
+	// behalf: the confirm-details link and the double-opt-in link.
+	//
+	// These are the hardest copy in the catalog to get wrong safely. Both go to
+	// somebody who did not ask for them and may not remember the company, so a
+	// bare "confirm your details" reads exactly like a phishing mail; and both
+	// are EVIDENCE — the consent proof records which version a person was
+	// shown, so what these say is what an installation will one day have to
+	// stand behind. A translation that softens "we will not write to you about
+	// it" into a pleasantry changes what was promised, not just how it reads.
+	ConfirmRecordSubject  string
+	ConfirmRecordBody     string
+	ConfirmConsentSubject string
+	ConfirmConsentBody    string
+	// ConfirmPersonal says the link is the reader's alone. ConfirmExpiry is
+	// APPENDED to it when the link has a date, with the date as %s.
+	//
+	// Two strings rather than one sentence with a substitution: the shipped
+	// English replaced a phrase inside its own body text, which only works
+	// while every language spells that sentence the same way.
+	ConfirmPersonal string
+	ConfirmExpiry   string
+	// The closing line, different for the two messages: a record confirmation
+	// asks nothing of its reader, while an unanswered opt-in withholds the
+	// permission until they answer.
+	ConfirmRecordIgnore  string
+	ConfirmConsentIgnore string
 
 	// The morning brief. Shorter than the weekly on purpose: it arrives every
 	// working day, so it names the top of the queue and links to the rest

--- a/backend/migrations/core/1788822910_a_published_wording_names_its_language.down.sql
+++ b/backend/migrations/core/1788822910_a_published_wording_names_its_language.down.sql
@@ -1,0 +1,39 @@
+-- Reverting drops the controller wordings the narrow index cannot hold.
+--
+-- By the time this runs, bootstrap has published each controller template in
+-- every language this build speaks — three rows sharing (key, version). The old
+-- index admits one, so recreating it without deleting the others fails with a
+-- duplicate-key error and the whole rollback aborts.
+--
+-- The non-English rows go, not the English one. That leaves an installation
+-- where it was before the migration: one wording per version, in the fallback
+-- language, which is what every proof row written before this could have
+-- pointed at anyway.
+--
+-- Scoped to the two CONTROLLER TEMPLATES rather than to every non-English
+-- wording. A preference-centre sentence published per language by some later
+-- writer is not this migration's to delete, and a rollback that swept one would
+-- take evidence it never added.
+--
+-- WHEN THIS STOPS WORKING, and it should: consent_event.consent_text_version_id
+-- references this table with the default ON DELETE RESTRICT, and nothing writes
+-- that column today. The day a writer lands, a proof row naming a German
+-- wording refuses this DELETE and the rollback aborts — correctly, because
+-- deleting the row a proof points at is the falsification this table exists to
+-- prevent. At that point the rollback is genuinely unsupported, and this file
+-- should say so rather than be made to pass.
+
+-- Bounded, so a transaction holding a conflicting lock stalls this migration
+-- rather than every write to the table behind it.
+SET LOCAL lock_timeout = '3s';
+
+DELETE FROM consent_text_version
+ WHERE key IN ('record_confirmation', 'consent_confirmation')
+   AND locale IS NOT NULL
+   AND locale <> 'en';
+
+DROP INDEX IF EXISTS consent_text_version_published;
+
+CREATE UNIQUE INDEX consent_text_version_published
+    ON consent_text_version (key, version)
+    WHERE published_at IS NOT NULL;

--- a/backend/migrations/core/1788822910_a_published_wording_names_its_language.up.sql
+++ b/backend/migrations/core/1788822910_a_published_wording_names_its_language.up.sql
@@ -1,0 +1,22 @@
+-- A published wording is unique per LANGUAGE, not per key and version alone.
+--
+-- The controller mail now speaks the installation's own language, so one
+-- template at one version has an English, a German and a Vietnamese text. The
+-- old index admitted exactly one of the three and the second publish collided,
+-- which would have failed the boot that published them.
+--
+-- locale already existed on this table, documented as "NULL means everywhere".
+-- That reading is unchanged: a wording narrowed to a language names it, and one
+-- that applies everywhere still names none. NULLS NOT DISTINCT is what keeps
+-- the everywhere-row unique against itself, which a plain unique index would
+-- not — under the default, two NULL locales are distinct and both would be
+-- admitted.
+-- Bounded, so a transaction holding a conflicting lock stalls this migration
+-- rather than every write to the table behind it.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS consent_text_version_published;
+
+CREATE UNIQUE INDEX consent_text_version_published
+    ON consent_text_version (key, version, locale) NULLS NOT DISTINCT
+    WHERE published_at IS NOT NULL;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1817,7 +1817,7 @@ BEGIN
 END;
 
 public.consent_text_version_pkey CREATE UNIQUE INDEX consent_text_version_pkey ON public.consent_text_version USING btree (id)
-public.consent_text_version_published CREATE UNIQUE INDEX consent_text_version_published ON public.consent_text_version USING btree (key, version) WHERE (published_at IS NOT NULL)
+public.consent_text_version_published CREATE UNIQUE INDEX consent_text_version_published ON public.consent_text_version USING btree (key, version, locale) NULLS NOT DISTINCT WHERE (published_at IS NOT NULL)
 public.contract acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.contract.archived_at timestamp with time zone gen=- def=-
 public.contract.auto_renew boolean NOT NULL gen=- def=false

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -118,7 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (127)
+## Census (128)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -186,6 +186,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by a pass the merge gate runs, analysed by one that lints, and read by both lint configs or neither. |
 | `machineryapplied_test.go` | H2 | Every setting read through settings.ApplyTx is declared MachineryApplied. |
 | `mailboxproofwriters_test.go` | H2 | A MailboxProof is set in exactly one place, and that place spends the token that earns it. |
+| `maillanguagereader_test.go` | H2 | One reader of the installation's base language. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `meetinghistorywriters_test.go` | H2 | Every statement that writes activity.meeting\_status also records the transition. |


### PR DESCRIPTION
The confirm-details link and the double-opt-in link were the last mail the product sent in hard-coded English, while `installation.base_language` offers `en`, `de` and `vi`. A German installation asked a stranger, **in English**, whether it might keep writing to them — and for the opt-in link that is the message where being understood is the point, because an unanswered one withholds the permission.

They now render from `internal/platform/mailcopy`, whose own doc comment says why it exists: *"three senders each inventing their own is how one product comes to have three voices."* These templates were a fourth.

## How the language gets there

A `MailLanguageReader` seam, mirroring the `InstallationCountryReader` already beside it — identity owns the setting, consent may not import a sibling, compose injects the edge. `BaseLanguage` becomes `MachineryApplied`, so identity's own reset-mail path reads it through the same `LanguageOf` instead of its own `SELECT`. One query, one answer to what an absent row means, **held by a new gate** (`maillanguagereader_test.go`, mutation-checked).

## Two things that had to change with it

**One sentence changed shape.** *"This link is personal to you and works until X"* substituted a phrase inside its own body text, which only works while every language spells that sentence the same way. It is now two strings with the expiry appended. Both templates are bumped to **version 2** — the wording a consent proof names cannot change quietly.

**The date is ISO.** Go's layouts name months in English, so a formatted date was the one part of a mail a catalog of translations could not fix (`gültig bis zum 9 March 2026`). The tree had already decided this twice — `weeklymail.go` and `briefmailrender.go` each held their own `mailDateLayout` with the same reasoning — so this is now one `mailcopy.DateLayout` all three read.

## Schema

`consent_text_version` gains its `locale`. The column already existed, documented as *"NULL means everywhere"*, so the migration only widens the published index, `NULLS NOT DISTINCT` so the everywhere-row stays unique against itself.

Bootstrap publishes **every** language rather than the one live at boot: the setting can change afterwards, and a wording nobody can resolve is not evidence. The down migration deletes the non-English controller rows before narrowing the index — verified by running both directions against a real database, because otherwise the rollback aborts on the three rows boot published. It also records when it will legitimately stop working: the day something writes `consent_event.consent_text_version_id`, a proof row naming a German wording will refuse that DELETE, correctly.

## Stated, not implied

Nothing yet writes `consent_event.consent_text_version_id`, so nothing records **which** of the three a given proof was rendered from. This change makes all three resolvable; picking one is a writer that does not exist. The code says so rather than implying the question is answered.

## Review found

Three reviewers, and between them: the English month inside a German sentence; a down migration that could not run; a completeness census I rewrote that already existed one directory over; a fourth copy of the language list; an unchecked format string that would put `%!s(MISSING)` in a consent mail (now gated); and two comments claiming a proof row names its text when nothing writes that column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the confirm-details and double-opt-in mails use the installation's base language instead of hard-coded English, so a German installation no longer asks a stranger in English whether it may keep writing to them.

- Controller templates now render from `platform/mailcopy` in the installation's language (en, de, vi).
- A `MailLanguageReader` seam injects the language, mirroring `InstallationCountryReader`.
- `BaseLanguage` is now `MachineryApplied`; identity's reset mail reads through the same `LanguageOf`.
- Both templates bumped to version 2; expiry date is appended as separate copy and uses ISO format.
- `consent_text_version` unique index now includes `locale` (`NULLS NOT DISTINCT`); bootstrap publishes all three languages per template.
- The down migration deletes non-English controller rows before narrowing the index; it will refuse once consent proofs reference them.
- Nothing yet writes `consent_event.consent_text_version_id`, so the code states which language a proof was rendered from remains unrecorded.

<sup>Written for commit 24dbc3f2e88f676b78bd599058f0c8fb5a82928f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Confirmation and consent emails are now available in English, German, and Vietnamese.
  - Confirmation messages use the installation’s configured base language, with English as a fallback.
  - Localized subjects, body text, links, expiry details, and ignore instructions are supported.
  - Multiple language versions of published consent templates can now coexist.

- **Improvements**
  - Email dates now use a consistent ISO date format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->