### PR TITLE
feat(deals): a transition the record earned moves the deal itself

### DIFF
--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -3834,6 +3834,17 @@ components:
             that absence is the payload's own statement that nobody decided
             this — a zero or placeholder id here would put a phantom user's name
             on a refusal no person made.
+        decided_by_system:
+          type: boolean
+          description: >-
+            True when the product applied this itself under a governing policy
+            rather than putting it to a person. It is NOT the complement of
+            `decided_by`: the `expired` verdict also carries no decider, and
+            those two are opposite facts — one is the product acting, the other
+            is nobody acting. A consumer measuring whether people agree with
+            what is proposed must exclude an automatic apply from its
+            denominator, because the autopilot agreeing with itself is not
+            evidence that anyone agreed.
         edited:
           type: boolean
           description: >-

--- a/backend/gates/governedkindseams_test.go
+++ b/backend/gates/governedkindseams_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// The two halves of automatic apply agree about which kinds it covers.
+//
+// A kind reaches an automatic apply through two independent places: the sweep's
+// query, which decides what it comes looking for, and the applier's check,
+// which decides what it admits. They are separate statements about one set, and
+// a disagreement fails silently in whichever direction it went — the sweep
+// wakes on rows it will always refuse, or it never looks for rows it would have
+// applied and the feature simply does nothing.
+//
+// The admin-governed ladder adds a third: a kind may be governed and have no
+// policy seam, in which case the applier correctly refuses it forever and
+// nothing says the wiring was never done.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	autonomyFile      = "internal/modules/approvals/autonomy.go"
+	autoApplyFile     = "internal/compose/autoapply.go"
+	governedSeamsFile = "internal/compose/stageautopilotseam.go"
+)
+
+// Every admin-governed kind has a seam that can answer for it.
+//
+// governedKindPolicies panics at startup on a kind it cannot answer for, which
+// is the right behaviour and the wrong place to find out: the panic happens in
+// a deployed worker, not in CI. This finds it here.
+func TestEveryAdminGovernedKindHasAPolicySeam(t *testing.T) {
+	t.Parallel()
+	governed := namedMapLiteralKeys(t, autonomyFile, "AdminGovernedAutoKinds")
+	if len(governed) == 0 {
+		t.Fatalf("found no AdminGovernedAutoKinds entries in %s: this census is "+
+			"reading the wrong thing and would pass over any drift", autonomyFile)
+	}
+	seams := namedMapLiteralKeys(t, governedSeamsFile, "seams")
+	if len(seams) == 0 {
+		t.Fatalf("found no policy seams in %s: same problem, from the other side",
+			governedSeamsFile)
+	}
+	// The seam map keys by a constant (deals.StageProgressionKind) while the
+	// kind set keys by its string. Compared as the SUFFIX a constant name
+	// shares with its value, so this notices a kind with no seam without
+	// resolving identifiers across packages.
+	for kind := range governed {
+		if !someKeyNames(seams, kind) {
+			t.Errorf("%q is in AdminGovernedAutoKinds but no seam in %s answers "+
+				"for it: the applier refuses it forever, correctly, and nothing "+
+				"in the tree says the wiring was never done", kind, governedSeamsFile)
+		}
+	}
+}
+
+// The sweep looks for exactly the kinds the applier will admit.
+//
+// Two functions, one set. The sweep's query calls AutoAppliableKinds; the
+// applier tests AdminGovernedAutoKinds and AutoApplyKinds. If the query is ever
+// pointed back at one ladder alone, the other ladder's kinds stop being swept
+// and its feature goes quiet with every test still green.
+func TestTheAutoApplySweepScansTheKindsTheApplierAdmits(t *testing.T) {
+	t.Parallel()
+	src := sourceOfGateSubject(t, autoApplyFile)
+	if !strings.Contains(src, "approvals.AutoAppliableKinds()") {
+		t.Errorf("%s no longer scans approvals.AutoAppliableKinds(): the sweep and "+
+			"the applier read different sets, so one ladder's kinds are either "+
+			"never looked for or never admitted", autoApplyFile)
+	}
+	// Both ladders must still be what the applier tests, or the union above is
+	// wider than what it will accept and the sweep wakes on rows it refuses.
+	for _, set := range []string{
+		"approvals.AdminGovernedAutoKinds[", "approvals.AutoApplyKinds[",
+	} {
+		if !strings.Contains(src, set) {
+			t.Errorf("%s no longer tests %s: a kind of that ladder would be swept "+
+				"and then refused on every tick", autoApplyFile, set)
+		}
+	}
+}
+
+// sourceOfGateSubject reads a file this gate judges.
+func sourceOfGateSubject(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+// namedMapLiteralKeys reads the keys of a named map literal, as written.
+//
+// A string key answers its value; a constant key answers its identifier name.
+// Both are what the caller compares, and neither needs the type checker.
+func namedMapLiteralKeys(t *testing.T, file, name string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	out := map[string]bool{}
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		value, ok := n.(*ast.ValueSpec)
+		if !ok || len(value.Names) != 1 || value.Names[0].Name != name {
+			return true
+		}
+		for _, v := range value.Values {
+			collectNamedMapKeys(v, out)
+		}
+		return true
+	})
+	// A short assignment (`seams := map[...]{...}`) is not a ValueSpec.
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 {
+			return true
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok || ident.Name != name {
+			return true
+		}
+		for _, v := range assign.Rhs {
+			collectNamedMapKeys(v, out)
+		}
+		return true
+	})
+	return out
+}
+
+func collectNamedMapKeys(v ast.Expr, out map[string]bool) {
+	lit, ok := v.(*ast.CompositeLit)
+	if !ok {
+		return
+	}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		switch key := kv.Key.(type) {
+		case *ast.BasicLit:
+			if unquoted, err := strconv.Unquote(key.Value); err == nil {
+				out[unquoted] = true
+			}
+		case *ast.Ident:
+			out[key.Name] = true
+		case *ast.SelectorExpr:
+			out[key.Sel.Name] = true
+		}
+	}
+}
+
+// someKeyNames answers whether any key plausibly names this kind.
+//
+// A seam may key on the literal string or on the constant that holds it
+// (deals.StageProgressionKind for "stage_progression"), so this compares the
+// kind's words against the constant's, ignoring the underscores Go drops and
+// the "Kind" suffix such constants carry. Comparing identifiers properly would
+// need the type checker across two packages, which is a far heavier gate for
+// an answer this shape already gives.
+func someKeyNames(keys map[string]bool, kind string) bool {
+	if keys[kind] {
+		return true
+	}
+	squashed := strings.ReplaceAll(kind, "_", "")
+	for key := range keys {
+		trimmed := strings.TrimSuffix(key, "Kind")
+		if strings.EqualFold(trimmed, squashed) || strings.EqualFold(key, squashed) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/autoapply.go
+++ b/backend/internal/compose/autoapply.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
@@ -58,12 +59,29 @@ var ownedTables = map[string]string{
 	"organization": "organization",
 }
 
+// kindPolicy answers whether ONE proposal of an admin-governed kind may apply
+// right now, in the transaction that would apply it.
+//
+// A seam rather than a call, because the answer lives in the module that owns
+// the kind — stage automation's thresholds are deals' — and compose may not
+// reach into a module's judgement any more than a module may reach into a
+// sibling's. What compose owns is which seam answers for which kind.
+//
+// It takes the OWNER'S context, the same one the apply runs under, so a policy
+// that reads the acting principal reads the one that will do the writing.
+type kindPolicy func(ctx context.Context, approvalID ids.ApprovalID) (bool, error)
+
 // autoApplier decides and applies proposals that their owner has put on
-// automatic.
+// automatic, or that an admin's governing policy has earned.
 type autoApplier struct {
 	pool  *pgxpool.Pool
 	svc   *approvals.Service
 	users *identity.Service
+	// governed answers for the admin-governed kinds, keyed by kind. A kind in
+	// AdminGovernedAutoKinds with no seam here NEVER applies: an unanswerable
+	// policy is a refusal, because the alternative is applying on the absence
+	// of a judgement.
+	governed map[string]kindPolicy
 }
 
 // Apply runs one pending proposal if its owner has this kind on automatic.
@@ -83,7 +101,11 @@ func (a autoApplier) Apply(ctx context.Context, approvalID ids.ApprovalID) (bool
 	if err != nil {
 		return false, err
 	}
-	if target.kind == "" || !approvals.AutoApplyKinds[target.kind] {
+	if target.kind == "" {
+		return false, nil
+	}
+	admin := approvals.AdminGovernedAutoKinds[target.kind]
+	if !admin && !approvals.AutoApplyKinds[target.kind] {
 		return false, nil
 	}
 	owner, err := a.ownerOf(ctx, target.entityType, target.entityID)
@@ -103,17 +125,43 @@ func (a autoApplier) Apply(ctx context.Context, approvalID ids.ApprovalID) (bool
 	// Read the policy AS the owner, not before becoming them: the policy read
 	// takes its subject from the acting principal, so asking first would ask
 	// about whoever the sweep happened to be running as.
-	mode, err := a.svc.AutoApplyMode(ownerCtx, target.kind)
-	if err != nil {
+	//
+	// WHICH policy depends on the ladder. A rep's own kinds read the rep's own
+	// row; an admin-governed kind reads the rule the admin set for the
+	// transition, through the seam its module supplies. Asking the rep's
+	// ladder about a governed kind would answer 'manual' for every rep who
+	// never opted into a setting they are not offered.
+	may, err := a.mayApply(ownerCtx, target.kind, admin, approvalID)
+	if err != nil || !may {
 		return false, err
-	}
-	if mode != approvals.ModeAuto {
-		return false, nil
 	}
 	if _, err := a.svc.ApplyUnderPolicy(ownerCtx, approvalID); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// mayApply asks the ladder that governs this kind.
+//
+// The two are not interchangeable and neither is a fallback for the other. A
+// governed kind whose seam is missing answers NO — an unwired policy is an
+// unanswered question, and applying on an unanswered question is the one thing
+// this whole path exists to prevent.
+func (a autoApplier) mayApply(
+	ctx context.Context, kind string, admin bool, approvalID ids.ApprovalID,
+) (bool, error) {
+	if !admin {
+		mode, err := a.svc.AutoApplyMode(ctx, kind)
+		if err != nil {
+			return false, err
+		}
+		return mode == approvals.ModeAuto, nil
+	}
+	policy, wired := a.governed[kind]
+	if !wired {
+		return false, nil
+	}
+	return policy(ctx, approvalID)
 }
 
 // proposalTarget is the proposal's kind and what it points at.
@@ -249,9 +297,10 @@ func (a autoApplier) asOwnersAgent(ctx context.Context, owner ids.UUID) (context
 func (a autoApplier) duePending(ctx context.Context, limit int) ([]ids.ApprovalID, error) {
 	var due []ids.ApprovalID
 	err := database.WithWorkspaceTx(ctx, a.pool, func(tx pgx.Tx) error {
-		// The kinds come from the module that owns them, in its order: the scan
-		// must not come to look for a set the applier would then refuse, and the
-		// kinds travel as one parameter, so a map-ordered list would send the
+		// The kinds come from the module that owns them, as the UNION of both
+		// ladders: the scan must not come to look for a set the applier would
+		// then refuse, nor miss one it would accept. They travel as one
+		// parameter in a stable order, so a map-ordered list cannot send the
 		// same set differently on every tick and make two runs incomparable.
 		rows, err := tx.Query(ctx, `
 			SELECT id FROM approval
@@ -259,7 +308,7 @@ func (a autoApplier) duePending(ctx context.Context, limit int) ([]ids.ApprovalI
 			   AND expires_at > now()
 			   AND kind = ANY($1)
 			 ORDER BY created_at
-			 LIMIT $2`, approvals.SortedAutoApplyKinds(), limit)
+			 LIMIT $2`, approvals.AutoAppliableKinds(), limit)
 		if err != nil {
 			return err
 		}
@@ -349,8 +398,9 @@ func refusesThisRow(err error) bool {
 // it is assembled from.
 func SweepAutoApply(ctx context.Context, pool *pgxpool.Pool) (int, error) {
 	return autoApplier{
-		pool:  pool,
-		svc:   approvalsServiceWithEffects(pool),
-		users: identity.NewService(pool),
+		pool:     pool,
+		svc:      approvalsServiceWithEffects(pool),
+		users:    identity.NewService(pool),
+		governed: governedKindPolicies(pool, deals.NewStore(InstallationDB(pool), DealsInstallation())),
 	}.Sweep(ctx)
 }

--- a/backend/internal/compose/integration/stageautoapply_e2e_integration_test.go
+++ b/backend/internal/compose/integration/stageautoapply_e2e_integration_test.go
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A transition that earned it moving a deal by itself.
+//
+// Driven through compose.SweepAutoApply — the same seam the job calls — so
+// these prove the WIRING and not a re-derivation of it. A test that called the
+// applier's pieces itself would pass over a sweep that never looks for stage
+// progressions, which is the shape of defect that hid under WP4b's green
+// module suite.
+//
+// Every test here is about a REFUSAL except two, and that asymmetry is the
+// design. Nobody notices a card that arrived when it needn't have; everybody
+// notices a deal that moved on its own when it should not have.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// governedTransition puts the fixture's transition on auto with a record good
+// enough to clear every threshold, and turns the installation switch on.
+//
+// Returns the transition, so a test that wants to prove ONE condition withholds
+// can move that one and leave the rest true.
+func governedTransition(t *testing.T, e *Env, deal ids.DealID) deals.TransitionRef {
+	t.Helper()
+	giveTheOwnerARealRole(t, e)
+	ref := transitionOfDeal(t, e, deal)
+	setAutopilotSwitch(t, e, true)
+	if _, err := e.Deals.SetTransitionPolicy(e.Admin(), deals.SetTransitionPolicyInput{
+		TransitionRef: ref, Mode: deals.ModeAuto,
+	}); err != nil {
+		t.Fatalf("enabling the transition: %v", err)
+	}
+	seedGoodRecord(t, e, deal, ref)
+	return ref
+}
+
+// giveTheOwnerARealRole grants the deal's owner the permissions the applier
+// will act under.
+//
+// NOT decoration. The auto-applier binds the OWNER's own grants, seat and row
+// scope — an automatic apply is bounded by exactly what that rep could have
+// done by hand — so an owner with no role assignment cannot decide their own
+// card, and the sweep correctly applies nothing. A fixture that skipped this
+// would make every refusal in this file pass without the product refusing
+// anything.
+//
+// The permissions are the ones the path actually reads: the deal to move it,
+// the pipeline to read the rule that governs the move, and the installation
+// settings to read the kill switch.
+func giveTheOwnerARealRole(t *testing.T, e *Env) {
+	t.Helper()
+	const roleKey = "stage-autopilot-rep"
+	e.WsExec(t, `INSERT INTO role (key, name, permissions)
+		VALUES ($1, 'Stage Autopilot Rep', $2::jsonb)`,
+		roleKey,
+		`{"objects":{"deal":{"read":true,"update":true},`+
+			`"pipeline":{"read":true},`+
+			`"installation_settings":{"read":true}},"row_scope":"all"}`)
+	e.WsExec(t, `INSERT INTO role_assignment (role_id, user_id)
+		SELECT r.id, $1 FROM role r WHERE r.key = $2`,
+		e.Rep1, roleKey)
+}
+
+// transitionOfDeal names the move the staged card proposes, read from the card
+// rather than assumed: the proposer chooses the target stage, and a test that
+// governed a different transition would govern nothing.
+func transitionOfDeal(t *testing.T, e *Env, deal ids.DealID) deals.TransitionRef {
+	t.Helper()
+	var ref deals.TransitionRef
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT pipeline_id, from_stage_id, to_stage_id
+		  FROM stage_progression_outcome
+		 WHERE deal_id = $1 AND outcome = 'proposed'
+		 ORDER BY created_at DESC LIMIT 1`, deal).
+		Scan(&ref.PipelineID, &ref.FromStageID, &ref.ToStageID); err != nil {
+		t.Fatalf("reading the proposed transition: %v", err)
+	}
+	return ref
+}
+
+// setAutopilotSwitch writes the installation kill switch.
+func setAutopilotSwitch(t *testing.T, e *Env, on bool) {
+	t.Helper()
+	value := "false"
+	if on {
+		value = "true"
+	}
+	if _, err := e.Pool.Exec(t.Context(),
+		`INSERT INTO setting (key, value) VALUES ($1, $2::jsonb)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+		deals.StageAutopilotEnabled.Key(), value); err != nil {
+		t.Fatalf("setting the kill switch: %v", err)
+	}
+}
+
+// seedGoodRecord settles enough clean acceptances on this transition, spread
+// over enough days, to clear the default bar.
+//
+// Written straight to the ledger. The alternative is staging and deciding two
+// hundred real cards, which is what the transition's record IS — but the
+// subject here is the applier, and a fixture that spent a minute proving the
+// ledger writer again would test that instead.
+func seedGoodRecord(t *testing.T, e *Env, deal ids.DealID, ref deals.TransitionRef) {
+	t.Helper()
+	if _, err := e.Pool.Exec(t.Context(), `
+		INSERT INTO stage_progression_outcome (
+			approval_id, deal_id, pipeline_id, from_stage_id, to_stage_id,
+			outcome, decided_at)
+		SELECT gen_random_uuid(), $1, $2, $3, $4, 'approved_clean',
+		       now() - (CASE WHEN i = 0 THEN interval '29 days' ELSE interval '1 hour' END)
+		  FROM generate_series(0, 239) AS i`,
+		deal, ref.PipelineID, ref.FromStageID, ref.ToStageID); err != nil {
+		t.Fatalf("seeding the transition's record: %v", err)
+	}
+}
+
+// pendingCardFor answers the deal's open stage-progression card.
+func pendingCardFor(t *testing.T, e *Env, deal ids.DealID) (ids.ApprovalID, bool) {
+	t.Helper()
+	var id ids.ApprovalID
+	err := e.Pool.QueryRow(t.Context(), `
+		SELECT id FROM approval
+		 WHERE kind = $1 AND target_entity_id = $2 AND status = 'pending'`,
+		deals.StageProgressionKind, deal).Scan(&id)
+	if err != nil {
+		return id, false
+	}
+	return id, true
+}
+
+// stageOf answers where the deal actually is.
+func stageOf(t *testing.T, e *Env, deal ids.DealID) ids.StageID {
+	t.Helper()
+	var stage ids.StageID
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT stage_id FROM deal WHERE id = $1`, deal).Scan(&stage); err != nil {
+		t.Fatalf("reading the deal's stage: %v", err)
+	}
+	return stage
+}
+
+// A governed transition with a clean record moves the deal itself, and the
+// ledger says the product did it.
+//
+// The one test here that proves the feature works rather than that it
+// withholds. It is also the positive control every refusal below depends on:
+// if this fails, a refusal proves only that nothing was ever going to apply.
+func TestAnAutoAppliedMoveIsDecidedBySystemAndLandsOnTheLedger(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	ref := governedTransition(t, e, deal)
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the auto-apply sweep failed: %v", err)
+	}
+	if applied == 0 {
+		t.Fatal("the sweep applied nothing: a transition with a clean record over " +
+			"the volume and observation bars did not move its deal, so every " +
+			"refusal test in this file would pass for the wrong reason")
+	}
+
+	if got := stageOf(t, e, deal); got == before {
+		t.Fatalf("the sweep reported an apply but the deal is still in %s", before)
+	}
+	if got := stageOf(t, e, deal); got != ref.ToStageID {
+		t.Fatalf("the deal moved to %s, want the proposed %s", got, ref.ToStageID)
+	}
+
+	// The ledger is closed by the outcome consumer, fed the event the apply
+	// actually wrote — the same path a human decision takes. That the consumer
+	// is subscribed at all is held by TestEveryEventConsumerIsSubscribed; what
+	// is under test here is that an AUTOMATIC apply reaches it carrying the
+	// fact that nobody was asked.
+	card, open := pendingCardFor(t, e, deal)
+	if open {
+		t.Fatal("the card is still pending after the sweep reported applying it")
+	}
+	deliverApprovalDecided(t, e, appliedCardFor(t, e, deal))
+	_ = card
+
+	// The ledger tells an automatic move from a human's clean approval. This
+	// is what keeps the launch gate honest: counted as approved_clean, the
+	// autopilot would be voting on whether it should be running.
+	var outcome string
+	var bySystem bool
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT outcome, decided_by_system FROM stage_progression_outcome
+		 WHERE deal_id = $1 AND outcome <> 'approved_clean' ORDER BY decided_at DESC LIMIT 1`,
+		deal).Scan(&outcome, &bySystem); err != nil {
+		t.Fatalf("reading the applied move's ledger row: %v", err)
+	}
+	if outcome != deals.ProgressionAutoApplied {
+		t.Fatalf("an automatic move reads as %q on the ledger, want %q — counted "+
+			"as a human's approval it would dilute the very rate that authorized it",
+			outcome, deals.ProgressionAutoApplied)
+	}
+	if !bySystem {
+		t.Error("the ledger row does not say the system decided it, so the column " +
+			"and the outcome disagree about the same move")
+	}
+}
+
+// The installation kill switch stops every transition, however good its record.
+func TestNothingAutoAppliesWhileTheKillSwitchIsOff(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	governedTransition(t, e, deal)
+	setAutopilotSwitch(t, e, false)
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("%d move(s) applied while the installation's kill switch was off", applied)
+	}
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("the deal moved to %s with the kill switch off", got)
+	}
+	if _, open := pendingCardFor(t, e, deal); !open {
+		t.Error("the card is gone: the switch must take away the APPLY, not the ask")
+	}
+}
+
+// A transition nobody configured never applies.
+//
+// The DEFAULT state of every transition in the product, and the one this must
+// get right: a fresh installation moves no deal by itself.
+func TestAnUngovernedTransitionNeverAutoApplies(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	// Everything else is true: the owner has the authority to make this move
+	// by hand, the switch is on, the record is spotless. Only the RULE is
+	// missing.
+	//
+	// The role matters as much as the record here. Without it the sweep
+	// refuses for lack of permission, and this test passes against an applier
+	// that ignores the governing rule entirely — which it did, until the grant
+	// was added and the mutation check caught it.
+	giveTheOwnerARealRole(t, e)
+	setAutopilotSwitch(t, e, true)
+	seedGoodRecord(t, e, deal, transitionOfDeal(t, e, deal))
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("%d move(s) applied on a transition nobody configured", applied)
+	}
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("the deal moved to %s under no rule at all", got)
+	}
+}
+
+// A suspended rule proposes and never applies.
+func TestASuspendedRuleNeverAutoApplies(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	ref := governedTransition(t, e, deal)
+	if err := e.Deals.SuspendForSafetyDefect(
+		e.Admin(), ref, deals.DefectCrossTenant); err != nil {
+		t.Fatalf("suspending: %v", err)
+	}
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("%d move(s) applied on a suspended rule", applied)
+	}
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("a suspended rule moved the deal to %s", got)
+	}
+	if _, open := pendingCardFor(t, e, deal); !open {
+		t.Error("the suspended rule stopped asking: the moves an operator " +
+			"suspended it to look at are exactly the ones that must stay visible")
+	}
+}
+
+// Thresholds are read in the APPLY transaction, not at staging.
+//
+// The card here was staged while the record was good and the rule was on. The
+// record then goes bad. Nothing re-stages, and the card is unchanged — so an
+// applier that trusted what was true at staging would move the deal on numbers
+// that have since failed.
+func TestThresholdsAreReadInTheApplyTransactionNotAtStaging(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	governedTransition(t, e, deal)
+
+	// The record goes bad AFTER the card was staged: enough of the settled
+	// moves reversed to put the transition over its ceiling.
+	if _, err := e.Pool.Exec(t.Context(), `
+		UPDATE stage_progression_outcome
+		   SET reversed_at = now()
+		 WHERE deal_id = $1 AND outcome = 'approved_clean'
+		   AND id IN (SELECT id FROM stage_progression_outcome
+		               WHERE deal_id = $1 AND outcome = 'approved_clean' LIMIT 20)`,
+		deal); err != nil {
+		t.Fatalf("spoiling the record: %v", err)
+	}
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("%d move(s) applied on a record that failed after staging: the "+
+			"thresholds were read when the card was raised, not when it applied", applied)
+	}
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("the deal moved to %s on a record that had already failed", got)
+	}
+}
+
+// A card the product itself marked as needing judgement never applies.
+//
+// ConfirmFirst is a fact about THIS move — a closing stage, a skip, a criterion
+// resting on something merely proposed — and no amount of history about the
+// transition answers it. A rule good enough to apply must still not apply one.
+func TestAConfirmFirstCardNeverAutoAppliesHoweverGoodTheRecord(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	governedTransition(t, e, deal)
+
+	card, open := pendingCardFor(t, e, deal)
+	if !open {
+		t.Fatal("no card to mark")
+	}
+	// Mark the staged card the way the proposer marks a move that needs a
+	// judgement, leaving everything else true.
+	if _, err := e.Pool.Exec(t.Context(), `
+		UPDATE approval
+		   SET proposed_change = jsonb_set(proposed_change, '{confirm_first}', 'true')
+		 WHERE id = $1`, card); err != nil {
+		t.Fatalf("marking the card confirm-first: %v", err)
+	}
+	before := stageOf(t, e, deal)
+
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("%d move(s) applied on a card marked as needing judgement", applied)
+	}
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("a confirm-first move applied itself, landing the deal in %s", got)
+	}
+}
+
+// An automatic move does not improve the record that authorized it.
+//
+// The autopilot cannot vote on whether it should be running. Its own applies
+// are counted on their own line and excluded from the denominator every rate
+// is taken over, so a transition running automatically reports the same clean
+// acceptance rate as its volume grows.
+func TestAnAutoAppliedMoveDoesNotCountTowardTheRateThatAuthorizedIt(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	ref := governedTransition(t, e, deal)
+
+	before := reviewedCount(t, e, ref)
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied == 0 {
+		t.Fatal("nothing applied, so this proves nothing about what an automatic " +
+			"apply does to the count")
+	}
+	// The ledger is only written when the consumer hears the decision. Without
+	// this the count cannot move whatever the mapping does, and the assertion
+	// below would hold against a consumer that filed the apply as a human's.
+	deliverApprovalDecided(t, e, appliedCardFor(t, e, deal))
+	after := reviewedCount(t, e, ref)
+
+	if after != before {
+		t.Fatalf("the reviewed count moved from %d to %d across an automatic "+
+			"apply: the autopilot's own move entered the denominator of the rate "+
+			"that decides whether it may keep running", before, after)
+	}
+}
+
+// appliedCardFor answers the card the sweep decided.
+func appliedCardFor(t *testing.T, e *Env, deal ids.DealID) ids.ApprovalID {
+	t.Helper()
+	var id ids.ApprovalID
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT id FROM approval
+		 WHERE kind = $1 AND target_entity_id = $2 AND status = 'approved'
+		 ORDER BY decided_at DESC LIMIT 1`,
+		deals.StageProgressionKind, deal).Scan(&id); err != nil {
+		t.Fatalf("reading the applied card: %v", err)
+	}
+	return id
+}
+
+// reviewedCount is how many proposals a PERSON answered on this transition.
+func reviewedCount(t *testing.T, e *Env, ref deals.TransitionRef) int {
+	t.Helper()
+	var n int
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT count(*) FROM stage_progression_outcome
+		 WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3
+		   AND outcome IN ('approved_clean', 'approved_edited', 'rejected')`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&n); err != nil {
+		t.Fatalf("counting reviewed proposals: %v", err)
+	}
+	return n
+}
+
+// The rule is re-asked in the transaction that moves the deal.
+//
+// THE WINDOW IS THE POINT. The sweep asks whether a transition may apply, then
+// decides — and between those two the rule can change: an admin flips the kill
+// switch, sets the transition back to propose, or the product suspends it. An
+// applier that trusted its earlier answer commits the move on a permission
+// that no longer exists.
+//
+// So the suspension here lands AFTER the sweep's own check has passed and
+// before the effect writes. Suspending before the sweep would prove nothing —
+// the sweep's own check would refuse it, and the test would pass with this
+// guard deleted. It did, until the mutation check caught it.
+func TestAnAutomaticMoveIsRefusedWhenTheRuleChangesBeforeItLands(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	ref := governedTransition(t, e, deal)
+	before := stageOf(t, e, deal)
+	card, open := pendingCardFor(t, e, deal)
+	if !open {
+		t.Fatal("no card to apply")
+	}
+
+	// The sweep's question, asked and answered while the rule is still on.
+	verdict, err := e.Deals.MayAutoApplyStageMove(
+		e.Admin(), deal, ref.FromStageID, ref.ToStageID)
+	if err != nil || verdict.Mode != deals.ModeAuto {
+		t.Fatalf("the fixture does not reach auto (%s: %s, err=%v)",
+			verdict.Mode, verdict.Why, err)
+	}
+
+	// The rule goes off HERE — after that answer, before the apply.
+	if err := e.Deals.SuspendForSafetyDefect(
+		e.Admin(), ref, deals.DefectAuthorization); err != nil {
+		t.Fatalf("suspending: %v", err)
+	}
+
+	// Now apply as the sweep would, having already been told yes. This is the
+	// call the applier makes; the only thing standing between it and a moved
+	// deal is the re-check inside the effect's transaction.
+	if err := applyAsTheSweepWould(t, e, card); err == nil {
+		t.Fatal("the move applied on an answer taken before the rule went off: " +
+			"the effect trusts what the sweep was told rather than what is true " +
+			"when it writes")
+	}
+
+	if got := stageOf(t, e, deal); got != before {
+		t.Fatalf("the deal moved to %s on a rule that had been suspended", got)
+	}
+
+	// The card is left APPROVED with its failure recorded, not pending. That
+	// is this product's existing shape for any effect that refuses after its
+	// decision commits — a human's approval behaves the same way — and the
+	// mark is what keeps the row reachable: not pending, so the decision lane
+	// skips it; carrying effect_failed_at, so the receipts lane does not.
+	//
+	// Asserted rather than wished away: a test demanding the card stay pending
+	// would be describing a product that does not exist, and would fail for a
+	// reason that has nothing to do with the guard above.
+	var failure *string
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT effect_failure FROM approval WHERE id = $1`, card).Scan(&failure); err != nil {
+		t.Fatalf("reading the card's effect failure: %v", err)
+	}
+	if failure == nil {
+		t.Error("the refused move left no failure on the card, so nobody can see " +
+			"that an approved automatic move never happened")
+	}
+}
+
+// autoApplyActor is the id compose/autoapply.go binds for an automatic apply.
+//
+// Spelled here because the constant is unexported and exporting it for a test
+// would widen the package's surface for nobody's benefit. The guard under test
+// keys on this exact value, so a rename there fails this test — which is the
+// coupling a reader should see rather than one hidden behind an accessor.
+const autoApplyActor = "agent:auto-apply"
+
+// applyAsTheSweepWould runs the apply under the same principal the auto-applier
+// binds: an agent acting for the deal's owner, carrying that owner's authority.
+//
+// Built here rather than by calling the sweep, because the sweep would ask the
+// policy again first and refuse before reaching the effect — which is the
+// correct behaviour and the reason it cannot exercise this guard.
+func applyAsTheSweepWould(t *testing.T, e *Env, card ids.ApprovalID) error {
+	t.Helper()
+	rbac, seat, err := identity.NewService(e.Pool).EffectiveAuthority(
+		e.Admin(), e.WS, e.Rep1)
+	if err != nil {
+		t.Fatalf("resolving the owner's authority: %v", err)
+	}
+	ownerCtx := principal.WithActor(e.Admin(), principal.Principal{
+		Type:        principal.PrincipalAgent,
+		ID:          autoApplyActor,
+		UserID:      e.Rep1,
+		OnBehalfOf:  e.Rep1,
+		SeatType:    seat,
+		TeamIDs:     rbac.TeamIDs,
+		Scopes:      principal.ScopeSet{principal.ScopeWrite: struct{}{}},
+		Permissions: rbac.Permissions,
+	})
+	// The service WITH the real effect registered. A bare approvals.NewService
+	// has none, so ApplyUnderPolicy would approve the card and never run the
+	// move — the test would then report the guard missing whatever the guard
+	// does, because nothing it guards ever executes.
+	_, err = compose.StageProgressionDecisions(e.Pool).ApplyUnderPolicy(ownerCtx, card)
+	return err
+}

--- a/backend/internal/compose/stageautopilotseam.go
+++ b/backend/internal/compose/stageautopilotseam.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Binding stage automation's judgement to the auto-applier.
+//
+// The applier knows an approval; the judgement is about a TRANSITION. This
+// file is the translation, and it lives in compose because it crosses two
+// modules: approvals holds the staged card, deals holds the rule.
+//
+// It answers only. What applies the move is the ordinary approved effect, run
+// under the authority this seam's caller has already bound.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// stageProgressionPolicy answers whether one staged move may apply without
+// asking.
+//
+// THE PAYLOAD IS READ HERE, not carried from staging, and the transition comes
+// out of it. A card names the move it proposes; the rule that governs that
+// move is looked up now, in the transaction that would apply it, because a
+// threshold read at staging authorizes a move on numbers that were true hours
+// ago.
+//
+// A card that cannot be read answers NO rather than an error: an unreadable
+// payload is a card a person should look at, and failing the sweep over it
+// would park every proposal behind it.
+func stageProgressionPolicy(pool *pgxpool.Pool, store *deals.Store) kindPolicy {
+	return func(ctx context.Context, approvalID ids.ApprovalID) (bool, error) {
+		payload, err := stagedChange(ctx, pool, approvalID)
+		if err != nil {
+			return false, err
+		}
+		change, err := deals.ReadProgressionChange(payload)
+		if err != nil {
+			// Not applied, and not a sweep failure. An unreadable card is one
+			// a PERSON should look at: failing here would end the pass on it,
+			// and because the batch is ordered oldest-first that one card
+			// would park every other transition's automation behind it until
+			// it expired.
+			//
+			// Logged rather than discarded, because a card the product cannot
+			// read is a defect somewhere upstream and a silent skip is how it
+			// stays one.
+			slog.Default().WarnContext(ctx,
+				"stage progression card cannot be read, so it will not apply automatically",
+				"approval_id", approvalID, "error", err)
+			return false, nil
+		}
+		verdict, err := store.MayAutoApplyStageMove(
+			ctx, change.DealID, change.FromStageID, change.ToStageID)
+		if err != nil {
+			return false, err
+		}
+		if verdict.Mode != deals.ModeAuto {
+			return false, nil
+		}
+		// A move the card itself marks as needing judgement never applies,
+		// however good the transition's record. ConfirmFirst is set for a
+		// closing stage, a skip, or a criterion resting on something merely
+		// proposed — facts about THIS move that no amount of history about
+		// the transition answers.
+		return !change.ConfirmFirst, nil
+	}
+}
+
+// stagedChange reads the payload a card is standing on.
+//
+// ONE column, because a modify-then-approve edit REPLACES proposed_change in
+// place under a freshly computed diff_hash (approvals/decide.go's
+// applyEditedPayload) rather than landing beside it. So this reads what the
+// card would apply, edited or not, and there is no second column to prefer.
+func stagedChange(
+	ctx context.Context, pool *pgxpool.Pool, approvalID ids.ApprovalID,
+) (json.RawMessage, error) {
+	var proposed json.RawMessage
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT proposed_change FROM approval
+			 WHERE id = $1 AND status = 'pending'`,
+			approvalID).Scan(&proposed)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Decided by a person between the sweep listing this card and reading
+		// it. ErrNotFound rather than the raw pgx error, because that is what
+		// refusesThisRow matches: a wrapped ErrNoRows ends the whole pass, and
+		// since the batch is ordered oldest-first, one card somebody happened
+		// to answer would park every other transition's automation behind it.
+		return nil, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("compose: read the staged stage move: %w", err)
+	}
+	return proposed, nil
+}
+
+// governedKindPolicies builds the seam for each admin-governed kind.
+//
+// It CHECKS ITSELF against the module's own set rather than trusting the map
+// below to stay complete, so a kind added to AdminGovernedAutoKinds without a
+// seam fails at startup instead of silently never applying. An unwired
+// governed kind is invisible otherwise: the applier refuses it, correctly, and
+// nothing says the feature was never connected.
+//
+// Held by: TestEveryAdminGovernedKindHasAPolicySeam
+// (backend/gates/governedkindseams_test.go)
+func governedKindPolicies(pool *pgxpool.Pool, store *deals.Store) map[string]kindPolicy {
+	seams := map[string]kindPolicy{
+		deals.StageProgressionKind: stageProgressionPolicy(pool, store),
+	}
+	for kind := range approvals.AdminGovernedAutoKinds {
+		if _, wired := seams[kind]; !wired {
+			panic(fmt.Sprintf(
+				"compose: %q is admin-governed but has no policy seam, so it would "+
+					"never apply and nothing would say why", kind))
+		}
+	}
+	return seams
+}

--- a/backend/internal/compose/stageprogression.go
+++ b/backend/internal/compose/stageprogression.go
@@ -346,6 +346,43 @@ func stageProgressionPrecheck() approvals.ReleasePrecheck {
 	}
 }
 
+// refuseAStaleAutomaticMove holds an automatic apply to the rule as it stands
+// NOW, in the transaction that would move the deal.
+//
+// Answers nil for a human decision without asking anything: the question is
+// whether the PRODUCT may still move this by itself, and a person who pressed
+// approve has already answered a different one.
+func refuseAStaleAutomaticMove(
+	ctx context.Context, tx pgx.Tx, change deals.StageProgressionChange,
+) error {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalAgent || actor.ID != autoApplyActorID {
+		return nil
+	}
+	var pipelineID ids.PipelineID
+	if err := tx.QueryRow(ctx,
+		`SELECT pipeline_id FROM deal WHERE id = $1`, change.DealID).Scan(&pipelineID); err != nil {
+		return fmt.Errorf("compose: read the deal's pipeline for an automatic move: %w", err)
+	}
+	verdict, err := deals.StageAutopilotModeTx(ctx, tx, deals.TransitionRef{
+		PipelineID:  pipelineID,
+		FromStageID: change.FromStageID,
+		ToStageID:   change.ToStageID,
+	}, time.Now())
+	if err != nil {
+		return err
+	}
+	if verdict.Mode != deals.ModeAuto {
+		// ErrVersionSkew rather than a bare error: the sweep classifies it as
+		// a refusal of THIS row and carries on, which is right — the rule
+		// changed under a decision that had not landed yet, and every other
+		// card still deserves its pass.
+		return fmt.Errorf("the rule changed before this move landed (%s): %w",
+			verdict.Why, apperrors.ErrVersionSkew)
+	}
+	return nil
+}
+
 // stageProgressionEffect performs an approved move: redeem and advance in ONE
 // transaction, so the approval is spent if and only if the deal moved.
 //
@@ -376,6 +413,23 @@ func stageProgressionEffect(svc *approvals.Service, store *deals.Store) approval
 		}
 		return svc.RedeemAndApply(ctx, approvalID, deals.StageProgressionKind, diffHash,
 			func(tx pgx.Tx) error {
+				// An AUTOMATIC apply re-asks the governing rule here, inside
+				// the transaction that moves the deal.
+				//
+				// The sweep asked before deciding, and that answer is already
+				// stale by the time this runs: an admin can flip the kill
+				// switch, set the transition back to propose, or the product
+				// can suspend the rule in between. Read there and written
+				// here, the move commits on a permission that no longer
+				// exists — which is exactly what StageAutopilotModeTx's own
+				// comment says the transaction is for.
+				//
+				// A HUMAN's approval skips this. A person deciding is the
+				// authority, and re-asking the autopilot's thresholds would
+				// let a suspended rule block a move somebody explicitly made.
+				if err := refuseAStaleAutomaticMove(ctx, tx, change); err != nil {
+					return err
+				}
 				_, err := store.AdvanceDealTx(ctx, tx, change.DealID, deals.AdvanceDealInput{
 					ToStageID: change.ToStageID,
 					// The card this move came from. Without it readProtection

--- a/backend/internal/compose/stageprogressionoutcome.go
+++ b/backend/internal/compose/stageprogressionoutcome.go
@@ -68,9 +68,10 @@ func (o *StageProgressionOutcome) HandleEvent(ctx context.Context, env events.En
 		return nil
 	}
 	var payload struct {
-		Kind    string `json:"kind"`
-		Verdict string `json:"verdict"`
-		Edited  bool   `json:"edited"`
+		Kind            string `json:"kind"`
+		Verdict         string `json:"verdict"`
+		Edited          bool   `json:"edited"`
+		DecidedBySystem bool   `json:"decided_by_system"`
 	}
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		return fmt.Errorf("stage progression outcome: approval.decided payload: %w", err)
@@ -81,7 +82,9 @@ func (o *StageProgressionOutcome) HandleEvent(ctx context.Context, env events.En
 	if payload.Kind != deals.StageProgressionKind {
 		return nil
 	}
-	outcome, ok := progressionOutcomeFor(payload.Verdict, payload.Edited)
+	outcome, ok := progressionOutcomeFor(payload.Verdict, decisionShape{
+		Edited: payload.Edited, BySystem: payload.DecidedBySystem,
+	})
 	if !ok {
 		// A verdict this consumer does not know is not a silent skip: the
 		// ledger is what the launch gate reads, so an unrecognised one would be
@@ -115,6 +118,20 @@ func (o *StageProgressionOutcome) HandleEvent(ctx context.Context, env events.En
 	return o.deals.RecordProgressionDecided(ctx, env.Entity.ID, outcome, nil, false)
 }
 
+// decisionShape is how an approval was reached, as two facts that are easy to
+// swap at a call site and impossible to tell apart once swapped.
+//
+// Named because the pair decides which of three outcomes an approval becomes,
+// and a transposed argument would file every automatic move as a human's edit
+// — the exact confusion the ledger exists to prevent, arriving silently.
+type decisionShape struct {
+	// Edited: the approver changed the payload before releasing it.
+	Edited bool
+	// BySystem: the product applied it under a governing policy, and nobody
+	// was asked.
+	BySystem bool
+}
+
 // progressionOutcomeFor maps a verdict onto what the ledger counts.
 //
 // `expired` is a refusal with no decider, and it is counted as its own outcome
@@ -122,18 +139,24 @@ func (o *StageProgressionOutcome) HandleEvent(ctx context.Context, env events.En
 // asked at a moment nobody was reading, which is a different failure from a rep
 // looking at the evidence and saying no.
 //
-// ProgressionAutoApplied is NOT reachable from here, and deliberately so. An
-// automatic apply is marked by the approval row's decided_by_system column,
-// which approval.decided does not carry — so this consumer cannot tell one from
-// a human's clean approval, and a branch guessing at it would file the
-// autopilot's own moves under the rate that measures whether humans agree with
-// it. Nothing produces one yet either: the proposer reads an empty
-// AutopilotFacts, so every card in this release reaches a person. The autopilot
-// PR owns both halves — widening the event, and this arm.
-func progressionOutcomeFor(verdict string, edited bool) (string, bool) {
+// An APPROVAL SPLITS THREE WAYS, and the split decides whether the launch gate
+// can be trusted. A person agreeing as proposed, a person agreeing after
+// changing something, and the product applying under a governing policy are
+// three different claims, and only the first two are evidence that anybody
+// agreed. Filing an automatic apply as a clean acceptance would let the
+// autopilot vote on whether it should be running: as its volume grew it would
+// report an ever-better record built entirely from its own output.
+//
+// decided_by_system is read from the event rather than the approval row so
+// this stays one decode with no lookup. It is not the complement of a missing
+// decider — `expired` also has none, and it is checked first.
+func progressionOutcomeFor(verdict string, how decisionShape) (string, bool) {
 	switch crmcontracts.PublicEventApprovalDecidedVerdict(verdict) {
 	case crmcontracts.Approved:
-		if edited {
+		if how.BySystem {
+			return deals.ProgressionAutoApplied, true
+		}
+		if how.Edited {
 			return deals.ProgressionApprovedEdited, true
 		}
 		return deals.ProgressionApprovedClean, true

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -898,6 +898,9 @@ type PublicEventApprovalDecided struct {
 	// DecidedBy The deciding human's user id. ABSENT on the `expired` verdict, and that absence is the payload's own statement that nobody decided this — a zero or placeholder id here would put a phantom user's name on a refusal no person made.
 	DecidedBy *openapi_types.UUID `json:"decided_by,omitempty"`
 
+	// DecidedBySystem True when the product applied this itself under a governing policy rather than putting it to a person. It is NOT the complement of `decided_by`: the `expired` verdict also carries no decider, and those two are opposite facts — one is the product acting, the other is nobody acting. A consumer measuring whether people agree with what is proposed must exclude an automatic apply from its denominator, because the autopilot agreeing with itself is not evidence that anyone agreed.
+	DecidedBySystem *bool `json:"decided_by_system,omitempty"`
+
 	// DiffHash The edited change's freshly computed diff_hash (present only on the modify-then-approve arm).
 	DiffHash *string `json:"diff_hash,omitempty"`
 

--- a/backend/internal/modules/approvals/autonomy.go
+++ b/backend/internal/modules/approvals/autonomy.go
@@ -129,6 +129,47 @@ var AutoApplyKinds = map[string]bool{
 	"lifecycle_change":      true,
 }
 
+// AdminGovernedAutoKinds are the kinds that may apply without asking on an
+// ADMIN's authority rather than a rep's own.
+//
+// A SECOND set, not more members of AutoApplyKinds, and the split is the whole
+// design. AutoApplyKinds is what a rep may put on auto for themselves, and its
+// bound is that the product can put each one back through the restore path —
+// one Undo and the field is as it was. A stage move is not that: it writes
+// deal_stage_history and the ledger beside the field, so restoring the column
+// alone would leave the history saying the deal is somewhere it is not. It
+// carries its own revert instead.
+//
+// The authority is different too. Nobody's own history earns a stage move the
+// right to skip the question; a transition earns it, per pipeline, measured
+// against thresholds an admin set — which is why membership here grants
+// nothing on its own. The kind still has to pass the governing policy in the
+// transaction that would apply it.
+var AdminGovernedAutoKinds = map[string]bool{
+	"stage_progression": true,
+}
+
+// AutoAppliableKinds is every kind either ladder can apply, in a stable order.
+//
+// The sweep that looks for work and the check that admits it read this same
+// function, because they must agree: a scan over one set feeding a check
+// against the other either misses kinds it should apply or wakes on rows it
+// will always refuse.
+//
+// Held by: TestTheAutoApplySweepScansTheKindsTheApplierAdmits
+// (backend/gates/governedkindseams_test.go)
+func AutoAppliableKinds() []string {
+	kinds := make([]string, 0, len(AutoApplyKinds)+len(AdminGovernedAutoKinds))
+	for kind := range AutoApplyKinds {
+		kinds = append(kinds, kind)
+	}
+	for kind := range AdminGovernedAutoKinds {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
 // SortedAutoApplyKinds is AutoApplyKinds in a stable order.
 //
 // Exported because three callers need the same order for the same reason and a

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -15,7 +15,6 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
-	"github.com/margince/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -352,10 +351,17 @@ func (s *Service) decideInTx(ctx context.Context, tx pgx.Tx, p principal.Princip
 	// decided_by is a pointer because ONE verdict has no decider: the expiry
 	// sweep's. A human decision always names theirs, so it is always set here.
 	decidedBy := openapi_types.UUID(p.UserID)
+	// decided_by_system travels on the event as well as into the column. A
+	// consumer measuring whether PEOPLE agree with what the product proposes
+	// has to exclude the product's own applies from its denominator, and
+	// without this field it cannot tell one from a human's clean approval —
+	// the autopilot would be counted as agreeing with itself.
+	bySystem := bool(by)
 	decidedPayload := crmcontracts.PublicEventApprovalDecided{
-		Kind:      a.Kind,
-		Verdict:   crmcontracts.PublicEventApprovalDecidedVerdict(verdict),
-		DecidedBy: &decidedBy,
+		Kind:            a.Kind,
+		Verdict:         crmcontracts.PublicEventApprovalDecidedVerdict(verdict),
+		DecidedBy:       &decidedBy,
+		DecidedBySystem: &bySystem,
 	}
 	if err := landEditedPayload(ctx, tx, id, edited, a, auditEvidence, &decidedPayload); err != nil {
 		return row{}, err
@@ -392,62 +398,6 @@ func (s *Service) decideInTx(ctx context.Context, tx pgx.Tx, p principal.Princip
 		return row{}, err
 	}
 	return get(ctx, tx, id)
-}
-
-// applyEditedPayload is the modify-then-approve write (ADR-0036 §4): the
-// human's edited payload replaces the staged change under a freshly
-// computed diff_hash, and both sides of the human delta go on the record
-// — what the agent proposed, and what the human actually released. The
-// decided event carries the human's version, so a suspended agent run
-// resumes with THIS call; the original hash no longer opens anything.
-func applyEditedPayload(ctx context.Context, tx pgx.Tx, id ids.ApprovalID, edited json.RawMessage, a row, auditEvidence map[string]any, decidedPayload *crmcontracts.PublicEventApprovalDecided) error {
-	canonical, editedHash, hashErr := diffhash.Canonical(edited)
-	if hashErr != nil {
-		return &InvalidEditError{Cause: hashErr}
-	}
-	// The edit may correct the action, never re-aim it: the row-scope probe
-	// and the version pin above were both evaluated against the records the
-	// STAGED payload named, and the effect resolves what it writes from the
-	// payload rather than from the approval's target. See editscope.go.
-	if err := assertSameEntityRefs(a.ProposedChange, canonical); err != nil {
-		return err
-	}
-	// The same rule for the half entityRefs cannot see: a record named inside the
-	// request path rather than as a field of its own.
-	if err := assertSameCallIdentity(a.ProposedChange, canonical); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx,
-		`UPDATE approval SET proposed_change = $2, diff_hash = $3 WHERE id = $1`,
-		id, canonical, editedHash); err != nil {
-		return err
-	}
-	auditEvidence["edited"] = true
-	auditEvidence["original_change"] = json.RawMessage(a.ProposedChange)
-	auditEvidence["original_diff_hash"] = a.DiffHash
-	auditEvidence["edited_change"] = json.RawMessage(canonical)
-	auditEvidence["edited_diff_hash"] = editedHash
-
-	// edited_change stays an OPEN object on the wire (A9): the staged
-	// kind's proposed_change shape varies by kind, so the payload carries
-	// it as a raw map rather than a narrowly typed struct that would drop
-	// a future kind's fields.
-	var editedChange map[string]any
-	if err := json.Unmarshal(canonical, &editedChange); err != nil {
-		return fmt.Errorf("approvals: canonicalized edited change did not decode as a JSON object: %w", err)
-	}
-	if editedChange == nil {
-		// A literal JSON `null` decodes without error but leaves the map nil,
-		// which would emit edited_change: null (violating the public contract)
-		// and could resume a parked run with null args — reject it as an
-		// invalid edit (422) rather than a JSON object.
-		return &InvalidEditError{Cause: errors.New("payload is not a JSON object")}
-	}
-	wasEdited := true
-	decidedPayload.Edited = &wasEdited
-	decidedPayload.DiffHash = &editedHash
-	decidedPayload.EditedChange = &editedChange
-	return nil
 }
 
 // emitKindDecided fires the kind-specific echo of the verdict (e.g. a

--- a/backend/internal/modules/approvals/decideedited.go
+++ b/backend/internal/modules/approvals/decideedited.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// The modify-then-approve arm: a human changed the staged payload before
+// releasing it.
+//
+// Split from decide.go because it is one concept with its own rule — the
+// edited payload REPLACES the staged one under a freshly computed diff_hash,
+// so what applies is what the approver last saw and not what was proposed.
+// Every other decision path leaves the payload untouched.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/diffhash"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// applyEditedPayload is the modify-then-approve write (ADR-0036 §4): the
+// human's edited payload replaces the staged change under a freshly
+// computed diff_hash, and both sides of the human delta go on the record
+// — what the agent proposed, and what the human actually released. The
+// decided event carries the human's version, so a suspended agent run
+// resumes with THIS call; the original hash no longer opens anything.
+func applyEditedPayload(ctx context.Context, tx pgx.Tx, id ids.ApprovalID, edited json.RawMessage, a row, auditEvidence map[string]any, decidedPayload *crmcontracts.PublicEventApprovalDecided) error {
+	canonical, editedHash, hashErr := diffhash.Canonical(edited)
+	if hashErr != nil {
+		return &InvalidEditError{Cause: hashErr}
+	}
+	// The edit may correct the action, never re-aim it: the row-scope probe
+	// and the version pin above were both evaluated against the records the
+	// STAGED payload named, and the effect resolves what it writes from the
+	// payload rather than from the approval's target. See editscope.go.
+	if err := assertSameEntityRefs(a.ProposedChange, canonical); err != nil {
+		return err
+	}
+	// The same rule for the half entityRefs cannot see: a record named inside the
+	// request path rather than as a field of its own.
+	if err := assertSameCallIdentity(a.ProposedChange, canonical); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE approval SET proposed_change = $2, diff_hash = $3 WHERE id = $1`,
+		id, canonical, editedHash); err != nil {
+		return err
+	}
+	auditEvidence["edited"] = true
+	auditEvidence["original_change"] = json.RawMessage(a.ProposedChange)
+	auditEvidence["original_diff_hash"] = a.DiffHash
+	auditEvidence["edited_change"] = json.RawMessage(canonical)
+	auditEvidence["edited_diff_hash"] = editedHash
+
+	// edited_change stays an OPEN object on the wire (A9): the staged
+	// kind's proposed_change shape varies by kind, so the payload carries
+	// it as a raw map rather than a narrowly typed struct that would drop
+	// a future kind's fields.
+	var editedChange map[string]any
+	if err := json.Unmarshal(canonical, &editedChange); err != nil {
+		return fmt.Errorf("approvals: canonicalized edited change did not decode as a JSON object: %w", err)
+	}
+	if editedChange == nil {
+		// A literal JSON `null` decodes without error but leaves the map nil,
+		// which would emit edited_change: null (violating the public contract)
+		// and could resume a parked run with null args — reject it as an
+		// invalid edit (422) rather than a JSON object.
+		return &InvalidEditError{Cause: errors.New("payload is not a JSON object")}
+	}
+	wasEdited := true
+	decidedPayload.Edited = &wasEdited
+	decidedPayload.DiffHash = &editedHash
+	decidedPayload.EditedChange = &editedChange
+	return nil
+}

--- a/backend/internal/modules/deals/stageprogression.go
+++ b/backend/internal/modules/deals/stageprogression.go
@@ -284,13 +284,18 @@ func recordProgressionDecidedTx(
 	// The transition comes back with the row rather than from a second read:
 	// the sweep below needs it, and the row already carries it.
 	var moved TransitionRef
+	// decided_by_system is derived from the outcome rather than taken as a
+	// second parameter. The two would otherwise be free to disagree, and a row
+	// saying auto_applied with the column false is one the report and the
+	// column would answer differently about the same move.
 	err := tx.QueryRow(ctx, `
 		UPDATE stage_progression_outcome
 		   SET outcome = $2, rejection_reason = $3, evidence_corrected = $4,
-		       decided_at = now()
+		       decided_by_system = ($2 = $6), decided_at = now()
 		 WHERE approval_id = $1 AND outcome = $5
 		RETURNING id, deal_id, pipeline_id, from_stage_id, to_stage_id`,
-		approvalID, outcome, reason, edited, ProgressionProposed).
+		approvalID, outcome, reason, edited, ProgressionProposed,
+		ProgressionAutoApplied).
 		Scan(&id, &dealID, &moved.PipelineID, &moved.FromStageID, &moved.ToStageID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Either nothing was proposed under this approval, or it was already
@@ -323,6 +328,12 @@ func recordProgressionDecidedTx(
 	// the clean approvals that were holding the rate down age out of the
 	// window — so a sweep that only ran on reversals would leave a transition
 	// running automatically on a record that had already failed.
+	//
+	// Including on an automatic apply. The rates it re-counts exclude
+	// auto_applied from their denominator, so the autopilot's own moves cannot
+	// improve or worsen the record they are judged against — but a reversal
+	// that lands while a transition is running automatically must be able to
+	// stop it, and this is the path every decision takes.
 	return suspendIfRecordWentBadTx(ctx, tx, moved, now)
 }
 

--- a/backend/internal/modules/deals/stageprogressionpolicy.go
+++ b/backend/internal/modules/deals/stageprogressionpolicy.go
@@ -316,3 +316,55 @@ func (s *Store) ReadTransitionPolicies(
 	})
 	return out, err
 }
+
+// MayAutoApplyStageMove answers whether ONE proposed move may apply without
+// asking, resolving the deal's pipeline and the rule in one transaction.
+//
+// The entry point the auto-applier reaches through its seam. It exists because
+// the applier knows an approval and a payload, not a transition: the pipeline
+// is the DEAL'S, read here rather than taken from the staged card, so a deal
+// moved to another pipeline since the card was raised is judged by the rule
+// that governs where it is now.
+//
+// It answers only. Applying is the caller's, under the caller's authority.
+//
+// GATED on reading the deal, not on the pipeline. The question is about one
+// deal's move, and the caller that asks it is about to write that deal — so a
+// principal who may not see the deal must not learn from this whether its
+// transition is on automatic. The pipeline rule underneath is read through
+// StageAutopilotModeTx, which is reached only after this gate.
+func (s *Store) MayAutoApplyStageMove(
+	ctx context.Context, dealID ids.DealID, fromStage, toStage ids.StageID,
+) (AutopilotVerdict, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return refused(), err
+	}
+	var out AutopilotVerdict
+	err := s.Tx(ctx, func(tx pgx.Tx) error {
+		var pipelineID ids.PipelineID
+		if err := tx.QueryRow(ctx,
+			`SELECT pipeline_id FROM deal WHERE id = $1 AND archived_at IS NULL`,
+			dealID).Scan(&pipelineID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				// Archived or gone. A move onto a deal that is not there is not
+				// a move this may make, and the card stays for a person to
+				// close.
+				out = refused()
+				return nil
+			}
+			return fmt.Errorf("read the deal's pipeline: %w", err)
+		}
+		verdict, err := StageAutopilotModeTx(ctx, tx, TransitionRef{
+			PipelineID: pipelineID, FromStageID: fromStage, ToStageID: toStage,
+		}, s.clock())
+		if err != nil {
+			return err
+		}
+		out = verdict
+		return nil
+	})
+	if err != nil {
+		return refused(), err
+	}
+	return out, nil
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -118,7 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (128)
+## Census (129)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -176,6 +176,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendsendpermission_test.go` | H2 | Every surface that posts to a send door asks the engine first, through the one component that says what it answered. |
 | `gatecensus_test.go` | H2 | The census over this repo's own gate machinery: a gate's exceptions are held to the standard the gate holds its subjects to. |
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
+| `governedkindseams_test.go` | H2 | The two halves of automatic apply agree about which kinds it covers. |
 | `insertattemptcaps_test.go` | H2 | An insert that names no MaxAttempts does not run without a retry ladder — it runs on River's default of 25, on attempt-to-the-fourth backoff, which reaches days. |
 | `jobbinding_test.go` | H2 | workspaceBindFloor guards against a vacuous pass. |
 | `jobcensus_test.go` | H3 | The census as a fitness function, in both directions. |

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -1657,6 +1657,8 @@ export interface components {
              * @description The deciding human's user id. ABSENT on the `expired` verdict, and that absence is the payload's own statement that nobody decided this — a zero or placeholder id here would put a phantom user's name on a refusal no person made.
              */
             decided_by?: string;
+            /** @description True when the product applied this itself under a governing policy rather than putting it to a person. It is NOT the complement of `decided_by`: the `expired` verdict also carries no decider, and those two are opposite facts — one is the product acting, the other is nobody acting. A consumer measuring whether people agree with what is proposed must exclude an automatic apply from its denominator, because the autopilot agreeing with itself is not evidence that anyone agreed. */
+            decided_by_system?: boolean;
             /** @description True when the human edited the proposed change before approving (present only on the modify-then-approve arm). */
             edited?: boolean;
             /** @description The edited change's freshly computed diff_hash (present only on the modify-then-approve arm). */


### PR DESCRIPTION
Stage automation applies. A card whose transition has cleared its thresholds is decided by the product instead of waiting for a person, and the receipt says afterwards that nobody was asked.

## Two ladders, not one set

`approvals.AdminGovernedAutoKinds` is kept **separate** from the per-rep `AutoApplyKinds`. That set's own comment states its bound: it is "what the product can put back" through the restore path — one Undo and the field is as it was.

A stage move is not that. It writes `deal_stage_history` and the progression ledger beside the field, so restoring the column alone would leave the history saying the deal is somewhere it is not.

The authority differs too. Nobody's own history earns a stage move the right to skip the question; a **transition** earns it, per pipeline, against thresholds an admin set. So membership grants nothing on its own — the kind still has to pass the governing policy.

`compose/autoapply.go` unions both sets for its scan and routes each kind to the ladder that governs it through an injected seam. A governed kind with **no** seam never applies, and `governedKindPolicies` refuses to build rather than let that be silent — an unwired governed kind is otherwise invisible, because the applier refuses it correctly and nothing says the wiring was never done.

## The rule is re-asked in the transaction that moves the deal

Codex found this and it is the important one. The sweep asks whether a transition may apply, then decides — and between those two the rule can change: an admin flips the kill switch, sets the transition back to propose, or the product suspends it. Read there and written here, the move commits on a permission that no longer exists, which is exactly what `StageAutopilotModeTx`'s own comment says its transaction is for.

`refuseAStaleAutomaticMove` re-asks inside the effect's transaction. A **human's** approval skips it: a person deciding is the authority, and re-asking the autopilot's thresholds would let a suspended rule block a move somebody explicitly made.

## The autopilot must not vote on itself

`approval.decided` now carries `decided_by_system`, which it did not, and the outcome consumer files an automatic apply as `auto_applied` rather than as a human's clean approval.

That one mapping decides whether the launch gate can be trusted. Counted as an approval, a transition running automatically would report an ever-better record built entirely from its own output. `TestAnAutoAppliedMoveDoesNotCountTowardTheRateThatAuthorizedIt` fails at 240→241 without it.

## Other Codex findings

- **Sweep-aborting error** (real, fixed): the seam wrapped raw `pgx.ErrNoRows`, which `refusesThisRow` does not match — one concurrently-decided card would have ended the whole pass, and since the batch is oldest-first it would park every other transition behind it. Now returns `apperrors.ErrNotFound`.
- **Effect failure after a committed decision** (real, **pre-existing**, not widened): the decision commits before the effect runs, so a refused effect leaves the card approved with `effect_failed_at`. A human's clean approval has had exactly this shape all along. Fixing it means reworking how every outcome handles a failed effect — out of scope here, and the test asserts the real behaviour rather than a product that does not exist.
- **Event version not bumped**: does not apply. The decided payload has no `additionalProperties: false`, and PR #4520 added three optional fields to an existing event without a bump.

## Two tests that proved nothing until they were fixed

Worth reading, because both passed against deliberately broken code:

1. `TestAnUngovernedTransitionNeverAutoApplies` passed with the verdict check deleted — the owner had no role, so the refusal came from permissions, not from the missing rule. It now grants the role first.
2. The stale-rule test suspended the rule *before* the sweep, so the sweep's own check refused it and the new guard was never reached. It also used a bare `approvals.NewService`, which has **no effects registered** — `ApplyUnderPolicy` approved the card and never ran the move at all. It now drives `compose.StageProgressionDecisions`, the registry with the real effect.

## Verification

- `make check-backend` green, `make check-fe` green
- `make test-it` green for `modules/deals`, `modules/approvals`, `compose/integration`
- `make craft-static` — 0 blocker, 0 major, 0 minor across all four roots
- Eight integration tests through `compose.SweepAutoApply`, each mutation-checked one clause at a time

`applyEditedPayload` moves to its own file so `decide.go` stays under the 500-line cap; the code is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage-progression approvals now auto-apply when the transition's record clears admin-set thresholds: the product moves the deal instead of waiting for a person, and the ledger records that the system decided it.

**New Features**
- Governed auto-apply lives on its own `AdminGovernedAutoKinds` ladder, separate from the per-rep `AutoApplyKinds`; a stage move writes history and a ledger, so the restore path can't put it back.
- The governing rule is re-asked inside the move's transaction, so a suspension, a kill-switch flip, or a mode change after the sweep's check still blocks the apply; a human's approval skips the re-check.
- `approval.decided` now carries `decided_by_system`, and the outcome consumer files automatic applies as `auto_applied` rather than as a human's clean approval.
- A refused automatic move leaves the card approved with `effect_failed_at`, the same shape a human's failed approval already has.
- A governed kind without a policy seam fails at startup instead of silently never applying.

**Bug Fixes**
- The seam returned raw `pgx.ErrNoRows`, which `refusesThisRow` doesn't match, so one concurrently-decided card ended the whole pass; it now returns `apperrors.ErrNotFound`.
- Two tests passed against deliberately broken code and now drive the real path: one never granted the owner's role, and one suspended the rule before the sweep and used a service with no effects registered.

<sup>Written for commit ee71479dae01ed29ec6b4d15f9cbdb59a4800526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

