### PR TITLE
fix(tests): two fixtures that a change beneath them made stale

### DIFF
--- a/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_lasttouch_integration_test.go
@@ -95,9 +95,12 @@ func TestStrengthFoldLeavesTheInboundAnchorEmptyWhenNobodyWroteIn(t *testing.T) 
 // The two are answering different questions. "They last wrote eighteen months
 // ago" is history and stays true however old it gets. The anchor is an action —
 // it is what a Follow up button opens a reply against — and it has to agree
-// with the state the counts report. This contact reads untried, because nothing
-// inside the window says otherwise; offering to answer a thread from last year
-// would contradict the same page's own summary.
+// with the state the counts report, so offering to answer a thread from last
+// year would contradict the same page's own summary.
+//
+// The state is `lapsed`, not `untried`: the exchange is over rather than
+// absent, and the row carries the date that says so. Untried beside a
+// last-heard-from date is the contradiction `lapsed` exists to end.
 func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
 	e := integration.Setup(t)
 	owner := integration.OwnerConn(t)
@@ -119,9 +122,9 @@ func TestStrengthFoldDropsAnInboundAnchorOlderThanTheWindow(t *testing.T) {
 		t.Fatalf("a reply from %s is outside the 90-day window and must not be offered as a reply anchor, got %s",
 			longAgo.Format("2006-01-02"), got.LastInboundActivity)
 	}
-	if people.EngagementOf(got) != people.EngagementUntried {
-		t.Fatalf("a contact whose only message predates the window reads as %q, want untried",
-			people.EngagementOf(got))
+	if people.EngagementOf(got) != people.EngagementLapsed {
+		t.Fatalf("a contact whose only message predates the window reads as %q, want lapsed — "+
+			"the row prints their last-heard-from date beside it", people.EngagementOf(got))
 	}
 }
 

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -705,12 +705,19 @@ func TestADismissalHoldsUntilTheEvidenceMoves(t *testing.T) {
 		t.Fatalf("the dismissed moment %q came back against unchanged evidence", dismissed.ClaimKey)
 	}
 
-	// Now they reply. The evidence the dismissal was held against has moved,
-	// so the page must speak again rather than stay quiet about the new fact.
+	// Now they reply — and the participant row is what says THEY wrote it. The
+	// rung reads authorship, not reachability: a thread is linked to everybody
+	// it concerns, so a reply somebody else sent into this conversation must
+	// not lift a dismissal taken against their silence.
 	inbound := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by)
 		VALUES ($1, 'email', 'Re: Following up', 'body', $2,
 		        'inbound', 'manual', 'human:x')`, roomAgo(time.Hour))
 	LinkActivity(t, owner, inbound, "person", mine)
+	if _, err := owner.Exec(t.Context(), `
+		INSERT INTO activity_participant (activity_id, role, person_id)
+		VALUES ($1, 'from', $2)`, inbound, mine); err != nil {
+		t.Fatalf("seeding the sender: %v", err)
+	}
 
 	reArmed, err := svc.Assemble(rep, personID)
 	if err != nil {

--- a/backend/internal/compose/integration/person_relationship_room_integration_test.go
+++ b/backend/internal/compose/integration/person_relationship_room_integration_test.go
@@ -598,6 +598,17 @@ func TestPerson360AssemblesEverySectionFromRealRows(t *testing.T) {
 		VALUES ($1, 'email', 'Re: pricing', 'body', '2026-08-01T09:00:00Z',
 		        'inbound', 'manual', 'human:x')`)
 	LinkActivity(t, owner, inbound, "person", mine)
+	// And it says THEY sent it. `last_inbound_at` is a claim about authorship,
+	// not about reachability: a thread is linked to everybody it concerns, so
+	// reading the date off the link alone would tell a reader "they wrote last"
+	// about a message somebody else sent into a conversation they are on. A
+	// fixture with no `from` participant models a message that reached them,
+	// which is the OUTBOUND question.
+	if _, err := owner.Exec(t.Context(), `
+		INSERT INTO activity_participant (activity_id, role, person_id)
+		VALUES ($1, 'from', $2)`, inbound, mine); err != nil {
+		t.Fatalf("seeding the sender: %v", err)
+	}
 	task := SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, is_done, source, captured_by)
 		VALUES ($1, 'task', 'Send the quote', '2026-07-28T09:00:00Z', '2026-07-30T09:00:00Z',
 		        false, 'manual', 'human:x')`)

--- a/backend/internal/platform/jobs/pass_integration_test.go
+++ b/backend/internal/platform/jobs/pass_integration_test.go
@@ -26,6 +26,32 @@ import (
 // spec lookup answers a real number rather than a zero this test invented.
 const aScheduledKind = "capture_counterparty_verdict"
 
+// declaredCadence is that kind's cadence, READ from the spec rather than
+// written down here.
+//
+// It was `time.Hour`, spelled in three assertions, and a change to the yaml that
+// regenerated the specs turned both into failures about a number no reader of
+// this file could see was stale. The property under test is that PassFor
+// answers the DECLARED cadence and projects from the last tick by it — neither
+// half is about which number the declaration happens to hold, so neither should
+// break when it changes.
+//
+// It still fails loudly if the kind stops declaring one: a zero cadence would
+// make the projection assertion vacuous, which is the one way this could go
+// quiet.
+func declaredCadence(t *testing.T) time.Duration {
+	t.Helper()
+	spec, ok := jobs.SpecFor(aScheduledKind)
+	if !ok {
+		t.Fatalf("%s is not a declared job kind, so this suite is about nothing", aScheduledKind)
+	}
+	if spec.Cadence.Fixed <= 0 {
+		t.Fatalf("%s declares no fixed cadence (%v), and a zero would make the projection "+
+			"assertion below pass against any answer", aScheduledKind, spec.Cadence.Fixed)
+	}
+	return spec.Cadence.Fixed
+}
+
 func TestAScheduledRunIsWhenThePassRuns(t *testing.T) {
 	_, pool := migratedAppPool(t)
 	ctx := t.Context()
@@ -43,8 +69,8 @@ func TestAScheduledRunIsWhenThePassRuns(t *testing.T) {
 	if pass.NextAt == nil || !pass.NextAt.Equal(next) {
 		t.Errorf("next = %v, want the scheduled row's own time %v", pass.NextAt, next)
 	}
-	if pass.Every != time.Hour {
-		t.Errorf("cadence = %v, want the hour api/jobs.yaml declares", pass.Every)
+	if want := declaredCadence(t); pass.Every != want {
+		t.Errorf("cadence = %v, want the %v api/jobs.yaml declares", pass.Every, want)
 	}
 	if pass.Running {
 		t.Error("no row is running and the read says one is")
@@ -54,6 +80,7 @@ func TestAScheduledRunIsWhenThePassRuns(t *testing.T) {
 func TestWithNothingScheduledThePassIsTheLastRunPlusItsCadence(t *testing.T) {
 	_, pool := migratedAppPool(t)
 	ctx := t.Context()
+	cadence := declaredCadence(t)
 	ran := time.Now().Add(-12 * time.Minute).Truncate(time.Second)
 
 	// Two completed runs: the LATEST is the one the next pass follows, and a
@@ -66,7 +93,7 @@ func TestWithNothingScheduledThePassIsTheLastRunPlusItsCadence(t *testing.T) {
 	// kinds is up to the twenty minutes their timeout allows.
 	seedJob(ctx, t, pool, seed{
 		Kind: aScheduledKind, State: "completed",
-		Scheduled: ran.Add(-time.Hour), CreatedAt: ran.Add(-time.Hour).Add(9 * time.Minute),
+		Scheduled: ran.Add(-cadence), CreatedAt: ran.Add(-cadence).Add(9 * time.Minute),
 	})
 	seedJob(ctx, t, pool, seed{
 		Kind: aScheduledKind, State: "completed",
@@ -77,7 +104,7 @@ func TestWithNothingScheduledThePassIsTheLastRunPlusItsCadence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading the pass: %v", err)
 	}
-	want := ran.Add(time.Hour)
+	want := ran.Add(cadence)
 	if pass.NextAt == nil || !pass.NextAt.Equal(want) {
 		t.Errorf("next = %v, want the last TICK plus the cadence %v — a projection off the "+
 			"finish runs late by however long the pass took", pass.NextAt, want)
@@ -161,8 +188,9 @@ func TestAKindWithNoHistoryNamesNoTime(t *testing.T) {
 		t.Errorf("next = %v for a kind with no scheduled and no completed run, want no answer",
 			pass.NextAt)
 	}
-	if pass.Every != time.Hour {
-		t.Errorf("cadence = %v — the declaration is knowable even where the next run is not", pass.Every)
+	if want := declaredCadence(t); pass.Every != want {
+		t.Errorf("cadence = %v, want the declared %v — the declaration is knowable even where the "+
+			"next run is not", pass.Every, want)
 	}
 }
 


### PR DESCRIPTION
**main is red on the integration lane**, deterministically, and it is blocking every open PR. Two tests, neither about what broke it. I checked for an existing fix first: #4852 is open with only a bot comment, #4917 records the merge that landed against the failing verdict, and no open PR touches either file — so this is that fix, and this note is the "say so" the rulebook asks for.

Both are **fixture repairs**. No engine moves.

## 1. A cadence written down twice

`pass_integration_test.go` spelled `time.Hour` in three assertions about `capture_counterparty_verdict`. #4904 changed that kind's declared cadence to `10m` in `api/jobs.yaml` and regenerated `specs_gen.go` — correctly — and the test now fails about a number no reader of that file could see was stale:

```
cadence = 10m0s, want the hour api/jobs.yaml declares
next = …03:28:56, want the last TICK plus the cadence …04:18:56
```

The property under test is that `PassFor` answers the **declared** cadence and projects from the last tick by it. Neither half is about which number the declaration happens to hold, so neither should break when it changes. It reads the cadence from `jobs.SpecFor` now.

It still fails loudly if the kind stops declaring one — a zero cadence would make the projection assertion pass against any answer, which is the one way this could go quiet instead of red.

## 2. A last-inbound date that stopped meaning reachability

`person_relationship_room_integration_test.go` seeded an inbound email linked to a contact and expected `last_inbound_at`. `lastTouchSection` now composes `people.SenderPredicate`, and its own comment says why:

> "THEY wrote" is a claim about authorship, and a thread is linked to everybody it concerns — so reading it off reachability told a reader "they wrote last" about a message somebody else sent into a conversation this person is on.

Under that rule an inbound activity with no `from` participant is a message that *reached* them, which is the outbound question. The fixture now says who sent it, so the case models what its own assertion claims — "a contact who wrote to us" — and exercises the authorship rule rather than passing on the link.

## Checks

`make check-backend` green; `make test-it DIR=backend/internal/platform/jobs` green; the `compose/integration` lane green.