### PR TITLE
test(compose): a declared messaging pack is one the boot registers

### DIFF
--- a/backend/gates/messagingpackreach_test.go
+++ b/backend/gates/messagingpackreach_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind reachability H2
+
+package gates
+
+// Every messaging rule set a shipped unit declares is one the boot registers.
+//
+// The capability census beside this holds that SOME live unit declares
+// Messaging. RegisterExtensions' own tests hold that a declared set reaches the
+// registry. Neither can see the case between them: an apply loop that registers
+// most units and skips one. A synthetic unit in a unit test still lands, so
+// both stay green while the shipped German or Vietnamese pack silently does
+// not.
+//
+// The consequence is not a milder default. consent/authorizecap.go resolves an
+// unknown country to NO rules, and no rules means no ceiling — so a Vietnamese
+// pack that never registers removes the advertising frequency cap and the
+// subject prefix outright, on an installation whose unit list still names the
+// unit that declared them.
+//
+// So this reads the apply loop itself: it must register every rule set it
+// iterates, with nothing between the range and the call. A filter there is the
+// defect, and it is invisible to any test that supplies its own unit.
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+)
+
+const (
+	// applyFile holds the boot's extension reconciliation.
+	applyFile = "internal/compose/extensions.go"
+	// applyFunc is the reconciliation itself.
+	applyFunc = "RegisterExtensions"
+	// messagingField is the capability whose apply loop this reads.
+	messagingField = "Messaging"
+	// messagingRegister is the call that must be reached for every element.
+	messagingRegister = "Register"
+)
+
+func TestEveryDeclaredMessagingRuleSetIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	body := functionBodyIn(t, fset, applyFile, applyFunc)
+
+	loops := messagingApplyLoops(body)
+	if len(loops) == 0 {
+		t.Fatalf("%s ranges over no %s field — the apply this gate reads has moved, and a gate "+
+			"that found nothing to judge reports the boot clean", applyFunc, messagingField)
+	}
+	for _, loop := range loops {
+		if registersUnconditionally(loop) {
+			continue
+		}
+		t.Errorf("%s's %s loop does not register every rule set it iterates. A unit whose pack is "+
+			"skipped here still appears in the composed set, and the engine resolves its country "+
+			"to no rules at all — which is no ceiling rather than a cautious one",
+			applyFunc, messagingField)
+	}
+}
+
+// messagingApplyLoops finds the range statements over a unit's Messaging field.
+func messagingApplyLoops(body *ast.BlockStmt) []*ast.RangeStmt {
+	var out []*ast.RangeStmt
+	ast.Inspect(body, func(n ast.Node) bool {
+		loop, isRange := n.(*ast.RangeStmt)
+		if !isRange {
+			return true
+		}
+		if sel, isSel := loop.X.(*ast.SelectorExpr); isSel && sel.Sel.Name == messagingField {
+			out = append(out, loop)
+		}
+		return true
+	})
+	return out
+}
+
+// registersUnconditionally reports whether the loop body is the register call
+// and nothing else.
+//
+// Asked as "one statement, and it is the call" rather than by looking for a
+// filter. A deny-list of skip shapes would have to name `continue`, an `if`
+// around the call, an early `return`, a `break`, and whatever the next author
+// writes; the shape that is CORRECT is a single expression statement, and
+// everything else is worth a human reading.
+func registersUnconditionally(loop *ast.RangeStmt) bool {
+	if len(loop.Body.List) != 1 {
+		return false
+	}
+	stmt, isExpr := loop.Body.List[0].(*ast.ExprStmt)
+	if !isExpr {
+		return false
+	}
+	call, isCall := stmt.X.(*ast.CallExpr)
+	if !isCall {
+		return false
+	}
+	sel, isSel := call.Fun.(*ast.SelectorExpr)
+	return isSel && sel.Sel.Name == messagingRegister
+}
+
+// functionBodyIn returns one named function's body from one file.
+func functionBodyIn(t *testing.T, fset *token.FileSet, path, name string) *ast.BlockStmt {
+	t.Helper()
+	for _, file := range parseTreeUnder(t, fset, path) {
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if isFunc && fn.Name.Name == name && fn.Body != nil {
+				return fn.Body
+			}
+		}
+	}
+	t.Fatalf("%s declares no %s: the subject this gate reads has moved", path, name)
+	return nil
+}

--- a/backend/internal/compose/extensions_test.go
+++ b/backend/internal/compose/extensions_test.go
@@ -6,8 +6,10 @@ package compose
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
@@ -69,6 +71,86 @@ func TestRegisterExtensionsAppliesDeclaredCapabilities(t *testing.T) {
 	}
 	if _, ok := jurisdiction.For("zx"); !ok {
 		t.Fatal("the declared pack did not reach the jurisdiction registry")
+	}
+}
+
+// TestRegisterExtensionsAppliesDeclaredMessagingRules is the messaging half of
+// the test above, and it was missing.
+//
+// The capability census holds that some live unit DECLARES Messaging. Nothing
+// held that a declared rule set reaches the registry the authorization engine
+// asks. Those are different failures and only the second one is silent: with
+// the wiring gone the unit is still reported as composed while its policy is
+// absent, and every consent test goes on passing because each registers rules
+// of its own.
+//
+// This holds the MECHANISM on a synthetic unit. That the SHIPPED packs reach it
+// is a different question and a different corpus, held by
+// TestEveryDeclaredMessagingRuleSetIsRegistered (backend/gates/messagingpackreach_test.go)
+// — a test supplying its own unit cannot see an apply loop that skips somebody
+// else's.
+//
+// The code is used ONCE in this process, like every other code in this file.
+// messagingrules has no deregister, and preflight refuses a code the registry
+// already holds — so a second run inside one binary meets its own leftover.
+// That is why this fails under -count=2, exactly as its jurisdiction sibling
+// above does, and why a new case here takes a new code rather than reusing one.
+func TestRegisterExtensionsAppliesDeclaredMessagingRules(t *testing.T) {
+	const replyWindow = 9 * 24 * time.Hour
+	err := RegisterExtensions(composableAll([]extension.Extension{{
+		Name:    "msg-ok",
+		Version: "0.0.1",
+		Messaging: []messagingrules.Rules{{
+			Jurisdiction: "zw",
+			Version:      1,
+			ReplyWindow:  replyWindow,
+		}},
+	}}), nil, nil)
+	if err != nil {
+		t.Fatalf("RegisterExtensions: %v", err)
+	}
+	landed, ok := messagingrules.For("zw")
+	if !ok {
+		t.Fatal("the declared rule set did not reach the messaging registry — the unit is still " +
+			"reported as composed in, while the engine resolves its country to no rules at all")
+	}
+	// The CONTENT, not merely a row under that code. A registry entry carrying
+	// somebody else's windows answers the engine as confidently as the right
+	// one, and asking only whether the code is present cannot tell them apart.
+	if landed.ReplyWindow != replyWindow {
+		t.Errorf("the registered reply window is %v, want the declared %v", landed.ReplyWindow, replyWindow)
+	}
+}
+
+// TestNoMessagingRulesApplyWhenTheSetIsInvalid is the other half: a rejected
+// composition must leave the registry untouched.
+//
+// The registry is process-wide and has no deregister, so a rule set applied by
+// a boot that then aborted would still be answering for that jurisdiction in
+// whatever came next.
+//
+// The set is refused by an UNDECLARED JOB, which is deliberate.
+// buildExtensionJobs is the last of the five fallible steps that run before
+// anything applies, so a refusal there holds the whole validate-then-apply
+// window. A refusal from the first step would say nothing about the other four:
+// TestRegisterExtensionsRejectsAnInvalidUnitName beside it asserts the error and
+// nothing about the registry, which is the shape this must not take.
+func TestNoMessagingRulesApplyWhenTheSetIsInvalid(t *testing.T) {
+	err := RegisterExtensions(composableAll([]extension.Extension{{
+		Name:      "undeclared-job-msg",
+		Version:   "0.0.1",
+		Messaging: []messagingrules.Rules{{Jurisdiction: "zp", Version: 1}},
+		Jobs:      []extension.Job{{Name: "refresh", Handle: noopTick}},
+	}}), nil, nil)
+	// The MESSAGE, not merely an error. Asked as "did it fail", this would pass
+	// on a refusal from any of the five steps — including one that fired before
+	// the loop this is about, which would make the assertion below true for a
+	// reason that says nothing about the window.
+	if err == nil || !strings.Contains(err.Error(), "no kind in its api/jobs.yaml fragment declares it") {
+		t.Fatalf("err = %v, want the undeclared-job rejection from buildExtensionJobs", err)
+	}
+	if _, ok := messagingrules.For("zp"); ok {
+		t.Fatal("the unit's rules landed although the composed set failed validation")
 	}
 }
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -251,7 +251,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistdestination_test.go` | H2 | Every source the worklist can emit has one screen it belongs on. |
 | `worklistreasonkinds_test.go` | H2 | Every reason a row gives is one the contract declares and a client can render. |
 
-## Reachability (17)
+## Reachability (18)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -261,6 +261,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `consentproof_test.go` | H2 | The Art. 7(1) demonstrability invariant as a fitness function: every write that sets a person\_consent STATE appends a consent\_event proof row in the same function (data-model §3.4 — the current state is always backed by an append-only event saying when, how, and by whom). |
 | `dedupespine_test.go` | H2 | The identity-spine fitness functions. |
 | `liveprobelock_test.go` | H2 | A live-probed write of a HELD row locks its subject. |
+| `messagingpackreach_test.go` | H2 | Every messaging rule set a shipped unit declares is one the boot registers. |
 | `moduleaudits_test.go` | H2 | A module that owns tables writes their history. |
 | `orgrenamerecheck_test.go` | H2 | A company's NAME is the axis on which two records of one company converge, so every rename has to ask whether it just created a duplicate. |
 | `personscrub_test.go` | H2 | Erasing a person and anonymizing one are the same act with one difference: the erased subject goes on a suppression list, and the anonymized subject may lawfully return. |


### PR DESCRIPTION
`RegisterExtensions` applies each unit's declared `Messaging` rule sets into the process-wide registry the outbound authorization engine reads for jurisdiction windows and frequency caps. **Nothing held that wiring.** Inserting `if r.Jurisdiction == "de" { continue }` into the apply loop left the whole merge gate green.

The consequence is not a milder default. `consent/authorizecap.go` resolves an unknown country to **no rules, and no rules means no ceiling** — so a Vietnamese pack that never registers removes the advertising frequency cap and the `[QC]` subject prefix outright, on an installation whose unit list still names the unit that declared them.

## Two tests for the mechanism

Mirroring the jurisdiction pair already in the file: a declared set reaches the registry **with the windows it declared** (a row carrying somebody else's rules answers the engine just as confidently), and a rejected composition leaves the registry untouched.

The second is refused by an **undeclared job** rather than an invalid unit name. Five fallible steps run before anything applies and `buildExtensionJobs` is the last of them, so refusing there holds the whole validate-then-apply window; a refusal from the first says nothing about the other four. It pins the error message, so it proves *which* step refused.

## One gate for the shipped packs

Both tests supply their own unit — so a synthetic rule set lands while somebody else's is skipped, and **the original defect still passed them.** Codex caught that. `gates/messagingpackreach_test.go` reads the apply loop itself and requires it to register every set it iterates. Mutation-checked against three skip shapes including the original.

The capability census already covered `Messaging` (it derives capability names from `extension.Extension`'s fields, so a grep for the name finds nothing — which is the design working), but only that some live unit *declares* it, never that a declared set arrives anywhere.

## Review found

A false claim in my own comment — I wrote that a mutation "passed" when it fails; the observation was true of an earlier version of the test and I carried it forward. Also: the test accepting any error rather than the one it names, an overstated claim that the manifest reports the pack (it carries no jurisdiction or messaging data), and the gap above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing coverage that let `RegisterExtensions` skip registering a unit's declared messaging rule sets without any test failing, which would leave the authorization engine with no rules (and therefore no frequency cap) for that jurisdiction.

- Adds two compose tests: a declared set lands in the registry with its declared reply window, and a rejected composition leaves the registry untouched.
- Adds a reachability gate that reads the `RegisterExtensions` apply loop and requires every iterated messaging set to be registered unconditionally.
- The rejection test now pins the undeclared-job error from `buildExtensionJobs`, proving which step refused.

<sup>Written for commit 0c79d570df5e1d97ad579d430bc65ce42fe36d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that declared messaging rule sets are registered with the correct reply window.
  * Added validation that undeclared jobs do not alter the messaging registry.
  * Added reachability checks to ensure all declared messaging rule sets are registered during startup.

* **Documentation**
  * Updated the gate inventory to include the new messaging registration reachability check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->