### PR TITLE
fix(onboarding): the mailbox section states its ask without a red tag

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5283,7 +5283,6 @@ export const de = {
   "ob.conv.connect.networkTitle": "Dein Netzwerk",
   "ob.conv.connect.networkHint":
     "Hinterlege dein Profil, damit das Netzwerk, das du später importierst, dir zugeordnet wird. Der Import selbst liegt in den Einstellungen.",
-  "ob.conv.connect.required": "erforderlich",
   "ob.conv.connect.recommended": "empfohlen",
   "ob.conv.connect.gmailBrings": "Mail über Google gelesen und gesendet",
   "ob.conv.connect.microsoftBrings": "Mail über Microsoft gelesen und gesendet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5396,7 +5396,6 @@ export const en = {
   "ob.conv.connect.networkTitle": "Your network",
   "ob.conv.connect.networkHint":
     "Save your profile so the network you import later is attributed to you. The import itself lives in Settings.",
-  "ob.conv.connect.required": "required",
   "ob.conv.connect.recommended": "recommended",
   // Neither grant carries calendar or contacts — those are their own,
   // separate consent (Settings → Calendar) — and neither carries sign-in:

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5220,7 +5220,6 @@ export const vi = {
   "ob.conv.connect.networkTitle": "Mạng lưới quan hệ của bạn",
   "ob.conv.connect.networkHint":
     "Lưu hồ sơ của bạn để mạng lưới bạn nhập sau này được ghi nhận cho bạn. Việc nhập nằm trong Cài đặt.",
-  "ob.conv.connect.required": "bắt buộc",
   "ob.conv.connect.recommended": "nên có",
   "ob.conv.connect.gmailBrings": "Email được đọc và gửi qua Google",
   "ob.conv.connect.microsoftBrings": "Email được đọc và gửi qua Microsoft",

--- a/frontend/src/screens/onboarding-conversation/connect-scene.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-scene.tsx
@@ -244,12 +244,7 @@ export function ConnectScene({
       <ConnectGuarantees />
 
       <div className="ob-connect-section-head">
-        <h3>
-          {t("ob.conv.connect.mailboxTitle")}
-          <span className="ob-connect-pill ob-connect-pill-required">
-            {t("ob.conv.connect.required")}
-          </span>
-        </h3>
+        <h3>{t("ob.conv.connect.mailboxTitle")}</h3>
         <p className="t-sub">{t("ob.conv.connect.mailboxHint")}</p>
       </div>
 

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -1629,12 +1629,8 @@
   text-transform: uppercase;
 }
 
-.ob-connect-pill-required {
-  color: var(--danger);
-}
-
-/* Recommended reads calmly next to required's alarm colour — LinkedIn never
-   gates the act, so its tag must not look like one that does. */
+/* Recommended reads as a quiet aside, never an alarm — LinkedIn does not gate
+   the act, so its tag must not look like one that does. */
 .ob-connect-pill-recommended {
   color: var(--textMeta);
 }


### PR DESCRIPTION
## What

The onboarding connect scene no longer shows a red `required` pill next to the mailbox section heading. The heading and its hint stand alone; nothing about when the step can be completed changes.

## Why

The pill only restated, in alarm colour, a gate the step already enforces: `onFinish(skipped)` and the card roster decide whether a mailbox is connected, and skipping is a separate deliberate action. A tag that duplicates an enforced rule adds a second place to keep true without adding a constraint.

Removing the last render of `ob.conv.connect.required` makes the key an orphan in all three locales, which `frontend/src/i18n/i18n.test.ts` fails on, so the translations go with it. The `.ob-connect-pill-required` rule loses its only user and the comment on `.ob-connect-pill-recommended` no longer refers to a colour that exists.

## How verified

`make check-fe` green end to end locally (exit 0) — ds gates, drift, lint, unit, build, composed typecheck and the extension suite — after `src/i18n/i18n.test.ts` (the orphan-key gate) and `src/screens/onboarding-conversation/connect-act.test.tsx` passed on their own, 56 tests. On CI every non-skipped check is green, `uat` (axe WCAG 2.2 AA at 390px) and `live-boot` included, and SonarCloud's quality gate passed. No Go changed, so the integration lane and `craft static` have nothing in this diff to look at.

- [x] `make check` is green — `check-fe` locally and on CI; `check-backend` has no changed Go to cover
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend-only diff
- [x] `make craft-static` reports no new blockers — no Go files changed
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

CodeRabbit's Docstring Coverage pre-merge warning is answered in a comment below: it counts `ConnectScene` only because the diff removed a JSX span inside it, and neither exported scene in that directory carries a component-level doc comment.

## AI involvement

Written by Claude Code under human direction: locating the pill, removing it, and pruning the CSS rule and the three translations it left behind.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. See [CONTRIBUTING.md](/CONTRIBUTING.md) and the [Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G64RZZ3jeuKKY8VU3WRAw6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the red `required` pill next to the mailbox section heading in the onboarding connect scene. The step already enforces mailbox connection on completion, so the pill only restated the gate in an alarm color.

- Removes the orphaned `ob.conv.connect.required` translation key from `de`, `en`, and `vi`.
- Drops the unused `.ob-connect-pill-required` CSS rule and updates the `.ob-connect-pill-recommended` comment.

<sup>Written for commit 903fdbc4a2bd4dfdc6deb9a814b8ce72c2a7ea29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the “Required” status pill from the mailbox connection heading.
  * Updated connection styling so recommended guidance appears as a quieter aside.

* **Localization**
  * Removed obsolete translations for the “Required” connection label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->