### PR TITLE
fix(evidence): a quotation carries what a reader saw, and nothing else

### DIFF
--- a/backend/internal/compose/evidencematch.go
+++ b/backend/internal/compose/evidencematch.go
@@ -45,6 +45,11 @@ func normalizeEvidence(s string) string {
 			continue
 		case r == '­': // soft hyphen: a rendering hint, not content
 			continue
+		case formatRune(r):
+			// The same rule one step wider — see formatrunes.go. A bidi
+			// override or a zero-width space between two letters must not
+			// stop a value matching the text that prints it.
+			continue
 		}
 		if space {
 			if b.Len() > 0 {

--- a/backend/internal/compose/formatrunes.go
+++ b/backend/internal/compose/formatrunes.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Runes a page can carry that are not what a reader sees.
+//
+// A crawled page reaches this tier through StripTags, which decodes character
+// references — so `&#x202E;` arrives as U+202E RIGHT-TO-LEFT OVERRIDE and
+// `&#x200B;` as a zero-width space, both invisible and both able to change what
+// a quotation LOOKS like without changing a byte a gate compares.
+//
+// The one that matters is the bidi family. An evidence snippet is rendered
+// verbatim in a blockquote beside a decision somebody is being asked to make,
+// and an override there makes the visible order differ from the stored order:
+// the quotation a reader approves is not the quotation on file. Zero-width
+// characters are the quieter half of the same problem — they break a word for
+// the eye and not for a comparison, or the reverse.
+//
+// Dropped rather than escaped, on the ground `normalizeEvidence` already drops
+// the soft hyphen: a rendering hint is not content, and there is nothing here a
+// reader loses.
+
+import "unicode"
+
+// formatRune reports a rune that carries no content: Unicode's Cf class (the
+// bidi controls, the zero-width joiners and spaces, the byte-order mark) and
+// the C0/C1 controls that survive text extraction.
+//
+// Whitespace is NOT this: a tab and a newline are separators every caller
+// already handles, and folding them in here would silently change how a passage
+// is segmented.
+func formatRune(r rune) bool {
+	if unicode.IsSpace(r) {
+		return false
+	}
+	return unicode.Is(unicode.Cf, r) || unicode.IsControl(r)
+}
+
+// withoutFormatRunes drops them, leaving the text a reader would have seen.
+func withoutFormatRunes(s string) string {
+	// The overwhelmingly common case is a page with none, and a page's text is
+	// long: scanning once and returning the original beats rebuilding it.
+	clean := true
+	for _, r := range s {
+		if formatRune(r) {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if !formatRune(r) {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}

--- a/backend/internal/compose/formatrunes_test.go
+++ b/backend/internal/compose/formatrunes_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The runes a crawled page can carry that a reader never sees.
+//
+// They reach this tier because StripTags decodes character references, so a
+// page writing `&#x202E;` hands over a real RIGHT-TO-LEFT OVERRIDE. What it
+// costs is specific: an evidence snippet is rendered verbatim in a blockquote
+// beside a decision somebody is being asked to make, and an override there
+// makes the visible order differ from the stored one — the quotation a reader
+// approves is not the quotation on file.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAPassageKeepsWhatAReaderSeesAndNothingElse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ordinary text is returned untouched", "Acme GmbH, Kiel", "Acme GmbH, Kiel"},
+		{"a right-to-left override", "HRB \u202e123456", "HRB 123456"},
+		{"the whole bidi family", "a\u202a\u202b\u202c\u202d\u202eb", "ab"},
+		{"the isolates too", "a\u2066\u2067\u2068\u2069b", "ab"},
+		{"a zero-width space breaking a word", "Analytical\u200bEngines", "AnalyticalEngines"},
+		{"a zero-width joiner and non-joiner", "a\u200c\u200db", "ab"},
+		{"a byte-order mark", "\ufeffAcme", "Acme"},
+		{"a C0 control", "Acme\x01GmbH", "AcmeGmbH"},
+		// Whitespace is a SEPARATOR every caller already handles, and folding
+		// it in here would silently change how a passage is segmented.
+		{"a newline survives", "one\ntwo", "one\ntwo"},
+		{"a tab survives", "one\ttwo", "one\ttwo"},
+		{"an ordinary space survives", "one two", "one two"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := withoutFormatRunes(tc.in); got != tc.want {
+				t.Errorf("withoutFormatRunes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// And the comparison side, which has to agree.
+//
+// The token comparison (`contentTokens`) already splits on anything that is not
+// a letter or a digit, so a format rune was never a difference to it. The
+// containment one is where it counts: `evidenceOnPage` falls back to a
+// substring test over the normalized text, and there a zero-width space on one
+// side and not the other is a quotation the gate refuses although the page
+// prints it.
+func TestAnInvisibleRuneDoesNotStopASnippetMatchingItsPage(t *testing.T) {
+	const pageText = "Impressum. Acme GmbH, Amtsgericht Kiel HRB 123456."
+	pageNorm := normalizeEvidence(pageText)
+
+	// The model quotes the page and its copy carries a zero-width space and an
+	// override the page does not have — or the page carries them and the quote
+	// does not. Neither is a difference a reader could see.
+	if !evidenceOnPage(pageText, pageNorm, "Amtsgericht Kiel HRB \u200b123456") {
+		t.Error("a quotation carrying a zero-width space matched nothing on the page that prints it")
+	}
+	if !evidenceOnPage(pageText, pageNorm, "Amtsgericht Kiel \u202eHRB 123456") {
+		t.Error("a quotation carrying a bidi override matched nothing on the page that prints it")
+	}
+	// And the gate still refuses a quotation the page does NOT print: stripping
+	// what a reader cannot see must not widen what counts as evidence.
+	if evidenceOnPage(pageText, pageNorm, "Amtsgericht Hamburg HRB 123456") {
+		t.Error("a quotation naming a court the page does not print was accepted as evidence")
+	}
+}
+
+// A snippet built from a page carrying one is stored without it, which is the
+// half normalizeEvidence cannot reach: what is rendered is the passage, not its
+// normalized form.
+func TestASnippetIsStoredWithoutTheRunesAReaderCannotSee(t *testing.T) {
+	idx := newSnippetIndex(excerptPages{{
+		URL:  "https://acme.example/impressum",
+		Text: "Impressum. Acme GmbH, Amtsgericht Kiel HRB \u202e123456\u202c.",
+	}})
+	if len(idx.refs) == 0 {
+		t.Fatal("the page produced no passage at all")
+	}
+	for _, ref := range idx.refs {
+		if strings.ContainsRune(ref.passage, '\u202e') || strings.ContainsRune(ref.passage, '\u202c') {
+			t.Errorf("a stored passage carries a bidi control: %q — rendered verbatim in a "+
+				"blockquote, it can show a reader an order the bytes do not have", ref.passage)
+		}
+	}
+}

--- a/backend/internal/compose/sitesnippet.go
+++ b/backend/internal/compose/sitesnippet.go
@@ -159,6 +159,13 @@ func newSnippetIndex(pages excerptPages) snippetIndex {
 	var idx snippetIndex
 	for _, page := range pages {
 		for _, passage := range segmentPassages(page.Text) {
+			// Stripped HERE, where the passage becomes the thing a snippet is
+			// cut from, so what is stored and shown is what a reader would have
+			// seen. normalizeEvidence drops the same runes, but only for the
+			// comparison — an evidence_snippet is rendered verbatim in a
+			// blockquote, and a bidi override there makes the quotation
+			// somebody approves differ from the quotation on file.
+			passage = withoutFormatRunes(passage)
 			idx.refs = append(idx.refs, snippetRef{
 				pageURL: page.URL,
 				passage: passage,


### PR DESCRIPTION
Closes #1162.

## What survives into a snippet

`StripTags` decodes character references, so a page writing `&#x202E;` hands over a real RIGHT-TO-LEFT OVERRIDE and `&#x200B;` a zero-width space. Both reach the reduced page text and the stored `evidence_snippet`, invisible and able to change what a quotation *looks like* without changing a byte any gate compares.

The one that costs something is the bidi family. A snippet is rendered verbatim in a `<blockquote>` beside a decision somebody is being asked to make (`onboarding-read.tsx`, `approvaleditor.tsx`), and an override there makes the visible order differ from the stored order — **the quotation a reader approves is not the quotation on file.**

## Two halves, and neither is the other

The ticket proposes `normalizeEvidence` as "the consistent home", beside the soft hyphen it already drops. That is right for the comparison and it does **not** close what the ticket describes: `entity.EvidenceSnippet = block` stores the raw passage, and what a reader sees is that, not its normalized form. So this does both.

- **Where the passage is cut** (`newSnippetIndex`) — what is stored and shown is what a reader would have seen.
- **In `normalizeEvidence`** — so the comparison is immune too.

Not in `StripTags`, for the reason the ticket gives: its output is the evidence contract.

## What the comparison half is actually for

The token comparison was already immune — `contentTokens` splits on anything that is not a letter or a digit, so a format rune was never a difference to it. `evidenceOnPage`'s **containment** fallback is where it counts: a substring test over the normalized text, where a zero-width space on one side and not the other refuses a quotation the page really does print.

My first test picked the token path and the mutation did not kill it, which is how I found that. The test now exercises `evidenceOnPage` directly, in both directions, plus the case that must still be refused — stripping what a reader cannot see must not widen what counts as evidence.

## The class, and what is deliberately not in it

Unicode `Cf` (the bidi controls, the zero-width joiners and spaces, the byte-order mark) plus the C0/C1 controls that survive extraction. **Whitespace is not**: a tab and a newline are separators every caller already handles, and folding them in would silently change how a passage is segmented.

Dropped rather than escaped, on the ground the soft hyphen is: a rendering hint is not content, and there is nothing here a reader loses.

## Tests

`formatrunes_test.go`: eleven cases over the class and its boundary, the containment path in both directions plus a refusal that must stand, and a snippet built from a page carrying an override asserted free of it. Every literal is an escape sequence — staticcheck's ST1018 refuses the runes in source, which is the same argument this change makes about a blockquote.

Mutation-checked: removing either half fails its own test and not the other's.

## Checks

`make check-backend` green, `make craft-static` clean, `compose` integration lane green.