### PR TITLE
feat(deals): an automatic stage move can be taken back

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4946,6 +4946,84 @@ paths:
         '422': { $ref: '#/components/responses/ValidationError' }
 
   # ------------------------ /deals/{id}/stage-evidence ------------------------
+  /deals/{id}/stage-progressions/{approvalId}/revert:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+      - name: approvalId
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+        description: The stage-progression approval whose move is being taken back.
+    post:
+      tags: [Deals]
+      operationId: revertStageProgression
+      summary: Take back a stage move the product made by itself.
+      # human-only, and deliberately. Undoing what the autopilot did is a
+      # judgement about whether the product was right, and an agent reversing
+      # the product's own moves would be one machine grading another with
+      # nobody in the loop. A person disagrees; that is the whole verb.
+      x-agent-access: human-only
+      description: |
+        Undo for an AUTOMATICALLY applied stage move, inside the window the
+        transition's rule allows (`undo_window_hours`, default 72).
+
+        It is a separate verb rather than the general undo path because a stage
+        move is not restorable by writing the field back: it wrote
+        `deal_stage_history` and the progression ledger beside the column, so
+        restoring `stage_id` alone would leave the history saying the deal is
+        somewhere it is not. The general replay engine refuses `advance_stage`
+        for exactly this reason.
+
+        What it does: moves the deal back to the stage it came from, appends a
+        new `deal_stage_history` row for the move back (history is append-only;
+        nothing is erased), and marks the progression ledger row `reversed` with
+        who did it and when.
+
+        **A reversal does not refute the evidence.** Taking a move back says the
+        deal should not have moved, which is a different claim from "the
+        criteria were wrongly read" — a rep may agree with every observation and
+        still want the deal where it was. Evidence is withdrawn only through its
+        own correction path.
+
+        Refused after the window closes: the move stands, the audit trail keeps
+        it, and moving the deal back by hand is the remaining route — which is
+        counted as a reversal too, on the same ledger.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The deal, back at the stage it came from.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Deal' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: |
+            No such deal, no such progression, or the caller may not see it.
+            Also the answer when the approval names a different deal, so a
+            caller cannot learn that a progression exists by probing ids.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '409':
+          description: |
+            The move cannot be taken back: the undo window has closed, the move
+            was made by a person rather than automatically, or it has already
+            been reversed.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+              examples:
+                windowClosed:
+                  value:
+                    type: 'https://errors.gradion.com/undo_window_closed'
+                    title: The undo window has closed
+                    status: 409
+                    code: undo_window_closed
+                    detail: This move can no longer be taken back automatically; move the deal by hand instead.
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   /deals/{id}/stage-evidence:
     parameters:
       - $ref: '#/components/parameters/Id'

--- a/backend/gates/updateguard_test.go
+++ b/backend/gates/updateguard_test.go
@@ -152,6 +152,13 @@ var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// consequence), and one clearing is one clearing. Both send the conditional
 	// UPDATE through QueryRow so the row the write produced is the row the
 	// audit describes.
+	// A reversal, from both doors that can make one: the undo verb and the
+	// detection of a manual move back. Both LOCK the ledger row first (FOR
+	// UPDATE OF o in lockReversibleMove and in the detection query), and the
+	// write is conditioned on reversed_at IS NULL on top of that — so a second
+	// caller gets ErrNoRows and treats it as the decline it is. One reversal
+	// counted twice would double the safety rate that governs the transition.
+	"internal/modules/deals:markMoveReversed":          "the caller holds the row (FOR UPDATE) and the write is conditioned on reversed_at IS NULL; ErrNoRows means somebody reversed it first, which is a decline rather than a failure",
 	"internal/modules/deals:suspendTransitionPolicyTx": "conditioned on suspended_at IS NULL; ErrNoRows means a concurrent pass suspended it first and that reason stands",
 	"internal/modules/deals:ResumeTransitionPolicy":    "conditioned on suspended_at IS NOT NULL; ErrNoRows means a concurrent caller already cleared it",
 

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -475,6 +475,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/deals/{id}/advance":                                        {Op: "advanceDeal", Access: "tool", Tool: "advance_deal", RecordType: "deal", Tier: "dynamic", Scope: "write"},
 	"POST /v1/deals/{id}/offers":                                         {Op: "createOffer", Access: "tool", Tool: "create_record", RecordType: "offer", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/deals/{id}/role-proposals":                                 {Op: "proposeDealRoles", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/deals/{id}/stage-progressions/{approvalId}/revert":         {Op: "revertStageProgression", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/dedupe/candidates/{id}/disposition":                        {Op: "disposeDedupeCandidate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/dedupe/candidates/{id}/undo":                               {Op: "undoDedupeDisposition", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "tool", Tool: "send_account_email", RecordType: "activity", Tier: "auto_execute", Scope: "send"},

--- a/backend/internal/compose/integration/stagerevert_e2e_integration_test.go
+++ b/backend/internal/compose/integration/stagerevert_e2e_integration_test.go
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Taking back a stage move the product made by itself.
+//
+// Split from the apply tests beside it because the two answer different
+// questions: those ask whether a transition may move a deal at all, these ask
+// what happens when somebody disagrees with a move it made. The fixtures they
+// share — a governed transition and a real automatic apply — live there,
+// because that is where they are built.
+//
+// Two doors reach one fact. A rep can press Undo or simply drag the deal back,
+// and both must reach the ledger: counted on only one, the safety rate would
+// be dodgeable by the route nobody instrumented.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// autoAppliedMove drives a real automatic apply and answers the card that made
+// it, so an undo test starts from a move the product actually made.
+func autoAppliedMove(t *testing.T, e *Env) (ids.DealID, ids.ApprovalID, deals.TransitionRef) {
+	t.Helper()
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	ref := governedTransition(t, e, deal)
+	applied, err := compose.SweepAutoApply(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+	if applied == 0 {
+		t.Fatal("nothing applied, so there is no automatic move to take back")
+	}
+	card := appliedCardFor(t, e, deal)
+	deliverApprovalDecided(t, e, card)
+	return deal, card, ref
+}
+
+// ledgerOutcomeFor answers how the ledger records one card's move.
+func ledgerOutcomeFor(t *testing.T, e *Env, card ids.ApprovalID) (string, bool) {
+	t.Helper()
+	var outcome string
+	var reversed bool
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT outcome, reversed_at IS NOT NULL
+		  FROM stage_progression_outcome WHERE approval_id = $1`,
+		card).Scan(&outcome, &reversed); err != nil {
+		t.Fatalf("reading the ledger row: %v", err)
+	}
+	return outcome, reversed
+}
+
+// Undo inside the window moves the deal back and counts a reversal.
+func TestUndoInsideTheWindowMovesTheDealBackAndCountsAReversal(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+	if got := stageOf(t, e, deal); got != ref.ToStageID {
+		t.Fatalf("the fixture's deal is at %s, not the stage the sweep moved it "+
+			"to (%s) — the undo below would prove nothing", got, ref.ToStageID)
+	}
+	if outcome, _ := ledgerOutcomeFor(t, e, card); outcome != deals.ProgressionAutoApplied {
+		t.Fatalf("the fixture's move reads as %q, not an automatic one", outcome)
+	}
+
+	if _, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID); err != nil {
+		t.Fatalf("taking the move back: %v", err)
+	}
+
+	if got := stageOf(t, e, deal); got != ref.FromStageID {
+		t.Fatalf("the deal is at %s after the undo, want the stage it came from (%s)",
+			got, ref.FromStageID)
+	}
+	outcome, reversed := ledgerOutcomeFor(t, e, card)
+	if outcome != deals.ProgressionReversed {
+		t.Errorf("the ledger reads %q after an undo, want %q — the safety number "+
+			"is taken over this column, so a move nobody counts is one that never "+
+			"stops the transition", outcome, deals.ProgressionReversed)
+	}
+	if !reversed {
+		t.Error("reversed_at is unset: the outcome and the timestamp are two " +
+			"spellings of one fact and the report reads either")
+	}
+
+	// History is APPEND-ONLY. The move back is its own row; erasing the
+	// original would leave the trail claiming the deal was never moved.
+	var rows int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_history WHERE deal_id = $1`, deal).Scan(&rows); err != nil {
+		t.Fatalf("counting history: %v", err)
+	}
+	if rows < 2 {
+		t.Errorf("the deal has %d history rows after a move and an undo, want at "+
+			"least 2 — the undo rewrote history instead of recording itself", rows)
+	}
+}
+
+// An undo does not refute the evidence the move rested on.
+//
+// Taking a move back says the deal should not have moved. It does not say the
+// criteria were misread — a rep may agree with every observation and still want
+// the deal where it was, and a reversal that quietly withdrew the claims would
+// retract evidence nobody disputed.
+func TestAnUndoDoesNotRefuteTheEvidenceTheMoveRestedOn(t *testing.T) {
+	e := Setup(t)
+	deal, card, _ := autoAppliedMove(t, e)
+
+	var before int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_evidence WHERE deal_id = $1 AND refuted_at IS NULL`,
+		deal).Scan(&before); err != nil {
+		t.Fatalf("counting standing evidence: %v", err)
+	}
+	if before == 0 {
+		t.Fatal("the fixture cites no standing evidence, so nothing could be " +
+			"refuted and this test would pass however the undo behaved")
+	}
+
+	if _, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID); err != nil {
+		t.Fatalf("taking the move back: %v", err)
+	}
+
+	var after int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_evidence WHERE deal_id = $1 AND refuted_at IS NULL`,
+		deal).Scan(&after); err != nil {
+		t.Fatalf("counting standing evidence: %v", err)
+	}
+	if after != before {
+		t.Errorf("standing evidence went from %d to %d across an undo: taking a "+
+			"move back withdrew claims nobody disputed", before, after)
+	}
+}
+
+// After the window, the undo is refused and the move stands.
+func TestUndoAfterTheWindowIsRefusedAndTheAuditStays(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	// Push the decision past the transition's own undo window.
+	if _, err := e.Pool.Exec(t.Context(), `
+		UPDATE stage_progression_outcome
+		   SET decided_at = now() - interval '73 hours'
+		 WHERE approval_id = $1`, card); err != nil {
+		t.Fatalf("ageing the move: %v", err)
+	}
+
+	_, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID)
+	if err == nil {
+		t.Fatal("a move older than its undo window was taken back anyway")
+	}
+	var closed *deals.UndoWindowClosedError
+	if !errors.As(err, &closed) {
+		t.Fatalf("the refusal is %v, want an UndoWindowClosedError so the caller "+
+			"gets a 409 naming what to do instead", err)
+	}
+
+	if got := stageOf(t, e, deal); got != ref.ToStageID {
+		t.Errorf("the deal moved to %s on a refused undo", got)
+	}
+	if outcome, reversed := ledgerOutcomeFor(t, e, card); reversed ||
+		outcome != deals.ProgressionAutoApplied {
+		t.Errorf("the refused undo still marked the ledger (%q, reversed=%v)",
+			outcome, reversed)
+	}
+}
+
+// A move a PERSON approved is not undone by this verb.
+//
+// There was never anything automatic to take back. Moving the deal back is an
+// ordinary stage move the rep can make, and that route counts as a reversal on
+// the same ledger.
+func TestAHumanApprovedMoveIsNotTakenBackByTheUndoVerb(t *testing.T) {
+	e := Setup(t)
+	deal, staged := proposeOnMetCriteria(t, e)
+	if !staged {
+		t.Fatal("the proposal did not stage")
+	}
+	giveTheOwnerARealRole(t, e)
+	card, open := pendingCardFor(t, e, deal)
+	if !open {
+		t.Fatal("no card to approve")
+	}
+	if _, err := compose.StageProgressionDecisions(e.Pool).Decide(
+		e.Admin(), card, true, nil); err != nil {
+		t.Fatalf("approving the card as a person: %v", err)
+	}
+	deliverApprovalDecided(t, e, card)
+
+	_, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID)
+	if err == nil {
+		t.Fatal("the undo verb took back a move a person had approved")
+	}
+	var closed *deals.UndoWindowClosedError
+	if !errors.As(err, &closed) {
+		t.Fatalf("the refusal is %v, want an UndoWindowClosedError", err)
+	}
+}
+
+// A manual move back over a recent automatic one counts as a reversal.
+//
+// The route a rep who disagrees actually takes. Counted only on the undo
+// button, the safety number would be dodgeable by dragging the deal back —
+// the transition would keep applying while people quietly corrected it.
+func TestAManualMoveBackInsideTheWindowAlsoCountsAsReversalWithoutRefutingEvidence(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	var evidenceBefore int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_evidence WHERE deal_id = $1 AND refuted_at IS NULL`,
+		deal).Scan(&evidenceBefore); err != nil {
+		t.Fatalf("counting standing evidence: %v", err)
+	}
+
+	// No undo button — an ordinary stage move, back the way it came.
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), deal, deals.AdvanceDealInput{
+		ToStageID: ref.FromStageID,
+	}); err != nil {
+		t.Fatalf("moving the deal back by hand: %v", err)
+	}
+
+	outcome, reversed := ledgerOutcomeFor(t, e, card)
+	if outcome != deals.ProgressionReversed || !reversed {
+		t.Errorf("a manual move back left the ledger at (%q, reversed=%v): the "+
+			"safety number can be dodged by dragging the deal instead of pressing "+
+			"undo, and the transition keeps applying", outcome, reversed)
+	}
+
+	var evidenceAfter int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_evidence WHERE deal_id = $1 AND refuted_at IS NULL`,
+		deal).Scan(&evidenceAfter); err != nil {
+		t.Fatalf("counting standing evidence: %v", err)
+	}
+	if evidenceAfter != evidenceBefore {
+		t.Errorf("standing evidence went from %d to %d: moving a deal back "+
+			"withdrew claims nobody disputed", evidenceBefore, evidenceAfter)
+	}
+}
+
+// An ordinary forward move undoes nothing.
+//
+// The guard on the guard: reversal detection that matched any stage move would
+// mark unrelated moves as reversals and report a transition as unsafe because
+// its deals kept progressing.
+func TestAnOrdinaryStageMoveIsNotCountedAsAReversal(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	// Forward again, to a third OPEN stage — the opposite direction from an
+	// undo. Open, because a terminal stage needs a lost reason or a contract
+	// and this test is about direction, not about closing a deal.
+	var onward ids.StageID
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT id FROM stage
+		 WHERE pipeline_id = $1 AND id <> $2 AND id <> $3
+		   AND archived_at IS NULL AND semantic = 'open'
+		 ORDER BY "position" DESC LIMIT 1`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&onward); err != nil {
+		t.Skipf("the fixture pipeline has no third open stage to move on to: %v", err)
+	}
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), deal, deals.AdvanceDealInput{
+		ToStageID: onward,
+	}); err != nil {
+		t.Fatalf("moving the deal onward: %v", err)
+	}
+
+	if outcome, reversed := ledgerOutcomeFor(t, e, card); reversed ||
+		outcome != deals.ProgressionAutoApplied {
+		t.Errorf("moving a deal ONWARD marked the earlier move reversed (%q, %v): "+
+			"every progressing deal would report its transition as unsafe",
+			outcome, reversed)
+	}
+}
+
+// A deal that has moved on cannot be sent backwards by an old card.
+//
+// Undo means "put it back", which is only meaningful while the deal is still
+// where the move put it. Without this check, choosing which approval to revert
+// chooses where the deal lands: automatic A→B, a rep moves it on to C, and
+// reverting the A→B card takes it C→A — a move nobody made and an undo of
+// nothing.
+func TestAnUndoIsRefusedOnceTheDealHasMovedOn(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	var onward ids.StageID
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT id FROM stage
+		 WHERE pipeline_id = $1 AND id <> $2 AND id <> $3
+		   AND archived_at IS NULL AND semantic = 'open'
+		 ORDER BY "position" DESC LIMIT 1`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&onward); err != nil {
+		t.Skipf("the fixture pipeline has no third open stage: %v", err)
+	}
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), deal, deals.AdvanceDealInput{
+		ToStageID: onward,
+	}); err != nil {
+		t.Fatalf("moving the deal onward: %v", err)
+	}
+
+	_, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID)
+	if err == nil {
+		t.Fatal("an old card sent a deal backwards from a stage the move never " +
+			"touched: choosing which approval to revert chooses where the deal lands")
+	}
+	var closed *deals.UndoWindowClosedError
+	if !errors.As(err, &closed) {
+		t.Fatalf("the refusal is %v, want an UndoWindowClosedError", err)
+	}
+	if got := stageOf(t, e, deal); got != onward {
+		t.Errorf("the deal is at %s after a refused undo, want %s", got, onward)
+	}
+}
+
+// An undone move is not proposed again.
+//
+// readProtection asks whether any history row on this deal names a move it
+// undid. The reversal has to write that link or the product re-proposes the
+// exact move a person just took back — the definition of not listening.
+func TestAnUndoneMoveIsNotProposedAgain(t *testing.T) {
+	e := Setup(t)
+	deal, card, _ := autoAppliedMove(t, e)
+	if _, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID); err != nil {
+		t.Fatalf("taking the move back: %v", err)
+	}
+
+	var linked int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_history WHERE deal_id = $1 AND reversal_of IS NOT NULL`,
+		deal).Scan(&linked); err != nil {
+		t.Fatalf("reading the history link: %v", err)
+	}
+	if linked == 0 {
+		t.Fatal("the undo wrote no reversal_of link, so readProtection cannot see " +
+			"that this deal has already had the argument and the product will " +
+			"propose the same move again")
+	}
+}
+
+// A manual move back also records what it undid.
+func TestAManualMoveBackRecordsWhatItUndid(t *testing.T) {
+	e := Setup(t)
+	deal, _, ref := autoAppliedMove(t, e)
+	if _, err := e.Deals.AdvanceDeal(e.Admin(), deal, deals.AdvanceDealInput{
+		ToStageID: ref.FromStageID,
+	}); err != nil {
+		t.Fatalf("moving the deal back by hand: %v", err)
+	}
+
+	var linked int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM deal_stage_history WHERE deal_id = $1 AND reversal_of IS NOT NULL`,
+		deal).Scan(&linked); err != nil {
+		t.Fatalf("reading the history link: %v", err)
+	}
+	if linked == 0 {
+		t.Error("dragging a deal back left no reversal_of link, so the product " +
+			"will propose the move again — the undo BUTTON records it and this " +
+			"route does not, which is the half nobody presses")
+	}
+}
+
+// The undo window is the one the move was made under.
+//
+// An admin shortening the window must not retroactively close it on moves
+// already made, and lengthening it must not reopen ones people were told had
+// closed. The promise is made when the move is applied.
+func TestTheUndoWindowIsTheOneTheMoveWasMadeUnder(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	var frozen *int
+	if err := e.Pool.QueryRow(t.Context(),
+		`SELECT undo_window_hours FROM stage_progression_outcome WHERE approval_id = $1`,
+		card).Scan(&frozen); err != nil {
+		t.Fatalf("reading the frozen window: %v", err)
+	}
+	if frozen == nil {
+		t.Fatal("the automatic move froze no undo window, so a later policy edit " +
+			"decides whether it can still be taken back")
+	}
+
+	// The admin shortens the window to an hour, and ages the move past it.
+	if _, err := e.Deals.SetTransitionPolicy(e.Admin(), deals.SetTransitionPolicyInput{
+		TransitionRef: ref, Mode: deals.ModeAuto, UndoWindowHours: ptrTo(1),
+	}); err != nil {
+		t.Fatalf("shortening the window: %v", err)
+	}
+	if _, err := e.Pool.Exec(t.Context(),
+		`UPDATE stage_progression_outcome SET decided_at = now() - interval '2 hours'
+		  WHERE approval_id = $1`, card); err != nil {
+		t.Fatalf("ageing the move: %v", err)
+	}
+
+	// Two hours old, under the ONE hour the admin just set but inside the
+	// seventy-two the move was made under. It must still be undoable.
+	if _, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID); err != nil {
+		t.Fatalf("the undo was refused on a window the admin shortened AFTER the "+
+			"move was made: %v — a person told they had three days to take this "+
+			"back finds it closed because somebody edited a setting", err)
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+// An AGENT moving a deal back is not a person taking a move back.
+//
+// The undo verb is human-only, and this door must not be the way around it.
+// Read as manual, an agent's ordinary advance would record a reversal nobody
+// made, attribute it to the agent's user, and let one machine undo what
+// another machine did with no person in the loop.
+//
+// readProtection names its human positively for the same reason, and says so:
+// an agent moving a deal is precisely what a human has not done.
+func TestAnAgentMovingADealBackIsNotCountedAsAHumanReversal(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	agentCtx := principal.WithActor(e.Admin(), principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:" + ids.NewV7().String(),
+		UserID: e.Rep1, OnBehalfOf: e.Rep1,
+		Scopes: principal.ScopeSet{principal.ScopeWrite: struct{}{}},
+		Permissions: principal.Permissions{
+			RowScope: principal.RowScopeAll,
+			Objects:  map[string]principal.ObjectGrant{"deal": {Read: true, Update: true}},
+		},
+	})
+	if _, err := e.Deals.AdvanceDeal(agentCtx, deal, deals.AdvanceDealInput{
+		ToStageID: ref.FromStageID,
+	}); err != nil {
+		t.Fatalf("the agent could not move the deal back, so this test never "+
+			"reaches the question it asks: %v", err)
+	}
+
+	outcome, reversed := ledgerOutcomeFor(t, e, card)
+	if reversed || outcome != deals.ProgressionAutoApplied {
+		t.Errorf("an AGENT's move back was counted as a human reversal (%q, %v): "+
+			"the undo verb is human-only and this is the way around it, with the "+
+			"reversal recorded against a person who did nothing", outcome, reversed)
+	}
+}
+
+// A reversal is measured against the rule that authorized the move.
+//
+// The safety ceiling exists to count exactly this outcome. Left to the
+// decision path alone an undo would never trip it — nothing decides a card
+// here, so the sweep that runs on decisions never sees it, and a run of undos
+// would age out of the window with the transition still applying.
+func TestAnUndoIsCountedAgainstTheRuleThatAuthorizedTheMove(t *testing.T) {
+	e := Setup(t)
+	deal, card, ref := autoAppliedMove(t, e)
+
+	// A record sitting JUST under its ceiling, so this one undo is what
+	// crosses it. The fixture already seeded 240 clean rows, so the unsafe
+	// count is chosen against the real denominator rather than a guess: it is
+	// marked on rows that already exist.
+	var reviewed int
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT count(*) FROM stage_progression_outcome
+		 WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3
+		   AND outcome IN ('approved_clean', 'approved_edited', 'rejected', 'reversed')`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&reviewed); err != nil {
+		t.Fatalf("counting the reviewed record: %v", err)
+	}
+	// The undo adds ONE unsafe row and moves the auto-applied row into the
+	// reviewed denominator, so after it the rate is (marked+1)/(reviewed+1).
+	// Mark the smallest number that leaves this just UNDER the 1% ceiling
+	// before the undo and just over it after — computed against the real
+	// denominator rather than assumed, because the fixture's size is the
+	// governedTransition helper's to choose and it has changed once already.
+	after := reviewed + 1
+	// The smallest count whose (marked+1)/after strictly exceeds 1%. Solved
+	// rather than derived by division, because integer truncation is what got
+	// this wrong twice: after/100 is the floor, and the guards below caught it
+	// sitting a row short of the ceiling on both attempts.
+	marked := 1
+	for float64(marked+1)/float64(after) <= 0.01 {
+		marked++
+	}
+	if marked < 1 {
+		t.Fatalf("the fixture's record (%d reviewed) is too small to sit just "+
+			"under a 1%% ceiling", reviewed)
+	}
+	// The guard on the guard: the arithmetic must actually straddle the
+	// ceiling, or this test passes for a reason that has nothing to do with
+	// the undo being counted.
+	if float64(marked)/float64(reviewed) > 0.01 {
+		t.Fatalf("the seeded record is ALREADY over its ceiling (%d/%d), so the "+
+			"undo is not what crosses it", marked, reviewed)
+	}
+	if float64(marked+1)/float64(after) <= 0.01 {
+		t.Fatalf("the record is still under its ceiling after the undo "+
+			"(%d/%d), so nothing would suspend however the undo behaved",
+			marked+1, after)
+	}
+	justUnder := marked
+	if _, err := e.Pool.Exec(t.Context(), `
+		UPDATE stage_progression_outcome SET reversed_at = now()
+		 WHERE id IN (
+		     SELECT id FROM stage_progression_outcome
+		      WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3
+		        AND outcome = 'approved_clean'
+		      LIMIT $4)`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID, justUnder); err != nil {
+		t.Fatalf("spoiling the record: %v", err)
+	}
+	if off, why := suspensionStateOf(t, e, ref); off {
+		t.Fatalf("the rule is already suspended (%s), so the undo below could "+
+			"not be what suspends it", why)
+	}
+
+	if _, err := e.Deals.RevertStageProgression(e.Admin(), deal, card.UUID); err != nil {
+		t.Fatalf("taking the move back: %v", err)
+	}
+
+	if off, _ := suspensionStateOf(t, e, ref); !off {
+		t.Error("the undo did not count against the rule: a run of undos ages " +
+			"out of the window with the transition still applying, and the " +
+			"ceiling that exists to catch exactly this never fires")
+	}
+}
+
+// suspensionStateOf answers whether the product has turned this rule off.
+func suspensionStateOf(t *testing.T, e *Env, ref deals.TransitionRef) (bool, string) {
+	t.Helper()
+	var at *time.Time
+	var reason *string
+	if err := e.Pool.QueryRow(t.Context(), `
+		SELECT suspended_at, suspended_reason FROM stage_progression_policy
+		 WHERE pipeline_id = $1 AND from_stage_id = $2 AND to_stage_id = $3`,
+		ref.PipelineID, ref.FromStageID, ref.ToStageID).Scan(&at, &reason); err != nil {
+		t.Fatalf("reading the rule's suspension: %v", err)
+	}
+	if at == nil {
+		return false, ""
+	}
+	return true, *reason
+}

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -180,9 +180,17 @@ var replayableOperations = map[string]replayTarget{
 	"PATCH /v1/organizations/{id}/facts/{factKey}":               {object: tableOrganization, table: tableOrganization, pathParam: "id"},
 	"DELETE /v1/organizations/{id}/facts/{factKey}":              {object: tableOrganization, rowNote: "the removal answers 204: the row is gone, so a replay has no record to re-probe — what the original write was gated on was the organization named in the path, and that gate ran then"},
 	"POST /v1/organizations/{id}/facts/{factKey}/confirm":        {object: tableOrganization, table: tableOrganization, pathParam: "id"},
-	"POST /v1/deals":                       {object: tableDeal, table: tableDeal, idPath: "id"},
-	"PATCH /v1/deals/{id}":                 {object: tableDeal, table: tableDeal, idPath: "id"},
-	"POST /v1/deals/{id}/advance":          {object: tableDeal, table: tableDeal, idPath: "id"},
+	"POST /v1/deals":              {object: tableDeal, table: tableDeal, idPath: "id"},
+	"PATCH /v1/deals/{id}":        {object: tableDeal, table: tableDeal, idPath: "id"},
+	"POST /v1/deals/{id}/advance": {object: tableDeal, table: tableDeal, idPath: "id"},
+	// Taking back an automatic stage move answers the deal, and the deal's
+	// grant governs it — the progression ledger carries no authority of its
+	// own. A retried undo must replay rather than re-execute: the second run
+	// would find the move already reversed and refuse with a 409, telling the
+	// caller their own retry had failed.
+	"POST /v1/deals/{id}/stage-progressions/{approvalId}/revert": {
+		object: tableDeal, table: tableDeal, idPath: "id",
+	},
 	"POST /v1/contracts":                   {object: probeContract, moduleProbe: probeContract, idPath: "id", rowNote: "a contract carries no owner column; visibility is inherited from its deal or organization, so the contracts store owns the probe"},
 	"POST /v1/deal-rooms":                  {object: probeDealRoom, moduleProbe: probeDealRoom, idPath: "id", rowNote: "a Deal Room carries no owner column; its visibility is its parent deal's, so the dealrooms store owns the probe"},
 	"POST /v1/projects":                    {object: tableProject, table: tableProject, idPath: "id"},

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -883,6 +883,10 @@ func (stubs) ListStageEvidence(w nethttp.ResponseWriter, r *nethttp.Request, id 
 	httperr.NotImplemented(w, r, "ListStageEvidence")
 }
 
+func (stubs) RevertStageProgression(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, approvalId openapi_types.UUID, params crmcontracts.RevertStageProgressionParams) {
+	httperr.NotImplemented(w, r, "RevertStageProgression")
+}
+
 func (stubs) ListDealStakeholders(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
 	httperr.NotImplemented(w, r, "ListDealStakeholders")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -38555,6 +38555,25 @@ type CreateOfferParams struct {
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
 }
 
+// RevertStageProgressionParams defines parameters for RevertStageProgression.
+type RevertStageProgressionParams struct {
+	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
+	// create (API-CC-6). **Scope:** the key is unique within
+	// `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+	// returns the original status + body. Reusing the same key with a *different* request body
+	// returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+	// **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+	// answer lost": without it the blind retry answers `409 version_skew`, because the first
+	// attempt already bumped the version.
+	// **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+	// retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+	// (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+	// what makes an operation replay-safe** — an operation that omits it ignores the header rather
+	// than half-honouring it, so read this contract, not the client, to know which calls are safe
+	// to retry blind.
+	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+}
+
 // GetDealStatusParams defines parameters for GetDealStatus.
 type GetDealStatusParams struct {
 	// Refresh Rewrite even when the fingerprint still matches. The reader asking for a second opinion.
@@ -51098,6 +51117,9 @@ type ServerInterface interface {
 	// What has been observed about this deal against its stage's criteria.
 	// (GET /deals/{id}/stage-evidence)
 	ListStageEvidence(w http.ResponseWriter, r *http.Request, id Id)
+	// Take back a stage move the product made by itself.
+	// (POST /deals/{id}/stage-progressions/{approvalId}/revert)
+	RevertStageProgression(w http.ResponseWriter, r *http.Request, id Id, approvalId openapi_types.UUID, params RevertStageProgressionParams)
 	// List a deal's stakeholders (deal↔person relationships).
 	// (GET /deals/{id}/stakeholders)
 	ListDealStakeholders(w http.ResponseWriter, r *http.Request, id Id)
@@ -53585,6 +53607,12 @@ func (_ Unimplemented) ProposeDealRoles(w http.ResponseWriter, r *http.Request, 
 // What has been observed about this deal against its stage's criteria.
 // (GET /deals/{id}/stage-evidence)
 func (_ Unimplemented) ListStageEvidence(w http.ResponseWriter, r *http.Request, id Id) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Take back a stage move the product made by itself.
+// (POST /deals/{id}/stage-progressions/{approvalId}/revert)
+func (_ Unimplemented) RevertStageProgression(w http.ResponseWriter, r *http.Request, id Id, approvalId openapi_types.UUID, params RevertStageProgressionParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -64712,6 +64740,73 @@ func (siw *ServerInterfaceWrapper) ListStageEvidence(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListStageEvidence(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RevertStageProgression operation middleware
+func (siw *ServerInterfaceWrapper) RevertStageProgression(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "approvalId" -------------
+	var approvalId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "approvalId", chi.URLParam(r, "approvalId"), &approvalId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "approvalId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params RevertStageProgressionParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "Idempotency-Key" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("Idempotency-Key")]; found {
+		var IdempotencyKey IdempotencyKey
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "Idempotency-Key", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "Idempotency-Key", valueList[0], &IdempotencyKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "Idempotency-Key", Err: err})
+			return
+		}
+
+		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevertStageProgression(w, r, id, approvalId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -82832,6 +82927,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/deals/{id}/stage-evidence", wrapper.ListStageEvidence)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/deals/{id}/stage-progressions/{approvalId}/revert", wrapper.RevertStageProgression)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/deals/{id}/stakeholders", wrapper.ListDealStakeholders)

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -42,6 +42,21 @@ type AdvanceDealInput struct {
 	// product, not overruling it, so a move made THROUGH one must not protect
 	// the deal against the next proposal. Nil for an ordinary advance.
 	ApprovalID *ids.UUID
+	// IsExplicitUndo marks the move RevertStageProgression makes.
+	//
+	// It suppresses the automatic reversal detection below, which would
+	// otherwise find the very move being undone and mark it — and the undo
+	// then marks it again, so one reversal is counted twice and the safety
+	// rate reads double. The undo does its own marking, because only it knows
+	// which card the caller asked about.
+	IsExplicitUndo bool
+	// ReversalOf names the deal_stage_history row this move undoes.
+	//
+	// Written into the history row, where readProtection reads it: a move that
+	// was undone once is a move this deal has already had the argument about,
+	// and the product must not propose it again. Without it a reversed move is
+	// re-proposable the moment the fortnight's human-move protection lapses.
+	ReversalOf *ids.UUID
 }
 
 // StagePipelineMismatchError maps to 422: the target stage exists but
@@ -175,11 +190,25 @@ func (s *Store) advanceOnTx(
 		// rationale). Won/lost stages carry their semantic 100/0 in the same
 		// column, so terminal moves snapshot too.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO deal_stage_history (deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change, win_probability_at_change, approval_id)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			`INSERT INTO deal_stage_history (deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change, win_probability_at_change, approval_id, reversal_of)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 			id, ids.UUID(*current.StageId), in.ToStageID, by,
-			current.AmountMinor, current.Currency, winProbability, in.ApprovalID); err != nil {
+			current.AmountMinor, current.Currency, winProbability, in.ApprovalID,
+			in.ReversalOf); err != nil {
 			return fmt.Errorf("record stage history: %w", err)
+		}
+
+		// A move BACK over a recent automatic one is a reversal, counted on the
+		// same ledger as the undo button. Not doing this here would let the
+		// safety number be dodged by the obvious route: a rep who disagrees
+		// with what the autopilot did drags the deal back by hand, the rate
+		// that governs the transition never moves, and it keeps applying.
+		if !in.IsExplicitUndo {
+			if err := countAManualMoveBackAsAReversal(
+				ctx, tx, id, ids.StageID{UUID: ids.UUID(*current.StageId)}, in,
+				s.clock()); err != nil {
+				return err
+			}
 		}
 
 		if err := announceStageAdvance(ctx, tx, id, in, current, p, status, winProbability); err != nil {

--- a/backend/internal/modules/deals/exitcriteria_handlers.go
+++ b/backend/internal/modules/deals/exitcriteria_handlers.go
@@ -126,3 +126,21 @@ func (h Handlers) ListStageEvidence(w http.ResponseWriter, r *http.Request, id c
 	}
 	httperr.WriteJSON(w, http.StatusOK, map[string]any{"data": evidence, "page": crmcontracts.PageInfo{}})
 }
+
+// RevertStageProgression takes back a stage move the product made by itself.
+//
+// The approval id is the caller's only handle on which move to undo; the stage
+// to return to comes from the ledger, never from the request. A caller who
+// could name the target could send a deal anywhere and call it an undo.
+func (h Handlers) RevertStageProgression(
+	w http.ResponseWriter, r *http.Request, id crmcontracts.Id,
+	approvalID openapi_types.UUID, _ crmcontracts.RevertStageProgressionParams,
+) {
+	deal, err := h.store.RevertStageProgression(
+		r.Context(), pathID[ids.DealKind](id), ids.UUID(approvalID))
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, deal)
+}

--- a/backend/internal/modules/deals/handlers.go
+++ b/backend/internal/modules/deals/handlers.go
@@ -105,6 +105,9 @@ func WriteOfferError(w http.ResponseWriter, r *http.Request, err error) {
 // writeStoreErr maps this module's typed store errors onto the wire
 // codes the contract names, then falls through to the sentinel registry.
 func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
+	if writeUndoConflict(w, r, err) {
+		return
+	}
 	if writeOfferTemplateConflict(w, r, err) {
 		return
 	}
@@ -123,6 +126,26 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 	httperr.Write(w, r, err)
+}
+
+// writeUndoConflict maps a refused stage-move undo onto the wire.
+//
+// The REASON travels, because the three ways this declines call for three
+// different things from the reader: a closed window means move the deal by
+// hand, a human-decided move means there was never anything automatic to take
+// back, and an already-reversed one means somebody got there first. One
+// generic "cannot undo" would send all three to look for the same thing.
+func writeUndoConflict(w http.ResponseWriter, r *http.Request, err error) bool {
+	var undo *UndoWindowClosedError
+	if !errors.As(err, &undo) {
+		return false
+	}
+	httperr.Write(w, r, &httperr.DetailedError{
+		Status: http.StatusConflict,
+		Code:   "undo_window_closed",
+		Detail: undo.Reason,
+	})
+	return true
 }
 
 // writeOfferTemplateConflict maps the two offer_template pre-checked

--- a/backend/internal/modules/deals/stageprogression.go
+++ b/backend/internal/modules/deals/stageprogression.go
@@ -289,11 +289,23 @@ func recordProgressionDecidedTx(
 	// saying auto_applied with the column false is one the report and the
 	// column would answer differently about the same move.
 	err := tx.QueryRow(ctx, `
-		UPDATE stage_progression_outcome
+		UPDATE stage_progression_outcome o
 		   SET outcome = $2, rejection_reason = $3, evidence_corrected = $4,
-		       decided_by_system = ($2 = $6), decided_at = now()
-		 WHERE approval_id = $1 AND outcome = $5
-		RETURNING id, deal_id, pipeline_id, from_stage_id, to_stage_id`,
+		       decided_by_system = ($2 = $6), decided_at = now(),
+		       -- The undo window is frozen HERE, on an automatic move only,
+		       -- because this is when the promise is made. Read live at undo
+		       -- time it would be whatever the rule says then, so an admin
+		       -- shortening it would close the window on moves already made
+		       -- and lengthening it would reopen ones people were told had
+		       -- closed.
+		       undo_window_hours = CASE WHEN $2 = $6 THEN (
+		           SELECT p.undo_window_hours FROM stage_progression_policy p
+		            WHERE p.pipeline_id = o.pipeline_id
+		              AND p.from_stage_id = o.from_stage_id
+		              AND p.to_stage_id = o.to_stage_id
+		       ) END
+		 WHERE o.approval_id = $1 AND o.outcome = $5
+		RETURNING o.id, o.deal_id, o.pipeline_id, o.from_stage_id, o.to_stage_id`,
 		approvalID, outcome, reason, edited, ProgressionProposed,
 		ProgressionAutoApplied).
 		Scan(&id, &dealID, &moved.PipelineID, &moved.FromStageID, &moved.ToStageID)

--- a/backend/internal/modules/deals/stagerevert.go
+++ b/backend/internal/modules/deals/stagerevert.go
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Taking back a stage move the product made by itself.
+//
+// A SEPARATE VERB from the general undo path, and the reason is structural
+// rather than a preference. The replay engine restores a record by writing its
+// fields back, which works for a corrected close date or a renamed
+// organization — one column, one restore. A stage move wrote deal_stage_history
+// and the progression ledger BESIDE the column, so writing stage_id back would
+// leave the history saying the deal is somewhere it is not. The engine refuses
+// `advance_stage` by name for exactly this, so the move carries its own undo.
+//
+// What a reversal claims is narrow and worth stating: the deal should not have
+// moved. It does NOT claim the evidence was wrong. A rep may agree with every
+// observation the card cited and still want the deal where it was, and a
+// reversal that quietly refuted the claims would withdraw evidence nobody
+// disputed. Evidence is corrected through its own path.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// UndoWindowClosedError refuses a move that can no longer be taken back.
+//
+// Its own type rather than a bare conflict, because the three ways this verb
+// declines are different situations for the caller: a window that has closed
+// (move the deal by hand instead), a move a person made (there is nothing
+// automatic to undo), and one already reversed (somebody got there first).
+//
+// Mapped to 409 by writeUndoConflict in handlers.go, the way this package maps
+// every pre-checked conflict. Nothing about the request is malformed — the
+// record is in a state that refuses it — so it is not a 422.
+type UndoWindowClosedError struct{ Reason string }
+
+func (e *UndoWindowClosedError) Error() string { return e.Reason }
+
+// RevertStageProgression moves a deal back to the stage an automatic move took
+// it from.
+//
+// ONE TRANSACTION for all three writes: the deal moves back, a new history row
+// records the move back, and the ledger row is marked reversed. Split apart,
+// a failure between them leaves a deal at one stage with a ledger saying it is
+// at another — and the ledger is what the launch gate reads to decide whether
+// this transition may keep running.
+//
+// The stage the deal came from is read from the LEDGER, not supplied by the
+// caller. A caller who could name the target could send a deal anywhere by
+// calling this an undo, and undo means precisely "where it was".
+func (s *Store) RevertStageProgression(
+	ctx context.Context, dealID ids.DealID, approvalID ids.UUID,
+) (crmcontracts.Deal, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionUpdate); err != nil {
+		return crmcontracts.Deal{}, err
+	}
+	// Resolved before the transaction opens: the catalog reads through its own
+	// connection, and a second connection inside a transaction can deadlock
+	// undetectably against a lock that transaction holds.
+	active, err := s.activeColumns(ctx)
+	if err != nil {
+		return crmcontracts.Deal{}, err
+	}
+	var out crmcontracts.Deal
+	err = s.Tx(ctx, func(tx pgx.Tx) error {
+		// THE DEAL FIRST, then the ledger row. The other door onto a reversal
+		// — a person moving the deal back by hand — takes the deal's lock in
+		// advanceOnTx and then the ledger row's, so taking them the other way
+		// round here is a cycle: one undo and one manual move back, running at
+		// once, each holding what the other waits for. Postgres resolves that
+		// by aborting one of them, which reaches a rep as an unexplained
+		// failure to undo.
+		if err := lockDealForReversal(ctx, tx, dealID); err != nil {
+			return err
+		}
+		// VISIBILITY BEFORE ANY CONFLICT. The three refusals below say
+		// different things — the window has closed, a person made this move,
+		// it is already taken back — and each is a fact about a record. Asked
+		// after them, a caller with the object grant but no row scope could
+		// tell an eligible hidden move from an expired one by the 409 they
+		// got back, and learn that a deal exists by the shape of its refusal.
+		//
+		// advanceOnTx checks writability again on its own; this is not that.
+		// It is the existence-hiding the module keeps everywhere: a row-scope
+		// miss is a 404.
+		if err := auth.EnsureWritable(ctx, tx, dealTable, dealID.UUID); err != nil {
+			return err
+		}
+		move, err := lockReversibleMove(ctx, tx, dealID, approvalID, s.clock())
+		if err != nil {
+			return err
+		}
+		// The paperless-win argument the deal ALREADY holds, carried back with
+		// it. An undo can land a deal on a won stage — the move being taken
+		// back was a move away from one — and a win with no agreement behind
+		// it is refused unless somebody says why. That somebody already did,
+		// when the deal was first won; making them retype it to undo a move
+		// the PRODUCT made would refuse the undo for a reason the record
+		// answers.
+		wonReason, wonDetail, err := heldWinReason(ctx, tx, dealID)
+		if err != nil {
+			return err
+		}
+		out, err = s.advanceOnTx(ctx, tx, dealID, AdvanceDealInput{
+			ToStageID:                move.FromStageID,
+			WonWithoutContractReason: wonReason,
+			WonWithoutContractDetail: wonDetail,
+			// No ApprovalID. This move is not made THROUGH a card — it is a
+			// person overruling one, and recording the card here would tell
+			// readProtection that the rep agreed with the product.
+			//
+			// IsExplicitUndo suppresses the automatic reversal detection: it
+			// would find this very move and mark it, and markMoveReversed
+			// below would mark it again — one reversal counted twice, and the
+			// safety rate reading double.
+			IsExplicitUndo: true,
+			// What this move undoes, so readProtection knows the deal has
+			// already had this argument and the product does not propose the
+			// same move again.
+			ReversalOf: move.HistoryID,
+		}, active)
+		if err != nil {
+			return err
+		}
+		return markMoveReversed(ctx, tx, move, s.clock())
+	})
+	return out, err
+}
+
+// heldWinReason answers the paperless-win argument the deal already carries.
+//
+// Read from the deal rather than asked of the caller: this is an UNDO, and the
+// argument for the state it returns to was made when the deal reached it. A
+// deal that never claimed a paperless win answers nil for both, which is what
+// an ordinary move needs.
+func heldWinReason(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID,
+) (*string, *string, error) {
+	var reason, detail *string
+	if err := tx.QueryRow(ctx, `
+		SELECT won_without_contract_reason, won_without_contract_detail
+		  FROM deal WHERE id = $1`, dealID).Scan(&reason, &detail); err != nil {
+		return nil, nil, fmt.Errorf("read the deal's win-evidence claim: %w", err)
+	}
+	return reason, detail, nil
+}
+
+// reversibleMove is the ledger row a revert is about.
+type reversibleMove struct {
+	ID          ids.UUID
+	DealID      ids.DealID
+	FromStageID ids.StageID
+	ToStageID   ids.StageID
+	PipelineID  ids.PipelineID
+	// HistoryID is the deal_stage_history row the original move wrote, so the
+	// move back can name what it undid. Nil when the history row is gone,
+	// which does not stop the undo — the ledger is the record that matters and
+	// a missing history row is not a reason to leave a deal where it should
+	// not be.
+	HistoryID *ids.UUID
+}
+
+// lockDealForReversal takes the deal's row lock before anything else.
+//
+// The lock ORDER is the point, not the lock: every path that touches both a
+// deal and its progression ledger has to take them in one order, and the
+// ordinary advance takes the deal first. See RevertStageProgression.
+//
+// ErrNotFound for a deal that is gone or archived, which is the same answer a
+// caller who cannot see it gets from the visibility gate below.
+func lockDealForReversal(ctx context.Context, tx pgx.Tx, dealID ids.DealID) error {
+	var id ids.DealID
+	err := tx.QueryRow(ctx,
+		`SELECT id FROM deal WHERE id = $1 AND archived_at IS NULL FOR UPDATE`,
+		dealID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return apperrors.ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("hold the deal being moved back: %w", err)
+	}
+	return nil
+}
+
+// historyRowOf finds the history row an automatic move wrote.
+//
+// Matched by the APPROVAL, which advanceOnTx stamps onto the row for a move
+// made through a card. That is exact where matching on the stage pair would
+// not be: a deal can travel the same transition more than once.
+//
+// Answers ids.Nil and no error when there is no such row. A missing history
+// row does not stop an undo — the ledger is the record that decides whether
+// the move can be taken back, and a deal is not left where it should not be
+// because one trail row is gone — so the caller tests the id rather than
+// branching on an error.
+func historyRowOf(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID, approvalID ids.UUID,
+) (ids.UUID, error) {
+	var id ids.UUID
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM deal_stage_history
+		 WHERE deal_id = $1 AND approval_id = $2
+		 ORDER BY changed_at DESC LIMIT 1`, dealID, approvalID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.Nil, nil
+	}
+	if err != nil {
+		return ids.Nil, fmt.Errorf("find the history row this undo takes back: %w", err)
+	}
+	return id, nil
+}
+
+// lockReversibleMove reads the move and holds it, refusing everything that is
+// not an automatic move still inside its window.
+//
+// LOCKED, because the decision is made from what it read: two reverts of one
+// move would both see it un-reversed, both move the deal back, and the second
+// would write a history row for a move that did not happen.
+//
+// The window comes from the transition's OWN rule, read here rather than
+// carried as a constant — an installation that gave a transition a longer undo
+// window meant it for that transition. A move with no rule any more (the admin
+// deleted it) falls back to the column default, because the window a move was
+// made under is a promise to the person it was made for.
+func lockReversibleMove(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID, approvalID ids.UUID, now time.Time,
+) (reversibleMove, error) {
+	var m reversibleMove
+	var outcome string
+	var decidedAt time.Time
+	var reversedAt *time.Time
+	var undoHours int
+	err := tx.QueryRow(ctx, `
+		SELECT o.id, o.deal_id, o.from_stage_id, o.to_stage_id, o.pipeline_id,
+		       o.outcome, o.decided_at, o.reversed_at,
+		       -- The window FROZEN on the move, then the rule's current one,
+		       -- then the column default. A move made before the freeze column
+		       -- existed reads the rule live, exactly as it always did.
+		       coalesce(o.undo_window_hours, p.undo_window_hours, 72)
+		  FROM stage_progression_outcome o
+		  LEFT JOIN stage_progression_policy p
+		    ON p.pipeline_id = o.pipeline_id
+		   AND p.from_stage_id = o.from_stage_id
+		   AND p.to_stage_id = o.to_stage_id
+		 WHERE o.approval_id = $1 AND o.deal_id = $2
+		 FOR UPDATE OF o`,
+		approvalID, dealID).
+		Scan(&m.ID, &m.DealID, &m.FromStageID, &m.ToStageID, &m.PipelineID,
+			&outcome, &decidedAt, &reversedAt, &undoHours)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No such move, or one belonging to a different deal. ErrNotFound for
+		// both, so a caller cannot learn that a progression exists by putting
+		// its id against a deal they can see.
+		return m, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return m, fmt.Errorf("read the move being taken back: %w", err)
+	}
+	if reversedAt != nil {
+		return m, &UndoWindowClosedError{Reason: "this move has already been taken back"}
+	}
+	if outcome != ProgressionAutoApplied {
+		// A human's approval is not undone here. Somebody read the card and
+		// agreed; moving the deal back is an ordinary stage move they can make
+		// themselves, and it is counted as a reversal on the same ledger.
+		return m, &UndoWindowClosedError{
+			Reason: "this move was made by a person, so there is nothing automatic to take back",
+		}
+	}
+	if now.After(decidedAt.Add(time.Duration(undoHours) * time.Hour)) {
+		return m, &UndoWindowClosedError{
+			Reason: "this move can no longer be taken back automatically; move the deal by hand instead",
+		}
+	}
+	// THE DEAL MUST STILL BE WHERE THE MOVE PUT IT. Without this an old card
+	// is a way to send a deal backwards from wherever it has since reached:
+	// automatic A→B, a rep moves it B→C, and reverting the still-open A→B
+	// card would take it C→A — a move nobody made and no undo of anything.
+	//
+	// Undo means "put it back", which is only meaningful while it is still
+	// where it was put.
+	var stage ids.StageID
+	if err := tx.QueryRow(ctx,
+		`SELECT stage_id FROM deal WHERE id = $1`, dealID).Scan(&stage); err != nil {
+		return m, fmt.Errorf("read where the deal is now: %w", err)
+	}
+	if stage != m.ToStageID {
+		return m, &UndoWindowClosedError{
+			Reason: "this deal has moved on since, so there is no longer that move to take back",
+		}
+	}
+	historyID, err := historyRowOf(ctx, tx, dealID, approvalID)
+	if err != nil {
+		return m, err
+	}
+	if historyID != ids.Nil {
+		m.HistoryID = &historyID
+	}
+	return m, nil
+}
+
+// markMoveReversed closes the ledger row and says who did it.
+//
+// The outcome becomes `reversed` AND reversed_at is set, both. The report's
+// safety numerator reads either — a row standing at reversed with a null
+// timestamp is legal under the table's constraint — so writing one without the
+// other would leave the two spellings of one fact disagreeing.
+func markMoveReversed(
+	ctx context.Context, tx pgx.Tx, move reversibleMove, now time.Time,
+) error {
+	actor := reversalActor(ctx)
+	var reversed bool
+	if err := tx.QueryRow(ctx, `
+		UPDATE stage_progression_outcome
+		   SET outcome = $2, reversed_at = now(), reversed_by = $3
+		 WHERE id = $1 AND reversed_at IS NULL
+		RETURNING true`,
+		move.ID, ProgressionReversed, actor).Scan(&reversed); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Reversed by a concurrent caller between the lock and here. It
+			// cannot happen while the lock above is held, and answering it as
+			// a conflict rather than a crash is what the row's own guard is
+			// for if the lock is ever loosened.
+			return &UndoWindowClosedError{Reason: "this move has already been taken back"}
+		}
+		return fmt.Errorf("record the move as taken back: %w", err)
+	}
+	auditID, err := storekit.Audit(ctx, tx, "update", progressionEntity, move.ID,
+		map[string]any{progressionOutcomeKey: ProgressionAutoApplied},
+		map[string]any{
+			progressionOutcomeKey: ProgressionReversed,
+			progressionDealKey:    move.DealID.String(),
+			// The stage the deal went BACK to, so a reader of the trail sees
+			// where the undo put it rather than only that one happened.
+			progressionToKey: move.FromStageID.String(),
+		})
+	if err != nil {
+		return fmt.Errorf("audit the move being taken back: %w", err)
+	}
+	if err := emitProgressionChanged(ctx, tx, auditID, move.DealID); err != nil {
+		return err
+	}
+	// A reversal is the one outcome the safety ceiling exists to count, so the
+	// rule is re-measured in the same transaction that records it. Left to the
+	// decision path alone, an undo would never trip a ceiling: nothing decides
+	// a card here, so the sweep that runs on decisions never sees it, and a
+	// run of undos would age out of the window with the transition still
+	// applying.
+	return suspendIfRecordWentBadTx(ctx, tx, TransitionRef{
+		PipelineID:  move.PipelineID,
+		FromStageID: move.FromStageID,
+		ToStageID:   move.ToStageID,
+	}, now)
+}
+
+// reversalActor is the person the undo is recorded against.
+//
+// Nil for a principal with no human behind it, matching the column's ON DELETE
+// SET NULL: an instant whose person has since been erased is what an anonymized
+// workspace looks like, and the audit row still holds who.
+func reversalActor(ctx context.Context) *ids.UUID {
+	p, ok := principal.Actor(ctx)
+	if !ok || p.UserID.IsZero() {
+		return nil
+	}
+	id := p.UserID
+	return &id
+}
+
+// countAManualMoveBackAsAReversal marks an automatic move that a person has
+// just undone by hand.
+//
+// THE SAME FACT AS THE UNDO BUTTON, reached the other way. A rep who disagrees
+// with what the autopilot did can press Undo or simply drag the deal back, and
+// only one of those routes going onto the ledger would leave the safety number
+// dodgeable by the more obvious one — the transition would keep applying while
+// people quietly corrected it all day.
+//
+// It does NOT refute the evidence, for the same reason the explicit undo does
+// not: moving a deal back says it should not have moved, not that the criteria
+// were misread.
+//
+// Narrow on purpose. It matches only a move whose direction exactly undoes an
+// automatic one (this move's target is that move's origin, and vice versa),
+// still inside that move's undo window, not already reversed. A deal that
+// wanders forward and back over a week is not undoing anything.
+func countAManualMoveBackAsAReversal(
+	ctx context.Context, tx pgx.Tx, dealID ids.DealID,
+	fromStage ids.StageID, in AdvanceDealInput, now time.Time,
+) error {
+	if in.ApprovalID != nil {
+		// This move came THROUGH a card, so it is somebody agreeing with the
+		// product rather than overruling it — including the card that would
+		// move the deal back again.
+		return nil
+	}
+	// A PERSON's move, named positively rather than as "not through a card".
+	// An agent can advance a deal too, and its move carries no approval id
+	// either — read as a human's, it would record a reversal nobody made,
+	// attribute it to the agent's user, and let a machine reverse what another
+	// machine did with no person in the loop. The undo verb is human-only for
+	// exactly that reason, and this door must not be the way around it.
+	//
+	// readProtection names its human the same way, and its comment says why:
+	// an agent moving a deal is precisely what a human has not done.
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman {
+		return nil
+	}
+	var move reversibleMove
+	var approvalID ids.UUID
+	err := tx.QueryRow(ctx, `
+		SELECT o.id, o.deal_id, o.from_stage_id, o.to_stage_id, o.pipeline_id,
+		       o.approval_id
+		  FROM stage_progression_outcome o
+		  LEFT JOIN stage_progression_policy p
+		    ON p.pipeline_id = o.pipeline_id
+		   AND p.from_stage_id = o.from_stage_id
+		   AND p.to_stage_id = o.to_stage_id
+		 WHERE o.deal_id = $1
+		   AND o.outcome = $2
+		   AND o.reversed_at IS NULL
+		   -- The move being undone went from where this one is going, to where
+		   -- this one is coming from. Both halves, or a deal moved forward
+		   -- again after an undo would count as undoing something itself.
+		   AND o.from_stage_id = $3
+		   AND o.to_stage_id = $4
+		   AND o.decided_at > $5::timestamptz - make_interval(
+		           hours => coalesce(o.undo_window_hours, p.undo_window_hours, 72))
+		 ORDER BY o.decided_at DESC
+		 LIMIT 1
+		 FOR UPDATE OF o`,
+		dealID, ProgressionAutoApplied, in.ToStageID, fromStage, now).
+		Scan(&move.ID, &move.DealID, &move.FromStageID, &move.ToStageID,
+			&move.PipelineID, &approvalID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The ordinary case: an ordinary stage move undoing nothing.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("look for an automatic move this one takes back: %w", err)
+	}
+	// The history row for THIS move is already written by the time detection
+	// runs, so the link is stamped onto it rather than passed in. Same fact
+	// either way: readProtection asks whether any history row on this deal
+	// names a move it undid.
+	undone, err := historyRowOf(ctx, tx, dealID, approvalID)
+	if err != nil {
+		return err
+	}
+	if undone != ids.Nil {
+		if _, err := tx.Exec(ctx, `
+			UPDATE deal_stage_history
+			   SET reversal_of = $2
+			 WHERE id = (SELECT id FROM deal_stage_history
+			              WHERE deal_id = $1
+			              ORDER BY changed_at DESC LIMIT 1)`,
+			dealID, undone); err != nil {
+			return fmt.Errorf("link this move to the one it undid: %w", err)
+		}
+	}
+	return markMoveReversed(ctx, tx, move, now)
+}

--- a/backend/migrations/core/1788835722_a_move_keeps_the_undo_window_it_was_made_under.down.sql
+++ b/backend/migrations/core/1788835722_a_move_keeps_the_undo_window_it_was_made_under.down.sql
@@ -1,0 +1,4 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE stage_progression_outcome
+  DROP COLUMN IF EXISTS undo_window_hours;

--- a/backend/migrations/core/1788835722_a_move_keeps_the_undo_window_it_was_made_under.up.sql
+++ b/backend/migrations/core/1788835722_a_move_keeps_the_undo_window_it_was_made_under.up.sql
@@ -1,0 +1,22 @@
+-- The undo window a move was made under, frozen onto the move.
+--
+-- Read live from stage_progression_policy, the window is whatever the rule
+-- says NOW: an admin shortening it from 72 hours to 1 retroactively closes the
+-- window on every move already made, and lengthening it reopens moves people
+-- were told they could no longer take back. Neither is a change anybody asked
+-- for, and the second is worse — a deal moves back days after its window was
+-- described as closed.
+--
+-- The window is a promise made to the person the move was made for, so it is
+-- recorded when the promise is made. A policy edit then governs the next move
+-- and not the last one.
+-- Bounded, like every migration that takes a table lock here: an ADD COLUMN
+-- waits behind whatever is holding the table, and an unbounded wait blocks
+-- every writer behind it rather than failing the deploy.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE stage_progression_outcome
+  ADD COLUMN undo_window_hours integer;
+
+COMMENT ON COLUMN stage_progression_outcome.undo_window_hours IS
+  'The undo window in force when this move was applied, frozen so a later policy edit cannot extend or close it. NULL on rows written before this column existed, which read the rule live as they always did.';

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -5274,6 +5274,7 @@ public.stage_progression_outcome.stage_progression_outcome_reversed_by_fkey FORE
 public.stage_progression_outcome.stage_progression_outcome_to_stage_fkey FOREIGN KEY (to_stage_id) REFERENCES stage(id) ON DELETE CASCADE
 public.stage_progression_outcome.to_stage_id uuid NOT NULL gen=- def=-
 public.stage_progression_outcome.trg_stage_progression_outcome_updated CREATE TRIGGER trg_stage_progression_outcome_updated BEFORE UPDATE ON public.stage_progression_outcome FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version()
+public.stage_progression_outcome.undo_window_hours integer gen=- def=-
 public.stage_progression_outcome.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.stage_progression_outcome.version bigint NOT NULL gen=- def=1
 public.stage_progression_outcome_approval_ux CREATE UNIQUE INDEX stage_progression_outcome_approval_ux ON public.stage_progression_outcome USING btree (approval_id)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3287,6 +3287,54 @@ export interface paths {
         patch: operations["updateStage"];
         trace?: never;
     };
+    "/deals/{id}/stage-progressions/{approvalId}/revert": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                /** @description The stage-progression approval whose move is being taken back. */
+                approvalId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Take back a stage move the product made by itself.
+         * @description Undo for an AUTOMATICALLY applied stage move, inside the window the
+         *     transition's rule allows (`undo_window_hours`, default 72).
+         *
+         *     It is a separate verb rather than the general undo path because a stage
+         *     move is not restorable by writing the field back: it wrote
+         *     `deal_stage_history` and the progression ledger beside the column, so
+         *     restoring `stage_id` alone would leave the history saying the deal is
+         *     somewhere it is not. The general replay engine refuses `advance_stage`
+         *     for exactly this reason.
+         *
+         *     What it does: moves the deal back to the stage it came from, appends a
+         *     new `deal_stage_history` row for the move back (history is append-only;
+         *     nothing is erased), and marks the progression ledger row `reversed` with
+         *     who did it and when.
+         *
+         *     **A reversal does not refute the evidence.** Taking a move back says the
+         *     deal should not have moved, which is a different claim from "the
+         *     criteria were wrongly read" — a rep may agree with every observation and
+         *     still want the deal where it was. Evidence is withdrawn only through its
+         *     own correction path.
+         *
+         *     Refused after the window closes: the move stands, the audit trail keeps
+         *     it, and moving the deal back by hand is the remaining route — which is
+         *     counted as a reversal too, on the same ledger.
+         */
+        post: operations["revertStageProgression"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/deals/{id}/stage-evidence": {
         parameters: {
             query?: never;
@@ -38424,6 +38472,78 @@ export interface operations {
             };
             404: components["responses"]["NotFound"];
             409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    revertStageProgression: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a mutation safe to retry — an update exactly as much as a
+                 *     create (API-CC-6). **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+                 *     answer lost": without it the blind retry answers `409 version_skew`, because the first
+                 *     attempt already bumped the version.
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+                 *     what makes an operation replay-safe** — an operation that omits it ignores the header rather
+                 *     than half-honouring it, so read this contract, not the client, to know which calls are safe
+                 *     to retry blind.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                /** @description The stage-progression approval whose move is being taken back. */
+                approvalId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The deal, back at the stage it came from. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deal"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /**
+             * @description No such deal, no such progression, or the caller may not see it.
+             *     Also the answer when the approval names a different deal, so a
+             *     caller cannot learn that a progression exists by probing ids.
+             */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /**
+             * @description The move cannot be taken back: the undo window has closed, the move
+             *     was made by a person rather than automatically, or it has already
+             *     been reversed.
+             */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
             422: components["responses"]["ValidationError"];
         };
     };


### PR DESCRIPTION
Undo for a move the product made by itself, inside the window the transition's rule allows.

## Why a separate verb

A stage move is not restorable by writing the field back. It wrote `deal_stage_history` and the progression ledger beside the column, so restoring `stage_id` alone would leave the history saying the deal is somewhere it is not. The general replay engine refuses `advance_stage` by name for exactly this reason, so the move carries its own undo.

## Two doors reach one fact

A rep can press Undo or simply drag the deal back. **Both mark the ledger.** Counted on only the button, the safety rate would be dodgeable by the route nobody instrumented — the transition would keep applying while people quietly corrected it all day.

**A reversal does not refute the evidence.** Taking a move back says the deal should not have moved, which is a different claim from "the criteria were wrongly read". A rep may agree with every observation the card cited and still want the deal where it was.

## The undo window is frozen onto the move

Read live from the rule, the window is whatever the rule says *now*: an admin shortening it retroactively closes the window on moves already made, and lengthening it reopens moves people were told they could no longer take back.

The window is a promise made to the person the move was made for, so it is recorded when the promise is made. New nullable column; rows written before it read the rule live, as they always did.

## Five refusals, each its own situation

The window has closed, the move was a person's, it is already reversed, the deal has moved on since, or the caller cannot see the deal. The reasons travel, because each calls for something different from the reader.

The last one is a **404 computed before any of the others**. Asked after them, a caller with the object grant but no row scope could tell an eligible hidden move from an expired one by the shape of the 409 they got back, and learn a deal exists from the wording of its refusal.

## Four more defects the review found, all real

- **The reversal wrote no `deal_stage_history.reversal_of`**, which `readProtection` reads — and the column's own comment says it is "set by the revert path". Without it the product re-proposes the exact move somebody just took back, the moment the fortnight's human-move protection lapses.
- **An agent's move back was read as a human's.** The undo verb is `x-agent-access: human-only`, and this door was the way around it — with the reversal recorded against a person who did nothing. `readProtection` names its human positively for the same reason, and its comment says why.
- **A reversal never re-measured the rule.** Nothing decides a card on this path, so the sweep that runs on decisions never saw it: a run of undos would age out of the window with the transition still applying.
- **Lock order was a cycle.** The undo locked the ledger row then the deal; an ordinary advance locks them the other way. One undo and one manual move back, at once, is a deadlock Postgres breaks by aborting one — reaching a rep as an unexplained failure to undo.

One review finding I disagreed with after checking: `tableDeal` is the correct replay target, since the gate governs disclosure of the stored response and that response is a `Deal`.

## A test that caught its own arithmetic twice

`TestAnUndoIsCountedAgainstTheRuleThatAuthorizedTheMove` needs a record that sits just under the 1% ceiling before the undo and just over it after. I got the integer arithmetic wrong twice; both times a **straddle guard** in the test caught it and named which side was wrong, rather than the test passing for a reason unrelated to the undo. The count is now solved for rather than divided.

## Verification

- `make check-backend` green, `make check-fe` green
- `make test-it` green for `compose/integration` and `migrations`
- `make craft-static` — 0 blocker, 0 major, 0 minor across all four roots
- Thirteen integration tests, each mutation-checked one clause at a time

The e2e file was split in two (`stageautoapply` / `stagerevert`) to stay under the 1000-line cap; the tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /deals/{id}/stage-progressions/{approvalId}/revert` so reps can take back a stage move the product applied automatically, within the window the transition's rule allowed. A manual drag back counts the same way on the same ledger, so the safety rate can't be dodged.

**New Features**
- The undo moves the deal back to the stage it came from, appends a history row, and marks the ledger reversed; it does not refute the cited evidence.
- The undo window is frozen onto the move, so later policy edits don't retroactively close or reopen it.
- Refusals return 409 with a distinct reason (window closed, human-made move, already reversed, deal moved on); visibility misses return 404 before any refusal.
- Reversals write a `reversal_of` history link so the product won't re-propose the same move, and re-measure the transition rule the move came from.
- Agent moves back aren't counted as human reversals, and the lock order now matches the advance path to avoid deadlock.

**Migration**
- Adds a nullable `undo_window_hours` column to `stage_progression_outcome`; rows written before it read the rule live.

<sup>Written for commit 6cd954613e0e68493e28be2b1768a9d8d697a7a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for authorized human users to undo eligible automatic deal stage changes within the configured undo window.
  - Manual moves back over recent automatic changes are recognized as reversals.
  - Reversals preserve deal history and supporting evidence.

- **Bug Fixes**
  - Added clear conflict responses when an undo window has closed, a move was already reversed, or the deal has advanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->