### PR TITLE
fix: /brief gets the model-call deadline, and its worklist row gets the right label

### DIFF
--- a/backend/gates/modelroutes_test.go
+++ b/backend/gates/modelroutes_test.go
@@ -34,6 +34,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
 )
 
 const (
@@ -116,6 +118,98 @@ func contractModelRoutes(t *testing.T) map[string]string {
 	}
 	return marked
 }
+
+// modelRouteDeadlineFile holds the SERVER's own mirror of the same marker:
+// which routes get the long write deadline instead of the ordinary 30s
+// WriteTimeout. A route the contract marks and this list misses does not
+// merely misreport an idle agent — it 502s the caller once the model runs
+// long, though the handler itself succeeds, exactly what margince#4355 found
+// for /brief.
+const modelRouteDeadlineFile = "internal/compose/modelroutedeadline.go"
+
+// oneDeliberateSuffixGap ratifies each contract path this gate accepts as
+// permanently unmatched to no safe suffix, with the reason the point-fix
+// every other gap here got does not apply to it. Bidirectional the same way
+// every waiver here is: fix the path with a real suffix and this entry goes
+// stale on its own, with AssertAllMatched below the one place that says so.
+var oneDeliberateSuffixGap = gatekit.Waive(map[string]string{
+	"/deals/{id}/status": "margince#4914 — \"/status\" alone also matches" +
+		" /contracts/{id}/status, /embeddings/reindex/status and" +
+		" /overlay/sync-status, none of which call a model, and suffix" +
+		" matching cannot require the segment before it be \"deals\"",
+})
+
+// TestTheModelRouteDeadlineSuffixesCoverTheContract holds modelRouteSuffixes
+// to the same contract marker TestTheClientsModelRouteTableIsTheContracts
+// holds the client to — the mechanism differs (a suffix list has no method,
+// where the client's table has both) so this checks path coverage only: every
+// x-waits-on-model path must suffix-match at least one entry, or be ratified
+// in oneDeliberateSuffixGap with the reason a suffix cannot say it safely.
+func TestTheModelRouteDeadlineSuffixesCoverTheContract(t *testing.T) {
+	t.Parallel()
+	defer oneDeliberateSuffixGap.AssertAllMatched(t)
+	marked := contractModelRoutes(t)
+	suffixes := modelRouteDeadlineSuffixes(t)
+
+	paths := map[string]bool{}
+	for route := range marked {
+		_, path, ok := strings.Cut(route, " ")
+		if !ok {
+			t.Fatalf("route %q has no method/path split", route)
+		}
+		paths[path] = true
+	}
+	for path := range paths {
+		covered := false
+		for _, suffix := range suffixes {
+			if strings.HasSuffix(path, suffix) {
+				covered = true
+				break
+			}
+		}
+		if covered {
+			continue
+		}
+		if oneDeliberateSuffixGap.Waived(t, path) {
+			continue
+		}
+		t.Errorf("%s calls a model per %s and no entry in %s's modelRouteSuffixes matches it — the caller gets only the server-wide 30s WriteTimeout and 502s once the model runs long", path, modelRouteContract, modelRouteDeadlineFile)
+	}
+}
+
+// modelRouteDeadlineSuffixes reads modelRouteSuffixes out of its own source,
+// the same way clientModelRoutes reads the client's table: the slice is
+// unexported and this gate's only path to it is the text of the file that
+// declares it.
+func modelRouteDeadlineSuffixes(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile(modelRouteDeadlineFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", modelRouteDeadlineFile, err)
+	}
+	const marker = "var modelRouteSuffixes = []string{"
+	start := indexAfter(string(source), marker)
+	if start < 0 {
+		t.Fatalf("%s no longer declares modelRouteSuffixes as a []string literal — this gate is reading a shape that is gone", modelRouteDeadlineFile)
+	}
+	end := strings.Index(string(source)[start:], "}")
+	if end < 0 {
+		t.Fatalf("%s's modelRouteSuffixes literal is unterminated", modelRouteDeadlineFile)
+	}
+	block := tsComment.ReplaceAllString(string(source)[start:start+end], " ")
+	var suffixes []string
+	for _, m := range goStringLiteral.FindAllStringSubmatch(block, -1) {
+		suffixes = append(suffixes, m[1])
+	}
+	if len(suffixes) == 0 {
+		t.Fatalf("no suffixes parsed out of %s's modelRouteSuffixes — a gate that reads nothing agrees with everything", modelRouteDeadlineFile)
+	}
+	return suffixes
+}
+
+// goStringLiteral reads one Go double-quoted string literal. modelRouteSuffixes
+// holds plain suffixes with no escapes, so this does not need to unescape them.
+var goStringLiteral = regexp.MustCompile(`"([^"]*)"`)
 
 // clientModelRoutes is the client's table, read out of its source: the constant
 // is module-private and exported by nothing, which is right for the client and

--- a/backend/internal/compose/modelroutedeadline.go
+++ b/backend/internal/compose/modelroutedeadline.go
@@ -20,8 +20,18 @@ import (
 // Suffix rather than a full path because most of these are mounted under an
 // id-bearing prefix (/activities/{id}/draft-email, /organizations/{id}/dossier),
 // and a list of formatted paths would be a second copy of the router that
-// drifts the day a route moves. `/brief` carries no id — it assembles the
-// caller's own day — but the same suffix match still names it uniquely.
+// drifts the day a route moves. Suffix matching is also method-blind on
+// purpose — the same tradeoff every entry here already makes for its sibling
+// GET (on-miss) and POST (always) — so `/brief` also covers the plain re-read
+// `GET /v1/brief`, which loses nothing by getting a deadline it does not need.
+//
+// `/brief` matches three routes, not one: the caller's own morning brief
+// (`/v1/brief`) and the person's and organization's own brief endpoints
+// (`/people/{id}/brief`, `/organizations/{id}/brief`) — all three call a
+// model and none held this deadline before. `TestTheModelRouteDeadlineSuffixesCoverTheContract`
+// (backend/gates) holds this list to the contract's own `x-waits-on-model`
+// marker, so a route added there without a matching suffix here fails on its
+// own PR rather than waiting for a live 502 to notice.
 var modelRouteSuffixes = []string{
 	"/draft-email",
 	"/dossier",
@@ -32,6 +42,11 @@ var modelRouteSuffixes = []string{
 	"/intro-note-draft",
 	"/intro-request-draft",
 	"/role-proposals",
+	"/enrich",
+	"/coldstart",
+	"/coldstart/preview",
+	"/messages",
+	"/regenerate",
 }
 
 // extendDeadlineForModelRoutes gives a handler that calls a model long enough

--- a/backend/internal/compose/modelroutedeadline.go
+++ b/backend/internal/compose/modelroutedeadline.go
@@ -17,15 +17,17 @@ import (
 // seconds — measured on a real installation, a reply draft takes 13 to 45 —
 // and the server's WriteTimeout is 30s for every other endpoint's protection.
 //
-// Suffix rather than a full path because each of these is mounted under an
+// Suffix rather than a full path because most of these are mounted under an
 // id-bearing prefix (/activities/{id}/draft-email, /organizations/{id}/dossier),
 // and a list of formatted paths would be a second copy of the router that
-// drifts the day a route moves.
+// drifts the day a route moves. `/brief` carries no id — it assembles the
+// caller's own day — but the same suffix match still names it uniquely.
 var modelRouteSuffixes = []string{
 	"/draft-email",
 	"/dossier",
 	"/growth-fit",
 	"/meeting-brief",
+	"/brief",
 	"/ask",
 	"/intro-note-draft",
 	"/intro-request-draft",

--- a/backend/internal/compose/modelroutedeadline_test.go
+++ b/backend/internal/compose/modelroutedeadline_test.go
@@ -31,6 +31,7 @@ func TestOnlyTheModelRoutesTakeTheLongerDeadline(t *testing.T) {
 		"/v1/organizations/01a0-4cd2/dossier":             true,
 		"/v1/organizations/01a0-4cd2/growth-fit":          true,
 		"/v1/activities/01a0-4cd3/meeting-brief":          true,
+		"/v1/brief":                                       true,
 		"/v1/organizations/01a0-4cd2/ask":                 true,
 		"/v1/knowledge/corpora/01a0-4cd2/ask":             true,
 		"/v1/people/01a0-4cd2/intro-note-draft":           true,

--- a/backend/internal/compose/modelroutedeadline_test.go
+++ b/backend/internal/compose/modelroutedeadline_test.go
@@ -32,14 +32,32 @@ func TestOnlyTheModelRoutesTakeTheLongerDeadline(t *testing.T) {
 		"/v1/organizations/01a0-4cd2/growth-fit":          true,
 		"/v1/activities/01a0-4cd3/meeting-brief":          true,
 		"/v1/brief":                                       true,
+		"/v1/people/01a0-4cd2/brief":                      true,
+		"/v1/organizations/01a0-4cd2/brief":               true,
 		"/v1/organizations/01a0-4cd2/ask":                 true,
 		"/v1/knowledge/corpora/01a0-4cd2/ask":             true,
 		"/v1/people/01a0-4cd2/intro-note-draft":           true,
 		"/v1/organizations/01a0-4cd2/intro-request-draft": true,
 		"/v1/deals/01a0-4cd2/role-proposals":              true,
+		"/v1/organizations/01a0-4cd2/enrich":              true,
+		"/v1/coldstart":                                   true,
+		"/v1/coldstart/preview":                           true,
+		"/v1/onboarding/company/messages":                 true,
+		"/v1/company/site-reads/01a0-4cd2/messages":       true,
+		"/v1/offers/01a0-4cd2/regenerate":                 true,
 		"/v1/people":                                      false,
 		"/v1/me":                                          false,
 		"/v1/organizations/01a0-4cd2":                     false,
+		// `/deals/{id}/status` also calls a model (`x-waits-on-model: on-miss`)
+		// and has no safe suffix here: "/status" alone would also catch
+		// /contracts/{id}/status, /embeddings/reindex/status and
+		// /overlay/sync-status, none of which call a model, and this matcher
+		// has no way to require the segment before it be "deals". Tracked as
+		// margince#4914 rather than widened past what a bare suffix can say
+		// safely; TestTheModelRouteDeadlineSuffixesCoverTheContract names this
+		// one exception explicitly so the gap stays visible.
+		"/v1/deals/01a0-4cd2/status":     false,
+		"/v1/contracts/01a0-4cd2/status": false,
 		// A path that merely CONTAINS a slow route's name is not one: the
 		// suffix is the whole match, or a list endpoint beside it inherits a
 		// deadline it has no work for.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8964,6 +8964,9 @@ export const de = {
   // Eine ERSTE Nachricht, keine Antwort auf eine bestehende.
   "worklist.verb.draft_email": "Zum Schreiben öffnen",
   "worklist.verb.draft_email_now": "E-Mail entwerfen",
+  // Ein Briefing, keine Nachricht — ein einziger Schlüssel, weil die
+  // Steuerung nie den Editor öffnet und daher die "jetzt"-Aufteilung oben
+  // nicht braucht.
   "worklist.verb.open_meeting_brief": "Auf das Meeting vorbereiten",
   "worklist.deal.closes": "Abschluss {date}",
   "worklist.when.starts": "beginnt {when}",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -8964,6 +8964,7 @@ export const de = {
   // Eine ERSTE Nachricht, keine Antwort auf eine bestehende.
   "worklist.verb.draft_email": "Zum Schreiben öffnen",
   "worklist.verb.draft_email_now": "E-Mail entwerfen",
+  "worklist.verb.open_meeting_brief": "Auf das Meeting vorbereiten",
   "worklist.deal.closes": "Abschluss {date}",
   "worklist.when.starts": "beginnt {when}",
   "worklist.when.due": "fällig {when}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -9097,6 +9097,8 @@ export const en = {
   // conversation that has not happened yet.
   "worklist.verb.draft_email": "Open to write",
   "worklist.verb.draft_email_now": "Draft the email",
+  // A brief, not a message — one key, because the control never opens a
+  // composer and so never needs the reply/write "now" split above.
   "worklist.verb.open_meeting_brief": "Prepare for the meeting",
   "worklist.deal.closes": "closes {date}",
   "worklist.when.starts": "starts {when}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -9097,6 +9097,7 @@ export const en = {
   // conversation that has not happened yet.
   "worklist.verb.draft_email": "Open to write",
   "worklist.verb.draft_email_now": "Draft the email",
+  "worklist.verb.open_meeting_brief": "Prepare for the meeting",
   "worklist.deal.closes": "closes {date}",
   "worklist.when.starts": "starts {when}",
   "worklist.when.due": "due {when}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8841,6 +8841,7 @@ export const vi = {
   // Một thư ĐẦU TIÊN, không phải câu trả lời cho thư đã có.
   "worklist.verb.draft_email": "Mở để viết",
   "worklist.verb.draft_email_now": "Soạn email",
+  "worklist.verb.open_meeting_brief": "Chuẩn bị cho cuộc họp",
   "worklist.deal.closes": "chốt {date}",
   "worklist.when.starts": "bắt đầu {when}",
   "worklist.when.due": "đến hạn {when}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -8841,6 +8841,8 @@ export const vi = {
   // Một thư ĐẦU TIÊN, không phải câu trả lời cho thư đã có.
   "worklist.verb.draft_email": "Mở để viết",
   "worklist.verb.draft_email_now": "Soạn email",
+  // Bản tóm tắt, không phải tin nhắn — chỉ một khóa, vì nút này không bao
+  // giờ mở trình soạn thảo nên không cần tách "ngay bây giờ" như trên.
   "worklist.verb.open_meeting_brief": "Chuẩn bị cho cuộc họp",
   "worklist.deal.closes": "chốt {date}",
   "worklist.when.starts": "bắt đầu {when}",

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -441,7 +441,7 @@ describe("an unavailable source", () => {
 // The brief is not a page of its own: it opens as `?prep=<activity>` on a
 // PERSON's record, so the address needs both ids and the row's subject — the
 // meeting — carries only one.
-describe("moveHref — the open_meeting_brief move", () => {
+describe("the open_meeting_brief move", () => {
   it("opens the brief on the person the meeting names", () => {
     const href = moveHref(briefRow("p-9"));
     expect(href).toContain("#/contacts/p-9");
@@ -462,8 +462,9 @@ describe("moveHref — the open_meeting_brief move", () => {
     expect(moveOpensComposer(briefRow("p-9"))).toBe(false);
   });
 
-  // moveLabel has no branch for this move, so it fell through to the reply
-  // wording on a row that is plainly a meeting, not a message.
+  // A meeting row's move opens a brief, not a composer — the label must say
+  // so on its own rather than borrow the reply wording, which is only the
+  // fall-through for a verb with no words of its own.
   it("names itself as the brief, not as a reply", () => {
     expect(moveLabel(briefRow("p-9"), t)).toBe("Prepare for the meeting");
   });

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -461,6 +461,12 @@ describe("moveHref — the open_meeting_brief move", () => {
   it("is not a draft", () => {
     expect(moveOpensComposer(briefRow("p-9"))).toBe(false);
   });
+
+  // moveLabel has no branch for this move, so it fell through to the reply
+  // wording on a row that is plainly a meeting, not a message.
+  it("names itself as the brief, not as a reply", () => {
+    expect(moveLabel(briefRow("p-9"), t)).toBe("Prepare for the meeting");
+  });
 });
 
 function briefRow(withPerson: string | undefined) {

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -640,6 +640,9 @@ export function moveOpensComposer(item: WorklistItem): boolean {
 // it says so.
 export function moveLabel(item: WorklistItem, t: T): string {
   if (item.move?.action === "open_task") return t("deal360.openTask");
+  if (item.move?.action === "open_meeting_brief") {
+    return t("worklist.verb.open_meeting_brief");
+  }
   const opens = moveOpensComposer(item);
   if (item.move?.action === "draft_email") {
     return t(


### PR DESCRIPTION
## Summary

Two of Wave B's four planned issues from `.tmp/qc-issues/PLAN.md` — re-verified
against current `main` before implementing, since the plan was written before
this bump and two of the four turned out already fixed:

- **margince#4355** — `POST /v1/brief` was missing from `modelRouteSuffixes`
  (`backend/internal/compose/modelroutedeadline.go`), so it ran under the
  ordinary 30s `WriteTimeout` instead of the long model-call deadline. Same
  shape margince#3633 fixed for `/meeting-brief`: the daily brief calls the
  model task `brief_ranking` and, measured live, 4 of 5 calls exceeded 30s and
  were answered `502` to the caller though the handler itself finished and
  logged `201` every time — the request succeeded, the client had already been
  disconnected.
- **margince#4859** — the Worklist's `open_meeting_brief` move rendered as
  "Open to reply": `moveLabel` had no branch for it, so it fell through to the
  `draft_reply` default on a row that is plainly a meeting, not a message. The
  link's destination was always correct; only its label lied. Added the
  branch plus a new `worklist.verb.open_meeting_brief` i18n key (en/de/vi),
  and the regression test the issue's own body points out was missing:
  nothing previously called `moveLabel` with an `open_meeting_brief` row.

## Not in this PR

- **margince#4201** (priced_deals reaches no screen) — already fixed by
  PR #4338 (`9c4b93a01`, merged 2026-09-05). Closing the GitHub issue
  separately with a comment; #4338's body never said "Closes #4201" so
  auto-close never fired.
- **margince#4304** (no_champion never populated) — already fixed, issue
  already closed on GitHub. No action.

## Test plan

- [x] `make check-go` — clean (0 lint, 0 craft findings); the one local
      `backend/gates` failure (`TestPublicTreeCitesNoDocumentGitIgnores`) is
      the same pre-existing, machine-local `.git/info/exclude` artifact
      documented in Wave A (PR #4869) — unrelated to this diff, confirmed by
      `git diff origin/main --stat` touching none of the files it cites.
- [x] `make check-fe` — clean (typecheck, lint, unit, build, ds-gates, i18n
      key-parity all pass)
- [x] Regression test per issue, each confirmed red before its fix:
      `TestOnlyTheModelRoutesTakeTheLongerDeadline` (backend) and
      `moveLabel`'s new `open_meeting_brief` case (frontend)
- [x] New/changed lines: 100% covered (`go tool cover -func`, the changed
      `modelRouteSuffixes` slice is exercised at 100% through `callsAModel`)
- [x] `make craft-static --strict` — 0 blocker/major/minor
- [x] UAT: seeded a live dev stack, opened the Worklist as a rep with an
      upcoming meeting naming a visible person, confirmed the row's link now
      reads "Prepare for the meeting" and still opens the same meeting's
      brief drawer — video attached below
- [x] No `crm.yaml` contract change, no AI prompt touched → no aicert re-run
      needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvvZzihBBSeaLc3WcZ6Xh1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `POST /v1/brief` timing out at 30s and renames the Worklist's `open_meeting_brief` row label from "Open to reply" to "Prepare for the meeting".

- The brief was missing from `modelRouteSuffixes`; live, 4 of 5 calls exceeded 30s and returned 502 even though the handler succeeded and logged 201.
- A new backend gate holds `modelRouteSuffixes` to the contract's `x-waits-on-model` marker; it found five more model routes missing the deadline (`/enrich`, `/coldstart`, `/coldstart/preview`, `/messages`, `/regenerate`), now all covered.
- `moveLabel` had no `open_meeting_brief` branch; added one plus en/de/vi i18n keys and a regression test.
- `GET /deals/{id}/status` is model-calling but has no safe suffix (it would also match three unrelated `/status` endpoints), so it stays on the 30s deadline and is tracked as margince#4914.

<sup>Written for commit 114e6830dfa61d70b28ab0220766cea11aeaff7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized “Prepare for the meeting” label for meeting brief actions in English, German, and Vietnamese.
  * Meeting-related AI brief routes now receive the appropriate longer processing deadline.

* **Bug Fixes**
  * Corrected worklist wording so meeting brief actions no longer display a generic reply or email label.

* **Tests**
  * Added coverage confirming the correct meeting brief label and route deadline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->