### PR TITLE
feat(consent): the double-opt-in link is mailed again, by the honest path

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14167,17 +14167,29 @@ paths:
       operationId: issueDoubleOptIn
       security: [ { cookieAuth: [] } ]   # human session only
       x-agent-access: human-only
-      summary: Double-opt-in issuance — not available until the confirmation mail is durable.
+      summary: Mail the subject a single-use link that confirms one marketing purpose.
       description: |
-        Answers `409` and mints nothing. A double opt-in is only evidence when the data subject
-        completes it from their own mailbox, and this installation has no durable path to deliver
-        that link yet. The earlier behaviour returned the plaintext token to the operator, who could
-        paste it straight back into `recordConsent` — a round trip in which the subject's mailbox
-        never participated, recorded as though it had.
+        Mints the double-opt-in link for `purpose_id` and stages it to the person's own live
+        primary address — `queued` reports whether it reached the lane, and an installation with
+        none still mints and answers 201. The purpose must be live and must itself require double
+        opt-in; anything else is a 422, because a mailed link asking about a purpose that needs no
+        confirmation asks a question the answer does not fit. The plaintext is never returned: this endpoint once handed it to the
+        authenticated operator, who could paste it straight back into `recordConsent` — a round
+        trip in which the subject's mailbox never participated, recorded as though it had. A double
+        opt-in is evidence only because the data subject completed it from their own mailbox, so
+        the link is mailed and nothing else.
 
-        Marketing opt-in meanwhile is captured through the confirm-details link
-        (`requestDetailsConfirmation`), which mails a single-use link to the person's own live
-        primary address and records their answer when they submit it.
+        The purpose rides the token rather than the submission, so whoever holds one link cannot
+        use it to grant a different purpose.
+
+        The mail rides the same durable lane as every other outbound message: a delivery row, an
+        authorization decision recording why the installation was allowed to send it, and a
+        timeline entry — which is what makes it visible to a subject-access export and reachable by
+        erasure. `queued` reports that the message was staged in the same transaction that minted
+        the link; `sendable` says whether this installation has a lane at all. An installation with
+        no lane still mints the token and answers 201, because the write happened and reporting it
+        as a failure would invite a second request that mints another token and supersedes the
+        first.
       requestBody:
         required: true
         content:
@@ -14188,9 +14200,21 @@ paths:
               properties:
                 purpose_id: { type: string, format: uuid }
       responses:
-        '409': { $ref: '#/components/responses/Conflict' }
+        '201':
+          description: Link issued, and what became of the delivery.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ConfirmRequestIssued' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '422':
+          description: |
+            The request named no purpose, named one no `consent_purpose` row holds, or the contact
+            carries no live email address — so there is no mailbox a link could reach.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
 
   /people/{id}/publish:
     parameters:

--- a/backend/gates/doitokenexposure_test.go
+++ b/backend/gates/doitokenexposure_test.go
@@ -135,6 +135,20 @@ func TestThePlaintextConfirmTokenReachesNoSinkButTheMail(t *testing.T) {
 	t.Parallel()
 
 	files := parseConsentPackage(t)
+	// Every function that HANDS BACK the carrier. A local bound from one of
+	// these holds the plaintext without ever naming the field, which is how the
+	// whole struct reaches a sink past a matcher that only knows `.Token`.
+	// Derived from the package rather than listed, so a third minting function
+	// enrols itself.
+	minters := carrierReturningFuncs(files)
+	// Under-recognition is how this arm dies quietly: a minters set that came
+	// back empty would walk no carrier at all and report PASS, exactly as the
+	// taint floor below guards the other half.
+	if len(minters) < carrierMinterFloor {
+		t.Fatalf("found %d functions returning %s, fewer than the %d this package holds — the "+
+			"carrier arm has stopped seeing its subject, and a whole-struct leak would read green",
+			len(minters), carrierType, carrierMinterFloor)
+	}
 	checked, tainted := 0, 0
 	for path, file := range files {
 		checked++
@@ -146,10 +160,23 @@ func TestThePlaintextConfirmTokenReachesNoSinkButTheMail(t *testing.T) {
 				continue
 			}
 			holders := taintedNamesIn(fn)
-			if len(holders) == 0 {
+			carriers := carrierLocalsIn(fn, minters)
+			// A function with no tainted LOCAL can still read the credential:
+			// `issued.Token` straight into a struct literal names nothing, and
+			// skipping on an empty name set let a handler hand the plaintext to
+			// WriteJSON with the walk never entering the function. The field
+			// read is the taint, whether or not a local ever holds it.
+			if len(holders) == 0 && len(carriers) == 0 && !readsTheCarrierField(fn) {
 				continue
 			}
 			tainted++
+			for _, finding := range wholeCarrierUses(fn, carriers) {
+				t.Errorf("%s: %s hands the WHOLE %s to %s. The struct carries the plaintext in a "+
+					"field, so publishing the value publishes the credential — a matcher keyed on "+
+					"the field name cannot see this, because the leak names no field. Pass the "+
+					"fields the caller actually needs.",
+					path, finding.holder, carrierType, finding.call)
+			}
 			for _, finding := range unratifiedUsesOf(fn, holders) {
 				t.Errorf("%s: %s hands the plaintext confirm token to %s, which is not one of "+
 					"the destinations it may reach (%s). The token is a bearer credential "+
@@ -170,6 +197,15 @@ func TestThePlaintextConfirmTokenReachesNoSinkButTheMail(t *testing.T) {
 	}
 }
 
+// carrierMinterFloor is how many carrier-returning functions the package holds:
+// IssueConfirmToken, IssueConsentLink and the shared issueLink beneath them.
+//
+// A floor rather than an exact count, so a fourth does not fail the gate — but
+// a set that lost one, or came back empty because the detector broke, does. Set
+// at what the package actually holds rather than below it: a floor with slack
+// is a floor a loss can hide under, which is the whole failure this guards.
+const carrierMinterFloor = 3
+
 // taintedFunctionFloor is how many functions the walk must still be following.
 // Set below the count the tree holds, so adding a holder does not fail the gate,
 // and far enough above zero that a walk which lost its SUBJECT does — a matcher
@@ -187,6 +223,157 @@ func functionsIn(file *ast.File) []*ast.FuncDecl {
 		}
 	}
 	return out
+}
+
+// carrierReturningFuncs names every function in the package whose results
+// include the carrier, receiver-independent.
+//
+// These are what mint or forward the credential. Deriving the set beats listing
+// it for the reason this file derives everything else: a list goes short
+// silently, and the half that stopped matching still reports PASS.
+func carrierReturningFuncs(files map[string]*ast.File) map[string]bool {
+	out := map[string]bool{}
+	for _, file := range files {
+		for _, fn := range functionsIn(file) {
+			if declaresTheCarrier(fn) {
+				out[fn.Name.Name] = true
+			}
+		}
+	}
+	return out
+}
+
+// carrierLocalsIn names the locals in one function bound from a call that
+// returns the carrier.
+//
+// The struct is the credential, not merely a box around it: it carries the
+// plaintext in a field, so handing the WHOLE value to a log publishes the token
+// as surely as reading the field would. A matcher keyed on the field name
+// cannot see that — the leak names no selector — and this is the arm that does.
+//
+// IssuedConfirm.Token carries `json:"-"`, which stops the JSON sinks on its
+// own. This arm is what covers the ones no tag reaches: slog, fmt, a template.
+func carrierLocalsIn(fn *ast.FuncDecl, minters map[string]bool) map[string]bool {
+	out := map[string]bool{}
+	bind := func(lhs []ast.Expr, rhs []ast.Expr) {
+		if len(rhs) != 1 || len(lhs) == 0 {
+			return
+		}
+		call, isCall := rhs[0].(*ast.CallExpr)
+		if !isCall || !minters[calleeName(call)] {
+			return
+		}
+		if name, isIdent := lhs[0].(*ast.Ident); isIdent && name.Name != "_" {
+			out[name.Name] = true
+		}
+	}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		// BOTH binding forms. `issued, err := mint()` is an AssignStmt and
+		// `var issued, err = mint()` is a ValueSpec, and a walk that knew only
+		// the first left the whole function untracked for anybody who wrote the
+		// second — a spelling difference deciding whether a leak is seen.
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			bind(v.Lhs, v.Rhs)
+		case *ast.ValueSpec:
+			names := make([]ast.Expr, 0, len(v.Names))
+			for _, name := range v.Names {
+				names = append(names, name)
+			}
+			bind(names, v.Values)
+		}
+		return true
+	})
+	return out
+}
+
+// wholeCarrierUses reports every call handed a carrier value entire.
+//
+// The BARE identifier only. `issued.DeliveredTo` is a field read and publishes
+// nothing — both confirmation doors build their response that way, and treating
+// the local as tainted wherever it appears reported them as leaks, which is the
+// cry-wolf shape this file already learned once.
+func wholeCarrierUses(fn *ast.FuncDecl, carriers map[string]bool) []sinkFinding {
+	var out []sinkFinding
+	if len(carriers) == 0 {
+		return nil
+	}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		callee := calleeName(call)
+		for _, arg := range call.Args {
+			if !carrierEscapesIn(arg, carriers) {
+				continue
+			}
+			// A minter handing the carrier onward is the value doing its job.
+			if minterReceives(callee) {
+				continue
+			}
+			out = append(out, sinkFinding{holder: fn.Name.Name, call: callee})
+		}
+		return true
+	})
+	return out
+}
+
+// carrierEscapesIn reports whether an argument hands a carrier value out whole,
+// however it is wrapped.
+//
+// The BARE identifier was the first shape and it was too narrow: `[]IssuedConfirm{issued}`
+// and `struct{ C IssuedConfirm }{C: issued}` both publish the value and name no
+// selector, so a matcher looking only at the top-level argument let them past.
+// json:"-" saves the JSON sinks, but a log line is not tag-aware, so the gate
+// has to see the wrapping.
+//
+// A FIELD READ is still not an escape — `issued.DeliveredTo` inside a literal is
+// how both doors legitimately build their response, and treating the local as
+// tainted wherever it appears is the cry-wolf shape this file learned once
+// already. So a selector on the carrier stops the descent.
+func carrierEscapesIn(arg ast.Expr, carriers map[string]bool) bool {
+	found := false
+	ast.Inspect(arg, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.SelectorExpr:
+			// Reading a field off the carrier publishes that field, not the
+			// credential. Do not descend into the base.
+			if id, isIdent := v.X.(*ast.Ident); isIdent && carriers[id.Name] {
+				return false
+			}
+		case *ast.Ident:
+			if carriers[v.Name] {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// minterReceives reports whether a callee legitimately takes the whole carrier.
+// Nothing does today; the hook exists so a future forwarder is ratified here by
+// name rather than by widening the matcher and losing the arm.
+func minterReceives(string) bool { return false }
+
+// readsTheCarrierField reports whether a function reads IssuedConfirm.Token at
+// all, independently of whether it binds the value to a name.
+//
+// The gate walks a function only when it has something to follow, and a name
+// set was the whole of that test until a handler read the field directly into a
+// composite literal — no local, so no holder, so the function was never
+// entered. This is the second way in.
+func readsTheCarrierField(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sel, isSel := n.(*ast.SelectorExpr)
+		if isSel && sel.Sel.Name == plaintextField {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // taintedNamesIn returns the identifiers inside one function that hold a
@@ -300,8 +487,9 @@ type sinkFinding struct{ holder, call string }
 // of the ratified destinations.
 //
 // A composite literal is not a call and is not reported: building the
-// IssuedConfirm the mail path reads is the value's whole purpose, and the
-// struct's own field is followed by carriesPlaintext wherever it is read.
+// IssuedConfirm the mail path reads is the value's whole purpose. The struct's
+// own field is followed by carriesPlaintext wherever it is read — including
+// inside a literal handed to a call, which is how a handler would leak it.
 func unratifiedUsesOf(fn *ast.FuncDecl, names map[string]bool) []sinkFinding {
 	var out []sinkFinding
 	ast.Inspect(fn, func(n ast.Node) bool {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -51738,7 +51738,7 @@ type ServerInterface interface {
 	// Mail this contact a single-use link to see what is held about them, correct it, and answer on marketing.
 	// (POST /people/{id}/consent/confirm-request)
 	RequestDetailsConfirmation(w http.ResponseWriter, r *http.Request, id Id)
-	// Double-opt-in issuance — not available until the confirmation mail is durable.
+	// Mail the subject a single-use link that confirms one marketing purpose.
 	// (POST /people/{id}/consent/double-opt-in)
 	IssueDoubleOptIn(w http.ResponseWriter, r *http.Request, id Id)
 	// May we write to this person right now — per purpose and channel, with the reason.
@@ -54852,7 +54852,7 @@ func (_ Unimplemented) RequestDetailsConfirmation(w http.ResponseWriter, r *http
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Double-opt-in issuance — not available until the confirmation mail is durable.
+// Mail the subject a single-use link that confirms one marketing purpose.
 // (POST /people/{id}/consent/double-opt-in)
 func (_ Unimplemented) IssueDoubleOptIn(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)

--- a/backend/internal/modules/consent/confirmtoken.go
+++ b/backend/internal/modules/consent/confirmtoken.go
@@ -52,7 +52,17 @@ const confirmTokenTTL = 14 * 24 * time.Hour
 // IssuedConfirm carries the plaintext exactly once, with the deadline the mail
 // may show the recipient.
 type IssuedConfirm struct {
-	Token     string
+	// Token is the plaintext, and `json:"-"` is not decoration: this struct
+	// carries a bearer credential over one person's record, and every field of
+	// it is one `WriteJSON(w, issued)` away from a response body. The tag makes
+	// that line publish nothing rather than the whole credential, which is the
+	// defect the operator-held double-opt-in endpoint was retired for.
+	//
+	// It is the belt, not the braces. Nothing may hand this token to a sink at
+	// all, which is what TestThePlaintextConfirmTokenReachesNoSinkButTheMail
+	// (backend/gates/doitokenexposure_test.go) holds — and that gate is what
+	// catches a log line, which a json tag cannot.
+	Token     string `json:"-"`
 	ExpiresAt time.Time
 	// DeliveredTo is where the link was posted. Returned rather than taken, so
 	// the mailbox the consent claim rests on is the subject's own.
@@ -123,6 +133,65 @@ func (s *Store) IssueConsentLink(ctx context.Context, personID ids.PersonID, pur
 	return s.issueLink(ctx, personID, LinkConsentConfirmation, purposeID)
 }
 
+// deliveryAddressTx reads the subject's own live primary address, the same way
+// the confirm card reads it.
+//
+// A person carrying none has no mailbox to prove, so there is nothing the link
+// could evidence: it is refused rather than minted against an address nobody
+// holds.
+func deliveryAddressTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (string, error) {
+	var deliveredTo string
+	err := tx.QueryRow(ctx, `
+		SELECT email FROM person_email
+		 WHERE person_id = $1 AND archived_at IS NULL
+		 ORDER BY is_primary DESC, created_at
+		 LIMIT 1`, personID).Scan(&deliveredTo)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", &ValidationError{
+			Field:  personIDKey,
+			Reason: "this contact carries no live email address, so there is no mailbox a confirm link could reach",
+		}
+	}
+	return deliveredTo, err
+}
+
+// requireConfirmablePurposeTx refuses a link minted against a purpose this mail
+// cannot honestly ask about. A record-confirmation link names no purpose and is
+// exempt.
+//
+// TWO refusals, because they fail differently for the reader. An ARCHIVED
+// purpose would mint and mail and then dead-end: consentCardFor resolves only a
+// live purpose, so the subject opens a 404 sent in the installation's name. A
+// purpose that does not REQUIRE double opt-in is a different mistake — the mail
+// would ask somebody to confirm a subscription whose grant never needed
+// confirming, and the answer would be recorded as mailbox-proven evidence
+// nobody asked for. The endpoint's whole subject is the double-opt-in purpose.
+func requireConfirmablePurposeTx(ctx context.Context, tx pgx.Tx, purposeID ids.PurposeID) error {
+	if purposeID.UUID == (ids.UUID{}) {
+		return nil
+	}
+	var requiresDOI bool
+	err := tx.QueryRow(ctx,
+		`SELECT requires_double_opt_in FROM consent_purpose
+		  WHERE id = $1 AND archived_at IS NULL`, purposeID).Scan(&requiresDOI)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &ValidationError{
+			Field:  purposeIDField,
+			Reason: "this purpose is archived, so a link asking somebody to confirm it could not be answered",
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if !requiresDOI {
+		return &ValidationError{
+			Field:  purposeIDField,
+			Reason: "this purpose is not confirmed by double opt-in, so there is nothing for a mailed link to ask",
+		}
+	}
+	return nil
+}
+
 func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind string, purposeID ids.PurposeID) (IssuedConfirm, error) {
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return IssuedConfirm{}, err
@@ -141,22 +210,13 @@ func (s *Store) issueLink(ctx context.Context, personID ids.PersonID, kind strin
 		if err := auth.HoldWritableLive(ctx, tx, "person", personID.UUID); err != nil {
 			return err
 		}
-		// The subject's own live primary address, read the same way the card
-		// reads it. A person carrying none has no mailbox to prove, so there is
-		// nothing this link could evidence and it is refused rather than minted
-		// against an address nobody holds.
-		var deliveredTo string
-		err := tx.QueryRow(ctx, `
-			SELECT email FROM person_email
-			 WHERE person_id = $1 AND archived_at IS NULL
-			 ORDER BY is_primary DESC, created_at
-			 LIMIT 1`, personID).Scan(&deliveredTo)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return &ValidationError{
-				Field:  personIDKey,
-				Reason: "this contact carries no live email address, so there is no mailbox a confirm link could reach",
-			}
+		// A purpose this mail can honestly ask about, checked inside the
+		// transaction that mints against it. The two ways it can fail, and why
+		// neither is caught by the foreign key, are on the function itself.
+		if err := requireConfirmablePurposeTx(ctx, tx, purposeID); err != nil {
+			return err
 		}
+		deliveredTo, err := deliveryAddressTx(ctx, tx, personID)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/consent/doidoor_integration_test.go
+++ b/backend/internal/modules/consent/doidoor_integration_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// The double-opt-in door reaches the mint.
+//
+// IssueConsentLink was built as the honest replacement for the retired operator
+// endpoint and then had no production caller at all: the handler refused, and
+// the only things reaching the store were two tests. A store method nothing
+// calls is a capability the product does not have, however well it is written —
+// and the two tests kept it green, so nothing said so.
+//
+// These go through the HANDLER rather than the store, because the store was
+// never the part that was missing.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// issuedBody is what the door answers: two facts about the delivery, and no
+// token.
+type issuedBody struct {
+	DeliveredTo string `json:"delivered_to"`
+	Queued      bool   `json:"queued"`
+	Sendable    bool   `json:"sendable"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
+func TestTheDoubleOptInDoorMintsALinkForTheNamedPurpose(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+	purpose := marketingPurposeID(t, e)
+
+	rec := postDoubleOptIn(t, e, purpose)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("the door answered %d: %s — it is meant to mint, not refuse",
+			rec.Code, rec.Body.String())
+	}
+
+	var got issuedBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding the answer: %v (%s)", err, rec.Body.String())
+	}
+	if got.DeliveredTo == "" {
+		t.Error("the answer names no address — the subject's own mailbox is what the proof rests on")
+	}
+
+	// The row the link actually is, and the purpose it carries. The purpose
+	// riding the TOKEN is what stops one link granting a different purpose, so
+	// a mint that stored the wrong one would be the whole defect back again.
+	var kind string
+	var storedPurpose ids.PurposeID
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT kind, purpose_id FROM confirm_token
+		 WHERE person_id = $1 AND consumed_at IS NULL`, e.person).Scan(&kind, &storedPurpose); err != nil {
+		t.Fatalf("reading the minted link: %v", err)
+	}
+	if kind != LinkConsentConfirmation {
+		t.Errorf("the door minted a %q link, want %q", kind, LinkConsentConfirmation)
+	}
+	if storedPurpose != purpose {
+		t.Errorf("the link carries purpose %s, want the one the caller named (%s)", storedPurpose, purpose)
+	}
+}
+
+// The property the retired endpoint failed: the plaintext never comes back, so
+// the operator cannot close the round trip the subject is supposed to close.
+func TestTheDoubleOptInDoorReturnsNoPlaintext(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+
+	rec := postDoubleOptIn(t, e, marketingPurposeID(t, e))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("the door answered %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The stored hash is not the token, so a body containing the token cannot be
+	// found by comparing against the row. Compare against the SHAPE instead: the
+	// answer's four fields are the whole contract, and any other string in it is
+	// something nobody declared.
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the answer: %v", err)
+	}
+	for field := range body {
+		switch field {
+		case "delivered_to", "expires_at", "queued", "sendable":
+		default:
+			t.Errorf("the answer carries an undeclared field %q: %s", field, rec.Body.String())
+		}
+	}
+}
+
+// A person with no live address has no mailbox to prove, so there is nothing
+// the link could evidence. The door must say so rather than mint against an
+// address nobody holds.
+func TestTheDoubleOptInDoorRefusesWhenThereIsNoMailbox(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	// Deliberately no seedSubjectAddress.
+
+	rec := postDoubleOptIn(t, e, marketingPurposeID(t, e))
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("the door minted a link for a person with no address: %s", rec.Body.String())
+	}
+	var minted int
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, e.person).Scan(&minted); err != nil {
+		t.Fatalf("counting minted links: %v", err)
+	}
+	if minted != 0 {
+		t.Errorf("%d links were minted for a person with no mailbox", minted)
+	}
+}
+
+// The mail must ask the question the link was minted for.
+//
+// The three arms above run with no lane wired, so stageConfirmMail returns at
+// its first line and nothing is rendered — which means none of them can see
+// templateForLinkKind handing back the RECORD-confirmation wording for a
+// consent link. That defect mails somebody "check what we hold about you" and
+// records their answer as a marketing grant, and it is invisible without the
+// lane.
+func TestTheDoubleOptInMailAsksTheConsentQuestion(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+	stager, vault := &recordingStager{}, &recordingVault{}
+
+	rec := postDoubleOptInWith(t, e, withLane(e, stager, vault), marketingPurposeID(t, e))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("the door answered %d: %s", rec.Code, rec.Body.String())
+	}
+	if stager.calls != 1 {
+		t.Fatalf("the lane was handed %d messages, want 1 — the mail is what carries the link",
+			stager.calls)
+	}
+	if stager.seen.Rendered.Key != TemplateConsentConfirmation {
+		t.Errorf("the mail rendered %q, want %q — a consent link that arrives asking about the "+
+			"record asks a question the answer does not fit",
+			stager.seen.Rendered.Key, TemplateConsentConfirmation)
+	}
+	// The category the engine is asked about comes off the template, not a
+	// caller, so a consent mail cannot be authorized as something else.
+	if stager.seen.Category != commsauthz.CategoryConsentConfirmation {
+		t.Errorf("the mail was staged as %q, want %q",
+			stager.seen.Category, commsauthz.CategoryConsentConfirmation)
+	}
+	// The link itself is sealed, never on the row the mail carries.
+	if vault.calls != 1 {
+		t.Errorf("the vault sealed %d links, want 1", vault.calls)
+	}
+}
+
+// An archived purpose is nobody's to confirm any more, so a link asking about
+// it could only ever arrive dead: consentCardFor resolves the card only for a
+// live purpose, and the subject would open a 404 sent in the installation's own
+// name. The foreign key does not catch this — an archived row still exists.
+func TestTheDoubleOptInDoorRefusesAnArchivedPurpose(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedMarketingPurpose(t, e)
+	seedSubjectAddress(t, e)
+	purpose := marketingPurposeID(t, e)
+	if _, err := e.owner.Exec(e.ctx,
+		`UPDATE consent_purpose SET archived_at = now() WHERE id = $1`, purpose); err != nil {
+		t.Fatalf("archiving the purpose: %v", err)
+	}
+
+	rec := postDoubleOptIn(t, e, purpose)
+	// The SPECIFIC status: "not 201" would also pass on a 500, and a caller
+	// cannot act on an internal error the way they can act on being told the
+	// purpose is archived.
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("the door answered %d for an archived purpose, want 422: %s",
+			rec.Code, rec.Body.String())
+	}
+	var minted int
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, e.person).Scan(&minted); err != nil {
+		t.Fatalf("counting minted links: %v", err)
+	}
+	if minted != 0 {
+		t.Errorf("%d links were minted against an archived purpose", minted)
+	}
+}
+
+// A purpose that needs no double opt-in has nothing for a mailed link to ask.
+// Confirming it would record mailbox-proven evidence for a grant that never
+// required proof, off the back of a mail the subject was asked to answer for no
+// reason. The endpoint's whole subject is the double-opt-in purpose, and the
+// contract says so.
+func TestTheDoubleOptInDoorRefusesAPurposeThatNeedsNoConfirmation(t *testing.T) {
+	e := setupChannelConsent(t)
+	seedSubjectAddress(t, e)
+	var plain ids.PurposeID
+	if err := e.owner.QueryRow(e.ctx,
+		`INSERT INTO consent_purpose (key, label, requires_double_opt_in)
+		 VALUES ('service_notices', 'Service notices', false)
+		 ON CONFLICT (key) DO UPDATE SET requires_double_opt_in = false
+		 RETURNING id`).Scan(&plain); err != nil {
+		t.Fatalf("seeding a non-DOI purpose: %v", err)
+	}
+
+	rec := postDoubleOptIn(t, e, plain)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("the door answered %d for a purpose needing no confirmation, want 422: %s",
+			rec.Code, rec.Body.String())
+	}
+	var minted int
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT count(*) FROM confirm_token WHERE person_id = $1`, e.person).Scan(&minted); err != nil {
+		t.Fatalf("counting minted links: %v", err)
+	}
+	if minted != 0 {
+		t.Errorf("%d links were minted for a purpose that needs no confirmation", minted)
+	}
+}
+
+// marketingPurposeID reads the seeded double-opt-in purpose.
+func marketingPurposeID(t *testing.T, e *channelConsentEnv) ids.PurposeID {
+	t.Helper()
+	var purpose ids.PurposeID
+	if err := e.owner.QueryRow(e.ctx,
+		`SELECT id FROM consent_purpose WHERE key = $1`, PurposeMarketingEmail).Scan(&purpose); err != nil {
+		t.Fatalf("read the marketing purpose: %v", err)
+	}
+	return purpose
+}
+
+// postDoubleOptIn drives the real handler with the environment's authenticated
+// context, the way the router does.
+func postDoubleOptIn(t *testing.T, e *channelConsentEnv, purpose ids.PurposeID) *httptest.ResponseRecorder {
+	t.Helper()
+	return postDoubleOptInWith(t, e, Handlers{store: e.store}, purpose)
+}
+
+// postDoubleOptInWith drives the door with whatever wiring the caller wants,
+// so one arm can watch the mail the lane was handed.
+func postDoubleOptInWith(
+	t *testing.T, e *channelConsentEnv, h Handlers, purpose ids.PurposeID,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{"purpose_id":"` + purpose.String() + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/people/x/consent/double-opt-in", body).WithContext(e.ctx)
+	req.Header.Set("Content-Type", "application/json")
+	h.IssueDoubleOptIn(rec, req, crmcontracts.Id(e.person.UUID))
+	return rec
+}

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -6,15 +6,14 @@ package consent
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
+	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -145,39 +144,45 @@ func (h Handlers) RecordConsent(w http.ResponseWriter, r *http.Request, id crmco
 	httperr.WriteJSON(w, http.StatusOK, wireState(state))
 }
 
-// IssueDoubleOptIn implements (POST /people/{id}/consent/double-opt-in) by
-// refusing, and mints nothing.
+// IssueDoubleOptIn implements (POST /people/{id}/consent/double-opt-in): mint
+// the link for one marketing purpose and queue it to the subject's own address.
 //
-// A double opt-in is evidence only because the data subject completed it from
-// their own mailbox. This endpoint returned the plaintext token to the
-// authenticated operator, who could paste it back into RecordConsent — so the
-// round trip the proof stands on could be closed without the subject's mailbox
-// ever taking part, and the resulting consent_event recorded a confirmation
-// that had not happened. Nothing here delivered the token either: the deliver
-// flag reached an audit payload and no mailer.
-//
-// It refuses rather than being deleted because the operation is in the public
-// contract and a caller deserves an answer that says why. It returns when the
-// confirmation mail has a durable path to the subject; until then marketing
-// opt-in is captured through the confirm-details link, which mails a single-use
-// link to the person's own live primary address.
-func (h Handlers) IssueDoubleOptIn(w http.ResponseWriter, r *http.Request, _ crmcontracts.Id) {
+// The plaintext is deliberately absent from the response. A double opt-in is
+// evidence only because the data subject completed it from their own mailbox,
+// and an endpoint that handed the token back would let one operator close both
+// halves of that round trip — which is what this one used to do.
+func (h Handlers) IssueDoubleOptIn(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	var req crmcontracts.IssueDoubleOptInJSONRequestBody
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	// The body id is still probed before the refusal. A caller who omitted the
-	// purpose has a malformed request whichever way this endpoint answers, and
-	// requiredbodyids holds every required id to a probe — an endpoint that
-	// refuses for its own reasons must not become the one place a missing id
-	// goes unnamed.
+	// Probed here as well as in the store, because requiredbodyids holds every
+	// required id to a probe at the door.
 	if err := httperr.RequireBodyID(purposeIDField, ids.UUID(req.PurposeId)); err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
-	httperr.Write(w, r, fmt.Errorf(
-		"a double opt-in link can only be completed by the data subject, and this installation "+
-			"cannot yet mail one: %w", apperrors.ErrConflict))
+	issued, err := h.store.IssueConsentLink(r.Context(),
+		pathID[ids.PersonKind](id), ids.From[ids.PurposeKind](ids.UUID(req.PurposeId)))
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	// The same two facts the confirm-request door reports, and for the same
+	// reason: `queued` says this installation put the message on the lane,
+	// `sendable` says it has a lane at all, and a rep's next move differs.
+	// Neither claims delivery.
+	httperr.WriteJSON(w, http.StatusCreated, struct {
+		DeliveredTo string    `json:"delivered_to"`
+		ExpiresAt   time.Time `json:"expires_at"`
+		Queued      bool      `json:"queued"`
+		Sendable    bool      `json:"sendable"`
+	}{
+		DeliveredTo: issued.DeliveredTo,
+		ExpiresAt:   issued.ExpiresAt,
+		Queued:      issued.Staged,
+		Sendable:    h.store.canSendConfirm(),
+	})
 }
 
 // SuppressPerson serves POST /people/{id}/consent/suppress: a person recording

--- a/backend/internal/modules/consent/requiredids_test.go
+++ b/backend/internal/modules/consent/requiredids_test.go
@@ -41,12 +41,11 @@ func TestAnOmittedPurposeIsNamed(t *testing.T) {
 	faulttest.AssertNamesOmittedID(t, err, "purpose_id")
 }
 
-// IssueDoubleOptInJSONBody.purpose_id is probed at the HANDLER, because that is
-// where the operation now ends: issuance refuses outright, so there is no store
-// method left to guard. The probe still has to run — a caller who omitted the
-// purpose sent a malformed request whichever way the endpoint answers, and the
-// refusal it gets must name the missing id rather than swallowing it behind the
-// conflict.
+// IssueDoubleOptInJSONBody.purpose_id is probed at the HANDLER as well as in
+// IssueConsentLink, because requiredbodyids holds every required id to a probe
+// at the transport: an endpoint that validated only in its store would be the
+// one place a missing id goes unnamed. What the caller is owed either way is a
+// 422 that says which field was missing, rather than a fault from further in.
 func TestAnOmittedPurposeIsNamedOnTheIssuanceRefusal(t *testing.T) {
 	rec := httptest.NewRecorder()
 	body := strings.NewReader(`{"purpose_id":"00000000-0000-0000-0000-000000000000"}`)
@@ -60,24 +59,5 @@ func TestAnOmittedPurposeIsNamedOnTheIssuanceRefusal(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "purpose_id") {
 		t.Errorf("the refusal must name purpose_id, got %s", rec.Body.String())
-	}
-}
-
-// And the refusal itself: a well-formed request is answered with a conflict that
-// explains the endpoint mints nothing, rather than a token.
-func TestIssuanceRefusesAndReturnsNoToken(t *testing.T) {
-	rec := httptest.NewRecorder()
-	body := strings.NewReader(`{"purpose_id":"` + ids.New[ids.PurposeKind]().String() + `"}`)
-	req := httptest.NewRequest(http.MethodPost, "/v1/people/x/consent/double-opt-in", body)
-	req.Header.Set("Content-Type", "application/json")
-
-	Handlers{}.IssueDoubleOptIn(rec, req, crmcontracts.Id(ids.New[ids.PersonKind]().UUID))
-
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("issuance refuses with a conflict, got %d: %s", rec.Code, rec.Body.String())
-	}
-	// The whole point: no capability leaves this endpoint.
-	if strings.Contains(rec.Body.String(), "doi_") {
-		t.Errorf("the refusal must carry no token material, got %s", rec.Body.String())
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9717,16 +9717,28 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Double-opt-in issuance — not available until the confirmation mail is durable.
-         * @description Answers `409` and mints nothing. A double opt-in is only evidence when the data subject
-         *     completes it from their own mailbox, and this installation has no durable path to deliver
-         *     that link yet. The earlier behaviour returned the plaintext token to the operator, who could
-         *     paste it straight back into `recordConsent` — a round trip in which the subject's mailbox
-         *     never participated, recorded as though it had.
+         * Mail the subject a single-use link that confirms one marketing purpose.
+         * @description Mints the double-opt-in link for `purpose_id` and stages it to the person's own live
+         *     primary address — `queued` reports whether it reached the lane, and an installation with
+         *     none still mints and answers 201. The purpose must be live and must itself require double
+         *     opt-in; anything else is a 422, because a mailed link asking about a purpose that needs no
+         *     confirmation asks a question the answer does not fit. The plaintext is never returned: this endpoint once handed it to the
+         *     authenticated operator, who could paste it straight back into `recordConsent` — a round
+         *     trip in which the subject's mailbox never participated, recorded as though it had. A double
+         *     opt-in is evidence only because the data subject completed it from their own mailbox, so
+         *     the link is mailed and nothing else.
          *
-         *     Marketing opt-in meanwhile is captured through the confirm-details link
-         *     (`requestDetailsConfirmation`), which mails a single-use link to the person's own live
-         *     primary address and records their answer when they submit it.
+         *     The purpose rides the token rather than the submission, so whoever holds one link cannot
+         *     use it to grant a different purpose.
+         *
+         *     The mail rides the same durable lane as every other outbound message: a delivery row, an
+         *     authorization decision recording why the installation was allowed to send it, and a
+         *     timeline entry — which is what makes it visible to a subject-access export and reachable by
+         *     erasure. `queued` reports that the message was staged in the same transaction that minted
+         *     the link; `sendable` says whether this installation has a lane at all. An installation with
+         *     no lane still mints the token and answers 201, because the write happened and reporting it
+         *     as a failure would invite a second request that mints another token and supersedes the
+         *     first.
          */
         post: operations["issueDoubleOptIn"];
         delete?: never;
@@ -47904,9 +47916,30 @@ export interface operations {
             };
         };
         responses: {
+            /** @description Link issued, and what became of the delivery. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfirmRequestIssued"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
-            409: components["responses"]["Conflict"];
-            422: components["responses"]["ValidationError"];
+            /**
+             * @description The request named no purpose, named one no `consent_purpose` row holds, or the contact
+             *     carries no live email address — so there is no mailbox a link could reach.
+             */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     publishCapturedPerson: {


### PR DESCRIPTION
`Store.IssueConsentLink` was built as the replacement for the retired operator double-opt-in endpoint and then had **no production caller**: the handler still answered 409, and the only things reaching the store were two tests.

Everything downstream was already finished — `stageConfirmMail` renders the registered consent template, `GetConfirmDetails` serves the narrow consent card, `confirmsubmit` records the grant against the purpose that rides the token. Only the door was shut.

## The property the old endpoint lacked

The plaintext never returns. That is what it was closed for: it handed the token to the authenticated operator, who could paste it back into `recordConsent` and close a round trip whose only value is that the *subject* closed it.

## Two purposes the mint now refuses

- **Archived** — it would mail a link whose card cannot resolve (`consentCardFor` reads `archived_at IS NULL`), so the subject opens a 404 sent in the installation's name.
- **Not requiring double opt-in** — it would ask somebody to confirm a grant that never needed confirming, and record the answer as mailbox-proven evidence nobody asked for. The contract says this endpoint confirms a double-opt-in purpose; now the code does too.

Both are 422s, checked inside the mint transaction. The foreign key catches neither: an archived row still exists.

## The gate was not watching this path — or the one beside it

`doitokenexposure_test.go` entered a function only once it found a tainted **local**, so a handler reading `issued.Token` straight into a struct literal was never walked. And the whole `IssuedConfirm` could be handed to `WriteJSON` or a log in one line: both matchers keyed on a `.Token` selector, and passing the struct names none. `IssuedConfirm` had no json tags, so that published the credential.

This was open for `RequestDetailsConfirmation` too, since the controller lane shipped.

The carrier is now tainted as a value — wherever it is bound (`:=` or `var`) and however it is wrapped (slice, struct field, map) — while a field read off it stays clean, because that is how both doors legitimately build their answers. Minters are derived from the package rather than listed, with a floor that fails if the set comes back short. `IssuedConfirm.Token` also carries `json:"-"`, covering the JSON sinks the shape matching cannot; the gate covers the ones no tag reaches.

## One test was proving nothing

`TestIssuanceReturnsNoTokenMaterial` passed on a **500** — nil store, no actor bound — so "not a 422" and "no token in the body" were both vacuous. It would have stayed green if the handler leaked the plaintext on every success path. Deleted; the claim is proven on a real database instead.

## Tests

Six integration tests, each mutation-checked: mints for the named purpose (asserting kind and stored purpose off the row), returns no plaintext, refuses with no mailbox, refuses an archived purpose, refuses a purpose needing no confirmation, and — with the lane wired — asserts the mail renders the **consent** template rather than the record one, which is the "mailed the wrong question" defect.

Five leak shapes verified caught: bare, slice, struct field, map, and a wrapped `slog` call.

`make check-backend` green against the rebased tree.

## Not in this change

The frontend has no way to reach this endpoint, and its tests assert the absence deliberately. Adding the UI is a button, a mutation, a pending state, i18n in three languages, and rewriting four tests — the visible half, and a design decision rather than a wiring one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The double-opt-in endpoint now mints the single-use link and mails it to the subject's own live primary address, instead of answering 409. The plaintext token is never returned, closing the old hole where an operator could finish a round trip only the subject's mailbox should close; installations without a mail lane still mint and answer 201.

**Bug Fixes**
- The mint rejects archived purposes and purposes that don't require double opt-in (both 422), instead of mailing a link that dead-ends or records evidence nobody asked for.
- Hardened the token-exposure gate to track the whole `IssuedConfirm` value however it's bound or wrapped, with `json:"-"` on `IssuedConfirm.Token`; a leak path open since the confirm-request door shipped is now covered.
- Deleted a unit test that passed on a 500; the no-plaintext claim is now proven by integration tests against a real database.
- The frontend has no way to reach this endpoint yet, which is intentionally out of scope.

<sup>Written for commit 9c9ab105a5e77b23e613ba1bcc014573c39616ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double opt-in requests now issue a single-use confirmation link and return delivery status, expiration, and destination details.
  * Confirmation emails can be queued when delivery is configured; links can still be issued when no delivery lane is available.
* **Security**
  * Plaintext confirmation tokens are no longer included in API responses.
* **Bug Fixes**
  * Requests now reject archived or ineligible purposes and subjects without a live primary email address.
  * API responses now clearly distinguish unauthorized, forbidden, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->