### PR TITLE
feat(extensions): a record the core cannot represent is a disposition

### DIFF
--- a/backend/internal/compose/extingress.go
+++ b/backend/internal/compose/extingress.go
@@ -82,8 +82,18 @@ func (r *callRuntime) Ingest(ctx context.Context, on extension.UserID, rec exten
 		return extension.Result{}, err
 	}
 	defer r.endIngest()
+	// A record the grammar refuses is a DISPOSITION, not an error. The unit
+	// moves its cursor past it either way — stopping on one malformed message
+	// parks the whole connection — so answering an error class only put the
+	// distinction it needs most, "the core skipped this" versus "I built
+	// something the core cannot use", somewhere it had to match on. The
+	// complaint still travels: a unit that logs the reason gets the same
+	// sentence it used to read off the error.
 	if err := rec.Validate(); err != nil {
-		return extension.Result{}, fmt.Errorf("%w: %s", extension.ErrInvalid, err.Error())
+		return extension.Result{
+			Disposition: extension.DispositionUnrepresentable,
+			Reason:      err.Error(),
+		}, nil
 	}
 	if err := refuseUndeclaredTransport(r.unit, rec.Activity.Kind, rec.Activity.ChannelProvider); err != nil {
 		return extension.Result{}, err

--- a/backend/internal/compose/extingress_test.go
+++ b/backend/internal/compose/extingress_test.go
@@ -214,8 +214,13 @@ func TestAnIngestInsideTheUnitsOwnTransactionIsRefused(t *testing.T) {
 	// this test needing a database to prove it.
 	unkeyed := aRecord()
 	unkeyed.Key = ""
-	if _, err := rt.Ingest(context.Background(), member, unkeyed); !errors.Is(err, extension.ErrInvalid) {
-		t.Fatalf("err = %v, want the next refusal along — the nesting one outlived the transactions it is about", err)
+	res, err := rt.Ingest(context.Background(), member, unkeyed)
+	if err != nil {
+		t.Fatalf("err = %v, want the call to reach the grammar — the nesting refusal outlived the "+
+			"transactions it is about", err)
+	}
+	if res.Disposition != extension.DispositionUnrepresentable {
+		t.Fatalf("disposition = %q, want the next answer along, which is the grammar's", res.Disposition)
 	}
 }
 
@@ -292,9 +297,21 @@ func TestARecordTheGrammarRefusesNeverReachesCapture(t *testing.T) {
 	unkeyed := aRecord()
 	unkeyed.Key = ""
 
-	_, err := ingestingRuntime(t).Ingest(context.Background(), extension.UserID(ids.NewV7().String()), unkeyed)
-	if !errors.Is(err, extension.ErrInvalid) {
-		t.Fatalf("err = %v, want ErrInvalid", err)
+	res, err := ingestingRuntime(t).Ingest(context.Background(), extension.UserID(ids.NewV7().String()), unkeyed)
+	if err != nil {
+		t.Fatalf("err = %v, want a disposition rather than an error class: a unit cannot stop its "+
+			"whole connection on one malformed record, so it moves past this either way", err)
+	}
+	if res.Disposition != extension.DispositionUnrepresentable {
+		t.Errorf("disposition = %q, want %q", res.Disposition, extension.DispositionUnrepresentable)
+	}
+	if res.Ref != (extension.Ref{}) {
+		t.Errorf("ref = %+v, want none — nothing was written", res.Ref)
+	}
+	// The complaint travels, so a unit logs the same sentence it used to read
+	// off the error rather than losing why the record was refused.
+	if res.Reason == "" {
+		t.Error("the refusal says nothing about what was wrong with the record")
 	}
 }
 

--- a/backend/pkg/extension/ingress.go
+++ b/backend/pkg/extension/ingress.go
@@ -405,6 +405,33 @@ const (
 	// connector's watermark, so a unit treats this exactly as it treats
 	// Accepted: move the cursor past it.
 	DispositionSkipped Disposition = "skipped"
+
+	// DispositionUnrepresentable is a record the core's grammar refuses: the
+	// unit built something this contract cannot express.
+	//
+	// It was an ErrInvalid, and that put the one distinction a unit most needs
+	// into error matching. A unit polling a provider cannot stop on a single
+	// malformed message — that parks the whole connection over one record — so
+	// it moves its cursor past it either way. What it could not do was tell
+	// "the core skipped this deliberately" from "I built something the core
+	// cannot use", because the first arrived as a Disposition and the second as
+	// an error class, and a provider format change that made EVERY record
+	// unrepresentable then presented exactly like a healthy quiet feed.
+	//
+	// It is a SUCCESS carrying a zero Ref, on the same terms as Skipped: the
+	// cursor advances, because waiting does not make a malformed record
+	// representable. And it is the one disposition a unit must COUNT. A run
+	// answering it for everything it pulled is a broken unit or a changed
+	// provider, and nothing else in the system is in a position to say so —
+	// the core writes no breadcrumb for it yet (the second half of the seam,
+	// which needs a table and its own decision about what such a row may hold).
+	//
+	// A unit switching on Disposition without a default gains an unhandled
+	// case here. Go does not enforce exhaustiveness, so nothing stops
+	// compiling; a unit that wants the count treats an unknown disposition as
+	// this one, which is the safe direction — an unrecognised outcome is not an
+	// acceptance.
+	DispositionUnrepresentable Disposition = "unrepresentable"
 )
 
 // Ref names a record the core holds.
@@ -415,12 +442,24 @@ type Ref struct {
 
 // Result is what one ingest did.
 //
-// BOTH DISPOSITIONS ADVANCE A CURSOR, and that is the point of returning one
-// instead of an error for the skip: a unit's watermark moves past every record
-// the core has finished deciding about, whether or not a row came of it.
+// EVERY DISPOSITION ADVANCES A CURSOR, and that is the point of returning one
+// instead of an error: a unit's watermark moves past every record the core has
+// finished deciding about, whether or not a row came of it — a deliberate skip
+// and a record the grammar refuses are both finished, and re-offering either on
+// the next poll would repeat it forever.
 type Result struct {
 	Ref         Ref
 	Disposition Disposition
+	// Reason says WHY, for the dispositions that are a refusal. It carries the
+	// core's complaint about an unrepresentable record so a unit can log the
+	// same sentence it used to read off the error — and it is empty for an
+	// acceptance and for a deliberate skip, where there is nothing the unit
+	// could act on.
+	//
+	// Prose for a log, never a value to branch on: the Disposition is what a
+	// unit decides from, and a unit parsing this string would be reading core
+	// text that is free to change.
+	Reason string
 }
 
 // The refusals an ingest can answer. Sentinels rather than typed errors,

--- a/backend/pkg/extension/ingress_test.go
+++ b/backend/pkg/extension/ingress_test.go
@@ -245,14 +245,29 @@ func TestTheDeclarationGrammar(t *testing.T) {
 // this type does NOT draw is the point of it: a replay answers Accepted like
 // any other landing, because the pipeline reports no difference and a
 // "replayed" value would be a promise this side cannot keep.
-func TestTheDispositionsAreTheTwoTheCoreCanHonestlyReport(t *testing.T) {
-	if extension.DispositionAccepted == extension.DispositionSkipped {
-		t.Fatal("the two dispositions are one value")
+func TestTheDispositionsAreTheThreeTheCoreCanHonestlyReport(t *testing.T) {
+	published := []extension.Disposition{
+		extension.DispositionAccepted,
+		extension.DispositionSkipped,
+		extension.DispositionUnrepresentable,
 	}
-	for _, d := range []extension.Disposition{extension.DispositionAccepted, extension.DispositionSkipped} {
+	// Distinct, because the whole value of the third is telling a deliberate
+	// skip from a record this unit built wrong — two of them sharing a value
+	// would put that distinction back where it was.
+	seen := map[extension.Disposition]bool{}
+	for _, d := range published {
 		if strings.TrimSpace(string(d)) == "" {
 			t.Errorf("a disposition renders as empty, which a unit cannot log or branch on")
 		}
+		if seen[d] {
+			t.Errorf("%q is published twice", d)
+		}
+		seen[d] = true
+	}
+	// The zero value is none of them. A Result a unit forgot to fill must not
+	// read as an acceptance.
+	if seen[extension.Disposition("")] {
+		t.Error("the empty disposition is one of the published ones, so an unset Result reads as an outcome")
 	}
 }
 

--- a/extensions/openchannel/drain.go
+++ b/extensions/openchannel/drain.go
@@ -21,9 +21,11 @@ package openchannel
 // stopped mid-batch therefore leaves everything it had not reached still
 // pending, which is the state it arrived in.
 //
-// EVERY Disposition IS A SUCCESS, Skipped included. The core drops a
-// wholly-internal message deliberately and commits a breadcrumb saying so;
-// treating that as a failure would retry a deliberate drop forever, on a cadence.
+// A Disposition IS THE ANSWER, and two of the three are successes. The core
+// drops a wholly-internal message deliberately and commits a breadcrumb saying
+// so; treating that as a failure would retry a deliberate drop forever, on a
+// cadence. The third — a record the grammar refuses — is this row's own
+// terminal fault, and it parks for the reason it always did.
 
 import (
 	"context"
@@ -128,14 +130,23 @@ func landAll(ctx context.Context, rt extension.Runtime, pending []queued) error 
 	landed := 0
 	for _, req := range pending {
 		result, err := ingestOne(ctx, rt, req)
-		if err == nil {
+		// A record the core's grammar refuses arrives as a DISPOSITION rather
+		// than an error, and it is this row's own terminal fault either way:
+		// the same bytes build the same record on every attempt. Routed to the
+		// same class the error used to reach, so what a member reads on their
+		// own screen is unchanged by where the core says it.
+		unrepresentable := err == nil && result.Disposition == extension.DispositionUnrepresentable
+		if err == nil && !unrepresentable {
 			landed++
 			if noted := markLanded(ctx, rt, req, result); noted != nil {
 				return extension.Failure(classDrainFailed, noted)
 			}
 			continue
 		}
-		class, terminal := drainFailure(err)
+		class, terminal := classRefusedByTheCore, true
+		if !unrepresentable {
+			class, terminal = drainFailure(err)
+		}
 		// On the tick's own context, and it is the one write that must not be
 		// lost: it is what stops the next tick starting at the same request with
 		// no record of why the last one stopped.

--- a/extensions/openchannel/drain.go
+++ b/extensions/openchannel/drain.go
@@ -130,27 +130,35 @@ func landAll(ctx context.Context, rt extension.Runtime, pending []queued) error 
 	landed := 0
 	for _, req := range pending {
 		result, err := ingestOne(ctx, rt, req)
-		// A record the core's grammar refuses arrives as a DISPOSITION rather
-		// than an error, and it is this row's own terminal fault either way:
-		// the same bytes build the same record on every attempt. Routed to the
-		// same class the error used to reach, so what a member reads on their
-		// own screen is unchanged by where the core says it.
-		unrepresentable := err == nil && result.Disposition == extension.DispositionUnrepresentable
-		if err == nil && !unrepresentable {
+		// The ACCEPTING dispositions are named, and everything else is a
+		// refusal — including one this build has never heard of. The core's own
+		// contract says an unrecognised outcome is not an acceptance, and a
+		// switch that landed everything but the refusals it knows would mark a
+		// future one as landed the day it ships.
+		landing := err == nil && (result.Disposition == extension.DispositionAccepted ||
+			result.Disposition == extension.DispositionSkipped)
+		if landing {
 			landed++
 			if noted := markLanded(ctx, rt, req, result); noted != nil {
 				return extension.Failure(classDrainFailed, noted)
 			}
 			continue
 		}
-		class, terminal := classRefusedByTheCore, true
-		if !unrepresentable {
-			class, terminal = drainFailure(err)
+		// A record the core's grammar refuses arrives as a DISPOSITION rather
+		// than an error, and it is this row's own terminal fault either way:
+		// the same bytes build the same record on every attempt. Routed to the
+		// same class the error used to reach, so what a member reads on their
+		// own screen is unchanged by where the core says it.
+		class, terminal, reason := classRefusedByTheCore, true, result.Reason
+		if err != nil {
+			// An error says what it is in its own text, which the job's process
+			// log already carries; there is no second sentence to keep.
+			class, terminal, reason = classOf(err)
 		}
 		// On the tick's own context, and it is the one write that must not be
 		// lost: it is what stops the next tick starting at the same request with
 		// no record of why the last one stopped.
-		if noted := markStalled(ctx, rt, req, class, terminal); noted != nil {
+		if noted := markStalled(ctx, rt, req, class, terminal, reason); noted != nil {
 			return extension.Failure(classDrainFailed, noted)
 		}
 		if !terminal {
@@ -206,6 +214,14 @@ func markLanded(ctx context.Context, rt extension.Runtime, req queued, result ex
 	})
 }
 
+// classOf is drainFailure with the reason slot a disposition fills, so the two
+// paths into markStalled hand it the same three values rather than one of them
+// assembling a tuple the other does not.
+func classOf(cause error) (extension.FailureClass, bool, string) {
+	class, terminal := drainFailure(cause)
+	return class, terminal, ""
+}
+
 // markStalled records on the row what stopped it, and parks the row when nothing
 // further will change the answer.
 //
@@ -213,7 +229,10 @@ func markLanded(ctx context.Context, rt extension.Runtime, req queued, result ex
 // renders, carrying the class that stopped it — and it writes a ledger row,
 // because a message this installation accepted and will now never act on is
 // exactly the kind of fact somebody asks about afterwards.
-func markStalled(ctx context.Context, rt extension.Runtime, req queued, class extension.FailureClass, terminal bool) error {
+func markStalled(
+	ctx context.Context, rt extension.Runtime, req queued,
+	class extension.FailureClass, terminal bool, reason string,
+) error {
 	// AN OUTAGE IS NOT THE REQUEST'S FAULT, so it does not spend the request's
 	// budget. The attempt cap exists to stop ONE request being retried forever
 	// on a fault of its own — a body the core keeps refusing, an owner whose
@@ -244,6 +263,6 @@ func markStalled(ctx context.Context, rt extension.Runtime, req queued, class ex
 		if state != stateParked {
 			return nil
 		}
-		return recordParked(ctx, tx, req, class)
+		return recordParked(ctx, tx, req, class, reason)
 	})
 }

--- a/extensions/openchannel/drain_test.go
+++ b/extensions/openchannel/drain_test.go
@@ -124,6 +124,39 @@ func TestASkippedRecordAdvancesTheRowJustAsAnAcceptedOneDoes(t *testing.T) {
 	}
 }
 
+// A record the core's grammar refuses is this row's own terminal fault, and it
+// arrives as a DISPOSITION rather than an error.
+//
+// The core moved that distinction into its return value so a unit can tell "the
+// core skipped this deliberately" from "I built something it cannot use"
+// without matching on an error class — a change that must not quietly turn a
+// permanent refusal into a landing. What a member reads on their own screen is
+// the same class it always was.
+func TestARecordTheCoreCannotRepresentParksRatherThanLanding(t *testing.T) {
+	t.Parallel()
+	rt := draining(queuedRow(firstRequestID, 0, landable(t, "m-1")))
+	rt.results = []extension.Result{{
+		Disposition: extension.DispositionUnrepresentable,
+		Reason:      "activity.body: too long",
+	}}
+	if err := drain(context.Background(), rt); err != nil {
+		t.Fatalf("a request only its own sender can fix failed the tick: %v", err)
+	}
+	_, args := rt.tx.statementMentioning(t, "last_error_class = $3")
+	if args[1] != stateParked {
+		t.Fatalf("the request was left in state %v; the same bytes build the same record every time", args[1])
+	}
+	if args[2] != classRefusedByTheCore.Class {
+		t.Fatalf("the row records class %v, want %v — a disposition must reach the same class the "+
+			"error class did, or a member reads something new for an unchanged fact",
+			args[2], classRefusedByTheCore.Class)
+	}
+	if len(rt.tx.audited) != 1 {
+		t.Fatalf("parking recorded %d ledger row(s); a message this installation accepted and will "+
+			"never act on is a fact somebody asks about", len(rt.tx.audited))
+	}
+}
+
 // A request nothing will ever land parks on the FIRST attempt rather than
 // spending five ticks at the head of a queue, and parking is never a silent
 // drop: the row stays, carrying the class, and a ledger row says what happened.

--- a/extensions/openchannel/drain_test.go
+++ b/extensions/openchannel/drain_test.go
@@ -155,6 +155,31 @@ func TestARecordTheCoreCannotRepresentParksRatherThanLanding(t *testing.T) {
 		t.Fatalf("parking recorded %d ledger row(s); a message this installation accepted and will "+
 			"never act on is a fact somebody asks about", len(rt.tx.audited))
 	}
+	// The core's own complaint travels into the ledger row: the class says
+	// which wall the message hit, and only this says what about the message hit
+	// it — which is the whole of what the sender can act on.
+	if detail := string(rt.tx.audited[0].Detail); !strings.Contains(detail, "activity.body: too long") {
+		t.Errorf("the ledger row reads %s, want it to carry the core's reason", detail)
+	}
+}
+
+// An outcome this build has never heard of is NOT an acceptance.
+//
+// The published contract says so, and a switch that landed everything except
+// the refusals it knows would mark a future one as landed the day it ships —
+// silently, on a row nobody looks at again.
+func TestADispositionThisBuildDoesNotKnowIsNotALanding(t *testing.T) {
+	t.Parallel()
+	rt := draining(queuedRow(firstRequestID, 0, landable(t, "m-1")))
+	rt.results = []extension.Result{{Disposition: extension.Disposition("from_a_later_core")}}
+	if err := drain(context.Background(), rt); err != nil {
+		t.Fatalf("an unknown disposition failed the tick: %v", err)
+	}
+	_, args := rt.tx.statementMentioning(t, "last_error_class = $3")
+	if args[1] != stateParked {
+		t.Fatalf("an unrecognised outcome left the request in state %v, want it parked rather than "+
+			"marked as landed", args[1])
+	}
 }
 
 // A request nothing will ever land parks on the FIRST attempt rather than
@@ -356,7 +381,7 @@ func TestAnOutageDoesNotSpendTheRequestsOwnAttemptBudget(t *testing.T) {
 	t.Parallel()
 	req := queued{id: "11111111-1111-1111-1111-111111111111", attempts: maxDrainAttempts - 1}
 	rt := &fakeRuntime{tx: &fakeTx{}}
-	if err := markStalled(context.Background(), rt, req, classCaptureUnavailable, false); err != nil {
+	if err := markStalled(context.Background(), rt, req, classCaptureUnavailable, false, ""); err != nil {
 		t.Fatalf("marking stalled: %v", err)
 	}
 	_, args := rt.tx.statementMentioning(t, "SET state =")
@@ -400,7 +425,7 @@ func TestAFaultTheRequestOwnsStillSpendsItsBudget(t *testing.T) {
 			}
 			req := queued{id: "11111111-1111-1111-1111-111111111111", attempts: maxDrainAttempts - 1}
 			rt := &fakeRuntime{tx: &fakeTx{}}
-			if err := markStalled(context.Background(), rt, req, class, terminal); err != nil {
+			if err := markStalled(context.Background(), rt, req, class, terminal, ""); err != nil {
 				t.Fatalf("marking stalled: %v", err)
 			}
 			_, args := rt.tx.statementMentioning(t, "SET state =")

--- a/extensions/openchannel/failureclasses.go
+++ b/extensions/openchannel/failureclasses.go
@@ -43,6 +43,12 @@ var (
 	// classRefusedByTheCore is the core refusing the built record as invalid —
 	// over-long text, a field it will not take. Also terminal: the same bytes
 	// build the same record on every attempt.
+	//
+	// Reached from the DispositionUnrepresentable the ingest answers, rather
+	// than from an error class: the core moved that distinction into its return
+	// value so a unit can tell "the core skipped this deliberately" from "I
+	// built something it cannot use" without matching on an error. What a
+	// member reads on their own screen is the same sentence either way.
 	classRefusedByTheCore = extension.FailureClass{
 		Class:    "refused_by_the_core",
 		Sentence: "the CRM refused a captured message as invalid, so no timeline entry was created for it",

--- a/extensions/openchannel/ledger.go
+++ b/extensions/openchannel/ledger.go
@@ -118,11 +118,17 @@ func endpointImage(e *endpoint) (json.RawMessage, error) {
 // the state and the attempt count — which the audit action and this detail
 // already say, while what a reader actually wants is why it stopped, and that is
 // context about the write rather than a field of the record.
-func recordParked(ctx context.Context, tx extension.Tx, req queued, class extension.FailureClass) error {
+func recordParked(ctx context.Context, tx extension.Tx, req queued, class extension.FailureClass, reason string) error {
+	// The reason is the CORE's own complaint about the record, carried through
+	// from the ingest — omitted when there is none, so a row parked for a fault
+	// that speaks for itself does not carry an empty field. It is what turns
+	// "the CRM refused this" into something the sender can act on: the class
+	// says which wall was hit, and this says what about the message hit it.
 	detail, err := json.Marshal(struct {
 		Class    string `json:"class"`
 		Attempts int    `json:"attempts"`
-	}{Class: class.Class, Attempts: req.attempts + 1})
+		Reason   string `json:"reason,omitempty"`
+	}{Class: class.Class, Attempts: req.attempts + 1, Reason: reason})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The first of the two seams #1195 names. It does not close the issue — see the last section.

## The gap

A unit polling a provider cannot stop on a single malformed message; that parks the whole connection over one record. So it moves its cursor past one either way. What it could **not** do was tell the two cases apart:

- *the core skipped this deliberately* — arrived as `DispositionSkipped`, a success;
- *I built something the core cannot use* — arrived as `ErrInvalid`, an error class.

One distinction, two mechanisms, and the one a unit most needs lived in its error matching. A provider format change that made every record unrepresentable then presented exactly like a healthy quiet feed.

## The disposition

`DispositionUnrepresentable`, on the published surface beside the two that were already there. A success carrying a zero `Ref`, on the same terms as `Skipped`: the cursor advances, because waiting does not make a malformed record representable.

`Result` gains a `Reason`, so the core's own complaint travels and a unit logs the sentence it used to read off the error instead of losing why the record was refused. Prose for a log, never a value to branch on — the `Disposition` is what a unit decides from, and a unit parsing that string would be reading core text that is free to change.

Its doc says the part the ticket asks for outright: **it is the one disposition a unit must count**, because a run answering it for everything it pulled is a broken unit or a changed provider, and nothing else in the system is in a position to say so.

## Compatibility

A unit switching on `Disposition` without a `default` gains an unhandled case. Go does not enforce exhaustiveness, so nothing stops compiling; a unit that treats an unknown disposition as this one is in the safe direction, since an unrecognised outcome is not an acceptance. Stated in the constant's own doc rather than left for someone to discover.

## The shipped unit keeps its behaviour exactly

`openchannel` classified `ErrInvalid` as `classRefusedByTheCore` — terminal, park on the first attempt, ledger row, event. It now reaches that same class from the disposition. A member reads the same sentence on their own screen for an unchanged fact; only where the core says it moved.

`TestARecordTheCoreCannotRepresentParksRatherThanLanding` holds that, and it is the test that matters here: a change like this quietly turning a permanent refusal into a landing is the failure worth guarding. Mutation-checked — routing the disposition back to the landing path fails it.

## What this does NOT do, and why it is not folded in

The issue's second bullet — a breadcrumb the **core** can see, so an installation reading only the CRM can tell a broken connector from a quiet one — is untouched. There is no core-side table for it: `raw_capture`'s drop breadcrumb has no extension analogue, and `extension_secret` is the only extension table in the schema. Adding one is a migration plus a decision about what such a row may hold — provider text or only a reason class — plus a retention answer, which is the same class of question #1670 tracks about what the surface must own.

So #1195 stays open, and I have commented there with what landed and what the remaining decision is.

## Checks

`make check-backend` green, `make craft-static` clean, `make test-extensions` green, and the `compose` integration lane green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct outcome for records that fail core validation, including an explanation of the refusal.
  * Such records now advance processing without being treated as system errors.
  * Refusal explanations are preserved in the processing record for easier review.

* **Bug Fixes**
  * Invalid records are parked instead of landed, with the appropriate refusal classification and audit entry.
  * Unrecognized outcomes are safely treated as refusals rather than successfully processed.
  * Genuine processing errors continue to follow the existing failure path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->