### PR TITLE
feat(observability): the engine's refusals are readable while they happen

### DIFF
--- a/backend/gates/authzmetriclabels_test.go
+++ b/backend/gates/authzmetriclabels_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// The outbound decision counter labels only closed vocabularies, and never the
+// recipient.
+//
+// /metrics is process-global: it binds no workspace and resolves no principal,
+// and it is unauthenticated unless a deployment sets a metrics token (an empty
+// token is the default, see compose.gateMetrics). A label carrying the address
+// a decision judged would publish who this installation writes to, across
+// tenants, and would do so as a series a scraper keeps forever.
+//
+// It is also unbounded. A counter's cardinality is the product of its label
+// values, so an address label mints one time series per recipient and the
+// scrape grows with the address book.
+//
+// commsauthz.Decision carries Recipient, so the field is one struct literal
+// away at all times. What stops it is that the counter is keyed by a type with
+// no such field: DecisionCount names three closed vocabularies and nothing else.
+//
+// TWO ARMS, because the key is not the only way a label is born. The first
+// reads the key type: a label the counter is grouped by must be one of the
+// three. The second reads the RENDERER, because a second Fprintf in that file
+// could emit a label from anything at all — a package variable, a passed
+// argument — while DecisionCount stays untouched and the first arm stays green.
+//
+// WHAT NEITHER ARM SEES, stated because a prohibition that overclaims is worse
+// than one that is narrow. Both read label NAMES; neither reads what a name is
+// bound to, so `verdict=%q` filled with an address would pass. And the second
+// arm reads literal format strings in one file, so a name assembled by
+// concatenation, held in a constant, or written by a helper elsewhere is
+// invisible to it. What makes those safe is the first arm plus the type
+// system: the renderer's only input is a DecisionCount, whose three fields are
+// closed vocabularies the database CHECKs also pin. These arms stop the easy
+// way in — adding a field, adding a line — not a determined author.
+
+import (
+	"go/ast"
+	"os"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	// decisionCountFile declares the counter's key.
+	decisionCountFile = "internal/modules/consent/decisioncounter.go"
+	// decisionCountType is the key itself.
+	decisionCountType = "DecisionCount"
+	// metricsRendererFile writes the counter onto /metrics.
+	metricsRendererFile = "internal/compose/authzmetrics.go"
+)
+
+// renderedLabels are the label names the renderer may emit. The same three the
+// key declares, spelled as they appear in the exposition.
+var renderedLabels = []string{"category", "mode", "verdict"}
+
+// decisionCountFields are the three closed vocabularies a decision may be
+// counted by, and the whole set.
+//
+// Spelled here rather than derived, because this gate's subject IS the list: a
+// gate reading the struct to learn what the struct may contain would ratify
+// whatever it found, which is the shape that passes while a recipient label is
+// added.
+var decisionCountFields = []string{"Verdict", "Category", "Mode"}
+
+// forbiddenLabelSubstrings name what a label must never carry. Matched on the
+// field name because a field is what becomes a label.
+var forbiddenLabelSubstrings = []string{
+	"recipient", "address", "email", "subject", "person", "lead", "actor", "reason",
+}
+
+func TestTheDecisionCounterLabelsOnlyClosedVocabularies(t *testing.T) {
+	t.Parallel()
+
+	fields := structFieldNames(t, decisionCountFile, decisionCountType)
+	if len(fields) == 0 {
+		t.Fatalf("%s declares no %s fields — the subject this gate reads has moved, and a gate "+
+			"that found nothing to judge reports the counter safe", decisionCountFile, decisionCountType)
+	}
+
+	for _, field := range fields {
+		if slices.Contains(decisionCountFields, field) {
+			continue
+		}
+		t.Errorf("%s.%s is a new counter label.\n\n"+
+			"Every field here becomes a /metrics label, on an endpoint that binds no workspace "+
+			"and authenticates nobody. A label must be a CLOSED vocabulary and must not name a "+
+			"person: add it to decisionCountFields only once it is both.",
+			decisionCountType, field)
+		for _, forbidden := range forbiddenLabelSubstrings {
+			if strings.Contains(strings.ToLower(field), forbidden) {
+				t.Errorf("%s.%s names %q. A recipient's address as a label publishes who this "+
+					"installation writes to, to an unauthenticated scraper, and mints one time "+
+					"series per person.", decisionCountType, field, forbidden)
+			}
+		}
+	}
+}
+
+// The renderer is where a label is actually written, so the second arm reads it.
+//
+// A gate holding only the key type would pass over a file that prints
+// `{address=%q}` beside the counter it is meant to guard: DecisionCount would
+// not have changed, and the label set it names would still be three. So this
+// parses every label name the file emits and holds THOSE to the same three.
+func TestTheRenderedLabelsAreOnlyTheDeclaredOnes(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile(metricsRendererFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v — the renderer this gate reads has moved, and a gate that "+
+			"found nothing to judge reports the labels safe", metricsRendererFile, err)
+	}
+	emitted := renderedLabelNames(string(source))
+	if len(emitted) == 0 {
+		t.Fatalf("%s emits no labelled metric line — this gate reads the rendering, and finding "+
+			"none means it is reading the wrong file", metricsRendererFile)
+	}
+	for _, label := range emitted {
+		if slices.Contains(renderedLabels, label) {
+			continue
+		}
+		t.Errorf("%s renders a %q label.\n\n"+
+			"Every label reaches an endpoint that binds no workspace and authenticates nobody. "+
+			"A label naming a person publishes who this installation writes to and mints one "+
+			"time series each. Add it to renderedLabels only once it is a closed vocabulary "+
+			"that names nobody.", metricsRendererFile, label)
+	}
+}
+
+// labelInExposition matches one label name in a Prometheus line: the `name=`
+// that opens a label pair inside the braces.
+var labelInExposition = regexp.MustCompile(`[{,]([a-z_][a-z0-9_]*)=`)
+
+// renderedLabelNames reads the label names a renderer emits, from the format
+// strings it writes them with.
+func renderedLabelNames(source string) []string {
+	var out []string
+	for _, match := range labelInExposition.FindAllStringSubmatch(source, -1) {
+		if !slices.Contains(out, match[1]) {
+			out = append(out, match[1])
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// A REMOVED label needs no arm here. The renderer names each field
+// (internal/compose/authzmetrics.go), so dropping one stops the compiler before
+// any test runs — a louder failure than this file could produce, and one nobody
+// can skip. An arm asserting it would be a second, weaker copy of what the type
+// system already holds.
+
+// structFieldNames returns one named struct's field names.
+func structFieldNames(t *testing.T, path, typeName string) []string {
+	t.Helper()
+	file := parseGo(t, path)
+	var fields []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, isSpec := n.(*ast.TypeSpec)
+		if !isSpec || spec.Name.Name != typeName {
+			return true
+		}
+		structType, isStruct := spec.Type.(*ast.StructType)
+		if !isStruct {
+			return false
+		}
+		for _, field := range structType.Fields.List {
+			for _, name := range field.Names {
+				fields = append(fields, name.Name)
+			}
+		}
+		return false
+	})
+	return fields
+}

--- a/backend/internal/compose/aimetrics.go
+++ b/backend/internal/compose/aimetrics.go
@@ -38,4 +38,5 @@ func (s Server) writeMetricsSections(w io.Writer) {
 	s.writeMCPAppMetrics(w)
 	s.writeLicenseMetrics(w)
 	s.writeCaptureSection(w)
+	s.writeAuthzSection(w)
 }

--- a/backend/internal/compose/authzmetrics.go
+++ b/backend/internal/compose/authzmetrics.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The outbound authorization counter family: what this process decided about
+// the mail it was asked to send.
+//
+// Until now /metrics said nothing about it. An operator could see the outbox
+// backlog and the job queue, but not that a category had begun refusing every
+// message — which from outside looks exactly like nobody sending any.
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+)
+
+// writeAuthzDecisionMetrics renders one counter per label combination seen.
+//
+// Sorted, because Prometheus does not care but a human reading a scrape by hand
+// does, and ranging a map would reshuffle the block on every request.
+func writeAuthzDecisionMetrics(w io.Writer, totals map[consent.DecisionCount]uint64) {
+	if len(totals) == 0 {
+		// This process has decided nothing yet. Printing zeros for every
+		// combination would claim the engine ran and decided nothing either
+		// way, which is a different fact from not having run — and the
+		// difference is the one an operator is reading this to tell.
+		return
+	}
+	counts := make([]consent.DecisionCount, 0, len(totals))
+	for count := range totals {
+		counts = append(counts, count)
+	}
+	sort.Slice(counts, func(i, j int) bool { return authzLabelKey(counts[i]) < authzLabelKey(counts[j]) })
+	_, _ = fmt.Fprintf(w, "# HELP margince_communication_authz_decisions_total What the outbound engine decided about each recipient at transmit, since process start.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE margince_communication_authz_decisions_total counter\n")
+	for _, count := range counts {
+		_, _ = fmt.Fprintf(w,
+			"margince_communication_authz_decisions_total{verdict=%q,category=%q,mode=%q} %d\n",
+			string(count.Verdict), string(count.Category), string(count.Mode), totals[count])
+	}
+}
+
+// authzLabelKey orders one counter line. It joins the three labels and nothing
+// else — the recipient is not a field of DecisionCount and must never become
+// one.
+func authzLabelKey(c consent.DecisionCount) string {
+	return string(c.Verdict) + "\x00" + string(c.Category) + "\x00" + string(c.Mode)
+}
+
+// writeAuthzSection is the fan-out's entry point.
+func (Server) writeAuthzSection(w io.Writer) {
+	writeAuthzDecisionMetrics(w, consent.DecisionTotals())
+}

--- a/backend/internal/compose/authzmetrics_test.go
+++ b/backend/internal/compose/authzmetrics_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+func TestTheDecisionCounterRendersOneLinePerLabelCombination(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	writeAuthzDecisionMetrics(&out, map[consent.DecisionCount]uint64{
+		{
+			Verdict:  commsauthz.VerdictDeny,
+			Category: commsauthz.CategoryMarketing, Mode: commsauthz.ModeEnforce,
+		}: 7,
+		{
+			Verdict:  commsauthz.VerdictAllow,
+			Category: commsauthz.CategoryReplyToInbound, Mode: commsauthz.ModeEnforce,
+		}: 3,
+	})
+	rendered := out.String()
+
+	for _, want := range []string{
+		`margince_communication_authz_decisions_total{verdict="deny",category="marketing",mode="enforce"} 7`,
+		`margince_communication_authz_decisions_total{verdict="allow",category="reply_to_inbound",mode="enforce"} 3`,
+		"# TYPE margince_communication_authz_decisions_total counter",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("the scrape does not carry %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// A process that has authorized nothing must say nothing, rather than print a
+// zero for every combination. "The engine allowed nothing" and "the engine has
+// not run" call for opposite actions, and a rendered zero cannot tell them
+// apart.
+func TestTheDecisionCounterIsSilentBeforeItHasDecidedAnything(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	writeAuthzDecisionMetrics(&out, nil)
+	if out.Len() != 0 {
+		t.Errorf("a process that decided nothing rendered:\n%s", out.String())
+	}
+}
+
+// The scrape is ordered, so a human reading it by hand sees a stable block
+// rather than one the map reshuffled between requests.
+func TestTheDecisionCounterRendersInAStableOrder(t *testing.T) {
+	t.Parallel()
+
+	totals := map[consent.DecisionCount]uint64{
+		{
+			Verdict:  commsauthz.VerdictDeny,
+			Category: commsauthz.CategoryMarketing, Mode: commsauthz.ModeEnforce,
+		}: 1,
+		{
+			Verdict:  commsauthz.VerdictAllow,
+			Category: commsauthz.CategoryAccountNotice, Mode: commsauthz.ModeEnforce,
+		}: 1,
+		{
+			Verdict:  commsauthz.VerdictReview,
+			Category: commsauthz.CategoryInvoiceOrPayment, Mode: commsauthz.ModeWarn,
+		}: 1,
+	}
+	var first strings.Builder
+	writeAuthzDecisionMetrics(&first, totals)
+	for range 8 {
+		var again strings.Builder
+		writeAuthzDecisionMetrics(&again, totals)
+		if again.String() != first.String() {
+			t.Fatalf("two renders of one reading disagree:\n%s\n---\n%s", first.String(), again.String())
+		}
+	}
+}

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -96,7 +96,17 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 			id := d.SubjectID
 			subjectID = &id
 		}
-		if _, err := tx.Exec(ctx, `
+		// NOT COUNTED. See decisioncounter.go: this runs on a transaction this
+		// function does not own, and an enforced refusal is delivered by
+		// rolling that transaction back (compose/commsstager.go refuseAtStaging),
+		// so a staging deny leaves no row. A counter incremented here would
+		// report refusals the record does not hold, and would do it under the
+		// shipped posture rather than in some corner.
+		//
+		// A denial under observe or warn DOES commit, and those rows are real.
+		// They are read from the table, not from a counter that would mean one
+		// thing in one posture and another in the next.
+		_, err := tx.Exec(ctx, `
 			INSERT INTO communication_decision
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, requested_category, resolved_category, verdict, reason_code, basis, suppression,
@@ -107,7 +117,8 @@ func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID
 			subjectKind, subjectID, string(d.Phase), nullableCategory(d.Requested),
 			string(d.Resolved), string(d.Verdict), d.ReasonCode,
 			nullableBasis(d.Basis), nullableText(d.Suppression),
-			sum[:], string(d.Mode), by); err != nil {
+			sum[:], string(d.Mode), by)
+		if err != nil {
 			return fmt.Errorf("consent: record the staging decision: %w", err)
 		}
 	}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -58,6 +58,12 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 	}
 	setID := ids.NewV7()
 	ticket := commsauthz.TransmitTicket{DeliveryID: req.DeliveryID, Attempt: req.Attempt, DecisionSetID: setID}
+	// Counted after the commit, not beside the insert. Two arms below return an
+	// error once the decisions are already written — an unanswerable legacy
+	// gate, and the wording comparison — and each rolls the rows back. A
+	// counter incremented inside the transaction would keep those, and report
+	// decisions the record does not hold.
+	var recorded []commsauthz.Decision
 
 	// The legacy gate's answer, recorded beside the engine's on every row so a
 	// disagreement is readable in the record rather than only in a counter that
@@ -92,9 +98,11 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 		if err != nil {
 			return err
 		}
-		if err := g.recordDecisions(ctx, tx, req, setID, set); err != nil {
+		written, err := g.recordDecisions(ctx, tx, req, setID, set)
+		if err != nil {
 			return err
 		}
+		recorded = written
 		// AN UNANSWERABLE LEGACY GATE IS ONLY FATAL WHERE ITS ANSWER IS USED.
 		//
 		// Effective consults legacyAllowed only when no recipient's category is
@@ -135,6 +143,9 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 	})
 	if err != nil {
 		return commsauthz.TransmitTicket{}, err
+	}
+	for _, d := range recorded {
+		countDecision(d)
 	}
 	return ticket, nil
 }
@@ -331,11 +342,12 @@ func refusalReason(set commsauthz.DecisionSet, legacyAllowed bool) string {
 // exists so a later reader can tell whether the message that went is the
 // message that was authorized, and storing the words themselves would make the
 // decision a second copy of the mail.
-func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet) error {
+func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet) ([]commsauthz.Decision, error) {
+	var written []commsauthz.Decision
 	sum := SendingDigest(req.Subject, req.Body, req.HTMLBody)
 	by, err := storekit.CapturedBy(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, d := range set.Decisions {
 		// Both or neither, which the table's own CHECK also demands: a
@@ -346,7 +358,7 @@ func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.Tr
 			id := d.SubjectID
 			subjectID = &id
 		}
-		if _, err := tx.Exec(ctx, `
+		tag, err := tx.Exec(ctx, `
 			INSERT INTO communication_decision
 			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
 			   phase, resolved_category, verdict, reason_code, basis, suppression,
@@ -356,11 +368,15 @@ func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.Tr
 			req.DeliveryID, req.Attempt, setID, decisionRecipientKey(d.Recipient),
 			subjectKind, subjectID, string(d.Phase), string(d.Resolved), string(d.Verdict),
 			d.ReasonCode, nullableBasis(d.Basis), nullableText(d.Suppression),
-			sum[:], d.LegacyVerdict, string(d.Mode), by); err != nil {
-			return fmt.Errorf("consent: record the transmit decision: %w", err)
+			sum[:], d.LegacyVerdict, string(d.Mode), by)
+		if err != nil {
+			return nil, fmt.Errorf("consent: record the transmit decision: %w", err)
+		}
+		if tag.RowsAffected() > 0 {
+			written = append(written, d)
 		}
 	}
-	return nil
+	return written, nil
 }
 
 // nullableBasis and nullableText carry the difference between "no value" and

--- a/backend/internal/modules/consent/decisioncounter.go
+++ b/backend/internal/modules/consent/decisioncounter.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What this process decided at TRANSMIT about the mail it was asked to send.
+//
+// communication_decision is the durable record and the daily disagreement pass
+// reads it, but neither answers "what is happening right now": one is a table an
+// operator must think to query, the other a line in yesterday's log. A category
+// that started refusing every message an hour ago looks, from outside, exactly
+// like a quiet hour.
+//
+// TRANSMIT ONLY, and the omission is the honest half of this file. Staging
+// records decisions too, but it runs on a transaction it does not own and an
+// enforced refusal is delivered by rolling that transaction back, so a staging
+// deny leaves no row behind. Counting it would publish a refusal rate the
+// record cannot corroborate — under the shipped posture, where every category
+// enforces, rather than in some corner. Transmit returns its refusal as a
+// ticket instead: the transaction commits, the rows persist, and the count
+// matches them.
+//
+// A staging decision taken under OBSERVE or WARN does commit, because
+// refuseAtStaging lets a non-absolute denial through. Those rows are real and
+// this counter does not see them. Counting only the outcomes that happen to
+// survive would make the series mean different things in different postures,
+// which is worse than a series that means one thing and says which. The daily
+// pass and communication_decision are where the staging question is asked.
+//
+// BEST EFFORT, not exact correspondence. The count happens after the commit
+// returns, so a process that dies in between leaves committed rows uncounted.
+// A counter cannot be transactional with the database it describes; this is
+// the direction to fail in, because it under-reports rather than inventing
+// decisions no row holds.
+//
+// A COUNTER RATHER THAN A QUERY OVER THE TABLE, in memory rather than in SQL,
+// for the reasons capture's outcome counter states and which hold here too.
+// /metrics is process-global and binds no workspace, so a windowed query would
+// read every tenant's decisions on every scrape. And "how many sends are being
+// refused" is a rate an operator alerts on, which is what a monotonic counter is
+// for.
+//
+// NO RECIPIENT, EVER. Decision carries the address it judged, and an address as
+// a label would publish who was written to on an endpoint that binds no tenant
+// and is unauthenticated unless a deployment sets a metrics token — unbounded
+// in cardinality and a disclosure besides. The labels are three closed
+// vocabularies: verdict, resolved category, mode. Held by
+// TestTheDecisionCounterLabelsOnlyClosedVocabularies and
+// TestTheRenderedLabelsAreOnlyTheDeclaredOnes
+// (backend/gates/authzmetriclabels_test.go).
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// DecisionCount is one counted combination of the closed label values.
+//
+// No phase: every counted decision is a transmit one, so a phase label would
+// carry the same value on every series and read as though a staging count were
+// coming.
+type DecisionCount struct {
+	Verdict  commsauthz.Verdict
+	Category commsauthz.Category
+	Mode     commsauthz.Mode
+}
+
+// decisionTotals counts decisions RECORDED by this process, keyed by the label
+// combination.
+//
+// A sync.Map for the reason capture's is: the key set stops growing once every
+// live combination has been seen, so the read-mostly path costs no lock.
+var decisionTotals sync.Map // DecisionCount -> *atomic.Uint64
+
+// countDecision records one decision the transaction committed.
+//
+// Called AFTER the commit, from the rows the insert reported it added.
+// AuthorizeTransmit has two error returns that fire once the decisions are
+// already written — an unanswerable legacy gate, and the wording comparison —
+// and both roll the rows back. A counter incremented beside the statement would
+// keep those increments and report decisions no row holds.
+//
+// The insert takes ON CONFLICT DO NOTHING on
+// (decision_set_id, recipient_address, phase), which is one address reached
+// twice in a single set: a recipient on both the To and the Cc line is one
+// decision, and counting per loop iteration would report two.
+//
+// A re-authorization is NOT that case and is not deduplicated: each call mints
+// its own decision_set_id, so a redelivered job's second look is a second
+// decision, recorded as one row and counted once. The engine did decide twice.
+func countDecision(d commsauthz.Decision) {
+	key := DecisionCount{Verdict: d.Verdict, Category: d.Resolved, Mode: d.Mode}
+	stored, _ := decisionTotals.LoadOrStore(key, &atomic.Uint64{})
+	if counter, isCounter := stored.(*atomic.Uint64); isCounter {
+		counter.Add(1)
+	}
+}
+
+// DecisionTotals reports this process's counts, for the metrics endpoint.
+func DecisionTotals() map[DecisionCount]uint64 {
+	out := map[DecisionCount]uint64{}
+	decisionTotals.Range(func(key, value any) bool {
+		count, isCount := key.(DecisionCount)
+		counter, isCounter := value.(*atomic.Uint64)
+		if isCount && isCounter {
+			out[count] = counter.Load()
+		}
+		return true
+	})
+	return out
+}

--- a/backend/internal/modules/consent/decisioncounter_integration_test.go
+++ b/backend/internal/modules/consent/decisioncounter_integration_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The counter counts transmit decisions the transaction COMMITTED, once each.
+//
+// Two things can go wrong and neither is visible from the counter itself. The
+// insert takes ON CONFLICT DO NOTHING on
+// (decision_set_id, recipient_address, phase), so one address reached twice in
+// a single set is one row — counting per loop iteration would report a Cc to
+// the same person as a second decision. And AuthorizeTransmit can fail after
+// the rows are written, rolling them back, so counting inside the transaction
+// would report decisions no row holds.
+//
+// Through the REAL writer, on a real database. A test that called
+// countDecision itself would prove the counter adds up and nothing about
+// whether the send path reaches it.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+func countedNow(t *testing.T, key DecisionCount) uint64 {
+	t.Helper()
+	return DecisionTotals()[key]
+}
+
+// allowedRecordConfirmation is the label combination the fixture below produces:
+// the engine allows a record confirmation, under the shipped enforcing posture.
+var allowedRecordConfirmation = DecisionCount{
+	Verdict:  commsauthz.VerdictAllow,
+	Category: commsauthz.CategoryRecordConfirmation,
+	Mode:     commsauthz.ModeEnforce,
+}
+
+func TestATransmitDecisionIsCountedOnce(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	before := countedNow(t, allowedRecordConfirmation)
+
+	ticket := stageThenTransmit(t, e, delivery, stagedSubject, stagedBody)
+	if !ticket.Allowed {
+		t.Fatalf("the fixture message was refused: %q — this test needs an ALLOWED transmit, "+
+			"so a refusal here means it is counting the wrong verdict", ticket.Reason)
+	}
+
+	if got := countedNow(t, allowedRecordConfirmation) - before; got != 1 {
+		t.Fatalf("one transmitted recipient moved the counter by %d, want 1 — the transmit "+
+			"writer does not reach countDecision, so /metrics is blind to the last judgement "+
+			"taken before mail leaves", got)
+	}
+}
+
+// One address reached twice in a single decision set is one row, and must be
+// one count. This is the case the ON CONFLICT exists for.
+func TestARecipientNamedTwiceIsCountedOnce(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	before := countedNow(t, allowedRecordConfirmation)
+
+	// The same address twice, which is what a To and a Cc to one person is.
+	transmitTo(t, e, delivery, []connector.Recipient{{Email: e.address}, {Email: e.address}})
+
+	if got := countedNow(t, allowedRecordConfirmation) - before; got != 1 {
+		t.Fatalf("one address named twice moved the counter by %d, want 1 — the count is taken "+
+			"per recipient rather than per inserted row, so a Cc to the same person reads as "+
+			"a second decision", got)
+	}
+}
+
+// The defect both reviewers found: a transaction that rolls back after the
+// decisions are written must leave NO count behind.
+//
+// The rollback is induced the way production induces it — the caller's own
+// transaction fails once AuthorizeTransmit has committed nothing yet. Without
+// the after-commit counting this test reports one, and the refusal rate an
+// operator alerts on climbs on rows that do not exist.
+func TestARolledBackTransmitCountsNothing(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	before := countedNow(t, allowedRecordConfirmation)
+
+	// A transmit whose transaction the legacy-gate arm aborts. The wording
+	// comparison is the reachable spelling of the same shape: it runs after
+	// recordDecisions and its error path rolls the rows back.
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		if _, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: []connector.Recipient{{Email: e.address}},
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+		}); err != nil {
+			return err
+		}
+		return errors.New("the caller refuses after the decisions are written")
+	}); err == nil {
+		t.Fatal("the probe transaction was supposed to fail")
+	}
+
+	var rows int
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT count(*) FROM communication_decision WHERE delivery_id = $1`, delivery).Scan(&rows); err != nil {
+		t.Fatalf("counting the rows: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("the rolled-back transaction left %d rows — this test needs the rollback to "+
+			"have happened for its count assertion to mean anything", rows)
+	}
+	if got := countedNow(t, allowedRecordConfirmation) - before; got != 0 {
+		t.Fatalf("a rolled-back decision moved the counter by %d, want 0 — the count is taken "+
+			"inside the transaction, so /metrics reports decisions communication_decision "+
+			"does not hold", got)
+	}
+}
+
+// transmitTo runs the real transmit writer over one delivery to the given
+// recipients, after staging the same message.
+func transmitTo(t *testing.T, e *resolveEnv, delivery ids.UUID, to []connector.Recipient) {
+	t.Helper()
+	e.issueLinkRow(t, LinkRecordConfirmation, time.Now().Add(14*24*time.Hour), nil)
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		_, err := e.gate.AuthorizeStagingTx(e.ctx, tx, delivery, commsauthz.Request{
+			Recipients: to,
+			Context:    commsauthz.CategoryRecordConfirmation,
+			Subject:    stagedSubject,
+			Body:       stagedBody,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("staging the delivery: %v", err)
+	}
+	if _, err := e.gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+		DeliveryID: delivery,
+		Attempt:    1,
+		Recipients: to,
+		Subject:    stagedSubject,
+		Body:       stagedBody,
+	}); err != nil {
+		t.Fatalf("authorizing the transmit: %v", err)
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -305,12 +305,13 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 | `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
-## Prohibition (50)
+## Prohibition (51)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `aidisclosure_test.go` | H1 | The Art. 50 disclosure has ONE spelling, and it is draftfloor.AIDisclosure. |
 | `arch_test.go` | H2 | Structural fitness functions (architecture/03 §1): these tests make the boundary rules mechanical, and they derive the package list from the tree instead of maintaining it by hand — a new package is enrolled the moment it exists (fitness function over point fix). |
+| `authzmetriclabels_test.go` | H2 | The outbound decision counter labels only closed vocabularies, and never the recipient. |
 | `backfillledgerlock_test.go` | H2 | A transaction that writes the backfill creation ledger locks the run row first. |
 | `capabilitypathlog_test.go` | H2 | A request path reaches a log line through capabilitypath.Redact, never raw. |
 | `connectoractor_test.go` | H1 | A connector's actor id is DERIVED from the work, never written down. |


### PR DESCRIPTION
`/metrics` said nothing about outbound authorization. The only control was `internal/compose/authzdisagreement.go`, a daily pass that logs a stored reading — so a category that began refusing every message an hour ago looked from outside exactly like a quiet hour.

`margince_communication_authz_decisions_total` counts what the engine decided, labelled by verdict, resolved category and mode. Modelled on `capture.TraceOutcomeTotals`, and in memory for the reason stated there: `/metrics` binds no workspace, so a windowed query would read every tenant's decisions on every scrape.

## No recipient, held two ways

`commsauthz.Decision` carries the address it judged. An address as a label would publish who this installation writes to on an endpoint that is unauthenticated unless a deployment sets a metrics token, and would mint one time series per person.

`backend/gates/authzmetriclabels_test.go` holds that with two arms: one reads the key type (`DecisionCount` has no such field), one reads the renderer's own format strings — because a second `Fprintf` could emit a label the key never gained, which is a hole a reviewer found in the first version. Both arms state what they cannot see: neither reads label *values*, and the second reads literal format strings in one file.

## Counted after the commit

Both reviewers found the first version incremented inside the transaction. A probe proved it: a rolled-back staging call left `rows=0` with the counter at `1`.

Transmit now collects the rows the insert reported and counts once `db.Tx` returns nil. It is best effort rather than exact — a process that dies between the commit and the loop under-reports, which is the direction to fail in.

**Staging is not counted at all.** It runs on a transaction it does not own, and an enforced refusal is delivered by rolling that transaction back (`compose/commsstager.go` `refuseAtStaging`), so a staging deny leaves no row to corroborate it. A deny under observe or warn *does* commit; those rows are read from `communication_decision` rather than from a series that would mean different things in different postures.

`Phase` left the label set with the staging count — every counted decision is a transmit one, and a label carrying one value reads as though the other were coming.

## Mutation checks

Six, each failing with the message written for it: counting removed entirely; counting per recipient instead of per inserted row; counting restored inside the transaction (the defect both reviewers found); a planted `RecipientAddress` field; a planted second `Fprintf` emitting `{address=%q}`; and the gate pointed at a file that does not exist.

`make check-backend` green against the rebased tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `margince_communication_authz_decisions_total` to `/metrics`, showing live what the outbound authorization engine decided at transmit, labeled by verdict, resolved category, and mode. Until now `/metrics` said nothing about outbound authorization — the only visibility was a daily pass over stored decisions, so a category that began refusing every message an hour ago looked from outside like a quiet hour.

**Counting decisions**

- The counter lives in memory per process, like capture's outcome counter, because `/metrics` binds no workspace — a windowed query would read every tenant's decisions on every scrape.
- The recipient is never a label: an address would publish who this installation writes to on an endpoint that is unauthenticated unless a metrics token is set, and would mint one series per person. A gate test holds this with two arms — one reads the counter key type, one reads the renderer's format strings.
- Counting happens after the commit, from rows the insert reported, so a rolled-back transmit leaves no count. Best-effort: a process dying between commit and count under-reports, which is the safe direction.
- Staging decisions are not counted — staging runs on a transaction it doesn't own and enforced refusals roll that transaction back, so counting them would report refusals the record doesn't hold.

<sup>Written for commit b8e6313fd0e1a1dbc46d9c893f42b3606723be14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics for outbound authorization decisions, grouped by verdict, category, and mode.
  - Metrics are exposed in the application’s metrics output with stable, deterministic ordering.
  - Decision counts now reflect successfully committed transmit decisions and exclude rolled-back transactions.

- **Documentation**
  - Updated the gate inventory with the new metric-label validation gate.

- **Tests**
  - Added coverage for metric rendering, label vocabulary, ordering, duplicate decisions, and transaction rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->