### PR TITLE
test(gates): a declared messaging obligation is one the engine applies

### DIFF
--- a/backend/gates/messagingruleapplied_test.go
+++ b/backend/gates/messagingruleapplied_test.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every obligation a messaging pack declares is one the engine applies, or one
+// this file records as not yet applied and says why.
+//
+// The gate beside this one holds that a declared rule set REACHES the registry.
+// Neither it nor the capability census can see what happens after: a field that
+// lands in the registry, merges correctly through Strictest, and is then read
+// by nobody. Every test in that chain passes, because each one is asking about
+// the step it owns.
+//
+// The consequence is a pack that states a country's law and an installation
+// that does not follow it. extensions/vn declares the Decree 91/2020/ND-CP
+// subject label, the advertiser-identification disclosure and the acknowledged
+// opt-out; the engine applies none of the three today, and no decision records
+// the ruleset version it was taken under. Before this gate nothing held that
+// apart: the pack's Rules literal reads as a complete statement of the decree,
+// and which of its fields reach a consumer could only be learnt by grepping for
+// each one. The field comments now say which are unapplied, and this is what
+// keeps them true.
+//
+// So the register below is the answer to "which ones bind": a field is applied
+// by a named reader in the engine, or it is listed here with the reason it is
+// not. Both halves are checked — an entry for a field that HAS a reader fails
+// just as a missing entry does, because a register that keeps stale lines
+// stops describing the tree.
+//
+// WHAT DECIDES THE LIST. The fields come from messaging.Rules itself, for the
+// reason the capability census derives its own corpus from extension.Extension:
+// a list written here would be a second copy of that struct, and the copy that
+// goes short is the one that still passes. A new obligation field is therefore
+// a failing test until somebody either wires it or records why not.
+
+import (
+	"go/ast"
+	"go/token"
+	"slices"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	// rulesSurfaceFile publishes the rule shape a pack declares.
+	rulesSurfaceFile = "pkg/extension/messaging/messaging.go"
+	// rulesType is the declaration whose fields are the obligations.
+	rulesType = "Rules"
+	// rulesEngineDir is the engine that applies them.
+	rulesEngineDir = "internal/modules/consent"
+)
+
+// rulesIdentityFields name the rule set rather than binding anything.
+//
+// Jurisdiction alone. It is the registry's key and the boot's duplicate check
+// (internal/compose/extensionpolicy.go), so demanding an engine reader for it
+// would be asking the engine to apply a label.
+//
+// Version is NOT identity, though it reads like it: messaging.Rules says it is
+// "stamped onto every decision taken under it", which is an obligation and a
+// promise to a subject who later asks which rules their message was judged
+// under. Excluding it here was this gate's own first blind spot — the register
+// below carries it instead, which is where an unkept promise belongs.
+var rulesIdentityFields = []string{"Jurisdiction"}
+
+// unappliedRules are the obligations the engine does not read yet, each with
+// the reason it cannot.
+//
+// A line here is a statement that the product declares a rule it does not
+// follow, so each says what is missing rather than that the work is pending.
+// Removing a line is the point of the register; adding one is a decision that
+// the gap is worth shipping, and it belongs in the change that opens it.
+//
+// A gatekit waiver rather than a bare map, so the two ways a line goes stale
+// are reported by the shared helper instead of a second hand-written check:
+// AssertAllMatched sees both a field that has since gained a reader and one the
+// struct no longer declares, because the arm below asks Waived only about a
+// field it has already found unapplied.
+var unappliedRules = gatekit.Waive(map[string]string{
+	"SubjectPrefix": "nothing prepends it. A send composes its own subject — " +
+		"activities.SendEmailInput.Subject is caller-supplied text — and no step " +
+		"between that and the provider consults the applicable rules, so an " +
+		"advertising message leaves unmarked whatever a pack declares",
+	"Disclosures": "nothing renders a disclosure into a message body. The kinds are a " +
+		"closed set and the merge keeps them, but no consumer turns one into text",
+	"OptOutAcknowledgement": "no acknowledgement is sent. The controller lane is the only " +
+		"one that may write to somebody who has just suppressed themselves, and it " +
+		"registers no template for this",
+	"Version": "no decision records which ruleset judged it. Strictest zeroes the version " +
+		"when it folds two jurisdictions and returns the codes it folded instead, and " +
+		"applicableRules discards that second result — so neither the version nor the " +
+		"codes reach communication_decision, which carries no column for either",
+})
+
+func TestEveryDeclaredMessagingObligationIsAppliedOrRecorded(t *testing.T) {
+	t.Parallel()
+
+	obligations := ruleObligationFields(t)
+	readers := engineRuleReaders(t)
+
+	for _, field := range obligations {
+		if readers[field] {
+			continue
+		}
+		if unappliedRules.Waived(t, field) {
+			continue
+		}
+		t.Errorf("messaging.Rules.%s is declared and no engine code reads it.\n\n"+
+			"A pack declaring this field states an obligation the installation does not "+
+			"discharge, and nothing tells an operator which of a country's rules actually "+
+			"bind. Either apply it in %s, or add it to unappliedRules with the reason it "+
+			"cannot be applied yet.",
+			field, rulesEngineDir)
+	}
+	unappliedRules.AssertAllMatched(t)
+}
+
+// TestTheEngineReadsAtLeastOneRuleField is the positive control for the reader
+// scan.
+//
+// The arm above reports a field applied when the scan finds a selector for it.
+// A directory that no longer exists is not the case to worry about —
+// parseTreeUnder fatals on that. The quiet one is a scan that still parses and
+// stops recognising reads: the lookup renamed, its results reordered, or the
+// engine's rule handling moved to a package outside this directory. Every field
+// then reports unapplied, which does fail, but as findings naming the wrong
+// subject — they read as somebody having deleted the engine's rule handling.
+//
+// So this asserts the scan still sees the applications the tree is known to
+// have, and says which cause to suspect when it does not.
+func TestTheEngineReadsAtLeastOneRuleField(t *testing.T) {
+	t.Parallel()
+
+	readers := engineRuleReaders(t)
+	// All four fields the engine reads today, not a sample: the corpus is small
+	// and known, and a scan that kept finding one of them while the rest moved
+	// to a subpackage would report the movers unapplied rather than say what
+	// happened.
+	//
+	// No shipped pack narrows the two windows — extensions/de and extensions/vn
+	// both declare the core defaults, and vn's own comment says so. What the
+	// scan proves is that the reader exists, which is what this gate asks; a
+	// pack that one day sends a shorter window reaches an engine that reads it.
+	for _, field := range []string{"FrequencyCap", "ReplyWindow", "DealFollowUpWindow", "MarketingExceptions"} {
+		if !readers[field] {
+			t.Fatalf("the reader scan finds nothing applying messaging.Rules.%s, which %s does apply.\n\n"+
+				"The scan has stopped seeing the engine, so every field reads as unapplied and "+
+				"the register above is being checked against an empty reading.", field, rulesEngineDir)
+		}
+	}
+}
+
+// ruleObligationFields is the field names of messaging.Rules less the identity
+// pair.
+func ruleObligationFields(t *testing.T) []string {
+	t.Helper()
+	file := parseGo(t, rulesSurfaceFile)
+	var fields []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || spec.Name.Name != rulesType {
+			return true
+		}
+		structType, isStruct := spec.Type.(*ast.StructType)
+		if !isStruct {
+			return false
+		}
+		for _, field := range structType.Fields.List {
+			for _, name := range field.Names {
+				fields = append(fields, name.Name)
+			}
+		}
+		return false
+	})
+	if len(fields) == 0 {
+		t.Fatalf("%s declares no %s fields — the subject this gate reads has moved, and a census "+
+			"that found nothing to judge reports every obligation applied", rulesSurfaceFile, rulesType)
+	}
+	for _, identity := range rulesIdentityFields {
+		if !slices.Contains(fields, identity) {
+			t.Fatalf("messaging.%s has no %s field — this census excludes the identity pair by name, "+
+				"so a rename here silently changes what it demands of the engine", rulesType, identity)
+		}
+	}
+	return slices.DeleteFunc(fields, func(f string) bool { return slices.Contains(rulesIdentityFields, f) })
+}
+
+// rulesLookup is the engine's one entry point to a jurisdiction's rules. Every
+// read of a rule field starts at a value this returns.
+const rulesLookup = "applicableRules"
+
+// engineRuleReaders reports which rule fields the engine reads.
+//
+// It counts a selector only when its base is a local bound from rulesLookup, so
+// a field is "applied" because the engine read it off a rule set and not
+// because some unrelated type in the package happens to carry the same name.
+// Matching the bare name was the first shape of this scan and it was wrong in
+// the one direction a census may not be: messaging.Rules nests types whose
+// field names (Window, Messages, Kind, Version) the engine already selects on
+// other values, so an obligation added under any of those names would have been
+// born reported-as-applied, with nothing failing.
+//
+// Where it cannot tell, it REFUSES rather than admits — the rule
+// machineryapplied_test.go states for the same choice. A read through a shape
+// this does not follow (a rule set stored in a struct field, passed through a
+// helper, ranged over) reports the field unapplied, which fails loudly and is
+// fixable. The opposite error is the silent one.
+func engineRuleReaders(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	read := map[string]bool{}
+	for _, file := range parseTreeUnder(t, fset, rulesEngineDir) {
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil {
+				continue
+			}
+			bound := ruleLocalsIn(fn.Body)
+			if len(bound) == 0 {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				sel, isSel := n.(*ast.SelectorExpr)
+				if !isSel {
+					return true
+				}
+				if base, isIdent := sel.X.(*ast.Ident); isIdent && bound[base.Name] {
+					read[sel.Sel.Name] = true
+				}
+				return true
+			})
+		}
+	}
+	return read
+}
+
+// ruleLocalsIn names the locals in one function body that hold a rule set: the
+// identifiers assigned from a rulesLookup call.
+//
+// Only the first result is taken. The lookup returns (Rules, bool, error), and
+// binding the name to position zero means a reshuffle of those results stops
+// the scan finding readers rather than silently following the wrong one — the
+// positive control is what reports that.
+func ruleLocalsIn(body *ast.BlockStmt) map[string]bool {
+	bound := map[string]bool{}
+	rebound := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, isAssign := n.(*ast.AssignStmt)
+		if !isAssign || len(assign.Lhs) == 0 {
+			return true
+		}
+		fromLookup := len(assign.Rhs) == 1 && isRulesLookupCall(assign.Rhs[0])
+		for i, lhs := range assign.Lhs {
+			name, isIdent := lhs.(*ast.Ident)
+			if !isIdent || name.Name == "_" {
+				continue
+			}
+			if fromLookup && i == 0 {
+				bound[name.Name] = true
+				continue
+			}
+			// Any other binding or assignment of the name: an inner block's
+			// own `rules`, a reassignment, a range variable. The scan reads a
+			// name and not a scope, so a name that means two things in one
+			// function means nothing it can trust.
+			rebound[name.Name] = true
+		}
+		return true
+	})
+	for _, other := range []map[string]bool{rebound, otherBindingsIn(body)} {
+		for name := range other {
+			delete(bound, name)
+		}
+	}
+	return bound
+}
+
+// otherBindingsIn names identifiers a function binds by some route other than
+// an assignment: a range variable, a var declaration, a closure's parameter.
+//
+// Collected so ruleLocalsIn can DROP a rule local whose name is also bound
+// elsewhere in the same function. The scan matches a name, not a lexical scope,
+// so a shadowed name would otherwise let a read off an unrelated value count as
+// a read of the rule set — the silent direction. Dropping it reports the field
+// unapplied instead, which fails loudly and is what the shadowing author must
+// then fix by renaming.
+func otherBindingsIn(body *ast.BlockStmt) map[string]bool {
+	bound := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.ValueSpec:
+			for _, name := range node.Names {
+				bound[name.Name] = true
+			}
+		case *ast.RangeStmt:
+			for _, expr := range []ast.Expr{node.Key, node.Value} {
+				if ident, isIdent := expr.(*ast.Ident); isIdent {
+					bound[ident.Name] = true
+				}
+			}
+		case *ast.FuncLit:
+			for _, field := range node.Type.Params.List {
+				for _, name := range field.Names {
+					bound[name.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return bound
+}
+
+// isRulesLookupCall reports whether an expression is a call resolving the
+// applicable rules.
+func isRulesLookupCall(expr ast.Expr) bool {
+	call, isCall := expr.(*ast.CallExpr)
+	return isCall && callsRulesLookup(call)
+}
+
+// callsRulesLookup reports whether a call resolves the applicable rules,
+// through a receiver or bare.
+func callsRulesLookup(call *ast.CallExpr) bool {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name == rulesLookup
+	case *ast.SelectorExpr:
+		return fun.Sel.Name == rulesLookup
+	}
+	return false
+}

--- a/backend/pkg/extension/messaging/messaging.go
+++ b/backend/pkg/extension/messaging/messaging.go
@@ -42,11 +42,14 @@ type Rules struct {
 	// Jurisdiction is whose rules these are, lower-case ISO 3166-1 alpha-2.
 	Jurisdiction jurisdiction.Code
 
-	// Version is the rule set's own version, stamped onto every decision taken
-	// under it. A decision a subject later asks about must be readable against
-	// the rules that were live when it was taken, and those rules change — so
-	// the number is recorded rather than re-derived from whatever the code says
-	// today.
+	// Version is the rule set's own version. A decision a subject later asks
+	// about must be readable against the rules that were live when it was
+	// taken, and those rules change, so the number is meant to be recorded
+	// rather than re-derived from whatever the code says today.
+	//
+	// DECLARED, NOT YET APPLIED: no decision records it. Held by
+	// TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
+	// (backend/gates/messagingruleapplied_test.go), which carries the reason.
 	Version int
 
 	// ReplyWindow is how long an inbound message keeps making a reply a reply
@@ -69,10 +72,20 @@ type Rules struct {
 	MarketingExceptions []MarketingException
 
 	// Disclosures are what a first message to somebody must carry.
+	//
+	// DECLARED, NOT YET APPLIED: no consumer renders a disclosure into a
+	// message body. Held by TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
+	// (backend/gates/messagingruleapplied_test.go), which fails when a pack
+	// declares an obligation the engine does not discharge and no entry
+	// records why.
 	Disclosures []Disclosure
 
-	// SubjectPrefix is prepended to an advertising message's subject, exactly
-	// once. Empty means none.
+	// SubjectPrefix is the marking an advertising message's subject must carry,
+	// exactly once. Empty means none.
+	//
+	// DECLARED, NOT YET APPLIED: nothing prepends it. No send path consults a
+	// pack's prefix before composing a subject. Held by the same gate as
+	// Disclosures.
 	SubjectPrefix string
 
 	// FrequencyCap bounds advertising to one address in a window. Nil means
@@ -80,7 +93,10 @@ type Rules struct {
 	FrequencyCap *FrequencyCap
 
 	// OptOutAcknowledgement records whether an opt-out is owed a confirming
-	// message. False means none is sent, which is the default.
+	// message. False means none is owed, which is the default.
+	//
+	// DECLARED, NOT YET APPLIED: nothing sends the acknowledgement. Held by the
+	// same gate as Disclosures.
 	OptOutAcknowledgement bool
 }
 
@@ -146,8 +162,12 @@ func (e MarketingException) Validate() error {
 }
 
 // DisclosureKind names something a first message must carry. Closed for the
-// reason ExceptionKind is: the engine renders each kind it knows, and one it
-// does not know would be an obligation nothing discharges.
+// reason ExceptionKind is: a pack may only name an obligation the engine can
+// be held to, and one outside this set is an obligation nothing could ever
+// discharge.
+//
+// The set being closed is not a claim that the kinds are rendered. None of them
+// is today — see Disclosures above for what holds that gap visible.
 type DisclosureKind string
 
 const (
@@ -170,7 +190,7 @@ func (k DisclosureKind) Validate() error {
 	case ControllerIdentity, PrivacyContact, ObjectionRoute, AdvertiserContact:
 		return nil
 	}
-	return fmt.Errorf("disclosure %q is not one the engine renders", string(k))
+	return fmt.Errorf("disclosure %q is not one this contract defines", string(k))
 }
 
 // Disclosure is one obligation a message carries, and where it binds.

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -118,7 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 | `worklistverdictstandings_test.go` | H2 | The queue's verdict standings ARE the deal card's, and this derives them from the card rather than keeping a second list of them. |
 
-## Census (129)
+## Census (130)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -191,6 +191,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |
 | `meetinghistorywriters_test.go` | H2 | Every statement that writes activity.meeting\_status also records the transition. |
+| `messagingruleapplied_test.go` | H2 | Every obligation a messaging pack declares is one the engine applies, or one this file records as not yet applied and says why. |
 | `metricsuffix_test.go` | H2 | A `\_total` suffix means COUNTER, in both directions. |
 | `migrationcitations_test.go` | H1 | No file acquires a citation of a migration version that does not exist. |
 | `noticedutycensus_test.go` | H3 | Every way a contact can arrive has a decided disclosure duty. |

--- a/extensions/vn/vn.go
+++ b/extensions/vn/vn.go
@@ -78,27 +78,28 @@ const advertisingLabel = "[QC]"
 // authorizes nothing here.
 //
 // THE [QC] PREFIX is Art. 12: an advertising message must be labelled as
-// advertising in its subject, and the decree fixes the label. It is DECLARED
-// here and applied by nothing yet — the renderer that would apply it, once, to
-// advertising only, needs the controller template catalog that has not landed.
-// Declaring it now is deliberate: the rule is what the decree says, and a pack
-// that waited would leave the obligation unrecorded until the machinery caught
-// up.
+// advertising in its subject, and the decree fixes the label. Declaring it
+// while nothing applies it is deliberate: the rule is what the decree says, and
+// a pack that waited would leave the obligation unrecorded until the machinery
+// caught up. Which obligations here bind today is not this comment's to claim —
+// TestEveryDeclaredMessagingObligationIsAppliedOrRecorded
+// (backend/gates/messagingruleapplied_test.go) holds the answer, and fails when
+// a field is applied or abandoned without the record moving with it.
 //
 // ADVERTISER IDENTIFICATION is Art. 13: an advertising message names the
 // advertiser and gives a way to reach them. It is declared as an
 // AdvertiserContact disclosure alongside the Art. 13 GDPR-shaped controller
 // disclosures, because a Vietnamese recipient is owed BOTH — who is processing
 // their data and who is advertising to them are the same organisation here and
-// need not be, and the two obligations come from different instruments. Also
-// declared and not yet rendered, for the same reason as the prefix.
+// need not be, and the two obligations come from different instruments. It also
+// needs an advertiser phone and website, which the installation settings do not
+// carry.
 //
 // THE ACKNOWLEDGED OPT-OUT is Art. 16: a recipient who refuses further
 // advertising is owed a confirmation that their refusal was received, sent
 // within twenty-four hours and carrying no advertising of its own. The flag says
 // one is owed; the engine's controller lane is what will send it, which is the
-// only lane that may write to somebody who has just suppressed themselves. Also
-// declared and not yet wired.
+// only lane that may write to somebody who has just suppressed themselves.
 //
 // THE DAILY CEILING is the one rule here the engine applies today. It refuses
 // regardless of rollout mode, because an installation declaring a country is


### PR DESCRIPTION
`extensions/vn` states the Decree 91/2020/ND-CP rules as data: the `[QC]` advertising subject label, the advertiser-identification disclosure, the acknowledged opt-out, the daily ceiling. Only the ceiling and the two windows reach a consumer. The other three fields are read by nobody, and nothing said so — the pack's `Rules` literal reads as a complete statement of the decree, and which fields bind could only be learnt by grepping for each one.

The new gate derives its corpus from `messaging.Rules` itself, so a new obligation field is a failing test until somebody wires it or records why not. A field counts as applied when the engine reads it off a value bound from `applicableRules`; otherwise it carries a `gatekit` waiver naming what the gap costs.

## Four fields are registered unapplied

`SubjectPrefix`, `Disclosures`, `OptOutAcknowledgement`, and `Version`.

`Version` is the one this gate's own first shape hid. I had excluded it as identity alongside `Jurisdiction`, but `messaging.Rules` promises it is "stamped onto every decision taken under it" and nothing stamps it: `Strictest` zeroes it when it folds two jurisdictions and returns the folded codes instead, which `applicableRules` discards with `_`. `communication_decision` carries no column for either. A subject asking which rules judged their message cannot be answered. The promise is now a waiver line rather than a comment nothing held.

## Comments that claimed behaviour the code does not have

- `DisclosureKind`: "the engine renders each kind it knows" — it renders none. The sibling error string a pack author sees at boot said the same thing; both corrected.
- `SubjectPrefix`: the missing marketing template was not the reason. A marketing subject is caller-supplied text (`activities.SendEmailInput.Subject`) and never reaches the controller catalog.
- The positive control claimed a moved directory yields an empty scan; `parseTreeUnder` fatals on that instead.

## The reader scan

Matching a bare field name was the first shape and it was wrong in the direction a census may not be: `messaging.Rules` nests types whose field names (`Window`, `Messages`, `Kind`, `Locale`) the engine already selects on other values, so an obligation added under any of them would have been born reported-as-applied with nothing failing. Both reviewers found this independently, with different probes.

The scan now binds to the lookup and drops any name also bound elsewhere in the same function — over-refusing, which fails loudly. That follows the principle `machineryapplied_test.go` states for the same choice.

## Mutation checks

Twelve, all failing correctly when they should: seven collision probes (`ZzProbe`, `Window`, `Locale`, `Subject`, `Recipients`, `Kind`, `Messages`), a shadowed-local probe, a stale entry for an applied field, an entry naming a field the struct does not declare, a reasonless entry, and the scan blinded two ways (directory moved, lookup renamed).

## What this does not do

It records four unkept promises rather than fixing them. The Vietnamese advertising label, the advertiser disclosure, the acknowledged opt-out and the decision's ruleset version all remain unimplemented — `AdvertiserContact` additionally has no data source, since installation settings carry no phone or website. Building or dropping them is a product decision; this makes it visible and stops it growing quietly.

`make check-backend` green against the rebased tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a census gate that derives a messaging pack's obligations from `messaging.Rules` itself, so a declared rule the engine does not apply fails until somebody wires it or records why not.

- `SubjectPrefix`, `Disclosures`, `OptOutAcknowledgement`, and `Version` are registered as unapplied, each with a `gatekit` waiver naming what the gap costs.
- The reader scan counts a field applied only when read off a local bound from `applicableRules`, and drops names also bound elsewhere in the function, so shadowed or nested-field reads fail loudly.
- Corrects comments in `messaging.go` and `extensions/vn` that claimed behavior the code does not have, including the `DisclosureKind` validation error.

<sup>Written for commit 109d8d9264a1bb47c51de308c5df0d6a17c111e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

