### PR TITLE
test(launcher): the module's coverage becomes a real number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,26 @@ jobs:
           # rather than waiting for somebody to remember to delete this line.
           MIGRATION_VERSIONS_BASELINE_RESET: "1"
         run: make check-backend
+      # The launcher's own coverage profile, from the lane `make check-backend`
+      # just ran. It is a SECOND run of that module's suite — under a second
+      # and about a hundred tests — rather than a flag on the gate itself,
+      # because the gate must fail on the test result and not on whether a
+      # profile could be written.
+      #
+      # The product profile cannot contain a launcher line: that one is
+      # `go test -coverpkg=./...` over the backend module, and this module sits
+      # outside go.work on purpose. So without this the figure for shipped code
+      # a user runs is 0% however thoroughly it is tested, which is why it was
+      # excluded from the measurement rather than measured.
+      - name: Launcher coverage
+        working-directory: .
+        run: make test-desktop-launcher LAUNCHER_COVER_OUT=desktop/launcher/coverage.out
+      - name: Upload launcher coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage-launcher
+          path: desktop/launcher/coverage.out
+          if-no-files-found: ignore
 
   # The composed-build lane (ADR-0120): materialize the walking-skeleton
   # reference extension into extensions/, compose, and run the backend
@@ -815,7 +835,7 @@ jobs:
       # skipped area uploaded nothing); if-no-files-found tolerates the gap so
       # the scan still posts. The paths match sonar-project.properties
       # (backend/coverage.out, backend/coverage-extensions.out,
-      # frontend/coverage/lcov.info).
+      # desktop/launcher/coverage.out, frontend/coverage/lcov.info).
       - name: Download Go coverage
         if: ${{ env.SONAR_TOKEN != '' && needs.integration.result == 'success' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -828,6 +848,12 @@ jobs:
         with:
           name: go-coverage-extensions
           path: backend
+      - name: Download launcher coverage
+        if: ${{ env.SONAR_TOKEN != '' && needs.deterministic-gates.result == 'success' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: go-coverage-launcher
+          path: desktop/launcher
       - name: Download FE coverage
         if: ${{ env.SONAR_TOKEN != '' && needs.frontend.result == 'success' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/Makefile
+++ b/Makefile
@@ -759,8 +759,14 @@ craft-test:
 ##
 ## GOWORK=off for the reason its go.mod states: inside a workspace that does not
 ## list the module, every package fails to resolve.
+##
+## LAUNCHER_COVER_OUT (optional): also write a coverage profile there. It exists
+## because the product profile CANNOT contain a launcher line — that one is
+## `go test -coverpkg=./...` over the backend module, and this module is not in
+## it — so the number reported for shipped code a user runs was 0% whatever the
+## suite did. A profile of its own is what makes the figure real.
 test-desktop-launcher:
-	GOWORK=off go test -C desktop/launcher -count=1 ./...
+	GOWORK=off go test -C desktop/launcher -count=1 	  $(if $(LAUNCHER_COVER_OUT),-covermode=atomic -coverprofile=$(abspath $(LAUNCHER_COVER_OUT))) ./...
 
 ## craft-residue — fail if any unresolved CRAFT-FIX/CRAFT-DISPUTE marker was
 ## left in the backend tree (the review-loop residue check, ADR-0045). The CI

--- a/desktop/launcher/mainhelpers_test.go
+++ b/desktop/launcher/mainhelpers_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The decisions a start makes before it spawns anything.
+//
+// Each is a pure function over a file or a string, and each answers a question
+// a user's data depends on — which port to listen on, and whether a cluster
+// that already exists is left alone. They ran nowhere: this module is outside
+// go.work, so `./...` inside backend cannot reach them, and until the module
+// got a lane of its own the tests it did carry ran nowhere either.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The port a user chose, and the refusal for one the OS would reject.
+//
+// A bad value has to fail HERE, naming the file and the key, or it surfaces
+// later as a listen error about a number the user cannot connect to what they
+// typed.
+func TestResolvePortReadsTheSettingOrRefusesItByName(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		env     []string
+		want    int
+		wantErr string
+	}{
+		{name: "no setting at all falls back to the default", want: defaultPort},
+		{name: "an empty value is not a setting", env: []string{"MARGINCE_PORT="}, want: defaultPort},
+		{name: "another key is left alone", env: []string{"MARGINCE_OTHER=9"}, want: defaultPort},
+		{name: "a number is taken", env: []string{"MARGINCE_PORT=9123"}, want: 9123},
+		{name: "the first setting wins", env: []string{"MARGINCE_PORT=9123", "MARGINCE_PORT=9124"}, want: 9123},
+		{name: "the lowest port a listener can take", env: []string{"MARGINCE_PORT=1"}, want: 1},
+		{name: "the highest", env: []string{"MARGINCE_PORT=65535"}, want: 65535},
+		{name: "zero is not a port", env: []string{"MARGINCE_PORT=0"}, wantErr: `"0"`},
+		{name: "one past the top", env: []string{"MARGINCE_PORT=65536"}, wantErr: `"65536"`},
+		{name: "a negative number", env: []string{"MARGINCE_PORT=-1"}, wantErr: `"-1"`},
+		{name: "words are not numbers", env: []string{"MARGINCE_PORT=eighty"}, wantErr: `"eighty"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			port, err := resolvePort(tc.env)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("resolvePort(%v) = %d, want a refusal", tc.env, port)
+				}
+				// The value the user typed, quoted back: a refusal that does not
+				// name it leaves them looking for a setting they cannot find.
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("the refusal reads %q, want it to quote %s", err, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), "margince.env") {
+					t.Errorf("the refusal reads %q, want it to name the file to edit", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolvePort(%v): %v", tc.env, err)
+			}
+			if port != tc.want {
+				t.Errorf("resolvePort(%v) = %d, want %d", tc.env, port, tc.want)
+			}
+		})
+	}
+}
+
+// Whether a cluster already exists, which decides whether one is CREATED.
+//
+// The wrong answer in one direction re-runs initdb over somebody's database.
+// PG_VERSION is the marker because initCluster renames a finished staging
+// directory into place, so the file exists only for a cluster initdb completed.
+func TestNeedsInitdbAnswersFromTheClusterMarker(t *testing.T) {
+	l := newTestLayout(t)
+
+	needs, err := needsInitdb(l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !needs {
+		t.Fatal("an installation with no data directory was read as already holding a cluster")
+	}
+
+	if err := os.MkdirAll(l.pgData(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A directory alone is not a cluster: an interrupted creation leaves one,
+	// and reading it as finished is how a half-built database gets started.
+	if needs, err = needsInitdb(l); err != nil || !needs {
+		t.Fatalf("an empty data directory: needs=%t err=%v, want true", needs, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(l.pgData(), "PG_VERSION"), []byte("16\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if needs, err = needsInitdb(l); err != nil || needs {
+		t.Fatalf("a finished cluster: needs=%t err=%v, want false — initdb would run over the "+
+			"user's own database", needs, err)
+	}
+}
+
+// A first run writes the settings template; no later run touches it.
+//
+// It carries secrets and the user's own choices, and an update that rewrote it
+// would take both away — which is exactly what the template's own first lines
+// promise it will not do.
+func TestTheSettingsTemplateNeverReplacesAUsersOwnChoices(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "margince.env")
+
+	if err := ensureEnvFile(path); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) == 0 {
+		t.Fatal("the settings file was created empty, so it documents nothing a user could turn on")
+	}
+	// Readable only by its owner: it is the file the template tells a user to
+	// put a licence token and a mail credential into.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("the settings file is mode %04o, want 0600 — it holds secrets", perm)
+	}
+
+	edited := "MARGINCE_PORT=9123\n"
+	if err := os.WriteFile(path, []byte(edited), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureEnvFile(path); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	again, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(again) != edited {
+		t.Error("a later start rewrote the settings file, taking the user's own choices with it")
+	}
+}
+
+// A socket path the system cannot take is refused BEFORE the database is
+// started, with the move that fixes it.
+//
+// The limit is the kernel's, and the failure it produces if the launcher does
+// not check is a bind error naming a byte count — a sentence that tells a user
+// nothing about the folder they chose.
+func TestADeeplyNestedInstallationIsRefusedWithSomethingToDo(t *testing.T) {
+	shallow := layout{root: shortTempDir(t)}
+	dir, err := resolveSocketDir(shallow)
+	if err != nil {
+		t.Fatalf("an ordinary installation was refused: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("the socket directory was not created: %v", err)
+	}
+
+	deep := layout{root: filepath.Join(shallow.root, strings.Repeat("a-long-folder-name/", 12))}
+	_, err = resolveSocketDir(deep)
+	if err == nil {
+		t.Fatal("a socket path past the system limit was accepted; the failure moves to a bind " +
+			"error about a byte count, which names nothing the user chose")
+	}
+	for _, want := range []string{"too deeply nested", "Move the Margince folder"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal reads %q, want it to contain %q", err, want)
+		}
+	}
+}
+
+// shortTempDir is a scratch directory under a SHORT base, because the ordinary
+// one is not.
+//
+// The unix socket path limit this test is about is around a hundred bytes, and
+// macOS hands `t.TempDir()` a path of its own that is most of that before the
+// installation's own folders are added — so a fixture built there is refused
+// for the reason the test means to prove is unusual.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "mgl")
+	if err != nil {
+		t.Fatalf("a short scratch directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("removing %s: %v", dir, err)
+		}
+	})
+	return dir
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -138,7 +138,7 @@ sonar.test.inclusions=\
 # in the measurement (#1541). frontend/vite.config.ts sets the reporter's
 # projectRoot to the repo root and frontend/scripts/check-lcov-paths.sh fails
 # the fe-unit job if a record stops resolving.
-sonar.go.coverage.reportPaths=backend/coverage.out,backend/coverage-extensions.out
+sonar.go.coverage.reportPaths=backend/coverage.out,backend/coverage-extensions.out,desktop/launcher/coverage.out
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
 
 # --- Copy-paste detection: the three i18n catalogs mirror each other's key
@@ -190,14 +190,13 @@ sonar.cpd.exclusions=\
 # typed by tsc, linted by biome and driven in jsdom, so they report real coverage
 # and the exclusion is gone rather than moved — a view that is not measured is
 # exactly what #742 was filed about.
-# desktop/launcher is the desktop bundle's supervisor: its own Go module,
-# deliberately outside go.work, so the product coverage profile (go test
-# -coverpkg over the backend module) structurally cannot contain one of its
-# lines — it reports 0% with an exhaustive suite or with none. Excluded so the
-# gate measures something true, NOT because the code deserves no tests: unlike
-# backend/tools it is shipped product and currently has none. That gap is
-# issue #1241, which also carries the fix that removes this line — give the
-# module its own lane and coverage profile, and the number becomes real.
+# desktop/launcher is no longer excluded. It is its own Go module, deliberately
+# outside go.work, so the product profile (go test -coverpkg over the backend
+# module) structurally cannot contain one of its lines — which is why it read 0%
+# with an exhaustive suite or with none. It now emits a profile of its own from
+# its own lane, named in sonar.go.coverage.reportPaths above, so the figure is
+# real rather than absent. What stays excluded is only what no lane here can
+# reach: see the *_windows.go and *_darwin.go entries below.
 # vitest.setup.ts is the unit suite's own setup file — the hooks and DOM stubs
 # vitest runs AROUND the modules it instruments, named by `setupFiles` in
 # vite.config.ts. The v8 provider reports the code under test, never the harness
@@ -211,11 +210,13 @@ sonar.cpd.exclusions=\
 # stays what it was; the wrong metric is coverage, and only coverage. Same
 # rationale as *_windows.go below: an honest exclusion beats a gap no work would
 # close.
-# *_windows.go: no lane in this repository runs Windows, so these lines can never
-# be covered by any test anyone could write here. Counting them reports a gap no
-# work would close, which is worse than an honest exclusion — the build tag is
-# the statement that they are unreachable, and `GOOS=windows go build ./...` in
-# `make check` is what keeps them compiling. Same rationale as desktop/launcher.
+# *_windows.go and *_darwin.go: every lane in this repository runs Linux, so
+# these lines can never be covered by any test anyone could write here. Counting
+# them reports a gap no work would close, which is worse than an honest
+# exclusion — the build tag is the statement that they are unreachable, and the
+# cross-compiles in `make check` are what keep them compiling. The desktop
+# entries are the launcher's platform layers, and they are the ONLY part of that
+# module still outside the measurement.
 # *-gl.ts and the two painters beside them: the WebGL2 renderers and the 2D
 # canvas strokes. No lane in this repository has a GPU or a canvas — jsdom
 # answers `getContext("webgl2")` and `getContext("2d")` with null and the browser
@@ -246,9 +247,10 @@ sonar.coverage.exclusions=\
   frontend/src/design-system/webgl-program.ts,\
   frontend/src/design-system/crawl-paint.ts,\
   backend/**/*_windows.go,\
+  desktop/**/*_windows.go,\
+  desktop/**/*_darwin.go,\
   backend/cmd/**,\
   backend/tools/**,\
-  desktop/launcher/**,\
   backend/internal/platform/testdb/**,\
   e2e/llm/check.py,\
   frontend/src/main.tsx,\


### PR DESCRIPTION
Closes #1241.

## Steps 1 and 2 have landed since; step 3 is this PR

The ticket asked for three things. `desktop/launcher` now carries eight test files and `make test-desktop-launcher` is in `make check`, so the module has a lane and a suite. What it did not have is a **measurement**:

> the product coverage profile is produced by `go test -coverpkg=./...` over the **backend** module, so `backend/coverage.out` structurally cannot contain a single launcher line. The module reports 0% whether it has an exhaustive suite or none at all.

That is still true, and it is why `desktop/launcher/**` sat in `sonar.coverage.exclusions` — the exclusion the ticket calls *"a permanent blind spot"* and asks step 3 to make temporary.

## Making the number real

- `make test-desktop-launcher LAUNCHER_COVER_OUT=<file>` emits a profile, mirroring `test-extensions`' own `EXT_COVER_OUT` for the same reason: extension units are their own modules and unreachable by the product profile too.
- CI runs it in `deterministic-gates` — the job that already runs the lane — and uploads `go-coverage-launcher`. A **second run** of the module's suite rather than a flag on the gate itself, and deliberately: the gate must fail on the test result, not on whether a profile could be written. It costs under a second.
- The `sonarcloud` job downloads it, guarded on `deterministic-gates` the way the other two downloads are guarded on their producers.
- `sonar.go.coverage.reportPaths` gains `desktop/launcher/coverage.out`.
- **`desktop/launcher/**` is gone from `sonar.coverage.exclusions`**, replaced by `desktop/**/*_windows.go` and `desktop/**/*_darwin.go` — the honest remainder, on exactly the ground the backend's own `*_windows.go` entry states: every lane here runs Linux, so those lines are unreachable by any test anyone could write, and the cross-compiles in `make check` are what keep them compiling.

The module reports **35.6%** today. Low, and now visible — which is the whole point of the ticket.

## Four more decisions tested

Each is a pure function over an input, needs no process supervision, and answers something a user's data depends on:

- **`resolvePort`** — the setting, the default, the first-wins rule, the boundaries at 1 and 65535, and the refusal for a value the OS would reject, which must name the file and quote what they typed or it sends them looking for a setting they cannot find.
- **`needsInitdb`** — an empty data *directory* is not a cluster. Reading one as finished is how initdb runs over somebody's database; `PG_VERSION` is the marker because `initCluster` renames a finished staging directory into place.
- **`ensureEnvFile`** — written on a first run, mode 0600 because the template tells a user to put a licence token and a mail credential in it, and never rewritten afterwards.
- **`resolveSocketDir`** — an installation nested too deep for a unix socket is refused before the database starts, with the move that fixes it, instead of a bind error naming a byte count. Its fixture needs a *short* temp base: macOS hands `t.TempDir()` a path that is most of the hundred-byte limit before the installation's own folders are added, which is stated in the helper.

The one-line path helpers (`pgData`, `logs`, `webRoot`, …) are deliberately left uncovered. An assertion that `pgData` joins `data` and `pg` restates the line under it and fails only when somebody changes it on purpose, which is a change detector rather than a test.

`TestTheSettingsTemplateNeverReplacesAUsersOwnChoices` reads that way because the uniqueness-claim gate correctly refused its first name: "written once" in a test name is a claim about the tree that no gate holds.

## Checks

`make check-backend` green, `make craft-static` clean, `make test-desktop-launcher` green, and `scripts/check-ci-doc-parity.sh` still OK over the edited workflow.