### PR TITLE
fix(httperr): a value of the wrong type is the caller's spelling

### DIFF
--- a/backend/gates/testdata/sourcecensus.json
+++ b/backend/gates/testdata/sourcecensus.json
@@ -528,7 +528,7 @@
     "arm": "one-spelling",
     "want": "silent",
     "name": "an unrelated SQLSTATE-shaped literal",
-    "body": "const probeLen = \"22001\""
+    "body": "const probeLen = \"22012\""
   },
   {
     "gate": "one-spelling",

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/retrieval"
@@ -253,5 +254,48 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	if _, err := retriever.AssembleContext(e.AsTeamRep(e.Rep1, e.Team1),
 		datasource.EntityRef{Type: datasource.EntityPerson, ID: privatePerson}, retrieval.AssembleOptions{}); err == nil {
 		t.Fatal("foreign anchor must be absent, not assembled")
+	}
+}
+
+// A value the caller spelled wrong is the CALLER's mistake, and the report
+// engine binds one straight onto a typed column.
+//
+// `owner_id` is a uuid, so `"not-a-uuid"` reaches Postgres as text it cannot
+// read: SQLSTATE 22P02, which the classification net did not know, so the
+// caller got an opaque 500 whose advice was to retry a plan that fails the same
+// way forever. Nothing about a client typo is a server fault.
+func TestAWrongTypedFilterIsTheCallersMistakeNotAServerFault(t *testing.T) {
+	e := SetupSearch(t)
+	provider := compose.NewProvider(e.Pool)
+
+	_, err := provider.RunReport(e.AsTeamRep(e.Rep1, e.Team1), datasource.ReportPlan{
+		Entity:  datasource.EntityPerson,
+		GroupBy: []string{"source"},
+		Filter:  map[string]string{"owner_id": "not-a-uuid"},
+	})
+	if err == nil {
+		t.Fatal("a filter value no uuid column can read was accepted; either the plan stopped " +
+			"binding it or this fixture no longer reaches the type it is about")
+	}
+
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("the refusal reached the unhandled path, which answers 500 internal: %v", err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422 — retrying the same spelling can never work", fault.Status)
+	}
+	if fault.Code != "value_wrong_type" {
+		t.Errorf("code = %q, want %q", fault.Code, "value_wrong_type")
+	}
+	// Postgres names the type and quotes the value back; the caller gets the
+	// sentence, the operator gets the cause.
+	for _, leak := range []string{"22P02", "uuid", "not-a-uuid"} {
+		if strings.Contains(fault.Detail, leak) {
+			t.Errorf("the refusal leaks %q: %q", leak, fault.Detail)
+		}
+	}
+	if fault.InfraCause == nil {
+		t.Error("the cause reaches no log — withholding a message is not the same as losing it")
 	}
 }

--- a/backend/internal/platform/database/storekit/sqlstate.go
+++ b/backend/internal/platform/database/storekit/sqlstate.go
@@ -19,6 +19,17 @@ const (
 	pgQueryCanceled       = "57014"
 	pgLockNotAvailable    = "55P03"
 	pgProgramLimitExceed  = "54000"
+
+	// The representation errors: a value the caller supplied is not of the type
+	// the column it was compared against holds. Listed rather than matched on
+	// the whole "22" class, which also carries arithmetic — a division by zero
+	// is a server's sum, not a caller's spelling — and substring faults that
+	// say nothing about the request.
+	pgInvalidTextRepresentation = "22P02"
+	pgNumericValueOutOfRange    = "22003"
+	pgStringDataRightTruncation = "22001"
+	pgInvalidDatetimeFormat     = "22007"
+	pgDatetimeFieldOverflow     = "22008"
 )
 
 // pgViolation names the violated constraint when err is the given
@@ -133,4 +144,27 @@ func IsQueryCanceled(err error) bool {
 func IsProgramLimitExceeded(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == pgProgramLimitExceed
+}
+
+// IsInvalidValueForType detects a value the database could not read as the type
+// it was compared against: a malformed uuid, a number where a numeric column
+// was expected, a date that is not one.
+//
+// It is the caller's spelling, not a server fault. The report engine binds a
+// caller's own `filters` and derivation predicates straight onto typed columns,
+// so `{"stage_id": "not-a-uuid"}` reached the transport as an opaque 500 whose
+// advice was to retry — advice that can never work, since the same text is the
+// same non-uuid forever.
+func IsInvalidValueForType(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.Code {
+	case pgInvalidTextRepresentation, pgNumericValueOutOfRange,
+		pgStringDataRightTruncation, pgInvalidDatetimeFormat, pgDatetimeFieldOverflow:
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/internal/platform/httperr/constraintfault.go
+++ b/backend/internal/platform/httperr/constraintfault.go
@@ -59,6 +59,14 @@ func constraintFault(err error) (Fault, bool) {
 				"the same request will fail the same way.",
 			InfraCause: err,
 		}, true
+	case storekit.IsInvalidValueForType(err):
+		return Fault{
+			Status: http.StatusUnprocessableEntity, Code: "value_wrong_type",
+			Detail: "a value in this request is not of the type the field it names holds — a " +
+				"malformed id, a number where text was sent, a date that is not one. Check each " +
+				"value against this operation's schema; do not retry unchanged.",
+			InfraCause: err,
+		}, true
 	case isConstrainedValue(err):
 		return Fault{
 			Status: http.StatusUnprocessableEntity, Code: "value_not_allowed",

--- a/backend/internal/platform/httperr/httperr_test.go
+++ b/backend/internal/platform/httperr/httperr_test.go
@@ -261,6 +261,28 @@ func TestClassify_anUntranslatedConstraintIsTheCallersMistakeNotAServerFault(t *
 				"Shorten it — most often this is a long text body — and send it again; " +
 				"the same request will fail the same way.",
 		},
+		{
+			// The report engine binds a caller's own `filters` onto typed
+			// columns, so `{"stage_id":"not-a-uuid"}` reaches the database as
+			// text a uuid column cannot read. Nothing about it is a server
+			// fault, and the same text is the same non-uuid forever.
+			name:     "a value that is not of the type its field holds",
+			sqlstate: "22P02", table: "deal", constraint: "",
+			pgMessage: `invalid input syntax for type uuid: "not-a-uuid"`,
+			wantCode:  "value_wrong_type",
+			wantDetail: "a value in this request is not of the type the field it names holds — a " +
+				"malformed id, a number where text was sent, a date that is not one. Check each " +
+				"value against this operation's schema; do not retry unchanged.",
+		},
+		{
+			name:     "a number the column cannot hold",
+			sqlstate: "22003", table: "deal", constraint: "",
+			pgMessage: "numeric field overflow",
+			wantCode:  "value_wrong_type",
+			wantDetail: "a value in this request is not of the type the field it names holds — a " +
+				"malformed id, a number where text was sent, a date that is not one. Check each " +
+				"value against this operation's schema; do not retry unchanged.",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := fmt.Errorf("writing the row: %w", &pgconn.PgError{


### PR DESCRIPTION
Closes #1151 for its first checkbox; the second is not reachable from here and the last section says why.

## The defect

The report engine binds a caller's own `filters` and derivation predicates **straight onto typed columns**. So `{"stage_id":"not-a-uuid"}` reaches Postgres as text a uuid column cannot read — SQLSTATE `22P02` — and that was not in `httperr`'s classification net. A client typo answered an opaque `500 internal` whose advice is to retry a plan that fails the same way forever, and it put the caller's mistake in somebody else's error budget.

Reproduces on any report, exactly as the ticket says.

## The mapping

`storekit.IsInvalidValueForType` and a 422 `value_wrong_type`, beside the foreign-key, CHECK and size arms already there — the same shape #1260 used for `54000`.

Five codes, **listed rather than matched on the whole `22` class**: the invalid literal (`22P02`), the number the column cannot hold (`22003`), text too long for it (`22001`), a datetime that is not one (`22007`) and one out of range (`22008`). The class also carries arithmetic, and a division by zero is a server's sum rather than a caller's spelling.

## Tests

- Two cases in the unit table, with the same exact-sentence and no-leak assertions their neighbours carry — Postgres names the type and quotes the value back, so the caller gets the sentence and the operator gets the cause.
- **And the real engine**: `TestAWrongTypedFilterIsTheCallersMistakeNotAServerFault` runs a report plan filtered on `owner_id: "not-a-uuid"` against real Postgres and reads the 422 back. A unit test over a hand-built `PgError` proves the net and nothing about the binding.

Mutation-checked: disabling the arm fails the integration case 3/3.

## The second checkbox, and why it is not here

> The refusal names the offending key, the way `FieldNotAllowedError` already does for an unknown vocabulary key.

That one cannot be done from the SQLSTATE: Postgres does not say which parameter it choked on. Naming the key means refusing **before** the database, which needs the vocabulary to declare each filter's type — and `reportSpec.filters` is `map[string]string`, key to column expression, with no types anywhere.

Inferring one from the `_id` naming convention is exactly what that struct's own `nativeMeasures` comment argues against:

> Declared rather than inferred from the `_minor` / `_base_minor` naming convention. The convention is real and the frontend leans on it, but a convention is not a rule.

So the honest second half is typing the filter vocabulary, which is a larger change than the ticket's `S` and worth its own. I have said so on the issue rather than closing it.

## Also in this diff

`gates/testdata/sourcecensus.json`'s "an unrelated SQLSTATE-shaped literal" case used `22001` — which this change makes one of ours, so the census correctly flagged it. It is now `22012`, the division-by-zero the comment beside the new list names as deliberately not mapped, so the planted case and the source agree about what the tree does not own.

## Checks

`make check-backend` green, `make craft-static` clean, `compose/integration` lane green.