### PR TITLE
fix(onboarding): the mailbox import starts on the window, not on the count

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -5590,6 +5590,7 @@ export const de = {
   "ob.backread.window12m": "12 Monate — ganzer Vertriebszyklus",
   "ob.backread.window24m": "2 Jahre — die Beziehung, nicht nur der Deal",
   "ob.backread.window60m": "5 Jahre — alles, was das Postfach noch hat",
+  "ob.backread.estimating": "Nachrichten in diesem Zeitraum werden gezählt…",
   "ob.backread.estimate": "Etwa {messages} Nachrichten in diesem Zeitraum.",
   "ob.backread.estimateHeuristic":
     "Aus dem Postfach geschätzt, noch nicht gezählt.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -5708,6 +5708,7 @@ export const en = {
   "ob.backread.window12m": "12 months — full sales cycle",
   "ob.backread.window24m": "2 years — the relationship, not just the deal",
   "ob.backread.window60m": "5 years — everything the mailbox still holds",
+  "ob.backread.estimating": "Counting the messages in that window…",
   "ob.backread.estimate": "About {messages} messages in that window.",
   "ob.backread.estimateHeuristic":
     "Estimated from the mailbox, not counted yet.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5523,6 +5523,7 @@ export const vi = {
   "ob.backread.window12m": "12 tháng — trọn một chu kỳ bán hàng",
   "ob.backread.window24m": "2 năm — cả mối quan hệ, không chỉ deal",
   "ob.backread.window60m": "5 năm — tất cả những gì hộp thư còn giữ",
+  "ob.backread.estimating": "Đang đếm thư trong khoảng thời gian đó…",
   "ob.backread.estimate": "Khoảng {messages} thư trong khoảng thời gian đó.",
   "ob.backread.estimateHeuristic": "Ước tính từ hộp thư, chưa đếm thật.",
   "ob.backread.estimateCost": "Khoảng {cost} tiền gọi mô hình.",

--- a/frontend/src/screens/backfill.test.tsx
+++ b/frontend/src/screens/backfill.test.tsx
@@ -49,6 +49,9 @@ type StubOptions = {
   /** Status rows served per GET, consumed one at a time (last repeats). */
   statuses: BackfillStatus[];
   preview?: BackfillPreview;
+  /** The preview POST's own answer, for the cases that are about an estimate
+   *  which never lands or never comes — where a `preview` row cannot say it. */
+  previewRoute?: () => Response | Promise<Response>;
   /** The status the start POST flips the next GET to. */
   onStart?: BackfillStatus;
 };
@@ -71,7 +74,9 @@ function stubApi(options: StubOptions) {
       const url = new URL(request.url);
       const path = url.pathname;
       if (path.endsWith("/backfill/preview")) {
-        return jsonResponse(options.preview ?? previewOf(400));
+        return options.previewRoute
+          ? options.previewRoute()
+          : jsonResponse(options.preview ?? previewOf(400));
       }
       if (path.endsWith("/backfill") && request.method === "POST") {
         started = true;
@@ -217,6 +222,53 @@ describe("the connect-time backfill payoff", () => {
     render(<BackfillPanel provider="gmail" />);
 
     await screen.findByText(/~400/);
+    await userEvent.click(
+      screen.getByRole("button", { name: /Start the import/ }),
+    );
+
+    await waitFor(() =>
+      expect(requestsTo(calls, "/backfill", "POST").length).toBe(1),
+    );
+  });
+
+  // The estimate describes the window; the window is what the reader picked
+  // and what bounds the run. So the verb stands while the count is still
+  // running — the card used to appear only once an estimate landed, which took
+  // the start off screen for exactly the mailboxes slow enough to count.
+  it("offers the start while the scope is still being counted", async () => {
+    const calls = stubApi({
+      statuses: [statusNone],
+      // Never settles: the case is what the reader can do meanwhile.
+      previewRoute: () => new Promise<Response>(() => {}),
+      onStart: countsStatus("running", { captured: 0 }),
+    });
+    render(<BackfillPanel provider="gmail" />);
+
+    expect(await screen.findByText("Counting your mailbox…")).toBeTruthy();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Start the import/ }),
+    );
+
+    await waitFor(() =>
+      expect(requestsTo(calls, "/backfill", "POST").length).toBe(1),
+    );
+  });
+
+  // An estimator that refused left this card unrendered, so the only way to
+  // import a mailbox whose scope could not be counted was to stop offering to.
+  it("offers the start when the estimate was refused", async () => {
+    const calls = stubApi({
+      statuses: [statusNone],
+      previewRoute: () =>
+        jsonResponse(
+          { code: "internal", detail: "No answer from Gmail." },
+          502,
+        ),
+      onStart: countsStatus("running", { captured: 0 }),
+    });
+    render(<BackfillPanel provider="gmail" />);
+
+    expect(await screen.findByText(/No answer from Gmail\./)).toBeTruthy();
     await userEvent.click(
       screen.getByRole("button", { name: /Start the import/ }),
     );

--- a/frontend/src/screens/backfill.tsx
+++ b/frontend/src/screens/backfill.tsx
@@ -250,19 +250,15 @@ function BackfillSetup({
         choices={WINDOWS.map((w) => ({ value: w.value, label: t(w.label) }))}
         onChange={onWindowChange}
       />
-      {previewPending && !previewData && (
-        <p className="t-caption">{t("backfill.previewLoading")}</p>
-      )}
       {previewErrorMessage && (
         <p className="t-caption backfill-error">{previewErrorMessage}</p>
       )}
-      {previewData && (
-        <EstimateCard
-          preview={previewData}
-          starting={startPending}
-          onStart={onStart}
-        />
-      )}
+      <EstimateCard
+        preview={previewData}
+        counting={previewPending && !previewData}
+        starting={startPending}
+        onStart={onStart}
+      />
       {startErrorMessage && (
         <p className="t-caption backfill-error">
           {narrowing ? t("backfill.narrowingNote") : startErrorMessage}
@@ -280,26 +276,42 @@ function BackfillSetup({
   );
 }
 
-// EstimateCard is the consent surface: the labeled estimate the user acts on.
+// EstimateCard is the consent surface: whatever is known about the scope, and
+// the verb that acts on it.
+//
+// The verb stands in every scope state — counted, still counting, or refused.
+// The window is what the reader picked and what bounds the run; the estimate
+// only describes that window, so a count that is slow or that failed is a
+// reason to say so, never a reason to withhold the import. Drawing the card
+// only on a landed estimate took the start button off screen for exactly the
+// mailboxes slow enough to make someone wonder, and off screen for good when
+// the estimator refused.
 function EstimateCard({
   preview,
+  counting,
   starting,
   onStart,
 }: {
-  preview: components["schemas"]["BackfillPreview"];
+  preview: components["schemas"]["BackfillPreview"] | undefined;
+  /** No estimate for this window yet and one is on its way. A refused estimate
+   *  is neither: its sentence is already above the card. */
+  counting: boolean;
   starting: boolean;
   onStart: () => void;
 }) {
   const t = useT();
   const { locale } = useLocale();
-  const costMinor = preview.estimated_cost_minor ?? 0;
+  const costMinor = preview?.estimated_cost_minor ?? 0;
   return (
     <div className="backfill-estimate">
-      <p>
-        {t("backfill.estimateMessages")}{" "}
-        <strong>~{formatNumber(preview.estimated_messages, locale)}</strong>
-      </p>
-      {costMinor > 0 && (
+      {counting && <p className="t-caption">{t("backfill.previewLoading")}</p>}
+      {preview && (
+        <p>
+          {t("backfill.estimateMessages")}{" "}
+          <strong>~{formatNumber(preview.estimated_messages, locale)}</strong>
+        </p>
+      )}
+      {preview && costMinor > 0 && (
         <p className="t-caption">
           {t("backfill.estimateCost")} ~
           {formatMoney(

--- a/frontend/src/screens/onboarding-backread.css
+++ b/frontend/src/screens/onboarding-backread.css
@@ -68,7 +68,9 @@
 /* ---- the scope before the spend ---------------------------------------- */
 
 /* Reserves the estimate's own two lines: the panel is laid out before the
-   preview answers, and the answer must not push the actions down the page. */
+   preview answers, and the answer must not push the actions down the page. It
+   is never empty while it waits — the counting line stands where the number
+   will land, so the arriving estimate replaces a sentence rather than a gap. */
 .ob-backread-scope {
   display: flex;
   flex-direction: column;

--- a/frontend/src/screens/onboarding-backread.stories.tsx
+++ b/frontend/src/screens/onboarding-backread.stories.tsx
@@ -2,10 +2,15 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import type { components } from "../api/schema";
 import { OnboardingBackread } from "./onboarding-backread";
-import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+import {
+  installFetchStub,
+  jsonResponse,
+  type RouteMap,
+  StoryProviders,
+} from "./story-utils";
 
 // The backread step for the fe-uat render gate — one story per honest branch:
 // the window pick with its scope, a failed estimate that still allows the read,
@@ -15,10 +20,7 @@ import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 
 type BackfillStatus = components["schemas"]["BackfillStatus"];
 
-function backreadStory(
-  initial: BackfillStatus,
-  routes: Record<string, (body: unknown) => Response> = {},
-) {
+function backreadStory(initial: BackfillStatus, routes: RouteMap = {}) {
   return () => {
     installFetchStub(routes);
     return (
@@ -61,6 +63,24 @@ export const Pick: Story = {
       }),
     },
   ),
+};
+
+// The count is still running. The scope says so and the read is offered
+// anyway: the window is what the reader picked and what bounds the run, so
+// nothing about the start is waiting on the number.
+export const Counting: Story = {
+  render: backreadStory(
+    { state: "none" },
+    // Never settles, which is the steady state this story is about.
+    { "POST /connectors/gmail/backfill/preview": () => new Promise(() => {}) },
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText(/Counting the messages/i);
+    await expect(
+      canvas.getByRole("button", { name: /Connect and read/i }),
+    ).toBeEnabled();
+  },
 };
 
 // A cold-start workspace has no priced call history, so the estimate is a

--- a/frontend/src/screens/onboarding-backread.test.tsx
+++ b/frontend/src/screens/onboarding-backread.test.tsx
@@ -85,10 +85,10 @@ describe("the scope preview", () => {
     );
   });
 
-  // Changing the window must not leave the old window's estimate on screen,
-  // and Start must not fire for a scope the reader never actually saw a
-  // preview for.
-  it("clears the previous window's estimate and holds Start until the new one settles", async () => {
+  // Changing the window must not leave the old window's estimate on screen —
+  // and while the new one is being counted the scope says so, rather than
+  // standing empty behind a start nobody can press.
+  it("clears the previous window's estimate and says it is counting the new one", async () => {
     // A box, not a bare `let`: TS's control-flow narrowing otherwise loses
     // the function type across the callback boundary that assigns it.
     const deferred: { resolve: ((r: Response) => void) | null } = {
@@ -107,11 +107,6 @@ describe("the scope preview", () => {
     render({ state: "none" });
 
     await screen.findByText("About 100 messages in that window.");
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Connect and read" }),
-      ).not.toBeDisabled(),
-    );
 
     await userEvent.click(screen.getByRole("radio", { name: /12 months/ }));
 
@@ -122,18 +117,42 @@ describe("the scope preview", () => {
       screen.queryByText(/messages in that window\./),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Connect and read" }),
-    ).toBeDisabled();
+      screen.getByText("Counting the messages in that window…"),
+    ).toBeInTheDocument();
 
     deferred.resolve?.(previewOf({ estimated_messages: 900 }));
     expect(
       await screen.findByText("About 900 messages in that window."),
     ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Connect and read" }),
-      ).not.toBeDisabled(),
-    );
+    expect(screen.queryByText(/Counting the messages/)).not.toBeInTheDocument();
+  });
+
+  // The count is a description of the window, not the consent to it: the
+  // reader picked the window, and holding the verb shut until a number lands
+  // reads as a broken button on exactly the mailbox slow enough to need one.
+  it("starts on the picked window while its count is still running", async () => {
+    const starts: unknown[] = [];
+    installFetchStub({
+      // Never settles: the whole case is what the reader can do meanwhile.
+      [PREVIEW_ROUTE]: () => new Promise<Response>(() => {}),
+      [START_ROUTE]: (body) => {
+        starts.push(body);
+        return jsonResponse({ state: "queued" }, 202);
+      },
+      [STATUS_ROUTE]: () => jsonResponse({ state: "queued" }),
+    });
+    render({ state: "none" });
+
+    expect(
+      await screen.findByText("Counting the messages in that window…"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("radio", { name: /3 months/ }));
+    const start = screen.getByRole("button", { name: "Connect and read" });
+    expect(start).toBeEnabled();
+    await userEvent.click(start);
+
+    await waitFor(() => expect(starts).toEqual([{ window: "3m" }]));
   });
 
   it("qualifies an estimate the server only guessed at", async () => {

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -119,11 +119,16 @@ export function OnboardingBackread({
   // `preview.data`/`preview.error` are the mutation's LAST result, which
   // survives past the render where `selected` changes to a window nobody has
   // previewed yet. `preview.variables` is the window that result actually
-  // belongs to, so it gates both what scope is shown and whether Start may
-  // fire: a stale estimate for the old window is withheld rather than shown
-  // as though it answered the new pick, and Start waits for THIS selection's
-  // preview to settle — successfully or not (an estimate that failed is still
-  // a settled answer; see `BackreadScope`).
+  // belongs to, so it gates what scope is shown: a stale estimate for the old
+  // window is withheld rather than shown as though it answered the new pick,
+  // and until THIS selection's own count settles the scope says it is still
+  // counting rather than standing empty.
+  //
+  // Start does not wait on it. The window is the consent — it is what the
+  // reader picked and what bounds the run — while the estimate only describes
+  // that window, and counting a large mailbox takes seconds. A verb held shut
+  // for those seconds gives no reason for being shut, so it reads as a broken
+  // button at the one moment the reader is least sure anything is working.
   const previewForSelection = preview.variables === selected;
   const previewSettled = previewForSelection && !preview.isPending;
 
@@ -172,7 +177,7 @@ export function OnboardingBackread({
             ? safeDetail(preview.isError, preview.error, t)
             : null
         }
-        previewReady={previewSettled}
+        counting={!previewSettled}
         starting={start.isPending}
         held={disabled}
         startProblem={safeDetail(start.isError, start.error, t)}
@@ -204,7 +209,7 @@ function BackreadSetup({
   onSelect,
   preview,
   previewProblem,
-  previewReady,
+  counting,
   starting,
   startProblem,
   held,
@@ -219,10 +224,10 @@ function BackreadSetup({
    *  begin ahead of it. Separate from `starting`, which also drives the verb's
    *  own copy — a button reading "starting…" when nothing started is a lie. */
   held?: boolean;
-  /** True once THIS selection's own preview has settled (found or failed).
-   *  Start waits for it so a read can never fire against a scope the reader
-   *  has not actually seen. */
-  previewReady: boolean;
+  /** THIS selection's estimate has not settled yet (found or failed), so the
+   *  scope is still being counted. It is a sentence in the scope panel, never
+   *  a hold on the start: see the note in `OnboardingBackread`. */
+  counting: boolean;
   starting: boolean;
   startProblem: string | null;
   onStart: () => void;
@@ -247,14 +252,14 @@ function BackreadSetup({
           />
         ))}
       </fieldset>
-      <BackreadScope preview={preview} problem={previewProblem} />
+      <BackreadScope
+        preview={preview}
+        problem={previewProblem}
+        counting={counting}
+      />
       <p className="ob-backread-note t-caption">{t("ob.backread.note")}</p>
       <div className="ob-backread-acts">
-        <Button
-          variant="primary"
-          disabled={starting || !previewReady || held}
-          onClick={onStart}
-        >
+        <Button variant="primary" disabled={starting || held} onClick={onStart}>
           {t("ob.backread.start")}
         </Button>
         <Button disabled={held} onClick={() => onDone()}>
@@ -270,13 +275,19 @@ function BackreadSetup({
   );
 }
 
-// What the selected window would touch. An estimator that failed is stated and
-// leaves the start available: not knowing the size of the mailbox is a reason
-// to say so, never a reason to refuse the read.
+// What the selected window would touch. An estimate still being counted, and an
+// estimator that failed, are each stated here and neither stands in the way of
+// the start: not knowing the size of the mailbox yet is a reason to say so,
+// never a reason to refuse the read.
 function BackreadScope({
   preview,
   problem,
-}: Readonly<{ preview: BackfillPreview | undefined; problem: string | null }>) {
+  counting,
+}: Readonly<{
+  preview: BackfillPreview | undefined;
+  problem: string | null;
+  counting: boolean;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   // Absent when no model rate applied to this window — an unpriced estimate
@@ -292,6 +303,11 @@ function BackreadScope({
 
   return (
     <div className="ob-backread-scope" aria-live="polite">
+      {counting && (
+        <p className="ob-backread-counting t-caption">
+          {t("ob.backread.estimating")}
+        </p>
+      )}
       {preview && (
         <p className="ob-backread-estimate">
           {t("ob.backread.estimate", {


### PR DESCRIPTION
## What

The backread step of onboarding no longer holds its start verb shut while the
scope estimate is being counted. The scope panel now says
"Counting the messages in that window…" where the number will land, and
"Connect and read" is pressable throughout — a start fired mid-count posts the
window the reader has selected, exactly as it does once the estimate arrives.

The Settings connected-inboxes card gets the same treatment in its own shape:
its consent card renders in every scope state rather than only on a landed
estimate, so the start is on screen while the count runs and after a count that
failed.

## Why

The window is the consent — it is what the reader picked and what bounds the
run. The estimate only *describes* that window, so it is a sentence, not a gate.
A verb held shut with nothing said about why reads as a broken button, and it
does so on exactly the mailboxes slow enough to make someone wonder whether
anything is working. Preview-before-spend is unchanged: the preview still
auto-loads for the selected window, the estimate and its cost still print when
they arrive, and the spend still waits for an explicit start.

The Settings surface carried the same defect one step further. Drawing its
consent card only on `previewData` meant a refused estimate left no start button
at all, so a mailbox whose scope could not be counted could never be imported
from Settings.

## How verified

- `make check-fe` green (lint, 630 test files / 8348 tests, both builds).
- New unit cases pin the behaviour on both surfaces: a start fired against a
  never-settling preview posts the picked window (onboarding), and the Settings
  card offers the start both while counting and after a refused estimate. The
  existing case that asserted the button was disabled mid-count now asserts the
  counting sentence instead.
- New `Counting` story on the backread step for the render gate; `Onboarding/Backread`
  reviewed in both themes.
- Copy added to all three catalogs (`en`, `de`, `vi`).

- [x] `make check` is green
- [x] `make test-integration` is green (or: this change does not touch tenant data / RLS / the write shape) — frontend-only, no backend, no schema, no store path
- [x] `make craft-static` reports no new blockers — no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

AI-assisted end to end: the diff, its tests, the story and this description were
written by Claude Code from a description of the confusing screen, then run
against the repository's own frontend gate.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. See
[CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6hz7ty1Er31srpCr2prKX

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6hz7ty1Er31srpCr2prKX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the mailbox import start while the scope estimate is still being counted, on both the onboarding backread step and the Settings connected-inboxes card. The estimate only describes the window the reader picked, so it no longer gates the start.

**Bug Fixes**
- The onboarding scope panel shows a counting sentence where the number will land, and "Connect and read" stays pressable throughout.
- The Settings consent card renders in every scope state, so a refused estimate no longer leaves a mailbox unimportable from Settings.
- Adds the counting copy to the `en`, `de`, and `vi` catalogs.

<sup>Written for commit 5cc86f46d232bf7308e912eecd7db437dd6d0f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

