### PR TITLE
fix(erasure): a decided staging loses its token, not only its payload

### DIFF
--- a/backend/internal/compose/erasureapprovals_integration_test.go
+++ b/backend/internal/compose/erasureapprovals_integration_test.go
@@ -304,3 +304,41 @@ func TestAnAutomationRunIsReachedByAddressAndNothingElse(t *testing.T) {
 		t.Fail()
 	}
 }
+
+// The other half of withdrawing a decided staging: the AUTHORITY, not only the
+// payload.
+//
+// An agent-minted staging a human had approved but the agent had not yet
+// redeemed kept a live token. Redemption validates the untouched diff_hash
+// rather than the payload — ADR-0055 redemption is "repeat the identical call
+// with the approval token" and the agent still holds the original arguments —
+// so for the length of the redemption window after the certificate said the
+// subject's data was destroyed, that call could still run against them.
+func TestErasureSpendsTheTokenOnAnApprovedButUnredeemedStaging(t *testing.T) {
+	e := integration.Setup(t)
+	subject, approvalID := erasureSubject(t, e)
+
+	// Agent-minted, approved, and nobody has come back for it: the exact row
+	// the payload scrub left spendable.
+	passport := e.SeedPassport(t, integration.OwnerConn(t), "erasure redemption probe")
+	e.WsExec(t, `
+		UPDATE approval
+		   SET status = 'approved', decided_at = now(), passport_id = $2, consumed_at = NULL
+		 WHERE id = $1`, approvalID, passport)
+
+	if err := privacy.NewEraser(e.DB()).ErasePerson(e.Admin(), subject.UUID, "subject request"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The verdict survives: what a human approved is a fact about that human.
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE id = $1 AND status = 'approved'`,
+		approvalID); n != 1 {
+		t.Error("erasure rewrote a verdict a human had already given")
+	}
+	// The token does not.
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE id = $1 AND consumed_at IS NOT NULL`,
+		approvalID); n != 1 {
+		t.Fatal("the approval is still spendable: an agent holding the original arguments can redeem " +
+			"it and run the call against a subject the certificate says was erased")
+	}
+}

--- a/backend/internal/modules/privacy/erasure_approvals.go
+++ b/backend/internal/modules/privacy/erasure_approvals.go
@@ -239,10 +239,31 @@ func redactStagedApprovals(ctx context.Context, tx pgx.Tx, subject ids.PersonID,
 		return fmt.Errorf("ending the agent runs waiting on the withdrawn approvals: %w", err)
 	}
 
-	// Then the ones somebody already decided: payload gone, verdict intact.
+	// Then the ones somebody already decided: payload gone, verdict intact —
+	// and the redemption authority SPENT.
+	//
+	// Emptying the payload was only half the withdrawal. An agent-minted
+	// staging a human had approved but the agent had not yet redeemed kept a
+	// live token, and redemption validates the untouched diff_hash rather than
+	// the payload — ADR-0055 redemption is "repeat the identical call with the
+	// approval token", and the agent still holds the original arguments. So for
+	// the length of the redemption window after the certificate said the
+	// subject's data was destroyed, that call could still run against them.
+	//
+	// The verdict stays: what a human approved is a fact about that human, and
+	// this does not touch it. What changes is that the token cannot be spent —
+	// consumed_at IS NULL is the guard RedeemInTx takes, and it is the same
+	// terminal marker a real redemption sets, so nothing downstream learns a
+	// new state. coalesce keeps a genuine redemption's own instant.
+	//
+	// The lapse sweep then passes this row over, which is correct rather than a
+	// side effect: it exists to tell an approver that nobody came back for
+	// their decision, and here nobody will — because the subject was erased,
+	// not because an agent neglected it.
 	if _, err := tx.Exec(ctx, `
 		UPDATE approval
-		   SET `+blankStagedProposal+`
+		   SET `+blankStagedProposal+`,
+		       consumed_at = coalesce(consumed_at, now())
 		 WHERE status <> 'pending' AND (`+subjectApprovalMatch+`)`,
 		subject.UUID, leadIDs, addresses); err != nil {
 		return fmt.Errorf("emptying the decided approvals naming the subject: %w", err)


### PR DESCRIPTION
Closes #1335.

## The gap

`redactStagedApprovals` withdraws **pending** stagings and empties **decided** ones. An agent-minted staging a human had already approved but the agent had not yet redeemed falls in the second bucket: its payload was emptied, its verdict kept — and its approval token was left live.

`RedeemInTx` validates the untouched `diff_hash`, not the payload. Redemption *is* repeating the identical call with the token, and the agent still holds the original arguments. So for the length of the redemption window after the certificate said the subject's data was destroyed, that call could still run against them.

It is the same class the pending arm already closes: a card whose payload was destroyed but whose **authority** was not.

## The fix

The decided arm now spends the authority in the same statement that empties the payload:

```sql
UPDATE approval
   SET <blank the proposal>,
       consumed_at = coalesce(consumed_at, now())
 WHERE status <> 'pending' AND (<subject match>)
```

- **The verdict is untouched.** What a human approved is a fact about that human, and the ticket is explicit that it stays.
- **`consumed_at` rather than a new marker**, because it is the exact column `RedeemInTx` guards on (`consumed_at IS NULL`) and the same one a real redemption sets — so nothing downstream learns a state it has never seen. A spent token answers `ErrApprovalTokenInvalid`, which is what an invalid token has always answered.
- **`coalesce`** keeps a genuine redemption's own instant rather than overwriting when it happened.

Applied to every decided row this scrub matches, not only the agent-minted ones. A server-proposed staging would run its effect from the emptied payload and write nothing, so consuming it costs nothing — and narrowing the statement to `passport_id IS NOT NULL` would leave the shape to be got wrong again by the next thing that mints a token.

## The one behaviour that changes elsewhere, and why it is right

`MarkLapsedRedemptions` skips rows with `consumed_at IS NOT NULL`, so an erasure-consumed staging is no longer annotated "nobody came back for your decision". That sentence would be false here: nobody will come back, and the reason is the erasure rather than an agent's neglect. Stated in the code beside the change.

## Test

`TestErasureSpendsTheTokenOnAnApprovedButUnredeemedStaging` seeds the exact row the scrub used to leave spendable — agent-minted against a real passport, approved, unconsumed — runs `ErasePerson`, and asserts both halves: the verdict survives and the token does not.

Mutation-checked: dropping the `consumed_at` assignment fails it 3/3.

## Checks

`make check-backend` green; the `compose` integration lane green.