### PR TITLE
fix(httperr): a value too large to index is the caller's to shorten

### DIFF
--- a/backend/internal/compose/integration/activity_bodysize_integration_test.go
+++ b/backend/internal/compose/integration/activity_bodysize_integration_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A body the HTTP chassis accepts and the search index cannot hold.
+//
+// `activity.search_tsv` is GENERATED from the subject and body, and
+// to_tsvector's output has a hard 1,048,575-byte ceiling. Output runs about
+// 1.10x input for word-dense text, so a body around 950 KB overflows it — well
+// inside the chassis's 1 MiB request cap. The write raised 54000, which the
+// classification net did not know, so a legal-sized request answered an opaque
+// 500 whose advice was to retry a call that fails the same way forever.
+//
+// Asked of the REAL database rather than a fabricated PgError, because the
+// mapping is only worth having if Postgres actually raises that SQLSTATE here:
+// a unit test over a hand-built error proves the net and nothing about the
+// column.
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestABodyTooLargeToIndexIsRefusedRatherThanAnsweredAsAServerFault(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+
+	subject, body := "A very long note", wordDense(1_000_000)
+	_, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "note", Subject: &subject, Body: &body,
+	})
+	if err == nil {
+		t.Fatal("a body past the index ceiling was accepted; either the column changed or this " +
+			"fixture no longer reaches the limit it is about")
+	}
+
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("the refusal reached the unhandled path, which answers 500 internal: %v", err)
+	}
+	if fault.Status != 422 {
+		t.Errorf("status = %d, want 422 — the request was legal and the value is the caller's to "+
+			"shorten, so retrying is advice that can never work", fault.Status)
+	}
+	if fault.Code != "value_too_large" {
+		t.Errorf("code = %q, want %q", fault.Code, "value_too_large")
+	}
+	// The database's own words carry the byte counts and the internal type
+	// name; the caller gets the sentence, the operator gets the cause.
+	for _, leak := range []string{"tsvector", "54000", "1048575"} {
+		if strings.Contains(fault.Detail, leak) {
+			t.Errorf("the refusal leaks %q: %q", leak, fault.Detail)
+		}
+	}
+	if fault.InfraCause == nil {
+		t.Error("the cause reaches no log — withholding a message is not the same as losing it")
+	}
+}
+
+// wordDense builds text whose tsvector output EXCEEDS its input: distinct
+// words, each indexed, with no repetition for the dictionary to fold away. A
+// megabyte of one repeated word would compress to a single lexeme and prove
+// nothing.
+func wordDense(bytes int) string {
+	var b strings.Builder
+	b.Grow(bytes + 16)
+	for i := 0; b.Len() < bytes; i++ {
+		b.WriteString("w")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(" ")
+	}
+	return b.String()
+}

--- a/backend/internal/platform/database/storekit/sqlstate.go
+++ b/backend/internal/platform/database/storekit/sqlstate.go
@@ -18,6 +18,7 @@ const (
 	pgExclusionViolation  = "23P01"
 	pgQueryCanceled       = "57014"
 	pgLockNotAvailable    = "55P03"
+	pgProgramLimitExceed  = "54000"
 )
 
 // pgViolation names the violated constraint when err is the given
@@ -113,4 +114,23 @@ func CheckViolation(err error) (constraint string, ok bool) {
 func IsQueryCanceled(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == pgQueryCanceled
+}
+
+// IsProgramLimitExceeded detects a 54000: a value the database accepted as
+// input but cannot store or index at that size.
+//
+// The case that earned it is `activity.search_tsv`, a GENERATED column whose
+// to_tsvector output has a hard 1,048,575-byte ceiling. Output runs about
+// 1.10x input for word-dense text, so a body around 950 KB overflows it —
+// comfortably inside the HTTP chassis's 1 MiB request cap, which means a
+// legal-sized request produced an unexplained server fault.
+//
+// It is a CLASS rather than that one limit, and it is named that way on
+// purpose: 54000 also covers a row too wide for an index and a statement with
+// too many arguments. What every member has in common is the only thing a
+// caller can act on — the value they sent is too large — and none of them is a
+// server fault to retry.
+func IsProgramLimitExceeded(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgProgramLimitExceed
 }

--- a/backend/internal/platform/httperr/constraintfault.go
+++ b/backend/internal/platform/httperr/constraintfault.go
@@ -23,8 +23,8 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 )
 
-// constraintFault answers a foreign-key or CHECK violation that reached the
-// transport untranslated.
+// constraintFault answers a foreign-key, CHECK or size violation that reached
+// the transport untranslated.
 //
 // It exists because the alternative is a 500 telling the caller to retry, and a
 // constraint breach is deterministic: the same call fails the same way forever.
@@ -49,6 +49,14 @@ func constraintFault(err error) (Fault, bool) {
 		return Fault{
 			Status: http.StatusUnprocessableEntity, Code: "reference_not_found",
 			Detail:     referenceNotFoundDetail(err),
+			InfraCause: err,
+		}, true
+	case storekit.IsProgramLimitExceeded(err):
+		return Fault{
+			Status: http.StatusUnprocessableEntity, Code: "value_too_large",
+			Detail: "a value in this request is too large for the database to store or index. " +
+				"Shorten it — most often this is a long text body — and send it again; " +
+				"the same request will fail the same way.",
 			InfraCause: err,
 		}, true
 	case isConstrainedValue(err):

--- a/backend/internal/platform/httperr/httperr_test.go
+++ b/backend/internal/platform/httperr/httperr_test.go
@@ -247,6 +247,20 @@ func TestClassify_anUntranslatedConstraintIsTheCallersMistakeNotAServerFault(t *
 			wantDetail: "a value in this request is outside what its field accepts. Check each value against " +
 				"this operation's schema; do not retry unchanged.",
 		},
+		{
+			// A GENERATED tsvector column overflows its 1,048,575-byte output
+			// ceiling at roughly 950 KB of word-dense body — comfortably inside
+			// the chassis's 1 MiB request cap, so the request was legal and the
+			// answer was an unexplained 500. It carries no constraint name at
+			// all, which is why the net has to branch on the SQLSTATE.
+			name:     "a value too large to store or index",
+			sqlstate: "54000", table: "activity", constraint: "",
+			pgMessage: "string is too long for tsvector (1099556 bytes, max 1048575 bytes)",
+			wantCode:  "value_too_large",
+			wantDetail: "a value in this request is too large for the database to store or index. " +
+				"Shorten it — most often this is a long text body — and send it again; " +
+				"the same request will fail the same way.",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := fmt.Errorf("writing the row: %w", &pgconn.PgError{
@@ -276,7 +290,7 @@ func TestClassify_anUntranslatedConstraintIsTheCallersMistakeNotAServerFault(t *
 			// assertion above is the stronger guard anyway — it pins the whole
 			// sentence, so anything riding along fails there first.
 			for _, leak := range []string{tc.constraint, tc.sqlstate, tc.pgMessage} {
-				if strings.Contains(fault.Detail, leak) {
+				if leak != "" && strings.Contains(fault.Detail, leak) {
 					t.Errorf("detail leaks %q: %q", leak, fault.Detail)
 				}
 			}


### PR DESCRIPTION
Closes #1260.

## The defect

`activity.search_tsv` is a GENERATED column over the subject and body, and `to_tsvector`'s output has a hard 1,048,575-byte ceiling. Output runs about 1.10x input for word-dense text, so a body around 950 KB overflows it — **well inside the chassis's 1 MiB request cap**. So a legal-sized request produced `54000`, which `storekit`'s classification net did not know, and the caller got an opaque `500 {"code":"internal"}` whose advice is to retry a call that fails the same way forever.

Every activity kind with a free-text body reaches it with nothing exotic: a long note, a large email, a pasted transcript. The transcript path added a 256 KiB cap of its own specifically to stay clear of the ceiling; no other writer of `activity.body` has one — which is why the ticket asks for the net rather than a per-kind bound, and why that is what this is.

## The mapping

`storekit.IsProgramLimitExceeded` and a 422 `value_too_large` from `constraintFault`, beside the foreign-key and CHECK arms that already exist for the same reason.

Mapped as a **class**, not as that one limit, and named that way on purpose: 54000 also covers a row too wide for an index and a statement with too many arguments. What every member has in common is the only thing a caller can act on — the value they sent is too large — and none of them is a server fault to retry. The detail says that and nothing about the schema; the SQLSTATE and Postgres's own byte counts go to the operator through `InfraCause`, as every other arm does.

422 rather than 413: the request was legal, and 413 would tell a caller the wrong thing to measure.

## Tests

- The unit table in `httperr_test.go` gains the case, with the same exact-sentence and no-leak assertions its neighbours carry. Its leak sweep now skips an empty constraint name — 54000 carries none, and `strings.Contains(x, "")` is true for everything.
- **And the real database**, because a unit test over a hand-built `PgError` proves the net and nothing about the column: `TestABodyTooLargeToIndexIsRefusedRatherThanAnsweredAsAServerFault` writes a megabyte of word-dense text through the activities store and reads the 422 back. Word-dense on purpose — a megabyte of one repeated word folds to a single lexeme and would prove nothing.

Mutation-checked: disabling the arm fails the integration case 3/3.

## What this does not fix

The ticket also notes the CPU cost — a full tsvector build runs and is discarded on every attempt, which an attacker can loop. A typed refusal does not stop that; bounding the body before the write would, and that is a different change with its own decision about where the bound goes (the transcript path's 256 KiB is one answer, and it is not obviously the right one for a pasted email). The 500 was the part the ticket scoped, and it is the part that costs an honest caller.

## Checks

`make check-backend` green; the `compose/integration` lane green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Oversized values that exceed database processing limits are now reported as a clear `422 value_too_large` error instead of an opaque server error.
  - Error messages provide guidance to shorten the submitted value.
  - Internal database details remain hidden from end-users while remaining available for infrastructure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->